### PR TITLE
raftstore: update approximate size and keys after merge

### DIFF
--- a/components/test_raftstore/pd.rs
+++ b/components/test_raftstore/pd.rs
@@ -319,7 +319,7 @@ impl Cluster {
 
     fn get_region_approximate_keys(&self, region_id: u64) -> Option<u64> {
         self.region_approximate_keys.get(&region_id).cloned()
-    } 
+    }
 
     fn get_stores(&self) -> Vec<metapb::Store> {
         self.stores.values().map(|s| s.store.clone()).collect()
@@ -893,7 +893,7 @@ impl TestPdClient {
     pub fn get_region_approximate_size(&self, region_id: u64) -> Option<u64> {
         self.cluster.rl().get_region_approximate_size(region_id)
     }
-    
+
     pub fn get_region_approximate_keys(&self, region_id: u64) -> Option<u64> {
         self.cluster.rl().get_region_approximate_keys(region_id)
     }

--- a/components/test_raftstore/pd.rs
+++ b/components/test_raftstore/pd.rs
@@ -317,6 +317,10 @@ impl Cluster {
         self.region_approximate_size.get(&region_id).cloned()
     }
 
+    fn get_region_approximate_keys(&self, region_id: u64) -> Option<u64> {
+        self.region_approximate_keys.get(&region_id).cloned()
+    } 
+
     fn get_stores(&self) -> Vec<metapb::Store> {
         self.stores.values().map(|s| s.store.clone()).collect()
     }
@@ -888,6 +892,10 @@ impl TestPdClient {
 
     pub fn get_region_approximate_size(&self, region_id: u64) -> Option<u64> {
         self.cluster.rl().get_region_approximate_size(region_id)
+    }
+    
+    pub fn get_region_approximate_keys(&self, region_id: u64) -> Option<u64> {
+        self.cluster.rl().get_region_approximate_keys(region_id)
     }
 }
 

--- a/components/test_raftstore/util.rs
+++ b/components/test_raftstore/util.rs
@@ -17,9 +17,9 @@ use std::thread;
 use std::time::Duration;
 
 use protobuf;
+use rand::Rng;
 use rocksdb::{CompactionJobInfo, DB};
 use tempdir::TempDir;
-use rand::Rng;
 
 use kvproto::metapb::{self, RegionEpoch};
 use kvproto::pdpb::{ChangePeer, Merge, RegionHeartbeatResponse, SplitRegion, TransferLeader};

--- a/src/raftstore/store/store.rs
+++ b/src/raftstore/store/store.rs
@@ -1853,6 +1853,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let peer = self.region_peers.get_mut(&region_id).unwrap();
         peer.set_region(region);
         if peer.is_leader() {
+            // make approximate size and keys updated in time.
+            peer.size_diff_hint = self.cfg.region_split_check_diff.0;
             info!("notify pd with merge {:?} into {:?}", source, peer.region());
             peer.heartbeat_pd(&self.pd_worker);
         }

--- a/tests/raftstore_cases/test_merge.rs
+++ b/tests/raftstore_cases/test_merge.rs
@@ -455,17 +455,35 @@ fn test_merge_approximate_size_and_keys() {
     let right = pd_client.get_region(&max_key).unwrap();
 
     assert_ne!(left, right);
-    let size = pd_client.get_region_approximate_size(left.get_id()).unwrap() 
-    + pd_client.get_region_approximate_size(right.get_id()).unwrap();
+    let size = pd_client
+        .get_region_approximate_size(left.get_id())
+        .unwrap()
+        + pd_client
+            .get_region_approximate_size(right.get_id())
+            .unwrap();
     assert_ne!(size, 0);
-    let keys = pd_client.get_region_approximate_keys(left.get_id()).unwrap() 
-    + pd_client.get_region_approximate_keys(right.get_id()).unwrap();
+    let keys = pd_client
+        .get_region_approximate_keys(left.get_id())
+        .unwrap()
+        + pd_client
+            .get_region_approximate_keys(right.get_id())
+            .unwrap();
     assert_ne!(keys, 0);
 
     pd_client.must_merge(left.get_id(), right.get_id());
     thread::sleep(Duration::from_secs(1));
-    
+
     let region = pd_client.get_region(b"").unwrap();
-    assert_eq!(pd_client.get_region_approximate_size(region.get_id()).unwrap(), size);
-    assert_eq!(pd_client.get_region_approximate_keys(region.get_id()).unwrap(), keys);
+    assert_eq!(
+        pd_client
+            .get_region_approximate_size(region.get_id())
+            .unwrap(),
+        size
+    );
+    assert_eq!(
+        pd_client
+            .get_region_approximate_keys(region.get_id())
+            .unwrap(),
+        keys
+    );
 }

--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -16,8 +16,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{fs, thread};
 
-use rand::{self, Rng};
-
 use kvproto::metapb;
 use raft::eraftpb::MessageType;
 
@@ -26,7 +24,7 @@ use tikv::pd::PdClient;
 use tikv::raftstore::store::engine::Iterable;
 use tikv::raftstore::store::keys::data_key;
 use tikv::raftstore::store::{Callback, WriteResponse};
-use tikv::storage::{CF_DEFAULT, CF_WRITE};
+use tikv::storage::{CF_WRITE};
 use tikv::util::config::*;
 
 pub const REGION_MAX_SIZE: u64 = 50000;
@@ -169,48 +167,6 @@ fn test_server_split_region_twice() {
     });
     cluster.split_region(&region3, split_key, Callback::Write(c));
     rx1.recv_timeout(Duration::from_secs(5)).unwrap();
-}
-
-/// Keep putting random kvs until specified size limit is reached.
-fn put_till_size<T: Simulator>(
-    cluster: &mut Cluster<T>,
-    limit: u64,
-    range: &mut Iterator<Item = u64>,
-) -> Vec<u8> {
-    put_cf_till_size(cluster, CF_DEFAULT, limit, range)
-}
-
-fn put_cf_till_size<T: Simulator>(
-    cluster: &mut Cluster<T>,
-    cf: &'static str,
-    limit: u64,
-    range: &mut Iterator<Item = u64>,
-) -> Vec<u8> {
-    assert!(limit > 0);
-    let mut len = 0;
-    let mut last_len = 0;
-    let mut rng = rand::thread_rng();
-    let mut key = vec![];
-    while len < limit {
-        let key_id = range.next().unwrap();
-        let key_str = format!("{:09}", key_id);
-        key = key_str.into_bytes();
-        let mut value = vec![0; 64];
-        rng.fill_bytes(&mut value);
-        cluster.must_put_cf(cf, &key, &value);
-        // plus 1 for the extra encoding prefix
-        len += key.len() as u64 + 1;
-        len += value.len() as u64;
-        // Flush memtable to SST periodically, to make approximate size more accurate.
-        if len - last_len >= 1000 {
-            cluster.must_flush_cf(cf, true);
-            last_len = len;
-        }
-    }
-    // Approximate size of memtable is inaccurate for small data,
-    // we flush it to SST so we can use the size properties instead.
-    cluster.must_flush_cf(cf, true);
-    key
 }
 
 fn test_auto_split_region<T: Simulator>(cluster: &mut Cluster<T>) {

--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -24,7 +24,7 @@ use tikv::pd::PdClient;
 use tikv::raftstore::store::engine::Iterable;
 use tikv::raftstore::store::keys::data_key;
 use tikv::raftstore::store::{Callback, WriteResponse};
-use tikv::storage::{CF_WRITE};
+use tikv::storage::CF_WRITE;
 use tikv::util::config::*;
 
 pub const REGION_MAX_SIZE: u64 = 50000;


### PR DESCRIPTION
## What have you changed? (mandatory)
After merge set `peer.size_diff_hint` to make sure approximate size and keys updated in time. Due to `split_check_diff`, when there is no write to this region, the size and keys may incorrect and lead to PD produce wrong schedule.

## What are the type of the changes? (mandatory)
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)
unit test
manual test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No 

## Does this PR affect tidb-ansible update? (mandatory)
No

