### PR TITLE
[release-2.0] Cherry-pick: service/kv: Add end_key limit to kv_scan interface (#3720)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-2.0#d31f6ac859997c9607879816c67d3acb3d33b966"
+source = "git+https://github.com/MyonKeminta/kvproto.git?rev=1488e9bb760ca83fdc7dbf77bf0412bcd0f3cd77#1488e9bb760ca83fdc7dbf77bf0412bcd0f3cd77"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1292,7 +1292,7 @@ dependencies = [
  "grpcio 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-2.0)",
+ "kvproto 0.0.1 (git+https://github.com/MyonKeminta/kvproto.git?rev=1488e9bb760ca83fdc7dbf77bf0412bcd0f3cd77)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1628,7 +1628,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-2.0)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/MyonKeminta/kvproto.git?rev=1488e9bb760ca83fdc7dbf77bf0412bcd0f3cd77)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/MyonKeminta/kvproto.git?rev=1488e9bb760ca83fdc7dbf77bf0412bcd0f3cd77#1488e9bb760ca83fdc7dbf77bf0412bcd0f3cd77"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-2.0#2b379bf42507735a8615f973e1bfd4caa075b155"
 dependencies = [
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1292,7 +1292,7 @@ dependencies = [
  "grpcio 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/MyonKeminta/kvproto.git?rev=1488e9bb760ca83fdc7dbf77bf0412bcd0f3cd77)",
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-2.0)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1628,7 +1628,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/MyonKeminta/kvproto.git?rev=1488e9bb760ca83fdc7dbf77bf0412bcd0f3cd77)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-2.0)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,8 @@ git = "https://github.com/pingcap/rust-rocksdb.git"
 branch = "release-2.0"
 
 [dependencies.kvproto]
-git = "https://github.com/MyonKeminta/kvproto.git"
-rev = "1488e9bb760ca83fdc7dbf77bf0412bcd0f3cd77"
+git = "https://github.com/pingcap/kvproto.git"
+branch = "release-2.0"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,8 @@ git = "https://github.com/pingcap/rust-rocksdb.git"
 branch = "release-2.0"
 
 [dependencies.kvproto]
-git = "https://github.com/pingcap/kvproto.git"
-branch = "release-2.0"
+git = "https://github.com/MyonKeminta/kvproto.git"
+rev = "1488e9bb760ca83fdc7dbf77bf0412bcd0f3cd77"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/benches/bin/mvcc.rs
+++ b/benches/bin/mvcc.rs
@@ -84,6 +84,7 @@ fn bench_tombstone_scan() -> BenchSamples {
                 .scan(
                     Context::new(),
                     Key::from_raw(&k),
+                    None,
                     1,
                     false,
                     ts_generator.next().unwrap()

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -201,10 +201,17 @@ impl<T: RaftStoreRouter + 'static> tikvpb_grpc::Tikv for Service<T> {
         let mut options = Options::default();
         options.key_only = req.get_key_only();
 
+        let end_key = if req.get_end_key().is_empty() {
+            None
+        } else {
+            Some(Key::from_raw(req.get_end_key()))
+        };
+
         let future = self.storage
             .async_scan(
                 req.take_context(),
                 Key::from_raw(req.get_start_key()),
+                end_key,
                 req.get_limit() as usize,
                 req.get_version(),
                 options,

--- a/tests/storage/assert_storage.rs
+++ b/tests/storage/assert_storage.rs
@@ -271,7 +271,7 @@ impl AssertionStorage {
     ) {
         let key_address = make_key(start_key);
         let result = self.store
-            .scan(self.ctx.clone(), key_address, limit, false, ts)
+            .scan(self.ctx.clone(), key_address, None, limit, false, ts)
             .unwrap();
         let result: Vec<Option<KvPair>> = result.into_iter().map(Result::ok).collect();
         let expect: Vec<Option<KvPair>> = expect
@@ -290,7 +290,7 @@ impl AssertionStorage {
     ) {
         let key_address = make_key(start_key);
         let result = self.store
-            .scan(self.ctx.clone(), key_address, limit, true, ts)
+            .scan(self.ctx.clone(), key_address, None, limit, true, ts)
             .unwrap();
         let result: Vec<Option<KvPair>> = result.into_iter().map(Result::ok).collect();
         let expect: Vec<Option<KvPair>> = expect

--- a/tests/storage/sync_storage.rs
+++ b/tests/storage/sync_storage.rs
@@ -91,13 +91,21 @@ impl SyncStorage {
     pub fn scan(
         &self,
         ctx: Context,
-        key: Key,
+        start_key: Key,
+        end_key: Option<Key>,
         limit: usize,
         key_only: bool,
         start_ts: u64,
     ) -> Result<Vec<Result<KvPair>>> {
         self.store
-            .async_scan(ctx, key, limit, start_ts, Options::new(0, false, key_only))
+            .async_scan(
+                ctx,
+                start_key,
+                end_key,
+                limit,
+                start_ts,
+                Options::new(0, false, key_only),
+            )
             .wait()
     }
 

--- a/tests/storage_cases/test_raft_storage.rs
+++ b/tests/storage_cases/test_raft_storage.rs
@@ -57,7 +57,7 @@ fn test_raft_storage() {
     assert!(storage.batch_get(ctx.clone(), &[key.clone()], 20).is_err());
     assert!(
         storage
-            .scan(ctx.clone(), key.clone(), 1, false, 20)
+            .scan(ctx.clone(), key.clone(), None, 1, false, 20)
             .is_err()
     );
     assert!(
@@ -161,7 +161,7 @@ fn test_raft_storage_store_not_match() {
     assert!(storage.batch_get(ctx.clone(), &[key.clone()], 20).is_err());
     assert!(
         storage
-            .scan(ctx.clone(), key.clone(), 1, false, 20)
+            .scan(ctx.clone(), key.clone(), None, 1, false, 20)
             .is_err()
     );
     assert!(


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR cherry picks #3720 (commit 7ee13c3) to release-2.0 branch.

This may helps fixing a bug that when kv_scan goes out of range, TiKV may panic.

This PR requires merging https://github.com/pingcap/kvproto/pull/315 first.

## What are the type of the changes? (mandatory)

- New feature (non-breaking change which adds functionality)

## How has this PR been tested? (mandatory)

By CI

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

https://github.com/pingcap/kvproto/pull/315
