### PR TITLE
tikv-ctl: Add delete-range subcommand to tikv-ctl

### DIFF
--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -697,6 +697,16 @@ impl Debugger {
         ));
         Ok(res)
     }
+
+    pub fn delete_range(&self, start_key: &[u8], end_key: &[u8]) -> Result<()> {
+        let db = &self.engines.kv;
+        for cf in &[CF_DEFAULT, CF_WRITE, CF_LOCK] {
+            box_try!(raftstore_util::delete_all_in_range_cf(
+                db, cf, start_key, end_key, false
+            ));
+        }
+        Ok(())
+    }
 }
 
 pub struct MvccChecker {


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

## What have you changed? (mandatory)

This PR added a subcommand named `delete-range` which scans and deletes all keys in a range.
It deletes in all of default_cf, write_cf, lock_cf.

It doesn't invoke delete_files_in_range, but scan and delete one by one.

Since it's a dangerous operation, I added some verbose warnings and asks for confirmation.

## What are the type of the changes? (mandatory)

- New feature (non-breaking change which adds functionality)

## How has this PR been tested? (mandatory)

By manual test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
