### PR TITLE
storage/txn: reduce clone in txn scheduler

### DIFF
--- a/src/coprocessor/dag/executor/scanner.rs
+++ b/src/coprocessor/dag/executor/scanner.rs
@@ -319,7 +319,7 @@ pub mod test {
             let txn_modifies = {
                 let mut txn = MvccTxn::new(self.snapshot.clone(), START_TS, true).unwrap();
                 for &(ref key, _) in kv_data {
-                    txn.commit(&Key::from_raw(key), COMMIT_TS).unwrap();
+                    txn.commit(Key::from_raw(key), COMMIT_TS).unwrap();
                 }
                 txn.into_modifies()
             };

--- a/src/storage/gc_worker.rs
+++ b/src/storage/gc_worker.rs
@@ -141,7 +141,7 @@ impl<E: Engine> GCRunner<E> {
         let mut txn = MvccTxn::new(snapshot, 0, !ctx.get_not_fill_cache()).unwrap();
         for k in keys {
             // TODO: Duplicated code in scheduler.rs
-            let gc_info = txn.gc(&k, safe_point)?;
+            let gc_info = txn.gc(k.clone(), safe_point)?;
 
             if gc_info.found_versions >= GC_LOG_FOUND_VERSION_THRESHOLD {
                 info!(

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -221,7 +221,7 @@ pub mod tests {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
-        txn.commit(&Key::from_raw(key), commit_ts).unwrap();
+        txn.commit(Key::from_raw(key), commit_ts).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
 
@@ -229,7 +229,7 @@ pub mod tests {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
-        assert!(txn.commit(&Key::from_raw(key), commit_ts).is_err());
+        assert!(txn.commit(Key::from_raw(key), commit_ts).is_err());
     }
 
     pub fn must_rollback<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
@@ -237,7 +237,7 @@ pub mod tests {
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         txn.collapse_rollback(false);
-        txn.rollback(&Key::from_raw(key)).unwrap();
+        txn.rollback(Key::from_raw(key)).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
 
@@ -245,7 +245,7 @@ pub mod tests {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
-        txn.rollback(&Key::from_raw(key)).unwrap();
+        txn.rollback(Key::from_raw(key)).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
 
@@ -253,14 +253,14 @@ pub mod tests {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
-        assert!(txn.rollback(&Key::from_raw(key)).is_err());
+        assert!(txn.rollback(Key::from_raw(key)).is_err());
     }
 
     pub fn must_gc<E: Engine>(engine: &E, key: &[u8], safe_point: u64) {
         let ctx = Context::new();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, 0, true).unwrap();
-        txn.gc(&Key::from_raw(key), safe_point).unwrap();
+        txn.gc(Key::from_raw(key), safe_point).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
 

--- a/src/storage/mvcc/reader/mod.rs
+++ b/src/storage/mvcc/reader/mod.rs
@@ -542,28 +542,25 @@ mod tests {
         }
 
         fn commit(&mut self, pk: &[u8], start_ts: u64, commit_ts: u64) {
-            let k = Key::from_raw(pk);
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
             let mut txn = MvccTxn::new(snap, start_ts, true).unwrap();
-            txn.commit(&k, commit_ts).unwrap();
+            txn.commit(Key::from_raw(pk), commit_ts).unwrap();
             self.write(txn.into_modifies());
         }
 
         fn rollback(&mut self, pk: &[u8], start_ts: u64) {
-            let k = Key::from_raw(pk);
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
             let mut txn = MvccTxn::new(snap, start_ts, true).unwrap();
             txn.collapse_rollback(false);
-            txn.rollback(&k).unwrap();
+            txn.rollback(Key::from_raw(pk)).unwrap();
             self.write(txn.into_modifies());
         }
 
         fn gc(&mut self, pk: &[u8], safe_point: u64) {
-            let k = Key::from_raw(pk);
             loop {
                 let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
                 let mut txn = MvccTxn::new(snap, safe_point, true).unwrap();
-                txn.gc(&k, safe_point).unwrap();
+                txn.gc(Key::from_raw(pk), safe_point).unwrap();
                 let modifies = txn.into_modifies();
                 if modifies.is_empty() {
                     return;

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -293,10 +293,10 @@ impl<S: Snapshot> MvccTxn<S> {
         let write = Write::new(WriteType::Rollback, self.start_ts, None);
         let ts = self.start_ts;
         self.put_write(key.clone(), ts, write.to_bytes());
+        self.unlock_key(key.clone());
         if self.collapse_rollback {
-            self.collapse_prev_rollback(key.clone())?;
+            self.collapse_prev_rollback(key)?;
         }
-        self.unlock_key(key);
         Ok(())
     }
 

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -220,7 +220,7 @@ mod test {
                 let mut txn = MvccTxn::new(self.snapshot.clone(), START_TS, true).unwrap();
                 for key in &self.keys {
                     let key = key.as_bytes();
-                    txn.commit(&Key::from_raw(key), COMMIT_TS).unwrap();
+                    txn.commit(Key::from_raw(key), COMMIT_TS).unwrap();
                 }
                 self.engine.write(&self.ctx, txn.into_modifies()).unwrap();
             }


### PR DESCRIPTION
## What have you changed? (mandatory)
Before we move `command` to `Msg::WritePrepareFinished`, but actually we just need `ctx` in `command`. Now we just move ctx to `Msg::WritePrepareFinished`, so make other place no need to clone.
- reduce mutation clone in `process_write_impl()`
- reduce key clone

## What are the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
No need

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No