### PR TITLE
test: enable debug logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.0.1"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.3.0 (git+https://github.com/carllerche/bytes)",
+ "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.0.14 (git+https://github.com/stepancheg/rust-protobuf.git)",
@@ -20,6 +21,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -48,6 +57,15 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "env_logger"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +87,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "log"
 version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -142,6 +168,21 @@ dependencies = [
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "regex"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rocksdb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ git = "https://github.com/stepancheg/rust-protobuf.git"
 
 [dependencies.bytes]
 git = "https://github.com/carllerche/bytes"
+
+[dev-dependencies]
+env_logger = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ run:
 	cargo run
 
 test:
-	RUST_BACKTRACE=1 cargo test -- --nocapture
+	RUST_LOG=tikv=DEBUG RUST_BACKTRACE=1 cargo test -- --nocapture
 
 bench:
 	RUST_BACKTRACE=1 cargo bench -- --nocapture

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ extern crate rand;
 extern crate tempdir;
 extern crate rocksdb;
 
+#[cfg(test)]
+extern crate env_logger;
+
 pub mod util;
 pub mod raft;
 pub mod proto;


### PR DESCRIPTION
Docs: https://github.com/rust-lang-nursery/log#in-tests

Usage summary:

```
use env_logger;

#[test]
fn test_func() {
    env_logger::init().expect("");
    ...
}
```

Please use env_logger::init() in all tests that you want to view log.
