### PR TITLE
Fix CI by installing tarpaulin from git, so that Cargo.lock is not ignored

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,9 @@ jobs:
       - run:
           name: Installing tarpaulin
           command: |
-            RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin --git https://github.com/xd009642/tarpaulin --tag 0.6.3 --force
+            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
+              RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin --git https://github.com/xd009642/tarpaulin --tag 0.6.3 --force
+            fi
       - restore_cache:
           # Actually master does not need to download the cache. However we cannot make conditions here.
           name: Downloading ./target Cache from master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-Dwarnings"
       FAIL_POINT: "1"
-      TARPAULIN_VERSION: "0.6.1"
     steps:
       - run:
           name: Updating PATH and Define Environment Variable at Runtime

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,12 +71,7 @@ jobs:
       - run:
           name: Installing tarpaulin
           command: |
-            CURRENT_TARPAULIN_VERSION=`(cargo tarpaulin --version || echo "0") | awk '{ print $3 }'`
-            echo "Tarpaulin version is now: ${CURRENT_TARPAULIN_VERSION}"
-            echo "Tarpaulin version should be: ${TARPAULIN_VERSION}"
-            if [[ "${CURRENT_TARPAULIN_VERSION}" != "${TARPAULIN_VERSION}" ]]; then
-                RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin  --version ${TARPAULIN_VERSION} --force
-            fi
+            RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin --git https://github.com/xd009642/tarpaulin --tag 0.6.3 --force
       - restore_cache:
           # Actually master does not need to download the cache. However we cannot make conditions here.
           name: Downloading ./target Cache from master


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Currently CI is broken. We attempted to fix it previously in #3241, but it turns out that specifying tarpaulin version is not enough. We need to freeze all versions of all tarpaulin's dependencies as well.

Before [tarpaulin publishes its lock file](https://github.com/xd009642/tarpaulin/issues/147) && (maybe) we upgrade our rust version, we need to install tarpaulin from a git location so that Cargo.lock is respected.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

CI: https://circleci.com/gh/tikv/tikv/13810

As you can see, Tarpaulin is successfully installed.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
