### PR TITLE
raftserver: use slab instead of hashmap for connections.

### DIFF
--- a/src/raftserver/server/conn.rs
+++ b/src/raftserver/server/conn.rs
@@ -45,8 +45,7 @@ fn try_read_data<T: TryRead, B: MutBuf>(r: &mut T, buf: &mut B) -> Result<()> {
         let n = try!(r.try_read(buf.mut_bytes()));
         match n {
             None => {
-                // nothing to do here now, but should we return an error or panic?
-                error!("connection read None data");
+                // nothing to do here.
             }
             Some(n) => buf.advance(n),
         }

--- a/src/raftserver/server/mod.rs
+++ b/src/raftserver/server/mod.rs
@@ -16,8 +16,6 @@ pub use self::run::Runner;
 pub use self::handler::ServerHandler;
 
 const SERVER_TOKEN: Token = Token(1);
-const FIRST_CUSTOM_TOKEN: Token = Token(1024);
-const INVALID_TOKEN: Token = Token(0);
 const DEFAULT_BASE_TICK_MS: u64 = 100;
 
 pub struct ConnData {


### PR DESCRIPTION
Slab is more commonly used with mio.

@ngaut @BusyJay 
