### PR TITLE
 raftstore/apply: make it scale

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -231,6 +231,9 @@
 ## Interval to clean up import SST files.
 # cleanup-import-sst-interval = "10m"
 
+## Use how many theads to handle log apply
+# apply-pool-size = 2
+
 [coprocessor]
 ## When it is set to `true`, TiKV will try to split a Region with table prefix if that Region
 ## crosses tables.

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -125,6 +125,9 @@ pub struct Config {
     /// Maximum size of every local read task batch.
     pub local_read_batch_size: u64,
 
+    pub apply_max_batch_size: usize,
+    pub apply_pool_size: usize,
+
     // Deprecated! These two configuration has been moved to Coprocessor.
     // They are preserved for compatibility check.
     #[doc(hidden)]
@@ -191,6 +194,8 @@ impl Default for Config {
             use_delete_range: false,
             cleanup_import_sst_interval: ReadableDuration::minutes(10),
             local_read_batch_size: 1024,
+            apply_max_batch_size: 1024,
+            apply_pool_size: 1,
 
             // They are preserved for compatibility check.
             region_max_size: ReadableSize(0),
@@ -328,6 +333,13 @@ impl Config {
         if self.local_read_batch_size == 0 {
             return Err(box_err!("local-read-batch-size must be greater than 0"));
         }
+
+        if self.apply_pool_size == 0 {
+            return Err(box_err!("apply-pool-size should not be 0."));
+        }
+        if self.apply_max_batch_size == 0 {
+            return Err(box_err!("apply-max-batch-size should be greeter than 0"));
+        }
         Ok(())
     }
 }
@@ -411,6 +423,14 @@ mod tests {
 
         cfg = Config::new();
         cfg.local_read_batch_size = 0;
+        assert!(cfg.validate().is_err());
+
+        cfg = Config::new();
+        cfg.apply_max_batch_size = 0;
+        assert!(cfg.validate().is_err());
+
+        cfg = Config::new();
+        cfg.apply_pool_size = 0;
         assert!(cfg.validate().is_err());
     }
 }

--- a/src/raftstore/store/fsm/metrics.rs
+++ b/src/raftstore/store/fsm/metrics.rs
@@ -1,0 +1,22 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use prometheus::{exponential_buckets, Histogram};
+
+lazy_static! {
+    pub static ref APPLY_PROPOSAL: Histogram = register_histogram!(
+        "tikv_raftstore_apply_proposal",
+        "Proposal count of all regions in a mio tick",
+        exponential_buckets(1.0, 2.0, 20).unwrap()
+    ).unwrap();
+}

--- a/src/raftstore/store/fsm/mod.rs
+++ b/src/raftstore/store/fsm/mod.rs
@@ -15,12 +15,23 @@
 //! and store is also a special state machine that handles all requests across
 //! stores. They are mixed for now, will be separated in the future.
 
+pub mod apply;
 mod batch;
+mod metrics;
 mod peer;
 mod router;
 mod store;
 
+pub use self::apply::{
+    create_apply_batch_system, Apply, ApplyBatchSystem, ApplyMetrics, ApplyRes, ApplyRouter,
+    Builder as ApplyPollerBuilder, ChangePeer, ExecResult, Msg as ApplyTask, Proposal,
+    RegionProposal, Registration, TaskRes as ApplyTaskRes,
+};
+pub use self::batch::{
+    BatchRouter, BatchSystem, Fsm, HandlerBuilder, NormalScheduler, PollHandler,
+};
 pub use self::peer::DestroyPeerJob;
+pub use self::router::{BasicMailbox, Mailbox};
 pub use self::store::{
     create_event_loop, new_compaction_listener, StoreChannel, StoreInfo, StoreStat,
 };
@@ -48,15 +59,15 @@ use super::local_metrics::RaftMetrics;
 use super::peer::Peer;
 use super::peer_storage::CacheQueryStats;
 use super::worker::{
-    ApplyTask, ApplyTaskRes, CleanupSSTTask, CompactTask, ConsistencyCheckTask, RaftlogGcTask,
-    ReadTask, RegionTask, SplitCheckTask,
+    CleanupSSTTask, CompactTask, ConsistencyCheckTask, RaftlogGcTask, ReadTask, RegionTask,
+    SplitCheckTask,
 };
 use super::{Engines, Msg, SignificantMsg, SnapManager};
 use import::SSTImporter;
 
 type Key = Vec<u8>;
 
-pub struct Store<T, C: 'static> {
+pub struct Store<T: 'static, C: 'static> {
     cfg: Rc<Config>,
     engines: Engines,
     store: metapb::Store,
@@ -85,7 +96,8 @@ pub struct Store<T, C: 'static> {
     pd_worker: FutureWorker<PdTask>,
     consistency_check_worker: Worker<ConsistencyCheckTask>,
     cleanup_sst_worker: Worker<CleanupSSTTask>,
-    pub apply_worker: Worker<ApplyTask>,
+    apply_system: ApplyBatchSystem,
+    apply_router: ApplyRouter,
     local_reader: Worker<ReadTask>,
     apply_res_receiver: Option<StdReceiver<ApplyTaskRes>>,
 

--- a/src/raftstore/store/fsm/router.rs
+++ b/src/raftstore/store/fsm/router.rs
@@ -310,6 +310,16 @@ where
         }
     }
 
+    pub fn register_all(&self, mailboxes: Vec<(u64, BasicMailbox<N>)>) {
+        let mut normals = self.normals.lock().unwrap();
+        normals.reserve(mailboxes.len());
+        for (addr, mailbox) in mailboxes {
+            if let Some(m) = normals.insert(addr, mailbox) {
+                m.close();
+            }
+        }
+    }
+
     /// Get the mailbox of specified address.
     pub fn mailbox(&self, addr: u64) -> Option<Mailbox<N, Ns>> {
         self.check_do(addr, |mailbox| {

--- a/src/raftstore/store/worker/metrics.rs
+++ b/src/raftstore/store/worker/metrics.rs
@@ -44,11 +44,6 @@ lazy_static! {
         "tikv_raftstore_hash_duration_seconds",
         "Bucketed histogram of raftstore hash compution duration"
     ).unwrap();
-    pub static ref APPLY_PROPOSAL: Histogram = register_histogram!(
-        "tikv_raftstore_apply_proposal",
-        "Proposal count of all regions in a mio tick",
-        exponential_buckets(1.0, 2.0, 20).unwrap()
-    ).unwrap();
     pub static ref STALE_PEER_PENDING_DELETE_RANGE_GAUGE: Gauge = register_gauge!(
         "tikv_pending_delete_ranges_of_stale_peer",
         "Total number of tikv pending delete range of stale peer"

--- a/src/raftstore/store/worker/mod.rs
+++ b/src/raftstore/store/worker/mod.rs
@@ -44,7 +44,6 @@ impl MsgSender for Sender<Msg> {
     }
 }
 
-pub mod apply;
 mod cleanup_sst;
 mod compact;
 mod consistency_check;
@@ -54,10 +53,6 @@ mod read;
 mod region;
 mod split_check;
 
-pub use self::apply::{
-    Apply, ApplyMetrics, ApplyRes, Proposal, RegionProposal, Registration, Runner as ApplyRunner,
-    Task as ApplyTask, TaskRes as ApplyTaskRes,
-};
 pub use self::cleanup_sst::{Runner as CleanupSSTRunner, Task as CleanupSSTTask};
 pub use self::compact::{Runner as CompactRunner, Task as CompactTask};
 pub use self::consistency_check::{Runner as ConsistencyCheckRunner, Task as ConsistencyCheckTask};

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -279,6 +279,7 @@ fn test_node_merge_multiple_snapshots_together() {
 // }
 
 fn test_node_merge_multiple_snapshots(together: bool) {
+    let _guard = ::setup();
     let mut cluster = new_node_cluster(0, 3);
     configure_for_merge(&mut cluster);
     let pd_client = Arc::clone(&cluster.pd_client);

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -161,6 +161,8 @@ fn test_serde_custom_tikv_config() {
         region_max_size: ReadableSize(0),
         region_split_size: ReadableSize(0),
         local_read_batch_size: 33,
+        apply_max_batch_size: 22,
+        apply_pool_size: 4,
     };
     value.pd = PdConfig {
         endpoints: vec!["example.com:443".to_owned()],

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -115,6 +115,8 @@ merge-check-tick-interval = "11s"
 use-delete-range = true
 cleanup-import-sst-interval = "12m"
 local-read-batch-size = 33
+apply-max-batch-size = 22
+apply-pool-size = 4
 
 [coprocessor]
 split-region-on-table = true


### PR DESCRIPTION
This commit uses the batch/router system introduced in #3927 and #3916
to make apply scale.

Note this commit doesn't utilize the control FSM. It creates apply
delegate directly when sending a messages. That's because all messages
in apply are order-sensitive, using control FSM to create apply delegate
can introduce messages reorder. Creating a delegate is pretty
lightweight, so put it inside send method is acceptable.