### PR TITLE
raftstore: fix redundant heartbeat

### DIFF
--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -897,9 +897,12 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
                     // Add this peer to cache and heartbeats.
                     let now = Instant::now();
-                    p.peer_heartbeats.insert(peer.get_id(), now);
+                    let id = peer.get_id();
+                    p.peer_heartbeats.insert(id, now);
                     if p.is_leader() {
-                        p.peers_start_pending_time.push((peer.get_id(), now));
+                        if !p.peers_start_pending_time.iter().any(|&(pid, _)| pid == id) {
+                            p.peers_start_pending_time.push((id, now));
+                        }
                     }
                     p.insert_peer_cache(peer);
                 }

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -905,6 +905,11 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 }
             }
 
+            // In pattern matching above, if the peer is the leader,
+            // it will push the change peer into `peers_start_pending_time`
+            // without checking if it is duplicated. We move `heartbeat_pd` here
+            // to utilize `collect_pending_peers` in `heartbeat_pd` to avoid
+            // adding the redundant peer.
             if p.is_leader() {
                 // Notify pd immediately.
                 info!(


### PR DESCRIPTION
## What have you changed? (mandatory)
This PR fixes the problem which may send redundant heartbeat to PD. If a peer is the leader, it will call `heartbeat_pd`, which will put the pending peer into `peers_start_pending_time`. And if the `ConfChangeType` is `AddLearnerNode`, it will be pushed again. So it might send two heartbeats to PD at the same time. 

## What are the type of the changes? (mandatory)
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)
manual tests