### PR TITLE
coprocessor/dag/expr: add some un-pushed builtin UDF(CharLength)

### DIFF
--- a/src/coprocessor/dag/expr/builtin_string.rs
+++ b/src/coprocessor/dag/expr/builtin_string.rs
@@ -19,16 +19,19 @@ use coprocessor::codec::Datum;
 use std::borrow::Cow;
 
 impl ScalarFunc {
+    #[inline]
     pub fn length(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         let input = try_opt!(self.children[0].eval_string(ctx, row));
         Ok(Some(input.len() as i64))
     }
 
+    #[inline]
     pub fn bit_length(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         let input = try_opt!(self.children[0].eval_string(ctx, row));
         Ok(Some(input.len() as i64 * 8))
     }
 
+    #[inline]
     pub fn ascii(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         let input = try_opt!(self.children[0].eval_string(ctx, row));
         if input.len() == 0 {
@@ -36,6 +39,16 @@ impl ScalarFunc {
         } else {
             Ok(Some(i64::from(input[0])))
         }
+    }
+
+    #[inline]
+    pub fn char_length(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
+        if types::is_binary_str(self.children[0].get_tp()) {
+            let input = try_opt!(self.children[0].eval_string(ctx, row));
+            return Ok(Some(input.len() as i64));
+        }
+        let input = try_opt!(self.children[0].eval_string_and_decode(ctx, row));
+        Ok(Some(input.chars().count() as i64))
     }
 
     #[inline]
@@ -416,6 +429,78 @@ mod test {
                 COLLATION_BIN_ID,
             );
             let op = scalar_func_expr(ScalarFuncSig::Lower, &[input]);
+            let op = Expression::build(&mut ctx, op).unwrap();
+            let got = op.eval(&mut ctx, &[]).unwrap();
+            assert_eq!(got, exp);
+        }
+    }
+
+    #[test]
+    fn test_char_length() {
+        // Test non-bianry string case
+        let cases = vec![
+            (Datum::Bytes(b"HELLO".to_vec()), Datum::I64(5)),
+            (Datum::Bytes(b"123".to_vec()), Datum::I64(3)),
+            (Datum::Bytes(b"".to_vec()), Datum::I64(0)),
+            (Datum::Bytes("CAFÉ".as_bytes().to_vec()), Datum::I64(4)),
+            (Datum::Bytes("数据库".as_bytes().to_vec()), Datum::I64(3)),
+            (
+                Datum::Bytes(
+                    "НОЧЬ НА ОКРАИНЕ МОСКВЫ"
+                        .as_bytes()
+                        .to_vec(),
+                ),
+                Datum::I64(22),
+            ),
+            (
+                Datum::Bytes("قاعدة البيانات".as_bytes().to_vec()),
+                Datum::I64(14),
+            ),
+            (Datum::Null, Datum::Null),
+        ];
+
+        let mut ctx = EvalContext::default();
+        for (input, exp) in cases {
+            let input = datum_expr(input);
+            let op = scalar_func_expr(ScalarFuncSig::CharLength, &[input]);
+            let op = Expression::build(&mut ctx, op).unwrap();
+            let got = op.eval(&mut ctx, &[]).unwrap();
+            assert_eq!(got, exp);
+        }
+
+        // Test binary string case
+        let cases = vec![
+            (Datum::Bytes(b"HELLO".to_vec()), Datum::I64(5)),
+            (Datum::Bytes(b"123".to_vec()), Datum::I64(3)),
+            (Datum::Bytes(b"".to_vec()), Datum::I64(0)),
+            (Datum::Bytes("CAFÉ".as_bytes().to_vec()), Datum::I64(5)),
+            (Datum::Bytes("数据库".as_bytes().to_vec()), Datum::I64(9)),
+            (
+                Datum::Bytes(
+                    "НОЧЬ НА ОКРАИНЕ МОСКВЫ"
+                        .as_bytes()
+                        .to_vec(),
+                ),
+                Datum::I64(41),
+            ),
+            (
+                Datum::Bytes("قاعدة البيانات".as_bytes().to_vec()),
+                Datum::I64(27),
+            ),
+            (Datum::Null, Datum::Null),
+        ];
+
+        let mut ctx = EvalContext::default();
+        for (input, exp) in cases {
+            let input = string_datum_expr_with_tp(
+                input,
+                VAR_STRING,
+                BINARY_FLAG,
+                -1,
+                CHARSET_BIN.to_owned(),
+                COLLATION_BIN_ID,
+            );
+            let op = scalar_func_expr(ScalarFuncSig::CharLength, &[input]);
             let op = Expression::build(&mut ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);

--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -192,6 +192,7 @@ impl ScalarFunc {
             | ScalarFuncSig::JsonTypeSig
             | ScalarFuncSig::JsonUnquoteSig
             | ScalarFuncSig::ASCII
+            | ScalarFuncSig::CharLength
             | ScalarFuncSig::Upper
             | ScalarFuncSig::Lower
             | ScalarFuncSig::Length
@@ -271,7 +272,6 @@ impl ScalarFunc {
             | ScalarFuncSig::Atan2Args
             | ScalarFuncSig::BitCount
             | ScalarFuncSig::Char
-            | ScalarFuncSig::CharLength
             | ScalarFuncSig::Compress
             | ScalarFuncSig::Concat
             | ScalarFuncSig::ConcatWS
@@ -774,6 +774,7 @@ dispatch_call! {
         BitXorSig => bit_xor,
 
         Length => length,
+        CharLength => char_length,
         BitLength => bit_length,
         ASCII => ascii,
     }
@@ -1097,6 +1098,7 @@ mod test {
                     ScalarFuncSig::Bin,
                     ScalarFuncSig::BitNegSig,
                     ScalarFuncSig::BitLength,
+                    ScalarFuncSig::CharLength,
                     ScalarFuncSig::Length,
                     ScalarFuncSig::Lower,
                     ScalarFuncSig::Upper,
@@ -1217,7 +1219,6 @@ mod test {
             ScalarFuncSig::Atan2Args,
             ScalarFuncSig::BitCount,
             ScalarFuncSig::Char,
-            ScalarFuncSig::CharLength,
             ScalarFuncSig::Compress,
             ScalarFuncSig::Concat,
             ScalarFuncSig::ConcatWS,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

implement builtin function: `CharLength` in `coprocessor`.
This is for #3275

## What are the type of the changes? (mandatory)

Improvement

## How has this PR been tested? (mandatory)

unittest

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

## Does this PR affect tidb-ansible update? (mandatory)

## Refer to a related PR or issue link (optional)

#3275 

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

