### PR TITLE
raftstore: update size after leader transfer

### DIFF
--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -1271,11 +1271,9 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let region_id = region.get_id();
         let peer = self.region_peers.get_mut(&region_id).unwrap();
         peer.set_region(region);
-        // make approximate size and keys updated in time.
-        // the reason why follower need to update is that there is a issue that after merge
-        // and then transfer leader, the new leader may have stale size and keys.
-        peer.size_diff_hint = self.cfg.region_split_check_diff.0;
         if peer.is_leader() {
+            // make approximate size and keys updated in time.
+            peer.size_diff_hint = self.cfg.region_split_check_diff.0;
             info!("notify pd with merge {:?} into {:?}", source, peer.region());
             peer.heartbeat_pd(&self.pd_worker);
         }

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -824,6 +824,8 @@ impl Peer {
                         "{} becomes leader and lease expired time is {:?}",
                         self.tag, self.leader_lease
                     );
+                    // make approximate size and keys updated after leader transfer, cause new leader may have a stale size and keys.
+                    self.size_diff_hint = self.cfg.region_split_check_diff.0;
                     self.heartbeat_pd(worker)
                 }
                 StateRole::Follower => {

--- a/tests/raftstore_cases/test_update_region_size.rs
+++ b/tests/raftstore_cases/test_update_region_size.rs
@@ -13,10 +13,12 @@
 
 use std::sync::Arc;
 use std::{thread, time};
+use std::time::Duration;
 
 use test_raftstore::*;
 use tikv::pd::PdClient;
 use tikv::util::config::*;
+use tikv::storage::CF_WRITE;
 
 fn flush<T: Simulator>(cluster: &mut Cluster<T>) {
     for engines in cluster.engines.values() {
@@ -82,4 +84,130 @@ fn test_server_update_region_size() {
     let count = 1;
     let mut cluster = new_server_cluster(0, count);
     test_update_regoin_size(&mut cluster);
+}
+
+
+/// Test whether approximate size and keys are updated after merge
+#[test]
+fn test_transfer_approximate_size_and_keys() {
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.raft_store.split_region_check_tick_interval = ReadableDuration::millis(20);
+    cluster.cfg.raft_store.region_split_check_diff = ReadableSize(100);
+    cluster.run();
+
+    let mut range = 1..;
+    put_cf_till_size(&mut cluster, CF_WRITE, 100, &mut range);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    let region = pd_client.get_region(b"").unwrap();
+
+    // make sure all peer's approximate size is not None.
+    cluster.must_transfer_leader(region.get_id(), region.get_peers()[0].clone());
+    thread::sleep(Duration::from_millis(100));
+    cluster.must_transfer_leader(region.get_id(), region.get_peers()[1].clone());
+    thread::sleep(Duration::from_millis(100));
+    cluster.must_transfer_leader(region.get_id(), region.get_peers()[2].clone());
+    thread::sleep(Duration::from_millis(100));
+    
+    let old_size = pd_client
+        .get_region_approximate_size(region.get_id())
+        .unwrap();
+    assert_ne!(old_size, 0);
+
+    cluster.must_transfer_leader(region.get_id(), region.get_peers()[0].clone());
+
+    // make sure split check is invoked so size and keys are updated.
+    put_cf_till_size(&mut cluster, CF_WRITE, 100, &mut range);
+    thread::sleep(Duration::from_millis(100));
+    let new_size = pd_client
+        .get_region_approximate_size(region.get_id())
+        .unwrap();
+    assert_ne!(old_size, new_size);
+
+    // make sure split check is invoked so size and keys are updated.
+    cluster.must_transfer_leader(region.get_id(), region.get_peers()[2].clone());
+    thread::sleep(Duration::from_millis(100));
+
+    // size and keys should be updated
+    let new_size = pd_client
+        .get_region_approximate_size(region.get_id())
+        .unwrap();
+    assert_ne!(old_size, new_size);
+}
+
+
+/// Test whether approximate size and keys are updated after merge
+#[test]
+fn test_merge_approximate_size_and_keys() {
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.raft_store.split_region_check_tick_interval = ReadableDuration::millis(20);
+    cluster.run();
+
+    let mut range = 1..;
+    let middle_key = put_cf_till_size(&mut cluster, CF_WRITE, 100, &mut range);
+    let max_key = put_cf_till_size(&mut cluster, CF_WRITE, 100, &mut range);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    let region = pd_client.get_region(b"").unwrap();
+
+    cluster.must_split(&region, &middle_key);
+    // make sure split check is invoked so size and keys are updated.
+    thread::sleep(Duration::from_millis(100));
+
+    let left = pd_client.get_region(b"").unwrap();
+    let right = pd_client.get_region(&max_key).unwrap();
+    assert_ne!(left, right);
+
+    // make sure all peer's approximate size is not None.
+    cluster.must_transfer_leader(right.get_id(), right.get_peers()[0].clone());
+    thread::sleep(Duration::from_millis(100));
+    cluster.must_transfer_leader(right.get_id(), right.get_peers()[1].clone());
+    thread::sleep(Duration::from_millis(100));
+    cluster.must_transfer_leader(right.get_id(), right.get_peers()[2].clone());
+    thread::sleep(Duration::from_millis(100));
+
+    let size = pd_client
+        .get_region_approximate_size(right.get_id())
+        .unwrap();
+    assert_ne!(size, 0);
+    let keys = pd_client
+        .get_region_approximate_keys(right.get_id())
+        .unwrap();
+    assert_ne!(keys, 0);
+
+    pd_client.must_merge(left.get_id(), right.get_id());
+    // make sure split check is invoked so size and keys are updated.
+    thread::sleep(Duration::from_millis(100));
+
+    let region = pd_client.get_region(b"").unwrap();
+    // size and keys should be updated.
+    assert_ne!(
+        pd_client
+            .get_region_approximate_size(region.get_id())
+            .unwrap(),
+        size
+    );
+    assert_ne!(
+        pd_client
+            .get_region_approximate_keys(region.get_id())
+            .unwrap(),
+        keys
+    );
+
+    // after merge and then transfer leader, if not update new leader's approximate size, it maybe be stale.
+    cluster.must_transfer_leader(region.get_id(), region.get_peers()[0].clone());
+    // make sure split check is invoked
+    thread::sleep(Duration::from_millis(100));
+    assert_ne!(
+        pd_client
+            .get_region_approximate_size(region.get_id())
+            .unwrap(),
+        size
+    );
+    assert_ne!(
+        pd_client
+            .get_region_approximate_keys(region.get_id())
+            .unwrap(),
+        keys
+    );
 }

--- a/tests/raftstore_cases/test_update_region_size.rs
+++ b/tests/raftstore_cases/test_update_region_size.rs
@@ -12,13 +12,13 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::{thread, time};
 use std::time::Duration;
+use std::{thread, time};
 
 use test_raftstore::*;
 use tikv::pd::PdClient;
-use tikv::util::config::*;
 use tikv::storage::CF_WRITE;
+use tikv::util::config::*;
 
 fn flush<T: Simulator>(cluster: &mut Cluster<T>) {
     for engines in cluster.engines.values() {
@@ -86,7 +86,6 @@ fn test_server_update_region_size() {
     test_update_regoin_size(&mut cluster);
 }
 
-
 /// Test whether approximate size and keys are updated after merge
 #[test]
 fn test_transfer_approximate_size_and_keys() {
@@ -108,7 +107,7 @@ fn test_transfer_approximate_size_and_keys() {
     thread::sleep(Duration::from_millis(100));
     cluster.must_transfer_leader(region.get_id(), region.get_peers()[2].clone());
     thread::sleep(Duration::from_millis(100));
-    
+
     let old_size = pd_client
         .get_region_approximate_size(region.get_id())
         .unwrap();
@@ -134,7 +133,6 @@ fn test_transfer_approximate_size_and_keys() {
         .unwrap();
     assert_ne!(old_size, new_size);
 }
-
 
 /// Test whether approximate size and keys are updated after merge
 #[test]

--- a/tests/raftstore_cases/test_update_region_size.rs
+++ b/tests/raftstore_cases/test_update_region_size.rs
@@ -86,9 +86,9 @@ fn test_server_update_region_size() {
     test_update_regoin_size(&mut cluster);
 }
 
-/// Test whether approximate size and keys are updated after merge
+/// Test whether approximate size and keys are updated after transfer leader
 #[test]
-fn test_transfer_approximate_size_and_keys() {
+fn test_transfer_leader_approximate_size_and_keys() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.cfg.raft_store.split_region_check_tick_interval = ReadableDuration::millis(20);
     cluster.cfg.raft_store.region_split_check_diff = ReadableSize(100);


### PR DESCRIPTION
## What have you changed? (mandatory)
Assume that a region is on storeA, storeB and storeC, and leader is on storeA with a calculated approximate size based on current stats. Then leader is transferred to storeB and approximate size of region is changed a lot. Once leader is transferred back to storeA and there is no write, namely, split-checker is not invoked. At this point, pd will get a stale approximate size of the region from storeA.

**To be noted, it may cause performance issue when transferring leaders dramatically**

## What are the type of the changes? (mandatory)
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)
unit-test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No


