### PR TITLE
Provide seeded KV generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,7 +1569,7 @@ dependencies = [
 name = "test_util"
 version = "0.0.1"
 dependencies = [
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tikv 3.0.0-alpha",

--- a/benches/misc/mod.rs
+++ b/benches/misc/mod.rs
@@ -41,17 +41,7 @@ mod serialization;
 mod storage;
 mod writebatch;
 
-use test::Bencher;
-
-use test_util::KvGenerator;
-
 #[bench]
 fn _bench_check_requirement(_: &mut test::Bencher) {
     tikv::util::config::check_max_open_fds(4096).unwrap();
-}
-
-#[bench]
-fn bench_kv_iter(b: &mut Bencher) {
-    let mut g = KvGenerator::new(100, 1000);
-    b.iter(|| g.next());
 }

--- a/benches/raftstore/mod.rs
+++ b/benches/raftstore/mod.rs
@@ -82,7 +82,7 @@ where
     F: ClusterFactory<T>,
 {
     let mut cluster = input.factory.build(input.nodes);
-    let mut kvs = generate_random_kvs(DEFAULT_DATA_SIZE, 100, 128);
+    let mut kvs = KvGenerator::new(100, 128).generate(DEFAULT_DATA_SIZE);
     prepare_cluster(&mut cluster, &kvs);
 
     let mut keys = kvs
@@ -109,7 +109,7 @@ where
     F: ClusterFactory<T>,
 {
     let mut cluster = input.factory.build(input.nodes);
-    let mut kvs = generate_random_kvs(DEFAULT_DATA_SIZE, 100, 128);
+    let mut kvs = KvGenerator::new(100, 128).generate(DEFAULT_DATA_SIZE);;
     prepare_cluster(&mut cluster, &kvs);
 
     let mut keys = kvs

--- a/benches/raftstore/mod.rs
+++ b/benches/raftstore/mod.rs
@@ -109,7 +109,7 @@ where
     F: ClusterFactory<T>,
 {
     let mut cluster = input.factory.build(input.nodes);
-    let mut kvs = KvGenerator::new(100, 128).generate(DEFAULT_DATA_SIZE);;
+    let mut kvs = KvGenerator::new(100, 128).generate(DEFAULT_DATA_SIZE);
     prepare_cluster(&mut cluster, &kvs);
 
     let mut keys = kvs

--- a/components/test_util/Cargo.toml
+++ b/components/test_util/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 [dependencies]
 tikv = { path = "../../" }
 time = "0.1"
-rand = "0.3"
+rand = "0.5"
 slog = "2.3"
 slog-scope = "4.0"

--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -11,6 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(test, feature(test))]
+#[cfg(test)]
+extern crate test;
+
 extern crate rand;
 #[macro_use]
 extern crate slog;


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR provides `with_seed` for `KvGenerator` so that it is possible to generate a reproduceable and stable KV pairs. It can eliminate performance jitters in benchmarks.

Extracted from https://github.com/tikv/tikv/pull/3477, also seems to be useful in https://github.com/tikv/tikv/pull/3787.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)
