### PR TITLE
Remove unnecessary &mut in Coprocessor

### DIFF
--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -35,13 +35,13 @@ struct AggFuncExpr {
 }
 
 impl AggFuncExpr {
-    fn batch_build(ctx: &mut EvalContext, expr: Vec<Expr>) -> Result<Vec<AggFuncExpr>> {
+    fn batch_build(ctx: &EvalContext, expr: Vec<Expr>) -> Result<Vec<AggFuncExpr>> {
         expr.into_iter()
             .map(|v| AggFuncExpr::build(ctx, v))
             .collect()
     }
 
-    fn build(ctx: &mut EvalContext, mut expr: Expr) -> Result<AggFuncExpr> {
+    fn build(ctx: &EvalContext, mut expr: Expr) -> Result<AggFuncExpr> {
         let args = Expression::batch_build(ctx, expr.take_children().into_vec())?;
         let tp = expr.get_tp();
         let eval_buffer = Vec::with_capacity(args.len());
@@ -95,10 +95,10 @@ impl AggExecutor {
         let mut visitor = ExprColumnRefVisitor::new(src.get_len_of_columns());
         visitor.batch_visit(&group_by)?;
         visitor.batch_visit(&aggr_func)?;
-        let mut ctx = EvalContext::new(eval_config);
+        let ctx = EvalContext::new(eval_config);
         Ok(AggExecutor {
-            group_by: Expression::batch_build(&mut ctx, group_by)?,
-            aggr_func: AggFuncExpr::batch_build(&mut ctx, aggr_func)?,
+            group_by: Expression::batch_build(&ctx, group_by)?,
+            aggr_func: AggFuncExpr::batch_build(&ctx, aggr_func)?,
             executed: false,
             ctx,
             related_cols_offset: visitor.column_offsets(),

--- a/src/coprocessor/dag/executor/selection.rs
+++ b/src/coprocessor/dag/executor/selection.rs
@@ -37,9 +37,9 @@ impl SelectionExecutor {
         let conditions = meta.take_conditions().into_vec();
         let mut visitor = ExprColumnRefVisitor::new(src.get_len_of_columns());
         visitor.batch_visit(&conditions)?;
-        let mut ctx = EvalContext::new(eval_cfg);
+        let ctx = EvalContext::new(eval_cfg);
         Ok(SelectionExecutor {
-            conditions: Expression::batch_build(&mut ctx, conditions)?,
+            conditions: Expression::batch_build(&ctx, conditions)?,
             related_cols_offset: visitor.column_offsets(),
             ctx,
             src,

--- a/src/coprocessor/dag/expr/builtin_arithmetic.rs
+++ b/src/coprocessor/dag/expr/builtin_arithmetic.rs
@@ -582,7 +582,7 @@ mod tests {
                 .contains(FieldTypeFlag::UNSIGNED);
             let unsigned = lus | rus;
 
-            let mut op = Expression::build(&mut ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();
+            let mut op = Expression::build(&ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();
             if unsigned {
                 // According to TiDB, the result is unsigned if any of arguments is unsigned.
                 op.mut_field_type()
@@ -688,7 +688,7 @@ mod tests {
             let lhs = datum_expr(tt.1);
             let rhs = datum_expr(tt.2);
 
-            let op = Expression::build(&mut ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();
+            let op = Expression::build(&ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, tt.3);
         }
@@ -913,7 +913,7 @@ mod tests {
             let lhs = datum_expr(tt.1);
             let rhs = datum_expr(tt.2);
 
-            let op = Expression::build(&mut ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();
+            let op = Expression::build(&ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, tt.3);
         }
@@ -996,7 +996,7 @@ mod tests {
                 .contains(FieldTypeFlag::UNSIGNED);
             let unsigned = lus | rus;
 
-            let mut op = Expression::build(&mut ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();
+            let mut op = Expression::build(&ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();
             if unsigned {
                 // According to TiDB, the result is unsigned if any of arguments is unsigned.
                 op.mut_field_type()
@@ -1032,7 +1032,7 @@ mod tests {
             let rhs = datum_expr(right);
 
             let mut op = Expression::build(
-                &mut ctx,
+                &ctx,
                 scalar_func_expr(ScalarFuncSig::MultiplyIntUnsigned, &[lhs, rhs]),
             ).unwrap();
             op.mut_field_type()
@@ -1055,7 +1055,7 @@ mod tests {
             let rhs = datum_expr(right);
 
             let mut op = Expression::build(
-                &mut ctx,
+                &ctx,
                 scalar_func_expr(ScalarFuncSig::MultiplyIntUnsigned, &[lhs, rhs]),
             ).unwrap();
             op.mut_field_type()
@@ -1096,7 +1096,7 @@ mod tests {
             let lhs = datum_expr(tt.1);
             let rhs = datum_expr(tt.2);
 
-            let op = Expression::build(&mut ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();
+            let op = Expression::build(&ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap_err();
             assert!(check_overflow(got).is_ok());
         }
@@ -1156,7 +1156,7 @@ mod tests {
                     .set_sql_mode(*sql_mode)
                     .set_strict_sql_mode(*strict_sql_mode);
                 let mut ctx = EvalContext::new(::std::sync::Arc::new(cfg));
-                let op = Expression::build(&mut ctx, scalar_func.clone()).unwrap();
+                let op = Expression::build(&ctx, scalar_func.clone()).unwrap();
                 let got = op.eval(&mut ctx, &[]);
                 if *is_ok {
                     assert_eq!(got.unwrap(), Datum::Null);

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -840,7 +840,7 @@ mod tests {
                     .as_mut_accessor()
                     .set_flag(flag.unwrap());
             }
-            let e = Expression::build(&mut ctx, exp).unwrap();
+            let e = Expression::build(&ctx, exp).unwrap();
             let res = e.eval_int(&mut ctx, &col).unwrap();
             assert_eq!(res.unwrap(), expect);
             // test None
@@ -870,7 +870,7 @@ mod tests {
         for (sig, tp, col, expect) in cases {
             let col_expr = col_expr(0, tp);
             let mut exp = scalar_func_expr(sig, &[col_expr]);
-            let e = Expression::build(&mut ctx, exp).unwrap();
+            let e = Expression::build(&ctx, exp).unwrap();
             let res = e.eval_int(&mut ctx, &col).unwrap();
             assert_eq!(res.unwrap(), expect);
         }
@@ -1006,7 +1006,7 @@ mod tests {
                 .as_mut_accessor()
                 .set_flen(flen)
                 .set_decimal(decimal);
-            let e = Expression::build(&mut ctx, exp).unwrap();
+            let e = Expression::build(&ctx, exp).unwrap();
             let res = e.eval_real(&mut ctx, &col).unwrap();
             assert_eq!(format!("{}", res.unwrap()), format!("{}", expect));
             // test None
@@ -1144,7 +1144,7 @@ mod tests {
                 .as_mut_accessor()
                 .set_flen(flen)
                 .set_decimal(decimal);
-            let e = Expression::build(&mut ctx, exp).unwrap();
+            let e = Expression::build(&ctx, exp).unwrap();
             let res = e.eval_decimal(&mut ctx, &col).unwrap();
             assert_eq!(res.unwrap().into_owned(), expect);
             // test None
@@ -1303,7 +1303,7 @@ mod tests {
                 ex.mut_field_type().as_mut_accessor().set_tp(to_tp.unwrap());
             }
             ex.mut_field_type().set_charset(String::from(charset));
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_string(&mut ctx, &col).unwrap();
             assert_eq!(
                 res.unwrap().into_owned(),
@@ -1479,7 +1479,7 @@ mod tests {
                 .as_mut_accessor()
                 .set_decimal(isize::from(to_fsp))
                 .set_tp(to_tp);
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
 
             let res = e.eval_time(&mut ctx, col).unwrap();
             let data = res.unwrap().into_owned();
@@ -1643,7 +1643,7 @@ mod tests {
             ex.mut_field_type()
                 .as_mut_accessor()
                 .set_decimal(isize::from(to_fsp));
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_duration(&mut ctx, col).unwrap();
             let data = res.unwrap().into_owned();
             let mut expt = exp.clone();
@@ -1694,7 +1694,7 @@ mod tests {
                     .set_flag(flag.unwrap());
             }
             let ex = scalar_func_expr(ScalarFuncSig::CastIntAsJson, &[col_expr]);
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_json(&mut ctx, &cols).unwrap();
             if exp.is_none() {
                 assert!(res.is_none());
@@ -1714,7 +1714,7 @@ mod tests {
         for (cols, exp) in cases {
             let col_expr = col_expr(0, FieldTypeTp::Double);
             let ex = scalar_func_expr(ScalarFuncSig::CastRealAsJson, &[col_expr]);
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_json(&mut ctx, &cols).unwrap();
             if exp.is_none() {
                 assert!(res.is_none());
@@ -1738,7 +1738,7 @@ mod tests {
             let col_expr = col_expr(0, FieldTypeTp::NewDecimal);
             let ex = scalar_func_expr(ScalarFuncSig::CastDecimalAsJson, &[col_expr]);
 
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_json(&mut ctx, &cols).unwrap();
             if exp.is_none() {
                 assert!(res.is_none());
@@ -1773,7 +1773,7 @@ mod tests {
                 flag |= FieldTypeFlag::PARSE_TO_JSON;
                 ex.mut_field_type().as_mut_accessor().set_flag(flag);
             }
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_json(&mut ctx, &cols).unwrap();
             if exp.is_none() {
                 assert!(res.is_none());
@@ -1822,7 +1822,7 @@ mod tests {
         for (tp, cols, exp) in cases {
             let col_expr = col_expr(0, tp);
             let ex = scalar_func_expr(ScalarFuncSig::CastTimeAsJson, &[col_expr]);
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_json(&mut ctx, &cols).unwrap();
             if exp.is_none() {
                 assert!(res.is_none());
@@ -1848,7 +1848,7 @@ mod tests {
         for (cols, exp) in cases {
             let col_expr = col_expr(0, FieldTypeTp::String);
             let ex = scalar_func_expr(ScalarFuncSig::CastDurationAsJson, &[col_expr]);
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_json(&mut ctx, &cols).unwrap();
             if exp.is_none() {
                 assert!(res.is_none());
@@ -1871,7 +1871,7 @@ mod tests {
         for (cols, exp) in cases {
             let col_expr = col_expr(0, FieldTypeTp::String);
             let ex = scalar_func_expr(ScalarFuncSig::CastJsonAsJson, &[col_expr]);
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_json(&mut ctx, &cols).unwrap();
             if exp.is_none() {
                 assert!(res.is_none());
@@ -1907,7 +1907,7 @@ mod tests {
             // test with overflow as warning
             let mut ctx =
                 EvalContext::new(Arc::new(EvalConfig::from_flags(FLAG_OVERFLOW_AS_WARNING)));
-            let e = Expression::build(&mut ctx, ex.clone()).unwrap();
+            let e = Expression::build(&ctx, ex.clone()).unwrap();
             let res = e.eval_int(&mut ctx, &cols).unwrap().unwrap();
             assert_eq!(res, exp);
             assert_eq!(ctx.warnings.warning_cnt, 1);
@@ -1918,7 +1918,7 @@ mod tests {
 
             // test overflow as error
             ctx = EvalContext::new(Arc::new(EvalConfig::default()));
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_int(&mut ctx, &cols);
             assert!(res.is_err());
         }
@@ -1953,7 +1953,7 @@ mod tests {
             ex.mut_field_type().as_mut_accessor().set_flag(flag);
 
             let mut ctx = EvalContext::new(Arc::new(EvalConfig::default()));
-            let e = Expression::build(&mut ctx, ex.clone()).unwrap();
+            let e = Expression::build(&ctx, ex.clone()).unwrap();
             let res = e.eval_int(&mut ctx, &cols).unwrap().unwrap();
             assert_eq!(res, exp);
             assert_eq!(ctx.warnings.warning_cnt, warnings_cnt);
@@ -1980,7 +1980,7 @@ mod tests {
             let mut cfg = EvalConfig::new();
             cfg.set_overflow_as_warning(true).set_in_select_stmt(true);
             let mut ctx = EvalContext::new(Arc::new(cfg));
-            let e = Expression::build(&mut ctx, ex.clone()).unwrap();
+            let e = Expression::build(&ctx, ex.clone()).unwrap();
             let res = e.eval_int(&mut ctx, &cols).unwrap().unwrap();
             assert_eq!(res, exp);
             assert_eq!(ctx.warnings.warning_cnt, 1);
@@ -1991,7 +1991,7 @@ mod tests {
 
             // test overflow as error
             ctx = EvalContext::new(Arc::new(EvalConfig::default()));
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_int(&mut ctx, &cols);
             assert!(res.is_err());
         }
@@ -2007,7 +2007,7 @@ mod tests {
 
     //     // test with overflow as warning
     //     let mut ctx = EvalContext::new(Arc::new(EvalConfig::from_flags(FLAG_OVERFLOW_AS_WARNING)));
-    //     let e = Expression::build(&mut ctx, ex.clone()).unwrap();
+    //     let e = Expression::build(&ctx, ex.clone()).unwrap();
     //     let res = e.eval_duration(&mut ctx, &cols).unwrap();
     //     assert!(res.is_none());
     //     assert_eq!(ctx.warnings.warning_cnt, 1);
@@ -2015,7 +2015,7 @@ mod tests {
 
     //     // test overflow as error
     //     ctx = EvalContext::new(Arc::new(EvalConfig::default()));
-    //     let e = Expression::build(&mut ctx, ex).unwrap();
+    //     let e = Expression::build(&ctx, ex).unwrap();
     //     let res = e.eval_duration(&mut ctx, &cols);
     //     assert!(res.is_err());
     // }

--- a/src/coprocessor/dag/expr/builtin_compare.rs
+++ b/src/coprocessor/dag/expr/builtin_compare.rs
@@ -605,7 +605,7 @@ mod tests {
             expr.set_sig(sig);
 
             expr.set_children(RepeatedField::from_vec(children));
-            let e = Expression::build(&mut ctx, expr).unwrap();
+            let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &row).unwrap();
             assert_eq!(res, exp);
         }
@@ -740,7 +740,7 @@ mod tests {
             expr.set_sig(sig);
 
             expr.set_children(RepeatedField::from_vec(children));
-            let e = Expression::build(&mut ctx, expr).unwrap();
+            let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &row).unwrap();
             assert_eq!(res, exp);
         }
@@ -927,7 +927,7 @@ mod tests {
                     expr.set_tp(ExprType::ScalarFunc);
                     expr.set_sig(greatest_sig);
                     expr.set_children(RepeatedField::from_vec(children));
-                    let e = Expression::build(&mut ctx, expr).unwrap();
+                    let e = Expression::build(&ctx, expr).unwrap();
                     let res = e.eval(&mut ctx, &[]).unwrap();
                     assert_eq!(res, greatest_exp);
                 }
@@ -938,7 +938,7 @@ mod tests {
                     expr.set_tp(ExprType::ScalarFunc);
                     expr.set_sig(least_sig);
                     expr.set_children(RepeatedField::from_vec(children));
-                    let e = Expression::build(&mut ctx, expr).unwrap();
+                    let e = Expression::build(&ctx, expr).unwrap();
                     let res = e.eval(&mut ctx, &[]).unwrap();
                     assert_eq!(res, least_exp);
                 }
@@ -988,7 +988,7 @@ mod tests {
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(ScalarFuncSig::GreatestTime);
             expr.set_children(RepeatedField::from_vec(children));
-            let e = Expression::build(&mut ctx, expr).unwrap();
+            let e = Expression::build(&ctx, expr).unwrap();
             let err = e.eval(&mut ctx, &[]).unwrap_err();
             assert_eq!(err.code(), ERR_TRUNCATE_WRONG_VALUE);
         }

--- a/src/coprocessor/dag/expr/builtin_control.rs
+++ b/src/coprocessor/dag/expr/builtin_control.rs
@@ -329,8 +329,7 @@ mod tests {
         for (operator, branch1, branch2, exp) in tests {
             let arg1 = datum_expr(branch1);
             let arg2 = datum_expr(branch2);
-            let op =
-                Expression::build(&mut ctx, scalar_func_expr(operator, &[arg1, arg2])).unwrap();
+            let op = Expression::build(&ctx, scalar_func_expr(operator, &[arg1, arg2])).unwrap();
             let res = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }
@@ -464,9 +463,9 @@ mod tests {
             let arg1 = datum_expr(cond);
             let arg2 = datum_expr(branch1);
             let arg3 = datum_expr(branch2);
-            let expected = Expression::build(&mut ctx, datum_expr(exp)).unwrap();
-            let op = Expression::build(&mut ctx, scalar_func_expr(operator, &[arg1, arg2, arg3]))
-                .unwrap();
+            let expected = Expression::build(&ctx, datum_expr(exp)).unwrap();
+            let op =
+                Expression::build(&ctx, scalar_func_expr(operator, &[arg1, arg2, arg3])).unwrap();
             let lhs = op.eval(&mut ctx, &[]).unwrap();
             let rhs = expected.eval(&mut ctx, &[]).unwrap();
             assert_eq!(lhs, rhs);
@@ -539,7 +538,7 @@ mod tests {
             expr.set_sig(sig);
 
             expr.set_children(RepeatedField::from_vec(children));
-            let e = Expression::build(&mut ctx, expr).unwrap();
+            let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &row).unwrap();
             assert_eq!(res, exp);
         }

--- a/src/coprocessor/dag/expr/builtin_encryption.rs
+++ b/src/coprocessor/dag/expr/builtin_encryption.rs
@@ -199,7 +199,7 @@ mod tests {
         for (input_str, exp_str) in cases {
             let input = datum_expr(Datum::Bytes(input_str.as_bytes().to_vec()));
             let op = scalar_func_expr(ScalarFuncSig::MD5, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::Bytes(exp_str.as_bytes().to_vec());
             assert_eq!(got, exp, "md5('{:?}')", input_str);
@@ -208,7 +208,7 @@ mod tests {
         // test NULL case
         let input = datum_expr(Datum::Null);
         let op = scalar_func_expr(ScalarFuncSig::MD5, &[input]);
-        let op = Expression::build(&mut ctx, op).unwrap();
+        let op = Expression::build(&ctx, op).unwrap();
         let got = op.eval(&mut ctx, &[]).unwrap();
         let exp = Datum::Null;
         assert_eq!(got, exp, "md5(NULL)");
@@ -228,7 +228,7 @@ mod tests {
         for (input_str, exp_str) in cases {
             let input = datum_expr(Datum::Bytes(input_str.as_bytes().to_vec()));
             let op = scalar_func_expr(ScalarFuncSig::SHA1, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::Bytes(exp_str.as_bytes().to_vec());
             assert_eq!(got, exp, "sha1('{:?}')", input_str);
@@ -237,7 +237,7 @@ mod tests {
         // test NULL case
         let input = datum_expr(Datum::Null);
         let op = scalar_func_expr(ScalarFuncSig::SHA1, &[input]);
-        let op = Expression::build(&mut ctx, op).unwrap();
+        let op = Expression::build(&ctx, op).unwrap();
         let got = op.eval(&mut ctx, &[]).unwrap();
         let exp = Datum::Null;
         assert_eq!(got, exp, "sha1(NULL)");
@@ -265,7 +265,7 @@ mod tests {
             let hash_length = datum_expr(Datum::I64(hash_length_i64));
 
             let op = scalar_func_expr(ScalarFuncSig::SHA2, &[input, hash_length]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::Bytes(exp_str.as_bytes().to_vec());
             assert_eq!(got, exp, "sha2('{:?}', {:?})", input_str, hash_length_i64);
@@ -287,7 +287,7 @@ mod tests {
                 ScalarFuncSig::SHA2,
                 &[datum_expr(input.clone()), datum_expr(hash_length.clone())],
             );
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp, "sha2('{:?}', {:?})", input, hash_length);
         }

--- a/src/coprocessor/dag/expr/builtin_json.rs
+++ b/src/coprocessor/dag/expr/builtin_json.rs
@@ -231,7 +231,7 @@ mod tests {
 
             let arg = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::JsonTypeSig, &[arg]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -269,7 +269,7 @@ mod tests {
 
             let arg = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::JsonUnquoteSig, &[arg]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -299,7 +299,7 @@ mod tests {
         for (inputs, exp) in cases {
             let args = inputs.into_iter().map(datum_expr).collect::<Vec<_>>();
             let op = scalar_func_expr(ScalarFuncSig::JsonObjectSig, &args);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -329,7 +329,7 @@ mod tests {
         for (inputs, exp) in cases {
             let args = inputs.into_iter().map(datum_expr).collect::<Vec<_>>();
             let op = scalar_func_expr(ScalarFuncSig::JsonArraySig, &args);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -384,7 +384,7 @@ mod tests {
         for (sig, inputs, exp) in cases {
             let args: Vec<_> = inputs.into_iter().map(datum_expr).collect();
             let op = scalar_func_expr(sig, &args);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -415,7 +415,7 @@ mod tests {
         for (inputs, exp) in cases {
             let args: Vec<_> = inputs.into_iter().map(datum_expr).collect();
             let op = scalar_func_expr(ScalarFuncSig::JsonMergeSig, &args);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -429,10 +429,10 @@ mod tests {
             (ScalarFuncSig::JsonInsertSig, make_null_datums(6)),
             (ScalarFuncSig::JsonReplaceSig, make_null_datums(8)),
         ];
-        let mut ctx = EvalContext::default();
+        let ctx = EvalContext::default();
         for (sig, args) in cases {
             let args: Vec<_> = args.into_iter().map(datum_expr).collect();
-            let op = Expression::build(&mut ctx, scalar_func_expr(sig, &args));
+            let op = Expression::build(&ctx, scalar_func_expr(sig, &args));
             assert!(op.is_err());
         }
     }

--- a/src/coprocessor/dag/expr/builtin_like.rs
+++ b/src/coprocessor/dag/expr/builtin_like.rs
@@ -165,7 +165,7 @@ mod tests {
             let pattern = datum_expr(Datum::Bytes(pattern_str.as_bytes().to_vec()));
             let escape = datum_expr(Datum::I64(escape as i64));
             let op = scalar_func_expr(ScalarFuncSig::LikeSig, &[target, pattern, escape]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::from(exp);
             assert_eq!(got, exp, "{:?} like {:?}", target_str, pattern_str);
@@ -194,7 +194,7 @@ mod tests {
             let target = datum_expr(Datum::Bytes(target_str.as_bytes().to_vec()));
             let pattern = datum_expr(Datum::Bytes(pattern_str.as_bytes().to_vec()));
             let op = scalar_func_expr(ScalarFuncSig::RegexpSig, &[target, pattern]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::from(exp);
             assert_eq!(got, exp, "{:?} rlike {:?}", target_str, pattern_str);
@@ -231,7 +231,7 @@ mod tests {
             let target = datum_expr(Datum::Bytes(target_str.clone()));
             let pattern = datum_expr(Datum::Bytes(pattern_str.as_bytes().to_vec()));
             let op = scalar_func_expr(ScalarFuncSig::RegexpBinarySig, &[target, pattern]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::from(exp);
             assert_eq!(got, exp, "{:?} binary rlike {:?}", target_str, pattern_str);

--- a/src/coprocessor/dag/expr/builtin_miscellaneous.rs
+++ b/src/coprocessor/dag/expr/builtin_miscellaneous.rs
@@ -144,7 +144,7 @@ mod tests {
             let input = datum_expr(Datum::Bytes(input_str.as_bytes().to_vec()));
 
             let op = scalar_func_expr(ScalarFuncSig::IsIPv4, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::from(expected);
             assert_eq!(got, exp);
@@ -164,7 +164,7 @@ mod tests {
             let input = datum_expr(Datum::Bytes(input_str.as_bytes().to_vec()));
 
             let op = scalar_func_expr(ScalarFuncSig::IsIPv6, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::from(expected);
             assert_eq!(got, exp);
@@ -201,7 +201,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::InetAton, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -226,7 +226,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::InetNtoa, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -286,7 +286,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::Inet6Aton, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -357,7 +357,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::Inet6Ntoa, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }

--- a/src/coprocessor/dag/expr/builtin_op.rs
+++ b/src/coprocessor/dag/expr/builtin_op.rs
@@ -306,15 +306,14 @@ mod tests {
             let arg1 = datum_expr(lhs);
             let arg2 = datum_expr(rhs);
             {
-                let op = Expression::build(
-                    &mut ctx,
-                    scalar_func_expr(op, &[arg1.clone(), arg2.clone()]),
-                ).unwrap();
+                let op =
+                    Expression::build(&ctx, scalar_func_expr(op, &[arg1.clone(), arg2.clone()]))
+                        .unwrap();
                 let res = op.eval_int(&mut ctx, &[]).unwrap();
                 assert_eq!(res, exp);
             }
             {
-                let op = Expression::build(&mut ctx, scalar_func_expr(op, &[arg2, arg1])).unwrap();
+                let op = Expression::build(&ctx, scalar_func_expr(op, &[arg2, arg1])).unwrap();
                 let res = op.eval_int(&mut ctx, &[]).unwrap();
                 assert_eq!(res, exp);
             }
@@ -368,7 +367,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (operator, arg, exp) in tests {
             let arg1 = datum_expr(arg);
-            let op = Expression::build(&mut ctx, scalar_func_expr(operator, &[arg1])).unwrap();
+            let op = Expression::build(&ctx, scalar_func_expr(operator, &[arg1])).unwrap();
             let res = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }
@@ -426,7 +425,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (op, arg, exp) in tests {
             let arg1 = datum_expr(arg);
-            let op = Expression::build(&mut ctx, scalar_func_expr(op, &[arg1])).unwrap();
+            let op = Expression::build(&ctx, scalar_func_expr(op, &[arg1])).unwrap();
             let res = op.eval_int(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }
@@ -444,7 +443,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (op, argument) in tests {
             let arg = datum_expr(argument);
-            let op = Expression::build(&mut ctx, scalar_func_expr(op, &[arg])).unwrap();
+            let op = Expression::build(&ctx, scalar_func_expr(op, &[arg])).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap_err();
             assert!(check_overflow(got).is_ok());
         }
@@ -460,8 +459,8 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (lhs, rhs, exp) in cases {
             let args = &[datum_expr(lhs), datum_expr(rhs)];
-            let op = Expression::build(&mut ctx, scalar_func_expr(ScalarFuncSig::BitAndSig, args))
-                .unwrap();
+            let op =
+                Expression::build(&ctx, scalar_func_expr(ScalarFuncSig::BitAndSig, args)).unwrap();
             let res = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }
@@ -477,8 +476,8 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (lhs, rhs, exp) in cases {
             let args = &[datum_expr(lhs), datum_expr(rhs)];
-            let op = Expression::build(&mut ctx, scalar_func_expr(ScalarFuncSig::BitOrSig, args))
-                .unwrap();
+            let op =
+                Expression::build(&ctx, scalar_func_expr(ScalarFuncSig::BitOrSig, args)).unwrap();
             let res = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }
@@ -494,8 +493,8 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (lhs, rhs, exp) in cases {
             let args = &[datum_expr(lhs), datum_expr(rhs)];
-            let op = Expression::build(&mut ctx, scalar_func_expr(ScalarFuncSig::BitXorSig, args))
-                .unwrap();
+            let op =
+                Expression::build(&ctx, scalar_func_expr(ScalarFuncSig::BitXorSig, args)).unwrap();
             let res = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }
@@ -511,8 +510,8 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (arg, exp) in cases {
             let args = &[datum_expr(arg)];
-            let op = Expression::build(&mut ctx, scalar_func_expr(ScalarFuncSig::BitNegSig, args))
-                .unwrap();
+            let op =
+                Expression::build(&ctx, scalar_func_expr(ScalarFuncSig::BitNegSig, args)).unwrap();
             let res = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }
@@ -537,7 +536,7 @@ mod tests {
             let lhs = datum_expr(lhs);
             let rhs = datum_expr(rhs);
             let op = Expression::build(
-                &mut ctx,
+                &ctx,
                 scalar_func_expr(ScalarFuncSig::LeftShift, &[lhs, rhs]),
             ).unwrap();
             let res = op.eval(&mut ctx, &[]).unwrap();
@@ -564,7 +563,7 @@ mod tests {
             let lhs = datum_expr(lhs);
             let rhs = datum_expr(rhs);
             let op = Expression::build(
-                &mut ctx,
+                &ctx,
                 scalar_func_expr(ScalarFuncSig::RightShift, &[lhs, rhs]),
             ).unwrap();
             let res = op.eval(&mut ctx, &[]).unwrap();

--- a/src/coprocessor/dag/expr/builtin_other.rs
+++ b/src/coprocessor/dag/expr/builtin_other.rs
@@ -67,7 +67,7 @@ mod tests {
         for (input, exp) in cases {
             let args = &[datum_expr(input)];
             let op = scalar_func_expr(ScalarFuncSig::BitCount, args);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let res = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }
@@ -101,7 +101,7 @@ mod tests {
             let args = &[datum_expr(input)];
             let child = scalar_func_expr(ScalarFuncSig::CastStringAsInt, args);
             let op = scalar_func_expr(ScalarFuncSig::BitCount, &[child]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let res = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }
@@ -133,7 +133,7 @@ mod tests {
             let args = &[datum_expr(input)];
             let child = scalar_func_expr(ScalarFuncSig::CastDecimalAsInt, args);
             let op = scalar_func_expr(ScalarFuncSig::BitCount, &[child]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let res = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }

--- a/src/coprocessor/dag/expr/builtin_string.rs
+++ b/src/coprocessor/dag/expr/builtin_string.rs
@@ -785,7 +785,7 @@ mod tests {
         for (input_str, exp) in cases {
             let input = datum_expr(Datum::Bytes(input_str.as_bytes().to_vec()));
             let op = scalar_func_expr(ScalarFuncSig::Length, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::from(exp);
             assert_eq!(got, exp, "length('{:?}')", input_str);
@@ -794,7 +794,7 @@ mod tests {
         // test NULL case
         let input = datum_expr(Datum::Null);
         let op = scalar_func_expr(ScalarFuncSig::Length, &[input]);
-        let op = Expression::build(&mut ctx, op).unwrap();
+        let op = Expression::build(&ctx, op).unwrap();
         let got = op.eval(&mut ctx, &[]).unwrap();
         let exp = Datum::Null;
         assert_eq!(got, exp, "length(NULL)");
@@ -816,7 +816,7 @@ mod tests {
         for (input_str, exp) in cases {
             let input = datum_expr(Datum::Bytes(input_str.as_bytes().to_vec()));
             let op = scalar_func_expr(ScalarFuncSig::BitLength, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::from(exp);
             assert_eq!(got, exp, "bit_length('{:?}')", input_str);
@@ -825,7 +825,7 @@ mod tests {
         // test NULL case
         let input = datum_expr(Datum::Null);
         let op = scalar_func_expr(ScalarFuncSig::BitLength, &[input]);
-        let op = Expression::build(&mut ctx, op).unwrap();
+        let op = Expression::build(&ctx, op).unwrap();
         let got = op.eval(&mut ctx, &[]).unwrap();
         let exp = Datum::Null;
         assert_eq!(got, exp, "bit_length(NULL)");
@@ -870,7 +870,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::Bin, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -904,7 +904,7 @@ mod tests {
         for (input_str, exp) in cases {
             let input = datum_expr(Datum::Bytes(input_str.as_bytes().to_vec()));
             let op = scalar_func_expr(ScalarFuncSig::LTrim, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::Bytes(exp.as_bytes().to_vec());
             assert_eq!(got, exp, "ltrim('{:?}')", input_str);
@@ -913,7 +913,7 @@ mod tests {
         // test NULL case
         let input = datum_expr(Datum::Null);
         let op = scalar_func_expr(ScalarFuncSig::LTrim, &[input]);
-        let op = Expression::build(&mut ctx, op).unwrap();
+        let op = Expression::build(&ctx, op).unwrap();
         let got = op.eval(&mut ctx, &[]).unwrap();
         let exp = Datum::Null;
         assert_eq!(got, exp, "ltrim(NULL)");
@@ -947,7 +947,7 @@ mod tests {
         for (input_str, exp) in cases {
             let input = datum_expr(Datum::Bytes(input_str.as_bytes().to_vec()));
             let op = scalar_func_expr(ScalarFuncSig::RTrim, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::Bytes(exp.as_bytes().to_vec());
             assert_eq!(got, exp, "rtrim('{:?}')", input_str);
@@ -956,7 +956,7 @@ mod tests {
         // test NULL case
         let input = datum_expr(Datum::Null);
         let op = scalar_func_expr(ScalarFuncSig::RTrim, &[input]);
-        let op = Expression::build(&mut ctx, op).unwrap();
+        let op = Expression::build(&ctx, op).unwrap();
         let got = op.eval(&mut ctx, &[]).unwrap();
         let exp = Datum::Null;
         assert_eq!(got, exp, "rtrim(NULL)");
@@ -995,7 +995,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (arg, exp) in cases {
             let op = scalar_func_expr(ScalarFuncSig::Reverse, &[datum_expr(arg)]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1026,7 +1026,7 @@ mod tests {
                 Collation::Binary,
             );
             let op = scalar_func_expr(ScalarFuncSig::ReverseBinary, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1074,7 +1074,7 @@ mod tests {
             let arg1 = datum_expr(arg1);
             let arg2 = datum_expr(arg2);
             let op = scalar_func_expr(ScalarFuncSig::Left, &[arg1, arg2]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1121,7 +1121,7 @@ mod tests {
             let arg1 = datum_expr(arg1);
             let arg2 = datum_expr(arg2);
             let op = scalar_func_expr(ScalarFuncSig::Right, &[arg1, arg2]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1156,7 +1156,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::ASCII, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1202,7 +1202,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::Upper, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1252,7 +1252,7 @@ mod tests {
                 Collation::Binary,
             );
             let op = scalar_func_expr(ScalarFuncSig::Upper, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1298,7 +1298,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::Lower, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1347,7 +1347,7 @@ mod tests {
                 Collation::Binary,
             );
             let op = scalar_func_expr(ScalarFuncSig::Lower, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1399,7 +1399,7 @@ mod tests {
         for (row, exp) in cases {
             let children: Vec<Expr> = row.iter().map(|d| datum_expr(d.clone())).collect();
             let mut expr = scalar_func_expr(ScalarFuncSig::Concat, &children);
-            let e = Expression::build(&mut ctx, expr).unwrap();
+            let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }
@@ -1454,7 +1454,7 @@ mod tests {
         for (row, exp) in cases {
             let children: Vec<Expr> = row.iter().map(|d| datum_expr(d.clone())).collect();
             let mut expr = scalar_func_expr(ScalarFuncSig::ConcatWS, &children);
-            let e = Expression::build(&mut ctx, expr).unwrap();
+            let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
         }
@@ -1488,7 +1488,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::CharLength, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1525,7 +1525,7 @@ mod tests {
                 Collation::Binary,
             );
             let op = scalar_func_expr(ScalarFuncSig::CharLength, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1546,7 +1546,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::HexIntArg, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1570,7 +1570,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::HexStrArg, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1601,7 +1601,7 @@ mod tests {
         for (input, exp) in cases {
             let input = datum_expr(input);
             let op = scalar_func_expr(ScalarFuncSig::UnHex, &[input]);
-            let op = Expression::build(&mut ctx, op).unwrap();
+            let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
@@ -1685,7 +1685,7 @@ mod tests {
         for (args, exp) in cases {
             let children: Vec<Expr> = (0..args.len()).map(|id| col_expr(id as i64)).collect();
             let op = scalar_func_expr(ScalarFuncSig::Elt, &children);
-            let e = Expression::build(&mut ctx, op).unwrap();
+            let e = Expression::build(&ctx, op).unwrap();
             let res = e.eval(&mut ctx, &args).unwrap();
             assert_eq!(res, exp);
         }

--- a/src/coprocessor/dag/expr/column.rs
+++ b/src/coprocessor/dag/expr/column.rs
@@ -127,7 +127,7 @@ mod tests {
             .set_tp(FieldTypeTp::String)
             .set_flen(flen);
         c.set_field_type(field_tp);
-        let e = Expression::build(&mut ctx, c).unwrap();
+        let e = Expression::build(&ctx, c).unwrap();
         // test without pad_char_to_full_length
         let s = "你好".as_bytes().to_owned();
         let row = vec![Datum::Bytes(s.clone())];
@@ -168,7 +168,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (ii, exp) in expecteds.iter().enumerate().take(row.len()) {
             let c = col_expr(ii as i64);
-            let e = Expression::build(&mut ctx, c).unwrap();
+            let e = Expression::build(&ctx, c).unwrap();
 
             let i = e.eval_int(&mut ctx, &row).unwrap_or(None);
             let r = e.eval_real(&mut ctx, &row).unwrap_or(None);
@@ -213,7 +213,7 @@ mod tests {
             let mut field_tp = FieldType::new();
             field_tp.as_mut_accessor().set_tp(tp);
             c.set_field_type(field_tp);
-            let e = Expression::build(&mut ctx, c).unwrap();
+            let e = Expression::build(&ctx, c).unwrap();
             let res = e.eval_string(&mut ctx, &row).unwrap().unwrap();
             assert_eq!(res.as_ref(), b"12");
         }
@@ -223,7 +223,7 @@ mod tests {
             let mut field_tp = FieldType::new();
             field_tp.as_mut_accessor().set_tp(tp);
             c.set_field_type(field_tp);
-            let e = Expression::build(&mut ctx, c).unwrap();
+            let e = Expression::build(&ctx, c).unwrap();
             let res = e.eval_string(&mut ctx, &row);
             assert!(res.is_err());
         }

--- a/src/coprocessor/dag/expr/constant.rs
+++ b/src/coprocessor/dag/expr/constant.rs
@@ -171,7 +171,7 @@ mod tests {
 
         let mut ctx = EvalContext::default();
         for (case, expected) in tests.into_iter().zip(expecteds.into_iter()) {
-            let e = Expression::build(&mut ctx, case).unwrap();
+            let e = Expression::build(&ctx, case).unwrap();
 
             let i = e.eval_int(&mut ctx, &[]).unwrap_or(None);
             let r = e.eval_real(&mut ctx, &[]).unwrap_or(None);

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -219,7 +219,7 @@ impl Expression {
         }
     }
 
-    pub fn batch_build(ctx: &mut EvalContext, exprs: Vec<Expr>) -> Result<Vec<Self>> {
+    pub fn batch_build(ctx: &EvalContext, exprs: Vec<Expr>) -> Result<Vec<Self>> {
         let mut data = Vec::with_capacity(exprs.len());
         for expr in exprs {
             let ex = Expression::build(ctx, expr)?;
@@ -228,7 +228,7 @@ impl Expression {
         Ok(data)
     }
 
-    pub fn build(ctx: &mut EvalContext, mut expr: Expr) -> Result<Self> {
+    pub fn build(ctx: &EvalContext, mut expr: Expr) -> Result<Self> {
         debug!("build expr:{:?}", expr);
         let field_type = expr.take_field_type();
         match expr.get_tp() {
@@ -505,7 +505,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         let args: Vec<Expr> = args.iter().map(|arg| datum_expr(arg.clone())).collect();
         let expr = scalar_func_expr(sig, &args);
-        let mut op = Expression::build(&mut ctx, expr).unwrap();
+        let mut op = Expression::build(&ctx, expr).unwrap();
         f(&mut op, &args);
         op.eval(&mut ctx, &[])
     }
@@ -555,7 +555,7 @@ mod tests {
                 .as_mut_accessor()
                 .set_decimal(cop_datatype::UNSPECIFIED_LENGTH)
                 .set_flen(cop_datatype::UNSPECIFIED_LENGTH);
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval(&mut ctx, &cols).unwrap();
             if let Datum::F64(_) = exp {
                 assert_eq!(format!("{}", res), format!("{}", exp));
@@ -581,7 +581,7 @@ mod tests {
                     .as_mut_accessor()
                     .set_flag(flag.unwrap());
             }
-            let e = Expression::build(&mut ctx, ex).unwrap();
+            let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval(&mut ctx, &cols).unwrap();
             assert_eq!(res, exp);
         }


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Some `&mut` are not necessary, this PR substitute them with `&`.

Extracted from https://github.com/tikv/tikv/pull/3898

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)
