### PR TITLE
*: refactor raftkv.

### DIFF
--- a/src/raftserver/mod.rs
+++ b/src/raftserver/mod.rs
@@ -7,7 +7,7 @@ use mio::{self, NotifyError};
 
 pub mod store;
 pub mod errors;
-pub mod server;
+// pub mod server;
 pub mod coprocessor;
 pub use self::errors::{Result, Error, other};
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -18,10 +18,9 @@ pub mod node;
 
 pub use self::config::{Config, DEFAULT_LISTENING_ADDR};
 pub use self::errors::{Result, Error, other};
-pub use self::server::{Server, create_event_loop};
-pub use self::transport::ServerTransport;
-pub use self::node::Node;
-
+pub use self::server::{Server, create_event_loop, bind};
+pub use self::transport::{ServerTransport, MockTransport};
+pub use self::node::{Node, create_raft_storage};
 
 const MAX_SEND_RETRY_CNT: i32 = 20;
 

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -103,3 +103,28 @@ impl<T: PdClient> Transport for ServerTransport<T> {
         Ok(())
     }
 }
+
+// FakeTransport is used for Memory and RocksDB to pass compile.
+pub struct MockTransport;
+
+impl Transport for MockTransport {
+    fn add_sendch(&mut self, _: u64, _: StoreSendCh) {
+        unimplemented!();
+    }
+
+    fn remove_sendch(&mut self, _: u64) -> Option<StoreSendCh> {
+        unimplemented!();
+    }
+
+    fn send_raft_msg(&self, _: RaftMessage) -> RaftResult<()> {
+        unimplemented!();
+    }
+
+    fn send_command(&self, _: RaftCmdRequest, _: Callback) -> RaftResult<()> {
+        unimplemented!();
+    }
+
+    fn send(&self, _: RaftMessage) -> RaftResult<()> {
+        unimplemented!();
+    }
+}

--- a/src/storage/engine/memory.rs
+++ b/src/storage/engine/memory.rs
@@ -1,12 +1,12 @@
 use std::sync::RwLock;
 use std::collections::BTreeMap;
 use std::collections::Bound::{Included, Unbounded};
+use std::fmt::{self, Formatter, Debug};
 
 use storage::{Key, Value, KvPair, KvContext};
 use util::HandyRwLock;
 use super::{Engine, Modify, Result};
 
-#[derive(Debug)]
 pub struct EngineBtree {
     map: RwLock<BTreeMap<Vec<u8>, Value>>,
 }
@@ -15,6 +15,12 @@ impl EngineBtree {
     pub fn new() -> EngineBtree {
         info!("EngineBtree: creating");
         EngineBtree { map: RwLock::new(BTreeMap::new()) }
+    }
+}
+
+impl Debug for EngineBtree {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "Memory")
     }
 }
 

--- a/tests/raftserver/node.rs
+++ b/tests/raftserver/node.rs
@@ -83,9 +83,9 @@ impl Simulator for NodeCluster {
         let mut node = Node::new(&cfg, self.pd_client.clone(), self.trans.clone());
 
         node.start(vec![engine]).unwrap();
-        assert!(node_id == 0 || node_id == node.get_node_id());
+        assert!(node_id == 0 || node_id == node.id());
 
-        let node_id = node.get_node_id();
+        let node_id = node.id();
         self.nodes.insert(node_id, node);
 
         node_id


### PR DESCRIPTION
- Origin raftkv use whole raft server, now only uses Node.
- Because Node needs some traits, so we should create the raftkv explicitly outer, not in default new_engine. 
- Simplify tikv-server, only support one store in command flag. We will refactor internal Node, test, pd to support one node, one store later. 

@ngaut @BusyJay @disksing 

After this PR merged, we should change ticlient(@disksing)  , pd(@qiuyesuifeng) using msgpb.Message to communicate with tikv server. 
