### PR TITLE
raftstore: Add RegionChangeObserver

### DIFF
--- a/src/raftstore/coprocessor/mod.rs
+++ b/src/raftstore/coprocessor/mod.rs
@@ -135,3 +135,8 @@ pub trait RoleObserver: Coprocessor {
     /// have changed.
     fn on_role_change(&self, _: &mut ObserverContext, _: StateRole) {}
 }
+
+pub trait RegionLoadObserver: Coprocessor {
+    /// Hook to call when the TiKV is starting up, and a region is loaded from disk
+    fn on_region_loaded(&self, _: &mut ObserverContext, _: ()) {}
+}

--- a/src/raftstore/coprocessor/mod.rs
+++ b/src/raftstore/coprocessor/mod.rs
@@ -136,7 +136,13 @@ pub trait RoleObserver: Coprocessor {
     fn on_role_change(&self, _: &mut ObserverContext, _: StateRole) {}
 }
 
-pub trait RegionLoadObserver: Coprocessor {
-    /// Hook to call when the TiKV is starting up, and a region is loaded from disk
-    fn on_region_loaded(&self, _: &mut ObserverContext, _: ()) {}
+pub enum RegionChangeEvent {
+    New,
+    Update,
+    Destroy,
+}
+
+pub trait RegionChangeObserver: Coprocessor {
+    /// Hook to call when a region changed on this TiKV
+    fn on_region_changed(&self, _: &mut ObserverContext, _: &RegionChangeEvent) {}
 }

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -32,7 +32,7 @@ use kvproto::raft_serverpb::{PeerState, RaftMessage, RegionLocalState};
 
 use pd::{PdClient, PdRunner, PdTask};
 use raftstore::coprocessor::split_observer::SplitObserver;
-use raftstore::coprocessor::CoprocessorHost;
+use raftstore::coprocessor::{CoprocessorHost, RegionChangeEvent};
 use raftstore::store::util::{is_initial_msg, KeysInfoFormatter};
 use raftstore::Result;
 use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
@@ -243,7 +243,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             // No need to check duplicated here, because we use region id as the key
             // in DB.
             self.region_peers.insert(region_id, peer);
-            self.coprocessor_host.on_region_loaded(region, ());
+            self.coprocessor_host
+                .on_region_changed(region, &RegionChangeEvent::New);
             Ok(true)
         })?;
 

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -243,6 +243,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             // No need to check duplicated here, because we use region id as the key
             // in DB.
             self.region_peers.insert(region_id, peer);
+            self.coprocessor_host.on_region_loaded(region, ());
             Ok(true)
         })?;
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR added a new observer, which is named `RegionChangeObserver`, to raftstore, so that we can monitor changes of regions (on the current TiKV) more conveniently.

It monitors these changes of local regions:
* A region is added to this TiKV, either being moved from other TiKVs or created after splitting.
* A region's epoch changed.
* A region is removed from this TiKV, either being merged or moved out from this TiKV.

## What are the type of the changes? (mandatory)

- New feature (non-breaking change which adds functionality)

## How has this PR been tested? (mandatory)

* Unit test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No


