### PR TITLE
executor/aggregate:adjust sum for aggregate functions (#3253)

### DIFF
--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -332,6 +332,7 @@ impl Datum {
                 d.as_f64()
             }
             Datum::Dec(d) => d.as_f64(),
+            Datum::Json(j) => j.cast_to_real(ctx),
             _ => Err(box_err!("failed to convert {} to f64", self)),
         }
     }
@@ -967,6 +968,7 @@ pub fn split_datum(buf: &[u8], desc: bool) -> Result<(&[u8], &[u8])> {
 mod test {
     use super::*;
     use coprocessor::codec::mysql::{Decimal, Duration, Time, MAX_FSP};
+    use coprocessor::dag::expr::{EvalConfig, EvalContext, FLAG_IGNORE_TRUNCATE};
     use util::as_slice;
 
     use std::cmp::Ordering;
@@ -1654,7 +1656,6 @@ mod test {
             ),
             (Datum::Dec(0u64.into()), Some(false)),
         ];
-        use coprocessor::dag::expr::{EvalConfig, EvalContext, FLAG_IGNORE_TRUNCATE};
 
         let cfg = EvalConfig::new(0, FLAG_IGNORE_TRUNCATE).unwrap();
         let mut ctx = EvalContext::new(Arc::new(cfg));
@@ -1803,6 +1804,44 @@ mod test {
 
         for d in illegal_cases {
             assert!(d.into_json().is_err());
+        }
+    }
+
+    #[test]
+    fn test_into_f64() {
+        let tests = vec![
+            (Datum::I64(1), f64::from(1)),
+            (Datum::U64(1), f64::from(1)),
+            (Datum::F64(3.3), f64::from(3.3)),
+            (Datum::Bytes(b"Hello,world".to_vec()), f64::from(0)),
+            (Datum::Bytes(b"123".to_vec()), f64::from(123)),
+            (
+                Datum::Time(Time::parse_utc_datetime("2012-12-31 11:30:45", 0).unwrap()),
+                Decimal::from_bytes(b"20121231113045")
+                    .unwrap()
+                    .unwrap()
+                    .as_f64()
+                    .unwrap(),
+            ),
+            (
+                Datum::Dur(Duration::parse(b"11:30:45", 0).unwrap()),
+                f64::from(113045),
+            ),
+            (
+                Datum::Dec(Decimal::from_bytes(b"11.2").unwrap().unwrap()),
+                f64::from(11.2),
+            ),
+            (
+                Datum::Json(Json::from_str(r#"false"#).unwrap()),
+                f64::from(0),
+            ),
+        ];
+
+        let cfg = EvalConfig::new(0, FLAG_IGNORE_TRUNCATE).unwrap();
+        let mut ctx = EvalContext::new(Arc::new(cfg));
+        for (d, exp) in tests {
+            let got = d.into_f64(&mut ctx).unwrap();
+            assert_eq!(Datum::F64(got), Datum::F64(exp));
         }
     }
 }

--- a/src/coprocessor/codec/mysql/json/json_cast.rs
+++ b/src/coprocessor/codec/mysql/json/json_cast.rs
@@ -11,7 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::Json;
+use super::{Json, Result};
+use coprocessor::codec::convert;
+use coprocessor::dag::expr::EvalContext;
 
 impl Json {
     pub fn cast_to_int(&self) -> i64 {
@@ -25,23 +27,26 @@ impl Json {
         }
     }
 
-    pub fn cast_to_real(&self) -> f64 {
-        match *self {
+    ///  Keep compatible with TiDB's `ConvertJSONToFloat` function.
+    pub fn cast_to_real(&self, ctx: &mut EvalContext) -> Result<f64> {
+        let d = match *self {
             Json::Object(_) | Json::Array(_) | Json::None | Json::Boolean(false) => 0f64,
             Json::Boolean(true) => 1f64,
             Json::I64(d) => d as f64,
             Json::U64(d) => d as f64,
             Json::Double(d) => d,
-            Json::String(ref s) => s.parse::<f64>().unwrap_or(0f64),
-        }
+            Json::String(ref s) => convert::bytes_to_f64(ctx, s.as_bytes())?,
+        };
+        Ok(d)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::f64;
-
     use super::*;
+    use coprocessor::dag::expr::{EvalConfig, EvalContext, FLAG_IGNORE_TRUNCATE};
+    use std::f64;
+    use std::sync::Arc;
 
     #[test]
     fn test_cast_to_int() {
@@ -79,10 +84,11 @@ mod test {
             (r#""hello""#, 0f64),
             (r#""1234""#, 1234f64),
         ];
-
+        let cfg = EvalConfig::new(0, FLAG_IGNORE_TRUNCATE).unwrap();
+        let mut ctx = EvalContext::new(Arc::new(cfg));
         for (jstr, exp) in test_cases {
             let json: Json = jstr.parse().unwrap();
-            let get = json.cast_to_real();
+            let get = json.cast_to_real(&mut ctx).unwrap();
             assert!(
                 (get - exp).abs() < f64::EPSILON,
                 "cast_to_int get: {}, exp: {}",

--- a/src/coprocessor/dag/executor/aggregate.rs
+++ b/src/coprocessor/dag/executor/aggregate.rs
@@ -177,6 +177,7 @@ impl Sum {
     /// add others to res.
     ///
     /// return false means the others is skipped.
+    /// Keep compatible with TiDB's `calculateSum` function.
     fn add_asssign(&mut self, ctx: &mut EvalContext, mut args: Vec<Datum>) -> Result<bool> {
         if args.len() != 1 {
             return Err(box_err!(
@@ -192,7 +193,11 @@ impl Sum {
         let v = match a {
             Datum::I64(v) => Datum::Dec(Decimal::from(v)),
             Datum::U64(v) => Datum::Dec(Decimal::from(v)),
-            v => v,
+            Datum::Dec(d) => Datum::Dec(d),
+            v => {
+                let f = v.into_f64(ctx)?;
+                Datum::F64(f)
+            }
         };
         let res = match self.res.take() {
             Some(b) => eval_arith(ctx, v, b, Datum::checked_add)?,
@@ -280,8 +285,9 @@ impl AggrFunc for Extremum {
 
 #[cfg(test)]
 mod test {
-    use coprocessor::dag::expr::EvalContext;
+    use coprocessor::dag::expr::{EvalConfig, EvalContext, FLAG_IGNORE_TRUNCATE};
     use std::ops::Add;
+    use std::sync::Arc;
     use std::{i64, u64};
 
     use super::*;
@@ -310,5 +316,24 @@ mod test {
         sum.update(&mut ctx, vec![v2]).unwrap();
         let v = sum.res.take().unwrap();
         assert_eq!(v, Datum::Dec(res));
+    }
+
+    #[test]
+    fn test_sum_as_f64() {
+        let mut sum = Sum { res: None };
+        let cfg = EvalConfig::new(0, FLAG_IGNORE_TRUNCATE).unwrap();
+        let mut ctx = EvalContext::new(Arc::new(cfg));
+        let data = vec![
+            Datum::Bytes(b"123.09xxx".to_vec()),
+            Datum::Bytes(b"aaa".to_vec()),
+            Datum::Null,
+            Datum::F64(12.1),
+        ];
+        let res = 123.09 + 12.1;
+        for v in data {
+            sum.update(&mut ctx, vec![v]).unwrap();
+        }
+        let v = sum.res.take().unwrap();
+        assert_eq!(v, Datum::F64(res));
     }
 }

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -180,7 +180,7 @@ impl FnCall {
 
     pub fn cast_json_as_real(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<f64>> {
         let val = try_opt!(self.children[0].eval_json(ctx, row));
-        let val = val.cast_to_real();
+        let val = val.cast_to_real(ctx)?;
         Ok(Some(self.produce_float_with_specified_tp(ctx, val)?))
     }
 
@@ -268,7 +268,7 @@ impl FnCall {
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, Decimal>>> {
         let val = try_opt!(self.children[0].eval_json(ctx, row));
-        let val = val.cast_to_real();
+        let val = val.cast_to_real(ctx)?;
         let dec = Decimal::from_f64(val)?;
         self.produce_dec_with_specified_tp(ctx, Cow::Owned(dec))
             .map(Some)


### PR DESCRIPTION
## What have you changed? (mandatory)
This PR cherry-pick #3253 to release-2.0.
This PR adjust the sum operation for aggregate functions(make it keep compatible with TiDB's `calculateSum` function.).

## What are the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

unit test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Refer to a related PR or issue link (optional)

The related source in tidb:https://github.com/pingcap/tidb/blob/master/expression/aggregation/util.go#L57

@breeswish @zz-jason PTAL

