### PR TITLE
util/mpsc: refactor channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -309,13 +309,28 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.2.4"
+name = "crossbeam"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -330,6 +345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,7 +361,7 @@ dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -345,13 +369,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -366,8 +390,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "csv"
@@ -489,7 +516,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -538,7 +565,7 @@ name = "handlebars"
 version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -576,7 +603,7 @@ dependencies = [
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -693,7 +720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -975,7 +1002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
-version = "1.6.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -995,20 +1022,21 @@ version = "0.0.1"
 
 [[package]]
 name = "parking_lot"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.2.13"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1086,7 +1114,7 @@ name = "prometheus-static-metric"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1126,7 +1154,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1183,9 +1211,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1588,7 +1616,7 @@ name = "thread_local"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1607,8 +1635,7 @@ dependencies = [
  "cop_datatype 0.0.1",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-channel 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fail 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1945,12 +1972,14 @@ dependencies = [
 "checksum criterion-plot 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7894b77aa2820337ddf3a6655c24116fb7e53dbdc9735d43a4dec7da5d2c4716"
 "checksum criterion-stats 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "61ee46663c1c4c770b215f6c412fb1e822cfb5122dbc98347dc5789613c69d2b"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
-"checksum crossbeam-channel 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6c0a94250b0278d7fc5a894c3d276b11ea164edc8bf8feb10ca1ea517b44a649"
+"checksum crossbeam 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d1c92ff2d7a202d592f5a412d75cf421495c913817781c1cb383bf12a77e185f"
+"checksum crossbeam-channel 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ac88e108fa40799b39c08eb2a93bedf4cc99a9e5577f08ddf6dd6134ae65bf0"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
+"checksum crossbeam-deque 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fe1b6f945f824c7a25afe44f62e25d714c0cc523f8e99d8db5cd1026e1269d3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
-"checksum crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30fecfcac6abfef8771151f8be4abc9e4edc112c2bcb233314cafde2680536e9"
+"checksum crossbeam-epoch 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2449aaa4ec7ef96e5fb24db16024b935df718e9ae1cec0a1e68feeca2efca7b8"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
-"checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
+"checksum crossbeam-utils 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c55913cc2799171a550e307918c0a360e8c16004820291bf3b638969b4a01816"
 "checksum csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71903184af9960c555e7f3b32ff17390d20ecaaf17d4f18c4a0993f2df8a49e3"
 "checksum csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
@@ -1989,7 +2018,7 @@ dependencies = [
 "checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)" = "<none>"
@@ -2021,10 +2050,10 @@ dependencies = [
 "checksum num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e96f040177bb3da242b5b1ecf3f54b5d5af3efbbfb18608977a5d2767b22f10"
 "checksum num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "51eab148f171aefad295f8cece636fc488b9b392ef544da31ea4b8ef6b9e9c39"
 "checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
-"checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
+"checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
-"checksum parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69376b761943787ebd5cc85a5bc95958651a22609c5c1c2b65de21786baec72b"
-"checksum parking_lot_core 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "538ef00b7317875071d5e00f603f24d16f0b474c1a5fc0ccb8b454ca72eafa79"
+"checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
+"checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
 "checksum parse-zoneinfo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "089a398ccdcdd77b8c38909d5a1e4b67da1bc4c9dbfe6d5b536c828eddb779e5"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
 "checksum pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0fce5d8b5cc33983fc74f78ad552b5522ab41442c4ca91606e4236eb4b5ceefc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,7 @@ fail = "0.2"
 uuid = { version = "0.6", features = [ "serde", "v4" ] }
 grpcio = { version = "0.4", features = [ "secure" ] }
 raft = "0.4"
-crossbeam-channel = "0.2"
-crossbeam = "0.2"
+crossbeam = "0.5"
 fxhash = "0.2"
 derive_more = "0.11.0"
 num = "0.2"

--- a/benches/misc/channel/bench_channel.rs
+++ b/benches/misc/channel/bench_channel.rs
@@ -15,7 +15,7 @@ use std::sync::mpsc::channel;
 use std::thread;
 use test::Bencher;
 
-use crossbeam_channel;
+use crossbeam::channel;
 use mio::{EventLoop, Handler, Sender};
 use tikv::util::mpsc;
 
@@ -123,7 +123,7 @@ fn bench_util_channel(b: &mut Bencher) {
 
 #[bench]
 fn bench_util_loose(b: &mut Bencher) {
-    let (mut tx, rx) = mpsc::loose_bounded(480000);
+    let (tx, rx) = mpsc::loose_bounded(480000);
 
     let t = thread::spawn(move || {
         let mut n2: usize = 0;
@@ -150,7 +150,7 @@ fn bench_util_loose(b: &mut Bencher) {
 
 #[bench]
 fn bench_crossbeam_channel(b: &mut Bencher) {
-    let (tx, rx) = crossbeam_channel::unbounded();
+    let (tx, rx) = channel::unbounded();
 
     let t = thread::spawn(move || {
         let mut n2: usize = 0;
@@ -166,10 +166,10 @@ fn bench_crossbeam_channel(b: &mut Bencher) {
     let mut n1 = 0;
     b.iter(|| {
         n1 += 1;
-        tx.send(1)
+        tx.send(1).unwrap();
     });
 
-    tx.send(0);
+    tx.send(0).unwrap();
     let n2 = t.join().unwrap();
     assert_eq!(n1, n2);
 }

--- a/benches/misc/mod.rs
+++ b/benches/misc/mod.rs
@@ -15,7 +15,7 @@
 
 extern crate arrow;
 extern crate byteorder;
-extern crate crossbeam_channel;
+extern crate crossbeam;
 extern crate kvproto;
 extern crate log;
 extern crate mio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,6 @@ extern crate chrono;
 extern crate chrono_tz;
 extern crate crc;
 extern crate crossbeam;
-#[macro_use]
-extern crate crossbeam_channel;
 extern crate crypto;
 #[macro_use]
 extern crate fail;

--- a/src/util/mpsc.rs
+++ b/src/util/mpsc.rs
@@ -118,13 +118,7 @@ impl<T> Sender<T> {
     #[inline]
     pub fn try_send(&self, t: T) -> Result<(), TrySendError<T>> {
         if self.state.is_half_closed() {
-            channel::select! {
-                send(self.sender, t) -> res => match res {
-                    Ok(()) => Ok(()),
-                    Err(SendError(t)) => Err(TrySendError::Disconnected(t)),
-                },
-                default => Err(TrySendError::Full(t)),
-            }
+            self.sender.try_send(t)
         } else {
             Err(TrySendError::Disconnected(t))
         }

--- a/src/util/mpsc.rs
+++ b/src/util/mpsc.rs
@@ -19,47 +19,46 @@ supports closed detection and try operations.
 
 */
 
-#![cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
-
-use crossbeam::sync::AtomicOption;
-use crossbeam_channel;
-use futures::task::{self, Task};
-use futures::{Async, Poll, Stream};
-use std::sync::atomic::{AtomicIsize, Ordering};
-use std::sync::mpsc::{RecvError, RecvTimeoutError, SendError, TryRecvError, TrySendError};
+use crossbeam::channel::{
+    self, RecvError, RecvTimeoutError, SendError, TryRecvError, TrySendError,
+};
+use std::cell::Cell;
+use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 struct State {
     sender_cnt: AtomicIsize,
-    receiver_cnt: AtomicIsize,
-    // Because we don't support sending messages asychrounously, so
-    // only recv_task needs to be kept.
-    recv_task: AtomicOption<Task>,
+    connected: AtomicBool,
 }
 
 impl State {
     fn new() -> State {
         State {
             sender_cnt: AtomicIsize::new(1),
-            receiver_cnt: AtomicIsize::new(1),
-            recv_task: AtomicOption::new(),
+            connected: AtomicBool::new(true),
         }
     }
 
     #[inline]
-    fn is_receiver_closed(&self) -> bool {
-        self.receiver_cnt.load(Ordering::Acquire) == 0
-    }
-
-    #[inline]
-    fn is_sender_closed(&self) -> bool {
-        self.sender_cnt.load(Ordering::Acquire) == 0
+    fn is_half_closed(&self) -> bool {
+        self.connected.load(Ordering::Acquire)
     }
 }
 
+/// A sender that can be half closed.
+///
+/// Half closed means that sender can no longer send out any messages after closing.
+/// However, receiver may still block at receiving.
+///
+/// Note that for a channel, there should be no such concept as half closed.
+/// However, to fully implement a close mechanism, like waking up waiting
+/// receivers, requires a cost of performance. And the mechanism is unnecessary
+/// for current usage.
+///
+/// TODO: Remove half closed when crossbeam-rs/crossbeam#236 is resolved.
 pub struct Sender<T> {
-    sender: crossbeam_channel::Sender<T>,
+    sender: channel::Sender<T>,
     state: Arc<State>,
 }
 
@@ -77,97 +76,121 @@ impl<T> Clone for Sender<T> {
 impl<T> Drop for Sender<T> {
     #[inline]
     fn drop(&mut self) {
-        self.state.sender_cnt.fetch_add(-1, Ordering::AcqRel);
-        if self.state.is_sender_closed() {
-            self.notify();
+        let res = self.state.sender_cnt.fetch_add(-1, Ordering::AcqRel);
+        if res == 1 {
+            self.half_close();
         }
     }
 }
 
+/// The receive end of a channel.
 pub struct Receiver<T> {
-    receiver: crossbeam_channel::Receiver<T>,
+    receiver: channel::Receiver<T>,
     state: Arc<State>,
 }
 
 impl<T> Sender<T> {
+    /// Returns the number of messages in the channel.
     #[inline]
-    fn notify(&self) {
-        let task = self.state.recv_task.take(Ordering::AcqRel);
-        if let Some(t) = task {
-            t.notify();
-        }
+    pub fn len(&self) -> usize {
+        self.sender.len()
     }
 
+    /// Returns true if the channel is empty.
+    ///
+    /// Note: Zero-capacity channels are always empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.sender.is_empty()
+    }
+
+    /// Blocks the current thread until a message is sent or the channel is disconnected.
     #[inline]
     pub fn send(&self, t: T) -> Result<(), SendError<T>> {
-        if !self.state.is_receiver_closed() {
-            self.sender.send(t);
-            self.notify();
-            return Ok(());
+        if self.state.is_half_closed() {
+            self.sender.send(t)
+        } else {
+            Err(SendError(t))
         }
-        Err(SendError(t))
     }
 
+    /// Attempts to send a message into the channel without blocking.
     #[inline]
     pub fn try_send(&self, t: T) -> Result<(), TrySendError<T>> {
-        if !self.state.is_receiver_closed() {
-            crossbeam_channel::select! {
-                send(self.sender, t) => {},
-                default => return Err(TrySendError::Full(t)),
+        if self.state.is_half_closed() {
+            channel::select! {
+                send(self.sender, t) -> res => match res {
+                    Ok(()) => Ok(()),
+                    Err(SendError(t)) => Err(TrySendError::Disconnected(t)),
+                },
+                default => Err(TrySendError::Full(t)),
             }
-            self.notify();
-            Ok(())
         } else {
             Err(TrySendError::Disconnected(t))
         }
     }
+
+    /// Stop the sender from sending any further messages.
+    #[inline]
+    pub fn half_close(&self) {
+        self.state.connected.store(false, Ordering::Release);
+    }
+
+    /// Check if the sender is half closed.
+    #[inline]
+    pub fn is_half_closed(&self) -> bool {
+        self.state.is_half_closed()
+    }
 }
 
 impl<T> Receiver<T> {
+    /// Returns the number of messages in the channel.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.receiver.len()
+    }
+
+    /// Returns true if the channel is empty.
+    ///
+    /// Note: Zero-capacity channels are always empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.receiver.is_empty()
+    }
+
+    /// Blocks the current thread until a message is received or
+    /// the channel is empty and disconnected.
     #[inline]
     pub fn recv(&self) -> Result<T, RecvError> {
-        match self.receiver.recv() {
-            Some(t) => Ok(t),
-            None => Err(RecvError),
-        }
+        self.receiver.recv()
     }
 
+    /// Attempts to receive a message from the channel without blocking.
     #[inline]
     pub fn try_recv(&self) -> Result<T, TryRecvError> {
-        match self.receiver.try_recv() {
-            Some(t) => Ok(t),
-            None => {
-                if !self.state.is_sender_closed() {
-                    return Err(TryRecvError::Empty);
-                }
-                self.receiver.try_recv().ok_or(TryRecvError::Disconnected)
-            }
-        }
+        self.receiver.try_recv()
     }
 
+    /// Waits for a message to be received from the channel,
+    /// but only for a limited time.
     #[inline]
     pub fn recv_timeout(&self, timeout: Duration) -> Result<T, RecvTimeoutError> {
-        crossbeam_channel::select! {
-            recv(self.receiver, task) => match task {
-                Some(t) => Ok(t),
-                None => Err(RecvTimeoutError::Disconnected),
-            }
-            recv(crossbeam_channel::after(timeout)) => Err(RecvTimeoutError::Timeout),
-        }
+        self.receiver.recv_timeout(timeout)
     }
 }
 
 impl<T> Drop for Receiver<T> {
     #[inline]
     fn drop(&mut self) {
-        self.state.receiver_cnt.fetch_add(-1, Ordering::AcqRel);
+        self.state.connected.store(false, Ordering::Release);
     }
 }
 
+/// Create an unbounded channel.
 #[inline]
 pub fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
     let state = Arc::new(State::new());
-    let (sender, receiver) = crossbeam_channel::unbounded();
+    let (sender, receiver) = channel::unbounded();
     (
         Sender {
             sender,
@@ -177,10 +200,11 @@ pub fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
     )
 }
 
+/// Create a bounded channel.
 #[inline]
 pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
     let state = Arc::new(State::new());
-    let (sender, receiver) = crossbeam_channel::bounded(cap);
+    let (sender, receiver) = channel::bounded(cap);
     (
         Sender {
             sender,
@@ -188,27 +212,6 @@ pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
         },
         Receiver { receiver, state },
     )
-}
-
-impl<T> Stream for Receiver<T> {
-    type Error = ();
-    type Item = T;
-
-    fn poll(&mut self) -> Poll<Option<T>, ()> {
-        match self.try_recv() {
-            Ok(m) => Ok(Async::Ready(Some(m))),
-            Err(TryRecvError::Empty) => {
-                let t = self.state.recv_task.swap(task::current(), Ordering::AcqRel);
-                if t.is_some() {
-                    return Ok(Async::NotReady);
-                }
-                // Note: If there is a message or all the senders are dropped after
-                // polling but before task is set, `t` should be None.
-                self.poll()
-            }
-            Err(TryRecvError::Disconnected) => Ok(Async::Ready(None)),
-        }
-    }
 }
 
 const CHECK_INTERVAL: usize = 8;
@@ -216,30 +219,61 @@ const CHECK_INTERVAL: usize = 8;
 /// A sender of channel that limits the maximun pending messages count loosely.
 pub struct LooseBoundedSender<T> {
     sender: Sender<T>,
-    tried_cnt: usize,
+    tried_cnt: Cell<usize>,
     limit: usize,
 }
 
 impl<T> LooseBoundedSender<T> {
+    /// Returns the number of messages in the channel.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.sender.len()
+    }
+
+    /// Returns true if the channel is empty.
+    ///
+    /// Note: Zero-capacity channels are always empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.sender.is_empty()
+    }
+
     /// Send a message regardless its capacity limit.
     #[inline]
-    pub fn force_send(&mut self, t: T) -> Result<(), SendError<T>> {
-        self.tried_cnt += 1;
+    pub fn force_send(&self, t: T) -> Result<(), SendError<T>> {
+        let cnt = self.tried_cnt.get();
+        self.tried_cnt.set(cnt + 1);
         self.sender.send(t)
     }
 
+    /// Attempts to send a message into the channel without blocking.
     #[inline]
-    pub fn try_send(&mut self, t: T) -> Result<(), TrySendError<T>> {
-        if self.tried_cnt < CHECK_INTERVAL {
-            self.force_send(t)
-                .map_err(|SendError(t)| TrySendError::Disconnected(t))
-        } else if self.sender.sender.len() < self.limit {
-            self.tried_cnt = 0;
-            self.force_send(t)
-                .map_err(|SendError(t)| TrySendError::Disconnected(t))
+    pub fn try_send(&self, t: T) -> Result<(), TrySendError<T>> {
+        let cnt = self.tried_cnt.get();
+        if cnt < CHECK_INTERVAL {
+            self.tried_cnt.set(cnt + 1);
+        } else if self.len() < self.limit {
+            self.tried_cnt.set(1);
         } else {
-            Err(TrySendError::Full(t))
+            return Err(TrySendError::Full(t));
         }
+
+        match self.sender.send(t) {
+            Ok(()) => Ok(()),
+            Err(SendError(t)) => Err(TrySendError::Disconnected(t)),
+        }
+    }
+
+    /// Stop the sender from sending any further messages.
+    #[inline]
+    pub fn half_close(&self) {
+        self.sender.half_close();
+    }
+
+    /// Check if the sender is half closed.
+    #[inline]
+    pub fn is_half_closed(&self) -> bool {
+        self.sender.state.is_half_closed()
     }
 }
 
@@ -248,18 +282,19 @@ impl<T> Clone for LooseBoundedSender<T> {
     fn clone(&self) -> LooseBoundedSender<T> {
         LooseBoundedSender {
             sender: self.sender.clone(),
-            tried_cnt: self.tried_cnt,
+            tried_cnt: self.tried_cnt.clone(),
             limit: self.limit,
         }
     }
 }
 
+/// Create a loosely bounded channel with the given capacity.
 pub fn loose_bounded<T>(cap: usize) -> (LooseBoundedSender<T>, Receiver<T>) {
     let (sender, receiver) = unbounded();
     (
         LooseBoundedSender {
             sender,
-            tried_cnt: 0,
+            tried_cnt: Cell::new(0),
             limit: cap,
         },
         receiver,
@@ -268,9 +303,7 @@ pub fn loose_bounded<T>(cap: usize) -> (LooseBoundedSender<T>, Receiver<T>) {
 
 #[cfg(test)]
 mod tests {
-    use futures::sync::mpsc;
-    use futures::{Future, Sink, Stream};
-    use std::sync::mpsc::*;
+    use crossbeam::channel::*;
     use std::thread;
     use std::time::*;
 
@@ -299,6 +332,7 @@ mod tests {
         drop(rx);
         assert_eq!(tx.send(2), Err(SendError(2)));
         assert_eq!(tx.try_send(2), Err(TrySendError::Disconnected(2)));
+        assert!(!tx.is_half_closed());
 
         let (tx, rx) = super::bounded::<u64>(10);
         tx.send(2).unwrap();
@@ -312,6 +346,25 @@ mod tests {
             rx.recv_timeout(Duration::from_millis(100)),
             Err(RecvTimeoutError::Disconnected)
         );
+
+        let (tx, rx) = super::bounded::<u64>(10);
+        assert!(tx.is_empty());
+        assert!(tx.is_half_closed());
+        assert_eq!(tx.len(), 0);
+        assert!(rx.is_empty());
+        assert_eq!(rx.len(), 0);
+        tx.send(2).unwrap();
+        tx.send(3).unwrap();
+        assert_eq!(tx.len(), 2);
+        assert_eq!(rx.len(), 2);
+        tx.half_close();
+        assert_eq!(tx.send(3), Err(SendError(3)));
+        assert_eq!(tx.try_send(3), Err(TrySendError::Disconnected(3)));
+        assert!(!tx.is_half_closed());
+        assert_eq!(rx.try_recv(), Ok(2));
+        assert_eq!(rx.recv(), Ok(3));
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+        // assert_eq!(rx.recv(), Err(RecvError));
 
         let (tx1, rx1) = super::bounded::<u64>(10);
         let (tx2, rx2) = super::bounded::<u64>(0);
@@ -351,6 +404,7 @@ mod tests {
         drop(rx);
         assert_eq!(tx.send(2), Err(SendError(2)));
         assert_eq!(tx.try_send(2), Err(TrySendError::Disconnected(2)));
+        assert!(!tx.is_half_closed());
 
         let (tx, rx) = super::unbounded::<u64>();
         drop(tx);
@@ -370,42 +424,30 @@ mod tests {
         assert_eq!(rx.recv(), Ok(10));
         let elapsed = timer.elapsed();
         assert!(elapsed >= Duration::from_millis(100), "{:?}", elapsed);
-    }
 
-    #[test]
-    fn test_notify() {
-        let (tx1, rx1) = super::unbounded();
-        let (tx2, rx2) = mpsc::unbounded();
-        let mut rx2 = rx2.wait();
-        let j = thread::spawn(move || {
-            rx1.map_err(|_| ())
-                .forward(tx2.sink_map_err(|_| ()))
-                .wait()
-                .unwrap();
-        });
-        tx1.send(2).unwrap();
-        assert_eq!(rx2.next().unwrap(), Ok(2));
-        for i in 0..100 {
-            tx1.send(i).unwrap();
-        }
-        for i in 0..100 {
-            assert_eq!(rx2.next().unwrap(), Ok(i));
-        }
-        thread::spawn(move || {
-            for i in 100..10000 {
-                tx1.send(i).unwrap();
-            }
-        });
-        for i in 100..10000 {
-            assert_eq!(rx2.next().unwrap(), Ok(i));
-        }
-        // j should automatically stop when tx1 is dropped.
-        j.join().unwrap();
+        let (tx, rx) = super::unbounded::<u64>();
+        assert!(tx.is_empty());
+        assert!(tx.is_half_closed());
+        assert_eq!(tx.len(), 0);
+        assert!(rx.is_empty());
+        assert_eq!(rx.len(), 0);
+        tx.send(2).unwrap();
+        tx.send(3).unwrap();
+        assert_eq!(tx.len(), 2);
+        assert_eq!(rx.len(), 2);
+        tx.half_close();
+        assert_eq!(tx.send(3), Err(SendError(3)));
+        assert_eq!(tx.try_send(3), Err(TrySendError::Disconnected(3)));
+        assert!(!tx.is_half_closed());
+        assert_eq!(rx.try_recv(), Ok(2));
+        assert_eq!(rx.recv(), Ok(3));
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+        // assert_eq!(rx.recv(), Err(RecvError));
     }
 
     #[test]
     fn test_loose() {
-        let (mut tx, rx) = super::loose_bounded(10);
+        let (tx, rx) = super::loose_bounded(10);
         tx.try_send(1).unwrap();
         for i in 2..11 {
             tx.clone().try_send(i).unwrap();
@@ -442,7 +484,7 @@ mod tests {
             assert_eq!(tx.try_send(2), Err(TrySendError::Disconnected(2)));
         }
 
-        let (mut tx, rx) = super::loose_bounded(10);
+        let (tx, rx) = super::loose_bounded(10);
         tx.try_send(2).unwrap();
         drop(tx);
         assert_eq!(rx.recv(), Ok(2));
@@ -453,7 +495,7 @@ mod tests {
             Err(RecvTimeoutError::Disconnected)
         );
 
-        let (mut tx, rx) = super::loose_bounded(10);
+        let (tx, rx) = super::loose_bounded(10);
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(100));
             tx.try_send(10).unwrap();

--- a/src/util/worker/mod.rs
+++ b/src/util/worker/mod.rs
@@ -28,11 +28,11 @@ Briefly speaking, this is a mpsc (multiple-producer-single-consumer) model.
 mod future;
 mod metrics;
 
+use crossbeam::channel::{RecvTimeoutError, TryRecvError, TrySendError};
 use prometheus::IntGauge;
 use std::error::Error;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::mpsc::{RecvTimeoutError, TryRecvError, TrySendError};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, Builder as ThreadBuilder, JoinHandle};
 use std::time::Duration;


### PR DESCRIPTION
- remove future support to make performance better
- add half close support
- add several useful APIs

Previous:

```
test channel::bench_channel::bench_crossbeam_channel                  ... bench:          24 ns/iter (+/- 0)
test channel::bench_channel::bench_util_channel                       ... bench:          75 ns/iter (+/- 1)
test channel::bench_channel::bench_util_loose                         ... bench:          90 ns/iter (+/- 5)
```

After:

```
test channel::bench_channel::bench_crossbeam_channel                  ... bench:          27 ns/iter (+/- 0)
test channel::bench_channel::bench_util_channel                       ... bench:          27 ns/iter (+/- 0)
test channel::bench_channel::bench_util_loose                         ... bench:          76 ns/iter (+/- 1)


```