### PR TITLE
raftstore: fix a check about messages from merged region.

### DIFF
--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -366,7 +366,6 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 let merge_target = if let Some(peer) = util::find_peer(region, from_store_id) {
                     // Maybe the target is promoted from learner to voter, but the follower
                     // doesn't know it. So we only compare peer id.
-                    // println!("peer: {:?}, from peer: {:?}", peer, msg.get_from_peer());
                     assert_eq!(peer.get_id(), msg.get_from_peer().get_id());
                     // Let stale peer decides whether it should wait for merging or just remove
                     // itself.

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -364,7 +364,10 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 );
 
                 let merge_target = if let Some(peer) = util::find_peer(region, from_store_id) {
-                    assert_eq!(peer, msg.get_from_peer());
+                    // Maybe the target is promoted from learner to voter, but the follower
+                    // doesn't know it. So we only compare peer id.
+                    // println!("peer: {:?}, from peer: {:?}", peer, msg.get_from_peer());
+                    assert_eq!(peer.get_id(), msg.get_from_peer().get_id());
                     // Let stale peer decides whether it should wait for merging or just remove
                     // itself.
                     Some(local_state.get_merge_state().get_target().to_owned())

--- a/tests/raftstore_cases/test_merge.rs
+++ b/tests/raftstore_cases/test_merge.rs
@@ -609,7 +609,7 @@ fn test_merge_with_slow_promote() {
     must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
     must_get_equal(&cluster.get_engine(3), b"k3", b"v3");
 
-    let delay_filter = box DelayFilter::new(Duration::from_millis(200));
+    let delay_filter = box DelayFilter::new(Duration::from_millis(20));
     cluster.sim.wl().add_send_filter(3, delay_filter);
 
     pd_client.must_add_peer(right.get_id(), new_peer(3, right.get_id() + 3));

--- a/tests/raftstore_cases/test_merge.rs
+++ b/tests/raftstore_cases/test_merge.rs
@@ -25,6 +25,7 @@ use tikv::raftstore::store::keys;
 use tikv::raftstore::store::Peekable;
 use tikv::storage::{CF_RAFT, CF_WRITE};
 use tikv::util::config::*;
+use tikv::util::HandyRwLock;
 
 /// Test if merge is working as expected in a general condition.
 #[test]
@@ -582,4 +583,37 @@ fn test_node_merge_update_region() {
     assert_eq!(resp.get_responses().len(), 1);
     assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::Get);
     assert_eq!(resp.get_responses()[0].get_get().get_value(), b"v3");
+}
+
+#[test]
+fn test_merge_with_slow_promote() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_merge(&mut cluster);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let r1 = cluster.run_conf_change();
+    pd_client.must_add_peer(r1, new_peer(2, 2));
+
+    let region = pd_client.get_region(b"k1").unwrap();
+    cluster.must_split(&region, b"k2");
+
+    let left = pd_client.get_region(b"k1").unwrap();
+    let right = pd_client.get_region(b"k2").unwrap();
+
+    pd_client.must_add_peer(left.get_id(), new_peer(3, left.get_id() + 3));
+    pd_client.must_add_peer(right.get_id(), new_learner_peer(3, right.get_id() + 3));
+
+    cluster.must_put(b"k1", b"v1");
+    cluster.must_put(b"k3", b"v3");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k3", b"v3");
+
+    let delay_filter = box DelayFilter::new(Duration::from_millis(200));
+    cluster.sim.wl().add_send_filter(3, delay_filter);
+
+    pd_client.must_add_peer(right.get_id(), new_peer(3, right.get_id() + 3));
+    pd_client.must_merge(right.get_id(), left.get_id());
+    cluster.sim.wl().clear_send_filters(3);
+    cluster.must_transfer_leader(left.get_id(), new_peer(3, left.get_id() + 3));
 }


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

## What have you changed? (mandatory)
Messages come from merged peers maybe are still with `is learner = true`, but it has been already promoted on leader, so the check `peer == msg.get_from_peer()` could fail.
This PR fix it.

## What are the type of the changes? (mandatory)
Bug fix.

## How has this PR been tested? (mandatory)
make dev.