### PR TITLE
add detailed information in error logs

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -87,11 +87,11 @@ fn check_system_config(config: &TiKvConfig) {
 
     // check rocksdb data dir
     if let Err(e) = tikv_util::config::check_data_dir(&config.storage.data_dir) {
-        warn!("{:?}", e);
+        warn!("rockdsb check data dir: {:?}", e);
     }
     // check raft data dir
     if let Err(e) = tikv_util::config::check_data_dir(&config.raft_store.raftdb_path) {
-        warn!("{:?}", e);
+        warn!("raft check data dir: {:?}", e);
     }
 }
 

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -592,8 +592,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let timer = LocalReader::new_timer();
         box_try!(self.local_reader.start_with_timer(reader, timer));
 
-        if let Err(e) = util_sys::pri::set_priority(util_sys::HIGH_PRI) {
-            warn!("set priority for raftstore failed, error: {:?}", e);
+        if let Err(e) = util_sys::thread::set_priority(util_sys::HIGH_PRI) {
+            warn!("set thread priority for raftstore failed, error: {:?}", e);
         }
 
         event_loop.run(self)?;

--- a/src/util/sys/mod.rs
+++ b/src/util/sys/mod.rs
@@ -1,7 +1,7 @@
 pub const HIGH_PRI: i32 = -1;
 
 #[cfg(target_os = "linux")]
-pub mod pri {
+pub mod thread {
     use libc;
     use std::io::Error;
 
@@ -60,7 +60,7 @@ pub mod pri {
 }
 
 #[cfg(not(target_os = "linux"))]
-pub mod pri {
+pub mod thread {
     use std::io::Error;
 
     pub fn set_priority(_: i32) -> Result<(), Error> {


### PR DESCRIPTION
When going through the TiKV startup log I saw messages that were difficult to understand. These changes would help me understand the log messages (and code in one case) more quickly.


## What are the type of the changes? (mandatory)

This change affects log messages, but I don't think we have any contract for those.

## How has this PR been tested? (mandatory)

`make`. I have not actually looked at the log output after these changes.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no
