### PR TITLE
*: update rustfmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,5 @@ genprotobuf:
 	cd ./src/proto && protoc --rust_out . *.proto
 
 format:
-	rustfmt --write-mode overwrite src/lib.rs src/bin/*.rs tests/tests.rs
+	@cargo fmt -- --write-mode overwrite | grep -v "found TODO" || exit 0
+	@rustfmt --write-mode overwrite tests/tests.rs | grep -v "found TODO" || exit 0

--- a/src/raft/errors.rs
+++ b/src/raft/errors.rs
@@ -49,7 +49,7 @@ impl cmp::PartialEq for Error {
             (&Error::Io(ref e1), &Error::Io(ref e2)) => e1.kind() == e2.kind(),
             (&Error::StepLocalMsg, &Error::StepLocalMsg) => true,
             (&Error::ConfigInvalid(ref e1), &Error::ConfigInvalid(ref e2)) => e1 == e2,
-            _ => false, 
+            _ => false,
         }
     }
 }

--- a/src/raft/log_unstable.rs
+++ b/src/raft/log_unstable.rs
@@ -175,13 +175,13 @@ mod test {
     #[test]
     fn test_maybe_first_index() {
         // entry, offset, snap, wok, windex,
-        let tests = vec![  
+        let tests = vec![
             // no snapshot
             (Some(new_entry(5,1)), 5, None, false, 0),
             (None, 0, None, false, 0),
             // has snapshot
             (Some(new_entry(5, 1)), 5, Some(new_snapshot(4,1)), true, 5),
-            (None, 5, Some(new_snapshot(4,1)), true, 5), 
+            (None, 5, Some(new_snapshot(4,1)), true, 5),
         ];
 
         for (entries, offset, snapshot, wok, windex) in tests {
@@ -201,7 +201,7 @@ mod test {
     #[test]
     fn test_maybe_last_index() {
         // entry, offset, snap, wok, windex,
-        let tests = vec![  
+        let tests = vec![
             (Some(new_entry(5,1)), 5, None, true, 5),
             (Some(new_entry(5,1)), 5, Some(new_snapshot(4,1)), true, 5),
             // last in snapshot
@@ -227,7 +227,7 @@ mod test {
     #[test]
     fn test_maybe_term() {
         // entry, offset, snap, index, wok, wterm
-        let tests = vec![  
+        let tests = vec![
             // term from entries
             (Some(new_entry(5,1)), 5, None, 5, true, 1),
             (Some(new_entry(5,1)), 5, None, 6, false, 0),
@@ -275,7 +275,7 @@ mod test {
     #[test]
     fn test_stable_to() {
         // entries, offset, snap, index, term, woffset, wlen
-        let tests = vec![  
+        let tests = vec![
             (vec![], 0, None, 5, 1, 0, 0),
             // stable to the first entry
             (vec![new_entry(5,1)], 5, None, 5, 1, 6, 0),
@@ -292,7 +292,7 @@ mod test {
             (vec![new_entry(5,1), new_entry(6,1)], 5, Some(new_snapshot(4,1)), 5, 1, 6, 1),
             // stable to the first entry and term mismatch
             (vec![new_entry(6,2)], 5, Some(new_snapshot(5,1)), 6, 1, 5, 1),
-            // stable to snapshot 
+            // stable to snapshot
             (vec![new_entry(5,1)], 5, Some(new_snapshot(4,1)), 4, 1, 5, 1),
             // stable to old entry
             (vec![new_entry(5,2)], 5, Some(new_snapshot(4,2)), 4, 1, 5, 1),
@@ -315,26 +315,26 @@ mod test {
         // entries, offset, snap, to_append, woffset, wentries
         let tests = vec![
             // replace to the end
-            (vec![new_entry(5, 1)], 5, None, 
-                vec![new_entry(6, 1), new_entry(7, 1)], 
+            (vec![new_entry(5, 1)], 5, None,
+                vec![new_entry(6, 1), new_entry(7, 1)],
                     5, vec![new_entry(5,1), new_entry(6,1), new_entry(7,1)]),
 
             // replace to unstable entries
-           (vec![new_entry(5, 1)], 5, None, 
-               vec![new_entry(5, 2), new_entry(6, 2)], 
+           (vec![new_entry(5, 1)], 5, None,
+               vec![new_entry(5, 2), new_entry(6, 2)],
                    5, vec![new_entry(5, 2), new_entry(6, 2)]),
 
-            (vec![new_entry(5, 1)], 5, None, 
-                vec![new_entry(4, 2), new_entry(5, 2), new_entry(6, 2)], 
+            (vec![new_entry(5, 1)], 5, None,
+                vec![new_entry(4, 2), new_entry(5, 2), new_entry(6, 2)],
                     4, vec![new_entry(4,2), new_entry(5, 2), new_entry(6, 2)]),
 
             // truncate existing entries and append
-           (vec![new_entry(5, 1), new_entry(6, 1), new_entry(7, 1)], 5, None, 
-               vec![new_entry(6, 2)], 
+           (vec![new_entry(5, 1), new_entry(6, 1), new_entry(7, 1)], 5, None,
+               vec![new_entry(6, 2)],
                    5, vec![new_entry(5, 1), new_entry(6, 2)]),
 
-            (vec![new_entry(5, 1), new_entry(6, 1), new_entry(7, 1)], 5, None, 
-                vec![new_entry(7, 2), new_entry(8, 2)], 
+            (vec![new_entry(5, 1), new_entry(6, 1), new_entry(7, 1)], 5, None,
+                vec![new_entry(7, 2), new_entry(8, 2)],
                     5, vec![new_entry(5, 1), new_entry(6, 1), new_entry(7, 2), new_entry(8, 2)]),
       ];
 

--- a/src/raft/raft_log.rs
+++ b/src/raft/raft_log.rs
@@ -31,7 +31,8 @@ pub struct RaftLog<T>
     pub applied: u64,
 }
 
-impl<T> ToString for RaftLog<T> where T: Storage
+impl<T> ToString for RaftLog<T>
+    where T: Storage
 {
     fn to_string(&self) -> String {
         format!("committed={}, applied={}, unstable.offset={}, unstable.entries.len()={}",
@@ -42,7 +43,8 @@ impl<T> ToString for RaftLog<T> where T: Storage
     }
 }
 
-impl<T> RaftLog<T> where T: Storage
+impl<T> RaftLog<T>
+    where T: Storage
 {
     pub fn new(storage: Arc<T>) -> RaftLog<T> {
         let first_index = storage.first_index().unwrap_or_else(|e| panic!(e));
@@ -418,7 +420,8 @@ mod test {
             (vec![new_entry(2, 2), new_entry(3, 3)], 0),
             (vec![new_entry(3, 3)], 0),
             // no conflict, but has new entries
-            (vec![new_entry(1, 1), new_entry(2, 2), new_entry(3, 3), new_entry(4, 4), new_entry(5, 4)], 4),
+            (vec![new_entry(1, 1), new_entry(2, 2), new_entry(3, 3), new_entry(4, 4),
+                new_entry(5, 4)], 4),
             (vec![new_entry(2, 2), new_entry(3, 3), new_entry(4, 4), new_entry(5, 4)], 4),
             (vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 4)], 4),
             (vec![new_entry(4, 4), new_entry(5, 4)], 4),
@@ -475,7 +478,8 @@ mod test {
             // conflicts with index 1
             (vec![new_entry(1, 2)], 1, vec![new_entry(1, 2)], 1),
             // conflicts with index 2
-            (vec![new_entry(2, 3), new_entry(3, 3)], 3, vec![new_entry(1, 1), new_entry(2, 3), new_entry(3, 3)], 2),
+            (vec![new_entry(2, 3), new_entry(3, 3)], 3, vec![new_entry(1, 1), new_entry(2, 3),
+                new_entry(3, 3)], 2),
         ];
         for (i, &(ref ents, windex, ref wents, wunstable)) in tests.iter().enumerate() {
             let store = MemStorage::new();
@@ -627,15 +631,15 @@ mod test {
             (snapi + 1, snapt, vec![], snapi + 1),
             (snapi, snapt, vec![], snapi + 1),
             (snapi - 1, snapt, vec![], snapi + 1),
-            
+
             (snapi + 1, snapt + 1, vec![], snapi + 1),
             (snapi, snapt + 1, vec![], snapi + 1),
             (snapi - 1, snapt + 1, vec![], snapi + 1),
-            
+
             (snapi + 1, snapt, vec![new_entry(snapi + 1, snapt)], snapi + 2),
             (snapi, snapt, vec![new_entry(snapi + 1, snapt)], snapi + 1),
             (snapi - 1, snapt, vec![new_entry(snapi + 1, snapt)], snapi + 1),
-            
+
             (snapi + 1, snapt + 1, vec![new_entry(snapi + 1, snapt)], snapi + 1),
             (snapi, snapt + 1, vec![new_entry(snapi + 1, snapt)], snapi + 1),
             (snapi - 1, snapt + 1, vec![new_entry(snapi + 1, snapt)], snapi + 1),
@@ -783,7 +787,8 @@ mod test {
             // test no limit
             (offset - 1, offset + 1, raft_log::NO_LIMIT, vec![], false),
             (offset, offset + 1, raft_log::NO_LIMIT, vec![], false),
-            (half - 1, half + 1, raft_log::NO_LIMIT, vec![new_entry(half - 1, half - 1), new_entry(half, half)], false),
+            (half - 1, half + 1, raft_log::NO_LIMIT, vec![new_entry(half - 1, half - 1),
+                new_entry(half, half)], false),
             (half, half + 1, raft_log::NO_LIMIT, vec![new_entry(half, half)], false),
             (last - 1, last, raft_log::NO_LIMIT, vec![new_entry(last - 1, last - 1)], false),
             (last, last + 1, raft_log::NO_LIMIT, vec![], true),
@@ -791,10 +796,14 @@ mod test {
             // test limit
             (half - 1, half + 1, 0, vec![new_entry(half - 1, half - 1)], false),
             (half - 1, half + 1, halfe_size + 1, vec![new_entry(half - 1, half - 1)], false),
-            (half - 1, half + 1, halfe_size * 2, vec![new_entry(half - 1, half - 1), new_entry(half, half)], false),
-            (half - 1, half + 2, halfe_size * 3, vec![new_entry(half - 1, half - 1), new_entry(half, half), new_entry(half + 1, half + 1)], false),
+            (half - 1, half + 1, halfe_size * 2, vec![new_entry(half - 1, half - 1),
+                                                      new_entry(half, half)], false),
+            (half - 1, half + 2, halfe_size * 3, vec![new_entry(half - 1, half - 1),
+                                                      new_entry(half, half),
+                                                      new_entry(half + 1, half + 1)], false),
             (half, half + 2, halfe_size, vec![new_entry(half, half)], false),
-            (half, half + 2, halfe_size * 2, vec![new_entry(half, half), new_entry(half + 1, half + 1)], false),
+            (half, half + 2, halfe_size * 2, vec![new_entry(half, half),
+                new_entry(half + 1, half + 1)], false),
         ];
 
         for (i, &(from, to, limit, ref w, wpanic)) in tests.iter().enumerate() {
@@ -858,8 +867,10 @@ mod test {
             (last_term, last_index, last_index + 1, vec![new_entry(last_index + 1, 4)],
              Some(last_index + 1), last_index + 1, false),
             (last_term, last_index, last_index + 2, vec![new_entry(last_index + 1, 4)],
-             Some(last_index + 1), last_index + 1, false), // do not increase commit higher than lastnewi
-            (last_term, last_index, last_index + 2, vec![new_entry(last_index + 1, 4), new_entry(last_index + 2, 4)],
+             Some(last_index + 1), last_index + 1, false), // do not increase commit higher than
+                                                           // lastnewi
+            (last_term, last_index, last_index + 2, vec![new_entry(last_index + 1, 4),
+                new_entry(last_index + 2, 4)],
              Some(last_index + 2), last_index + 2, false),
             // match with the the entry in the middle
             (last_term - 1, last_index - 1, last_index, vec![new_entry(last_index, 4)],
@@ -868,7 +879,8 @@ mod test {
              Some(last_index - 1), last_index - 1, false),
             (last_term - 3, last_index - 3, last_index, vec![new_entry(last_index - 2, 4)],
              Some(last_index - 2), last_index - 2, true), // conflict with existing committed entry
-            (last_term - 2, last_index - 2, last_index, vec![new_entry(last_index - 1, 4), new_entry(last_index, 4)],
+            (last_term - 2, last_index - 2, last_index, vec![new_entry(last_index - 1, 4),
+                                                             new_entry(last_index, 4)],
              Some(last_index), last_index, false),
         ];
 

--- a/src/raftserver/server/conn.rs
+++ b/src/raftserver/server/conn.rs
@@ -162,8 +162,8 @@ impl Conn {
         // Later we can write data directly, if meet WOUNDBLOCK error(don't write all data OK),
         // we can register writable at that time.
         // We must also check `socket is not connected` error too, when we connect to a remote
-        // peer, mio puts this socket in event loop immediately, but this socket may not be connected
-        // at that time, so we must register writable too for this case.
+        // peer, mio puts this socket in event loop immediately, but this socket may not be
+        // connected at that time, so we must register writable too for this case.
         self.res.push_back(msg.encode_to_buf());
 
         if !self.interest.is_writable() {

--- a/src/raftserver/store/region.rs
+++ b/src/raftserver/store/region.rs
@@ -26,9 +26,9 @@ use raftserver::{Result, other};
 //  2, find data region using key \x00\x03"123" in meta2.
 //  3, find data using key "123".
 //
-// Client should cache all region route meta so that it can send the commands to the relevant region
-// directly and correctly. If the request key is not in the region, clients should re-flesh the cache
-// from placement driver first then re-send again.
+// Client should cache all region route meta so that it can send the commands to the relevant
+// region directly and correctly. If the request key is not in the region, clients should re-flesh
+// the cache from placement driver first then re-send again.
 
 
 trait RouteMetaAction <T: Mutator>{

--- a/src/storage/engine/memory.rs
+++ b/src/storage/engine/memory.rs
@@ -18,19 +18,22 @@ impl EngineBtree {
 impl Engine for EngineBtree {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         trace!("EngineBtree: get {:?}", key);
-        let m = self.map.read().unwrap(); // Use unwrap here since the usage pattern is simple, should never be poisoned.
+        let m = self.map.read().unwrap(); // Use unwrap here since the usage pattern is simple,
+                                          // should never be poisoned.
         Ok(m.get(key).cloned())
     }
 
     fn seek(&self, key: &[u8]) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
         trace!("EngineBtree: seek {:?}", key);
-        let m = self.map.read().unwrap(); // Use unwrap here since the usage pattern is simple, should never be poisoned.
+        let m = self.map.read().unwrap(); // Use unwrap here since the usage pattern is simple,
+                                          // should never be poisoned.
         let mut iter = m.range::<Vec<u8>, Vec<u8>>(Included(&key.to_owned()), Unbounded);
         Ok(iter.next().map(|(k, v)| (k.clone(), v.clone())))
     }
 
     fn write(&self, batch: Vec<Modify>) -> Result<()> {
-        let mut m = self.map.write().unwrap(); // Use unwrap here since the usage pattern is simple, should never be poisoned.
+        let mut m = self.map.write().unwrap(); // Use unwrap here since the usage pattern is
+                                               // simple, should never be poisoned.
         for rev in batch {
             match rev {
                 Modify::Delete(k) => {

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -54,7 +54,11 @@ impl Scheduler {
                 Pending::Command(Command::Scan{start_key, limit, version, callback}) => {
                     self.exec_scan(start_key, limit, version, callback)
                 }
-                Pending::Command(Command::Prewrite{puts, deletes, locks, start_version, callback}) => {
+                Pending::Command(Command::Prewrite{puts,
+                                                   deletes,
+                                                   locks,
+                                                   start_version,
+                                                   callback}) => {
                     self.exec_prewrite(puts, deletes, locks, start_version, callback)
                 }
                 _ => unreachable!(),

--- a/src/util/codec/rpc.rs
+++ b/src/util/codec/rpc.rs
@@ -1,7 +1,7 @@
 // This package handles RPC message data encoding/decoding.
 // Every RPC message data contains two parts: header + payload.
 // Header is 16 bytes, format:
-//  | 0xdaf4 (2 bytes magic value) | 0x01 (version 2 bytes) | msg_len (4 bytes) | msg_id (8 bytes) |,
+//  | 0xdaf4(2 bytes magic value) | 0x01(version 2 bytes) | msg_len(4 bytes) | msg_id(8 bytes) |,
 // all use bigendian.
 // Now the version is always 1.
 // Payload can be any arbitrary data, but we use Protobuf in our program default.

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -1,7 +1,7 @@
 //! The macros crate contains all useful needed macros.
 
 /// Get the count of macro's arguments.
-/// 
+///
 /// # Examples
 ///
 /// ```
@@ -13,7 +13,7 @@
 /// assert_eq!(count_args!(1, 2, 3), 3);
 /// # }
 /// ```
-/// 
+///
 /// [rfc#88](https://github.com/rust-lang/rfcs/pull/88) proposes to use $# to count the number
 /// of args, but it has not been implemented yet.
 #[macro_export]

--- a/tests/test_raft.rs
+++ b/tests/test_raft.rs
@@ -510,12 +510,20 @@ fn test_leader_election() {
         (Network::new(vec![None, NOP_STEPPER, NOP_STEPPER]), StateRole::Candidate),
         (Network::new(vec![None, NOP_STEPPER, NOP_STEPPER, None]), StateRole::Candidate),
         (Network::new(vec![None, NOP_STEPPER, NOP_STEPPER, None, None]), StateRole::Leader),
-        
+
         // three logs further along than 0
-        (Network::new(vec![None, Some(ents(vec![1])), Some(ents(vec![2])), Some(ents(vec![1, 3])), None]), StateRole::Follower),
-        
+        (Network::new(vec![None,
+                           Some(ents(vec![1])),
+                           Some(ents(vec![2])),
+                           Some(ents(vec![1, 3])),
+                           None]), StateRole::Follower),
+
         // logs converge
-        (Network::new(vec![Some(ents(vec![1])), None, Some(ents(vec![2])), Some(ents(vec![1])), None]), StateRole::Leader),
+        (Network::new(vec![Some(ents(vec![1])),
+                           None,
+                           Some(ents(vec![2])),
+                           Some(ents(vec![1])),
+                           None]), StateRole::Leader),
     ];
 
     for (i, &mut (ref mut network, state)) in tests.iter_mut().enumerate() {
@@ -537,8 +545,15 @@ fn test_leader_election() {
 #[test]
 fn test_log_replicatioin() {
     let mut tests = vec![
-        (Network::new(vec![None, None, None]), vec![new_message(1, 1, MessageType::MsgPropose, 1)], 2),
-        (Network::new(vec![None, None, None]), vec![new_message(1, 1, MessageType::MsgPropose, 1), new_message(1, 2, MessageType::MsgHup, 0), new_message(1, 2, MessageType::MsgPropose, 1)], 4),
+        (Network::new(vec![None, None, None]),
+            vec![new_message(1, 1, MessageType::MsgPropose, 1)],
+            2),
+
+        (Network::new(vec![None, None, None]),
+            vec![new_message(1, 1, MessageType::MsgPropose, 1),
+                new_message(1, 2, MessageType::MsgHup, 0),
+                new_message(1, 2, MessageType::MsgPropose, 1)],
+            4),
     ];
 
     for (i, &mut (ref mut network, ref msgs, wcommitted)) in tests.iter_mut().enumerate() {
@@ -844,13 +859,13 @@ fn test_commit() {
         (vec![1], vec![empty_entry(1, 1)], 2, 0),
         (vec![2], vec![empty_entry(1, 1), empty_entry(2, 2)], 2, 2),
         (vec![1], vec![empty_entry(2, 1)], 2, 1),
-        
+
         // odd
         (vec![2, 1, 1], vec![empty_entry(1, 1), empty_entry(2, 2)], 1, 1),
         (vec![2, 1, 1], vec![empty_entry(1, 1), empty_entry(1, 2)], 2, 0),
         (vec![2, 1, 2], vec![empty_entry(1, 1), empty_entry(2, 2)], 2, 2),
         (vec![2, 1, 2], vec![empty_entry(1, 1), empty_entry(1, 2)], 2, 0),
-        
+
         // even
         (vec![2, 1, 1, 1], vec![empty_entry(1, 1), empty_entry(2, 2)], 1, 1),
         (vec![2, 1, 1, 1], vec![empty_entry(1, 1), empty_entry(1, 2)], 2, 0),
@@ -924,7 +939,8 @@ fn test_step_ignore_old_term_msg() {
 // test_handle_msg_append ensures:
 // 1. Reply false if log doesn’t contain an entry at prevLogIndex whose term matches prevLogTerm.
 // 2. If an existing entry conflicts with a new one (same index but different terms),
-//    delete the existing entry and all that follow it; append any new entries not already in the log.
+//    delete the existing entry and all that follow it; append any new entries not already in the
+//    log.
 // 3. If leaderCommit > commitIndex, set commitIndex = min(leaderCommit, index of last new entry).
 #[test]
 fn test_handle_msg_append() {
@@ -946,17 +962,18 @@ fn test_handle_msg_append() {
         // Ensure 1
         (nm(2, 3, 2, 3, None), 2, 0, true), // previous log mismatch
         (nm(2, 3, 3, 3, None), 2, 0, true), // previous log non-exist
-        
+
         // Ensure 2
         (nm(2, 1, 1, 1, None), 2, 1, false),
         (nm(2, 0, 0, 1, Some(vec![(1, 2)])), 1, 1, false),
         (nm(2, 2, 2, 3, Some(vec![(3, 2), (4, 2)])), 4, 3, false),
         (nm(2, 2, 2, 4, Some(vec![(3, 2)])), 3, 3, false),
         (nm(2, 1, 1, 4, Some(vec![(2, 2)])), 2, 2, false),
-        
+
         // Ensure 3
         (nm(1, 1, 1, 3, None), 2, 1, false), // match entry 1, commit up to last new entry 1
-        (nm(1, 1, 1, 3, Some(vec![(2, 2)])), 2, 2, false), // match entry 1, commit up to last new entry 2
+        (nm(1, 1, 1, 3, Some(vec![(2, 2)])), 2, 2, false), // match entry 1, commit up to last new
+                                                           // entry 2
         (nm(2, 2, 2, 3, None), 2, 2, false), // match entry 2, commit up to last new entry 2
         (nm(2, 2, 2, 4, None), 2, 2, false), // commit up to log.last()
     ];
@@ -1050,7 +1067,8 @@ fn test_handle_heartbeat_resp() {
     assert_eq!(msgs.len(), 1);
     assert_eq!(msgs[0].get_msg_type(), MessageType::MsgAppend);
 
-    // A second heartbeat response with no AppResp does not re-send because we are in the wait state.
+    // A second heartbeat response with no AppResp does not re-send because we are in the wait
+    // state.
     sm.step(new_message(2, 0, MessageType::MsgHeartbeatResponse, 0)).expect("");
     msgs = sm.read_messages();
     assert_eq!(msgs.len(), 0);
@@ -1131,25 +1149,25 @@ fn test_recv_msg_request_vote() {
         (StateRole::Follower, 0, 1, INVALID_ID, true),
         (StateRole::Follower, 0, 2, INVALID_ID, true),
         (StateRole::Follower, 0, 3, INVALID_ID, false),
-        
+
         (StateRole::Follower, 1, 0, INVALID_ID, true),
         (StateRole::Follower, 1, 1, INVALID_ID, true),
         (StateRole::Follower, 1, 2, INVALID_ID, true),
         (StateRole::Follower, 1, 3, INVALID_ID, false),
-        
+
         (StateRole::Follower, 2, 0, INVALID_ID, true),
         (StateRole::Follower, 2, 1, INVALID_ID, true),
         (StateRole::Follower, 2, 2, INVALID_ID, false),
         (StateRole::Follower, 2, 3, INVALID_ID, false),
-        
+
         (StateRole::Follower, 3, 0, INVALID_ID, true),
         (StateRole::Follower, 3, 1, INVALID_ID, true),
         (StateRole::Follower, 3, 2, INVALID_ID, false),
         (StateRole::Follower, 3, 3, INVALID_ID, false),
-        
+
         (StateRole::Follower, 3, 2, 2, false),
         (StateRole::Follower, 3, 2, 1, true),
-        
+
         (StateRole::Leader, 3, 3, 1, true),
         (StateRole::Candidate, 3, 3, 1, true),
     ];
@@ -1184,11 +1202,11 @@ fn test_state_transition() {
         (StateRole::Follower, StateRole::Follower, true, 1, INVALID_ID),
         (StateRole::Follower, StateRole::Candidate, true, 1, INVALID_ID),
         (StateRole::Follower, StateRole::Leader, false, 0, INVALID_ID),
-        
+
         (StateRole::Candidate, StateRole::Follower, true, 0, INVALID_ID),
         (StateRole::Candidate, StateRole::Candidate, true, 1, INVALID_ID),
         (StateRole::Candidate, StateRole::Leader, true, 0, 1),
-        
+
         (StateRole::Leader, StateRole::Follower, true, 1, INVALID_ID),
         (StateRole::Leader, StateRole::Candidate, false, 1, INVALID_ID),
         (StateRole::Leader, StateRole::Leader, true, 0, 1),
@@ -1318,7 +1336,8 @@ fn test_leader_append_response() {
     // initial progress: match = 0; next = 3
     let mut tests = vec![
         (3, true, 0, 3, 0, 0, 0), // stale resp; no replies
-        (2, true, 0, 2, 1, 1, 0), // denied resp; leader does not commit; descrease next and send probing msg
+        (2, true, 0, 2, 1, 1, 0), // denied resp; leader does not commit; descrease next and send
+                                  // probing msg
         (2, false, 2, 4, 2, 2, 2), // accept resp; leader commits; broadcast with commit index
         (0, false, 0, 3, 0, 0, 0),
     ];

--- a/tests/test_raft_paper.rs
+++ b/tests/test_raft_paper.rs
@@ -209,12 +209,12 @@ fn test_leader_election_in_one_round_rpc() {
         (5, map!(2 => true, 3 => true, 4 => true, 5 => true), StateRole::Leader),
         (5, map!(2 => true, 3 => true, 4 => true), StateRole::Leader),
         (5, map!(2 => true, 3 => true), StateRole::Leader),
-        
+
         // return to follower state if it receives vote denial from a majority
         (3, map!(2 => false, 3 => false), StateRole::Follower),
         (5, map!(2 => false, 3 => false, 4 => false, 5 => false), StateRole::Follower),
         (5, map!(2 => true, 3 => false, 4 => false, 5 => false), StateRole::Follower),
-        
+
         // stay in candidate if it does not obtain the majority
         (3, map!(), StateRole::Candidate),
         (5, map!(2 => true), StateRole::Candidate),
@@ -599,7 +599,7 @@ fn test_follower_check_msg_append() {
         (ents[0].get_term(), ents[0].get_index(), 1, false, 0),
         // match with uncommitted entries
         (ents[1].get_term(), ents[1].get_index(), 2, false, 0),
-        
+
         // unmatch with existing entry
         (ents[0].get_term(), ents[1].get_index(), ents[1].get_index(), true, 2),
         // unexisting entry
@@ -641,8 +641,16 @@ fn test_follower_check_msg_append() {
 #[test]
 fn test_follower_append_entries() {
     let mut tests = vec![
-        (2, 2, vec![empty_entry(3, 3)], vec![empty_entry(1, 1), empty_entry(2, 2), empty_entry(3, 3)], vec![empty_entry(3, 3)]),
-        (1, 1, vec![empty_entry(3, 2), empty_entry(4, 3)], vec![empty_entry(1, 1), empty_entry(3, 2), empty_entry(4, 3)], vec![empty_entry(3, 2), empty_entry(4, 3)]),
+        (2, 2,
+            vec![empty_entry(3, 3)],
+            vec![empty_entry(1, 1), empty_entry(2, 2), empty_entry(3, 3)],
+            vec![empty_entry(3, 3)]),
+
+        (1, 1,
+            vec![empty_entry(3, 2), empty_entry(4, 3)],
+            vec![empty_entry(1, 1), empty_entry(3, 2), empty_entry(4, 3)],
+            vec![empty_entry(3, 2), empty_entry(4, 3)]),
+
         (0, 0, vec![empty_entry(1, 1)], vec![empty_entry(1, 1), empty_entry(2, 2)], vec![]),
         (0, 0, vec![empty_entry(3, 1)], vec![empty_entry(3, 1)], vec![empty_entry(3, 1)]),
     ];
@@ -720,13 +728,14 @@ fn test_leader_sync_follower_log() {
             empty_entry(0, 0),
             empty_entry(1, 1), empty_entry(1, 2), empty_entry(1, 3),
             empty_entry(4, 4), empty_entry(4, 5), empty_entry(4, 6), empty_entry(4, 7),
-            
+
         ],
         vec![
             empty_entry(0, 0),
             empty_entry(1, 1), empty_entry(1, 2), empty_entry(1, 3),
             empty_entry(2, 4), empty_entry(2, 5), empty_entry(2, 6),
-            empty_entry(3, 7), empty_entry(3, 8), empty_entry(3, 9), empty_entry(3, 10), empty_entry(3, 11),
+            empty_entry(3, 7), empty_entry(3, 8), empty_entry(3, 9), empty_entry(3, 10),
+                empty_entry(3, 11),
         ],
     ];
     for (i, tt) in tests.drain(..).enumerate() {

--- a/tests/test_raw_node.rs
+++ b/tests/test_raw_node.rs
@@ -78,8 +78,8 @@ fn test_raw_node_step() {
     }
 }
 
-// test_raw_node_propose_and_conf_change ensures that RawNode.propose and RawNode.propose_conf_change
-// send the given proposal and ConfChange to the underlying raft.
+// test_raw_node_propose_and_conf_change ensures that RawNode.propose and
+// RawNode.propose_conf_change send the given proposal and ConfChange to the underlying raft.
 #[test]
 fn test_raw_node_propose_and_conf_change() {
     let s = new_storage();


### PR DESCRIPTION
Note:

The rustfmt binary must be updated to `0.3.0`. It could be done with following commands:

```
rm -f ~/.cargo/bin/cargo-fmt
rm -f ~/.cargo/bin/rustfmt
cargo install rustfmt
```
