### PR TITLE
tests: Relax some Prevote tests.

### DIFF
--- a/tests/raftstore_cases/mod.rs
+++ b/tests/raftstore_cases/mod.rs
@@ -20,8 +20,7 @@ mod test_conf_change;
 mod test_lease_read;
 mod test_merge;
 mod test_multi;
-// TODO: test prevote.
-// mod test_prevote;
+mod test_prevote;
 mod test_region_heartbeat;
 mod test_service;
 mod test_single;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Trying to make the `test_prevote` tests reliable on CI, seems it's not possible without changing some behavior around cluster/simulator.

This is not a bug in the code, it's just that we don't have a way to clear a particular send filter, so we can only attach our notifiers after clearing the send filters, meaning that the prevote message could appear before we are detecting it. Several reproductions showed a prevote appearing at the same nanosecond as the notifiers, so we miss it.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

The CI

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

