### PR TITLE
Use failure for cop_datatype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,8 +279,8 @@ version = "0.0.1"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tipb 0.0.1 (git+https://github.com/pingcap/tipb.git)",
 ]
 

--- a/components/cop_datatype/Cargo.toml
+++ b/components/cop_datatype/Cargo.toml
@@ -9,4 +9,4 @@ tipb = { git = "https://github.com/pingcap/tipb.git" }
 bitflags = "1.0"
 enum-primitive-derive = "0.1"
 num-traits = "0.2"
-quick-error = "1.2"
+failure = "0.1"

--- a/components/cop_datatype/src/def/eval_type.rs
+++ b/components/cop_datatype/src/def/eval_type.rs
@@ -36,9 +36,9 @@ impl fmt::Display for EvalType {
 }
 
 impl ::std::convert::TryFrom<::FieldTypeTp> for EvalType {
-    type Error = ::Error;
+    type Error = ::DataTypeError;
 
-    fn try_from(tp: ::FieldTypeTp) -> Result<Self, ::Error> {
+    fn try_from(tp: ::FieldTypeTp) -> Result<Self, ::DataTypeError> {
         let eval_type = match tp {
             ::FieldTypeTp::Tiny
             | ::FieldTypeTp::Short
@@ -62,7 +62,9 @@ impl ::std::convert::TryFrom<::FieldTypeTp> for EvalType {
             | ::FieldTypeTp::String => EvalType::Bytes,
             _ => {
                 // Note: In TiDB, Bit's eval type is Int, but it is not yet supported in TiKV.
-                return Err(::Error::UnsupportedType(tp.to_string()));
+                return Err(::DataTypeError::UnsupportedType {
+                    name: tp.to_string(),
+                });
             }
         };
         Ok(eval_type)

--- a/components/cop_datatype/src/error.rs
+++ b/components/cop_datatype/src/error.rs
@@ -11,14 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum Error {
-        UnsupportedType(name: String) {
-            display("Unsupported type {}", name)
-            description("Unsupported type")
-        }
-    }
+#[derive(Debug, Fail)]
+pub enum DataTypeError {
+    #[fail(display = "Unsupported type: {}", name)]
+    UnsupportedType { name: String },
 }
-
-pub type Result<T> = ::std::result::Result<T, Error>;

--- a/components/cop_datatype/src/lib.rs
+++ b/components/cop_datatype/src/lib.rs
@@ -19,7 +19,7 @@ extern crate bitflags;
 #[macro_use]
 extern crate enum_primitive_derive;
 #[macro_use]
-extern crate quick_error;
+extern crate failure;
 extern crate num_traits;
 #[cfg(test)]
 extern crate test;


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR substitute quick-error with [Failure](https://github.com/rust-lang-nursery/failure) in cop_datatype, for better error management.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)
