### PR TITLE
util: Add map macro

### DIFF
--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -1,0 +1,70 @@
+//! The macros crate contains all useful needed macros.
+
+/// Get the count of macro's arguments.
+/// 
+/// # Examples
+///
+/// ```
+/// # #[macro_use] extern crate tikv;
+/// # fn main() {
+/// assert_eq!(count_args!(), 0);
+/// assert_eq!(count_args!(1), 1);
+/// assert_eq!(count_args!(1, 2), 2);
+/// assert_eq!(count_args!(1, 2, 3), 3);
+/// # }
+/// ```
+/// 
+/// [rfc#88](https://github.com/rust-lang/rfcs/pull/88) proposes to use $# to count the number
+/// of args, but it has not been implemented yet.
+#[macro_export]
+macro_rules! count_args {
+    () => { 0 };
+    ($head:expr $(, $tail:expr)*) => { 1 + count_args!($($tail),*) };
+}
+
+/// Initial a HashMap with specify key-value pairs.
+///
+/// # Examples
+///
+/// ```
+/// # #[macro_use] extern crate tikv;
+/// # use std::collections::HashMap;
+/// # fn main() {
+/// // empty map
+/// let m: HashMap<u8, u8> = map!();
+/// assert!(m.is_empty());
+///
+/// // one initial kv pairs.
+/// let m = map!("key" => "value");
+/// assert_eq!(m.len(), 1);
+/// assert_eq!(m["key"], "value");
+///
+/// // initialize with multiple kv pairs.
+/// let m = map!("key1" => "value1", "key2" => "value2");
+/// assert_eq!(m.len(), 2);
+/// assert_eq!(m["key1"], "value1");
+/// assert_eq!(m["key2"], "value2");
+/// # }
+/// ```
+///
+/// This macro may be removed once
+/// [official implementation](https://github.com/rust-lang/rfcs/issues/542) is provided.
+#[macro_export]
+macro_rules! map {
+    () => {
+        {
+            use std::collections::HashMap;
+            HashMap::new()
+        }
+    };
+    ( $( $k:expr => $v:expr ),+ ) => {
+        {
+            use std::collections::HashMap;
+            let mut temp_map = HashMap::with_capacity(count_args!($(($k, $v)),+));
+            $(
+                temp_map.insert($k, $v);
+            )+
+            temp_map
+        }
+    };
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,6 +8,7 @@ pub use log::LogLevelFilter;
 use log::{self, Log, LogMetadata, LogRecord, SetLoggerError};
 
 pub mod codec;
+pub mod macros;
 
 pub fn init_log(level: LogLevelFilter) -> Result<(), SetLoggerError> {
     log::set_logger(|filter| {


### PR DESCRIPTION
Add a map macro to construct map quickly.

For example:

```
let empty_map: HashMap<u8, u8> = map!();
let m = map!(2 => 3);
```
