### PR TITLE
use closure directly since RFC 2132 is completed

### DIFF
--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -101,7 +101,7 @@ pub fn init_data_with_details<E: Engine>(
     }
     let pd_worker = FutureWorker::new("test-pd-worker");
     let pool = ReadPool::new("readpool", read_pool_cfg, || {
-        || ReadPoolContext::new(pd_worker.scheduler())
+        ReadPoolContext::new(pd_worker.scheduler())
     });
     let cop = Endpoint::new(cfg, store.get_engine(), pool);
     (store, cop)

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -135,7 +135,7 @@ impl Simulator for ServerCluster {
         let pd_worker = FutureWorker::new("test-future-worker");
         let storage_read_pool =
             ReadPool::new("store-read", &cfg.readpool.storage.build_config(), || {
-                || storage::ReadPoolContext::new(pd_worker.scheduler())
+                storage::ReadPoolContext::new(pd_worker.scheduler())
             });
         let store = create_raft_storage(
             sim_router.clone(),
@@ -165,7 +165,7 @@ impl Simulator for ServerCluster {
         let server_cfg = Arc::new(cfg.server.clone());
         let security_mgr = Arc::new(SecurityManager::new(&cfg.security).unwrap());
         let cop_read_pool = ReadPool::new("cop", &cfg.readpool.coprocessor.build_config(), || {
-            || coprocessor::ReadPoolContext::new(pd_worker.scheduler())
+            coprocessor::ReadPoolContext::new(pd_worker.scheduler())
         });
         let cop = coprocessor::Endpoint::new(&server_cfg, store.get_engine(), cop_read_pool);
         let mut server = None;

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -156,8 +156,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     );
     let storage_read_pool =
         ReadPool::new("store-read", &cfg.readpool.storage.build_config(), || {
-            let pd_sender = pd_sender.clone();
-            move || storage::ReadPoolContext::new(pd_sender.clone())
+            storage::ReadPoolContext::new(pd_sender.clone())
         });
     let storage = create_raft_storage(
         raft_router.clone(),
@@ -199,8 +198,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     let server_cfg = Arc::new(cfg.server.clone());
     // Create server
     let cop_read_pool = ReadPool::new("cop", &cfg.readpool.coprocessor.build_config(), || {
-        let pd_sender = pd_sender.clone();
-        move || coprocessor::ReadPoolContext::new(pd_sender.clone())
+        coprocessor::ReadPoolContext::new(pd_sender.clone())
     });
     let cop = coprocessor::Endpoint::new(&server_cfg, storage.get_engine(), cop_read_pool);
     let mut server = Server::new(

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -648,7 +648,7 @@ mod tests {
         let pd_worker = FutureWorker::new("test-pd-worker");
         let engine = TestEngineBuilder::new().build().unwrap();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(pd_worker.scheduler())
+            ReadPoolContext::new(pd_worker.scheduler())
         });
         let cop = Endpoint::new(&Config::default(), engine, read_pool);
 
@@ -685,7 +685,7 @@ mod tests {
         let pd_worker = FutureWorker::new("test-pd-worker");
         let engine = TestEngineBuilder::new().build().unwrap();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(pd_worker.scheduler())
+            ReadPoolContext::new(pd_worker.scheduler())
         });
         let cop = Endpoint::new(
             &Config {
@@ -725,7 +725,7 @@ mod tests {
         let pd_worker = FutureWorker::new("test-pd-worker");
         let engine = TestEngineBuilder::new().build().unwrap();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(pd_worker.scheduler())
+            ReadPoolContext::new(pd_worker.scheduler())
         });
         let cop = Endpoint::new(&Config::default(), engine, read_pool);
 
@@ -744,7 +744,7 @@ mod tests {
         let pd_worker = FutureWorker::new("test-pd-worker");
         let engine = TestEngineBuilder::new().build().unwrap();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(pd_worker.scheduler())
+            ReadPoolContext::new(pd_worker.scheduler())
         });
         let cop = Endpoint::new(&Config::default(), engine, read_pool);
 
@@ -770,7 +770,7 @@ mod tests {
                 max_tasks_per_worker_normal: 2,
                 ..readpool::Config::default_for_test()
             },
-            || || ReadPoolContext::new(pd_worker.scheduler()),
+            || ReadPoolContext::new(pd_worker.scheduler()),
         );
         let cop = Endpoint::new(&Config::default(), engine, read_pool);
 
@@ -815,7 +815,7 @@ mod tests {
         let pd_worker = FutureWorker::new("test-pd-worker");
         let engine = TestEngineBuilder::new().build().unwrap();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(pd_worker.scheduler())
+            ReadPoolContext::new(pd_worker.scheduler())
         });
         let cop = Endpoint::new(&Config::default(), engine, read_pool);
 
@@ -835,7 +835,7 @@ mod tests {
         let pd_worker = FutureWorker::new("test-pd-worker");
         let engine = TestEngineBuilder::new().build().unwrap();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(pd_worker.scheduler())
+            ReadPoolContext::new(pd_worker.scheduler())
         });
         let cop = Endpoint::new(&Config::default(), engine, read_pool);
 
@@ -880,7 +880,7 @@ mod tests {
         let pd_worker = FutureWorker::new("test-pd-worker");
         let engine = TestEngineBuilder::new().build().unwrap();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(pd_worker.scheduler())
+            ReadPoolContext::new(pd_worker.scheduler())
         });
         let cop = Endpoint::new(&Config::default(), engine, read_pool);
 
@@ -900,7 +900,7 @@ mod tests {
         let pd_worker = FutureWorker::new("test-pd-worker");
         let engine = TestEngineBuilder::new().build().unwrap();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(pd_worker.scheduler())
+            ReadPoolContext::new(pd_worker.scheduler())
         });
         let cop = Endpoint::new(&Config::default(), engine, read_pool);
 
@@ -986,7 +986,7 @@ mod tests {
         let pd_worker = FutureWorker::new("test-pd-worker");
         let engine = TestEngineBuilder::new().build().unwrap();
         let read_pool = ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-            || ReadPoolContext::new(pd_worker.scheduler())
+            ReadPoolContext::new(pd_worker.scheduler())
         });
         let cop = Endpoint::new(
             &Config {
@@ -1041,7 +1041,7 @@ mod tests {
         let read_pool = ReadPool::new(
             "readpool",
             &readpool::Config::default_with_concurrency(1),
-            || || ReadPoolContext::new(pd_worker.scheduler()),
+            || ReadPoolContext::new(pd_worker.scheduler()),
         );
         let mut config = Config::default();
         config.end_point_request_max_handle_duration =

--- a/src/server/readpool/mod.rs
+++ b/src/server/readpool/mod.rs
@@ -53,12 +53,9 @@ impl<T: futurepool::Context + 'static> Clone for ReadPool<T> {
 }
 
 impl<T: futurepool::Context + 'static> ReadPool<T> {
-    // Rust does not support copying closures (RFC 2132) so that we need a closure builder.
-    // TODO: Use a single closure once RFC 2132 is implemented.
-    pub fn new<F, CF>(name_prefix: &str, config: &Config, context_factory_builder: F) -> Self
+    pub fn new<F>(name_prefix: &str, config: &Config, context_factory: F) -> Self
     where
-        F: futurepool::Factory<CF>,
-        CF: futurepool::Factory<T>,
+        F: Fn() -> T,
     {
         let tick_interval = Duration::from_secs(TICK_INTERVAL_SEC);
 
@@ -68,21 +65,21 @@ impl<T: futurepool::Context + 'static> ReadPool<T> {
                 config.stack_size.0 as usize,
                 &format!("{}-high", name_prefix),
                 tick_interval,
-                context_factory_builder.build(),
+                &context_factory,
             ),
             pool_normal: FuturePool::new(
                 config.normal_concurrency,
                 config.stack_size.0 as usize,
                 &format!("{}-normal", name_prefix),
                 tick_interval,
-                context_factory_builder.build(),
+                &context_factory,
             ),
             pool_low: FuturePool::new(
                 config.low_concurrency,
                 config.stack_size.0 as usize,
                 &format!("{}-low", name_prefix),
                 tick_interval,
-                context_factory_builder.build(),
+                &context_factory,
             ),
             max_tasks_high: config.max_tasks_per_worker_high * config.high_concurrency,
             max_tasks_normal: config.max_tasks_per_worker_normal * config.normal_concurrency,
@@ -194,7 +191,7 @@ mod tests {
 
     #[test]
     fn test_future_execute() {
-        let read_pool = ReadPool::new("readpool", &Config::default_for_test(), || || Context {});
+        let read_pool = ReadPool::new("readpool", &Config::default_for_test(), || Context {});
 
         expect_val(
             vec![1, 2, 4],
@@ -251,7 +248,7 @@ mod tests {
                 max_tasks_per_worker_high: 2,
                 ..Config::default_for_test()
             },
-            || || Context {},
+            || Context {},
         );
 
         wait_on_new_thread(

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -295,7 +295,7 @@ mod tests {
         let cop_read_pool = ReadPool::new(
             "cop-readpool",
             &readpool::Config::default_for_test(),
-            || || coprocessor::ReadPoolContext::new(pd_worker.scheduler()),
+            || coprocessor::ReadPoolContext::new(pd_worker.scheduler()),
         );
         let cop = coprocessor::Endpoint::new(&cfg, storage.get_engine(), cop_read_pool);
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -472,9 +472,9 @@ impl<E: Engine> TestStorageBuilder<E> {
 
         let read_pool = {
             let pd_worker = FutureWorker::new("test-future–worker");
-            ReadPool::new("readpool", &readpool::Config::default_for_test(), || {
-                || ReadPoolContext::new(pd_worker.scheduler())
-            })
+            ReadPool::new("readpool", &readpool::Config::default_for_test(), ||
+                ReadPoolContext::new(pd_worker.scheduler())
+            )
         };
         Storage::from_engine(
             self.engine,

--- a/src/util/futurepool.rs
+++ b/src/util/futurepool.rs
@@ -179,7 +179,7 @@ impl<T: Context + 'static> FuturePool<T> {
         context_factory: F,
     ) -> FuturePool<T>
     where
-        F: Factory<T>,
+        F: Fn() -> T,
     {
         let (tx, rx) = mpsc::sync_channel(pool_size);
         let pool = cpupool::Builder::new()
@@ -196,8 +196,7 @@ impl<T: Context + 'static> FuturePool<T> {
         let contexts = (0..pool_size)
             .map(|_| {
                 let thread_id = rx.recv().unwrap();
-                let context = context_factory.build();
-                let context_delegator = ContextDelegator::new(context, tick_interval);
+                let context_delegator = ContextDelegator::new(context_factory(), tick_interval);
                 (thread_id, context_delegator)
             })
             .collect();


### PR DESCRIPTION
Signed-off-by: Fullstop000 <fullstop1005@gmail.com>

## What have you changed? (mandatory)

A trait `Factory` is used to re-produce a closure (especially for `ReadPoolContext`) because `Clone/Copy closure` was not implemented then.

Since `Clone/Copy closure` in RFC 2132 is stabilized after rust 1.26,  we can just use closure instead.

## What are the type of the changes? (mandatory)
Improvement

## How has this PR been tested? (mandatory)
Tested

## Does this PR affect documentation (docs) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No

## Refer to a related PR or issue link (optional)
https://github.com/tikv/tikv/issues/3988
