### PR TITLE
*: introduce crate `tempdir`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -154,6 +155,14 @@ dependencies = [
 name = "slab"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "tempdir"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ byteorder = "0.4"
 mio = "0.5"
 rand = "0.3"
 quick-error = "0.2"
+tempdir = "0.3"
 
 [dependencies.protobuf]
 git = "https://github.com/stepancheg/rust-protobuf.git"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate bytes;
 extern crate byteorder;
 extern crate mio;
 extern crate rand;
+extern crate tempdir;
 
 pub mod util;
 pub mod raft;

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -55,8 +55,8 @@ pub type Result<T> = result::Result<T, Error>;
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
     use super::{Dsn, Engine, Modify};
+    use tempdir::TempDir;
 
     #[test]
     fn memory() {
@@ -68,13 +68,11 @@ mod tests {
 
     #[test]
     fn rocksdb() {
-        let dir = "/tmp/rocks-test";
-        fs::remove_dir_all(dir).ok();
-        let mut e = super::new_engine(Dsn::RocksDBPath(dir)).unwrap();
+        let dir = TempDir::new("rocksdb_test").unwrap();
+        let mut e = super::new_engine(Dsn::RocksDBPath(dir.path().to_str().unwrap())).unwrap();
         get_put(e.as_mut());
         batch(e.as_mut());
         seek(e.as_mut());
-        fs::remove_dir_all(dir).unwrap();
     }
 
     fn assert_has<T: Engine + ?Sized>(engine: &T, key: &[u8], value: &[u8]) {


### PR DESCRIPTION
`tempdir` is a library for managing a temporary directory and deleting all contents when it's dropped. (RAII)

Should be helpful for testing. For more details: http://doc.rust-lang.org/tempdir/tempdir/index.html
