### PR TITLE
*: switch grpc event engine from epollsig to epollex

### DIFF
--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -42,5 +42,10 @@ pub fn setup_for_ci() {
         // but also stops tests immediately.
         tikv::util::set_panic_hook(true, "./");
     }
+
+    // HACK! Always use epollex in tests.
+    // See more: https://github.com/grpc/grpc/blob/v1.17.2/src/core/lib/iomgr/ev_posix.cc#L124
+    env::set_var("GRPC_POLL_STRATEGY", "epollex");
+
     tikv::util::check_environment_variables();
 }

--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -43,4 +43,5 @@ pub fn setup_for_ci() {
         // but also stops tests immediately.
         tikv::util::set_panic_hook(true, "./");
     }
+    tikv::util::check_environment_variables();
 }

--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -32,7 +32,6 @@ extern crate signal;
 #[macro_use(
     slog_kv,
     slog_error,
-    slog_warn,
     slog_info,
     slog_log,
     slog_record,

--- a/src/bin/tikv-importer.rs
+++ b/src/bin/tikv-importer.rs
@@ -50,7 +50,7 @@ use clap::{App, Arg, ArgMatches};
 
 use tikv::config::TiKvConfig;
 use tikv::import::ImportKVServer;
-use tikv::util as tikv_util;
+use tikv::util::{self as tikv_util, check_environment_variables};
 
 fn main() {
     let matches = App::new("TiKV Importer")

--- a/src/bin/tikv-importer.rs
+++ b/src/bin/tikv-importer.rs
@@ -30,7 +30,6 @@ extern crate signal;
 #[macro_use(
     slog_kv,
     slog_error,
-    slog_warn,
     slog_info,
     slog_log,
     slog_record,

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -71,7 +71,7 @@ use tikv::util::security::SecurityManager;
 use tikv::util::time::Monitor;
 use tikv::util::transport::SendCh;
 use tikv::util::worker::{Builder, FutureWorker};
-use tikv::util::{self as tikv_util, rocksdb as rocksdb_util};
+use tikv::util::{self as tikv_util, check_environment_variables, rocksdb as rocksdb_util};
 
 const RESERVED_OPEN_FDS: u64 = 1000;
 

--- a/src/bin/util/setup.rs
+++ b/src/bin/util/setup.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::env;
 use std::process;
 use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 
@@ -142,32 +141,5 @@ pub fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatc
 
     if let Some(import_dir) = matches.value_of("import-dir") {
         config.import.import_dir = import_dir.to_owned();
-    }
-}
-
-/// Check environment variables that affect TiKV.
-#[allow(dead_code)]
-pub fn check_environment_variables() {
-    if cfg!(unix) && env::var("TZ").is_err() {
-        env::set_var("TZ", ":/etc/localtime");
-        warn!("environment variable `TZ` is missing, using `/etc/localtime`");
-    }
-
-    if let Ok(var) = env::var("GRPC_POLL_STRATEGY") {
-        info!(
-            "environment variable `GRPC_POLL_STRATEGY` is present, {}",
-            var
-        );
-    } else if cfg!(target_os = "linux") {
-        // Set gRPC event engine to epollsig if it is missing.
-        // See more: https://github.com/grpc/grpc/blob/486761d04e03a9183d8013eddd86c3134d52d459\
-        //           /src/core/lib/iomgr/ev_posix.cc#L149
-        env::set_var("GRPC_POLL_STRATEGY", "epollsig");
-    }
-
-    for proxy in &["http_proxy", "https_proxy"] {
-        if let Ok(var) = env::var(proxy) {
-            info!("environment variable `{}` is present, `{}`", proxy, var);
-        }
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -15,13 +15,11 @@ use std::collections::hash_map::Entry;
 use std::collections::vec_deque::{Iter, VecDeque};
 use std::fs::File;
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::ops::Deref;
-use std::ops::DerefMut;
+use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use std::{io, u64};
-use std::{slice, thread};
+use std::{env, io, slice, thread, u64};
 
 use protobuf::Message;
 use rand::{self, ThreadRng};
@@ -524,6 +522,32 @@ pub fn set_panic_hook(panic_abort: bool, data_dir: &str) {
             process::exit(1);
         }
     })
+}
+
+/// Checks environment variables that affect TiKV.
+pub fn check_environment_variables() {
+    if cfg!(unix) && env::var("TZ").is_err() {
+        env::set_var("TZ", ":/etc/localtime");
+        warn!("environment variable `TZ` is missing, using `/etc/localtime`");
+    }
+
+    if let Ok(var) = env::var("GRPC_POLL_STRATEGY") {
+        info!(
+            "environment variable `GRPC_POLL_STRATEGY` is present, {}",
+            var
+        );
+    } else if cfg!(target_os = "linux") {
+        // Set gRPC event engine to epollex if it is missing.
+        // See more: https://github.com/grpc/grpc/blob/486761d04e03a9183d8013eddd86c3134d52d459\
+        //           /src/core/lib/iomgr/ev_posix.cc#L149
+        env::set_var("GRPC_POLL_STRATEGY", "epollex");
+    }
+
+    for proxy in &["http_proxy", "https_proxy"] {
+        if let Ok(var) = env::var(proxy) {
+            info!("environment variable `{}` is present, `{}`", proxy, var);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -536,11 +536,6 @@ pub fn check_environment_variables() {
             "environment variable `GRPC_POLL_STRATEGY` is present, {}",
             var
         );
-    } else if cfg!(target_os = "linux") {
-        // Set gRPC event engine to epollex if it is missing.
-        // See more: https://github.com/grpc/grpc/blob/486761d04e03a9183d8013eddd86c3134d52d459\
-        //           /src/core/lib/iomgr/ev_posix.cc#L149
-        env::set_var("GRPC_POLL_STRATEGY", "epollex");
     }
 
     for proxy in &["http_proxy", "https_proxy"] {


### PR DESCRIPTION
## What have you changed? (mandatory)

Switch grpc event engine from epollsig to epollex, because epollsig is no longer supported in gRPC 1.17.x.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Uint testing

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

Yes, we must make sure the linux kernel support the epoll `EPOLLEXCLUSIVE` flag.

## Refer to a related PR or issue link (optional)

#4023 

