### PR TITLE
store/util: human readable expired time

### DIFF
--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -631,7 +631,6 @@ impl fmt::Debug for Lease {
 /// A remote lease, it can only be derived by `Lease`. It will be sent
 /// to the local read thread, so name it remote. If Lease expires, the remote must
 /// expire too.
-#[derive(Debug)]
 pub struct RemoteLease {
     expired_time: Arc<AtomicU64>,
     term: u64,
@@ -658,6 +657,18 @@ impl RemoteLease {
 
     pub fn term(&self) -> u64 {
         self.term
+    }
+}
+
+impl fmt::Debug for RemoteLease {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("RemoteLease")
+            .field(
+                "expired_time",
+                &u64_to_timespec(self.expired_time.load(AtomicOrdering::Relaxed)),
+            )
+            .field("term", &self.term)
+            .finish()
     }
 }
 


### PR DESCRIPTION
## What have you changed? (mandatory)

Manually `impl Debug for RemoteLease`, and makes expired time human readable. It is convenient for debugging lease read tests.

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Unit tests.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

#3544 