### PR TITLE
Provide BufferWriter and BufferReader as alternatives to Read and Write trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "codec"
+version = "0.0.1"
+dependencies = [
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cookie"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,8 @@ members = [
   "components/test_raftstore",
   "components/test_storage",
   "components/test_coprocessor",
-  "components/test_util"
+  "components/test_util",
+  "components/codec",
 ]
 
 [profile.dev]

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test:
 	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${LOCAL_DIR}/lib" && \
 	export LOG_LEVEL=DEBUG && \
 	export RUST_BACKTRACE=1 && \
-	cargo test --features "${ENABLE_FEATURES}" ${EXTRA_CARGO_ARGS} -- --nocapture && \
+	cargo test --features "${ENABLE_FEATURES}" --all --exclude tikv_fuzz ${EXTRA_CARGO_ARGS} -- --nocapture && \
 	cargo test --features "${ENABLE_FEATURES}" --bench benches ${EXTRA_CARGO_ARGS} -- --nocapture  && \
 	if [[ "`uname`" == "Linux" ]]; then \
 		export MALLOC_CONF=prof:true,prof_active:false && \
@@ -93,7 +93,7 @@ test:
 	# TODO: remove above target once https://github.com/rust-lang/cargo/issues/2984 is resolved.
 
 bench:
-	LOG_LEVEL=ERROR RUST_BACKTRACE=1 cargo bench --features "${ENABLE_FEATURES}" -- --nocapture
+	LOG_LEVEL=ERROR RUST_BACKTRACE=1 cargo bench --all --exclude tikv_fuzz --features "${ENABLE_FEATURES}" -- --nocapture
 
 unset-override:
 	@# unset first in case of any previous overrides

--- a/components/codec/Cargo.toml
+++ b/components/codec/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "codec"
+version = "0.0.1"
+publish = false
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+quick-error = "1.2"
+
+[dev-dependencies]
+rand = "0.5"

--- a/components/codec/buffer.rs
+++ b/components/codec/buffer.rs
@@ -248,12 +248,6 @@ mod tests {
         buffer.advance(22);
         assert_eq!(buffer, &base[40..40]);
         assert_eq!(buffer.bytes(), &base[40..40]);
-
-        let result = ::std::panic::catch_unwind(move || {
-            // When buffer is `&[u8]`, advance cannot exceed len.
-            buffer.advance(1);
-        });
-        assert!(result.is_err());
     }
 
     #[test]
@@ -432,7 +426,9 @@ mod tests {
             assert_ne!(vec_ptr, vec.as_ptr());
 
             // Move len() forward and check whether our previous written data exists.
-            unsafe { vec.advance_mut(payload_len); }
+            unsafe {
+                vec.advance_mut(payload_len);
+            }
             assert_eq!(vec.as_slice(), payload.as_slice());
         }
     }

--- a/components/codec/buffer.rs
+++ b/components/codec/buffer.rs
@@ -1,0 +1,439 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A trait to provide sequential read over a memory buffer.
+///
+/// The memory buffer can be `&[u8]` or `std::io::Cursor<AsRef<[u8]>>`.
+pub trait BufferReader {
+    /// Returns a slice starting at current position.
+    ///
+    /// The returned slice can be empty.
+    fn bytes(&self) -> &[u8];
+
+    /// Advances the position of internal cursor.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic in some implementors when remaining space
+    /// is not large enough to advance.
+    fn advance(&mut self, count: usize);
+}
+
+impl<T: AsRef<[u8]>> BufferReader for ::std::io::Cursor<T> {
+    fn bytes(&self) -> &[u8] {
+        let pos = self.position() as usize;
+        let slice = self.get_ref().as_ref();
+        if pos >= slice.len() {
+            return &[];
+        }
+        &slice[pos..]
+    }
+
+    fn advance(&mut self, count: usize) {
+        let mut pos = self.position();
+        pos += count as u64;
+        self.set_position(pos);
+    }
+}
+
+impl<'a> BufferReader for &'a [u8] {
+    fn bytes(&self) -> &[u8] {
+        self
+    }
+
+    fn advance(&mut self, count: usize) {
+        *self = &self[count..]
+    }
+}
+
+impl<'a, T: BufferReader + ?Sized> BufferReader for &'a mut T {
+    fn bytes(&self) -> &[u8] {
+        (**self).bytes()
+    }
+
+    fn advance(&mut self, count: usize) {
+        (**self).advance(count)
+    }
+}
+
+impl<T: BufferReader + ?Sized> BufferReader for Box<T> {
+    fn bytes(&self) -> &[u8] {
+        (**self).bytes()
+    }
+
+    fn advance(&mut self, count: usize) {
+        (**self).advance(count)
+    }
+}
+
+/// A trait to provide sequential write over a fixed size
+/// or dynamic size memory buffer.
+///
+/// The memory buffer can be `std::io::Cursor<AsRef<[u8]>>` or `&mut [u8]`,
+/// which is fixed sized, or `Vec<u8>`, which is dynamically sized.
+pub trait BufferWriter {
+    /// Returns a mutable slice starting at current position.
+    ///
+    /// The caller may hint the underlying buffer to grow according to `size`
+    /// if the underlying buffer is dynamically sized (i.e. is capable to grow).
+    ///
+    /// The size of the returned slice may be less than `size` given. For example,
+    /// when underlying buffer is fixed sized and there is no enough space any more.
+    ///
+    /// The returned mutable slice is for writing only and should be never used for
+    /// reading since it might contain uninitialized memory when underlying buffer
+    /// is dynamically sized. For this reason, this function is marked `unsafe`.
+    unsafe fn bytes_mut(&mut self, size: usize) -> &mut [u8];
+
+    /// Advances the position of internal cursor for a previous write.
+    ///
+    /// The caller should ensure that advanced positions have been all written
+    /// previously. If the cursor is moved beyond actually written data, it will
+    /// leave uninitialized memory. For this reason, this function is marked
+    /// `unsafe`.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic in some implementors when remaining space
+    /// is not large enough to advance.
+    unsafe fn advance_mut(&mut self, count: usize);
+}
+
+impl<T: AsMut<[u8]>> BufferWriter for ::std::io::Cursor<T> {
+    unsafe fn bytes_mut(&mut self, _size: usize) -> &mut [u8] {
+        // `size` is ignored since this buffer is not capable to grow.
+        let pos = self.position() as usize;
+        let slice = self.get_mut().as_mut();
+        if pos >= slice.len() {
+            return &mut [];
+        }
+        &mut slice[pos..]
+    }
+
+    unsafe fn advance_mut(&mut self, count: usize) {
+        let mut pos = self.position();
+        pos += count as u64;
+        self.set_position(pos);
+    }
+}
+
+impl<'a> BufferWriter for &'a mut [u8] {
+    unsafe fn bytes_mut(&mut self, _size: usize) -> &mut [u8] {
+        self
+    }
+
+    unsafe fn advance_mut(&mut self, count: usize) {
+        let original_self = ::std::mem::replace(self, &mut []);
+        *self = &mut original_self[count..];
+    }
+}
+
+impl BufferWriter for Vec<u8> {
+    unsafe fn bytes_mut(&mut self, size: usize) -> &mut [u8] {
+        // Return a slice starting from `self.len()` position and
+        // has at least `size` space.
+
+        // Ensure returned slice has enough space
+        self.reserve(size);
+        let ptr = self.as_mut_ptr();
+        &mut ::std::slice::from_raw_parts_mut(ptr, self.capacity())[self.len()..]
+    }
+
+    unsafe fn advance_mut(&mut self, count: usize) {
+        let len = self.len();
+        self.set_len(len + count);
+    }
+}
+
+impl<'a, T: BufferWriter + ?Sized> BufferWriter for &'a mut T {
+    unsafe fn bytes_mut(&mut self, size: usize) -> &mut [u8] {
+        (**self).bytes_mut(size)
+    }
+
+    unsafe fn advance_mut(&mut self, count: usize) {
+        (**self).advance_mut(count)
+    }
+}
+
+impl<T: BufferWriter + ?Sized> BufferWriter for Box<T> {
+    unsafe fn bytes_mut(&mut self, size: usize) -> &mut [u8] {
+        (**self).bytes_mut(size)
+    }
+
+    unsafe fn advance_mut(&mut self, count: usize) {
+        (**self).advance_mut(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand;
+
+    use super::*;
+
+    #[test]
+    fn test_buffer_reader_cursor() {
+        let mut base: Vec<u8> = Vec::with_capacity(40);
+        for _ in 0..40 {
+            base.push(rand::random());
+        }
+
+        let mut buffer = ::std::io::Cursor::new(base.clone());
+
+        assert_eq!(buffer.bytes(), &base[0..40]);
+        buffer.advance(13);
+        assert_eq!(buffer.position(), 13);
+        assert_eq!(buffer.bytes(), &base[13..40]);
+        buffer.advance(5);
+        assert_eq!(buffer.position(), 18);
+        assert_eq!(buffer.bytes(), &base[18..40]);
+
+        // Reset to valid position
+        buffer.set_position(7);
+        assert_eq!(buffer.bytes(), &base[7..40]);
+
+        buffer.advance(31);
+        assert_eq!(buffer.position(), 38);
+        assert_eq!(buffer.bytes(), &base[38..40]);
+
+        buffer.advance(2);
+        assert_eq!(buffer.position(), 40);
+        assert_eq!(buffer.bytes(), &base[40..40]);
+
+        // Advance exceeds len
+        buffer.advance(7);
+        assert_eq!(buffer.position(), 47);
+        assert_eq!(buffer.bytes(), &base[40..40]);
+
+        // Reset to valid position
+        buffer.set_position(0);
+        assert_eq!(buffer.bytes(), &base[0..40]);
+
+        // Reset to invalid position
+        buffer.set_position(100);
+        assert_eq!(buffer.bytes(), &base[40..40]);
+    }
+
+    #[test]
+    fn test_buffer_reader_slice() {
+        let mut base: Vec<u8> = Vec::with_capacity(40);
+        for _ in 0..40 {
+            base.push(rand::random());
+        }
+
+        let buffer = base.clone();
+        let mut buffer = buffer.as_slice();
+
+        assert_eq!(buffer, &base[0..40]);
+        assert_eq!(buffer.bytes(), &base[0..40]);
+
+        buffer.advance(13);
+        assert_eq!(buffer, &base[13..40]);
+        assert_eq!(buffer.bytes(), &base[13..40]);
+
+        buffer.advance(5);
+        assert_eq!(buffer, &base[18..40]);
+        assert_eq!(buffer.bytes(), &base[18..40]);
+
+        buffer.advance(22);
+        assert_eq!(buffer, &base[40..40]);
+        assert_eq!(buffer.bytes(), &base[40..40]);
+
+        let result = ::std::panic::catch_unwind(move || {
+            // When buffer is `&[u8]`, advance cannot exceed len.
+            buffer.advance(1);
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_buffer_writer_cursor() {
+        unsafe {
+            let mut base: Vec<u8> = Vec::with_capacity(40);
+            for _ in 0..40 {
+                base.push(rand::random());
+            }
+
+            // A series of bytes to write
+            let mut base_write: Vec<u8> = Vec::with_capacity(100);
+            for _ in 0..100 {
+                base_write.push(rand::random());
+            }
+
+            let mut buffer = ::std::io::Cursor::new(base.clone());
+
+            buffer.bytes_mut(13)[..13].clone_from_slice(&base_write[0..13]);
+            buffer.advance_mut(13);
+            assert_eq!(&buffer.get_ref()[0..13], &base_write[0..13]);
+            assert_eq!(&buffer.get_ref()[13..], &base[13..]);
+            assert_eq!(buffer.position(), 13);
+
+            // Acquire 10, only write 5
+            buffer.bytes_mut(10)[..5].clone_from_slice(&base_write[13..18]);
+            buffer.advance_mut(5);
+            assert_eq!(&buffer.get_ref()[0..18], &base_write[0..18]);
+            assert_eq!(&buffer.get_ref()[18..], &base[18..]);
+            assert_eq!(buffer.position(), 18);
+
+            // Reset to valid position
+            buffer.set_position(7);
+            buffer.bytes_mut(16)[..16].clone_from_slice(&base_write[18..34]);
+            buffer.advance_mut(16);
+            assert_eq!(&buffer.get_ref()[0..7], &base_write[0..7]);
+            assert_eq!(&buffer.get_ref()[7..23], &base_write[18..34]);
+            assert_eq!(&buffer.get_ref()[23..], &base[23..]);
+            assert_eq!(buffer.position(), 23);
+
+            buffer.bytes_mut(15)[..15].clone_from_slice(&base_write[34..49]);
+            buffer.advance_mut(15);
+            assert_eq!(&buffer.get_ref()[0..7], &base_write[0..7]);
+            assert_eq!(&buffer.get_ref()[7..38], &base_write[18..49]);
+            assert_eq!(&buffer.get_ref()[38..], &base[38..]);
+            assert_eq!(buffer.position(), 38);
+
+            // Acquire a slice more than available
+            assert_eq!(buffer.bytes_mut(5).len(), 2);
+            buffer.bytes_mut(2)[..2].clone_from_slice(&base_write[49..51]);
+            buffer.advance_mut(2);
+            assert_eq!(&buffer.get_ref()[0..7], &base_write[0..7]);
+            assert_eq!(&buffer.get_ref()[7..38], &base_write[18..49]);
+            assert_eq!(&buffer.get_ref()[7..40], &base_write[18..51]);
+            assert_eq!(buffer.position(), 40);
+
+            // Reset to valid position
+            buffer.set_position(0);
+            buffer.bytes_mut(5)[..5].clone_from_slice(&base_write[51..56]);
+            buffer.advance_mut(5);
+            assert_eq!(&buffer.get_ref()[0..5], &base_write[51..56]);
+            assert_eq!(&buffer.get_ref()[5..7], &base_write[5..7]);
+            assert_eq!(&buffer.get_ref()[7..40], &base_write[18..51]);
+            assert_eq!(buffer.position(), 5);
+
+            // Reset to invalid position
+            buffer.set_position(100);
+            assert_eq!(buffer.bytes_mut(1).len(), 0);
+            assert_eq!(&buffer.get_ref()[0..5], &base_write[51..56]);
+            assert_eq!(&buffer.get_ref()[5..7], &base_write[5..7]);
+            assert_eq!(&buffer.get_ref()[7..40], &base_write[18..51]);
+        }
+    }
+
+    #[test]
+    fn test_buffer_writer_slice() {
+        unsafe {
+            let mut base: Vec<u8> = Vec::with_capacity(40);
+            for _ in 0..40 {
+                base.push(rand::random());
+            }
+
+            // A series of bytes to write
+            let mut base_write: Vec<u8> = Vec::with_capacity(100);
+            for _ in 0..100 {
+                base_write.push(rand::random());
+            }
+
+            let mut buffer = base.clone();
+            let mut buffer = buffer.as_mut_slice();
+
+            buffer.bytes_mut(13)[..13].clone_from_slice(&base_write[0..13]);
+            assert_eq!(&buffer[0..13], &base_write[0..13]);
+            assert_eq!(&buffer[13..], &base[13..]);
+            buffer.advance_mut(13);
+
+            // Acquire 10, only write 5.
+            buffer.bytes_mut(10)[..5].clone_from_slice(&base_write[13..18]);
+            assert_eq!(&buffer[0..5], &base_write[13..18]);
+            assert_eq!(&buffer[5..], &base[18..]);
+            buffer.advance_mut(5);
+
+            buffer.bytes_mut(22)[..22].clone_from_slice(&base_write[18..40]);
+            assert_eq!(&buffer[0..22], &base_write[18..40]);
+            assert_eq!(&buffer[22..], &base[40..]);
+            buffer.advance_mut(22);
+
+            assert_eq!(buffer, &base[40..]);
+        }
+    }
+
+    #[test]
+    fn test_buffer_writer_vec() {
+        unsafe {
+            // A series of bytes to write
+            let mut base_write: Vec<u8> = Vec::with_capacity(100);
+            for _ in 0..100 {
+                base_write.push(rand::random());
+            }
+
+            let mut buffer: Vec<u8> = Vec::with_capacity(20);
+            buffer.bytes_mut(13)[..13].clone_from_slice(&base_write[0..13]);
+            buffer.advance_mut(13);
+            assert_eq!(&buffer[0..13], &base_write[0..13]);
+            assert_eq!(buffer.len(), 13);
+
+            // Vec remaining 7, acquire 10, only write 5
+            assert!(buffer.bytes_mut(10).len() >= 10);
+            buffer.bytes_mut(10)[..5].clone_from_slice(&base_write[13..18]);
+            buffer.advance_mut(5);
+            assert_eq!(&buffer[0..18], &base_write[0..18]);
+            assert_eq!(buffer.len(), 18);
+
+            // Reset len
+            buffer.set_len(7);
+            buffer.bytes_mut(16)[..16].clone_from_slice(&base_write[18..34]);
+            buffer.advance_mut(16);
+            assert_eq!(&buffer[0..7], &base_write[0..7]);
+            assert_eq!(&buffer[7..23], &base_write[18..34]);
+            assert_eq!(buffer.len(), 23);
+
+            buffer.bytes_mut(15)[..15].clone_from_slice(&base_write[34..49]);
+            buffer.advance_mut(15);
+            assert_eq!(&buffer[0..7], &base_write[0..7]);
+            assert_eq!(&buffer[7..38], &base_write[18..49]);
+            assert_eq!(buffer.len(), 38);
+
+            buffer.bytes_mut(2)[..2].clone_from_slice(&base_write[49..51]);
+            buffer.advance_mut(2);
+            assert_eq!(&buffer[0..7], &base_write[0..7]);
+            assert_eq!(&buffer[7..40], &base_write[18..51]);
+            assert_eq!(buffer.len(), 40);
+        }
+    }
+
+    /// Test whether it is safe to store values in `Vec` after `len()`, i.e. during
+    /// reallocation these values are copied.
+    #[test]
+    fn test_vec_reallocate() {
+        for payload_len in 1..1024 {
+            let mut payload: Vec<u8> = Vec::with_capacity(payload_len);
+            for _ in 0..payload_len {
+                payload.push(rand::random());
+            }
+
+            // Write payload to space after `len()` before `capacity()`.
+            let mut vec: Vec<u8> = Vec::with_capacity(payload_len);
+            let vec_ptr = vec.as_ptr();
+            unsafe {
+                let slice = vec.bytes_mut(payload_len);
+                slice[..payload_len].clone_from_slice(payload.as_slice());
+            }
+
+            // Re-allocate the vector space and ensure that the address is changed.
+            vec.reserve(::std::cmp::max(payload_len * 3, 32));
+            assert_ne!(vec_ptr, vec.as_ptr());
+
+            // Move len() forward and check whether our previous written data exists.
+            unsafe { vec.advance_mut(payload_len); }
+            assert_eq!(vec.as_slice(), payload.as_slice());
+        }
+    }
+}

--- a/components/codec/error.rs
+++ b/components/codec/error.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+quick_error! {
+    #[derive(Debug)]
+    pub enum Error {
+        BufferTooSmall {
+            description("The buffer is too small to read or write data")
+        }
+        UnexpectedEOF {
+            description("Expecting more data but got EOF")
+        }
+        BadPadding {
+            description("Data padding is wrong")
+        }
+    }
+}
+
+pub type Result<T> = ::std::result::Result<T, Error>;

--- a/components/codec/lib.rs
+++ b/components/codec/lib.rs
@@ -16,9 +16,9 @@
 #[macro_use]
 extern crate quick_error;
 #[cfg(test)]
-extern crate test;
-#[cfg(test)]
 extern crate rand;
+#[cfg(test)]
+extern crate test;
 
 mod buffer;
 mod error;

--- a/components/codec/lib.rs
+++ b/components/codec/lib.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(test, feature(test))]
+
+#[macro_use]
+extern crate quick_error;
+#[cfg(test)]
+extern crate test;
+#[cfg(test)]
+extern crate rand;
+
+mod buffer;
+mod error;
+
+pub mod prelude {
+    pub use super::buffer::{BufferReader, BufferWriter};
+}
+
+pub use self::buffer::{BufferReader, BufferWriter};
+pub use self::error::{Error, Result};


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Previously we found that [Read trait](https://github.com/tikv/tikv/issues/2989) and [Write trait](https://github.com/tikv/tikv/issues/3345) is not efficient.

This PR proposes `BufferWriter` and `BufferReader` as a high-performance alternative to `Write` and `Read` trait. `BufferWriter` and `BufferReader` provides direct access to the underlying buffer slice so that there will be zero copy when reading or writing. As a trade off, it can only operate on memory buffers and does not support other places like Files.

The idea of `BufferWriter` and `BufferReader` comes from [`bytes::Buf`](https://docs.rs/bytes/0.4.10/bytes/trait.Buf.html). However the interface is simplified to further improve performance (from 4ns to 1ns) because there is no need to support non-contiguous memory here.

`BufferReader` implementors:

- `&[u8]`
- `Cursor<AsRef<[u8]>>`

`BufferWriter` implementors:

- `&mut [u8]` (fixed-size)
- `Cursor<AsMut<[u8]>>` (fixed-size)
- `Vec<u8>` (dynamic-size)

This PR is extracted from https://github.com/tikv/tikv/pull/3629

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Unit test
