### PR TITLE
coprocessor/dag/expr: add some un-pushed builtin UDFs(BitCount)

### DIFF
--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -192,6 +192,7 @@ impl ScalarFunc {
             | ScalarFuncSig::JsonUnquoteSig
             | ScalarFuncSig::Length
             | ScalarFuncSig::Bin
+            | ScalarFuncSig::BitCount
             | ScalarFuncSig::BitLength
             | ScalarFuncSig::BitNegSig => (1, 1),
 
@@ -264,7 +265,6 @@ impl ScalarFunc {
             | ScalarFuncSig::Asin
             | ScalarFuncSig::Atan1Arg
             | ScalarFuncSig::Atan2Args
-            | ScalarFuncSig::BitCount
             | ScalarFuncSig::Char
             | ScalarFuncSig::CharLength
             | ScalarFuncSig::Compress
@@ -771,6 +771,7 @@ dispatch_call! {
         BitNegSig => bit_neg,
         BitOrSig => bit_or,
         BitXorSig => bit_xor,
+        BitCount => bit_count,
 
         Length => length,
         BitLength => bit_length,
@@ -1086,6 +1087,7 @@ mod test {
                     ScalarFuncSig::JsonTypeSig,
                     ScalarFuncSig::JsonUnquoteSig,
                     ScalarFuncSig::Bin,
+                    ScalarFuncSig::BitCount,
                     ScalarFuncSig::BitNegSig,
                     ScalarFuncSig::BitLength,
                     ScalarFuncSig::Length,
@@ -1204,7 +1206,6 @@ mod test {
             ScalarFuncSig::Asin,
             ScalarFuncSig::Atan1Arg,
             ScalarFuncSig::Atan2Args,
-            ScalarFuncSig::BitCount,
             ScalarFuncSig::Char,
             ScalarFuncSig::CharLength,
             ScalarFuncSig::Compress,


### PR DESCRIPTION
## What have you changed? (mandatory)
Implemented builtin function: **BitCount** in `coprocessor`, this is for https://github.com/tikv/tikv/issues/3275

## What are the type of the changes? (mandatory)
Improvement

## How has this PR been tested? (mandatory)
Added some more UT cases

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No

## Refer to a related PR or issue link (optional)
https://github.com/tikv/tikv/issues/3275
