### PR TITLE
More table scan benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,8 @@ test_util = { path = "components/test_util" }
 test_raftstore = { path = "components/test_raftstore" }
 test_storage = { path = "components/test_storage" }
 test_coprocessor = { path = "components/test_coprocessor" }
-criterion = "0.2"
+# See https://japaric.github.io/criterion.rs/book/user_guide/known_limitations.html
+criterion = { version = "0.2", features=['real_blackbox'] }
 arrow = "0.10.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/benches/coprocessor_executors.rs
+++ b/benches/coprocessor_executors.rs
@@ -11,68 +11,509 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[macro_use]
 extern crate criterion;
 
 extern crate test_coprocessor;
 extern crate tikv;
 extern crate tipb;
+extern crate kvproto;
 
 use criterion::{black_box, Bencher, Criterion};
 
+use kvproto::coprocessor::KeyRange;
 use tipb::executor::TableScan;
 
 use test_coprocessor::*;
+use tikv::storage::RocksEngine;
 use tikv::coprocessor::codec::Datum;
 use tikv::coprocessor::dag::executor::{Executor, TableScanExecutor};
 
-fn bench_table_scan_primary_key(b: &mut Bencher) {
-    let id = ColumnBuilder::new()
-        .col_type(TYPE_LONG)
-        .primary_key(true)
-        .build();
-    let foo = ColumnBuilder::new().col_type(TYPE_LONG).build();
-    let table = TableBuilder::new()
-        .add_col(id.clone())
-        .add_col(foo.clone())
-        .build();
-
-    let mut store = Store::new();
-    for i in 0..10 {
-        store.begin();
-        store
-            .insert_into(&table)
-            .set(&id, Datum::I64(i))
-            .set(&foo, Datum::I64(0xDEADBEEF))
-            .execute();
-        store.commit();
-    }
-
-    let mut meta = TableScan::new();
-    meta.set_table_id(table.id);
-    meta.set_desc(false);
-    meta.mut_columns().push(id.get_column_info());
-
+fn bench_table_scan_next(
+    b: &mut Bencher,
+    meta: &TableScan,
+    ranges: &[KeyRange],
+    store: &Store<RocksEngine>
+) {
     b.iter_with_setup(
         || {
             let mut executor = TableScanExecutor::new(
                 meta.clone(),
-                vec![table.get_select_range()],
+                ranges.to_vec(),
                 store.to_fixture_store(),
                 false,
             ).unwrap();
             // There is a step of building scanner in the first `next()` which cost time,
             // so we next() before hand.
-            executor.next().unwrap();
+            executor.next().unwrap().unwrap();
             executor
         },
         |mut executor| {
-            black_box(executor.next().unwrap());
+            black_box(black_box(&mut executor).next().unwrap().unwrap());
         },
     );
 }
 
-fn main() {
-    let mut criterion = Criterion::default().sample_size(10).configure_from_args();
-    criterion.bench_function("table_scan_primary_key", bench_table_scan_primary_key);
-    criterion.final_summary();
+/// next() for 1 time, 1 interested column, which is PK (which is in the key)
+///
+/// This kind of scanner is used in SQLs like SELECT COUNT(*).
+fn bench_table_scan_primary_key(c: &mut Criterion) {
+    c.bench_function("table_scan_primary_key", |b| {
+        let id = ColumnBuilder::new()
+            .col_type(TYPE_LONG)
+            .primary_key(true)
+            .build();
+        let foo = ColumnBuilder::new().col_type(TYPE_LONG).build();
+        let table = TableBuilder::new()
+            .add_col(id.clone())
+            .add_col(foo.clone())
+            .build();
+
+        let mut store = Store::new();
+        for i in 0..10 {
+            store.begin();
+            store
+                .insert_into(&table)
+                .set(&id, Datum::I64(i))
+                .set(&foo, Datum::I64(0xDEADBEEF))
+                .execute();
+            store.commit();
+        }
+
+        let mut meta = TableScan::new();
+        meta.set_table_id(table.id);
+        meta.set_desc(false);
+        meta.mut_columns().push(id.get_column_info());
+
+        bench_table_scan_next(b, &meta, &[table.get_select_range()], &store);
+    });
 }
+
+/// next() for 1 time, 1 interested column, at the front of each row. Each row contains 100 columns.
+///
+/// This kind of scanner is used in SQLs like SELECT COUNT(column)
+fn bench_table_scan_datum_front(c: &mut Criterion) {
+    c.bench_function("table_scan_datum_front", |b| {
+        let mut cols = vec![];
+        for _ in 0..100 {
+            let col = ColumnBuilder::new().col_type(TYPE_LONG).build();
+            cols.push(col);
+        }
+        let mut table = TableBuilder::new();
+        for col in &cols {
+            table = table.add_col(col.clone());
+        }
+        let table = table.build();
+
+        let mut store = Store::new();
+        for i in 0..10 {
+            store.begin();
+            {
+                let mut insert = store.insert_into(&table);
+                for (idx, col) in cols.iter().enumerate() {
+                    insert = insert.set(&col, Datum::I64((i ^ idx) as i64));
+                }
+                insert.execute();
+            }
+            store.commit();
+        }
+
+        let mut meta = TableScan::new();
+        meta.set_table_id(table.id);
+        meta.set_desc(false);
+        meta.mut_columns().push(cols[0].get_column_info());
+
+        bench_table_scan_next(b, &meta, &[table.get_select_range()], &store);
+    });
+}
+
+/// next() for 1 time, 1 interested column, at the front of each row. Each row contains 100 columns
+/// and length is very long.
+///
+/// Bench the impact of large values.
+fn bench_table_scan_long_datum_front(c: &mut Criterion) {
+    c.bench_function("table_scan_long_datum_front", |b| {
+        let mut cols = vec![];
+        for _ in 0..100 {
+            let col = ColumnBuilder::new().col_type(TYPE_VAR_CHAR).build();
+            cols.push(col);
+        }
+        let mut table = TableBuilder::new();
+        for col in &cols {
+            table = table.add_col(col.clone());
+        }
+        let table = table.build();
+
+        let mut store = Store::new();
+        for _ in 0..10 {
+            let bytes = vec![0xCC; 1000];
+            store.begin();
+            {
+                let mut insert = store.insert_into(&table);
+                for col in &cols {
+                    insert = insert.set(col, Datum::Bytes(bytes.clone()));
+                }
+                insert.execute();
+            }
+            store.commit();
+        }
+
+        let mut meta = TableScan::new();
+        meta.set_table_id(table.id);
+        meta.set_desc(false);
+        meta.mut_columns().push(cols[0].get_column_info());
+
+        bench_table_scan_next(b, &meta, &[table.get_select_range()], &store);
+    });
+}
+
+/// next() for 1 time, 2 interested columns, at the front of each row. Each row contains 100
+/// columns.
+fn bench_table_scan_datum_multi_front(c: &mut Criterion) {
+    c.bench_function("table_scan_datum_multi_front", |b| {
+        let mut cols = vec![];
+        for _ in 0..100 {
+            let col = ColumnBuilder::new().col_type(TYPE_LONG).build();
+            cols.push(col);
+        }
+        let mut table = TableBuilder::new();
+        for col in &cols {
+            table = table.add_col(col.clone());
+        }
+        let table = table.build();
+
+        let mut store = Store::new();
+        for i in 0..10 {
+            store.begin();
+            {
+                let mut insert = store.insert_into(&table);
+                for (idx, col) in cols.iter().enumerate() {
+                    insert = insert.set(&col, Datum::I64((i ^ idx) as i64));
+                }
+                insert.execute();
+            }
+            store.commit();
+        }
+
+        let mut meta = TableScan::new();
+        meta.set_table_id(table.id);
+        meta.set_desc(false);
+        meta.mut_columns().push(cols[0].get_column_info());
+        meta.mut_columns().push(cols[1].get_column_info());
+
+        bench_table_scan_next(b, &meta, &[table.get_select_range()], &store);
+    });
+}
+
+/// next() for 1 time, 1 interested column, at the end of each row. Each row contains 100 columns.
+fn bench_table_scan_datum_end(c: &mut Criterion) {
+    c.bench_function("table_scan_datum_end", |b| {
+        let mut cols = vec![];
+        for _ in 0..100 {
+            let col = ColumnBuilder::new().col_type(TYPE_LONG).build();
+            cols.push(col);
+        }
+        let mut table = TableBuilder::new();
+        for col in &cols {
+            table = table.add_col(col.clone());
+        }
+        let table = table.build();
+
+        let mut store = Store::new();
+        for i in 0..10 {
+            store.begin();
+            {
+                let mut insert = store.insert_into(&table);
+                for (idx, col) in cols.iter().enumerate() {
+                    insert = insert.set(&col, Datum::I64((i ^ idx) as i64));
+                }
+                insert.execute();
+            }
+            store.commit();
+        }
+
+        let mut meta = TableScan::new();
+        meta.set_table_id(table.id);
+        meta.set_desc(false);
+        meta.mut_columns().push(cols[99].get_column_info());
+
+        bench_table_scan_next(b, &meta, &[table.get_select_range()], &store);
+    });
+}
+
+/// next() for 1 time, 100 interested columns, each column in the row is interested
+/// (i.e. there is totally 100 columns in the row).
+fn bench_table_scan_datum_all(c: &mut Criterion) {
+    c.bench_function("table_scan_datum_all", |b| {
+        let mut cols = vec![];
+        for _ in 0..100 {
+            let col = ColumnBuilder::new().col_type(TYPE_LONG).build();
+            cols.push(col);
+        }
+        let mut table = TableBuilder::new();
+        for col in &cols {
+            table = table.add_col(col.clone());
+        }
+        let table = table.build();
+
+        let mut store = Store::new();
+        for i in 0..10 {
+            store.begin();
+            {
+                let mut insert = store.insert_into(&table);
+                for (idx, col) in cols.iter().enumerate() {
+                    insert = insert.set(&col, Datum::I64((i ^ idx) as i64));
+                }
+                insert.execute();
+            }
+            store.commit();
+        }
+
+        let mut meta = TableScan::new();
+        meta.set_table_id(table.id);
+        meta.set_desc(false);
+        for col in &cols {
+            meta.mut_columns().push(col.get_column_info());
+        }
+
+        bench_table_scan_next(b, &meta, &[table.get_select_range()], &store);
+    });
+}
+
+/// next() for 1 time, 1 interested column, but the column is missing from each row (i.e. it's
+/// default value is used instead). Each row contains totally 10 columns.
+fn bench_table_scan_datum_absent(c: &mut Criterion) {
+    c.bench_function("table_scan_datum_absent", |b| {
+        let mut cols = vec![];
+        for _ in 0..10 {
+            let col = ColumnBuilder::new().col_type(TYPE_LONG).build();
+            cols.push(col);
+        }
+        let mut table = TableBuilder::new();
+        for col in &cols {
+            table = table.add_col(col.clone());
+        }
+        let table = table.build();
+
+        let mut store = Store::new();
+        for i in 0..10 {
+            store.begin();
+            {
+                let mut insert = store.insert_into(&table);
+                for (idx, col) in cols.iter().enumerate().skip(1) {
+                    insert = insert.set(&col, Datum::I64((i ^ idx) as i64));
+                }
+                insert.execute();
+            }
+            store.commit();
+        }
+
+        let mut meta = TableScan::new();
+        meta.set_table_id(table.id);
+        meta.set_desc(false);
+        meta.mut_columns().push(cols[0].get_column_info());
+
+        bench_table_scan_next(b, &meta, &[table.get_select_range()], &store);
+    });
+}
+
+/// next() for 1 time, 1 interested column, but the column is missing from each row (i.e. it's
+/// default value is used instead). Each row contains totally 100 columns.
+fn bench_table_scan_datum_absent_large_row(c: &mut Criterion) {
+    c.bench_function("table_scan_datum_absent_large_row", |b| {
+        let mut cols = vec![];
+        for _ in 0..100 {
+            let col = ColumnBuilder::new().col_type(TYPE_LONG).build();
+            cols.push(col);
+        }
+        let mut table = TableBuilder::new();
+        for col in &cols {
+            table = table.add_col(col.clone());
+        }
+        let table = table.build();
+
+        let mut store = Store::new();
+        for i in 0..10 {
+            store.begin();
+            {
+                let mut insert = store.insert_into(&table);
+                for (idx, col) in cols.iter().enumerate().skip(1) {
+                    insert = insert.set(&col, Datum::I64((i ^ idx) as i64));
+                }
+                insert.execute();
+            }
+            store.commit();
+        }
+
+        let mut meta = TableScan::new();
+        meta.set_table_id(table.id);
+        meta.set_desc(false);
+        meta.mut_columns().push(cols[0].get_column_info());
+
+        bench_table_scan_next(b, &meta, &[table.get_select_range()], &store);
+    });
+}
+
+/// next() for 1 time, 1 interested column, which is PK. However the range given is a point range.
+fn bench_table_scan_point_range(c: &mut Criterion) {
+    c.bench_function("table_scan_point_range", |b| {
+        let id = ColumnBuilder::new()
+            .col_type(TYPE_LONG)
+            .primary_key(true)
+            .build();
+        let foo = ColumnBuilder::new().col_type(TYPE_LONG).build();
+        let table = TableBuilder::new()
+            .add_col(id.clone())
+            .add_col(foo.clone())
+            .build();
+
+        let mut store = Store::new();
+        for i in 0..10 {
+            store.begin();
+            store
+                .insert_into(&table)
+                .set(&id, Datum::I64(i))
+                .set(&foo, Datum::I64(0xDEADBEEF))
+                .execute();
+            store.commit();
+        }
+
+        let mut meta = TableScan::new();
+        meta.set_table_id(table.id);
+        meta.set_desc(false);
+        meta.mut_columns().push(id.get_column_info());
+
+        // We pass 2 point-ranges instead of 1 point-range, because there is a warm-up next().
+        bench_table_scan_next(b, &meta, &[
+            table.get_point_select_range(0),
+            table.get_point_select_range(1),
+        ], &store);
+    });
+}
+
+/// 1 interested column, which is PK. However 1000 point ranges (in ascending order) are given and
+/// this case benches the performance when all ranges are consumed.
+fn bench_table_scan_multi_point_range(c: &mut Criterion) {
+    c.bench_function("table_scan_multi_point_range", |b| {
+        let id = ColumnBuilder::new()
+            .col_type(TYPE_LONG)
+            .primary_key(true)
+            .build();
+        let foo = ColumnBuilder::new().col_type(TYPE_LONG).build();
+        let table = TableBuilder::new()
+            .add_col(id.clone())
+            .add_col(foo.clone())
+            .build();
+
+        let mut store = Store::new();
+        for i in 0..1001 {
+            store.begin();
+            store
+                .insert_into(&table)
+                .set(&id, Datum::I64(i))
+                .set(&foo, Datum::I64(0xDEADBEEF))
+                .execute();
+            store.commit();
+        }
+
+        let mut meta = TableScan::new();
+        meta.set_table_id(table.id);
+        meta.set_desc(false);
+        meta.mut_columns().push(id.get_column_info());
+
+        b.iter_with_setup(
+            || {
+                let mut ranges = vec![];
+                // Generate 1001 ranges, because there will be a warm-up next().
+                for i in 0..1001 {
+                    ranges.push(table.get_point_select_range(i));
+                }
+                let mut executor = TableScanExecutor::new(
+                    meta.clone(),
+                    ranges,
+                    store.to_fixture_store(),
+                    false,
+                ).unwrap();
+                // There is a step of building scanner in the first `next()` which cost time,
+                // so we next() before hand.
+                executor.next().unwrap().unwrap();
+                executor
+            },
+            |mut executor| {
+                let executor = black_box(&mut executor);
+                for _ in 0..1000 {
+                    black_box(executor.next().unwrap().unwrap());
+                }
+            },
+        );
+    });
+}
+
+/// 1 interested column, which is PK. One range is given, which contains 1000 rows. This case
+/// benches the performance when all records of this range are consumed.
+fn bench_table_scan_multi_rows(c: &mut Criterion) {
+    c.bench_function("table_scan_multi_rows", |b| {
+        let id = ColumnBuilder::new()
+            .col_type(TYPE_LONG)
+            .primary_key(true)
+            .build();
+        let foo = ColumnBuilder::new().col_type(TYPE_LONG).build();
+        let table = TableBuilder::new()
+            .add_col(id.clone())
+            .add_col(foo.clone())
+            .build();
+
+        let mut store = Store::new();
+        for i in 0..1001 {
+            store.begin();
+            store
+                .insert_into(&table)
+                .set(&id, Datum::I64(i))
+                .set(&foo, Datum::I64(0xDEADBEEF))
+                .execute();
+            store.commit();
+        }
+
+        let mut meta = TableScan::new();
+        meta.set_table_id(table.id);
+        meta.set_desc(false);
+        meta.mut_columns().push(id.get_column_info());
+
+        b.iter_with_setup(
+            || {
+                let mut executor = TableScanExecutor::new(
+                    meta.clone(),
+                    vec![table.get_select_range()],
+                    store.to_fixture_store(),
+                    false,
+                ).unwrap();
+                // There is a step of building scanner in the first `next()` which cost time,
+                // so we next() before hand.
+                executor.next().unwrap().unwrap();
+                executor
+            },
+            |mut executor| {
+                let executor = black_box(&mut executor);
+                for _ in 0..1000 {
+                    black_box(executor.next().unwrap().unwrap());
+                }
+            },
+        );
+    });
+}
+
+criterion_group!(benches,
+    bench_table_scan_primary_key,
+    bench_table_scan_datum_front,
+    bench_table_scan_datum_multi_front,
+    bench_table_scan_long_datum_front,
+    bench_table_scan_datum_multi_front,
+    bench_table_scan_datum_end,
+    bench_table_scan_datum_all,
+    bench_table_scan_datum_absent,
+    bench_table_scan_datum_absent_large_row,
+    bench_table_scan_point_range,
+    bench_table_scan_multi_point_range,
+    bench_table_scan_multi_rows,
+);
+criterion_main!(benches);

--- a/components/test_coprocessor/src/table.rs
+++ b/components/test_coprocessor/src/table.rs
@@ -20,6 +20,7 @@ use tipb::schema::{self, ColumnInfo};
 
 use protobuf::RepeatedField;
 
+use tikv::coprocessor;
 use tikv::coprocessor::codec::table;
 use tikv::util::codec::number::NumberEncoder;
 
@@ -77,6 +78,16 @@ impl Table {
         let mut range = KeyRange::new();
         range.set_start(table::encode_row_key(self.id, ::std::i64::MIN));
         range.set_end(table::encode_row_key(self.id, ::std::i64::MAX));
+        range
+    }
+
+    pub fn get_point_select_range(&self, handle_id: i64) -> KeyRange {
+        let start_key = table::encode_row_key(self.id, handle_id);
+        let mut end_key = start_key.clone();
+        coprocessor::util::convert_to_prefix_next(&mut end_key);
+        let mut range = KeyRange::new();
+        range.set_start(start_key);
+        range.set_end(end_key);
         range
     }
 

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -21,7 +21,7 @@ mod metrics;
 mod readpool_context;
 mod statistics;
 mod tracker;
-mod util;
+pub mod util;
 
 pub use self::endpoint::Endpoint;
 pub use self::error::{Error, Result};


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR introduces more table scan benchmarks.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## Benchmark result if necessary (optional)

```
table_scan_primary_key  time:   [1.8638 us 1.9087 us 1.9560 us]        
table_scan_datum_front  time:   [1.5506 us 1.5698 us 1.5898 us]      
table_scan_datum_multi_front                                                                            
                        time:   [1.5804 us 1.6001 us 1.6205 us]
table_scan_long_datum_front                                                                             
                        time:   [2.9741 us 3.0109 us 3.0465 us]
table_scan_datum_multi_front                                                                            
                        time:   [1.5683 us 1.5876 us 1.6078 us]
table_scan_datum_end    time:   [6.6916 us 6.7473 us 6.8107 us]     
table_scan_datum_all    time:   [7.5426 us 7.6066 us 7.6727 us]        
table_scan_datum_absent time:   [1.9153 us 1.9411 us 1.9695 us]       
table_scan_datum_absent_large_row                                                                            
                        time:   [6.7280 us 6.7993 us 6.8696 us]
table_scan_point_range  time:   [1.7835 us 1.8059 us 1.8283 us]
table_scan_multi_point_range                                                                             
                        time:   [656.08 us 659.43 us 662.97 us]
table_scan_multi_rows   time:   [305.62 us 308.04 us 310.54 us]                                   
```

The benchmark result is layered, which does not include costs in RocksDB. See comments in the code for details of each benchmark.

Performance defects according to benchmark:

1. Point selects are 2x slower than range selects.
2. Performance will be greatly affected when there are many columns (i.e. 100 columns).
3. Selecting an absent column can be very slow (if there are many columns).

To resolve defect 1, we need to refine point select requests to avoid calculation of prefix_next. Notice that there will be notable Protobuf decoding cost as well when there are a lot of ranges, which is not included in this bench.
To resolve defect 2 and 3, we can implement new row format according to [RFC](https://github.com/pingcap/tidb/blob/master/docs/design/2018-07-19-row-format.md).