### PR TITLE
Use get/set to access peer_storage internal state.

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -831,7 +831,7 @@ impl Peer {
 
         // There may be some values that are not applied by this leader yet but the old leader,
         // if applied_index_term isn't equal to current term.
-        self.get_store().applied_index_term == self.term()
+        self.get_store().applied_index_term() == self.term()
             // There may be stale read if the old leader splits really slow,
             // the new region may already elected a new leader while
             // the old leader still think it owns the splitted range.
@@ -1122,9 +1122,11 @@ impl Peer {
             self.raft_group
                 .advance_apply(apply_state.get_applied_index());
         }
-        self.mut_store().apply_state = apply_state;
-        let progress_to_be_updated = self.mut_store().applied_index_term != applied_index_term;
-        self.mut_store().applied_index_term = applied_index_term;
+
+        let progress_to_be_updated = self.mut_store().applied_index_term() != applied_index_term;
+        self.mut_store().set_applied_state(apply_state);
+        self.mut_store().set_applied_term(applied_index_term);
+
         self.peer_stat.written_keys += apply_metrics.written_keys;
         self.peer_stat.written_bytes += apply_metrics.written_bytes;
         self.delete_keys_hint += apply_metrics.delete_keys_hint;
@@ -1983,7 +1985,7 @@ pub trait RequestInspector {
 
 impl RequestInspector for Peer {
     fn has_applied_to_current_term(&mut self) -> bool {
-        self.get_store().applied_index_term == self.term()
+        self.get_store().applied_index_term() == self.term()
     }
 
     fn inspect_lease(&mut self) -> LeaseState {

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -256,10 +256,10 @@ pub struct PeerStorage {
     pub engines: Engines,
 
     region: metapb::Region,
-    pub raft_state: RaftLocalState,
-    pub apply_state: RaftApplyState,
-    pub applied_index_term: u64,
-    pub last_term: u64,
+    raft_state: RaftLocalState,
+    apply_state: RaftApplyState,
+    applied_index_term: u64,
+    last_term: u64,
 
     snap_state: RefCell<SnapState>,
     region_sched: Scheduler<RegionTask>,
@@ -608,6 +608,26 @@ impl PeerStorage {
     #[inline]
     pub fn applied_index(&self) -> u64 {
         self.apply_state.get_applied_index()
+    }
+
+    #[inline]
+    pub fn set_applied_state(&mut self, apply_state: RaftApplyState) {
+        self.apply_state = apply_state;
+    }
+
+    #[inline]
+    pub fn set_applied_term(&mut self, applied_index_term: u64) {
+        self.applied_index_term = applied_index_term;
+    }
+
+    #[inline]
+    pub fn apply_state(&self) -> &RaftApplyState {
+        &self.apply_state
+    }
+
+    #[inline]
+    pub fn applied_index_term(&self) -> u64 {
+        self.applied_index_term
     }
 
     #[inline]
@@ -1771,6 +1791,7 @@ mod test {
         ctx.save_apply_state_to(&s.engines.kv, &mut kv_wb).unwrap();
         s.engines.kv.write(kv_wb).unwrap();
         s.apply_state = ctx.apply_state;
+
         let (tx, rx) = channel();
         tx.send(snap.clone()).unwrap();
         s.set_snap_state(SnapState::Generating(rx));

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -1916,8 +1916,8 @@ impl Registration {
         Registration {
             id: peer.peer_id(),
             term: peer.term(),
-            apply_state: peer.get_store().apply_state.clone(),
-            applied_index_term: peer.get_store().applied_index_term,
+            apply_state: peer.get_store().apply_state().clone(),
+            applied_index_term: peer.get_store().applied_index_term(),
             region: peer.region().clone(),
         }
     }

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -60,7 +60,7 @@ impl ReadDelegate {
             region,
             peer_id,
             term: peer.term(),
-            applied_index_term: peer.get_store().applied_index_term,
+            applied_index_term: peer.get_store().applied_index_term(),
             leader_lease: None,
             tag: format!("[region {}] {}", region_id, peer_id),
         }


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

## What have you changed? (mandatory)
Remove `pub` for some fields in `PeerStorage`. Users should use set/get to access them.
It's good for adding some follow-up action after we update these fields.

## What are the type of the changes? (mandatory)
Improvement.

## How has this PR been tested? (mandatory)
make dev.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No.

## Does this PR affect tidb-ansible update? (mandatory)
No.