### PR TITLE
Upgrade jemalloc, fix mem-profiling build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,18 +812,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jemalloc-sys"
-version = "0.1.0"
-source = "git+https://github.com/busyjay/jemallocator.git?branch=dev#079e31b1b9c9eccff9bb01afd2eab7f5037d9bf1"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "jemallocator"
-version = "0.1.0"
-source = "git+https://github.com/busyjay/jemallocator.git?branch=dev#079e31b1b9c9eccff9bb01afd2eab7f5037d9bf1"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
+ "jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1927,7 +1935,7 @@ dependencies = [
  "hashbrown 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)",
+ "jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2418,6 +2426,7 @@ dependencies = [
 "checksum flate2-crc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8a792245eaed7747984647ce20582507985d69ccfacdddcb60bd5f451f21cbc5"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "237b7991317b8d94391c0a4813b1f74fd81c11352440cd598d2b763ed288bfc1"
+"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "884dbe32a6ae4cd7da5c6db9b78114449df9953b8d490c9d7e1b51720b922c62"
@@ -2442,8 +2451,8 @@ dependencies = [
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itertools-num 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d78fa608383e6e608ba36f962ac991d5d6878d7203eb93b4711b14fa6717813"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
-"checksum jemalloc-sys 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
-"checksum jemallocator 0.1.0 (git+https://github.com/busyjay/jemallocator.git?branch=dev)" = "<none>"
+"checksum jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "bfc62c8e50e381768ce8ee0428ee53741929f7ebd73e4d83f669bcf7693e00ae"
+"checksum jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0cd42ac65f758063fea55126b0148b1ce0a6354ff78e07a4d6806bc65c4ab3"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 default = []
 portable = ["rocksdb/portable"]
 sse = ["rocksdb/sse"]
-mem-profiling = ["jemallocator"]
+mem-profiling = ["jemallocator/profiling"]
 no-fail = ["fail/no_fail"]
 
 [lib]
@@ -130,10 +130,7 @@ features = ["nightly", "push", "process"]
 version = "0.1.4"
 
 [dependencies.jemallocator]
-git = "https://github.com/busyjay/jemallocator.git"
-branch = "dev"
-features = ["profiling"]
-optional = true
+version = "0.1.9"
 
 [dev-dependencies]
 test_util = { path = "components/test_util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ features = ["nightly", "push", "process"]
 version = "0.1.4"
 
 [dependencies.jemallocator]
+features = ["unprefixed_malloc_on_supported_platforms"]
 version = "0.1.9"
 
 [dev-dependencies]

--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -16,6 +16,8 @@ extern crate clap;
 extern crate chrono;
 extern crate futures;
 extern crate grpcio;
+#[cfg(feature = "mem-profiling")]
+extern crate jemallocator;
 extern crate kvproto;
 extern crate libc;
 #[macro_use]

--- a/src/bin/util/profiling.rs
+++ b/src/bin/util/profiling.rs
@@ -69,7 +69,9 @@ mod imp {
     mod tests {
         use std::fs;
 
-        use tempdir::TempDir;
+        extern crate tempdir;
+
+        use self::tempdir::TempDir;
 
         // Only trigger this test with prof set to true.
         #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ extern crate grpcio as grpc;
 extern crate hashbrown;
 extern crate hex;
 extern crate indexmap;
-#[cfg(unix)]
+#[cfg(all(unix, not(fuzzing)))]
 extern crate jemallocator;
 extern crate kvproto;
 
@@ -143,6 +143,8 @@ pub use storage::Storage;
 // generally shouldn't be opinionated about their allocators like
 // this. It's easier to do this in one place than to have all our bins
 // turn it on themselves.
-#[cfg(unix)]
+//
+// cfg `fuzzing` is defined by `run_libfuzzer` in `fuzz/cli.rs`
+#[cfg(all(unix, not(fuzzing)))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ extern crate grpcio as grpc;
 extern crate hashbrown;
 extern crate hex;
 extern crate indexmap;
+#[cfg(unix)]
+extern crate jemallocator;
 extern crate kvproto;
 
 #[macro_use]
@@ -136,3 +138,11 @@ pub mod server;
 pub mod storage;
 
 pub use storage::Storage;
+
+// As of now TiKV always turns on jemalloc on Unix, though libraries
+// generally shouldn't be opinionated about their allocators like
+// this. It's easier to do this in one place than to have all our bins
+// turn it on themselves.
+#[cfg(unix)]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;

--- a/src/util/jemalloc.rs
+++ b/src/util/jemalloc.rs
@@ -15,15 +15,7 @@
 mod jemalloc {
     use libc::{self, c_char, c_void};
     use std::{ptr, slice};
-
-    extern "C" {
-        #[cfg_attr(target_os = "macos", link_name = "je_malloc_stats_print")]
-        fn malloc_stats_print(
-            write_cb: extern "C" fn(*mut c_void, *const c_char),
-            cbopaque: *mut c_void,
-            opts: *const c_char,
-        );
-    }
+    use jemallocator::ffi::malloc_stats_print;
 
     extern "C" fn write_cb(printer: *mut c_void, msg: *const c_char) {
         unsafe {

--- a/src/util/jemalloc.rs
+++ b/src/util/jemalloc.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(unix)]
+#[cfg(all(unix, not(fuzzing)))]
 mod jemalloc {
     use libc::{self, c_char, c_void};
     use std::{ptr, slice};
@@ -48,10 +48,8 @@ mod jemalloc {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(not(all(unix, not(fuzzing))))]
 mod jemalloc {
-    use tikv::raftstore::store::Engines;
-
     pub fn dump_stats() -> String {
         String::default()
     }

--- a/src/util/jemalloc.rs
+++ b/src/util/jemalloc.rs
@@ -13,9 +13,9 @@
 
 #[cfg(all(unix, not(fuzzing)))]
 mod jemalloc {
+    use jemallocator::ffi::malloc_stats_print;
     use libc::{self, c_char, c_void};
     use std::{ptr, slice};
-    use jemallocator::ffi::malloc_stats_print;
 
     extern "C" fn write_cb(printer: *mut c_void, msg: *const c_char) {
         unsafe {


### PR DESCRIPTION
## What have you changed? (mandatory)

This upgrades jemallocator to the latest published version, changes the code to use the stable allocator API, makes the `mem-profiling` build compile, and updates the codebase to continue working with libfuzzer.

This is part of [upgrading to Rust 2018](https://github.com/tikv/tikv/pull/3952). I've pulled out only the jemalloc changes to try to land them alone, make sure everything continues to work.

Things to note:

- This upgrades to the latest published jemallocator, away from @BusyJay's fork. I suspect that the fixes in BusyJay's fork are incorporated into the latest jemallocator, but don't know for sure.

- jemalloc is used on all Unixes, and nowhere else.

- jemalloc is configured to not prefix its symbols, such that on supported platforms it replaces libc malloc, letting RocksDB and Rust share the same allocator. This works on Linux, but notably not macOS.

- jemallocator is always a dependency now, even if it's not used, where before it was only a dependency when the `mem-profiling` feature is on. Presumably that means it has to build correctly even on Windows, which I suspect it will.

- The global allocator is set within the tikv library, so all the bins, tests, and benches that link to it should use jemalloc. The component tests, because they don't link to tikv, don't use jemalloc.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

I ran the unit tests, clippy and rustfmt. I made sure that libfuzzer and honggfuzz continue to work.

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

Full Rust 2018 upgrade PR: https://github.com/tikv/tikv/pull/3952