### PR TITLE
coprocessor/dag/expr: add some un-pushed builtin UDF(ASCII)

### DIFF
--- a/src/coprocessor/dag/expr/builtin_string.rs
+++ b/src/coprocessor/dag/expr/builtin_string.rs
@@ -28,6 +28,15 @@ impl ScalarFunc {
         Ok(Some(input.len() as i64 * 8))
     }
 
+    pub fn ascii(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
+        let input = try_opt!(self.children[0].eval_string(ctx, row));
+        if input.len() == 0 {
+            Ok(Some(0))
+        } else {
+            Ok(Some(i64::from(input[0])))
+        }
+    }
+
     #[inline]
     pub fn bin<'a, 'b: 'a>(
         &'b self,
@@ -147,6 +156,41 @@ mod test {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::Bin, &[input]);
+            let op = Expression::build(&mut ctx, op).unwrap();
+            let got = op.eval(&mut ctx, &[]).unwrap();
+            assert_eq!(got, exp);
+        }
+    }
+
+    #[test]
+    fn test_ascii() {
+        let cases = vec![
+            (Datum::Bytes(b"1010".to_vec()), Datum::I64(49)),
+            (Datum::Bytes(b"-1".to_vec()), Datum::I64(45)),
+            (Datum::Bytes(b"".to_vec()), Datum::I64(0)),
+            (Datum::Bytes(b"999".to_vec()), Datum::I64(57)),
+            (Datum::Bytes(b"hello".to_vec()), Datum::I64(104)),
+            (Datum::Bytes("Grüße".as_bytes().to_vec()), Datum::I64(71)),
+            (Datum::Bytes("München".as_bytes().to_vec()), Datum::I64(77)),
+            (Datum::Null, Datum::Null),
+            (
+                Datum::Bytes("数据库".as_bytes().to_vec()),
+                Datum::I64(230),
+            ),
+            (
+                Datum::Bytes("忠犬ハチ公".as_bytes().to_vec()),
+                Datum::I64(229),
+            ),
+            (
+                Datum::Bytes("Αθήνα".as_bytes().to_vec()),
+                Datum::I64(206),
+            ),
+        ];
+
+        let mut ctx = EvalContext::default();
+        for (input, exp) in cases {
+            let input = datum_expr(input);
+            let op = scalar_func_expr(ScalarFuncSig::ASCII, &[input]);
             let op = Expression::build(&mut ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);

--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -190,6 +190,7 @@ impl ScalarFunc {
             | ScalarFuncSig::CRC32
             | ScalarFuncSig::JsonTypeSig
             | ScalarFuncSig::JsonUnquoteSig
+            | ScalarFuncSig::ASCII
             | ScalarFuncSig::Length
             | ScalarFuncSig::Bin
             | ScalarFuncSig::BitLength
@@ -262,7 +263,6 @@ impl ScalarFunc {
             | ScalarFuncSig::AddTimeStringNull
             | ScalarFuncSig::AesDecrypt
             | ScalarFuncSig::AesEncrypt
-            | ScalarFuncSig::ASCII
             | ScalarFuncSig::Asin
             | ScalarFuncSig::Atan1Arg
             | ScalarFuncSig::Atan2Args
@@ -775,6 +775,7 @@ dispatch_call! {
 
         Length => length,
         BitLength => bit_length,
+        ASCII => ascii,
     }
     REAL_CALLS {
         CastIntAsReal => cast_int_as_real,
@@ -1087,6 +1088,7 @@ mod test {
                     ScalarFuncSig::CRC32,
                     ScalarFuncSig::JsonTypeSig,
                     ScalarFuncSig::JsonUnquoteSig,
+                    ScalarFuncSig::ASCII,
                     ScalarFuncSig::Bin,
                     ScalarFuncSig::BitNegSig,
                     ScalarFuncSig::BitLength,
@@ -1203,7 +1205,6 @@ mod test {
             ScalarFuncSig::AddTimeStringNull,
             ScalarFuncSig::AesDecrypt,
             ScalarFuncSig::AesEncrypt,
-            ScalarFuncSig::ASCII,
             ScalarFuncSig::Asin,
             ScalarFuncSig::Atan1Arg,
             ScalarFuncSig::Atan2Args,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

implement builtin function: `ASCII`  in `coprocessor`.
This is for #3275

## What are the type of the changes? (mandatory)

Improvement

## How has this PR been tested? (mandatory)

unittest

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

## Does this PR affect tidb-ansible update? (mandatory)

## Refer to a related PR or issue link (optional)

#3275 

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

