### PR TITLE
service/kv: Add end_key support for raw_scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#1b5d69cd1d263f9473f7ed2847a7660af394c437"
+source = "git+https://github.com/MyonKeminta/kvproto.git?branch=misono/raw-scan-end-key#77409af083919de4f0bc4a101f58e48e8e55716d"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1531,7 +1531,7 @@ name = "test_coprocessor"
 version = "0.0.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/MyonKeminta/kvproto.git?branch=misono/raw-scan-end-key)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_storage 0.0.1",
  "tikv 3.0.0-alpha",
@@ -1544,7 +1544,7 @@ version = "0.0.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/MyonKeminta/kvproto.git?branch=misono/raw-scan-end-key)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1560,7 +1560,7 @@ name = "test_storage"
 version = "0.0.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/MyonKeminta/kvproto.git?branch=misono/raw-scan-end-key)",
  "test_raftstore 0.0.1",
  "tikv 3.0.0-alpha",
 ]
@@ -1626,7 +1626,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto 0.0.1 (git+https://github.com/MyonKeminta/kvproto.git?branch=misono/raw-scan-end-key)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1992,7 +1992,7 @@ dependencies = [
 "checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
+"checksum kvproto 0.0.1 (git+https://github.com/MyonKeminta/kvproto.git?branch=misono/raw-scan-end-key)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,8 @@ git = "https://github.com/pingcap/murmur3.git"
 git = "https://github.com/pingcap/rust-rocksdb.git"
 
 [dependencies.kvproto]
-git = "https://github.com/pingcap/kvproto.git"
+git = "https://github.com/MyonKeminta/kvproto.git"
+branch = "misono/raw-scan-end-key"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -10,7 +10,8 @@ test_storage = { path = "../test_storage" }
 futures = "0.1"
 
 [dependencies.kvproto]
-git = "https://github.com/pingcap/kvproto.git"
+git = "https://github.com/MyonKeminta/kvproto.git"
+branch = "misono/raw-scan-end-key"
 
 [dependencies.tipb]
 git = "https://github.com/pingcap/tipb.git"

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -15,7 +15,8 @@ rand = "0.3"
 log = "0.3.9"
 
 [dependencies.kvproto]
-git = "https://github.com/pingcap/kvproto.git"
+git = "https://github.com/MyonKeminta/kvproto.git"
+branch = "misono/raw-scan-end-key"
 
 [dependencies.rocksdb]
 git = "https://github.com/pingcap/rust-rocksdb.git"

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -9,4 +9,5 @@ test_raftstore = { path = "../test_raftstore" }
 futures = "0.1"
 
 [dependencies.kvproto]
-git = "https://github.com/pingcap/kvproto.git"
+git = "https://github.com/MyonKeminta/kvproto.git"
+branch = "misono/raw-scan-end-key"

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -568,7 +568,7 @@ impl<E: Engine> AssertionStorage<E> {
     ) {
         let result: Vec<KvPair> = self
             .store
-            .raw_scan(self.ctx.clone(), cf, start_key, limit)
+            .raw_scan(self.ctx.clone(), cf, start_key, None, limit)
             .unwrap()
             .into_iter()
             .map(|x| x.unwrap())

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -216,21 +216,24 @@ impl<E: Engine> SyncTestStorage<E> {
         ctx: Context,
         cf: String,
         start_key: Vec<u8>,
+        end_key: Option<Vec<u8>>,
         limit: usize,
     ) -> Result<Vec<Result<KvPair>>> {
         self.store
-            .async_raw_scan(ctx, cf, start_key, limit, false, false)
+            .async_raw_scan(ctx, cf, start_key, end_key, limit, false, false)
             .wait()
     }
+
     pub fn reverse_raw_scan(
         &self,
         ctx: Context,
         cf: String,
         start_key: Vec<u8>,
+        end_key: Option<Vec<u8>>,
         limit: usize,
     ) -> Result<Vec<Result<KvPair>>> {
         self.store
-            .async_raw_scan(ctx, cf, start_key, limit, false, true)
+            .async_raw_scan(ctx, cf, start_key, end_key, limit, false, true)
             .wait()
     }
 }

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -583,12 +583,19 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
     ) {
         let timer = GRPC_MSG_HISTOGRAM_VEC.raw_scan.start_coarse_timer();
 
+        let end_key = if req.get_end_key().is_empty() {
+            Some(req.take_end_key())
+        } else {
+            None
+        };
+
         let future = self
             .storage
             .async_raw_scan(
                 req.take_context(),
                 req.take_cf(),
                 req.take_start_key(),
+                end_key,
                 req.get_limit() as usize,
                 req.get_key_only(),
                 req.get_reverse(),


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Support end_key limit for raw_scan interface of TiKV.

## What are the type of the changes? (mandatory)

- New feature (non-breaking change which adds functionality)

## How has this PR been tested? (mandatory)

* By unit tests.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
