### PR TITLE
implement builtin string function left_binary and right_binary

### DIFF
--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -93,7 +93,9 @@ impl ScalarFunc {
             | ScalarFuncSig::IfNullDuration
             | ScalarFuncSig::IfNullJson
             | ScalarFuncSig::Left
+            | ScalarFuncSig::LeftBinary
             | ScalarFuncSig::Right
+            | ScalarFuncSig::RightBinary
             | ScalarFuncSig::LogicalAnd
             | ScalarFuncSig::LogicalOr
             | ScalarFuncSig::LogicalXor
@@ -411,7 +413,6 @@ impl ScalarFunc {
             | ScalarFuncSig::JSONAnyValue
             | ScalarFuncSig::LastInsertID
             | ScalarFuncSig::LastInsertIDWithID
-            | ScalarFuncSig::LeftBinary
             | ScalarFuncSig::Locate2Args
             | ScalarFuncSig::Locate3Args
             | ScalarFuncSig::LocateBinary2Args
@@ -436,7 +437,6 @@ impl ScalarFunc {
             | ScalarFuncSig::ReleaseLock
             | ScalarFuncSig::Repeat
             | ScalarFuncSig::Replace
-            | ScalarFuncSig::RightBinary
             | ScalarFuncSig::RowCount
             | ScalarFuncSig::RowSig
             | ScalarFuncSig::SecToTime
@@ -936,6 +936,8 @@ dispatch_call! {
 
         Left => left,
         Right => right,
+        LeftBinary => left_binary,
+        RightBinary => right_binary,
         Upper => upper,
         Lower => lower,
         DateFormatSig => date_format,
@@ -1118,7 +1120,9 @@ mod tests {
                     ScalarFuncSig::IfNullDuration,
                     ScalarFuncSig::IfNullJson,
                     ScalarFuncSig::Left,
+                    ScalarFuncSig::LeftBinary,
                     ScalarFuncSig::Right,
+                    ScalarFuncSig::RightBinary,
                     ScalarFuncSig::LogicalAnd,
                     ScalarFuncSig::LogicalOr,
                     ScalarFuncSig::LogicalXor,
@@ -1475,7 +1479,6 @@ mod tests {
             ScalarFuncSig::JSONAnyValue,
             ScalarFuncSig::LastInsertID,
             ScalarFuncSig::LastInsertIDWithID,
-            ScalarFuncSig::LeftBinary,
             ScalarFuncSig::Locate2Args,
             ScalarFuncSig::Locate3Args,
             ScalarFuncSig::LocateBinary2Args,
@@ -1500,7 +1503,6 @@ mod tests {
             ScalarFuncSig::ReleaseLock,
             ScalarFuncSig::Repeat,
             ScalarFuncSig::Replace,
-            ScalarFuncSig::RightBinary,
             ScalarFuncSig::RowCount,
             ScalarFuncSig::RowSig,
             ScalarFuncSig::SecToTime,


### PR DESCRIPTION

## What have you changed? (mandatory)

1. implement builtin string function `left_binary` and `right_binary`
2. fix the existed `left` and `right` function's length overflow issue

## What are the type of the changes? (mandatory)

Improvement

## How has this PR been tested? (mandatory)

Unit Test

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

#3275 
