### PR TITLE
mvcc: record start_ts in write conflict error

### DIFF
--- a/components/test_storage/assert_storage.rs
+++ b/components/test_storage/assert_storage.rs
@@ -433,12 +433,13 @@ impl<E: Engine> AssertionStorage<E> {
         match err {
             storage::Error::Txn(txn::Error::Mvcc(mvcc::Error::WriteConflict {
                 start_ts,
-                conflict_ts,
+                conflict_start_ts,
                 ref key,
                 ref primary,
+                ..
             })) => {
                 assert_eq!(cur_start_ts, start_ts);
-                assert_eq!(confl_ts, conflict_ts);
+                assert_eq!(confl_ts, conflict_start_ts);
                 assert_eq!(key.to_owned(), confl_key.to_owned());
                 assert_eq!(primary.to_owned(), cur_primary.to_owned());
             }

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1110,13 +1110,14 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
         // failed in prewrite
         storage::Error::Txn(TxnError::Mvcc(MvccError::WriteConflict {
             start_ts,
-            conflict_ts,
+            conflict_start_ts,
             ref key,
             ref primary,
+            ..
         })) => {
             let mut write_conflict = WriteConflict::new();
             write_conflict.set_start_ts(start_ts);
-            write_conflict.set_conflict_ts(conflict_ts);
+            write_conflict.set_conflict_ts(conflict_start_ts);
             write_conflict.set_key(key.to_owned());
             write_conflict.set_primary(primary.to_owned());
             key_error.set_conflict(write_conflict);
@@ -1237,19 +1238,21 @@ mod tests {
     #[test]
     fn test_extract_key_error_write_conflict() {
         let start_ts = 110;
-        let conflict_ts = 108;
+        let conflict_start_ts = 108;
+        let conflict_commit_ts = 109;
         let key = b"key".to_vec();
         let primary = b"primary".to_vec();
         let case = storage::Error::from(TxnError::from(MvccError::WriteConflict {
             start_ts,
-            conflict_ts,
+            conflict_start_ts,
+            conflict_commit_ts,
             key: key.clone(),
             primary: primary.clone(),
         }));
         let mut expect = KeyError::new();
         let mut write_conflict = WriteConflict::new();
         write_conflict.set_start_ts(start_ts);
-        write_conflict.set_conflict_ts(conflict_ts);
+        write_conflict.set_conflict_ts(conflict_start_ts);
         write_conflict.set_key(key);
         write_conflict.set_primary(primary);
         expect.set_conflict(write_conflict);

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -63,10 +63,10 @@ quick_error! {
             description("txn lock not found")
             display("txn lock not found {}-{} key:{:?}", start_ts, commit_ts, escape(key))
         }
-        WriteConflict { start_ts: u64, conflict_ts: u64, key: Vec<u8>, primary: Vec<u8> } {
+        WriteConflict { start_ts: u64, conflict_start_ts: u64, conflict_commit_ts: u64, key: Vec<u8>, primary: Vec<u8> } {
             description("write conflict")
-            display("write conflict {} with {}, key:{:?}, primary:{:?}",
-             start_ts, conflict_ts, escape(key), escape(primary))
+            display("write conflict, start_ts:{}, conflict_start_ts:{}, conflict_commit_ts:{}, key:{:?}, primary:{:?}",
+             start_ts, conflict_start_ts, conflict_commit_ts, escape(key), escape(primary))
         }
         KeyVersion {description("bad format key(version)")}
         Other(err: Box<error::Error + Sync + Send>) {
@@ -107,12 +107,14 @@ impl Error {
             }),
             Error::WriteConflict {
                 start_ts,
-                conflict_ts,
+                conflict_start_ts,
+                conflict_commit_ts,
                 ref key,
                 ref primary,
             } => Some(Error::WriteConflict {
                 start_ts,
-                conflict_ts,
+                conflict_start_ts,
+                conflict_commit_ts,
                 key: key.to_owned(),
                 primary: primary.to_owned(),
             }),

--- a/tests/storage_cases/test_storage.rs
+++ b/tests/storage_cases/test_storage.rs
@@ -831,16 +831,16 @@ fn test_txn_store_write_conflict() {
     let store = AssertionStorage::default();
     let key = b"key";
     let primary = b"key";
-    let start_ts = 5;
-    let conflict_ts = 10;
-    store.put_ok(key, primary, start_ts, conflict_ts);
+    let conflict_start_ts = 5;
+    let conflict_commit_ts = 10;
+    store.put_ok(key, primary, conflict_start_ts, conflict_commit_ts);
     let start_ts2 = 6;
     store.prewrite_conflict(
         vec![Mutation::Put((Key::from_raw(key), primary.to_vec()))],
         primary,
         start_ts2,
         key,
-        conflict_ts,
+        conflict_start_ts,
     );
 }
 


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
cherry-pick #3740 
tidb uses the `start_ts` to track down a specific transaction. It will be more useful to use `start_ts` in the WriteConflict error messages.

Update `WriteConflict` error to include both `start_ts` and `commit_ts`. When convert the error to `kvproto::WriteConflict`, use `start_ts` instead of `commit_ts`.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
no test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)