### PR TITLE
storage: remove unused variants

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -97,8 +97,6 @@ impl Mutation {
 pub enum StorageCb {
     Boolean(Callback<()>),
     Booleans(Callback<Vec<Result<()>>>),
-    SingleValue(Callback<Option<Value>>),
-    KvPairs(Callback<Vec<Result<KvPair>>>),
     MvccInfoByKey(Callback<MvccInfo>),
     MvccInfoByStartTs(Callback<Option<(Key, MvccInfo)>>),
     Locks(Callback<Vec<LockInfo>>),

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -27,7 +27,7 @@ use storage::{
     Command, Engine, Error as StorageError, Result as StorageResult, ScanMode, Snapshot,
     Statistics, StatisticsSummary, StorageCb,
 };
-use storage::{Key, KvPair, MvccInfo, Value};
+use storage::{Key, MvccInfo, Value};
 use util::collections::HashMap;
 use util::threadpool::{self, Context as ThreadContext, ContextFactory as ThreadContextFactory};
 use util::time::SlowTimer;
@@ -45,10 +45,8 @@ pub const RESOLVE_LOCK_BATCH_SIZE: usize = 256;
 pub enum ProcessResult {
     Res,
     MultiRes { results: Vec<StorageResult<()>> },
-    MultiKvpairs { pairs: Vec<StorageResult<KvPair>> },
     MvccKey { mvcc: MvccInfo },
     MvccStartTs { mvcc: Option<(Key, MvccInfo)> },
-    Value { value: Option<Value> },
     Locks { locks: Vec<LockInfo> },
     NextCommand { cmd: Command },
     Failed { err: StorageError },
@@ -64,16 +62,6 @@ pub fn execute_callback(callback: StorageCb, pr: ProcessResult) {
         },
         StorageCb::Booleans(cb) => match pr {
             ProcessResult::MultiRes { results } => cb(Ok(results)),
-            ProcessResult::Failed { err } => cb(Err(err)),
-            _ => panic!("process result mismatch"),
-        },
-        StorageCb::SingleValue(cb) => match pr {
-            ProcessResult::Value { value } => cb(Ok(value)),
-            ProcessResult::Failed { err } => cb(Err(err)),
-            _ => panic!("process result mismatch"),
-        },
-        StorageCb::KvPairs(cb) => match pr {
-            ProcessResult::MultiKvpairs { pairs } => cb(Ok(pairs)),
             ProcessResult::Failed { err } => cb(Err(err)),
             _ => panic!("process result mismatch"),
         },


### PR DESCRIPTION
## What have you changed? (mandatory)

`ProcessResult::MultiKvpairs`, `ProcessResult::Value`,
`StorageCb::SingleValue` and `StorageCb::KvPairs` are no longer
constructed since https://github.com/tikv/tikv/pull/2713

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Unit tests.

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.
