### PR TITLE
util/file_log: close the log file explicitly

### DIFF
--- a/src/util/file_log.rs
+++ b/src/util/file_log.rs
@@ -93,8 +93,9 @@ impl RotatingFileLogger {
 
     /// Flushes and closes log file, without rotation.
     fn close(&mut self) -> io::Result<()> {
-        self.file.as_mut().unwrap().flush()?;
-        self.file = None;
+        if let Some(mut file) = self.file.take(){
+            return file.flush()
+        }
         Ok(())
     }
 }

--- a/src/util/file_log.rs
+++ b/src/util/file_log.rs
@@ -181,13 +181,14 @@ mod tests {
         let one_day = Duration::days(1);
 
         let mut logger = RotatingFileLogger::new(&log_file, one_day).unwrap();
-        logger.write(b"write before close").unwrap();
+        // Handles written amount returned.
+        let _ = logger.write(b"write before close").unwrap();
         logger.flush().unwrap();
         logger.close().unwrap();
         assert!(::panic_hook::recover_safe(|| logger.write(b"write after close")).is_err());
         assert!(::panic_hook::recover_safe(|| logger.flush()).is_err());
         assert!(::panic_hook::recover_safe(|| logger.close()).is_err());
-        // Reopens file, otherwise `close()` fails in assertion when `drop()`.
+        // Reopens file, otherwise `close()` will fail in assertion when `drop()`.
         logger.open().unwrap();
         drop(logger);
     }


### PR DESCRIPTION
Signed-off-by: Max <xiahaijiao@hotmail.com>


## What have you changed? (mandatory)
The original method named `close()`, however,  it doesn't close the file immediately at all.
According to @brson  said: 
> The `rotate` method is renaming a file while holding a file handle to it, which may or may not be ok, but e.g. doesn't generally work on windows.

```rust
    fn rotate(&mut self) -> io::Result<()> {
        self.close()?;
        let new_path = rotation_file_path_with_timestamp(&self.file_path, &Utc::now());
        fs::rename(&self.file_path, &new_path)?;
        self.update_rotation_time();
        self.open()
    }
```

So I close the log file explicityly here.


## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
cargo test

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

