### PR TITLE
[MVCC PR] Improve forward scan

### DIFF
--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -42,7 +42,7 @@ pub use self::perf_context::{PerfStatisticsDelta, PerfStatisticsInstant};
 // only used for rocksdb without persistent.
 pub const TEMP_DIR: &str = "";
 
-const SEEK_BOUND: usize = 30;
+pub const SEEK_BOUND: usize = 4;
 const DEFAULT_TIMEOUT_SECS: u64 = 5;
 
 const STAT_TOTAL: &str = "total";

--- a/src/storage/mvcc/reader/cf_reader.rs
+++ b/src/storage/mvcc/reader/cf_reader.rs
@@ -229,9 +229,7 @@ impl<S: Snapshot> CfReader<S> {
         while write_cursor.valid() {
             let commit_ts = {
                 let current_key = write_cursor.key(&mut self.statistics.write);
-                // TODO: if length is not equal, no need to truncate.
-                let current_user_key = Key::truncate_ts_for(current_key)?;
-                if user_key.encoded().as_slice() != current_user_key {
+                if !Key::is_user_key_eq(current_key, user_key.encoded().as_slice()) {
                     // Meet another key: don't need to scan more.
                     break;
                 }
@@ -267,9 +265,7 @@ impl<S: Snapshot> CfReader<S> {
         while default_cursor.valid() {
             let start_ts = {
                 let current_key = default_cursor.key(&mut self.statistics.data);
-                // TODO: if length is not equal, no need to truncate.
-                let current_user_key = Key::truncate_ts_for(current_key)?;
-                if user_key.encoded().as_slice() != current_user_key {
+                if !Key::is_user_key_eq(current_key, user_key.encoded().as_slice()) {
                     // Meet another key: don't need to scan more.
                     break;
                 }
@@ -329,8 +325,7 @@ impl<S: Snapshot> CfReader<S> {
         }
         let commit_ts = {
             let current_key = write_cursor.key(&mut self.statistics.write);
-            let current_user_key = Key::truncate_ts_for(current_key)?;
-            if user_key.encoded().as_slice() != current_user_key {
+            if !Key::is_user_key_eq(current_key, user_key.encoded().as_slice()) {
                 // Meet another key: don't need to scan more.
                 return Ok(None);
             }
@@ -388,9 +383,7 @@ impl<S: Snapshot> CfReader<S> {
         while write_cursor.valid() {
             let commit_ts = {
                 let current_key = write_cursor.key(&mut self.statistics.write);
-                // TODO: if length is not equal, no need to truncate.
-                let current_user_key = Key::truncate_ts_for(current_key)?;
-                if user_key.encoded().as_slice() != current_user_key {
+                if !Key::is_user_key_eq(current_key, user_key.encoded().as_slice()) {
                     // Meet another key: don't need to scan more.
                     break;
                 }

--- a/src/storage/mvcc/reader/forward_scanner.rs
+++ b/src/storage/mvcc/reader/forward_scanner.rs
@@ -275,8 +275,7 @@ impl<S: Snapshot> ForwardScanner<S> {
                     }
                     {
                         let current_key = self.write_cursor.key(&mut self.statistics.write);
-                        if Key::truncate_ts_for(current_key)?
-                            != current_user_key.encoded().as_slice()
+                        if !Key::is_user_key_eq(current_key, current_user_key.encoded().as_slice())
                         {
                             // Found another user key, don't need to seek again.
                             needs_seek = false;
@@ -337,7 +336,7 @@ impl<S: Snapshot> ForwardScanner<S> {
         for _ in 0..SEEK_BOUND {
             {
                 let current_key = self.write_cursor.key(&mut self.statistics.write);
-                if Key::truncate_ts_for(current_key)? != user_key.encoded().as_slice() {
+                if !Key::is_user_key_eq(current_key, user_key.encoded().as_slice()) {
                     // Meet another key.
                     return Ok(None);
                 }
@@ -364,7 +363,7 @@ impl<S: Snapshot> ForwardScanner<S> {
                 return Ok(None);
             }
             let current_key = self.write_cursor.key(&mut self.statistics.write);
-            if Key::truncate_ts_for(current_key)? != user_key.encoded().as_slice() {
+            if !Key::is_user_key_eq(current_key, user_key.encoded().as_slice()) {
                 // Meet another key.
                 return Ok(None);
             }
@@ -412,7 +411,7 @@ impl<S: Snapshot> ForwardScanner<S> {
                 return Ok(None);
             }
             let current_key = self.write_cursor.key(&mut self.statistics.write);
-            if Key::truncate_ts_for(current_key)? != user_key.encoded().as_slice() {
+            if !Key::is_user_key_eq(current_key, user_key.encoded().as_slice()) {
                 // Meet another key.
                 return Ok(None);
             }

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -185,28 +185,7 @@ impl<S: Snapshot> PointGetter<S> {
             self.statistics.write.processed += 1;
 
             match write.write_type {
-                WriteType::Put => {
-                    if self.omit_value {
-                        return Ok(Some(vec![]));
-                    }
-                    match write.short_value {
-                        Some(value) => {
-                            // Value is carried in `write`.
-                            return Ok(Some(value));
-                        }
-                        None => {
-                            // Value is in the default CF.
-                            self.ensure_default_cursor()?;
-                            let value = super::util::near_load_data_by_write(
-                                &mut self.default_cursor.as_mut().unwrap(),
-                                user_key,
-                                write,
-                                &mut self.statistics,
-                            )?;
-                            return Ok(Some(value));
-                        }
-                    }
-                }
+                WriteType::Put => return Ok(Some(self.load_data_by_write(write, user_key)?)),
                 WriteType::Delete => return Ok(None),
                 WriteType::Lock | WriteType::Rollback => {
                     // Continue iterate next `write`.
@@ -217,7 +196,34 @@ impl<S: Snapshot> PointGetter<S> {
         }
     }
 
+    /// Load the value by the given `write`. If value is carried in `write`, it will be returned
+    /// directly. Otherwise there will be a default CF look up.
+    #[inline]
+    fn load_data_by_write(&mut self, write: Write, user_key: &Key) -> Result<Value> {
+        if self.omit_value {
+            return Ok(vec![]);
+        }
+        match write.short_value {
+            Some(value) => {
+                // Value is carried in `write`.
+                Ok(value)
+            }
+            None => {
+                // Value is in the default CF.
+                self.ensure_default_cursor()?;
+                let value = super::util::near_load_data_by_write(
+                    &mut self.default_cursor.as_mut().unwrap(),
+                    user_key,
+                    write,
+                    &mut self.statistics,
+                )?;
+                Ok(value)
+            }
+        }
+    }
+
     /// Create the default cursor if it doesn't exist.
+    #[inline]
     fn ensure_default_cursor(&mut self) -> Result<()> {
         if self.default_cursor.is_some() {
             return Ok(());

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -175,9 +175,7 @@ impl<S: Snapshot> PointGetter<S> {
             // We may move forward / seek to another key. In this case, the scan ends.
             {
                 let cursor_key = self.write_cursor.key(&mut self.statistics.write);
-                // TODO: if length is not equal, no need to truncate.
-                let current_user_key = Key::truncate_ts_for(cursor_key)?;
-                if user_key.encoded().as_slice() != current_user_key {
+                if !Key::is_user_key_eq(cursor_key, user_key.encoded().as_slice()) {
                     // Meet another key.
                     return Ok(None);
                 }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -165,6 +165,15 @@ impl Key {
 
     /// Whether the user key part of a ts encoded key `ts_encoded_key` equals to the encoded
     /// user key `user_key`.
+    ///
+    /// There is an optimziation in this function, which is to compare the last 8 encoded bytes
+    /// first before comparing the rest. It is because in TiDB many records are ended with an 8
+    /// byte row id and in many situations only this part is different when calling this function.
+    //
+    // TODO: If the last 8 byte is memory aligned, it would be better.
+    // TODO: It may be UB to do like this. We should investigate whether `==` is smart enough
+    //       to optimize an 8-byte compare. Note that `==` will result in `memcmp` and `memcmp`
+    //       might be very smart.
     #[inline]
     #[cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
     pub fn is_user_key_eq(ts_encoded_key: &[u8], user_key: &[u8]) -> bool {

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -162,6 +162,30 @@ impl Key {
         let mut ts = &key[len - number::U64_SIZE..];
         number::decode_u64_desc(&mut ts)
     }
+
+    /// Whether the user key part of a ts encoded key `ts_encoded_key` equals to the encoded
+    /// user key `user_key`.
+    #[inline]
+    #[cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
+    pub fn is_user_key_eq(ts_encoded_key: &[u8], user_key: &[u8]) -> bool {
+        let user_key_len = user_key.len();
+        if ts_encoded_key.len() != user_key_len + number::U64_SIZE {
+            return false;
+        }
+        if user_key_len >= number::U64_SIZE {
+            // We compare last 8 bytes as u64 first, then compare the rest.
+            unsafe {
+                let ks_ptr = ts_encoded_key[user_key_len - 8..].as_ptr() as *const u64;
+                let rs_ptr = user_key[user_key_len - 8..].as_ptr() as *const u64;
+                if *ks_ptr != *rs_ptr {
+                    return false;
+                }
+            }
+            ts_encoded_key[..user_key_len - 8] == user_key[..user_key_len - 8]
+        } else {
+            ts_encoded_key[..user_key_len] == user_key[..]
+        }
+    }
 }
 
 impl Clone for Key {
@@ -213,5 +237,60 @@ mod tests {
         let enc = Key::from_encoded(k.to_vec()).append_ts(ts);
         let res = Key::split_on_ts_for(enc.encoded()).unwrap();
         assert_eq!(res, (k.as_ref(), ts));
+    }
+
+    #[test]
+    fn test_is_user_key_eq() {
+        // make a short name to keep format for the test.
+        fn eq(a: &[u8], b: &[u8]) -> bool {
+            Key::is_user_key_eq(a, b)
+        }
+        assert_eq!(false, eq(b"", b""));
+        assert_eq!(false, eq(b"12345", b""));
+        assert_eq!(true, eq(b"12345678", b""));
+        assert_eq!(true, eq(b"x12345678", b"x"));
+        assert_eq!(false, eq(b"x12345", b"x"));
+        // user key len == 3
+        assert_eq!(true, eq(b"xyz12345678", b"xyz"));
+        assert_eq!(true, eq(b"xyz________", b"xyz"));
+        assert_eq!(false, eq(b"xyy12345678", b"xyz"));
+        assert_eq!(false, eq(b"yyz12345678", b"xyz"));
+        assert_eq!(false, eq(b"xyz12345678", b"xy"));
+        assert_eq!(false, eq(b"xyy12345678", b"xy"));
+        assert_eq!(false, eq(b"yyz12345678", b"xy"));
+        // user key len == 7
+        assert_eq!(true, eq(b"abcdefg12345678", b"abcdefg"));
+        assert_eq!(true, eq(b"abcdefgzzzzzzzz", b"abcdefg"));
+        assert_eq!(false, eq(b"abcdefg12345678", b"abcdef"));
+        assert_eq!(false, eq(b"abcdefg12345678", b"bcdefg"));
+        assert_eq!(false, eq(b"abcdefv12345678", b"abcdefg"));
+        assert_eq!(false, eq(b"vbcdefg12345678", b"abcdefg"));
+        assert_eq!(false, eq(b"abccefg12345678", b"abcdefg"));
+        // user key len == 8
+        assert_eq!(true, eq(b"abcdefgh12345678", b"abcdefgh"));
+        assert_eq!(true, eq(b"abcdefghyyyyyyyy", b"abcdefgh"));
+        assert_eq!(false, eq(b"abcdefgh12345678", b"abcdefg"));
+        assert_eq!(false, eq(b"abcdefgh12345678", b"bcdefgh"));
+        assert_eq!(false, eq(b"abcdefgz12345678", b"abcdefgh"));
+        assert_eq!(false, eq(b"zbcdefgh12345678", b"abcdefgh"));
+        assert_eq!(false, eq(b"abcddfgh12345678", b"abcdefgh"));
+        // user key len == 9
+        assert_eq!(true, eq(b"abcdefghi12345678", b"abcdefghi"));
+        assert_eq!(true, eq(b"abcdefghixxxxxxxx", b"abcdefghi"));
+        assert_eq!(false, eq(b"abcdefghi12345678", b"abcdefgh"));
+        assert_eq!(false, eq(b"abcdefghi12345678", b"bcdefghi"));
+        assert_eq!(false, eq(b"abcdefghy12345678", b"abcdefghi"));
+        assert_eq!(false, eq(b"ybcdefghi12345678", b"abcdefghi"));
+        assert_eq!(false, eq(b"abcddfghi12345678", b"abcdefghi"));
+        // user key len == 11
+        assert_eq!(true, eq(b"abcdefghijk87654321", b"abcdefghijk"));
+        assert_eq!(true, eq(b"abcdefghijkabcdefgh", b"abcdefghijk"));
+        assert_eq!(false, eq(b"abcdefghijk87654321", b"abcdefghij"));
+        assert_eq!(false, eq(b"abcdefghijk87654321", b"bcdefghijk"));
+        assert_eq!(false, eq(b"abcdefghijx87654321", b"abcdefghijk"));
+        assert_eq!(false, eq(b"xbcdefghijk87654321", b"abcdefghijk"));
+        assert_eq!(false, eq(b"abxdefghijk87654321", b"abcdefghijk"));
+        assert_eq!(false, eq(b"axcdefghijk87654321", b"abcdefghijk"));
+        assert_eq!(false, eq(b"abcdeffhijk87654321", b"abcdefghijk"));
     }
 }


### PR DESCRIPTION
## What have you changed? (mandatory)

This PR is an improvement over the proposed [Mvcc refinement PR](https://github.com/tikv/tikv/pull/3344).

It:
- Mostly removes the usage of near_seek in forward scan
- Prevents key clone in more cases
- Adds very verbose comments

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

CI

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

Later.

## Add a few positive/negative examples (optional)

