### PR TITLE
Allow configuring leader transfer max allowed log lag

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -473,8 +473,8 @@
 # use-direct-io-for-flush-and-compaction = false
 # enable-pipelined-write = true
 # allow-concurrent-memtable-write = false
-# bytes-per-sync = "0MB"
-# wal-bytes-per-sync = "0KB"
+# bytes-per-sync = "1MB"
+# wal-bytes-per-sync = "512KB"
 
 # info-log-max-size = "1GB"
 # info-log-roll-time = "0"

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -214,6 +214,7 @@
 # bit smaller.
 # region-max-keys = 1440000
 # region-split-keys = 960000
+
 [rocksdb]
 # Maximum number of concurrent background jobs (compactions and flushes)
 # max-background-jobs = 8
@@ -306,25 +307,23 @@
 
 # Allows OS to incrementally sync files to disk while they are being
 # written, asynchronously, in the background.
-# bytes-per-sync = "0MB"
+# bytes-per-sync = "1MB"
 
 # Allows OS to incrementally sync WAL to disk while it is being written.
-# wal-bytes-per-sync = "0KB"
+# wal-bytes-per-sync = "512KB"
 
 # Specify the maximal size of the Rocksdb info log file. If the log file
 # is larger than `max_log_file_size`, a new info log file will be created.
 # If max_log_file_size == 0, all logs will be written to one log file.
-# Default: 1GB
 # info-log-max-size = "1GB"
 
 # Time for the Rocksdb info log file to roll (in seconds).
 # If specified with non-zero value, log file will be rolled
 # if it has been active longer than `log_file_time_to_roll`.
-# Default: 0 (disabled)
+# 0 means disabled.
 # info-log-roll-time = "0"
 
 # Maximal Rocksdb info log files to be kept.
-# Default: 10
 # info-log-keep-log-file-num = 10
 
 # This specifies the Rocksdb info LOG dir.
@@ -332,7 +331,6 @@
 # If it is non empty, the log files will be in the specified dir,
 # and the db data dir's absolute path will be used as the log file
 # name's prefix.
-# Default: empty
 # info-log-dir = ""
 
 # Column Family default used to store actual data of the database.

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -92,6 +92,8 @@ pub struct Config {
     pub abnormal_leader_missing_duration: ReadableDuration,
     pub peer_stale_state_check_interval: ReadableDuration,
 
+    pub leader_transfer_max_log_lag: u64,
+
     pub snap_apply_batch_size: ReadableSize,
 
     // Interval (ms) to check region whether the data is consistent.
@@ -167,6 +169,7 @@ impl Default for Config {
             max_leader_missing_duration: ReadableDuration::hours(2),
             abnormal_leader_missing_duration: ReadableDuration::minutes(10),
             peer_stale_state_check_interval: ReadableDuration::minutes(5),
+            leader_transfer_max_log_lag: 10,
             snap_apply_batch_size: ReadableSize::mb(10),
             lock_cf_compact_interval: ReadableDuration::minutes(10),
             lock_cf_compact_bytes_threshold: ReadableSize::mb(256),
@@ -280,6 +283,12 @@ impl Config {
                 "peer stale state check interval {} ms is less than election timeout x 2 {} ms",
                 stale_state_check,
                 election_timeout * 2
+            ));
+        }
+
+        if self.leader_transfer_max_log_lag < 10 {
+            return Err(box_err!(
+                "raftstore.leader-transfer-max-log-lag should be >= 10."
             ));
         }
 

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -57,7 +57,6 @@ use super::store::{DestroyPeerJob, Store};
 use super::transport::Transport;
 use super::util::{self, check_region_epoch, Lease, LeaseState};
 
-const TRANSFER_LEADER_ALLOW_LOG_LAG: u64 = 10;
 const DEFAULT_APPEND_WB_SIZE: usize = 4 * 1024;
 
 const SHRINK_CACHE_CAPACITY: usize = 64;
@@ -1460,7 +1459,7 @@ impl Peer {
         }
 
         let last_index = self.get_store().last_index();
-        last_index <= status.progress[&peer_id].matched + TRANSFER_LEADER_ALLOW_LOG_LAG
+        last_index <= status.progress[&peer_id].matched + self.cfg.leader_transfer_max_log_lag
     }
 
     fn read_local(&mut self, req: RaftCmdRequest, cb: Callback, metrics: &mut RaftProposeMetrics) {

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -139,6 +139,7 @@ fn test_serde_custom_tikv_config() {
         max_leader_missing_duration: ReadableDuration::hours(12),
         abnormal_leader_missing_duration: ReadableDuration::hours(6),
         peer_stale_state_check_interval: ReadableDuration::hours(2),
+        leader_transfer_max_log_lag: 123,
         snap_apply_batch_size: ReadableSize::mb(12),
         lock_cf_compact_interval: ReadableDuration::minutes(12),
         lock_cf_compact_bytes_threshold: ReadableSize::mb(123),

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -97,6 +97,7 @@ max-peer-down-duration = "12m"
 max-leader-missing-duration = "12h"
 abnormal-leader-missing-duration = "6h"
 peer-stale-state-check-interval = "2h"
+leader-transfer-max-log-lag = 123
 snap-apply-batch-size = "12MB"
 consistency-check-interval = "12s"
 report-region-flow-interval = "12m"


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

When user's disk is very fast, current hard-coded value 10 might not be sufficient. This is a hot fix for a client's problem to make it configurable. However we need better solutions in future.

I also by hand changed some outdated default values appear in config files.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

Manually.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

https://github.com/pingcap/tidb-ansible/pull/510

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

