### PR TITLE
util: add from_encoded_slice

### DIFF
--- a/src/import/client.rs
+++ b/src/import/client.rs
@@ -181,7 +181,7 @@ impl ImportClient for Client {
 
         let mut req = SplitRegionRequest::new();
         req.set_context(ctx);
-        req.set_split_key(Key::from_encoded(split_key.to_owned()).raw()?);
+        req.set_split_key(Key::from_encoded_slice(split_key).raw()?);
 
         let ch = self.resolve(store_id)?;
         let client = TikvClient::new(ch);

--- a/src/raftstore/coprocessor/split_check/table.rs
+++ b/src/raftstore/coprocessor/split_check/table.rs
@@ -181,7 +181,7 @@ fn last_key_of_region(db: &DB, region: &Region) -> Result<Option<Vec<u8>>> {
 }
 
 fn to_encoded_table_prefix(encoded_key: &[u8]) -> Option<Vec<u8>> {
-    if let Ok(raw_key) = Key::from_encoded(encoded_key.to_vec()).raw() {
+    if let Ok(raw_key) = Key::from_encoded_slice(encoded_key).raw() {
         table_codec::extract_table_prefix(&raw_key)
             .map(|k| Key::from_raw(k).take_encoded())
             .ok()

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -532,11 +532,11 @@ mod tests {
         let mut iter = Cursor::new(snap.iter(IterOption::default()), ScanMode::Mixed);
         assert!(
             !iter
-                .reverse_seek(&Key::from_encoded(b"a2".to_vec()), &mut statistics)
+                .reverse_seek(&Key::from_encoded_slice(b"a2"), &mut statistics)
                 .unwrap()
         );
         assert!(
-            iter.reverse_seek(&Key::from_encoded(b"a7".to_vec()), &mut statistics)
+            iter.reverse_seek(&Key::from_encoded_slice(b"a7"), &mut statistics)
                 .unwrap()
         );
         let mut pair = (
@@ -545,7 +545,7 @@ mod tests {
         );
         assert_eq!(pair, (b"a5".to_vec(), b"v5".to_vec()));
         assert!(
-            iter.reverse_seek(&Key::from_encoded(b"a5".to_vec()), &mut statistics)
+            iter.reverse_seek(&Key::from_encoded_slice(b"a5"), &mut statistics)
                 .unwrap()
         );
         pair = (
@@ -555,15 +555,15 @@ mod tests {
         assert_eq!(pair, (b"a3".to_vec(), b"v3".to_vec()));
         assert!(
             !iter
-                .reverse_seek(&Key::from_encoded(b"a3".to_vec()), &mut statistics)
+                .reverse_seek(&Key::from_encoded_slice(b"a3"), &mut statistics)
                 .unwrap()
         );
         assert!(
-            iter.reverse_seek(&Key::from_encoded(b"a1".to_vec()), &mut statistics)
+            iter.reverse_seek(&Key::from_encoded_slice(b"a1"), &mut statistics)
                 .is_err()
         );
         assert!(
-            iter.reverse_seek(&Key::from_encoded(b"a8".to_vec()), &mut statistics)
+            iter.reverse_seek(&Key::from_encoded_slice(b"a8"), &mut statistics)
                 .is_err()
         );
 
@@ -590,11 +590,11 @@ mod tests {
         let mut iter = Cursor::new(snap.iter(IterOption::default()), ScanMode::Mixed);
         assert!(
             !iter
-                .reverse_seek(&Key::from_encoded(b"a1".to_vec()), &mut statistics)
+                .reverse_seek(&Key::from_encoded_slice(b"a1"), &mut statistics)
                 .unwrap()
         );
         assert!(
-            iter.reverse_seek(&Key::from_encoded(b"a2".to_vec()), &mut statistics)
+            iter.reverse_seek(&Key::from_encoded_slice(b"a2"), &mut statistics)
                 .unwrap()
         );
         let pair = (

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -144,7 +144,7 @@ pub fn delete_all_in_range_cf(
     // traditional way to cleanup.
     if use_delete_range && cf != CF_RAFT && cf != CF_LOCK {
         if cf == CF_WRITE {
-            let start = Key::from_encoded(start_key.to_vec()).append_ts(u64::MAX);
+            let start = Key::from_encoded_slice(start_key).append_ts(u64::MAX);
             wb.delete_range_cf(handle, start.encoded(), end_key)?;
         } else {
             wb.delete_range_cf(handle, start_key, end_key)?;
@@ -1270,7 +1270,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let middle_key = Key::from_encoded(keys::origin_key(&middle_key).to_owned())
+        let middle_key = Key::from_encoded_slice(keys::origin_key(&middle_key))
             .raw()
             .unwrap();
         assert_eq!(escape(&middle_key), "key_049");

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -917,7 +917,7 @@ impl MvccChecker {
         let handle = box_try!(get_cf_handle(self.db.as_ref(), cf));
         match ts {
             Some(ts) => {
-                let key = Key::from_encoded(key.to_vec()).append_ts(ts);
+                let key = Key::from_encoded_slice(key).append_ts(ts);
                 box_try!(wb.delete_cf(handle, &keys::data_key(key.encoded())));
             }
             None => box_try!(wb.delete_cf(handle, &keys::data_key(key))),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1245,7 +1245,7 @@ impl<E: Engine> Storage<E> {
                             if i + 1 == ranges_len {
                                 None
                             } else {
-                                Some(Key::from_encoded(ranges[i + 1].get_start_key().to_vec()))
+                                Some(Key::from_encoded_slice(ranges[i + 1].get_start_key()))
                             }
                         } else {
                             Some(Key::from_encoded(end_key))

--- a/src/storage/mvcc/reader.rs
+++ b/src/storage/mvcc/reader.rs
@@ -369,12 +369,12 @@ impl<S: Snapshot> MvccReader<S> {
                 }
                 match (w_key, l_key) {
                     (None, None) => return Ok(None),
-                    (None, Some(k)) => Key::from_encoded(k.to_vec()),
+                    (None, Some(k)) => Key::from_encoded_slice(k),
                     (Some(k), None) => Key::from_encoded(k.to_vec()).truncate_ts()?,
                     (Some(wk), Some(lk)) => if wk < lk {
                         Key::from_encoded(wk.to_vec()).truncate_ts()?
                     } else {
-                        Key::from_encoded(lk.to_vec())
+                        Key::from_encoded_slice(lk)
                     },
                 }
             };
@@ -414,10 +414,10 @@ impl<S: Snapshot> MvccReader<S> {
                 }
                 match (w_key, l_key) {
                     (None, None) => return Ok(None),
-                    (None, Some(k)) => Key::from_encoded(k.to_vec()),
+                    (None, Some(k)) => Key::from_encoded_slice(k),
                     (Some(k), None) => Key::from_encoded(k.to_vec()).truncate_ts()?,
                     (Some(wk), Some(lk)) => if wk < lk {
-                        Key::from_encoded(lk.to_vec())
+                        Key::from_encoded_slice(lk)
                     } else {
                         Key::from_encoded(wk.to_vec()).truncate_ts()?
                     },
@@ -601,7 +601,7 @@ impl<S: Snapshot> MvccReader<S> {
         }
         let mut locks = Vec::with_capacity(limit);
         while cursor.valid() {
-            let key = Key::from_encoded(cursor.key(&mut self.statistics.lock).to_vec());
+            let key = Key::from_encoded_slice(cursor.key(&mut self.statistics.lock));
             let lock = Lock::parse(cursor.value(&mut self.statistics.lock))?;
             if filter(&lock) {
                 locks.push((key, lock));
@@ -654,7 +654,7 @@ impl<S: Snapshot> MvccReader<S> {
         }
         let mut v = vec![];
         while ok {
-            let cur_key = Key::from_encoded(cursor.key(&mut self.statistics.data).to_vec());
+            let cur_key = Key::from_encoded_slice(cursor.key(&mut self.statistics.data));
             let ts = cur_key.decode_ts()?;
             let cur_key_without_ts = cur_key.truncate_ts()?;
             if cur_key_without_ts.encoded().as_slice() == key.encoded().as_slice() {

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -77,7 +77,7 @@ impl Key {
         Key(encoded_key)
     }
 
-    /// Creates a key with reserver capacity for timestamp from encoded bytes slice.
+    /// Creates a key with reserved capacity for timestamp from encoded bytes slice.
     #[inline]
     pub fn from_encoded_slice(encoded_key: &[u8]) -> Key {
         let mut k = Vec::with_capacity(encoded_key.len() + number::U64_SIZE);

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -71,10 +71,18 @@ impl Key {
         bytes::decode_bytes(&mut self.0.as_slice(), false)
     }
 
-    /// Creates a key from encoded bytes.
+    /// Creates a key from encoded bytes vector.
     #[inline]
     pub fn from_encoded(encoded_key: Vec<u8>) -> Key {
         Key(encoded_key)
+    }
+
+    /// Creates a key with reserver capacity for timestamp from encoded bytes slice.
+    #[inline]
+    pub fn from_encoded_slice(encoded_key: &[u8]) -> Key {
+        let mut k = Vec::with_capacity(encoded_key.len() + number::U64_SIZE);
+        k.extend_from_slice(encoded_key);
+        Key(k)
     }
 
     /// Gets the encoded representation of this key.
@@ -210,7 +218,7 @@ mod tests {
         let k = b"k";
         let ts = 123;
         assert!(Key::split_on_ts_for(k).is_err());
-        let enc = Key::from_encoded(k.to_vec()).append_ts(ts);
+        let enc = Key::from_encoded_slice(k).append_ts(ts);
         let res = Key::split_on_ts_for(enc.encoded()).unwrap();
         assert_eq!(res, (k.as_ref(), ts));
     }


### PR DESCRIPTION
Signed-off-by: Connor1996 <zbk602423539@gmail.com>

## What have you changed? (mandatory)
- add `from_encoded_slice()` that reserve capacity for timestamp
- call `from_encoded_slice()` instead of `from_encoded(xxx.to_vec()/to_own())` in some code place, but not all cause `xxx` maybe timestamped key slice and there is no need to reserve more capacity.

## What are the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
No need

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No need

## Does this PR affect tidb-ansible update? (mandatory)
No need
