### PR TITLE
reduce decode in load_data

### DIFF
--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -107,7 +107,6 @@ impl<S: Snapshot> MvccReader<S> {
                 Some(v) => v,
             }
         };
-
         self.statistics.data.processed += 1;
         self.statistics.data.flow_stats.read_bytes += k.encoded().len() + res.len();
         self.statistics.data.flow_stats.read_keys += 1;

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -109,7 +109,7 @@ impl<S: Snapshot> MvccReader<S> {
         };
 
         self.statistics.data.processed += 1;
-        self.statistics.data.flow_stats.read_bytes += k.raw().unwrap_or_default().len() + res.len();
+        self.statistics.data.flow_stats.read_bytes += k.encoded().len() + res.len();
         self.statistics.data.flow_stats.read_keys += 1;
         Ok(res)
     }

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -107,6 +107,7 @@ impl<S: Snapshot> MvccReader<S> {
                 Some(v) => v,
             }
         };
+
         self.statistics.data.processed += 1;
         self.statistics.data.flow_stats.read_bytes += k.encoded().len() + res.len();
         self.statistics.data.flow_stats.read_keys += 1;


### PR DESCRIPTION

## What have you changed? (mandatory)

When counting the read bytes, we don't need to decode the key, this will reduce memory allocation and memory copying.

## What are the type of the changes? (mandatory)

- Improvement

## How has this PR been tested? (mandatory)
CI

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
