### PR TITLE
Print help message when starting tikv-ctl without argument

### DIFF
--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -1522,6 +1522,11 @@ fn main() {
         );
 
     let matches = app.clone().get_matches();
+    if matches.args.is_empty() {
+        let _ = app.print_help();
+        println!();
+        return;
+    }
 
     // Deal with arguments about key utils.
     if let Some(hex) = matches.value_of("hex-to-escaped") {


### PR DESCRIPTION
Signed-off-by: Xiaoguang Sun <sunxiaoguang@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/pingcap/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
Print help message when no argument is given to tikv-ctl

## What are the type of the changes? (mandatory)
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)
Running tikv-ctl without any argument manually gets help message back instead of panicking 

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No

## Refer to a related PR or issue link (optional)
#3453 

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)
