### PR TITLE
mvcc/txn: use structured log format and hex key format

### DIFF
--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -215,8 +215,10 @@ impl<S: Snapshot> MvccTxn<S> {
                         // None: related Rollback has been collapsed.
                         // Rollback: rollback by concurrent transaction.
                         info!(
-                            "txn conflict (lock not found), key:{}, start_ts:{}, commit_ts:{}",
-                            key, self.start_ts, commit_ts
+                            "txn conflict (lock not found)";
+                            "key" => %key,
+                            "start_ts" => self.start_ts,
+                            "commit_ts" => commit_ts,
                         );
                         Err(Error::TxnLockNotFound {
                             start_ts: self.start_ts,
@@ -262,10 +264,10 @@ impl<S: Snapshot> MvccTxn<S> {
                         } else {
                             MVCC_CONFLICT_COUNTER.rollback_committed.inc();
                             info!(
-                                "txn conflict (committed), key:{}, start_ts:{}, commit_ts:{}",
-                                key.clone(),
-                                self.start_ts,
-                                ts
+                                "txn conflict (committed)";
+                                "key" => %key,
+                                "start_ts" => self.start_ts,
+                                "commit_ts" => ts,
                             );
                             Err(Error::Committed { commit_ts: ts })
                         }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -17,12 +17,13 @@ use std::fmt::{self, Display, Formatter};
 use std::u64;
 
 use byteorder::{ByteOrder, NativeEndian};
+use hex;
 
 use storage::mvcc::{Lock, Write};
+use util::codec;
 use util::codec::bytes;
 use util::codec::bytes::BytesEncoder;
 use util::codec::number::{self, NumberEncoder};
-use util::{codec, escape};
 /// Value type which is essentially raw bytes.
 pub type Value = Vec<u8>;
 
@@ -224,7 +225,7 @@ impl Clone for Key {
 
 impl Display for Key {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", escape(&self.0))
+        write!(f, "{}", hex::encode_upper(&self.0))
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Update the log format and the key format according to the RFCs.

Check the document for how the format work: https://docs.rs/slog/2.0.0-3.1/slog/macro.log.html#values-implementing-fmtdisplay

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Unit test

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

https://github.com/tikv/rfcs/blob/master/text/2018-12-19-unified-log-format.md
https://github.com/tikv/rfcs/blob/master/text/2018-11-12-unified-key-format.md

