### PR TITLE
codec: move timestamp append to key type.

### DIFF
--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -20,12 +20,11 @@ use std::u64;
 
 use byteorder::{ByteOrder, NativeEndian};
 
+use storage::mvcc::{Lock, Write};
 use util::codec::bytes;
+use util::codec::bytes::BytesEncoder;
 use util::codec::number::{self, NumberEncoder};
 use util::{codec, escape};
-
-use storage::mvcc::{Lock, Write};
-
 /// Value type which is essentially raw bytes.
 pub type Value = Vec<u8>;
 
@@ -64,7 +63,11 @@ impl Key {
     /// Creates a key from raw bytes.
     #[inline]
     pub fn from_raw(key: &[u8]) -> Key {
-        Key(codec::bytes::encode_bytes(key))
+        // adding extra length for appending timestamp
+        let len = codec::bytes::max_encoded_bytes_size(key.len()) + codec::number::U64_SIZE;
+        let mut encoded = Vec::with_capacity(len);
+        encoded.encode_bytes(key, false).unwrap();
+        Key(encoded)
     }
 
     /// Gets and moves the raw representation of this key.

--- a/src/util/codec/bytes.rs
+++ b/src/util/codec/bytes.rs
@@ -25,8 +25,7 @@ const ENC_DESC_PADDING: [u8; ENC_GROUP_SIZE] = [!0; ENC_GROUP_SIZE];
 
 // returns the maximum encoded bytes size.
 pub fn max_encoded_bytes_size(n: usize) -> usize {
-    // reserve number::U64_SIZE for later append_ts
-    (n / ENC_GROUP_SIZE + 1) * (ENC_GROUP_SIZE + 1) + number::U64_SIZE
+    (n / ENC_GROUP_SIZE + 1) * (ENC_GROUP_SIZE + 1)
 }
 
 pub trait BytesEncoder: NumberEncoder {
@@ -443,11 +442,7 @@ mod tests {
     #[test]
     fn test_max_encoded_bytes_size() {
         let n = bytes::ENC_GROUP_SIZE;
-        let tbl: Vec<(usize, usize)> = vec![
-            (0, n + 1 + number::U64_SIZE),
-            (n / 2, n + 1 + number::U64_SIZE),
-            (n, 2 * (n + 1) + number::U64_SIZE),
-        ];
+        let tbl: Vec<(usize, usize)> = vec![(0, n + 1), (n / 2, n + 1), (n, 2 * (n + 1))];
         for (x, y) in tbl {
             assert_eq!(max_encoded_bytes_size(x), y);
         }


### PR DESCRIPTION
Signed-off-by: பாலாஜி ஜின்னா <rbalajis25@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
appending timestamp length ot codec has been moved to key type

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
make test
## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
no
## Does this PR affect tidb-ansible update? (mandatory)
no

## Refer to a related PR or issue link (optional)
#3631

