### PR TITLE
raftstore/router: stable test

### DIFF
--- a/src/raftstore/store/fsm/router.rs
+++ b/src/raftstore/store/fsm/router.rs
@@ -520,7 +520,9 @@ mod tests {
         }
 
         fn shutdown(&self) {
-            self.sender.send(None).unwrap();
+            // Note that CounterScheduler is used as both normal scheduler
+            // and control scheduler, so this method can be called twice.
+            let _ = self.sender.send(None);
         }
     }
 


### PR DESCRIPTION
Because CountScheduler is used as both NormalScheduler and ControlScheduler, so it will be shutdown twice, which can lead to panic occasionally.

Close #3959.

Signed-off-by: Jay Lee <busyjaylee@gmail.com>
