### PR TITLE
Remove Generic from DAGContext

### DIFF
--- a/src/coprocessor/dag/dag.rs
+++ b/src/coprocessor/dag/dag.rs
@@ -24,16 +24,15 @@ use storage::{Snapshot, SnapshotStore};
 
 use super::executor::{build_exec, Executor, ExecutorMetrics};
 
-pub struct DAGContext<S: Snapshot + 'static> {
-    _phantom: PhantomData<S>,
+pub struct DAGContext {
     req_ctx: ReqContext,
     exec: Box<Executor + Send>,
     output_offsets: Vec<u32>,
     batch_row_limit: usize,
 }
 
-impl<S: Snapshot + 'static> DAGContext<S> {
-    pub fn new(
+impl DAGContext {
+    pub fn new<S: Snapshot + 'static>(
         mut req: DAGRequest,
         ranges: Vec<KeyRange>,
         snap: S,
@@ -101,7 +100,7 @@ impl<S: Snapshot + 'static> DAGContext<S> {
     }
 }
 
-impl<S: Snapshot> RequestHandler for DAGContext<S> {
+impl RequestHandler for DAGContext {
     fn handle_request(&mut self) -> Result<Response> {
         let mut record_cnt = 0;
         let mut chunks = Vec::new();

--- a/src/coprocessor/dag/dag.rs
+++ b/src/coprocessor/dag/dag.rs
@@ -72,7 +72,6 @@ impl DAGContext {
             req.get_collect_range_counts(),
         )?;
         Ok(Self {
-            _phantom: Default::default(),
             req_ctx,
             exec: dag_executor,
             output_offsets: req.take_output_offsets(),

--- a/src/coprocessor/dag/dag.rs
+++ b/src/coprocessor/dag/dag.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::marker::PhantomData;
 use std::sync::Arc;
 
 use kvproto::coprocessor::{KeyRange, Response};


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

`DAGContext` does need to be generic.

Extracted from [Coprocessor ReadPool PR](https://github.com/tikv/tikv/pull/3515).

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Compiler.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.
