### PR TITLE
remove use-delete-range from configuration file

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -230,10 +230,6 @@
 ## Interval (s) to check Region whether the data are consistent.
 # consistency-check-interval = 0
 
-## Whether to enable Delete Range feature.
-## Delete Range can drop a large number of continuous keys.
-# use-delete-range = false
-
 ## Delay time before deleting a stale peer.
 # clean-stale-peer-delay = "10m"
 


### PR DESCRIPTION

## What have you changed? (mandatory)

Since delete-range is not a RocksDB's stable feature, we remove it from configuration file to avoid users' misusing.

## What are the type of the changes? (mandatory)

- Improvement

## How has this PR been tested? (mandatory)

No

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
