### PR TITLE
produce an Alpine Linux image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
-.git
 target
+# Including .git lets the build inside Docker get the git commit
+# .git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 # pingcap/rust: 2017-06-12
-FROM pingcap/rust
+FROM pingcap/rust as builder
 
 MAINTAINER Liu Yin <liuy@pingcap.com>
 
-ADD . /tikv
+COPY . /tikv
+WORKDIR /tikv
 
-RUN cd /tikv && \
-    make && \
-    cp -f bin/tikv-server /tikv-server && \
-    rm -rf /tikv
+RUN make
+
+
+FROM pingcap/alpine-glibc
+COPY --from=builder /tikv/bin/tikv-server /tikv-server
 
 EXPOSE 20160
 


### PR DESCRIPTION
## What have you changed? (mandatory)

The Dockerfile produces an Alpine Linux image now.
I am trying to make our docker runtime uniform.
The docker-compose repo already uses Alpine with glibc.
https://github.com/pingcap/tidb-docker-compose/blob/master/tikv/Dockerfile
This final image matches our production image other than that it uses UTC for TZ instead of /etc/localtime.

It may be the case that this image is not that useful and should be replaced with a more development oriented Dockerfile: let me know.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

I only tested by briefly starting TiKV up. That did point out to me that the git hash was missing, which I corrected by removing .git form the .dockerignore

```
➜ tikv git:(docker-alpine) docker run --rm -it pingcap/tikv
2018/10/22 18:40:31.507 INFO mod.rs:27: Welcome to TiKV. 
Release Version:   2.1.0-rc.2
Git Commit Hash:   d046faecf56a11e526ce4f0211fe76ac5f1c7296
Git Commit Branch: master
UTC Build Time:    2018-10-22 03:43:53
Rust Version:      rustc 1.29.0-nightly (4f3c7a472 2018-07-17)
2018/10/22 18:40:31.511 INFO config.rs:145: no advertise-addr is specified, fall back to addr.
2018/10/22 18:40:31.516 ERRO tikv-server.rs:396: invalid configuration: StringError("please specify pd.endpoints.")

```

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

Not that I know of.

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

