### PR TITLE
*: disable sign-off requirement for org members

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,3 @@
+# Disable sign-off checking for members of the TiKV organization
+require:
+  members: false


### PR DESCRIPTION
Signed-off-by: rleungx <rleungx@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
After this PR, we do not require explicit sign-off from GitHub users that are part of the TiKV organization.