### PR TITLE
[WIP] Flatten aggregation for count

### DIFF
--- a/src/coprocessor/dag/executor/flat_agg.rs
+++ b/src/coprocessor/dag/executor/flat_agg.rs
@@ -11,38 +11,57 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::Executor;
 use coprocessor::codec::datum;
 use coprocessor::*;
 use kvproto::coprocessor::{KeyRange, Response};
 use kvproto::kvrpcpb::IsolationLevel;
 use protobuf::{Message as PbMsg, RepeatedField};
 use storage::engine::ScanMode;
-use storage::{Iterator, Key, Snapshot, SnapshotStore, StoreScanner};
+use storage::{Key, Snapshot, SnapshotStore, StoreScanner};
 use tipb::executor::ExecType;
 use tipb::expression::ExprType;
+use tipb::schema::ColumnInfo;
 use tipb::select::{Chunk, DAGRequest, SelectResponse};
 
 pub struct FlatAggExecutor<S: Snapshot + 'static> {
-    store: SnapshotStore<S>,
     scanner: StoreScanner<S>,
+
+    col: ColumnInfo,
 }
 
 impl<S: Snapshot + 'static> FlatAggExecutor<S> {
-    pub fn new(range: &KeyRange, snap: S, start_ts: u64) -> Self {
+    pub fn new(range: &KeyRange, snap: S, start_ts: u64, col: ColumnInfo) -> Self {
         let store = SnapshotStore::new(snap, start_ts, IsolationLevel::SI, true);
         let lower_bound = Some(Key::from_raw(range.get_start()));
         let upper_bound = Some(Key::from_raw(range.get_end()));
+
         let scanner = store
-            .scanner(ScanMode::Forward, true, lower_bound, upper_bound)
+            .scanner(
+                ScanMode::Forward,
+                col.get_pk_handle(),
+                lower_bound,
+                upper_bound,
+            )
             .unwrap();
-        Self { store, scanner }
+        Self { scanner, col }
     }
+
     pub fn exec(&mut self) -> Result<Response> {
+        let col_id = self.col.get_column_id();
+        let count_pk_handle = self.col.get_pk_handle();
+
         let mut count: i64 = 0;
-        while let Some((_k, _v)) = self.scanner.next()? {
-            count += 1;
+        while let Some((_key, val)) = self.scanner.next()? {
+            if count_pk_handle {
+                count += 1;
+            } else if let Some(loc) = extract_col_location(&val, col_id)? {
+                if val[loc.offset] != datum::NIL_FLAG {
+                    count += 1;
+                }
+            }
         }
+
+        // Construct response
         let mut chunk = Chunk::new();
         chunk
             .mut_rows_data()
@@ -55,7 +74,39 @@ impl<S: Snapshot + 'static> FlatAggExecutor<S> {
         Ok(resp)
     }
 }
-/// Only support `select count(*) from ...` now.
+
+struct ColLocation {
+    pub id: i64,
+    pub offset: usize,
+    pub len: usize,
+}
+
+impl ColLocation {
+    pub fn new(id: i64, offset: usize, len: usize) -> Self {
+        Self { id, offset, len }
+    }
+}
+
+fn extract_col_location(mut data: &[u8], col_id: i64) -> Result<Option<ColLocation>> {
+    if data.is_empty() || (data.len() == 1 && data[0] == datum::NIL_FLAG) {
+        return Ok(None);
+    }
+
+    let length = data.len();
+    while data.is_empty() {
+        let id = datum::decode_datum(&mut data)?.i64();
+        let offset = length - data.len();
+        let (val, rem) = datum::split_datum(data, false)?;
+        if id == col_id {
+            return Ok(Some(ColLocation::new(id, offset, val.len())));
+        }
+        data = rem;
+    }
+
+    Ok(None)
+}
+
+/// Only support `select count(*)/count(k) from ...` now.
 pub fn build_flat_agg_from_dag<S: Snapshot + 'static>(
     req: &DAGRequest,
     ranges: &[KeyRange],
@@ -65,9 +116,11 @@ pub fn build_flat_agg_from_dag<S: Snapshot + 'static>(
     if executors.len() != 2 {
         return None;
     }
+
     if ranges.len() != 1 {
         return None;
     }
+
     let mut unique = false;
     let mut cols = vec![];
     match executors[0].get_tp() {
@@ -81,36 +134,46 @@ pub fn build_flat_agg_from_dag<S: Snapshot + 'static>(
         }
         _ => panic!("unknown first executor type {:?}", executors[0].get_tp()),
     }
+
     if cols.len() != 1 {
         return None;
     }
-    if !cols[0].get_pk_handle() {
-        return None;
-    }
+
+    //    if !cols[0].get_pk_handle() {
+    //        return None;
+    //    }
+
     if !executors[1].has_aggregation() {
         return None;
     }
+
     let agg = executors[1].get_aggregation();
     let agg_funcs = agg.get_agg_func();
     if agg_funcs.len() != 1 {
         return None;
     }
+
     if !agg.get_group_by().is_empty() {
         return None;
     }
+
     if agg_funcs[0].get_tp() != ExprType::Count {
         return None;
     }
+
     let children = agg_funcs[0].get_children();
     if children.len() != 1 {
         return None;
     }
-    if children[0].get_tp() != ExprType::Int64 {
-        return None;
-    }
+
+    //    if children[0].get_tp() != ExprType::Int64 {
+    //        return None;
+    //    }
+
     Some(FlatAggExecutor::<S>::new(
         &ranges[0],
         snap,
         req.get_start_ts(),
+        cols.into_iter().next().unwrap(),
     ))
 }

--- a/src/coprocessor/dag/executor/flat_agg.rs
+++ b/src/coprocessor/dag/executor/flat_agg.rs
@@ -122,27 +122,15 @@ pub fn build_flat_agg_from_dag<S: Snapshot + 'static>(
         return None;
     }
 
-    let mut unique = false;
-    let mut cols = vec![];
-    match executors[0].get_tp() {
-        ExecType::TypeTableScan => {
-            cols = executors[0].get_tbl_scan().get_columns().to_owned();
-            unique = true;
-        }
-        ExecType::TypeIndexScan => {
-            cols = executors[0].get_idx_scan().get_columns().to_owned();
-            unique = executors[0].get_idx_scan().get_unique();
-        }
+    let cols = match executors[0].get_tp() {
+        ExecType::TypeTableScan => executors[0].get_tbl_scan().get_columns().to_owned(),
+        ExecType::TypeIndexScan => executors[0].get_idx_scan().get_columns().to_owned(),
         _ => panic!("unknown first executor type {:?}", executors[0].get_tp()),
-    }
+    };
 
     if cols.len() != 1 {
         return None;
     }
-
-    //    if !cols[0].get_pk_handle() {
-    //        return None;
-    //    }
 
     if !executors[1].has_aggregation() {
         return None;
@@ -166,10 +154,6 @@ pub fn build_flat_agg_from_dag<S: Snapshot + 'static>(
     if children.len() != 1 {
         return None;
     }
-
-    //    if children[0].get_tp() != ExprType::Int64 {
-    //        return None;
-    //    }
 
     Some(FlatAggExecutor::<S>::new(
         &ranges[0],

--- a/src/coprocessor/dag/executor/flat_agg.rs
+++ b/src/coprocessor/dag/executor/flat_agg.rs
@@ -93,7 +93,7 @@ fn extract_col_location(mut data: &[u8], col_id: i64) -> Result<Option<ColLocati
     }
 
     let length = data.len();
-    while data.is_empty() {
+    while !data.is_empty() {
         let id = datum::decode_datum(&mut data)?.i64();
         let offset = length - data.len();
         let (val, rem) = datum::split_datum(data, false)?;
@@ -106,7 +106,8 @@ fn extract_col_location(mut data: &[u8], col_id: i64) -> Result<Option<ColLocati
     Ok(None)
 }
 
-/// Only support `select count(*)/count(k) from ...` now.
+/// Support `select count(*)/count(k) from ...` now.
+/// TODO: support sum/avg
 pub fn build_flat_agg_from_dag<S: Snapshot + 'static>(
     req: &DAGRequest,
     ranges: &[KeyRange],

--- a/src/coprocessor/dag/executor/flat_agg.rs
+++ b/src/coprocessor/dag/executor/flat_agg.rs
@@ -1,0 +1,116 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::Executor;
+use coprocessor::codec::datum;
+use coprocessor::*;
+use kvproto::coprocessor::{KeyRange, Response};
+use kvproto::kvrpcpb::IsolationLevel;
+use protobuf::{Message as PbMsg, RepeatedField};
+use storage::engine::ScanMode;
+use storage::{Iterator, Key, Snapshot, SnapshotStore, StoreScanner};
+use tipb::executor::ExecType;
+use tipb::expression::ExprType;
+use tipb::select::{Chunk, DAGRequest, SelectResponse};
+
+pub struct FlatAggExecutor<S: Snapshot + 'static> {
+    store: SnapshotStore<S>,
+    scanner: StoreScanner<S>,
+}
+
+impl<S: Snapshot + 'static> FlatAggExecutor<S> {
+    pub fn new(range: &KeyRange, snap: S, start_ts: u64) -> Self {
+        let store = SnapshotStore::new(snap, start_ts, IsolationLevel::SI, true);
+        let lower_bound = Some(Key::from_raw(range.get_start()));
+        let upper_bound = Some(Key::from_raw(range.get_end()));
+        let scanner = store
+            .scanner(ScanMode::Forward, true, lower_bound, upper_bound)
+            .unwrap();
+        Self { store, scanner }
+    }
+    pub fn exec(&mut self) -> Result<Response> {
+        let mut count: i64 = 0;
+        while let Some((_k, _v)) = self.scanner.next()? {
+            count += 1;
+        }
+        let mut chunk = Chunk::new();
+        chunk
+            .mut_rows_data()
+            .extend_from_slice(&datum::encode_value(&[datum::Datum::I64(count)])?);
+        let mut sel_resp = SelectResponse::new();
+        sel_resp.set_chunks(RepeatedField::from_vec(vec![chunk]));
+        let mut resp = Response::new();
+        let data = box_try!(sel_resp.write_to_bytes());
+        resp.set_data(data);
+        Ok(resp)
+    }
+}
+/// Only support `select count(*) from ...` now.
+pub fn build_flat_agg_from_dag<S: Snapshot + 'static>(
+    req: &DAGRequest,
+    ranges: &[KeyRange],
+    snap: S,
+) -> Option<FlatAggExecutor<S>> {
+    let executors = req.get_executors();
+    if executors.len() != 2 {
+        return None;
+    }
+    if ranges.len() != 1 {
+        return None;
+    }
+    let mut unique = false;
+    let mut cols = vec![];
+    match executors[0].get_tp() {
+        ExecType::TypeTableScan => {
+            cols = executors[0].get_tbl_scan().get_columns().to_owned();
+            unique = true;
+        }
+        ExecType::TypeIndexScan => {
+            cols = executors[0].get_idx_scan().get_columns().to_owned();
+            unique = executors[0].get_idx_scan().get_unique();
+        }
+        _ => panic!("unknown first executor type {:?}", executors[0].get_tp()),
+    }
+    if cols.len() != 1 {
+        return None;
+    }
+    if !cols[0].get_pk_handle() {
+        return None;
+    }
+    if !executors[1].has_aggregation() {
+        return None;
+    }
+    let agg = executors[1].get_aggregation();
+    let agg_funcs = agg.get_agg_func();
+    if agg_funcs.len() != 1 {
+        return None;
+    }
+    if !agg.get_group_by().is_empty() {
+        return None;
+    }
+    if agg_funcs[0].get_tp() != ExprType::Count {
+        return None;
+    }
+    let children = agg_funcs[0].get_children();
+    if children.len() != 1 {
+        return None;
+    }
+    if children[0].get_tp() != ExprType::Int64 {
+        return None;
+    }
+    Some(FlatAggExecutor::<S>::new(
+        &ranges[0],
+        snap,
+        req.get_start_ts(),
+    ))
+}

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -31,6 +31,7 @@ use coprocessor::*;
 
 mod aggregate;
 mod aggregation;
+mod flat_agg;
 mod index_scan;
 mod limit;
 mod scanner;
@@ -42,6 +43,7 @@ mod topn_heap;
 mod metrics;
 
 pub use self::aggregation::{HashAggExecutor, StreamAggExecutor};
+pub use self::flat_agg::{build_flat_agg_from_dag, FlatAggExecutor};
 pub use self::index_scan::IndexScanExecutor;
 pub use self::limit::LimitExecutor;
 pub use self::metrics::*;

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -151,10 +151,10 @@ impl<E: Engine> Host<E> {
 
         match cop_req {
             CopRequest::DAG(dag) => {
-                let flag_agg = build_flat_agg_from_dag(&dag, &ranges, snap.clone());
-                if let Some(mut flag_agg) = flag_agg {
+                let flat_agg = build_flat_agg_from_dag(&dag, &ranges, snap.clone());
+                if let Some(mut flat_agg) = flat_agg {
                     let do_request = move |_| {
-                        let resp = flag_agg.exec().unwrap_or_else(|e| {
+                        let resp = flat_agg.exec().unwrap_or_else(|e| {
                             let mut metrics = BasicLocalMetrics::default();
                             err_resp(e, &mut metrics)
                         });

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -41,8 +41,8 @@ use util::worker::{Runnable, Scheduler};
 
 use super::checksum::ChecksumContext;
 use super::codec::table;
-use super::dag::executor::ExecutorMetrics;
 use super::dag::executor::build_flat_agg_from_dag;
+use super::dag::executor::ExecutorMetrics;
 use super::dag::DAGContext;
 use super::local_metrics::BasicLocalMetrics;
 use super::metrics::*;


### PR DESCRIPTION
## What have you changed? (mandatory)

Currently, all aggregations are using the same framework, for some simple aggregations, the cost of the framework is expensive. For `select count(*) from t` query, actually we don't need to know the detail of each column for each row, we can simply cumulate the count. For `select count(k) from t` query, we only need to care about the column `k`, and cumulate the count if it is not nil.

This pr introduce a flatten aggregation module, count(*) and count(k) are supported.

## What are the type of the changes? (mandatory)

Improvement

## How has this PR been tested? (mandatory)

None

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

None

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)
For `select count(*) from t`:
master
```
mysql> select count(*) from sbtest.sbtest1;
+-----------+
| count(*)  |
+-----------+
| 100000000 |
+-----------+
1 row in set (5.75 sec)

mysql> select count(*) from sbtest.sbtest1;
+-----------+
| count(*)  |
+-----------+
| 100000000 |
+-----------+
1 row in set (5.74 sec)
```

this pr 
```
mysql> select count(*) from sbtest.sbtest1;
+-----------+
| count(*)  |
+-----------+
| 100000000 |
+-----------+
1 row in set (3.61 sec)

mysql> select count(*) from sbtest.sbtest1;
+-----------+
| count(*)  |
+-----------+
| 100000000 |
+-----------+
1 row in set (3.74 sec)
```

For `select count(k) from t`:
master
```
mysql> select count(k) from sbtest.sbtest1;
+-----------+
| count(k)  |
+-----------+
| 100000000 |
+-----------+
1 row in set (11.26 sec)

mysql> select count(k) from sbtest.sbtest1;
+-----------+
| count(k)  |
+-----------+
| 100000000 |
+-----------+
1 row in set (10.99 sec)
```

this pr
```
mysql> select count(k) from sbtest.sbtest1;
+-----------+
| count(k)  |
+-----------+
| 100000000 |
+-----------+
1 row in set (7.46 sec)

mysql> select count(k) from sbtest.sbtest1;
+-----------+
| count(k)  |
+-----------+
| 100000000 |
+-----------+
1 row in set (7.50 sec)
```

## Add a few positive/negative examples (optional)

