### PR TITLE
*: add agg function var_pop

### DIFF
--- a/src/coprocessor/dag/executor/aggregate.rs
+++ b/src/coprocessor/dag/executor/aggregate.rs
@@ -463,7 +463,7 @@ mod tests {
         }
         assert_eq!(aggr.c, 3);
     }
-    
+
     #[test]
     fn test_variance() {
         let mut var = Variance {


### PR DESCRIPTION
## What have you changed? (mandatory)

How to calculate variance, see the algorithm:
```
// Evaluate the variance using the algorithm described by Chan, Golub, and LeVeque in
// "Algorithms for computing the sample variance: analysis and recommendations"
// The American Statistician, 37 (1983) pp. 242--247.
//
// variance = variance1 + variance2 + n/(m*(m+n)) * pow(((m/n)*t1 - t2),2)
//
// where:
// - variance is $$\sum_{k=i}^{j}{(a_k-avg_{ij})^2}$$ (this is actually n times the variance) and is updated at every step.
// - n is the count of elements in chunk1
// - m is the count of elements in chunk2
// - t1 = sum of elements in chunk1,
// - t2 = sum of elements in chunk2.
//
// This algorithm was proven to be numerically stable by J.L. Barlow in
// "Error analysis of a pairwise summation algorithm to compute sample variance"
// Numer. Math, 58 (1991) pp. 583--590
```

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- New feature (non-breaking change which adds functionality)

## How has this PR been tested? (mandatory)

Yes.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

Yes.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

tidb PR: https://github.com/pingcap/tidb/pull/7718
parser PR: https://github.com/pingcap/parser/pull/53
