### PR TITLE
*: escape batch split keys

### DIFF
--- a/src/pd/pd.rs
+++ b/src/pd/pd.rs
@@ -37,6 +37,7 @@ use raftstore::store::Callback;
 use raftstore::store::Msg;
 use storage::FlowStatistics;
 use util::collections::HashMap;
+use util::escape;
 use util::rocksdb::*;
 use util::time::time_now_sec;
 use util::transport::SendCh;
@@ -132,9 +133,11 @@ impl Display for Task {
                 ..
             } => write!(
                 f,
-                "ask split region {} with keys {:?}",
+                "ask split region {} with {} keys range from {:?} to {:?}",
                 region.get_id(),
-                split_keys
+                split_keys.len(),
+                split_keys.first().as_ref().map(|k| escape(k)),
+                split_keys.last().as_ref().map(|k| escape(k))
             ),
             Task::Heartbeat {
                 ref region,

--- a/src/pd/pd.rs
+++ b/src/pd/pd.rs
@@ -30,6 +30,7 @@ use super::metrics::*;
 use pd::{PdClient, RegionStat};
 use prometheus::local::LocalHistogram;
 use raftstore::store::store::StoreInfo;
+use raftstore::store::util::print_split_info;
 use raftstore::store::util::{
     get_region_approximate_keys, get_region_approximate_size, is_epoch_stale,
 };
@@ -37,7 +38,6 @@ use raftstore::store::Callback;
 use raftstore::store::Msg;
 use storage::FlowStatistics;
 use util::collections::HashMap;
-use util::escape;
 use util::rocksdb::*;
 use util::time::time_now_sec;
 use util::transport::SendCh;
@@ -132,24 +132,8 @@ impl Display for Task {
                 ref split_keys,
                 ..
             } => {
-                if split_keys.len() == 1 {
-                    write!(
-                        f,
-                        "ask split region {} with {} key {:?}",
-                        region.get_id(),
-                        split_keys.len(),
-                        split_keys.first().as_ref().map(|k| escape(k)),
-                    )
-                } else {
-                    write!(
-                        f,
-                        "ask split region {} with {} keys range from {:?} to {:?}",
-                        region.get_id(),
-                        split_keys.len(),
-                        split_keys.first().as_ref().map(|k| escape(k)),
-                        split_keys.last().as_ref().map(|k| escape(k))
-                    )
-                }
+                write!(f, "ask split region ")?;
+                print_split_info(f, region.get_id(), split_keys)
             }
             Task::Heartbeat {
                 ref region,

--- a/src/pd/pd.rs
+++ b/src/pd/pd.rs
@@ -31,7 +31,7 @@ use pd::{Error, PdClient, RegionStat};
 use prometheus::local::LocalHistogram;
 use raftstore::store::cmd_resp::new_error;
 use raftstore::store::store::StoreInfo;
-use raftstore::store::util::print_split_info;
+use raftstore::store::util::format_split_info;
 use raftstore::store::util::{
     get_region_approximate_keys, get_region_approximate_size, is_epoch_stale,
 };
@@ -151,10 +151,11 @@ impl Display for Task {
                 ref region,
                 ref split_keys,
                 ..
-            } => {
-                write!(f, "ask split region ")?;
-                print_split_info(f, region.get_id(), split_keys)
-            }
+            } => write!(
+                f,
+                "ask split region {}",
+                format_split_info(region.get_id(), split_keys)
+            ),
             Task::Heartbeat {
                 ref region,
                 ref peer,

--- a/src/pd/pd.rs
+++ b/src/pd/pd.rs
@@ -131,14 +131,26 @@ impl Display for Task {
                 ref region,
                 ref split_keys,
                 ..
-            } => write!(
-                f,
-                "ask split region {} with {} keys range from {:?} to {:?}",
-                region.get_id(),
-                split_keys.len(),
-                split_keys.first().as_ref().map(|k| escape(k)),
-                split_keys.last().as_ref().map(|k| escape(k))
-            ),
+            } => {
+                if split_keys.len() == 1 {
+                    write!(
+                        f,
+                        "ask split region {} with {} key {:?}",
+                        region.get_id(),
+                        split_keys.len(),
+                        split_keys.first().as_ref().map(|k| escape(k)),
+                    )
+                } else {
+                    write!(
+                        f,
+                        "ask split region {} with {} keys range from {:?} to {:?}",
+                        region.get_id(),
+                        split_keys.len(),
+                        split_keys.first().as_ref().map(|k| escape(k)),
+                        split_keys.last().as_ref().map(|k| escape(k))
+                    )
+                }
+            }
             Task::Heartbeat {
                 ref region,
                 ref peer,

--- a/src/pd/pd.rs
+++ b/src/pd/pd.rs
@@ -31,7 +31,7 @@ use pd::{Error, PdClient, RegionStat};
 use prometheus::local::LocalHistogram;
 use raftstore::store::cmd_resp::new_error;
 use raftstore::store::store::StoreInfo;
-use raftstore::store::util::format_split_info;
+use raftstore::store::util::KeysInfoFormatter;
 use raftstore::store::util::{
     get_region_approximate_keys, get_region_approximate_size, is_epoch_stale,
 };
@@ -153,8 +153,9 @@ impl Display for Task {
                 ..
             } => write!(
                 f,
-                "ask split region {}",
-                format_split_info(region.get_id(), split_keys)
+                "ask split region {} with {}",
+                region.get_id(),
+                KeysInfoFormatter(&split_keys)
             ),
             Task::Heartbeat {
                 ref region,

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -244,7 +244,14 @@ impl fmt::Debug for Msg {
                 ref region_id,
                 ref split_keys,
                 ..
-            } => write!(fmt, "Split region {} at key {:?}", region_id, split_keys),
+            } => write!(
+                fmt,
+                "Split region {} with {} keys range from {:?} to from {:?}",
+                region_id,
+                split_keys.len(),
+                split_keys.first().as_ref().map(|k| escape(k)),
+                split_keys.last().as_ref().map(|k| escape(k))
+            ),
             Msg::RegionApproximateSize { region_id, size } => write!(
                 fmt,
                 "Region's approximate size [region_id: {}, size: {:?}]",

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -244,14 +244,26 @@ impl fmt::Debug for Msg {
                 ref region_id,
                 ref split_keys,
                 ..
-            } => write!(
-                fmt,
-                "Split region {} with {} keys range from {:?} to from {:?}",
-                region_id,
-                split_keys.len(),
-                split_keys.first().as_ref().map(|k| escape(k)),
-                split_keys.last().as_ref().map(|k| escape(k))
-            ),
+            } => {
+                if split_keys.len() == 1 {
+                    write!(
+                        fmt,
+                        "Split region {} with {} key {:?}",
+                        region_id,
+                        split_keys.len(),
+                        split_keys.first().as_ref().map(|k| escape(k)),
+                    )
+                } else {
+                    write!(
+                        fmt,
+                        "Split region {} with {} keys range from {:?} to {:?}",
+                        region_id,
+                        split_keys.len(),
+                        split_keys.first().as_ref().map(|k| escape(k)),
+                        split_keys.last().as_ref().map(|k| escape(k))
+                    )
+                }
+            }
             Msg::RegionApproximateSize { region_id, size } => write!(
                 fmt,
                 "Region's approximate size [region_id: {}, size: {:?}]",

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -23,7 +23,7 @@ use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse};
 use kvproto::raft_serverpb::RaftMessage;
 
 use raft::SnapshotStatus;
-use raftstore::store::util::print_split_info;
+use raftstore::store::util::format_split_info;
 use util::escape;
 use util::rocksdb::CompactedEvent;
 
@@ -245,10 +245,11 @@ impl fmt::Debug for Msg {
                 region_id,
                 ref split_keys,
                 ..
-            } => {
-                write!(fmt, "Split region ")?;
-                print_split_info(fmt, region_id, split_keys)
-            }
+            } => write!(
+                fmt,
+                "Split region {}",
+                format_split_info(region_id, split_keys)
+            ),
             Msg::RegionApproximateSize { region_id, size } => write!(
                 fmt,
                 "Region's approximate size [region_id: {}, size: {:?}]",

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -23,7 +23,7 @@ use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse};
 use kvproto::raft_serverpb::RaftMessage;
 
 use raft::SnapshotStatus;
-use raftstore::store::util::format_split_info;
+use raftstore::store::util::KeysInfoFormatter;
 use util::escape;
 use util::rocksdb::CompactedEvent;
 
@@ -247,8 +247,9 @@ impl fmt::Debug for Msg {
                 ..
             } => write!(
                 fmt,
-                "Split region {}",
-                format_split_info(region_id, split_keys)
+                "Split region {} with {}",
+                region_id,
+                KeysInfoFormatter(&split_keys)
             ),
             Msg::RegionApproximateSize { region_id, size } => write!(
                 fmt,

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -23,6 +23,7 @@ use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse};
 use kvproto::raft_serverpb::RaftMessage;
 
 use raft::SnapshotStatus;
+use raftstore::store::util::print_split_info;
 use util::escape;
 use util::rocksdb::CompactedEvent;
 
@@ -241,28 +242,12 @@ impl fmt::Debug for Msg {
                 escape(hash)
             ),
             Msg::SplitRegion {
-                ref region_id,
+                region_id,
                 ref split_keys,
                 ..
             } => {
-                if split_keys.len() == 1 {
-                    write!(
-                        fmt,
-                        "Split region {} with {} key {:?}",
-                        region_id,
-                        split_keys.len(),
-                        split_keys.first().as_ref().map(|k| escape(k)),
-                    )
-                } else {
-                    write!(
-                        fmt,
-                        "Split region {} with {} keys range from {:?} to {:?}",
-                        region_id,
-                        split_keys.len(),
-                        split_keys.first().as_ref().map(|k| escape(k)),
-                        split_keys.last().as_ref().map(|k| escape(k))
-                    )
-                }
+                write!(fmt, "Split region ")?;
+                print_split_info(fmt, region_id, split_keys)
             }
             Msg::RegionApproximateSize { region_id, size } => write!(
                 fmt,

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -3303,7 +3303,6 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
             } => {
                 self.on_hash_computed(region_id, index, hash);
             }
-            // TODO: format keys
             Msg::SplitRegion {
                 region_id,
                 region_epoch,
@@ -3311,8 +3310,11 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
                 callback,
             } => {
                 info!(
-                    "[region {}] on split region at key {:?}.",
-                    region_id, split_keys
+                    "[region {}] on split region with {} keys range from {:?} to {:?}.",
+                    region_id,
+                    split_keys.len(),
+                    split_keys.first().as_ref().map(|k| escape(k)),
+                    split_keys.last().as_ref().map(|k| escape(k))
                 );
                 self.on_prepare_split_region(region_id, region_epoch, split_keys, callback);
             }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -41,7 +41,7 @@ use raft::{self, SnapshotStatus, INVALID_INDEX, NO_LIMIT};
 use pd::{PdClient, PdRunner, PdTask};
 use raftstore::coprocessor::split_observer::SplitObserver;
 use raftstore::coprocessor::CoprocessorHost;
-use raftstore::store::util::format_split_info;
+use raftstore::store::util::KeysInfoFormatter;
 use raftstore::{Error, Result};
 use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use util::collections::{HashMap, HashSet};
@@ -3314,8 +3314,9 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
                 callback,
             } => {
                 info!(
-                    "on split region {}",
-                    format_split_info(region_id, &split_keys)
+                    "on split region {} with {}",
+                    region_id,
+                    KeysInfoFormatter(&split_keys)
                 );
                 self.on_prepare_split_region(region_id, region_epoch, split_keys, callback);
             }

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -41,7 +41,7 @@ use raft::{self, SnapshotStatus, INVALID_INDEX, NO_LIMIT};
 use pd::{PdClient, PdRunner, PdTask};
 use raftstore::coprocessor::split_observer::SplitObserver;
 use raftstore::coprocessor::CoprocessorHost;
-use raftstore::store::util::print_split_info;
+use raftstore::store::util::format_split_info;
 use raftstore::{Error, Result};
 use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use util::collections::{HashMap, HashSet};
@@ -3313,9 +3313,10 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
                 split_keys,
                 callback,
             } => {
-                let mut s = String::new();
-                print_split_info(&mut s, region_id, &split_keys).unwrap();
-                info!("on split region {}", s);
+                info!(
+                    "on split region {}",
+                    format_split_info(region_id, &split_keys)
+                );
                 self.on_prepare_split_region(region_id, region_epoch, split_keys, callback);
             }
             Msg::RegionApproximateSize { region_id, size } => {

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -3309,13 +3309,22 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
                 split_keys,
                 callback,
             } => {
-                info!(
-                    "[region {}] on split region with {} keys range from {:?} to {:?}.",
-                    region_id,
-                    split_keys.len(),
-                    split_keys.first().as_ref().map(|k| escape(k)),
-                    split_keys.last().as_ref().map(|k| escape(k))
-                );
+                if split_keys.len() == 1 {
+                    info!(
+                        "on split region {} with {} key {:?}",
+                        region_id,
+                        split_keys.len(),
+                        split_keys.first().as_ref().map(|k| escape(k)),
+                    );
+                } else {
+                    info!(
+                        "on split region {} with {} keys range from {:?} to {:?}",
+                        region_id,
+                        split_keys.len(),
+                        split_keys.first().as_ref().map(|k| escape(k)),
+                        split_keys.last().as_ref().map(|k| escape(k))
+                    );
+                }
                 self.on_prepare_split_region(region_id, region_epoch, split_keys, callback);
             }
             Msg::RegionApproximateSize { region_id, size } => {

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -765,21 +765,21 @@ impl Engines {
     }
 }
 
-pub fn format_split_info(region_id: u64, split_keys: &[Vec<u8>]) -> String {
-    if split_keys.len() == 1 {
-        format!(
-            "{} with key {:?}",
-            region_id,
-            split_keys.first().as_ref().map(|k| escape(k)),
-        )
-    } else {
-        format!(
-            "{} with {} keys range from {:?} to {:?}",
-            region_id,
-            split_keys.len(),
-            split_keys.first().as_ref().map(|k| escape(k)),
-            split_keys.last().as_ref().map(|k| escape(k))
-        )
+pub struct KeysInfoFormatter<'a>(pub &'a [Vec<u8>]);
+
+impl<'a> fmt::Display for KeysInfoFormatter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.0.len() {
+            0 => write!(f, "no key"),
+            1 => write!(f, "key \"{}\"", escape(self.0.first().unwrap())),
+            _ => write!(
+                f,
+                "{} keys range from \"{}\" to \"{}\"",
+                self.0.len(),
+                escape(self.0.first().unwrap()),
+                escape(self.0.last().unwrap())
+            ),
+        }
     }
 }
 

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -28,6 +28,7 @@ use rocksdb::{Range, TablePropertiesCollection, Writable, WriteBatch, DB};
 use time::{Duration, Timespec};
 
 use storage::{Key, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE, LARGE_CFS};
+use util::escape;
 use util::properties::RangeProperties;
 use util::rocksdb::stats::get_range_entries_and_versions;
 use util::time::monotonic_raw_now;
@@ -747,6 +748,30 @@ impl Engines {
             kv: kv_engine,
             raft: raft_engine,
         }
+    }
+}
+
+pub fn print_split_info(
+    fmt: &mut fmt::Write,
+    region_id: u64,
+    split_keys: &Vec<Vec<u8>>,
+) -> fmt::Result {
+    if split_keys.len() == 1 {
+        write!(
+            fmt,
+            "{} with key {:?}",
+            region_id,
+            split_keys.first().as_ref().map(|k| escape(k)),
+        )
+    } else {
+        write!(
+            fmt,
+            "{} with {} keys range from {:?} to {:?}",
+            region_id,
+            split_keys.len(),
+            split_keys.first().as_ref().map(|k| escape(k)),
+            split_keys.last().as_ref().map(|k| escape(k))
+        )
     }
 }
 

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -751,21 +751,15 @@ impl Engines {
     }
 }
 
-pub fn print_split_info(
-    fmt: &mut fmt::Write,
-    region_id: u64,
-    split_keys: &Vec<Vec<u8>>,
-) -> fmt::Result {
+pub fn format_split_info(region_id: u64, split_keys: &[Vec<u8>]) -> String {
     if split_keys.len() == 1 {
-        write!(
-            fmt,
+        format!(
             "{} with key {:?}",
             region_id,
             split_keys.first().as_ref().map(|k| escape(k)),
         )
     } else {
-        write!(
-            fmt,
+        format!(
             "{} with {} keys range from {:?} to {:?}",
             region_id,
             split_keys.len(),


### PR DESCRIPTION
## What have you changed? (mandatory)
escape batch split keys and only print out the first and last split key.

## What are the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
No need

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No


