### PR TITLE
A better scalable thread pool scheme

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 #![crate_type = "lib"]
 #![cfg_attr(test, feature(test))]
 #![feature(fnbox)]
+#![feature(asm)]
 #![feature(alloc)]
 #![feature(slice_patterns)]
 #![feature(box_syntax)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -40,6 +40,7 @@ pub mod metrics;
 pub mod panic_hook;
 pub mod rocksdb;
 pub mod security;
+pub mod spmcqueue;
 pub mod sys;
 pub mod threadpool;
 pub mod time;
@@ -164,7 +165,7 @@ pub fn to_socket_addr<A: ToSocketAddrs>(addr: A) -> io::Result<SocketAddr> {
 /// assert_eq!(r"a\\023", escape(b"a\\023"));
 /// assert_eq!(r"a\000", escape(b"a\0"));
 /// assert_eq!("a\\r\\n\\t '\\\"\\\\", escape(b"a\r\n\t '\"\\"));
-/// assert_eq!(r"\342\235\244\360\237\220\267", escape("❤🐷".as_bytes()));
+/// assert_eq!(r"\342\235\244\360\237\220\267", escape("鉂ゐ煇?.as_bytes()));
 /// ```
 pub fn escape(data: &[u8]) -> String {
     let mut escaped = Vec::with_capacity(data.len() * 4);
@@ -207,7 +208,7 @@ pub fn escape(data: &[u8]) -> String {
 /// assert_eq!(unescape(r"a\\023"), b"a\\023");
 /// assert_eq!(unescape(r"a\000"), b"a\0");
 /// assert_eq!(unescape("a\\r\\n\\t '\\\"\\\\"), b"a\r\n\t '\"\\");
-/// assert_eq!(unescape(r"\342\235\244\360\237\220\267"), "❤🐷".as_bytes());
+/// assert_eq!(unescape(r"\342\235\244\360\237\220\267"), "鉂ゐ煇?.as_bytes());
 /// ```
 ///
 pub fn unescape(s: &str) -> Vec<u8> {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -165,7 +165,7 @@ pub fn to_socket_addr<A: ToSocketAddrs>(addr: A) -> io::Result<SocketAddr> {
 /// assert_eq!(r"a\\023", escape(b"a\\023"));
 /// assert_eq!(r"a\000", escape(b"a\0"));
 /// assert_eq!("a\\r\\n\\t '\\\"\\\\", escape(b"a\r\n\t '\"\\"));
-/// assert_eq!(r"\342\235\244\360\237\220\267", escape("鉂ゐ煇?.as_bytes()));
+/// assert_eq!(r"\342\235\244\360\237\220\267", escape("❤🐷".as_bytes()));
 /// ```
 pub fn escape(data: &[u8]) -> String {
     let mut escaped = Vec::with_capacity(data.len() * 4);
@@ -208,7 +208,7 @@ pub fn escape(data: &[u8]) -> String {
 /// assert_eq!(unescape(r"a\\023"), b"a\\023");
 /// assert_eq!(unescape(r"a\000"), b"a\0");
 /// assert_eq!(unescape("a\\r\\n\\t '\\\"\\\\"), b"a\r\n\t '\"\\");
-/// assert_eq!(unescape(r"\342\235\244\360\237\220\267"), "鉂ゐ煇?.as_bytes());
+/// assert_eq!(unescape(r"\342\235\244\360\237\220\267"), "❤🐷".as_bytes());
 /// ```
 ///
 pub fn unescape(s: &str) -> Vec<u8> {

--- a/src/util/spmcqueue.rs
+++ b/src/util/spmcqueue.rs
@@ -1,0 +1,649 @@
+use std::boxed::Box;
+use std::mem;
+use std::ptr;
+use std::sync::Barrier;
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+use std::usize;
+use std::vec::Vec;
+
+#[derive(Debug)]
+enum Payload<T> {
+    /// A node with actual data that can be popped.
+    Data(T),
+    /// A node representing a blocked request for data.
+    Blocked(*mut thread::Thread),
+}
+
+const CELLS_NUM: usize = 1 << 9;
+const CELLS_BIT: usize = CELLS_NUM - 1;
+const SPINS: usize = 1 << 11;
+const DEFAULT_THRESHOLD: usize = 1 << 3;
+const PUT_FLAG: u32 = 1;
+const POP_FLAG: u32 = 1 << 1;
+const BOTH_FLAG: u32 = PUT_FLAG | POP_FLAG;
+
+struct Node<T> {
+    id: usize,
+    cells: [AtomicPtr<Payload<T>>; CELLS_NUM],
+    next: AtomicPtr<Node<T>>,
+}
+
+pub struct Queue_<T> {
+    // if AtomicUsize == usize::MAX, There are other threads that have been reclaiming memory, Just give up
+    next_reclaim_index: AtomicUsize,
+    next_reclaim_node_ptr: AtomicPtr<Node<T>>,
+
+    threshold: usize,
+
+    put_index: usize,
+    put_node: AtomicPtr<Node<T>>,
+
+    pop_index: AtomicUsize,
+    pop_node: AtomicPtr<Node<T>>,
+
+    put_handles: Vec<AtomicPtr<Handle<T>>>,
+    pop_handles: Vec<AtomicPtr<Handle<T>>>,
+
+    stopped: AtomicBool,
+    num_threads_put: usize,
+    num_threads_pop: usize,
+
+    barrier: Barrier,
+}
+
+pub struct Handle<T> {
+    spare: *mut Node<T>,
+    put_node: AtomicPtr<Node<T>>,
+    pop_node: AtomicPtr<Node<T>>,
+    queue: *mut Queue_<T>,
+    thread: AtomicPtr<thread::Thread>,
+    ptr: *mut Payload<T>,
+    role_flag: u32,
+}
+
+impl<T> Handle<T> {
+    pub fn push(&mut self, t: T) {
+        let queue = unsafe { &mut *self.queue };
+        queue.push(self, t);
+    }
+
+    pub fn pop(&mut self) -> Result<T, usize> {
+        let queue = unsafe { &*self.queue };
+        queue.pop(self)
+    }
+
+    pub fn wait(&mut self, pop_index: usize) -> Result<T, usize> {
+        let queue = unsafe { &*self.queue };
+        queue.wait(self, pop_index)
+    }
+
+    pub fn wait_timeout(&mut self, pop_index: usize, timeout: Duration) -> Result<T, usize> {
+        let queue = unsafe { &*self.queue };
+        queue.wait_timeout(self, pop_index, timeout)
+    }
+
+    pub fn update_pop_node(&mut self) {
+        assert_eq!(self.role_flag, POP_FLAG);
+        let queue = unsafe { &*self.queue };
+        queue.update_pop_node(self);
+    }
+
+    pub fn stop(&mut self) {
+        assert_eq!(self.role_flag, PUT_FLAG);
+        let queue = unsafe { &*self.queue };
+        queue.stop();
+    }
+}
+
+const DEFAULT_NUM_THREADS: usize = 1 << 3;
+impl<T> Default for Queue_<T> {
+    fn default() -> Self {
+        Self::new(1, DEFAULT_NUM_THREADS)
+    }
+}
+
+impl<T> Queue_<T> {
+    /// Create a new, empty queue.
+    pub fn new(num_threads_put: usize, num_threads_pop: usize) -> Queue_<T> {
+        let node_ptr = Box::into_raw(Box::new(Node {
+            id: 0,
+            cells: unsafe { mem::zeroed() },
+            next: AtomicPtr::default(),
+        }));
+        // producers
+        assert_eq!(num_threads_put, 1);
+        let mut put_handles_ = Vec::with_capacity(num_threads_put);
+        for _ in 0..num_threads_put {
+            put_handles_.push(AtomicPtr::default());
+        }
+        // consumers
+        let mut pop_handles_ = Vec::with_capacity(num_threads_pop);
+        for _ in 0..num_threads_pop {
+            pop_handles_.push(AtomicPtr::default());
+        }
+
+        Queue_ {
+            threshold: DEFAULT_THRESHOLD,
+            next_reclaim_index: AtomicUsize::new(0),
+            next_reclaim_node_ptr: AtomicPtr::new(node_ptr),
+            put_node: AtomicPtr::new(node_ptr),
+            pop_node: AtomicPtr::new(node_ptr),
+            put_index: 0,
+            pop_index: AtomicUsize::new(0),
+            put_handles: put_handles_,
+            pop_handles: pop_handles_,
+            stopped: AtomicBool::new(false),
+            num_threads_put,
+            num_threads_pop,
+            barrier: Barrier::new(num_threads_put + num_threads_pop),
+        }
+    }
+
+    pub fn register_as_producer(&self) -> *mut Handle<T> {
+        self.register(PUT_FLAG)
+    }
+
+    pub fn register_as_consumer(&self) -> *mut Handle<T> {
+        self.register(POP_FLAG)
+    }
+
+    fn register(&self, flag: u32) -> *mut Handle<T> {
+        if flag & BOTH_FLAG == BOTH_FLAG {
+            panic!("thread can't both be enqueuer and dequeuer");
+        }
+
+        let handle = Box::into_raw(Box::new(Handle::<T> {
+            thread: AtomicPtr::default(),
+            ptr: ptr::null_mut(),
+            spare: ptr::null_mut(),
+            queue: self as *const Queue_<T> as *mut Queue_<T>,
+            put_node: AtomicPtr::new(self.put_node.load(Ordering::Acquire)),
+            pop_node: AtomicPtr::new(self.pop_node.load(Ordering::Acquire)),
+            role_flag: flag,
+        }));
+        let handle_obj = unsafe { &mut *handle };
+        if flag & PUT_FLAG == PUT_FLAG {
+            let mut i = 0;
+            while i < self.num_threads_put {
+                if self.put_handles[i]
+                    .compare_exchange(
+                        ptr::null_mut(),
+                        handle,
+                        Ordering::Release,
+                        Ordering::Relaxed,
+                    )
+                    .is_ok()
+                {
+                    break;
+                }
+                i += 1;
+            }
+            if i == self.num_threads_put {
+                panic!("put is too much");
+            }
+        }
+
+        if flag & POP_FLAG == POP_FLAG {
+            handle_obj.thread.store(
+                Box::into_raw(Box::new(thread::current())),
+                Ordering::Release,
+            );
+            let mut i = 0;
+            while i < self.num_threads_pop {
+                if self.pop_handles[i]
+                    .compare_exchange(
+                        ptr::null_mut(),
+                        handle,
+                        Ordering::Release,
+                        Ordering::Relaxed,
+                    )
+                    .is_ok()
+                {
+                    break;
+                }
+                i += 1;
+            }
+            if i == self.num_threads_pop {
+                panic!("pop is too much");
+            }
+        }
+        self.barrier.wait();
+        handle
+    }
+
+    fn update_private_node(
+        &self,
+        private_handle: &mut Handle<T>,
+        private_node: *mut Node<T>,
+        id: usize,
+    ) -> &Node<T> {
+        let mut private_put_node = unsafe { &*private_node };
+        loop {
+            if private_put_node.id < id {
+                if private_put_node.next.load(Ordering::Acquire).is_null() {
+                    let mut new_shared_node_ptr = private_handle.spare;
+                    if new_shared_node_ptr.is_null() {
+                        new_shared_node_ptr = Box::into_raw(Box::new(Node {
+                            id: private_put_node.id + 1,
+                            cells: unsafe { mem::zeroed() },
+                            next: AtomicPtr::default(),
+                        }));
+                    } else {
+                        unsafe { &mut *new_shared_node_ptr }.id = private_put_node.id + 1;
+                    }
+                    match private_put_node.next.compare_exchange(
+                        ptr::null_mut(),
+                        new_shared_node_ptr,
+                        Ordering::Release,
+                        Ordering::Relaxed,
+                    ) {
+                        Ok(_) => {
+                            private_handle.spare = ptr::null_mut();
+                        }
+                        Err(_) => {
+                            private_handle.spare = new_shared_node_ptr;
+                        }
+                    }
+                }
+
+                private_put_node = unsafe { &*private_put_node.next.load(Ordering::Acquire) };
+            } else {
+                return private_put_node;
+            }
+        }
+    }
+
+    fn push(&mut self, private_put_handle: &mut Handle<T>, t: T) {
+        // put the data(t) in the heap
+        let ptr = Box::into_raw(Box::new(Payload::Data(t)));
+        // get the node_id and node_index.
+        let mut put_index = self.put_index;
+        self.put_index = put_index + 1;
+        let id = put_index / CELLS_NUM;
+        // put_index in the node
+        put_index &= CELLS_BIT;
+
+        // Try to fill in the nodes we need
+        let node_ptr = private_put_handle.put_node.load(Ordering::Acquire);
+        let private_put_node = self.update_private_node(private_put_handle, node_ptr, id);
+        private_put_handle.put_node.store(
+            private_put_node as *const Node<T> as *mut Node<T>,
+            Ordering::Release,
+        );
+
+        // put_index in private_put_node is the need'd cell
+        let ptr_order = private_put_node.cells[put_index].swap(ptr, Ordering::Relaxed);
+        if !ptr_order.is_null() {
+            // there is one consumer wait for the data, just wake up it...
+            let pay = unsafe { Box::from_raw(ptr_order) };
+            match *pay {
+                Payload::Blocked(thread) => unsafe {
+                    (*thread).unpark();
+                },
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    /*
+    fn pop(&self, private_pop_handle: &mut Handle<T>) -> Option<T> {
+        let mut v;
+        let mut pop_index = self.pop_index.fetch_add(1, Ordering::Relaxed);
+        let id = pop_index / CELLS_NUM;
+        // pop_index in node
+        pop_index &= CELLS_BIT;
+
+        // Try to fill in the nodes we need
+        let node_ptr = private_pop_handle.pop_node.load(Ordering::Acquire);
+        let private_pop_node = self.update_private_node(private_pop_handle, node_ptr, id);
+        private_pop_handle.pop_node.store(
+            private_pop_node as *const Node<T> as *mut Node<T>,
+            Ordering::Release,
+        );
+
+        if self.stopped.load(Ordering::Acquire) {
+            // queue is stopped, and return None,
+            return self.try_clean_none(private_pop_handle, pop_index);
+        }
+
+        // pop_index in private_pop_node is the need'd cell
+        // to test SPINS times to probes the datas
+        let mut times = SPINS;
+        loop {
+            v = private_pop_node.cells[pop_index].load(Ordering::Acquire);
+            if !v.is_null() {
+                return self.get_data(v, private_pop_handle, pop_index);
+            }
+            times -= 1;
+            if times == 0 {
+                break;
+            }
+        }
+
+        // now We've tried many times. should wait for data
+        let ptr_handle = private_pop_handle.thread.load(Ordering::Acquire);
+        let ptr = Box::into_raw(Box::new(Payload::Blocked(ptr_handle)));
+
+        v = private_pop_node.cells[pop_index].swap(ptr, Ordering::Relaxed);
+        if v.is_null() {
+            // we should wait for the data..(woke by producers)
+            thread::park();
+            if self.stopped.load(Ordering::Acquire) {
+                // queue is stopped, and return None,
+                return self.try_clean_none(private_pop_handle, pop_index);
+            }
+            v = private_pop_node.cells[pop_index].load(Ordering::Acquire);
+            while v == ptr {
+                // with spurious wakeup
+                thread::park();
+                if self.stopped.load(Ordering::Acquire) {
+                    // queue is stopped, and return None,
+                    return self.try_clean_none(private_pop_handle, pop_index);
+                }
+                v = private_pop_node.cells[pop_index].load(Ordering::Acquire);
+            }
+            self.get_data(v, private_pop_handle, pop_index)
+        } else {
+            // v is not null, We got the data
+            unsafe {
+                // just reclaim the not needed data
+                Box::from_raw(ptr);
+            }
+            self.get_data(v, private_pop_handle, pop_index)
+        }
+    }
+    */
+
+    fn pop(&self, private_pop_handle: &mut Handle<T>) -> Result<T, usize> {
+        let mut v;
+        let mut pop_index = self.pop_index.fetch_add(1, Ordering::Relaxed);
+        let id = pop_index / CELLS_NUM;
+        // pop_index in node
+        pop_index &= CELLS_BIT;
+
+        // Try to fill in the nodes we need
+        let node_ptr = private_pop_handle.pop_node.load(Ordering::Acquire);
+        let private_pop_node = self.update_private_node(private_pop_handle, node_ptr, id);
+        private_pop_handle.pop_node.store(
+            private_pop_node as *const Node<T> as *mut Node<T>,
+            Ordering::Release,
+        );
+
+        if self.stopped.load(Ordering::Acquire) {
+            // queue is stopped, and return None,
+            return self.try_clean_none(private_pop_handle, pop_index);
+        }
+
+        // pop_index in private_pop_node is the need'd cell
+        // to test SPINS times to probes the datas
+        let mut times = SPINS;
+        loop {
+            v = private_pop_node.cells[pop_index].load(Ordering::Acquire);
+            if !v.is_null() {
+                return self.get_data(v, private_pop_handle, pop_index);
+            }
+            times -= 1;
+            if times == 0 {
+                break;
+            }
+        }
+
+        // now We've tried many times. should wait for data
+        let ptr_handle = private_pop_handle.thread.load(Ordering::Acquire);
+        let ptr = Box::into_raw(Box::new(Payload::Blocked(ptr_handle)));
+        v = private_pop_node.cells[pop_index].swap(ptr, Ordering::Relaxed);
+        if v.is_null() {
+            // we should wait for the data..(woke by producers)
+            private_pop_handle.ptr = ptr;
+            Err(pop_index)
+        } else {
+            // v is not null, We got the data
+            unsafe {
+                // just reclaim the not needed data
+                Box::from_raw(ptr);
+            }
+            self.get_data(v, private_pop_handle, pop_index)
+        }
+    }
+
+    fn wait(&self, private_pop_handle: &mut Handle<T>, pop_index: usize) -> Result<T, usize> {
+        // we should wait for the data..(woke by producers)
+        let private_pop_node = unsafe { &*private_pop_handle.pop_node.load(Ordering::Acquire) };
+        loop {
+            let v = private_pop_node.cells[pop_index].load(Ordering::Acquire);
+            if v != private_pop_handle.ptr {
+                private_pop_handle.ptr = ptr::null_mut();
+                return self.get_data(v, private_pop_handle, pop_index);
+            }
+            if self.stopped.load(Ordering::Acquire) {
+                // queue is stopped, and return None,
+                return self.try_clean_none(private_pop_handle, pop_index);
+            }
+            thread::park();
+        }
+    }
+
+    fn wait_timeout(
+        &self,
+        private_pop_handle: &mut Handle<T>,
+        pop_index: usize,
+        timeout: Duration,
+    ) -> Result<T, usize> {
+        // we should wait for the data..(woke by producers)
+        let beginning_park = Instant::now();
+        let mut timeout_remaining;
+        let private_pop_node = unsafe { &*private_pop_handle.pop_node.load(Ordering::Acquire) };
+        loop {
+            let v = private_pop_node.cells[pop_index].load(Ordering::Acquire);
+            if v != private_pop_handle.ptr {
+                private_pop_handle.ptr = ptr::null_mut();
+                return self.get_data(v, private_pop_handle, pop_index);
+            }
+            if self.stopped.load(Ordering::Acquire) {
+                // queue is stopped, and return None,
+                return self.try_clean_none(private_pop_handle, pop_index);
+            }
+            // with spurious wakeup
+            let elapsed = beginning_park.elapsed();
+            if elapsed >= timeout {
+                return Err(pop_index);
+            }
+            timeout_remaining = timeout - elapsed;
+            thread::park_timeout(timeout_remaining);
+        }
+    }
+
+    // return data and maybe reclaim the queue's nodes
+    fn get_data(
+        &self,
+        v: *mut Payload<T>,
+        private_pop_handle: &mut Handle<T>,
+        pop_index: usize,
+    ) -> Result<T, usize> {
+        let resu = unsafe { Box::from_raw(v) };
+        let result = match *resu {
+            Payload::Data(t) => Ok(t),
+            _ => unreachable!(),
+        };
+        self.try_clean(private_pop_handle, pop_index);
+        result
+    }
+
+    fn update_pop_node(&self, private_pop_handle: &mut Handle<T>) {
+        let id = self.pop_index.load(Ordering::Acquire) / CELLS_NUM;
+        let node_ptr = private_pop_handle.pop_node.load(Ordering::Acquire);
+        let private_pop_node = self.update_private_node(private_pop_handle, node_ptr, id);
+        private_pop_handle.pop_node.store(
+            private_pop_node as *const Node<T> as *mut Node<T>,
+            Ordering::Release,
+        );
+    }
+
+    fn try_clean_none(
+        &self,
+        private_pop_handle: &mut Handle<T>,
+        pop_index: usize,
+    ) -> Result<T, usize> {
+        self.try_clean(private_pop_handle, pop_index);
+        Err(usize::MAX)
+    }
+
+    fn try_clean(&self, private_pop_handle: &mut Handle<T>, pop_index: usize) {
+        if pop_index & CELLS_BIT == CELLS_BIT {
+            //fence(Ordering::Acquire);
+            let init_index = self.next_reclaim_index.load(Ordering::Acquire);
+            if ((unsafe { &*private_pop_handle.pop_node.load(Ordering::Acquire) }.id) - init_index)
+                >= self.threshold && init_index < usize::MAX
+                && self.next_reclaim_index
+                    .compare_exchange(init_index, usize::MAX, Ordering::Release, Ordering::Relaxed)
+                    .is_ok()
+            {
+                let mut init_node = self.next_reclaim_node_ptr.load(Ordering::Acquire);
+
+                let th = &self.pop_handles[0];
+                let mut min_node = unsafe { &*th.load(Ordering::Acquire) }
+                    .pop_node
+                    .load(Ordering::Acquire);
+
+                for i in 1..self.num_threads_pop {
+                    let next = &self.pop_handles[i];
+                    if next.load(Ordering::Acquire).is_null() {
+                        break;
+                    }
+                    let next_min = unsafe { &*next.load(Ordering::Acquire) }
+                        .pop_node
+                        .load(Ordering::Acquire);
+                    if (unsafe { &*next_min }).id < (unsafe { &*min_node }).id {
+                        min_node = next_min;
+                    }
+                    if (unsafe { &*min_node }).id <= init_index {
+                        break;
+                    }
+                }
+
+                for i in 0..self.num_threads_put {
+                    let next = &self.put_handles[i];
+                    if next.load(Ordering::Acquire).is_null() {
+                        break;
+                    }
+                    let next_min = unsafe { &*next.load(Ordering::Acquire) }
+                        .put_node
+                        .load(Ordering::Acquire);
+                    if (unsafe { &*next_min }).id < (unsafe { &*min_node }).id {
+                        min_node = next_min;
+                    }
+                    if (unsafe { &*min_node }).id <= init_index {
+                        break;
+                    }
+                }
+
+                let new_id = (unsafe { &*min_node }).id;
+                if new_id <= init_index {
+                    self.next_reclaim_index.store(init_index, Ordering::Release);
+                } else {
+                    self.next_reclaim_node_ptr
+                        .store(min_node, Ordering::Release);
+                    self.next_reclaim_index.store(new_id, Ordering::Release);
+
+                    loop {
+                        let tmp = &(unsafe { &*init_node }).next;
+                        let init_node_next = tmp.load(Ordering::Acquire);
+                        unsafe { Box::from_raw(init_node) };
+                        if init_node_next == min_node {
+                            break;
+                        }
+                        init_node = init_node_next;
+                    }
+                }
+            }
+        }
+    }
+
+    fn stop(&self) {
+        self.stopped.store(true, Ordering::Release);
+        for i in 0..self.num_threads_pop {
+            let th = &self.pop_handles[i];
+            if th.load(Ordering::Acquire).is_null() {
+                return;
+            }
+            let handle = unsafe { &*th.load(Ordering::Acquire) };
+            let thread = unsafe { &*handle.thread.load(Ordering::Acquire) };
+            thread.unpark();
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_put_pop_data() {
+        let num_threads = 64;
+        const COUNT: usize = 1000;
+        let per_thread_count = COUNT / num_threads;
+        let queue = Arc::new(Queue_::<usize>::new(1, num_threads));
+
+        let array: [AtomicUsize; COUNT] = unsafe { mem::zeroed() };
+        let array_arc = Arc::new(array);
+        let mut guards = vec![];
+
+        for _ in 0..num_threads {
+            let queue_pop = Arc::clone(&queue);
+            let array_arc = Arc::clone(&array_arc);
+            guards.push(thread::spawn(move || {
+                let handle = queue_pop.register(2);
+                let handle = unsafe { &mut *handle };
+                for _ in 0..per_thread_count + 10000 {
+                    match handle.pop() {
+                        Ok(data) => {
+                            array_arc[data].store(1, Ordering::Release);
+                        }
+                        Err(index) => {
+                            if index == usize::MAX {
+                                return;
+                            }
+                            match handle.wait_timeout(index, Duration::from_secs(1)) {
+                                Ok(data) => {
+                                    array_arc[data].store(1, Ordering::Release);
+                                }
+                                Err(index) => {
+                                    if index == usize::MAX {
+                                        return;
+                                    }
+                                    match handle.wait(index) {
+                                        Ok(data) => {
+                                            array_arc[data].store(1, Ordering::Release);
+                                        }
+                                        Err(_) => {
+                                            return;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }));
+        }
+
+        let handle = queue.register(1);
+        let handle = unsafe { &mut *handle };
+        for i in 0..COUNT {
+            handle.push(i);
+        }
+
+        thread::sleep(Duration::from_secs(2));
+        handle.stop();
+        for guard in guards {
+            guard.join().unwrap();
+        }
+
+        for item in array_arc.iter().take(COUNT) {
+            assert_eq!(item.load(Ordering::Acquire), 1);
+        }
+    }
+}

--- a/src/util/threadpool.rs
+++ b/src/util/threadpool.rs
@@ -1,3 +1,16 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::boxed::FnBox;
 use std::fmt::Write;
 use std::marker::PhantomData;

--- a/src/util/threadpool.rs
+++ b/src/util/threadpool.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering as AtomicOr
 use std::thread::{Builder, JoinHandle};
 use std::time::Duration;
 use std::usize;
-use util::spmcqueue::{Handle, Queue_};
+use util::spmcqueue::{Handle, SpmcQueue};
 
 pub const DEFAULT_TASKS_PER_TICK: usize = 10000;
 const DEFAULT_THREAD_COUNT: usize = 1;
@@ -65,13 +65,13 @@ impl<C: Context> Task<C> {
 
 // First in first out queue.
 pub struct FifoQueue<C> {
-    queue: Queue_<Task<C>>,
+    queue: SpmcQueue<Task<C>>,
 }
 
 impl<C: Context> FifoQueue<C> {
     fn new(num_producers: usize, num_consumers: usize) -> FifoQueue<C> {
         FifoQueue {
-            queue: Queue_::new(num_producers, num_consumers),
+            queue: SpmcQueue::new(num_producers, num_consumers),
         }
     }
 }


### PR DESCRIPTION
## What have you changed?
Introducing a new thread pool, better performance and scalability.
update `/util/threadpool.rs, /util/mod.rs, lib.rs`. add `/util/spmcqueue.rs`. 

## Why this change was made?
The current threadpool is based on single producer/mutiple consumers queue(VecDeque) with mutex(as https://gist.github.com/siddontang/fa81a59e7234e9960f8514785af69e1e), this caused bad performance with Lock Contention. **more precisely, only one of conumsers(worker threads) or the producer can be made progress at any time. this is a hot spot problem**.

**With new thread pool scheme,** 

- **Nonblocking/Better scalable**: Each operation does not block the other operations, Producers will not be blocked by consumers, threadpool's execute is very direct and fast.

- **No Lock Contention**: There is no conflicts with producer and conumsers, The only conflict is Consumers' conflict, and we conquer this problem through a fetch-and-add(common atomic operation).

- **Direct data exchange**: Just a xchg atomic operation.

- **Data structure / Organization**: Linked  node(with growing id), one node with(1<<N, 512) cells. **consumer take the last cell in node maybe try to memory reclaim(batch nods).**

## Benchmark: compare with current thread pool and spin thread pool
With this Simple benchmark, **new thread pool scheme provides an obvious performance advantage.**

@siddontang 's current thread pool: https://gist.github.com/siddontang/fa81a59e7234e9960f8514785af69e1e
@siddontang 's spin thread pool:
https://gist.github.com/siddontang/5b4b023475a55e0d4898117790a224c9
New threadpool:
https://gist.github.com/Pslydhh/4f3fda8a27fb24644aa1d77b76991c6a

base: linux 2cores Intel(R) Xeon(R) CPU E5-2682 v4 @ 2.50GHz

cur thread pool                 spin thread pool                                 new thread pool
Using 8 threads                 Using 8 threads                                   Using 8 threads
603709 QPS                       519200 QPS                                        2228426 QPS
596301 QPS                       522523 QPS                                        2120498 QPS
1021619 QPS                     537190 QPS                                        1801233 QPS
731460 QPS                       515027 QPS                                        2072558 QPS
223569 QPS                       528928 QPS                                        1814707 QPS
280141 QPS                       486561 QPS                                        2006970 QPS
311056 QPS                       548325 QPS                                        2032390 QPS
221035 QPS                       521873 QPS                                        2009320 QPS
226694 QPS                       596767 QPS                                        1910401 QPS

cur thread pool                 spin thread pool                                 new thread pool
Using 2 threads                 Using 2 threads                                  Using 2 threads
1672643 QPS                     2321171 QPS                                      2944188 QPS
1700202 QPS                     2292505 QPS                                      3078022 QPS
1747062 QPS                     2564804 QPS                                      3131144 QPS
1673945 QPS                     2555916 QPS                                      3157857 QPS
1910982 QPS                     2429625 QPS                                      2880966 QPS
1770090 QPS                     2468685 QPS                                      2945744 QPS
1487229 QPS                     2446119 QPS                                      2979314 QPS
1580273 QPS                     2357457 QPS                                      2975794 QPS
1778112 QPS                     2288835 QPS                                      2850212 QPS

## Notes:
**The task executed by the threadpool shouldn't blocks worker thread for a long time.**



