### PR TITLE
Expose test utils for engine and mvcc

### DIFF
--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -228,6 +228,15 @@ pub mod tests {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, None, IsolationLevel::SI, true);
+        txn.collapse_rollback(false);
+        txn.rollback(&Key::from_raw(key)).unwrap();
+        write(engine, &ctx, txn.into_modifies());
+    }
+
+    pub fn must_rollback_collapsed<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts, None, IsolationLevel::SI, true);
         txn.rollback(&Key::from_raw(key)).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -122,3 +122,286 @@ impl Error {
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;
+
+#[cfg(test)]
+pub mod tests {
+    use kvproto::kvrpcpb::{Context, IsolationLevel};
+
+    use storage::CF_WRITE;
+    use storage::{Engine, Key, Modify, Mutation, Options, ScanMode, Snapshot};
+
+    use super::*;
+
+    fn write<E: Engine>(engine: &E, ctx: &Context, modifies: Vec<Modify>) {
+        if !modifies.is_empty() {
+            engine.write(ctx, modifies).unwrap();
+        }
+    }
+
+    pub fn must_get<E: Engine>(engine: &E, key: &[u8], ts: u64, expect: &[u8]) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts, None, IsolationLevel::SI, true);
+        assert_eq!(txn.get(&Key::from_raw(key)).unwrap().unwrap(), expect);
+    }
+
+    pub fn must_get_rc<E: Engine>(engine: &E, key: &[u8], ts: u64, expect: &[u8]) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts, None, IsolationLevel::RC, true);
+        assert_eq!(txn.get(&Key::from_raw(key)).unwrap().unwrap(), expect)
+    }
+
+    pub fn must_get_none<E: Engine>(engine: &E, key: &[u8], ts: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts, None, IsolationLevel::SI, true);
+        assert!(txn.get(&Key::from_raw(key)).unwrap().is_none());
+    }
+
+    pub fn must_get_err<E: Engine>(engine: &E, key: &[u8], ts: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts, None, IsolationLevel::SI, true);
+        assert!(txn.get(&Key::from_raw(key)).is_err());
+    }
+
+    pub fn must_prewrite_put<E: Engine>(engine: &E, key: &[u8], value: &[u8], pk: &[u8], ts: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts, None, IsolationLevel::SI, true);
+        txn.prewrite(
+            Mutation::Put((Key::from_raw(key), value.to_vec())),
+            pk,
+            &Options::default(),
+        ).unwrap();
+        write(engine, &ctx, txn.into_modifies());
+    }
+
+    pub fn must_prewrite_delete<E: Engine>(engine: &E, key: &[u8], pk: &[u8], ts: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts, None, IsolationLevel::SI, true);
+        txn.prewrite(
+            Mutation::Delete(Key::from_raw(key)),
+            pk,
+            &Options::default(),
+        ).unwrap();
+        engine.write(&ctx, txn.into_modifies()).unwrap();
+    }
+
+    pub fn must_prewrite_lock<E: Engine>(engine: &E, key: &[u8], pk: &[u8], ts: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts, None, IsolationLevel::SI, true);
+        txn.prewrite(Mutation::Lock(Key::from_raw(key)), pk, &Options::default())
+            .unwrap();
+        engine.write(&ctx, txn.into_modifies()).unwrap();
+    }
+
+    pub fn must_prewrite_lock_err<E: Engine>(engine: &E, key: &[u8], pk: &[u8], ts: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts, None, IsolationLevel::SI, true);
+        assert!(
+            txn.prewrite(Mutation::Lock(Key::from_raw(key)), pk, &Options::default())
+                .is_err()
+        );
+    }
+
+    pub fn must_commit<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts, None, IsolationLevel::SI, true);
+        txn.commit(&Key::from_raw(key), commit_ts).unwrap();
+        write(engine, &ctx, txn.into_modifies());
+    }
+
+    pub fn must_commit_err<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts, None, IsolationLevel::SI, true);
+        assert!(txn.commit(&Key::from_raw(key), commit_ts).is_err());
+    }
+
+    pub fn must_rollback<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts, None, IsolationLevel::SI, true);
+        txn.rollback(&Key::from_raw(key)).unwrap();
+        write(engine, &ctx, txn.into_modifies());
+    }
+
+    pub fn must_rollback_err<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts, None, IsolationLevel::SI, true);
+        assert!(txn.rollback(&Key::from_raw(key)).is_err());
+    }
+
+    pub fn must_gc<E: Engine>(engine: &E, key: &[u8], safe_point: u64) {
+        let ctx = Context::new();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, 0, None, IsolationLevel::SI, true);
+        txn.gc(&Key::from_raw(key), safe_point).unwrap();
+        write(engine, &ctx, txn.into_modifies());
+    }
+
+    pub fn must_locked<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
+        assert_eq!(lock.ts, start_ts);
+    }
+
+    pub fn must_unlocked<E: Engine>(engine: &E, key: &[u8]) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        assert!(reader.load_lock(&Key::from_raw(key)).unwrap().is_none());
+    }
+
+    pub fn must_written<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: u64,
+        commit_ts: u64,
+        tp: WriteType,
+    ) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let k = Key::from_raw(key).append_ts(commit_ts);
+        let v = snapshot.get_cf(CF_WRITE, &k).unwrap().unwrap();
+        let write = Write::parse(&v).unwrap();
+        assert_eq!(write.start_ts, start_ts);
+        assert_eq!(write.write_type, tp);
+    }
+
+    pub fn must_seek_write_none<E: Engine>(engine: &E, key: &[u8], ts: u64) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        assert!(
+            reader
+                .seek_write(&Key::from_raw(key), ts)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    pub fn must_seek_write<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        ts: u64,
+        start_ts: u64,
+        commit_ts: u64,
+        write_type: WriteType,
+    ) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let (t, write) = reader.seek_write(&Key::from_raw(key), ts).unwrap().unwrap();
+        assert_eq!(t, commit_ts);
+        assert_eq!(write.start_ts, start_ts);
+        assert_eq!(write.write_type, write_type);
+    }
+
+    pub fn must_reverse_seek_write_none<E: Engine>(engine: &E, key: &[u8], ts: u64) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        assert!(
+            reader
+                .reverse_seek_write(&Key::from_raw(key), ts)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    pub fn must_reverse_seek_write<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        ts: u64,
+        start_ts: u64,
+        commit_ts: u64,
+        write_type: WriteType,
+    ) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let (t, write) = reader
+            .reverse_seek_write(&Key::from_raw(key), ts)
+            .unwrap()
+            .unwrap();
+        assert_eq!(t, commit_ts);
+        assert_eq!(write.start_ts, start_ts);
+        assert_eq!(write.write_type, write_type);
+    }
+
+    pub fn must_get_commit_ts<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let (ts, write_type) = reader
+            .get_txn_commit_info(&Key::from_raw(key), start_ts)
+            .unwrap()
+            .unwrap();
+        assert_ne!(write_type, WriteType::Rollback);
+        assert_eq!(ts, commit_ts);
+    }
+
+    pub fn must_get_commit_ts_none<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+
+        let ret = reader.get_txn_commit_info(&Key::from_raw(key), start_ts);
+        assert!(ret.is_ok());
+        match ret.unwrap() {
+            None => {}
+            Some((_, write_type)) => {
+                assert_eq!(write_type, WriteType::Rollback);
+            }
+        }
+    }
+
+    pub fn must_get_rollback_ts<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+
+        let (ts, write_type) = reader
+            .get_txn_commit_info(&Key::from_raw(key), start_ts)
+            .unwrap()
+            .unwrap();
+        assert_eq!(ts, start_ts);
+        assert_eq!(write_type, WriteType::Rollback);
+    }
+
+    pub fn must_get_rollback_ts_none<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+
+        let ret = reader
+            .get_txn_commit_info(&Key::from_raw(key), start_ts)
+            .unwrap();
+        assert_eq!(ret, None);
+    }
+
+    pub fn must_scan_keys<E: Engine>(
+        engine: &E,
+        start: Option<&[u8]>,
+        limit: usize,
+        keys: Vec<&[u8]>,
+        next_start: Option<&[u8]>,
+    ) {
+        let expect = (
+            keys.into_iter().map(Key::from_raw).collect(),
+            next_start.map(|x| Key::from_raw(x).append_ts(0)),
+        );
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let mut reader = MvccReader::new(
+            snapshot,
+            Some(ScanMode::Mixed),
+            false,
+            None,
+            None,
+            IsolationLevel::SI,
+        );
+        assert_eq!(
+            reader.scan_keys(start.map(Key::from_raw), limit).unwrap(),
+            expect
+        );
+    }
+}

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -810,20 +810,20 @@ mod tests {
 
         // Add a Rollback whose start ts is 1.
         must_prewrite_put(&engine, key, value, key, 1);
-        must_rollback(&engine, key, 1);
+        must_rollback_collapsed(&engine, key, 1);
         must_get_rollback_ts(&engine, key, 1);
 
         // Add a Rollback whose start ts is 2, the previous Rollback whose
         // start ts is 1 will be collapsed.
         must_prewrite_put(&engine, key, value, key, 2);
-        must_rollback(&engine, key, 2);
+        must_rollback_collapsed(&engine, key, 2);
         must_get_none(&engine, key, 2);
         must_get_rollback_ts(&engine, key, 2);
         must_get_rollback_ts_none(&engine, key, 1);
 
         // Rollback arrive before Prewrite, it will collapse the
         // previous rollback whose start ts is 2.
-        must_rollback(&engine, key, 3);
+        must_rollback_collapsed(&engine, key, 3);
         must_get_none(&engine, key, 3);
         must_get_rollback_ts(&engine, key, 3);
         must_get_rollback_ts_none(&engine, key, 2);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR moves and exposes some test utility functions of storage/engine and storage/mvcc, so that other parts can utilize them as well.

This change is extracted from [Mvcc Refinement PR](https://github.com/tikv/tikv/pull/3344).

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

CI.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

