### PR TITLE
import: uncomment two asserts in unit test, as the blocking PR has landed

### DIFF
--- a/src/import/import_mode.rs
+++ b/src/import/import_mode.rs
@@ -153,17 +153,14 @@ mod tests {
                 cf_opts.get_level_zero_slowdown_writes_trigger(),
                 opts.level0_slowdown_writes_trigger
             );
-            // TODO: https://github.com/facebook/rocksdb/pull/3823
-            // These options are set correctly, but we can't get them
-            // because of the issue above.
-            // assert_eq!(
-            //     cf_opts.get_soft_pending_compaction_bytes_limit(),
-            //     opts.soft_pending_compaction_bytes_limit
-            // );
-            // assert_eq!(
-            //     cf_opts.get_hard_pending_compaction_bytes_limit(),
-            //     opts.hard_pending_compaction_bytes_limit
-            // );
+            assert_eq!(
+                cf_opts.get_soft_pending_compaction_bytes_limit(),
+                opts.soft_pending_compaction_bytes_limit
+            );
+            assert_eq!(
+                cf_opts.get_hard_pending_compaction_bytes_limit(),
+                opts.hard_pending_compaction_bytes_limit
+            );
         }
     }
 


### PR DESCRIPTION
Signed-off-by: kennytm <kennytm@gmail.com>

## What have you changed? (mandatory)

- Re-enabled two asserts in the import_mode unit test blocked by facebook/rocksdb#3823. 

## What are the type of the changes? (mandatory)

- Bug fix

## How has this PR been tested? (mandatory)

- `cargo test --no-run` passed

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
