### PR TITLE
reader/backward_scanner: Remove near_seek_for_prev from backward_scanner

### DIFF
--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -427,7 +427,7 @@ impl<I: Iterator> Cursor<I> {
         Ok(true)
     }
 
-    fn seek_for_prev(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<bool> {
+    pub fn seek_for_prev(&mut self, key: &Key, statistics: &mut CFStatistics) -> Result<bool> {
         self.valid = true;
 
         assert_ne!(self.scan_mode, ScanMode::Forward);

--- a/src/storage/mvcc/reader/backward_scanner.rs
+++ b/src/storage/mvcc/reader/backward_scanner.rs
@@ -419,6 +419,7 @@ impl<S: Snapshot> BackwardScanner<S> {
                 let current_key = self.write_cursor.key(&mut self.statistics.write);
                 if !Key::is_user_key_eq(current_key, current_user_key.encoded().as_slice()) {
                     // Found another user key. We are done here.
+                    return Ok(());
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

## What have you changed? (mandatory)

This PR is merging to #3344 .
In this PR, `near_seek_for_prev` call is removed from `BackwardScanner`. The logic of `near_seek_for_prev` was put in `BackwardScanner` itself.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

By already-existed unit tests

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
