### PR TITLE
[Mvcc refinement]  optimize mvcc scanners

### DIFF
--- a/src/storage/mvcc/reader/backward_scanner.rs
+++ b/src/storage/mvcc/reader/backward_scanner.rs
@@ -312,14 +312,12 @@ impl<S: Snapshot> BackwardScanner<S> {
         if last_checked_commit_ts == ts {
             return Ok(self.handle_last_version(last_version, user_key)?);
         }
+        assert!(ts > last_checked_commit_ts);
 
         // After several `prev()`, we still not get the latest version for the specified ts,
         // use seek to locate the latest version.
-        assert!(ts > last_checked_commit_ts);
-
         // `user_key` must have reserved space here, so it's clone has reserved space too. So no
         // reallocation happends in `append_ts`.
-        // TODO: Try to avoid `clone` here.
         let seek_key = user_key.clone().append_ts(ts);
 
         // TODO: Replace by cast + seek().

--- a/src/storage/mvcc/reader/backward_scanner.rs
+++ b/src/storage/mvcc/reader/backward_scanner.rs
@@ -212,7 +212,7 @@ impl<S: Snapshot> BackwardScanner<S> {
                 };
 
                 // Use `from_encoded_slice` to reserve space for ts, so later we can append ts to
-                // the key or it's clones without reallocation.
+                // the key or its clones without reallocation.
                 (Key::from_encoded_slice(res.0), res.1, res.2)
             };
 
@@ -316,7 +316,7 @@ impl<S: Snapshot> BackwardScanner<S> {
 
         // After several `prev()`, we still not get the latest version for the specified ts,
         // use seek to locate the latest version.
-        // `user_key` must have reserved space here, so it's clone has reserved space too. So no
+        // `user_key` must have reserved space here, so its clone has reserved space too. So no
         // reallocation happends in `append_ts`.
         let seek_key = user_key.clone().append_ts(ts);
 

--- a/src/storage/mvcc/reader/forward_scanner.rs
+++ b/src/storage/mvcc/reader/forward_scanner.rs
@@ -418,8 +418,8 @@ impl<S: Snapshot> ForwardScanner<S> {
 
         // We have not found another user key for now, so we directly `seek()`.
         // After that, we must pointing to another key, or out of bound.
-        // `user_key` must have reserved space here, so it's clone has reserved space too. So no
-        // reallocation happends in `append_ts`.
+        // `current_user_key` must have reserved space here, so it's clone has reserved space too.
+        // So no reallocation happends in `append_ts`.
         // TODO: Try to avoid `clone` here.
         self.write_cursor.seek(
             &current_user_key.clone().append_ts(0),

--- a/src/storage/mvcc/reader/forward_scanner.rs
+++ b/src/storage/mvcc/reader/forward_scanner.rs
@@ -316,7 +316,6 @@ impl<S: Snapshot> ForwardScanner<S> {
         if needs_seek {
             // `user_key` must have reserved space here, so it's clone has reserved space too. So no
             // reallocation happends in `append_ts`.
-            // TODO: Try to avoid `clone` here.
             self.write_cursor
                 .seek(&user_key.clone().append_ts(ts), &mut self.statistics.write)?;
             if !self.write_cursor.valid() {
@@ -420,7 +419,6 @@ impl<S: Snapshot> ForwardScanner<S> {
         // After that, we must pointing to another key, or out of bound.
         // `current_user_key` must have reserved space here, so it's clone has reserved space too.
         // So no reallocation happends in `append_ts`.
-        // TODO: Try to avoid `clone` here.
         self.write_cursor.seek(
             &current_user_key.clone().append_ts(0),
             &mut self.statistics.write,

--- a/src/storage/mvcc/reader/forward_scanner.rs
+++ b/src/storage/mvcc/reader/forward_scanner.rs
@@ -231,7 +231,7 @@ impl<S: Snapshot> ForwardScanner<S> {
                 };
 
                 // Use `from_encoded_slice` to reserve space for ts, so later we can append ts to
-                // the key or it's clones without reallocation.
+                // the key or its clones without reallocation.
                 (Key::from_encoded_slice(res.0), res.1, res.2)
             };
 
@@ -314,7 +314,7 @@ impl<S: Snapshot> ForwardScanner<S> {
         }
         // If we have not found `${user_key}_${ts}` in a few `next()`, directly `seek()`.
         if needs_seek {
-            // `user_key` must have reserved space here, so it's clone has reserved space too. So no
+            // `user_key` must have reserved space here, so its clone has reserved space too. So no
             // reallocation happends in `append_ts`.
             self.write_cursor
                 .seek(&user_key.clone().append_ts(ts), &mut self.statistics.write)?;
@@ -417,7 +417,7 @@ impl<S: Snapshot> ForwardScanner<S> {
 
         // We have not found another user key for now, so we directly `seek()`.
         // After that, we must pointing to another key, or out of bound.
-        // `current_user_key` must have reserved space here, so it's clone has reserved space too.
+        // `current_user_key` must have reserved space here, so its clone has reserved space too.
         // So no reallocation happends in `append_ts`.
         self.write_cursor.seek(
             &current_user_key.clone().append_ts(0),


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

## What have you changed? (mandatory)

This PR is merging to #3344

There are some places where can be slightly optimized in MVCC scanners.
In this PR:
* In BackwardScanner: removed `last_handled_key` from `reverse_get`, use timestamp compares instead, which is faster than comparing keys.
* Avoid reallocation at `append_ts` in both ForwardScanner and BackwardScanner.
* (Maybe more changes later)

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

By `make dev`

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

#3344

