### PR TITLE
benches/coprocessor: add some benchmark cases

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -18,6 +18,7 @@ extern crate kvproto;
 extern crate log;
 #[macro_use(slog_o, slog_kv)]
 extern crate slog;
+extern crate byteorder;
 extern crate mio;
 extern crate protobuf;
 extern crate raft;

--- a/benches/coprocessor/codec/mod.rs
+++ b/benches/coprocessor/codec/mod.rs
@@ -1,2 +1,68 @@
 mod chunk;
 mod mysql;
+
+use byteorder::{BigEndian, ByteOrder, LittleEndian};
+use test::black_box;
+use test::Bencher;
+
+use tikv::coprocessor::codec::table::*;
+
+#[bench]
+fn bench_table_prefix_start_with(b: &mut Bencher) {
+    let key: &[u8] = b"tabc";
+    b.iter(|| {
+        let n = black_box(1000);
+        (0..n).all(|_| black_box(key.starts_with(TABLE_PREFIX)))
+    });
+}
+
+#[bench]
+fn bench_table_prefix_check(b: &mut Bencher) {
+    let key: &[u8] = b"tabc";
+    b.iter(|| {
+        let n = black_box(1000);
+        (0..n).all(|_| black_box(key.len() > 1 && key[0] == TABLE_PREFIX[0]))
+    });
+}
+
+#[bench]
+fn bench_record_prefix_start_with(b: &mut Bencher) {
+    let key: &[u8] = b"_rabc";
+    b.iter(|| {
+        let n = black_box(1000);
+        (0..n).all(|_| black_box(key.starts_with(RECORD_PREFIX_SEP)))
+    });
+}
+
+#[bench]
+fn bench_record_prefix_equal_check(b: &mut Bencher) {
+    let key: &[u8] = b"_rabc";
+    b.iter(|| {
+        let n = black_box(1000);
+        (0..n).all(|_| {
+            black_box(
+                key.len() > 2 && key[0] == RECORD_PREFIX_SEP[0] && key[1] == RECORD_PREFIX_SEP[1],
+            )
+        })
+    });
+}
+
+#[bench]
+fn bench_record_prefix_bigendian_check(b: &mut Bencher) {
+    let key: &[u8] = b"_rabc";
+    let prefix: u16 = BigEndian::read_u16(RECORD_PREFIX_SEP);
+    b.iter(|| {
+        let n = black_box(1000);
+        (0..n).all(|_| black_box(key.len() > 2 && BigEndian::read_u16(key) == prefix))
+    });
+}
+
+#[bench]
+fn bench_record_prefix_littleendian_check(b: &mut Bencher) {
+    let key: &[u8] = b"_rabc";
+    let prefix: u16 = LittleEndian::read_u16(RECORD_PREFIX_SEP);
+    b.iter(|| {
+        let n = black_box(1000);
+        (0..n).all(|_| black_box(key.len() > 2 && LittleEndian::read_u16(key) == prefix))
+    });
+}

--- a/benches/coprocessor/dag/expr/mod.rs
+++ b/benches/coprocessor/dag/expr/mod.rs
@@ -1,0 +1,1 @@
+mod scalar;

--- a/benches/coprocessor/dag/expr/scalar.rs
+++ b/benches/coprocessor/dag/expr/scalar.rs
@@ -1,0 +1,74 @@
+use std::usize;
+use test::{black_box, Bencher};
+use tikv::util::collections::HashMap;
+use tipb::expression::ScalarFuncSig;
+
+fn get_scalar_args_with_match(sig: ScalarFuncSig) -> (usize, usize) {
+    // Only select some functions to benchmark
+    let (min_args, max_args) = match sig {
+        ScalarFuncSig::LTInt => (2, 2),
+        ScalarFuncSig::CastIntAsInt => (1, 1),
+        ScalarFuncSig::IfInt => (3, 3),
+        ScalarFuncSig::JsonArraySig => (0, usize::MAX),
+        ScalarFuncSig::CoalesceDecimal => (1, usize::MAX),
+        ScalarFuncSig::JsonExtractSig => (2, usize::MAX),
+        ScalarFuncSig::JsonSetSig => (3, usize::MAX),
+        _ => (0, 0),
+    };
+
+    (min_args, max_args)
+}
+
+fn init_scalar_args_map() -> HashMap<ScalarFuncSig, (usize, usize)> {
+    let mut m: HashMap<ScalarFuncSig, (usize, usize)> = HashMap::default();
+
+    let tbls = vec![
+        (ScalarFuncSig::LTInt, (2, 2)),
+        (ScalarFuncSig::CastIntAsInt, (1, 1)),
+        (ScalarFuncSig::IfInt, (3, 3)),
+        (ScalarFuncSig::JsonArraySig, (0, usize::MAX)),
+        (ScalarFuncSig::CoalesceDecimal, (1, usize::MAX)),
+        (ScalarFuncSig::JsonExtractSig, (2, usize::MAX)),
+        (ScalarFuncSig::JsonSetSig, (3, usize::MAX)),
+        (ScalarFuncSig::Acos, (0, 0)),
+    ];
+
+    for tbl in tbls {
+        m.insert(tbl.0, tbl.1);
+    }
+
+    m
+}
+
+fn get_scalar_args_with_map(
+    m: &HashMap<ScalarFuncSig, (usize, usize)>,
+    sig: ScalarFuncSig,
+) -> (usize, usize) {
+    if let Some((min_args, max_args)) = m.get(&sig).cloned() {
+        return (min_args, max_args);
+    }
+
+    (0, 0)
+}
+
+#[bench]
+fn bench_get_scalar_args_with_match(b: &mut Bencher) {
+    b.iter(|| {
+        for _ in 0..1000 {
+            black_box(get_scalar_args_with_match(black_box(ScalarFuncSig::AbsInt)));
+        }
+    })
+}
+
+#[bench]
+fn bench_get_scalar_args_with_map(b: &mut Bencher) {
+    let m = init_scalar_args_map();
+    b.iter(|| {
+        for _ in 0..1000 {
+            black_box(get_scalar_args_with_map(
+                black_box(&m),
+                black_box(ScalarFuncSig::AbsInt),
+            ));
+        }
+    })
+}

--- a/benches/coprocessor/dag/mod.rs
+++ b/benches/coprocessor/dag/mod.rs
@@ -1,0 +1,1 @@
+mod expr;

--- a/benches/coprocessor/mod.rs
+++ b/benches/coprocessor/mod.rs
@@ -1,1 +1,2 @@
 mod codec;
+mod dag;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Add some benchmark cases to ensure whether we need to introduce some optimizations from Go.

In Go, I found that using BigEndian to read u16 is faster than comparing table prefix. And sometimes, using a map is faster than switch-case. 

But in Rust, seem that we don't need these optimizations.

## What are the type of the changes? (mandatory)

No

## How has this PR been tested? (mandatory)

No need

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

test coprocessor::dag::expr::scalar::bench_get_scalar_args_with_map   ... bench:       7,700 ns/iter (+/- 1,349)
test coprocessor::dag::expr::scalar::bench_get_scalar_args_with_match ... bench:       2,811 ns/iter (+/- 220)
test coprocessor::codec::bench_table_prefix_check                     ... bench:         555 ns/iter (+/- 24)
test coprocessor::codec::bench_table_prefix_start_with                ... bench:         563 ns/iter (+/- 31)
test coprocessor::codec::bench_record_prefix_bigendian_check          ... bench:         595 ns/iter (+/- 54)
test coprocessor::codec::bench_record_prefix_equal_check              ... bench:         671 ns/iter (+/- 23)
test coprocessor::codec::bench_record_prefix_littleendian_check       ... bench:         529 ns/iter (+/- 20)
test coprocessor::codec::bench_record_prefix_start_with               ... bench:         514 ns/iter (+/- 12)

## Add a few positive/negative examples (optional)

/cc @AndreMouche @breeswish 