### PR TITLE
raftstore/tests: remove debug println

### DIFF
--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -261,14 +261,14 @@ mod tests {
             engine.put_cf(default_cf, &key, &[0; 1024]).unwrap();
             engine.flush_cf(default_cf, true).unwrap();
         }
-        println!("start");
+
         runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::SCAN));
         must_split_at(
             &rx,
             &region,
             vec![Key::from_raw(b"0080").append_ts(2).take_encoded()],
         );
-        println!("end");
+
         drop(rx);
         // It should be safe even the result can't be sent back.
         runnable.run(SplitCheckTask::new(region, true, CheckPolicy::SCAN));


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>


## What have you changed? (mandatory)

I found two lines "start" and "end" are printed while running tests. I thought it might be used for debugging and was merged to master by mistake. So I'm trying to remove it.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

No need to test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

