### PR TITLE
*: replace monotonic_raw_now with Lease::now

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -44,7 +44,7 @@ use raftstore::store::worker::{
 use raftstore::store::{keys, Callback, Config, Engines, ReadResponse, RegionSnapshot};
 use raftstore::{Error, Result};
 use util::collections::{HashMap, HashSet};
-use util::time::{duration_to_sec};
+use util::time::duration_to_sec;
 use util::worker::{FutureWorker, Scheduler};
 use util::{escape, MustConsumeVec};
 

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1978,7 +1978,7 @@ pub trait RequestInspector {
         // Local read should be performed, if and only if leader is in lease.
         // None for now.
         match self.inspect_lease() {
-            LeaseState::Valid | LeaseState::Postponed => Ok(RequestPolicy::ReadLocal),
+            LeaseState::Valid => Ok(RequestPolicy::ReadLocal),
             LeaseState::Expired | LeaseState::Suspect => {
                 // Perform a consistent read to Raft quorum and try to renew the leader lease.
                 Ok(RequestPolicy::ReadIndex)

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -509,6 +509,8 @@ pub enum LeaseState {
     Valid,
     /// The lease is expired.
     Expired,
+    /// Postponed lease check.
+    Postponed,
 }
 
 impl Lease {
@@ -521,6 +523,12 @@ impl Lease {
             last_update: Timespec::new(0, 0),
             remote: None,
         }
+    }
+
+    /// Returns the current `Timespec`.
+    #[inline]
+    pub fn now() -> Timespec {
+        monotonic_raw_now()
     }
 
     /// The valid leader lease should be `lease = max_lease - (commit_ts - send_ts)`
@@ -819,46 +827,46 @@ mod tests {
             }
         };
 
-        inspect_test(&lease, Some(monotonic_raw_now()), LeaseState::Expired);
+        inspect_test(&lease, Some(Lease::now()), LeaseState::Expired);
 
-        let now = monotonic_raw_now();
+        let now = Lease::now();
         let next_expired_time = lease.next_expired_time(now);
         assert_eq!(now + duration, next_expired_time);
 
         // Transit to the Valid state.
         lease.renew(now);
-        inspect_test(&lease, Some(monotonic_raw_now()), LeaseState::Valid);
+        inspect_test(&lease, Some(Lease::now()), LeaseState::Valid);
         inspect_test(&lease, None, LeaseState::Valid);
 
         // After lease expired time.
         sleep_test(duration, &lease, LeaseState::Expired);
-        inspect_test(&lease, Some(monotonic_raw_now()), LeaseState::Expired);
+        inspect_test(&lease, Some(Lease::now()), LeaseState::Expired);
         inspect_test(&lease, None, LeaseState::Expired);
 
         // Transit to the Suspect state.
-        lease.suspect(monotonic_raw_now());
-        inspect_test(&lease, Some(monotonic_raw_now()), LeaseState::Suspect);
+        lease.suspect(Lease::now());
+        inspect_test(&lease, Some(Lease::now()), LeaseState::Suspect);
         inspect_test(&lease, None, LeaseState::Suspect);
 
         // After lease expired time, still suspect.
         sleep_test(duration, &lease, LeaseState::Suspect);
-        inspect_test(&lease, Some(monotonic_raw_now()), LeaseState::Suspect);
+        inspect_test(&lease, Some(Lease::now()), LeaseState::Suspect);
 
         // Clear lease.
         lease.expire();
-        inspect_test(&lease, Some(monotonic_raw_now()), LeaseState::Expired);
+        inspect_test(&lease, Some(Lease::now()), LeaseState::Expired);
         inspect_test(&lease, None, LeaseState::Expired);
 
         // An expired remote lease can never renew.
-        lease.renew(monotonic_raw_now() + TimeDuration::minutes(1));
+        lease.renew(Lease::now() + TimeDuration::minutes(1));
         assert_eq!(
-            remote.inspect(Some(monotonic_raw_now())),
+            remote.inspect(Some(Lease::now())),
             LeaseState::Expired
         );
 
         // A new remote lease.
         let m1 = lease.maybe_new_remote_lease(1).unwrap();
-        assert_eq!(m1.inspect(Some(monotonic_raw_now())), LeaseState::Valid);
+        assert_eq!(m1.inspect(Some(Lease::now())), LeaseState::Valid);
     }
 
     #[test]

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -509,8 +509,6 @@ pub enum LeaseState {
     Valid,
     /// The lease is expired.
     Expired,
-    /// Postponed lease check.
-    Postponed,
 }
 
 impl Lease {

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -859,10 +859,7 @@ mod tests {
 
         // An expired remote lease can never renew.
         lease.renew(Lease::now() + TimeDuration::minutes(1));
-        assert_eq!(
-            remote.inspect(Some(Lease::now())),
-            LeaseState::Expired
-        );
+        assert_eq!(remote.inspect(Some(Lease::now())), LeaseState::Expired);
 
         // A new remote lease.
         let m1 = lease.maybe_new_remote_lease(1).unwrap();

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -463,7 +463,7 @@ impl<'r, 'm> RequestInspector for Inspector<'r, 'm> {
         // TODO: disable localreader if we did not enable raft's check_quorum.
         if self.delegate.leader_lease.is_some() {
             // We skip lease check, because it is postponed until `handle_read`.
-            LeaseState::Postponed
+            LeaseState::Valid
         } else {
             debug!("{} leader lease is None", self.delegate.tag,);
             self.metrics.rejected_by_no_lease += 1;

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -463,7 +463,7 @@ impl<'r, 'm> RequestInspector for Inspector<'r, 'm> {
         // TODO: disable localreader if we did not enable raft's check_quorum.
         if self.delegate.leader_lease.is_some() {
             // We skip lease check, because it is postponed until `handle_read`.
-            LeaseState::Valid
+            LeaseState::Postponed
         } else {
             debug!("{} leader lease is None", self.delegate.tag,);
             self.metrics.rejected_by_no_lease += 1;
@@ -664,7 +664,6 @@ mod tests {
     use raftstore::store::Callback;
     use storage::ALL_CFS;
     use util::rocksdb;
-    use util::time::monotonic_raw_now;
 
     use super::*;
 
@@ -773,7 +772,7 @@ mod tests {
         assert_eq!(reader.metrics.borrow().rejected_by_no_region, 1);
 
         // Register region 1
-        lease.renew(monotonic_raw_now());
+        lease.renew(Lease::now());
         let remote = lease.maybe_new_remote_lease(term6).unwrap();
         // But the applied_index_term is stale.
         let register_region1 = Task::Register(ReadDelegate {
@@ -816,7 +815,7 @@ mod tests {
         must_redirect(&mut reader, &rx, cmd.clone());
 
         // Renew lease.
-        lease.renew(monotonic_raw_now());
+        lease.renew(Lease::now());
 
         // Batch snapshot.
         let region = region1.clone();
@@ -898,7 +897,7 @@ mod tests {
         // Expire lease manually, and it can not be renewed.
         let previous_lease_rejection = reader.metrics.borrow().rejected_by_lease_expire;
         lease.expire();
-        lease.renew(monotonic_raw_now());
+        lease.renew(Lease::now());
         must_redirect(&mut reader, &rx, cmd.clone());
         assert_eq!(
             reader.metrics.borrow().rejected_by_lease_expire,


### PR DESCRIPTION
Signed-off-by: Neil Shen <overvenus@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Integrates `monotonic_raw_now` to lease and add a new lease state `Postponed`.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

unit test.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/pull/3443#discussion_r212389832
