### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git
+target


### PR DESCRIPTION
## What have you changed? (mandatory)
add `target` to `.dockerignore`, otherwise it will make too large image when `docker build`

## What are the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
manual test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No 

## Does this PR affect tidb-ansible update? (mandatory)
No 

## Add a few positive/negative examples (optional)
before:
```bash
docker build -t hub.pingcap.com/pingcap/tikv:v2.1.0-rc.1 .
Sending build context to Docker daemon  23.65GB
```

after:
```bash
docker build -t hub.pingcap.com/pingcap/tikv:v2.1.0-rc.1 .
Sending build context to Docker daemon  312.6MB
```

