### PR TITLE
tests: stable test_delay_split_region

### DIFF
--- a/tests/raftstore_cases/test_split_region.rs
+++ b/tests/raftstore_cases/test_split_region.rs
@@ -290,6 +290,9 @@ fn test_delay_split_region() {
     cluster.cfg.raft_store.raft_log_gc_count_limit = 500;
     cluster.cfg.raft_store.merge_max_log_gap = 100;
     cluster.cfg.raft_store.raft_log_gc_threshold = 500;
+    // To stable the test, we use a large hearbeat timeout 200ms(100ms * 2).
+    // And to elect leader quickly, set election timeout to 1s(100ms * 10).
+    configure_for_lease_read(&mut cluster, Some(100), Some(10));
 
     // We use three nodes for this test.
     cluster.run();
@@ -327,12 +330,12 @@ fn test_delay_split_region() {
     // Split should be bcast eagerly, otherwise following must_put will fail
     // as no leader is available.
     cluster.must_split(&region, k2);
-    cluster.must_put(b"k0", b"v0");
+    cluster.must_put(b"k6", b"v6");
 
     sleep_ms(100);
     // After split, skip bcast is enabled again, so all followers should not
     // commit the log.
-    check_cluster(&mut cluster, b"k0", b"v0", false);
+    check_cluster(&mut cluster, b"k6", b"v6", false);
 }
 
 fn test_split_overlap_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {


### PR DESCRIPTION
## What have you changed? (mandatory)

This PR stables test_delay_split_region. There is a mistake in the test that we should have sent a new request to original region after split, but instead we send a request to new region. The tests fails when followers send heartbeat responses to leader and the responses arrived after leader sent a new appned to followers. They cause leader sends a new append to followers and advances theirs committed index. 

To stable the test, we should use a large hearbeat timeout and use "k6" instead of "k0".

https://github.com/tikv/tikv/blob/7c8ed8fcdbbf91d81b5e7836cbac959b2fb229ec/tests/raftstore_cases/test_split_region.rs#L327-L335

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

Unit tests.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

Close #3669 
