### PR TITLE
Move read flow statistics to cursor

### DIFF
--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -539,13 +539,19 @@ mod tests {
             iter.reverse_seek(&Key::from_encoded(b"a7".to_vec()), &mut statistics)
                 .unwrap()
         );
-        let mut pair = (iter.key().to_vec(), iter.value().to_vec());
+        let mut pair = (
+            iter.key(&mut statistics).to_vec(),
+            iter.value(&mut statistics).to_vec(),
+        );
         assert_eq!(pair, (b"a5".to_vec(), b"v5".to_vec()));
         assert!(
             iter.reverse_seek(&Key::from_encoded(b"a5".to_vec()), &mut statistics)
                 .unwrap()
         );
-        pair = (iter.key().to_vec(), iter.value().to_vec());
+        pair = (
+            iter.key(&mut statistics).to_vec(),
+            iter.value(&mut statistics).to_vec(),
+        );
         assert_eq!(pair, (b"a3".to_vec(), b"v3".to_vec()));
         assert!(
             !iter
@@ -564,7 +570,10 @@ mod tests {
         assert!(iter.seek_to_last(&mut statistics));
         let mut res = vec![];
         loop {
-            res.push((iter.key().to_vec(), iter.value().to_vec()));
+            res.push((
+                iter.key(&mut statistics).to_vec(),
+                iter.value(&mut statistics).to_vec(),
+            ));
             if !iter.prev(&mut statistics) {
                 break;
             }
@@ -588,7 +597,10 @@ mod tests {
             iter.reverse_seek(&Key::from_encoded(b"a2".to_vec()), &mut statistics)
                 .unwrap()
         );
-        let pair = (iter.key().to_vec(), iter.value().to_vec());
+        let pair = (
+            iter.key(&mut statistics).to_vec(),
+            iter.value(&mut statistics).to_vec(),
+        );
         assert_eq!(pair, (b"a1".to_vec(), b"v1".to_vec()));
         for kv_pairs in test_data.windows(2) {
             let seek_key = Key::from_encoded(kv_pairs[1].0.clone());
@@ -597,14 +609,20 @@ mod tests {
                 "{}",
                 seek_key
             );
-            let pair = (iter.key().to_vec(), iter.value().to_vec());
+            let pair = (
+                iter.key(&mut statistics).to_vec(),
+                iter.value(&mut statistics).to_vec(),
+            );
             assert_eq!(pair, kv_pairs[0]);
         }
 
         assert!(iter.seek_to_last(&mut statistics));
         let mut res = vec![];
         loop {
-            res.push((iter.key().to_vec(), iter.value().to_vec()));
+            res.push((
+                iter.key(&mut statistics).to_vec(),
+                iter.value(&mut statistics).to_vec(),
+            ));
             if !iter.prev(&mut statistics) {
                 break;
             }

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -298,6 +298,18 @@ impl Statistics {
         detail.set_write(self.write.scan_info());
         detail
     }
+
+    pub fn mut_cf_statistics(&mut self, cf: &str) -> &mut CFStatistics {
+        if cf.is_empty() {
+            return &mut self.data;
+        }
+        match cf {
+            CF_DEFAULT => &mut self.data,
+            CF_LOCK => &mut self.lock,
+            CF_WRITE => &mut self.write,
+            _ => unreachable!(),
+        }
+    }
 }
 
 #[derive(Default, Debug)]
@@ -319,6 +331,9 @@ pub struct Cursor<I: Iterator> {
     // the data cursor can be seen will be
     min_key: Option<Vec<u8>>,
     max_key: Option<Vec<u8>>,
+
+    is_key_read: bool,
+    is_value_read: bool,
 }
 
 impl<I: Iterator> Cursor<I> {
@@ -328,6 +343,9 @@ impl<I: Iterator> Cursor<I> {
             scan_mode: mode,
             min_key: None,
             max_key: None,
+
+            is_key_read: false,
+            is_value_read: false,
         }
     }
 
@@ -340,14 +358,12 @@ impl<I: Iterator> Cursor<I> {
 
         if self.scan_mode == ScanMode::Forward
             && self.valid()
-            && self.iter.key() >= key.encoded().as_slice()
+            && self.key(statistics) >= key.encoded().as_slice()
         {
             return Ok(true);
         }
 
-        statistics.seek += 1;
-
-        if !self.iter.seek(key)? {
+        if !self.internal_seek(key, statistics)? {
             self.max_key = Some(key.encoded().to_owned());
             return Ok(false);
         }
@@ -363,7 +379,7 @@ impl<I: Iterator> Cursor<I> {
         if !self.iter.valid() {
             return self.seek(key, statistics);
         }
-        let ord = self.iter.key().cmp(key.encoded());
+        let ord = self.key(statistics).cmp(key.encoded());
         if ord == Ordering::Equal
             || (self.scan_mode == ScanMode::Forward && ord == Ordering::Greater)
         {
@@ -375,12 +391,12 @@ impl<I: Iterator> Cursor<I> {
         }
         if ord == Ordering::Greater {
             near_loop!(
-                self.prev(statistics) && self.iter.key() > key.encoded().as_slice(),
+                self.prev(statistics) && self.key(statistics) > key.encoded().as_slice(),
                 self.seek(key, statistics),
                 statistics
             );
             if self.iter.valid() {
-                if self.iter.key() < key.encoded().as_slice() {
+                if self.key(statistics) < key.encoded().as_slice() {
                     self.next(statistics);
                 }
             } else {
@@ -390,7 +406,7 @@ impl<I: Iterator> Cursor<I> {
         } else {
             // ord == Less
             near_loop!(
-                self.next(statistics) && self.iter.key() < key.encoded().as_slice(),
+                self.next(statistics) && self.key(statistics) < key.encoded().as_slice(),
                 self.seek(key, statistics),
                 statistics
             );
@@ -408,13 +424,13 @@ impl<I: Iterator> Cursor<I> {
     /// around `key`, otherwise you should `seek` first.
     pub fn get(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<Option<&[u8]>> {
         if self.scan_mode != ScanMode::Backward {
-            if self.near_seek(key, statistics)? && self.iter.key() == &**key.encoded() {
-                return Ok(Some(self.iter.value()));
+            if self.near_seek(key, statistics)? && self.key(statistics) == &**key.encoded() {
+                return Ok(Some(self.value(statistics)));
             }
             return Ok(None);
         }
-        if self.near_seek_for_prev(key, statistics)? && self.iter.key() == &**key.encoded() {
-            return Ok(Some(self.iter.value()));
+        if self.near_seek_for_prev(key, statistics)? && self.key(statistics) == &**key.encoded() {
+            return Ok(Some(self.value(statistics)));
         }
         Ok(None)
     }
@@ -428,13 +444,12 @@ impl<I: Iterator> Cursor<I> {
 
         if self.scan_mode == ScanMode::Backward
             && self.valid()
-            && self.iter.key() <= key.encoded().as_slice()
+            && self.key(statistics) <= key.encoded().as_slice()
         {
             return Ok(true);
         }
 
-        statistics.seek_for_prev += 1;
-        if !self.iter.seek_for_prev(key)? {
+        if !self.internal_seek_for_prev(key, statistics)? {
             self.min_key = Some(key.encoded().to_owned());
             return Ok(false);
         }
@@ -447,7 +462,7 @@ impl<I: Iterator> Cursor<I> {
         if !self.iter.valid() {
             return self.seek_for_prev(key, statistics);
         }
-        let ord = self.iter.key().cmp(key.encoded());
+        let ord = self.key(statistics).cmp(key.encoded());
         if ord == Ordering::Equal || (self.scan_mode == ScanMode::Backward && ord == Ordering::Less)
         {
             return Ok(true);
@@ -460,12 +475,12 @@ impl<I: Iterator> Cursor<I> {
 
         if ord == Ordering::Less {
             near_loop!(
-                self.next(statistics) && self.iter.key() < key.encoded().as_slice(),
+                self.next(statistics) && self.key(statistics) < key.encoded().as_slice(),
                 self.seek_for_prev(key, statistics),
                 statistics
             );
             if self.iter.valid() {
-                if self.iter.key() > key.encoded().as_slice() {
+                if self.key(statistics) > key.encoded().as_slice() {
                     self.prev(statistics);
                 }
             } else {
@@ -474,7 +489,7 @@ impl<I: Iterator> Cursor<I> {
             }
         } else {
             near_loop!(
-                self.prev(statistics) && self.iter.key() > key.encoded().as_slice(),
+                self.prev(statistics) && self.key(statistics) > key.encoded().as_slice(),
                 self.seek_for_prev(key, statistics),
                 statistics
             );
@@ -492,7 +507,7 @@ impl<I: Iterator> Cursor<I> {
             return Ok(false);
         }
 
-        if self.iter.key() == &**key.encoded() {
+        if self.key(statistics) == &**key.encoded() {
             // should not update min_key here. otherwise reverse_seek_le may not
             // work as expected.
             return Ok(self.prev(statistics));
@@ -510,7 +525,7 @@ impl<I: Iterator> Cursor<I> {
             return Ok(false);
         }
 
-        if self.iter.key() == &**key.encoded() {
+        if self.key(statistics) == &**key.encoded() {
             return Ok(self.prev(statistics));
         }
 
@@ -518,42 +533,75 @@ impl<I: Iterator> Cursor<I> {
     }
 
     #[inline]
-    pub fn key(&self) -> &[u8] {
-        self.iter.key()
+    pub fn key(&mut self, statistics: &mut CFStatistics) -> &[u8] {
+        let key = self.iter.key();
+        if !self.is_key_read {
+            self.is_key_read = true;
+            statistics.flow_stats.read_bytes += key.len();
+            statistics.flow_stats.read_keys += 1;
+        }
+        key
     }
 
     #[inline]
-    pub fn value(&self) -> &[u8] {
-        self.iter.value()
+    pub fn value(&mut self, statistics: &mut CFStatistics) -> &[u8] {
+        let value = self.iter.value();
+        if !self.is_value_read {
+            self.is_value_read = true;
+            statistics.flow_stats.read_bytes += value.len();
+        }
+        value
     }
 
     #[inline]
     pub fn seek_to_first(&mut self, statistics: &mut CFStatistics) -> bool {
         statistics.seek += 1;
+        self.is_key_read = false;
+        self.is_value_read = false;
         self.iter.seek_to_first()
     }
 
     #[inline]
     pub fn seek_to_last(&mut self, statistics: &mut CFStatistics) -> bool {
         statistics.seek += 1;
+        self.is_key_read = false;
+        self.is_value_read = false;
         self.iter.seek_to_last()
     }
 
     #[inline]
     pub fn internal_seek(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<bool> {
         statistics.seek += 1;
+        self.is_key_read = false;
+        self.is_value_read = false;
         self.iter.seek(key)
+    }
+
+    #[inline]
+    pub fn internal_seek_for_prev(
+        &mut self,
+        key: &Key,
+        statistics: &mut CFStatistics,
+    ) -> Result<bool> {
+        statistics.seek_for_prev += 1;
+        self.is_key_read = false;
+        self.is_value_read = false;
+        self.iter.seek_for_prev(key)
     }
 
     #[inline]
     pub fn next(&mut self, statistics: &mut CFStatistics) -> bool {
         statistics.next += 1;
+        self.is_key_read = false;
+        self.is_value_read = false;
         self.iter.next()
     }
 
     #[inline]
     pub fn prev(&mut self, statistics: &mut CFStatistics) -> bool {
         statistics.prev += 1;
+        self.is_key_read = false;
+        self.is_value_read = false;
         self.iter.prev()
     }
 
@@ -712,29 +760,26 @@ mod tests {
 
     fn assert_seek<E: Engine>(engine: &E, key: &[u8], pair: (&[u8], &[u8])) {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut iter = snapshot
+        let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
         let mut statistics = CFStatistics::default();
-        iter.seek(&Key::from_raw(key), &mut statistics).unwrap();
-        assert_eq!(
-            (iter.key(), iter.value()),
-            (&*bytes::encode_bytes(pair.0), pair.1)
-        );
+        cursor.seek(&Key::from_raw(key), &mut statistics).unwrap();
+        assert_eq!(cursor.key(&mut statistics), &*bytes::encode_bytes(pair.0));
+        assert_eq!(cursor.value(&mut statistics), pair.1);
     }
 
     fn assert_reverse_seek<E: Engine>(engine: &E, key: &[u8], pair: (&[u8], &[u8])) {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut iter = snapshot
+        let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
         let mut statistics = CFStatistics::default();
-        iter.reverse_seek(&Key::from_raw(key), &mut statistics)
+        cursor
+            .reverse_seek(&Key::from_raw(key), &mut statistics)
             .unwrap();
-        assert_eq!(
-            (iter.key(), iter.value()),
-            (&*bytes::encode_bytes(pair.0), pair.1)
-        );
+        assert_eq!(cursor.key(&mut statistics), &*bytes::encode_bytes(pair.0));
+        assert_eq!(cursor.value(&mut statistics), pair.1);
     }
 
     fn assert_near_seek<I: Iterator>(cursor: &mut Cursor<I>, key: &[u8], pair: (&[u8], &[u8])) {
@@ -745,10 +790,8 @@ mod tests {
                 .unwrap(),
             escape(key)
         );
-        assert_eq!(
-            (cursor.key(), cursor.value()),
-            (&*bytes::encode_bytes(pair.0), pair.1)
-        );
+        assert_eq!(cursor.key(&mut statistics), &*bytes::encode_bytes(pair.0));
+        assert_eq!(cursor.value(&mut statistics), pair.1);
     }
 
     fn assert_near_reverse_seek<I: Iterator>(
@@ -763,10 +806,8 @@ mod tests {
                 .unwrap(),
             escape(key)
         );
-        assert_eq!(
-            (cursor.key(), cursor.value()),
-            (&*bytes::encode_bytes(pair.0), pair.1)
-        );
+        assert_eq!(cursor.key(&mut statistics), &*bytes::encode_bytes(pair.0));
+        assert_eq!(cursor.value(&mut statistics), pair.1);
     }
 
     fn test_get_put<E: Engine>(engine: &E) {
@@ -920,8 +961,11 @@ mod tests {
                 $res
             );
             if let Some((ref k, ref v)) = $res {
-                assert_eq!($cursor.key(), bytes::encode_bytes(k.as_bytes()).as_slice());
-                assert_eq!($cursor.value(), v.as_bytes());
+                assert_eq!(
+                    $cursor.key(&mut statistics),
+                    bytes::encode_bytes(k.as_bytes()).as_slice()
+                );
+                assert_eq!($cursor.value(&mut statistics), v.as_bytes());
             }
         }};
     }
@@ -1099,8 +1143,8 @@ mod tests {
         iter.seek(&Key::from_raw(b"foo30"), &mut statistics)
             .unwrap();
 
-        assert_eq!(iter.key(), &*bytes::encode_bytes(b"foo4"));
-        assert_eq!(iter.value(), b"bar4");
+        assert_eq!(iter.key(&mut statistics), &*bytes::encode_bytes(b"foo4"));
+        assert_eq!(iter.value(&mut statistics), b"bar4");
         assert_eq!(statistics.seek, 1);
         assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 0);
 
@@ -1109,8 +1153,8 @@ mod tests {
         iter.near_seek(&Key::from_raw(b"foo55"), &mut statistics)
             .unwrap();
 
-        assert_eq!(iter.key(), &*bytes::encode_bytes(b"foo6"));
-        assert_eq!(iter.value(), b"bar6");
+        assert_eq!(iter.key(&mut statistics), &*bytes::encode_bytes(b"foo6"));
+        assert_eq!(iter.value(&mut statistics), b"bar6");
         assert_eq!(statistics.seek, 0);
         assert_eq!(statistics.next, 1);
         assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 2);
@@ -1119,20 +1163,20 @@ mod tests {
         let mut statistics = CFStatistics::default();
         iter.prev(&mut statistics);
 
-        assert_eq!(iter.key(), &*bytes::encode_bytes(b"foo4"));
-        assert_eq!(iter.value(), b"bar4");
+        assert_eq!(iter.key(&mut statistics), &*bytes::encode_bytes(b"foo4"));
+        assert_eq!(iter.value(&mut statistics), b"bar4");
         assert_eq!(statistics.prev, 1);
         assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 2);
 
         iter.prev(&mut statistics);
-        assert_eq!(iter.key(), &*bytes::encode_bytes(b"foo2"));
-        assert_eq!(iter.value(), b"bar2");
+        assert_eq!(iter.key(&mut statistics), &*bytes::encode_bytes(b"foo2"));
+        assert_eq!(iter.value(&mut statistics), b"bar2");
         assert_eq!(statistics.prev, 2);
         assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 3);
 
         iter.prev(&mut statistics);
-        assert_eq!(iter.key(), &*bytes::encode_bytes(b"foo"));
-        assert_eq!(iter.value(), b"bar1");
+        assert_eq!(iter.key(&mut statistics), &*bytes::encode_bytes(b"foo"));
+        assert_eq!(iter.value(&mut statistics), b"bar1");
         assert_eq!(statistics.prev, 3);
         assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 3);
     }

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -350,6 +350,7 @@ impl<I: Iterator> Cursor<I> {
     }
 
     /// Mark key and value as unread. It will be invoked once cursor is moved.
+    #[inline]
     fn mark_unread(&mut self) {
         self.cur_key_has_read = false;
         self.cur_value_has_read = false;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1102,7 +1102,7 @@ impl<E: Engine> Storage<E> {
         start_key: &Key,
         end_key: Option<Key>,
         limit: usize,
-        stats: &mut Statistics,
+        statistics: &mut Statistics,
         key_only: bool,
     ) -> Result<Vec<Result<KvPair>>> {
         let mut option = IterOption::default();
@@ -1110,20 +1110,21 @@ impl<E: Engine> Storage<E> {
             option.set_upper_bound(end.take_encoded());
         }
         let mut cursor = snapshot.iter_cf(Self::rawkv_cf(cf)?, option, ScanMode::Forward)?;
-        if !cursor.seek(start_key, &mut stats.data)? {
+        let statistics = statistics.mut_cf_statistics(cf);
+        if !cursor.seek(start_key, statistics)? {
             return Ok(vec![]);
         }
         let mut pairs = vec![];
         while cursor.valid() && pairs.len() < limit {
             pairs.push(Ok((
-                cursor.key().to_owned(),
+                cursor.key(statistics).to_owned(),
                 if key_only {
                     vec![]
                 } else {
-                    cursor.value().to_owned()
+                    cursor.value(statistics).to_owned()
                 },
             )));
-            cursor.next(&mut stats.data);
+            cursor.next(statistics);
         }
         Ok(pairs)
     }
@@ -1161,24 +1162,10 @@ impl<E: Engine> Storage<E> {
                         limit,
                         &mut statistics,
                         key_only,
-                    ).map_err(Error::from)
-                        .map(|r| {
-                            let mut valid_keys = 0;
-                            let mut bytes_read = 0;
-                            let mut stats = Statistics::default();
-                            r.iter().for_each(|r| {
-                                if let Ok(ref pair) = *r {
-                                    valid_keys += 1;
-                                    bytes_read += pair.0.len() + pair.1.len();
-                                }
-                            });
-                            stats.data.flow_stats.read_keys = valid_keys;
-                            stats.data.flow_stats.read_bytes = bytes_read;
-                            thread_ctx.collect_read_flow(ctx.get_region_id(), &stats);
-                            thread_ctx.collect_key_reads(CMD, valid_keys as u64);
-                            r
-                        });
+                    ).map_err(Error::from);
 
+                    thread_ctx.collect_read_flow(ctx.get_region_id(), &statistics);
+                    thread_ctx.collect_key_reads(CMD, statistics.write.flow_stats.read_keys as u64);
                     thread_ctx.collect_scan_count(CMD, &statistics);
 
                     result
@@ -1272,22 +1259,11 @@ impl<E: Engine> Storage<E> {
                             &mut statistics,
                             key_only,
                         )?;
-                        let mut valid_keys = 0;
-                        let mut bytes_read = 0;
-                        let mut stats = Statistics::default();
-                        pairs.iter().for_each(|r| {
-                            if let Ok(ref pair) = *r {
-                                valid_keys += 1;
-                                bytes_read += pair.0.len() + pair.1.len();
-                            }
-                        });
-                        stats.data.flow_stats.read_keys = valid_keys;
-                        stats.data.flow_stats.read_bytes = bytes_read;
-                        thread_ctx.collect_read_flow(ctx.get_region_id(), &stats);
-                        thread_ctx.collect_key_reads(CMD, valid_keys as u64);
                         result.extend(pairs.into_iter());
                     }
 
+                    thread_ctx.collect_read_flow(ctx.get_region_id(), &statistics);
+                    thread_ctx.collect_key_reads(CMD, statistics.write.flow_stats.read_keys as u64);
                     thread_ctx.collect_scan_count(CMD, &statistics);
 
                     Ok(result)

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -109,8 +109,6 @@ impl<S: Snapshot> MvccReader<S> {
         };
 
         self.statistics.data.processed += 1;
-        self.statistics.data.flow_stats.read_bytes += k.raw().unwrap_or_default().len() + res.len();
-        self.statistics.data.flow_stats.read_keys += 1;
         Ok(res)
     }
 
@@ -191,16 +189,14 @@ impl<S: Snapshot> MvccReader<S> {
         if !ok {
             return Ok(None);
         }
-        let write_key = Key::from_encoded(cursor.key().to_vec());
+        let write_key = Key::from_encoded(cursor.key(&mut self.statistics.write).to_vec());
         let commit_ts = write_key.decode_ts()?;
         let k = write_key.truncate_ts()?;
         if &k != key {
             return Ok(None);
         }
-        let write = Write::parse(cursor.value())?;
+        let write = Write::parse(cursor.value(&mut self.statistics.write))?;
         self.statistics.write.processed += 1;
-        self.statistics.write.flow_stats.read_bytes += cursor.key().len() + cursor.value().len();
-        self.statistics.write.flow_stats.read_keys += 1;
         Ok(Some((commit_ts, write)))
     }
 
@@ -332,9 +328,10 @@ impl<S: Snapshot> MvccReader<S> {
         let mut ok = cursor.seek_to_first(&mut self.statistics.write);
 
         while ok {
-            if Write::parse(cursor.value())?.start_ts == ts {
+            if Write::parse(cursor.value(&mut self.statistics.write))?.start_ts == ts {
                 return Ok(Some(
-                    Key::from_encoded(cursor.key().to_vec()).truncate_ts()?,
+                    Key::from_encoded(cursor.key(&mut self.statistics.write).to_vec())
+                        .truncate_ts()?,
                 ));
             }
             ok = cursor.next(&mut self.statistics.write);
@@ -356,7 +353,7 @@ impl<S: Snapshot> MvccReader<S> {
                 let (mut w_key, mut l_key) = (None, None);
                 if write_valid {
                     if w_cur.near_seek(&key, &mut self.statistics.write)? {
-                        w_key = Some(w_cur.key());
+                        w_key = Some(w_cur.key(&mut self.statistics.write));
                     } else {
                         w_key = None;
                         write_valid = false;
@@ -364,7 +361,7 @@ impl<S: Snapshot> MvccReader<S> {
                 }
                 if lock_valid {
                     if l_cur.near_seek(&key, &mut self.statistics.lock)? {
-                        l_key = Some(l_cur.key());
+                        l_key = Some(l_cur.key(&mut self.statistics.lock));
                     } else {
                         l_key = None;
                         lock_valid = false;
@@ -401,7 +398,7 @@ impl<S: Snapshot> MvccReader<S> {
                 let (mut w_key, mut l_key) = (None, None);
                 if write_valid {
                     if w_cur.near_reverse_seek(&key, &mut self.statistics.write)? {
-                        w_key = Some(w_cur.key());
+                        w_key = Some(w_cur.key(&mut self.statistics.write));
                     } else {
                         w_key = None;
                         write_valid = false;
@@ -409,7 +406,7 @@ impl<S: Snapshot> MvccReader<S> {
                 }
                 if lock_valid {
                     if l_cur.near_reverse_seek(&key, &mut self.statistics.lock)? {
-                        l_key = Some(l_cur.key());
+                        l_key = Some(l_cur.key(&mut self.statistics.lock));
                     } else {
                         l_key = None;
                         lock_valid = false;
@@ -445,10 +442,19 @@ impl<S: Snapshot> MvccReader<S> {
         // Check lock.
         match self.isolation_level {
             IsolationLevel::SI => {
-                let l_cur = self.lock_cursor.as_ref().unwrap();
-                if l_cur.valid() && l_cur.key() == user_key.encoded().as_slice() {
-                    self.statistics.lock.processed += 1;
-                    self.check_lock_impl(user_key, ts, Lock::parse(l_cur.value())?)?;
+                let lock = {
+                    let l_cur = self.lock_cursor.as_mut().unwrap();
+                    if l_cur.valid()
+                        && l_cur.key(&mut self.statistics.lock) == user_key.encoded().as_slice()
+                    {
+                        self.statistics.lock.processed += 1;
+                        Some(Lock::parse(l_cur.value(&mut self.statistics.lock))?)
+                    } else {
+                        None
+                    }
+                };
+                if let Some(lock) = lock {
+                    self.check_lock_impl(user_key, ts, lock)?;
                 }
             }
             IsolationLevel::RC => {}
@@ -465,9 +471,9 @@ impl<S: Snapshot> MvccReader<S> {
 
             let mut write = {
                 let (commit_ts, key) = {
-                    let w_cur = self.write_cursor.as_ref().unwrap();
-                    last_handled_key = Some(w_cur.key().to_vec());
-                    let w_key = Key::from_encoded(w_cur.key().to_vec());
+                    let w_cur = self.write_cursor.as_mut().unwrap();
+                    last_handled_key = Some(w_cur.key(&mut self.statistics.write).to_vec());
+                    let w_key = Key::from_encoded(w_cur.key(&mut self.statistics.write).to_vec());
                     (w_key.decode_ts()?, w_key.truncate_ts()?)
                 };
 
@@ -477,7 +483,12 @@ impl<S: Snapshot> MvccReader<S> {
                     return self.get_value(user_key, lastest_version.0, lastest_version.1);
                 }
                 self.statistics.write.processed += 1;
-                Write::parse(self.write_cursor.as_ref().unwrap().value())?
+                Write::parse(
+                    self.write_cursor
+                        .as_mut()
+                        .unwrap()
+                        .value(&mut self.statistics.write),
+                )?
             };
 
             match write.write_type {
@@ -514,20 +525,24 @@ impl<S: Snapshot> MvccReader<S> {
             let mut write = {
                 // If we reach the last handled key, it means we have checked all versions
                 // for this user key.
-                if self.write_cursor.as_ref().unwrap().key()
+                if self
+                    .write_cursor
+                    .as_mut()
+                    .unwrap()
+                    .key(&mut self.statistics.write)
                     >= last_handled_key.as_ref().unwrap().as_slice()
                 {
                     return self.get_value(user_key, lastest_version.0, lastest_version.1);
                 }
 
-                let w_cur = self.write_cursor.as_ref().unwrap();
-                let w_key = Key::from_encoded(w_cur.key().to_vec());
+                let w_cur = self.write_cursor.as_mut().unwrap();
+                let w_key = Key::from_encoded(w_cur.key(&mut self.statistics.write).to_vec());
                 let commit_ts = w_key.decode_ts()?;
                 assert!(commit_ts <= ts);
                 let key = w_key.truncate_ts()?;
                 assert_eq!(&key, user_key);
                 self.statistics.write.processed += 1;
-                Write::parse(w_cur.value())?
+                Write::parse(w_cur.value(&mut self.statistics.write))?
             };
 
             match write.write_type {
@@ -586,8 +601,8 @@ impl<S: Snapshot> MvccReader<S> {
         }
         let mut locks = Vec::with_capacity(limit);
         while cursor.valid() {
-            let key = Key::from_encoded(cursor.key().to_vec());
-            let lock = Lock::parse(cursor.value())?;
+            let key = Key::from_encoded(cursor.key(&mut self.statistics.lock).to_vec());
+            let lock = Lock::parse(cursor.value(&mut self.statistics.lock))?;
             if filter(&lock) {
                 locks.push((key, lock));
                 if limit > 0 && locks.len() == limit {
@@ -622,7 +637,8 @@ impl<S: Snapshot> MvccReader<S> {
                 self.statistics.write.processed += keys.len();
                 return Ok((keys, start));
             }
-            let key = Key::from_encoded(cursor.key().to_vec()).truncate_ts()?;
+            let key =
+                Key::from_encoded(cursor.key(&mut self.statistics.write).to_vec()).truncate_ts()?;
             start = Some(key.clone().append_ts(0));
             keys.push(key);
         }
@@ -638,11 +654,11 @@ impl<S: Snapshot> MvccReader<S> {
         }
         let mut v = vec![];
         while ok {
-            let cur_key = Key::from_encoded(cursor.key().to_vec());
+            let cur_key = Key::from_encoded(cursor.key(&mut self.statistics.data).to_vec());
             let ts = cur_key.decode_ts()?;
             let cur_key_without_ts = cur_key.truncate_ts()?;
             if cur_key_without_ts.encoded().as_slice() == key.encoded().as_slice() {
-                v.push((ts, cursor.value().to_vec()));
+                v.push((ts, cursor.value(&mut self.statistics.data).to_vec()));
             }
             if cur_key_without_ts.encoded().as_slice() != key.encoded().as_slice() {
                 break;

--- a/tests/storage_cases/test_raftkv.rs
+++ b/tests/storage_cases/test_raftkv.rs
@@ -168,15 +168,13 @@ fn assert_none_cf<E: Engine>(ctx: &Context, engine: &E, cf: CfName, key: &[u8]) 
 
 fn assert_seek<E: Engine>(ctx: &Context, engine: &E, key: &[u8], pair: (&[u8], &[u8])) {
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut iter = snapshot
+    let mut cursor = snapshot
         .iter(IterOption::default(), ScanMode::Mixed)
         .unwrap();
     let mut statistics = CFStatistics::default();
-    iter.seek(&Key::from_raw(key), &mut statistics).unwrap();
-    assert_eq!(
-        (iter.key(), iter.value()),
-        (&*bytes::encode_bytes(pair.0), pair.1)
-    );
+    cursor.seek(&Key::from_raw(key), &mut statistics).unwrap();
+    assert_eq!(cursor.key(&mut statistics), &*bytes::encode_bytes(pair.0));
+    assert_eq!(cursor.value(&mut statistics), pair.1);
 }
 
 fn assert_seek_cf<E: Engine>(
@@ -187,15 +185,13 @@ fn assert_seek_cf<E: Engine>(
     pair: (&[u8], &[u8]),
 ) {
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut iter = snapshot
+    let mut cursor = snapshot
         .iter_cf(cf, IterOption::default(), ScanMode::Mixed)
         .unwrap();
     let mut statistics = CFStatistics::default();
-    iter.seek(&Key::from_raw(key), &mut statistics).unwrap();
-    assert_eq!(
-        (iter.key(), iter.value()),
-        (&*bytes::encode_bytes(pair.0), pair.1)
-    );
+    cursor.seek(&Key::from_raw(key), &mut statistics).unwrap();
+    assert_eq!(cursor.key(&mut statistics), &*bytes::encode_bytes(pair.0));
+    assert_eq!(cursor.value(&mut statistics), pair.1);
 }
 
 fn assert_near_seek<I: Iterator>(cursor: &mut Cursor<I>, key: &[u8], pair: (&[u8], &[u8])) {
@@ -206,10 +202,8 @@ fn assert_near_seek<I: Iterator>(cursor: &mut Cursor<I>, key: &[u8], pair: (&[u8
             .unwrap(),
         escape(key)
     );
-    assert_eq!(
-        (cursor.key(), cursor.value()),
-        (&*bytes::encode_bytes(pair.0), pair.1)
-    );
+    assert_eq!(cursor.key(&mut statistics), &*bytes::encode_bytes(pair.0));
+    assert_eq!(cursor.value(&mut statistics), pair.1);
 }
 
 fn assert_near_reverse_seek<I: Iterator>(cursor: &mut Cursor<I>, key: &[u8], pair: (&[u8], &[u8])) {
@@ -220,10 +214,8 @@ fn assert_near_reverse_seek<I: Iterator>(cursor: &mut Cursor<I>, key: &[u8], pai
             .unwrap(),
         escape(key)
     );
-    assert_eq!(
-        (cursor.key(), cursor.value()),
-        (&*bytes::encode_bytes(pair.0), pair.1)
-    );
+    assert_eq!(cursor.key(&mut statistics), &*bytes::encode_bytes(pair.0));
+    assert_eq!(cursor.value(&mut statistics), pair.1);
 }
 
 fn get_put<E: Engine>(ctx: &Context, engine: &E) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Previously our flow statistics is not very accurate. For example, when doing `near_seek`, the read during each `next()` attempt is not counted in the statistics. According to PD developers, these read flows should be counted however. Also, previously we self-implemented some read statistics in raw_scan and raw_batch_scan.

This PR moves the read flow statistics logic from mvcc layer into `Cursor` layer, the same as CFStatistics. In detail, when `key()` or `value()` is called, its read flow is counted. Subsequent calls will not be counted unless the cursor is moved (e.g. by `seek()`, `next()`, etc).

This change is extracted from the [Mvcc Refinement PR](https://github.com/pingcap/tikv/pull/3344).

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

CI

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

There is no notable performance difference after applying this PR's change:

master:

```
test storage::scan::bench_seek_ts                                    ... bench:      85,256 ns/iter (+/- 39,536)
test storage::scan::bench_seek_ts                                    ... bench:      82,645 ns/iter (+/- 13,326)
test storage::scan::bench_seek_ts                                    ... bench:      85,052 ns/iter (+/- 26,659)
test storage::scan::bench_seek_ts                                    ... bench:      87,078 ns/iter (+/- 10,894)
```

this PR:

```
test storage::scan::bench_seek_ts                                    ... bench:      84,566 ns/iter (+/- 17,616)
test storage::scan::bench_seek_ts                                    ... bench:      82,349 ns/iter (+/- 14,759)
test storage::scan::bench_seek_ts                                    ... bench:      82,558 ns/iter (+/- 14,742)
test storage::scan::bench_seek_ts                                    ... bench:      88,204 ns/iter (+/- 11,680)
test storage::scan::bench_seek_ts                                    ... bench:      82,717 ns/iter (+/- 12,728)
```

## Add a few positive/negative examples (optional)

