### PR TITLE
coprocessor: add EvalConfigBuilder

### DIFF
--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -322,7 +322,7 @@ mod test {
     use std::{f64, i64, isize, u64};
 
     use coprocessor::codec::mysql::types;
-    use coprocessor::dag::expr::{EvalConfig, EvalContext, FLAG_IGNORE_TRUNCATE};
+    use coprocessor::dag::expr::{EvalConfig, EvalContext};
 
     use super::*;
 
@@ -436,8 +436,7 @@ mod test {
             ("123.e", "123."),
         ];
 
-        let cfg = EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap();
-        let mut ctx = EvalContext::new(Arc::new(cfg));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         for (i, o) in cases {
             assert_eq!(super::get_valid_float_prefix(&mut ctx, i).unwrap(), o);
         }

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -1002,7 +1002,7 @@ pub fn split_datum(buf: &[u8], desc: bool) -> Result<(&[u8], &[u8])> {
 mod test {
     use super::*;
     use coprocessor::codec::mysql::{Decimal, Duration, Time, MAX_FSP};
-    use coprocessor::dag::expr::{EvalConfig, EvalContext, FLAG_IGNORE_TRUNCATE};
+    use coprocessor::dag::expr::{EvalConfig, EvalContext};
     use util::as_slice;
 
     use std::cmp::Ordering;
@@ -1691,8 +1691,7 @@ mod test {
             (Datum::Dec(0u64.into()), Some(false)),
         ];
 
-        let cfg = EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap();
-        let mut ctx = EvalContext::new(Arc::new(cfg));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
 
         for (d, b) in tests {
             if d.clone().into_bool(&mut ctx).unwrap() != b {
@@ -1871,8 +1870,7 @@ mod test {
             ),
         ];
 
-        let cfg = EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap();
-        let mut ctx = EvalContext::new(Arc::new(cfg));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         for (d, exp) in tests {
             let got = d.into_f64(&mut ctx).unwrap();
             assert_eq!(Datum::F64(got), Datum::F64(exp));
@@ -1902,8 +1900,7 @@ mod test {
             (Datum::Json(Json::from_str(r#"false"#).unwrap()), 0),
         ];
 
-        let cfg = EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap();
-        let mut ctx = EvalContext::new(Arc::new(cfg));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         for (d, exp) in tests {
             let got = d.into_i64(&mut ctx).unwrap();
             assert_eq!(got, exp);

--- a/src/coprocessor/codec/mysql/json/json_cast.rs
+++ b/src/coprocessor/codec/mysql/json/json_cast.rs
@@ -44,7 +44,7 @@ impl Json {
 #[cfg(test)]
 mod test {
     use super::*;
-    use coprocessor::dag::expr::{EvalConfig, EvalContext, FLAG_IGNORE_TRUNCATE};
+    use coprocessor::dag::expr::{EvalConfig, EvalContext};
     use std::f64;
     use std::sync::Arc;
 
@@ -84,8 +84,7 @@ mod test {
             (r#""hello""#, 0f64),
             (r#""1234""#, 1234f64),
         ];
-        let cfg = EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap();
-        let mut ctx = EvalContext::new(Arc::new(cfg));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         for (jstr, exp) in test_cases {
             let json: Json = jstr.parse().unwrap();
             let get = json.cast_to_real(&mut ctx).unwrap();

--- a/src/coprocessor/dag/dag.rs
+++ b/src/coprocessor/dag/dag.rs
@@ -40,26 +40,24 @@ impl<S: Snapshot + 'static> DAGContext<S> {
         req_ctx: ReqContext,
         batch_row_limit: usize,
     ) -> Result<Self> {
-        let mut eval_cfg = box_try!(EvalConfig::new(req.get_flags()));
-
+        let mut eval_cfg = EvalConfig::new().set_by_flags(req.get_flags());
         // We respect time zone name first, then offset.
         if req.has_time_zone_name() && !req.get_time_zone_name().is_empty() {
-            box_try!(eval_cfg.set_time_zone_by_name(req.get_time_zone_name()));
+            eval_cfg = box_try!(eval_cfg.set_time_zone_by_name(req.get_time_zone_name()));
         } else if req.has_time_zone_offset() {
-            box_try!(eval_cfg.set_time_zone_by_offset(req.get_time_zone_offset()));
+            eval_cfg = box_try!(eval_cfg.set_time_zone_by_offset(req.get_time_zone_offset()));
         } else {
             // This should not be reachable. However we will not panic here in case
             // of compatibility issues.
         }
-
         if req.has_max_warning_count() {
-            eval_cfg.set_max_warning_cnt(req.get_max_warning_count() as usize);
+            eval_cfg = eval_cfg.set_max_warning_cnt(req.get_max_warning_count() as usize);
         }
         if req.has_sql_mode() {
-            eval_cfg.set_sql_mode(req.get_sql_mode())
+            eval_cfg = eval_cfg.set_sql_mode(req.get_sql_mode());
         }
         if req.has_is_strict_sql_mode() {
-            eval_cfg.set_strict_sql_mode(req.get_is_strict_sql_mode());
+            eval_cfg = eval_cfg.set_strict_sql_mode(req.get_is_strict_sql_mode());
         }
         let store = SnapshotStore::new(
             snap,

--- a/src/coprocessor/dag/executor/aggregate.rs
+++ b/src/coprocessor/dag/executor/aggregate.rs
@@ -300,7 +300,7 @@ impl AggrFunc for Extremum {
 
 #[cfg(test)]
 mod test {
-    use coprocessor::dag::expr::{EvalConfig, EvalContext, FLAG_IGNORE_TRUNCATE};
+    use coprocessor::dag::expr::{EvalConfig, EvalContext};
     use std::ops::Add;
     use std::sync::Arc;
     use std::{i64, u64};
@@ -336,7 +336,7 @@ mod test {
     #[test]
     fn test_sum_as_f64() {
         let mut sum = Sum { res: None };
-        let cfg = EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap();
+        let cfg = EvalConfig::default_for_test();
         let mut ctx = EvalContext::new(Arc::new(cfg));
         let data = vec![
             Datum::Bytes(b"123.09xxx".to_vec()),
@@ -357,7 +357,7 @@ mod test {
         let mut aggr = AggBitAnd {
             c: 0xffffffffffffffff,
         };
-        let cfg = EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap();
+        let cfg = EvalConfig::default_for_test();
         let mut ctx = EvalContext::new(Arc::new(cfg));
         assert_eq!(aggr.c, u64::MAX);
 
@@ -381,7 +381,7 @@ mod test {
     #[test]
     fn test_bit_or() {
         let mut aggr = AggBitOr { c: 0 };
-        let cfg = EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap();
+        let cfg = EvalConfig::default_for_test();
         let mut ctx = EvalContext::new(Arc::new(cfg));
         let data = vec![
             Datum::U64(1),
@@ -404,7 +404,7 @@ mod test {
     #[test]
     fn test_bit_xor() {
         let mut aggr = AggBitXor { c: 0 };
-        let cfg = EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap();
+        let cfg = EvalConfig::default_for_test();
         let mut ctx = EvalContext::new(Arc::new(cfg));
 
         let data = vec![

--- a/src/coprocessor/dag/expr/builtin_arithmetic.rs
+++ b/src/coprocessor/dag/expr/builtin_arithmetic.rs
@@ -1094,9 +1094,10 @@ mod test {
             let rhs = datum_expr(right);
             let scalar_func = scalar_func_expr(sig, &[lhs, rhs]);
             for (flag, sql_mode, strict_sql_mode, is_ok, has_warning) in &cases {
-                let mut cfg = EvalConfig::new(*flag).unwrap();
-                cfg.set_sql_mode(*sql_mode);
-                cfg.set_strict_sql_mode(*strict_sql_mode);
+                let cfg = EvalConfig::new()
+                    .set_by_flags(*flag)
+                    .set_sql_mode(*sql_mode)
+                    .set_strict_sql_mode(*strict_sql_mode);
                 let mut ctx = EvalContext::new(Arc::new(cfg));
                 let op = Expression::build(&mut ctx, scalar_func.clone()).unwrap();
                 let got = op.eval(&mut ctx, &[]);

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -714,7 +714,7 @@ mod test {
     use coprocessor::codec::mysql::{self, charset, types, Decimal, Duration, Json, Time, Tz};
     use coprocessor::codec::{convert, Datum};
     use coprocessor::dag::expr::test::{col_expr as base_col_expr, scalar_func_expr};
-    use coprocessor::dag::expr::{self, EvalConfig, EvalContext, Expression, FLAG_IGNORE_TRUNCATE};
+    use coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
 
     pub fn col_expr(col_id: i64, tp: i32) -> Expr {
         let mut expr = base_col_expr(col_id);
@@ -726,7 +726,7 @@ mod test {
 
     #[test]
     fn test_cast_as_int() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let t = Time::parse_utc_datetime("2012-12-12 12:00:23", 0).unwrap();
         #[cfg_attr(feature = "cargo-clippy", allow(inconsistent_digit_grouping))]
         let time_int = 2012_12_12_12_00_23i64;
@@ -822,7 +822,7 @@ mod test {
 
     #[test]
     fn test_cast_as_real() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let t = Time::parse_utc_datetime("2012-12-12 12:00:23", 0).unwrap();
         #[cfg_attr(feature = "cargo-clippy", allow(inconsistent_digit_grouping))]
         let int_t = 2012_12_12_12_00_23u64;
@@ -959,7 +959,7 @@ mod test {
 
     #[test]
     fn test_cast_as_decimal() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let t = Time::parse_utc_datetime("2012-12-12 12:00:23", 0).unwrap();
         let int_t = 20121212120023u64;
         let duration_t = Duration::parse(b"12:00:23", 0).unwrap();
@@ -1095,7 +1095,7 @@ mod test {
 
     #[test]
     fn test_cast_as_str() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let t_str = "2012-12-12 12:00:23";
         let t = Time::parse_utc_datetime(t_str, 0).unwrap();
         let dur_str = b"12:00:23";
@@ -1258,7 +1258,7 @@ mod test {
 
     #[test]
     fn test_cast_as_time() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let today = Utc::now();
         let t_date_str = format!("{}", today.format("%Y-%m-%d"));
         let t_time_str = format!("{}", today.format("%Y-%m-%d %H:%M:%S"));
@@ -1439,7 +1439,7 @@ mod test {
 
     #[test]
     fn test_cast_as_duration() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let today = Utc::now();
         let t_date_str = format!("{}", today.format("%Y-%m-%d"));
 
@@ -1599,7 +1599,7 @@ mod test {
 
     #[test]
     fn test_cast_int_as_json() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let cases = vec![
             (
                 Some(types::UNSIGNED_FLAG),
@@ -1637,7 +1637,7 @@ mod test {
 
     #[test]
     fn test_cast_real_as_json() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let cases = vec![
             (vec![Datum::F64(32.0001)], Some(Json::Double(32.0001))),
             (vec![Datum::Null], None),
@@ -1657,7 +1657,7 @@ mod test {
 
     #[test]
     fn test_cast_decimal_as_json() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let cases = vec![
             (
                 vec![Datum::Dec(Decimal::from_f64(32.0001).unwrap())],
@@ -1681,7 +1681,7 @@ mod test {
 
     #[test]
     fn test_cast_str_as_json() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let cases = vec![
             (
                 false,
@@ -1716,8 +1716,7 @@ mod test {
 
     #[test]
     fn test_cast_time_as_json() {
-        let mut cfg = EvalConfig::default();
-        cfg.ignore_truncate = true;
+        let cfg = EvalConfig::default_for_test();
         let mut ctx = EvalContext::new(Arc::new(cfg));
         let time_str = "2012-12-12 11:11:11";
         let date_str = "2012-12-12";
@@ -1766,7 +1765,7 @@ mod test {
 
     #[test]
     fn test_cast_duration_as_json() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let dur_str = "11:12:08";
         let dur_str_expect = "11:12:08.000000";
 
@@ -1792,7 +1791,7 @@ mod test {
 
     #[test]
     fn test_cast_json_as_json() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let cases = vec![
             (
                 vec![Datum::Json(Json::Boolean(true))],
@@ -1837,9 +1836,8 @@ mod test {
             ex.mut_field_type().set_flag(flag as u32);
 
             // test with overflow as warning
-            let mut ctx = EvalContext::new(Arc::new(
-                EvalConfig::new(expr::FLAG_OVERFLOW_AS_WARNING).unwrap(),
-            ));
+            let mut ctx =
+                EvalContext::new(Arc::new(EvalConfig::new().set_overflow_as_warning(true)));
             let e = Expression::build(&mut ctx, ex.clone()).unwrap();
             let res = e.eval_int(&mut ctx, &cols).unwrap().unwrap();
             assert_eq!(res, exp);
@@ -1906,8 +1904,9 @@ mod test {
             let ex = scalar_func_expr(ScalarFuncSig::CastStringAsInt, &[col_expr]);
             // test with overflow as warning && in select stmt
             let mut ctx = EvalContext::new(Arc::new(
-                EvalConfig::new(expr::FLAG_OVERFLOW_AS_WARNING | expr::FLAG_IN_SELECT_STMT)
-                    .unwrap(),
+                EvalConfig::new()
+                    .set_overflow_as_warning(true)
+                    .set_in_select_stmt(true),
             ));
             let e = Expression::build(&mut ctx, ex.clone()).unwrap();
             let res = e.eval_int(&mut ctx, &cols).unwrap().unwrap();
@@ -1936,7 +1935,7 @@ mod test {
 
     //     // test with overflow as warning
     //     let mut ctx = EvalContext::new(Arc::new(
-    //         EvalConfig::new(expr::FLAG_OVERFLOW_AS_WARNING).unwrap(),
+    //         EvalConfig::new().set_overflow_as_warning(true),
     //     ));
     //     let e = Expression::build(&mut ctx, ex.clone()).unwrap();
     //     let res = e.eval_duration(&mut ctx, &cols).unwrap();

--- a/src/coprocessor/dag/expr/builtin_math.rs
+++ b/src/coprocessor/dag/expr/builtin_math.rs
@@ -133,7 +133,7 @@ mod test {
     use coprocessor::codec::mysql::types;
     use coprocessor::codec::{convert, mysql, Datum};
     use coprocessor::dag::expr::test::{check_overflow, datum_expr, scalar_func_expr, str2dec};
-    use coprocessor::dag::expr::{EvalConfig, EvalContext, Expression, FLAG_IGNORE_TRUNCATE};
+    use coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
     use std::sync::Arc;
     use std::{f64, i64, u64};
     use tipb::expression::ScalarFuncSig;
@@ -234,7 +234,7 @@ mod test {
         ];
 
         // for ceil decimal to int.
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         for (sig, arg, exp) in tests {
             let arg = datum_expr(arg);
             let mut op =
@@ -302,7 +302,7 @@ mod test {
             ),
         ];
         // for ceil decimal to int.
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new().set_ignore_truncate(true)));
         for (sig, arg, exp) in tests {
             let arg = datum_expr(arg);
             let mut op =

--- a/src/coprocessor/dag/expr/ctx.rs
+++ b/src/coprocessor/dag/expr/ctx.rs
@@ -48,11 +48,10 @@ pub const FLAG_DIVIDED_BY_ZERO_AS_WARNING: u64 = 1 << 8;
 pub const MODE_ERROR_FOR_DIVISION_BY_ZERO: u64 = 27;
 
 const DEFAULT_MAX_WARNING_CNT: usize = 64;
+
 #[derive(Debug)]
 pub struct EvalConfig {
-    /// Timezone to use when parse or calculate time.
-    ///
-    /// By default, the time zone is UTC.
+    /// timezone to use when parse/calculate time.
     pub tz: Tz,
     pub ignore_truncate: bool,
     pub truncate_as_warning: bool,
@@ -70,60 +69,112 @@ pub struct EvalConfig {
 
 impl Default for EvalConfig {
     fn default() -> EvalConfig {
-        EvalConfig::new(0).unwrap()
+        EvalConfig::new()
     }
 }
 
 impl EvalConfig {
-    pub fn new(flags: u64) -> Result<EvalConfig> {
-        let e = EvalConfig {
+    pub fn new() -> EvalConfig {
+        EvalConfig {
             tz: Tz::utc(),
-            ignore_truncate: (flags & FLAG_IGNORE_TRUNCATE) > 0,
-            truncate_as_warning: (flags & FLAG_TRUNCATE_AS_WARNING) > 0,
-            overflow_as_warning: (flags & FLAG_OVERFLOW_AS_WARNING) > 0,
-            in_insert_stmt: (flags & FLAG_IN_INSERT_STMT) > 0,
-            in_update_or_delete_stmt: (flags & FLAG_IN_UPDATE_OR_DELETE_STMT) > 0,
-            in_select_stmt: (flags & FLAG_IN_SELECT_STMT) > 0,
-            pad_char_to_full_length: (flags & FLAG_PAD_CHAR_TO_FULL_LENGTH) > 0,
-            divided_by_zero_as_warning: (flags & FLAG_DIVIDED_BY_ZERO_AS_WARNING) > 0,
+            ignore_truncate: false,
+            truncate_as_warning: false,
+            overflow_as_warning: false,
+            in_insert_stmt: false,
+            in_update_or_delete_stmt: false,
+            in_select_stmt: false,
+            pad_char_to_full_length: false,
+            divided_by_zero_as_warning: false,
             max_warning_cnt: DEFAULT_MAX_WARNING_CNT,
             sql_mode: 0,
             strict_sql_mode: false,
-        };
-
-        Ok(e)
+        }
     }
 
-    pub fn set_time_zone_by_name(&mut self, tz_name: &str) -> Result<()> {
+    pub fn set_ignore_truncate(mut self, new_value: bool) -> Self {
+        self.ignore_truncate = new_value;
+        self
+    }
+
+    pub fn set_truncate_as_warning(mut self, new_value: bool) -> Self {
+        self.truncate_as_warning = new_value;
+        self
+    }
+
+    pub fn set_overflow_as_warning(mut self, new_value: bool) -> Self {
+        self.overflow_as_warning = new_value;
+        self
+    }
+
+    pub fn set_in_insert_stmt(mut self, new_value: bool) -> Self {
+        self.in_insert_stmt = new_value;
+        self
+    }
+
+    pub fn set_in_update_or_delete_stmt(mut self, new_value: bool) -> Self {
+        self.in_update_or_delete_stmt = new_value;
+        self
+    }
+
+    pub fn set_in_select_stmt(mut self, new_value: bool) -> Self {
+        self.in_select_stmt = new_value;
+        self
+    }
+
+    pub fn set_pad_char_to_full_length(mut self, new_value: bool) -> Self {
+        self.pad_char_to_full_length = new_value;
+        self
+    }
+
+    pub fn set_divided_by_zero_as_warning(mut self, new_value: bool) -> Self {
+        self.divided_by_zero_as_warning = new_value;
+        self
+    }
+
+    pub fn set_max_warning_cnt(mut self, new_value: usize) -> Self {
+        self.max_warning_cnt = new_value;
+        self
+    }
+
+    pub fn set_sql_mode(mut self, new_value: u64) -> Self {
+        self.sql_mode = new_value;
+        self
+    }
+
+    pub fn set_strict_sql_mode(mut self, new_value: bool) -> Self {
+        self.strict_sql_mode = new_value;
+        self
+    }
+
+    pub fn set_time_zone_by_name(mut self, tz_name: &str) -> Result<Self> {
         match Tz::from_tz_name(tz_name) {
             Some(tz) => {
                 self.tz = tz;
-                Ok(())
+                Ok(self)
             }
             None => Err(Error::invalid_timezone(tz_name)),
         }
     }
 
-    pub fn set_time_zone_by_offset(&mut self, offset_sec: i64) -> Result<()> {
+    pub fn set_time_zone_by_offset(mut self, offset_sec: i64) -> Result<Self> {
         match Tz::from_offset(offset_sec) {
             Some(tz) => {
                 self.tz = tz;
-                Ok(())
+                Ok(self)
             }
             None => Err(Error::invalid_timezone(&format!("offset {}s", offset_sec))),
         }
     }
 
-    pub fn set_max_warning_cnt(&mut self, max_warning_cnt: usize) {
-        self.max_warning_cnt = max_warning_cnt;
-    }
-
-    pub fn set_sql_mode(&mut self, sql_mode: u64) {
-        self.sql_mode = sql_mode
-    }
-
-    pub fn set_strict_sql_mode(&mut self, strict_sql_mode: bool) {
-        self.strict_sql_mode = strict_sql_mode
+    pub fn set_by_flags(self, flags: u64) -> Self {
+        self.set_ignore_truncate((flags & FLAG_IGNORE_TRUNCATE) > 0)
+            .set_truncate_as_warning((flags & FLAG_TRUNCATE_AS_WARNING) > 0)
+            .set_overflow_as_warning((flags & FLAG_OVERFLOW_AS_WARNING) > 0)
+            .set_in_insert_stmt((flags & FLAG_IN_INSERT_STMT) > 0)
+            .set_in_update_or_delete_stmt((flags & FLAG_IN_UPDATE_OR_DELETE_STMT) > 0)
+            .set_in_select_stmt((flags & FLAG_IN_SELECT_STMT) > 0)
+            .set_pad_char_to_full_length((flags & FLAG_PAD_CHAR_TO_FULL_LENGTH) > 0)
+            .set_divided_by_zero_as_warning((flags & FLAG_DIVIDED_BY_ZERO_AS_WARNING) > 0)
     }
 
     /// detects if 'ERROR_FOR_DIVISION_BY_ZERO' mode is set in sql_mode
@@ -133,6 +184,11 @@ impl EvalConfig {
 
     pub fn new_eval_warnings(&self) -> EvalWarnings {
         EvalWarnings::new(self.max_warning_cnt)
+    }
+
+    #[cfg(test)]
+    pub fn default_for_test() -> EvalConfig {
+        EvalConfig::new().set_ignore_truncate(true)
     }
 }
 
@@ -242,7 +298,7 @@ impl EvalContext {
         &mut self,
         bytes: &[u8],
         orig_err: Error,
-        negitive: bool,
+        negative: bool,
     ) -> Result<i64> {
         if !self.cfg.in_select_stmt || !self.cfg.overflow_as_warning {
             return Err(orig_err);
@@ -250,7 +306,7 @@ impl EvalContext {
         let orig_str = String::from_utf8_lossy(bytes);
         self.warnings
             .append_warning(Error::truncated_wrong_val("INTEGER", &orig_str));
-        if negitive {
+        if negative {
             Ok(i64::MIN)
         } else {
             Ok(u64::MAX as i64)
@@ -273,19 +329,18 @@ mod test {
     #[test]
     fn test_handle_truncate() {
         // ignore_truncate = false, truncate_as_warning = false
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(0).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new()));
         assert!(ctx.handle_truncate(false).is_ok());
         assert!(ctx.handle_truncate(true).is_err());
         assert!(ctx.take_warnings().warnings.is_empty());
         // ignore_truncate = false;
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         assert!(ctx.handle_truncate(false).is_ok());
         assert!(ctx.handle_truncate(true).is_ok());
         assert!(ctx.take_warnings().warnings.is_empty());
 
         // ignore_truncate = false, truncate_as_warning = true
-        let mut ctx =
-            EvalContext::new(Arc::new(EvalConfig::new(FLAG_TRUNCATE_AS_WARNING).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new().set_truncate_as_warning(true)));
         assert!(ctx.handle_truncate(false).is_ok());
         assert!(ctx.handle_truncate(true).is_ok());
         assert!(!ctx.take_warnings().warnings.is_empty());
@@ -293,7 +348,7 @@ mod test {
 
     #[test]
     fn test_max_warning_cnt() {
-        let eval_cfg = Arc::new(EvalConfig::new(FLAG_TRUNCATE_AS_WARNING).unwrap());
+        let eval_cfg = Arc::new(EvalConfig::new().set_truncate_as_warning(true));
         let mut ctx = EvalContext::new(Arc::clone(&eval_cfg));
         assert!(ctx.handle_truncate(true).is_ok());
         assert!(ctx.handle_truncate(true).is_ok());
@@ -342,9 +397,10 @@ mod test {
             ), //warning
         ];
         for (flag, sql_mode, strict_sql_mode, is_ok, is_empty) in cases {
-            let mut cfg = EvalConfig::new(flag).unwrap();
-            cfg.set_sql_mode(sql_mode);
-            cfg.set_strict_sql_mode(strict_sql_mode);
+            let cfg = EvalConfig::new()
+                .set_by_flags(flag)
+                .set_sql_mode(sql_mode)
+                .set_strict_sql_mode(strict_sql_mode);
             let mut ctx = EvalContext::new(Arc::new(cfg));
             assert_eq!(ctx.handle_division_by_zero().is_ok(), is_ok);
             assert_eq!(ctx.take_warnings().warnings.is_empty(), is_empty);

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -300,7 +300,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::{Error, EvalConfig, EvalContext, Expression, FLAG_IGNORE_TRUNCATE};
+    use super::{Error, EvalConfig, EvalContext, Expression};
     use coprocessor::codec::error::{ERR_DATA_OUT_OF_RANGE, ERR_DIVISION_BY_ZERO};
     use coprocessor::codec::mysql::json::JsonEncoder;
     use coprocessor::codec::mysql::{
@@ -451,7 +451,7 @@ mod test {
 
     #[test]
     fn test_expression_eval() {
-        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new(FLAG_IGNORE_TRUNCATE).unwrap()));
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let cases = vec![
             (
                 ScalarFuncSig::CastStringAsReal,


### PR DESCRIPTION
## What have you changed? (mandatory)

- Added `EvalConfigBuilder` described in #3303 
- Replaced some usages of `EvalConfig` with `EvalConfigBuilder`

## What are the type of the changes? (mandatory)

- Improvement

## How has this PR been tested? (mandatory)

No test needed since no user-logic is changed.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.