### PR TITLE
raftstore: bcast commit for urgent requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
  "grpcio-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -470,7 +470,7 @@ dependencies = [
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -605,7 +605,7 @@ source = "git+https://github.com/pingcap/kvproto.git#279515615485b0f2d12f1421cc4
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1000,7 +1000,7 @@ dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "procinfo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.0.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1028,7 +1028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quick-error"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1047,14 +1047,20 @@ dependencies = [
 [[package]]
 name = "raft"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/pingcap/raft-rs.git#b10d74ced67f57e7a591ecc590991b616e4ec570"
 dependencies = [
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "raft"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+replace = "raft 0.3.1 (git+https://github.com/pingcap/raft-rs.git)"
 
 [[package]]
 name = "rand"
@@ -1424,7 +1430,7 @@ version = "0.0.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
- "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_storage 0.0.1",
  "tikv 2.1.0-rc.1",
  "tipb 0.0.1 (git+https://github.com/pingcap/tipb.git)",
@@ -1438,7 +1444,7 @@ dependencies = [
  "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
@@ -1525,8 +1531,8 @@ dependencies = [
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus-static-metric 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1583,7 +1589,7 @@ name = "tipb"
 version = "0.0.1"
 source = "git+https://github.com/pingcap/tipb.git#658ea9c14169a59084290fe68060d53ea52722a2"
 dependencies = [
- "protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1921,11 +1927,12 @@ dependencies = [
 "checksum procinfo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f42e8578852a3306838981aedad8c5642ba794929aa12af0c9eb6c072b77af6c"
 "checksum prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "760293453bee1de0a12987422d7c4885f7ee933e4417bb828ed23f7d05c3c390"
 "checksum prometheus-static-metric 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1d2b4a6a1ae793e7eb6773a5301a5a08e8929ea5517b677c93e57ce2d0973c02"
-"checksum protobuf 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a163be69698a5cb7baa28819474344d3a268b3f3e41877e61d5555e3d3add1af"
+"checksum protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "128a4f37a2df739a567a8685b17f54aa19b9c3c4a6a5b8731e97a419b3db451c"
 "checksum quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ac990ab4e038dd8481a5e3fd00641067fcfc674ad663f3222752ed5284e05d4"
-"checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+"checksum raft 0.3.1 (git+https://github.com/pingcap/raft-rs.git)" = "<none>"
 "checksum raft 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27c39f5f16d12860761c64f564b7ddb0bd257a490cf2267bb5e58b4ae886e10f"
 "checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ slog-stdlog = "3.0.4-pre"
 slog-term = "2.4"
 byteorder = "1.2"
 rand = "0.3"
-quick-error = "0.2"
+quick-error = "1.2.2"
 tempdir = "0.3"
 time = "0.1"
 toml = "0.4"
@@ -81,6 +81,9 @@ derive_more = "0.11.0"
 num = "0.2.0"
 hex = "0.3"
 rust-crypto = "^0.2"
+
+[replace]
+"raft:0.3.1" = { git = "https://github.com/pingcap/raft-rs.git" }
 
 [dependencies.murmur3]
 git = "https://github.com/pingcap/murmur3.git"

--- a/components/test_util/lib.rs
+++ b/components/test_util/lib.rs
@@ -25,6 +25,7 @@ mod security;
 use std::env;
 
 pub use kv_generator::*;
+pub use logging::*;
 pub use security::*;
 
 pub fn setup_for_ci() {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -16,7 +16,7 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 use std::sync::{atomic, Arc};
 use std::time::{Duration, Instant};
-use std::{cmp, mem, slice};
+use std::{cmp, mem, slice, u64};
 
 use kvproto::metapb;
 use kvproto::pdpb::PeerStats;
@@ -250,6 +250,7 @@ pub struct Peer {
     // Index of last scheduled committed raft log.
     pub last_applying_idx: u64,
     pub last_compacted_idx: u64,
+    last_urgent_proposal_idx: u64,
     // The index of the latest committed split command.
     last_committed_split_idx: u64,
     // Approximate size of logs that is applied but not compacted yet.
@@ -393,6 +394,7 @@ impl Peer {
             tag,
             last_applying_idx: applied_index,
             last_compacted_idx: 0,
+            last_urgent_proposal_idx: u64::MAX,
             last_committed_split_idx: 0,
             consistency_state: ConsistencyState {
                 last_check_time: Instant::now(),
@@ -1062,6 +1064,10 @@ impl Peer {
             }
             if !committed_entries.is_empty() {
                 self.last_applying_idx = committed_entries.last().unwrap().get_index();
+                if self.last_applying_idx >= self.last_urgent_proposal_idx {
+                    self.raft_group.skip_bcast_commit(true);
+                    self.last_urgent_proposal_idx = u64::MAX;
+                }
                 apply_tasks.push(Apply::new(self.region_id, self.term(), committed_entries));
             }
         }
@@ -1252,6 +1258,7 @@ impl Peer {
         metrics.all += 1;
 
         let mut is_conf_change = false;
+        let is_urgent = is_request_urgent(&req);
 
         let policy = self.inspect(&req);
         let res = match policy {
@@ -1278,6 +1285,10 @@ impl Peer {
                 false
             }
             Ok(idx) => {
+                if is_urgent {
+                    self.last_urgent_proposal_idx = idx;
+                    self.raft_group.skip_bcast_commit(false);
+                }
                 let meta = ProposalMeta {
                     index: idx,
                     term: self.term(),
@@ -2175,6 +2186,28 @@ fn get_sync_log_from_request(msg: &RaftCmdRequest) -> bool {
     msg.get_header().get_sync_log()
 }
 
+/// We enable follower lazy commit to get a better performance.
+/// But it may not be appropriate for some requests. This function
+/// checks whether the request should be committed on all followers
+/// as soon as possible.
+fn is_request_urgent(req: &RaftCmdRequest) -> bool {
+    if !req.has_admin_request() {
+        return false;
+    }
+
+    match req.get_admin_request().get_cmd_type() {
+        AdminCmdType::Split
+        | AdminCmdType::BatchSplit
+        | AdminCmdType::ChangePeer
+        | AdminCmdType::ComputeHash
+        | AdminCmdType::VerifyHash
+        | AdminCmdType::PrepareMerge
+        | AdminCmdType::CommitMerge
+        | AdminCmdType::RollbackMerge => true,
+        _ => false,
+    }
+}
+
 fn make_transfer_leader_response() -> RaftCmdResponse {
     let mut response = AdminResponse::new();
     response.set_cmd_type(AdminCmdType::TransferLeader);
@@ -2209,6 +2242,31 @@ mod tests {
                 tp
             );
         }
+    }
+
+    #[test]
+    fn test_urgent() {
+        let urgent_types = [
+            AdminCmdType::Split,
+            AdminCmdType::BatchSplit,
+            AdminCmdType::ChangePeer,
+            AdminCmdType::ComputeHash,
+            AdminCmdType::VerifyHash,
+            AdminCmdType::PrepareMerge,
+            AdminCmdType::CommitMerge,
+            AdminCmdType::RollbackMerge,
+        ];
+        for tp in AdminCmdType::values() {
+            let mut req = RaftCmdRequest::new();
+            req.mut_admin_request().set_cmd_type(*tp);
+            assert_eq!(
+                is_request_urgent(&req),
+                urgent_types.contains(tp),
+                "{:?}",
+                tp
+            );
+        }
+        assert!(!is_request_urgent(&RaftCmdRequest::new()));
     }
 
     #[test]


### PR DESCRIPTION
TiKV disable broadcast commit by default to reduce messages, which lead
to good overall performance. This option can also lead to delay apply on
all follower nodes. Sometimes it's unexpected for urgent requests like
split or similiar. This PR enables broadcast commit for those requests
temporary.

Close #3578.