### PR TITLE
Set max-message-size to i32::MAX.

### DIFF
--- a/components/test_raftstore/server.rs
+++ b/components/test_raftstore/server.rs
@@ -168,7 +168,6 @@ impl Simulator for ServerCluster {
             server = Some(Server::new(
                 &server_cfg,
                 &security_mgr,
-                cfg.coprocessor.region_split_size.0 as usize,
                 store.clone(),
                 cop_read_pool.clone(),
                 sim_router.clone(),

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -192,7 +192,6 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     let mut server = Server::new(
         &server_cfg,
         &security_mgr,
-        cfg.coprocessor.region_split_size.0 as usize,
         storage.clone(),
         cop_read_pool,
         raft_router,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -103,7 +103,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static, E: Engine> Server<T, S,
             .stream_initial_window_size(cfg.grpc_stream_initial_window_size.0 as i32)
             .max_concurrent_stream(cfg.grpc_concurrent_stream)
             .max_receive_message_len(MAX_GRPC_RECV_MSG_LEN)
-            .max_send_message_len(cmp::max(region_split_size * 4, i32::MAX as usize) as i32)
+            .max_send_message_len(i32::MAX)
             .build_args();
         let grpc_server = {
             let mut sb = ServerBuilder::new(Arc::clone(&env))

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::i32;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
-use std::{cmp, i32};
 
 use grpc::{ChannelBuilder, EnvBuilder, Environment, Server as GrpcServer, ServerBuilder};
 use kvproto::debugpb_grpc::create_debug;
@@ -62,7 +62,6 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static, E: Engine> Server<T, S,
     pub fn new(
         cfg: &Arc<Config>,
         security_mgr: &Arc<SecurityManager>,
-        region_split_size: usize,
         storage: Storage<E>,
         // TODO: Remove once endpoint itself is passed to here.
         cop_readpool: ReadPool<coprocessor::ReadPoolContext>,
@@ -301,7 +300,6 @@ mod tests {
         let mut server = Server::new(
             &cfg,
             &security_mgr,
-            1024,
             storage,
             cop_read_pool,
             router,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::i32;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
@@ -102,7 +101,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static, E: Engine> Server<T, S,
             .stream_initial_window_size(cfg.grpc_stream_initial_window_size.0 as i32)
             .max_concurrent_stream(cfg.grpc_concurrent_stream)
             .max_receive_message_len(MAX_GRPC_RECV_MSG_LEN)
-            .max_send_message_len(i32::MAX)
+            .max_send_message_len(-1)
             .build_args();
         let grpc_server = {
             let mut sb = ServerBuilder::new(Arc::clone(&env))


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

## What have you changed? (mandatory)
Change the max-grpc-message-size to i32::MAX.

The old configuration is:
```rust
builder.max_send_message_len(cmp::max(region_split_size * 4, i32::MAX as usize) as i32)
```
The **cmp::max** should be **cmp::min** in fact, so it's a bug. However, set it to `i32::MAX` maybe is more better because if the region doesn't split as expected, and its size grows vary large, a gRPC error will be raised.

So this PR changes it to `i32::MAX`. So we won't meet the error any more. 

## What are the type of the changes? (mandatory)
Bug fix.

## How has this PR been tested? (mandatory)
make dev.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No.

## Does this PR affect tidb-ansible update? (mandatory)
No.