### PR TITLE
Copr: add builtin function "concat_ws"

### DIFF
--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -309,6 +309,7 @@ impl ScalarFunc {
             | ScalarFuncSig::CaseWhenReal
             | ScalarFuncSig::CaseWhenString
             | ScalarFuncSig::Concat
+            | ScalarFuncSig::ConcatWS
             | ScalarFuncSig::CaseWhenTime => (1, usize::MAX),
 
             ScalarFuncSig::JsonExtractSig
@@ -363,7 +364,6 @@ impl ScalarFunc {
             | ScalarFuncSig::AesDecrypt
             | ScalarFuncSig::AesEncrypt
             | ScalarFuncSig::Char
-            | ScalarFuncSig::ConcatWS
             | ScalarFuncSig::ConnectionID
             | ScalarFuncSig::Convert
             | ScalarFuncSig::ConvertTz
@@ -942,6 +942,7 @@ dispatch_call! {
         DayName => day_name,
         Bin => bin,
         Concat => concat,
+        ConcatWS => concat_ws,
         LTrim => ltrim,
         RTrim => rtrim,
         Reverse => reverse,
@@ -1332,6 +1333,7 @@ mod tests {
                     ScalarFuncSig::CaseWhenString,
                     ScalarFuncSig::CaseWhenTime,
                     ScalarFuncSig::Concat,
+                    ScalarFuncSig::ConcatWS,
                 ],
                 1,
                 usize::MAX,
@@ -1416,7 +1418,6 @@ mod tests {
             ScalarFuncSig::AesDecrypt,
             ScalarFuncSig::AesEncrypt,
             ScalarFuncSig::Char,
-            ScalarFuncSig::ConcatWS,
             ScalarFuncSig::ConnectionID,
             ScalarFuncSig::Convert,
             ScalarFuncSig::ConvertTz,


### PR DESCRIPTION
Summarize your change (mandatory)
1 I write a builtin function concat_ws(line 82) in builtin_string.rs.
2 And i change builtin_string.rs and scalar_function.rs
3 I write a test in builtin_string.rs(line 937), it works!
Please NOTE that:
This is the first time i try to become a contributor, so please forgiven me if the change is not perfect.
