### PR TITLE
importer: Wait before scatter

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -687,3 +687,4 @@
 
 ## Stream channel window size, stream will be blocked on channel full.
 # stream-channel-window = 128
+# wait-before-scatter-ms = 10

--- a/etc/tikv-importer.toml
+++ b/etc/tikv-importer.toml
@@ -51,3 +51,4 @@ num-import-jobs = 24
 # stream-channel-window = 128
 # maximum number of open engines
 max-open-engines = 8
+wait-before-scatter-ms = 10

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub region_split_size: ReadableSize,
     pub stream_channel_window: usize,
     pub max_open_engines: usize,
+    pub wait_before_scatter_ms: u64,
 }
 
 impl Default for Config {
@@ -42,6 +43,7 @@ impl Default for Config {
             region_split_size: ReadableSize::mb(SPLIT_SIZE_MB),
             stream_channel_window: 128,
             max_open_engines: 8,
+            wait_before_scatter_ms: 10,
         }
     }
 }

--- a/src/import/prepare.rs
+++ b/src/import/prepare.rs
@@ -125,7 +125,7 @@ impl<Client: ImportClient> PrepareJob<Client> {
     fn run_prepare_job(&self, range: RangeInfo) -> Result<bool> {
         let id = self.counter.fetch_add(1, Ordering::SeqCst);
         let tag = format!("[PrepareRangeJob {}:{}]", self.engine.uuid(), id);
-        let job = PrepareRangeJob::new(tag, range, Arc::clone(&self.client));
+        let job = PrepareRangeJob::new(tag, range, Arc::clone(&self.client), self.cfg.clone());
         job.run()
     }
 }
@@ -136,6 +136,7 @@ struct PrepareRangeJob<Client> {
     tag: String,
     range: RangeInfo,
     client: Arc<Client>,
+    cfg: Config,
 }
 
 impl<Client: ImportClient> PrepareRangeJob<Client> {

--- a/src/import/prepare.rs
+++ b/src/import/prepare.rs
@@ -139,8 +139,18 @@ struct PrepareRangeJob<Client> {
 }
 
 impl<Client: ImportClient> PrepareRangeJob<Client> {
-    fn new(tag: String, range: RangeInfo, client: Arc<Client>) -> PrepareRangeJob<Client> {
-        PrepareRangeJob { tag, range, client }
+    fn new(
+        tag: String,
+        range: RangeInfo,
+        client: Arc<Client>,
+        cfg: Config,
+    ) -> PrepareRangeJob<Client> {
+        PrepareRangeJob {
+            tag,
+            range,
+            client,
+            cfg,
+        }
     }
 
     fn run(&self) -> Result<bool> {
@@ -185,6 +195,13 @@ impl<Client: ImportClient> PrepareRangeJob<Client> {
         }
         match self.split_region(&region) {
             Ok(new_region) => {
+                // We have to wait for few milliseconds because the PD may haven't received
+                // any heartbeat from the new split region, such that the PD cannot create
+                // scatter operator for the new split region because it doesn't have the
+                // meta data of the new split region
+                if self.cfg.wait_before_scatter_ms > 0 {
+                    thread::sleep(Duration::from_millis(self.cfg.wait_before_scatter_ms));
+                }
                 self.scatter_region(&new_region)?;
                 Ok(true)
             }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -490,6 +490,7 @@ fn test_serde_custom_tikv_config() {
         region_split_size: ReadableSize::mb(123),
         stream_channel_window: 123,
         max_open_engines: 2,
+        wait_before_scatter_ms: 8,
     };
 
     let custom = read_file_in_project_dir("tests/integrations/config/test-custom.toml");

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -400,3 +400,4 @@ max-prepare-duration = "12m"
 region-split-size = "123MB"
 stream-channel-window = 123
 max-open-engines = 2
+wait-before-scatter-ms = 8


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
We need to wait for few milliseconds because the PD may haven't received any heartbeat from the new split region, such that the PD cannot create scatter operator for the new split region because it doesn't have the meta data of the new split region

## What are the type of the changes? (mandatory)
- Improvement

## How has this PR been tested? (mandatory)
Start two tests, one is for old version, another is for new version.  Observe the scatter operator create metrics. The result shows that this diff works well.

## Does this PR affect documentation (docs) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No
