### PR TITLE
*: get rid of all unsafe transmute() calls

### DIFF
--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -16,7 +16,6 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::io::Write;
-use std::mem;
 use std::str::FromStr;
 use std::{i64, str};
 
@@ -347,7 +346,7 @@ impl Datum {
         }
     }
 
-    /// `into_i64` converts self into f64.
+    /// `into_i64` converts self into i64.
     /// source function name is `ToInt64`.
     pub fn into_i64(self, ctx: &mut EvalContext) -> Result<i64> {
         let (lower_bound, upper_bound) = (i64::MIN, i64::MAX);
@@ -394,7 +393,7 @@ impl Datum {
         match *self {
             Datum::I64(i) => i,
             Datum::U64(u) => u as i64,
-            Datum::F64(f) => unsafe { mem::transmute(f) },
+            Datum::F64(f) => f.to_bits() as i64,
             Datum::Dur(ref d) => d.to_nanos(),
             Datum::Time(_)
             | Datum::Bytes(_)

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1591,7 +1591,8 @@ impl Peer {
         let last_ready_read_count = self.raft_group.raft.ready_read_count();
 
         let id = self.pending_reads.next_id();
-        let ctx: [u8; 8] = unsafe { mem::transmute(id) };
+        let ctx = id.to_bytes();
+        // TODO: Replace with to_ne_bytes() here if we upgrade rustc to 1.30 or above
         self.raft_group.read_index(ctx.to_vec());
 
         let pending_read_count = self.raft_group.raft.pending_read_count();

--- a/src/util/codec/number.rs
+++ b/src/util/codec/number.rs
@@ -33,7 +33,7 @@ fn order_decode_i64(u: u64) -> i64 {
 }
 
 fn order_encode_f64(v: f64) -> u64 {
-    let u: u64 = unsafe { mem::transmute(v) };
+    let u = v.to_bits();
     if v.is_sign_positive() {
         u | SIGN_MARK
     } else {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Replaced all `transmute()` calls in this repository by their safe counterparts.

Before this PR there were only 3 `transmute()` calls inside TiKV, two of which converts from `f64` to `u64`/`i64`, and one converts an `i64` to `[u8; 8]`. In both cases the safe equivalents do exist:

* `f64::to_bits()` ([implemented using `transmute`](https://github.com/rust-lang/rust/blob/4f3c7a472b77ba3f3afbc12d004b9d1bbcee7fe7/src/libcore/num/f64.rs#L440-L444))
* `i64::to_bytes()` ([implemented using `transmute`](https://github.com/rust-lang/rust/blob/4f3c7a472b77ba3f3afbc12d004b9d1bbcee7fe7/src/libcore/num/mod.rs#L1909-L1913))

And thus all transmutes, which should [only be used as the absolute last resort](https://doc.rust-lang.org/std/mem/fn.transmute.html), can be avoided.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

`cargo check` and nothing breaks.

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

