### PR TITLE
[release-2.1] cherry-pick: Add end_key limit to kv_scan interface (#3720)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#529c652955d8fa74faf56f91b2f428d5779fd7d5"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-2.1#8e3f33ac49297d7c93b61a955531191084a2f685"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1437,7 +1437,7 @@ name = "test_coprocessor"
 version = "0.0.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-2.1)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_storage 0.0.1",
  "tikv 2.1.0-rc.4",
@@ -1450,7 +1450,7 @@ version = "0.0.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-2.1)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1466,7 +1466,7 @@ name = "test_storage"
 version = "0.0.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-2.1)",
  "test_raftstore 0.0.1",
  "tikv 2.1.0-rc.4",
 ]
@@ -1530,7 +1530,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-2.1)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1888,7 +1888,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-2.1)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#0ba3ca8a6e3775accbe4bdf844162cd7685dafe2"
+source = "git+https://github.com/pingcap/kvproto.git#1b5d69cd1d263f9473f7ed2847a7660af394c437"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"
+branch="release-2.1"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/benches/storage/scan.rs
+++ b/benches/storage/scan.rs
@@ -81,6 +81,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
                 .scan(
                     Context::new(),
                     Key::from_raw(&k),
+                    None,
                     1,
                     false,
                     ts_generator.next().unwrap()

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.1"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"
+branch="release-2.1"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.3.9"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"
+branch="release-2.1"
 
 [dependencies.rocksdb]
 git = "https://github.com/pingcap/rust-rocksdb.git"

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -13,3 +13,4 @@ futures = "0.1"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"
+branch="release-2.1"

--- a/components/test_storage/assert_storage.rs
+++ b/components/test_storage/assert_storage.rs
@@ -320,7 +320,7 @@ impl<E: Engine> AssertionStorage<E> {
         let key_address = Key::from_raw(start_key);
         let result = self
             .store
-            .scan(self.ctx.clone(), key_address, limit, false, ts)
+            .scan(self.ctx.clone(), key_address, None, limit, false, ts)
             .unwrap();
         let result: Vec<Option<KvPair>> = result.into_iter().map(Result::ok).collect();
         let expect: Vec<Option<KvPair>> = expect
@@ -340,7 +340,7 @@ impl<E: Engine> AssertionStorage<E> {
         let key_address = Key::from_raw(start_key);
         let result = self
             .store
-            .reverse_scan(self.ctx.clone(), key_address, limit, false, ts)
+            .reverse_scan(self.ctx.clone(), key_address, None, limit, false, ts)
             .unwrap();
         let result: Vec<Option<KvPair>> = result.into_iter().map(Result::ok).collect();
         let expect: Vec<Option<KvPair>> = expect
@@ -360,7 +360,7 @@ impl<E: Engine> AssertionStorage<E> {
         let key_address = Key::from_raw(start_key);
         let result = self
             .store
-            .scan(self.ctx.clone(), key_address, limit, true, ts)
+            .scan(self.ctx.clone(), key_address, None, limit, true, ts)
             .unwrap();
         let result: Vec<Option<KvPair>> = result.into_iter().map(Result::ok).collect();
         let expect: Vec<Option<KvPair>> = expect

--- a/components/test_storage/sync_storage.rs
+++ b/components/test_storage/sync_storage.rs
@@ -95,20 +95,8 @@ impl<E: Engine> SyncStorage<E> {
     pub fn scan(
         &self,
         ctx: Context,
-        key: Key,
-        limit: usize,
-        key_only: bool,
-        start_ts: u64,
-    ) -> Result<Vec<Result<KvPair>>> {
-        self.store
-            .async_scan(ctx, key, limit, start_ts, Options::new(0, false, key_only))
-            .wait()
-    }
-
-    pub fn reverse_scan(
-        &self,
-        ctx: Context,
-        key: Key,
+        start_key: Key,
+        end_key: Option<Key>,
         limit: usize,
         key_only: bool,
         start_ts: u64,
@@ -116,7 +104,29 @@ impl<E: Engine> SyncStorage<E> {
         self.store
             .async_scan(
                 ctx,
-                key,
+                start_key,
+                end_key,
+                limit,
+                start_ts,
+                Options::new(0, false, key_only),
+            )
+            .wait()
+    }
+
+    pub fn reverse_scan(
+        &self,
+        ctx: Context,
+        start_key: Key,
+        end_key: Option<Key>,
+        limit: usize,
+        key_only: bool,
+        start_ts: u64,
+    ) -> Result<Vec<Result<KvPair>>> {
+        self.store
+            .async_scan(
+                ctx,
+                start_key,
+                end_key,
                 limit,
                 start_ts,
                 Options::new(0, false, key_only).reverse_scan(),

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -122,11 +122,18 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         options.key_only = req.get_key_only();
         options.reverse_scan = req.get_reverse();
 
+        let end_key = if req.get_end_key().is_empty() {
+            None
+        } else {
+            Some(Key::from_raw(req.get_end_key()))
+        };
+
         let future = self
             .storage
             .async_scan(
                 req.take_context(),
                 Key::from_raw(req.get_start_key()),
+                end_key,
                 req.get_limit() as usize,
                 req.get_version(),
                 options,

--- a/src/storage/gc_worker.rs
+++ b/src/storage/gc_worker.rs
@@ -536,6 +536,7 @@ mod tests {
             .async_scan(
                 Context::default(),
                 Key::from_encoded_slice(b""),
+                None,
                 expected_data.len() + 1,
                 1,
                 Options::default(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -632,6 +632,7 @@ impl<E: Engine> Storage<E> {
         &self,
         ctx: Context,
         start_key: Key,
+        end_key: Option<Key>,
         limit: usize,
         start_ts: u64,
         options: Options,
@@ -665,13 +666,13 @@ impl<E: Engine> Storage<E> {
                             ScanMode::Forward,
                             options.key_only,
                             Some(start_key),
-                            None,
+                            end_key,
                         )?;
                     } else {
                         scanner = snap_store.scanner(
                             ScanMode::Backward,
                             options.key_only,
-                            None,
+                            end_key,
                             Some(start_key),
                         )?;
                     };
@@ -1630,6 +1631,7 @@ mod tests {
                 .async_scan(
                     Context::new(),
                     Key::from_raw(b"x"),
+                    None,
                     1000,
                     1,
                     Options::default(),
@@ -1671,18 +1673,91 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
+        // Forward
         expect_multi_values(
             vec![None, None, None],
             storage
                 .async_scan(
                     Context::new(),
                     Key::from_raw(b"\x00"),
+                    None,
                     1000,
                     5,
                     Options::default(),
                 )
                 .wait(),
         );
+        // Backward
+        expect_multi_values(
+            vec![None, None, None],
+            storage
+                .async_scan(
+                    Context::new(),
+                    Key::from_raw(b"\xff"),
+                    None,
+                    1000,
+                    5,
+                    Options::default().reverse_scan(),
+                )
+                .wait(),
+        );
+        // Forward with bound
+        expect_multi_values(
+            vec![None, None],
+            storage
+                .async_scan(
+                    Context::new(),
+                    Key::from_raw(b"\x00"),
+                    Some(Key::from_raw(b"c")),
+                    1000,
+                    5,
+                    Options::default(),
+                )
+                .wait(),
+        );
+        // Backward with bound
+        expect_multi_values(
+            vec![None, None],
+            storage
+                .async_scan(
+                    Context::new(),
+                    Key::from_raw(b"\xff"),
+                    Some(Key::from_raw(b"b")),
+                    1000,
+                    5,
+                    Options::default().reverse_scan(),
+                )
+                .wait(),
+        );
+        // Forward with limit
+        expect_multi_values(
+            vec![None, None],
+            storage
+                .async_scan(
+                    Context::new(),
+                    Key::from_raw(b"\x00"),
+                    None,
+                    2,
+                    5,
+                    Options::default(),
+                )
+                .wait(),
+        );
+        // Backward with limit
+        expect_multi_values(
+            vec![None, None],
+            storage
+                .async_scan(
+                    Context::new(),
+                    Key::from_raw(b"\xff"),
+                    None,
+                    2,
+                    5,
+                    Options::default().reverse_scan(),
+                )
+                .wait(),
+        );
+
         storage
             .async_commit(
                 Context::new(),
@@ -1697,6 +1772,7 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
+        // Forward
         expect_multi_values(
             vec![
                 Some((b"a".to_vec(), b"aa".to_vec())),
@@ -1707,13 +1783,100 @@ mod tests {
                 .async_scan(
                     Context::new(),
                     Key::from_raw(b"\x00"),
+                    None,
                     1000,
                     5,
                     Options::default(),
                 )
                 .wait(),
         );
+        // Backward
+        expect_multi_values(
+            vec![
+                Some((b"c".to_vec(), b"cc".to_vec())),
+                Some((b"b".to_vec(), b"bb".to_vec())),
+                Some((b"a".to_vec(), b"aa".to_vec())),
+            ],
+            storage
+                .async_scan(
+                    Context::new(),
+                    Key::from_raw(b"\xff"),
+                    None,
+                    1000,
+                    5,
+                    Options::default().reverse_scan(),
+                )
+                .wait(),
+        );
+        // Forward with bound
+        expect_multi_values(
+            vec![
+                Some((b"a".to_vec(), b"aa".to_vec())),
+                Some((b"b".to_vec(), b"bb".to_vec())),
+            ],
+            storage
+                .async_scan(
+                    Context::new(),
+                    Key::from_raw(b"\x00"),
+                    Some(Key::from_raw(b"c")),
+                    1000,
+                    5,
+                    Options::default(),
+                )
+                .wait(),
+        );
+        // Backward with bound
+        expect_multi_values(
+            vec![
+                Some((b"c".to_vec(), b"cc".to_vec())),
+                Some((b"b".to_vec(), b"bb".to_vec())),
+            ],
+            storage
+                .async_scan(
+                    Context::new(),
+                    Key::from_raw(b"\xff"),
+                    Some(Key::from_raw(b"b")),
+                    1000,
+                    5,
+                    Options::default().reverse_scan(),
+                )
+                .wait(),
+        );
         storage.stop().unwrap();
+        // Forward with limit
+        expect_multi_values(
+            vec![
+                Some((b"a".to_vec(), b"aa".to_vec())),
+                Some((b"b".to_vec(), b"bb".to_vec())),
+            ],
+            storage
+                .async_scan(
+                    Context::new(),
+                    Key::from_raw(b"\x00"),
+                    None,
+                    2,
+                    5,
+                    Options::default(),
+                )
+                .wait(),
+        );
+        // Backward with limit
+        expect_multi_values(
+            vec![
+                Some((b"c".to_vec(), b"cc".to_vec())),
+                Some((b"b".to_vec(), b"bb".to_vec())),
+            ],
+            storage
+                .async_scan(
+                    Context::new(),
+                    Key::from_raw(b"\xff"),
+                    None,
+                    2,
+                    5,
+                    Options::default().reverse_scan(),
+                )
+                .wait(),
+        );
     }
 
     #[test]

--- a/tests/storage_cases/test_raft_storage.rs
+++ b/tests/storage_cases/test_raft_storage.rs
@@ -54,7 +54,7 @@ fn test_raft_storage() {
     assert!(storage.batch_get(ctx.clone(), &[key.clone()], 20).is_err());
     assert!(
         storage
-            .scan(ctx.clone(), key.clone(), 1, false, 20)
+            .scan(ctx.clone(), key.clone(), None, 1, false, 20)
             .is_err()
     );
     assert!(
@@ -158,7 +158,7 @@ fn test_raft_storage_store_not_match() {
     assert!(storage.batch_get(ctx.clone(), &[key.clone()], 20).is_err());
     assert!(
         storage
-            .scan(ctx.clone(), key.clone(), 1, false, 20)
+            .scan(ctx.clone(), key.clone(), None, 1, false, 20)
             .is_err()
     );
     assert!(


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR cherry-picks #3720 to release-2.1 branch.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

By CI

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

