### PR TITLE
Follow Rust Naming Guideline for Key encoded & raw interface

### DIFF
--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -1531,7 +1531,7 @@ fn main() {
         println!("{}", &unescape(escaped).to_hex().to_uppercase());
         return;
     } else if let Some(encoded) = matches.value_of("decode") {
-        match Key::from_encoded(unescape(encoded)).take_raw() {
+        match Key::from_encoded(unescape(encoded)).into_raw() {
             Ok(k) => println!("{}", escape(&k)),
             Err(e) => eprintln!("decode meets error: {}", e),
         };

--- a/src/coprocessor/dag/executor/scanner.rs
+++ b/src/coprocessor/dag/executor/scanner.rs
@@ -97,7 +97,7 @@ impl<S: Snapshot> Scanner<S> {
         let kv = self.scanner.next()?;
 
         let (key, value) = match kv {
-            Some((k, v)) => (box_try!(k.take_raw()), v),
+            Some((k, v)) => (box_try!(k.into_raw()), v),
             None => {
                 self.no_more = true;
                 return Ok(None);

--- a/src/import/client.rs
+++ b/src/import/client.rs
@@ -181,7 +181,7 @@ impl ImportClient for Client {
 
         let mut req = SplitRegionRequest::new();
         req.set_context(ctx);
-        req.set_split_key(Key::from_encoded_slice(split_key).take_raw()?);
+        req.set_split_key(Key::from_encoded_slice(split_key).into_raw()?);
 
         let ch = self.resolve(store_id)?;
         let client = TikvClient::new(ch);

--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -74,7 +74,7 @@ impl Engine {
             match m.get_op() {
                 Mutation_OP::Put => {
                     let k = Key::from_raw(m.get_key()).append_ts(commit_ts);
-                    wb.put(k.encoded(), m.get_value()).unwrap();
+                    wb.put(k.as_encoded(), m.get_value()).unwrap();
                 }
             }
         }
@@ -316,7 +316,7 @@ mod tests {
     }
 
     fn new_encoded_key(i: u8, ts: u64) -> Vec<u8> {
-        Key::from_raw(&[i]).append_ts(ts).take_encoded()
+        Key::from_raw(&[i]).append_ts(ts).into_encoded()
     }
 
     #[test]
@@ -399,7 +399,7 @@ mod tests {
         assert_eq!(keys.len(), n as usize);
         for (i, expected) in keys.iter().enumerate() {
             let k = Key::from_raw(&[i as u8]);
-            assert_eq!(k.encoded(), expected.encoded());
+            assert_eq!(k.as_encoded(), expected.as_encoded());
         }
     }
 

--- a/src/import/kv_service.rs
+++ b/src/import/kv_service.rs
@@ -247,11 +247,11 @@ impl ImportKv for ImportKVService {
             let start = Key::from_raw(compact.get_range().get_start());
             compact
                 .mut_range()
-                .set_start(keys::data_key(start.encoded()));
+                .set_start(keys::data_key(start.as_encoded()));
             let end = Key::from_raw(compact.get_range().get_end());
             compact
                 .mut_range()
-                .set_end(keys::data_end_key(end.encoded()));
+                .set_end(keys::data_end_key(end.as_encoded()));
         }
 
         ctx.spawn(

--- a/src/import/prepare.rs
+++ b/src/import/prepare.rs
@@ -281,7 +281,7 @@ mod tests {
         if k.is_empty() {
             vec![]
         } else {
-            Key::from_raw(k).take_encoded()
+            Key::from_raw(k).into_encoded()
         }
     }
 

--- a/src/import/stream.rs
+++ b/src/import/stream.rs
@@ -393,7 +393,7 @@ mod tests {
     fn new_encoded_range(start: u8, end: u8) -> Range {
         let k1 = Key::from_raw(&[start]).append_ts(0);
         let k2 = Key::from_raw(&[end]).append_ts(0);
-        new_range(k1.encoded(), k2.encoded())
+        new_range(k1.as_encoded(), k2.as_encoded())
     }
 
     #[test]
@@ -405,8 +405,8 @@ mod tests {
 
         for i in 0..16 {
             let k = Key::from_raw(&[i]).append_ts(0);
-            assert_eq!(k.encoded().len(), 17);
-            engine.put(k.encoded(), k.encoded()).unwrap();
+            assert_eq!(k.as_encoded().len(), 17);
+            engine.put(k.as_encoded(), k.as_encoded()).unwrap();
         }
 
         let mut cfg = Config::default();
@@ -422,8 +422,8 @@ mod tests {
         let mut last = vec![];
         for i in keys {
             let k = Key::from_raw(&[i]).append_ts(0);
-            client.add_region_range(&last, k.encoded());
-            last = k.take_encoded();
+            client.add_region_range(&last, k.as_encoded());
+            last = k.into_encoded();
         }
         // Add an unrelated range.
         client.add_region_range(&last, b"abc");
@@ -481,10 +481,10 @@ mod tests {
         let mut stream = SSTFileStream::new(cfg, client, engine, sst_range, finished_ranges);
         for (start, end, range_end) in expected_ranges {
             let (range, ssts) = stream.next().unwrap().unwrap();
-            let start = Key::from_raw(&[start]).append_ts(0).take_encoded();
-            let end = Key::from_raw(&[end]).append_ts(0).take_encoded();
+            let start = Key::from_raw(&[start]).append_ts(0).into_encoded();
+            let end = Key::from_raw(&[end]).append_ts(0).into_encoded();
             let range_end = match range_end {
-                Some(v) => Key::from_raw(&[v]).append_ts(0).take_encoded(),
+                Some(v) => Key::from_raw(&[v]).append_ts(0).into_encoded(),
                 None => RANGE_MAX.to_owned(),
             };
             assert_eq!(range.get_start(), start.as_slice());

--- a/src/raftstore/coprocessor/split_check/half.rs
+++ b/src/raftstore/coprocessor/split_check/half.rs
@@ -159,7 +159,7 @@ mod tests {
         let cf_handle = engine.cf_handle(CF_DEFAULT).unwrap();
         for i in 0..11 {
             let k = format!("{:04}", i).into_bytes();
-            let k = keys::data_key(Key::from_raw(&k).encoded());
+            let k = keys::data_key(Key::from_raw(&k).as_encoded());
             engine.put_cf(cf_handle, &k, &k).unwrap();
             // Flush for every key so that we can know the exact middle key.
             engine.flush_cf(cf_handle, true).unwrap();
@@ -170,12 +170,12 @@ mod tests {
             CheckPolicy::SCAN,
         ));
         let split_key = Key::from_raw(b"0005");
-        must_split_at(&rx, &region, vec![split_key.clone().take_encoded()]);
+        must_split_at(&rx, &region, vec![split_key.clone().into_encoded()]);
         runnable.run(SplitCheckTask::new(
             region.clone(),
             false,
             CheckPolicy::APPROXIMATE,
         ));
-        must_split_at(&rx, &region, vec![split_key.take_encoded()]);
+        must_split_at(&rx, &region, vec![split_key.into_encoded()]);
     }
 }

--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -224,7 +224,7 @@ mod tests {
             let key = keys::data_key(
                 Key::from_raw(format!("{:04}", i).as_bytes())
                     .append_ts(2)
-                    .encoded(),
+                    .as_encoded(),
             );
             let write_value = Write::new(WriteType::Put, 0, None).to_bytes();
             let write_cf = engine.cf_handle(CF_WRITE).unwrap();
@@ -249,7 +249,7 @@ mod tests {
             let key = keys::data_key(
                 Key::from_raw(format!("{:04}", i).as_bytes())
                     .append_ts(2)
-                    .encoded(),
+                    .as_encoded(),
             );
 
             let write_value =
@@ -265,7 +265,7 @@ mod tests {
         must_split_at(
             &rx,
             &region,
-            vec![Key::from_raw(b"0080").append_ts(2).take_encoded()],
+            vec![Key::from_raw(b"0080").append_ts(2).into_encoded()],
         );
 
         drop(rx);
@@ -314,7 +314,7 @@ mod tests {
             let key = keys::data_key(
                 Key::from_raw(format!("{:04}", i).as_bytes())
                     .append_ts(2)
-                    .encoded(),
+                    .as_encoded(),
             );
             let write_value = Write::new(WriteType::Put, 0, None).to_bytes();
             let write_cf = engine.cf_handle(CF_WRITE).unwrap();
@@ -339,7 +339,7 @@ mod tests {
             let key = keys::data_key(
                 Key::from_raw(format!("{:04}", i).as_bytes())
                     .append_ts(2)
-                    .encoded(),
+                    .as_encoded(),
             );
 
             let write_value =
@@ -356,14 +356,14 @@ mod tests {
         must_split_at(
             &rx,
             &region,
-            vec![Key::from_raw(b"0080").append_ts(2).take_encoded()],
+            vec![Key::from_raw(b"0080").append_ts(2).into_encoded()],
         );
 
         for i in 160..300 {
             let key = keys::data_key(
                 Key::from_raw(format!("{:04}", i).as_bytes())
                     .append_ts(2)
-                    .encoded(),
+                    .as_encoded(),
             );
 
             let write_value = Write::new(WriteType::Put, 0, None).to_bytes();
@@ -380,9 +380,9 @@ mod tests {
             &rx,
             &region,
             vec![
-                Key::from_raw(b"0080").append_ts(2).take_encoded(),
-                Key::from_raw(b"0160").append_ts(2).take_encoded(),
-                Key::from_raw(b"0240").append_ts(2).take_encoded(),
+                Key::from_raw(b"0080").append_ts(2).into_encoded(),
+                Key::from_raw(b"0160").append_ts(2).into_encoded(),
+                Key::from_raw(b"0240").append_ts(2).into_encoded(),
             ],
         );
 
@@ -390,7 +390,7 @@ mod tests {
             let key = keys::data_key(
                 Key::from_raw(format!("{:04}", i).as_bytes())
                     .append_ts(2)
-                    .encoded(),
+                    .as_encoded(),
             );
 
             let write_value = Write::new(WriteType::Put, 0, None).to_bytes();
@@ -407,11 +407,11 @@ mod tests {
             &rx,
             &region,
             vec![
-                Key::from_raw(b"0080").append_ts(2).take_encoded(),
-                Key::from_raw(b"0160").append_ts(2).take_encoded(),
-                Key::from_raw(b"0240").append_ts(2).take_encoded(),
-                Key::from_raw(b"0320").append_ts(2).take_encoded(),
-                Key::from_raw(b"0400").append_ts(2).take_encoded(),
+                Key::from_raw(b"0080").append_ts(2).into_encoded(),
+                Key::from_raw(b"0160").append_ts(2).into_encoded(),
+                Key::from_raw(b"0240").append_ts(2).into_encoded(),
+                Key::from_raw(b"0320").append_ts(2).into_encoded(),
+                Key::from_raw(b"0400").append_ts(2).into_encoded(),
             ],
         );
 

--- a/src/raftstore/coprocessor/split_check/table.rs
+++ b/src/raftstore/coprocessor/split_check/table.rs
@@ -183,9 +183,9 @@ fn last_key_of_region(db: &DB, region: &Region) -> Result<Option<Vec<u8>>> {
 }
 
 fn to_encoded_table_prefix(encoded_key: &[u8]) -> Option<Vec<u8>> {
-    if let Ok(raw_key) = Key::from_encoded_slice(encoded_key).raw() {
+    if let Ok(raw_key) = Key::from_encoded_slice(encoded_key).to_raw() {
         table_codec::extract_table_prefix(&raw_key)
-            .map(|k| Key::from_raw(k).take_encoded())
+            .map(|k| Key::from_raw(k).into_encoded())
             .ok()
     } else {
         None
@@ -257,7 +257,7 @@ mod test {
         for i in 1..3 {
             let mut key = gen_table_prefix(i);
             key.extend_from_slice(padding);
-            let k = keys::data_key(Key::from_raw(&key).encoded());
+            let k = keys::data_key(Key::from_raw(&key).as_encoded());
             engine.put_cf(write_cf, &k, &k).unwrap();
             data_keys.push(k)
         }
@@ -267,12 +267,12 @@ mod test {
             for (start_id, end_id, want) in cases {
                 region.set_start_key(
                     start_id
-                        .map(|id| Key::from_raw(&gen_table_prefix(id)).take_encoded())
+                        .map(|id| Key::from_raw(&gen_table_prefix(id)).into_encoded())
                         .unwrap_or_else(Vec::new),
                 );
                 region.set_end_key(
                     end_id
-                        .map(|id| Key::from_raw(&gen_table_prefix(id)).take_encoded())
+                        .map(|id| Key::from_raw(&gen_table_prefix(id)).into_encoded())
                         .unwrap_or_else(Vec::new),
                 );
                 assert_eq!(last_key_of_region(&engine, &region).unwrap(), want);
@@ -334,7 +334,7 @@ mod test {
                     let key = Key::from_raw(&gen_table_prefix(id));
                     match rx.try_recv() {
                         Ok(Msg::SplitRegion { split_keys, .. }) => {
-                            assert_eq!(split_keys, vec![key.take_encoded()]);
+                            assert_eq!(split_keys, vec![key.into_encoded()]);
                         }
                         others => panic!("expect {:?}, but got {:?}", key, others),
                     }
@@ -349,7 +349,7 @@ mod test {
 
         let gen_encoded_table_prefix = |table_id| {
             let key = Key::from_raw(&gen_table_prefix(table_id));
-            key.take_encoded()
+            key.into_encoded()
         };
 
         // arbitrary padding.
@@ -365,7 +365,7 @@ mod test {
 
             let mut key = gen_table_prefix(i);
             key.extend_from_slice(padding);
-            let s = keys::data_key(Key::from_raw(&key).encoded());
+            let s = keys::data_key(Key::from_raw(&key).as_encoded());
             engine.put_cf(write_cf, &s, &s).unwrap();
         }
 
@@ -392,7 +392,7 @@ mod test {
         for i in 1..4 {
             let mut key = gen_table_prefix(3);
             key.extend_from_slice(format!("{:?}{}", padding, i).as_bytes());
-            let s = keys::data_key(Key::from_raw(&key).encoded());
+            let s = keys::data_key(Key::from_raw(&key).as_encoded());
             engine.put_cf(write_cf, &s, &s).unwrap();
         }
 
@@ -413,10 +413,10 @@ mod test {
         for i in 0..3 {
             // m is less than t and is the prefix of meta keys.
             let key = format!("m{:?}{}", padding, i);
-            let s = keys::data_key(Key::from_raw(key.as_bytes()).encoded());
+            let s = keys::data_key(Key::from_raw(key.as_bytes()).as_encoded());
             engine.put_cf(write_cf, &s, &s).unwrap();
             let key = format!("u{:?}{}", padding, i);
-            let s = keys::data_key(Key::from_raw(key.as_bytes()).encoded());
+            let s = keys::data_key(Key::from_raw(key.as_bytes()).as_encoded());
             engine.put_cf(write_cf, &s, &s).unwrap();
         }
 

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -157,7 +157,7 @@ pub fn delete_all_in_range_cf(
     if use_delete_range && cf != CF_RAFT && cf != CF_LOCK {
         if cf == CF_WRITE {
             let start = Key::from_encoded_slice(start_key).append_ts(u64::MAX);
-            wb.delete_range_cf(handle, start.encoded(), end_key)?;
+            wb.delete_range_cf(handle, start.as_encoded(), end_key)?;
         } else {
             wb.delete_range_cf(handle, start_key, end_key)?;
         }
@@ -1047,7 +1047,7 @@ mod tests {
 
         let cases = [("a", 1024), ("b", 2048), ("c", 4096)];
         for &(key, vlen) in &cases {
-            let key = keys::data_key(Key::from_raw(key.as_bytes()).append_ts(2).encoded());
+            let key = keys::data_key(Key::from_raw(key.as_bytes()).append_ts(2).as_encoded());
             let write_v = Write::new(WriteType::Put, 0, None).to_bytes();
             let write_cf = db.cf_handle(CF_WRITE).unwrap();
             db.put_cf(write_cf, &key, &write_v).unwrap();
@@ -1136,7 +1136,7 @@ mod tests {
 
         let mut kvs: Vec<(&[u8], &[u8])> = vec![];
         for (_, key) in keys.iter().enumerate() {
-            kvs.push((key.encoded().as_slice(), b"value"));
+            kvs.push((key.as_encoded().as_slice(), b"value"));
         }
         let kvs_left: Vec<(&[u8], &[u8])> = vec![(kvs[0].0, kvs[0].1), (kvs[3].0, kvs[3].1)];
         for &(k, v) in kvs.as_slice() {
@@ -1153,8 +1153,8 @@ mod tests {
         let end = Key::from_raw(b"k4");
         delete_all_in_range(
             &db,
-            start.encoded().as_slice(),
-            end.encoded().as_slice(),
+            start.as_encoded().as_slice(),
+            end.as_encoded().as_slice(),
             use_delete_range,
         ).unwrap();
         check_data(&db, ALL_CFS, kvs_left.as_slice());
@@ -1452,7 +1452,7 @@ mod tests {
         big_value.extend(iter::repeat(b'v').take(256));
         for i in 0..100 {
             let k = format!("key_{:03}", i).into_bytes();
-            let k = keys::data_key(Key::from_raw(&k).encoded());
+            let k = keys::data_key(Key::from_raw(&k).as_encoded());
             engine.put_cf(cf_handle, &k, &big_value).unwrap();
             // Flush for every key so that we can know the exact middle key.
             engine.flush_cf(cf_handle, true).unwrap();
@@ -1464,7 +1464,7 @@ mod tests {
             .unwrap();
 
         let middle_key = Key::from_encoded_slice(keys::origin_key(&middle_key))
-            .take_raw()
+            .into_raw()
             .unwrap();
         assert_eq!(escape(&middle_key), "key_049");
     }

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -321,13 +321,13 @@ mod test {
         let cf = get_cf_handle(db, CF_WRITE).unwrap();
         let k = MvccKey::from_encoded(data_key(k)).append_ts(commit_ts);
         let w = Write::new(WriteType::Put, start_ts, Some(v.to_vec()));
-        db.put_cf(cf, k.encoded(), &w.to_bytes()).unwrap();
+        db.put_cf(cf, k.as_encoded(), &w.to_bytes()).unwrap();
     }
 
     fn delete(db: &DB, k: &[u8], commit_ts: u64) {
         let cf = get_cf_handle(db, CF_WRITE).unwrap();
         let k = MvccKey::from_encoded(data_key(k)).append_ts(commit_ts);
-        db.delete_cf(cf, k.encoded()).unwrap();
+        db.delete_cf(cf, k.as_encoded()).unwrap();
     }
 
     fn open_db(path: &str) -> DB {

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -918,7 +918,7 @@ impl MvccChecker {
         match ts {
             Some(ts) => {
                 let key = Key::from_encoded_slice(key).append_ts(ts);
-                box_try!(wb.delete_cf(handle, &keys::data_key(key.encoded())));
+                box_try!(wb.delete_cf(handle, &keys::data_key(key.as_encoded())));
             }
             None => box_try!(wb.delete_cf(handle, &keys::data_key(key))),
         };
@@ -1438,7 +1438,7 @@ mod tests {
         let cf_default_data = vec![(b"k1", b"v", 5), (b"k2", b"x", 10), (b"k3", b"y", 15)];
         for &(prefix, value, ts) in &cf_default_data {
             let encoded_key = Key::from_raw(prefix).append_ts(ts);
-            let key = keys::data_key(encoded_key.encoded().as_slice());
+            let key = keys::data_key(encoded_key.as_encoded().as_slice());
             engine.put(key.as_slice(), value).unwrap();
         }
 
@@ -1450,7 +1450,7 @@ mod tests {
         ];
         for &(prefix, tp, value, version) in &cf_lock_data {
             let encoded_key = Key::from_raw(prefix);
-            let key = keys::data_key(encoded_key.encoded().as_slice());
+            let key = keys::data_key(encoded_key.as_encoded().as_slice());
             let lock = Lock::new(tp, value.to_vec(), version, 0, None);
             let value = lock.to_bytes();
             engine
@@ -1467,7 +1467,7 @@ mod tests {
         ];
         for &(prefix, tp, start_ts, commit_ts) in &cf_write_data {
             let encoded_key = Key::from_raw(prefix).append_ts(commit_ts);
-            let key = keys::data_key(encoded_key.encoded().as_slice());
+            let key = keys::data_key(encoded_key.as_encoded().as_slice());
             let write = Write::new(tp, start_ts, None);
             let value = write.to_bytes();
             engine
@@ -1839,7 +1839,7 @@ mod tests {
         for &(cf, ref k, ref v, _) in &kv {
             wb.put_cf(
                 get_cf_handle(&db, cf).unwrap(),
-                &keys::data_key(k.encoded()),
+                &keys::data_key(k.as_encoded()),
                 v,
             ).unwrap();
         }
@@ -1854,7 +1854,7 @@ mod tests {
             let data =
                 db.get_cf(
                     get_cf_handle(&db, cf).unwrap(),
-                    &keys::data_key(k.encoded()),
+                    &keys::data_key(k.as_encoded()),
                 ).unwrap();
             match expect {
                 Expect::Keep => assert!(data.is_some()),

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1095,7 +1095,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
                 } else {
                     match v {
                         Ok(Some((k, vv))) => {
-                            resp.set_key(k.take_raw().unwrap());
+                            resp.set_key(k.into_raw().unwrap());
                             resp.set_info(extract_mvcc_info(vv));
                         }
                         Ok(None) => {
@@ -1128,7 +1128,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         let req = StoreMessage::SplitRegion {
             region_id,
             region_epoch: req.take_context().take_region_epoch(),
-            split_keys: vec![Key::from_raw(req.get_split_key()).take_encoded()],
+            split_keys: vec![Key::from_raw(req.get_split_key()).into_encoded()],
             callback: Callback::Write(cb),
         };
 

--- a/src/storage/engine/cursor_builder.rs
+++ b/src/storage/engine/cursor_builder.rs
@@ -83,8 +83,8 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
     /// Build `Cursor` from the current configuration.
     pub fn build(self) -> Result<Cursor<S::Iter>> {
         let mut iter_opt = IterOption::new(
-            self.lower_bound.map(|k| k.take_encoded()),
-            self.upper_bound.map(|k| k.take_encoded()),
+            self.lower_bound.map(|k| k.into_encoded()),
+            self.upper_bound.map(|k| k.into_encoded()),
             self.fill_cache,
         );
         if self.prefix_seek {

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -319,7 +319,7 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
             match m {
                 Modify::Delete(cf, k) => {
                     let mut delete = DeleteRequest::new();
-                    delete.set_key(k.take_encoded());
+                    delete.set_key(k.into_encoded());
                     if cf != CF_DEFAULT {
                         delete.set_cf(cf.to_string());
                     }
@@ -328,7 +328,7 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
                 }
                 Modify::Put(cf, k, v) => {
                     let mut put = PutRequest::new();
-                    put.set_key(k.take_encoded());
+                    put.set_key(k.into_encoded());
                     put.set_value(v);
                     if cf != CF_DEFAULT {
                         put.set_cf(cf.to_string());
@@ -339,8 +339,8 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
                 Modify::DeleteRange(cf, start_key, end_key) => {
                     let mut delete_range = DeleteRangeRequest::new();
                     delete_range.set_cf(cf.to_string());
-                    delete_range.set_start_key(start_key.take_encoded());
-                    delete_range.set_end_key(end_key.take_encoded());
+                    delete_range.set_start_key(start_key.into_encoded());
+                    delete_range.set_end_key(end_key.into_encoded());
                     req.set_cmd_type(CmdType::DeleteRange);
                     req.set_delete_range(delete_range);
                 }
@@ -507,7 +507,7 @@ impl Snapshot for RegionSnapshot {
         fail_point!("raftkv_snapshot_get", |_| Err(box_err!(
             "injected error for get"
         )));
-        let v = box_try!(self.get_value(key.encoded()));
+        let v = box_try!(self.get_value(key.as_encoded()));
         Ok(v.map(|v| v.to_vec()))
     }
 
@@ -515,7 +515,7 @@ impl Snapshot for RegionSnapshot {
         fail_point!("raftkv_snapshot_get_cf", |_| Err(box_err!(
             "injected error for get_cf"
         )));
-        let v = box_try!(self.get_value_cf(cf, key.encoded()));
+        let v = box_try!(self.get_value_cf(cf, key.as_encoded()));
         Ok(v.map(|v| v.to_vec()))
     }
 
@@ -559,14 +559,14 @@ impl EngineIterator for RegionIterator {
         fail_point!("raftkv_iter_seek", |_| Err(box_err!(
             "injected error for iter_seek"
         )));
-        RegionIterator::seek(self, key.encoded()).map_err(From::from)
+        RegionIterator::seek(self, key.as_encoded()).map_err(From::from)
     }
 
     fn seek_for_prev(&mut self, key: &Key) -> engine::Result<bool> {
         fail_point!("raftkv_iter_seek_for_prev", |_| Err(box_err!(
             "injected error for iter_seek_for_prev"
         )));
-        RegionIterator::seek_for_prev(self, key.encoded()).map_err(From::from)
+        RegionIterator::seek_for_prev(self, key.as_encoded()).map_err(From::from)
     }
 
     fn seek_to_first(&mut self) -> bool {
@@ -582,7 +582,7 @@ impl EngineIterator for RegionIterator {
     }
 
     fn validate_key(&self, key: &Key) -> engine::Result<()> {
-        self.should_seekable(key.encoded()).map_err(From::from)
+        self.should_seekable(key.as_encoded()).map_err(From::from)
     }
 
     fn key(&self) -> &[u8] {

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -146,29 +146,29 @@ fn write_modifies(db: &DB, modifies: Vec<Modify>) -> Result<()> {
         let res = match rev {
             Modify::Delete(cf, k) => if cf == CF_DEFAULT {
                 trace!("RocksEngine: delete {}", k);
-                wb.delete(k.encoded())
+                wb.delete(k.as_encoded())
             } else {
                 trace!("RocksEngine: delete_cf {} {}", cf, k);
                 let handle = rocksdb::get_cf_handle(db, cf)?;
-                wb.delete_cf(handle, k.encoded())
+                wb.delete_cf(handle, k.as_encoded())
             },
             Modify::Put(cf, k, v) => if cf == CF_DEFAULT {
                 trace!("RocksEngine: put {},{}", k, escape(&v));
-                wb.put(k.encoded(), &v)
+                wb.put(k.as_encoded(), &v)
             } else {
                 trace!("RocksEngine: put_cf {}, {}, {}", cf, k, escape(&v));
                 let handle = rocksdb::get_cf_handle(db, cf)?;
-                wb.put_cf(handle, k.encoded(), &v)
+                wb.put_cf(handle, k.as_encoded(), &v)
             },
             Modify::DeleteRange(cf, start_key, end_key) => {
                 trace!(
                     "RocksEngine: delete_range_cf {}, {}, {}",
                     cf,
-                    escape(start_key.encoded()),
-                    escape(end_key.encoded())
+                    escape(start_key.as_encoded()),
+                    escape(end_key.as_encoded())
                 );
                 let handle = rocksdb::get_cf_handle(db, cf)?;
-                wb.delete_range_cf(handle, start_key.encoded(), end_key.encoded())
+                wb.delete_range_cf(handle, start_key.as_encoded(), end_key.as_encoded())
             }
         };
         if let Err(msg) = res {
@@ -219,13 +219,13 @@ impl Snapshot for RocksSnapshot {
 
     fn get(&self, key: &Key) -> Result<Option<Value>> {
         trace!("RocksSnapshot: get {}", key);
-        let v = box_try!(self.get_value(key.encoded()));
+        let v = box_try!(self.get_value(key.as_encoded()));
         Ok(v.map(|v| v.to_vec()))
     }
 
     fn get_cf(&self, cf: CfName, key: &Key) -> Result<Option<Value>> {
         trace!("RocksSnapshot: get_cf {} {}", cf, key);
-        let v = box_try!(self.get_value_cf(cf, key.encoded()));
+        let v = box_try!(self.get_value_cf(cf, key.as_encoded()));
         Ok(v.map(|v| v.to_vec()))
     }
 
@@ -258,13 +258,13 @@ impl<D: Deref<Target = DB> + Send> EngineIterator for DBIterator<D> {
     }
 
     fn seek(&mut self, key: &Key) -> Result<bool> {
-        Ok(DBIterator::seek(self, key.encoded().as_slice().into()))
+        Ok(DBIterator::seek(self, key.as_encoded().as_slice().into()))
     }
 
     fn seek_for_prev(&mut self, key: &Key) -> Result<bool> {
         Ok(DBIterator::seek_for_prev(
             self,
-            key.encoded().as_slice().into(),
+            key.as_encoded().as_slice().into(),
         ))
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -341,24 +341,24 @@ impl Command {
             Command::Prewrite { ref mutations, .. } => for m in mutations {
                 match *m {
                     Mutation::Put((ref key, ref value)) => {
-                        bytes += key.encoded().len();
+                        bytes += key.as_encoded().len();
                         bytes += value.len();
                     }
                     Mutation::Delete(ref key) | Mutation::Lock(ref key) => {
-                        bytes += key.encoded().len();
+                        bytes += key.as_encoded().len();
                     }
                 }
             },
             Command::Commit { ref keys, .. } | Command::Rollback { ref keys, .. } => {
                 for key in keys {
-                    bytes += key.encoded().len();
+                    bytes += key.as_encoded().len();
                 }
             }
             Command::ResolveLock { ref key_locks, .. } => for lock in key_locks {
-                bytes += lock.0.encoded().len();
+                bytes += lock.0.as_encoded().len();
             },
             Command::Cleanup { ref key, .. } => {
-                bytes += key.encoded().len();
+                bytes += key.as_encoded().len();
             }
             _ => {}
         }
@@ -591,7 +591,7 @@ impl<E: Engine> Storage<E> {
                                 !(v.is_ok() && v.as_ref().unwrap().is_none())
                             )
                             .map(|(v, k)| match v {
-                                Ok(Some(x)) => Ok((k.take_raw().unwrap(), x)),
+                                Ok(Some(x)) => Ok((k.into_raw().unwrap(), x)),
                                 Err(e) => Err(Error::from(e)),
                                 _ => unreachable!(),
                             })
@@ -707,7 +707,7 @@ impl<E: Engine> Storage<E> {
         callback: Callback<Vec<Result<()>>>,
     ) -> Result<()> {
         for m in &mutations {
-            let size = m.key().encoded().len();
+            let size = m.key().as_encoded().len();
             if size > self.max_key_size {
                 callback(Err(Error::KeyTooLarge(size, self.max_key_size)));
                 return Ok(());
@@ -946,8 +946,8 @@ impl<E: Engine> Storage<E> {
                         .map(|(k, v)| match v {
                             Ok(Some(v)) => {
                                 stats.data.flow_stats.read_keys += 1;
-                                stats.data.flow_stats.read_bytes += k.encoded().len() + v.len();
-                                Ok((k.take_encoded(), v))
+                                stats.data.flow_stats.read_bytes += k.as_encoded().len() + v.len();
+                                Ok((k.into_encoded(), v))
                             }
                             Err(e) => Err(Error::from(e)),
                             _ => unreachable!(),
@@ -1113,7 +1113,7 @@ impl<E: Engine> Storage<E> {
     ) -> Result<Vec<Result<KvPair>>> {
         let mut option = IterOption::default();
         if let Some(end) = end_key {
-            option.set_upper_bound(end.take_encoded());
+            option.set_upper_bound(end.into_encoded());
         }
         let mut cursor = snapshot.iter_cf(Self::rawkv_cf(cf)?, option, ScanMode::Forward)?;
         let statistics = statistics.mut_cf_statistics(cf);

--- a/src/storage/mvcc/reader/backward_scanner.rs
+++ b/src/storage/mvcc/reader/backward_scanner.rs
@@ -308,7 +308,7 @@ impl<S: Snapshot> BackwardScanner<S> {
                 let current_key = self.write_cursor.key(&mut self.statistics.write);
                 last_checked_commit_ts = Key::decode_ts_from(current_key)?;
 
-                if !Key::is_user_key_eq(current_key, user_key.encoded().as_slice()) {
+                if !Key::is_user_key_eq(current_key, user_key.as_encoded().as_slice()) {
                     // Meet another key, use `last_version` as the return.
                     *met_prev_user_key = true;
                     is_done = true;
@@ -357,7 +357,7 @@ impl<S: Snapshot> BackwardScanner<S> {
                 // We should never reach another user key.
                 assert!(Key::is_user_key_eq(
                     current_key,
-                    user_key.encoded().as_slice()
+                    user_key.as_encoded().as_slice()
                 ));
                 Key::decode_ts_from(current_key)?
             };
@@ -448,7 +448,7 @@ impl<S: Snapshot> BackwardScanner<S> {
             }
             {
                 let current_key = self.write_cursor.key(&mut self.statistics.write);
-                if !Key::is_user_key_eq(current_key, current_user_key.encoded().as_slice()) {
+                if !Key::is_user_key_eq(current_key, current_user_key.as_encoded().as_slice()) {
                     // Found another user key. We are done here.
                     return Ok(());
                 }

--- a/src/storage/mvcc/reader/forward_scanner.rs
+++ b/src/storage/mvcc/reader/forward_scanner.rs
@@ -333,7 +333,7 @@ impl<S: Snapshot> ForwardScanner<S> {
             }
             {
                 let current_key = self.write_cursor.key(&mut self.statistics.write);
-                if !Key::is_user_key_eq(current_key, user_key.encoded().as_slice()) {
+                if !Key::is_user_key_eq(current_key, user_key.as_encoded().as_slice()) {
                     // Meet another key.
                     *met_next_user_key = true;
                     return Ok(None);
@@ -356,7 +356,7 @@ impl<S: Snapshot> ForwardScanner<S> {
                 return Ok(None);
             }
             let current_key = self.write_cursor.key(&mut self.statistics.write);
-            if !Key::is_user_key_eq(current_key, user_key.encoded().as_slice()) {
+            if !Key::is_user_key_eq(current_key, user_key.as_encoded().as_slice()) {
                 // Meet another key.
                 *met_next_user_key = true;
                 return Ok(None);
@@ -384,7 +384,7 @@ impl<S: Snapshot> ForwardScanner<S> {
                 return Ok(None);
             }
             let current_key = self.write_cursor.key(&mut self.statistics.write);
-            if !Key::is_user_key_eq(current_key, user_key.encoded().as_slice()) {
+            if !Key::is_user_key_eq(current_key, user_key.as_encoded().as_slice()) {
                 // Meet another key.
                 *met_next_user_key = true;
                 return Ok(None);
@@ -439,7 +439,7 @@ impl<S: Snapshot> ForwardScanner<S> {
             }
             {
                 let current_key = self.write_cursor.key(&mut self.statistics.write);
-                if !Key::is_user_key_eq(current_key, current_user_key.encoded().as_slice()) {
+                if !Key::is_user_key_eq(current_key, current_user_key.as_encoded().as_slice()) {
                     // Found another user key. We are done here.
                     return Ok(());
                 }

--- a/src/storage/mvcc/reader/util.rs
+++ b/src/storage/mvcc/reader/util.rs
@@ -38,7 +38,7 @@ pub fn check_lock(key: &Key, ts: u64, lock: &Lock) -> Result<CheckLockResult> {
         return Ok(CheckLockResult::NotLocked);
     }
 
-    let raw_key = key.raw()?;
+    let raw_key = key.to_raw()?;
 
     if ts == ::std::u64::MAX && raw_key == lock.primary {
         // When `ts == u64::MAX` (which means to get latest committed version for
@@ -82,7 +82,7 @@ where
     let seek_key = user_key.clone().append_ts(write.start_ts);
     default_cursor.near_seek(&seek_key, &mut statistics.data)?;
     assert!(default_cursor.valid());
-    assert!(default_cursor.key(&mut statistics.data) == seek_key.encoded().as_slice());
+    assert!(default_cursor.key(&mut statistics.data) == seek_key.as_encoded().as_slice());
     statistics.data.processed += 1;
     Ok(default_cursor.value(&mut statistics.data).to_vec())
 }
@@ -102,7 +102,7 @@ where
     let seek_key = user_key.clone().append_ts(write.start_ts);
     default_cursor.near_seek_for_prev(&seek_key, &mut statistics.data)?;
     assert!(default_cursor.valid());
-    assert!(default_cursor.key(&mut statistics.data) == seek_key.encoded().as_slice());
+    assert!(default_cursor.key(&mut statistics.data) == seek_key.as_encoded().as_slice());
     statistics.data.processed += 1;
     Ok(default_cursor.value(&mut statistics.data).to_vec())
 }

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -527,7 +527,7 @@ fn process_read_impl<E: Engine>(
                 let mut lock_info = LockInfo::new();
                 lock_info.set_primary_lock(lock.primary);
                 lock_info.set_lock_version(lock.ts);
-                lock_info.set_key(key.take_raw()?);
+                lock_info.set_key(key.into_raw()?);
                 locks.push(lock_info);
             }
             sched_ctx

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -136,7 +136,7 @@ impl<S: Snapshot> StoreScanner<S> {
         while results.len() < limit {
             match self.next() {
                 Ok(Some((k, v))) => {
-                    results.push(Ok((k.raw()?, v)));
+                    results.push(Ok((k.to_raw()?, v)));
                 }
                 Ok(None) => break,
                 Err(e @ Error::Mvcc(MvccError::KeyIsLocked { .. })) => {

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -69,7 +69,7 @@ impl Key {
 
     /// Gets and moves the raw representation of this key.
     #[inline]
-    pub fn take_raw(self) -> Result<Vec<u8>, codec::Error> {
+    pub fn into_raw(self) -> Result<Vec<u8>, codec::Error> {
         let mut k = self.0;
         bytes::decode_bytes_in_place(&mut k, false)?;
         Ok(k)
@@ -77,7 +77,7 @@ impl Key {
 
     /// Gets the raw representation of this key.
     #[inline]
-    pub fn raw(&self) -> Result<Vec<u8>, codec::Error> {
+    pub fn to_raw(&self) -> Result<Vec<u8>, codec::Error> {
         bytes::decode_bytes(&mut self.0.as_slice(), false)
     }
 
@@ -97,13 +97,13 @@ impl Key {
 
     /// Gets the encoded representation of this key.
     #[inline]
-    pub fn encoded(&self) -> &Vec<u8> {
+    pub fn as_encoded(&self) -> &Vec<u8> {
         &self.0
     }
 
     /// Gets and moves the encoded representation of this key.
     #[inline]
-    pub fn take_encoded(self) -> Vec<u8> {
+    pub fn into_encoded(self) -> Vec<u8> {
         self.0
     }
 
@@ -225,7 +225,7 @@ impl Clone for Key {
 /// Hash for `Key`.
 impl Hash for Key {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.encoded().hash(state)
+        self.as_encoded().hash(state)
     }
 }
 
@@ -259,7 +259,7 @@ mod tests {
         let ts = 123;
         assert!(Key::split_on_ts_for(k).is_err());
         let enc = Key::from_encoded_slice(k).append_ts(ts);
-        let res = Key::split_on_ts_for(enc.encoded()).unwrap();
+        let res = Key::split_on_ts_for(enc.as_encoded()).unwrap();
         assert_eq!(res, (k.as_ref(), ts));
     }
 

--- a/src/util/rocksdb/properties.rs
+++ b/src/util/rocksdb/properties.rs
@@ -678,7 +678,7 @@ mod tests {
         let mut collector = MvccPropertiesCollector::new();
         for &(key, ts, write_type, entry_type) in &cases {
             let k = Key::from_raw(key.as_bytes()).append_ts(ts);
-            let k = keys::data_key(k.encoded());
+            let k = keys::data_key(k.as_encoded());
             let v = Write::new(write_type, ts, None).to_bytes();
             collector.add(&k, &v, entry_type, 0, 0);
         }
@@ -701,7 +701,7 @@ mod tests {
         for i in 0..num_entries {
             let s = format!("{:032}", i);
             let k = Key::from_raw(s.as_bytes()).append_ts(ts);
-            let k = keys::data_key(k.encoded());
+            let k = keys::data_key(k.as_encoded());
             let w = Write::new(WriteType::Put, ts, Some(s.as_bytes().to_owned()));
             entries.push((k, w.to_bytes()));
         }
@@ -721,9 +721,9 @@ mod tests {
         for i in 0..num_rows {
             let key = format!("k-{}", i);
             let k1 = Key::from_raw(key.as_bytes()).append_ts(2);
-            let k1 = keys::data_key(k1.encoded());
+            let k1 = keys::data_key(k1.as_encoded());
             let k2 = Key::from_raw(key.as_bytes()).append_ts(1);
-            let k2 = keys::data_key(k2.encoded());
+            let k2 = keys::data_key(k2.as_encoded());
             let v = Write::new(WriteType::Put, 0, None).to_bytes();
             collector.add(&k1, &v, DBEntryType::Put, 0, 0);
             collector.add(&k2, &v, DBEntryType::Put, 0, 0);
@@ -754,7 +754,7 @@ mod tests {
         ];
         for &(key, size, offset) in &cases {
             let k = Key::from_raw(key.as_bytes());
-            let k = keys::data_key(k.encoded());
+            let k = keys::data_key(k.as_encoded());
             let h = &props.index_handles[&k];
             assert_eq!(h.size, size);
             assert_eq!(h.offset, offset);

--- a/src/util/rocksdb/stats.rs
+++ b/src/util/rocksdb/stats.rs
@@ -104,11 +104,11 @@ mod tests {
 
         let cases = ["a", "b", "c"];
         for &key in &cases {
-            let k1 = keys::data_key(Key::from_raw(key.as_bytes()).append_ts(2).encoded());
+            let k1 = keys::data_key(Key::from_raw(key.as_bytes()).append_ts(2).as_encoded());
             let write_cf = db.cf_handle(CF_WRITE).unwrap();
             db.put_cf(write_cf, &k1, b"v1").unwrap();
             db.delete_cf(write_cf, &k1).unwrap();
-            let key = keys::data_key(Key::from_raw(key.as_bytes()).append_ts(3).encoded());
+            let key = keys::data_key(Key::from_raw(key.as_bytes()).append_ts(3).as_encoded());
             db.put_cf(write_cf, &key, b"v2").unwrap();
             db.flush_cf(write_cf, true).unwrap();
         }

--- a/tests/raftstore_cases/test_compact_after_delete.rs
+++ b/tests/raftstore_cases/test_compact_after_delete.rs
@@ -25,13 +25,13 @@ fn gen_mvcc_put_kv(k: &[u8], v: &[u8], start_ts: u64, commit_ts: u64) -> (Vec<u8
     let k = MvccKey::from_encoded(data_key(k));
     let k = k.append_ts(commit_ts);
     let w = Write::new(WriteType::Put, start_ts, Some(v.to_vec()));
-    (k.encoded().clone(), w.to_bytes())
+    (k.as_encoded().clone(), w.to_bytes())
 }
 
 fn gen_delete_k(k: &[u8], commit_ts: u64) -> Vec<u8> {
     let k = MvccKey::from_encoded(data_key(k));
     let k = k.append_ts(commit_ts);
-    k.encoded().clone()
+    k.as_encoded().clone()
 }
 
 fn test_compact_after_delete<T: Simulator>(cluster: &mut Cluster<T>) {

--- a/tests/raftstore_cases/test_service.rs
+++ b/tests/raftstore_cases/test_service.rs
@@ -490,7 +490,7 @@ fn test_split_region() {
         Key::from_encoded(resp.get_left().get_end_key().to_vec())
             .truncate_ts()
             .unwrap()
-            .encoded()
+            .as_encoded()
             .as_slice(),
         key
     );


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Extracted from [Mvcc refinement PR](https://github.com/tikv/tikv/pull/3344).

This PR changes the following interface according to [Rust's naming guideline](https://rust-lang-nursery.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv):

- Key::encoded() -> Key::as_encoded()
- Key::raw() -> Key::to_raw()
- Key::take_encoded() -> Key::into_encoded()
- Key::take_raw() -> Key::into_raw()

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

CI

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

