### PR TITLE
*: remove async batch snap

### DIFF
--- a/benches/raftkv/mod.rs
+++ b/benches/raftkv/mod.rs
@@ -22,13 +22,15 @@ use kvproto::metapb::Region;
 use kvproto::raft_cmdpb::{RaftCmdResponse, Response};
 
 use tikv::raftstore::store::{
-    cmd_resp, engine, util, BatchReadCallback, Callback, Msg, ReadResponse, RegionSnapshot,
-    SignificantMsg, WriteResponse,
+    cmd_resp, engine, util, Callback, Msg, ReadResponse, RegionSnapshot, SignificantMsg,
+    WriteResponse,
 };
 use tikv::raftstore::Result;
 use tikv::server::transport::RaftStoreRouter;
 use tikv::storage::engine::raftkv::CmdRes;
-use tikv::storage::engine::{BatchCallback, BatchResults, Callback as EngineCallback, Modify};
+use tikv::storage::engine::{
+    Callback as EngineCallback, CbContext, Modify, Result as EngineResult,
+};
 use tikv::storage::types::Key;
 use tikv::storage::{Engine, RaftKv, ALL_CFS, CF_DEFAULT};
 use tikv::util::rocksdb;
@@ -49,10 +51,11 @@ impl SyncBenchRouter {
     fn invoke(&self, msg: Msg) {
         let mut response = RaftCmdResponse::new();
         cmd_resp::bind_term(&mut response, 1);
-        match msg {
-            Msg::RaftCmd {
-                request, callback, ..
-            } => match callback {
+        if let Msg::RaftCmd {
+            request, callback, ..
+        } = msg
+        {
+            match callback {
                 Callback::Read(cb) => {
                     let snapshot = engine::Snapshot::new(Arc::clone(&self.db));
                     let region = self.region.to_owned();
@@ -69,19 +72,7 @@ impl SyncBenchRouter {
                     cb(WriteResponse { response })
                 }
                 _ => unreachable!(),
-            },
-            Msg::BatchRaftSnapCmds { on_finished, .. } => {
-                let snapshot = engine::Snapshot::new(Arc::clone(&self.db));
-                let region = self.region.to_owned();
-                match on_finished {
-                    Callback::BatchRead(on_finished) => on_finished(vec![Some(ReadResponse {
-                        response,
-                        snapshot: Some(RegionSnapshot::from_snapshot(snapshot.into_sync(), region)),
-                    })]),
-                    _ => unreachable!(),
-                }
             }
-            _ => (),
         }
     }
 }
@@ -109,49 +100,35 @@ fn new_engine() -> (TempDir, Arc<DB>) {
     (dir, Arc::new(db))
 }
 
+// speed of light for async_snapshot
 #[bench]
-fn bench_async_batch_snapshots(b: &mut test::Bencher) {
-    let leader = util::new_peer(2, 3);
-    let mut region = Region::new();
-    region.set_id(1);
-    region.set_start_key(vec![]);
-    region.set_end_key(vec![]);
-    region.mut_peers().push(leader.clone());
-    region.mut_region_epoch().set_version(2);
-    region.mut_region_epoch().set_conf_ver(5);
-    let (_tmp, db) = new_engine();
-    let kv = RaftKv::new(SyncBenchRouter::new(region.clone(), db));
+fn bench_async_snapshots_noop(b: &mut test::Bencher) {
+    let (_dir, db) = new_engine();
+    let snapshot = engine::Snapshot::new(Arc::clone(&db));
+    let resp = ReadResponse {
+        response: RaftCmdResponse::new(),
+        snapshot: Some(RegionSnapshot::from_snapshot(
+            snapshot.into_sync(),
+            Region::new(),
+        )),
+    };
 
     b.iter(|| {
-        let mut ctx = Context::new();
-        ctx.set_region_id(region.get_id());
-        ctx.set_region_epoch(region.get_region_epoch().clone());
-        ctx.set_peer(leader.clone());
-
-        let on_finished: BatchCallback<RegionSnapshot> = Box::new(move |results| {
-            test::black_box(results);
-        });
-        kv.async_batch_snapshot(vec![ctx], on_finished).unwrap();
-    });
-}
-
-// speed of light for batch_snapshot
-#[bench]
-#[cfg_attr(feature = "cargo-clippy", allow(unit_arg))]
-fn bench_async_batch_snapshots_noop(b: &mut test::Bencher) {
-    b.iter(|| {
-        let on_finished: BatchCallback<RegionSnapshot> = Box::new(move |results: Vec<_>| {
-            test::black_box(results);
-        });
-        let on_finished: BatchCallback<CmdRes> = Box::new(move |results: BatchResults<_>| {
-            test::black_box(results);
-            test::black_box(on_finished(vec![]));
-        });
-        let on_finished: BatchReadCallback = Box::new(move |results: Vec<Option<ReadResponse>>| {
-            test::black_box(results);
-            test::black_box(on_finished(vec![]));
-        });
-        test::black_box(on_finished(vec![]));
+        let cb1: EngineCallback<RegionSnapshot> =
+            Box::new(move |(_, res): (CbContext, EngineResult<RegionSnapshot>)| {
+                assert!(res.is_ok());
+            });
+        let cb2: EngineCallback<CmdRes> =
+            Box::new(move |(ctx, res): (CbContext, EngineResult<CmdRes>)| {
+                if let Ok(CmdRes::Snap(snap)) = res {
+                    cb1((ctx, Ok(snap)));
+                }
+            });
+        let cb: Callback = Callback::Read(Box::new(move |resp: ReadResponse| {
+            let res = CmdRes::Snap(resp.snapshot.unwrap());
+            cb2((CbContext::new(), Ok(res)));
+        }));
+        cb.invoke_read(resp.clone());
     });
 }
 

--- a/benches/raftkv/mod.rs
+++ b/benches/raftkv/mod.rs
@@ -100,7 +100,7 @@ fn new_engine() -> (TempDir, Arc<DB>) {
     (dir, Arc::new(db))
 }
 
-// speed of light for async_snapshot
+// The lower limit of time a async_snapshot may take.
 #[bench]
 fn bench_async_snapshots_noop(b: &mut test::Bencher) {
     let (_dir, db) = new_engine();

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -1042,18 +1042,6 @@ impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
                     .observe(duration_to_sec(send_time.elapsed()) as f64);
                 self.propose_raft_command(request, callback)
             }
-            // For now, it is only called by batch snapshot.
-            Msg::BatchRaftSnapCmds {
-                send_time,
-                batch,
-                on_finished,
-            } => {
-                self.raft_metrics
-                    .propose
-                    .request_wait_time
-                    .observe(duration_to_sec(send_time.elapsed()) as f64);
-                self.propose_batch_raft_snapshot_command(batch, on_finished);
-            }
             Msg::Quit => {
                 info!("{} receive quit message", self.tag);
                 event_loop.shutdown();

--- a/src/raftstore/store/metrics.rs
+++ b/src/raftstore/store/metrics.rs
@@ -201,14 +201,6 @@ lazy_static! {
             &["type"]
         ).unwrap();
 
-    pub static ref BATCH_SNAPSHOT_COMMANDS: Histogram =
-        register_histogram!(
-            "tikv_raftstore_batch_snapshot_commands_total",
-            "Bucketed histogram of total size of batch snapshot commands",
-            vec![1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0,
-                 20.0, 24.0, 32.0, 64.0, 128.0, 256.0]
-        ).unwrap();
-
     pub static ref LEADER_MISSING: IntGauge =
         register_int_gauge!(
             "tikv_raftstore_leader_missing",

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -40,8 +40,8 @@ pub use self::fsm::{
     StoreStat,
 };
 pub use self::msg::{
-    BatchReadCallback, Callback, Msg, ReadCallback, ReadResponse, SeekRegionCallback,
-    SeekRegionFilter, SeekRegionResult, SignificantMsg, Tick, WriteCallback, WriteResponse,
+    Callback, Msg, ReadCallback, ReadResponse, SeekRegionCallback, SeekRegionFilter,
+    SeekRegionResult, SignificantMsg, Tick, WriteCallback, WriteResponse,
 };
 pub use self::peer::{
     Peer, PeerStat, ProposalContext, ReadExecutor, RequestInspector, RequestPolicy,

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -187,7 +187,7 @@ impl Task {
         Task::Read(msg)
     }
 
-    /// Task accepts `Mag`s that contain Get/Snap requests and BatchRaftSnapCmds.
+    /// Task accepts `Mag`s that contain Get/Snap requests.
     /// Returns `true`, it can be saftly sent to localreader,
     /// Returns `false`, it must not be sent to localreader.
     #[inline]
@@ -211,7 +211,6 @@ impl Task {
                     true
                 }
             }
-            StoreMsg::BatchRaftSnapCmds { .. } => true,
             _ => false,
         }
     }
@@ -244,9 +243,6 @@ fn handle_busy(cmd: StoreMsg) {
 
     match cmd {
         StoreMsg::RaftCmd { callback, .. } => callback.invoke_read(read_resp),
-        StoreMsg::BatchRaftSnapCmds {
-            batch, on_finished, ..
-        } => on_finished.invoke_batch_read(vec![Some(read_resp); batch.len()]),
         other => panic!("unexpected cmd {:?}", other),
     }
 }
@@ -406,44 +402,6 @@ impl<C: Sender<StoreMsg>> LocalReader<C> {
             callback,
         });
     }
-
-    fn propose_batch_raft_snapshot_command(
-        &mut self,
-        batch: Vec<RaftCmdRequest>,
-        on_finished: Callback,
-        executor: &mut ReadExecutor,
-    ) {
-        let size = batch.len();
-        let mut ret = Vec::with_capacity(size);
-        for req in batch {
-            let region_id = req.get_header().get_region_id();
-            match self.pre_propose_raft_command(&req) {
-                Ok(Some(delegate)) => {
-                    let mut metrics = self.metrics.borrow_mut();
-                    let resp = delegate.handle_read(&req, executor, &mut *metrics);
-                    ret.push(resp);
-                }
-                // It can not handle the rquest, instead of forwarding to raftstore,
-                // it returns a `None` which means users need to retry the requsets
-                // via `async_snapshot`.
-                Ok(None) => {
-                    ret.push(None);
-                }
-                Err(e) => {
-                    let mut response = cmd_resp::new_error(e);
-                    if let Some(delegate) = self.delegates.get(&region_id) {
-                        cmd_resp::bind_term(&mut response, delegate.term);
-                    }
-                    ret.push(Some(ReadResponse {
-                        response,
-                        snapshot: None,
-                    }));
-                }
-            }
-        }
-
-        on_finished.invoke_batch_read(ret);
-    }
 }
 
 struct Inspector<'r, 'm> {
@@ -504,16 +462,6 @@ impl<C: Sender<StoreMsg>> Runnable<Task> for LocalReader<C> {
                     callback,
                 }) => {
                     self.propose_raft_command(request, callback, send_time, &mut executor);
-                    if sent.is_none() {
-                        sent = Some(send_time);
-                    }
-                }
-                Task::Read(StoreMsg::BatchRaftSnapCmds {
-                    send_time,
-                    batch,
-                    on_finished,
-                }) => {
-                    self.propose_batch_raft_snapshot_command(batch, on_finished, &mut executor);
                     if sent.is_none() {
                         sent = Some(send_time);
                     }
@@ -706,7 +654,6 @@ mod tests {
     fn must_extract_cmds(msg: StoreMsg) -> Vec<RaftCmdRequest> {
         match msg {
             StoreMsg::RaftCmd { request, .. } => vec![request],
-            StoreMsg::BatchRaftSnapCmds { batch, .. } => batch,
             other => panic!("unexpected msg: {:?}", other),
         }
     }
@@ -818,19 +765,6 @@ mod tests {
 
         // Renew lease.
         lease.renew(monotonic_raw_now());
-
-        // Batch snapshot.
-        let region = region1.clone();
-        let batch_task = Task::read(StoreMsg::new_batch_raft_snapshot_cmd(
-            vec![cmd.clone()],
-            Box::new(move |mut resps: Vec<Option<ReadResponse>>| {
-                assert_eq!(resps.len(), 1);
-                let snap = resps.remove(0).unwrap().snapshot.unwrap();
-                assert_eq!(snap.get_region(), &region);
-            }),
-        ));
-        reader.run_batch(&mut vec![batch_task]);
-        assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Empty);
 
         // Store id mismatch.
         let mut cmd_store_id = cmd.clone();

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -21,9 +21,7 @@ use super::metrics::*;
 use super::resolve::StoreAddrResolver;
 use super::snap::Task as SnapTask;
 use raft::SnapshotStatus;
-use raftstore::store::{
-    BatchReadCallback, Callback, Msg as StoreMsg, ReadTask, SignificantMsg, Transport,
-};
+use raftstore::store::{Callback, Msg as StoreMsg, ReadTask, SignificantMsg, Transport};
 use raftstore::{Error as RaftStoreError, Result as RaftStoreResult};
 use server::raft_client::RaftClient;
 use server::Result;
@@ -47,15 +45,6 @@ pub trait RaftStoreRouter: Send + Clone {
     // Send RaftCmdRequest to local store.
     fn send_command(&self, req: RaftCmdRequest, cb: Callback) -> RaftStoreResult<()> {
         self.try_send(StoreMsg::new_raft_cmd(req, cb))
-    }
-
-    // Send a batch of RaftCmdRequests to local store.
-    fn send_batch_commands(
-        &self,
-        batch: Vec<RaftCmdRequest>,
-        on_finished: BatchReadCallback,
-    ) -> RaftStoreResult<()> {
-        self.try_send(StoreMsg::new_batch_raft_snapshot_cmd(batch, on_finished))
     }
 
     // Send significant message. We should guarantee that the message can't be dropped.
@@ -132,14 +121,6 @@ impl RaftStoreRouter for ServerRaftStoreRouter {
 
     fn send_command(&self, req: RaftCmdRequest, cb: Callback) -> RaftStoreResult<()> {
         self.try_send(StoreMsg::new_raft_cmd(req, cb))
-    }
-
-    fn send_batch_commands(
-        &self,
-        batch: Vec<RaftCmdRequest>,
-        on_finished: BatchReadCallback,
-    ) -> RaftStoreResult<()> {
-        self.try_send(StoreMsg::new_batch_raft_snapshot_cmd(batch, on_finished))
     }
 
     fn significant_send(&self, msg: SignificantMsg) -> RaftStoreResult<()> {

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -27,13 +27,13 @@ use protobuf::RepeatedField;
 
 use super::metrics::*;
 use super::{
-    BatchCallback, Callback, CbContext, Cursor, Engine, Iterator as EngineIterator, Modify,
-    RegionInfoProvider, ScanMode, Snapshot,
+    Callback, CbContext, Cursor, Engine, Iterator as EngineIterator, Modify, RegionInfoProvider,
+    ScanMode, Snapshot,
 };
 use raftstore::errors::Error as RaftServerError;
 use raftstore::store::engine::IterOption;
 use raftstore::store::engine::Peekable;
-use raftstore::store::{self, Callback as StoreCallback, ReadResponse, WriteResponse};
+use raftstore::store::{Callback as StoreCallback, ReadResponse, WriteResponse};
 use raftstore::store::{
     Msg as StoreMsg, RegionIterator, RegionSnapshot, SeekRegionFilter, SeekRegionResult,
 };
@@ -178,37 +178,6 @@ impl<S: RaftStoreRouter> RaftKv<S> {
         RaftKv { router }
     }
 
-    fn batch_call_snap_commands(
-        &self,
-        batch: Vec<RaftCmdRequest>,
-        on_finished: BatchCallback<CmdRes>,
-    ) -> Result<()> {
-        let batch_size = batch.len();
-        let mut counts = Vec::with_capacity(batch_size);
-        for req in &batch {
-            let count = req.get_requests().len();
-            counts.push(count);
-        }
-        let on_finished: store::BatchReadCallback =
-            Box::new(move |resps: Vec<Option<store::ReadResponse>>| {
-                assert_eq!(batch_size, resps.len());
-                let mut cmd_resps = Vec::with_capacity(resps.len());
-                for (count, resp) in counts.into_iter().zip(resps) {
-                    match resp {
-                        Some(resp) => {
-                            let (cb_ctx, cmd_res) = on_read_result(resp, count);
-                            cmd_resps.push(Some((cb_ctx, cmd_res.map_err(Error::into))));
-                        }
-                        None => cmd_resps.push(None),
-                    }
-                }
-                on_finished(cmd_resps);
-            });
-
-        self.router.send_batch_commands(batch, on_finished)?;
-        Ok(())
-    }
-
     fn new_request_header(&self, ctx: &Context) -> RaftRequestHeader {
         let mut header = RaftRequestHeader::new();
         header.set_region_id(ctx.get_region_id());
@@ -268,23 +237,6 @@ impl<S: RaftStoreRouter> RaftKv<S> {
                 }),
             )
             .map_err(From::from)
-    }
-
-    fn batch_exec_snap_requests(
-        &self,
-        batch: Vec<(Context, Vec<Request>)>,
-        on_finished: BatchCallback<CmdRes>,
-    ) -> Result<()> {
-        let batch = batch.into_iter().map(|(ctx, reqs)| {
-            let header = self.new_request_header(&ctx);
-            let mut cmd = RaftCmdRequest::new();
-            cmd.set_header(header);
-            cmd.set_requests(RepeatedField::from_vec(reqs));
-
-            cmd
-        });
-
-        self.batch_call_snap_commands(batch.collect(), on_finished)
     }
 }
 
@@ -405,68 +357,6 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
             ASYNC_REQUESTS_COUNTER_VEC.snapshot.get(status_kind).inc();
             e.into()
         })
-    }
-
-    fn async_batch_snapshot(
-        &self,
-        batch: Vec<Context>,
-        on_finished: BatchCallback<Self::Snap>,
-    ) -> engine::Result<()> {
-        fail_point!("raftkv_async_batch_snapshot");
-        if batch.is_empty() {
-            return Err(engine::Error::EmptyRequest);
-        }
-
-        let batch_size = batch.len();
-        ASYNC_REQUESTS_COUNTER_VEC
-            .snapshot
-            .all
-            .inc_by(batch_size as i64);
-        let req_timer = ASYNC_REQUESTS_DURATIONS_VEC.snapshot.start_coarse_timer();
-
-        let on_finished: BatchCallback<CmdRes> = box move |cmd_resps: super::BatchResults<_>| {
-            req_timer.observe_duration();
-            assert_eq!(batch_size, cmd_resps.len());
-            let mut snapshots = Vec::with_capacity(cmd_resps.len());
-            for resp in cmd_resps {
-                match resp {
-                    Some((cb_ctx, Ok(CmdRes::Resp(r)))) => {
-                        snapshots.push(Some((
-                            cb_ctx,
-                            Err(invalid_resp_type(CmdType::Snap, r[0].get_cmd_type()).into()),
-                        )));
-                    }
-                    Some((cb_ctx, Ok(CmdRes::Snap(s)))) => {
-                        ASYNC_REQUESTS_COUNTER_VEC.snapshot.success.inc();
-                        snapshots.push(Some((cb_ctx, Ok(s))));
-                    }
-                    Some((cb_ctx, Err(e))) => {
-                        let status_kind = get_status_kind_from_engine_error(&e);
-                        ASYNC_REQUESTS_COUNTER_VEC.snapshot.get(status_kind).inc();
-                        snapshots.push(Some((cb_ctx, Err(e))));
-                    }
-                    None => snapshots.push(None),
-                }
-            }
-            on_finished(snapshots);
-        };
-
-        let batch = batch.into_iter().map(|ctx| {
-            let mut req = Request::new();
-            req.set_cmd_type(CmdType::Snap);
-
-            (ctx, vec![req])
-        });
-
-        self.batch_exec_snap_requests(batch.collect(), on_finished)
-            .map_err(|e| {
-                let status_kind = get_status_kind_from_error(&e);
-                ASYNC_REQUESTS_COUNTER_VEC
-                    .snapshot
-                    .get(status_kind)
-                    .inc_by(batch_size as i64);
-                e.into()
-            })
     }
 }
 


### PR DESCRIPTION
## What have you changed? (mandatory)

The async batch snapshot API is obsolete. The coprocessor and scheduler no longer use it, so it can be removed.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Unit tests.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

#2107 and #3551
