### PR TITLE
apply: Make DeleteRange safe again

### DIFF
--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -1762,16 +1762,8 @@ impl ApplyDelegate {
             });
 
         // Delete all remaining keys.
-        // If it's not CF_LOCK and use_delete_range is false, skip this step to speed up (#3034)
-        // TODO: Remove the `if` line after apply pool is implemented
-        if cf == CF_LOCK || use_delete_range {
-            util::delete_all_in_range_cf(
-                &self.engines.kv,
-                cf,
-                &start_key,
-                &end_key,
-                use_delete_range,
-            ).unwrap_or_else(|e| {
+        util::delete_all_in_range_cf(&self.engines.kv, cf, &start_key, &end_key, use_delete_range)
+            .unwrap_or_else(|e| {
                 panic!(
                     "{} failed to delete all in range [{}, {}), cf: {}, err: {:?}",
                     self.tag,
@@ -1781,7 +1773,6 @@ impl ApplyDelegate {
                     e
                 );
             });
-        }
 
         ranges.push(Range::new(cf.to_owned(), start_key, end_key));
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -476,7 +476,6 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         ctx.spawn(future);
     }
 
-    // WARNING: Currently this API may leave some dirty keys in TiKV. Be careful using this API.
     fn kv_delete_range(
         &mut self,
         ctx: RpcContext,

--- a/tests/integrations/raftstore/test_single.rs
+++ b/tests/integrations/raftstore/test_single.rs
@@ -63,7 +63,7 @@ fn test_delete<T: Simulator>(cluster: &mut Cluster<T>) {
 fn test_delete_range<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.run();
 
-    let cf = "lock";
+    let cf = "default";
 
     for i in 1..1000 {
         let (k, v) = (format!("key{}", i), format!("value{}", i));


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR makes the kv delete range request safe again.
Previously, we skipped scanning and deleting remaining keys after delete_files_in_range to speedup delete_range as a workaround solution (#3046 ). Now we use unsafe_destroy_range instead, which is much faster, so the delete_range interface is not used by TiDB. I think it might be ok to make it safe again.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

By CI

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

