### PR TITLE
*: replace FxHashMap with Hashbrown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,7 +1136,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1615,8 +1625,8 @@ dependencies = [
  "fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
@@ -1972,6 +1982,7 @@ dependencies = [
 "checksum grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ceb617aadae035882ff0e96fc312e4c7f65abc26aad9336f1e5d199d588a702"
 "checksum grpcio-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c01243bb555ae2ba819d428cffb7e93575ae047cf033f6242959a8a9ecc51ef6"
 "checksum handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d89ec99d1594f285d4590fc32bac5f75cdab383f1123d504d27862c644a807dd"
+"checksum hashbrown 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "64b7d419d0622ae02fe5da6b9a5e1964b610a65bb37923b976aeebb6dbb8f86e"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2da7d3a34cf6406d9d700111b8eafafe9a251de41ae71d8052748259343b58"
 "checksum httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46534074dbb80b070d60a5cb8ecadd8963a00a438ae1a95268850a7ef73b67ae"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ name = "misc"
 path = "benches/misc/mod.rs"
 
 [dependencies]
+hashbrown = {version = "0.1", features = ["serde"]}
 log = { version = "0.3", features = ["release_max_level_debug"] }
 slog = "2.3"
 slog-async = "2.3"
@@ -90,7 +91,6 @@ grpcio = { version = "0.4", features = [ "secure" ] }
 raft = "0.4"
 crossbeam-channel = "0.2"
 crossbeam = "0.2"
-fxhash = "0.2"
 derive_more = "0.11.0"
 num = "0.2"
 num-traits = "0.2"

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::hash_map::Entry;
 use std::collections::BTreeMap;
 use std::collections::Bound::{Excluded, Unbounded};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -30,7 +29,7 @@ use raft::eraftpb;
 use tikv::pd::{Error, Key, PdClient, PdFuture, RegionStat, Result};
 use tikv::raftstore::store::keys::{self, data_key, enc_end_key, enc_start_key};
 use tikv::raftstore::store::util::check_key_in_region;
-use tikv::util::collections::{HashMap, HashSet};
+use tikv::util::collections::{HashMap, HashMapEntry, HashSet};
 use tikv::util::timer::GLOBAL_TIMER_HANDLE;
 use tikv::util::{escape, Either, HandyRwLock};
 
@@ -679,7 +678,7 @@ impl TestPdClient {
     fn schedule_operator(&self, region_id: u64, op: Operator) {
         let mut cluster = self.cluster.wl();
         match cluster.operators.entry(region_id) {
-            Entry::Occupied(mut e) => {
+            HashMapEntry::Occupied(mut e) => {
                 debug!(
                     "[region {}] schedule operator {:?} and remove {:?}",
                     region_id,
@@ -688,7 +687,7 @@ impl TestPdClient {
                 );
                 e.insert(op);
             }
-            Entry::Vacant(e) => {
+            HashMapEntry::Vacant(e) => {
                 debug!("[region {}] schedule operator {:?}", region_id, op);
                 e.insert(op);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,8 @@ extern crate fs2;
 #[macro_use]
 extern crate futures;
 extern crate futures_cpupool;
-extern crate fxhash;
 extern crate grpcio as grpc;
+extern crate hashbrown;
 extern crate hex;
 extern crate indexmap;
 extern crate kvproto;

--- a/src/util/collections.rs
+++ b/src/util/collections.rs
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use fxhash::FxHashMap as HashMap;
-pub use fxhash::FxHashSet as HashSet;
-pub use std::collections::hash_map::Entry as HashMapEntry;
+pub type HashMap<K, V> = ::hashbrown::HashMap<K, V, ::hashbrown::hash_map::DefaultHashBuilder>;
+pub type HashSet<T> = ::hashbrown::HashSet<T, ::hashbrown::hash_map::DefaultHashBuilder>;
+pub use hashbrown::hash_map::Entry as HashMapEntry;
 
 pub use indexmap::map::Entry as OrderMapEntry;
 pub use indexmap::IndexMap as OrderMap;


### PR DESCRIPTION
Signed-off-by: Max <xiahaijiao@hotmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
According to [hashbrow](https://github.com/Amanieu/hashbrown)'s own description, it around 2x faster than FxHashMap and 8x faster than the standard HashMap. 
Actually, after replacing FxHashMap with it, we get a 0.1% ~ 5% faster TiKV.

## What are the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)


## How has this PR been tested? (mandatory)

unit test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Benchmark result if necessary (optional)

YCSB test:
```
hashbrown: tikv.type = txn, thread count = 64
INSERT - Takes(s): 495.8, Count: 10000000, OPS: 20169.9, Avg(us): 3117, Min(us): 819, Max(us): 69614, 95th(us): 5000, 99th(us): 18000
hashmap: tikv.type = txn, thread count = 64
INSERT - Takes(s): 496.7, Count: 9999983, OPS: 20133.9, Avg(us): 3124, Min(us): 782, Max(us): 62549, 95th(us): 5000, 99th(us): 18000

hashbrown: tikv.type = txn, thread count = 256
INSERT - Takes(s): 363.8, Count: 9999872, OPS: 27484.0, Avg(us): 9239, Min(us): 771, Max(us): 523468, 95th(us): 21000, 99th(us): 40000
hashmap: tikv.type = txn, thread count = 256
INSERT - Takes(s): 374.0, Count: 9999872, OPS: 26738.4, Avg(us): 9501, Min(us): 816, Max(us): 509826, 95th(us): 21000, 99th(us): 40000

hashbrown: tikv.type = coprocessor, thread count = 256
READ - Takes(s): 128.0, Count: 4997837, OPS: 39032.4, Avg(us): 3256, Min(us): 168, Max(us): 21918, 95th(us): 10000, 99th(us): 13000
SCAN - Takes(s): 128.0, Count: 5002033, OPS: 39065.1, Avg(us): 3269, Min(us): 174, Max(us): 21542, 95th(us): 10000, 99th(us): 13000
hashmap: tikv.type = coprocessor, thread count = 256
READ - Takes(s): 136.3, Count: 4997475, OPS: 36670.0, Avg(us): 3465, Min(us): 156, Max(us): 26466, 95th(us): 11000, 99th(us): 14000
SCAN - Takes(s): 136.3, Count: 5002397, OPS: 36706.1, Avg(us): 3477, Min(us): 176, Max(us): 27311, 95th(us): 11000, 99th(us): 14000

```
hashbrown: bench coprocessor_executors 
```
table_scan_primary_key  time:   [3.9244 us 4.1098 us 4.2934 us]
table_scan_datum_front  time:   [3.2248 us 3.3881 us 3.5500 us]
table_scan_datum_multi_front
                        time:   [3.1052 us 3.2606 us 3.4218 us]
table_scan_long_datum_front
                        time:   [6.7027 us 6.8680 us 7.0394 us]
table_scan_datum_multi_front
                        time:   [3.4057 us 3.5340 us 3.6657 us]
table_scan_datum_end    time:   [11.266 us 11.516 us 11.770 us]
table_scan_datum_all    time:   [13.645 us 13.973 us 14.331 us]
table_scan_datum_absent time:   [3.8640 us 4.0111 us 4.1564 us]
table_scan_datum_absent_large_row
                        time:   [11.039 us 11.327 us 11.633 us]
table_scan_point_range  time:   [3.5550 us 3.6698 us 3.7875 us]
table_scan_multi_point_range
                        time:   [1.0680 ms 1.1084 ms 1.1501 ms]
```

hashmap: bench coprocessor_executors 
```
table_scan_primary_key  time:   [3.9903 us 4.1838 us 4.3751 us]
table_scan_datum_front  time:   [3.5119 us 3.6384 us 3.7685 us]
table_scan_datum_multi_front
                        time:   [3.2485 us 3.3864 us 3.5255 us]
table_scan_long_datum_front
                        time:   [6.9669 us 7.2070 us 7.4425 us]
table_scan_datum_multi_front
                        time:   [3.6411 us 3.7748 us 3.9055 us]
table_scan_datum_end    time:   [11.143 us 11.377 us 11.620 us]
table_scan_datum_all    time:   [13.625 us 13.984 us 14.343 us]
table_scan_datum_absent time:   [4.1761 us 4.3115 us 4.4479 us]
table_scan_datum_absent_large_row
                        time:   [11.220 us 11.467 us 11.744 us]
table_scan_point_range  time:   [3.7014 us 3.8362 us 3.9800 us]
table_scan_multi_point_range
                        time:   [1.0570 ms 1.0858 ms 1.1146 ms]
```
