### PR TITLE
raftstore: avoid large write batch during raft log gc

### DIFF
--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -159,7 +159,7 @@ pub fn conf_change_type_str(conf_type: eraftpb::ConfChangeType) -> &'static str 
 
 // In our tests, we found that if the batch size is too large, running delete_all_in_range will
 // reduce OLTP QPS by 30% ~ 60%. We found that 32K is a proper choice.
-const MAX_DELETE_BATCH_SIZE: usize = 32 * 1024;
+pub const MAX_DELETE_BATCH_SIZE: usize = 32 * 1024;
 
 pub fn delete_all_in_range(
     db: &DB,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Use small write batches during raft log gc to reduce latency.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

- Manual test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

![selection_101](https://user-images.githubusercontent.com/7806468/48529151-d63b8f00-e8cc-11e8-84e3-d742442941cc.jpg)
![selection_100](https://user-images.githubusercontent.com/7806468/48529159-da67ac80-e8cc-11e8-9bec-da1b8642a9f2.jpg)

The left-hand side shows the write latency and write batch size of the master branch.
The right-hand side shows the write latency and write batch size of the branch in this PR.

As you can see, raft log gc will write large batches during heavy write workload, which will cause high write latency. Using small write batches helps to reduce write latency. You may notice that there are still some large write batches at the beginning with this branch, those are written by appending raft logs because of a lot of logs are accumulated during applying snapshot at the very beginning.

## Add a few positive/negative examples (optional)

