### PR TITLE
*: Unify name of test mods

### DIFF
--- a/src/bin/util/profiling.rs
+++ b/src/bin/util/profiling.rs
@@ -66,7 +66,7 @@ mod imp {
     }
 
     #[cfg(test)]
-    mod test {
+    mod tests {
         use std::fs;
 
         use tempdir::TempDir;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1168,7 +1168,7 @@ pub fn check_and_persist_critical_config(config: &TiKvConfig) -> Result<(), Stri
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use tempdir::TempDir;
 
     use super::*;

--- a/src/coprocessor/codec/chunk/chunk.rs
+++ b/src/coprocessor/codec/chunk/chunk.rs
@@ -164,7 +164,7 @@ impl<'a> Iterator for RowIterator<'a> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use coprocessor::codec::datum::Datum;
     use coprocessor::codec::mysql::*;

--- a/src/coprocessor/codec/chunk/column.rs
+++ b/src/coprocessor/codec/chunk/column.rs
@@ -386,7 +386,7 @@ pub trait ColumnEncoder: NumberEncoder {
 impl<T: Write> ColumnEncoder for T {}
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use coprocessor::codec::chunk::test::field_type;
     use coprocessor::codec::datum::Datum;

--- a/src/coprocessor/codec/chunk/column.rs
+++ b/src/coprocessor/codec/chunk/column.rs
@@ -388,7 +388,7 @@ impl<T: Write> ColumnEncoder for T {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coprocessor::codec::chunk::test::field_type;
+    use coprocessor::codec::chunk::tests::field_type;
     use coprocessor::codec::datum::Datum;
     use coprocessor::codec::mysql::*;
     use std::{f64, u64};

--- a/src/coprocessor/codec/chunk/mod.rs
+++ b/src/coprocessor/codec/chunk/mod.rs
@@ -19,7 +19,7 @@ pub use coprocessor::codec::{Error, Result};
 pub use self::chunk::{Chunk, ChunkEncoder};
 
 #[cfg(test)]
-mod test {
+mod tests {
     use tipb::expression::FieldType;
 
     pub fn field_type(tp: u8) -> FieldType {

--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -323,7 +323,7 @@ fn float_str_to_int_string<'a, 'b: 'a>(valid_float: &'b str) -> Result<Cow<'a, s
 const MAX_ZERO_COUNT: i64 = 20;
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::f64::EPSILON;
     use std::sync::Arc;
     use std::{f64, i64, isize, u64};

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -1015,7 +1015,7 @@ pub fn split_datum(buf: &[u8], desc: bool) -> Result<(&[u8], &[u8])> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use coprocessor::codec::mysql::{Decimal, Duration, Time, MAX_FSP};
     use coprocessor::dag::expr::{EvalConfig, EvalContext};

--- a/src/coprocessor/codec/mysql/decimal.rs
+++ b/src/coprocessor/codec/mysql/decimal.rs
@@ -2201,7 +2201,7 @@ impl Neg for Decimal {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use super::{DEFAULT_DIV_FRAC_INCR, WORD_BUF_LEN};
 

--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -299,7 +299,7 @@ impl Duration {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use coprocessor::codec::mysql::MAX_FSP;
     use util::escape;

--- a/src/coprocessor/codec/mysql/json/binary.rs
+++ b/src/coprocessor/codec/mysql/json/binary.rs
@@ -389,7 +389,7 @@ fn get_var_u64_binary_len(mut v: u64) -> usize {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/coprocessor/codec/mysql/json/comparison.rs
+++ b/src/coprocessor/codec/mysql/json/comparison.rs
@@ -127,7 +127,7 @@ impl PartialOrd for Json {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/coprocessor/codec/mysql/json/json_cast.rs
+++ b/src/coprocessor/codec/mysql/json/json_cast.rs
@@ -42,7 +42,7 @@ impl Json {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use coprocessor::dag::expr::{EvalConfig, EvalContext};
     use std::f64;

--- a/src/coprocessor/codec/mysql/json/json_extract.rs
+++ b/src/coprocessor/codec/mysql/json/json_extract.rs
@@ -83,7 +83,7 @@ pub fn extract_json(j: &Json, path_legs: &[PathLeg]) -> Vec<Json> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::super::path_expr::{
         PathExpressionFlag, PATH_EXPRESSION_CONTAINS_ASTERISK,
         PATH_EXPRESSION_CONTAINS_DOUBLE_ASTERISK, PATH_EXPR_ARRAY_INDEX_ASTERISK,

--- a/src/coprocessor/codec/mysql/json/json_merge.rs
+++ b/src/coprocessor/codec/mysql/json/json_merge.rs
@@ -60,7 +60,7 @@ impl Json {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/coprocessor/codec/mysql/json/json_modify.rs
+++ b/src/coprocessor/codec/mysql/json/json_modify.rs
@@ -105,7 +105,7 @@ impl Json {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::super::path_expr::parse_json_path_expr;
     use super::*;
 

--- a/src/coprocessor/codec/mysql/json/json_remove.rs
+++ b/src/coprocessor/codec/mysql/json/json_remove.rs
@@ -66,7 +66,7 @@ impl Json {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::super::path_expr::parse_json_path_expr;
     use super::*;
 

--- a/src/coprocessor/codec/mysql/json/json_type.rs
+++ b/src/coprocessor/codec/mysql/json/json_type.rs
@@ -40,7 +40,7 @@ impl Json {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/coprocessor/codec/mysql/json/json_unquote.rs
+++ b/src/coprocessor/codec/mysql/json/json_unquote.rs
@@ -86,7 +86,7 @@ fn decode_escaped_unicode(s: &str) -> Result<char> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use std::collections::BTreeMap;
 

--- a/src/coprocessor/codec/mysql/json/mod.rs
+++ b/src/coprocessor/codec/mysql/json/mod.rs
@@ -96,7 +96,7 @@ pub fn json_object(kvs: Vec<Datum>) -> Result<Json> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/coprocessor/codec/mysql/json/path_expr.rs
+++ b/src/coprocessor/codec/mysql/json/path_expr.rs
@@ -158,7 +158,7 @@ pub fn parse_json_path_expr(path_expr: &str) -> Result<PathExpression> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/coprocessor/codec/mysql/json/serde.rs
+++ b/src/coprocessor/codec/mysql/json/serde.rs
@@ -150,7 +150,7 @@ impl<'de> Deserialize<'de> for Json {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/coprocessor/codec/mysql/mod.rs
+++ b/src/coprocessor/codec/mysql/mod.rs
@@ -75,7 +75,7 @@ pub use self::types::{
 };
 
 #[cfg(test)]
-mod test {
+mod tests {
     #[test]
     fn test_parse_frace() {
         let cases = vec![

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -822,7 +822,7 @@ impl Time {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     use std::cmp::Ordering;

--- a/src/coprocessor/codec/overflow.rs
+++ b/src/coprocessor/codec/overflow.rs
@@ -75,7 +75,7 @@ pub fn div_i64_with_u64(a: i64, b: u64) -> Result<u64> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::error::{ERR_DATA_OUT_OF_RANGE, ERR_DIVISION_BY_ZERO};
     use std::{i64, u64};
 

--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -417,7 +417,7 @@ pub fn cut_idx_key(key: Vec<u8>, col_ids: &[i64]) -> Result<(RowColsDict, Option
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::i64;
 
     use tipb::schema::ColumnInfo;

--- a/src/coprocessor/dag/executor/aggregate.rs
+++ b/src/coprocessor/dag/executor/aggregate.rs
@@ -299,7 +299,7 @@ impl AggrFunc for Extremum {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::dag::expr::{EvalConfig, EvalContext};
     use std::ops::Add;
     use std::sync::Arc;

--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -395,7 +395,7 @@ impl StreamAggExecutor {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::i64;
 
     use kvproto::kvrpcpb::IsolationLevel;
@@ -412,11 +412,11 @@ mod test {
     use util::codec::number::NumberEncoder;
     use util::collections::HashMap;
 
-    use super::super::index_scan::test::IndexTestWrapper;
+    use super::super::index_scan::tests::IndexTestWrapper;
     use super::super::index_scan::IndexScanExecutor;
-    use super::super::scanner::test::{get_range, new_col_info, Data, TestStore};
+    use super::super::scanner::tests::{get_range, new_col_info, Data, TestStore};
     use super::super::table_scan::TableScanExecutor;
-    use super::super::topn::test::gen_table_data;
+    use super::super::topn::tests::gen_table_data;
     use super::*;
 
     #[inline]

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -271,7 +271,7 @@ impl<S: Snapshot> Executor for IndexScanExecutor<S> {
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use byteorder::{BigEndian, WriteBytesExt};
     use std::i64;
 
@@ -284,7 +284,7 @@ pub mod test {
     use storage::SnapshotStore;
     use util::collections::HashMap;
 
-    use super::super::scanner::test::{new_col_info, Data, TestStore};
+    use super::super::scanner::tests::{new_col_info, Data, TestStore};
     use super::*;
 
     const TABLE_ID: i64 = 1;

--- a/src/coprocessor/dag/executor/limit.rs
+++ b/src/coprocessor/dag/executor/limit.rs
@@ -71,7 +71,7 @@ impl<'a> Executor for LimitExecutor<'a> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use kvproto::kvrpcpb::IsolationLevel;
     use protobuf::RepeatedField;
     use tipb::executor::TableScan;
@@ -80,9 +80,9 @@ mod test {
     use coprocessor::codec::mysql::types;
     use storage::SnapshotStore;
 
-    use super::super::scanner::test::{get_range, new_col_info, TestStore};
+    use super::super::scanner::tests::{get_range, new_col_info, TestStore};
     use super::super::table_scan::TableScanExecutor;
-    use super::super::topn::test::gen_table_data;
+    use super::super::topn::tests::gen_table_data;
     use super::*;
 
     #[test]

--- a/src/coprocessor/dag/executor/scanner.rs
+++ b/src/coprocessor/dag/executor/scanner.rs
@@ -184,7 +184,7 @@ impl<S: Snapshot> Scanner<S> {
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use std::i64;
 
     use kvproto::kvrpcpb::{Context, IsolationLevel};

--- a/src/coprocessor/dag/executor/selection.rs
+++ b/src/coprocessor/dag/executor/selection.rs
@@ -105,9 +105,9 @@ mod tests {
     use storage::SnapshotStore;
     use util::codec::number::NumberEncoder;
 
-    use super::super::scanner::test::{get_range, new_col_info, TestStore};
+    use super::super::scanner::tests::{get_range, new_col_info, TestStore};
     use super::super::table_scan::TableScanExecutor;
-    use super::super::topn::test::gen_table_data;
+    use super::super::topn::tests::gen_table_data;
     use super::*;
 
     fn new_const_expr() -> Expr {

--- a/src/coprocessor/dag/executor/table_scan.rs
+++ b/src/coprocessor/dag/executor/table_scan.rs
@@ -223,7 +223,7 @@ impl<S: Snapshot> Executor for TableScanExecutor<S> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::i64;
 
     use kvproto::kvrpcpb::IsolationLevel;
@@ -232,7 +232,7 @@ mod test {
 
     use storage::SnapshotStore;
 
-    use super::super::scanner::test::{
+    use super::super::scanner::tests::{
         get_point_range, get_range, prepare_table_data, Data, TestStore,
     };
     use super::*;

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -160,7 +160,7 @@ impl Executor for TopNExecutor {
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use std::cell::RefCell;
     use std::sync::Arc;
 
@@ -179,7 +179,7 @@ pub mod test {
 
     use storage::SnapshotStore;
 
-    use super::super::scanner::test::{get_range, new_col_info, TestStore};
+    use super::super::scanner::tests::{get_range, new_col_info, TestStore};
     use super::super::table_scan::TableScanExecutor;
     use super::*;
 

--- a/src/coprocessor/dag/expr/builtin_arithmetic.rs
+++ b/src/coprocessor/dag/expr/builtin_arithmetic.rs
@@ -296,7 +296,7 @@ mod tests {
     use coprocessor::codec::error::ERR_DIVISION_BY_ZERO;
     use coprocessor::codec::mysql::{types, Decimal};
     use coprocessor::codec::{mysql, Datum};
-    use coprocessor::dag::expr::test::{
+    use coprocessor::dag::expr::tests::{
         check_divide_by_zero, check_overflow, datum_expr, scalar_func_expr, str2dec,
     };
     use coprocessor::dag::expr::*;

--- a/src/coprocessor/dag/expr/builtin_arithmetic.rs
+++ b/src/coprocessor/dag/expr/builtin_arithmetic.rs
@@ -292,7 +292,7 @@ impl ScalarFunc {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::error::ERR_DIVISION_BY_ZERO;
     use coprocessor::codec::mysql::{types, Decimal};
     use coprocessor::codec::{mysql, Datum};

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -707,7 +707,7 @@ impl ScalarFunc {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::str::FromStr;
     use std::sync::Arc;
     use std::{i64, u64};

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -720,7 +720,7 @@ mod tests {
     use coprocessor::codec::mysql::{self, charset, types, Decimal, Duration, Json, Time, Tz};
     use coprocessor::codec::{convert, Datum};
     use coprocessor::dag::expr::ctx::FLAG_OVERFLOW_AS_WARNING;
-    use coprocessor::dag::expr::test::{col_expr as base_col_expr, scalar_func_expr};
+    use coprocessor::dag::expr::tests::{col_expr as base_col_expr, scalar_func_expr};
     use coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
 
     pub fn col_expr(col_id: i64, tp: i32) -> Expr {

--- a/src/coprocessor/dag/expr/builtin_compare.rs
+++ b/src/coprocessor/dag/expr/builtin_compare.rs
@@ -475,7 +475,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::super::EvalConfig;
     use super::*;
     use coprocessor::codec::error::ERR_TRUNCATE_WRONG_VALUE;

--- a/src/coprocessor/dag/expr/builtin_compare.rs
+++ b/src/coprocessor/dag/expr/builtin_compare.rs
@@ -481,7 +481,7 @@ mod tests {
     use coprocessor::codec::error::ERR_TRUNCATE_WRONG_VALUE;
     use coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
     use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::test::{col_expr, datum_expr, str2dec};
+    use coprocessor::dag::expr::tests::{col_expr, datum_expr, str2dec};
     use coprocessor::dag::expr::{EvalContext, Expression};
     use protobuf::RepeatedField;
     use std::sync::Arc;

--- a/src/coprocessor/dag/expr/builtin_control.rs
+++ b/src/coprocessor/dag/expr/builtin_control.rs
@@ -234,7 +234,7 @@ mod tests {
 
     use coprocessor::codec::mysql::{Duration, Json, Time};
     use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::test::{col_expr, datum_expr, scalar_func_expr, str2dec};
+    use coprocessor::dag::expr::tests::{col_expr, datum_expr, scalar_func_expr, str2dec};
     use coprocessor::dag::expr::{EvalContext, Expression};
 
     #[test]

--- a/src/coprocessor/dag/expr/builtin_control.rs
+++ b/src/coprocessor/dag/expr/builtin_control.rs
@@ -228,7 +228,7 @@ impl ScalarFunc {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use protobuf::RepeatedField;
     use tipb::expression::{Expr, ExprType, ScalarFuncSig};
 

--- a/src/coprocessor/dag/expr/builtin_encryption.rs
+++ b/src/coprocessor/dag/expr/builtin_encryption.rs
@@ -96,7 +96,7 @@ impl ScalarFunc {
 #[cfg(test)]
 mod tests {
     use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::test::{datum_expr, scalar_func_expr};
+    use coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
     use coprocessor::dag::expr::{EvalContext, Expression};
     use tipb::expression::ScalarFuncSig;
 

--- a/src/coprocessor/dag/expr/builtin_encryption.rs
+++ b/src/coprocessor/dag/expr/builtin_encryption.rs
@@ -94,7 +94,7 @@ impl ScalarFunc {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::Datum;
     use coprocessor::dag::expr::test::{datum_expr, scalar_func_expr};
     use coprocessor::dag::expr::{EvalContext, Expression};

--- a/src/coprocessor/dag/expr/builtin_json.rs
+++ b/src/coprocessor/dag/expr/builtin_json.rs
@@ -199,7 +199,7 @@ impl<'a> JsonFuncArgsParser<'a> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::mysql::Json;
     use coprocessor::codec::Datum;
     use coprocessor::dag::expr::test::{datum_expr, make_null_datums, scalar_func_expr};

--- a/src/coprocessor/dag/expr/builtin_json.rs
+++ b/src/coprocessor/dag/expr/builtin_json.rs
@@ -202,7 +202,7 @@ impl<'a> JsonFuncArgsParser<'a> {
 mod tests {
     use coprocessor::codec::mysql::Json;
     use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::test::{datum_expr, make_null_datums, scalar_func_expr};
+    use coprocessor::dag::expr::tests::{datum_expr, make_null_datums, scalar_func_expr};
     use coprocessor::dag::expr::{EvalContext, Expression};
     use tipb::expression::ScalarFuncSig;
 

--- a/src/coprocessor/dag/expr/builtin_like.rs
+++ b/src/coprocessor/dag/expr/builtin_like.rs
@@ -119,7 +119,7 @@ fn like(target: &[u8], pattern: &[u8], escape: u32, recurse_level: usize) -> Res
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::Datum;
     use coprocessor::dag::expr::test::{datum_expr, scalar_func_expr};
     use coprocessor::dag::expr::{EvalContext, Expression};

--- a/src/coprocessor/dag/expr/builtin_like.rs
+++ b/src/coprocessor/dag/expr/builtin_like.rs
@@ -121,7 +121,7 @@ fn like(target: &[u8], pattern: &[u8], escape: u32, recurse_level: usize) -> Res
 #[cfg(test)]
 mod tests {
     use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::test::{datum_expr, scalar_func_expr};
+    use coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
     use coprocessor::dag::expr::{EvalContext, Expression};
     use tipb::expression::ScalarFuncSig;
 

--- a/src/coprocessor/dag/expr/builtin_math.rs
+++ b/src/coprocessor/dag/expr/builtin_math.rs
@@ -485,7 +485,7 @@ fn get_rand(arg: Option<u64>) -> XorShiftRng {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::mysql::types;
     use coprocessor::codec::{convert, mysql, Datum};
     use coprocessor::dag::expr::test::{check_overflow, eval_func, eval_func_with, str2dec};

--- a/src/coprocessor/dag/expr/builtin_math.rs
+++ b/src/coprocessor/dag/expr/builtin_math.rs
@@ -488,7 +488,7 @@ fn get_rand(arg: Option<u64>) -> XorShiftRng {
 mod tests {
     use coprocessor::codec::mysql::types;
     use coprocessor::codec::{convert, mysql, Datum};
-    use coprocessor::dag::expr::test::{check_overflow, eval_func, eval_func_with, str2dec};
+    use coprocessor::dag::expr::tests::{check_overflow, eval_func, eval_func_with, str2dec};
     use std::f64::consts::{FRAC_1_SQRT_2, PI};
     use std::{f64, i64, u64};
     use tipb::expression::ScalarFuncSig;

--- a/src/coprocessor/dag/expr/builtin_miscellaneous.rs
+++ b/src/coprocessor/dag/expr/builtin_miscellaneous.rs
@@ -127,7 +127,7 @@ impl ScalarFunc {
 #[cfg(test)]
 mod tests {
     use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::test::{datum_expr, scalar_func_expr};
+    use coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
     use coprocessor::dag::expr::{EvalContext, Expression};
     use tipb::expression::ScalarFuncSig;
 

--- a/src/coprocessor/dag/expr/builtin_miscellaneous.rs
+++ b/src/coprocessor/dag/expr/builtin_miscellaneous.rs
@@ -125,7 +125,7 @@ impl ScalarFunc {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::Datum;
     use coprocessor::dag::expr::test::{datum_expr, scalar_func_expr};
     use coprocessor::dag::expr::{EvalContext, Expression};

--- a/src/coprocessor/dag/expr/builtin_op.rs
+++ b/src/coprocessor/dag/expr/builtin_op.rs
@@ -197,7 +197,7 @@ impl ScalarFunc {
 mod tests {
     use coprocessor::codec::mysql::Duration;
     use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::test::{check_overflow, datum_expr, scalar_func_expr, str2dec};
+    use coprocessor::dag::expr::tests::{check_overflow, datum_expr, scalar_func_expr, str2dec};
     use coprocessor::dag::expr::{EvalContext, Expression};
     use std::i64;
     use tipb::expression::ScalarFuncSig;

--- a/src/coprocessor/dag/expr/builtin_op.rs
+++ b/src/coprocessor/dag/expr/builtin_op.rs
@@ -194,7 +194,7 @@ impl ScalarFunc {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::mysql::Duration;
     use coprocessor::codec::Datum;
     use coprocessor::dag::expr::test::{check_overflow, datum_expr, scalar_func_expr, str2dec};

--- a/src/coprocessor/dag/expr/builtin_other.rs
+++ b/src/coprocessor/dag/expr/builtin_other.rs
@@ -36,7 +36,7 @@ impl ScalarFunc {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::mysql::Decimal;
     use coprocessor::codec::Datum;
     use coprocessor::dag::expr::ctx::FLAG_OVERFLOW_AS_WARNING;

--- a/src/coprocessor/dag/expr/builtin_other.rs
+++ b/src/coprocessor/dag/expr/builtin_other.rs
@@ -40,7 +40,7 @@ mod tests {
     use coprocessor::codec::mysql::Decimal;
     use coprocessor::codec::Datum;
     use coprocessor::dag::expr::ctx::FLAG_OVERFLOW_AS_WARNING;
-    use coprocessor::dag::expr::test::{datum_expr, scalar_func_expr};
+    use coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
     use coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
     use std::str::FromStr;
     use std::sync::Arc;

--- a/src/coprocessor/dag/expr/builtin_string.rs
+++ b/src/coprocessor/dag/expr/builtin_string.rs
@@ -262,7 +262,7 @@ impl ScalarFunc {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::mysql::charset::{CHARSET_BIN, COLLATION_BIN_ID};
     use coprocessor::codec::mysql::types::{BINARY_FLAG, VAR_STRING};
     use coprocessor::codec::Datum;

--- a/src/coprocessor/dag/expr/builtin_string.rs
+++ b/src/coprocessor/dag/expr/builtin_string.rs
@@ -266,7 +266,7 @@ mod tests {
     use coprocessor::codec::mysql::charset::{CHARSET_BIN, COLLATION_BIN_ID};
     use coprocessor::codec::mysql::types::{BINARY_FLAG, VAR_STRING};
     use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::test::{
+    use coprocessor::dag::expr::tests::{
         col_expr, datum_expr, scalar_func_expr, string_datum_expr_with_tp,
     };
     use coprocessor::dag::expr::{EvalContext, Expression};

--- a/src/coprocessor/dag/expr/builtin_time.rs
+++ b/src/coprocessor/dag/expr/builtin_time.rs
@@ -123,7 +123,7 @@ impl ScalarFunc {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::mysql::Time;
     use coprocessor::codec::Datum;
     use coprocessor::dag::expr::test::{datum_expr, scalar_func_expr};

--- a/src/coprocessor/dag/expr/builtin_time.rs
+++ b/src/coprocessor/dag/expr/builtin_time.rs
@@ -126,7 +126,7 @@ impl ScalarFunc {
 mod tests {
     use coprocessor::codec::mysql::Time;
     use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::test::{datum_expr, scalar_func_expr};
+    use coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
     use coprocessor::dag::expr::*;
     use coprocessor::dag::expr::{EvalContext, Expression};
     use std::sync::Arc;

--- a/src/coprocessor/dag/expr/column.rs
+++ b/src/coprocessor/dag/expr/column.rs
@@ -92,7 +92,7 @@ mod tests {
 
     use coprocessor::codec::mysql::{types, Decimal, Duration, Json, Time};
     use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::test::col_expr;
+    use coprocessor::dag::expr::tests::col_expr;
     use coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
 
     #[derive(PartialEq, Debug)]

--- a/src/coprocessor/dag/expr/column.rs
+++ b/src/coprocessor/dag/expr/column.rs
@@ -84,7 +84,7 @@ impl Column {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::sync::Arc;
     use std::{str, u64};
 

--- a/src/coprocessor/dag/expr/constant.rs
+++ b/src/coprocessor/dag/expr/constant.rs
@@ -125,7 +125,7 @@ impl Constant {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
     use coprocessor::codec::Datum;
     use coprocessor::dag::expr::test::datum_expr;

--- a/src/coprocessor/dag/expr/constant.rs
+++ b/src/coprocessor/dag/expr/constant.rs
@@ -128,7 +128,7 @@ impl Constant {
 mod tests {
     use coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
     use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::test::datum_expr;
+    use coprocessor::dag::expr::tests::datum_expr;
     use coprocessor::dag::expr::{EvalContext, Expression};
     use std::u64;
 

--- a/src/coprocessor/dag/expr/ctx.rs
+++ b/src/coprocessor/dag/expr/ctx.rs
@@ -349,7 +349,7 @@ impl EvalContext {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::super::Error;
     use super::*;
     use std::sync::Arc;

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -322,7 +322,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::{Error, EvalConfig, EvalContext, Expression};
     use coprocessor::codec::error::{ERR_DATA_OUT_OF_RANGE, ERR_DIVISION_BY_ZERO};
     use coprocessor::codec::mysql::json::JsonEncoder;

--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -983,7 +983,7 @@ dispatch_call! {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use coprocessor::dag::expr::{Error, ScalarFunc};
     use std::usize;
     use tipb::expression::ScalarFuncSig;

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -296,7 +296,7 @@ impl SampleCollector {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use coprocessor::codec::datum;
     use coprocessor::codec::datum::Datum;

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -74,7 +74,7 @@ impl CMSketch {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use coprocessor::codec::datum;
     use coprocessor::codec::datum::Datum;

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -66,7 +66,7 @@ impl FMSketch {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use coprocessor::codec::datum;
     use coprocessor::codec::datum::Datum;

--- a/src/coprocessor/statistics/histogram.rs
+++ b/src/coprocessor/statistics/histogram.rs
@@ -165,7 +165,7 @@ impl Histogram {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use coprocessor::codec::datum;
     use coprocessor::codec::datum::Datum;

--- a/src/coprocessor/util.rs
+++ b/src/coprocessor/util.rs
@@ -133,7 +133,7 @@ pub fn get_pk(col: &ColumnInfo, h: i64) -> Datum {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     fn test_prefix_next_once(key: &[u8], expected: &[u8]) {

--- a/src/raftstore/coprocessor/dispatcher.rs
+++ b/src/raftstore/coprocessor/dispatcher.rs
@@ -271,7 +271,7 @@ impl CoprocessorHost {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use protobuf::RepeatedField;
     use raftstore::coprocessor::*;
     use std::sync::atomic::*;

--- a/src/raftstore/coprocessor/split_check/table.rs
+++ b/src/raftstore/coprocessor/split_check/table.rs
@@ -224,7 +224,7 @@ fn is_same_table(left_key: &[u8], right_key: &[u8]) -> bool {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::io::Write;
     use std::sync::mpsc;
     use std::sync::Arc;

--- a/src/raftstore/coprocessor/split_observer.rs
+++ b/src/raftstore/coprocessor/split_observer.rs
@@ -166,7 +166,7 @@ impl AdminObserver for SplitObserver {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use byteorder::{BigEndian, WriteBytesExt};
     use coprocessor::codec::{datum, table, Datum};

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -1430,7 +1430,7 @@ impl Storage for PeerStorage {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use kvproto::raft_serverpb::RaftSnapshotData;
     use protobuf;
     use raft::eraftpb::HardState;

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -1449,7 +1449,7 @@ impl SnapManagerBuilder {
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use protobuf::Message;
     use std::fs::{self, File, OpenOptions};
     use std::io::{self, Read, Seek, SeekFrom, Write};

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -247,7 +247,7 @@ fn collect_ranges_need_compact(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::thread::sleep;
     use std::time::Duration;
 

--- a/src/raftstore/store/worker/consistency_check.rs
+++ b/src/raftstore/store/worker/consistency_check.rs
@@ -136,7 +136,7 @@ impl<C: MsgSender> Runnable<Task> for Runner<C> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use byteorder::{BigEndian, WriteBytesExt};
     use crc::crc32::{self, Digest, Hasher32};

--- a/src/raftstore/store/worker/raftlog_gc.rs
+++ b/src/raftstore/store/worker/raftlog_gc.rs
@@ -130,7 +130,7 @@ impl Runnable<Task> for Runner {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use std::sync::mpsc;
     use std::time::Duration;

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -638,7 +638,7 @@ impl RunnableWithTimer<Task, Event> for Runner {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::io;
     use std::sync::atomic::AtomicUsize;
     use std::sync::{mpsc, Arc};
@@ -648,7 +648,7 @@ mod test {
     use kvproto::raft_serverpb::{PeerState, RegionLocalState};
     use raftstore::store::engine::{Mutable, Peekable};
     use raftstore::store::peer_storage::JOB_STATUS_PENDING;
-    use raftstore::store::snap::test::get_test_db_for_regions;
+    use raftstore::store::snap::tests::get_test_db_for_regions;
     use raftstore::store::worker::RegionRunner;
     use raftstore::store::{keys, Engines, SnapKey, SnapManager};
     use rocksdb::{ColumnFamilyOptions, Writable, WriteBatch};

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -160,7 +160,7 @@ impl<S: Snapshot> StoreScanner<S> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::SnapshotStore;
     use kvproto::kvrpcpb::{Context, IsolationLevel};
     use storage::engine::{self, Engine, RocksEngine, RocksSnapshot, TEMP_DIR};

--- a/src/util/codec/number.rs
+++ b/src/util/codec/number.rs
@@ -318,7 +318,7 @@ pub fn read_u8(data: &mut BytesSlice) -> Result<u8> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use util::codec::Error;
 

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -830,7 +830,7 @@ mod check_data_dir {
     }
 
     #[cfg(test)]
-    mod test {
+    mod tests {
         use std::fs::File;
         use std::io::Write;
         use std::os::unix::fs::symlink;
@@ -967,7 +967,7 @@ pub fn check_addr(addr: &str) -> Result<(), ConfigError> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::fs::File;
     use std::path::Path;
 

--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -93,7 +93,7 @@ pub fn calc_crc32<P: AsRef<Path>>(path: P) -> io::Result<u32> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use rand::{thread_rng, Rng};
     use std::fs::OpenOptions;
     use std::io::Write;

--- a/src/util/io_limiter.rs
+++ b/src/util/io_limiter.rs
@@ -104,7 +104,7 @@ impl<'a, T: Write + 'a> Write for LimitWriter<'a, T> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::fs::File;
     use std::io::{Read, Write};
     use std::sync::Arc;

--- a/src/util/threadpool.rs
+++ b/src/util/threadpool.rs
@@ -348,7 +348,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     use std::sync::atomic::{AtomicIsize, Ordering};

--- a/src/util/worker/future.rs
+++ b/src/util/worker/future.rs
@@ -188,7 +188,7 @@ impl<T: Display + Send + 'static> Worker<T> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::sync::mpsc;
     use std::sync::mpsc::*;
     use std::time::Duration;

--- a/src/util/worker/mod.rs
+++ b/src/util/worker/mod.rs
@@ -390,7 +390,7 @@ impl<T: Display + Send + 'static> Worker<T> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Usually we put unit test in the same file under
```
#[cfg(test)]
mod tests {
    ...
```

By conventions we use `mod tests`. However in TiKV's code we use both `mod tests` and `mod test`. This PR unifies them, so when someone tries to run a specified test case, he won't need to check whether the mod name is `test` or `tests`.

This PR is very simple since it changes nothing about logic.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

By CI

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No