### PR TITLE
pd: avoid sending stale heartbeat after reconnecting

### DIFF
--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -295,7 +295,7 @@ where
             Err(Error::Incompatible) => true,
             Err(Error::Grpc(::grpc::Error::RpcFinished(err))) => {
                 // This means the old rpc connected with PD is finished (maybe PD restart),
-                // and this error will be retruned by the first heartbeat request after connecting
+                // and this error will be returned by the first heartbeat request after connecting
                 // which calls sender.send_all(). If retry, it may send the first heartbeat region
                 // heartbeat request to PD again which maybe stale.
                 error!("rpc finished: {:?}, not retry", err);

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -302,7 +302,6 @@ fn test_restart_heartbeat_secure() {
 
 fn restart_heartbeat(mgr: SecurityManager) {
     let mgr = Arc::new(mgr);
-    // Service has only one GetMembersResponse, so the leader never changes.
     let mut server =
         MockServer::<Service>::with_configuration(&mgr, vec![("127.0.0.1".to_owned(), 0); 1], None);
     let eps = server.bind_addrs();
@@ -352,7 +351,7 @@ fn restart_heartbeat(mgr: SecurityManager) {
     server.stop();
     server.start(&mgr, eps);
 
-    // Send some heartbeats to invoke pd-client to reconnect 
+    // Send some heartbeats to invoke pd-client to reconnect
     let mut region1 = region.clone();
     region1.set_id(10);
     poller

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -345,7 +345,7 @@ fn restart_heartbeat(mgr: SecurityManager) {
     poller
         .spawn(client.region_heartbeat(region.clone(), peer.clone(), RegionStat::default()))
         .forget();
-    rx.recv_timeout(Duration::from_millis(100)).unwrap();
+    rx.recv_timeout(Duration::from_millis(300)).unwrap();
 
     // Restart PD
     server.stop();
@@ -357,11 +357,11 @@ fn restart_heartbeat(mgr: SecurityManager) {
     poller
         .spawn(client.region_heartbeat(region1.clone(), peer.clone(), RegionStat::default()))
         .forget();
-    thread::sleep(Duration::from_millis(1200));
+    thread::sleep(Duration::from_millis(1500));
     poller
         .spawn(client.region_heartbeat(region1.clone(), peer.clone(), RegionStat::default()))
         .forget();
-    rx.recv_timeout(Duration::from_millis(100)).unwrap();
+    rx.recv_timeout(Duration::from_millis(500)).unwrap();
 
     // Check whether region info is right
     let region = client.get_region_by_id(region.get_id()).wait().unwrap();

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -345,7 +345,7 @@ fn restart_heartbeat(mgr: SecurityManager) {
     poller
         .spawn(client.region_heartbeat(region.clone(), peer.clone(), RegionStat::default()))
         .forget();
-    rx.recv_timeout(Duration::from_millis(300)).unwrap();
+    rx.recv_timeout(Duration::from_millis(100)).unwrap();
 
     // Restart PD
     server.stop();
@@ -357,7 +357,7 @@ fn restart_heartbeat(mgr: SecurityManager) {
     poller
         .spawn(client.region_heartbeat(region1.clone(), peer.clone(), RegionStat::default()))
         .forget();
-    thread::sleep(Duration::from_millis(1500));
+    thread::sleep(Duration::from_millis(1200));
     poller
         .spawn(client.region_heartbeat(region1.clone(), peer.clone(), RegionStat::default()))
         .forget();

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -350,14 +350,14 @@ fn restart_heartbeat(mgr: SecurityManager) {
     // Restart PD
     server.stop();
     server.start(&mgr, eps);
-    thread::sleep(Duration::from_millis(500));
+    thread::sleep(Duration::from_millis(100));
     // Send some heartbeats to invoke pd-client to reconnect
     let mut region1 = region.clone();
     region1.set_id(10);
     poller
         .spawn(client.region_heartbeat(region1.clone(), peer.clone(), RegionStat::default()))
         .forget();
-    thread::sleep(Duration::from_millis(1200));
+    thread::sleep(Duration::from_millis(1000));
     poller
         .spawn(client.region_heartbeat(region1.clone(), peer.clone(), RegionStat::default()))
         .forget();

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -350,14 +350,14 @@ fn restart_heartbeat(mgr: SecurityManager) {
     // Restart PD
     server.stop();
     server.start(&mgr, eps);
-
+    thread::sleep(Duration::from_millis(500));
     // Send some heartbeats to invoke pd-client to reconnect
     let mut region1 = region.clone();
     region1.set_id(10);
     poller
         .spawn(client.region_heartbeat(region1.clone(), peer.clone(), RegionStat::default()))
         .forget();
-    thread::sleep(Duration::from_millis(200));
+    thread::sleep(Duration::from_millis(1200));
     poller
         .spawn(client.region_heartbeat(region1.clone(), peer.clone(), RegionStat::default()))
         .forget();


### PR DESCRIPTION
## What have you changed? (mandatory)
Please notice the code block in src/pd/client.rs `fn region_heartbeat()`
```rust
if let Either::Right(ref sender) = inner.hb_sender {
    return Box::new(future::result(
        sender
            .unbounded_send(req)
            .map_err(|e| Error::Other(Box::new(e))),
    )) as PdFuture<_>;
}

info!("heartbeat sender is refreshed.");
let sender = inner.hb_sender.as_mut().left().unwrap().take().unwrap();
let (tx, rx) = mpsc::unbounded();
tx.unbounded_send(req).unwrap();
inner.hb_sender = Either::Right(tx);
Box::new(
    sender
        .sink_map_err(Error::Grpc)
        .send_all(rx.then(|r| match r {
            Ok(r) => Ok((r, WriteFlags::default())),
            Err(()) => Err(Error::Other(box_err!("failed to recv heartbeat"))),
        }))
        .then(|result| match result {
            Ok((mut sender, _)) => {
                info!("cancel region heartbeat sender");
                sender.get_mut().cancel();
                Ok(())
            }
            Err(e) => {
                error!("failed to send heartbeat: {:?}", e);
                Err(e)
            }
        }),
) as PdFuture<_>
```
For the first heartbeat request, it will make a channel to update `inner.hb_sender`  and then use `send_all()` to send all the following heartbeat requests. And `send_all()` is a future that it actually waits for the requests from `rx` and send them all. But once the `send_all` returns error, it will retry and send the first heartbeat request again. So do not let it retry for Error::RpcFinished.

## What are the type of the changes? (mandatory)
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)
unit-test
manual-test

## Does this PR affect documentation (docs) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No

## Refer to a related PR or issue link (optional)
Fix #3868 
