### PR TITLE
*: regress grpcio to v0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,19 +448,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grpcio"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grpcio-sys"
-version = "0.4.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -609,10 +609,10 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#0ba3ca8a6e3775accbe4bdf844162cd7685dafe2"
+source = "git+https://github.com/pingcap/kvproto.git#529c652955d8fa74faf56f91b2f428d5779fd7d5"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1058,7 +1058,7 @@ version = "0.3.1"
 source = "git+https://github.com/pingcap/raft-rs.git#b10d74ced67f57e7a591ecc590991b616e4ec570"
 dependencies = [
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1449,7 +1449,7 @@ name = "test_raftstore"
 version = "0.0.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1526,7 +1526,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
@@ -1871,8 +1871,8 @@ dependencies = [
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ceb617aadae035882ff0e96fc312e4c7f65abc26aad9336f1e5d199d588a702"
-"checksum grpcio-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c01243bb555ae2ba819d428cffb7e93575ae047cf033f6242959a8a9ecc51ef6"
+"checksum grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6420fb7aca82b4bf1cf98aa2c70a55cb0cbaa4c5152ba51a47c37d758ac27b2d"
+"checksum grpcio-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d45a6906ba6faa1be0f04bb61c0a49aef5f279f090b0d24d81912c1c08b995e"
 "checksum handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d89ec99d1594f285d4590fc32bac5f75cdab383f1123d504d27862c644a807dd"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2da7d3a34cf6406d9d700111b8eafafe9a251de41ae71d8052748259343b58"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ zipf = "0.2.0"
 bitflags = "1.0.1"
 fail = "0.2"
 uuid = { version = "0.6", features = [ "serde", "v4" ] }
-grpcio = { version = "0.4", features = [ "secure" ] }
+grpcio = { version = "0.3", features = [ "secure" ] }
 raft = "0.3"
 crossbeam-channel = "0.2"
 crossbeam = "0.2"

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -13,7 +13,7 @@ tempdir = "0.3"
 raft = "0.3"
 futures = "0.1"
 tokio-timer = "0.2"
-grpcio = { version = "0.4", features = [ "secure" ] }
+grpcio = { version = "0.3", features = [ "secure" ] }
 rand = "0.3"
 log = "0.3.9"
 

--- a/src/import/kv_service.rs
+++ b/src/import/kv_service.rs
@@ -53,7 +53,7 @@ impl ImportKVService {
 
 impl ImportKv for ImportKVService {
     fn switch_mode(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: SwitchModeRequest,
         sink: UnarySink<SwitchModeResponse>,
@@ -82,7 +82,7 @@ impl ImportKv for ImportKVService {
     }
 
     fn open_engine(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: OpenEngineRequest,
         sink: UnarySink<OpenEngineResponse>,
@@ -103,7 +103,7 @@ impl ImportKv for ImportKVService {
     }
 
     fn write_engine(
-        &mut self,
+        &self,
         ctx: RpcContext,
         stream: RequestStream<WriteEngineRequest>,
         sink: ClientStreamingSink<WriteEngineResponse>,
@@ -160,7 +160,7 @@ impl ImportKv for ImportKVService {
     }
 
     fn close_engine(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: CloseEngineRequest,
         sink: UnarySink<CloseEngineResponse>,
@@ -191,7 +191,7 @@ impl ImportKv for ImportKVService {
     }
 
     fn import_engine(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: ImportEngineRequest,
         sink: UnarySink<ImportEngineResponse>,
@@ -212,7 +212,7 @@ impl ImportKv for ImportKVService {
     }
 
     fn cleanup_engine(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: CleanupEngineRequest,
         sink: UnarySink<CleanupEngineResponse>,
@@ -233,7 +233,7 @@ impl ImportKv for ImportKVService {
     }
 
     fn compact_cluster(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: CompactClusterRequest,
         sink: UnarySink<CompactClusterResponse>,

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -71,7 +71,7 @@ impl<Router: RaftStoreRouter> ImportSSTService<Router> {
 
 impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
     fn switch_mode(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: SwitchModeRequest,
         sink: UnarySink<SwitchModeResponse>,
@@ -100,7 +100,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
 
     /// Receive SST from client and save the file for later ingesting.
     fn upload(
-        &mut self,
+        &self,
         ctx: RpcContext,
         stream: RequestStream<UploadRequest>,
         sink: ClientStreamingSink<UploadResponse>,
@@ -154,7 +154,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
     /// If the ingestion fails because the region is not found or the epoch does
     /// not match, the remaining files will eventually be cleaned up by
     /// CleanupSSTWorker.
-    fn ingest(&mut self, ctx: RpcContext, mut req: IngestRequest, sink: UnarySink<IngestResponse>) {
+    fn ingest(&self, ctx: RpcContext, mut req: IngestRequest, sink: UnarySink<IngestResponse>) {
         let label = "ingest";
         let timer = Instant::now_coarse();
 
@@ -194,7 +194,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
         )
     }
 
-    fn compact(&mut self, ctx: RpcContext, req: CompactRequest, sink: UnarySink<CompactResponse>) {
+    fn compact(&self, ctx: RpcContext, req: CompactRequest, sink: UnarySink<CompactResponse>) {
         let label = "compact";
         let timer = Instant::now_coarse();
         let engine = Arc::clone(&self.engine);

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -71,7 +71,7 @@ impl Conn {
         let client = TikvClient::new(channel);
         let (tx, rx) = mpsc::unbounded();
         let (tx_close, rx_close) = oneshot::channel();
-        let (sink, receiver) = client.raft().unwrap();
+        let (sink, _) = client.raft().unwrap();
         let addr = addr.to_owned();
         client.spawn(
             rx_close
@@ -92,7 +92,8 @@ impl Conn {
                             warn!("send raftmessage to {} failed: {:?}", addr, e);
                         }),
                 )
-                .then(|_| receiver.then(|_| Ok(()))),
+                .map(|_| ())
+                .map_err(|_| ()),
         );
         Conn {
             stream: tx,

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -86,7 +86,7 @@ impl<T: RaftStoreRouter> Service<T> {
 }
 
 impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
-    fn get(&mut self, ctx: RpcContext, mut req: GetRequest, sink: UnarySink<GetResponse>) {
+    fn get(&self, ctx: RpcContext, mut req: GetRequest, sink: UnarySink<GetResponse>) {
         const TAG: &str = "debug_get";
 
         let db = req.get_db();
@@ -108,7 +108,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
         self.handle_response(ctx, sink, f, TAG);
     }
 
-    fn raft_log(&mut self, ctx: RpcContext, req: RaftLogRequest, sink: UnarySink<RaftLogResponse>) {
+    fn raft_log(&self, ctx: RpcContext, req: RaftLogRequest, sink: UnarySink<RaftLogResponse>) {
         const TAG: &str = "debug_raft_log";
 
         let region_id = req.get_region_id();
@@ -130,7 +130,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
     }
 
     fn region_info(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: RegionInfoRequest,
         sink: UnarySink<RegionInfoResponse>,
@@ -163,7 +163,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
     }
 
     fn region_size(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: RegionSizeRequest,
         sink: UnarySink<RegionSizeResponse>,
@@ -199,7 +199,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
     }
 
     fn scan_mvcc(
-        &mut self,
+        &self,
         _: RpcContext,
         mut req: ScanMvccRequest,
         sink: ServerStreamingSink<ScanMvccResponse>,
@@ -226,7 +226,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
         self.pool.spawn(future).forget();
     }
 
-    fn compact(&mut self, ctx: RpcContext, req: CompactRequest, sink: UnarySink<CompactResponse>) {
+    fn compact(&self, ctx: RpcContext, req: CompactRequest, sink: UnarySink<CompactResponse>) {
         let debugger = self.debugger.clone();
         let f = self.pool.spawn_fn(move || {
             debugger
@@ -244,7 +244,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
     }
 
     fn inject_fail_point(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: InjectFailPointRequest,
         sink: UnarySink<InjectFailPointResponse>,
@@ -267,7 +267,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
     }
 
     fn recover_fail_point(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: RecoverFailPointRequest,
         sink: UnarySink<RecoverFailPointResponse>,
@@ -287,7 +287,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
     }
 
     fn list_fail_points(
-        &mut self,
+        &self,
         ctx: RpcContext,
         _: ListFailPointsRequest,
         sink: UnarySink<ListFailPointsResponse>,
@@ -310,7 +310,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
     }
 
     fn get_metrics(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: GetMetricsRequest,
         sink: UnarySink<GetMetricsResponse>,
@@ -335,7 +335,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
     }
 
     fn check_region_consistency(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: RegionConsistencyCheckRequest,
         sink: UnarySink<RegionConsistencyCheckResponse>,
@@ -356,7 +356,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
     }
 
     fn modify_tikv_config(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: ModifyTikvConfigRequest,
         sink: UnarySink<ModifyTikvConfigResponse>,
@@ -378,7 +378,7 @@ impl<T: RaftStoreRouter + 'static + Send> debugpb_grpc::Debug for Service<T> {
     }
 
     fn get_region_properties(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: GetRegionPropertiesRequest,
         sink: UnarySink<GetRegionPropertiesResponse>,

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::{Future, Sink, Stream};
+use futures::{future, Future, Sink, Stream};
 use grpc::{
     ClientStreamingSink, Error as GrpcError, RequestStream, RpcContext, RpcStatus, RpcStatusCode,
     ServerStreamingSink, UnarySink, WriteFlags,
@@ -82,7 +82,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> Service<T, E> {
 }
 
 impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E> {
-    fn kv_get(&mut self, ctx: RpcContext, mut req: GetRequest, sink: UnarySink<GetResponse>) {
+    fn kv_get(&self, ctx: RpcContext, mut req: GetRequest, sink: UnarySink<GetResponse>) {
         let timer = GRPC_MSG_HISTOGRAM_VEC.kv_get.start_coarse_timer();
 
         let future = self
@@ -115,7 +115,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         ctx.spawn(future);
     }
 
-    fn kv_scan(&mut self, ctx: RpcContext, mut req: ScanRequest, sink: UnarySink<ScanResponse>) {
+    fn kv_scan(&self, ctx: RpcContext, mut req: ScanRequest, sink: UnarySink<ScanResponse>) {
         let timer = GRPC_MSG_HISTOGRAM_VEC.kv_scan.start_coarse_timer();
 
         let mut options = Options::default();
@@ -151,7 +151,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn kv_prewrite(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: PrewriteRequest,
         sink: UnarySink<PrewriteResponse>,
@@ -201,12 +201,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         ctx.spawn(future);
     }
 
-    fn kv_commit(
-        &mut self,
-        ctx: RpcContext,
-        mut req: CommitRequest,
-        sink: UnarySink<CommitResponse>,
-    ) {
+    fn kv_commit(&self, ctx: RpcContext, mut req: CommitRequest, sink: UnarySink<CommitResponse>) {
         let timer = GRPC_MSG_HISTOGRAM_VEC.kv_commit.start_coarse_timer();
 
         let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
@@ -239,12 +234,12 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         ctx.spawn(future);
     }
 
-    fn kv_import(&mut self, _: RpcContext, _: ImportRequest, _: UnarySink<ImportResponse>) {
+    fn kv_import(&self, _: RpcContext, _: ImportRequest, _: UnarySink<ImportResponse>) {
         unimplemented!();
     }
 
     fn kv_cleanup(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: CleanupRequest,
         sink: UnarySink<CleanupResponse>,
@@ -283,7 +278,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn kv_batch_get(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: BatchGetRequest,
         sink: UnarySink<BatchGetResponse>,
@@ -319,7 +314,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn kv_batch_rollback(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: BatchRollbackRequest,
         sink: UnarySink<BatchRollbackResponse>,
@@ -359,7 +354,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn kv_scan_lock(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: ScanLockRequest,
         sink: UnarySink<ScanLockResponse>,
@@ -398,7 +393,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn kv_resolve_lock(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: ResolveLockRequest,
         sink: UnarySink<ResolveLockResponse>,
@@ -442,7 +437,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         ctx.spawn(future);
     }
 
-    fn kv_gc(&mut self, ctx: RpcContext, mut req: GCRequest, sink: UnarySink<GCResponse>) {
+    fn kv_gc(&self, ctx: RpcContext, mut req: GCRequest, sink: UnarySink<GCResponse>) {
         let timer = GRPC_MSG_HISTOGRAM_VEC.kv_gc.start_coarse_timer();
 
         let (cb, f) = paired_future_callback();
@@ -471,7 +466,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
 
     // WARNING: Currently this API may leave some dirty keys in TiKV. Be careful using this API.
     fn kv_delete_range(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: DeleteRangeRequest,
         sink: UnarySink<DeleteRangeResponse>,
@@ -505,12 +500,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         ctx.spawn(future);
     }
 
-    fn raw_get(
-        &mut self,
-        ctx: RpcContext,
-        mut req: RawGetRequest,
-        sink: UnarySink<RawGetResponse>,
-    ) {
+    fn raw_get(&self, ctx: RpcContext, mut req: RawGetRequest, sink: UnarySink<RawGetResponse>) {
         let timer = GRPC_MSG_HISTOGRAM_VEC.raw_get.start_coarse_timer();
 
         let future = self
@@ -539,7 +529,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn raw_batch_get(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: RawBatchGetRequest,
         sink: UnarySink<RawBatchGetResponse>,
@@ -568,12 +558,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         ctx.spawn(future);
     }
 
-    fn raw_scan(
-        &mut self,
-        ctx: RpcContext,
-        mut req: RawScanRequest,
-        sink: UnarySink<RawScanResponse>,
-    ) {
+    fn raw_scan(&self, ctx: RpcContext, mut req: RawScanRequest, sink: UnarySink<RawScanResponse>) {
         let timer = GRPC_MSG_HISTOGRAM_VEC.raw_scan.start_coarse_timer();
 
         let future = self
@@ -604,7 +589,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn raw_batch_scan(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: RawBatchScanRequest,
         sink: UnarySink<RawBatchScanResponse>,
@@ -638,12 +623,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         ctx.spawn(future);
     }
 
-    fn raw_put(
-        &mut self,
-        ctx: RpcContext,
-        mut req: RawPutRequest,
-        sink: UnarySink<RawPutResponse>,
-    ) {
+    fn raw_put(&self, ctx: RpcContext, mut req: RawPutRequest, sink: UnarySink<RawPutResponse>) {
         let timer = GRPC_MSG_HISTOGRAM_VEC.raw_put.start_coarse_timer();
 
         let (cb, f) = paired_future_callback();
@@ -675,7 +655,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn raw_batch_put(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: RawBatchPutRequest,
         sink: UnarySink<RawBatchPutResponse>,
@@ -712,7 +692,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn raw_delete(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: RawDeleteRequest,
         sink: UnarySink<RawDeleteResponse>,
@@ -744,7 +724,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn raw_batch_delete(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: RawBatchDeleteRequest,
         sink: UnarySink<RawBatchDeleteResponse>,
@@ -777,7 +757,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn raw_delete_range(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: RawDeleteRangeRequest,
         sink: UnarySink<RawDeleteRangeResponse>,
@@ -813,7 +793,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn unsafe_destroy_range(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: UnsafeDestroyRangeRequest,
         sink: UnarySink<UnsafeDestroyRangeResponse>,
@@ -853,7 +833,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         ctx.spawn(future);
     }
 
-    fn coprocessor(&mut self, ctx: RpcContext, req: Request, sink: UnarySink<Response>) {
+    fn coprocessor(&self, ctx: RpcContext, req: Request, sink: UnarySink<Response>) {
         let timer = GRPC_MSG_HISTOGRAM_VEC.coprocessor.start_coarse_timer();
 
         let future = self
@@ -871,7 +851,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn coprocessor_stream(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: Request,
         sink: ServerStreamingSink<Response>,
@@ -902,10 +882,10 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn raft(
-        &mut self,
+        &self,
         ctx: RpcContext,
         stream: RequestStream<RaftMessage>,
-        sink: ClientStreamingSink<Done>,
+        _: ClientStreamingSink<Done>,
     ) {
         let ch = self.ch.clone();
         ctx.spawn(
@@ -913,27 +893,15 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
                 .map_err(Error::from)
                 .for_each(move |msg| {
                     RAFT_MESSAGE_RECV_COUNTER.inc();
-                    ch.send_raft_msg(msg).map_err(Error::from)
+                    future::result(ch.send_raft_msg(msg)).map_err(Error::from)
                 })
-                .then(|res| {
-                    let status = match res {
-                        Err(e) => {
-                            let msg = format!("{:?}", e);
-                            error!("send raft msg to raft store fail: {}", msg);
-                            RpcStatus::new(RpcStatusCode::Unknown, Some(msg))
-                        }
-                        Ok(_) => RpcStatus::new(RpcStatusCode::Unknown, None),
-                    };
-                    sink.fail(status)
-                })
-                .map_err(|e| {
-                    error!("send response fail: {:?}", e);
-                }),
+                .map_err(|e| error!("send raft msg to raft store fail: {}", e))
+                .then(|_| future::ok::<_, ()>(())),
         );
     }
 
     fn snapshot(
-        &mut self,
+        &self,
         ctx: RpcContext,
         stream: RequestStream<SnapshotChunk>,
         sink: ClientStreamingSink<Done>,
@@ -950,7 +918,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn mvcc_get_by_key(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: MvccGetByKeyRequest,
         sink: UnarySink<MvccGetByKeyResponse>,
@@ -988,7 +956,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn mvcc_get_by_start_ts(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: MvccGetByStartTsRequest,
         sink: UnarySink<MvccGetByStartTsResponse>,
@@ -1031,7 +999,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     }
 
     fn split_region(
-        &mut self,
+        &self,
         ctx: RpcContext,
         mut req: SplitRegionRequest,
         sink: UnarySink<SplitRegionResponse>,

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -289,13 +289,7 @@ fn recv_snap<R: RaftStoreRouter + 'static>(
                 })
         },
     );
-    f.then(move |res| match res {
-        Ok(()) => sink.success(Done::new()),
-        Err(e) => {
-            let status = RpcStatus::new(RpcStatusCode::Unknown, Some(format!("{:?}", e)));
-            sink.fail(status)
-        }
-    }).map_err(Error::from)
+    f.and_then(move |_| sink.success(Done::new()).map_err(Error::from))
 }
 
 pub struct Runner<R: RaftStoreRouter + 'static> {

--- a/tests/pd/mock/server.rs
+++ b/tests/pd/mock/server.rs
@@ -109,7 +109,7 @@ impl<C: PdMocker + Send + Sync + 'static> Server<C> {
     }
 }
 
-fn hijack_unary<F, R, C: PdMocker>(mock: &mut PdMock<C>, ctx: RpcContext, sink: UnarySink<R>, f: F)
+fn hijack_unary<F, R, C: PdMocker>(mock: &PdMock<C>, ctx: RpcContext, sink: UnarySink<R>, f: F)
 where
     R: Send + 'static,
     F: Fn(&PdMocker) -> Option<Result<R>>,
@@ -162,7 +162,7 @@ impl<C: PdMocker> Clone for PdMock<C> {
 
 impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     fn get_members(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: GetMembersRequest,
         sink: UnarySink<GetMembersResponse>,
@@ -170,12 +170,12 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
         hijack_unary(self, ctx, sink, |c| c.get_members(&req))
     }
 
-    fn tso(&mut self, _: RpcContext, _: RequestStream<TsoRequest>, _: DuplexSink<TsoResponse>) {
+    fn tso(&self, _: RpcContext, _: RequestStream<TsoRequest>, _: DuplexSink<TsoResponse>) {
         unimplemented!()
     }
 
     fn bootstrap(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: BootstrapRequest,
         sink: UnarySink<BootstrapResponse>,
@@ -184,7 +184,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     }
 
     fn is_bootstrapped(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: IsBootstrappedRequest,
         sink: UnarySink<IsBootstrappedResponse>,
@@ -192,30 +192,20 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
         hijack_unary(self, ctx, sink, |c| c.is_bootstrapped(&req))
     }
 
-    fn alloc_id(&mut self, ctx: RpcContext, req: AllocIDRequest, sink: UnarySink<AllocIDResponse>) {
+    fn alloc_id(&self, ctx: RpcContext, req: AllocIDRequest, sink: UnarySink<AllocIDResponse>) {
         hijack_unary(self, ctx, sink, |c| c.alloc_id(&req))
     }
 
-    fn get_store(
-        &mut self,
-        ctx: RpcContext,
-        req: GetStoreRequest,
-        sink: UnarySink<GetStoreResponse>,
-    ) {
+    fn get_store(&self, ctx: RpcContext, req: GetStoreRequest, sink: UnarySink<GetStoreResponse>) {
         hijack_unary(self, ctx, sink, |c| c.get_store(&req))
     }
 
-    fn put_store(
-        &mut self,
-        ctx: RpcContext,
-        req: PutStoreRequest,
-        sink: UnarySink<PutStoreResponse>,
-    ) {
+    fn put_store(&self, ctx: RpcContext, req: PutStoreRequest, sink: UnarySink<PutStoreResponse>) {
         hijack_unary(self, ctx, sink, |c| c.put_store(&req))
     }
 
     fn get_all_stores(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: GetAllStoresRequest,
         sink: UnarySink<GetAllStoresResponse>,
@@ -224,7 +214,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     }
 
     fn store_heartbeat(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: StoreHeartbeatRequest,
         sink: UnarySink<StoreHeartbeatResponse>,
@@ -233,7 +223,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     }
 
     fn region_heartbeat(
-        &mut self,
+        &self,
         ctx: RpcContext,
         stream: RequestStream<RegionHeartbeatRequest>,
         sink: DuplexSink<RegionHeartbeatResponse>,
@@ -264,7 +254,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     }
 
     fn get_region(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: GetRegionRequest,
         sink: UnarySink<GetRegionResponse>,
@@ -273,7 +263,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     }
 
     fn get_region_by_id(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: GetRegionByIDRequest,
         sink: UnarySink<GetRegionResponse>,
@@ -281,12 +271,12 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
         hijack_unary(self, ctx, sink, |c| c.get_region_by_id(&req))
     }
 
-    fn ask_split(&mut self, _: RpcContext, _: AskSplitRequest, _: UnarySink<AskSplitResponse>) {
+    fn ask_split(&self, _: RpcContext, _: AskSplitRequest, _: UnarySink<AskSplitResponse>) {
         unimplemented!()
     }
 
     fn report_split(
-        &mut self,
+        &self,
         _: RpcContext,
         _: ReportSplitRequest,
         _: UnarySink<ReportSplitResponse>,
@@ -295,7 +285,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     }
 
     fn ask_batch_split(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: AskBatchSplitRequest,
         sink: UnarySink<AskBatchSplitResponse>,
@@ -304,7 +294,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     }
 
     fn report_batch_split(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: ReportBatchSplitRequest,
         sink: UnarySink<ReportBatchSplitResponse>,
@@ -313,7 +303,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     }
 
     fn get_cluster_config(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: GetClusterConfigRequest,
         sink: UnarySink<GetClusterConfigResponse>,
@@ -322,7 +312,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     }
 
     fn put_cluster_config(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: PutClusterConfigRequest,
         sink: UnarySink<PutClusterConfigResponse>,
@@ -331,7 +321,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     }
 
     fn scatter_region(
-        &mut self,
+        &self,
         ctx: RpcContext,
         req: ScatterRegionRequest,
         sink: UnarySink<ScatterRegionResponse>,
@@ -339,17 +329,12 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
         hijack_unary(self, ctx, sink, |c| c.scatter_region(&req))
     }
 
-    fn get_prev_region(
-        &mut self,
-        _: RpcContext,
-        _: GetRegionRequest,
-        _: UnarySink<GetRegionResponse>,
-    ) {
+    fn get_prev_region(&self, _: RpcContext, _: GetRegionRequest, _: UnarySink<GetRegionResponse>) {
         unimplemented!()
     }
 
     fn get_gc_safe_point(
-        &mut self,
+        &self,
         _ctx: RpcContext,
         _req: GetGCSafePointRequest,
         _sink: UnarySink<GetGCSafePointResponse>,
@@ -358,19 +343,10 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     }
 
     fn update_gc_safe_point(
-        &mut self,
+        &self,
         _ctx: RpcContext,
         _req: UpdateGCSafePointRequest,
         _sink: UnarySink<UpdateGCSafePointResponse>,
-    ) {
-        unimplemented!()
-    }
-
-    fn sync_regions(
-        &mut self,
-        _ctx: RpcContext,
-        _stream: RequestStream<SyncRegionRequest>,
-        _sink: DuplexSink<SyncRegionResponse>,
     ) {
         unimplemented!()
     }


### PR DESCRIPTION
## What have you changed? (mandatory)

This reverts commit 839e4a277220af2e25feaf7242c48bb68f3f9074.
Due to grpc/grpc#17043, grpc server threads may meet segment fault and crash the whole tikv.
To workaround the issue, we regress  grpcio to v0.3.

CC #3744 