### PR TITLE
tests: disable slow bench test

### DIFF
--- a/benches/storage/scan.rs
+++ b/benches/storage/scan.rs
@@ -23,6 +23,7 @@ use tikv::util::worker::FutureWorker;
 
 /// In mvcc kv is not actually deleted, which may cause performance issue
 /// when doing scan.
+#[ignore]
 #[bench]
 fn bench_tombstone_scan(b: &mut Bencher) {
     let pd_worker = FutureWorker::new("test-pd-worker");


### PR DESCRIPTION
tombstone_scan is slow to start and it doesn't have to be run
every time.
