### PR TITLE
raftserver: simplify and cleanup

### DIFF
--- a/src/raftserver/conn.rs
+++ b/src/raftserver/conn.rs
@@ -118,7 +118,6 @@ impl Conn {
             }
 
             bufs.push(ConnData {
-                token: self.token,
                 msg_id: self.last_msg_id,
                 data: payload.flip(),
             });

--- a/src/raftserver/handler.rs
+++ b/src/raftserver/handler.rs
@@ -3,6 +3,8 @@
 
 use std::vec::Vec;
 
+use mio::Token;
+
 use raftserver::{Result, ConnData, Sender, TimerMsg};
 
 // ServerHandler is for server logic, we must implement it for our raft server.
@@ -19,6 +21,7 @@ pub trait ServerHandler :Sized {
     // You can use sender to communicate with event loop.
     fn handle_read_data(&mut self,
                         sender: &Sender,
+                        token: Token,
                         msgs: Vec<ConnData>)
                         -> Result<(Vec<ConnData>)> {
         Ok((msgs))

--- a/src/raftserver/mod.rs
+++ b/src/raftserver/mod.rs
@@ -31,7 +31,6 @@ pub struct Config {
 }
 
 pub struct ConnData {
-    token: Token,
     msg_id: u64,
     data: ByteBuf,
 }
@@ -52,22 +51,26 @@ pub enum TimerMsg {
     None,
 }
 
-pub struct TimerData {
-    delay: u64,
-    msg: TimerMsg,
-}
-
 pub enum Msg {
     // Quit event loop.
     Quit,
     // Read data from connection.
-    ReadData(ConnData),
+    ReadData {
+        token: Token,
+        data: ConnData,
+    },
     // Write data to connection.
-    WriteData(ConnData),
+    WriteData {
+        token: Token,
+        data: ConnData,
+    },
     // Tick is for base internal tick message.
     Tick,
     // Timer is for custom timeout message.
-    Timer(TimerData),
+    Timer {
+        delay: u64,
+        msg: TimerMsg,
+    },
 }
 
 #[derive(Debug)]
@@ -117,17 +120,20 @@ impl Sender {
         Ok(())
     }
 
-    pub fn write_data(&self, data: ConnData) -> Result<()> {
-        try!(self.send(Msg::WriteData(data)));
+    pub fn write_data(&self, token: Token, data: ConnData) -> Result<()> {
+        try!(self.send(Msg::WriteData {
+            token: token,
+            data: data,
+        }));
 
         Ok(())
     }
 
     pub fn timeout_ms(&self, delay: u64, m: TimerMsg) -> Result<()> {
-        try!(self.send(Msg::Timer(TimerData {
+        try!(self.send(Msg::Timer {
             delay: delay,
             msg: m,
-        })));
+        }));
 
         Ok(())
     }


### PR DESCRIPTION
- simplify msg enum, define struct in enum directly.
- append write buf after read handled, no need using sender to notify.
