### PR TITLE
server/server.rs: Fix http_proxy brokes test_peer_resolve

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -58,7 +58,9 @@ dependencies:
   post:
     # check format first
     - make format && git diff-index --quiet HEAD -- || (git diff; echo please make format and run tests before creating a PR!; exit 1)
-
+    # only update cache when dependency changes or ci configuration changes
+    - git diff-index --quiet HEAD~ Cargo.lock circle.yml ci-build || env SKIP_TESTS=true make trace_test:
+        timeout: 1800
 
 test:
   override:

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -262,6 +262,7 @@ mod tests {
 
     #[test]
     fn test_peer_resolve() {
+        // http proxy may broke this test. Remove them before running the test.
         env::remove_var("http_proxy");
         env::remove_var("https_proxy");
         let mut cfg = Config::default();

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -194,6 +194,7 @@ mod tests {
     use std::sync::*;
     use std::sync::mpsc::*;
     use std::sync::atomic::*;
+    use std::env;
 
     use super::*;
     use super::super::{Config, Result};
@@ -259,8 +260,9 @@ mod tests {
     }
 
     #[test]
-    // if this failed, unset the environmental variables 'http_proxy' and 'https_proxy', and retry.
     fn test_peer_resolve() {
+        env::remove_var("http_proxy");
+        env::remove_var("https_proxy");
         let mut cfg = Config::default();
         let storage_cfg = StorageConfig::default();
         cfg.addr = "127.0.0.1:0".to_owned();


### PR DESCRIPTION
Remove environment variable `http_proxy` and `https_proxy` before running test `test_peer_resolve`. So we don't need to unset them before running the test.
Previously `http_proxy` will broke this test.