### PR TITLE
raftstore/coprocessor: use scan way when approximate way fail

### DIFF
--- a/src/raftstore/coprocessor/mod.rs
+++ b/src/raftstore/coprocessor/mod.rs
@@ -108,7 +108,7 @@ pub trait SplitChecker {
     fn split_keys(&mut self) -> Vec<Vec<u8>>;
 
     /// Get approximate split keys without scan.
-    fn approximate_split_keys(&self, _: &Region, _: &DB) -> Result<Vec<Vec<u8>>> {
+    fn approximate_split_keys(&mut self, _: &Region, _: &DB) -> Result<Vec<Vec<u8>>> {
         Ok(vec![])
     }
 

--- a/src/raftstore/coprocessor/split_check/half.rs
+++ b/src/raftstore/coprocessor/split_check/half.rs
@@ -65,7 +65,7 @@ impl SplitChecker for Checker {
         }
     }
 
-    fn approximate_split_keys(&self, region: &Region, engine: &DB) -> Result<Vec<Vec<u8>>> {
+    fn approximate_split_keys(&mut self, region: &Region, engine: &DB) -> Result<Vec<Vec<u8>>> {
         Ok(box_try!(
             raftstore_util::get_region_approximate_middle(engine, region)
                 .map(|keys| keys.map_or(vec![], |key| vec![key]))

--- a/src/raftstore/coprocessor/split_check/mod.rs
+++ b/src/raftstore/coprocessor/split_check/mod.rs
@@ -74,8 +74,8 @@ impl Host {
         false
     }
 
-    pub fn split_keys(self) -> Vec<Vec<u8>> {
-        for mut checker in self.checkers {
+    pub fn split_keys(&mut self) -> Vec<Vec<u8>> {
+        for checker in &mut self.checkers {
             let keys = checker.split_keys();
             if !keys.is_empty() {
                 return keys;
@@ -84,7 +84,7 @@ impl Host {
         vec![]
     }
 
-    pub fn approximate_split_keys(mut self, region: &Region, engine: &DB) -> Result<Vec<Vec<u8>>> {
+    pub fn approximate_split_keys(&mut self, region: &Region, engine: &DB) -> Result<Vec<Vec<u8>>> {
         for checker in &mut self.checkers {
             let keys = box_try!(checker.approximate_split_keys(region, engine));
             if !keys.is_empty() {

--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -92,7 +92,7 @@ impl SplitChecker for Checker {
         self.policy
     }
 
-    fn approximate_split_keys(&self, region: &Region, engine: &DB) -> Result<Vec<Vec<u8>>> {
+    fn approximate_split_keys(&mut self, region: &Region, engine: &DB) -> Result<Vec<Vec<u8>>> {
         Ok(box_try!(raftstore_util::get_region_approximate_split_keys(
             engine,
             region,

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -491,6 +491,9 @@ pub fn get_region_approximate_split_keys(
 
     let default_cf_size = box_try!(get_cf_size(CF_DEFAULT));
     let write_cf_size = box_try!(get_cf_size(CF_WRITE));
+    if default_cf_size + write_cf_size == 0 {
+        return Err(box_err!("default cf and write cf is empty"));
+    }
 
     // assume the size of keys is uniform distribution in both cfs.
     let (cf, cf_split_size) = if default_cf_size >= write_cf_size {
@@ -544,6 +547,18 @@ pub fn get_region_approximate_split_keys_cf(
     if keys.len() == 1 {
         return Ok(vec![]);
     }
+    if keys.is_empty() || total_size == 0 || split_size == 0 {
+        return Err(box_err!(
+            "unexpected key len {} or total_size {} or split size {}, len of collection {}, cf {}, start {}, end {}",
+            keys.len(),
+            total_size,
+            split_size,
+            collection.len(),
+            cfname,
+            escape(&start),
+            escape(&end)
+        ));
+    }
     keys.sort();
 
     // use total size of this range and the number of keys in this range to
@@ -551,8 +566,16 @@ pub fn get_region_approximate_split_keys_cf(
     // split_key every `split_size / distance` keys.
     let len = keys.len();
     let distance = total_size as f64 / len as f64;
-    assert!(split_size != 0);
     let n = (split_size as f64 / distance).ceil() as usize;
+    if n == 0 {
+        return Err(box_err!(
+            "unexpected n == 0, total_size: {}, split_size: {}, len: {}, distance: {}",
+            total_size,
+            split_size,
+            keys.len(),
+            distance
+        ));
+    }
 
     // cause first element of the iterator will always be returned by step_by(),
     // so the first key returned may not the desired split key. Note that, the
@@ -1694,6 +1717,43 @@ mod tests {
             .into_raw()
             .unwrap();
         assert_eq!(escape(&middle_key), "key_049");
+    }
+
+    #[test]
+    fn test_get_region_approximate_split_keys_error() {
+        let tmp = TempDir::new("test_raftstore_util").unwrap();
+        let path = tmp.path().to_str().unwrap();
+
+        let db_opts = DBOptions::new();
+        let mut cf_opts = ColumnFamilyOptions::new();
+        cf_opts.set_level_zero_file_num_compaction_trigger(10);
+
+        let cfs_opts = LARGE_CFS
+            .iter()
+            .map(|cf| CFOptions::new(cf, cf_opts.clone()))
+            .collect();
+        let engine = rocksdb_util::new_engine_opt(path, db_opts, cfs_opts).unwrap();
+
+        let region = make_region(1, vec![], vec![]);
+        assert_eq!(
+            get_region_approximate_split_keys(&engine, &region, 3, 5, 1).is_err(),
+            true
+        );
+
+        let cf_handle = engine.cf_handle(CF_DEFAULT).unwrap();
+        let mut big_value = Vec::with_capacity(256);
+        big_value.extend(iter::repeat(b'v').take(256));
+        for i in 0..100 {
+            let k = format!("key_{:03}", i).into_bytes();
+            let k = keys::data_key(Key::from_raw(&k).as_encoded());
+            engine.put_cf(cf_handle, &k, &big_value).unwrap();
+            // Flush for every key so that we can know the exact middle key.
+            engine.flush_cf(cf_handle, true).unwrap();
+        }
+        assert_eq!(
+            get_region_approximate_split_keys(&engine, &region, 3, 5, 1).is_err(),
+            true
+        );
     }
 
     #[test]


### PR DESCRIPTION
What have you changed? (mandatory)
use scan way when approximate way fail and add some check

What are the type of the changes? (mandatory)
Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)
unit-test 

## Does this PR affect documentation (docs) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No
