### PR TITLE
expr/builtin_fncall: implement math.Sin

### DIFF
--- a/src/coprocessor/dag/expr/builtin_math.rs
+++ b/src/coprocessor/dag/expr/builtin_math.rs
@@ -126,6 +126,12 @@ impl ScalarFunc {
         let n = try_opt!(self.children[0].eval_real(ctx, row));
         Ok(Some(n.tan()))
     }
+
+    #[inline]
+    pub fn sin(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<f64>> {
+        let n = try_opt!(self.children[0].eval_real(ctx, row));
+        Ok(Some(n.sin()))
+    }
 }
 
 #[cfg(test)]
@@ -134,6 +140,7 @@ mod test {
     use coprocessor::codec::{convert, mysql, Datum};
     use coprocessor::dag::expr::test::{check_overflow, datum_expr, scalar_func_expr, str2dec};
     use coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
+    use std::f64::consts::{FRAC_1_SQRT_2, PI};
     use std::sync::Arc;
     use std::{f64, i64, u64};
     use tipb::expression::ScalarFuncSig;
@@ -374,6 +381,35 @@ mod test {
         let tests_invalid_f64 = vec![
             (ScalarFuncSig::Tan, Datum::F64(f64::INFINITY)),
             (ScalarFuncSig::Tan, Datum::F64(f64::NAN)),
+        ];
+        let mut ctx = EvalContext::default();
+        for (sig, arg, exp) in tests {
+            let arg = datum_expr(arg);
+            let f = scalar_func_expr(sig, &[arg]);
+            let op = Expression::build(&mut ctx, f).unwrap();
+            let got = op.eval(&mut ctx, &[]).unwrap();
+            assert!((got.f64() - exp).abs() < f64::EPSILON);
+        }
+        for (sig, arg) in tests_invalid_f64 {
+            let arg = datum_expr(arg);
+            let f = scalar_func_expr(sig, &[arg]);
+            let op = Expression::build(&mut ctx, f).unwrap();
+            let got = op.eval(&mut ctx, &[]).unwrap();
+            assert!(got.f64().is_nan());
+        }
+    }
+
+    #[test]
+    fn test_sin() {
+        let tests = vec![
+            (ScalarFuncSig::Sin, Datum::F64(0.0_f64), 0.0_f64),
+            (ScalarFuncSig::Sin, Datum::F64(PI / 4.0_f64), FRAC_1_SQRT_2),
+            (ScalarFuncSig::Sin, Datum::F64(PI / 2.0_f64), 1.0_f64),
+            (ScalarFuncSig::Sin, Datum::F64(PI), 0.0_f64),
+        ];
+        let tests_invalid_f64 = vec![
+            (ScalarFuncSig::Sin, Datum::F64(f64::INFINITY)),
+            (ScalarFuncSig::Sin, Datum::F64(f64::NAN)),
         ];
         let mut ctx = EvalContext::default();
         for (sig, arg, exp) in tests {

--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -192,6 +192,7 @@ impl ScalarFunc {
             | ScalarFuncSig::FloorDecToInt
             | ScalarFuncSig::CRC32
             | ScalarFuncSig::Tan
+            | ScalarFuncSig::Sin
             | ScalarFuncSig::JsonTypeSig
             | ScalarFuncSig::JsonUnquoteSig
             | ScalarFuncSig::ASCII
@@ -414,7 +415,6 @@ impl ScalarFunc {
             | ScalarFuncSig::SHA1
             | ScalarFuncSig::SHA2
             | ScalarFuncSig::Sign
-            | ScalarFuncSig::Sin
             | ScalarFuncSig::Sleep
             | ScalarFuncSig::Space
             | ScalarFuncSig::Sqrt
@@ -808,6 +808,7 @@ dispatch_call! {
         CaseWhenReal => case_when_real,
 
         Tan => tan,
+        Sin => sin,
     }
     DEC_CALLS {
         CastIntAsDecimal => cast_int_as_decimal,
@@ -1098,6 +1099,7 @@ mod test {
                     ScalarFuncSig::FloorDecToInt,
                     ScalarFuncSig::CRC32,
                     ScalarFuncSig::Tan,
+                    ScalarFuncSig::Sin,
                     ScalarFuncSig::JsonTypeSig,
                     ScalarFuncSig::JsonUnquoteSig,
                     ScalarFuncSig::ASCII,
@@ -1364,7 +1366,6 @@ mod test {
             ScalarFuncSig::SHA1,
             ScalarFuncSig::SHA2,
             ScalarFuncSig::Sign,
-            ScalarFuncSig::Sin,
             ScalarFuncSig::Sleep,
             ScalarFuncSig::Space,
             ScalarFuncSig::Sqrt,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- add math.Sin, as suggested [here](https://pingcap.github.io/blog/adding-built-in-functions-to-tikv/)

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- New feature (non-breaking change which adds functionality)

## How has this PR been tested? (mandatory)

unit test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Refer to a related PR or issue link (optional)
https://github.com/tikv/tikv/issues/3275

The related source in tidb: https://github.com/pingcap/tidb/blob/55d8eff75859814114f9c6aa3efe2e3f69f7981f/expression/builtin_math.go#L1676

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

