### PR TITLE
docs/op-guide: add two lines to host network mode

### DIFF
--- a/docs/op-guide/deploy-tikv-using-docker-compose.md
+++ b/docs/op-guide/deploy-tikv-using-docker-compose.md
@@ -43,8 +43,10 @@ Make sure you have installed the following items on your machine:
 2. Edit the `compose/values.yaml` file to configure `networkMode` to `host` and comment the TiDB section out.
 
     ```bash
-    cd tidb-docker-compose/compose
-    networkMode: host
+    cd tidb-docker-compose
+    vim compose/values.yaml
+    sed -i 's/pushgateway:9091/127.0.0.1:9091/g' config/* # Change the Pushgateway address for the "host" network mode
+    sed -i 's/prometheus:9090/127.0.0.1:9090/g' config/* # Change the Prometheus address for the "host" network mode
     ```
 
 3. Generate the `generated-docker-compose.yml` file.


### PR DESCRIPTION
Signed-off-by: lilin90 <lilin@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Add two lines of code for the host network mode in docker compose guide.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

Will update docs/tikv soon.

## Refer to a related PR or issue link (optional)

https://github.com/pingcap/tidb-docker-compose#host-network-mode-linux