### PR TITLE
[release 2.1] cherry pick: When tikv is closing, should return retryable error to tidb

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1136,6 +1136,10 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
             warn!("txn conflicts: {:?}", err);
             key_error.set_retryable(format!("{:?}", err));
         }
+        storage::Error::Closed => {
+            warn!("tikv server is closing");
+            key_error.set_retryable(format!("{:?}", err));
+        }
         _ => {
             error!("txn aborts: {:?}", err);
             key_error.set_abort(format!("{:?}", err));


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Cherry-pick https://github.com/tikv/tikv/pull/3891 to release-2.1 branch.


