### PR TITLE
raftserver: move some codes to sub server mod.

### DIFF
--- a/src/raftserver/mod.rs
+++ b/src/raftserver/mod.rs
@@ -1,195 +1,40 @@
 #![allow(dead_code)]
 
 use std::thread;
-use std::convert;
 use std::time::Duration;
-use std::string::String;
 
-use bytes::{Buf, ByteBuf};
-use mio::{self, Token, NotifyError};
-
-use util::codec::rpc;
+use mio::{self, NotifyError};
 
 pub mod store;
 pub mod errors;
+pub mod server;
 pub use self::errors::{Result, Error, other};
-
-const SERVER_TOKEN: Token = Token(1);
-const FIRST_CUSTOM_TOKEN: Token = Token(1024);
-const INVALID_TOKEN: Token = Token(0);
-const DEFAULT_BASE_TICK_MS: u64 = 100;
-
-#[derive(Clone, Debug)]
-pub struct Config {
-    pub addr: String,
-}
-
-pub struct ConnData {
-    msg_id: u64,
-    data: ByteBuf,
-}
-
-impl ConnData {
-    pub fn from_string<S: Into<String>>(msg_id: u64, data: S) -> ConnData {
-        ConnData {
-            msg_id: msg_id,
-            data: ByteBuf::from_slice(data.into().as_bytes()),
-        }
-    }
-
-    pub fn encode_to_buf(&self) -> ByteBuf {
-        let mut buf = ByteBuf::mut_with_capacity(rpc::MSG_HEADER_LEN + self.data.bytes().len());
-
-        // Must ok here
-        rpc::encode_data(&mut buf, self.msg_id, self.data.bytes()).unwrap();
-
-        buf.flip()
-    }
-}
-
-pub enum TimerMsg {
-    // None is just for test, we will remove this later.
-    None,
-}
-
-pub enum Msg {
-    // Quit event loop.
-    Quit,
-    // Read data from connection.
-    ReadData {
-        token: Token,
-        data: ConnData,
-    },
-    // Write data to connection.
-    WriteData {
-        token: Token,
-        data: ConnData,
-    },
-    // Tick is for base internal tick message.
-    Tick,
-    // Timer is for custom timeout message.
-    Timer {
-        delay: u64,
-        msg: TimerMsg,
-    },
-    // Send data to remote peer with address.
-    SendPeer {
-        addr: String,
-        data: ConnData,
-    },
-}
-
-#[derive(Debug)]
-pub struct Sender {
-    sender: mio::Sender<Msg>,
-}
-
-impl Clone for Sender {
-    fn clone(&self) -> Sender {
-        Sender { sender: self.sender.clone() }
-    }
-}
 
 const MAX_SEND_RETRY_CNT: i32 = 20;
 
-impl Sender {
-    pub fn new(sender: mio::Sender<Msg>) -> Sender {
-        Sender { sender: sender }
-    }
-
-    fn send(&self, msg: Msg) -> Result<()> {
-        let mut value = msg;
-        for _ in 0..MAX_SEND_RETRY_CNT {
-            let r = self.sender.send(value);
-            if r.is_ok() {
-                return Ok(());
-            }
-
-            match r.unwrap_err() {
-                NotifyError::Full(m) => {
-                    warn!("notify queue is full, sleep and retry");
-                    thread::sleep(Duration::from_millis(100));
-                    value = m;
-                    continue;
-                }
-                e@_ => {
-                    return Err(convert::From::from(e));
-                }
-            }
+// send_msg wraps Sender and retries some times if queue is full.
+pub fn send_msg<M: Send + Sync>(sender: &mio::Sender<M>,
+                                msg: M)
+                                -> ::std::result::Result<(), NotifyError<M>> {
+    let mut value: M = msg;
+    for _ in 0..MAX_SEND_RETRY_CNT {
+        let r = sender.send(value);
+        if r.is_ok() {
+            return Ok(());
         }
 
-        Err(convert::From::from(NotifyError::Full(value)))
-    }
-
-    pub fn kill(&self) -> Result<()> {
-        try!(self.send(Msg::Quit));
-        Ok(())
-    }
-
-    pub fn write_data(&self, token: Token, data: ConnData) -> Result<()> {
-        try!(self.send(Msg::WriteData {
-            token: token,
-            data: data,
-        }));
-
-        Ok(())
-    }
-
-    pub fn timeout_ms(&self, delay: u64, m: TimerMsg) -> Result<()> {
-        try!(self.send(Msg::Timer {
-            delay: delay,
-            msg: m,
-        }));
-
-        Ok(())
-    }
-
-    pub fn send_peer(&self, addr: String, data: ConnData) -> Result<()> {
-        try!(self.send(Msg::SendPeer {
-            addr: addr,
-            data: data,
-        }));
-
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::thread;
-
-    use mio::{EventLoop, Handler};
-
-    use super::*;
-
-    struct SenderHandler;
-
-    impl Handler for SenderHandler {
-        type Timeout = ();
-        type Message = Msg;
-
-        fn notify(&mut self, event_loop: &mut EventLoop<SenderHandler>, msg: Msg) {
-            match msg {
-                Msg::Quit => event_loop.shutdown(),
-                _ => {}
+        match r.unwrap_err() {
+            NotifyError::Full(m) => {
+                warn!("notify queue is full, sleep and retry");
+                thread::sleep(Duration::from_millis(100));
+                value = m;
+                continue;
+            }
+            e@_ => {
+                return Err(e);
             }
         }
     }
 
-    #[test]
-    fn test_sender() {
-        let mut event_loop = EventLoop::new().unwrap();
-        let sender = Sender::new(event_loop.channel());
-        let h = thread::spawn(move || {
-            event_loop.run(&mut SenderHandler).unwrap();
-        });
-
-        for _ in 1..10000 {
-            sender.timeout_ms(100, TimerMsg::None).unwrap();
-        }
-
-        sender.kill().unwrap();
-
-        h.join().unwrap();
-    }
+    Err(NotifyError::Full(value))
 }

--- a/src/raftserver/server/conn.rs
+++ b/src/raftserver/server/conn.rs
@@ -9,7 +9,8 @@ use mio::{Token, EventLoop, EventSet, PollOpt, TryRead, TryWrite};
 use mio::tcp::TcpStream;
 use bytes::{Buf, MutBuf, ByteBuf, MutByteBuf, alloc};
 
-use raftserver::{Result, ConnData};
+use raftserver::Result;
+use super::ConnData;
 use super::server::Server;
 use super::handler::ServerHandler;
 use util::codec::rpc;

--- a/src/raftserver/server/handler.rs
+++ b/src/raftserver/server/handler.rs
@@ -5,7 +5,8 @@ use std::vec::Vec;
 
 use mio::Token;
 
-use raftserver::{Result, ConnData, Sender, TimerMsg};
+use raftserver::Result;
+use super::{ConnData, Sender, TimerMsg};
 
 // ServerHandler is for server logic, we must implement it for our raft server.
 // We use a event loop to handle all events, when an event is triggered,

--- a/src/raftserver/server/mod.rs
+++ b/src/raftserver/server/mod.rs
@@ -1,3 +1,11 @@
+use std::string::String;
+
+use bytes::{Buf, ByteBuf};
+use mio::{self, Token};
+
+use raftserver::{Result, send_msg};
+use util::codec::rpc;
+
 mod bench;
 mod conn;
 mod server;
@@ -5,5 +13,158 @@ pub mod handler;
 pub mod run;
 
 pub use self::run::Runner;
-
 pub use self::handler::ServerHandler;
+
+const SERVER_TOKEN: Token = Token(1);
+const FIRST_CUSTOM_TOKEN: Token = Token(1024);
+const INVALID_TOKEN: Token = Token(0);
+const DEFAULT_BASE_TICK_MS: u64 = 100;
+
+pub struct ConnData {
+    msg_id: u64,
+    data: ByteBuf,
+}
+
+impl ConnData {
+    pub fn from_string<S: Into<String>>(msg_id: u64, data: S) -> ConnData {
+        ConnData {
+            msg_id: msg_id,
+            data: ByteBuf::from_slice(data.into().as_bytes()),
+        }
+    }
+
+    pub fn encode_to_buf(&self) -> ByteBuf {
+        let mut buf = ByteBuf::mut_with_capacity(rpc::MSG_HEADER_LEN + self.data.bytes().len());
+
+        // Must ok here
+        rpc::encode_data(&mut buf, self.msg_id, self.data.bytes()).unwrap();
+
+        buf.flip()
+    }
+}
+
+pub enum TimerMsg {
+    // None is just for test, we will remove this later.
+    None,
+}
+
+pub enum Msg {
+    // Quit event loop.
+    Quit,
+    // Read data from connection.
+    ReadData {
+        token: Token,
+        data: ConnData,
+    },
+    // Write data to connection.
+    WriteData {
+        token: Token,
+        data: ConnData,
+    },
+    // Tick is for base internal tick message.
+    Tick,
+    // Timer is for custom timeout message.
+    Timer {
+        delay: u64,
+        msg: TimerMsg,
+    },
+    // Send data to remote peer with address.
+    SendPeer {
+        addr: String,
+        data: ConnData,
+    },
+}
+
+#[derive(Debug)]
+pub struct Sender {
+    sender: mio::Sender<Msg>,
+}
+
+impl Clone for Sender {
+    fn clone(&self) -> Sender {
+        Sender { sender: self.sender.clone() }
+    }
+}
+
+impl Sender {
+    pub fn new(sender: mio::Sender<Msg>) -> Sender {
+        Sender { sender: sender }
+    }
+
+    fn send(&self, msg: Msg) -> Result<()> {
+        try!(send_msg(&self.sender, msg));
+        Ok(())
+    }
+
+    pub fn kill(&self) -> Result<()> {
+        try!(self.send(Msg::Quit));
+        Ok(())
+    }
+
+    pub fn write_data(&self, token: Token, data: ConnData) -> Result<()> {
+        try!(self.send(Msg::WriteData {
+            token: token,
+            data: data,
+        }));
+
+        Ok(())
+    }
+
+    pub fn timeout_ms(&self, delay: u64, m: TimerMsg) -> Result<()> {
+        try!(self.send(Msg::Timer {
+            delay: delay,
+            msg: m,
+        }));
+
+        Ok(())
+    }
+
+    pub fn send_peer(&self, addr: String, data: ConnData) -> Result<()> {
+        try!(self.send(Msg::SendPeer {
+            addr: addr,
+            data: data,
+        }));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use mio::{EventLoop, Handler};
+
+    use super::*;
+
+    struct SenderHandler;
+
+    impl Handler for SenderHandler {
+        type Timeout = ();
+        type Message = Msg;
+
+        fn notify(&mut self, event_loop: &mut EventLoop<SenderHandler>, msg: Msg) {
+            match msg {
+                Msg::Quit => event_loop.shutdown(),
+                _ => {}
+            }
+        }
+    }
+
+    #[test]
+    fn test_sender() {
+        let mut event_loop = EventLoop::new().unwrap();
+        let sender = Sender::new(event_loop.channel());
+        let h = thread::spawn(move || {
+            event_loop.run(&mut SenderHandler).unwrap();
+        });
+
+        for _ in 1..10000 {
+            sender.timeout_ms(100, TimerMsg::None).unwrap();
+        }
+
+        sender.kill().unwrap();
+
+        h.join().unwrap();
+    }
+}

--- a/src/raftserver/server/run.rs
+++ b/src/raftserver/server/run.rs
@@ -5,7 +5,8 @@ use std::option::Option;
 use mio::{EventLoop, EventSet, PollOpt};
 use mio::tcp::TcpListener;
 
-use raftserver::{Result, Sender, SERVER_TOKEN};
+use raftserver::Result;
+use super::{Sender, SERVER_TOKEN};
 use super::server::Server;
 use super::handler::ServerHandler;
 
@@ -67,10 +68,9 @@ mod tests {
     use bytes::{Buf, ByteBuf};
     use mio::{EventLoop, Token};
 
-    use super::*;
+    use super::super::*;
     use raftserver::*;
     use util::codec::rpc;
-    use super::super::ServerHandler;
 
     struct BaseHandler;
 

--- a/src/raftserver/server/server.rs
+++ b/src/raftserver/server/server.rs
@@ -6,8 +6,9 @@ use std::collections::HashMap;
 use mio::{Token, Handler, EventLoop, EventSet, PollOpt};
 use mio::tcp::{TcpListener, TcpStream};
 
-use raftserver::{SERVER_TOKEN, FIRST_CUSTOM_TOKEN, DEFAULT_BASE_TICK_MS, INVALID_TOKEN};
-use raftserver::{Msg, Sender, Result, ConnData, TimerMsg};
+use raftserver::Result;
+use super::{SERVER_TOKEN, FIRST_CUSTOM_TOKEN, DEFAULT_BASE_TICK_MS, INVALID_TOKEN};
+use super::{Msg, Sender, ConnData, TimerMsg};
 use super::conn::Conn;
 use super::handler::ServerHandler;
 


### PR DESCRIPTION
@ngaut 

The origin codes belong to raftserver/server mod. Store mod will use its own Msg type.

I will refactor the Msg in raftserver/server later after finishing store mod. 
