### PR TITLE
add is_unsigned to Expression

### DIFF
--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -131,11 +131,7 @@ impl ScalarFunc {
 
     pub fn cast_int_as_real(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<f64>> {
         let val = try_opt!(self.children[0].eval_int(ctx, row));
-        if !self.children[0]
-            .field_type()
-            .flag()
-            .contains(FieldTypeFlag::UNSIGNED)
-        {
+        if !self.children[0].is_unsigned() {
             Ok(Some(self.produce_float_with_specified_tp(ctx, val as f64)?))
         } else {
             let uval = val as u64;
@@ -289,11 +285,7 @@ impl ScalarFunc {
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, [u8]>>> {
         let val = try_opt!(self.children[0].eval_int(ctx, row));
-        let s = if self.children[0]
-            .field_type()
-            .flag()
-            .contains(FieldTypeFlag::UNSIGNED)
-        {
+        let s = if self.children[0].is_unsigned() {
             let uval = val as u64;
             format!("{}", uval)
         } else {

--- a/src/coprocessor/dag/expr/builtin_compare.rs
+++ b/src/coprocessor/dag/expr/builtin_compare.rs
@@ -17,9 +17,6 @@ use std::{f64, i64};
 
 use chrono::TimeZone;
 
-use cop_datatype::prelude::*;
-use cop_datatype::FieldTypeFlag;
-
 use super::{Error, EvalContext, Result, ScalarFunc};
 use coprocessor::codec::mysql::{Decimal, Duration, Json, Time, TimeType};
 use coprocessor::codec::{datum, mysql, Datum};
@@ -45,14 +42,8 @@ impl ScalarFunc {
     ) -> Result<Option<i64>> {
         let e = |i: usize| self.children[i].eval_int(ctx, row);
         do_compare(e, op, |l, r| {
-            let lhs_unsigned = self.children[0]
-                .field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED);
-            let rhs_unsigned = self.children[1]
-                .field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED);
+            let lhs_unsigned = self.children[0].is_unsigned();
+            let rhs_unsigned = self.children[1].is_unsigned();
             Ok(cmp_i64_with_unsigned_flag(l, lhs_unsigned, r, rhs_unsigned))
         })
     }
@@ -278,14 +269,8 @@ impl ScalarFunc {
             self,
             |v| v.eval_int(ctx, row),
             |l, r| {
-                let lhs_unsigned = self.children[0]
-                    .field_type()
-                    .flag()
-                    .contains(FieldTypeFlag::UNSIGNED);
-                let rhs_unsigned = self.children[1]
-                    .field_type()
-                    .flag()
-                    .contains(FieldTypeFlag::UNSIGNED);
+                let lhs_unsigned = self.children[0].is_unsigned();
+                let rhs_unsigned = self.children[1].is_unsigned();
                 Ok(cmp_i64_with_unsigned_flag(
                     *l,
                     lhs_unsigned,
@@ -329,21 +314,14 @@ impl ScalarFunc {
             None => return Ok(Some(-1)),
             Some(v) => v,
         };
-        let tus = self.children[0]
-            .field_type()
-            .flag()
-            .contains(FieldTypeFlag::UNSIGNED);
+        let tus = self.children[0].is_unsigned();
 
         let mut left = 1;
         let mut right = self.children.len();
         while left < right {
             let mid = left + (right - left) / 2;
             let m = self.children[mid].eval_int(ctx, row)?.unwrap_or(target);
-
-            let mus = self.children[mid]
-                .field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED);
+            let mus = self.children[mid].is_unsigned();
 
             let cmp = match (tus, mus) {
                 (false, false) => target < m,

--- a/src/coprocessor/dag/expr/builtin_math.rs
+++ b/src/coprocessor/dag/expr/builtin_math.rs
@@ -19,9 +19,6 @@ use num::traits::Pow;
 use rand::{Rng, SeedableRng, XorShiftRng};
 use time;
 
-use cop_datatype::prelude::*;
-use cop_datatype::FieldTypeFlag;
-
 use super::{Error, EvalContext, Result, ScalarFunc};
 use coprocessor::codec::mysql::{Decimal, RoundMode, DEFAULT_FSP};
 use coprocessor::codec::Datum;
@@ -385,22 +382,10 @@ impl ScalarFunc {
     pub fn truncate_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         let x = try_opt!(self.children[0].eval_int(ctx, row));
         let d = try_opt!(self.children[1].eval_int(ctx, row));
-        let d = if self.children[1]
-            .field_type()
-            .flag()
-            .contains(FieldTypeFlag::UNSIGNED)
-        {
-            0
-        } else {
-            d
-        };
+        let d = if self.children[1].is_unsigned() { 0 } else { d };
         if d >= 0 {
             Ok(Some(x))
-        } else if self.children[0]
-            .field_type()
-            .flag()
-            .contains(FieldTypeFlag::UNSIGNED)
-        {
+        } else if self.children[0].is_unsigned() {
             if d < -19 {
                 return Ok(Some(0));
             }
@@ -420,11 +405,7 @@ impl ScalarFunc {
     pub fn truncate_real(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<f64>> {
         let x = try_opt!(self.children[0].eval_real(ctx, row));
         let d = try_opt!(self.children[1].eval_int(ctx, row));
-        let d = if self.children[1]
-            .field_type()
-            .flag()
-            .contains(FieldTypeFlag::UNSIGNED)
-        {
+        let d = if self.children[1].is_unsigned() {
             (d as u64).min(i32::max_value() as u64) as i32
         } else if d >= 0 {
             d.min(i64::from(i32::max_value())) as i32
@@ -451,11 +432,7 @@ impl ScalarFunc {
     ) -> Result<Option<Cow<Decimal>>> {
         let x = try_opt!(self.children[0].eval_decimal(ctx, row));
         let d = try_opt!(self.children[1].eval_int(ctx, row));
-        let d = if self.children[1]
-            .field_type()
-            .flag()
-            .contains(FieldTypeFlag::UNSIGNED)
-        {
+        let d = if self.children[1].is_unsigned() {
             (d as u64).min(127) as i8
         } else if d >= 0 {
             d.min(127) as i8

--- a/src/coprocessor/dag/expr/builtin_op.rs
+++ b/src/coprocessor/dag/expr/builtin_op.rs
@@ -14,9 +14,6 @@
 use std::borrow::Cow;
 use std::i64;
 
-use cop_datatype::prelude::*;
-use cop_datatype::FieldTypeFlag;
-
 use super::{Error, EvalContext, Result, ScalarFunc};
 use coprocessor::codec::mysql::Decimal;
 use coprocessor::codec::Datum;
@@ -96,11 +93,7 @@ impl ScalarFunc {
 
     pub fn unary_minus_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         let val = try_opt!(self.children[0].eval_int(ctx, row));
-        if self.children[0]
-            .field_type()
-            .flag()
-            .contains(FieldTypeFlag::UNSIGNED)
-        {
+        if self.children[0].is_unsigned() {
             let uval = val as u64;
             if uval > i64::MAX as u64 + 1 {
                 return Err(Error::overflow("BIGINT", &format!("-{}", uval)));

--- a/src/coprocessor/dag/expr/builtin_string.rs
+++ b/src/coprocessor/dag/expr/builtin_string.rs
@@ -18,13 +18,12 @@ use std::i64;
 
 use hex::{self, FromHex};
 
+use cop_datatype;
 use cop_datatype::prelude::*;
-use cop_datatype::{self, FieldTypeFlag};
 
 use super::{EvalContext, Result, ScalarFunc};
 use coprocessor::codec::Datum;
 use safemem;
-use tipb::expression::FieldType;
 
 const SPACE: u8 = 0o40u8;
 
@@ -414,13 +413,7 @@ impl ScalarFunc {
             return Ok(Some(Cow::Borrowed(b"")));
         }
 
-        let (count, is_positive) = i64_to_usize(
-            count,
-            self.children[2]
-                .field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED),
-        );
+        let (count, is_positive) = i64_to_usize(count, self.children[2].is_unsigned());
 
         let r = if is_positive {
             substring_index_positive(&s, delim.as_ref(), count)
@@ -444,13 +437,7 @@ impl ScalarFunc {
 
         // we need to check the unsigned_flag , othewise a input larger than
         // i64::max_value() will overflow to a negative number
-        let (pos, positive_search) = i64_to_usize(
-            pos,
-            self.children[1]
-                .field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED),
-        );
+        let (pos, positive_search) = i64_to_usize(pos, self.children[1].is_unsigned());
 
         let start = if positive_search {
             s.char_indices()
@@ -482,20 +469,8 @@ impl ScalarFunc {
         let pos = try_opt!(self.children[1].eval_int(ctx, row));
         let len = try_opt!(self.children[2].eval_int(ctx, row));
 
-        let (pos, positive_search) = i64_to_usize(
-            pos,
-            self.children[1]
-                .field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED),
-        );
-        let (len, len_positive) = i64_to_usize(
-            len,
-            self.children[2]
-                .field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED),
-        );
+        let (pos, positive_search) = i64_to_usize(pos, self.children[1].is_unsigned());
+        let (len, len_positive) = i64_to_usize(len, self.children[2].is_unsigned());
 
         if pos == 0 || len == 0 || !len_positive {
             return Ok(Some(Cow::Borrowed(b"")));
@@ -570,13 +545,7 @@ impl ScalarFunc {
         let pos = try_opt!(self.children[1].eval_int(ctx, row));
         let (len, len_positive) = if with_len {
             let len = try_opt!(self.children[2].eval_int(ctx, row));
-            i64_to_usize(
-                len,
-                self.children[2]
-                    .field_type()
-                    .flag()
-                    .contains(FieldTypeFlag::UNSIGNED),
-            )
+            i64_to_usize(len, self.children[2].is_unsigned())
         } else {
             (s.len(), true)
         };
@@ -585,13 +554,7 @@ impl ScalarFunc {
             return Ok(Some(Cow::Borrowed(b"")));
         }
 
-        let (pos, positive_search) = i64_to_usize(
-            pos,
-            self.children[1]
-                .field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED),
-        );
+        let (pos, positive_search) = i64_to_usize(pos, self.children[1].is_unsigned());
 
         let start = if positive_search {
             (pos - 1).min(s.len())
@@ -610,10 +573,7 @@ impl ScalarFunc {
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, [u8]>>> {
         let len = try_opt!(self.children[0].eval_int(ctx, row));
-        let unsigned = self.children[0]
-            .field_type()
-            .flag()
-            .contains(FieldTypeFlag::UNSIGNED);
+        let unsigned = self.children[0].is_unsigned();
         let len = if unsigned {
             len as u64 as usize
         } else if len <= 0 {
@@ -653,7 +613,7 @@ impl ScalarFunc {
         let input_len = input.chars().count();
 
         match validate_target_len_for_pad(
-            self.children[1].field_type(),
+            self.children[1].is_unsigned(),
             target_len,
             input_len,
             4,
@@ -683,7 +643,7 @@ impl ScalarFunc {
         let pad = try_opt!(self.children[2].eval_string(ctx, row));
 
         match validate_target_len_for_pad(
-            self.children[1].field_type(),
+            self.children[1].is_unsigned(),
             target_len,
             input.len(),
             1,
@@ -715,7 +675,7 @@ impl ScalarFunc {
         let input_len = input.chars().count();
 
         match validate_target_len_for_pad(
-            self.children[1].field_type(),
+            self.children[1].is_unsigned(),
             target_len,
             input_len,
             4,
@@ -749,7 +709,7 @@ impl ScalarFunc {
         let pad = try_opt!(self.children[2].eval_string(ctx, row));
 
         match validate_target_len_for_pad(
-            self.children[1].field_type(),
+            self.children[1].is_unsigned(),
             target_len,
             input.len(),
             1,
@@ -782,7 +742,7 @@ impl ScalarFunc {
 // otherwise return Some(target_len)
 #[inline]
 fn validate_target_len_for_pad(
-    ft: &FieldType,
+    len_unsigned: bool,
     target_len: i64,
     input_len: usize,
     size_of_type: usize,
@@ -791,7 +751,6 @@ fn validate_target_len_for_pad(
     if target_len == 0 {
         return Some(0);
     }
-    let len_unsigned = ft.flag().contains(FieldTypeFlag::UNSIGNED);
     let (target_len, target_len_positive) = i64_to_usize(target_len, len_unsigned);
     if !target_len_positive
         || target_len.saturating_mul(size_of_type) > cop_datatype::MAX_BLOB_WIDTH as usize
@@ -2385,8 +2344,6 @@ mod tests {
 
     #[test]
     fn test_validate_target_len_for_pad() {
-        use cop_datatype::FieldTypeAccessor;
-        use tipb::expression::FieldType;
         let cases = vec![
             // target_len, input_len, size_of_type, pad_empty, result
             (0, 10, 1, false, Some(0)),
@@ -2397,8 +2354,7 @@ mod tests {
             (12, 10, 1, false, Some(12)),
         ];
         for case in cases {
-            let ft = FieldType::default();
-            let got = super::validate_target_len_for_pad(&ft, case.0, case.1, case.2, case.3);
+            let got = super::validate_target_len_for_pad(false, case.0, case.1, case.2, case.3);
             assert_eq!(got, case.4);
         }
 
@@ -2410,10 +2366,8 @@ mod tests {
             (12u64, 10, 4, false, Some(12)),
         ];
         for case in unsigned_cases {
-            let mut ft = FieldType::default();
-            ft.as_mut_accessor().set_flag(FieldTypeFlag::UNSIGNED);
             let got =
-                super::validate_target_len_for_pad(&ft, case.0 as i64, case.1, case.2, case.3);
+                super::validate_target_len_for_pad(true, case.0 as i64, case.1, case.2, case.3);
             assert_eq!(got, case.4);
         }
     }

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -21,6 +21,7 @@ use rand::XorShiftRng;
 use tipb::expression::{Expr, ExprType, FieldType, ScalarFuncSig};
 
 use cop_datatype::prelude::*;
+use cop_datatype::FieldTypeFlag;
 use coprocessor::codec::mysql::charset;
 use coprocessor::codec::mysql::{Decimal, Duration, Json, Time, MAX_FSP};
 use coprocessor::codec::{self, Datum};
@@ -207,6 +208,11 @@ impl Expression {
             Expression::ColumnRef(ref column) => column.eval_json(row),
             Expression::ScalarFn(ref f) => f.eval_json(ctx, row),
         }
+    }
+
+    #[inline]
+    pub fn is_unsigned(&self) -> bool {
+        self.field_type().flag().contains(FieldTypeFlag::UNSIGNED)
     }
 }
 


### PR DESCRIPTION
Signed-off-by: niedhui <niedhui@gmail.com>

## What have you changed? (mandatory)
 
add an inline helper method `is_unsigned` to `Expression` for convenience. 
although there're other flags, since this is used in so many places, so I think it's can be a start to hide more 'cop_datatype' details for this layer.

## What are the type of the changes? (mandatory)

Improvement

## How has this PR been tested? (mandatory)

unit test

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

#3803 

