### PR TITLE
coprocessor/dag/expr: add un-pushed builtin UDFs(InetAton, InetNtoa)

### DIFF
--- a/src/coprocessor/dag/expr/builtin_miscellaneous.rs
+++ b/src/coprocessor/dag/expr/builtin_miscellaneous.rs
@@ -59,8 +59,7 @@ impl ScalarFunc {
 
         if dot_count == 1 {
             result <<= 16;
-        }
-        if dot_count == 2 {
+        } else if dot_count == 2 {
             result <<= 8;
         }
         Ok(Some(((result << 8) + byte_result) as i64))

--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -238,6 +238,8 @@ impl ScalarFunc {
             | ScalarFuncSig::BitNegSig
             | ScalarFuncSig::IsIPv4
             | ScalarFuncSig::IsIPv6
+            | ScalarFuncSig::InetAton
+            | ScalarFuncSig::InetNtoa
             | ScalarFuncSig::Inet6Aton
             | ScalarFuncSig::Inet6Ntoa
             | ScalarFuncSig::HexIntArg
@@ -369,8 +371,6 @@ impl ScalarFunc {
             | ScalarFuncSig::GetParamString
             | ScalarFuncSig::GetVar
             | ScalarFuncSig::Hour
-            | ScalarFuncSig::InetAton
-            | ScalarFuncSig::InetNtoa
             | ScalarFuncSig::Insert
             | ScalarFuncSig::InsertBinary
             | ScalarFuncSig::Instr
@@ -793,6 +793,7 @@ dispatch_call! {
         ASCII => ascii,
         IsIPv4 => is_ipv4,
         IsIPv6 => is_ipv6,
+        InetAton => inet_aton,
     }
     REAL_CALLS {
         CastIntAsReal => cast_int_as_real,
@@ -910,6 +911,7 @@ dispatch_call! {
         HexIntArg => hex_int_arg,
         HexStrArg => hex_str_arg,
         UnHex => un_hex,
+        InetNtoa => inet_ntoa,
         Inet6Aton => inet6_aton,
         Inet6Ntoa => inet6_ntoa,
         MD5 => md5,
@@ -1373,8 +1375,6 @@ mod test {
             ScalarFuncSig::GetParamString,
             ScalarFuncSig::GetVar,
             ScalarFuncSig::Hour,
-            ScalarFuncSig::InetAton,
-            ScalarFuncSig::InetNtoa,
             ScalarFuncSig::Insert,
             ScalarFuncSig::InsertBinary,
             ScalarFuncSig::Instr,


### PR DESCRIPTION
## What have you changed? (mandatory)
This PR implements two builtin functions: `InetAton` and `InetNtoa` in coprocessor.

## What are the type of the changes? (mandatory)
- Improvement

## How has this PR been tested? (mandatory)
- Unit test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No

## Refer to a related PR or issue link (optional)
#3275.

