### PR TITLE
raftstore/region_info_accessor: Fix the panic when got overlapping regions with version 0

### DIFF
--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -380,7 +380,7 @@ impl RegionCollector {
             if region.get_region_epoch().get_version() == 0 {
                 // Ignore messages with version 0.
                 // In raftstore `Peer::replicate`, the region meta's fields are all initialized with
-                // default value expect region_id. So if there are more than one region replicating
+                // default value except region_id. So if there is more than one region replicating
                 // when the TiKV just starts, the assertion "Any two region with different ids and
                 // overlapping ranges must have different version" fails.
                 //

--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -379,6 +379,14 @@ impl RegionCollector {
             let region = event.get_region();
             if region.get_region_epoch().get_version() == 0 {
                 // Ignore messages with version 0.
+                // In raftstore `Peer::replicate`, the region meta's fields are all initialized with
+                // default value expect region_id. So if there are more than one region replicating
+                // when the TiKV just starts, the assertion "Any two region with different ids and
+                // overlapping ranges must have different version" fails.
+                //
+                // Since 0 is actually an invalid value of version, we can simply ignore the
+                // messages with version 0. The region will be created later when the region's epoch
+                // is properly set and an Update message was sent.
                 return;
             }
             if !self.check_region_range(region, true) {


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

In raftstore `Peer::replicate`, the epoch is initialized with 0 before getting the real epoch. Then in some cases, region_info_accessor may got two overlapping regions, both of which has version 0. So the assertion "Two overlapping regions with different ids must have different versions" fails in this case.

The region information with version `0` is invalid and useless. So in order to fix this panic, we can simply ignore messages with version 0. The region will be created later when the region's epoch is properly set and an Update message was sent.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

- Unit test.

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
