### PR TITLE
pd: return actual err from pd_client

### DIFF
--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -291,7 +291,7 @@ where
     fn should_retry(resp: &Result<Resp>) -> bool {
         match resp {
             Ok(_) => false,
-            // all grpc related error are mapped to Error::Grpc
+            // all grpc related errors are mapped to Error::Grpc
             Err(Error::Grpc(err)) => {
                 error!("request failed: {:?}, retry", err);
                 true
@@ -304,7 +304,7 @@ where
     fn post_loop(ctx: Result<Self>) -> Result<Resp> {
         let ctx = ctx.expect("end loop with Ok(_)");
         ctx.resp
-            .unwrap_or_else(|| Err(box_err!("response in empty")))
+            .unwrap_or_else(|| Err(box_err!("response is empty")))
     }
 
     /// Returns a Future, it is resolves once a future returned by the closure

--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Debug;
 use std::result;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -226,7 +227,7 @@ const MAX_REQUEST_COUNT: usize = 3;
 impl<Req, Resp, F> Request<Req, Resp, F>
 where
     Req: Clone + Send + 'static,
-    Resp: Send + 'static,
+    Resp: Send + Debug + 'static,
     F: FnMut(&RwLock<Inner>, Req) -> PdFuture<Resp> + Send + 'static,
 {
     fn reconnect_if_needed(mut self) -> Box<Future<Item = Self, Error = Self> + Send> {
@@ -268,7 +269,7 @@ where
                     Ok(ctx)
                 }
                 Err(err) => {
-                    error!("request failed: {:?}", err);
+                    ctx.resp = Some(Err(err));
                     Err(ctx)
                 }
             })
@@ -279,7 +280,8 @@ where
         let ctx = match ctx {
             Ok(ctx) | Err(ctx) => ctx,
         };
-        let done = ctx.reconnect_count == 0 || ctx.resp.is_some();
+        let done = ctx.reconnect_count == 0
+            || (ctx.resp.is_some() && !Self::should_retry(ctx.resp.as_ref().unwrap()));
         if done {
             Ok(Loop::Break(ctx))
         } else {
@@ -287,9 +289,23 @@ where
         }
     }
 
+    fn should_retry(resp: &Result<Resp>) -> bool {
+        match resp {
+            Ok(_) => false,
+            // all grpc related error are mapped to Error::Grpc
+            Err(Error::Grpc(err)) => {
+                error!("request failed: {:?}, retry", err);
+                true
+            }
+            // other err are returned by response header from pd, no need to retry
+            Err(_) => false,
+        }
+    }
+
     fn post_loop(ctx: Result<Self>) -> Result<Resp> {
         let ctx = ctx.expect("end loop with Ok(_)");
-        ctx.resp.unwrap_or_else(|| Err(box_err!("fail to request")))
+        ctx.resp
+            .unwrap_or_else(|| Err(box_err!("response in empty")))
     }
 
     /// Returns a Future, it is resolves once a future returned by the closure

--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Debug;
 use std::result;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -227,7 +226,7 @@ const MAX_REQUEST_COUNT: usize = 3;
 impl<Req, Resp, F> Request<Req, Resp, F>
 where
     Req: Clone + Send + 'static,
-    Resp: Send + Debug + 'static,
+    Resp: Send + 'static,
     F: FnMut(&RwLock<Inner>, Req) -> PdFuture<Resp> + Send + 'static,
 {
     fn reconnect_if_needed(mut self) -> Box<Future<Item = Self, Error = Self> + Send> {

--- a/tests/pd/mock/mocker/mod.rs
+++ b/tests/pd/mock/mocker/mod.rs
@@ -23,7 +23,7 @@ mod split;
 
 pub use self::bootstrap::AlreadyBootstrapped;
 pub use self::leader_change::LeaderChange;
-pub use self::retry::Retry;
+pub use self::retry::{NotRetry, Retry};
 pub use self::service::Service;
 pub use self::split::Split;
 

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -197,6 +197,35 @@ fn test_retry_sync() {
     test_retry(sync)
 }
 
+fn test_not_retry<F: Fn(&RpcClient)>(func: F) {
+    let eps_count = 1;
+    // Retry mocker returns `Err(_)` for most request, here two thirds are `Err(_)`.
+    let not_retry = Arc::new(NotRetry::new());
+    let server = MockServer::with_case(eps_count, not_retry);
+    let eps = server.bind_addrs();
+
+    let client = new_client(eps, None);
+
+    func(&client);
+}
+
+#[test]
+fn test_not_retry_async() {
+    let async = |client: &RpcClient| {
+        let region = client.get_region_by_id(1);
+        region.wait().unwrap_err();
+    };
+    test_not_retry(async);
+}
+
+#[test]
+fn test_not_retry_sync() {
+    let sync = |client: &RpcClient| {
+        client.get_store(1).unwrap_err();
+    };
+    test_not_retry(sync);
+}
+
 fn restart_leader(mgr: SecurityManager) {
     let mgr = Arc::new(mgr);
     // Service has only one GetMembersResponse, so the leader never changes.

--- a/tests/pd/test_rpc_client.rs
+++ b/tests/pd/test_rpc_client.rs
@@ -202,7 +202,7 @@ fn test_retry_sync() {
 
 fn test_not_retry<F: Fn(&RpcClient)>(func: F) {
     let eps_count = 1;
-    // Retry mocker returns `Err(_)` for most request, here two thirds are `Err(_)`.
+    // NotRetry mocker returns Ok() with error header first, and next returns Ok() without any error header.
     let not_retry = Arc::new(NotRetry::new());
     let server = MockServer::with_case(eps_count, not_retry);
     let eps = server.bind_addrs();


### PR DESCRIPTION
## What have you changed? (mandatory)
- return actual err from pd_client, before will return "fail to request" anyway and print error log innerly
- no need to retry errors that from response header

## What are the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
integration-test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No
