### PR TITLE
Split-checkers support produce multiple split keys

### DIFF
--- a/src/raftstore/coprocessor/config.rs
+++ b/src/raftstore/coprocessor/config.rs
@@ -26,15 +26,15 @@ pub struct Config {
     /// batch_split_limit limits the number of produced split-key for one batch.
     pub batch_split_limit: u64,
 
-    /// When region [a,b) size meets region_max_size, it will be split into
-    /// several regions [a,c), [c,d), [d,e), [e,b). And the size of [a,c),
-    /// [c,d), [d,e) will be region_split_size (maybe a little larger).
+    /// When region [a,e) size meets region_max_size, it will be split into
+    /// several regions [a,b), [b,c), [c,d), [d,e). And the size of [a,b),
+    /// [b,c), [c,d) will be region_split_size (maybe a little larger).
     pub region_max_size: ReadableSize,
     pub region_split_size: ReadableSize,
 
-    /// When the number of keys in region [a,b) meets the region_max_keys,
-    /// it will be split into two several regions [a,c), [c,d), [d,e), [e,b).
-    /// And the number of keys in [a,c), [c,d), [d,e) will be region_split_keys.
+    /// When the number of keys in region [a,e) meets the region_max_keys,
+    /// it will be split into two several regions [a,b), [b,c), [c,d), [d,e).
+    /// And the number of keys in [a,b), [b,c), [c,d) will be region_split_keys.
     pub region_max_keys: u64,
     pub region_split_keys: u64,
 }

--- a/src/raftstore/coprocessor/config.rs
+++ b/src/raftstore/coprocessor/config.rs
@@ -22,14 +22,19 @@ pub struct Config {
     /// that region crosses tables.
     pub split_region_on_table: bool,
 
-    /// When region [a, b) size meets region_max_size, it will be split
-    /// into two region into [a, c), [c, b). And the size of [a, c) will
-    /// be region_split_size (or a little bit smaller).
+    /// For once split check, there are several split_key produced for batch.
+    /// batch_split_limit limits the number of produced split-key for one batch.
+    pub batch_split_limit: u64,
+
+    /// When region [a,b) size meets region_max_size, it will be split into
+    /// several regions [a,c), [c,d), [d,e), [e,b). And the size of [a,c),
+    /// [c,d), [d,e) will be region_split_size (maybe a little larger).
     pub region_max_size: ReadableSize,
     pub region_split_size: ReadableSize,
-    /// When the number of keys in region [a,d) meets the region_max_keys,
-    /// it will be split into two regions [a,c),[c,d). And the keys of [a,c)
-    /// will be region_split_keys.
+    
+    /// When the number of keys in region [a,b) meets the region_max_keys,
+    /// it will be split into two several regions [a,c), [c,d), [d,e), [e,b).
+    /// And the number of keys in [a,c), [c,d), [d,e) will be region_split_keys.
     pub region_max_keys: u64,
     pub region_split_keys: u64,
 }
@@ -38,12 +43,15 @@ pub struct Config {
 pub const SPLIT_SIZE_MB: u64 = 96;
 /// Default region split keys.
 pub const SPLIT_KEYS: u64 = 960000;
+/// Default batch split limit.
+pub const BATCH_SPLIT_LIMIT: u64 = 100;
 
 impl Default for Config {
     fn default() -> Config {
         let split_size = ReadableSize::mb(SPLIT_SIZE_MB);
         Config {
             split_region_on_table: true,
+            batch_split_limit: BATCH_SPLIT_LIMIT,
             region_split_size: split_size,
             region_max_size: split_size / 2 * 3,
             region_split_keys: SPLIT_KEYS,

--- a/src/raftstore/coprocessor/config.rs
+++ b/src/raftstore/coprocessor/config.rs
@@ -31,7 +31,7 @@ pub struct Config {
     /// [c,d), [d,e) will be region_split_size (maybe a little larger).
     pub region_max_size: ReadableSize,
     pub region_split_size: ReadableSize,
-    
+
     /// When the number of keys in region [a,b) meets the region_max_keys,
     /// it will be split into two several regions [a,c), [c,d), [d,e), [e,b).
     /// And the number of keys in [a,c), [c,d), [d,e) will be region_split_keys.

--- a/src/raftstore/coprocessor/config.rs
+++ b/src/raftstore/coprocessor/config.rs
@@ -44,7 +44,7 @@ pub const SPLIT_SIZE_MB: u64 = 96;
 /// Default region split keys.
 pub const SPLIT_KEYS: u64 = 960000;
 /// Default batch split limit.
-pub const BATCH_SPLIT_LIMIT: u64 = 100;
+pub const BATCH_SPLIT_LIMIT: u64 = 10;
 
 impl Default for Config {
     fn default() -> Config {

--- a/src/raftstore/coprocessor/dispatcher.rs
+++ b/src/raftstore/coprocessor/dispatcher.rs
@@ -129,12 +129,20 @@ impl CoprocessorHost {
         ch: RetryableSendCh<Msg, C>,
     ) -> CoprocessorHost {
         let mut registry = Registry::default();
-        let split_size_check_observer =
-            SizeCheckObserver::new(cfg.region_max_size.0, cfg.region_split_size.0, cfg.batch_split_limit, ch.clone());
+        let split_size_check_observer = SizeCheckObserver::new(
+            cfg.region_max_size.0,
+            cfg.region_split_size.0,
+            cfg.batch_split_limit,
+            ch.clone(),
+        );
         registry.register_split_check_observer(200, Box::new(split_size_check_observer));
 
-        let split_keys_check_observer =
-            KeysCheckObserver::new(cfg.region_max_keys, cfg.region_split_keys, cfg.batch_split_limit, ch);
+        let split_keys_check_observer = KeysCheckObserver::new(
+            cfg.region_max_keys,
+            cfg.region_split_keys,
+            cfg.batch_split_limit,
+            ch,
+        );
         registry.register_split_check_observer(200, Box::new(split_keys_check_observer));
 
         // TableCheckObserver has higher priority than SizeCheckObserver.

--- a/src/raftstore/coprocessor/dispatcher.rs
+++ b/src/raftstore/coprocessor/dispatcher.rs
@@ -130,11 +130,11 @@ impl CoprocessorHost {
     ) -> CoprocessorHost {
         let mut registry = Registry::default();
         let split_size_check_observer =
-            SizeCheckObserver::new(cfg.region_max_size.0, cfg.region_split_size.0, ch.clone());
+            SizeCheckObserver::new(cfg.region_max_size.0, cfg.region_split_size.0, cfg.batch_split_limit, ch.clone());
         registry.register_split_check_observer(200, Box::new(split_size_check_observer));
 
         let split_keys_check_observer =
-            KeysCheckObserver::new(cfg.region_max_keys, cfg.region_split_keys, ch);
+            KeysCheckObserver::new(cfg.region_max_keys, cfg.region_split_keys, cfg.batch_split_limit, ch);
         registry.register_split_check_observer(200, Box::new(split_keys_check_observer));
 
         // TableCheckObserver has higher priority than SizeCheckObserver.

--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -47,10 +47,11 @@ impl SplitChecker for Checker {
             return false;
         }
 
-        let over_limit = self.split_keys.len() as u64 >= self.batch_split_limit;
+        let mut over_limit = self.split_keys.len() as u64 >= self.batch_split_limit;
         if self.current_count >= self.split_keys_count && !over_limit {
             self.split_keys.push(keys::origin_key(key.key()).to_vec());
             self.current_count = 0;
+            over_limit = self.split_keys.len() as u64 >= self.batch_split_limit;
         }
         self.current_count += 1;
 

--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -56,8 +56,9 @@ impl SplitChecker for Checker {
 
     fn split_keys(&mut self) -> Vec<Vec<u8>> {
         // make sure not to split when less than max_keys_count for last part
-        if self.current_count + self.split_keys_count < self.max_keys_count 
-        && (self.split_keys.len() as u64) < self.batch_split_limit {
+        if self.current_count + self.split_keys_count < self.max_keys_count
+            && (self.split_keys.len() as u64) < self.batch_split_limit
+        {
             self.split_keys.pop();
         }
         if !self.split_keys.is_empty() {

--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -282,7 +282,7 @@ pub mod tests {
 
     #[test]
     fn test_checker_with_same_max_and_split_size() {
-        let mut checker = Checker::new(24, 24);
+        let mut checker = Checker::new(24, 24, 100);
         let region = Region::default();
         let mut ctx = ObserverContext::new(&region);
         loop {

--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -57,7 +57,8 @@ impl SplitChecker for Checker {
     fn split_keys(&mut self) -> Vec<Vec<u8>> {
         // make sure not to split when less than max_size for last part
         if self.current_size + self.split_size < self.max_size
-        && (self.split_keys.len() as u64) < self.batch_split_limit {
+            && (self.split_keys.len() as u64) < self.batch_split_limit
+        {
             self.split_keys.pop();
         }
         if !self.split_keys.is_empty() {

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -412,7 +412,7 @@ fn test_serde_custom_tikv_config() {
         region_split_size: ReadableSize::mb(12),
         region_max_keys: 100000,
         region_split_keys: 100000,
-        batch_split_limit: 10,
+        batch_split_limit: 1,
     };
     value.security = SecurityConfig {
         ca_path: "invalid path".to_owned(),

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -412,7 +412,7 @@ fn test_serde_custom_tikv_config() {
         region_split_size: ReadableSize::mb(12),
         region_max_keys: 100000,
         region_split_keys: 100000,
-        batch_split_limit: 100,
+        batch_split_limit: 10,
     };
     value.security = SecurityConfig {
         ca_path: "invalid path".to_owned(),

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -408,11 +408,11 @@ fn test_serde_custom_tikv_config() {
     };
     value.coprocessor = CopConfig {
         split_region_on_table: true,
+        batch_split_limit: 1,
         region_max_size: ReadableSize::mb(12),
         region_split_size: ReadableSize::mb(12),
         region_max_keys: 100000,
         region_split_keys: 100000,
-        batch_split_limit: 1,
     };
     value.security = SecurityConfig {
         ca_path: "invalid path".to_owned(),

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -412,6 +412,7 @@ fn test_serde_custom_tikv_config() {
         region_split_size: ReadableSize::mb(12),
         region_max_keys: 100000,
         region_split_keys: 100000,
+        batch_split_limit: 100,
     };
     value.security = SecurityConfig {
         ca_path: "invalid path".to_owned(),

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -111,11 +111,11 @@ local-read-batch-size = 33
 
 [coprocessor]
 split-region-on-table = true
+batch-split-limit = 1
 region-max-size = "12MB"
 region-split-size = "12MB"
 region-max-keys = 100000
 region-split-keys = 100000
-batch-split-limit = 1
 
 [rocksdb]
 wal-recovery-mode = 1

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -115,6 +115,7 @@ region-max-size = "12MB"
 region-split-size = "12MB"
 region-max-keys = 100000
 region-split-keys = 100000
+batch-split-limit = 1
 
 [rocksdb]
 wal-recovery-mode = 1

--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -267,10 +267,10 @@ fn test_auto_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
             Ok(true)
         })
         .expect("");
-    assert!(size >= REGION_SPLIT_SIZE);
-    // although size may be larger than REGION_SPLIT_SIZE, but the diff should
+    assert!(size <= REGION_SPLIT_SIZE);
+    // although size may be smaller than REGION_SPLIT_SIZE, but the diff should
     // be small.
-    assert!(size < REGION_SPLIT_SIZE + 1000);
+    assert!(size > REGION_SPLIT_SIZE - 1000);
 
     let epoch = left.get_region_epoch().clone();
     let get = new_request(left.get_id(), epoch, vec![new_get_cmd(&max_key)], false);

--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -267,10 +267,10 @@ fn test_auto_split_region<T: Simulator>(cluster: &mut Cluster<T>) {
             Ok(true)
         })
         .expect("");
-    assert!(size <= REGION_SPLIT_SIZE);
-    // although size may be smaller than REGION_SPLIT_SIZE, but the diff should
+    assert!(size >= REGION_SPLIT_SIZE);
+    // although size may be larger than REGION_SPLIT_SIZE, but the diff should
     // be small.
-    assert!(size > REGION_SPLIT_SIZE - 1000);
+    assert!(size < REGION_SPLIT_SIZE + 1000);
 
     let epoch = left.get_region_epoch().clone();
     let get = new_request(left.get_id(), epoch, vec![new_get_cmd(&max_key)], false);


### PR DESCRIPTION
## What have you changed? (mandatory)
For batch split PR, we just make it possible for split-checker to return multiple keys. But actually the implementation of split-checks doesn't change which is still producing only one key. This PR is support to produce multiple split keys.  

## What are the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
unit-test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
New config

## Does this PR affect tidb-ansible update? (mandatory)

## Refer to a related PR or issue link (optional)



