### PR TITLE
raftstore: add a way to get approximate split keys

### DIFF
--- a/src/raftstore/coprocessor/mod.rs
+++ b/src/raftstore/coprocessor/mod.rs
@@ -107,8 +107,8 @@ pub trait SplitChecker {
     fn split_keys(&mut self) -> Vec<Vec<u8>>;
 
     /// Get approximate split keys without scan.
-    fn approximate_split_key(&self, _: &Region, _: &DB) -> Result<Option<Vec<u8>>> {
-        Ok(None)
+    fn approximate_split_keys(&self, _: &Region, _: &DB) -> Result<Vec<Vec<u8>>> {
+        Ok(vec![])
     }
 }
 

--- a/src/raftstore/coprocessor/split_check/half.rs
+++ b/src/raftstore/coprocessor/split_check/half.rs
@@ -62,10 +62,11 @@ impl SplitChecker for Checker {
         }
     }
 
-    fn approximate_split_key(&self, region: &Region, engine: &DB) -> Result<Option<Vec<u8>>> {
-        Ok(box_try!(raftstore_util::get_region_approximate_middle(
-            engine, region
-        )))
+    fn approximate_split_keys(&self, region: &Region, engine: &DB) -> Result<Vec<Vec<u8>>> {
+        Ok(box_try!(
+            raftstore_util::get_region_approximate_middle(engine, region)
+                .map(|keys| keys.map_or(vec![], |key| vec![key]))
+        ))
     }
 }
 

--- a/src/raftstore/coprocessor/split_check/mod.rs
+++ b/src/raftstore/coprocessor/split_check/mod.rs
@@ -74,18 +74,14 @@ impl Host {
         vec![]
     }
 
-    pub fn approximate_split_key(
-        mut self,
-        region: &Region,
-        engine: &DB,
-    ) -> Result<Option<Vec<u8>>> {
+    pub fn approximate_split_keys(mut self, region: &Region, engine: &DB) -> Result<Vec<Vec<u8>>> {
         for checker in &mut self.checkers {
-            match box_try!(checker.approximate_split_key(region, engine)) {
-                Some(split_key) => return Ok(Some(split_key)),
-                None => continue,
+            let keys = box_try!(checker.approximate_split_keys(region, engine));
+            if !keys.is_empty() {
+                return Ok(keys);
             }
         }
-        Ok(None)
+        Ok(vec![])
     }
 
     #[inline]

--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -13,6 +13,9 @@
 
 use std::mem;
 
+use super::super::error::Result;
+use kvproto::metapb::Region;
+use raftstore::store::util as raftstore_util;
 use raftstore::store::{keys, util, Msg};
 use rocksdb::DB;
 use util::transport::{RetryableSendCh, Sender};
@@ -75,6 +78,16 @@ impl SplitChecker for Checker {
         } else {
             vec![]
         }
+    }
+
+    fn approximate_split_keys(&self, region: &Region, engine: &DB) -> Result<Vec<Vec<u8>>> {
+        Ok(box_try!(raftstore_util::get_region_approximate_split_keys(
+            engine,
+            region,
+            self.split_size,
+            self.max_size,
+            self.batch_split_limit,
+        )))
     }
 }
 

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -495,7 +495,7 @@ pub fn get_region_approximate_split_keys_cf(
 
     // cause first element of the iterator will always be returned by step_by(),
     // for convenience, we insert a useless key in front and then just drop it.
-    let mut keys = vec!["".as_bytes().to_vec()];
+    let mut keys = vec![b"".to_vec()];
     for (_, v) in &*collection {
         let props = RangeProperties::decode(v.user_collected_properties())?;
         keys.extend(
@@ -1628,7 +1628,7 @@ mod tests {
             })
             .collect::<Vec<Vec<u8>>>();
 
-        assert_eq!(split_keys, vec!["key_002".as_bytes().to_vec()]);
+        assert_eq!(split_keys, vec![b"key_002".to_vec()]);
 
         for i in 5..10 {
             let k = format!("key_{:03}", i).into_bytes();
@@ -1652,10 +1652,7 @@ mod tests {
             })
             .collect::<Vec<Vec<u8>>>();
 
-        assert_eq!(
-            split_keys,
-            vec!["key_002".as_bytes().to_vec(), "key_005".as_bytes().to_vec()]
-        );
+        assert_eq!(split_keys, vec![b"key_002".to_vec(), b"key_005".to_vec()]);
 
         for i in 10..20 {
             let k = format!("key_{:03}", i).into_bytes();
@@ -1682,11 +1679,11 @@ mod tests {
         assert_eq!(
             split_keys,
             vec![
-                "key_002".as_bytes().to_vec(),
-                "key_005".as_bytes().to_vec(),
-                "key_008".as_bytes().to_vec(),
-                "key_011".as_bytes().to_vec(),
-                "key_014".as_bytes().to_vec(),
+                b"key_002".to_vec(),
+                b"key_005".to_vec(),
+                b"key_008".to_vec(),
+                b"key_011".to_vec(),
+                b"key_014".to_vec(),
             ]
         );
     }

--- a/src/raftstore/store/worker/split_check.rs
+++ b/src/raftstore/store/worker/split_check.rs
@@ -221,7 +221,7 @@ impl<C: Sender<Msg>> Runner<C> {
                 host.split_keys()
             }
             CheckPolicy::APPROXIMATE => {
-                let res = host.approximate_split_key(region, &self.engine);
+                let res = host.approximate_split_keys(region, &self.engine);
                 if let Err(e) = res {
                     error!(
                         "[region {}] failed to get approxiamte split key: {}",
@@ -230,7 +230,9 @@ impl<C: Sender<Msg>> Runner<C> {
                     return;
                 }
                 res.unwrap()
-                    .map_or_else(Vec::new, |r| vec![keys::origin_key(&r).to_vec()])
+                    .into_iter()
+                    .map(|k| keys::origin_key(&k).to_vec())
+                    .collect()
             }
         };
 

--- a/src/util/rocksdb/properties.rs
+++ b/src/util/rocksdb/properties.rs
@@ -39,8 +39,8 @@ const PROP_ROWS_INDEX_DISTANCE: u64 = 10000;
 const PROP_TOTAL_SIZE: &str = "tikv.total_size";
 const PROP_SIZE_INDEX: &str = "tikv.size_index";
 const PROP_RANGE_INDEX: &str = "tikv.range_index";
-pub const PROP_SIZE_INDEX_DISTANCE: u64 = 4 * 1024 * 1024;
-pub const PROP_KEYS_INDEX_DISTANCE: u64 = 40 * 1024;
+const PROP_SIZE_INDEX_DISTANCE: u64 = 4 * 1024 * 1024;
+const PROP_KEYS_INDEX_DISTANCE: u64 = 40 * 1024;
 
 #[derive(Clone, Debug, Default)]
 pub struct MvccProperties {

--- a/src/util/rocksdb/properties.rs
+++ b/src/util/rocksdb/properties.rs
@@ -39,8 +39,8 @@ const PROP_ROWS_INDEX_DISTANCE: u64 = 10000;
 const PROP_TOTAL_SIZE: &str = "tikv.total_size";
 const PROP_SIZE_INDEX: &str = "tikv.size_index";
 const PROP_RANGE_INDEX: &str = "tikv.range_index";
-const PROP_SIZE_INDEX_DISTANCE: u64 = 4 * 1024 * 1024;
-const PROP_KEYS_INDEX_DISTANCE: u64 = 40 * 1024;
+pub const PROP_SIZE_INDEX_DISTANCE: u64 = 4 * 1024 * 1024;
+pub const PROP_KEYS_INDEX_DISTANCE: u64 = 40 * 1024;
 
 #[derive(Clone, Debug, Default)]
 pub struct MvccProperties {


### PR DESCRIPTION
## What have you changed? (mandatory)
This PR adds a way to get approximate split keys. Note that, when `CheckPolicy::APPROXIMATE`, it will call `approximate_split_keys()`, but now split_check_tick will only produce task of `CheckPolicy::SCAN`, I will adjust it in another PR.

## What are the type of the changes? (mandatory)
- New feature (non-breaking change which adds functionality)

## How has this PR been tested? (mandatory)
unit-test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No need

## Does this PR affect tidb-ansible update? (mandatory)
No

