### PR TITLE
util/logger: fix grpc log redirection

### DIFF
--- a/src/util/logger/mod.rs
+++ b/src/util/logger/mod.rs
@@ -47,8 +47,6 @@ where
     D: Drain + Send + 'static,
     <D as Drain>::Err: ::std::fmt::Debug,
 {
-    grpc::redirect_log();
-
     let logger = if use_async {
         let drain = Async::new(drain.fuse())
             .chan_size(SLOG_CHANNEL_SIZE)
@@ -66,6 +64,7 @@ where
     ::slog_global::set_global(logger);
     if init_stdlog {
         ::slog_global::redirect_std_log(Some(level))?;
+        grpc::redirect_log();
     }
 
     Ok(())


### PR DESCRIPTION
## What have you changed? (mandatory)

Fix grpc log redirection, `grpc::redirect_log` does not redirect log if the log level does not set. 

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

Manual testing

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

