### PR TITLE
raftstore: lazy remove ReadDelegate when peer is destroyed asynchronously

### DIFF
--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -780,13 +780,10 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             self.apply_worker
                 .schedule(ApplyTask::destroy(job.region_id))
                 .unwrap();
-            self.local_reader
-                .schedule(ReadTask::destroy(job.region_id))
-                .unwrap();
         }
         if job.async_remove {
             info!(
-                "[region {}] {} is destroyed asychroniously",
+                "[region {}] {} is destroyed asynchronously",
                 job.region_id,
                 job.peer.get_id()
             );

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -544,7 +544,7 @@ impl Peer {
         let progress = ReadProgress::region(region);
         // Always update read delegate's region to avoid stale region info after a follower
         // becomeing a leader.
-        self.update_read_progress(progress);
+        self.maybe_update_read_progress(progress);
     }
 
     pub fn peer_id(&self) -> u64 {
@@ -808,7 +808,7 @@ impl Peer {
                     // this peer becomes leader because it's more convenient to do it here and
                     // it has no impact on the correctness.
                     let progress = ReadProgress::term(self.term());
-                    self.update_read_progress(progress);
+                    self.maybe_update_read_progress(progress);
                     self.maybe_renew_leader_lease(monotonic_raw_now());
                     debug!(
                         "{} becomes leader and lease expired time is {:?}",
@@ -1168,7 +1168,7 @@ impl Peer {
         // Only leaders need to update applied_index_term.
         if progress_to_be_updated && self.is_leader() {
             let progress = ReadProgress::applied_index_term(applied_index_term);
-            self.update_read_progress(progress);
+            self.maybe_update_read_progress(progress);
         }
     }
 
@@ -1202,11 +1202,14 @@ impl Peer {
         let term = self.term();
         if let Some(remote_lease) = self.leader_lease.maybe_new_remote_lease(term) {
             let progress = ReadProgress::leader_lease(remote_lease);
-            self.update_read_progress(progress);
+            self.maybe_update_read_progress(progress);
         }
     }
 
-    fn update_read_progress(&self, progress: ReadProgress) {
+    fn maybe_update_read_progress(&self, progress: ReadProgress) {
+        if self.pending_remove {
+            return;
+        }
         let update = ReadTask::update(self.region_id, progress);
         debug!("{} update {}", self.tag, update);
         self.read_scheduler.schedule(update).unwrap();

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -961,6 +961,15 @@ impl ApplyDelegate {
 
         match change_type {
             ConfChangeType::AddNode => {
+                let add_ndoe_fp = || {
+                    fail_point!(
+                        "apply_on_add_node_1_2",
+                        { self.id == 2 && self.region_id() == 1 },
+                        |_| {}
+                    )
+                };
+                add_ndoe_fp();
+
                 PEER_ADMIN_CMD_COUNTER_VEC
                     .with_label_values(&["add_peer", "all"])
                     .inc();

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -499,10 +499,7 @@ impl<C: Sender<StoreMsg>> Runnable<Task> for LocalReader<C> {
         for task in tasks.drain(..) {
             match task {
                 Task::Register(delegate) => {
-                    debug!(
-                        "{} register ReadDelegate for {:?}",
-                        delegate.tag, delegate.peer_id
-                    );
+                    info!("{} register ReadDelegate", delegate.tag);
                     self.delegates.insert(delegate.region.get_id(), delegate);
                 }
                 Task::Read(StoreMsg::RaftCmd {
@@ -532,14 +529,16 @@ impl<C: Sender<StoreMsg>> Runnable<Task> for LocalReader<C> {
                     if let Some(delegate) = self.delegates.get_mut(&region_id) {
                         delegate.update(progress);
                     } else {
-                        panic!(
-                            "unregistered ReadDelegate, region_id: {}, {:?}",
+                        warn!(
+                            "update unregistered ReadDelegate, region_id: {}, {:?}",
                             region_id, progress
                         );
                     }
                 }
                 Task::Destroy(region_id) => {
-                    self.delegates.remove(&region_id);
+                    if let Some(delegate) = self.delegates.remove(&region_id) {
+                        info!("{} destroy ReadDelegate", delegate.tag);
+                    }
                 }
             }
         }

--- a/tests/failpoints_cases/test_stale_peer.rs
+++ b/tests/failpoints_cases/test_stale_peer.rs
@@ -46,3 +46,51 @@ fn test_one_node_leader_missing() {
     thread::sleep(cluster.cfg.raft_store.peer_stale_state_check_interval.0 * 3);
     fail::remove(check_stale_state);
 }
+
+#[test]
+fn test_node_update_localreader_after_removed() {
+    let _guard = ::setup();
+
+    let mut cluster = new_node_cluster(0, 6);
+    let pd_client = cluster.pd_client.clone();
+    // Disable default max peer number check.
+    pd_client.disable_default_operator();
+    let r1 = cluster.run_conf_change();
+
+    // Add 4 peers.
+    for i in 2..6 {
+        pd_client.must_add_peer(r1, new_peer(i, i));
+    }
+
+    // Make sure peer 1 leads the region.
+    cluster.must_transfer_leader(r1, new_peer(1, 1));
+    let (key, value) = (b"k1", b"v1");
+    cluster.must_put(key, value);
+    assert_eq!(cluster.get(key), Some(value.to_vec()));
+
+    // Make sure peer 2 is initialized.
+    let engine_2 = cluster.get_engine(2);
+    must_get_equal(&engine_2, key, value);
+
+    // Pause peer 2 apply worker if it executes AddNode.
+    let add_node_fp = "apply_on_add_node_1_2";
+    fail::cfg(add_node_fp, "pause").unwrap();
+
+    // Add peer 6.
+    pd_client.must_add_peer(r1, new_peer(6, 6));
+
+    // Isolate peer 2 from rest of the cluster.
+    cluster.add_send_filter(IsolationFilterFactory::new(2));
+
+    // Remove peer 2, so it will receive a gc msssage
+    // after max_leader_missing_duration timeout.
+    pd_client.must_remove_peer(r1, new_peer(2, 2));
+    thread::sleep(cluster.cfg.raft_store.max_leader_missing_duration.0 * 2);
+
+    // Continue peer 2 apply worker, so that peer 2 tries to
+    // update region to its read delegate.
+    fail::remove(add_node_fp);
+
+    // Make sure peer 2 is removed in node 2.
+    cluster.must_region_not_exist(r1, 2);
+}


### PR DESCRIPTION
Signed-off-by: Neil Shen <overvenus@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

There is a bug when we  destroy peers asychroniously, because we destroy read delegates right after receiving a GC message, peers may send update(region) to its delegate, but the delegate is destroyed already.

This PR fix the bug by lazy remove ReadDelegate when peer is destroyed asychroniously.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

Unit tests.

## Refer to a related PR or issue link (optional)

#2639 
