### PR TITLE
Remove `Storage::start()` and `Storage::stop()`

### DIFF
--- a/benches/storage/scan.rs
+++ b/benches/storage/scan.rs
@@ -15,22 +15,16 @@ use test::Bencher;
 
 use kvproto::kvrpcpb::Context;
 
-use test_storage::SyncStorage;
+use test_storage::SyncTestStorageBuilder;
 use test_util::*;
-use tikv::server::readpool::{self, ReadPool};
-use tikv::storage::{self, Key, Mutation};
-use tikv::util::worker::FutureWorker;
+use tikv::storage::{Key, Mutation};
 
 /// In mvcc kv is not actually deleted, which may cause performance issue
 /// when doing scan.
 #[ignore]
 #[bench]
 fn bench_tombstone_scan(b: &mut Bencher) {
-    let pd_worker = FutureWorker::new("test-pd-worker");
-    let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-        || storage::ReadPoolContext::new(pd_worker.scheduler())
-    });
-    let store = SyncStorage::new(&Default::default(), read_pool);
+    let store = SyncTestStorageBuilder::new().build().unwrap();
     let mut ts_generator = 1..;
 
     let mut kvs = KvGenerator::new(100, 1000);

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -52,7 +52,7 @@ pub type SimulateEngine = RaftKv<SimulateStoreTransport>;
 
 struct ServerMeta {
     node: Node<TestPdClient>,
-    server: Server<SimulateStoreTransport, PdStoreAddrResolver, SimulateEngine>,
+    server: Server<SimulateStoreTransport, PdStoreAddrResolver>,
     router: SimulateStoreTransport,
     sim_trans: SimulateServerTransport,
     store_ch: SendCh<StoreMsg>,
@@ -137,9 +137,13 @@ impl Simulator for ServerCluster {
             ReadPool::new("store-read", &cfg.readpool.storage.build_config(), || {
                 || storage::ReadPoolContext::new(pd_worker.scheduler())
             });
-        let mut store =
-            create_raft_storage(sim_router.clone(), &cfg.storage, storage_read_pool).unwrap();
-        store.start(&cfg.storage).unwrap();
+        let store = create_raft_storage(
+            sim_router.clone(),
+            &cfg.storage,
+            storage_read_pool,
+            None,
+            None,
+        ).unwrap();
         self.storages.insert(node_id, store.get_engine());
 
         // Create import service.

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -14,32 +14,25 @@
 use kvproto::kvrpcpb::{Context, LockInfo};
 
 use test_raftstore::{Cluster, ServerCluster, SimulateEngine};
-use tikv::server::readpool::{self, ReadPool};
-use tikv::storage::config::Config;
 use tikv::storage::engine::{self, RocksEngine};
 use tikv::storage::mvcc::{self, MAX_TXN_WRITE_SIZE};
 use tikv::storage::txn;
 use tikv::storage::{self, Engine, Key, KvPair, Mutation, Value};
-use tikv::util::worker::FutureWorker;
 use tikv::util::HandyRwLock;
 
 use super::*;
 
 #[derive(Clone)]
 pub struct AssertionStorage<E: Engine> {
-    pub store: SyncStorage<E>,
+    pub store: SyncTestStorage<E>,
     pub ctx: Context,
 }
 
 impl Default for AssertionStorage<RocksEngine> {
     fn default() -> Self {
-        let pd_worker = FutureWorker::new("test-future–worker");
-        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || storage::ReadPoolContext::new(pd_worker.scheduler())
-        });
         AssertionStorage {
             ctx: Context::new(),
-            store: SyncStorage::new(&Config::default(), read_pool),
+            store: SyncTestStorageBuilder::new().build().unwrap(),
         }
     }
 }
@@ -66,11 +59,7 @@ impl AssertionStorage<SimulateEngine> {
         self.ctx.set_region_id(region.get_id());
         self.ctx.set_region_epoch(region.get_region_epoch().clone());
         self.ctx.set_peer(leader.clone());
-        let pd_worker = FutureWorker::new("test-future–worker");
-        let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || storage::ReadPoolContext::new(pd_worker.scheduler())
-        });
-        self.store = SyncStorage::from_engine(engine, &Config::default(), read_pool);
+        self.store = SyncTestStorageBuilder::from_engine(engine).build().unwrap();
     }
 
     pub fn delete_ok_for_cluster(

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -11,66 +11,65 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-
 use futures::Future;
 
 use kvproto::kvrpcpb::{Context, LockInfo};
-use tikv::server::readpool::ReadPool;
 use tikv::storage::config::Config;
 use tikv::storage::engine::RocksEngine;
-use tikv::storage::{
-    self, Engine, Key, KvPair, Mutation, Options, Result, Storage, TestEngineBuilder, Value,
-};
+use tikv::storage::{Engine, Key, KvPair, Mutation, Options, Result, Storage, Value};
+use tikv::storage::{TestEngineBuilder, TestStorageBuilder};
 use tikv::util::collections::HashMap;
 
-/// `SyncStorage` wraps `Storage` with sync API, usually used for testing.
-pub struct SyncStorage<E: Engine> {
-    store: Storage<E>,
-    cnt: Arc<AtomicUsize>,
+/// A builder to build a `SyncTestStorage`.
+///
+/// Only used for test purpose.
+pub struct SyncTestStorageBuilder<E: Engine> {
+    engine: E,
+    config: Option<Config>,
 }
 
-impl SyncStorage<RocksEngine> {
-    pub fn new(config: &Config, read_pool: ReadPool<storage::ReadPoolContext>) -> Self {
-        let engine = TestEngineBuilder::new().build().unwrap();
-        let storage = Storage::from_engine(engine, config, read_pool).unwrap();
-        let mut s = SyncStorage {
-            store: storage,
-            cnt: Arc::new(AtomicUsize::new(0)),
-        };
-        s.start(config);
-        s
-    }
-}
-
-impl<E: Engine> SyncStorage<E> {
-    pub fn from_engine(
-        engine: E,
-        config: &Config,
-        read_pool: ReadPool<storage::ReadPoolContext>,
-    ) -> Self {
-        let mut s = SyncStorage::prepare(engine, config, read_pool);
-        s.start(config);
-        s
-    }
-
-    pub fn prepare(
-        engine: E,
-        config: &Config,
-        read_pool: ReadPool<storage::ReadPoolContext>,
-    ) -> Self {
-        let storage = Storage::from_engine(engine, config, read_pool).unwrap();
+impl SyncTestStorageBuilder<RocksEngine> {
+    pub fn new() -> Self {
         Self {
-            store: storage,
-            cnt: Arc::new(AtomicUsize::new(0)),
+            engine: TestEngineBuilder::new().build().unwrap(),
+            config: None,
+        }
+    }
+}
+
+impl<E: Engine> SyncTestStorageBuilder<E> {
+    pub fn from_engine(engine: E) -> Self {
+        Self {
+            engine,
+            config: None,
         }
     }
 
-    pub fn start(&mut self, config: &Config) {
-        self.store.start(config).unwrap();
+    pub fn config(mut self, config: Config) -> Self {
+        self.config = Some(config);
+        self
     }
 
+    pub fn build(mut self) -> Result<SyncTestStorage<E>> {
+        let mut builder = TestStorageBuilder::from_engine(self.engine);
+        if self.config.is_some() {
+            builder = builder.config(self.config.take().unwrap());
+        }
+        Ok(SyncTestStorage {
+            store: builder.build()?,
+        })
+    }
+}
+
+/// A `Storage` like structure with sync API.
+///
+/// Only used for test purpose.
+#[derive(Clone)]
+pub struct SyncTestStorage<E: Engine> {
+    store: Storage<E>,
+}
+
+impl<E: Engine> SyncTestStorage<E> {
     pub fn get_storage(&self) -> Storage<E> {
         self.store.clone()
     }
@@ -222,23 +221,5 @@ impl<E: Engine> SyncStorage<E> {
         self.store
             .async_raw_scan(ctx, cf, start_key, limit, false)
             .wait()
-    }
-}
-
-impl<E: Engine> Clone for SyncStorage<E> {
-    fn clone(&self) -> Self {
-        self.cnt.fetch_add(1, Ordering::SeqCst);
-        Self {
-            store: self.store.clone(),
-            cnt: Arc::clone(&self.cnt),
-        }
-    }
-}
-
-impl<E: Engine> Drop for SyncStorage<E> {
-    fn drop(&mut self) {
-        if self.cnt.fetch_sub(1, Ordering::SeqCst) == 0 {
-            self.store.stop().unwrap()
-        }
     }
 }

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -52,8 +52,8 @@ impl<E: Engine> SyncTestStorageBuilder<E> {
 
     pub fn build(mut self) -> Result<SyncTestStorage<E>> {
         let mut builder = TestStorageBuilder::from_engine(self.engine);
-        if self.config.is_some() {
-            builder = builder.config(self.config.take().unwrap());
+        if let Some(config) = self.config.take() {
+            builder = builder.config(config);
         }
         Ok(SyncTestStorage {
             store: builder.build()?,

--- a/components/test_storage/src/util.rs
+++ b/components/test_storage/src/util.rs
@@ -14,10 +14,6 @@
 use kvproto::kvrpcpb::Context;
 
 use test_raftstore::{new_server_cluster, Cluster, ServerCluster, SimulateEngine};
-use tikv::server::readpool::{self, ReadPool};
-use tikv::storage;
-use tikv::storage::config::Config;
-use tikv::util::worker::FutureWorker;
 use tikv::util::HandyRwLock;
 
 use super::*;
@@ -43,15 +39,15 @@ pub fn new_raft_engine(
 pub fn new_raft_storage_with_store_count(
     count: usize,
     key: &str,
-) -> (Cluster<ServerCluster>, SyncStorage<SimulateEngine>, Context) {
-    let pd_worker = FutureWorker::new("test-future–worker");
-    let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-        || storage::ReadPoolContext::new(pd_worker.scheduler())
-    });
+) -> (
+    Cluster<ServerCluster>,
+    SyncTestStorage<SimulateEngine>,
+    Context,
+) {
     let (cluster, engine, ctx) = new_raft_engine(count, key);
     (
         cluster,
-        SyncStorage::from_engine(engine, &Config::default(), read_pool),
+        SyncTestStorageBuilder::from_engine(engine).build().unwrap(),
         ctx,
     )
 }

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -158,14 +158,13 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
             let pd_sender = pd_sender.clone();
             move || storage::ReadPoolContext::new(pd_sender.clone())
         });
-    let mut storage = create_raft_storage(raft_router.clone(), &cfg.storage, storage_read_pool)
-        .unwrap_or_else(|e| fatal!("failed to create raft stroage: {:?}", e));
-    storage
-        .mut_gc_worker()
-        .set_local_storage(Arc::clone(&kv_engine));
-    storage
-        .mut_gc_worker()
-        .set_raft_store_router(raft_router.clone());
+    let storage = create_raft_storage(
+        raft_router.clone(),
+        &cfg.storage,
+        storage_read_pool,
+        Some(Arc::clone(&kv_engine)),
+        Some(raft_router.clone()),
+    ).unwrap_or_else(|e| fatal!("failed to create raft stroage: {:?}", e));
 
     // Create raft engine.
     let raft_db_opts = cfg.raftdb.build_opt();
@@ -234,12 +233,6 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
         importer,
     ).unwrap_or_else(|e| fatal!("failed to start node: {:?}", e));
     initial_metric(&cfg.metric, Some(node.id()));
-
-    // Start storage.
-    info!("start storage");
-    if let Err(e) = storage.start(&cfg.storage) {
-        fatal!("failed to start storage, error: {:?}", e);
-    }
 
     let mut metrics_flusher = MetricsFlusher::new(
         engines.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1233,11 +1233,11 @@ mod tests {
 
     #[test]
     fn test_create_parent_dir_if_missing() {
-        let tmp_path = TempDir::new("test_create_parent_dir_if_missing").unwrap();
-        let pathbuf = tmp_path.into_path().join("not_exist_dir");
+        let root_path = TempDir::new("test_create_parent_dir_if_missing").unwrap();
+        let path = root_path.path().join("not_exist_dir");
 
         let mut tikv_cfg = TiKvConfig::default();
-        tikv_cfg.storage.data_dir = pathbuf.as_path().to_str().unwrap().to_owned();
+        tikv_cfg.storage.data_dir = path.as_path().to_str().unwrap().to_owned();
         assert!(check_and_persist_critical_config(&tikv_cfg).is_ok());
     }
 

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -2037,6 +2037,7 @@ mod tests {
         };
         assert_eq!(s1.truncated_index(), 3);
         assert_eq!(s1.truncated_term(), 3);
+        worker.stop().unwrap().join().unwrap();
 
         let td2 = TempDir::new("tikv-store-test").unwrap();
         let mut s2 = new_storage(sched.clone(), &td2);

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -574,11 +574,11 @@ impl Snap {
         Ok(())
     }
 
-    fn get_display_path(dir_path: &PathBuf, prefix: &str) -> String {
+    fn get_display_path(dir_path: impl AsRef<Path>, prefix: &str) -> String {
         let cf_names = "(".to_owned() + &SNAPSHOT_CFS.join("|") + ")";
         format!(
             "{}/{}_{}{}",
-            dir_path.display(),
+            dir_path.as_ref().display(),
             prefix,
             cf_names,
             SST_FILE_SUFFIX
@@ -1637,7 +1637,7 @@ pub mod tests {
         let dir = TempDir::new("test-display-path").unwrap();
         let key = SnapKey::new(1, 1, 1);
         let prefix = format!("{}_{}", SNAP_GEN_PREFIX, key);
-        let display_path = Snap::get_display_path(&dir.into_path(), &prefix);
+        let display_path = Snap::get_display_path(dir.path(), &prefix);
         assert_ne!(display_path, "");
     }
 

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -31,8 +31,10 @@ use raftstore::store::{
     self, keys, Config as StoreConfig, Engines, Msg, Peekable, ReadTask, SignificantMsg,
     SnapManager, Store, StoreChannel, Transport,
 };
+use rocksdb::DB;
 use server::readpool::ReadPool;
 use server::Config as ServerConfig;
+use server::ServerRaftStoreRouter;
 use storage::{self, Config as StorageConfig, RaftKv, Storage};
 use util::transport::SendCh;
 use util::worker::{FutureWorker, Worker};
@@ -44,12 +46,14 @@ pub fn create_raft_storage<S>(
     router: S,
     cfg: &StorageConfig,
     read_pool: ReadPool<storage::ReadPoolContext>,
+    local_storage: Option<Arc<DB>>,
+    raft_store_router: Option<ServerRaftStoreRouter>,
 ) -> Result<Storage<RaftKv<S>>>
 where
     S: RaftStoreRouter + 'static,
 {
     let engine = RaftKv::new(router);
-    let store = Storage::from_engine(engine, cfg, read_pool)?;
+    let store = Storage::from_engine(engine, cfg, read_pool, local_storage, raft_store_router)?;
     Ok(store)
 }
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -36,7 +36,7 @@ use super::{Config, Result};
 
 const MAX_GRPC_RECV_MSG_LEN: i32 = 10 * 1024 * 1024;
 
-pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver + 'static, E: Engine> {
+pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver + 'static> {
     env: Arc<Environment>,
     // Grpc server.
     grpc_server: GrpcServer,
@@ -44,16 +44,14 @@ pub struct Server<T: RaftStoreRouter + 'static, S: StoreAddrResolver + 'static, 
     // Transport.
     trans: ServerTransport<T, S>,
     raft_router: T,
-    // The kv storage.
-    storage: Storage<E>,
     // For sending/receiving snapshots.
     snap_mgr: SnapManager,
     snap_worker: Worker<SnapTask>,
 }
 
-impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static, E: Engine> Server<T, S, E> {
+impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
     #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
-    pub fn new(
+    pub fn new<E: Engine>(
         cfg: &Arc<Config>,
         security_mgr: &Arc<SecurityManager>,
         storage: Storage<E>,
@@ -76,12 +74,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static, E: Engine> Server<T, S,
             Arc::clone(security_mgr),
         )));
         let snap_worker = Worker::new("snap-handler");
-        let kv_service = KvService::new(
-            storage.clone(),
-            cop,
-            raft_router.clone(),
-            snap_worker.scheduler(),
-        );
+        let kv_service = KvService::new(storage, cop, raft_router.clone(), snap_worker.scheduler());
         let addr = SocketAddr::from_str(&cfg.addr)?;
         info!("listening on {}", addr);
         let ip = format!("{}", addr.ip());
@@ -124,7 +117,6 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static, E: Engine> Server<T, S,
             local_addr: addr,
             trans,
             raft_router,
-            storage,
             snap_mgr,
             snap_worker,
         };
@@ -152,9 +144,6 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static, E: Engine> Server<T, S,
 
     pub fn stop(&mut self) -> Result<()> {
         self.snap_worker.stop();
-        if let Err(e) = self.storage.stop() {
-            error!("failed to stop store: {:?}", e);
-        }
         self.grpc_server.shutdown();
         Ok(())
     }
@@ -246,7 +235,7 @@ mod tests {
         let mut cfg = Config::default();
         cfg.addr = "127.0.0.1:0".to_owned();
 
-        let storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
 
         let (tx, rx) = mpsc::channel();
         let (significant_msg_sender, significant_msg_receiver) = mpsc::channel();

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -964,11 +964,11 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     ) {
         let timer = GRPC_MSG_HISTOGRAM_VEC.mvcc_get_by_key.start_coarse_timer();
 
-        let storage = self.storage.clone();
-
         let key = Key::from_raw(req.get_key());
         let (cb, f) = paired_future_callback();
-        let res = storage.async_mvcc_by_key(req.take_context(), key.clone(), cb);
+        let res = self
+            .storage
+            .async_mvcc_by_key(req.take_context(), key.clone(), cb);
 
         let future = AndThenWith::new(res, f.map_err(Error::from))
             .and_then(|v| {
@@ -1004,11 +1004,10 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
             .mvcc_get_by_start_ts
             .start_coarse_timer();
 
-        let storage = self.storage.clone();
-
         let (cb, f) = paired_future_callback();
-
-        let res = storage.async_mvcc_by_start_ts(req.take_context(), req.get_start_ts(), cb);
+        let res = self
+            .storage
+            .async_mvcc_by_start_ts(req.take_context(), req.get_start_ts(), cb);
 
         let future = AndThenWith::new(res, f.map_err(Error::from))
             .and_then(|v| {

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -14,7 +14,7 @@
 use std::boxed::FnBox;
 use std::cell::Cell;
 use std::cmp::Ordering;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::time::Duration;
 use std::{error, result};
 
@@ -68,7 +68,7 @@ pub enum Modify {
     DeleteRange(CfName, Key, Key),
 }
 
-pub trait Engine: Send + Debug + Clone + Sized + 'static {
+pub trait Engine: Send + Display + Debug + Clone + Sized + 'static {
     type Iter: Iterator;
     type Snap: Snapshot<Iter = Self::Iter>;
 

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::{self, Debug, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::io::Error as IoError;
 use std::result;
 use std::sync::mpsc;
@@ -245,6 +245,12 @@ fn invalid_resp_type(exp: CmdType, act: CmdType) -> Error {
         "cmd type not match, want {:?}, got {:?}!",
         exp, act
     ))
+}
+
+impl<S: RaftStoreRouter> Display for RaftKv<S> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "RaftKv")
+    }
 }
 
 impl<S: RaftStoreRouter> Debug for RaftKv<S> {

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -122,11 +122,17 @@ impl RocksEngine {
     }
 }
 
+impl Display for RocksEngine {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "RocksDB")
+    }
+}
+
 impl Debug for RocksEngine {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
-            "Rocksdb [is_temp: {}]",
+            "RocksDB [is_temp: {}]",
             self.core.lock().unwrap().temp_dir.is_some()
         )
     }

--- a/src/storage/gc_worker.rs
+++ b/src/storage/gc_worker.rs
@@ -422,7 +422,12 @@ pub struct GCWorker<E: Engine> {
 }
 
 impl<E: Engine> GCWorker<E> {
-    pub fn new(engine: E, ratio_threshold: f64) -> GCWorker<E> {
+    pub fn new(
+        engine: E,
+        local_storage: Option<Arc<DB>>,
+        raft_store_router: Option<ServerRaftStoreRouter>,
+        ratio_threshold: f64,
+    ) -> GCWorker<E> {
         let worker = Arc::new(Mutex::new(
             Builder::new("gc-worker")
                 .pending_capacity(GC_MAX_PENDING_TASKS)
@@ -431,25 +436,12 @@ impl<E: Engine> GCWorker<E> {
         let worker_scheduler = worker.lock().unwrap().scheduler();
         GCWorker {
             engine,
-            local_storage: None,
-            raft_store_router: None,
+            local_storage,
+            raft_store_router,
             ratio_threshold,
             worker,
             worker_scheduler,
         }
-    }
-
-    /// This method should be called before `start`.
-    /// Set `local_storage`, the underlying RocksDB of the `engine`. `local_storage` is where we
-    /// will run `destroy_range` on. If it was set, the `gc_worker` will be able to handle
-    /// `destroy_range`. Since we cant't simply get it from `engine`, we need the caller to set it
-    /// explicitly.
-    pub fn set_local_storage(&mut self, local_storage: Arc<DB>) {
-        self.local_storage = Some(local_storage);
-    }
-
-    pub fn set_raft_store_router(&mut self, router: ServerRaftStoreRouter) {
-        self.raft_store_router = Some(router);
     }
 
     pub fn start(&mut self) -> Result<()> {
@@ -523,10 +515,9 @@ impl<E: Engine> GCWorker<E> {
 mod tests {
     use super::*;
     use futures::Future;
-    use server::readpool::{self, ReadPool};
     use std::collections::BTreeMap;
-    use storage::{Config, Mutation, Options, ReadPoolContext, Storage, TestEngineBuilder};
-    use util::worker::FutureWorker;
+    use storage::{Mutation, Options, Storage};
+    use storage::{TestEngineBuilder, TestStorageBuilder};
 
     /// Assert the data in `storage` is the same as `expected_data`. Keys in `expected_data` should
     /// be encoded form without ts.
@@ -562,16 +553,10 @@ mod tests {
 
         let engine = TestEngineBuilder::new().build().unwrap();
         let db = engine.get_rocksdb();
-
-        let pd_worker = FutureWorker::new("test-pd-worker");
-        let read_pool = ReadPool::new(
-            "storage-readpool",
-            &readpool::Config::default_for_test(),
-            || || ReadPoolContext::new(pd_worker.scheduler()),
-        );
-        let mut storage = Storage::from_engine(engine, &Config::default(), read_pool).unwrap();
-        storage.mut_gc_worker().set_local_storage(db);
-        storage.start(&Config::default()).unwrap();
+        let storage = TestStorageBuilder::from_engine(engine)
+            .local_storage(db)
+            .build()
+            .unwrap();
 
         // Convert keys to key value pairs, where the value is "value-{key}".
         let data: BTreeMap<_, _> = init_keys
@@ -635,7 +620,6 @@ mod tests {
         // Check remaining data is as expected.
         check_data(&storage, &data);
 
-        storage.stop().unwrap();
         Ok(())
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -11,26 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use self::gc_worker::GCWorker;
-use self::metrics::*;
-use self::mvcc::Lock;
-use self::txn::CMD_BATCH_SIZE;
-use futures::{future, Future};
-use kvproto::errorpb;
-use kvproto::kvrpcpb::{CommandPri, Context, KeyRange, LockInfo};
-use raftstore::store::engine::IterOption;
-use server::readpool::{self, ReadPool};
-use std::boxed::FnBox;
-use std::cmp;
-use std::error;
-use std::fmt::{self, Debug, Display, Formatter};
-use std::io::Error as IoError;
-use std::sync::{Arc, Mutex};
-use std::u64;
-use util;
-use util::collections::HashMap;
-use util::worker::{self, Builder, ScheduleError, Worker};
-
 pub mod config;
 pub mod engine;
 pub mod gc_worker;
@@ -39,6 +19,32 @@ pub mod mvcc;
 mod readpool_context;
 pub mod txn;
 pub mod types;
+
+use std::boxed::FnBox;
+use std::cmp;
+use std::error;
+use std::fmt::{self, Debug, Display, Formatter};
+use std::io::Error as IoError;
+use std::sync::{atomic, Arc, Mutex};
+use std::u64;
+
+use futures::{future, Future};
+use kvproto::errorpb;
+use kvproto::kvrpcpb::{CommandPri, Context, KeyRange, LockInfo};
+
+use rocksdb::DB;
+
+use raftstore::store::engine::IterOption;
+use server::readpool::{self, ReadPool};
+use server::ServerRaftStoreRouter;
+use util;
+use util::collections::HashMap;
+use util::worker::{self, Builder, ScheduleError, Worker};
+
+use self::gc_worker::GCWorker;
+use self::metrics::*;
+use self::mvcc::Lock;
+use self::txn::CMD_BATCH_SIZE;
 
 pub use self::config::{Config, DEFAULT_DATA_DIR, DEFAULT_ROCKSDB_SUB_DIR};
 pub use self::engine::raftkv::RaftKv;
@@ -392,76 +398,155 @@ impl Options {
     }
 }
 
-/// A builder to build a temporary `Storage<RocksEngine>`.
+/// A builder to build a temporary `Storage<E>`.
 ///
 /// Only used for test purpose.
 #[must_use]
-pub struct TestStorageBuilder {
-    config: Option<Config>,
-    engine: Option<RocksEngine>,
+pub struct TestStorageBuilder<E: Engine> {
+    engine: E,
+    config: Config,
+    local_storage: Option<Arc<DB>>,
+    raft_store_router: Option<ServerRaftStoreRouter>,
 }
 
-impl TestStorageBuilder {
+impl TestStorageBuilder<RocksEngine> {
+    /// Build `Storage<RocksEngine>`.
     pub fn new() -> Self {
         Self {
-            config: None,
-            engine: None,
+            engine: TestEngineBuilder::new().build().unwrap(),
+            config: Config::default(),
+            local_storage: None,
+            raft_store_router: None,
+        }
+    }
+}
+
+impl<E: Engine> TestStorageBuilder<E> {
+    pub fn from_engine(engine: E) -> Self {
+        Self {
+            engine,
+            config: Config::default(),
+            local_storage: None,
+            raft_store_router: None,
         }
     }
 
     /// Customize the config of the `Storage`.
     ///
     /// By default, `Config::default()` will be used.
-    pub fn config(mut self, config: &Config) -> Self {
-        self.config = Some(config.clone());
+    pub fn config(mut self, config: Config) -> Self {
+        self.config = config;
         self
     }
 
-    /// Customize the engine of the `Storage`.
+    /// Set local storage for GCWorker.
     ///
-    /// By default, an engine created from `TestEngineBuilder` will be used.
-    pub fn engine(mut self, engine: RocksEngine) -> Self {
-        self.engine = Some(engine);
+    /// By default, `None` will be used.
+    pub fn local_storage(mut self, local_storage: Arc<DB>) -> Self {
+        self.local_storage = Some(local_storage);
         self
     }
 
-    /// Build a `Storage<RocksEngine>`.
-    pub fn build_and_start(self) -> Result<Storage<RocksEngine>> {
+    /// Set raft store router for GCWorker.
+    ///
+    /// By default, `None` will be used.
+    pub fn raft_store_router(mut self, raft_store_router: ServerRaftStoreRouter) -> Self {
+        self.raft_store_router = Some(raft_store_router);
+        self
+    }
+
+    /// Build a `Storage<E>`.
+    pub fn build(self) -> Result<Storage<E>> {
         use util::worker::FutureWorker;
 
-        let config = match self.config {
-            None => Config::default(),
-            Some(cfg) => cfg,
-        };
         let read_pool = {
             let pd_worker = FutureWorker::new("test-future–worker");
             ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
                 || ReadPoolContext::new(pd_worker.scheduler())
             })
         };
-        let engine = match self.engine {
-            None => TestEngineBuilder::new().build()?,
-            Some(e) => e,
-        };
-        let mut storage = Storage::from_engine(engine, &config, read_pool)?;
-        storage.start(&config)?;
-        Ok(storage)
+        Storage::from_engine(
+            self.engine,
+            &self.config,
+            read_pool,
+            self.local_storage,
+            self.raft_store_router,
+        )
     }
 }
 
-#[derive(Clone)]
 pub struct Storage<E: Engine> {
+    // TODO: Too many Arcs, would be slow when clone.
     engine: E,
 
-    // to schedule the execution of storage commands
+    /// To schedule the execution of storage commands
     worker: Arc<Mutex<Worker<Msg>>>,
     worker_scheduler: worker::Scheduler<Msg>,
 
     read_pool: ReadPool<ReadPoolContext>,
     gc_worker: GCWorker<E>,
 
-    // Storage configurations.
+    /// How many strong references. Thread pool and workers will be stopped
+    /// once there are no more references.
+    refs: Arc<atomic::AtomicUsize>,
+
+    // Fields below are storage configurations.
     max_key_size: usize,
+}
+
+impl<E: Engine> Clone for Storage<E> {
+    #[inline]
+    fn clone(&self) -> Self {
+        let refs = self.refs.fetch_add(1, atomic::Ordering::SeqCst);
+
+        debug!(
+            "Storage ({} engine) referenced (reference count before operation: {})",
+            self.engine, refs
+        );
+
+        Self {
+            engine: self.engine.clone(),
+            worker: self.worker.clone(),
+            worker_scheduler: self.worker_scheduler.clone(),
+            read_pool: self.read_pool.clone(),
+            gc_worker: self.gc_worker.clone(),
+            refs: self.refs.clone(),
+            max_key_size: self.max_key_size,
+        }
+    }
+}
+
+impl<E: Engine> Drop for Storage<E> {
+    #[inline]
+    fn drop(&mut self) {
+        let refs = self.refs.fetch_sub(1, atomic::Ordering::SeqCst);
+
+        debug!(
+            "Storage ({} engine) de-referenced (reference count before operation: {})",
+            self.engine, refs
+        );
+
+        if refs != 1 {
+            return;
+        }
+
+        let mut worker = self.worker.lock().unwrap();
+        if let Err(e) = worker.schedule(Msg::Quit) {
+            error!("Failed to ask scheduler to quit: {:?}", e);
+        }
+
+        let h = worker.stop().unwrap();
+        if let Err(e) = h.join() {
+            error!("Failed to join sched_handle: {:?}", e);
+        }
+
+        let r = self.gc_worker.stop();
+        if let Err(e) = r {
+            error!("Failed to stop gc_worker: {:?}", e);
+        }
+
+        info!("Storage ({} engine) stopped.", self.engine);
+    }
 }
 
 impl<E: Engine> Storage<E> {
@@ -469,9 +554,9 @@ impl<E: Engine> Storage<E> {
         engine: E,
         config: &Config,
         read_pool: ReadPool<ReadPoolContext>,
+        local_storage: Option<Arc<DB>>,
+        raft_store_router: Option<ServerRaftStoreRouter>,
     ) -> Result<Self> {
-        info!("storage {:?} started.", engine);
-
         let worker = Arc::new(Mutex::new(
             Builder::new("storage-scheduler")
                 .batch_size(CMD_BATCH_SIZE)
@@ -479,54 +564,34 @@ impl<E: Engine> Storage<E> {
                 .create(),
         ));
         let worker_scheduler = worker.lock().unwrap().scheduler();
-        let gc_worker = GCWorker::new(engine.clone(), config.gc_ratio_threshold);
+        let runner = Scheduler::new(
+            engine.clone(),
+            worker_scheduler.clone(),
+            config.scheduler_concurrency,
+            config.scheduler_worker_pool_size,
+            config.scheduler_pending_write_threshold.0 as usize,
+        );
+        let mut gc_worker = GCWorker::new(
+            engine.clone(),
+            local_storage,
+            raft_store_router,
+            config.gc_ratio_threshold,
+        );
+
+        worker.lock().unwrap().start(runner)?;
+        gc_worker.start()?;
+
+        info!("Storage ({} engine) started.", engine);
+
         Ok(Storage {
             engine,
             worker,
             worker_scheduler,
             read_pool,
             gc_worker,
+            refs: Arc::new(atomic::AtomicUsize::new(1)),
             max_key_size: config.max_key_size,
         })
-    }
-
-    pub fn mut_gc_worker(&mut self) -> &mut GCWorker<E> {
-        &mut self.gc_worker
-    }
-
-    pub fn start(&mut self, config: &Config) -> Result<()> {
-        let sched_concurrency = config.scheduler_concurrency;
-        let sched_worker_pool_size = config.scheduler_worker_pool_size;
-        let sched_pending_write_threshold = config.scheduler_pending_write_threshold.0 as usize;
-        let mut worker = self.worker.lock().unwrap();
-        let scheduler = Scheduler::new(
-            self.engine.clone(),
-            worker.scheduler(),
-            sched_concurrency,
-            sched_worker_pool_size,
-            sched_pending_write_threshold,
-        );
-        worker.start(scheduler)?;
-        self.gc_worker.start()?;
-        Ok(())
-    }
-
-    pub fn stop(&mut self) -> Result<()> {
-        let mut worker = self.worker.lock().unwrap();
-        if let Err(e) = worker.schedule(Msg::Quit) {
-            error!("send quit cmd to scheduler failed, error:{:?}", e);
-            return Err(box_err!("failed to ask sched to quit: {:?}", e));
-        }
-
-        let h = worker.stop().unwrap();
-        if let Err(e) = h.join() {
-            return Err(box_err!("failed to join sched_handle, err:{:?}", e));
-        }
-
-        self.gc_worker.stop()?;
-
-        info!("storage {:?} closed.", self.engine);
-        Ok(())
     }
 
     pub fn get_engine(&self) -> E {
@@ -1556,7 +1621,7 @@ mod tests {
 
     #[test]
     fn test_get_put() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
         expect_none(
             storage
@@ -1604,18 +1669,13 @@ mod tests {
                 .async_get(Context::new(), Key::from_raw(b"x"), 101)
                 .wait(),
         );
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_cf_error() {
         // New engine lacks normal column families.
         let engine = TestEngineBuilder::new().cfs(["foo"]).build().unwrap();
-        let mut storage = TestStorageBuilder::new()
-            .engine(engine)
-            .build_and_start()
-            .unwrap();
+        let storage = TestStorageBuilder::from_engine(engine).build().unwrap();
         let (tx, rx) = channel();
         storage
             .async_prewrite(
@@ -1672,13 +1732,11 @@ mod tests {
                 )
                 .wait(),
         );
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_scan() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
         storage
             .async_prewrite(
@@ -1899,13 +1957,11 @@ mod tests {
                 )
                 .wait(),
         );
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_batch_get() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
         storage
             .async_prewrite(
@@ -1965,13 +2021,11 @@ mod tests {
                 )
                 .wait(),
         );
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_txn() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
         storage
             .async_prewrite(
@@ -2041,18 +2095,13 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_sched_too_busy() {
         let mut config = Config::default();
         config.scheduler_pending_write_threshold = ReadableSize(1);
-        let mut storage = TestStorageBuilder::new()
-            .config(&config)
-            .build_and_start()
-            .unwrap();
+        let storage = TestStorageBuilder::new().config(config).build().unwrap();
         let (tx, rx) = channel();
         expect_none(
             storage
@@ -2092,13 +2141,11 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_cleanup() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
         storage
             .async_prewrite(
@@ -2125,13 +2172,11 @@ mod tests {
                 .async_get(Context::new(), Key::from_raw(b"x"), 105)
                 .wait(),
         );
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_high_priority_get_put() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
         let mut ctx = Context::new();
         ctx.set_priority(CommandPri::High);
@@ -2170,18 +2215,13 @@ mod tests {
             b"100".to_vec(),
             storage.async_get(ctx, Key::from_raw(b"x"), 101).wait(),
         );
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_high_priority_no_block() {
         let mut config = Config::default();
         config.scheduler_worker_pool_size = 1;
-        let mut storage = TestStorageBuilder::new()
-            .config(&config)
-            .build_and_start()
-            .unwrap();
+        let storage = TestStorageBuilder::new().config(config).build().unwrap();
         let (tx, rx) = channel();
         expect_none(
             storage
@@ -2221,13 +2261,11 @@ mod tests {
         );
         // Command Get with high priority not block by command Pause.
         assert_eq!(rx.recv().unwrap(), 3);
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_delete_range() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
         // Write x and y.
         storage
@@ -2319,13 +2357,11 @@ mod tests {
                 .async_get(Context::new(), Key::from_raw(b"z"), 101)
                 .wait(),
         );
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_raw_delete_range() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
 
         let test_data = [
@@ -2435,13 +2471,11 @@ mod tests {
         }
 
         rx.recv().unwrap();
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_raw_batch_put() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
 
         let test_data = vec![
@@ -2472,13 +2506,11 @@ mod tests {
                     .wait(),
             );
         }
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_raw_batch_get() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
 
         let test_data = vec![
@@ -2512,13 +2544,11 @@ mod tests {
                 .async_raw_batch_get(Context::new(), "".to_string(), keys)
                 .wait(),
         );
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_raw_batch_delete() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
 
         let test_data = vec![
@@ -2613,13 +2643,11 @@ mod tests {
                     .wait(),
             );
         }
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_raw_scan() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
 
         let test_data = vec![
@@ -2689,13 +2717,11 @@ mod tests {
                 .async_raw_scan(Context::new(), "".to_string(), b"c2".to_vec(), 20, false)
                 .wait(),
         );
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_raw_batch_scan() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
 
         let test_data = vec![
@@ -2877,13 +2903,11 @@ mod tests {
                 .async_raw_batch_scan(Context::new(), "".to_string(), ranges, 5, true)
                 .wait(),
         );
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_scan_lock() {
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
         storage
             .async_prewrite(
@@ -3086,15 +3110,13 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
-
-        storage.stop().unwrap();
     }
 
     #[test]
     fn test_resolve_lock() {
         use storage::txn::RESOLVE_LOCK_BATCH_SIZE;
 
-        let mut storage = TestStorageBuilder::new().build_and_start().unwrap();
+        let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
 
         // These locks (transaction ts=99) are not going to be resolved.
@@ -3215,7 +3237,5 @@ mod tests {
                 ts += 10;
             }
         }
-
-        storage.stop().unwrap();
     }
 }

--- a/src/storage/mvcc/reader/backward_scanner.rs
+++ b/src/storage/mvcc/reader/backward_scanner.rs
@@ -1203,8 +1203,6 @@ mod tests {
         assert_eq!(scanner.read_next().unwrap(), None);
     }
 
-    // This test runs slow, so we ignore it.
-    #[ignore]
     #[test]
     fn test_many_tombstones() {
         let engine = TestEngineBuilder::new().build().unwrap();

--- a/src/storage/mvcc/reader/backward_scanner.rs
+++ b/src/storage/mvcc/reader/backward_scanner.rs
@@ -1203,6 +1203,8 @@ mod tests {
         assert_eq!(scanner.read_next().unwrap(), None);
     }
 
+    // This test runs slow, so we ignore it.
+    #[ignore]
     #[test]
     fn test_many_tombstones() {
         let engine = TestEngineBuilder::new().build().unwrap();

--- a/tests/import/kv_service.rs
+++ b/tests/import/kv_service.rs
@@ -24,7 +24,7 @@ use kvproto::import_kvpb_grpc::*;
 use tikv::config::TiKvConfig;
 use tikv::import::ImportKVServer;
 
-fn new_kv_server() -> (ImportKVServer, ImportKvClient) {
+fn new_kv_server() -> (ImportKVServer, ImportKvClient, TempDir) {
     let temp_dir = TempDir::new("test_import_kv_server").unwrap();
 
     let mut cfg = TiKvConfig::default();
@@ -39,12 +39,13 @@ fn new_kv_server() -> (ImportKVServer, ImportKvClient) {
     };
     let client = ImportKvClient::new(ch);
 
-    (server, client)
+    // Return temp_dir as well, so that temp dir will be property deleted when it is dropped.
+    (server, client, temp_dir)
 }
 
 #[test]
 fn test_kv_service() {
-    let (mut server, client) = new_kv_server();
+    let (mut server, client, _) = new_kv_server();
     server.start();
 
     let uuid = Uuid::new_v4().as_bytes().to_vec();

--- a/tests/import/kv_service.rs
+++ b/tests/import/kv_service.rs
@@ -39,7 +39,7 @@ fn new_kv_server() -> (ImportKVServer, ImportKvClient, TempDir) {
     };
     let client = ImportKvClient::new(ch);
 
-    // Return temp_dir as well, so that temp dir will be property deleted when it is dropped.
+    // Return temp_dir as well, so that temp dir will be properly deleted when it is dropped.
     (server, client, temp_dir)
 }
 

--- a/tests/storage_cases/test_raft_storage.rs
+++ b/tests/storage_cases/test_raft_storage.rs
@@ -22,7 +22,11 @@ use tikv::storage::{self, Mutation};
 use tikv::storage::{engine, mvcc, txn, Engine, Key};
 use tikv::util::HandyRwLock;
 
-fn new_raft_storage() -> (Cluster<ServerCluster>, SyncStorage<SimulateEngine>, Context) {
+fn new_raft_storage() -> (
+    Cluster<ServerCluster>,
+    SyncTestStorage<SimulateEngine>,
+    Context,
+) {
     new_raft_storage_with_store_count(1, "")
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Use lifetime to manage the start and the stop of `Storage`. Storage will be always stopped once it is destroyed and will be always started once it is created.

Resolve https://github.com/tikv/tikv/issues/3759
Resolve https://github.com/tikv/tikv/issues/3756

Several benefits:
- No undefined behaviour any more caused by double `start()` or double `stop()` or `stop()` before `start()` or `start()` after `stop()`.
- Resource will be never leaked if `stop()` is not called.

After this PR, there will be **no** remaining garbage test directories in temp dir.

This PR also fixes https://github.com/tikv/tikv/issues/3767 by adding `worker.stop()`. However the best solution is fixing https://github.com/tikv/tikv/issues/3768 like what we do in this PR .

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

CI
