### PR TITLE
Change codegen-units to 1 && Copy release profile to bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,5 +142,12 @@ codegen-units = 4
 lto = true
 opt-level = 3
 debug = true
-# TODO: remove this once rust-lang/rust#50199 is resolved.
-codegen-units = 2
+# TODO: remove this once rust-lang/rust#50199 and rust-lang/rust#53833 are resolved.
+codegen-units = 1
+
+# The benchmark profile is identical to release, except that lto = false
+[profile.bench]
+lto = false
+opt-level = 3
+debug = true
+codegen-units = 1


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Please see https://github.com/tikv/tikv/issues/3640 for details.

I used our [MVCC benchmark](https://github.com/tikv/tikv/pull/3477) to see the performance impact of codegen-units = 2 vs codegen-units = 1:

```
forward_scan/keys = 5000, versions = 1, key_len = 32, value_len = 5
                        time:   [3.4019 ms 3.6358 ms 3.8353 ms]
                        change: [-0.4594% +5.4282% +11.678%] (p = 0.10 > 0.05)
forward_scan/keys = 5000, versions = 1, key_len = 32, value_len = 100
                        time:   [4.4820 ms 4.5976 ms 4.7174 ms]
                        change: [-11.861% -8.5681% -5.0378%] (p = 0.00 < 0.05)
forward_scan/keys = 5000, versions = 2, key_len = 32, value_len = 5
                        time:   [4.2251 ms 4.4809 ms 4.7280 ms]
                        change: [-1.3413% +2.3642% +5.7073%] (p = 0.23 > 0.05)
forward_scan/keys = 5000, versions = 2, key_len = 32, value_len = 100
                        time:   [6.0814 ms 6.2023 ms 6.2922 ms]
                        change: [-4.6860% -2.2389% +0.2196%] (p = 0.11 > 0.05)
forward_scan/keys = 5000, versions = 20, key_len = 32, value_len = 5
                        time:   [18.842 ms 19.214 ms 20.022 ms]
                        change: [-1.7689% +4.0995% +10.279%] (p = 0.21 > 0.05)
forward_scan/keys = 5000, versions = 20, key_len = 32, value_len = 100
                        time:   [35.944 ms 39.025 ms 40.946 ms]
                        change: [-7.1411% -0.3021% +6.8241%] (p = 0.93 > 0.05)
backward_scan/keys = 5000, versions = 1, key_len = 32, value_len = 5
                        time:   [10.673 ms 10.735 ms 10.840 ms]
                        change: [-3.6131% -1.8265% +0.0736%] (p = 0.09 > 0.05)
backward_scan/keys = 5000, versions = 1, key_len = 32, value_len = 100
                        time:   [14.052 ms 14.308 ms 14.574 ms]
                        change: [-6.5935% -4.8769% -3.2316%] (p = 0.00 < 0.05)
backward_scan/keys = 5000, versions = 2, key_len = 32, value_len = 5
                        time:   [19.792 ms 19.909 ms 20.038 ms]
                        change: [-3.7817% -2.0858% -0.5946%] (p = 0.02 < 0.05)
backward_scan/keys = 5000, versions = 2, key_len = 32, value_len = 100
                        time:   [26.296 ms 26.364 ms 26.494 ms]
                        change: [-5.4753% -3.3814% -1.0802%] (p = 0.01 < 0.05)
backward_scan/keys = 5000, versions = 20, key_len = 32, value_len = 5
                        time:   [106.59 ms 106.96 ms 107.75 ms]
                        change: [-1.6760% +0.3741% +2.7044%] (p = 0.76 > 0.05)
backward_scan/keys = 5000, versions = 20, key_len = 32, value_len = 100
                        time:   [152.21 ms 153.80 ms 155.79 ms]
                        change: [-3.1075% -1.6511% -0.0766%] (p = 0.06 > 0.05)
```

Generally, all cases are improved, from 1% to 10% in different scenarios. More specifically, considering these stable cases (p <= 0.05) there is about 5% improvements. The build time increased about only 1 minute in my own PC.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)
