### PR TITLE
*: install a new logger when panic to avoid no global logger

### DIFF
--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -35,17 +35,12 @@ pub use macros::*;
 pub use security::*;
 
 pub fn setup_for_ci() {
-    let guard = if env::var("CI").is_ok() && env::var("LOG_FILE").is_ok() {
-        Some(logging::init_log_for_test())
-    } else {
-        None
-    };
+    if env::var("CI").is_ok() && env::var("LOG_FILE").is_ok() {
+        logging::init_log_for_test().cancel_reset();
+    }
     if env::var("PANIC_ABORT").is_ok() {
         // Panics as aborts, it's helpful for debugging,
         // but also stops tests immediately.
-        tikv::util::set_exit_hook(true, guard, "./");
-    } else if let Some(guard) = guard {
-        // Do not reset the global logger.
-        guard.cancel_reset();
+        tikv::util::set_panic_hook(true, "./");
     }
 }

--- a/src/bin/tikv-importer.rs
+++ b/src/bin/tikv-importer.rs
@@ -98,8 +98,8 @@ fn main() {
         .get_matches();
 
     let config = setup_config(&matches);
-    let guard = initial_logger(&config);
-    tikv_util::set_exit_hook(false, Some(guard), &config.storage.data_dir);
+    initial_logger(&config).cancel_reset();
+    tikv_util::set_panic_hook(false, &config.storage.data_dir);
 
     initial_metric(&config.metric, None);
     util::print_tikv_info();

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -408,8 +408,8 @@ fn main() {
     // Sets the global logger ASAP.
     // It is okay to use the config w/o `validata()`,
     // because `initial_logger()` handles various conditions.
-    let guard = initial_logger(&config);
-    tikv_util::set_exit_hook(false, Some(guard), &config.storage.data_dir);
+    initial_logger(&config).cancel_reset();
+    tikv_util::set_panic_hook(false, &config.storage.data_dir);
 
     // Print version information.
     util::print_tikv_info();

--- a/src/util/logger/mod.rs
+++ b/src/util/logger/mod.rs
@@ -120,16 +120,6 @@ pub fn get_string_by_level(lv: Level) -> &'static str {
     }
 }
 
-pub fn convert_slog_level_to_log_level(lv: Level) -> log::LogLevel {
-    match lv {
-        Level::Critical | Level::Error => log::LogLevel::Error,
-        Level::Warning => log::LogLevel::Warn,
-        Level::Debug => log::LogLevel::Debug,
-        Level::Trace => log::LogLevel::Trace,
-        Level::Info => log::LogLevel::Info,
-    }
-}
-
 #[test]
 fn test_get_level_by_string() {
     // Ensure UPPER, Capitalized, and lower case all map over.
@@ -142,6 +132,54 @@ fn test_get_level_by_string() {
     // Ensure that all non-defined values map to `Info`.
     assert_eq!(None, get_level_by_string("Off"));
     assert_eq!(None, get_level_by_string("definitely not an option"));
+}
+
+pub fn convert_slog_level_to_log_level(lv: Level) -> log::LogLevel {
+    match lv {
+        Level::Critical | Level::Error => log::LogLevel::Error,
+        Level::Warning => log::LogLevel::Warn,
+        Level::Debug => log::LogLevel::Debug,
+        Level::Trace => log::LogLevel::Trace,
+        Level::Info => log::LogLevel::Info,
+    }
+}
+
+pub fn convert_log_level_to_slog_level(lv: log::LogLevel) -> Level {
+    match lv {
+        log::LogLevel::Error => Level::Error,
+        log::LogLevel::Warn => Level::Warning,
+        log::LogLevel::Debug => Level::Debug,
+        log::LogLevel::Trace => Level::Trace,
+        log::LogLevel::Info => Level::Info,
+    }
+}
+
+#[test]
+fn test_log_level_conversion() {
+    assert_eq!(
+        Level::Error,
+        convert_log_level_to_slog_level(convert_slog_level_to_log_level(Level::Critical))
+    );
+    assert_eq!(
+        Level::Error,
+        convert_log_level_to_slog_level(convert_slog_level_to_log_level(Level::Error))
+    );
+    assert_eq!(
+        Level::Warning,
+        convert_log_level_to_slog_level(convert_slog_level_to_log_level(Level::Warning))
+    );
+    assert_eq!(
+        Level::Debug,
+        convert_log_level_to_slog_level(convert_slog_level_to_log_level(Level::Debug))
+    );
+    assert_eq!(
+        Level::Trace,
+        convert_log_level_to_slog_level(convert_slog_level_to_log_level(Level::Trace))
+    );
+    assert_eq!(
+        Level::Info,
+        convert_log_level_to_slog_level(convert_slog_level_to_log_level(Level::Info))
+    );
 }
 
 pub struct TikvFormat<D>

--- a/src/util/logger/mod.rs
+++ b/src/util/logger/mod.rs
@@ -90,7 +90,7 @@ pub fn file_drainer(
 
 /// Constructs a new terminal drainer which outputs logs to stderr.
 pub fn term_drainer() -> TikvFormat<TermDecorator> {
-    let decorator = TermDecorator::new().build();
+    let decorator = TermDecorator::new().stderr().build();
     TikvFormat::new(decorator)
 }
 


### PR DESCRIPTION
## What have you changed? (mandatory)

Dropping the logger guard replaces the original logger with the `NoGlobalLogger` which panics when we continue log something. So it causes panic in panic and tirggers the `ud2` trap.
This PR replaces the old logger with a terminal logger to avoid panic in panic.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

Manual test.

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

Merge #3987 first.
