### PR TITLE
raftstore: make it scale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,11 +126,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -156,11 +151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "byteorder"
 version = "1.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bytes"
-version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1060,22 +1050,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "mio"
 version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1100,17 +1074,6 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "miow"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1145,15 +1108,6 @@ dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nix"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1700,11 +1654,6 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "slab"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1995,7 +1944,6 @@ dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "murmur3 0.4.0 (git+https://github.com/pingcap/murmur3.git)",
  "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2469,13 +2417,11 @@ dependencies = [
 "checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
 "checksum base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "621fc7ecb8008f86d7fb9b95356cd692ce9514b80a86d85b397f32a22da7b9e2"
 "checksum base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30e93c03064e7590d0466209155251b90c22e37fab1daf2771582598b5827557"
-"checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum blob 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "122c3fa3949d822d2a51c648db9e8105d6e75b89dc628cc366901d3d396fa4f4"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e4ca3a1755927e5b00c3fe43250053b957b5c074d9f17782b88ef7aa0fb4dfe2"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
-"checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)" = "<none>"
 "checksum cargo_metadata 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "48e8d5fd5b81d86d3ec3c820ecf5a3027fa22d6aede2be981cf07a8ce16451bb"
@@ -2565,16 +2511,13 @@ dependencies = [
 "checksum mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5c93a4bd787ddc6e7833c519b73a50883deb5863d76d9b71eb8216fb7f94e66"
 "checksum miniz_oxide 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ad30a47319c16cde58d0314f5d98202a80c9083b5f61178457403dfb14e509c"
 "checksum miniz_oxide_c_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28edaef377517fd9fe3e085c37d892ce7acd1fbeab9239c5a36eec352d8a8b7e"
-"checksum mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a637d1ca14eacae06296a008fa7ad955347e34efcb5891cfd8ba05491a37907e"
 "checksum mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
-"checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum more-asserts 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf21d96e87e5d48e3b50ab1512142f2fbe06fc48b7b032dead87fbfcb83f9a89"
 "checksum murmur3 0.4.0 (git+https://github.com/pingcap/murmur3.git)" = "<none>"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
-"checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 "checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
@@ -2640,7 +2583,6 @@ dependencies = [
 "checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
 "checksum signal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "106428d9d96840ecdec5208c13ab8a4e28c38da1e0ccf2909fb44e41b992f897"
 "checksum simplelog 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9cc12b39fdf4c9a07f88bffac2d628f0118ed5ac077a4b0feece61fadf1429e5"
-"checksum slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d807fd58c4181bbabed77cb3b891ba9748241a552bcc5be698faaebefc54f46e"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "09e4f1d0276ac7d448d98db16f0dab0220c24d4842d88ce4dad4b306fa234f1d"
 "checksum slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e544d16c6b230d84c866662fe55e31aacfca6ae71e6fc49ae9a311cb379bfc2f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ regex = "1.0"
 fnv = "1.0"
 sys-info = "0.5.1"
 indexmap = { version = "1.0", features = ["serde-1"] }
-mio = "0.5"
 futures = "0.1"
 futures-cpupool = "0.1"
 tikv_alloc = { path = "components/tikv_alloc" }

--- a/README.md
+++ b/README.md
@@ -189,5 +189,4 @@ TiKV is under the Apache 2.0 license. See the [LICENSE](./LICENSE) file for deta
 
 - Thanks [etcd](https://github.com/coreos/etcd) for providing some great open source tools.
 - Thanks [RocksDB](https://github.com/facebook/rocksdb) for their powerful storage engines.
-- Thanks [mio](https://github.com/carllerche/mio) for providing metal I/O library for Rust.
 - Thanks [rust-clippy](https://github.com/Manishearth/rust-clippy). We do love the great project.

--- a/benches/misc/mod.rs
+++ b/benches/misc/mod.rs
@@ -18,7 +18,6 @@ extern crate byteorder;
 extern crate crossbeam;
 extern crate futures;
 extern crate kvproto;
-extern crate mio;
 extern crate num_traits;
 extern crate protobuf;
 extern crate raft;

--- a/benches/misc/raftkv/mod.rs
+++ b/benches/misc/raftkv/mod.rs
@@ -22,7 +22,7 @@ use kvproto::metapb::Region;
 use kvproto::raft_cmdpb::{RaftCmdResponse, Response};
 
 use tikv::raftstore::store::{
-    cmd_resp, engine, util, Callback, Msg, ReadResponse, RegionSnapshot, SignificantMsg,
+    cmd_resp, engine, util, Callback, Msg, PeerMsg, ReadResponse, RegionSnapshot, SignificantMsg,
     WriteResponse,
 };
 use tikv::raftstore::Result;
@@ -51,9 +51,9 @@ impl SyncBenchRouter {
     fn invoke(&self, msg: Msg) {
         let mut response = RaftCmdResponse::new();
         cmd_resp::bind_term(&mut response, 1);
-        if let Msg::RaftCmd {
+        if let Msg::PeerMsg(PeerMsg::RaftCmd {
             request, callback, ..
-        } = msg
+        }) = msg
         {
             match callback {
                 Callback::Read(cb) => {
@@ -88,7 +88,7 @@ impl RaftStoreRouter for SyncBenchRouter {
         Ok(())
     }
 
-    fn significant_send(&self, _: SignificantMsg) -> Result<()> {
+    fn significant_send(&self, _region_id: u64, _: SignificantMsg) -> Result<()> {
         Ok(())
     }
 }

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -28,11 +28,11 @@ use kvproto::raft_serverpb::RaftMessage;
 
 use tikv::config::TiKvConfig;
 use tikv::pd::PdClient;
+use tikv::raftstore::store::fsm::SendCh;
 use tikv::raftstore::store::*;
 use tikv::raftstore::{Error, Result};
 use tikv::storage::CF_DEFAULT;
 use tikv::util::collections::{HashMap, HashSet};
-use tikv::util::transport::SendCh;
 use tikv::util::{escape, rocksdb, HandyRwLock};
 
 use super::*;
@@ -64,7 +64,7 @@ pub trait Simulator {
     ) -> Result<()>;
     fn send_raft_msg(&mut self, msg: RaftMessage) -> Result<()>;
     fn get_snap_dir(&self, node_id: u64) -> String;
-    fn get_store_sendch(&self, node_id: u64) -> Option<SendCh<Msg>>;
+    fn get_store_sendch(&self, node_id: u64) -> Option<SendCh>;
     fn add_send_filter(&mut self, node_id: u64, filter: SendFilter);
     fn clear_send_filters(&mut self, node_id: u64);
     fn add_recv_filter(&mut self, node_id: u64, filter: RecvFilter);
@@ -212,6 +212,10 @@ impl<T: Simulator> Cluster<T> {
 
     pub fn get_raft_engine(&self, node_id: u64) -> Arc<DB> {
         Arc::clone(&self.engines[&node_id].raft)
+    }
+
+    pub fn get_all_engines(&self, node_id: u64) -> Engines {
+        self.engines[&node_id].clone()
     }
 
     pub fn send_raft_msg(&mut self, msg: RaftMessage) -> Result<()> {
@@ -807,12 +811,12 @@ impl<T: Simulator> Cluster<T> {
             .get_store_sendch(leader.get_store_id())
             .unwrap();
         let split_key = split_key.to_vec();
-        ch.try_send(Msg::SplitRegion {
+        ch.try_send(Msg::PeerMsg(PeerMsg::SplitRegion {
             region_id: region.get_id(),
             region_epoch: region.get_region_epoch().clone(),
             split_keys: vec![split_key.clone()],
             callback: cb,
-        }).unwrap();
+        })).unwrap();
     }
 
     pub fn must_split(&mut self, region: &metapb::Region, split_key: &[u8]) {

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -11,9 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Deref;
 use std::path::Path;
-use std::sync::{mpsc, Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use tempdir::TempDir;
 
@@ -26,14 +25,13 @@ use raft::SnapshotStatus;
 use tikv::config::TiKvConfig;
 use tikv::import::SSTImporter;
 use tikv::raftstore::coprocessor::CoprocessorHost;
+use tikv::raftstore::store::fsm::{create_raft_batch_system, SendCh};
 use tikv::raftstore::store::*;
 use tikv::raftstore::Result;
 use tikv::server::transport::{RaftStoreRouter, ServerRaftStoreRouter};
 use tikv::server::Node;
 use tikv::util::collections::{HashMap, HashSet};
-use tikv::util::transport::SendCh;
 use tikv::util::worker::{FutureWorker, Worker};
-use tikv::util::HandyRwLock;
 
 use super::*;
 
@@ -44,25 +42,17 @@ pub struct ChannelTransportCore {
 
 #[derive(Clone)]
 pub struct ChannelTransport {
-    core: Arc<RwLock<ChannelTransportCore>>,
+    core: Arc<Mutex<ChannelTransportCore>>,
 }
 
 impl ChannelTransport {
     pub fn new() -> ChannelTransport {
         ChannelTransport {
-            core: Arc::new(RwLock::new(ChannelTransportCore {
+            core: Arc::new(Mutex::new(ChannelTransportCore {
                 snap_paths: HashMap::default(),
                 routers: HashMap::default(),
             })),
         }
-    }
-}
-
-impl Deref for ChannelTransport {
-    type Target = Arc<RwLock<ChannelTransportCore>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.core
     }
 }
 
@@ -77,14 +67,14 @@ impl Channel<RaftMessage> for ChannelTransport {
         if msg.get_message().get_msg_type() == MessageType::MsgSnapshot {
             let snap = msg.get_message().get_snapshot();
             let key = SnapKey::from_snap(snap).unwrap();
-            let from = match self.rl().snap_paths.get(&from_store) {
+            let from = match self.core.lock().unwrap().snap_paths.get(&from_store) {
                 Some(p) => {
                     p.0.register(key.clone(), SnapEntry::Sending);
                     p.0.get_snapshot_for_sending(&key).unwrap()
                 }
                 None => return Err(box_err!("missing temp dir for store {}", from_store)),
             };
-            let to = match self.rl().snap_paths.get(&to_store) {
+            let to = match self.core.lock().unwrap().snap_paths.get(&to_store) {
                 Some(p) => {
                     p.0.register(key.clone(), SnapEntry::Receiving);
                     let data = msg.get_message().get_snapshot().get_data();
@@ -94,7 +84,7 @@ impl Channel<RaftMessage> for ChannelTransport {
             };
 
             defer!({
-                let core = self.rl();
+                let core = self.core.lock().unwrap();
                 core.snap_paths[&from_store]
                     .0
                     .deregister(&key, &SnapEntry::Sending);
@@ -106,12 +96,13 @@ impl Channel<RaftMessage> for ChannelTransport {
             copy_snapshot(from, to)?;
         }
 
-        match self.core.rl().routers.get(&to_store) {
+        let core = self.core.lock().unwrap();
+
+        match core.routers.get(&to_store) {
             Some(h) => {
                 h.send_raft_msg(msg)?;
                 if is_snapshot {
                     // should report snapshot finish.
-                    let core = self.rl();
                     core.routers[&from_store]
                         .report_snapshot_status(region_id, to_peer_id, SnapshotStatus::Finish)
                         .unwrap();
@@ -148,7 +139,14 @@ impl NodeCluster {
 impl NodeCluster {
     #[allow(dead_code)]
     pub fn get_node_router(&self, node_id: u64) -> SimulateTransport<Msg, ServerRaftStoreRouter> {
-        self.trans.rl().routers.get(&node_id).cloned().unwrap()
+        self.trans
+            .core
+            .lock()
+            .unwrap()
+            .routers
+            .get(&node_id)
+            .cloned()
+            .unwrap()
     }
 
     // Set a function that will be invoked after creating each CoprocessorHost. The first argument
@@ -167,9 +165,7 @@ impl Simulator for NodeCluster {
         engines: Option<Engines>,
     ) -> (u64, Engines, Option<TempDir>) {
         assert!(node_id == 0 || !self.nodes.contains_key(&node_id));
-
-        let mut event_loop = create_event_loop(&cfg.raft_store).unwrap();
-        let (snap_status_sender, snap_status_receiver) = mpsc::channel();
+        let (router, system) = create_raft_batch_system(&cfg.raft_store);
         let pd_worker = FutureWorker::new("test-pd-worker");
 
         // Create localreader.
@@ -178,7 +174,7 @@ impl Simulator for NodeCluster {
 
         let simulate_trans = SimulateTransport::new(self.trans.clone());
         let mut node = Node::new(
-            &mut event_loop,
+            system,
             &cfg.server,
             &cfg.raft_store,
             Arc::clone(&self.pd_client),
@@ -187,13 +183,20 @@ impl Simulator for NodeCluster {
         // Create engine
         let (engines, path) = create_test_engine(engines, node.get_sendch(), &cfg);
 
-        let (snap_mgr, tmp) = if node_id == 0 || !self.trans.rl().snap_paths.contains_key(&node_id)
+        let (snap_mgr, tmp) = if node_id == 0
+            || !self
+                .trans
+                .core
+                .lock()
+                .unwrap()
+                .snap_paths
+                .contains_key(&node_id)
         {
             let tmp = TempDir::new("test_cluster").unwrap();
             let snap_mgr = SnapManager::new(tmp.path().to_str().unwrap(), Some(node.get_sendch()));
             (snap_mgr, Some(tmp))
         } else {
-            let trans = self.trans.rl();
+            let trans = self.trans.core.lock().unwrap();
             let &(ref snap_mgr, _) = &trans.snap_paths[&node_id];
             (snap_mgr.clone(), None)
         };
@@ -211,11 +214,9 @@ impl Simulator for NodeCluster {
         };
 
         node.start(
-            event_loop,
             engines.clone(),
             simulate_trans.clone(),
             snap_mgr.clone(),
-            snap_status_receiver,
             pd_worker,
             local_reader,
             coprocessor_host,
@@ -236,16 +237,19 @@ impl Simulator for NodeCluster {
         );
         if let Some(tmp) = tmp {
             self.trans
-                .wl()
+                .core
+                .lock()
+                .unwrap()
                 .snap_paths
                 .insert(node.id(), (snap_mgr, tmp));
         }
 
         let node_id = node.id();
-        let router =
-            ServerRaftStoreRouter::new(node.get_sendch(), snap_status_sender.clone(), local_ch);
+        let router = ServerRaftStoreRouter::new(node.get_sendch(), router.clone(), local_ch);
         self.trans
-            .wl()
+            .core
+            .lock()
+            .unwrap()
             .routers
             .insert(node_id, SimulateTransport::new(router));
         self.nodes.insert(node_id, node);
@@ -255,7 +259,7 @@ impl Simulator for NodeCluster {
     }
 
     fn get_snap_dir(&self, node_id: u64) -> String {
-        self.trans.wl().snap_paths[&node_id]
+        self.trans.core.lock().unwrap().snap_paths[&node_id]
             .1
             .path()
             .to_str()
@@ -267,7 +271,13 @@ impl Simulator for NodeCluster {
         if let Some(mut node) = self.nodes.remove(&node_id) {
             node.stop().unwrap();
         }
-        self.trans.wl().routers.remove(&node_id).unwrap();
+        self.trans
+            .core
+            .lock()
+            .unwrap()
+            .routers
+            .remove(&node_id)
+            .unwrap();
     }
 
     fn get_node_ids(&self) -> HashSet<u64> {
@@ -280,11 +290,26 @@ impl Simulator for NodeCluster {
         request: RaftCmdRequest,
         cb: Callback,
     ) -> Result<()> {
-        if !self.trans.rl().routers.contains_key(&node_id) {
+        if !self
+            .trans
+            .core
+            .lock()
+            .unwrap()
+            .routers
+            .contains_key(&node_id)
+        {
             return Err(box_err!("missing sender for store {}", node_id));
         }
 
-        let router = self.trans.rl().routers.get(&node_id).cloned().unwrap();
+        let router = self
+            .trans
+            .core
+            .lock()
+            .unwrap()
+            .routers
+            .get(&node_id)
+            .cloned()
+            .unwrap();
         router.send_command(request, cb)
     }
 
@@ -307,16 +332,16 @@ impl Simulator for NodeCluster {
     }
 
     fn add_recv_filter(&mut self, node_id: u64, filter: RecvFilter) {
-        let mut trans = self.trans.wl();
+        let mut trans = self.trans.core.lock().unwrap();
         trans.routers.get_mut(&node_id).unwrap().add_filter(filter);
     }
 
     fn clear_recv_filters(&mut self, node_id: u64) {
-        let mut trans = self.trans.wl();
+        let mut trans = self.trans.core.lock().unwrap();
         trans.routers.get_mut(&node_id).unwrap().clear_filters();
     }
 
-    fn get_store_sendch(&self, node_id: u64) -> Option<SendCh<Msg>> {
+    fn get_store_sendch(&self, node_id: u64) -> Option<SendCh> {
         self.nodes.get(&node_id).map(|node| node.get_sendch())
     }
 }

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use std::path::Path;
-use std::sync::{mpsc, Arc, RwLock};
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use std::{thread, usize};
 
@@ -26,8 +26,9 @@ use tikv::config::TiKvConfig;
 use tikv::coprocessor;
 use tikv::import::{ImportSSTService, SSTImporter};
 use tikv::raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor};
+use tikv::raftstore::store::fsm::{create_raft_batch_system, SendCh};
 use tikv::raftstore::store::{Callback, Engines, Msg as StoreMsg, SnapManager};
-use tikv::raftstore::{store, Result};
+use tikv::raftstore::Result;
 use tikv::server::load_statistics::ThreadLoad;
 use tikv::server::readpool::ReadPool;
 use tikv::server::resolve::{self, Task as ResolveTask};
@@ -40,7 +41,6 @@ use tikv::server::{
 use tikv::storage::{self, RaftKv};
 use tikv::util::collections::{HashMap, HashSet};
 use tikv::util::security::SecurityManager;
-use tikv::util::transport::SendCh;
 use tikv::util::worker::{FutureWorker, Worker};
 
 use super::*;
@@ -56,7 +56,7 @@ struct ServerMeta {
     server: Server<SimulateStoreTransport, PdStoreAddrResolver>,
     router: SimulateStoreTransport,
     sim_trans: SimulateServerTransport,
-    store_ch: SendCh<StoreMsg>,
+    store_ch: SendCh,
     worker: Worker<ResolveTask>,
 }
 
@@ -126,16 +126,14 @@ impl Simulator for ServerCluster {
         }
 
         // Initialize raftstore channels.
-        let mut event_loop = store::create_event_loop(&cfg.raft_store).unwrap();
-        let store_sendch = SendCh::new(event_loop.channel(), "raftstore");
-        let (snap_status_sender, snap_status_receiver) = mpsc::channel();
+        let (router, system) = create_raft_batch_system(&cfg.raft_store);
+        let store_sendch = SendCh::new(router.clone(), "raftstore");
 
         // Create localreader.
         let local_reader = Worker::new("test-local-reader");
         let local_ch = local_reader.scheduler();
 
-        let raft_router =
-            ServerRaftStoreRouter::new(store_sendch.clone(), snap_status_sender, local_ch);
+        let raft_router = ServerRaftStoreRouter::new(store_sendch.clone(), router, local_ch);
         let sim_router = SimulateTransport::new(raft_router);
 
         // Create engine
@@ -212,7 +210,7 @@ impl Simulator for ServerCluster {
 
         // Create node.
         let mut node = Node::new(
-            &mut event_loop,
+            system,
             &cfg.server,
             &cfg.raft_store,
             Arc::clone(&self.pd_client),
@@ -228,11 +226,9 @@ impl Simulator for ServerCluster {
             .insert(node_id, region_info_accessor);
 
         node.start(
-            event_loop,
             engines.clone(),
             simulate_trans.clone(),
             snap_mgr.clone(),
-            snap_status_receiver,
             pd_worker,
             local_reader,
             coprocessor_host,
@@ -331,7 +327,7 @@ impl Simulator for ServerCluster {
         self.metas.get_mut(&node_id).unwrap().router.clear_filters();
     }
 
-    fn get_store_sendch(&self, node_id: u64) -> Option<SendCh<StoreMsg>> {
+    fn get_store_sendch(&self, node_id: u64) -> Option<SendCh> {
         self.metas.get(&node_id).map(|m| m.store_ch.clone())
     }
 }

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 use std::path::Path;
-use std::sync::{mpsc, Arc};
-use std::thread;
+use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
+use std::{thread, u64};
 
 use protobuf;
 use rand::Rng;
@@ -25,18 +25,18 @@ use kvproto::metapb::{self, RegionEpoch};
 use kvproto::pdpb::{ChangePeer, Merge, RegionHeartbeatResponse, SplitRegion, TransferLeader};
 use kvproto::raft_cmdpb::{AdminCmdType, CmdType, StatusCmdType};
 use kvproto::raft_cmdpb::{AdminRequest, RaftCmdRequest, RaftCmdResponse, Request, StatusRequest};
+use kvproto::raft_serverpb::{PeerState, RaftLocalState, RegionLocalState};
 use raft::eraftpb::ConfChangeType;
 
 use tikv::config::*;
-use tikv::raftstore::store::Msg as StoreMsg;
+use tikv::raftstore::store::fsm::SendCh;
 use tikv::raftstore::store::*;
 use tikv::raftstore::Result;
 use tikv::server::Config as ServerConfig;
-use tikv::storage::{Config as StorageConfig, CF_DEFAULT};
+use tikv::storage::{Config as StorageConfig, ALL_CFS, CF_DEFAULT, CF_RAFT};
 use tikv::util::config::*;
 use tikv::util::escape;
 use tikv::util::rocksdb::{self, CompactionListener};
-use tikv::util::transport::SendCh;
 
 use super::*;
 
@@ -82,6 +82,42 @@ pub fn must_get_cf_equal(engine: &Arc<DB>, cf: &str, key: &[u8], value: &[u8]) {
 
 pub fn must_get_cf_none(engine: &Arc<DB>, cf: &str, key: &[u8]) {
     must_get(engine, cf, key, None);
+}
+
+pub fn must_region_cleared(engine: &Engines, region: &metapb::Region) {
+    let id = region.get_id();
+    let state_key = keys::region_state_key(id);
+    let state: RegionLocalState = engine.kv.get_msg_cf(CF_RAFT, &state_key).unwrap().unwrap();
+    assert_eq!(state.get_state(), PeerState::Tombstone, "{:?}", state);
+    let start_key = keys::data_key(region.get_start_key());
+    let end_key = keys::data_key(region.get_end_key());
+    for cf in ALL_CFS {
+        engine
+            .kv
+            .scan_cf(cf, &start_key, &end_key, false, |k, v| {
+                panic!(
+                    "[region {}] unexpected ({:?}, {:?}) in cf {:?}",
+                    id, k, v, cf
+                );
+            })
+            .unwrap();
+    }
+    let log_min_key = keys::raft_log_key(id, 0);
+    let log_max_key = keys::raft_log_key(id, u64::MAX);
+    engine
+        .raft
+        .scan(&log_min_key, &log_max_key, false, |k, v| {
+            panic!("[region {}] unexpected log ({:?}, {:?})", id, k, v);
+        })
+        .unwrap();
+    let state_key = keys::raft_state_key(id);
+    let state: Option<RaftLocalState> = engine.raft.get_msg(&state_key).unwrap();
+    assert!(
+        state.is_none(),
+        "[region {}] raft state key should be removed: {:?}",
+        id,
+        state
+    );
 }
 
 pub fn new_store_cfg() -> Config {
@@ -445,7 +481,7 @@ fn dummpy_filter(_: &CompactionJobInfo) -> bool {
 
 pub fn create_test_engine(
     engines: Option<Engines>,
-    tx: SendCh<StoreMsg>,
+    tx: SendCh,
     cfg: &TiKvConfig,
 ) -> (Engines, Option<TempDir>) {
     // Create engine
@@ -455,8 +491,12 @@ pub fn create_test_engine(
         None => {
             path = Some(TempDir::new("test_cluster").unwrap());
             let mut kv_db_opt = cfg.rocksdb.build_opt();
+            let tx = Mutex::new(tx);
             let cmpacted_handler = box move |event| {
-                tx.send(StoreMsg::CompactedEvent(event)).unwrap();
+                tx.lock()
+                    .unwrap()
+                    .send(Msg::StoreMsg(StoreMsg::CompactedEvent(event)))
+                    .unwrap();
             };
             kv_db_opt.add_event_listener(CompactionListener::new(
                 cmpacted_handler,

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -54,7 +54,7 @@ use std::fs::File;
 use std::path::Path;
 use std::process;
 use std::sync::atomic::Ordering;
-use std::sync::{mpsc, Arc};
+use std::sync::Arc;
 use std::time::Duration;
 use std::usize;
 
@@ -66,7 +66,8 @@ use tikv::coprocessor;
 use tikv::import::{ImportSSTService, SSTImporter};
 use tikv::pd::{PdClient, RpcClient};
 use tikv::raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor};
-use tikv::raftstore::store::{self, new_compaction_listener, Engines, SnapManagerBuilder};
+use tikv::raftstore::store::fsm::{self, SendCh};
+use tikv::raftstore::store::{new_compaction_listener, Engines, SnapManagerBuilder};
 use tikv::server::readpool::ReadPool;
 use tikv::server::resolve;
 use tikv::server::status_server::StatusServer;
@@ -76,7 +77,6 @@ use tikv::storage::{self, AutoGCConfig, DEFAULT_ROCKSDB_SUB_DIR};
 use tikv::util::rocksdb::metrics_flusher::{MetricsFlusher, DEFAULT_FLUSHER_INTERVAL};
 use tikv::util::security::SecurityManager;
 use tikv::util::time::Monitor;
-use tikv::util::transport::SendCh;
 use tikv::util::worker::{Builder, FutureWorker};
 use tikv::util::{self as tikv_util, check_environment_variables, rocksdb as rocksdb_util};
 
@@ -128,10 +128,8 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     }
 
     // Initialize raftstore channels.
-    let mut event_loop = store::create_event_loop(&cfg.raft_store)
-        .unwrap_or_else(|e| fatal!("failed to create event loop: {:?}", e));
-    let store_sendch = SendCh::new(event_loop.channel(), "raftstore");
-    let (significant_msg_sender, significant_msg_receiver) = mpsc::channel();
+    let (router, system) = fsm::create_raft_batch_system(&cfg.raft_store);
+    let store_sendch = SendCh::new(router.clone(), "raftstore");
 
     // Create Local Reader.
     let local_reader = Builder::new("local-reader")
@@ -140,9 +138,8 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     let local_ch = local_reader.scheduler();
 
     // Create router.
-    let raft_router =
-        ServerRaftStoreRouter::new(store_sendch.clone(), significant_msg_sender, local_ch);
-    let compaction_listener = new_compaction_listener(store_sendch.clone());
+    let raft_router = ServerRaftStoreRouter::new(store_sendch.clone(), router.clone(), local_ch);
+    let compaction_listener = new_compaction_listener(router);
 
     // Create pd client and pd worker
     let pd_client = Arc::new(pd_client);
@@ -220,12 +217,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     let trans = server.transport();
 
     // Create node.
-    let mut node = Node::new(
-        &mut event_loop,
-        &server_cfg,
-        &cfg.raft_store,
-        pd_client.clone(),
-    );
+    let mut node = Node::new(system, &server_cfg, &cfg.raft_store, pd_client.clone());
 
     // Create CoprocessorHost.
     let mut coprocessor_host = CoprocessorHost::new(cfg.coprocessor.clone(), node.get_sendch());
@@ -235,11 +227,9 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     region_info_accessor.start();
 
     node.start(
-        event_loop,
         engines.clone(),
         trans,
         snap_mgr,
-        significant_msg_receiver,
         pd_worker,
         local_reader,
         coprocessor_host,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 #![feature(ascii_ctype)]
 #![feature(const_int_ops)]
 #![feature(use_extern_macros)]
+#![feature(cell_update)]
 #![recursion_limit = "200"]
 #![feature(range_contains)]
 // Currently this raises some false positives, so we allow it:
@@ -60,7 +61,6 @@ extern crate kvproto;
 extern crate lazy_static;
 extern crate libc;
 extern crate log;
-extern crate mio;
 extern crate murmur3;
 extern crate num;
 extern crate num_traits;

--- a/src/raftstore/coprocessor/dispatcher.rs
+++ b/src/raftstore/coprocessor/dispatcher.rs
@@ -131,7 +131,7 @@ pub struct CoprocessorHost {
 }
 
 impl CoprocessorHost {
-    pub fn new<C: Sender<Msg> + Send + Sync + 'static>(
+    pub fn new<C: Sender<Msg> + Send + 'static>(
         cfg: Config,
         ch: RetryableSendCh<Msg, C>,
     ) -> CoprocessorHost {

--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -11,11 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::mem;
-
 use kvproto::pdpb::CheckPolicy;
-use raftstore::store::{keys, util, Msg};
+use raftstore::store::{keys, util, Msg, PeerMsg};
 use rocksdb::DB;
+use std::mem;
+use std::sync::Mutex;
 use util::transport::{RetryableSendCh, Sender};
 
 use super::super::metrics::*;
@@ -92,7 +92,7 @@ pub struct KeysCheckObserver<C> {
     region_max_keys: u64,
     split_keys: u64,
     batch_split_limit: u64,
-    ch: RetryableSendCh<Msg, C>,
+    ch: Mutex<RetryableSendCh<Msg, C>>,
 }
 
 impl<C: Sender<Msg>> KeysCheckObserver<C> {
@@ -106,7 +106,7 @@ impl<C: Sender<Msg>> KeysCheckObserver<C> {
             region_max_keys,
             split_keys,
             batch_split_limit,
-            ch,
+            ch: Mutex::new(ch),
         }
     }
 }
@@ -141,11 +141,11 @@ impl<C: Sender<Msg> + Send> SplitCheckObserver for KeysCheckObserver<C> {
             }
         };
 
-        let res = Msg::RegionApproximateKeys {
+        let res = Msg::PeerMsg(PeerMsg::RegionApproximateKeys {
             region_id,
             keys: region_keys,
-        };
-        if let Err(e) = self.ch.try_send(res) {
+        });
+        if let Err(e) = self.ch.lock().unwrap().try_send(res) {
             warn!(
                 "[region {}] failed to send approximate region keys: {}",
                 region_id, e
@@ -189,7 +189,7 @@ mod tests {
     use rocksdb::{ColumnFamilyOptions, DBOptions, Writable, DB};
     use tempdir::TempDir;
 
-    use raftstore::store::{keys, Msg, SplitCheckRunner, SplitCheckTask};
+    use raftstore::store::{keys, Msg, PeerMsg, SplitCheckRunner, SplitCheckTask};
     use storage::mvcc::{Write, WriteType};
     use storage::{Key, ALL_CFS, CF_DEFAULT, CF_WRITE};
     use util::properties::RangePropertiesCollectorFactory;
@@ -269,8 +269,8 @@ mod tests {
         runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::SCAN));
         // keys has not reached the max_keys 100 yet.
         match rx.try_recv() {
-            Ok(Msg::RegionApproximateSize { region_id, .. })
-            | Ok(Msg::RegionApproximateKeys { region_id, .. }) => {
+            Ok(Msg::PeerMsg(PeerMsg::RegionApproximateSize { region_id, .. }))
+            | Ok(Msg::PeerMsg(PeerMsg::RegionApproximateKeys { region_id, .. })) => {
                 assert_eq!(region_id, region.get_id());
             }
             others => panic!("expect recv empty, but got {:?}", others),

--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -11,14 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::mem;
-
 use super::super::error::Result;
 use kvproto::metapb::Region;
 use kvproto::pdpb::CheckPolicy;
 use raftstore::store::util as raftstore_util;
-use raftstore::store::{keys, util, Msg};
+use raftstore::store::{keys, util, Msg, PeerMsg};
 use rocksdb::DB;
+use std::mem;
+use std::sync::Mutex;
 use util::transport::{RetryableSendCh, Sender};
 
 use super::super::metrics::*;
@@ -107,7 +107,7 @@ pub struct SizeCheckObserver<C> {
     region_max_size: u64,
     split_size: u64,
     split_limit: u64,
-    ch: RetryableSendCh<Msg, C>,
+    ch: Mutex<RetryableSendCh<Msg, C>>,
 }
 
 impl<C: Sender<Msg>> SizeCheckObserver<C> {
@@ -121,7 +121,7 @@ impl<C: Sender<Msg>> SizeCheckObserver<C> {
             region_max_size,
             split_size,
             split_limit,
-            ch,
+            ch: Mutex::new(ch),
         }
     }
 }
@@ -157,11 +157,11 @@ impl<C: Sender<Msg> + Send> SplitCheckObserver for SizeCheckObserver<C> {
         };
 
         // send it to rafastore to update region approximate size
-        let res = Msg::RegionApproximateSize {
+        let res = Msg::PeerMsg(PeerMsg::RegionApproximateSize {
             region_id,
             size: region_size,
-        };
-        if let Err(e) = self.ch.try_send(res) {
+        });
+        if let Err(e) = self.ch.lock().unwrap().try_send(res) {
             warn!(
                 "[region {}] failed to send approximate region size: {}",
                 region_id, e
@@ -213,7 +213,7 @@ pub mod tests {
 
     use super::Checker;
     use raftstore::coprocessor::{Config, CoprocessorHost, ObserverContext, SplitChecker};
-    use raftstore::store::{keys, KeyEntry, Msg, SplitCheckRunner, SplitCheckTask};
+    use raftstore::store::{keys, KeyEntry, Msg, PeerMsg, SplitCheckRunner, SplitCheckTask};
     use storage::{ALL_CFS, CF_WRITE};
     use util::config::ReadableSize;
     use util::properties::RangePropertiesCollectorFactory;
@@ -228,16 +228,16 @@ pub mod tests {
     ) {
         loop {
             match rx.try_recv() {
-                Ok(Msg::RegionApproximateSize { region_id, .. })
-                | Ok(Msg::RegionApproximateKeys { region_id, .. }) => {
+                Ok(Msg::PeerMsg(PeerMsg::RegionApproximateSize { region_id, .. }))
+                | Ok(Msg::PeerMsg(PeerMsg::RegionApproximateKeys { region_id, .. })) => {
                     assert_eq!(region_id, exp_region.get_id());
                 }
-                Ok(Msg::SplitRegion {
+                Ok(Msg::PeerMsg(PeerMsg::SplitRegion {
                     region_id,
                     region_epoch,
                     split_keys,
                     ..
-                }) => {
+                })) => {
                     assert_eq!(region_id, exp_region.get_id());
                     assert_eq!(&region_epoch, exp_region.get_region_epoch());
                     assert_eq!(split_keys, exp_split_keys);
@@ -293,7 +293,7 @@ pub mod tests {
         runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::SCAN));
         // size has not reached the max_size 100 yet.
         match rx.try_recv() {
-            Ok(Msg::RegionApproximateSize { region_id, .. }) => {
+            Ok(Msg::PeerMsg(PeerMsg::RegionApproximateSize { region_id, .. })) => {
                 assert_eq!(region_id, region.get_id());
             }
             others => panic!("expect recv empty, but got {:?}", others),

--- a/src/raftstore/coprocessor/split_check/table.rs
+++ b/src/raftstore/coprocessor/split_check/table.rs
@@ -235,7 +235,7 @@ mod tests {
     use tempdir::TempDir;
 
     use coprocessor::codec::table::{TABLE_PREFIX, TABLE_PREFIX_KEY_LEN};
-    use raftstore::store::{Msg, SplitCheckRunner, SplitCheckTask};
+    use raftstore::store::{Msg, PeerMsg, SplitCheckRunner, SplitCheckTask};
     use storage::types::Key;
     use storage::ALL_CFS;
     use util::codec::number::NumberEncoder;
@@ -349,7 +349,7 @@ mod tests {
                 if let Some(id) = table_id {
                     let key = Key::from_raw(&gen_table_prefix(id));
                     match rx.try_recv() {
-                        Ok(Msg::SplitRegion { split_keys, .. }) => {
+                        Ok(Msg::PeerMsg(PeerMsg::SplitRegion { split_keys, .. })) => {
                             assert_eq!(split_keys, vec![key.into_encoded()]);
                         }
                         others => panic!("expect {:?}, but got {:?}", key, others),

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -128,6 +128,10 @@ pub struct Config {
     pub apply_max_batch_size: usize,
     pub apply_pool_size: usize,
 
+    pub store_max_batch_size: usize,
+    pub store_pool_size: usize,
+    pub future_poll_size: usize,
+
     // Deprecated! These two configuration has been moved to Coprocessor.
     // They are preserved for compatibility check.
     #[doc(hidden)]
@@ -196,6 +200,9 @@ impl Default for Config {
             local_read_batch_size: 1024,
             apply_max_batch_size: 1024,
             apply_pool_size: 2,
+            store_max_batch_size: 1024,
+            store_pool_size: 2,
+            future_poll_size: 1,
 
             // They are preserved for compatibility check.
             region_max_size: ReadableSize(0),
@@ -340,6 +347,15 @@ impl Config {
         if self.apply_max_batch_size == 0 {
             return Err(box_err!("apply-max-batch-size should be greater than 0"));
         }
+        if self.store_pool_size == 0 {
+            return Err(box_err!("store-pool-size should be greater than 0"));
+        }
+        if self.store_max_batch_size == 0 {
+            return Err(box_err!("store-max-batch-size should be greater than 0"));
+        }
+        if self.future_poll_size == 0 {
+            return Err(box_err!("future-poll-size should be greater than 0."));
+        }
         Ok(())
     }
 }
@@ -431,6 +447,10 @@ mod tests {
 
         cfg = Config::new();
         cfg.apply_pool_size = 0;
+        assert!(cfg.validate().is_err());
+
+        cfg = Config::new();
+        cfg.future_poll_size = 0;
         assert!(cfg.validate().is_err());
     }
 }

--- a/src/raftstore/store/fsm/batch.rs
+++ b/src/raftstore/store/fsm/batch.rs
@@ -38,7 +38,7 @@ pub trait FsmScheduler {
 }
 
 /// A Fsm is a finite state machine. It should be able to be notified for
-/// updating internal state according to incomming messages.
+/// updating internal state according to incoming messages.
 pub trait Fsm {
     type Message: Send;
 
@@ -145,6 +145,10 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
         }
     }
 
+    pub fn normals_mut(&mut self) -> &mut [Box<N>] {
+        &mut self.normals
+    }
+
     fn push(&mut self, fsm: FsmTypes<N, C>) -> bool {
         match fsm {
             FsmTypes::Normal(n) => self.normals.push(n),
@@ -155,6 +159,11 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
             FsmTypes::Empty => return false,
         }
         true
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.normals.len() + self.control.is_some() as usize
     }
 
     fn is_empty(&self) -> bool {
@@ -255,7 +264,7 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
 /// Sync.
 pub trait PollHandler<N, C> {
     /// This function is called at the very beginning of every round.
-    fn begin(&mut self);
+    fn begin(&mut self, batch_size: usize);
 
     /// This function is called when handling readiness for control FSM.
     ///
@@ -272,7 +281,7 @@ pub trait PollHandler<N, C> {
     fn handle_normal(&mut self, normal: &mut N) -> Option<usize>;
 
     /// This function is called at the end of every round.
-    fn end(&mut self);
+    fn end(&mut self, batch: &mut [Box<N>]);
 }
 
 /// Internal poller that fetches batch and call handler hooks for readiness.
@@ -313,7 +322,7 @@ impl<N: Fsm, C: Fsm, Handler: PollHandler<N, C>> Poller<N, C, Handler> {
         let mut exhausted_fsms = Vec::with_capacity(batch_size);
         self.fetch_batch(&mut batch, batch_size);
         while !batch.is_empty() {
-            self.handler.begin();
+            self.handler.begin(batch.len());
             if batch.control.is_some() {
                 let len = self.handler.handle_control(batch.control.as_mut().unwrap());
                 if batch.control.as_ref().unwrap().is_stopped() {
@@ -332,7 +341,7 @@ impl<N: Fsm, C: Fsm, Handler: PollHandler<N, C>> Poller<N, C, Handler> {
                     }
                 }
             }
-            self.handler.end();
+            self.handler.end(batch.normals_mut());
             // Because release use `swap_remove` internally, so using pop here
             // to remove the correct FSM.
             while let Some((r, mark)) = exhausted_fsms.pop() {
@@ -365,7 +374,7 @@ pub trait HandlerBuilder<N, C> {
 /// to be defined: Normal and Control. Normal FSM handles the general
 /// task while Control FSM creates normal FSM instances.
 pub struct BatchSystem<N: Fsm, C: Fsm> {
-    name_prefix: String,
+    name_prefix: Option<String>,
     router: BatchRouter<N, C>,
     receiver: channel::Receiver<FsmTypes<N, C>>,
     pool_size: usize,
@@ -383,7 +392,7 @@ where
     }
 
     /// Start the batch system.
-    pub fn spawn<B>(&mut self, mut builder: B)
+    pub fn spawn<B>(&mut self, name_prefix: String, mut builder: B)
     where
         B: HandlerBuilder<N, C>,
         B::Handler: Send + 'static,
@@ -397,24 +406,29 @@ where
                 max_batch_size: self.max_batch_size,
             };
             let t = thread::Builder::new()
-                .name(thd_name!(format!("{}-{}", self.name_prefix, i)))
+                .name(thd_name!(format!("{}-{}", name_prefix, i)))
                 .spawn(move || {
                     poller.poll();
                 })
                 .unwrap();
             self.workers.push(t);
         }
+        self.name_prefix = Some(name_prefix);
     }
 
     /// Shutdown the batch system and wait till all background threads exit.
     pub fn shutdown(&mut self) {
-        info!("shutdown batch system {}", self.name_prefix);
+        if self.name_prefix.is_none() {
+            return;
+        }
+        let name_prefix = self.name_prefix.take().unwrap();
+        info!("shutdown batch system {}", name_prefix);
         self.router.broadcast_shutdown();
         for h in self.workers.drain(..) {
             debug!("waiting for {}", h.thread().name().unwrap());
             h.join().unwrap();
         }
-        info!("batch system {} is stopped.", self.name_prefix);
+        info!("batch system {} is stopped.", name_prefix);
     }
 }
 
@@ -424,7 +438,6 @@ pub type BatchRouter<N, C> = Router<N, C, NormalScheduler<N, C>, ControlSchedule
 ///
 /// `sender` and `controller` should be paired.
 pub fn create_system<N: Fsm, C: Fsm>(
-    name_prefix: String,
     pool_size: usize,
     max_batch_size: usize,
     sender: mpsc::LooseBoundedSender<C::Message>,
@@ -436,7 +449,7 @@ pub fn create_system<N: Fsm, C: Fsm>(
     let control_scheduler = ControlScheduler { sender: tx };
     let router = Router::new(control_box, normal_scheduler, control_scheduler);
     let system = BatchSystem {
-        name_prefix,
+        name_prefix: None,
         router: router.clone(),
         receiver: rx,
         pool_size,
@@ -507,7 +520,7 @@ mod tests {
     }
 
     impl PollHandler<Runner, Runner> for Handler {
-        fn begin(&mut self) {
+        fn begin(&mut self, _batch_size: usize) {
             self.local.begin += 1;
         }
 
@@ -527,7 +540,7 @@ mod tests {
             Some(0)
         }
 
-        fn end(&mut self) {
+        fn end(&mut self, _normals: &mut [Box<Runner>]) {
             let mut c = self.metrics.lock().unwrap();
             *c += self.local;
             self.local = HandleMetrics::default();
@@ -554,14 +567,13 @@ mod tests {
     #[test]
     fn test_batch() {
         let (control_tx, control_fsm) = new_runner(10);
-        let (router, mut system) =
-            super::create_system("test".to_owned(), 2, 2, control_tx, control_fsm);
+        let (router, mut system) = super::create_system(2, 2, control_tx, control_fsm);
         let builder = Builder {
             metrics: Arc::default(),
             router: router.clone(),
         };
         let metrics = builder.metrics.clone();
-        system.spawn(builder);
+        system.spawn("test".to_owned(), builder);
         let mut expected_metrics = HandleMetrics::default();
         assert_eq!(*metrics.lock().unwrap(), expected_metrics);
         let (tx, rx) = mpsc::unbounded();

--- a/src/raftstore/store/fsm/metrics.rs
+++ b/src/raftstore/store/fsm/metrics.rs
@@ -12,11 +12,86 @@
 // limitations under the License.
 
 use prometheus::{exponential_buckets, Histogram};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 
 lazy_static! {
     pub static ref APPLY_PROPOSAL: Histogram = register_histogram!(
         "tikv_raftstore_apply_proposal",
-        "Proposal count of all regions in a mio tick",
+        "The count of proposals sent by a region at once",
         exponential_buckets(1.0, 2.0, 20).unwrap()
     ).unwrap();
+}
+
+#[derive(Default)]
+pub struct StoreStat {
+    pub lock_cf_bytes_written: AtomicU64,
+    pub engine_total_bytes_written: AtomicU64,
+    pub engine_total_keys_written: AtomicU64,
+    pub is_busy: AtomicBool,
+}
+
+#[derive(Clone, Default)]
+pub struct GlobalStoreStat {
+    pub stat: Arc<StoreStat>,
+}
+
+impl GlobalStoreStat {
+    #[inline]
+    pub fn local(&self) -> LocalStoreStat {
+        LocalStoreStat {
+            lock_cf_bytes_written: 0,
+            engine_total_bytes_written: 0,
+            engine_total_keys_written: 0,
+            is_busy: false,
+
+            global: self.clone(),
+        }
+    }
+}
+
+pub struct LocalStoreStat {
+    pub lock_cf_bytes_written: u64,
+    pub engine_total_bytes_written: u64,
+    pub engine_total_keys_written: u64,
+    pub is_busy: bool,
+
+    global: GlobalStoreStat,
+}
+
+impl Clone for LocalStoreStat {
+    #[inline]
+    fn clone(&self) -> LocalStoreStat {
+        self.global.local()
+    }
+}
+
+impl LocalStoreStat {
+    pub fn flush(&mut self) {
+        if self.lock_cf_bytes_written != 0 {
+            self.global
+                .stat
+                .lock_cf_bytes_written
+                .fetch_add(self.lock_cf_bytes_written, Ordering::Relaxed);
+            self.lock_cf_bytes_written = 0;
+        }
+        if self.engine_total_bytes_written != 0 {
+            self.global
+                .stat
+                .engine_total_bytes_written
+                .fetch_add(self.engine_total_bytes_written, Ordering::Relaxed);
+            self.engine_total_bytes_written = 0;
+        }
+        if self.engine_total_keys_written != 0 {
+            self.global
+                .stat
+                .engine_total_keys_written
+                .fetch_add(self.engine_total_keys_written, Ordering::Relaxed);
+            self.engine_total_keys_written = 0;
+        }
+        if self.is_busy {
+            self.global.stat.is_busy.store(true, Ordering::Relaxed);
+            self.is_busy = false;
+        }
+    }
 }

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -12,17 +12,18 @@
 // limitations under the License.
 
 use protobuf::{Message, RepeatedField};
+use std::borrow::Cow;
 use std::collections::Bound::{Excluded, Included, Unbounded};
-use std::sync::mpsc::TryRecvError;
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{cmp, u64};
 
-use mio::EventLoop;
-use rocksdb::rocksdb_options::WriteOptions;
-
+use futures::Future;
+use kvproto::errorpb;
 use kvproto::import_sstpb::SSTMeta;
-use kvproto::metapb;
+use kvproto::metapb::{self, Region};
 use kvproto::pdpb::CheckPolicy;
 use kvproto::raft_cmdpb::{
     AdminCmdType, AdminRequest, RaftCmdRequest, RaftCmdResponse, StatusCmdType, StatusResponse,
@@ -31,33 +32,39 @@ use kvproto::raft_serverpb::{
     MergeState, PeerState, RaftMessage, RaftSnapshotData, RaftTruncatedState, RegionLocalState,
 };
 use raft::eraftpb::ConfChangeType;
+use raft::Ready;
 use raft::{self, SnapshotStatus, INVALID_INDEX, NO_LIMIT};
 
 use pd::{PdClient, PdTask};
 use raftstore::{Error, Result};
 use storage::CF_RAFT;
-use util::escape;
-use util::time::{duration_to_sec, SlowTimer};
-use util::worker::{FutureWorker, Stopped};
+use util::mpsc::{self, LooseBoundedSender, Receiver};
+use util::time::duration_to_sec;
+use util::worker::{Scheduler, Stopped};
+use util::{escape, is_zero_duration};
 
-use super::{store::register_timer, Key};
 use raftstore::coprocessor::RegionChangeEvent;
 use raftstore::store::cmd_resp::{bind_term, new_error};
 use raftstore::store::engine::{Peekable, Snapshot as EngineSnapshot};
+use raftstore::store::fsm::store::{PollContext, StoreMeta};
 use raftstore::store::fsm::{
-    ApplyMetrics, ApplyRes, ApplyTask, ApplyTaskRes, ChangePeer, ExecResult,
+    apply, ApplyMetrics, ApplyTask, ApplyTaskRes, BasicMailbox, ChangePeer, ExecResult, Fsm,
+    RegionProposal,
 };
 use raftstore::store::keys::{self, enc_end_key, enc_start_key};
-use raftstore::store::local_metrics::RaftMetrics;
 use raftstore::store::metrics::*;
 use raftstore::store::msg::Callback;
-use raftstore::store::peer::{ConsistencyState, Peer, ReadyContext, StaleState};
-use raftstore::store::peer_storage::ApplySnapResult;
+use raftstore::store::peer::{ConsistencyState, Peer, StaleState, WaitApplyResultState};
+use raftstore::store::peer_storage::{ApplySnapResult, InvokeContext};
 use raftstore::store::transport::Transport;
+use raftstore::store::util::KeysInfoFormatter;
 use raftstore::store::worker::{
-    CleanupSSTTask, ConsistencyCheckTask, RaftlogGcTask, ReadTask, SplitCheckTask,
+    CleanupSSTTask, ConsistencyCheckTask, RaftlogGcTask, ReadTask, RegionTask, SplitCheckTask,
 };
-use raftstore::store::{util, Msg, SignificantMsg, SnapKey, SnapshotDeleter, Store, Tick};
+use raftstore::store::Engines;
+use raftstore::store::{
+    util, Config, PeerMsg, PeerTick, SignificantMsg, SnapKey, SnapshotDeleter, StoreMsg,
+};
 
 pub struct DestroyPeerJob {
     pub initialized: bool,
@@ -66,143 +73,595 @@ pub struct DestroyPeerJob {
     pub peer: metapb::Peer,
 }
 
-impl<T, C> Store<T, C> {
-    pub fn poll_significant_msg(&mut self) {
-        // Poll all snapshot messages and handle them.
-        loop {
-            match self.significant_msg_receiver.try_recv() {
-                Ok(SignificantMsg::SnapshotStatus {
-                    region_id,
-                    to_peer_id,
-                    status,
-                }) => {
-                    // Report snapshot status to the corresponding peer.
-                    self.report_snapshot_status(region_id, to_peer_id, status);
-                }
-                Ok(SignificantMsg::Unreachable {
-                    region_id,
-                    to_peer_id,
-                }) => if let Some(peer) = self.region_peers.get_mut(&region_id) {
-                    peer.raft_group.report_unreachable(to_peer_id);
-                },
-                Err(TryRecvError::Empty) => {
-                    // The snapshot status receiver channel is empty
-                    return;
-                }
-                Err(e) => {
-                    error!(
-                        "{} unexpected error {:?} when receive from snapshot channel",
-                        self.tag, e
-                    );
-                    return;
-                }
-            }
-        }
-    }
+pub struct PeerFsm {
+    peer: Peer,
+    stopped: bool,
+    has_ready: bool,
+    mailbox: Option<BasicMailbox<PeerFsm>>,
+    pub receiver: Receiver<PeerMsg>,
+}
 
-    fn report_snapshot_status(&mut self, region_id: u64, to_peer_id: u64, status: SnapshotStatus) {
-        if let Some(peer) = self.region_peers.get_mut(&region_id) {
-            let to_peer = match peer.get_peer_from_cache(to_peer_id) {
-                Some(peer) => peer,
-                None => {
-                    // If to_peer is gone, ignore this snapshot status
-                    warn!(
-                        "[region {}] peer {} not found, ignore snapshot status {:?}",
-                        region_id, to_peer_id, status
-                    );
-                    return;
+impl Drop for PeerFsm {
+    fn drop(&mut self) {
+        self.peer.stop();
+        while let Ok(msg) = self.receiver.try_recv() {
+            let callback = match msg {
+                PeerMsg::RaftCmd { callback, .. } | PeerMsg::SplitRegion { callback, .. } => {
+                    callback
                 }
+                _ => continue,
             };
-            info!(
-                "[region {}] report snapshot status {:?} {:?}",
-                region_id, to_peer, status
-            );
-            peer.raft_group.report_snapshot(to_peer_id, status)
+
+            let mut err = errorpb::Error::new();
+            err.set_message("region is not found".to_owned());
+            err.mut_region_not_found().set_region_id(self.region_id());
+            let mut resp = RaftCmdResponse::new();
+            resp.mut_header().set_error(err);
+            callback.invoke_with_response(resp);
         }
     }
 }
 
-impl<T: Transport, C: PdClient> Store<T, C> {
-    pub fn register_raft_base_tick(&self, event_loop: &mut EventLoop<Self>) {
+impl PeerFsm {
+    // If we create the peer actively, like bootstrap/split/merge region, we should
+    // use this function to create the peer. The region must contain the peer info
+    // for this store.
+    pub fn create(
+        store_id: u64,
+        cfg: &Config,
+        sched: Scheduler<RegionTask>,
+        engines: Engines,
+        region: &metapb::Region,
+    ) -> Result<(LooseBoundedSender<PeerMsg>, Box<PeerFsm>)> {
+        let meta_peer = match util::find_peer(region, store_id) {
+            None => {
+                return Err(box_err!(
+                    "find no peer for store {} in region {:?}",
+                    store_id,
+                    region
+                ))
+            }
+            Some(peer) => peer.clone(),
+        };
+
+        info!(
+            "[region {}] create peer with id {}",
+            region.get_id(),
+            meta_peer.get_id(),
+        );
+        let (tx, rx) = mpsc::loose_bounded(cfg.notify_capacity);
+        Ok((
+            tx,
+            Box::new(PeerFsm {
+                peer: Peer::new(store_id, cfg, sched, engines, region, meta_peer)?,
+                stopped: false,
+                has_ready: false,
+                mailbox: None,
+                receiver: rx,
+            }),
+        ))
+    }
+
+    // The peer can be created from another node with raft membership changes, and we only
+    // know the region_id and peer_id when creating this replicated peer, the region info
+    // will be retrieved later after applying snapshot.
+    pub fn replicate(
+        store_id: u64,
+        cfg: &Config,
+        sched: Scheduler<RegionTask>,
+        engines: Engines,
+        region_id: u64,
+        peer: metapb::Peer,
+    ) -> Result<(LooseBoundedSender<PeerMsg>, Box<PeerFsm>)> {
+        // We will remove tombstone key when apply snapshot
+        info!(
+            "[region {}] replicate peer with id {}",
+            region_id,
+            peer.get_id()
+        );
+
+        let mut region = metapb::Region::new();
+        region.set_id(region_id);
+
+        let (tx, rx) = mpsc::loose_bounded(cfg.notify_capacity);
+        Ok((
+            tx,
+            Box::new(PeerFsm {
+                peer: Peer::new(store_id, cfg, sched, engines, &region, peer)?,
+                stopped: false,
+                has_ready: false,
+                mailbox: None,
+                receiver: rx,
+            }),
+        ))
+    }
+
+    #[inline]
+    pub fn region_id(&self) -> u64 {
+        self.peer.region().get_id()
+    }
+
+    #[inline]
+    pub fn get_peer(&self) -> &Peer {
+        &self.peer
+    }
+
+    #[inline]
+    pub fn stop(&mut self) {
+        self.stopped = true;
+    }
+
+    pub fn set_pending_merge_state(&mut self, state: MergeState) {
+        self.peer.pending_merge_state = Some(state);
+    }
+
+    pub fn schedule_applying_snapshot(&mut self) {
+        self.peer.mut_store().schedule_applying_snapshot();
+    }
+
+    pub fn have_pending_merge_apply_result(&self) -> bool {
+        self.peer.pending_merge_apply_result.is_some()
+    }
+}
+
+impl Fsm for PeerFsm {
+    type Message = PeerMsg;
+
+    #[inline]
+    fn is_stopped(&self) -> bool {
+        self.stopped
+    }
+
+    /// Set a mailbox to Fsm, which should be used to send message to itself.
+    #[inline]
+    fn set_mailbox(&mut self, mailbox: Cow<BasicMailbox<Self>>)
+    where
+        Self: Sized,
+    {
+        self.mailbox = Some(mailbox.into_owned());
+    }
+
+    /// Take the mailbox from Fsm. Implementation should ensure there will be
+    /// no reference to mailbox after calling this method.
+    #[inline]
+    fn take_mailbox(&mut self) -> Option<BasicMailbox<Self>>
+    where
+        Self: Sized,
+    {
+        self.mailbox.take()
+    }
+}
+
+pub struct PeerFsmDelegate<'a, T: 'static, C: 'static> {
+    fsm: &'a mut PeerFsm,
+    ctx: &'a mut PollContext<T, C>,
+}
+
+impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
+    pub fn new(fsm: &'a mut PeerFsm, ctx: &'a mut PollContext<T, C>) -> PeerFsmDelegate<'a, T, C> {
+        PeerFsmDelegate { fsm, ctx }
+    }
+
+    pub fn handle_msgs(&mut self, msgs: &mut Vec<PeerMsg>) {
+        for m in msgs.drain(..) {
+            match m {
+                PeerMsg::RaftMessage(msg) => if let Err(e) = self.on_raft_message(msg) {
+                    error!("{} handle raft message err: {:?}", self.fsm.peer.tag, e);
+                },
+                PeerMsg::RaftCmd {
+                    send_time,
+                    request,
+                    callback,
+                } => {
+                    self.ctx
+                        .raft_metrics
+                        .propose
+                        .request_wait_time
+                        .observe(duration_to_sec(send_time.elapsed()) as f64);
+                    self.propose_raft_command(request, callback)
+                }
+                PeerMsg::Tick(_, tick) => self.on_tick(tick),
+                PeerMsg::ApplyRes { res, .. } => {
+                    if let Some(state) = self.fsm.peer.pending_merge_apply_result.as_mut() {
+                        state.results.push(res);
+                        continue;
+                    }
+                    self.on_apply_res(res);
+                }
+                PeerMsg::SignificantMsg(msg) => self.on_significant_msg(msg),
+                PeerMsg::SplitRegion {
+                    region_epoch,
+                    split_keys,
+                    callback,
+                    ..
+                } => {
+                    info!(
+                        "{} on split with {}",
+                        self.fsm.peer.tag,
+                        KeysInfoFormatter(&split_keys)
+                    );
+                    self.on_prepare_split_region(region_epoch, split_keys, callback);
+                }
+                PeerMsg::ComputeHashResult { index, hash, .. } => {
+                    self.on_hash_computed(index, hash);
+                }
+                PeerMsg::RegionApproximateSize { size, .. } => {
+                    self.on_approximate_region_size(size);
+                }
+                PeerMsg::RegionApproximateKeys { keys, .. } => {
+                    self.on_approximate_region_keys(keys);
+                }
+                PeerMsg::CompactionDeclinedBytes { bytes, .. } => {
+                    self.on_compaction_declined_bytes(bytes);
+                }
+                PeerMsg::HalfSplitRegion {
+                    region_epoch,
+                    policy,
+                    ..
+                } => {
+                    self.on_schedule_half_split_region(&region_epoch, policy);
+                }
+                PeerMsg::MergeResult { target, stale, .. } => {
+                    self.on_merge_result(target, stale);
+                }
+                PeerMsg::GcSnap { snaps, .. } => {
+                    self.on_gc_snap(snaps);
+                }
+                PeerMsg::ClearRegionSize(_) => {
+                    self.on_clear_region_size();
+                }
+                PeerMsg::Start(_) => self.start(),
+                PeerMsg::Noop(_) => {}
+            }
+        }
+    }
+
+    fn on_tick(&mut self, tick: PeerTick) {
+        match tick {
+            PeerTick::Raft => self.on_raft_base_tick(),
+            PeerTick::RaftLogGc => self.on_raft_gc_log_tick(),
+            PeerTick::PdHeartbeat => self.on_pd_heartbeat_tick(),
+            PeerTick::SplitRegionCheck => self.on_split_region_check_tick(),
+            PeerTick::CheckMerge => self.on_check_merge(),
+            PeerTick::CheckPeerStaleState => self.on_check_peer_stale_state_tick(),
+        }
+    }
+
+    fn start(&mut self) {
+        if self.fsm.peer.pending_merge_state.is_some() {
+            self.notify_prepare_merge();
+        }
+        self.register_raft_base_tick();
+        self.register_raft_gc_log_tick();
+        self.register_pd_heartbeat_tick();
+        self.register_split_region_check_tick();
+        self.register_check_peer_stale_state_tick();
+        self.on_check_merge();
+    }
+
+    fn notify_prepare_merge(&self) {
+        let region_id = self.region_id();
+        let version = self.region().get_region_epoch().get_version();
+        // If there is no merge lock for that key, insert one to let target peer know `PrepareMerge`
+        // is already executed.
+        let mut meta = self.ctx.store_meta.lock().unwrap();
+        let (exist_version, ready_to_merge) =
+            match meta.merge_locks.insert(region_id, (version, None)) {
+                None => return,
+                Some((v, r)) => (v, r),
+            };
+        if exist_version == version {
+            let ready_to_merge = ready_to_merge.unwrap();
+            // Set `ready_to_merge` to true to indicate `PrepareMerge` is finished.
+            ready_to_merge.store(true, Ordering::SeqCst);
+            let state = self.fsm.peer.pending_merge_state.as_ref().unwrap();
+            let target_region_id = state.get_target().get_id();
+            // Send an empty message to target peer to make sure it will check `ready_to_merge`
+            self.ctx
+                .router
+                .force_send(target_region_id, PeerMsg::Noop(target_region_id))
+                .unwrap();
+        } else if exist_version > version {
+            meta.merge_locks
+                .insert(region_id, (exist_version, ready_to_merge));
+        } else {
+            panic!(
+                "{} expects version {} but got {}",
+                self.fsm.peer.tag, version, exist_version
+            );
+        }
+    }
+
+    pub fn resume_handling_pending_apply_result(&mut self) -> bool {
+        match self.fsm.peer.pending_merge_apply_result {
+            Some(ref state) => {
+                if !state.ready_to_merge.load(Ordering::SeqCst) {
+                    return false;
+                }
+            }
+            None => panic!(
+                "{} doesn't have pending apply result, can't be resume.",
+                self.fsm.peer.tag
+            ),
+        }
+
+        let mut pending_apply = self.fsm.peer.pending_merge_apply_result.take().unwrap();
+        let mut drainer = pending_apply.results.drain(..);
+        while let Some(res) = drainer.next() {
+            debug!(
+                "{} resume handling apply result {:?}",
+                self.fsm.peer.tag, res
+            );
+            self.on_apply_res(res);
+            // So meet another `CommitMerge` apply result needed to wait.
+            if let Some(state) = self.fsm.peer.pending_merge_apply_result.as_mut() {
+                state.results.extend(drainer);
+                return false;
+            }
+        }
+        true
+    }
+
+    fn on_gc_snap(&mut self, snaps: Vec<(SnapKey, bool)>) {
+        let s = self.fsm.peer.get_store();
+        let compacted_idx = s.truncated_index();
+        let compacted_term = s.truncated_term();
+        let is_applying_snap = s.is_applying_snapshot();
+        for (key, is_sending) in snaps {
+            if is_sending {
+                let s = match self.ctx.snap_mgr.get_snapshot_for_sending(&key) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        error!(
+                            "{} failed to load snapshot for {}: {:?}",
+                            self.fsm.peer.tag, key, e
+                        );
+                        continue;
+                    }
+                };
+                if key.term < compacted_term || key.idx < compacted_idx {
+                    info!(
+                        "{} snap file {} has been compacted, delete.",
+                        self.fsm.peer.tag, key
+                    );
+                    self.ctx.snap_mgr.delete_snapshot(&key, s.as_ref(), false);
+                } else if let Ok(meta) = s.meta() {
+                    let modified = match meta.modified() {
+                        Ok(m) => m,
+                        Err(e) => {
+                            error!(
+                                "{} failed to load snapshot for {}: {:?}",
+                                self.fsm.peer.tag, key, e
+                            );
+                            continue;
+                        }
+                    };
+                    if let Ok(elapsed) = modified.elapsed() {
+                        if elapsed > self.ctx.cfg.snap_gc_timeout.0 {
+                            info!(
+                                "{} snap file {} has been expired, delete.",
+                                self.fsm.peer.tag, key
+                            );
+                            self.ctx.snap_mgr.delete_snapshot(&key, s.as_ref(), false);
+                        }
+                    }
+                }
+            } else if key.term <= compacted_term
+                && (key.idx < compacted_idx || key.idx == compacted_idx && !is_applying_snap)
+            {
+                info!(
+                    "{} snap file {} has been applied, delete.",
+                    self.fsm.peer.tag, key
+                );
+                let a = match self.ctx.snap_mgr.get_snapshot_for_applying(&key) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        error!(
+                            "{} failed to load snapshot for {}: {:?}",
+                            self.fsm.peer.tag, key, e
+                        );
+                        continue;
+                    }
+                };
+                self.ctx.snap_mgr.delete_snapshot(&key, a.as_ref(), false);
+            }
+        }
+    }
+
+    fn on_clear_region_size(&mut self) {
+        self.fsm.peer.approximate_size = None;
+        self.fsm.peer.approximate_keys = None;
+    }
+
+    fn on_significant_msg(&mut self, msg: SignificantMsg) {
+        match msg {
+            SignificantMsg::SnapshotStatus {
+                to_peer_id, status, ..
+            } => {
+                // Report snapshot status to the corresponding peer.
+                self.report_snapshot_status(to_peer_id, status);
+            }
+            SignificantMsg::Unreachable { to_peer_id, .. } => {
+                self.fsm.peer.raft_group.report_unreachable(to_peer_id);
+            }
+        }
+    }
+
+    fn report_snapshot_status(&mut self, to_peer_id: u64, status: SnapshotStatus) {
+        let to_peer = match self.fsm.peer.get_peer_from_cache(to_peer_id) {
+            Some(peer) => peer,
+            None => {
+                // If to_peer is gone, ignore this snapshot status
+                warn!(
+                    "{} peer {} not found, ignore snapshot status {:?}",
+                    self.fsm.peer.tag, to_peer_id, status
+                );
+                return;
+            }
+        };
+        info!(
+            "{} report snapshot status {:?} {:?}",
+            self.fsm.peer.tag, to_peer, status
+        );
+        self.fsm.peer.raft_group.report_snapshot(to_peer_id, status)
+    }
+
+    pub fn collect_ready(&mut self, proposals: &mut Vec<RegionProposal>) {
+        let has_ready = self.fsm.has_ready;
+        self.fsm.has_ready = false;
+        if !has_ready || self.fsm.stopped {
+            return;
+        }
+        self.ctx.pending_count += 1;
+        self.ctx.has_ready = true;
+        if let Some(p) = self.fsm.peer.take_apply_proposals() {
+            proposals.push(p);
+        }
+        self.fsm.peer.handle_raft_ready_append(self.ctx);
+    }
+
+    pub fn post_raft_ready_append(&mut self, mut ready: Ready, invoke_ctx: InvokeContext) {
+        let is_merging = self.fsm.peer.pending_merge_state.is_some();
+        let res = self
+            .fsm
+            .peer
+            .post_raft_ready_append(self.ctx, &mut ready, invoke_ctx);
+        self.fsm.peer.handle_raft_ready_apply(self.ctx, ready);
+        let mut has_snapshot = false;
+        if let Some(apply_res) = res {
+            self.on_ready_apply_snapshot(apply_res);
+            has_snapshot = true;
+        }
+        if is_merging && has_snapshot {
+            // After applying a snapshot, merge is rollbacked implicitly.
+            self.on_ready_rollback_merge(0, None);
+        }
+    }
+
+    #[inline]
+    fn region_id(&self) -> u64 {
+        self.fsm.peer.region().get_id()
+    }
+
+    #[inline]
+    fn region(&self) -> &Region {
+        self.fsm.peer.region()
+    }
+
+    #[inline]
+    fn store_id(&self) -> u64 {
+        self.fsm.peer.peer.get_store_id()
+    }
+
+    #[inline]
+    fn schedule_tick(&self, tick: PeerTick, timeout: Duration) {
+        if is_zero_duration(&timeout) {
+            return;
+        }
+
+        let region_id = self.region_id();
+        let mb = match self.ctx.router.mailbox(region_id) {
+            Some(mb) => mb,
+            None => {
+                error!("{} failed to get mailbox for {:?}", self.fsm.peer.tag, tick);
+                return;
+            }
+        };
+        let peer_id = self.fsm.peer.peer_id();
+        let f = self
+            .ctx
+            .timer
+            .delay(timeout)
+            .map(move |_| {
+                if let Err(e) = mb.force_send(PeerMsg::Tick(region_id, tick)) {
+                    info!(
+                        "[region {}] {} failed to schedule peer tick {:?}: {:?}",
+                        region_id, peer_id, tick, e
+                    );
+                }
+            })
+            .map_err(move |e| {
+                panic!(
+                    "[region {}] {} tick {:?} is lost due to timeout error: {:?}",
+                    region_id, peer_id, tick, e
+                );
+            });
+        self.ctx.future_poller.spawn(f).unwrap();
+    }
+
+    fn register_raft_base_tick(&self) {
         // If we register raft base tick failed, the whole raft can't run correctly,
         // TODO: shutdown the store?
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::Raft,
-            self.cfg.raft_base_tick_interval.as_millis(),
-        ) {
-            error!("{} register raft base tick err: {:?}", self.tag, e);
-        };
+        self.schedule_tick(PeerTick::Raft, self.ctx.cfg.raft_base_tick_interval.0)
     }
 
-    pub fn on_raft_base_tick(&mut self, event_loop: &mut EventLoop<Self>) {
-        let timer = self.raft_metrics.process_tick.start_coarse_timer();
-        for peer in &mut self.region_peers.values_mut() {
-            if peer.pending_remove {
-                continue;
-            }
-            // When having pending snapshot, if election timeout is met, it can't pass
-            // the pending conf change check because first index has been updated to
-            // a value that is larger than last index.
-            if peer.is_applying_snapshot() || peer.has_pending_snapshot() {
-                // need to check if snapshot is applied.
-                peer.mark_to_be_checked(&mut self.pending_raft_groups);
-                continue;
-            }
-            if peer.raft_group.tick() {
-                peer.mark_to_be_checked(&mut self.pending_raft_groups);
-            }
+    fn on_raft_base_tick(&mut self) {
+        if self.fsm.peer.pending_remove {
+            self.fsm.peer.mut_store().flush_cache_metrics();
+            return;
         }
-        timer.observe_duration();
+        // When having pending snapshot, if election timeout is met, it can't pass
+        // the pending conf change check because first index has been updated to
+        // a value that is larger than last index.
+        if self.fsm.peer.is_applying_snapshot() || self.fsm.peer.has_pending_snapshot() {
+            // need to check if snapshot is applied.
+            self.fsm.has_ready = true;
+            self.register_raft_base_tick();
+            return;
+        }
+        if self.fsm.peer.raft_group.tick() {
+            self.fsm.has_ready = true;
+        }
 
-        self.raft_metrics.flush();
-        self.entry_cache_metries.borrow_mut().flush();
-
-        self.register_raft_base_tick(event_loop);
+        self.fsm.peer.mut_store().flush_cache_metrics();
+        self.register_raft_base_tick();
     }
 
-    pub fn poll_apply(&mut self) {
-        loop {
-            match self.apply_res_receiver.as_ref().unwrap().try_recv() {
-                Ok(ApplyTaskRes::Applies(multi_res)) => for res in multi_res {
-                    debug!(
-                        "{} async apply finish: {:?}",
-                        self.region_peers
-                            .get(&res.region_id)
-                            .map_or(&self.tag, |p| &p.tag),
-                        res
-                    );
-                    let ApplyRes {
-                        region_id,
-                        apply_state,
-                        applied_index_term,
-                        exec_res,
-                        metrics,
-                        merged,
-                    } = res;
-                    self.on_ready_result(region_id, merged, exec_res, &metrics);
-                    if let Some(p) = self.region_peers.get_mut(&region_id) {
-                        p.post_apply(
-                            &mut self.pending_raft_groups,
-                            apply_state,
-                            applied_index_term,
-                            merged,
-                            &metrics,
-                        );
-                    }
-                },
-                Ok(ApplyTaskRes::Destroy { region_id, peer_id }) => {
-                    let store_id = self.store_id();
-                    self.destroy_peer(region_id, util::new_peer(store_id, peer_id), false);
+    fn on_apply_res(&mut self, res: ApplyTaskRes) {
+        match res {
+            ApplyTaskRes::Apply(mut res) => {
+                debug!("{} async apply finish: {:?}", self.fsm.peer.tag, res);
+                if let Some(ready_to_merge) =
+                    self.on_ready_result(res.merged, &mut res.exec_res, &res.metrics)
+                {
+                    // There is a `CommitMerge` needed to wait
+                    self.fsm.peer.pending_merge_apply_result = Some(WaitApplyResultState {
+                        results: vec![ApplyTaskRes::Apply(res)],
+                        ready_to_merge,
+                    });
+                    return;
                 }
-                Err(TryRecvError::Empty) => break,
-                Err(e) => panic!("unexpected error {:?}", e),
+                if self.fsm.stopped {
+                    return;
+                }
+                self.fsm.has_ready |= self.fsm.peer.post_apply(
+                    self.ctx,
+                    res.apply_state,
+                    res.applied_index_term,
+                    res.merged,
+                    &res.metrics,
+                );
+            }
+            ApplyTaskRes::Destroy { peer_id, .. } => {
+                assert_eq!(peer_id, self.fsm.peer.peer_id());
+                self.destroy_peer(false);
             }
         }
     }
 
-    pub fn on_raft_message(&mut self, mut msg: RaftMessage) -> Result<()> {
+    fn on_raft_message(&mut self, mut msg: RaftMessage) -> Result<()> {
+        debug!(
+            "{} handle raft message {:?}, from {} to {}",
+            self.fsm.peer.tag,
+            msg.get_message().get_msg_type(),
+            msg.get_from_peer().get_id(),
+            msg.get_to_peer().get_id()
+        );
+
         if !self.validate_raft_msg(&msg) {
+            return Ok(());
+        }
+        if self.fsm.peer.pending_remove || self.fsm.stopped {
             return Ok(());
         }
 
@@ -212,19 +671,14 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             return Ok(());
         }
 
-        let region_id = msg.get_region_id();
         if msg.has_merge_target() {
             if self.need_gc_merge(&msg)? {
-                self.on_merge_fail(region_id);
+                self.on_stale_merge();
             }
             return Ok(());
         }
 
-        if self.check_msg(&msg)? {
-            return Ok(());
-        }
-
-        if !self.maybe_create_peer(region_id, &msg)? {
+        if self.check_msg(&msg) {
             return Ok(());
         }
 
@@ -233,23 +687,20 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             // delete them here. If the snapshot file will be reused when
             // receiving, then it will fail to pass the check again, so
             // missing snapshot files should not be noticed.
-            let s = self.snap_mgr.get_snapshot_for_applying(&key)?;
-            self.snap_mgr.delete_snapshot(&key, s.as_ref(), false);
+            let s = self.ctx.snap_mgr.get_snapshot_for_applying(&key)?;
+            self.ctx.snap_mgr.delete_snapshot(&key, s.as_ref(), false);
             return Ok(());
         }
 
-        let peer = self.region_peers.get_mut(&region_id).unwrap();
         let from_peer_id = msg.get_from_peer().get_id();
-        peer.insert_peer_cache(msg.take_from_peer());
-        peer.step(msg.take_message())?;
+        self.fsm.peer.insert_peer_cache(msg.take_from_peer());
+        self.fsm.peer.step(msg.take_message())?;
 
-        if peer.any_new_peer_catch_up(from_peer_id) {
-            peer.heartbeat_pd(&self.pd_worker);
+        if self.fsm.peer.any_new_peer_catch_up(from_peer_id) {
+            self.fsm.peer.heartbeat_pd(self.ctx);
         }
 
-        // Add into pending raft groups for later handling ready.
-        peer.mark_to_be_checked(&mut self.pending_raft_groups);
-
+        self.fsm.has_ready = true;
         Ok(())
     }
 
@@ -274,7 +725,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 to.get_store_id(),
                 self.store_id()
             );
-            self.raft_metrics.message_dropped.mismatch_store_id += 1;
+            self.ctx.raft_metrics.message_dropped.mismatch_store_id += 1;
             return false;
         }
 
@@ -283,17 +734,18 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 "[region {}] missing epoch in raft message, ignore it",
                 region_id
             );
-            self.raft_metrics.message_dropped.mismatch_region_epoch += 1;
+            self.ctx.raft_metrics.message_dropped.mismatch_region_epoch += 1;
             return false;
         }
 
         true
     }
 
-    fn check_msg(&mut self, msg: &RaftMessage) -> Result<bool> {
-        let region_id = msg.get_region_id();
+    /// Checks if the message is sent to the correct peer.
+    ///
+    /// Returns true means that the message can be dropped silently.
+    fn check_msg(&mut self, msg: &RaftMessage) -> bool {
         let from_epoch = msg.get_region_epoch();
-        let msg_type = msg.get_message().get_msg_type();
         let is_vote_msg = util::is_vote_msg(msg.get_message());
         let from_store_id = msg.get_from_peer().get_store_id();
 
@@ -315,145 +767,54 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         //  unlike case e, 2 will be stale forever.
         // TODO: for case f, if 2 is stale for a long time, 2 will communicate with pd and pd will
         // tell 2 is stale, so 2 can remove itself.
-        let trans = &self.trans;
-        let raft_metrics = &mut self.raft_metrics;
-        if let Some(peer) = self.region_peers.get(&region_id) {
-            let region = peer.region();
-            let epoch = region.get_region_epoch();
-
-            if util::is_epoch_stale(from_epoch, epoch)
-                && util::find_peer(region, from_store_id).is_none()
-            {
-                // The message is stale and not in current region.
-                Self::handle_stale_msg(trans, msg, epoch, is_vote_msg, None, raft_metrics);
-                return Ok(true);
-            }
-
-            return Ok(false);
-        }
-
-        // no exist, check with tombstone key.
-        let state_key = keys::region_state_key(region_id);
-        if let Some(local_state) = self
-            .engines
-            .kv
-            .get_msg_cf::<RegionLocalState>(CF_RAFT, &state_key)?
+        if util::is_epoch_stale(from_epoch, self.fsm.peer.region().get_region_epoch())
+            && util::find_peer(self.fsm.peer.region(), from_store_id).is_none()
         {
-            if local_state.get_state() != PeerState::Tombstone {
-                // Maybe split, but not registered yet.
-                raft_metrics.message_dropped.region_nonexistent += 1;
-                if util::is_first_vote_msg(msg.get_message()) {
-                    self.pending_votes.push(msg.to_owned());
-                    info!(
-                        "[region {}] doesn't exist yet, wait for it to be split",
-                        region_id
-                    );
-                    return Ok(true);
-                }
-                return Err(box_err!(
-                    "[region {}] region not exist but not tombstone: {:?}",
-                    region_id,
-                    local_state
-                ));
-            }
-            debug!("[region {}] tombstone state: {:?}", region_id, local_state);
-            let region = local_state.get_region();
-            let region_epoch = region.get_region_epoch();
-            if local_state.has_merge_state() {
-                info!(
-                    "[region {}] merged peer [epoch: {:?}] receive a stale message {:?}",
-                    region_id, region_epoch, msg_type
-                );
-
-                let merge_target = if let Some(peer) = util::find_peer(region, from_store_id) {
-                    // Maybe the target is promoted from learner to voter, but the follower
-                    // doesn't know it. So we only compare peer id.
-                    assert_eq!(peer.get_id(), msg.get_from_peer().get_id());
-                    // Let stale peer decides whether it should wait for merging or just remove
-                    // itself.
-                    Some(local_state.get_merge_state().get_target().to_owned())
-                } else {
-                    // If a peer is isolated before prepare_merge and conf remove, it should just
-                    // remove itself.
-                    None
-                };
-                Self::handle_stale_msg(trans, msg, region_epoch, true, merge_target, raft_metrics);
-                return Ok(true);
-            }
-            // The region in this peer is already destroyed
-            if util::is_epoch_stale(from_epoch, region_epoch) {
-                info!(
-                    "[region {}] tombstone peer [epoch: {:?}] \
-                     receive a stale message {:?}",
-                    region_id, region_epoch, msg_type,
-                );
-
-                let not_exist = util::find_peer(region, from_store_id).is_none();
-                Self::handle_stale_msg(
-                    trans,
-                    msg,
-                    region_epoch,
-                    is_vote_msg && not_exist,
-                    None,
-                    raft_metrics,
-                );
-
-                return Ok(true);
-            }
-
-            if from_epoch.get_conf_ver() == region_epoch.get_conf_ver() {
-                raft_metrics.message_dropped.region_tombstone_peer += 1;
-                return Err(box_err!(
-                    "tombstone peer [epoch: {:?}] receive an invalid \
-                     message {:?}, ignore it",
-                    region_epoch,
-                    msg_type
-                ));
-            }
-        }
-
-        Ok(false)
-    }
-
-    fn handle_stale_msg(
-        trans: &T,
-        msg: &RaftMessage,
-        cur_epoch: &metapb::RegionEpoch,
-        need_gc: bool,
-        target_region: Option<metapb::Region>,
-        raft_metrics: &mut RaftMetrics,
-    ) {
-        let region_id = msg.get_region_id();
-        let from_peer = msg.get_from_peer();
-        let to_peer = msg.get_to_peer();
-        let msg_type = msg.get_message().get_msg_type();
-
-        if !need_gc {
-            info!(
-                "[region {}] raft message {:?} is stale, current {:?}, ignore it",
-                region_id, msg_type, cur_epoch
+            // The message is stale and not in current region.
+            self.ctx.handle_stale_msg(
+                msg,
+                self.fsm.peer.region().get_region_epoch().clone(),
+                is_vote_msg,
+                None,
             );
-            raft_metrics.message_dropped.stale_msg += 1;
-            return;
+            return true;
         }
 
-        info!(
-            "[region {}] raft message {:?} is stale, current {:?}, tell to gc",
-            region_id, msg_type, cur_epoch
-        );
-
-        let mut gc_msg = RaftMessage::new();
-        gc_msg.set_region_id(region_id);
-        gc_msg.set_from_peer(to_peer.clone());
-        gc_msg.set_to_peer(from_peer.clone());
-        gc_msg.set_region_epoch(cur_epoch.clone());
-        if let Some(r) = target_region {
-            gc_msg.set_merge_target(r);
+        let target = msg.get_to_peer();
+        if target.get_id() < self.fsm.peer.peer_id() {
+            info!(
+                "{} target peer id {} is less than {}, msg maybe stale.",
+                self.fsm.peer.tag,
+                target.get_id(),
+                self.fsm.peer.peer_id()
+            );
+            self.ctx.raft_metrics.message_dropped.stale_msg += 1;
+            true
+        } else if target.get_id() > self.fsm.peer.peer_id() {
+            match self.fsm.peer.maybe_destroy() {
+                Some(job) => {
+                    info!(
+                        "{} is stale as received a larger peer {:?}, destroying.",
+                        self.fsm.peer.tag, target
+                    );
+                    if self.handle_destroy_peer(job) {
+                        if let Err(e) = self
+                            .ctx
+                            .router
+                            .send_control(StoreMsg::RaftMessage(msg.clone()))
+                        {
+                            info!(
+                                "{} failed to send back store message {:?}, are we shutting down?",
+                                self.fsm.peer.tag, e
+                            );
+                        }
+                    }
+                }
+                None => self.ctx.raft_metrics.message_dropped.applying_snap += 1,
+            }
+            true
         } else {
-            gc_msg.set_is_tombstone(true);
-        }
-        if let Err(e) = trans.send(gc_msg) {
-            error!("[region {}] send gc message failed {:?}", region_id, e);
+            false
         }
     }
 
@@ -470,14 +831,15 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         // in merge target is the state of target peer at the time when source peer is merged.
         // So here we need to check the target peer on this store to decide whether the source
         // to destory or wait target peer to catch up logs.
-        if let Some(epoch) = self.pending_cross_snap.get(&target_region_id).or_else(|| {
-            self.region_peers
+        let meta = self.ctx.store_meta.lock().unwrap();
+        if let Some(epoch) = meta.pending_cross_snap.get(&target_region_id).or_else(|| {
+            meta.regions
                 .get(&target_region_id)
-                .map(|p| p.region().get_region_epoch())
+                .map(|r| r.get_region_epoch())
         }) {
             info!(
-                "[region {}] checking target {} epoch: {:?}, msg target epoch: {:?}",
-                msg.get_region_id(),
+                "{} checking target {} epoch: {:?}, msg target epoch: {:?}",
+                self.fsm.peer.tag,
                 target_region_id,
                 epoch,
                 merge_target.get_region_epoch(),
@@ -493,12 +855,14 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
         let state_key = keys::region_state_key(target_region_id);
         if let Some(state) = self
-            .kv_engine()
+            .ctx
+            .engines
+            .kv
             .get_msg_cf::<RegionLocalState>(CF_RAFT, &state_key)?
         {
             debug!(
-                "[region {}] check local state {:?}",
-                target_region_id, state
+                "{} check target region {} local state {:?}",
+                self.fsm.peer.tag, target_region_id, state
             );
             if state.get_state() == PeerState::Tombstone
                 && state.get_region().get_region_epoch().get_conf_ver()
@@ -510,17 +874,11 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         }
 
         info!(
-            "[region {}] no replica of region {} exist, check pd.",
-            msg.get_region_id(),
-            target_region_id
+            "{} no replica of region {} exist, check pd.",
+            self.fsm.peer.tag, target_region_id
         );
         // We can't know whether the peer is destroyed or not for sure locally, ask
         // pd for help.
-        let merge_source = match self.region_peers.get(&msg.get_region_id()) {
-            // It has been gc.
-            None => return Ok(false),
-            Some(p) => p,
-        };
         let target_peer = merge_target
             .get_peers()
             .iter()
@@ -529,47 +887,39 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let task = PdTask::ValidatePeer {
             peer: target_peer.to_owned(),
             region: merge_target.to_owned(),
-            merge_source: Some(merge_source.region().get_id()),
+            merge_source: Some(self.region_id()),
         };
-        if let Err(e) = self.pd_worker.schedule(task) {
+        if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
             error!(
-                "[region {}] failed to validate target peer {:?}: {}",
-                msg.get_region_id(),
-                target_peer,
-                e
+                "{} failed to validate target peer {:?}: {}",
+                self.fsm.peer.tag, target_peer, e
             );
         }
         Ok(false)
     }
 
     fn handle_gc_peer_msg(&mut self, msg: &RaftMessage) {
-        let region_id = msg.get_region_id();
-
-        let mut job = None;
-        if let Some(peer) = self.region_peers.get_mut(&region_id) {
-            let from_epoch = msg.get_region_epoch();
-            if util::is_epoch_stale(peer.region().get_region_epoch(), from_epoch) {
-                if peer.peer != *msg.get_to_peer() {
-                    info!("[region {}] receive stale gc message, ignore.", region_id);
-                    self.raft_metrics.message_dropped.stale_msg += 1;
-                    return;
-                }
-                // TODO: ask pd to guarantee we are stale now.
-                info!(
-                    "[region {}] peer {:?} receives gc message, trying to remove",
-                    region_id,
-                    msg.get_to_peer()
-                );
-                job = peer.maybe_destroy();
-                if job.is_none() {
-                    self.raft_metrics.message_dropped.applying_snap += 1;
-                    return;
-                }
-            }
+        let from_epoch = msg.get_region_epoch();
+        if !util::is_epoch_stale(self.fsm.peer.region().get_region_epoch(), from_epoch) {
+            return;
         }
 
-        if let Some(job) = job {
-            self.handle_destroy_peer(job);
+        if self.fsm.peer.peer != *msg.get_to_peer() {
+            info!("{} receive stale gc message, ignore.", self.fsm.peer.tag);
+            self.ctx.raft_metrics.message_dropped.stale_msg += 1;
+            return;
+        }
+        // TODO: ask pd to guarantee we are stale now.
+        info!(
+            "{} peer {:?} receives gc message, trying to remove",
+            self.fsm.peer.tag,
+            msg.get_to_peer()
+        );
+        match self.fsm.peer.maybe_destroy() {
+            None => self.ctx.raft_metrics.message_dropped.applying_snap += 1,
+            Some(job) => {
+                self.handle_destroy_peer(job);
+            }
         }
     }
 
@@ -594,213 +944,94 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             .all(|p| p.get_id() != peer_id)
         {
             info!(
-                "[region {}] {:?} doesn't contain peer {:?}, skip.",
-                snap_region.get_id(),
+                "{} {:?} doesn't contain peer {:?}, skip.",
+                self.fsm.peer.tag,
                 snap_region,
                 msg.get_to_peer()
             );
-            self.raft_metrics.message_dropped.region_no_peer += 1;
+            self.ctx.raft_metrics.message_dropped.region_no_peer += 1;
             return Ok(Some(key));
         }
 
-        let r = self
+        let mut meta = self.ctx.store_meta.lock().unwrap();
+        if meta.regions[&self.region_id()] != *self.region() {
+            if !self.fsm.peer.is_initialized() {
+                info!("{} stale delegate detected, skip.", self.fsm.peer.tag);
+                return Ok(Some(key));
+            } else {
+                panic!(
+                    "{} meta corrupted: {:?} != {:?}",
+                    self.fsm.peer.tag,
+                    meta.regions[&self.region_id()],
+                    self.region()
+                );
+            }
+        }
+        let r = meta
             .region_ranges
-            .range((Excluded(enc_start_key(&snap_region)), Unbounded::<Key>))
-            .map(|(_, &region_id)| self.region_peers[&region_id].region())
+            .range((Excluded(enc_start_key(&snap_region)), Unbounded::<Vec<u8>>))
+            .map(|(_, &region_id)| &meta.regions[&region_id])
             .take_while(|r| enc_start_key(r) < enc_end_key(&snap_region))
             .skip_while(|r| r.get_id() == region_id)
             .next()
             .map(|r| r.to_owned());
         if let Some(exist_region) = r {
-            info!("region overlapped {:?}, {:?}", exist_region, snap_region);
-            let peer = &self.region_peers[&region_id];
+            info!(
+                "{} region overlapped {:?}, {:?}",
+                self.fsm.peer.tag, exist_region, snap_region
+            );
             // In some extreme case, it may happen that a new snapshot is received whereas a snapshot is still in applying
             // if the snapshot under applying is generated before merge and the new snapshot is generated after merge,
             // update `pending_cross_snap` here may cause source peer destroys itself improperly. So don't update
             // `pending_cross_snap` here if peer is applying snapshot.
-            if !peer.is_applying_snapshot() && !peer.has_pending_snapshot() {
-                self.pending_cross_snap
+            if !self.fsm.peer.is_applying_snapshot() && !self.fsm.peer.has_pending_snapshot() {
+                meta.pending_cross_snap
                     .insert(region_id, snap_region.get_region_epoch().to_owned());
             }
-            self.raft_metrics.message_dropped.region_overlap += 1;
+            self.ctx.raft_metrics.message_dropped.region_overlap += 1;
             return Ok(Some(key));
         }
-        for region in &self.pending_snapshot_regions {
+        for region in &meta.pending_snapshot_regions {
             if enc_start_key(region) < enc_end_key(&snap_region) &&
                enc_end_key(region) > enc_start_key(&snap_region) &&
                // Same region can overlap, we will apply the latest version of snapshot.
                region.get_id() != snap_region.get_id()
             {
-                info!("pending region overlapped {:?}, {:?}", region, snap_region);
-                self.raft_metrics.message_dropped.region_overlap += 1;
+                info!(
+                    "{} pending region overlapped {:?}, {:?}",
+                    self.fsm.peer.tag, region, snap_region
+                );
+                self.ctx.raft_metrics.message_dropped.region_overlap += 1;
                 return Ok(Some(key));
             }
         }
-        if let Some(r) = self.pending_cross_snap.get(&region_id) {
+        if let Some(r) = meta.pending_cross_snap.get(&region_id) {
             // Check it to avoid epoch moves backward.
             if util::is_epoch_stale(snap_region.get_region_epoch(), r) {
                 info!(
-                    "[region {}] snapshot epoch is stale, drop: {:?} < {:?}",
-                    snap_region.get_id(),
+                    "{} snapshot epoch is stale, drop: {:?} < {:?}",
+                    self.fsm.peer.tag,
                     snap_region.get_region_epoch(),
                     r
                 );
-                self.raft_metrics.message_dropped.stale_msg += 1;
+                self.ctx.raft_metrics.message_dropped.stale_msg += 1;
                 return Ok(Some(key));
             }
         }
         // check if snapshot file exists.
-        self.snap_mgr.get_snapshot_for_applying(&key)?;
+        self.ctx.snap_mgr.get_snapshot_for_applying(&key)?;
 
-        self.pending_snapshot_regions.push(snap_region);
-        self.pending_cross_snap.remove(&region_id);
+        meta.pending_snapshot_regions.push(snap_region);
+        self.ctx.queued_snapshot.insert(region_id);
+        meta.pending_cross_snap.remove(&region_id);
 
         Ok(None)
     }
 
-    /// For all Raft groups with newly `raft::Ready`, collect and send Raft message for them.
-    /// And then updates `RaftLocalState` and `SnapshotRaftState` (if needed) into engines.
-    pub fn on_raft_ready(&mut self) {
-        // Only enable the fail point when the store id is equal to 3, which is
-        // the id of slow store in tests.
-        fail_point!("on_raft_ready", self.store.get_id() == 3, |_| {});
-        let t = SlowTimer::new();
-        let pending_count = self.pending_raft_groups.len();
-        let previous_ready_metrics = self.raft_metrics.ready.clone();
-
-        self.raft_metrics.ready.pending_region += pending_count as u64;
-
-        let (kv_wb, raft_wb, append_res, sync_log, need_flush) = {
-            let mut ctx = ReadyContext::new(&mut self.raft_metrics, &self.trans, pending_count);
-            for region_id in self.pending_raft_groups.drain() {
-                if let Some(peer) = self.region_peers.get_mut(&region_id) {
-                    if let Some(region_proposal) = peer.take_apply_proposals() {
-                        let t = ApplyTask::Proposal(region_proposal);
-                        self.apply_router.schedule_task(region_id, t);
-                    }
-                    peer.handle_raft_ready_append(&mut ctx, &self.pd_worker);
-                }
-            }
-            (
-                ctx.kv_wb,
-                ctx.raft_wb,
-                ctx.ready_res,
-                ctx.sync_log,
-                ctx.need_flush,
-            )
-        };
-
-        if need_flush {
-            // In most cases, if the leader proposes a message, it will also
-            // broadcast the message to other followers, so we should flush the
-            // messages ASAP.
-            self.trans.flush();
-        }
-
-        self.raft_metrics.ready.has_ready_region += append_res.len() as u64;
-
-        // apply_snapshot, peer_destroy will clear_meta, so we need write region state first.
-        // otherwise, if program restart between two write, raft log will be removed,
-        // but region state may not changed in disk.
-        fail_point!("raft_before_save");
-        if !kv_wb.is_empty() {
-            // RegionLocalState, ApplyState
-            let mut write_opts = WriteOptions::new();
-            write_opts.set_sync(true);
-            self.engines
-                .kv
-                .write_opt(kv_wb, &write_opts)
-                .unwrap_or_else(|e| {
-                    panic!("{} failed to save append state result: {:?}", self.tag, e);
-                });
-        }
-        fail_point!("raft_between_save");
-
-        if !raft_wb.is_empty() {
-            // RaftLocalState, Raft Log Entry
-            let mut write_opts = WriteOptions::new();
-            write_opts.set_sync(self.cfg.sync_log || sync_log);
-            self.engines
-                .raft
-                .write_opt(raft_wb, &write_opts)
-                .unwrap_or_else(|e| {
-                    panic!("{} failed to save raft append result: {:?}", self.tag, e);
-                });
-        }
-        fail_point!("raft_after_save");
-
-        let mut ready_results = Vec::with_capacity(append_res.len());
-        for (mut ready, invoke_ctx) in append_res {
-            let region_id = invoke_ctx.region_id;
-            let mut is_merging;
-            let res = {
-                let peer = self.region_peers.get_mut(&region_id).unwrap();
-                is_merging = peer.pending_merge_state.is_some();
-                peer.post_raft_ready_append(
-                    &mut self.raft_metrics,
-                    &self.trans,
-                    &mut ready,
-                    invoke_ctx,
-                )
-            };
-            if is_merging && res.is_some() {
-                // After applying a snapshot, merge is rollbacked implicitly.
-                self.on_ready_rollback_merge(region_id, 0, None);
-            }
-            ready_results.push((region_id, ready, res));
-        }
-
-        self.raft_metrics
-            .append_log
-            .observe(duration_to_sec(t.elapsed()) as f64);
-
-        slow_log!(
-            t,
-            "{} handle {} pending peers include {} ready, {} entries, {} messages and {} \
-             snapshots",
-            self.tag,
-            pending_count,
-            ready_results.capacity(),
-            self.raft_metrics.ready.append - previous_ready_metrics.append,
-            self.raft_metrics.ready.message - previous_ready_metrics.message,
-            self.raft_metrics.ready.snapshot - previous_ready_metrics.snapshot
-        );
-
-        if !ready_results.is_empty() {
-            for (region_id, ready, res) in ready_results {
-                self.region_peers
-                    .get_mut(&region_id)
-                    .unwrap()
-                    .handle_raft_ready_apply(ready, &self.apply_router);
-                if let Some(apply_result) = res {
-                    self.on_ready_apply_snapshot(apply_result);
-                }
-            }
-        }
-
-        let dur = t.elapsed();
-        if !self.is_busy {
-            let election_timeout = Duration::from_millis(
-                self.cfg.raft_base_tick_interval.as_millis()
-                    * self.cfg.raft_election_timeout_ticks as u64,
-            );
-            if dur >= election_timeout {
-                self.is_busy = true;
-            }
-        }
-
-        self.raft_metrics
-            .process_ready
-            .observe(duration_to_sec(dur) as f64);
-
-        self.trans.flush();
-
-        slow_log!(t, "{} on {} regions raft ready", self.tag, pending_count);
-    }
-
-    pub fn handle_destroy_peer(&mut self, job: DestroyPeerJob) -> bool {
+    fn handle_destroy_peer(&mut self, job: DestroyPeerJob) -> bool {
         if job.initialized {
-            self.apply_router
+            self.ctx
+                .apply_router
                 .schedule_task(job.region_id, ApplyTask::destroy(job.region_id));
         }
         if job.async_remove {
@@ -811,217 +1042,213 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             );
             false
         } else {
-            self.destroy_peer(job.region_id, job.peer, false);
+            self.destroy_peer(false);
             true
         }
     }
 
-    pub fn destroy_peer(&mut self, region_id: u64, peer: metapb::Peer, keep_data: bool) {
-        // Can we destroy it in another thread later?
-
-        // Suppose cluster removes peer a from store and then add a new
-        // peer b to the same store again, if peer a is applying snapshot,
-        // then it will be considered stale and removed immediately, and the
-        // apply meta will be removed asynchronously. So the `destroy_peer` will
-        // be called again when `poll_apply`. We need to check if the peer exists
-        // and is the very target.
-        let mut p = match self.region_peers.remove(&region_id) {
-            None => return,
-            Some(p) => if p.peer_id() == peer.get_id() {
-                p
-            } else {
-                assert!(p.peer_id() > peer.get_id());
-                // It has been destroyed.
-                self.region_peers.insert(region_id, p);
-                return;
-            },
-        };
-
-        info!("[region {}] destroy peer {:?}", region_id, peer);
+    fn destroy_peer(&mut self, merged_by_target: bool) {
+        info!(
+            "{} starts destroy [merged_by_target: {}]",
+            self.fsm.peer.tag, merged_by_target
+        );
+        let region_id = self.region_id();
         // We can't destroy a peer which is applying snapshot.
-        assert!(!p.is_applying_snapshot());
-        self.pending_cross_snap.remove(&region_id);
+        assert!(!self.fsm.peer.is_applying_snapshot());
+        let mut meta = self.ctx.store_meta.lock().unwrap();
+        meta.pending_cross_snap.remove(&region_id);
+        meta.merge_locks.remove(&region_id);
         // Destroy read delegates.
-        self.local_reader
+        if self
+            .ctx
+            .local_reader
             .schedule(ReadTask::destroy(region_id))
-            .unwrap();
-        self.apply_router
+            .is_err()
+        {
+            info!(
+                "{} unable to destroy read delegate, are we shutting down?",
+                self.fsm.peer.tag
+            );
+        }
+        self.ctx
+            .apply_router
             .schedule_task(region_id, ApplyTask::destroy(region_id));
         // Trigger region change observer
-        self.coprocessor_host.on_region_changed(
-            p.region(),
+        self.ctx.coprocessor_host.on_region_changed(
+            self.fsm.peer.region(),
             RegionChangeEvent::Destroy,
-            p.get_role(),
+            self.fsm.peer.get_role(),
         );
         let task = PdTask::DestroyPeer { region_id };
-        if let Err(e) = self.pd_worker.schedule(task) {
-            error!("{} failed to notify pd: {}", self.tag, e);
+        if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
+            error!("{} failed to notify pd: {}", self.fsm.peer.tag, e);
         }
-        let is_initialized = p.is_initialized();
-        if let Err(e) = p.destroy(keep_data) {
+        let is_initialized = self.fsm.peer.is_initialized();
+        if let Err(e) = self.fsm.peer.destroy(self.ctx, merged_by_target) {
             // If not panic here, the peer will be recreated in the next restart,
             // then it will be gc again. But if some overlap region is created
             // before restarting, the gc action will delete the overlap region's
             // data too.
-            panic!(
-                "[region {}] destroy peer {:?} in store {} err {:?}",
-                region_id,
-                peer,
-                self.store_id(),
-                e
-            );
+            panic!("{} destroy err {:?}", self.fsm.peer.tag, e);
         }
+        self.ctx.router.close(region_id);
+        self.fsm.stop();
 
-        if is_initialized
-            && self
+        if is_initialized && !merged_by_target
+            && meta
                 .region_ranges
-                .remove(&enc_end_key(p.region()))
+                .remove(&enc_end_key(self.fsm.peer.region()))
                 .is_none()
         {
-            panic!(
-                "[region {}] remove peer {:?} in store {}",
-                region_id,
-                peer,
-                self.store_id()
-            );
+            panic!("{} meta corruption detected", self.fsm.peer.tag,);
         }
-        self.merging_regions
-            .as_mut()
-            .unwrap()
-            .retain(|r| r.get_id() != p.region().get_id());
+        if meta.regions.remove(&region_id).is_none() && !merged_by_target {
+            panic!("{} meta corruption detected", self.fsm.peer.tag,)
+        }
     }
 
-    fn on_ready_change_peer(&mut self, region_id: u64, cp: ChangePeer) {
-        let my_peer_id;
+    fn on_ready_change_peer(&mut self, cp: ChangePeer) {
         let change_type = cp.conf_change.get_change_type();
-        if let Some(p) = self.region_peers.get_mut(&region_id) {
-            p.raft_group.apply_conf_change(&cp.conf_change);
-            if cp.conf_change.get_node_id() == raft::INVALID_ID {
-                // Apply failed, skip.
-                return;
-            }
-            p.set_region(cp.region);
-
-            let peer_id = cp.peer.get_id();
-            match change_type {
-                ConfChangeType::AddNode | ConfChangeType::AddLearnerNode => {
-                    let peer = cp.peer.clone();
-                    if p.peer_id() == peer_id && p.peer.get_is_learner() {
-                        p.peer = peer.clone();
-                    }
-
-                    // Add this peer to cache and heartbeats.
-                    let now = Instant::now();
-                    let id = peer.get_id();
-                    p.peer_heartbeats.insert(id, now);
-                    if p.is_leader() {
-                        p.peers_start_pending_time.push((id, now));
-                    }
-                    p.recent_added_peer.update(id, now);
-                    p.insert_peer_cache(peer);
-                }
-                ConfChangeType::RemoveNode => {
-                    // Remove this peer from cache.
-                    p.peer_heartbeats.remove(&peer_id);
-                    if p.is_leader() {
-                        p.peers_start_pending_time.retain(|&(p, _)| p != peer_id);
-                    }
-                    p.remove_peer_from_cache(peer_id);
-                }
-            }
-
-            // In pattern matching above, if the peer is the leader,
-            // it will push the change peer into `peers_start_pending_time`
-            // without checking if it is duplicated. We move `heartbeat_pd` here
-            // to utilize `collect_pending_peers` in `heartbeat_pd` to avoid
-            // adding the redundant peer.
-            if p.is_leader() {
-                // Notify pd immediately.
-                info!(
-                    "{} notify pd with change peer region {:?}",
-                    p.tag,
-                    p.region()
-                );
-                p.heartbeat_pd(&self.pd_worker);
-            }
-            my_peer_id = p.peer_id();
-        } else {
-            panic!("{} missing region {}", self.tag, region_id);
+        self.fsm.peer.raft_group.apply_conf_change(&cp.conf_change);
+        if cp.conf_change.get_node_id() == raft::INVALID_ID {
+            // Apply failed, skip.
+            return;
         }
+        {
+            let mut meta = self.ctx.store_meta.lock().unwrap();
+            meta.set_region(
+                &self.ctx.coprocessor_host,
+                &self.ctx.local_reader,
+                cp.region,
+                &mut self.fsm.peer,
+            );
+        }
+
+        let peer_id = cp.peer.get_id();
+        match change_type {
+            ConfChangeType::AddNode | ConfChangeType::AddLearnerNode => {
+                let peer = cp.peer.clone();
+                if self.fsm.peer.peer_id() == peer_id && self.fsm.peer.peer.get_is_learner() {
+                    self.fsm.peer.peer = peer.clone();
+                }
+
+                // Add this peer to cache and heartbeats.
+                let now = Instant::now();
+                let id = peer.get_id();
+                self.fsm.peer.peer_heartbeats.insert(id, now);
+                if self.fsm.peer.is_leader() {
+                    self.fsm.peer.peers_start_pending_time.push((id, now));
+                }
+                self.fsm.peer.recent_added_peer.update(id, now);
+                self.fsm.peer.insert_peer_cache(peer);
+            }
+            ConfChangeType::RemoveNode => {
+                // Remove this peer from cache.
+                self.fsm.peer.peer_heartbeats.remove(&peer_id);
+                if self.fsm.peer.is_leader() {
+                    self.fsm
+                        .peer
+                        .peers_start_pending_time
+                        .retain(|&(p, _)| p != peer_id);
+                }
+                self.fsm.peer.remove_peer_from_cache(peer_id);
+            }
+        }
+
+        // In pattern matching above, if the peer is the leader,
+        // it will push the change peer into `peers_start_pending_time`
+        // without checking if it is duplicated. We move `heartbeat_pd` here
+        // to utilize `collect_pending_peers` in `heartbeat_pd` to avoid
+        // adding the redundant peer.
+        if self.fsm.peer.is_leader() {
+            // Notify pd immediately.
+            info!(
+                "{} notify pd with change peer region {:?}",
+                self.fsm.peer.tag,
+                self.fsm.peer.region()
+            );
+            self.fsm.peer.heartbeat_pd(self.ctx);
+        }
+        let my_peer_id = self.fsm.peer.peer_id();
 
         let peer = cp.peer;
 
         // We only care remove itself now.
         if change_type == ConfChangeType::RemoveNode && peer.get_store_id() == self.store_id() {
             if my_peer_id == peer.get_id() {
-                self.destroy_peer(region_id, peer, false)
+                self.destroy_peer(false)
             } else {
-                panic!("{} trying to remove unknown peer {:?}", self.tag, peer);
+                panic!(
+                    "{} trying to remove unknown peer {:?}",
+                    self.fsm.peer.tag, peer
+                );
             }
         }
     }
 
-    fn on_ready_compact_log(
-        &mut self,
-        region_id: u64,
-        first_index: u64,
-        state: RaftTruncatedState,
-    ) {
-        let peer = self.region_peers.get_mut(&region_id).unwrap();
-        let total_cnt = peer.last_applying_idx - first_index;
+    fn on_ready_compact_log(&mut self, first_index: u64, state: RaftTruncatedState) {
+        let total_cnt = self.fsm.peer.last_applying_idx - first_index;
         // the size of current CompactLog command can be ignored.
-        let remain_cnt = peer.last_applying_idx - state.get_index() - 1;
-        peer.raft_log_size_hint = peer.raft_log_size_hint * remain_cnt / total_cnt;
+        let remain_cnt = self.fsm.peer.last_applying_idx - state.get_index() - 1;
+        self.fsm.peer.raft_log_size_hint =
+            self.fsm.peer.raft_log_size_hint * remain_cnt / total_cnt;
         let task = RaftlogGcTask {
-            raft_engine: Arc::clone(&peer.get_store().get_raft_engine()),
-            region_id: peer.get_store().get_region_id(),
-            start_idx: peer.last_compacted_idx,
+            raft_engine: Arc::clone(&self.fsm.peer.get_store().get_raft_engine()),
+            region_id: self.fsm.peer.get_store().get_region_id(),
+            start_idx: self.fsm.peer.last_compacted_idx,
             end_idx: state.get_index() + 1,
         };
-        peer.last_compacted_idx = task.end_idx;
-        peer.mut_store().compact_to(task.end_idx);
-        if let Err(e) = self.raftlog_gc_worker.schedule(task) {
+        self.fsm.peer.last_compacted_idx = task.end_idx;
+        self.fsm.peer.mut_store().compact_to(task.end_idx);
+        if let Err(e) = self.ctx.raftlog_gc_scheduler.schedule(task) {
             error!(
-                "[region {}] failed to schedule compact task: {}",
-                region_id, e
+                "{} failed to schedule compact task: {}",
+                self.fsm.peer.tag, e
             );
         }
     }
 
-    fn on_ready_split_region(
-        &mut self,
-        region_id: u64,
-        derived: metapb::Region,
-        regions: Vec<metapb::Region>,
-    ) {
-        let (peer_stat, is_leader) = match self.region_peers.get_mut(&region_id) {
-            None => panic!("[region {}] region is missing", region_id),
-            Some(peer) => {
-                peer.set_region(derived.clone());
-                peer.post_split();
-                if peer.is_leader() {
-                    peer.heartbeat_pd(&self.pd_worker);
-                }
-                (peer.peer_stat.clone(), peer.is_leader())
-            }
-        };
-
+    fn on_ready_split_region(&mut self, derived: metapb::Region, regions: Vec<metapb::Region>) {
+        let mut guard = self.ctx.store_meta.lock().unwrap();
+        let meta: &mut StoreMeta = &mut *guard;
+        let region_id = derived.get_id();
+        meta.set_region(
+            &self.ctx.coprocessor_host,
+            &self.ctx.local_reader,
+            derived,
+            &mut self.fsm.peer,
+        );
+        self.fsm.peer.post_split();
+        let is_leader = self.fsm.peer.is_leader();
         if is_leader {
+            self.fsm.peer.heartbeat_pd(self.ctx);
             // Notify pd immediately to let it update the region meta.
-            if let Err(e) = report_split_pd(&regions, &self.pd_worker) {
-                error!("{} failed to notify pd: {}", self.tag, e);
+            info!(
+                "{} notify pd with split count {}",
+                self.fsm.peer.tag,
+                regions.len()
+            );
+            // Now pd only uses ReportBatchSplit for history operation show,
+            // so we send it independently here.
+            let task = PdTask::ReportBatchSplit {
+                regions: regions.to_vec(),
+            };
+            if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
+                error!("{} failed to notify pd: {}", self.fsm.peer.tag, e);
             }
         }
 
         let last_key = enc_end_key(regions.last().unwrap());
-        self.region_ranges
-            .remove(&last_key)
-            .expect("original region should exists");
+        if meta.region_ranges.remove(&last_key).is_none() {
+            panic!("{} original region should exists", self.fsm.peer.tag);
+        }
+        // It's not correct anymore, so set it to None to let split checker update it.
+        self.fsm.peer.approximate_size.take();
         let last_region_id = regions.last().unwrap().get_id();
         for new_region in regions {
             let new_region_id = new_region.get_id();
 
-            let not_exist = self
+            let not_exist = meta
                 .region_ranges
                 .insert(enc_end_key(&new_region), new_region_id)
                 .is_none();
@@ -1036,126 +1263,139 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 "[region {}] insert new region {:?}",
                 new_region_id, new_region
             );
-            if let Some(peer) = self.region_peers.get(&new_region_id) {
+            if let Some(r) = meta.regions.get(&new_region_id) {
                 // Suppose a new node is added by conf change and the snapshot comes slowly.
                 // Then, the region splits and the first vote message comes to the new node
                 // before the old snapshot, which will create an uninitialized peer on the
                 // store. After that, the old snapshot comes, followed with the last split
                 // proposal. After it's applied, the uninitialized peer will be met.
                 // We can remove this uninitialized peer directly.
-                if peer.get_store().is_initialized() {
+                if !r.get_peers().is_empty() {
                     panic!(
-                        "[region {}] duplicated region for split region",
-                        new_region_id
+                        "[region {}] duplicated region {:?} for split region {:?}",
+                        new_region_id, r, new_region
                     );
                 }
+                self.ctx.router.close(new_region_id);
             }
 
-            let mut new_peer = match Peer::create(self, &new_region) {
-                Ok(new_peer) => new_peer,
+            let (sender, mut new_peer) = match PeerFsm::create(
+                self.ctx.store_id(),
+                &self.ctx.cfg,
+                self.ctx.region_scheduler.clone(),
+                self.ctx.engines.clone(),
+                &new_region,
+            ) {
+                Ok((sender, new_peer)) => (sender, new_peer),
                 Err(e) => {
                     // peer information is already written into db, can't recover.
                     // there is probably a bug.
                     panic!("create new split region {:?} err {:?}", new_region, e);
                 }
             };
-            let peer = new_peer.peer.clone();
+            let meta_peer = new_peer.peer.peer.clone();
 
-            for peer in new_region.get_peers() {
+            for p in new_region.get_peers() {
                 // Add this peer to cache.
-                new_peer.insert_peer_cache(peer.clone());
+                new_peer.peer.insert_peer_cache(p.clone());
             }
 
             // New peer derive write flow from parent region,
             // this will be used by balance write flow.
-            new_peer.peer_stat = peer_stat.clone();
-
-            let campaigned = new_peer.maybe_campaign(is_leader, &mut self.pending_raft_groups);
+            new_peer.peer.peer_stat = self.fsm.peer.peer_stat.clone();
+            let campaigned = new_peer.peer.maybe_campaign(is_leader);
+            new_peer.has_ready |= campaigned;
 
             if is_leader {
                 // The new peer is likely to become leader, send a heartbeat immediately to reduce
                 // client query miss.
-                new_peer.heartbeat_pd(&self.pd_worker);
+                new_peer.peer.heartbeat_pd(self.ctx);
             }
 
-            new_peer.activate();
-            self.region_peers.insert(new_region_id, new_peer);
+            new_peer.peer.activate(self.ctx);
+            meta.regions.insert(new_region_id, new_region);
+            if last_region_id == new_region_id {
+                // To prevent from big region, the right region needs run split
+                // check again after split.
+                new_peer.peer.size_diff_hint = self.ctx.cfg.region_split_check_diff.0;
+            }
+            let mailbox = BasicMailbox::new(sender, new_peer);
+            self.ctx.router.register(new_region_id, mailbox);
+            self.ctx
+                .router
+                .force_send(new_region_id, PeerMsg::Start(new_region_id))
+                .unwrap();
 
             if !campaigned {
-                if let Some(msg) = self
+                if let Some(msg) = meta
                     .pending_votes
-                    .swap_remove_front(|m| m.get_to_peer() == &peer)
+                    .swap_remove_front(|m| m.get_to_peer() == &meta_peer)
                 {
-                    let _ = self.on_raft_message(msg);
+                    let _ = self
+                        .ctx
+                        .router
+                        .send(new_region_id, PeerMsg::RaftMessage(msg));
                 }
             }
         }
-
-        // To prevent from big region, the right region needs run split
-        // check again after split.
-        self.region_peers
-            .get_mut(&last_region_id)
-            .unwrap()
-            .size_diff_hint = self.cfg.region_split_check_diff.0;
     }
 
-    pub fn register_merge_check_tick(&self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::CheckMerge,
-            self.cfg.merge_check_tick_interval.as_millis(),
-        ) {
-            error!("{} register split region check tick err: {:?}", self.tag, e);
-        };
+    fn register_merge_check_tick(&self) {
+        self.schedule_tick(
+            PeerTick::CheckMerge,
+            self.ctx.cfg.merge_check_tick_interval.0,
+        )
     }
 
-    fn get_merge_peer(&self, tag: &str, target_region: &metapb::Region) -> Result<Option<&Peer>> {
+    fn validate_merge_peer(&self, target_region: &metapb::Region) -> Result<bool> {
         let region_id = target_region.get_id();
-        if let Some(p) = self.region_peers.get(&region_id) {
-            let exist_epoch = p.region().get_region_epoch();
+        let exist_region = {
+            let meta = self.ctx.store_meta.lock().unwrap();
+            meta.regions.get(&region_id).cloned()
+        };
+        if let Some(r) = exist_region {
+            let exist_epoch = r.get_region_epoch();
             let expect_epoch = target_region.get_region_epoch();
             // exist_epoch > expect_epoch
             if util::is_epoch_stale(expect_epoch, exist_epoch) {
                 return Err(box_err!(
                     "target region changed {:?} -> {:?}",
                     target_region,
-                    p.region()
+                    r
                 ));
             }
             // exist_epoch < expect_epoch
             if util::is_epoch_stale(exist_epoch, expect_epoch) {
                 info!(
                     "{} target region still not catch up: {:?} vs {:?}, skip.",
-                    tag,
-                    target_region,
-                    p.region()
+                    self.fsm.peer.tag, target_region, r
                 );
-                return Ok(None);
+                return Ok(false);
             }
-            return Ok(Some(p));
+            return Ok(true);
         }
 
         let state_key = keys::region_state_key(region_id);
-        let state: RegionLocalState = match self.engines.kv.get_msg_cf(CF_RAFT, &state_key) {
+        let state: RegionLocalState = match self.ctx.engines.kv.get_msg_cf(CF_RAFT, &state_key) {
             Err(e) => {
                 error!(
                     "{} failed to load region state of {}, ignore: {}",
-                    tag, region_id, e
+                    self.fsm.peer.tag, region_id, e
                 );
-                return Ok(None);
+                return Ok(false);
             }
             Ok(None) => {
                 info!(
                     "{} seems to merge into a new replica of region {}, let's wait.",
-                    tag, region_id
+                    self.fsm.peer.tag, region_id
                 );
-                return Ok(None);
+                return Ok(false);
             }
             Ok(Some(state)) => state,
         };
         if state.get_state() != PeerState::Tombstone {
-            info!("{} wait for region {} split.", tag, region_id);
-            return Ok(None);
+            info!("{} wait for region {} split.", self.fsm.peer.tag, region_id);
+            return Ok(false);
         }
 
         let tombstone_region = state.get_region();
@@ -1164,74 +1404,81 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         {
             info!(
                 "{} seems to merge into a new replica of region {}, let's wait.",
-                tag, region_id
+                self.fsm.peer.tag, region_id
             );
-            return Ok(None);
+            return Ok(false);
         }
 
         Err(box_err!("region {} is destroyed", region_id))
     }
 
-    fn schedule_merge(&mut self, region: &metapb::Region) -> Result<()> {
+    fn schedule_merge(&mut self) -> Result<()> {
         fail_point!("on_schedule_merge", |_| Ok(()));
-        let req = {
-            let peer = &self.region_peers[&region.get_id()];
-            let state = peer.pending_merge_state.as_ref().unwrap();
+        let (request, target_id) = {
+            let state = self.fsm.peer.pending_merge_state.as_ref().unwrap();
             let expect_region = state.get_target();
-            let sibling_peer = match self.get_merge_peer(&peer.tag, expect_region)? {
+            if !self.validate_merge_peer(expect_region)? {
                 // Wait till next round.
-                None => return Ok(()),
-                Some(p) => p,
-            };
-            if !sibling_peer.is_leader() {
-                info!("{} merge target peer is not leader, skip.", self.tag);
-                // skip early.
                 return Ok(());
             }
-            let sibling_region = sibling_peer.region();
+            let target_id = expect_region.get_id();
+            let sibling_region = expect_region;
 
-            let min_index = peer.get_min_progress() + 1;
+            let min_index = self.fsm.peer.get_min_progress() + 1;
             let low = cmp::max(min_index, state.get_min_index());
             // TODO: move this into raft module.
             // > over >= to include the PrepareMerge proposal.
             let entries = if low > state.get_commit() {
                 vec![]
             } else {
-                self.region_peers[&region.get_id()]
+                self.fsm
+                    .peer
                     .get_store()
                     .entries(low, state.get_commit() + 1, NO_LIMIT)
                     .unwrap()
             };
 
-            let mut request = new_admin_request(sibling_region.get_id(), sibling_peer.peer.clone());
+            let sibling_peer = util::find_peer(&sibling_region, self.store_id()).unwrap();
+            let mut request = new_admin_request(sibling_region.get_id(), sibling_peer.clone());
             request
                 .mut_header()
                 .set_region_epoch(sibling_region.get_region_epoch().clone());
             let mut admin = AdminRequest::new();
             admin.set_cmd_type(AdminCmdType::CommitMerge);
-            admin.mut_commit_merge().set_source(region.clone());
+            admin
+                .mut_commit_merge()
+                .set_source(self.fsm.peer.region().clone());
             admin.mut_commit_merge().set_commit(state.get_commit());
             admin
                 .mut_commit_merge()
                 .set_entries(RepeatedField::from_vec(entries));
             request.set_admin_request(admin);
-            request
+            (request, target_id)
         };
         // Please note that, here assumes that the unit of network isolation is store rather than
-        // peer. So a quorum stores of souce region should also be the quorum stores of target
+        // peer. So a quorum stores of source region should also be the quorum stores of target
         // region. Otherwise we need to enable proposal forwarding.
-        self.propose_raft_command(req, Callback::None);
-        Ok(())
+        self.ctx
+            .router
+            .force_send(
+                target_id,
+                PeerMsg::RaftCmd {
+                    send_time: Instant::now(),
+                    request,
+                    callback: Callback::None,
+                },
+            )
+            .map_err(|e| Error::Transport(e.into()))
     }
 
-    fn rollback_merge(&mut self, region: &metapb::Region) {
+    fn rollback_merge(&mut self) {
         let req = {
-            let peer = &self.region_peers[&region.get_id()];
-            let state = peer.pending_merge_state.as_ref().unwrap();
-            let mut request = new_admin_request(region.get_id(), peer.peer.clone());
+            let state = self.fsm.peer.pending_merge_state.as_ref().unwrap();
+            let mut request =
+                new_admin_request(self.fsm.peer.region().get_id(), self.fsm.peer.peer.clone());
             request
                 .mut_header()
-                .set_region_epoch(peer.region().get_region_epoch().clone());
+                .set_region_epoch(self.fsm.peer.region().get_region_epoch().clone());
             let mut admin = AdminRequest::new();
             admin.set_cmd_type(AdminCmdType::RollbackMerge);
             admin.mut_rollback_merge().set_commit(state.get_commit());
@@ -1241,33 +1488,32 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         self.propose_raft_command(req, Callback::None);
     }
 
-    pub fn on_check_merge(&mut self, event_loop: &mut EventLoop<Self>) {
-        let merging_regions = self.merging_regions.take().unwrap();
-        for region in &merging_regions {
-            if let Err(e) = self.schedule_merge(region) {
-                info!(
-                    "[region {}] failed to schedule merge, rollback: {:?}",
-                    region.get_id(),
-                    e
-                );
-                self.rollback_merge(region);
-            }
+    fn on_check_merge(&mut self) {
+        if self.fsm.stopped || self.fsm.peer.pending_merge_state.is_none() {
+            return;
         }
-        self.merging_regions = Some(merging_regions);
-        self.register_merge_check_tick(event_loop);
+        self.register_merge_check_tick();
+        if let Err(e) = self.schedule_merge() {
+            info!(
+                "{} failed to schedule merge, rollback: {:?}",
+                self.fsm.peer.tag, e
+            );
+            self.rollback_merge();
+        }
     }
 
-    pub fn on_ready_prepare_merge(
-        &mut self,
-        region: metapb::Region,
-        state: MergeState,
-        merged: bool,
-    ) {
+    fn on_ready_prepare_merge(&mut self, region: metapb::Region, state: MergeState, merged: bool) {
         {
-            let peer = self.region_peers.get_mut(&region.get_id()).unwrap();
-            peer.pending_merge_state = Some(state);
-            peer.set_region(region.clone());
+            let mut meta = self.ctx.store_meta.lock().unwrap();
+            meta.set_region(
+                &self.ctx.coprocessor_host,
+                &self.ctx.local_reader,
+                region.clone(),
+                &mut self.fsm.peer,
+            );
         }
+        self.fsm.peer.pending_merge_state = Some(state);
+        self.notify_prepare_merge();
 
         if merged {
             // CommitMerge will try to catch up log for source region. If PrepareMerge is executed
@@ -1275,42 +1521,103 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             return;
         }
 
-        if let Err(e) = self.schedule_merge(&region) {
-            info!(
-                "[region {}] failed to schedule merge, rollback: {:?}",
-                region.get_id(),
-                e
-            );
-            self.rollback_merge(&region);
-        }
-        self.merging_regions.as_mut().unwrap().push(region);
+        self.on_check_merge();
     }
 
-    fn on_ready_commit_merge(&mut self, region: metapb::Region, source: metapb::Region) {
-        let source_peer = {
-            let peer = self.region_peers.get_mut(&source.get_id()).unwrap();
-            assert!(peer.pending_merge_state.is_some());
-            peer.peer.clone()
-        };
-        self.destroy_peer(source.get_id(), source_peer, true);
-        // If merge backward, then stale meta is clear when source region is destroyed.
-        // So only forward needs to be considered.
-        if region.get_end_key() == source.get_end_key() {
-            self.region_ranges.remove(&keys::enc_start_key(&source));
-            self.region_ranges
-                .insert(keys::enc_end_key(&region), region.get_id());
+    fn on_ready_commit_merge(
+        &mut self,
+        region: metapb::Region,
+        source: metapb::Region,
+    ) -> Option<Arc<AtomicBool>> {
+        let mut meta = self.ctx.store_meta.lock().unwrap();
+        let source_region_id = source.get_id();
+        let source_version = source.get_region_epoch().get_version();
+        'check_locks: {
+            // The `PrepareMerge` and `CommitMerge` is executed sequentially, but we can not
+            // ensure the order to handle the apply results between different peers. So check
+            // the merge locks to ensure `on_ready_prepare_merge` is called.
+            if let Some((exist_version, ready_to_merge)) =
+                meta.merge_locks.remove(&source_region_id)
+            {
+                if exist_version == source_version {
+                    assert!(ready_to_merge.is_none());
+                    // So `on_ready_prepare_merge` is executed.
+                    break 'check_locks;
+                } else if exist_version < source_version {
+                    assert!(
+                        ready_to_merge.is_none(),
+                        "{} source region {} meets a commit merge before {} < {}",
+                        self.fsm.peer.tag,
+                        source_region_id,
+                        exist_version,
+                        source_version
+                    );
+                } else {
+                    panic!(
+                        "{} source region {} can't finished current merge: {} > {}",
+                        self.fsm.peer.tag, source_region_id, exist_version, source_region_id
+                    );
+                }
+            }
+
+            // The corresponding `on_ready_prepare_merge` is not executed yet.
+            // Insert the lock, and `on_ready_prepare_merge` will check and use `ready_to_merge`
+            // to notify.
+            let ready_to_merge = Arc::new(AtomicBool::new(false));
+            meta.merge_locks.insert(
+                source_region_id,
+                (source_version, Some(ready_to_merge.clone())),
+            );
+            return Some(ready_to_merge);
         }
-        let region_id = region.get_id();
-        let peer = self.region_peers.get_mut(&region_id).unwrap();
-        peer.set_region(region);
+
+        let prev = meta.region_ranges.remove(&enc_end_key(&source));
+        assert_eq!(prev, Some(source.get_id()));
+        let prev = if region.get_end_key() == source.get_end_key() {
+            meta.region_ranges.remove(&enc_start_key(&source))
+        } else {
+            meta.region_ranges.remove(&enc_end_key(&region))
+        };
+        if prev != Some(region.get_id()) {
+            panic!(
+                "{} meta corrupted: prev: {:?}, ranges: {:?}",
+                self.fsm.peer.tag, prev, meta.region_ranges
+            );
+        }
+        meta.region_ranges
+            .insert(enc_end_key(&region), region.get_id());
+        assert!(meta.regions.remove(&source.get_id()).is_some());
+        meta.set_region(
+            &self.ctx.coprocessor_host,
+            &self.ctx.local_reader,
+            region,
+            &mut self.fsm.peer,
+        );
         // make approximate size and keys updated in time.
         // the reason why follower need to update is that there is a issue that after merge
         // and then transfer leader, the new leader may have stale size and keys.
-        peer.size_diff_hint = self.cfg.region_split_check_diff.0;
-        if peer.is_leader() {
-            info!("notify pd with merge {:?} into {:?}", source, peer.region());
-            peer.heartbeat_pd(&self.pd_worker);
+        self.fsm.peer.size_diff_hint = self.ctx.cfg.region_split_check_diff.0;
+        if self.fsm.peer.is_leader() {
+            info!(
+                "{} notify pd with merge {:?} into {:?}",
+                self.fsm.peer.tag,
+                source,
+                self.fsm.peer.region()
+            );
+            self.fsm.peer.heartbeat_pd(self.ctx);
         }
+        self.ctx
+            .router
+            .send(
+                source.get_id(),
+                PeerMsg::MergeResult {
+                    region_id: source.get_id(),
+                    target: self.fsm.peer.peer.clone(),
+                    stale: false,
+                },
+            )
+            .unwrap();
+        None
     }
 
     /// Handle rollbacking Merge result.
@@ -1318,43 +1625,94 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     /// If commit is 0, it means that Merge is rollbacked by a snapshot; otherwise
     /// it's rollbacked by a proposal, and its value should be equal to the commit
     /// index of previous PrepareMerge.
-    fn on_ready_rollback_merge(
-        &mut self,
-        region_id: u64,
-        commit: u64,
-        region: Option<metapb::Region>,
-    ) {
-        let peer = self.region_peers.get_mut(&region_id).unwrap();
-        let pending_commit = peer.pending_merge_state.as_ref().unwrap().get_commit();
-        self.merging_regions.as_mut().unwrap().retain(|r| {
-            if r.get_id() != region_id {
-                return true;
-            }
-            if commit != 0 && pending_commit != commit {
-                panic!(
-                    "{} rollbacks a wrong merge: {} != {}",
-                    peer.tag, pending_commit, commit
+    fn on_ready_rollback_merge(&mut self, commit: u64, region: Option<metapb::Region>) {
+        let pending_commit = self
+            .fsm
+            .peer
+            .pending_merge_state
+            .as_ref()
+            .unwrap()
+            .get_commit();
+        if commit != 0 && pending_commit != commit {
+            panic!(
+                "{} rollbacks a wrong merge: {} != {}",
+                self.fsm.peer.tag, pending_commit, commit
+            );
+        }
+        self.fsm.peer.pending_merge_state = None;
+        {
+            let mut meta = self.ctx.store_meta.lock().unwrap();
+            if let Some(r) = region {
+                meta.set_region(
+                    &self.ctx.coprocessor_host,
+                    &self.ctx.local_reader,
+                    r,
+                    &mut self.fsm.peer,
                 );
             }
-            false
-        });
-        peer.pending_merge_state = None;
-        if let Some(r) = region {
-            peer.set_region(r);
+            let region = self.fsm.peer.region();
+            let region_id = region.get_id();
+            let source_version = region.get_region_epoch().get_version();
+            if let Some((exist_version, ready_to_merge)) = meta.merge_locks.remove(&region_id) {
+                if exist_version > source_version {
+                    assert!(
+                        ready_to_merge.is_some(),
+                        "{} unexpected empty merge state at {}",
+                        self.fsm.peer.tag,
+                        exist_version
+                    );
+                    meta.merge_locks
+                        .insert(region_id, (exist_version, ready_to_merge));
+                } else {
+                    assert!(
+                        ready_to_merge.is_none(),
+                        "{} rollback a commit merge state at {}",
+                        self.fsm.peer.tag,
+                        exist_version
+                    );
+                }
+            }
         }
-        if peer.is_leader() {
-            info!("{} notify pd with rollback merge {}", peer.tag, commit);
-            peer.heartbeat_pd(&self.pd_worker);
+        if self.fsm.peer.is_leader() {
+            info!(
+                "{} notify pd with rollback merge {}",
+                self.fsm.peer.tag, commit
+            );
+            self.fsm.peer.heartbeat_pd(self.ctx);
         }
     }
 
-    pub fn on_merge_fail(&mut self, region_id: u64) {
-        info!("[region {}] merge fail, try gc stale peer.", region_id);
-        if let Some(job) = self
-            .region_peers
-            .get_mut(&region_id)
-            .and_then(|p| p.maybe_destroy())
-        {
+    fn on_merge_result(&mut self, target: metapb::Peer, stale: bool) {
+        let exists = self
+            .fsm
+            .peer
+            .pending_merge_state
+            .as_ref()
+            .map_or(true, |s| s.get_target().get_peers().contains(&target));
+        if !exists {
+            panic!(
+                "{} unexpected merge result: {:?} {:?} {}",
+                self.fsm.peer.tag, self.fsm.peer.pending_merge_state, target, stale
+            );
+        }
+        if !stale {
+            info!(
+                "{} merge to {:?} finish.",
+                self.fsm.peer.tag,
+                self.fsm.peer.pending_merge_state.as_ref().unwrap().target
+            );
+            self.destroy_peer(true);
+        } else {
+            self.on_stale_merge();
+        }
+    }
+
+    fn on_stale_merge(&mut self) {
+        info!(
+            "{} successful merge to {:?} can't be continued, try to gc stale peer.",
+            self.fsm.peer.tag, self.fsm.peer.pending_merge_state
+        );
+        if let Some(job) = self.fsm.peer.maybe_destroy() {
             self.handle_destroy_peer(job);
         }
     }
@@ -1362,79 +1720,92 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     fn on_ready_apply_snapshot(&mut self, apply_result: ApplySnapResult) {
         let prev_region = apply_result.prev_region;
         let region = apply_result.region;
-        let region_id = region.get_id();
 
         info!(
-            "[region {}] snapshot for region {:?} is applied",
-            region_id, region
+            "{} snapshot for region {:?} is applied",
+            self.fsm.peer.tag, region
         );
 
-        if !prev_region.get_peers().is_empty() {
+        let mut meta = self.ctx.store_meta.lock().unwrap();
+        debug!(
+            "{} ranges {:?} prev_region {:?}",
+            self.fsm.peer.tag, meta.region_ranges, prev_region
+        );
+        let initialized = !prev_region.get_peers().is_empty();
+        if initialized {
             info!(
-                "[region {}] region changed from {:?} -> {:?} after applying snapshot",
-                region_id, prev_region, region
+                "{} region changed from {:?} -> {:?} after applying snapshot",
+                self.fsm.peer.tag, prev_region, region
             );
-            // we have already initialized the peer, so it must exist in region_ranges.
-            if self
-                .region_ranges
-                .remove(&enc_end_key(&prev_region))
-                .is_none()
-            {
+            let prev = meta.region_ranges.remove(&enc_end_key(&prev_region));
+            if prev != Some(region.get_id()) {
                 panic!(
-                    "[region {}] region should exist {:?}",
-                    region_id, prev_region
+                    "{} meta corrupted, expect {:?} got {:?}",
+                    self.fsm.peer.tag, prev_region, prev
                 );
             }
         }
-
-        self.region_ranges
-            .insert(enc_end_key(&region), region.get_id());
+        if let Some(r) = meta
+            .region_ranges
+            .insert(enc_end_key(&region), region.get_id())
+        {
+            panic!("{} unexpected region {:?}", self.fsm.peer.tag, r);
+        }
+        let prev = meta.regions.insert(region.get_id(), region);
+        assert_eq!(prev, Some(prev_region));
     }
 
     fn on_ready_result(
         &mut self,
-        region_id: u64,
         merged: bool,
-        exec_results: Vec<ExecResult>,
+        exec_results: &mut VecDeque<ExecResult>,
         metrics: &ApplyMetrics,
-    ) {
-        self.store_stat.lock_cf_bytes_written += metrics.lock_cf_written_bytes;
-        self.store_stat.engine_total_bytes_written += metrics.written_bytes;
-        self.store_stat.engine_total_keys_written += metrics.written_keys;
+    ) -> Option<Arc<AtomicBool>> {
+        if exec_results.is_empty() {
+            return None;
+        }
+
+        self.ctx.store_stat.lock_cf_bytes_written += metrics.lock_cf_written_bytes;
+        self.ctx.store_stat.engine_total_bytes_written += metrics.written_bytes;
+        self.ctx.store_stat.engine_total_keys_written += metrics.written_keys;
 
         // handle executing committed log results
-        for result in exec_results {
+        while let Some(result) = exec_results.pop_front() {
             match result {
-                ExecResult::ChangePeer(cp) => self.on_ready_change_peer(region_id, cp),
+                ExecResult::ChangePeer(cp) => self.on_ready_change_peer(cp),
                 ExecResult::CompactLog { first_index, state } => if !merged {
-                    self.on_ready_compact_log(region_id, first_index, state)
+                    self.on_ready_compact_log(first_index, state)
                 },
                 ExecResult::SplitRegion { derived, regions } => {
-                    self.on_ready_split_region(region_id, derived, regions)
+                    self.on_ready_split_region(derived, regions)
                 }
                 ExecResult::PrepareMerge { region, state } => {
                     self.on_ready_prepare_merge(region, state, merged);
                 }
                 ExecResult::CommitMerge { region, source } => {
-                    self.on_ready_commit_merge(region, source);
+                    if let Some(ready_to_merge) =
+                        self.on_ready_commit_merge(region.clone(), source.clone())
+                    {
+                        exec_results.push_front(ExecResult::CommitMerge { region, source });
+                        return Some(ready_to_merge);
+                    }
                 }
                 ExecResult::RollbackMerge { region, commit } => {
-                    self.on_ready_rollback_merge(region.get_id(), commit, Some(region))
+                    self.on_ready_rollback_merge(commit, Some(region))
                 }
                 ExecResult::ComputeHash {
                     region,
                     index,
                     snap,
                 } => self.on_ready_compute_hash(region, index, snap),
-                ExecResult::VerifyHash { index, hash } => {
-                    self.on_ready_verify_hash(region_id, index, hash)
-                }
+                ExecResult::VerifyHash { index, hash } => self.on_ready_verify_hash(index, hash),
                 ExecResult::DeleteRange { .. } => {
                     // TODO: clean user properties?
                 }
                 ExecResult::IngestSST { ssts } => self.on_ingest_sst_result(ssts),
             }
         }
+        None
     }
 
     /// Check if a request is valid if it has valid prepare_merge/commit_merge proposal.
@@ -1445,21 +1816,33 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             return Ok(());
         }
 
-        let region_id = msg.get_header().get_region_id();
-        let peer = &self.region_peers[&region_id];
-        let region = peer.region();
-
+        let region = self.fsm.peer.region();
         if msg.get_admin_request().has_prepare_merge() {
             let target_region = msg.get_admin_request().get_prepare_merge().get_target();
-            let peer = match self.region_peers.get(&target_region.get_id()) {
-                None => return Err(box_err!("target region doesn't exist.")),
-                Some(p) => p,
-            };
-            if peer.region() != target_region {
-                return Err(box_err!("target region not matched, skip proposing."));
+            {
+                let meta = self.ctx.store_meta.lock().unwrap();
+                match meta.regions.get(&target_region.get_id()) {
+                    Some(r) => if r != target_region {
+                        return Err(box_err!(
+                            "target region not matched, skip proposing: {:?} != {:?}",
+                            r,
+                            target_region
+                        ));
+                    },
+                    None => {
+                        return Err(box_err!(
+                            "target region {} doesn't exist.",
+                            target_region.get_id()
+                        ));
+                    }
+                }
             }
             if !util::is_sibling_regions(target_region, region) {
-                return Err(box_err!("regions are not sibling, skip proposing."));
+                return Err(box_err!(
+                    "{:?} and {:?} are not sibling, skip proposing.",
+                    target_region,
+                    region
+                ));
             }
             if !util::region_on_same_stores(target_region, region) {
                 return Err(box_err!(
@@ -1470,28 +1853,21 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             }
         } else {
             let source_region = msg.get_admin_request().get_commit_merge().get_source();
-            let source_peer = &self.region_peers[&source_region.get_id()];
-            // only merging peer can propose merge request.
-            assert!(
-                source_peer.pending_merge_state.is_some(),
-                "{} {} should be in merging state",
-                peer.tag,
-                source_peer.tag
-            );
-            assert_eq!(source_region, source_peer.region());
-            assert!(
-                util::is_sibling_regions(source_region, region),
-                "{:?} {:?} should be sibling",
-                source_region,
-                region
-            );
-            assert!(
-                util::region_on_same_stores(source_region, region),
-                "peers not matched: {:?} {:?}",
-                source_region,
-                region
-            );
-        };
+            if !util::is_sibling_regions(source_region, region) {
+                return Err(box_err!(
+                    "{:?} and {:?} should be sibling",
+                    source_region,
+                    region
+                ));
+            }
+            if !util::region_on_same_stores(source_region, region) {
+                return Err(box_err!(
+                    "peers not matched: {:?} {:?}",
+                    source_region,
+                    region
+                ));
+            }
+        }
 
         Ok(())
     }
@@ -1502,7 +1878,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     ) -> Result<Option<RaftCmdResponse>> {
         // Check store_id, make sure that the msg is dispatched to the right place.
         if let Err(e) = util::check_store_id(msg, self.store_id()) {
-            self.raft_metrics.invalid_proposal.mismatch_store_id += 1;
+            self.ctx.raft_metrics.invalid_proposal.mismatch_store_id += 1;
             return Err(e);
         }
         if msg.has_status_request() {
@@ -1512,46 +1888,35 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         }
 
         // Check whether the store has the right peer to handle the request.
-
-        let region_id = msg.get_header().get_region_id();
-        let peer = match self.region_peers.get(&region_id) {
-            Some(peer) => peer,
-            None => {
-                self.raft_metrics.invalid_proposal.region_not_found += 1;
-                return Err(Error::RegionNotFound(region_id));
-            }
-        };
-
-        if !peer.is_leader() {
-            self.raft_metrics.invalid_proposal.not_leader += 1;
-            return Err(Error::NotLeader(
-                region_id,
-                peer.get_peer_from_cache(peer.leader_id()),
-            ));
+        let region_id = self.region_id();
+        let leader_id = self.fsm.peer.leader_id();
+        if !self.fsm.peer.is_leader() {
+            self.ctx.raft_metrics.invalid_proposal.not_leader += 1;
+            let leader = self.fsm.peer.get_peer_from_cache(leader_id);
+            return Err(Error::NotLeader(region_id, leader));
         }
         // peer_id must be the same as peer's.
-        if let Err(e) = util::check_peer_id(msg, peer.peer_id()) {
-            self.raft_metrics.invalid_proposal.mismatch_peer_id += 1;
+        if let Err(e) = util::check_peer_id(msg, self.fsm.peer.peer_id()) {
+            self.ctx.raft_metrics.invalid_proposal.mismatch_peer_id += 1;
             return Err(e);
         }
         // Check whether the term is stale.
-        if let Err(e) = util::check_term(msg, peer.term()) {
-            self.raft_metrics.invalid_proposal.stale_command += 1;
+        if let Err(e) = util::check_term(msg, self.fsm.peer.term()) {
+            self.ctx.raft_metrics.invalid_proposal.stale_command += 1;
             return Err(e);
         }
 
-        match util::check_region_epoch(msg, peer.region(), true) {
+        match util::check_region_epoch(msg, self.fsm.peer.region(), true) {
             Err(Error::StaleEpoch(msg, mut new_regions)) => {
                 // Attach the region which might be split from the current region. But it doesn't
                 // matter if the region is not split from the current region. If the region meta
                 // received by the TiKV driver is newer than the meta cached in the driver, the meta is
                 // updated.
-                let sibling_region_id = self.find_sibling_region(peer.region());
-                if let Some(sibling_region_id) = sibling_region_id {
-                    let sibling_region = self.region_peers[&sibling_region_id].region();
-                    new_regions.push(sibling_region.to_owned());
+                let sibling_region = self.find_sibling_region();
+                if let Some(sibling_region) = sibling_region {
+                    new_regions.push(sibling_region);
                 }
-                self.raft_metrics.invalid_proposal.stale_epoch += 1;
+                self.ctx.raft_metrics.invalid_proposal.stale_epoch += 1;
                 Err(Error::StaleEpoch(msg, new_regions))
             }
             Err(e) => Err(e),
@@ -1559,22 +1924,30 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         }
     }
 
-    pub fn propose_raft_command(&mut self, mut msg: RaftCmdRequest, cb: Callback) {
+    fn propose_raft_command(&mut self, mut msg: RaftCmdRequest, cb: Callback) {
         match self.pre_propose_raft_command(&msg) {
             Ok(Some(resp)) => {
                 cb.invoke_with_response(resp);
                 return;
             }
             Err(e) => {
-                debug!("{} failed to propose {:?}: {:?}", self.tag, msg, e);
+                debug!("{} failed to propose {:?}: {:?}", self.fsm.peer.tag, msg, e);
                 cb.invoke_with_response(new_error(e));
                 return;
             }
             _ => (),
         }
 
+        if self.fsm.peer.pending_remove {
+            apply::notify_req_region_removed(self.region_id(), cb);
+            return;
+        }
+
         if let Err(e) = self.check_merge_proposal(&mut msg) {
-            warn!("{} failed to propose merge: {:?}: {}", self.tag, msg, e);
+            warn!(
+                "{} failed to propose merge: {:?}: {}",
+                self.fsm.peer.tag, msg, e
+            );
             cb.invoke_with_response(new_error(e));
             return;
         }
@@ -1585,213 +1958,209 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         // command log entry can't be committed.
 
         let mut resp = RaftCmdResponse::new();
-        let region_id = msg.get_header().get_region_id();
-        let peer = self.region_peers.get_mut(&region_id).unwrap();
-        let term = peer.term();
+        let term = self.fsm.peer.term();
         bind_term(&mut resp, term);
-        if peer.propose(cb, msg, resp, &mut self.raft_metrics.propose) {
-            peer.mark_to_be_checked(&mut self.pending_raft_groups);
+        if self.fsm.peer.propose(self.ctx, cb, msg, resp) {
+            self.fsm.has_ready = true;
         }
 
         // TODO: add timeout, if the command is not applied after timeout,
         // we will call the callback with timeout error.
     }
 
-    pub fn find_sibling_region(&self, region: &metapb::Region) -> Option<u64> {
-        let start = if self.cfg.right_derive_when_split {
-            Included(enc_start_key(region))
+    fn find_sibling_region(&self) -> Option<Region> {
+        let start = if self.ctx.cfg.right_derive_when_split {
+            Included(enc_start_key(self.fsm.peer.region()))
         } else {
-            Excluded(enc_end_key(region))
+            Excluded(enc_end_key(self.fsm.peer.region()))
         };
-        self.region_ranges
-            .range((start, Unbounded::<Key>))
+        let meta = self.ctx.store_meta.lock().unwrap();
+        meta.region_ranges
+            .range((start, Unbounded::<Vec<u8>>))
             .next()
-            .map(|(_, &region_id)| region_id)
+            .map(|(_, region_id)| meta.regions[region_id].to_owned())
     }
 
-    pub fn register_raft_gc_log_tick(&self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::RaftLogGc,
-            self.cfg.raft_log_gc_tick_interval.as_millis(),
-        ) {
-            // If failed, we can't cleanup the raft log regularly.
-            // Although the log size will grow larger and larger, it doesn't affect
-            // whole raft logic, and we can send truncate log command to compact it.
-            error!("{} register raft gc log tick err: {:?}", self.tag, e);
-        };
+    fn register_raft_gc_log_tick(&self) {
+        self.schedule_tick(
+            PeerTick::RaftLogGc,
+            self.ctx.cfg.raft_log_gc_tick_interval.0,
+        )
     }
 
     #[cfg_attr(feature = "cargo-clippy", allow(if_same_then_else))]
-    pub fn on_raft_gc_log_tick(&mut self, event_loop: &mut EventLoop<Self>) {
+    fn on_raft_gc_log_tick(&mut self) {
+        self.register_raft_gc_log_tick();
+
         // As leader, we would not keep caches for the peers that didn't response heartbeat in the
         // last few seconds. That happens probably because another TiKV is down. In this case if we
         // do not clean up the cache, it may keep growing.
         let drop_cache_duration =
-            self.cfg.raft_heartbeat_interval() + self.cfg.raft_entry_cache_life_time.0;
+            self.ctx.cfg.raft_heartbeat_interval() + self.ctx.cfg.raft_entry_cache_life_time.0;
         let cache_alive_limit = Instant::now() - drop_cache_duration;
 
         let mut total_gc_logs = 0;
 
-        for (&region_id, peer) in &mut self.region_peers {
-            let applied_idx = peer.get_store().applied_index();
-            if !peer.is_leader() {
-                peer.mut_store().compact_to(applied_idx + 1);
-                continue;
-            }
-
-            // Leader will replicate the compact log command to followers,
-            // If we use current replicated_index (like 10) as the compact index,
-            // when we replicate this log, the newest replicated_index will be 11,
-            // but we only compact the log to 10, not 11, at that time,
-            // the first index is 10, and replicated_index is 11, with an extra log,
-            // and we will do compact again with compact index 11, in cycles...
-            // So we introduce a threshold, if replicated index - first index > threshold,
-            // we will try to compact log.
-            // raft log entries[..............................................]
-            //                  ^                                       ^
-            //                  |-----------------threshold------------ |
-            //              first_index                         replicated_index
-            // `alive_cache_idx` is the smallest `replicated_index` of healthy up nodes.
-            // `alive_cache_idx` is only used to gc cache.
-            let truncated_idx = peer.get_store().truncated_index();
-            let last_idx = peer.get_store().last_index();
-            let (mut replicated_idx, mut alive_cache_idx) = (last_idx, last_idx);
-            for (peer_id, p) in peer.raft_group.raft.prs().iter() {
-                if replicated_idx > p.matched {
-                    replicated_idx = p.matched;
-                }
-                if let Some(last_heartbeat) = peer.peer_heartbeats.get(peer_id) {
-                    if alive_cache_idx > p.matched
-                        && p.matched >= truncated_idx
-                        && *last_heartbeat > cache_alive_limit
-                    {
-                        alive_cache_idx = p.matched;
-                    }
-                }
-            }
-            // When an election happened or a new peer is added, replicated_idx can be 0.
-            if replicated_idx > 0 {
-                assert!(
-                    last_idx >= replicated_idx,
-                    "expect last index {} >= replicated index {}",
-                    last_idx,
-                    replicated_idx
-                );
-                REGION_MAX_LOG_LAG.observe((last_idx - replicated_idx) as f64);
-            }
-            peer.mut_store()
-                .maybe_gc_cache(alive_cache_idx, applied_idx);
-            let first_idx = peer.get_store().first_index();
-            let mut compact_idx;
-            if applied_idx > first_idx
-                && applied_idx - first_idx >= self.cfg.raft_log_gc_count_limit
-            {
-                compact_idx = applied_idx;
-            } else if peer.raft_log_size_hint >= self.cfg.raft_log_gc_size_limit.0 {
-                compact_idx = applied_idx;
-            } else if replicated_idx < first_idx
-                || replicated_idx - first_idx <= self.cfg.raft_log_gc_threshold
-            {
-                continue;
-            } else {
-                compact_idx = replicated_idx;
-            }
-
-            // Have no idea why subtract 1 here, but original code did this by magic.
-            assert!(compact_idx > 0);
-            compact_idx -= 1;
-            if compact_idx < first_idx {
-                // In case compact_idx == first_idx before subtraction.
-                continue;
-            }
-
-            total_gc_logs += compact_idx - first_idx;
-
-            let term = peer.raft_group.raft.raft_log.term(compact_idx).unwrap();
-
-            // Create a compact log request and notify directly.
-            let request = new_compact_log_request(region_id, peer.peer.clone(), compact_idx, term);
-
-            if let Err(e) = self
-                .sendch
-                .try_send(Msg::new_raft_cmd(request, Callback::None))
-            {
-                error!("{} send compact log {} err {:?}", peer.tag, compact_idx, e);
-            }
+        let applied_idx = self.fsm.peer.get_store().applied_index();
+        if !self.fsm.peer.is_leader() {
+            self.fsm.peer.mut_store().compact_to(applied_idx + 1);
+            return;
         }
 
+        // Leader will replicate the compact log command to followers,
+        // If we use current replicated_index (like 10) as the compact index,
+        // when we replicate this log, the newest replicated_index will be 11,
+        // but we only compact the log to 10, not 11, at that time,
+        // the first index is 10, and replicated_index is 11, with an extra log,
+        // and we will do compact again with compact index 11, in cycles...
+        // So we introduce a threshold, if replicated index - first index > threshold,
+        // we will try to compact log.
+        // raft log entries[..............................................]
+        //                  ^                                       ^
+        //                  |-----------------threshold------------ |
+        //              first_index                         replicated_index
+        // `alive_cache_idx` is the smallest `replicated_index` of healthy up nodes.
+        // `alive_cache_idx` is only used to gc cache.
+        let truncated_idx = self.fsm.peer.get_store().truncated_index();
+        let last_idx = self.fsm.peer.get_store().last_index();
+        let (mut replicated_idx, mut alive_cache_idx) = (last_idx, last_idx);
+        for (peer_id, p) in self.fsm.peer.raft_group.raft.prs().iter() {
+            if replicated_idx > p.matched {
+                replicated_idx = p.matched;
+            }
+            if let Some(last_heartbeat) = self.fsm.peer.peer_heartbeats.get(peer_id) {
+                if alive_cache_idx > p.matched
+                    && p.matched >= truncated_idx
+                    && *last_heartbeat > cache_alive_limit
+                {
+                    alive_cache_idx = p.matched;
+                }
+            }
+        }
+        // When an election happened or a new peer is added, replicated_idx can be 0.
+        if replicated_idx > 0 {
+            assert!(
+                last_idx >= replicated_idx,
+                "expect last index {} >= replicated index {}",
+                last_idx,
+                replicated_idx
+            );
+            REGION_MAX_LOG_LAG.observe((last_idx - replicated_idx) as f64);
+        }
+        self.fsm
+            .peer
+            .mut_store()
+            .maybe_gc_cache(alive_cache_idx, applied_idx);
+        let first_idx = self.fsm.peer.get_store().first_index();
+        let mut compact_idx;
+        if applied_idx > first_idx
+            && applied_idx - first_idx >= self.ctx.cfg.raft_log_gc_count_limit
+        {
+            compact_idx = applied_idx;
+        } else if self.fsm.peer.raft_log_size_hint >= self.ctx.cfg.raft_log_gc_size_limit.0 {
+            compact_idx = applied_idx;
+        } else if replicated_idx < first_idx
+            || replicated_idx - first_idx <= self.ctx.cfg.raft_log_gc_threshold
+        {
+            return;
+        } else {
+            compact_idx = replicated_idx;
+        }
+
+        // Have no idea why subtract 1 here, but original code did this by magic.
+        assert!(compact_idx > 0);
+        compact_idx -= 1;
+        if compact_idx < first_idx {
+            // In case compact_idx == first_idx before subtraction.
+            return;
+        }
+
+        total_gc_logs += compact_idx - first_idx;
+
+        let term = self
+            .fsm
+            .peer
+            .raft_group
+            .raft
+            .raft_log
+            .term(compact_idx)
+            .unwrap();
+
+        // Create a compact log request and notify directly.
+        let region_id = self.fsm.peer.region().get_id();
+        let request =
+            new_compact_log_request(region_id, self.fsm.peer.peer.clone(), compact_idx, term);
+        self.propose_raft_command(request, Callback::None);
+
         PEER_GC_RAFT_LOG_COUNTER.inc_by(total_gc_logs as i64);
-        self.register_raft_gc_log_tick(event_loop);
     }
 
-    pub fn register_split_region_check_tick(&self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::SplitRegionCheck,
-            self.cfg.split_region_check_tick_interval.as_millis(),
-        ) {
-            error!("{} register split region check tick err: {:?}", self.tag, e);
-        };
+    fn register_split_region_check_tick(&self) {
+        self.schedule_tick(
+            PeerTick::SplitRegionCheck,
+            self.ctx.cfg.split_region_check_tick_interval.0,
+        )
     }
 
-    pub fn on_split_region_check_tick(&mut self, event_loop: &mut EventLoop<Self>) {
+    fn on_split_region_check_tick(&mut self) {
+        self.register_split_region_check_tick();
         // To avoid frequent scan, we only add new scan tasks if all previous tasks
         // have finished.
         // TODO: check whether a gc progress has been started.
-        if self.split_check_worker.is_busy() {
-            self.register_split_region_check_tick(event_loop);
+        if self.ctx.split_check_scheduler.is_busy() {
             return;
         }
-        for peer in self.region_peers.values_mut() {
-            if !peer.is_leader() {
-                continue;
-            }
-            // When restart, the approximate size will be None. The
-            // split check will first check the region size, and then
-            // check whether the region should split.  This should
-            // work even if we change the region max size.
-            // If peer says should update approximate size, update region
-            // size and check whether the region should split.
-            if peer.approximate_size.is_some()
-                && peer.compaction_declined_bytes < self.cfg.region_split_check_diff.0
-                && peer.size_diff_hint < self.cfg.region_split_check_diff.0
-            {
-                continue;
-            }
-            let task = SplitCheckTask::new(peer.region().clone(), true, CheckPolicy::SCAN);
-            if let Err(e) = self.split_check_worker.schedule(task) {
-                error!("{} failed to schedule split check: {}", self.tag, e);
-            }
-            peer.size_diff_hint = 0;
-            peer.compaction_declined_bytes = 0;
+
+        if !self.fsm.peer.is_leader() {
+            return;
         }
 
-        self.register_split_region_check_tick(event_loop);
+        // When restart, the approximate size will be None. The
+        // split check will first check the region size, and then
+        // check whether the region should split.  This should
+        // work even if we change the region max size.
+        // If peer says should update approximate size, update region
+        // size and check whether the region should split.
+        if self.fsm.peer.approximate_size.is_some()
+            && self.fsm.peer.compaction_declined_bytes < self.ctx.cfg.region_split_check_diff.0
+            && self.fsm.peer.size_diff_hint < self.ctx.cfg.region_split_check_diff.0
+        {
+            return;
+        }
+        let task = SplitCheckTask::new(self.fsm.peer.region().clone(), true, CheckPolicy::SCAN);
+        if let Err(e) = self.ctx.split_check_scheduler.schedule(task) {
+            error!(
+                "{} failed to schedule split check: {}",
+                self.fsm.peer.tag, e
+            );
+        }
+        self.fsm.peer.size_diff_hint = 0;
+        self.fsm.peer.compaction_declined_bytes = 0;
     }
 
-    pub fn on_prepare_split_region(
+    fn on_prepare_split_region(
         &mut self,
-        region_id: u64,
         region_epoch: metapb::RegionEpoch,
         split_keys: Vec<Vec<u8>>,
         cb: Callback,
     ) {
-        if let Err(e) = self.validate_split_region(region_id, &region_epoch, &split_keys) {
+        if let Err(e) = self.validate_split_region(&region_epoch, &split_keys) {
             cb.invoke_with_response(new_error(e));
             return;
         }
-        let peer = &self.region_peers[&region_id];
-        let region = peer.region();
+        let region = self.fsm.peer.region();
         let task = PdTask::AskBatchSplit {
             region: region.clone(),
             split_keys,
-            peer: peer.peer.clone(),
-            right_derive: self.cfg.right_derive_when_split,
+            peer: self.fsm.peer.peer.clone(),
+            right_derive: self.ctx.cfg.right_derive_when_split,
             callback: cb,
         };
-        if let Err(Stopped(t)) = self.pd_worker.schedule(task) {
-            error!("{} failed to notify pd to split: Stopped", peer.tag);
+        if let Err(Stopped(t)) = self.ctx.pd_scheduler.schedule(task) {
+            error!(
+                "{} failed to notify pd to split: Stopped",
+                self.fsm.peer.tag
+            );
             match t {
                 PdTask::AskBatchSplit { callback, .. } => {
                     callback.invoke_with_response(new_error(box_err!("failed to split: Stopped")));
@@ -1803,53 +2172,32 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
     fn validate_split_region(
         &mut self,
-        region_id: u64,
         epoch: &metapb::RegionEpoch,
         split_keys: &[Vec<u8>],
     ) -> Result<()> {
         if split_keys.is_empty() {
-            error!("[region {} no split key is specified.", region_id);
-            return Err(box_err!(
-                "[region {}] no split key is specified.",
-                region_id
-            ));
+            error!("{} no split key is specified.", self.fsm.peer.tag);
+            return Err(box_err!("{} no split key is specified.", self.fsm.peer.tag));
         }
         for key in split_keys {
             if key.is_empty() {
-                error!("[region {}] split key should not be empty!!!", region_id);
+                error!("{} split key should not be empty!!!", self.fsm.peer.tag);
                 return Err(box_err!(
-                    "[region {}] split key should not be empty",
-                    region_id
+                    "{} split key should not be empty",
+                    self.fsm.peer.tag
                 ));
             }
         }
-        let peer = match self.region_peers.get(&region_id) {
-            None => {
-                info!(
-                    "[region {}] region on {} doesn't exist, skip.",
-                    region_id,
-                    self.store_id()
-                );
-                return Err(Error::RegionNotFound(region_id));
-            }
-            Some(peer) => {
-                if !peer.is_leader() {
-                    // region on this store is no longer leader, skipped.
-                    info!(
-                        "[region {}] region on {} is not leader, skip.",
-                        region_id,
-                        self.store_id()
-                    );
-                    return Err(Error::NotLeader(
-                        region_id,
-                        peer.get_peer_from_cache(peer.leader_id()),
-                    ));
-                }
-                peer
-            }
-        };
+        if !self.fsm.peer.is_leader() {
+            // region on this store is no longer leader, skipped.
+            info!("{} is not leader, skip.", self.fsm.peer.tag);
+            return Err(Error::NotLeader(
+                self.region_id(),
+                self.fsm.peer.get_peer_from_cache(self.fsm.peer.leader_id()),
+            ));
+        }
 
-        let region = peer.region();
+        let region = self.fsm.peer.region();
         let latest_epoch = region.get_region_epoch();
 
         // This is a little difference for `check_region_epoch` in region split case.
@@ -1858,14 +2206,14 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         if latest_epoch.get_version() != epoch.get_version() {
             info!(
                 "{} epoch changed {:?} != {:?}, retry later",
-                peer.tag,
+                self.fsm.peer.tag,
                 region.get_region_epoch(),
                 epoch
             );
             return Err(Error::StaleEpoch(
                 format!(
                     "{} epoch changed {:?} != {:?}, retry later",
-                    peer.tag, latest_epoch, epoch
+                    self.fsm.peer.tag, latest_epoch, epoch
                 ),
                 vec![region.to_owned()],
             ));
@@ -1873,380 +2221,235 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         Ok(())
     }
 
-    pub fn on_approximate_region_size(&mut self, region_id: u64, size: u64) {
-        let peer = match self.region_peers.get_mut(&region_id) {
-            Some(peer) => peer,
-            None => {
-                warn!(
-                    "[region {}] receive stale approximate size {:?}",
-                    region_id, size,
-                );
-                return;
-            }
-        };
-        peer.approximate_size = Some(size);
+    fn on_approximate_region_size(&mut self, size: u64) {
+        self.fsm.peer.approximate_size = Some(size);
     }
 
-    pub fn on_approximate_region_keys(&mut self, region_id: u64, keys: u64) {
-        let peer = match self.region_peers.get_mut(&region_id) {
-            Some(peer) => peer,
-            None => {
-                warn!(
-                    "[region {}] receive stale approximate keys {:?}",
-                    region_id, keys,
-                );
-                return;
-            }
-        };
-        peer.approximate_keys = Some(keys);
+    fn on_approximate_region_keys(&mut self, keys: u64) {
+        self.fsm.peer.approximate_keys = Some(keys);
     }
 
-    pub fn on_schedule_half_split_region(
+    fn on_compaction_declined_bytes(&mut self, declined_bytes: u64) {
+        self.fsm.peer.compaction_declined_bytes += declined_bytes;
+        if self.fsm.peer.compaction_declined_bytes >= self.ctx.cfg.region_split_check_diff.0 {
+            UPDATE_REGION_SIZE_BY_COMPACTION_COUNTER.inc();
+        }
+    }
+
+    fn on_schedule_half_split_region(
         &mut self,
-        region_id: u64,
         region_epoch: &metapb::RegionEpoch,
         policy: CheckPolicy,
     ) {
-        let peer = match self.region_peers.get(&region_id) {
-            Some(peer) => peer,
-            None => {
-                error!("{:?}", Error::RegionNotFound(region_id));
-                return;
-            }
-        };
-
-        if !peer.is_leader() {
+        if !self.fsm.peer.is_leader() {
             // region on this store is no longer leader, skipped.
-            warn!(
-                "[region {}] region on {} is not leader, skip.",
-                region_id,
-                self.store_id()
-            );
+            warn!("{} is not leader, skip.", self.fsm.peer.tag);
             return;
         }
 
-        let region = peer.region();
+        let region = self.fsm.peer.region();
         if util::is_epoch_stale(region_epoch, region.get_region_epoch()) {
-            warn!("[region {}] receive a stale halfsplit message", region_id);
+            warn!("{} receive a stale halfsplit message", self.fsm.peer.tag);
             return;
         }
 
         let task = SplitCheckTask::new(region.clone(), false, policy);
-        if let Err(e) = self.split_check_worker.schedule(task) {
-            error!("{} failed to schedule split check: {}", self.tag, e);
-        }
-    }
-
-    pub fn on_pd_heartbeat_tick(&mut self, event_loop: &mut EventLoop<Self>) {
-        for peer in self.region_peers.values_mut() {
-            peer.check_peers();
-        }
-        let mut leader_count = 0;
-        for peer in self.region_peers.values_mut() {
-            if peer.is_leader() {
-                leader_count += 1;
-                peer.heartbeat_pd(&self.pd_worker);
-            }
-        }
-        STORE_PD_HEARTBEAT_GAUGE_VEC
-            .with_label_values(&["leader"])
-            .set(leader_count);
-        STORE_PD_HEARTBEAT_GAUGE_VEC
-            .with_label_values(&["region"])
-            .set(self.region_peers.len() as i64);
-
-        self.register_pd_heartbeat_tick(event_loop);
-    }
-
-    pub fn register_pd_heartbeat_tick(&self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::PdHeartbeat,
-            self.cfg.pd_heartbeat_tick_interval.as_millis(),
-        ) {
-            error!("{} register pd heartbeat tick err: {:?}", self.tag, e);
-        };
-    }
-
-    pub fn on_check_peer_stale_state_tick(&mut self, event_loop: &mut EventLoop<Self>) {
-        let mut leader_missing = 0;
-        for peer in &mut self.region_peers.values_mut() {
-            if peer.pending_remove {
-                continue;
-            }
-
-            if peer.is_applying_snapshot() || peer.has_pending_snapshot() {
-                continue;
-            }
-
-            // If this peer detects the leader is missing for a long long time,
-            // it should consider itself as a stale peer which is removed from
-            // the original cluster.
-            // This most likely happens in the following scenario:
-            // At first, there are three peer A, B, C in the cluster, and A is leader.
-            // Peer B gets down. And then A adds D, E, F into the cluster.
-            // Peer D becomes leader of the new cluster, and then removes peer A, B, C.
-            // After all these peer in and out, now the cluster has peer D, E, F.
-            // If peer B goes up at this moment, it still thinks it is one of the cluster
-            // and has peers A, C. However, it could not reach A, C since they are removed
-            // from the cluster or probably destroyed.
-            // Meantime, D, E, F would not reach B, since it's not in the cluster anymore.
-            // In this case, peer B would notice that the leader is missing for a long time,
-            // and it would check with pd to confirm whether it's still a member of the cluster.
-            // If not, it destroys itself as a stale peer which is removed out already.
-            let state = peer.check_stale_state();
-            fail_point!("peer_check_stale_state", state != StaleState::Valid, |_| {});
-            match state {
-                StaleState::Valid => (),
-                StaleState::LeaderMissing => {
-                    warn!(
-                        "{} leader missing longer than abnormal_leader_missing_duration {:?}",
-                        peer.tag, self.cfg.abnormal_leader_missing_duration.0,
-                    );
-                    leader_missing += 1;
-                }
-                StaleState::ToValidate => {
-                    // for peer B in case 1 above
-                    warn!(
-                        "{} leader missing longer than max_leader_missing_duration {:?}. \
-                         To check with pd whether it's still valid",
-                        peer.tag, self.cfg.max_leader_missing_duration.0,
-                    );
-                    let task = PdTask::ValidatePeer {
-                        peer: peer.peer.clone(),
-                        region: peer.region().clone(),
-                        merge_source: None,
-                    };
-                    if let Err(e) = self.pd_worker.schedule(task) {
-                        error!("{} failed to notify pd: {}", peer.tag, e)
-                    }
-                }
-            }
-        }
-        self.raft_metrics.leader_missing = leader_missing;
-
-        self.register_check_peer_stale_state_tick(event_loop);
-    }
-
-    pub fn register_check_peer_stale_state_tick(&self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::CheckPeerStaleState,
-            self.cfg.peer_stale_state_check_interval.as_millis(),
-        ) {
-            error!("{} register check peer state tick err: {:?}", self.tag, e);
-        }
-    }
-}
-
-fn report_split_pd(
-    regions: &[metapb::Region],
-    pd_worker: &FutureWorker<PdTask>,
-) -> ::std::result::Result<(), Stopped<PdTask>> {
-    info!("notify pd with split count {}", regions.len());
-
-    // Now pd only uses ReportBatchSplit for history operation show,
-    // so we send it independently here.
-    let task = PdTask::ReportBatchSplit {
-        regions: regions.to_vec(),
-    };
-
-    pd_worker.schedule(task)
-}
-
-// Consistency Check implementation.
-
-/// Verify and store the hash to state. return true means the hash has been stored successfully.
-fn verify_and_store_hash(
-    region_id: u64,
-    state: &mut ConsistencyState,
-    expected_index: u64,
-    expected_hash: Vec<u8>,
-) -> bool {
-    if expected_index < state.index {
-        REGION_HASH_COUNTER_VEC
-            .with_label_values(&["verify", "miss"])
-            .inc();
-        warn!(
-            "[region {}] has scheduled a new hash: {} > {}, skip.",
-            region_id, state.index, expected_index
-        );
-        return false;
-    }
-
-    if state.index == expected_index {
-        if state.hash.is_empty() {
-            warn!(
-                "[region {}] duplicated consistency check detected, skip.",
-                region_id
-            );
-            return false;
-        }
-        if state.hash != expected_hash {
-            panic!(
-                "[region {}] hash at {} not correct, want \"{}\", got \"{}\"!!!",
-                region_id,
-                state.index,
-                escape(&expected_hash),
-                escape(&state.hash)
-            );
-        }
-        info!(
-            "[region {}] consistency check at {} pass.",
-            region_id, state.index
-        );
-        REGION_HASH_COUNTER_VEC
-            .with_label_values(&["verify", "matched"])
-            .inc();
-        state.hash = vec![];
-        return false;
-    }
-
-    if state.index != INVALID_INDEX && !state.hash.is_empty() {
-        // Maybe computing is too slow or computed result is dropped due to channel full.
-        // If computing is too slow, miss count will be increased twice.
-        REGION_HASH_COUNTER_VEC
-            .with_label_values(&["verify", "miss"])
-            .inc();
-        warn!(
-            "[region {}] hash belongs to index {}, but we want {}, skip.",
-            region_id, state.index, expected_index
-        );
-    }
-
-    info!(
-        "[region {}] save hash of {} for consistency check later.",
-        region_id, expected_index
-    );
-    state.index = expected_index;
-    state.hash = expected_hash;
-    true
-}
-
-impl<T: Transport, C: PdClient> Store<T, C> {
-    pub fn register_consistency_check_tick(&self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::ConsistencyCheck,
-            self.cfg.consistency_check_interval.as_millis(),
-        ) {
-            error!("{} register consistency check tick err: {:?}", self.tag, e);
-        };
-    }
-
-    pub fn on_consistency_check_tick(&mut self, event_loop: &mut EventLoop<Self>) {
-        if self.consistency_check_worker.is_busy() {
-            // To avoid frequent scan, schedule new check only when all the
-            // scheduled check is done.
-            self.register_consistency_check_tick(event_loop);
-            return;
-        }
-        let (mut candidate_id, mut candidate_check_time) = (0, Instant::now());
-        for (&region_id, peer) in &mut self.region_peers {
-            if !peer.is_leader() {
-                continue;
-            }
-            if peer.consistency_state.last_check_time < candidate_check_time {
-                candidate_id = region_id;
-                candidate_check_time = peer.consistency_state.last_check_time;
-            }
-        }
-
-        if candidate_id != 0 {
-            let peer = &self.region_peers[&candidate_id];
-
-            info!("{} scheduling consistent check", peer.tag);
-            let msg = Msg::new_raft_cmd(
-                new_compute_hash_request(candidate_id, peer.peer.clone()),
-                Callback::None,
-            );
-
-            if let Err(e) = self.sendch.send(msg) {
-                error!("{} failed to schedule consistent check: {:?}", peer.tag, e);
-            }
-        }
-
-        self.register_consistency_check_tick(event_loop);
-    }
-
-    fn on_ready_compute_hash(&mut self, region: metapb::Region, index: u64, snap: EngineSnapshot) {
-        let region_id = region.get_id();
-        self.region_peers
-            .get_mut(&region_id)
-            .unwrap()
-            .consistency_state
-            .last_check_time = Instant::now();
-        let task = ConsistencyCheckTask::compute_hash(region, index, snap);
-        info!("[region {}] schedule {}", region_id, task);
-        if let Err(e) = self.consistency_check_worker.schedule(task) {
-            error!("[region {}] schedule failed: {:?}", region_id, e);
-        }
-    }
-
-    fn on_ready_verify_hash(
-        &mut self,
-        region_id: u64,
-        expected_index: u64,
-        expected_hash: Vec<u8>,
-    ) {
-        let state = match self.region_peers.get_mut(&region_id) {
-            None => {
-                warn!(
-                    "[region {}] receive stale hash at index {}",
-                    region_id, expected_index
-                );
-                return;
-            }
-            Some(p) => &mut p.consistency_state,
-        };
-
-        verify_and_store_hash(region_id, state, expected_index, expected_hash);
-    }
-
-    pub fn on_hash_computed(&mut self, region_id: u64, index: u64, hash: Vec<u8>) {
-        let (state, peer) = match self.region_peers.get_mut(&region_id) {
-            None => {
-                warn!(
-                    "[region {}] receive stale hash at index {}",
-                    region_id, index
-                );
-                return;
-            }
-            Some(p) => (&mut p.consistency_state, &p.peer),
-        };
-
-        if !verify_and_store_hash(region_id, state, index, hash) {
-            return;
-        }
-
-        let msg = Msg::new_raft_cmd(
-            new_verify_hash_request(region_id, peer.clone(), state),
-            Callback::None,
-        );
-        if let Err(e) = self.sendch.send(msg) {
+        if let Err(e) = self.ctx.split_check_scheduler.schedule(task) {
             error!(
-                "[region {}] failed to schedule verify command for index {}: {:?}",
-                region_id, index, e
+                "{} failed to schedule split check: {}",
+                self.fsm.peer.tag, e
             );
         }
+    }
+
+    fn on_pd_heartbeat_tick(&mut self) {
+        self.register_pd_heartbeat_tick();
+        self.fsm.peer.check_peers();
+
+        if !self.fsm.peer.is_leader() {
+            return;
+        }
+        self.fsm.peer.heartbeat_pd(self.ctx);
+    }
+
+    fn register_pd_heartbeat_tick(&self) {
+        self.schedule_tick(
+            PeerTick::PdHeartbeat,
+            self.ctx.cfg.pd_heartbeat_tick_interval.0,
+        )
+    }
+
+    fn on_check_peer_stale_state_tick(&mut self) {
+        if self.fsm.peer.pending_remove {
+            return;
+        }
+
+        self.register_check_peer_stale_state_tick();
+
+        if self.fsm.peer.is_applying_snapshot() || self.fsm.peer.has_pending_snapshot() {
+            return;
+        }
+
+        // If this peer detects the leader is missing for a long long time,
+        // it should consider itself as a stale peer which is removed from
+        // the original cluster.
+        // This most likely happens in the following scenario:
+        // At first, there are three peer A, B, C in the cluster, and A is leader.
+        // Peer B gets down. And then A adds D, E, F into the cluster.
+        // Peer D becomes leader of the new cluster, and then removes peer A, B, C.
+        // After all these peer in and out, now the cluster has peer D, E, F.
+        // If peer B goes up at this moment, it still thinks it is one of the cluster
+        // and has peers A, C. However, it could not reach A, C since they are removed
+        // from the cluster or probably destroyed.
+        // Meantime, D, E, F would not reach B, since it's not in the cluster anymore.
+        // In this case, peer B would notice that the leader is missing for a long time,
+        // and it would check with pd to confirm whether it's still a member of the cluster.
+        // If not, it destroys itself as a stale peer which is removed out already.
+        let state = self.fsm.peer.check_stale_state(self.ctx);
+        fail_point!("peer_check_stale_state", state != StaleState::Valid, |_| {});
+        match state {
+            StaleState::Valid => (),
+            StaleState::LeaderMissing => {
+                warn!(
+                    "{} leader missing longer than abnormal_leader_missing_duration {:?}",
+                    self.fsm.peer.tag, self.ctx.cfg.abnormal_leader_missing_duration.0,
+                );
+                self.ctx
+                    .raft_metrics
+                    .leader_missing
+                    .lock()
+                    .unwrap()
+                    .insert(self.region_id());
+            }
+            StaleState::ToValidate => {
+                // for peer B in case 1 above
+                warn!(
+                    "{} leader missing longer than max_leader_missing_duration {:?}. \
+                     To check with pd whether it's still valid",
+                    self.fsm.peer.tag, self.ctx.cfg.max_leader_missing_duration.0,
+                );
+                let task = PdTask::ValidatePeer {
+                    peer: self.fsm.peer.peer.clone(),
+                    region: self.fsm.peer.region().clone(),
+                    merge_source: None,
+                };
+                if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
+                    error!("{} failed to notify pd: {}", self.fsm.peer.tag, e)
+                }
+            }
+        }
+    }
+
+    fn register_check_peer_stale_state_tick(&self) {
+        self.schedule_tick(
+            PeerTick::CheckPeerStaleState,
+            self.ctx.cfg.peer_stale_state_check_interval.0,
+        )
+    }
+}
+
+impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
+    fn on_ready_compute_hash(&mut self, region: metapb::Region, index: u64, snap: EngineSnapshot) {
+        self.fsm.peer.consistency_state.last_check_time = Instant::now();
+        let task = ConsistencyCheckTask::compute_hash(region, index, snap);
+        info!("{} schedule {}", self.fsm.peer.tag, task);
+        if let Err(e) = self.ctx.consistency_check_scheduler.schedule(task) {
+            error!("{} schedule failed: {:?}", self.fsm.peer.tag, e);
+        }
+    }
+
+    fn on_ready_verify_hash(&mut self, expected_index: u64, expected_hash: Vec<u8>) {
+        self.verify_and_store_hash(expected_index, expected_hash);
+    }
+
+    fn on_hash_computed(&mut self, index: u64, hash: Vec<u8>) {
+        if !self.verify_and_store_hash(index, hash) {
+            return;
+        }
+
+        let req = new_verify_hash_request(
+            self.region_id(),
+            self.fsm.peer.peer.clone(),
+            &self.fsm.peer.consistency_state,
+        );
+        self.propose_raft_command(req, Callback::None);
     }
 
     fn on_ingest_sst_result(&mut self, ssts: Vec<SSTMeta>) {
         for sst in &ssts {
-            let region_id = sst.get_region_id();
-            if let Some(region) = self.region_peers.get_mut(&region_id) {
-                region.size_diff_hint += sst.get_length();
-            }
+            self.fsm.peer.size_diff_hint += sst.get_length();
         }
 
         let task = CleanupSSTTask::DeleteSST { ssts };
-        if let Err(e) = self.cleanup_sst_worker.schedule(task) {
-            error!("schedule to delete ssts: {:?}", e);
+        if let Err(e) = self.ctx.cleanup_sst_scheduler.schedule(task) {
+            error!("{} schedule to delete ssts: {:?}", self.fsm.peer.tag, e);
         }
+    }
+
+    /// Verify and store the hash to state. return true means the hash has been stored successfully.
+    fn verify_and_store_hash(&mut self, expected_index: u64, expected_hash: Vec<u8>) -> bool {
+        if expected_index < self.fsm.peer.consistency_state.index {
+            REGION_HASH_COUNTER_VEC
+                .with_label_values(&["verify", "miss"])
+                .inc();
+            warn!(
+                "{} has scheduled a new hash: {} > {}, skip.",
+                self.fsm.peer.tag, self.fsm.peer.consistency_state.index, expected_index
+            );
+            return false;
+        }
+        if self.fsm.peer.consistency_state.index == expected_index {
+            if self.fsm.peer.consistency_state.hash.is_empty() {
+                warn!(
+                    "{} duplicated consistency check detected, skip.",
+                    self.fsm.peer.tag
+                );
+                return false;
+            }
+            if self.fsm.peer.consistency_state.hash != expected_hash {
+                panic!(
+                    "{} hash at {} not correct, want \"{}\", got \"{}\"!!!",
+                    self.fsm.peer.tag,
+                    self.fsm.peer.consistency_state.index,
+                    escape(&expected_hash),
+                    escape(&self.fsm.peer.consistency_state.hash)
+                );
+            }
+            info!(
+                "{} consistency check at {} pass.",
+                self.fsm.peer.tag, self.fsm.peer.consistency_state.index
+            );
+            REGION_HASH_COUNTER_VEC
+                .with_label_values(&["verify", "matched"])
+                .inc();
+            self.fsm.peer.consistency_state.hash = vec![];
+            return false;
+        }
+        if self.fsm.peer.consistency_state.index != INVALID_INDEX
+            && !self.fsm.peer.consistency_state.hash.is_empty()
+        {
+            // Maybe computing is too slow or computed result is dropped due to channel full.
+            // If computing is too slow, miss count will be increased twice.
+            REGION_HASH_COUNTER_VEC
+                .with_label_values(&["verify", "miss"])
+                .inc();
+            warn!(
+                "{} hash belongs to index {}, but we want {}, skip.",
+                self.fsm.peer.tag, self.fsm.peer.consistency_state.index, expected_index
+            );
+        }
+
+        info!(
+            "{} save hash of {} for consistency check later.",
+            self.fsm.peer.tag, expected_index
+        );
+        self.fsm.peer.consistency_state.index = expected_index;
+        self.fsm.peer.consistency_state.hash = expected_hash;
+        true
     }
 }
 
-fn new_admin_request(region_id: u64, peer: metapb::Peer) -> RaftCmdRequest {
+pub fn new_admin_request(region_id: u64, peer: metapb::Peer) -> RaftCmdRequest {
     let mut request = RaftCmdRequest::new();
     request.mut_header().set_region_id(region_id);
     request.mut_header().set_peer(peer);
@@ -2268,15 +2471,6 @@ fn new_verify_hash_request(
     request
 }
 
-fn new_compute_hash_request(region_id: u64, peer: metapb::Peer) -> RaftCmdRequest {
-    let mut request = new_admin_request(region_id, peer);
-
-    let mut admin = AdminRequest::new();
-    admin.set_cmd_type(AdminCmdType::ComputeHash);
-    request.set_admin_request(admin);
-    request
-}
-
 fn new_compact_log_request(
     region_id: u64,
     peer: metapb::Peer,
@@ -2293,26 +2487,16 @@ fn new_compact_log_request(
     request
 }
 
-impl<T: Transport, C: PdClient> Store<T, C> {
-    /// load the target peer of request as mutable borrow.
-    fn mut_target_peer(&mut self, request: &RaftCmdRequest) -> Result<&mut Peer> {
-        let region_id = request.get_header().get_region_id();
-        match self.region_peers.get_mut(&region_id) {
-            None => Err(Error::RegionNotFound(region_id)),
-            Some(peer) => Ok(peer),
-        }
-    }
-
+impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
     // Handle status commands here, separate the logic, maybe we can move it
     // to another file later.
     // Unlike other commands (write or admin), status commands only show current
     // store status, so no need to handle it in raft group.
     fn execute_status_command(&mut self, request: &RaftCmdRequest) -> Result<RaftCmdResponse> {
         let cmd_type = request.get_status_request().get_cmd_type();
-        let region_id = request.get_header().get_region_id();
 
         let mut response = match cmd_type {
-            StatusCmdType::RegionLeader => self.execute_region_leader(request),
+            StatusCmdType::RegionLeader => self.execute_region_leader(),
             StatusCmdType::RegionDetail => self.execute_region_detail(request),
             StatusCmdType::InvalidStatus => Err(box_err!("invalid status command!")),
         }?;
@@ -2321,17 +2505,13 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let mut resp = RaftCmdResponse::new();
         resp.set_status_response(response);
         // Bind peer current term here.
-        if let Some(peer) = self.region_peers.get(&region_id) {
-            bind_term(&mut resp, peer.term());
-        }
+        bind_term(&mut resp, self.fsm.peer.term());
         Ok(resp)
     }
 
-    fn execute_region_leader(&mut self, request: &RaftCmdRequest) -> Result<StatusResponse> {
-        let peer = self.mut_target_peer(request)?;
-
+    fn execute_region_leader(&mut self) -> Result<StatusResponse> {
         let mut resp = StatusResponse::new();
-        if let Some(leader) = peer.get_peer_from_cache(peer.leader_id()) {
+        if let Some(leader) = self.fsm.peer.get_peer_from_cache(self.fsm.peer.leader_id()) {
             resp.mut_region_leader().set_leader(leader);
         }
 
@@ -2339,14 +2519,14 @@ impl<T: Transport, C: PdClient> Store<T, C> {
     }
 
     fn execute_region_detail(&mut self, request: &RaftCmdRequest) -> Result<StatusResponse> {
-        let peer = self.mut_target_peer(request)?;
-        if !peer.get_store().is_initialized() {
+        if !self.fsm.peer.get_store().is_initialized() {
             let region_id = request.get_header().get_region_id();
             return Err(Error::RegionNotInitialized(region_id));
         }
         let mut resp = StatusResponse::new();
-        resp.mut_region_detail().set_region(peer.region().clone());
-        if let Some(leader) = peer.get_peer_from_cache(peer.leader_id()) {
+        resp.mut_region_detail()
+            .set_region(self.fsm.peer.region().clone());
+        if let Some(leader) = self.fsm.peer.get_peer_from_cache(self.fsm.peer.leader_id()) {
             resp.mut_region_detail().set_leader(leader);
         }
 

--- a/src/raftstore/store/fsm/router.rs
+++ b/src/raftstore/store/fsm/router.rs
@@ -217,6 +217,12 @@ impl<Owner: Fsm, Scheduler: FsmScheduler<Fsm = Owner>> Mailbox<Owner, Scheduler>
     }
 }
 
+enum CheckDoResult<T> {
+    NotExist,
+    Invalid,
+    Valid(T),
+}
+
 /// Router route messages to its target mailbox.
 ///
 /// Every fsm has a mailbox, hence it's necessary to have an address book
@@ -265,8 +271,13 @@ where
     ///
     /// Generally, when sending a message to a mailbox, cache should be
     /// check first, if not found, lock should be acquired.
+    ///
+    /// Returns None means there is no mailbox inside the normal registry.
+    /// Some(None) means there is expected mailbox inside the normal registry
+    /// but it returns None after apply the given function. Some(Some) means
+    /// the given function returns Some and cache is updated if it's invalid.
     #[inline]
-    fn check_do<F, R>(&self, addr: u64, mut f: F) -> Option<R>
+    fn check_do<F, R>(&self, addr: u64, mut f: F) -> CheckDoResult<R>
     where
         F: FnMut(&BasicMailbox<N>) -> Option<R>,
     {
@@ -274,7 +285,7 @@ where
         let mut connected = true;
         if let Some(mailbox) = caches.get(&addr) {
             match f(mailbox) {
-                Some(r) => return Some(r),
+                Some(r) => return CheckDoResult::Valid(r),
                 None => {
                     connected = false;
                 }
@@ -290,16 +301,22 @@ where
             if !connected {
                 caches.remove(&addr);
             }
-            return None;
+            return CheckDoResult::NotExist;
         };
 
         let res = f(&mailbox);
-        if res.is_some() {
-            caches.insert(addr, mailbox);
-        } else if !connected {
-            caches.remove(&addr);
+        match res {
+            Some(r) => {
+                caches.insert(addr, mailbox);
+                CheckDoResult::Valid(r)
+            }
+            None => {
+                if !connected {
+                    caches.remove(&addr);
+                }
+                CheckDoResult::Invalid
+            }
         }
-        res
     }
 
     /// Register a mailbox with given address.
@@ -322,7 +339,7 @@ where
 
     /// Get the mailbox of specified address.
     pub fn mailbox(&self, addr: u64) -> Option<Mailbox<N, Ns>> {
-        self.check_do(addr, |mailbox| {
+        let res = self.check_do(addr, |mailbox| {
             if mailbox.sender.is_sender_connected() {
                 Some(Mailbox {
                     mailbox: mailbox.clone(),
@@ -331,7 +348,11 @@ where
             } else {
                 None
             }
-        })
+        });
+        match res {
+            CheckDoResult::Valid(r) => Some(r),
+            _ => None,
+        }
     }
 
     /// Get the mailbox of control fsm.
@@ -353,9 +374,7 @@ where
         msg: N::Message,
     ) -> Either<Result<(), TrySendError<N::Message>>, N::Message> {
         let mut msg = Some(msg);
-        let mut check_times = 0;
         let res = self.check_do(addr, |mailbox| {
-            check_times += 1;
             let m = msg.take().unwrap();
             match mailbox.try_send(m, &self.normal_scheduler) {
                 Ok(()) => Some(Ok(())),
@@ -370,14 +389,9 @@ where
             }
         });
         match res {
-            Some(r) => Either::Left(r),
-            None => {
-                if check_times == 1 {
-                    Either::Right(msg.unwrap())
-                } else {
-                    Either::Left(Err(TrySendError::Disconnected(msg.unwrap())))
-                }
-            }
+            CheckDoResult::Valid(r) => Either::Left(r),
+            CheckDoResult::Invalid => Either::Left(Err(TrySendError::Disconnected(msg.unwrap()))),
+            CheckDoResult::NotExist => Either::Right(msg.unwrap()),
         }
     }
 
@@ -561,7 +575,7 @@ pub mod tests {
         let normal_box = BasicMailbox::new(normal_tx, Box::new(normal_fsm));
         router.register(2, normal_box);
 
-        // Mising mailbox should report error.
+        // Missing mailbox should report error.
         assert_eq!(router.force_send(1, 1), Err(SendError(1)));
         assert_eq!(router.send(1, 1), Err(TrySendError::Disconnected(1)));
         assert!(schedule_rx.is_empty());

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -11,197 +11,711 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crossbeam::channel::{TryRecvError, TrySendError};
+use futures::Future;
+use kvproto::errorpb;
+use kvproto::import_sstpb::SSTMeta;
+use kvproto::metapb::{self, Region, RegionEpoch};
+use kvproto::pdpb::StoreStats;
+use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, RaftCmdResponse};
+use kvproto::raft_serverpb::{PeerState, RaftMessage, RegionLocalState};
 use protobuf;
-use std::cell::RefCell;
+use raft::{Ready, StateRole};
+use rocksdb::{CompactionJobInfo, WriteBatch, WriteOptions, DB};
 use std::collections::BTreeMap;
 use std::collections::Bound::{Excluded, Included, Unbounded};
-use std::rc::Rc;
-use std::sync::mpsc::{self, Receiver as StdReceiver};
-use std::sync::Arc;
-use std::time::Instant;
-use std::{thread, u64};
-use time;
-
-use mio::{self, EventLoop, EventLoopConfig, Sender};
-use rocksdb::{CompactionJobInfo, WriteBatch, DB};
-
-use kvproto::import_sstpb::SSTMeta;
-use kvproto::metapb;
-use kvproto::pdpb::StoreStats;
-use kvproto::raft_serverpb::{PeerState, RaftMessage, RegionLocalState};
-
-use raft::StateRole;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use std::{mem, thread, u64};
+use time::{self, Timespec};
+use tokio_threadpool::{Sender as ThreadPoolSender, ThreadPool};
 
 use pd::{PdClient, PdRunner, PdTask};
 use raftstore::coprocessor::split_observer::SplitObserver;
 use raftstore::coprocessor::{CoprocessorHost, RegionChangeEvent};
-use raftstore::store::util::{is_initial_msg, KeysInfoFormatter};
+use raftstore::store::util::is_initial_msg;
 use raftstore::Result;
 use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use util::collections::{HashMap, HashSet};
+use util::mpsc::{self, LooseBoundedSender, Receiver};
 use util::rocksdb::{CompactedEvent, CompactionListener};
 use util::time::{duration_to_sec, SlowTimer};
-use util::transport::SendCh;
-use util::worker::{FutureWorker, Scheduler, Worker};
-use util::{rocksdb, sys as util_sys, RingQueue};
+use util::timer::SteadyTimer;
+use util::transport::RetryableSendCh;
+use util::worker::{FutureScheduler, FutureWorker, Scheduler, Worker};
+use util::{is_zero_duration, rocksdb, sys as util_sys, Either, RingQueue};
 
 use import::SSTImporter;
 use raftstore::store::config::Config;
 use raftstore::store::engine::{Iterable, Mutable, Peekable};
-use raftstore::store::fsm::{create_apply_batch_system, ApplyPollerBuilder, ApplyRouter};
+use raftstore::store::fsm::metrics::*;
+use raftstore::store::fsm::peer::{new_admin_request, PeerFsm, PeerFsmDelegate};
+use raftstore::store::fsm::{
+    batch, create_apply_batch_system, ApplyBatchSystem, ApplyPollerBuilder, ApplyRouter, ApplyTask,
+    BasicMailbox, BatchRouter, BatchSystem, HandlerBuilder,
+};
+use raftstore::store::fsm::{ApplyNotifier, Fsm, PollHandler, RegionProposal};
 use raftstore::store::keys::{self, data_end_key, data_key, enc_end_key, enc_start_key};
 use raftstore::store::local_metrics::RaftMetrics;
 use raftstore::store::metrics::*;
-use raftstore::store::peer::Peer;
-use raftstore::store::peer_storage::{self, CacheQueryStats};
+use raftstore::store::peer_storage::{self, HandleRaftReadyContext, InvokeContext};
 use raftstore::store::transport::Transport;
 use raftstore::store::worker::{
     CleanupSSTRunner, CleanupSSTTask, CompactRunner, CompactTask, ConsistencyCheckRunner,
-    LocalReader, RaftlogGcRunner, ReadTask, RegionRunner, RegionTask, SplitCheckRunner,
+    ConsistencyCheckTask, LocalReader, RaftlogGcRunner, RaftlogGcTask, ReadTask, RegionRunner,
+    RegionTask, SplitCheckRunner, SplitCheckTask,
 };
 use raftstore::store::{
-    util, Engines, Msg, SignificantMsg, SnapManager, SnapshotDeleter, Store, Tick,
+    util, Callback, Engines, Msg, PeerMsg, SignificantMsg, SnapManager, SnapshotDeleter, StoreMsg,
+    StoreTick,
 };
 
 type Key = Vec<u8>;
 
-const MIO_TICK_RATIO: u64 = 10;
 const PENDING_VOTES_CAP: usize = 20;
-
-// A helper structure to bundle all channels for messages to `Store`.
-pub struct StoreChannel {
-    pub sender: Sender<Msg>,
-    pub significant_msg_receiver: StdReceiver<SignificantMsg>,
-}
-
-pub struct StoreStat {
-    pub lock_cf_bytes_written: u64,
-
-    pub engine_total_bytes_written: u64,
-    pub engine_total_keys_written: u64,
-
-    pub engine_last_total_bytes_written: u64,
-    pub engine_last_total_keys_written: u64,
-}
-
-impl Default for StoreStat {
-    fn default() -> StoreStat {
-        StoreStat {
-            lock_cf_bytes_written: 0,
-            engine_total_bytes_written: 0,
-            engine_total_keys_written: 0,
-
-            engine_last_total_bytes_written: 0,
-            engine_last_total_keys_written: 0,
-        }
-    }
-}
 
 pub struct StoreInfo {
     pub engine: Arc<DB>,
     pub capacity: u64,
 }
 
-pub fn create_event_loop<T, C>(cfg: &Config) -> Result<EventLoop<Store<T, C>>>
-where
-    T: Transport,
-    C: PdClient,
-{
-    let mut config = EventLoopConfig::new();
-    // To make raft base tick more accurate, timer tick should be small enough.
-    config.timer_tick_ms(cfg.raft_base_tick_interval.as_millis() / MIO_TICK_RATIO);
-    config.notify_capacity(cfg.notify_capacity);
-    config.messages_per_tick(cfg.messages_per_tick);
-    let event_loop = EventLoop::configured(config)?;
-    Ok(event_loop)
+pub struct StoreMeta {
+    // region end key -> region id
+    pub region_ranges: BTreeMap<Vec<u8>, u64>,
+    // region_id -> region
+    pub regions: HashMap<u64, Region>,
+    // A marker used to indicate if the peer of a region is going to apply a snapshot
+    // with different range.
+    // It assumes that when a peer is going to accept snapshot, it can never
+    // catch up by normal log replication.
+    pub pending_cross_snap: HashMap<u64, RegionEpoch>,
+    pub pending_votes: RingQueue<RaftMessage>,
+    // the regions with pending snapshots.
+    pub pending_snapshot_regions: Vec<Region>,
+    // source_region_id -> (version, BiLock).
+    pub merge_locks: HashMap<u64, (u64, Option<Arc<AtomicBool>>)>,
 }
 
-impl<T: Transport, C: PdClient> Store<T, C> {
-    #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
-    pub fn new(
-        ch: StoreChannel,
-        meta: metapb::Store,
-        mut cfg: Config,
-        engines: Engines,
-        trans: T,
-        pd_client: Arc<C>,
-        mgr: SnapManager,
-        pd_worker: FutureWorker<PdTask>,
-        local_reader: Worker<ReadTask>,
-        mut coprocessor_host: CoprocessorHost,
-        importer: Arc<SSTImporter>,
-    ) -> Result<Store<T, C>> {
-        // TODO: we can get cluster meta regularly too later.
-        cfg.validate()?;
-
-        let sendch = SendCh::new(ch.sender, "raftstore");
-        let tag = format!("[store {}]", meta.get_id());
-
-        // TODO load coprocessors from configuration
-        coprocessor_host
-            .registry
-            .register_admin_observer(100, box SplitObserver);
-
-        let (apply_router, apply_system) = create_apply_batch_system(&cfg);
-
-        let mut s = Store {
-            cfg: Rc::new(cfg),
-            store: meta,
-            engines,
-            sendch,
-            significant_msg_receiver: ch.significant_msg_receiver,
-            region_peers: HashMap::default(),
-            merging_regions: Some(vec![]),
-            pending_raft_groups: HashSet::default(),
-            split_check_worker: Worker::new("split-check"),
-            region_worker: Worker::new("snapshot-worker"),
-            raftlog_gc_worker: Worker::new("raft-gc-worker"),
-            compact_worker: Worker::new("compact-worker"),
-            pd_worker,
-            consistency_check_worker: Worker::new("consistency-check"),
-            cleanup_sst_worker: Worker::new("cleanup-sst"),
-            apply_router,
-            apply_system,
-            apply_res_receiver: None,
-            local_reader,
-            last_compact_checked_key: keys::DATA_MIN_KEY.to_vec(),
-            region_ranges: BTreeMap::new(),
-            pending_snapshot_regions: vec![],
+impl StoreMeta {
+    fn new(vote_capacity: usize) -> StoreMeta {
+        StoreMeta {
+            region_ranges: BTreeMap::default(),
+            regions: HashMap::default(),
             pending_cross_snap: HashMap::default(),
-            trans,
-            pd_client,
-            coprocessor_host: Arc::new(coprocessor_host),
-            importer,
-            snap_mgr: mgr,
-            raft_metrics: RaftMetrics::default(),
-            entry_cache_metries: Rc::new(RefCell::new(CacheQueryStats::default())),
-            pending_votes: RingQueue::with_capacity(PENDING_VOTES_CAP),
-            tag,
-            start_time: time::get_time(),
-            is_busy: false,
-            store_stat: StoreStat::default(),
-        };
-        s.init()?;
-        Ok(s)
+            pending_votes: RingQueue::with_capacity(vote_capacity),
+            pending_snapshot_regions: Vec::default(),
+            merge_locks: HashMap::default(),
+        }
     }
 
+    #[inline]
+    pub fn set_region(
+        &mut self,
+        host: &CoprocessorHost,
+        reader: &Scheduler<ReadTask>,
+        region: Region,
+        peer: &mut ::raftstore::store::Peer,
+    ) {
+        let prev = self.regions.insert(region.get_id(), region.clone());
+        if prev.map_or(true, |r| r.get_id() != region.get_id()) {
+            // TODO: may not be a good idea to panic when holding a lock.
+            panic!("{} region corrupted", peer.tag);
+        }
+        peer.set_region(host, reader, region);
+    }
+}
+
+pub type RaftRouter = BatchRouter<PeerFsm, StoreFsm>;
+
+impl RaftRouter {
+    pub fn send_raft_message(
+        &self,
+        mut msg: RaftMessage,
+    ) -> ::std::result::Result<(), TrySendError<RaftMessage>> {
+        let id = msg.get_region_id();
+        match self.try_send(id, PeerMsg::RaftMessage(msg)) {
+            Either::Left(Ok(())) => return Ok(()),
+            Either::Left(Err(TrySendError::Full(PeerMsg::RaftMessage(m)))) => {
+                return Err(TrySendError::Full(m))
+            }
+            Either::Left(Err(TrySendError::Disconnected(PeerMsg::RaftMessage(m)))) => {
+                return Err(TrySendError::Disconnected(m))
+            }
+            Either::Right(PeerMsg::RaftMessage(m)) => msg = m,
+            _ => unreachable!(),
+        }
+        match self.send_control(StoreMsg::RaftMessage(msg)) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(StoreMsg::RaftMessage(m))) => Err(TrySendError::Full(m)),
+            Err(TrySendError::Disconnected(StoreMsg::RaftMessage(m))) => {
+                Err(TrySendError::Disconnected(m))
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn send_peer_msg(&self, msg: PeerMsg) -> ::std::result::Result<(), TrySendError<Msg>> {
+        let region_id = match msg {
+            PeerMsg::RaftMessage(msg) => {
+                return match self.send_raft_message(msg) {
+                    Ok(()) => Ok(()),
+                    Err(TrySendError::Full(m)) => {
+                        Err(TrySendError::Full(Msg::PeerMsg(PeerMsg::RaftMessage(m))))
+                    }
+                    Err(TrySendError::Disconnected(m)) => Err(TrySendError::Disconnected(
+                        Msg::PeerMsg(PeerMsg::RaftMessage(m)),
+                    )),
+                };
+            }
+            PeerMsg::RaftCmd { ref request, .. } => request.get_header().get_region_id(),
+            PeerMsg::Tick(region_id, _)
+            | PeerMsg::ApplyRes { region_id, .. }
+            | PeerMsg::SplitRegion { region_id, .. }
+            | PeerMsg::ComputeHashResult { region_id, .. }
+            | PeerMsg::RegionApproximateSize { region_id, .. }
+            | PeerMsg::RegionApproximateKeys { region_id, .. }
+            | PeerMsg::CompactionDeclinedBytes { region_id, .. }
+            | PeerMsg::HalfSplitRegion { region_id, .. }
+            | PeerMsg::MergeResult { region_id, .. }
+            | PeerMsg::GcSnap { region_id, .. }
+            | PeerMsg::ClearRegionSize(region_id)
+            | PeerMsg::Start(region_id)
+            | PeerMsg::Noop(region_id) => region_id,
+            PeerMsg::SignificantMsg(ref msg) => match msg {
+                SignificantMsg::SnapshotStatus { region_id, .. }
+                | SignificantMsg::Unreachable { region_id, .. } => *region_id,
+            },
+        };
+        match self.send(region_id, msg) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(m)) => Err(TrySendError::Full(Msg::PeerMsg(m))),
+            Err(TrySendError::Disconnected(m)) => {
+                let callback = match m {
+                    PeerMsg::RaftCmd { callback, .. } | PeerMsg::SplitRegion { callback, .. } => {
+                        callback
+                    }
+                    _ => return Err(TrySendError::Disconnected(Msg::PeerMsg(m))),
+                };
+
+                let mut err = errorpb::Error::new();
+                err.set_message("region is not found".to_owned());
+                err.mut_region_not_found().set_region_id(region_id);
+                let mut resp = RaftCmdResponse::new();
+                resp.mut_header().set_error(err);
+                callback.invoke_with_response(resp);
+                Ok(())
+            }
+        }
+    }
+
+    fn send_store_msg(&self, msg: StoreMsg) -> ::std::result::Result<(), TrySendError<Msg>> {
+        match self.send_control(msg) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(m)) => Err(TrySendError::Full(Msg::StoreMsg(m))),
+            Err(TrySendError::Disconnected(m)) => Err(TrySendError::Disconnected(Msg::StoreMsg(m))),
+        }
+    }
+}
+
+// TODO: drop Sender support.
+impl ::util::transport::Sender<Msg> for RaftRouter {
+    fn send(&self, msg: Msg) -> ::std::result::Result<(), TrySendError<Msg>> {
+        match msg {
+            Msg::PeerMsg(msg) => self.send_peer_msg(msg),
+            Msg::StoreMsg(msg) => self.send_store_msg(msg),
+        }
+    }
+}
+
+pub type SendCh = RetryableSendCh<Msg, RaftRouter>;
+
+pub struct PollContext<T, C: 'static> {
+    pub cfg: Arc<Config>,
+    pub store: metapb::Store,
+    pub pd_scheduler: FutureScheduler<PdTask>,
+    pub raftlog_gc_scheduler: Scheduler<RaftlogGcTask>,
+    pub consistency_check_scheduler: Scheduler<ConsistencyCheckTask>,
+    pub split_check_scheduler: Scheduler<SplitCheckTask>,
+    pub cleanup_sst_scheduler: Scheduler<CleanupSSTTask>,
+    pub local_reader: Scheduler<ReadTask>,
+    pub region_scheduler: Scheduler<RegionTask>,
+    pub apply_router: ApplyRouter,
+    pub router: RaftRouter,
+    pub compact_scheduler: Scheduler<CompactTask>,
+    pub importer: Arc<SSTImporter>,
+    pub store_meta: Arc<Mutex<StoreMeta>>,
+    pub future_poller: ThreadPoolSender,
+    pub raft_metrics: RaftMetrics,
+    pub snap_mgr: SnapManager,
+    pub applying_snap_count: Arc<AtomicUsize>,
+    pub coprocessor_host: Arc<CoprocessorHost>,
+    pub timer: SteadyTimer,
+    pub trans: T,
+    pub pd_client: Arc<C>,
+    pub global_stat: GlobalStoreStat,
+    pub store_stat: LocalStoreStat,
+    pub engines: Engines,
+    pub kv_wb: WriteBatch,
+    pub raft_wb: WriteBatch,
+    pub pending_count: usize,
+    pub sync_log: bool,
+    pub is_busy: bool,
+    pub has_ready: bool,
+    pub ready_res: Vec<(Ready, InvokeContext)>,
+    pub need_flush_trans: bool,
+    pub queued_snapshot: HashSet<u64>,
+}
+
+impl<T, C> HandleRaftReadyContext for PollContext<T, C> {
+    #[inline]
+    fn kv_wb(&self) -> &WriteBatch {
+        &self.kv_wb
+    }
+
+    #[inline]
+    fn kv_wb_mut(&mut self) -> &mut WriteBatch {
+        &mut self.kv_wb
+    }
+
+    #[inline]
+    fn raft_wb(&self) -> &WriteBatch {
+        &self.raft_wb
+    }
+
+    #[inline]
+    fn raft_wb_mut(&mut self) -> &mut WriteBatch {
+        &mut self.raft_wb
+    }
+
+    #[inline]
+    fn sync_log(&self) -> bool {
+        self.sync_log
+    }
+
+    #[inline]
+    fn set_sync_log(&mut self, sync: bool) {
+        self.sync_log = sync;
+    }
+}
+
+impl<T, C> PollContext<T, C> {
+    #[inline]
+    pub fn store_id(&self) -> u64 {
+        self.store.get_id()
+    }
+}
+
+impl<T: Transport, C> PollContext<T, C> {
+    #[inline]
+    fn schedule_store_tick(&self, tick: StoreTick, timeout: Duration) {
+        if !is_zero_duration(&timeout) {
+            let mb = self.router.control_mailbox();
+            let f = self
+                .timer
+                .delay(timeout)
+                .map(move |_| {
+                    if let Err(e) = mb.force_send(StoreMsg::Tick(tick)) {
+                        info!(
+                            "failed to schedule store tick {:?}: {:?}, are we shutting down?",
+                            tick, e
+                        );
+                    }
+                })
+                .map_err(move |e| {
+                    panic!("tick {:?} is lost due to timeout error: {:?}", tick, e);
+                });
+            self.future_poller.spawn(f).unwrap();
+        }
+    }
+
+    pub fn handle_stale_msg(
+        &mut self,
+        msg: &RaftMessage,
+        cur_epoch: RegionEpoch,
+        need_gc: bool,
+        target_region: Option<metapb::Region>,
+    ) {
+        let region_id = msg.get_region_id();
+        let from_peer = msg.get_from_peer();
+        let to_peer = msg.get_to_peer();
+        let msg_type = msg.get_message().get_msg_type();
+
+        if !need_gc {
+            info!(
+                "[region {}] raft message {:?} is stale, current {:?}, ignore it",
+                region_id, msg_type, cur_epoch
+            );
+            self.raft_metrics.message_dropped.stale_msg += 1;
+            return;
+        }
+
+        info!(
+            "[region {}] raft message {:?} is stale, current {:?}, tell to gc",
+            region_id, msg_type, cur_epoch
+        );
+
+        let mut gc_msg = RaftMessage::new();
+        gc_msg.set_region_id(region_id);
+        gc_msg.set_from_peer(to_peer.clone());
+        gc_msg.set_to_peer(from_peer.clone());
+        gc_msg.set_region_epoch(cur_epoch.clone());
+        if let Some(r) = target_region {
+            gc_msg.set_merge_target(r);
+        } else {
+            gc_msg.set_is_tombstone(true);
+        }
+        if let Err(e) = self.trans.send(gc_msg) {
+            error!("[region {}] send gc message failed {:?}", region_id, e);
+        }
+        self.need_flush_trans = true;
+    }
+}
+
+struct Store {
+    tag: String,
+    last_compact_checked_key: Key,
+    stopped: bool,
+    start_time: Option<Timespec>,
+    consistency_check_time: HashMap<u64, Instant>,
+}
+
+pub struct StoreFsm {
+    store: Store,
+    receiver: Receiver<StoreMsg>,
+}
+
+impl StoreFsm {
+    pub fn new(cfg: &Config) -> (LooseBoundedSender<StoreMsg>, Box<StoreFsm>) {
+        let (tx, rx) = mpsc::loose_bounded(cfg.notify_capacity);
+        let fsm = Box::new(StoreFsm {
+            store: Store {
+                tag: "".to_owned(),
+                last_compact_checked_key: keys::DATA_MIN_KEY.to_vec(),
+                stopped: false,
+                start_time: None,
+                consistency_check_time: HashMap::default(),
+            },
+            receiver: rx,
+        });
+        (tx, fsm)
+    }
+}
+
+impl Fsm for StoreFsm {
+    type Message = StoreMsg;
+
+    #[inline]
+    fn is_stopped(&self) -> bool {
+        self.store.stopped
+    }
+}
+
+struct StoreFsmDelegate<'a, T: 'static, C: 'static> {
+    fsm: &'a mut StoreFsm,
+    ctx: &'a mut PollContext<T, C>,
+}
+
+impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
+    fn on_tick(&mut self, tick: StoreTick) {
+        let t = SlowTimer::new();
+        match tick {
+            StoreTick::PdStoreHeartbeat => self.on_pd_store_heartbeat_tick(),
+            StoreTick::SnapGc => self.on_snap_mgr_gc(),
+            StoreTick::CompactLockCf => self.on_compact_lock_cf(),
+            StoreTick::CompactCheck => self.on_compact_check_tick(),
+            StoreTick::ConsistencyCheck => self.on_consistency_check_tick(),
+            StoreTick::CleanupImportSST => self.on_cleanup_import_sst_tick(),
+        }
+        RAFT_EVENT_DURATION
+            .with_label_values(&[tick.tag()])
+            .observe(duration_to_sec(t.elapsed()) as f64);
+        slow_log!(t, "{} handle timeout {:?}", self.fsm.store.tag, tick);
+    }
+
+    fn handle_msgs(&mut self, msgs: &mut Vec<StoreMsg>) {
+        for m in msgs.drain(..) {
+            match m {
+                StoreMsg::Tick(tick) => self.on_tick(tick),
+                StoreMsg::RaftMessage(msg) => {
+                    if let Err(e) = self.on_raft_message(msg) {
+                        error!("{} handle raft message err: {:?}", self.fsm.store.tag, e);
+                    }
+                }
+                StoreMsg::CompactedEvent(event) => self.on_compaction_finished(event),
+                StoreMsg::ValidateSSTResult { invalid_ssts } => {
+                    self.on_validate_sst_result(invalid_ssts)
+                }
+                StoreMsg::ClearRegionSizeInRange { start_key, end_key } => {
+                    self.clear_region_size_in_range(&start_key, &end_key)
+                }
+                StoreMsg::SnapshotStats => self.store_heartbeat_pd(),
+                StoreMsg::Start { store } => self.start(store),
+            }
+        }
+    }
+
+    fn start(&mut self, store: metapb::Store) {
+        if self.fsm.store.start_time.is_some() {
+            panic!(
+                "{} unable to start again with meta {:?}",
+                self.fsm.store.tag, store
+            );
+        }
+        self.fsm.store.tag = format!("[store {}]", store.get_id());
+        self.fsm.store.start_time = Some(time::get_time());
+        self.register_cleanup_import_sst_tick();
+        self.register_compact_check_tick();
+        self.register_pd_store_heartbeat_tick();
+        self.register_compact_lock_cf_tick();
+        self.register_snap_mgr_gc_tick();
+        self.register_consistency_check_tick();
+    }
+}
+
+pub struct RaftPoller<T: 'static, C: 'static> {
+    tag: String,
+    store_msg_buf: Vec<StoreMsg>,
+    peer_msg_buf: Vec<PeerMsg>,
+    previous_metrics: RaftMetrics,
+    timer: SlowTimer,
+    poll_ctx: PollContext<T, C>,
+    pending_proposals: Vec<RegionProposal>,
+    messages_per_tick: usize,
+}
+
+impl<T: Transport, C: PdClient> RaftPoller<T, C> {
+    fn handle_raft_ready(&mut self, peers: &mut [Box<PeerFsm>]) {
+        if !self.pending_proposals.is_empty() {
+            for prop in self.pending_proposals.drain(..) {
+                self.poll_ctx
+                    .apply_router
+                    .schedule_task(prop.region_id, ApplyTask::Proposal(prop));
+            }
+        }
+        if self.poll_ctx.need_flush_trans {
+            self.poll_ctx.trans.flush();
+            self.poll_ctx.need_flush_trans = false;
+        }
+        let ready_cnt = self.poll_ctx.ready_res.len();
+        self.poll_ctx.raft_metrics.ready.has_ready_region += ready_cnt as u64;
+        fail_point!("raft_before_save");
+        if !self.poll_ctx.kv_wb.is_empty() {
+            let mut write_opts = WriteOptions::new();
+            write_opts.set_sync(true);
+            let kv_wb = mem::replace(&mut self.poll_ctx.kv_wb, WriteBatch::new());
+            self.poll_ctx
+                .engines
+                .kv
+                .write_opt(kv_wb, &write_opts)
+                .unwrap_or_else(|e| {
+                    panic!("{} failed to save append state result: {:?}", self.tag, e);
+                });
+        }
+        fail_point!("raft_between_save");
+        if !self.poll_ctx.raft_wb.is_empty() {
+            let mut write_opts = WriteOptions::new();
+            write_opts.set_sync(self.poll_ctx.cfg.sync_log || self.poll_ctx.sync_log);
+            let raft_wb = mem::replace(
+                &mut self.poll_ctx.raft_wb,
+                WriteBatch::with_capacity(4 * 1024),
+            );
+            self.poll_ctx
+                .engines
+                .raft
+                .write_opt(raft_wb, &write_opts)
+                .unwrap_or_else(|e| {
+                    panic!("{} failed to save raft append result: {:?}", self.tag, e);
+                });
+        }
+        fail_point!("raft_after_save");
+        if ready_cnt != 0 {
+            let mut batch_pos = 0;
+            let mut ready_res = mem::replace(&mut self.poll_ctx.ready_res, Vec::default());
+            for (mut ready, invoke_ctx) in ready_res.drain(..) {
+                let region_id = invoke_ctx.region_id;
+                if peers[batch_pos].region_id() == region_id {
+                } else {
+                    while peers[batch_pos].region_id() != region_id {
+                        batch_pos += 1;
+                    }
+                }
+                PeerFsmDelegate::new(&mut peers[batch_pos], &mut self.poll_ctx)
+                    .post_raft_ready_append(ready, invoke_ctx);
+            }
+        }
+        let dur = self.timer.elapsed();
+        if !self.poll_ctx.is_busy {
+            let election_timeout = Duration::from_millis(
+                self.poll_ctx.cfg.raft_base_tick_interval.as_millis()
+                    * self.poll_ctx.cfg.raft_election_timeout_ticks as u64,
+            );
+            if dur >= election_timeout {
+                self.poll_ctx.is_busy = true;
+            }
+        }
+
+        self.poll_ctx
+            .raft_metrics
+            .append_log
+            .observe(duration_to_sec(dur) as f64);
+
+        if self.poll_ctx.need_flush_trans {
+            self.poll_ctx.trans.flush();
+            self.poll_ctx.need_flush_trans = false;
+        }
+
+        slow_log!(
+            self.timer,
+            "{} handle {} pending peers include {} ready, {} entries, {} messages and {} \
+             snapshots",
+            self.tag,
+            self.poll_ctx.pending_count,
+            ready_cnt,
+            self.poll_ctx.raft_metrics.ready.append - self.previous_metrics.ready.append,
+            self.poll_ctx.raft_metrics.ready.message - self.previous_metrics.ready.message,
+            self.poll_ctx.raft_metrics.ready.snapshot - self.previous_metrics.ready.snapshot
+        );
+    }
+}
+
+impl<T: Transport, C: PdClient> PollHandler<PeerFsm, StoreFsm> for RaftPoller<T, C> {
+    fn begin(&mut self, batch_size: usize) {
+        self.previous_metrics = self.poll_ctx.raft_metrics.clone();
+        self.poll_ctx.pending_count = 0;
+        self.poll_ctx.sync_log = false;
+        self.poll_ctx.has_ready = false;
+        self.poll_ctx.need_flush_trans = false;
+        if self.pending_proposals.capacity() == 0 {
+            self.pending_proposals = Vec::with_capacity(batch_size);
+        }
+        self.timer = SlowTimer::new();
+    }
+
+    fn handle_control(&mut self, store: &mut StoreFsm) -> Option<usize> {
+        let mut expected_msg_count = None;
+        while self.store_msg_buf.len() < self.messages_per_tick {
+            match store.receiver.try_recv() {
+                Ok(msg) => self.store_msg_buf.push(msg),
+                Err(TryRecvError::Empty) => {
+                    expected_msg_count = Some(0);
+                    break;
+                }
+                Err(TryRecvError::Disconnected) => {
+                    store.store.stopped = true;
+                    expected_msg_count = Some(0);
+                    break;
+                }
+            }
+        }
+        let mut delegate = StoreFsmDelegate {
+            fsm: store,
+            ctx: &mut self.poll_ctx,
+        };
+        delegate.handle_msgs(&mut self.store_msg_buf);
+        expected_msg_count
+    }
+
+    fn handle_normal(&mut self, peer: &mut PeerFsm) -> Option<usize> {
+        let mut expected_msg_count = None;
+        if peer.have_pending_merge_apply_result() {
+            expected_msg_count = Some(peer.receiver.len());
+            let mut delegate = PeerFsmDelegate::new(peer, &mut self.poll_ctx);
+            if !delegate.resume_handling_pending_apply_result() {
+                return expected_msg_count;
+            }
+            expected_msg_count = None;
+        }
+
+        while self.peer_msg_buf.len() < self.messages_per_tick {
+            match peer.receiver.try_recv() {
+                // TODO: we may need a way to optimize the message copy.
+                Ok(msg) => self.peer_msg_buf.push(msg),
+                Err(TryRecvError::Empty) => {
+                    expected_msg_count = Some(0);
+                    break;
+                }
+                Err(TryRecvError::Disconnected) => {
+                    peer.stop();
+                    expected_msg_count = Some(0);
+                    break;
+                }
+            }
+        }
+        let mut delegate = PeerFsmDelegate::new(peer, &mut self.poll_ctx);
+        delegate.handle_msgs(&mut self.peer_msg_buf);
+        delegate.collect_ready(&mut self.pending_proposals);
+        expected_msg_count
+    }
+
+    fn end(&mut self, peers: &mut [Box<PeerFsm>]) {
+        if self.poll_ctx.has_ready {
+            self.handle_raft_ready(peers);
+        }
+        if self.poll_ctx.need_flush_trans {
+            self.poll_ctx.trans.flush();
+            self.poll_ctx.need_flush_trans = false;
+        }
+        if !self.poll_ctx.queued_snapshot.is_empty() {
+            let mut meta = self.poll_ctx.store_meta.lock().unwrap();
+            meta.pending_snapshot_regions
+                .retain(|r| !self.poll_ctx.queued_snapshot.contains(&r.get_id()));
+            self.poll_ctx.queued_snapshot.clear();
+        }
+        self.poll_ctx
+            .raft_metrics
+            .process_ready
+            .observe(duration_to_sec(self.timer.elapsed()) as f64);
+        self.poll_ctx.raft_metrics.flush();
+    }
+}
+
+pub struct RaftPollerBuilder<T, C> {
+    pub cfg: Arc<Config>,
+    pub store: metapb::Store,
+    pd_scheduler: FutureScheduler<PdTask>,
+    raftlog_gc_scheduler: Scheduler<RaftlogGcTask>,
+    consistency_check_scheduler: Scheduler<ConsistencyCheckTask>,
+    split_check_scheduler: Scheduler<SplitCheckTask>,
+    cleanup_sst_scheduler: Scheduler<CleanupSSTTask>,
+    local_reader: Scheduler<ReadTask>,
+    region_scheduler: Scheduler<RegionTask>,
+    apply_router: ApplyRouter,
+    pub router: RaftRouter,
+    compact_scheduler: Scheduler<CompactTask>,
+    pub importer: Arc<SSTImporter>,
+    store_meta: Arc<Mutex<StoreMeta>>,
+    future_poller: ThreadPoolSender,
+    snap_mgr: SnapManager,
+    pub coprocessor_host: Arc<CoprocessorHost>,
+    trans: T,
+    pd_client: Arc<C>,
+    global_stat: GlobalStoreStat,
+    pub engines: Engines,
+    applying_snap_count: Arc<AtomicUsize>,
+}
+
+impl<T, C> RaftPollerBuilder<T, C> {
     /// Initialize this store. It scans the db engine, loads all regions
     /// and their peers from it, and schedules snapshot worker if necessary.
     /// WARN: This store should not be used before initialized.
-    fn init(&mut self) -> Result<()> {
+    fn init(&mut self) -> Result<Vec<(LooseBoundedSender<PeerMsg>, Box<PeerFsm>)>> {
         // Scan region meta to get saved regions.
         let start_key = keys::REGION_META_MIN_KEY;
         let end_key = keys::REGION_META_MAX_KEY;
         let kv_engine = Arc::clone(&self.engines.kv);
+        let store_id = self.store.get_id();
         let mut total_count = 0;
         let mut tomebstone_count = 0;
         let mut applying_count = 0;
+        let mut region_peers = vec![];
 
         let t = Instant::now();
         let mut kv_wb = WriteBatch::new();
         let mut raft_wb = WriteBatch::new();
         let mut applying_regions = vec![];
-        let mut prepare_merge = vec![];
+        let mut merging_count = 0;
+        let mut meta = self.store_meta.lock().unwrap();
         kv_engine.scan_cf(CF_RAFT, start_key, end_key, false, |key, value| {
             let (region_id, suffix) = keys::decode_region_meta_key(key)?;
             if suffix != keys::REGION_STATE_SUFFIX {
@@ -214,11 +728,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             let region = local_state.get_region();
             if local_state.get_state() == PeerState::Tombstone {
                 tomebstone_count += 1;
-                debug!(
-                    "region {:?} is tombstone in store {}",
-                    region,
-                    self.store_id()
-                );
+                debug!("region {:?} is tombstone in store {}", region, store_id);
                 self.clear_stale_meta(&mut kv_wb, &mut raft_wb, &local_state);
                 return Ok(true);
             }
@@ -230,18 +740,24 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 applying_regions.push(region.clone());
                 return Ok(true);
             }
-            if local_state.get_state() == PeerState::Merging {
-                prepare_merge.push((
-                    local_state.get_region().to_owned(),
-                    local_state.get_merge_state().to_owned(),
-                ));
-            }
 
-            let peer = Peer::create(self, region)?;
-            self.region_ranges.insert(enc_end_key(region), region_id);
+            let (tx, mut peer) = PeerFsm::create(
+                store_id,
+                &self.cfg,
+                self.region_scheduler.clone(),
+                self.engines.clone(),
+                region,
+            )?;
+            if local_state.get_state() == PeerState::Merging {
+                info!("region {:?} is merging in store {}", region, store_id);
+                merging_count += 1;
+                peer.set_pending_merge_state(local_state.get_merge_state().to_owned());
+            }
+            meta.region_ranges.insert(enc_end_key(region), region_id);
+            meta.regions.insert(region_id, region.clone());
             // No need to check duplicated here, because we use region id as the key
             // in DB.
-            self.region_peers.insert(region_id, peer);
+            region_peers.push((tx, peer));
             self.coprocessor_host.on_region_changed(
                 region,
                 RegionChangeEvent::Create,
@@ -261,33 +777,25 @@ impl<T: Transport, C: PdClient> Store<T, C> {
 
         // schedule applying snapshot after raft writebatch were written.
         for region in applying_regions {
-            info!(
-                "region {:?} is applying in store {}",
-                region,
-                self.store_id()
-            );
-            let mut peer = Peer::create(self, &region)?;
-            peer.mut_store().schedule_applying_snapshot();
-            self.region_ranges
+            info!("region {:?} is applying in store {}", region, store_id);
+            let (tx, mut peer) = PeerFsm::create(
+                store_id,
+                &self.cfg,
+                self.region_scheduler.clone(),
+                self.engines.clone(),
+                &region,
+            )?;
+            peer.schedule_applying_snapshot();
+            meta.region_ranges
                 .insert(enc_end_key(&region), region.get_id());
-            self.region_peers.insert(region.get_id(), peer);
-        }
-
-        // recover prepare_merge
-        let merging_count = prepare_merge.len();
-        for (region, state) in prepare_merge {
-            info!(
-                "region {:?} is merging in store {}",
-                region,
-                self.store_id()
-            );
-            self.on_ready_prepare_merge(region, state, false);
+            meta.regions.insert(region.get_id(), region);
+            region_peers.push((tx, peer));
         }
 
         info!(
-            "{} starts with {} regions, including {} tombstones, {} applying \
+            "[store {}] starts with {} regions, including {} tombstones, {} applying \
              regions and {} merging regions, takes {:?}",
-            self.tag,
+            store_id,
             total_count,
             tomebstone_count,
             applying_count,
@@ -295,15 +803,13 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             t.elapsed()
         );
 
-        self.clear_stale_data()?;
+        self.clear_stale_data(&meta)?;
 
-        Ok(())
+        Ok(region_peers)
     }
-}
 
-impl<T, C> Store<T, C> {
     fn clear_stale_meta(
-        &mut self,
+        &self,
         kv_wb: &mut WriteBatch,
         raft_wb: &mut WriteBatch,
         origin_state: &RegionLocalState,
@@ -324,13 +830,13 @@ impl<T, C> Store<T, C> {
     }
 
     /// `clear_stale_data` clean up all possible garbage data.
-    fn clear_stale_data(&mut self) -> Result<()> {
+    fn clear_stale_data(&self, meta: &StoreMeta) -> Result<()> {
         let t = Instant::now();
 
         let mut ranges = Vec::new();
         let mut last_start_key = keys::data_key(b"");
-        for region_id in self.region_ranges.values() {
-            let region = self.region_peers[region_id].region();
+        for region_id in meta.region_ranges.values() {
+            let region = &meta.regions[region_id];
             let start_key = keys::enc_start_key(region);
             ranges.push((last_start_key, start_key));
             last_start_key = keys::enc_end_key(region);
@@ -340,218 +846,463 @@ impl<T, C> Store<T, C> {
         rocksdb::roughly_cleanup_ranges(&self.engines.kv, &ranges)?;
 
         info!(
-            "{} cleans up {} ranges garbage data, takes {:?}",
-            self.tag,
+            "[store {}] cleans up {} ranges garbage data, takes {:?}",
+            self.store.get_id(),
             ranges.len(),
             t.elapsed()
         );
 
         Ok(())
     }
+}
 
-    pub fn get_sendch(&self) -> SendCh<Msg> {
-        self.sendch.clone()
-    }
+impl<T, C> HandlerBuilder<PeerFsm, StoreFsm> for RaftPollerBuilder<T, C>
+where
+    T: Transport + 'static,
+    C: PdClient + 'static,
+{
+    type Handler = RaftPoller<T, C>;
 
-    #[inline]
-    pub fn get_snap_mgr(&self) -> SnapManager {
-        self.snap_mgr.clone()
-    }
-
-    pub fn snap_scheduler(&self) -> Scheduler<RegionTask> {
-        self.region_worker.scheduler()
-    }
-
-    pub fn apply_router(&self) -> ApplyRouter {
-        self.apply_router.clone()
-    }
-
-    pub fn read_scheduler(&self) -> Scheduler<ReadTask> {
-        self.local_reader.scheduler()
-    }
-
-    pub fn engines(&self) -> Engines {
-        self.engines.clone()
-    }
-
-    pub fn kv_engine(&self) -> Arc<DB> {
-        Arc::clone(&self.engines.kv)
-    }
-
-    pub fn raft_engine(&self) -> Arc<DB> {
-        Arc::clone(&self.engines.raft)
-    }
-
-    pub fn store_id(&self) -> u64 {
-        self.store.get_id()
-    }
-
-    pub fn get_peers(&self) -> &HashMap<u64, Peer> {
-        &self.region_peers
-    }
-
-    pub fn config(&self) -> Rc<Config> {
-        Rc::clone(&self.cfg)
+    fn build(&mut self) -> RaftPoller<T, C> {
+        let ctx = PollContext {
+            cfg: self.cfg.clone(),
+            store: self.store.clone(),
+            pd_scheduler: self.pd_scheduler.clone(),
+            raftlog_gc_scheduler: self.raftlog_gc_scheduler.clone(),
+            consistency_check_scheduler: self.consistency_check_scheduler.clone(),
+            split_check_scheduler: self.split_check_scheduler.clone(),
+            cleanup_sst_scheduler: self.cleanup_sst_scheduler.clone(),
+            local_reader: self.local_reader.clone(),
+            region_scheduler: self.region_scheduler.clone(),
+            apply_router: self.apply_router.clone(),
+            router: self.router.clone(),
+            compact_scheduler: self.compact_scheduler.clone(),
+            importer: self.importer.clone(),
+            store_meta: self.store_meta.clone(),
+            future_poller: self.future_poller.clone(),
+            raft_metrics: RaftMetrics::default(),
+            snap_mgr: self.snap_mgr.clone(),
+            applying_snap_count: self.applying_snap_count.clone(),
+            coprocessor_host: self.coprocessor_host.clone(),
+            timer: SteadyTimer::default(),
+            trans: self.trans.clone(),
+            pd_client: self.pd_client.clone(),
+            global_stat: self.global_stat.clone(),
+            store_stat: self.global_stat.local(),
+            engines: self.engines.clone(),
+            kv_wb: WriteBatch::new(),
+            raft_wb: WriteBatch::with_capacity(4 * 1024),
+            pending_count: 0,
+            sync_log: false,
+            is_busy: false,
+            has_ready: false,
+            ready_res: Vec::new(),
+            need_flush_trans: false,
+            queued_snapshot: HashSet::default(),
+        };
+        RaftPoller {
+            tag: format!("[store {}]", ctx.store.get_id()),
+            store_msg_buf: Vec::with_capacity(ctx.cfg.messages_per_tick),
+            peer_msg_buf: Vec::with_capacity(ctx.cfg.messages_per_tick),
+            previous_metrics: ctx.raft_metrics.clone(),
+            timer: SlowTimer::new(),
+            messages_per_tick: ctx.cfg.messages_per_tick,
+            poll_ctx: ctx,
+            pending_proposals: Vec::new(),
+        }
     }
 }
 
-impl<T: Transport, C: PdClient> Store<T, C> {
-    pub fn run(&mut self, event_loop: &mut EventLoop<Self>) -> Result<()> {
-        self.snap_mgr.init()?;
+struct Workers {
+    pd_worker: FutureWorker<PdTask>,
+    raftlog_gc_worker: Worker<RaftlogGcTask>,
+    consistency_check_worker: Worker<ConsistencyCheckTask>,
+    split_check_worker: Worker<SplitCheckTask>,
+    cleanup_sst_worker: Worker<CleanupSSTTask>,
+    local_reader: Worker<ReadTask>,
+    region_worker: Worker<RegionTask>,
+    compact_worker: Worker<CompactTask>,
+    coprocessor_host: Arc<CoprocessorHost>,
+    future_poller: ThreadPool,
+}
 
-        self.register_raft_base_tick(event_loop);
-        self.register_raft_gc_log_tick(event_loop);
-        self.register_split_region_check_tick(event_loop);
-        self.register_compact_check_tick(event_loop);
-        self.register_pd_store_heartbeat_tick(event_loop);
-        self.register_pd_heartbeat_tick(event_loop);
-        self.register_snap_mgr_gc_tick(event_loop);
-        self.register_compact_lock_cf_tick(event_loop);
-        self.register_consistency_check_tick(event_loop);
-        self.register_merge_check_tick(event_loop);
-        self.register_check_peer_stale_state_tick(event_loop);
-        self.register_cleanup_import_sst_tick(event_loop);
+pub struct RaftBatchSystem {
+    system: BatchSystem<PeerFsm, StoreFsm>,
+    apply_router: ApplyRouter,
+    apply_system: ApplyBatchSystem,
+    router: RaftRouter,
+    workers: Option<Workers>,
+}
+
+impl RaftBatchSystem {
+    pub fn router(&self) -> RaftRouter {
+        self.router.clone()
+    }
+
+    pub fn spawn<T: Transport + 'static, C: PdClient + 'static>(
+        &mut self,
+        meta: metapb::Store,
+        mut cfg: Config,
+        engines: Engines,
+        trans: T,
+        pd_client: Arc<C>,
+        mgr: SnapManager,
+        pd_worker: FutureWorker<PdTask>,
+        local_reader: Worker<ReadTask>,
+        mut coprocessor_host: CoprocessorHost,
+        importer: Arc<SSTImporter>,
+    ) -> Result<()> {
+        assert!(self.workers.is_none());
+        // TODO: we can get cluster meta regularly too later.
+        cfg.validate()?;
+
+        // TODO load coprocessors from configuration
+        coprocessor_host
+            .registry
+            .register_admin_observer(100, box SplitObserver);
+
+        let workers = Workers {
+            split_check_worker: Worker::new("split-check"),
+            region_worker: Worker::new("snapshot-worker"),
+            raftlog_gc_worker: Worker::new("raft-gc-worker"),
+            compact_worker: Worker::new("compact-worker"),
+            pd_worker,
+            local_reader,
+            consistency_check_worker: Worker::new("consistency-check"),
+            cleanup_sst_worker: Worker::new("cleanup-sst"),
+            coprocessor_host: Arc::new(coprocessor_host),
+            future_poller: ::tokio_threadpool::Builder::new()
+                .name_prefix("future-poller")
+                .pool_size(cfg.future_poll_size)
+                .build(),
+        };
+        let mut builder = RaftPollerBuilder {
+            cfg: Arc::new(cfg),
+            store: meta,
+            engines,
+            router: self.router.clone(),
+            split_check_scheduler: workers.split_check_worker.scheduler(),
+            region_scheduler: workers.region_worker.scheduler(),
+            raftlog_gc_scheduler: workers.raftlog_gc_worker.scheduler(),
+            compact_scheduler: workers.compact_worker.scheduler(),
+            pd_scheduler: workers.pd_worker.scheduler(),
+            consistency_check_scheduler: workers.consistency_check_worker.scheduler(),
+            cleanup_sst_scheduler: workers.cleanup_sst_worker.scheduler(),
+            apply_router: self.apply_router.clone(),
+            local_reader: workers.local_reader.scheduler(),
+            trans,
+            pd_client,
+            coprocessor_host: workers.coprocessor_host.clone(),
+            importer,
+            snap_mgr: mgr,
+            global_stat: GlobalStoreStat::default(),
+            store_meta: Arc::new(Mutex::new(StoreMeta::new(PENDING_VOTES_CAP))),
+            applying_snap_count: Arc::new(AtomicUsize::new(0)),
+            future_poller: workers.future_poller.sender().clone(),
+        };
+        let region_peers = builder.init()?;
+        let sendch = SendCh::new(builder.router.clone(), "raftstore");
+        self.start_system(workers, sendch, region_peers, builder)?;
+        Ok(())
+    }
+
+    fn start_system<T: Transport + 'static, C: PdClient + 'static>(
+        &mut self,
+        mut workers: Workers,
+        sendch: SendCh,
+        region_peers: Vec<(LooseBoundedSender<PeerMsg>, Box<PeerFsm>)>,
+        builder: RaftPollerBuilder<T, C>,
+    ) -> Result<()> {
+        builder.snap_mgr.init()?;
 
         let split_check_runner = SplitCheckRunner::new(
-            Arc::clone(&self.engines.kv),
-            self.sendch.clone(),
-            Arc::clone(&self.coprocessor_host),
+            Arc::clone(&builder.engines.kv),
+            sendch.clone(),
+            Arc::clone(&workers.coprocessor_host),
         );
 
-        box_try!(self.split_check_worker.start(split_check_runner));
+        box_try!(workers.split_check_worker.start(split_check_runner));
 
         let region_runner = RegionRunner::new(
-            self.engines.clone(),
-            self.snap_mgr.clone(),
-            self.cfg.snap_apply_batch_size.0 as usize,
-            self.cfg.use_delete_range,
-            self.cfg.clean_stale_peer_delay.0,
+            builder.engines.clone(),
+            builder.snap_mgr.clone(),
+            builder.cfg.snap_apply_batch_size.0 as usize,
+            builder.cfg.use_delete_range,
+            builder.cfg.clean_stale_peer_delay.0,
         );
         let timer = RegionRunner::new_timer();
-        box_try!(self.region_worker.start_with_timer(region_runner, timer));
+        box_try!(workers.region_worker.start_with_timer(region_runner, timer));
 
         let raftlog_gc_runner = RaftlogGcRunner::new(None);
-        box_try!(self.raftlog_gc_worker.start(raftlog_gc_runner));
+        box_try!(workers.raftlog_gc_worker.start(raftlog_gc_runner));
 
-        let compact_runner = CompactRunner::new(Arc::clone(&self.engines.kv));
-        box_try!(self.compact_worker.start(compact_runner));
+        let compact_runner = CompactRunner::new(Arc::clone(&builder.engines.kv));
+        box_try!(workers.compact_worker.start(compact_runner));
 
         let pd_runner = PdRunner::new(
-            self.store_id(),
-            Arc::clone(&self.pd_client),
-            self.sendch.clone(),
-            Arc::clone(&self.engines.kv),
-            self.pd_worker.scheduler(),
+            builder.store.get_id(),
+            Arc::clone(&builder.pd_client),
+            sendch.clone(),
+            Arc::clone(&builder.engines.kv),
+            workers.pd_worker.scheduler(),
         );
-        box_try!(self.pd_worker.start(pd_runner));
+        box_try!(workers.pd_worker.start(pd_runner));
 
-        let consistency_check_runner = ConsistencyCheckRunner::new(self.sendch.clone());
+        let consistency_check_runner = ConsistencyCheckRunner::new(sendch.clone());
         box_try!(
-            self.consistency_check_worker
+            workers
+                .consistency_check_worker
                 .start(consistency_check_runner)
         );
 
         let cleanup_sst_runner = CleanupSSTRunner::new(
-            self.store_id(),
-            self.sendch.clone(),
-            Arc::clone(&self.importer),
-            Arc::clone(&self.pd_client),
+            builder.store.get_id(),
+            sendch.clone(),
+            Arc::clone(&builder.importer),
+            Arc::clone(&builder.pd_client),
         );
-        box_try!(self.cleanup_sst_worker.start(cleanup_sst_runner));
+        box_try!(workers.cleanup_sst_worker.start(cleanup_sst_runner));
 
-        let (tx, rx) = mpsc::channel();
-        self.apply_res_receiver = Some(rx);
-        let builder = ApplyPollerBuilder::new(self, tx, self.apply_router.clone());
-        self.apply_system.spawn(builder);
-        self.apply_system.schedule_all(&self.region_peers);
+        let apply_poller_builder = ApplyPollerBuilder::new(
+            &builder,
+            ApplyNotifier::Router(self.router.clone()),
+            self.apply_router.clone(),
+        );
+        self.apply_system
+            .spawn("apply".to_owned(), apply_poller_builder);
+        self.apply_system
+            .schedule_all(region_peers.iter().map(|pair| pair.1.get_peer()));
 
-        let reader = LocalReader::new(self);
+        let reader = LocalReader::new(&builder, region_peers.iter().map(|pair| pair.1.get_peer()));
         let timer = LocalReader::new_timer();
-        box_try!(self.local_reader.start_with_timer(reader, timer));
+        box_try!(workers.local_reader.start_with_timer(reader, timer));
 
         if let Err(e) = util_sys::thread::set_priority(util_sys::HIGH_PRI) {
             warn!("set thread priority for raftstore failed, error: {:?}", e);
         }
-
-        event_loop.run(self)?;
+        let tag = format!("raftstore-{}", builder.store.get_id());
+        let store = builder.store.clone();
+        self.system.spawn(tag, builder);
+        let mut mailboxes = Vec::with_capacity(region_peers.len());
+        let mut address = Vec::with_capacity(region_peers.len());
+        for (tx, fsm) in region_peers {
+            address.push(fsm.region_id());
+            mailboxes.push((fsm.region_id(), BasicMailbox::new(tx, fsm)));
+        }
+        self.router.register_all(mailboxes);
+        self.router.send_control(StoreMsg::Start { store }).unwrap();
+        for addr in address {
+            self.router.force_send(addr, PeerMsg::Start(addr)).unwrap();
+        }
+        self.workers = Some(workers);
         Ok(())
     }
 
-    fn stop(&mut self) {
-        info!("start to stop raftstore.");
-
-        // Applying snapshot may take an unexpected long time.
-        for peer in self.region_peers.values_mut() {
-            peer.stop();
+    pub fn shutdown(&mut self) {
+        if self.workers.is_none() {
+            return;
         }
-
+        let mut workers = self.workers.take().unwrap();
         // Wait all workers finish.
         let mut handles: Vec<Option<thread::JoinHandle<()>>> = vec![];
-        handles.push(self.split_check_worker.stop());
-        handles.push(self.region_worker.stop());
-        handles.push(self.raftlog_gc_worker.stop());
-        handles.push(self.compact_worker.stop());
-        handles.push(self.pd_worker.stop());
-        handles.push(self.consistency_check_worker.stop());
-        handles.push(self.cleanup_sst_worker.stop());
-        handles.push(self.local_reader.stop());
-
+        handles.push(workers.split_check_worker.stop());
+        handles.push(workers.region_worker.stop());
+        handles.push(workers.raftlog_gc_worker.stop());
+        handles.push(workers.compact_worker.stop());
+        handles.push(workers.pd_worker.stop());
+        handles.push(workers.consistency_check_worker.stop());
+        handles.push(workers.cleanup_sst_worker.stop());
+        handles.push(workers.local_reader.stop());
         self.apply_system.shutdown();
-
+        self.system.shutdown();
         for h in handles {
             if let Some(h) = h {
                 h.join().unwrap();
             }
         }
+        workers.coprocessor_host.shutdown();
+        workers.future_poller.shutdown_now().wait().unwrap();
+    }
+}
 
-        self.coprocessor_host.shutdown();
+pub fn create_raft_batch_system(cfg: &Config) -> (RaftRouter, RaftBatchSystem) {
+    let (store_tx, store_fsm) = StoreFsm::new(cfg);
+    let (apply_router, apply_system) = create_apply_batch_system(&cfg);
+    let (router, system) = batch::create_system(
+        cfg.store_pool_size,
+        cfg.store_max_batch_size,
+        store_tx,
+        store_fsm,
+    );
+    let system = RaftBatchSystem {
+        system,
+        workers: None,
+        apply_router,
+        apply_system,
+        router: router.clone(),
+    };
+    (router, system)
+}
 
-        info!("stop raftstore finished.");
+impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
+    /// Checks if the message is targeting a stale peer.
+    ///
+    /// Returns true means the message can be dropped silently.
+    fn check_msg(&mut self, msg: &RaftMessage) -> Result<bool> {
+        let region_id = msg.get_region_id();
+        let from_epoch = msg.get_region_epoch();
+        let msg_type = msg.get_message().get_msg_type();
+        let is_vote_msg = util::is_vote_msg(msg.get_message());
+        let from_store_id = msg.get_from_peer().get_store_id();
+
+        // Check if the target peer is tomebtone.
+        let state_key = keys::region_state_key(region_id);
+        let local_state: RegionLocalState =
+            match self.ctx.engines.kv.get_msg_cf(CF_RAFT, &state_key)? {
+                Some(state) => state,
+                None => return Ok(false),
+            };
+
+        if local_state.get_state() != PeerState::Tombstone {
+            // Maybe split, but not registered yet.
+            self.ctx.raft_metrics.message_dropped.region_nonexistent += 1;
+            if util::is_first_vote_msg(msg.get_message()) {
+                let mut meta = self.ctx.store_meta.lock().unwrap();
+                // Last check on whether target peer is created, otherwise, the
+                // vote message will never be comsumed.
+                if meta.regions.contains_key(&region_id) {
+                    return Ok(false);
+                }
+                meta.pending_votes.push(msg.to_owned());
+                info!(
+                    "[region {}] doesn't exist yet, wait for it to be split",
+                    region_id
+                );
+                return Ok(true);
+            }
+            return Err(box_err!(
+                "[region {}] region not exist but not tombstone: {:?}",
+                region_id,
+                local_state
+            ));
+        }
+        debug!("[region {}] tombstone state: {:?}", region_id, local_state);
+        let region = local_state.get_region();
+        let region_epoch = region.get_region_epoch();
+        if local_state.has_merge_state() {
+            info!(
+                "[region {}] merged peer [epoch: {:?}] receive a stale message {:?}",
+                region_id, region_epoch, msg_type
+            );
+
+            let merge_target = if let Some(peer) = util::find_peer(region, from_store_id) {
+                // Maybe the target is promoted from learner to voter, but the follower
+                // doesn't know it. So we only compare peer id.
+                assert_eq!(peer.get_id(), msg.get_from_peer().get_id());
+                // Let stale peer decides whether it should wait for merging or just remove
+                // itself.
+                Some(local_state.get_merge_state().get_target().to_owned())
+            } else {
+                // If a peer is isolated before prepare_merge and conf remove, it should just
+                // remove itself.
+                None
+            };
+            self.ctx
+                .handle_stale_msg(msg, region_epoch.clone(), true, merge_target);
+            return Ok(true);
+        }
+        // The region in this peer is already destroyed
+        if util::is_epoch_stale(from_epoch, region_epoch) {
+            info!(
+                "[region {}] tombstone peer [epoch: {:?}] \
+                 receive a stale message {:?}",
+                region_id, region_epoch, msg_type,
+            );
+
+            let not_exist = util::find_peer(region, from_store_id).is_none();
+            self.ctx
+                .handle_stale_msg(msg, region_epoch.clone(), is_vote_msg && not_exist, None);
+
+            return Ok(true);
+        }
+
+        if from_epoch.get_conf_ver() == region_epoch.get_conf_ver() {
+            self.ctx.raft_metrics.message_dropped.region_tombstone_peer += 1;
+            return Err(box_err!(
+                "tombstone peer [epoch: {:?}] receive an invalid \
+                 message {:?}, ignore it",
+                region_epoch,
+                msg_type
+            ));
+        }
+
+        Ok(false)
+    }
+
+    fn on_raft_message(&mut self, mut msg: RaftMessage) -> Result<()> {
+        let region_id = msg.get_region_id();
+        match self.ctx.router.send(region_id, PeerMsg::RaftMessage(msg)) {
+            Ok(()) | Err(TrySendError::Full(_)) => return Ok(()),
+            Err(TrySendError::Disconnected(PeerMsg::RaftMessage(m))) => msg = m,
+            e => panic!(
+                "{} [region {}] unexpected redirect error: {:?}",
+                self.fsm.store.tag, region_id, e
+            ),
+        }
+
+        debug!(
+            "{} [region {}] handle raft message {:?}, from {} to {}",
+            self.fsm.store.tag,
+            region_id,
+            msg.get_message().get_msg_type(),
+            msg.get_from_peer().get_id(),
+            msg.get_to_peer().get_id()
+        );
+
+        if msg.get_to_peer().get_store_id() != self.ctx.store_id() {
+            warn!(
+                "[region {}] store not match, to store id {}, mine {}, ignore it",
+                region_id,
+                msg.get_to_peer().get_store_id(),
+                self.ctx.store_id()
+            );
+            self.ctx.raft_metrics.message_dropped.mismatch_store_id += 1;
+            return Ok(());
+        }
+
+        if !msg.has_region_epoch() {
+            error!(
+                "[region {}] missing epoch in raft message, ignore it",
+                region_id
+            );
+            self.ctx.raft_metrics.message_dropped.mismatch_region_epoch += 1;
+            return Ok(());
+        }
+        if msg.get_is_tombstone() || msg.has_merge_target() {
+            // Target tombstone peer doesn't exist, so ignore it.
+            return Ok(());
+        }
+        if self.check_msg(&msg)? {
+            return Ok(());
+        }
+        if !self.maybe_create_peer(region_id, &msg)? {
+            return Ok(());
+        }
+        let _ = self.ctx.router.send(region_id, PeerMsg::RaftMessage(msg));
+        Ok(())
     }
 
     /// If target peer doesn't exist, create it.
     ///
     /// return false to indicate that target peer is in invalid state or
     /// doesn't exist and can't be created.
-    pub fn maybe_create_peer(&mut self, region_id: u64, msg: &RaftMessage) -> Result<bool> {
+    fn maybe_create_peer(&mut self, region_id: u64, msg: &RaftMessage) -> Result<bool> {
         let target = msg.get_to_peer();
         // we may encounter a message with larger peer id, which means
         // current peer is stale, then we should remove current peer
-        let mut has_peer = false;
-        let mut job = None;
-        if let Some(p) = self.region_peers.get_mut(&region_id) {
-            has_peer = true;
-            let target_peer_id = target.get_id();
-            if p.peer_id() < target_peer_id {
-                job = p.maybe_destroy();
-                if job.is_none() {
-                    self.raft_metrics.message_dropped.applying_snap += 1;
-                    return Ok(false);
-                }
-            } else if p.peer_id() > target_peer_id {
-                info!(
-                    "[region {}] target peer id {} is less than {}, msg maybe stale.",
-                    region_id,
-                    target_peer_id,
-                    p.peer_id()
-                );
-                self.raft_metrics.message_dropped.stale_msg += 1;
-                return Ok(false);
-            }
-        }
-
-        if let Some(job) = job {
-            info!(
-                "[region {}] try to destroy stale peer {:?}",
-                region_id, job.peer
-            );
-            if !self.handle_destroy_peer(job) {
-                return Ok(false);
-            }
-            has_peer = false;
-        }
-
-        if has_peer {
+        let mut guard = self.ctx.store_meta.lock().unwrap();
+        let meta: &mut StoreMeta = &mut *guard;
+        if meta.regions.contains_key(&region_id) {
             return Ok(true);
         }
 
@@ -561,34 +1312,34 @@ impl<T: Transport, C: PdClient> Store<T, C> {
                 "target peer {:?} doesn't exist, stale message {:?}.",
                 target, msg_type
             );
-            self.raft_metrics.message_dropped.stale_msg += 1;
+            self.ctx.raft_metrics.message_dropped.stale_msg += 1;
             return Ok(false);
         }
 
         let start_key = data_key(msg.get_start_key());
-        if let Some((_, exist_region_id)) = self
+        if let Some((_, exist_region_id)) = meta
             .region_ranges
             .range((Excluded(start_key), Unbounded::<Key>))
             .next()
         {
-            let exist_region = self.region_peers[exist_region_id].region();
+            let exist_region = &meta.regions[&exist_region_id];
             if enc_start_key(exist_region) < data_end_key(msg.get_end_key()) {
                 debug!("msg {:?} is overlapped with region {:?}", msg, exist_region);
                 if util::is_first_vote_msg(msg.get_message()) {
-                    self.pending_votes.push(msg.to_owned());
+                    meta.pending_votes.push(msg.to_owned());
                 }
-                self.raft_metrics.message_dropped.region_overlap += 1;
+                self.ctx.raft_metrics.message_dropped.region_overlap += 1;
 
                 // Make sure the range of region from msg is covered by existing regions.
                 // If so, means that the region may be generated by some kinds of split
                 // and merge by catching logs. So there is no need to accept a snapshot.
                 if !is_range_covered(
-                    &self.region_ranges,
-                    |id: u64| self.region_peers[&id].region(),
+                    &meta.region_ranges,
+                    |id: u64| &meta.regions[&id],
                     data_key(msg.get_start_key()),
                     data_end_key(msg.get_end_key()),
                 ) {
-                    self.pending_cross_snap
+                    meta.pending_cross_snap
                         .insert(region_id, msg.get_region_epoch().to_owned());
                 }
 
@@ -597,10 +1348,24 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         }
 
         // New created peers should know it's learner or not.
-        let peer = Peer::replicate(self, region_id, target.clone())?;
+        let (tx, peer) = PeerFsm::replicate(
+            self.ctx.store_id(),
+            &self.ctx.cfg,
+            self.ctx.region_scheduler.clone(),
+            self.ctx.engines.clone(),
+            region_id,
+            target.clone(),
+        )?;
         // following snapshot may overlap, should insert into region_ranges after
         // snapshot is applied.
-        self.region_peers.insert(region_id, peer);
+        meta.regions
+            .insert(region_id, peer.get_peer().region().to_owned());
+        let mailbox = BasicMailbox::new(tx, peer);
+        self.ctx.router.register(region_id, mailbox);
+        self.ctx
+            .router
+            .force_send(region_id, PeerMsg::Start(region_id))
+            .unwrap();
         Ok(true)
     }
 
@@ -611,7 +1376,7 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         } else {
             0
         };
-        if total_bytes_declined < self.cfg.region_split_check_diff.0
+        if total_bytes_declined < self.ctx.cfg.region_split_check_diff.0
             || total_bytes_declined * 10 < event.total_input_bytes
         {
             return;
@@ -623,98 +1388,127 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             .observe(total_bytes_declined as f64);
 
         // self.cfg.region_split_check_diff.0 / 16 is an experienced value.
-        let mut region_declined_bytes = calc_region_declined_bytes(
-            event,
-            &self.region_ranges,
-            self.cfg.region_split_check_diff.0 / 16,
-        );
+        let mut region_declined_bytes = {
+            let meta = self.ctx.store_meta.lock().unwrap();
+            calc_region_declined_bytes(
+                event,
+                &meta.region_ranges,
+                self.ctx.cfg.region_split_check_diff.0 / 16,
+            )
+        };
 
         COMPACTION_RELATED_REGION_COUNT
             .with_label_values(&[&output_level_str])
             .observe(region_declined_bytes.len() as f64);
 
         for (region_id, declined_bytes) in region_declined_bytes.drain(..) {
-            if let Some(peer) = self.region_peers.get_mut(&region_id) {
-                peer.compaction_declined_bytes += declined_bytes;
-                if peer.compaction_declined_bytes >= self.cfg.region_split_check_diff.0 {
-                    UPDATE_REGION_SIZE_BY_COMPACTION_COUNTER.inc();
-                }
+            let _ = self.ctx.router.send(
+                region_id,
+                PeerMsg::CompactionDeclinedBytes {
+                    region_id,
+                    bytes: declined_bytes,
+                },
+            );
+        }
+    }
+
+    fn register_compact_check_tick(&self) {
+        self.ctx.schedule_store_tick(
+            StoreTick::CompactCheck,
+            self.ctx.cfg.region_compact_check_interval.0,
+        )
+    }
+
+    fn on_compact_check_tick(&mut self) {
+        self.register_compact_check_tick();
+        if self.ctx.compact_scheduler.is_busy() {
+            debug!(
+                "{} compact worker is busy, check space redundancy next time",
+                self.fsm.store.tag
+            );
+            return;
+        }
+
+        if rocksdb::auto_compactions_is_disabled(&self.ctx.engines.kv) {
+            debug!(
+                "{} skip compact check when disabled auto compactions.",
+                self.fsm.store.tag
+            );
+            return;
+        }
+
+        // Start from last checked key.
+        let mut ranges_need_check =
+            Vec::with_capacity(self.ctx.cfg.region_compact_check_step as usize + 1);
+        ranges_need_check.push(self.fsm.store.last_compact_checked_key.clone());
+
+        let largest_key = {
+            let meta = self.ctx.store_meta.lock().unwrap();
+            if meta.region_ranges.is_empty() {
+                debug!("{} there is no range need to check", self.fsm.store.tag);
+                return;
             }
-        }
-    }
-
-    fn register_compact_check_tick(&self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::CompactCheck,
-            self.cfg.region_compact_check_interval.as_millis(),
-        ) {
-            error!("{} register compact check tick err: {:?}", self.tag, e);
-        }
-    }
-
-    fn on_compact_check_tick(&mut self, event_loop: &mut EventLoop<Self>) {
-        if self.compact_worker.is_busy() {
-            debug!("compact worker is busy, check space redundancy next time");
-        } else if self.region_ranges.is_empty() {
-            debug!("there is no range need to check");
-        } else if rocksdb::auto_compactions_is_disabled(&self.engines.kv) {
-            debug!("skip compact check when disabled auto compactions.");
-        } else {
-            // Start from last checked key.
-            let mut ranges_need_check =
-                Vec::with_capacity(self.cfg.region_compact_check_step as usize + 1);
-            ranges_need_check.push(self.last_compact_checked_key.clone());
 
             // Collect continuous ranges.
-            let left_ranges = self.region_ranges.range((
-                Excluded(self.last_compact_checked_key.clone()),
+            let left_ranges = meta.region_ranges.range((
+                Excluded(self.fsm.store.last_compact_checked_key.clone()),
                 Unbounded::<Key>,
             ));
             ranges_need_check.extend(
                 left_ranges
-                    .take(self.cfg.region_compact_check_step as usize)
+                    .take(self.ctx.cfg.region_compact_check_step as usize)
                     .map(|(k, _)| k.to_owned()),
             );
 
             // Update last_compact_checked_key.
-            let largest_key = self.region_ranges.keys().last().unwrap().to_vec();
-            let last_key = ranges_need_check.last().unwrap().clone();
-            if last_key == largest_key {
-                // Range [largest key, DATA_MAX_KEY) also need to check.
-                if last_key != keys::DATA_MAX_KEY.to_vec() {
-                    ranges_need_check.push(keys::DATA_MAX_KEY.to_vec());
-                }
-                // Next task will start from the very beginning.
-                self.last_compact_checked_key = keys::DATA_MIN_KEY.to_vec();
-            } else {
-                self.last_compact_checked_key = last_key;
-            }
+            meta.region_ranges.keys().last().unwrap().to_vec()
+        };
 
-            // Schedule the task.
-            let cf_names = vec![CF_DEFAULT.to_owned(), CF_WRITE.to_owned()];
-            if let Err(e) = self.compact_worker.schedule(CompactTask::CheckAndCompact {
-                cf_names,
-                ranges: ranges_need_check,
-                tombstones_num_threshold: self.cfg.region_compact_min_tombstones,
-                tombstones_percent_threshold: self.cfg.region_compact_tombstones_percent,
-            }) {
-                error!("{} failed to schedule space check task: {}", self.tag, e);
+        let last_key = ranges_need_check.last().unwrap().clone();
+        if last_key == largest_key {
+            // Range [largest key, DATA_MAX_KEY) also need to check.
+            if last_key != keys::DATA_MAX_KEY.to_vec() {
+                ranges_need_check.push(keys::DATA_MAX_KEY.to_vec());
             }
+            // Next task will start from the very beginning.
+            self.fsm.store.last_compact_checked_key = keys::DATA_MIN_KEY.to_vec();
+        } else {
+            self.fsm.store.last_compact_checked_key = last_key;
         }
 
-        self.register_compact_check_tick(event_loop);
+        // Schedule the task.
+        let cf_names = vec![CF_DEFAULT.to_owned(), CF_WRITE.to_owned()];
+        if let Err(e) = self
+            .ctx
+            .compact_scheduler
+            .schedule(CompactTask::CheckAndCompact {
+                cf_names,
+                ranges: ranges_need_check,
+                tombstones_num_threshold: self.ctx.cfg.region_compact_min_tombstones,
+                tombstones_percent_threshold: self.ctx.cfg.region_compact_tombstones_percent,
+            }) {
+            error!(
+                "{} failed to schedule space check task: {}",
+                self.fsm.store.tag, e
+            );
+        }
     }
 
     fn store_heartbeat_pd(&mut self) {
         let mut stats = StoreStats::new();
 
-        let used_size = self.snap_mgr.get_total_snap_size();
+        let used_size = self.ctx.snap_mgr.get_total_snap_size();
         stats.set_used_size(used_size);
-        stats.set_store_id(self.store_id());
-        stats.set_region_count(self.region_peers.len() as u32);
+        stats.set_store_id(self.ctx.store_id());
+        {
+            let meta = self.ctx.store_meta.lock().unwrap();
+            stats.set_region_count(meta.regions.len() as u32);
+        }
+        STORE_PD_HEARTBEAT_GAUGE_VEC
+            .with_label_values(&["region"])
+            .set(i64::from(stats.get_region_count()));
 
-        let snap_stats = self.snap_mgr.stats();
+        let snap_stats = self.ctx.snap_mgr.stats();
         stats.set_sending_snap_count(snap_stats.sending_count as u32);
         stats.set_receiving_snap_count(snap_stats.receiving_count as u32);
         STORE_SNAPSHOT_TRAFFIC_GAUGE_VEC
@@ -724,178 +1518,184 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             .with_label_values(&["receiving"])
             .set(snap_stats.receiving_count as i64);
 
-        let mut apply_snapshot_count = 0;
-        for peer in self.region_peers.values_mut() {
-            if peer.mut_store().check_applying_snap() {
-                apply_snapshot_count += 1;
-            }
-        }
-
+        let apply_snapshot_count = self.ctx.applying_snap_count.load(Ordering::Relaxed);
         stats.set_applying_snap_count(apply_snapshot_count as u32);
         STORE_SNAPSHOT_TRAFFIC_GAUGE_VEC
             .with_label_values(&["applying"])
-            .set(apply_snapshot_count);
+            .set(apply_snapshot_count as i64);
 
-        stats.set_start_time(self.start_time.sec as u32);
+        stats.set_start_time(self.fsm.store.start_time.unwrap().sec as u32);
 
         // report store write flow to pd
         stats.set_bytes_written(
-            self.store_stat.engine_total_bytes_written
-                - self.store_stat.engine_last_total_bytes_written,
+            self.ctx
+                .global_stat
+                .stat
+                .engine_total_bytes_written
+                .swap(0, Ordering::Relaxed),
         );
         stats.set_keys_written(
-            self.store_stat.engine_total_keys_written
-                - self.store_stat.engine_last_total_keys_written,
+            self.ctx
+                .global_stat
+                .stat
+                .engine_total_keys_written
+                .swap(0, Ordering::Relaxed),
         );
-        self.store_stat.engine_last_total_bytes_written =
-            self.store_stat.engine_total_bytes_written;
-        self.store_stat.engine_last_total_keys_written = self.store_stat.engine_total_keys_written;
 
-        stats.set_is_busy(self.is_busy);
-        self.is_busy = false;
+        stats.set_is_busy(
+            self.ctx
+                .global_stat
+                .stat
+                .is_busy
+                .swap(false, Ordering::Relaxed),
+        );
 
         let store_info = StoreInfo {
-            engine: Arc::clone(&self.engines.kv),
-            capacity: self.cfg.capacity.0,
+            engine: Arc::clone(&self.ctx.engines.kv),
+            capacity: self.ctx.cfg.capacity.0,
         };
 
         let task = PdTask::StoreHeartbeat { stats, store_info };
-        if let Err(e) = self.pd_worker.schedule(task) {
-            error!("{} failed to notify pd: {}", self.tag, e);
+        if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
+            error!("{} failed to notify pd: {}", self.fsm.store.tag, e);
         }
     }
 
-    fn on_pd_store_heartbeat_tick(&mut self, event_loop: &mut EventLoop<Self>) {
+    fn on_pd_store_heartbeat_tick(&mut self) {
         self.store_heartbeat_pd();
-        self.register_pd_store_heartbeat_tick(event_loop);
+        self.register_pd_store_heartbeat_tick();
     }
 
     fn handle_snap_mgr_gc(&mut self) -> Result<()> {
-        let snap_keys = self.snap_mgr.list_idle_snap()?;
+        let snap_keys = self.ctx.snap_mgr.list_idle_snap()?;
         if snap_keys.is_empty() {
             return Ok(());
         }
-        let (mut last_region_id, mut compacted_idx, mut compacted_term) = (0, u64::MAX, u64::MAX);
-        let mut is_applying_snap = false;
+        let (mut last_region_id, mut keys) = (0, vec![]);
+        let schedule_gc_snap = |region_id: u64, snaps| -> Result<()> {
+            debug!(
+                "{} schedule snap gc for region {}",
+                self.fsm.store.tag, region_id
+            );
+            let gc_snap = PeerMsg::GcSnap { region_id, snaps };
+            match self.ctx.router.send(region_id, gc_snap) {
+                Ok(()) => Ok(()),
+                Err(TrySendError::Disconnected(PeerMsg::GcSnap { region_id, snaps })) => {
+                    // The snapshot exists because MsgAppend has been rejected. So the
+                    // peer must have been exist. But now it's disconnected, so the peer
+                    // has to be destroyed instead of being created.
+                    info!(
+                        "[region {}] is disconnected, remove snaps {:?}",
+                        region_id, snaps
+                    );
+                    for (key, is_sending) in snaps {
+                        let snap = if is_sending {
+                            self.ctx.snap_mgr.get_snapshot_for_sending(&key)?
+                        } else {
+                            self.ctx.snap_mgr.get_snapshot_for_applying(&key)?
+                        };
+                        self.ctx
+                            .snap_mgr
+                            .delete_snapshot(&key, snap.as_ref(), false);
+                    }
+                    Ok(())
+                }
+                Err(TrySendError::Full(_)) => Ok(()),
+                Err(TrySendError::Disconnected(_)) => unreachable!(),
+            }
+        };
         for (key, is_sending) in snap_keys {
-            if last_region_id != key.region_id {
-                last_region_id = key.region_id;
-                match self.region_peers.get(&key.region_id) {
-                    None => {
-                        // region is deleted
-                        compacted_idx = u64::MAX;
-                        compacted_term = u64::MAX;
-                        is_applying_snap = false;
-                    }
-                    Some(peer) => {
-                        let s = peer.get_store();
-                        compacted_idx = s.truncated_index();
-                        compacted_term = s.truncated_term();
-                        is_applying_snap = s.is_applying_snapshot();
-                    }
-                };
+            if last_region_id == key.region_id {
+                keys.push((key, is_sending));
+                continue;
             }
 
-            if is_sending {
-                let s = self.snap_mgr.get_snapshot_for_sending(&key)?;
-                if key.term < compacted_term || key.idx < compacted_idx {
-                    info!(
-                        "[region {}] snap file {} has been compacted, delete.",
-                        key.region_id, key
-                    );
-                    self.snap_mgr.delete_snapshot(&key, s.as_ref(), false);
-                } else if let Ok(meta) = s.meta() {
-                    let modified = box_try!(meta.modified());
-                    if let Ok(elapsed) = modified.elapsed() {
-                        if elapsed > self.cfg.snap_gc_timeout.0 {
-                            info!(
-                                "[region {}] snap file {} has been expired, delete.",
-                                key.region_id, key
-                            );
-                            self.snap_mgr.delete_snapshot(&key, s.as_ref(), false);
-                        }
-                    }
-                }
-            } else if key.term <= compacted_term
-                && (key.idx < compacted_idx || key.idx == compacted_idx && !is_applying_snap)
-            {
-                info!(
-                    "[region {}] snap file {} has been applied, delete.",
-                    key.region_id, key
-                );
-                let a = self.snap_mgr.get_snapshot_for_applying(&key)?;
-                self.snap_mgr.delete_snapshot(&key, a.as_ref(), false);
+            if !keys.is_empty() {
+                schedule_gc_snap(last_region_id, keys)?;
+                keys = vec![];
             }
+
+            last_region_id = key.region_id;
+            keys.push((key, is_sending));
+        }
+        if !keys.is_empty() {
+            schedule_gc_snap(last_region_id, keys)?;
         }
         Ok(())
     }
 
-    fn on_snap_mgr_gc(&mut self, event_loop: &mut EventLoop<Self>) {
+    fn on_snap_mgr_gc(&mut self) {
         if let Err(e) = self.handle_snap_mgr_gc() {
-            error!("{} failed to gc snap manager: {:?}", self.tag, e);
+            error!("{} failed to gc snap manager: {:?}", self.fsm.store.tag, e);
         }
-        self.register_snap_mgr_gc_tick(event_loop);
+        self.register_snap_mgr_gc_tick();
     }
 
-    fn on_compact_lock_cf(&mut self, event_loop: &mut EventLoop<Self>) {
+    fn on_compact_lock_cf(&mut self) {
         // Create a compact lock cf task(compact whole range) and schedule directly.
-        if self.store_stat.lock_cf_bytes_written > self.cfg.lock_cf_compact_bytes_threshold.0 {
-            self.store_stat.lock_cf_bytes_written = 0;
+        let lock_cf_bytes_written = self
+            .ctx
+            .global_stat
+            .stat
+            .lock_cf_bytes_written
+            .load(Ordering::Relaxed);
+        if lock_cf_bytes_written > self.ctx.cfg.lock_cf_compact_bytes_threshold.0 {
+            self.ctx
+                .global_stat
+                .stat
+                .lock_cf_bytes_written
+                .fetch_sub(lock_cf_bytes_written, Ordering::Relaxed);
+
             let task = CompactTask::Compact {
                 cf_name: String::from(CF_LOCK),
                 start_key: None,
                 end_key: None,
             };
-            if let Err(e) = self.compact_worker.schedule(task) {
+            if let Err(e) = self.ctx.compact_scheduler.schedule(task) {
                 error!(
                     "{} failed to schedule compact lock cf task: {:?}",
-                    self.tag, e
+                    self.fsm.store.tag, e
                 );
             }
         }
 
-        self.register_compact_lock_cf_tick(event_loop);
+        self.register_compact_lock_cf_tick();
     }
 
-    fn register_pd_store_heartbeat_tick(&self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::PdStoreHeartbeat,
-            self.cfg.pd_store_heartbeat_tick_interval.as_millis(),
-        ) {
-            error!("{} register pd store heartbeat tick err: {:?}", self.tag, e);
-        };
+    fn register_pd_store_heartbeat_tick(&self) {
+        self.ctx.schedule_store_tick(
+            StoreTick::PdStoreHeartbeat,
+            self.ctx.cfg.pd_store_heartbeat_tick_interval.0,
+        );
     }
 
-    fn register_snap_mgr_gc_tick(&self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::SnapGc,
-            self.cfg.snap_mgr_gc_tick_interval.as_millis(),
-        ) {
-            error!("{} register snap mgr gc tick err: {:?}", self.tag, e);
-        }
+    fn register_snap_mgr_gc_tick(&self) {
+        self.ctx
+            .schedule_store_tick(StoreTick::SnapGc, self.ctx.cfg.snap_mgr_gc_tick_interval.0)
     }
 
-    fn register_compact_lock_cf_tick(&self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::CompactLockCf,
-            self.cfg.lock_cf_compact_interval.as_millis(),
-        ) {
-            error!("{} register compact cf-lock tick err: {:?}", self.tag, e);
-        }
+    fn register_compact_lock_cf_tick(&self) {
+        self.ctx.schedule_store_tick(
+            StoreTick::CompactLockCf,
+            self.ctx.cfg.lock_cf_compact_interval.0,
+        )
     }
 }
 
-impl<T: Transport, C: PdClient> Store<T, C> {
+impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
     fn on_validate_sst_result(&mut self, ssts: Vec<SSTMeta>) {
+        if ssts.is_empty() {
+            return;
+        }
         // A stale peer can still ingest a stale SST before it is
         // destroyed. We need to make sure that no stale peer exists.
         let mut delete_ssts = Vec::new();
-        for sst in ssts {
-            if !self.region_peers.contains_key(&sst.get_region_id()) {
-                delete_ssts.push(sst);
+        {
+            let meta = self.ctx.store_meta.lock().unwrap();
+            for sst in ssts {
+                if !meta.regions.contains_key(&sst.get_region_id()) {
+                    delete_ssts.push(sst);
+                }
             }
         }
         if delete_ssts.is_empty() {
@@ -903,8 +1703,8 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         }
 
         let task = CleanupSSTTask::DeleteSST { ssts: delete_ssts };
-        if let Err(e) = self.cleanup_sst_worker.schedule(task) {
-            error!("schedule to delete ssts: {:?}", e);
+        if let Err(e) = self.ctx.cleanup_sst_scheduler.schedule(task) {
+            error!("{} schedule to delete ssts: {:?}", self.fsm.store.tag, e);
         }
     }
 
@@ -912,24 +1712,30 @@ impl<T: Transport, C: PdClient> Store<T, C> {
         let mut delete_ssts = Vec::new();
         let mut validate_ssts = Vec::new();
 
-        let ssts = box_try!(self.importer.list_ssts());
-        for sst in ssts {
-            if let Some(peer) = self.region_peers.get(&sst.get_region_id()) {
-                let region_epoch = peer.region().get_region_epoch();
-                if util::is_epoch_stale(sst.get_region_epoch(), region_epoch) {
-                    // If the SST epoch is stale, it will not be ingested anymore.
-                    delete_ssts.push(sst);
+        let ssts = box_try!(self.ctx.importer.list_ssts());
+        if ssts.is_empty() {
+            return Ok(());
+        }
+        {
+            let meta = self.ctx.store_meta.lock().unwrap();
+            for sst in ssts {
+                if let Some(r) = meta.regions.get(&sst.get_region_id()) {
+                    let region_epoch = r.get_region_epoch();
+                    if util::is_epoch_stale(sst.get_region_epoch(), region_epoch) {
+                        // If the SST epoch is stale, it will not be ingested anymore.
+                        delete_ssts.push(sst);
+                    }
+                } else {
+                    // If the peer doesn't exist, we need to validate the SST through PD.
+                    validate_ssts.push(sst);
                 }
-            } else {
-                // If the peer doesn't exist, we need to validate the SST through PD.
-                validate_ssts.push(sst);
             }
         }
 
         if !delete_ssts.is_empty() {
             let task = CleanupSSTTask::DeleteSST { ssts: delete_ssts };
-            if let Err(e) = self.cleanup_sst_worker.schedule(task) {
-                error!("schedule to delete ssts: {:?}", e);
+            if let Err(e) = self.ctx.cleanup_sst_scheduler.schedule(task) {
+                error!("{} schedule to delete ssts: {:?}", self.fsm.store.tag, e);
             }
         }
 
@@ -937,173 +1743,111 @@ impl<T: Transport, C: PdClient> Store<T, C> {
             let task = CleanupSSTTask::ValidateSST {
                 ssts: validate_ssts,
             };
-            if let Err(e) = self.cleanup_sst_worker.schedule(task) {
-                error!("schedule to validate ssts: {:?}", e);
+            if let Err(e) = self.ctx.cleanup_sst_scheduler.schedule(task) {
+                error!("{} schedule to validate ssts: {:?}", self.fsm.store.tag, e);
             }
         }
 
         Ok(())
     }
 
-    fn on_cleanup_import_sst_tick(&mut self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = self.on_cleanup_import_sst() {
-            error!("{} failed to cleanup import sst: {:?}", self.tag, e);
-        }
-        self.register_cleanup_import_sst_tick(event_loop);
+    fn register_consistency_check_tick(&mut self) {
+        self.ctx.schedule_store_tick(
+            StoreTick::ConsistencyCheck,
+            self.ctx.cfg.consistency_check_interval.0,
+        )
     }
 
-    fn register_cleanup_import_sst_tick(&self, event_loop: &mut EventLoop<Self>) {
-        if let Err(e) = register_timer(
-            event_loop,
-            Tick::CleanupImportSST,
-            self.cfg.cleanup_import_sst_interval.as_millis(),
-        ) {
-            error!("{} register cleanup import sst tick err: {:?}", self.tag, e);
+    fn on_consistency_check_tick(&mut self) {
+        self.register_consistency_check_tick();
+        if self.ctx.consistency_check_scheduler.is_busy() {
+            return;
         }
+        let (mut target_region_id, mut oldest) = (0, Instant::now());
+        let target_peer = {
+            let meta = self.ctx.store_meta.lock().unwrap();
+            for region_id in meta.regions.keys() {
+                match self.fsm.store.consistency_check_time.get(region_id) {
+                    Some(time) => {
+                        if *time < oldest {
+                            oldest = *time;
+                            target_region_id = *region_id;
+                        }
+                    }
+                    None => {
+                        target_region_id = *region_id;
+                        break;
+                    }
+                }
+            }
+            if target_region_id == 0 {
+                return;
+            }
+            match util::find_peer(&meta.regions[&target_region_id], self.ctx.store_id()) {
+                None => return,
+                Some(p) => p.clone(),
+            }
+        };
+        info!(
+            "{} scheduling consistency check for region {}",
+            self.fsm.store.tag, target_region_id
+        );
+        self.fsm
+            .store
+            .consistency_check_time
+            .insert(target_region_id, Instant::now());
+        let mut request = new_admin_request(target_region_id, target_peer);
+        let mut admin = AdminRequest::new();
+        admin.set_cmd_type(AdminCmdType::ComputeHash);
+        request.set_admin_request(admin);
+
+        let _ = self.ctx.router.send(
+            target_region_id,
+            PeerMsg::RaftCmd {
+                request,
+                callback: Callback::None,
+                send_time: Instant::now(),
+            },
+        );
+    }
+
+    fn on_cleanup_import_sst_tick(&mut self) {
+        if let Err(e) = self.on_cleanup_import_sst() {
+            error!(
+                "{} failed to cleanup import sst: {:?}",
+                self.fsm.store.tag, e
+            );
+        }
+        self.register_cleanup_import_sst_tick();
+    }
+
+    fn register_cleanup_import_sst_tick(&self) {
+        self.ctx.schedule_store_tick(
+            StoreTick::CleanupImportSST,
+            self.ctx.cfg.cleanup_import_sst_interval.0,
+        )
     }
 
     fn clear_region_size_in_range(&mut self, start_key: &[u8], end_key: &[u8]) {
         let start_key = data_key(start_key);
         let end_key = data_end_key(end_key);
 
-        for (_, region_id) in self
-            .region_ranges
-            .range((Excluded(start_key), Included(end_key)))
+        let mut regions = vec![];
         {
-            let peer = self.region_peers.get_mut(region_id).unwrap();
-
-            peer.approximate_size = None;
-            peer.approximate_keys = None;
-        }
-    }
-}
-
-pub fn register_timer<T: Transport, C: PdClient>(
-    event_loop: &mut EventLoop<Store<T, C>>,
-    tick: Tick,
-    delay: u64,
-) -> Result<()> {
-    // TODO: now mio TimerError doesn't implement Error trait,
-    // so we can't use `try!` directly.
-    if delay == 0 {
-        // 0 delay means turn off the timer.
-        return Ok(());
-    }
-    if let Err(e) = event_loop.timeout_ms(tick, delay) {
-        return Err(box_err!(
-            "failed to register timeout [{:?}, delay: {:?}ms]: {:?}",
-            tick,
-            delay,
-            e
-        ));
-    }
-    Ok(())
-}
-
-impl<T: Transport, C: PdClient> mio::Handler for Store<T, C> {
-    type Timeout = Tick;
-    type Message = Msg;
-
-    fn notify(&mut self, event_loop: &mut EventLoop<Self>, msg: Msg) {
-        match msg {
-            Msg::RaftMessage(data) => if let Err(e) = self.on_raft_message(data) {
-                error!("{} handle raft message err: {:?}", self.tag, e);
-            },
-            Msg::RaftCmd {
-                send_time,
-                request,
-                callback,
-            } => {
-                self.raft_metrics
-                    .propose
-                    .request_wait_time
-                    .observe(duration_to_sec(send_time.elapsed()) as f64);
-                self.propose_raft_command(request, callback)
-            }
-            Msg::Quit => {
-                info!("{} receive quit message", self.tag);
-                event_loop.shutdown();
-            }
-            Msg::SnapshotStats => self.store_heartbeat_pd(),
-            Msg::ComputeHashResult {
-                region_id,
-                index,
-                hash,
-            } => {
-                self.on_hash_computed(region_id, index, hash);
-            }
-            Msg::SplitRegion {
-                region_id,
-                region_epoch,
-                split_keys,
-                callback,
-            } => {
-                info!(
-                    "on split region {} with {}",
-                    region_id,
-                    KeysInfoFormatter(&split_keys)
-                );
-                self.on_prepare_split_region(region_id, region_epoch, split_keys, callback);
-            }
-            Msg::RegionApproximateSize { region_id, size } => {
-                self.on_approximate_region_size(region_id, size)
-            }
-            Msg::RegionApproximateKeys { region_id, keys } => {
-                self.on_approximate_region_keys(region_id, keys)
-            }
-            Msg::CompactedEvent(event) => self.on_compaction_finished(event),
-            Msg::HalfSplitRegion {
-                region_id,
-                region_epoch,
-                policy,
-            } => self.on_schedule_half_split_region(region_id, &region_epoch, policy),
-            Msg::MergeFail { region_id } => self.on_merge_fail(region_id),
-            Msg::ValidateSSTResult { invalid_ssts } => self.on_validate_sst_result(invalid_ssts),
-            Msg::ClearRegionSizeInRange { start_key, end_key } => {
-                self.clear_region_size_in_range(&start_key, &end_key)
+            let meta = self.ctx.store_meta.lock().unwrap();
+            for (_, region_id) in meta
+                .region_ranges
+                .range((Excluded(start_key), Included(end_key)))
+            {
+                regions.push(*region_id);
             }
         }
-    }
-
-    fn timeout(&mut self, event_loop: &mut EventLoop<Self>, timeout: Tick) {
-        let t = SlowTimer::new();
-        match timeout {
-            Tick::Raft => self.on_raft_base_tick(event_loop),
-            Tick::RaftLogGc => self.on_raft_gc_log_tick(event_loop),
-            Tick::SplitRegionCheck => self.on_split_region_check_tick(event_loop),
-            Tick::CompactCheck => self.on_compact_check_tick(event_loop),
-            Tick::PdHeartbeat => self.on_pd_heartbeat_tick(event_loop),
-            Tick::PdStoreHeartbeat => self.on_pd_store_heartbeat_tick(event_loop),
-            Tick::SnapGc => self.on_snap_mgr_gc(event_loop),
-            Tick::CompactLockCf => self.on_compact_lock_cf(event_loop),
-            Tick::ConsistencyCheck => self.on_consistency_check_tick(event_loop),
-            Tick::CheckMerge => self.on_check_merge(event_loop),
-            Tick::CheckPeerStaleState => self.on_check_peer_stale_state_tick(event_loop),
-            Tick::CleanupImportSST => self.on_cleanup_import_sst_tick(event_loop),
+        for region_id in regions {
+            let _ = self
+                .ctx
+                .router
+                .send(region_id, PeerMsg::ClearRegionSize(region_id));
         }
-        RAFT_EVENT_DURATION
-            .with_label_values(&[timeout.tag()])
-            .observe(duration_to_sec(t.elapsed()) as f64);
-        slow_log!(t, "{} handle timeout {:?}", self.tag, timeout);
-    }
-
-    // This method is invoked very frequently, should avoid time consuming operation.
-    fn tick(&mut self, event_loop: &mut EventLoop<Self>) {
-        if !event_loop.is_running() {
-            self.stop();
-            return;
-        }
-
-        // We handle raft ready in event loop.
-        if !self.pending_raft_groups.is_empty() {
-            self.on_raft_ready();
-        }
-
-        self.poll_significant_msg();
-
-        self.poll_apply();
-
-        self.pending_snapshot_regions.clear();
     }
 }
 
@@ -1122,9 +1866,11 @@ fn size_change_filter(info: &CompactionJobInfo) -> bool {
     true
 }
 
-pub fn new_compaction_listener(ch: SendCh<Msg>) -> CompactionListener {
+pub fn new_compaction_listener(ch: RaftRouter) -> CompactionListener {
+    let ch = Mutex::new(ch);
     let compacted_handler = box move |compacted_event: CompactedEvent| {
-        if let Err(e) = ch.try_send(Msg::CompactedEvent(compacted_event)) {
+        let ch = ch.lock().unwrap();
+        if let Err(e) = ch.send_control(StoreMsg::CompactedEvent(compacted_event)) {
             error!(
                 "Send compaction finished event to raftstore failed: {:?}",
                 e

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -35,13 +35,11 @@ pub use self::bootstrap::{
 };
 pub use self::config::Config;
 pub use self::engine::{Iterable, Mutable, Peekable};
-pub use self::fsm::{
-    create_event_loop, new_compaction_listener, DestroyPeerJob, Store, StoreChannel, StoreInfo,
-    StoreStat,
-};
+pub use self::fsm::{new_compaction_listener, DestroyPeerJob, StoreInfo};
 pub use self::msg::{
-    Callback, Msg, ReadCallback, ReadResponse, SeekRegionCallback, SeekRegionFilter,
-    SeekRegionResult, SignificantMsg, Tick, WriteCallback, WriteResponse,
+    Callback, Msg, PeerMsg, PeerTick, ReadCallback, ReadResponse, SeekRegionCallback,
+    SeekRegionFilter, SeekRegionResult, SignificantMsg, StoreMsg, StoreTick, WriteCallback,
+    WriteResponse,
 };
 pub use self::peer::{
     Peer, PeerStat, ProposalContext, ReadExecutor, RequestInspector, RequestPolicy,

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -23,7 +23,9 @@ use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse};
 use kvproto::raft_serverpb::RaftMessage;
 
 use raft::{SnapshotStatus, StateRole};
+use raftstore::store::fsm::apply::TaskRes as ApplyTaskRes;
 use raftstore::store::util::KeysInfoFormatter;
+use raftstore::store::SnapKey;
 use util::escape;
 use util::rocksdb::CompactedEvent;
 
@@ -104,37 +106,49 @@ impl fmt::Debug for Callback {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum Tick {
+pub enum PeerTick {
     Raft,
     RaftLogGc,
     SplitRegionCheck,
-    CompactCheck,
     PdHeartbeat,
+    CheckMerge,
+    CheckPeerStaleState,
+}
+
+impl PeerTick {
+    #[inline]
+    pub fn tag(self) -> &'static str {
+        match self {
+            PeerTick::Raft => "raft",
+            PeerTick::RaftLogGc => "raft_log_gc",
+            PeerTick::SplitRegionCheck => "split_region_check",
+            PeerTick::PdHeartbeat => "pd_heartbeat",
+            PeerTick::CheckMerge => "check_merge",
+            PeerTick::CheckPeerStaleState => "check_peer_stale_state",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum StoreTick {
+    CompactCheck,
     PdStoreHeartbeat,
     SnapGc,
     CompactLockCf,
     ConsistencyCheck,
-    CheckMerge,
-    CheckPeerStaleState,
     CleanupImportSST,
 }
 
-impl Tick {
+impl StoreTick {
     #[inline]
     pub fn tag(self) -> &'static str {
         match self {
-            Tick::Raft => "raft",
-            Tick::RaftLogGc => "raft_log_gc",
-            Tick::SplitRegionCheck => "split_region_check",
-            Tick::CompactCheck => "compact_check",
-            Tick::PdHeartbeat => "pd_heartbeat",
-            Tick::PdStoreHeartbeat => "pd_store_heartbeat",
-            Tick::SnapGc => "snap_gc",
-            Tick::CompactLockCf => "compact_lock_cf",
-            Tick::ConsistencyCheck => "consistency_check",
-            Tick::CheckMerge => "check_merge",
-            Tick::CheckPeerStaleState => "check_peer_stale_state",
-            Tick::CleanupImportSST => "cleanup_import_sst",
+            StoreTick::CompactCheck => "compact_check",
+            StoreTick::PdStoreHeartbeat => "pd_store_heartbeat",
+            StoreTick::SnapGc => "snap_gc",
+            StoreTick::CompactLockCf => "compact_lock_cf",
+            StoreTick::ConsistencyCheck => "consistency_check",
+            StoreTick::CleanupImportSST => "cleanup_import_sst",
         }
     }
 }
@@ -153,9 +167,7 @@ pub enum SignificantMsg {
     Unreachable { region_id: u64, to_peer_id: u64 },
 }
 
-pub enum Msg {
-    Quit,
-
+pub enum PeerMsg {
     // For notify.
     RaftMessage(RaftMessage),
 
@@ -173,9 +185,6 @@ pub enum Msg {
         split_keys: Vec<Vec<u8>>,
         callback: Callback,
     },
-
-    // For snapshot stats.
-    SnapshotStats,
 
     // For consistency check
     ComputeHashResult {
@@ -195,17 +204,143 @@ pub enum Msg {
         region_id: u64,
         keys: u64,
     },
-
-    // Compaction finished event
-    CompactedEvent(CompactedEvent),
+    CompactionDeclinedBytes {
+        region_id: u64,
+        bytes: u64,
+    },
     HalfSplitRegion {
         region_id: u64,
         region_epoch: RegionEpoch,
         policy: CheckPolicy,
     },
-    MergeFail {
+    MergeResult {
         region_id: u64,
+        target: metapb::Peer,
+        stale: bool,
     },
+    GcSnap {
+        region_id: u64,
+        snaps: Vec<(SnapKey, bool)>,
+    },
+    ClearRegionSize(u64),
+    Tick(u64, PeerTick),
+    SignificantMsg(SignificantMsg),
+    Start(u64),
+    ApplyRes {
+        region_id: u64,
+        res: ApplyTaskRes,
+    },
+    Noop(u64),
+}
+
+impl fmt::Debug for PeerMsg {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PeerMsg::RaftMessage(_) => write!(fmt, "Raft Message"),
+            PeerMsg::RaftCmd { .. } => write!(fmt, "Raft Command"),
+            PeerMsg::ComputeHashResult {
+                region_id,
+                index,
+                ref hash,
+            } => write!(
+                fmt,
+                "ComputeHashResult [region_id: {}, index: {}, hash: {}]",
+                region_id,
+                index,
+                escape(hash)
+            ),
+            PeerMsg::SplitRegion {
+                region_id,
+                ref split_keys,
+                ..
+            } => write!(
+                fmt,
+                "Split region {} with {}",
+                region_id,
+                KeysInfoFormatter(&split_keys)
+            ),
+            PeerMsg::RegionApproximateSize { region_id, size } => write!(
+                fmt,
+                "Region's approximate size [region_id: {}, size: {:?}]",
+                region_id, size
+            ),
+            PeerMsg::RegionApproximateKeys { region_id, keys } => write!(
+                fmt,
+                "Region's approximate keys [region_id: {}, keys: {:?}]",
+                region_id, keys
+            ),
+            PeerMsg::CompactionDeclinedBytes { region_id, bytes } => write!(
+                fmt,
+                "[region {}] compaction declined bytes {}",
+                region_id, bytes
+            ),
+            PeerMsg::HalfSplitRegion { ref region_id, .. } => {
+                write!(fmt, "Half Split region {}", region_id)
+            }
+            PeerMsg::MergeResult {
+                region_id,
+                target,
+                stale,
+            } => write!{
+                fmt,
+                "[reigon {}] target: {:?}, successful: {}",
+                region_id, target, stale
+            },
+            PeerMsg::GcSnap {
+                region_id,
+                ref snaps,
+            } => write!{
+                fmt,
+                "[region {}] gc snaps {:?}",
+                region_id, snaps
+            },
+            PeerMsg::ClearRegionSize(region_id) => write!{
+                fmt,
+                "[region {}] clear region size",
+                region_id
+            },
+            PeerMsg::Tick(region_id, tick) => write!{
+                fmt,
+                "[region {}] {:?}",
+                region_id,
+                tick
+            },
+            PeerMsg::SignificantMsg(msg) => write!(fmt, "{:?}", msg),
+            PeerMsg::ApplyRes { region_id, res } => {
+                write!(fmt, "[region {}] ApplyRes {:?}", region_id, res)
+            }
+            PeerMsg::Start(region_id) => write!(fmt, "[region {}] Startup", region_id),
+            PeerMsg::Noop(region_id) => write!(fmt, "[region {}] Noop", region_id),
+        }
+    }
+}
+
+impl Msg {
+    pub fn new_raft_cmd(request: RaftCmdRequest, callback: Callback) -> Msg {
+        Msg::PeerMsg(PeerMsg::RaftCmd {
+            send_time: Instant::now(),
+            request,
+            callback,
+        })
+    }
+
+    pub fn new_half_split_region(
+        region_id: u64,
+        region_epoch: RegionEpoch,
+        policy: CheckPolicy,
+    ) -> Msg {
+        Msg::PeerMsg(PeerMsg::HalfSplitRegion {
+            region_id,
+            region_epoch,
+            policy,
+        })
+    }
+}
+
+pub enum StoreMsg {
+    RaftMessage(RaftMessage),
+    // For snapshot stats.
+    SnapshotStats,
 
     ValidateSSTResult {
         invalid_ssts: Vec<SSTMeta>,
@@ -217,53 +352,23 @@ pub enum Msg {
         start_key: Vec<u8>,
         end_key: Vec<u8>,
     },
+
+    // Compaction finished event
+    CompactedEvent(CompactedEvent),
+    Tick(StoreTick),
+    Start {
+        store: metapb::Store,
+    },
 }
 
-impl fmt::Debug for Msg {
+impl fmt::Debug for StoreMsg {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Msg::Quit => write!(fmt, "Quit"),
-            Msg::RaftMessage(_) => write!(fmt, "Raft Message"),
-            Msg::RaftCmd { .. } => write!(fmt, "Raft Command"),
-            Msg::SnapshotStats => write!(fmt, "Snapshot stats"),
-            Msg::ComputeHashResult {
-                region_id,
-                index,
-                ref hash,
-            } => write!(
-                fmt,
-                "ComputeHashResult [region_id: {}, index: {}, hash: {}]",
-                region_id,
-                index,
-                escape(hash)
-            ),
-            Msg::SplitRegion {
-                region_id,
-                ref split_keys,
-                ..
-            } => write!(
-                fmt,
-                "Split region {} with {}",
-                region_id,
-                KeysInfoFormatter(&split_keys)
-            ),
-            Msg::RegionApproximateSize { region_id, size } => write!(
-                fmt,
-                "Region's approximate size [region_id: {}, size: {:?}]",
-                region_id, size
-            ),
-            Msg::RegionApproximateKeys { region_id, keys } => write!(
-                fmt,
-                "Region's approximate keys [region_id: {}, keys: {:?}]",
-                region_id, keys
-            ),
-            Msg::CompactedEvent(ref event) => write!(fmt, "CompactedEvent cf {}", event.cf),
-            Msg::HalfSplitRegion { ref region_id, .. } => {
-                write!(fmt, "Half Split region {}", region_id)
-            }
-            Msg::MergeFail { region_id } => write!(fmt, "MergeFail region_id {}", region_id),
-            Msg::ValidateSSTResult { .. } => write!(fmt, "Validate SST Result"),
-            Msg::ClearRegionSizeInRange {
+            StoreMsg::RaftMessage(_) => write!(fmt, "Raft Message"),
+            StoreMsg::SnapshotStats => write!(fmt, "Snapshot stats"),
+            StoreMsg::CompactedEvent(ref event) => write!(fmt, "CompactedEvent cf {}", event.cf),
+            StoreMsg::ValidateSSTResult { .. } => write!(fmt, "Validate SST Result"),
+            StoreMsg::ClearRegionSizeInRange {
                 ref start_key,
                 ref end_key,
             } => write!(
@@ -271,104 +376,15 @@ impl fmt::Debug for Msg {
                 "Clear Region size in range {:?} to {:?}",
                 start_key, end_key
             ),
+            StoreMsg::Tick(tick) => write!(fmt, "StoreTick {:?}", tick),
+            StoreMsg::Start { ref store } => write!(fmt, "Start store {:?}", store),
         }
     }
 }
 
-impl Msg {
-    pub fn new_raft_cmd(request: RaftCmdRequest, callback: Callback) -> Msg {
-        Msg::RaftCmd {
-            send_time: Instant::now(),
-            request,
-            callback,
-        }
-    }
-
-    pub fn new_half_split_region(
-        region_id: u64,
-        region_epoch: RegionEpoch,
-        policy: CheckPolicy,
-    ) -> Msg {
-        Msg::HalfSplitRegion {
-            region_id,
-            region_epoch,
-            policy,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::thread;
-    use std::time::Duration;
-
-    use mio::{EventLoop, Handler};
-
-    use super::*;
-    use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse, StatusRequest};
-    use raftstore::Error;
-    use util::transport::SendCh;
-
-    fn call_command(
-        sendch: &SendCh<Msg>,
-        request: RaftCmdRequest,
-        timeout: Duration,
-    ) -> Result<RaftCmdResponse, Error> {
-        wait_op!(
-            |cb: Box<FnBox(RaftCmdResponse) + 'static + Send>| {
-                let callback = Callback::Write(Box::new(move |write_resp: WriteResponse| {
-                    cb(write_resp.response);
-                }));
-                sendch.try_send(Msg::new_raft_cmd(request, callback))
-            },
-            timeout
-        ).ok_or_else(|| Error::Timeout(format!("request timeout for {:?}", timeout)))
-    }
-
-    struct TestHandler;
-
-    impl Handler for TestHandler {
-        type Timeout = ();
-        type Message = Msg;
-
-        fn notify(&mut self, event_loop: &mut EventLoop<Self>, msg: Self::Message) {
-            match msg {
-                Msg::Quit => event_loop.shutdown(),
-                Msg::RaftCmd {
-                    callback, request, ..
-                } => {
-                    // a trick for test timeout.
-                    if request.get_header().get_region_id() == u64::max_value() {
-                        thread::sleep(Duration::from_millis(100));
-                    }
-                    callback.invoke_with_response(RaftCmdResponse::new());
-                }
-                // we only test above message types, others panic.
-                _ => unreachable!(),
-            }
-        }
-    }
-
-    #[test]
-    fn test_sender() {
-        let mut event_loop = EventLoop::new().unwrap();
-        let sendch = &SendCh::new(event_loop.channel(), "test-sender");
-
-        let t = thread::spawn(move || {
-            event_loop.run(&mut TestHandler).unwrap();
-        });
-
-        let mut request = RaftCmdRequest::new();
-        request.mut_header().set_region_id(u64::max_value());
-        request.set_status_request(StatusRequest::new());
-        assert!(call_command(sendch, request.clone(), Duration::from_millis(500)).is_ok());
-        match call_command(sendch, request, Duration::from_millis(10)) {
-            Err(Error::Timeout(_)) => {}
-            _ => panic!("should failed with timeout"),
-        }
-
-        sendch.try_send(Msg::Quit).unwrap();
-
-        t.join().unwrap();
-    }
+// TODO: remove this enum and utilize the actual message instead.
+#[derive(Debug)]
+pub enum Msg {
+    PeerMsg(PeerMsg),
+    StoreMsg(StoreMsg),
 }

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -13,7 +13,7 @@
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
-use std::rc::Rc;
+use std::sync::atomic::AtomicBool;
 use std::sync::{atomic, Arc};
 use std::time::{Duration, Instant};
 use std::{cmp, mem, slice, u64};
@@ -38,26 +38,25 @@ use raft::{
 };
 use raftstore::coprocessor::{CoprocessorHost, RegionChangeEvent};
 use raftstore::store::engine::{Peekable, Snapshot, SyncSnapshot};
+use raftstore::store::fsm::store::PollContext;
 use raftstore::store::fsm::{
-    apply, Apply, ApplyMetrics, ApplyRouter, ApplyTask, Proposal, RegionProposal,
+    apply, Apply, ApplyMetrics, ApplyTask, ApplyTaskRes, Proposal, RegionProposal,
 };
-use raftstore::store::worker::{ReadProgress, ReadTask};
+use raftstore::store::worker::{ReadProgress, ReadTask, RegionTask};
 use raftstore::store::{keys, Callback, Config, Engines, ReadResponse, RegionSnapshot};
 use raftstore::{Error, Result};
-use util::collections::{HashMap, HashSet};
+use util::collections::HashMap;
 use util::time::{duration_to_sec, monotonic_raw_now};
-use util::worker::{FutureWorker, Scheduler};
+use util::worker::Scheduler;
 use util::{escape, MustConsumeVec};
 
 use super::cmd_resp;
-use super::local_metrics::{RaftMessageMetrics, RaftMetrics, RaftProposeMetrics, RaftReadyMetrics};
+use super::local_metrics::{RaftMessageMetrics, RaftReadyMetrics};
 use super::metrics::*;
 use super::peer_storage::{write_peer_state, ApplySnapResult, InvokeContext, PeerStorage};
 use super::transport::Transport;
 use super::util::{self, check_region_epoch, is_initial_msg, Lease, LeaseState};
-use super::{DestroyPeerJob, Store};
-
-const DEFAULT_APPEND_WB_SIZE: usize = 4 * 1024;
+use super::DestroyPeerJob;
 
 const SHRINK_CACHE_CAPACITY: usize = 64;
 
@@ -154,38 +153,6 @@ impl ProposalQueue {
     }
 }
 
-/// `ReadyContext` is for storing raft logs temporarily.
-pub struct ReadyContext<'a, T: 'a> {
-    /// If the raft log contains a snapshot, old RaftLocalState will be stored into `kv_wb`.
-    pub kv_wb: WriteBatch,
-    /// Raft logs will be stored into `raft_wb`.
-    pub raft_wb: WriteBatch,
-    /// Indicates whether the write in `raft_wb` should synchronize log or not.
-    pub sync_log: bool,
-    pub metrics: &'a mut RaftMetrics,
-    pub trans: &'a T,
-    /// All `Ready`s and their `InvokeContext`s will be stored into `ready_res`.
-    pub ready_res: Vec<(Ready, InvokeContext)>,
-    /// Whether `trans` needs to be flushed. It's set to true when any message is sent via
-    /// `trans`.
-    /// TODO: better move it into `trans`.
-    pub need_flush: bool,
-}
-
-impl<'a, T> ReadyContext<'a, T> {
-    pub fn new(metrics: &'a mut RaftMetrics, trans: &'a T, cap: usize) -> ReadyContext<'a, T> {
-        ReadyContext {
-            kv_wb: WriteBatch::new(),
-            raft_wb: WriteBatch::with_capacity(DEFAULT_APPEND_WB_SIZE),
-            sync_log: false,
-            metrics,
-            trans,
-            ready_res: Vec::with_capacity(cap),
-            need_flush: false,
-        }
-    }
-}
-
 bitflags! {
     // TODO: maybe declare it as protobuf struct is better.
     /// A bitmap contains some useful flags when dealing with `eraftpb::Entry`.
@@ -259,9 +226,20 @@ impl RecentAddedPeer {
     }
 }
 
+/// A struct that stores the state to wait for `PrepareMerge` apply result.
+///
+/// When handling the apply result of a `CommitMerge`, the source peer may have
+/// not handle the apply result of the `PrepareMerge`, so the target peer has
+/// to abort current handle process and wait for it asynchronously.
+pub struct WaitApplyResultState {
+    /// The following apply results waiting to be handled, including the `CommitMerge`.
+    /// These will be handled once `ready_to_merge` is true.
+    pub results: Vec<ApplyTaskRes>,
+    /// It is used by target peer to check whether the apply result of `PrepareMerge` is handled.
+    pub ready_to_merge: Arc<AtomicBool>,
+}
+
 pub struct Peer {
-    engines: Engines,
-    cfg: Rc<Config>,
     peer_cache: RefCell<HashMap<u64, metapb::Peer>>,
     pub peer: metapb::Peer,
     region_id: u64,
@@ -277,7 +255,6 @@ pub struct Peer {
     pub peers_start_pending_time: Vec<(u64, Instant)>,
     pub recent_added_peer: RecentAddedPeer,
 
-    coprocessor_host: Arc<CoprocessorHost>,
     /// an inaccurate difference in region size since last reset.
     pub size_diff_hint: u64,
     /// delete keys' count since last reset.
@@ -301,11 +278,6 @@ pub struct Peer {
     last_committed_split_idx: u64,
     // Approximate size of logs that is applied but not compacted yet.
     pub raft_log_size_hint: u64,
-    // When entry exceed max size, reject to propose the entry.
-    pub raft_entry_max_size: u64,
-
-    apply_router: ApplyRouter,
-    read_scheduler: Scheduler<ReadTask>,
 
     pub pending_remove: bool,
 
@@ -313,65 +285,23 @@ pub struct Peer {
     last_committed_prepare_merge_idx: u64,
     pub pending_merge_state: Option<MergeState>,
 
-    marked_to_be_checked: bool,
-
     leader_missing_time: Option<Instant>,
 
     leader_lease: Lease,
 
     // If a snapshot is being applied asynchronously, messages should not be sent.
     pending_messages: Vec<eraftpb::Message>,
+    pub pending_merge_apply_result: Option<WaitApplyResultState>,
 
     pub peer_stat: PeerStat,
 }
 
 impl Peer {
-    // If we create the peer actively, like bootstrap/split/merge region, we should
-    // use this function to create the peer. The region must contain the peer info
-    // for this store.
-    pub fn create<T, C>(store: &mut Store<T, C>, region: &metapb::Region) -> Result<Peer> {
-        let store_id = store.store_id();
-        let meta_peer = match util::find_peer(region, store_id) {
-            None => {
-                return Err(box_err!(
-                    "find no peer for store {} in region {:?}",
-                    store_id,
-                    region
-                ))
-            }
-            Some(peer) => peer.clone(),
-        };
-
-        info!(
-            "[region {}] create peer with id {}",
-            region.get_id(),
-            meta_peer.get_id(),
-        );
-        Peer::new(store, region, meta_peer)
-    }
-
-    // The peer can be created from another node with raft membership changes, and we only
-    // know the region_id and peer_id when creating this replicated peer, the region info
-    // will be retrieved later after applying snapshot.
-    pub fn replicate<T, C>(
-        store: &mut Store<T, C>,
-        region_id: u64,
-        peer: metapb::Peer,
-    ) -> Result<Peer> {
-        // We will remove tombstone key when apply snapshot
-        info!(
-            "[region {}] replicate peer with id {}",
-            region_id,
-            peer.get_id()
-        );
-
-        let mut region = metapb::Region::new();
-        region.set_id(region_id);
-        Peer::new(store, &region, peer)
-    }
-
-    fn new<T, C>(
-        store: &mut Store<T, C>,
+    pub fn new(
+        store_id: u64,
+        cfg: &Config,
+        sched: Scheduler<RegionTask>,
+        engines: Engines,
         region: &metapb::Region,
         peer: metapb::Peer,
     ) -> Result<Peer> {
@@ -379,19 +309,9 @@ impl Peer {
             return Err(box_err!("invalid peer id"));
         }
 
-        let cfg = store.config();
-
-        let store_id = store.store_id();
-        let sched = store.snap_scheduler();
         let tag = format!("[region {}] {}", region.get_id(), peer.get_id());
 
-        let ps = PeerStorage::new(
-            store.engines(),
-            region,
-            sched,
-            tag.clone(),
-            Rc::clone(&store.entry_cache_metries),
-        )?;
+        let ps = PeerStorage::new(engines.clone(), region, sched, tag.clone())?;
 
         let applied_index = ps.applied_index();
 
@@ -414,7 +334,6 @@ impl Peer {
 
         let raft_group = RawNode::new(&raft_cfg, ps, vec![])?;
         let mut peer = Peer {
-            engines: store.engines(),
             peer,
             region_id: region.get_id(),
             raft_group,
@@ -427,16 +346,12 @@ impl Peer {
             recent_added_peer: RecentAddedPeer::new(
                 cfg.raft_reject_transfer_leader_duration.as_secs(),
             ),
-            coprocessor_host: Arc::clone(&store.coprocessor_host),
             size_diff_hint: 0,
             delete_keys_hint: 0,
             approximate_size: None,
             approximate_keys: None,
             compaction_declined_bytes: 0,
-            apply_router: store.apply_router(),
-            read_scheduler: store.read_scheduler(),
             pending_remove: false,
-            marked_to_be_checked: false,
             pending_merge_state: None,
             last_committed_prepare_merge_idx: 0,
             leader_missing_time: Some(Instant::now()),
@@ -451,10 +366,9 @@ impl Peer {
                 hash: vec![],
             },
             raft_log_size_hint: 0,
-            raft_entry_max_size: cfg.raft_entry_max_size.0,
             leader_lease: Lease::new(cfg.raft_store_max_leader_lease()),
-            cfg,
             pending_messages: vec![],
+            pending_merge_apply_result: None,
             peer_stat: PeerStat::default(),
         };
 
@@ -468,14 +382,12 @@ impl Peer {
 
     /// Register self to apply_scheduler and read_scheduler so that the peer is then usable.
     /// Also trigger `RegionChangeEvent::Create` here.
-    pub fn activate(&self) {
-        self.apply_router
+    pub fn activate<T, C>(&self, ctx: &PollContext<T, C>) {
+        ctx.apply_router
             .schedule_task(self.region_id, ApplyTask::register(self));
-        self.read_scheduler
-            .schedule(ReadTask::register(self))
-            .unwrap();
+        ctx.local_reader.schedule(ReadTask::register(self)).unwrap();
 
-        self.coprocessor_host.on_region_changed(
+        ctx.coprocessor_host.on_region_changed(
             self.region(),
             RegionChangeEvent::Create,
             self.get_role(),
@@ -485,14 +397,6 @@ impl Peer {
     #[inline]
     fn next_proposal_index(&self) -> u64 {
         self.raft_group.raft.raft_log.last_index() + 1
-    }
-
-    /// Puts self `region_id` into `pending_raft_groups`.
-    pub fn mark_to_be_checked(&mut self, pending_raft_groups: &mut HashSet<u64>) {
-        if !self.marked_to_be_checked {
-            self.marked_to_be_checked = true;
-            pending_raft_groups.insert(self.region_id);
-        }
     }
 
     /// Tries to destroy itself. Returns a job (if needed) to do more cleaning tasks.
@@ -531,7 +435,7 @@ impl Peer {
     /// 1. Set the region to tombstone;
     /// 2. Clear data;
     /// 3. Notify all pending requests.
-    pub fn destroy(&mut self, keep_data: bool) -> Result<()> {
+    pub fn destroy<T, C>(&mut self, ctx: &PollContext<T, C>, keep_data: bool) -> Result<()> {
         fail_point!("raft_store_skip_destroy_peer", |_| Ok(()));
         let t = Instant::now();
 
@@ -543,7 +447,7 @@ impl Peer {
         let raft_wb = WriteBatch::new();
         self.mut_store().clear_meta(&kv_wb, &raft_wb)?;
         write_peer_state(
-            &self.engines.kv,
+            &ctx.engines.kv,
             &kv_wb,
             &region,
             PeerState::Tombstone,
@@ -551,9 +455,9 @@ impl Peer {
         )?;
         // write kv rocksdb first in case of restart happen between two write
         let mut write_opts = WriteOptions::new();
-        write_opts.set_sync(self.cfg.sync_log);
-        self.engines.kv.write_opt(kv_wb, &write_opts)?;
-        self.engines.raft.write_opt(raft_wb, &write_opts)?;
+        write_opts.set_sync(ctx.cfg.sync_log);
+        ctx.engines.kv.write_opt(kv_wb, &write_opts)?;
+        ctx.engines.raft.write_opt(raft_wb, &write_opts)?;
 
         if self.get_store().is_initialized() && !keep_data {
             // If we meet panic when deleting data and raft log, the dirty data
@@ -582,10 +486,6 @@ impl Peer {
         self.get_store().is_initialized()
     }
 
-    pub fn engines(&self) -> Engines {
-        self.engines.clone()
-    }
-
     #[inline]
     pub fn region(&self) -> &metapb::Region {
         self.get_store().region()
@@ -595,7 +495,12 @@ impl Peer {
     ///
     /// This will update the region of the peer, caller must ensure the region
     /// has been preserved in a durable device.
-    pub fn set_region(&mut self, region: metapb::Region) {
+    pub fn set_region(
+        &mut self,
+        host: &CoprocessorHost,
+        local_reader: &Scheduler<ReadTask>,
+        region: metapb::Region,
+    ) {
         if self.region().get_region_epoch().get_version() < region.get_region_epoch().get_version()
         {
             // Epoch version changed, disable read on the localreader for this region.
@@ -605,14 +510,10 @@ impl Peer {
         let progress = ReadProgress::region(region);
         // Always update read delegate's region to avoid stale region info after a follower
         // becomeing a leader.
-        self.maybe_update_read_progress(progress);
+        self.maybe_update_read_progress(local_reader, progress);
 
         if !self.pending_remove {
-            self.coprocessor_host.on_region_changed(
-                self.region(),
-                RegionChangeEvent::Update,
-                self.get_role(),
-            );
+            host.on_region_changed(self.region(), RegionChangeEvent::Update, self.get_role());
         }
     }
 
@@ -834,7 +735,7 @@ impl Peer {
         false
     }
 
-    pub fn check_stale_state(&mut self) -> StaleState {
+    pub fn check_stale_state<T, C>(&mut self, ctx: &mut PollContext<T, C>) -> StaleState {
         if self.is_leader() {
             // Leaders always have valid state.
             //
@@ -855,14 +756,14 @@ impl Peer {
                 self.leader_missing_time = Instant::now().into();
                 StaleState::Valid
             }
-            Some(instant) if instant.elapsed() >= self.cfg.max_leader_missing_duration.0 => {
+            Some(instant) if instant.elapsed() >= ctx.cfg.max_leader_missing_duration.0 => {
                 // Resets the `leader_missing_time` to avoid sending the same tasks to
                 // PD worker continuously during the leader missing timeout.
                 self.leader_missing_time = Instant::now().into();
                 StaleState::ToValidate
             }
             Some(instant)
-                if instant.elapsed() >= self.cfg.abnormal_leader_missing_duration.0
+                if instant.elapsed() >= ctx.cfg.abnormal_leader_missing_duration.0
                     && !naive_peer =>
             {
                 // A peer is considered as in the leader missing state
@@ -874,7 +775,7 @@ impl Peer {
         }
     }
 
-    fn on_role_changed(&mut self, ready: &Ready, worker: &FutureWorker<PdTask>) {
+    fn on_role_changed<T, C>(&mut self, ctx: &mut PollContext<T, C>, ready: &Ready) {
         // Update leader lease when the Raft state changes.
         if let Some(ref ss) = ready.ss {
             match ss.raft_state {
@@ -888,20 +789,20 @@ impl Peer {
                     // this peer becomes leader because it's more convenient to do it here and
                     // it has no impact on the correctness.
                     let progress = ReadProgress::term(self.term());
-                    self.maybe_update_read_progress(progress);
-                    self.maybe_renew_leader_lease(monotonic_raw_now());
+                    self.maybe_update_read_progress(&ctx.local_reader, progress);
+                    self.maybe_renew_leader_lease(&ctx.local_reader, monotonic_raw_now());
                     debug!(
                         "{} becomes leader and lease expired time is {:?}",
                         self.tag, self.leader_lease
                     );
-                    self.heartbeat_pd(worker)
+                    self.heartbeat_pd(ctx)
                 }
                 StateRole::Follower => {
                     self.leader_lease.expire();
                 }
                 _ => {}
             }
-            self.coprocessor_host
+            ctx.coprocessor_host
                 .on_role_change(self.region(), ss.raft_state);
         }
     }
@@ -956,12 +857,7 @@ impl Peer {
         Some(region_proposal)
     }
 
-    pub fn handle_raft_ready_append<T: Transport>(
-        &mut self,
-        ctx: &mut ReadyContext<T>,
-        worker: &FutureWorker<PdTask>,
-    ) {
-        self.marked_to_be_checked = false;
+    pub fn handle_raft_ready_append<T: Transport, C>(&mut self, ctx: &mut PollContext<T, C>) {
         if self.pending_remove {
             return;
         }
@@ -979,8 +875,8 @@ impl Peer {
         if !self.pending_messages.is_empty() {
             fail_point!("raft_before_follower_send");
             let messages = mem::replace(&mut self.pending_messages, vec![]);
-            ctx.need_flush = true;
-            self.send(ctx.trans, messages, &mut ctx.metrics.message)
+            ctx.need_flush_trans = true;
+            self.send(&ctx.trans, messages, &mut ctx.raft_metrics.message)
                 .unwrap_or_else(|e| {
                     warn!("{} clear snapshot pending messages err {:?}", self.tag, e);
                 });
@@ -1007,17 +903,17 @@ impl Peer {
 
         let mut ready = self.raft_group.ready_since(self.last_applying_idx);
 
-        self.on_role_changed(&ready, worker);
+        self.on_role_changed(ctx, &ready);
 
-        self.add_ready_metric(&ready, &mut ctx.metrics.ready);
+        self.add_ready_metric(&ready, &mut ctx.raft_metrics.ready);
 
         // The leader can write to disk and replicate to the followers concurrently
         // For more details, check raft thesis 10.2.1.
         if self.is_leader() {
             fail_point!("raft_before_leader_send");
             let msgs = ready.messages.drain(..);
-            ctx.need_flush = true;
-            self.send(ctx.trans, msgs, &mut ctx.metrics.message)
+            ctx.need_flush_trans = true;
+            self.send(&ctx.trans, msgs, &mut ctx.raft_metrics.message)
                 .unwrap_or_else(|e| {
                     // We don't care that the message is sent failed, so here just log this error.
                     warn!("{} leader send messages err {:?}", self.tag, e);
@@ -1036,10 +932,9 @@ impl Peer {
         ctx.ready_res.push((ready, invoke_ctx));
     }
 
-    pub fn post_raft_ready_append<T: Transport>(
+    pub fn post_raft_ready_append<T: Transport, C>(
         &mut self,
-        metrics: &mut RaftMetrics,
-        trans: &T,
+        ctx: &mut PollContext<T, C>,
         ready: &mut Ready,
         invoke_ctx: InvokeContext,
     ) -> Option<ApplySnapResult> {
@@ -1072,21 +967,25 @@ impl Peer {
             if self.is_applying_snapshot() {
                 self.pending_messages = mem::replace(&mut ready.messages, vec![]);
             } else {
-                self.send(trans, ready.messages.drain(..), &mut metrics.message)
-                    .unwrap_or_else(|e| {
-                        warn!("{} follower send messages err {:?}", self.tag, e);
-                    });
+                self.send(
+                    &ctx.trans,
+                    ready.messages.drain(..),
+                    &mut ctx.raft_metrics.message,
+                ).unwrap_or_else(|e| {
+                    warn!("{} follower send messages err {:?}", self.tag, e);
+                });
+                ctx.need_flush_trans = true;
             }
         }
 
         if apply_snap_result.is_some() {
-            self.activate();
+            self.activate(ctx);
         }
 
         apply_snap_result
     }
 
-    pub fn handle_raft_ready_apply(&mut self, mut ready: Ready, apply_router: &ApplyRouter) {
+    pub fn handle_raft_ready_apply<T, C>(&mut self, ctx: &mut PollContext<T, C>, mut ready: Ready) {
         // Call `handle_raft_committed_entries` directly here may lead to inconsistency.
         // In some cases, there will be some pending committed entries when applying a
         // snapshot. If we call `handle_raft_committed_entries` directly, these updates
@@ -1115,7 +1014,7 @@ impl Peer {
                 if lease_to_be_updated {
                     let propose_time = self.find_propose_time(entry.get_index(), entry.get_term());
                     if let Some(propose_time) = propose_time {
-                        self.maybe_renew_leader_lease(propose_time);
+                        self.maybe_renew_leader_lease(&ctx.local_reader, propose_time);
                         lease_to_be_updated = false;
                     }
                 }
@@ -1153,11 +1052,12 @@ impl Peer {
                     self.last_urgent_proposal_idx = u64::MAX;
                 }
                 let apply = Apply::new(self.region_id, self.term(), committed_entries);
-                apply_router.schedule_task(self.region_id, ApplyTask::apply(apply));
+                ctx.apply_router
+                    .schedule_task(self.region_id, ApplyTask::apply(apply));
             }
         }
 
-        self.apply_reads(&ready);
+        self.apply_reads(ctx, &ready);
 
         self.raft_group.advance_append(ready);
         if self.is_applying_snapshot() {
@@ -1168,14 +1068,14 @@ impl Peer {
         self.proposals.gc();
     }
 
-    fn apply_reads(&mut self, ready: &Ready) {
+    fn apply_reads<T, C>(&mut self, ctx: &mut PollContext<T, C>, ready: &Ready) {
         let mut propose_time = None;
         if self.ready_to_handle_read() {
             for state in &ready.read_states {
                 let mut read = self.pending_reads.reads.pop_front().unwrap();
                 assert_eq!(state.request_ctx.as_slice(), read.binary_id());
                 for (req, cb) in read.cmds.drain(..) {
-                    cb.invoke_read(self.handle_read(req, true));
+                    cb.invoke_read(self.handle_read(ctx, req, true));
                 }
                 propose_time = Some(read.renew_lease_time);
             }
@@ -1202,18 +1102,20 @@ impl Peer {
             if self.leader_lease.inspect(Some(propose_time)) == LeaseState::Suspect {
                 return;
             }
-            self.maybe_renew_leader_lease(propose_time);
+            self.maybe_renew_leader_lease(&ctx.local_reader, propose_time);
         }
     }
 
-    pub fn post_apply(
+    pub fn post_apply<T, C>(
         &mut self,
-        groups: &mut HashSet<u64>,
+        ctx: &mut PollContext<T, C>,
         apply_state: RaftApplyState,
         applied_index_term: u64,
         merged: bool,
         apply_metrics: &ApplyMetrics,
-    ) {
+    ) -> bool {
+        let mut has_ready = false;
+
         if self.is_applying_snapshot() {
             panic!("{} should not applying snapshot.", self.tag);
         }
@@ -1234,14 +1136,14 @@ impl Peer {
         self.size_diff_hint = cmp::max(diff, 0) as u64;
 
         if self.has_pending_snapshot() && self.ready_to_handle_pending_snap() {
-            self.mark_to_be_checked(groups);
+            has_ready = true;
         }
 
         if self.pending_reads.ready_cnt > 0 && self.ready_to_handle_read() {
             for _ in 0..self.pending_reads.ready_cnt {
                 let mut read = self.pending_reads.reads.pop_front().unwrap();
                 for (req, cb) in read.cmds.drain(..) {
-                    cb.invoke_read(self.handle_read(req, true));
+                    cb.invoke_read(self.handle_read(ctx, req, true));
                 }
             }
             self.pending_reads.ready_cnt = 0;
@@ -1251,8 +1153,9 @@ impl Peer {
         // Only leaders need to update applied_index_term.
         if progress_to_be_updated && self.is_leader() {
             let progress = ReadProgress::applied_index_term(applied_index_term);
-            self.maybe_update_read_progress(progress);
+            self.maybe_update_read_progress(&ctx.local_reader, progress);
         }
+        has_ready
     }
 
     pub fn post_split(&mut self) {
@@ -1262,7 +1165,7 @@ impl Peer {
     }
 
     /// Try to renew leader lease.
-    fn maybe_renew_leader_lease(&mut self, ts: Timespec) {
+    fn maybe_renew_leader_lease(&mut self, reader: &Scheduler<ReadTask>, ts: Timespec) {
         // A nonleader peer should never has leader lease.
         if !self.is_leader() {
             return;
@@ -1285,24 +1188,29 @@ impl Peer {
         let term = self.term();
         if let Some(remote_lease) = self.leader_lease.maybe_new_remote_lease(term) {
             let progress = ReadProgress::leader_lease(remote_lease);
-            self.maybe_update_read_progress(progress);
+            self.maybe_update_read_progress(reader, progress);
         }
     }
 
-    fn maybe_update_read_progress(&self, progress: ReadProgress) {
+    fn maybe_update_read_progress(
+        &self,
+        local_reader: &Scheduler<ReadTask>,
+        progress: ReadProgress,
+    ) {
         if self.pending_remove {
             return;
         }
         let update = ReadTask::update(self.region_id, progress);
         debug!("{} update {}", self.tag, update);
-        self.read_scheduler.schedule(update).unwrap();
+        if let Err(e) = local_reader.schedule(update) {
+            info!(
+                "{} failed to update read progress: {:?}, are we shutting down?",
+                self.tag, e
+            );
+        }
     }
 
-    pub fn maybe_campaign(
-        &mut self,
-        parent_is_leader: bool,
-        pending_raft_groups: &mut HashSet<u64>,
-    ) -> bool {
+    pub fn maybe_campaign(&mut self, parent_is_leader: bool) -> bool {
         if self.region().get_peers().len() <= 1 {
             // The peer campaigned when it was created, no need to do it again.
             return false;
@@ -1315,8 +1223,6 @@ impl Peer {
         // If last peer is the leader of the region before split, it's intuitional for
         // it to become the leader of new split region.
         let _ = self.raft_group.campaign();
-        self.mark_to_be_checked(pending_raft_groups);
-
         true
     }
 
@@ -1332,18 +1238,18 @@ impl Peer {
     /// Propose a request.
     ///
     /// Return true means the request has been proposed successfully.
-    pub fn propose(
+    pub fn propose<T, C>(
         &mut self,
+        ctx: &mut PollContext<T, C>,
         cb: Callback,
         req: RaftCmdRequest,
         mut err_resp: RaftCmdResponse,
-        metrics: &mut RaftProposeMetrics,
     ) -> bool {
         if self.pending_remove {
             return false;
         }
 
-        metrics.all += 1;
+        ctx.raft_metrics.propose.all += 1;
 
         let mut is_conf_change = false;
         let is_urgent = is_request_urgent(&req);
@@ -1351,17 +1257,17 @@ impl Peer {
         let policy = self.inspect(&req);
         let res = match policy {
             Ok(RequestPolicy::ReadLocal) => {
-                self.read_local(req, cb, metrics);
+                self.read_local(ctx, req, cb);
                 return false;
             }
-            Ok(RequestPolicy::ReadIndex) => return self.read_index(req, err_resp, cb, metrics),
-            Ok(RequestPolicy::ProposeNormal) => self.propose_normal(req, metrics),
+            Ok(RequestPolicy::ReadIndex) => return self.read_index(ctx, req, err_resp, cb),
+            Ok(RequestPolicy::ProposeNormal) => self.propose_normal(ctx, req),
             Ok(RequestPolicy::ProposeTransferLeader) => {
-                return self.propose_transfer_leader(req, cb, metrics)
+                return self.propose_transfer_leader(ctx, req, cb)
             }
             Ok(RequestPolicy::ProposeConfChange) => {
                 is_conf_change = true;
-                self.propose_conf_change(&req, metrics)
+                self.propose_conf_change(ctx, &req)
             }
             Err(e) => Err(e),
         };
@@ -1430,7 +1336,11 @@ impl Peer {
     ///    Then at least '(total - 1)/2 + 1' other nodes (the node about to be removed is excluded)
     ///    need to be up to date for now. If 'allow_remove_leader' is false then
     ///    the peer to be removed should not be the leader.
-    fn check_conf_change(&self, cmd: &RaftCmdRequest) -> Result<()> {
+    fn check_conf_change<T, C>(
+        &self,
+        ctx: &mut PollContext<T, C>,
+        cmd: &RaftCmdRequest,
+    ) -> Result<()> {
         let change_peer = apply::get_change_peer_cmd(cmd).unwrap();
         let change_type = change_peer.get_change_type();
         let peer = change_peer.get_peer();
@@ -1448,7 +1358,7 @@ impl Peer {
         }
 
         if change_type == ConfChangeType::RemoveNode
-            && !self.cfg.allow_remove_leader
+            && !ctx.cfg.allow_remove_leader
             && peer.get_id() == self.peer_id()
         {
             warn!(
@@ -1520,7 +1430,11 @@ impl Peer {
         self.raft_group.transfer_leader(peer.get_id());
     }
 
-    fn ready_to_transfer_leader(&self, peer: &metapb::Peer) -> bool {
+    fn ready_to_transfer_leader<T, C>(
+        &self,
+        ctx: &mut PollContext<T, C>,
+        peer: &metapb::Peer,
+    ) -> bool {
         let peer_id = peer.get_id();
         let status = self.raft_group.status();
 
@@ -1542,12 +1456,12 @@ impl Peer {
         }
 
         let last_index = self.get_store().last_index();
-        last_index <= status.progress[&peer_id].matched + self.cfg.leader_transfer_max_log_lag
+        last_index <= status.progress[&peer_id].matched + ctx.cfg.leader_transfer_max_log_lag
     }
 
-    fn read_local(&mut self, req: RaftCmdRequest, cb: Callback, metrics: &mut RaftProposeMetrics) {
-        metrics.local_read += 1;
-        cb.invoke_read(self.handle_read(req, false))
+    fn read_local<T, C>(&mut self, ctx: &mut PollContext<T, C>, req: RaftCmdRequest, cb: Callback) {
+        ctx.raft_metrics.propose.local_read += 1;
+        cb.invoke_read(self.handle_read(ctx, req, false))
     }
 
     fn pre_read_index(&self) -> Result<()> {
@@ -1574,26 +1488,27 @@ impl Peer {
     // 1. The region is in merging or splitting;
     // 2. The message is stale and dropped by the Raft group internally;
     // 3. There is already a read request proposed in the current lease;
-    fn read_index(
+    fn read_index<T, C>(
         &mut self,
+        poll_ctx: &mut PollContext<T, C>,
         req: RaftCmdRequest,
         mut err_resp: RaftCmdResponse,
         cb: Callback,
-        metrics: &mut RaftProposeMetrics,
     ) -> bool {
         if let Err(e) = self.pre_read_index() {
             debug!("{} prevents unsafe read index, err: {:?}", self.tag, e);
-            metrics.unsafe_read_index += 1;
+            poll_ctx.raft_metrics.propose.unsafe_read_index += 1;
             cmd_resp::bind_error(&mut err_resp, e);
             cb.invoke_with_response(err_resp);
             return false;
         }
 
-        metrics.read_index += 1;
+        poll_ctx.raft_metrics.propose.read_index += 1;
 
         let renew_lease_time = monotonic_raw_now();
         if let Some(read) = self.pending_reads.reads.back_mut() {
-            if read.renew_lease_time + self.cfg.raft_store_max_leader_lease() > renew_lease_time {
+            if read.renew_lease_time + poll_ctx.cfg.raft_store_max_leader_lease() > renew_lease_time
+            {
                 read.cmds.push((req, cb));
                 return false;
             }
@@ -1631,7 +1546,7 @@ impl Peer {
         // update leader lease.
         if self.leader_lease.inspect(Some(renew_lease_time)) == LeaseState::Suspect {
             let req = RaftCmdRequest::new();
-            if let Ok(index) = self.propose_normal(req, metrics) {
+            if let Ok(index) = self.propose_normal(poll_ctx, req) {
                 let meta = ProposalMeta {
                     index,
                     term: self.term(),
@@ -1654,11 +1569,15 @@ impl Peer {
             .unwrap_or_default()
     }
 
-    fn pre_propose_prepare_merge(&self, req: &mut RaftCmdRequest) -> Result<()> {
+    fn pre_propose_prepare_merge<T, C>(
+        &self,
+        ctx: &mut PollContext<T, C>,
+        req: &mut RaftCmdRequest,
+    ) -> Result<()> {
         let last_index = self.raft_group.raft.raft_log.last_index();
         let min_progress = self.get_min_progress();
         let min_index = min_progress + 1;
-        if min_progress == 0 || last_index - min_progress > self.cfg.merge_max_log_gap {
+        if min_progress == 0 || last_index - min_progress > ctx.cfg.merge_max_log_gap {
             return Err(box_err!(
                 "log gap ({}, {}] is too large, skip merge",
                 min_progress,
@@ -1693,7 +1612,7 @@ impl Peer {
                 cmd_type
             ));
         }
-        if entry_size as f64 > self.cfg.raft_entry_max_size.0 as f64 * 0.9 {
+        if entry_size as f64 > ctx.cfg.raft_entry_max_size.0 as f64 * 0.9 {
             return Err(box_err!(
                 "log gap size exceed entry size limit, skip merging."
             ));
@@ -1704,8 +1623,12 @@ impl Peer {
         Ok(())
     }
 
-    fn pre_propose(&self, req: &mut RaftCmdRequest) -> Result<ProposalContext> {
-        self.coprocessor_host.pre_propose(self.region(), req)?;
+    fn pre_propose<T, C>(
+        &self,
+        poll_ctx: &mut PollContext<T, C>,
+        req: &mut RaftCmdRequest,
+    ) -> Result<ProposalContext> {
+        poll_ctx.coprocessor_host.pre_propose(self.region(), req)?;
         let mut ctx = ProposalContext::empty();
 
         if get_sync_log_from_request(req) {
@@ -1722,17 +1645,17 @@ impl Peer {
         }
 
         if req.get_admin_request().has_prepare_merge() {
-            self.pre_propose_prepare_merge(req)?;
+            self.pre_propose_prepare_merge(poll_ctx, req)?;
             ctx.insert(ProposalContext::PREPARE_MERGE);
         }
 
         Ok(ctx)
     }
 
-    fn propose_normal(
+    fn propose_normal<T, C>(
         &mut self,
+        poll_ctx: &mut PollContext<T, C>,
         mut req: RaftCmdRequest,
-        metrics: &mut RaftProposeMetrics,
     ) -> Result<u64> {
         if self.pending_merge_state.is_some()
             && req.get_admin_request().get_cmd_type() != AdminCmdType::RollbackMerge
@@ -1740,10 +1663,10 @@ impl Peer {
             return Err(box_err!("peer in merging mode, can't do proposal."));
         }
 
-        metrics.normal += 1;
+        poll_ctx.raft_metrics.propose.normal += 1;
 
         // TODO: validate request for unexpected changes.
-        let ctx = match self.pre_propose(&mut req) {
+        let ctx = match self.pre_propose(poll_ctx, &mut req) {
             Ok(ctx) => ctx,
             Err(e) => {
                 warn!("{} skip proposal: {:?}", self.tag, e);
@@ -1755,7 +1678,7 @@ impl Peer {
         // TODO: use local histogram metrics
         PEER_PROPOSE_LOG_SIZE_HISTOGRAM.observe(data.len() as f64);
 
-        if data.len() as u64 > self.raft_entry_max_size {
+        if data.len() as u64 > poll_ctx.cfg.raft_entry_max_size.0 {
             error!("entry is too large, entry size {}", data.len());
             return Err(Error::RaftEntryTooLarge(self.region_id, data.len() as u64));
         }
@@ -1772,18 +1695,18 @@ impl Peer {
     }
 
     // Return true to if the transfer leader request is accepted.
-    fn propose_transfer_leader(
+    fn propose_transfer_leader<T, C>(
         &mut self,
+        ctx: &mut PollContext<T, C>,
         req: RaftCmdRequest,
         cb: Callback,
-        metrics: &mut RaftProposeMetrics,
     ) -> bool {
-        metrics.transfer_leader += 1;
+        ctx.raft_metrics.propose.transfer_leader += 1;
 
         let transfer_leader = get_transfer_leader_cmd(&req).unwrap();
         let peer = transfer_leader.get_peer();
 
-        let transferred = if self.ready_to_transfer_leader(peer) {
+        let transferred = if self.ready_to_transfer_leader(ctx, peer) {
             self.transfer_leader(peer);
             true
         } else {
@@ -1806,10 +1729,10 @@ impl Peer {
     // 2. Removing the leader is not allowed in the configuration;
     // 3. The conf change makes the raft group not healthy;
     // 4. The conf change is dropped by raft group internally.
-    fn propose_conf_change(
+    fn propose_conf_change<T, C>(
         &mut self,
+        ctx: &mut PollContext<T, C>,
         req: &RaftCmdRequest,
-        metrics: &mut RaftProposeMetrics,
     ) -> Result<u64> {
         if self.pending_merge_state.is_some() {
             return Err(box_err!("peer in merging mode, can't do proposal."));
@@ -1822,9 +1745,9 @@ impl Peer {
             ));
         }
 
-        self.check_conf_change(req)?;
+        self.check_conf_change(ctx, req)?;
 
-        metrics.conf_change += 1;
+        ctx.raft_metrics.propose.conf_change += 1;
 
         let data = req.write_to_bytes()?;
 
@@ -1856,9 +1779,14 @@ impl Peer {
         Ok(propose_index)
     }
 
-    fn handle_read(&mut self, req: RaftCmdRequest, check_epoch: bool) -> ReadResponse {
+    fn handle_read<T, C>(
+        &mut self,
+        ctx: &mut PollContext<T, C>,
+        req: RaftCmdRequest,
+        check_epoch: bool,
+    ) -> ReadResponse {
         let mut resp = ReadExecutor::new(
-            self.engines.kv.clone(),
+            ctx.engines.kv.clone(),
             check_epoch,
             false, /* we don't need snapshot time */
         ).execute(&req, self.region());
@@ -1904,18 +1832,18 @@ impl Peer {
         None
     }
 
-    pub fn heartbeat_pd(&mut self, worker: &FutureWorker<PdTask>) {
+    pub fn heartbeat_pd<T, C>(&mut self, ctx: &PollContext<T, C>) {
         let task = PdTask::Heartbeat {
             region: self.region().clone(),
             peer: self.peer.clone(),
-            down_peers: self.collect_down_peers(self.cfg.max_peer_down_duration.0),
+            down_peers: self.collect_down_peers(ctx.cfg.max_peer_down_duration.0),
             pending_peers: self.collect_pending_peers(),
             written_bytes: self.peer_stat.written_bytes,
             written_keys: self.peer_stat.written_keys,
             approximate_size: self.approximate_size,
             approximate_keys: self.approximate_keys,
         };
-        if let Err(e) = worker.schedule(task) {
+        if let Err(e) = ctx.pd_scheduler.schedule(task) {
             error!("{} failed to notify pd: {}", self.tag, e);
         }
     }

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -11,9 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::sync::Arc;
@@ -39,7 +38,6 @@ use util::{self, rocksdb};
 use super::engine::{Iterable, Mutable, Peekable, Snapshot as DbSnapshot};
 use super::keys::{self, enc_end_key, enc_start_key};
 use super::metrics::*;
-use super::peer::ReadyContext;
 use super::worker::RegionTask;
 use super::{SnapEntry, SnapKey, SnapManager, SnapshotStatistics};
 
@@ -236,21 +234,32 @@ impl EntryCache {
 
 #[derive(Default)]
 pub struct CacheQueryStats {
-    pub hit: u64,
-    pub miss: u64,
+    pub hit: Cell<u64>,
+    pub miss: Cell<u64>,
 }
 
 impl CacheQueryStats {
     pub fn flush(&mut self) {
-        RAFT_ENTRY_FETCHES
-            .with_label_values(&["hit"])
-            .inc_by(self.hit as i64);
-        RAFT_ENTRY_FETCHES
-            .with_label_values(&["miss"])
-            .inc_by(self.miss as i64);
-        self.hit = 0;
-        self.miss = 0;
+        if self.hit.get() > 0 {
+            RAFT_ENTRY_FETCHES
+                .with_label_values(&["hit"])
+                .inc_by(self.hit.replace(0) as i64);
+        }
+        if self.miss.get() > 0 {
+            RAFT_ENTRY_FETCHES
+                .with_label_values(&["miss"])
+                .inc_by(self.miss.replace(0) as i64);
+        }
     }
+}
+
+pub trait HandleRaftReadyContext {
+    fn kv_wb(&self) -> &WriteBatch;
+    fn kv_wb_mut(&mut self) -> &mut WriteBatch;
+    fn raft_wb(&self) -> &WriteBatch;
+    fn raft_wb_mut(&mut self) -> &mut WriteBatch;
+    fn sync_log(&self) -> bool;
+    fn set_sync_log(&mut self, sync: bool);
 }
 
 pub struct PeerStorage {
@@ -267,7 +276,7 @@ pub struct PeerStorage {
     snap_tried_cnt: RefCell<usize>,
 
     cache: EntryCache,
-    stats: Rc<RefCell<CacheQueryStats>>,
+    stats: CacheQueryStats,
 
     pub tag: String,
 }
@@ -467,9 +476,13 @@ impl PeerStorage {
         region: &metapb::Region,
         region_sched: Scheduler<RegionTask>,
         tag: String,
-        stats: Rc<RefCell<CacheQueryStats>>,
     ) -> Result<PeerStorage> {
-        debug!("creating storage on {} for {:?}", engines.kv.path(), region);
+        debug!(
+            "{} creating storage on {} for {:?}",
+            tag,
+            engines.kv.path(),
+            region
+        );
         let raft_state = init_raft_state(&engines.raft, region)?;
         let apply_state = init_apply_state(&engines.kv, region)?;
         if raft_state.get_last_index() < apply_state.get_applied_index() {
@@ -494,7 +507,7 @@ impl PeerStorage {
             applied_index_term: RAFT_INIT_LOG_TERM,
             last_term,
             cache: EntryCache::default(),
-            stats,
+            stats: CacheQueryStats::default(),
         })
     }
 
@@ -552,7 +565,7 @@ impl PeerStorage {
         let region_id = self.get_region_id();
         if high <= cache_low {
             // not overlap
-            self.stats.borrow_mut().miss += 1;
+            self.stats.miss.update(|m| m + 1);
             fetch_entries_to(
                 &self.engines.raft,
                 region_id,
@@ -565,7 +578,7 @@ impl PeerStorage {
         }
         let mut fetched_size = 0;
         let begin_idx = if low < cache_low {
-            self.stats.borrow_mut().miss += 1;
+            self.stats.miss.update(|m| m + 1);
             fetched_size = fetch_entries_to(
                 &self.engines.raft,
                 region_id,
@@ -583,7 +596,7 @@ impl PeerStorage {
             low
         };
 
-        self.stats.borrow_mut().hit += 1;
+        self.stats.hit.update(|h| h + 1);
         self.cache
             .fetch_entries_to(begin_idx, high, fetched_size, max_size, &mut ents);
         Ok(ents)
@@ -781,11 +794,11 @@ impl PeerStorage {
     // Append the given entries to the raft log using previous last index or self.last_index.
     // Return the new last index for later update. After we commit in engine, we can set last_index
     // to the return one.
-    pub fn append<T>(
+    pub fn append<H: HandleRaftReadyContext>(
         &mut self,
         invoke_ctx: &mut InvokeContext,
         entries: &[Entry],
-        ready_ctx: &mut ReadyContext<T>,
+        ready_ctx: &mut H,
     ) -> Result<u64> {
         debug!("{} append {} entries", self.tag, entries.len());
         let prev_last_index = invoke_ctx.raft_state.get_last_index();
@@ -799,10 +812,10 @@ impl PeerStorage {
         };
 
         for entry in entries {
-            if !ready_ctx.sync_log {
-                ready_ctx.sync_log = get_sync_log_from_entry(entry);
+            if !ready_ctx.sync_log() {
+                ready_ctx.set_sync_log(get_sync_log_from_entry(entry));
             }
-            ready_ctx.raft_wb.put_msg(
+            ready_ctx.raft_wb_mut().put_msg(
                 &keys::raft_log_key(self.get_region_id(), entry.get_index()),
                 entry,
             )?;
@@ -811,7 +824,7 @@ impl PeerStorage {
         // Delete any previously appended log entries which never committed.
         for i in (last_index + 1)..(prev_last_index + 1) {
             ready_ctx
-                .raft_wb
+                .raft_wb_mut()
                 .delete(&keys::raft_log_key(self.get_region_id(), i))?;
         }
 
@@ -843,6 +856,11 @@ impl PeerStorage {
                 self.cache.compact_to(apply_idx + 1);
             }
         }
+    }
+
+    #[inline]
+    pub fn flush_cache_metrics(&mut self) {
+        self.stats.flush();
     }
 
     // Apply the peer with given snapshot.
@@ -1052,9 +1070,9 @@ impl PeerStorage {
     /// to update the memory states properly.
     // Using `&Ready` here to make sure `Ready` struct is not modified in this function. This is
     // a requirement to advance the ready object properly later.
-    pub fn handle_raft_ready<T>(
+    pub fn handle_raft_ready<H: HandleRaftReadyContext>(
         &mut self,
-        ready_ctx: &mut ReadyContext<T>,
+        ready_ctx: &mut H,
         ready: &Ready,
     ) -> Result<InvokeContext> {
         let mut ctx = InvokeContext::new(self);
@@ -1065,8 +1083,8 @@ impl PeerStorage {
             self.apply_snapshot(
                 &mut ctx,
                 &ready.snapshot,
-                &ready_ctx.kv_wb,
-                &ready_ctx.raft_wb,
+                &ready_ctx.kv_wb(),
+                &ready_ctx.raft_wb(),
             )?;
             fail_point!("raft_after_apply_snap");
 
@@ -1074,7 +1092,7 @@ impl PeerStorage {
         };
 
         if ready.must_sync {
-            ready_ctx.sync_log = true;
+            ready_ctx.set_sync_log(true);
         }
 
         if !ready.entries.is_empty() {
@@ -1090,7 +1108,7 @@ impl PeerStorage {
         }
 
         if ctx.raft_state != self.raft_state {
-            ctx.save_raft_state_to(&mut ready_ctx.raft_wb)?;
+            ctx.save_raft_state_to(ready_ctx.raft_wb_mut())?;
             if snapshot_index > 0 {
                 // in case of restart happen when we just write region state to Applying,
                 // but not write raft_local_state to raft rocksdb in time.
@@ -1099,14 +1117,14 @@ impl PeerStorage {
                 ctx.save_snapshot_raft_state_to(
                     snapshot_index,
                     &self.engines.kv,
-                    &mut ready_ctx.kv_wb,
+                    &mut ready_ctx.kv_wb_mut(),
                 )?;
             }
         }
 
         // only when apply snapshot
         if ctx.apply_state != self.apply_state {
-            ctx.save_apply_state_to(&self.engines.kv, &mut ready_ctx.kv_wb)?;
+            ctx.save_apply_state_to(&self.engines.kv, &mut ready_ctx.kv_wb_mut())?;
         }
 
         Ok(ctx)
@@ -1445,7 +1463,6 @@ mod tests {
     use raft::eraftpb::{ConfState, Entry};
     use raft::{Error as RaftError, StorageError};
     use raftstore::store::bootstrap;
-    use raftstore::store::local_metrics::RaftMetrics;
     use raftstore::store::util::Engines;
     use raftstore::store::worker::RegionRunner;
     use raftstore::store::worker::RegionTask;
@@ -1471,8 +1488,35 @@ mod tests {
         let engines = Engines::new(kv_db, raft_db);
         bootstrap::bootstrap_store(&engines, 1, 1).expect("");
         let region = bootstrap::prepare_bootstrap(&engines, 1, 1, 1).expect("");
-        let metrics = Rc::new(RefCell::new(CacheQueryStats::default()));
-        PeerStorage::new(engines, &region, sched, "".to_owned(), metrics).unwrap()
+        PeerStorage::new(engines, &region, sched, "".to_owned()).unwrap()
+    }
+
+    #[derive(Default)]
+    struct ReadyContext {
+        kv_wb: WriteBatch,
+        raft_wb: WriteBatch,
+        sync_log: bool,
+    }
+
+    impl HandleRaftReadyContext for ReadyContext {
+        fn kv_wb(&self) -> &WriteBatch {
+            &self.kv_wb
+        }
+        fn kv_wb_mut(&mut self) -> &mut WriteBatch {
+            &mut self.kv_wb
+        }
+        fn raft_wb(&self) -> &WriteBatch {
+            &self.raft_wb
+        }
+        fn raft_wb_mut(&mut self) -> &mut WriteBatch {
+            &mut self.raft_wb
+        }
+        fn sync_log(&self) -> bool {
+            self.sync_log
+        }
+        fn set_sync_log(&mut self, sync: bool) {
+            self.sync_log = sync;
+        }
     }
 
     fn new_storage_from_ents(
@@ -1483,9 +1527,7 @@ mod tests {
         let mut store = new_storage(sched, path);
         let mut kv_wb = WriteBatch::new();
         let mut ctx = InvokeContext::new(&store);
-        let mut metrics = RaftMetrics::default();
-        let trans = 0;
-        let mut ready_ctx = ReadyContext::new(&mut metrics, &trans, ents.len());
+        let mut ready_ctx = ReadyContext::default();
         store
             .append(&mut ctx, &ents[1..], &mut ready_ctx)
             .expect("");
@@ -1508,9 +1550,7 @@ mod tests {
 
     fn append_ents(store: &mut PeerStorage, ents: &[Entry]) {
         let mut ctx = InvokeContext::new(store);
-        let mut metrics = RaftMetrics::default();
-        let trans = 0;
-        let mut ready_ctx = ReadyContext::new(&mut metrics, &trans, ents.len());
+        let mut ready_ctx = ReadyContext::default();
         store.append(&mut ctx, ents, &mut ready_ctx).unwrap();
         ctx.save_raft_state_to(&mut ready_ctx.raft_wb).unwrap();
         store.engines.raft.write(ready_ctx.raft_wb).expect("");
@@ -1772,9 +1812,7 @@ mod tests {
 
         let mut ctx = InvokeContext::new(&s);
         let mut kv_wb = WriteBatch::new();
-        let mut metrics = RaftMetrics::default();
-        let trans = 0;
-        let mut ready_ctx = ReadyContext::new(&mut metrics, &trans, 2);
+        let mut ready_ctx = ReadyContext::default();
         s.append(
             &mut ctx,
             &[new_entry(6, 5), new_entry(7, 5)],

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -329,9 +329,7 @@ impl RegionIterator {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
     use std::path::Path;
-    use std::rc::Rc;
     use std::sync::Arc;
 
     use kvproto::metapb::{Peer, Region};
@@ -340,7 +338,7 @@ mod tests {
 
     use raftstore::store::engine::*;
     use raftstore::store::keys::*;
-    use raftstore::store::{CacheQueryStats, Engines, PeerStorage};
+    use raftstore::store::{Engines, PeerStorage};
     use raftstore::Result;
     use storage::{CFStatistics, Cursor, Key, ScanMode, ALL_CFS, CF_DEFAULT};
     use util::rocksdb::compact_files_in_range;
@@ -361,14 +359,7 @@ mod tests {
     }
 
     fn new_peer_storage(engines: Engines, r: &Region) -> PeerStorage {
-        let metrics = Rc::new(RefCell::new(CacheQueryStats::default()));
-        PeerStorage::new(
-            engines,
-            r,
-            worker::dummy_scheduler(),
-            "".to_owned(),
-            metrics,
-        ).unwrap()
+        PeerStorage::new(engines, r, worker::dummy_scheduler(), "".to_owned()).unwrap()
     }
 
     fn load_default_dataset(engines: Engines) -> (PeerStorage, DataSet) {

--- a/src/raftstore/store/worker/cleanup_sst.rs
+++ b/src/raftstore/store/worker/cleanup_sst.rs
@@ -18,9 +18,9 @@ use kvproto::import_sstpb::SSTMeta;
 
 use import::SSTImporter;
 use pd::PdClient;
+use raftstore::store::fsm::SendCh;
 use raftstore::store::util::is_epoch_stale;
-use raftstore::store::Msg;
-use util::transport::SendCh;
+use raftstore::store::{Msg, StoreMsg};
 use util::worker::Runnable;
 
 pub enum Task {
@@ -39,7 +39,7 @@ impl fmt::Display for Task {
 
 pub struct Runner<C> {
     store_id: u64,
-    store_ch: SendCh<Msg>,
+    store_ch: SendCh,
     importer: Arc<SSTImporter>,
     pd_client: Arc<C>,
 }
@@ -47,7 +47,7 @@ pub struct Runner<C> {
 impl<C: PdClient> Runner<C> {
     pub fn new(
         store_id: u64,
-        store_ch: SendCh<Msg>,
+        store_ch: SendCh,
         importer: Arc<SSTImporter>,
         pd_client: Arc<C>,
     ) -> Runner<C> {
@@ -97,7 +97,7 @@ impl<C: PdClient> Runner<C> {
         // We need to send back the result to check for the stale
         // peer, which may ingest the stale SST before it is
         // destroyed.
-        let msg = Msg::ValidateSSTResult { invalid_ssts };
+        let msg = Msg::StoreMsg(StoreMsg::ValidateSSTResult { invalid_ssts });
         if let Err(e) = self.store_ch.try_send(msg) {
             error!("send validate sst result: {:?}", e);
         }

--- a/src/raftstore/store/worker/mod.rs
+++ b/src/raftstore/store/worker/mod.rs
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 use raftstore;
+use raftstore::store::fsm::SendCh;
 use raftstore::store::msg::Msg;
 use std::sync::mpsc::Sender;
-use util::transport::SendCh;
 
 pub trait MsgSender {
     fn send(&self, msg: Msg) -> raftstore::Result<()>;
@@ -22,7 +22,7 @@ pub trait MsgSender {
     fn try_send(&self, msg: Msg) -> raftstore::Result<()>;
 }
 
-impl MsgSender for SendCh<Msg> {
+impl MsgSender for SendCh {
     fn send(&self, msg: Msg) -> raftstore::Result<()> {
         SendCh::send(self, msg).map_err(|e| box_err!("{:?}", e))
     }

--- a/src/raftstore/store/worker/split_check.rs
+++ b/src/raftstore/store/worker/split_check.rs
@@ -25,7 +25,7 @@ use rocksdb::{DBIterator, DB};
 use raftstore::coprocessor::CoprocessorHost;
 use raftstore::coprocessor::SplitCheckerHost;
 use raftstore::store::engine::{IterOption, Iterable};
-use raftstore::store::{keys, Callback, Msg};
+use raftstore::store::{keys, Callback, Msg, PeerMsg};
 use raftstore::Result;
 use storage::{CfName, CF_WRITE, LARGE_CFS};
 use util::escape;
@@ -284,10 +284,10 @@ impl<C: Sender<Msg>> Runnable<Task> for Runner<C> {
 }
 
 fn new_split_region(region_id: u64, region_epoch: RegionEpoch, split_keys: Vec<Vec<u8>>) -> Msg {
-    Msg::SplitRegion {
+    Msg::PeerMsg(PeerMsg::SplitRegion {
         region_id,
         region_epoch,
         split_keys,
         callback: Callback::None,
-    }
+    })
 }

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -11,11 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::Bound::Excluded;
 use std::iter::FromIterator;
-use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::thread::{Builder as ThreadBuilder, JoinHandle};
@@ -40,7 +38,7 @@ use raftstore::store::{
     init_apply_state, init_raft_state, write_initial_apply_state, write_initial_raft_state,
     write_peer_state,
 };
-use raftstore::store::{keys, CacheQueryStats, Engines, Iterable, Peekable, PeerStorage};
+use raftstore::store::{keys, Engines, Iterable, Peekable, PeerStorage};
 use storage::mvcc::{Lock, LockType, Write, WriteType};
 use storage::types::Key;
 use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
@@ -447,7 +445,6 @@ impl Debugger {
                 region,
                 fake_snap_worker.scheduler(),
                 tag.clone(),
-                Rc::new(RefCell::new(CacheQueryStats::default())),
             ));
 
             let raft_cfg = raft::Config {

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -12,12 +12,9 @@
 // limitations under the License.
 
 use std::process;
-use std::sync::mpsc::Receiver;
-use std::sync::{mpsc, Arc};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-
-use mio::EventLoop;
 
 use super::transport::RaftStoreRouter;
 use super::Result;
@@ -27,16 +24,15 @@ use kvproto::raft_serverpb::StoreIdent;
 use pd::{Error as PdError, PdClient, PdTask, INVALID_ID};
 use protobuf::RepeatedField;
 use raftstore::coprocessor::dispatcher::CoprocessorHost;
+use raftstore::store::fsm::{RaftBatchSystem, SendCh};
 use raftstore::store::{
-    self, keys, Config as StoreConfig, Engines, Msg, Peekable, ReadTask, SignificantMsg,
-    SnapManager, Store, StoreChannel, Transport,
+    self, keys, Config as StoreConfig, Engines, Peekable, ReadTask, SnapManager, Transport,
 };
 use rocksdb::DB;
 use server::readpool::ReadPool;
 use server::Config as ServerConfig;
 use server::ServerRaftStoreRouter;
 use storage::{self, Config as StorageConfig, RaftKv, Storage};
-use util::transport::SendCh;
 use util::worker::{FutureWorker, Worker};
 
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
@@ -86,7 +82,7 @@ pub struct Node<C: PdClient + 'static> {
     store: metapb::Store,
     store_cfg: StoreConfig,
     store_handle: Option<thread::JoinHandle<()>>,
-    ch: SendCh<Msg>,
+    system: RaftBatchSystem,
 
     pd_client: Arc<C>,
 }
@@ -96,15 +92,12 @@ where
     C: PdClient,
 {
     /// Creates a new Node.
-    pub fn new<T>(
-        event_loop: &mut EventLoop<Store<T, C>>,
+    pub fn new(
+        system: RaftBatchSystem,
         cfg: &ServerConfig,
         store_cfg: &StoreConfig,
         pd_client: Arc<C>,
-    ) -> Node<C>
-    where
-        T: Transport + 'static,
-    {
+    ) -> Node<C> {
         let mut store = metapb::Store::new();
         store.set_id(INVALID_ID);
         if cfg.advertise_addr.is_empty() {
@@ -123,14 +116,13 @@ where
         }
         store.set_labels(RepeatedField::from_vec(labels));
 
-        let ch = SendCh::new(event_loop.channel(), "raftstore");
         Node {
             cluster_id: cfg.cluster_id,
             store,
             store_cfg: store_cfg.clone(),
             store_handle: None,
             pd_client,
-            ch,
+            system,
         }
     }
 
@@ -140,11 +132,9 @@ where
     #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
     pub fn start<T>(
         &mut self,
-        event_loop: EventLoop<Store<T, C>>,
         engines: Engines,
         trans: T,
         snap_mgr: SnapManager,
-        significant_msg_receiver: Receiver<SignificantMsg>,
         pd_worker: FutureWorker<PdTask>,
         local_read_worker: Worker<ReadTask>,
         coprocessor_host: CoprocessorHost,
@@ -180,12 +170,10 @@ where
         // inform pd.
         self.pd_client.put_store(self.store.clone())?;
         self.start_store(
-            event_loop,
             store_id,
             engines,
             trans,
             snap_mgr,
-            significant_msg_receiver,
             pd_worker,
             local_read_worker,
             coprocessor_host,
@@ -201,8 +189,8 @@ where
 
     /// Gets a transmission end of a channel which is used to send `Msg` to the
     /// raftstore.
-    pub fn get_sendch(&self) -> SendCh<Msg> {
-        self.ch.clone()
+    pub fn get_sendch(&self) -> SendCh {
+        SendCh::new(self.system.router(), "raftstore")
     }
 
     // check store, return store id for the engine.
@@ -336,12 +324,10 @@ where
     #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
     fn start_store<T>(
         &mut self,
-        mut event_loop: EventLoop<Store<T, C>>,
         store_id: u64,
         engines: Engines,
         trans: T,
         snap_mgr: SnapManager,
-        significant_msg_receiver: Receiver<SignificantMsg>,
         pd_worker: FutureWorker<PdTask>,
         local_read_worker: Worker<ReadTask>,
         coprocessor_host: CoprocessorHost,
@@ -359,55 +345,24 @@ where
         let cfg = self.store_cfg.clone();
         let pd_client = Arc::clone(&self.pd_client);
         let store = self.store.clone();
-        let sender = event_loop.channel();
-
-        let (tx, rx) = mpsc::channel();
-        let builder = thread::Builder::new().name(thd_name!(format!("raftstore-{}", store_id)));
-        let h = builder.spawn(move || {
-            let ch = StoreChannel {
-                sender,
-                significant_msg_receiver,
-            };
-            let mut store = match Store::new(
-                ch,
-                store,
-                cfg,
-                engines,
-                trans,
-                pd_client,
-                snap_mgr,
-                pd_worker,
-                local_read_worker,
-                coprocessor_host,
-                importer,
-            ) {
-                Err(e) => panic!("construct store {} err {:?}", store_id, e),
-                Ok(s) => s,
-            };
-            tx.send(0).unwrap();
-            if let Err(e) = store.run(&mut event_loop) {
-                error!("store {} run err {:?}", store_id, e);
-            };
-        })?;
-        // wait for store to be initialized
-        rx.recv().unwrap();
-
-        self.store_handle = Some(h);
+        self.system.spawn(
+            store,
+            cfg,
+            engines,
+            trans,
+            pd_client,
+            snap_mgr,
+            pd_worker,
+            local_read_worker,
+            coprocessor_host,
+            importer,
+        )?;
         Ok(())
     }
 
     fn stop_store(&mut self, store_id: u64) -> Result<()> {
         info!("stop raft store {} thread", store_id);
-        let h = match self.store_handle.take() {
-            None => return Ok(()),
-            Some(h) => h,
-        };
-
-        box_try!(self.ch.send(Msg::Quit));
-        if let Err(e) = h.join() {
-            return Err(box_err!("join store {} thread err {:?}", store_id, e));
-        }
-
+        self.system.shutdown();
         Ok(())
     }
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -275,7 +275,7 @@ mod tests {
             Ok(())
         }
 
-        fn significant_send(&self, msg: SignificantMsg) -> RaftStoreResult<()> {
+        fn significant_send(&self, _: u64, msg: SignificantMsg) -> RaftStoreResult<()> {
             self.significant_msg_sender.send(msg).unwrap();
             Ok(())
         }

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -31,7 +31,7 @@ use tokio::runtime::{Runtime, TaskExecutor};
 use tokio::timer::Delay;
 
 use coprocessor::Endpoint;
-use raftstore::store::{Callback, Msg as StoreMessage};
+use raftstore::store::{Callback, Msg as StoreMessage, PeerMsg};
 use server::load_statistics::ThreadLoad;
 use server::metrics::*;
 use server::snap::Task as SnapTask;
@@ -700,12 +700,12 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
 
         let region_id = req.get_context().get_region_id();
         let (cb, future) = paired_future_callback();
-        let req = StoreMessage::SplitRegion {
+        let req = StoreMessage::PeerMsg(PeerMsg::SplitRegion {
             region_id,
             region_epoch: req.take_context().take_region_epoch(),
             split_keys: vec![Key::from_raw(req.get_split_key()).into_encoded()],
             callback: Callback::Write(cb),
-        };
+        });
 
         if let Err(e) = self.ch.try_send(req) {
             self.send_fail_status(ctx, sink, Error::from(e), RpcStatusCode::ResourceExhausted);

--- a/src/storage/gc_worker.rs
+++ b/src/storage/gc_worker.rs
@@ -33,7 +33,7 @@ use super::mvcc::{MvccReader, MvccTxn};
 use super::{Callback, Error, Key, Result, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use pd::PdClient;
 use raftstore::store::keys;
-use raftstore::store::msg::Msg as RaftStoreMsg;
+use raftstore::store::msg::{Msg as RaftStoreMsg, StoreMsg};
 use raftstore::store::util::{delete_all_in_range_cf, find_peer};
 use raftstore::store::SeekRegionResult;
 use server::transport::{RaftStoreRouter, ServerRaftStoreRouter};
@@ -366,10 +366,10 @@ impl<E: Engine> GCRunner<E> {
 
         if let Some(router) = self.raft_store_router.as_ref() {
             router
-                .send(RaftStoreMsg::ClearRegionSizeInRange {
+                .send(RaftStoreMsg::StoreMsg(StoreMsg::ClearRegionSizeInRange {
                     start_key: start_key.as_encoded().to_vec(),
                     end_key: end_key.as_encoded().to_vec(),
-                })
+                }))
                 .unwrap_or_else(|e| {
                     // Warn and ignore it.
                     warn!(

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -14,12 +14,12 @@
 use std::collections::hash_map::Entry;
 use std::collections::vec_deque::{Iter, VecDeque};
 use std::fs::File;
-use std::net::{SocketAddr, ToSocketAddrs};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use std::{env, io, slice, thread, u64};
+use std::time::Duration;
+use std::{env, slice, thread, u64};
 
 use protobuf::Message;
 use rand::{self, ThreadRng};
@@ -165,14 +165,6 @@ impl<T> HandyRwLock<T> for RwLock<T> {
     fn rl(&self) -> RwLockReadGuard<T> {
         self.read().unwrap()
     }
-}
-
-/// A helper function to parse SocketAddr for mio.
-/// In mio example, it uses "127.0.0.1:80".parse() to get the SocketAddr,
-/// but it is just ok for "ip:port", not "host:port".
-pub fn to_socket_addr<A: ToSocketAddrs>(addr: A) -> io::Result<SocketAddr> {
-    let addrs = addr.to_socket_addrs()?;
-    Ok(addrs.collect::<Vec<SocketAddr>>()[0])
 }
 
 /// A function to escape a byte array to a readable ascii string.
@@ -541,12 +533,16 @@ pub fn check_environment_variables() {
     }
 }
 
+#[inline]
+pub fn is_zero_duration(d: &Duration) -> bool {
+    d.as_secs() == 0 && d.subsec_nanos() == 0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use protobuf::Message;
     use raft::eraftpb::Entry;
-    use std::net::{AddrParseError, SocketAddr};
     use std::rc::Rc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::*;
@@ -565,28 +561,6 @@ mod tests {
         let dir = TempDir::new("test_panic_mark_file_exists").unwrap();
         create_panic_mark_file(dir.path());
         assert!(panic_mark_file_exists(dir.path()));
-    }
-
-    #[test]
-    fn test_to_socket_addr() {
-        let tbls = vec![
-            ("", false),
-            ("127.0.0.1", false),
-            ("localhost", false),
-            ("127.0.0.1:80", true),
-            ("localhost:80", true),
-        ];
-
-        for (addr, ok) in tbls {
-            assert_eq!(to_socket_addr(addr).is_ok(), ok);
-        }
-
-        let tbls = vec![("localhost:80", false), ("127.0.0.1:80", true)];
-
-        for (addr, ok) in tbls {
-            let ret: Result<SocketAddr, AddrParseError> = addr.parse();
-            assert_eq!(ret.is_ok(), ok);
-        }
     }
 
     #[test]
@@ -753,5 +727,12 @@ mod tests {
         // Hex Octals
         assert_eq!(unescape(r"abc\x64\x65\x66ghi"), b"abcdefghi");
         assert_eq!(unescape(r"JKL\x4d\x4E\x4fPQR"), b"JKLMNOPQR");
+    }
+
+    #[test]
+    fn test_is_zero() {
+        assert!(is_zero_duration(&Duration::new(0, 0)));
+        assert!(!is_zero_duration(&Duration::new(1, 0)));
+        assert!(!is_zero_duration(&Duration::new(0, 1)));
     }
 }

--- a/src/util/transport.rs
+++ b/src/util/transport.rs
@@ -11,14 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crossbeam::{SendError, TrySendError};
+use prometheus::IntCounterVec;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::mpsc;
+use std::thread;
 use std::time::Duration;
-use std::{error, io, thread};
-
-use mio;
-use prometheus::IntCounterVec;
 
 lazy_static! {
     pub static ref CHANNEL_FULL_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
@@ -41,54 +40,38 @@ quick_error! {
             description("channel is closed")
             display("channel is closed")
         }
-        Other(err: Box<error::Error + Send + Sync>) {
-            from()
-            cause(err.as_ref())
-            description(err.description())
-            display("unknown error {:?}", err)
-        }
     }
 }
 
-impl<T: Debug> From<NotifyError<T>> for Error {
-    fn from(e: NotifyError<T>) -> Error {
+impl<T: Debug> From<TrySendError<T>> for Error {
+    #[inline]
+    fn from(e: TrySendError<T>) -> Error {
         match e {
             // ALERT!! May cause sensitive data leak.
-            NotifyError::Full(m) => Error::Discard(format!("Failed to send {:?} due to full", m)),
-            NotifyError::Closed(..) => Error::Closed,
-            _ => box_err!("{:?}", e),
+            TrySendError::Full(m) => Error::Discard(format!("Failed to send {:?} due to full", m)),
+            TrySendError::Disconnected(..) => Error::Closed,
         }
     }
 }
 
-#[derive(Debug)]
-pub enum NotifyError<T> {
-    Full(T),
-    Closed(Option<T>),
-    Io(io::Error),
+impl<T: Debug> From<SendError<T>> for Error {
+    #[inline]
+    fn from(_: SendError<T>) -> Error {
+        // ALERT!! May cause sensitive data leak.
+        Error::Closed
+    }
 }
 
 pub trait Sender<T>: Clone {
-    fn send(&self, t: T) -> Result<(), NotifyError<T>>;
-}
-
-impl<T: Send> Sender<T> for mio::Sender<T> {
-    fn send(&self, t: T) -> Result<(), NotifyError<T>> {
-        match mio::Sender::send(self, t) {
-            Ok(()) => Ok(()),
-            Err(mio::NotifyError::Closed(t)) => Err(NotifyError::Closed(t)),
-            Err(mio::NotifyError::Full(t)) => Err(NotifyError::Full(t)),
-            Err(mio::NotifyError::Io(e)) => Err(NotifyError::Io(e)),
-        }
-    }
+    fn send(&self, t: T) -> Result<(), TrySendError<T>>;
 }
 
 impl<T> Sender<T> for mpsc::SyncSender<T> {
-    fn send(&self, t: T) -> Result<(), NotifyError<T>> {
+    fn send(&self, t: T) -> Result<(), TrySendError<T>> {
         match mpsc::SyncSender::try_send(self, t) {
             Ok(()) => Ok(()),
-            Err(mpsc::TrySendError::Disconnected(t)) => Err(NotifyError::Closed(Some(t))),
-            Err(mpsc::TrySendError::Full(t)) => Err(NotifyError::Full(t)),
+            Err(mpsc::TrySendError::Disconnected(t)) => Err(TrySendError::Disconnected(t)),
+            Err(mpsc::TrySendError::Full(t)) => Err(TrySendError::Full(t)),
         }
     }
 }
@@ -132,12 +115,12 @@ impl<T: Debug, C: Sender<T>> RetryableSendCh<T, C> {
         loop {
             t = match self.ch.send(t) {
                 Ok(_) => return Ok(()),
-                Err(NotifyError::Full(m)) => {
+                Err(TrySendError::Full(m)) => {
                     if try_times <= 1 {
                         CHANNEL_FULL_COUNTER_VEC
                             .with_label_values(&[self.name])
                             .inc();
-                        return Err(NotifyError::Full(m).into());
+                        return Err(TrySendError::Full(m).into());
                     }
                     try_times -= 1;
                     m
@@ -162,7 +145,6 @@ impl<T, C: Sender<T>> Clone for RetryableSendCh<T, C> {
     }
 }
 
-pub type SendCh<T> = RetryableSendCh<T, mio::Sender<T>>;
 pub type SyncSendCh<T> = RetryableSendCh<T, mpsc::SyncSender<T>>;
 
 #[cfg(test)]
@@ -170,8 +152,6 @@ mod tests {
     use std::sync::mpsc::Receiver;
     use std::thread;
     use std::time::Duration;
-
-    use mio::{EventLoop, EventLoopConfig, Handler};
 
     use super::*;
 
@@ -203,55 +183,6 @@ mod tests {
             }
             true
         }
-    }
-
-    impl<S: Sender<Msg>> Handler for SenderHandler<S> {
-        type Timeout = ();
-        type Message = Msg;
-
-        fn notify(&mut self, event_loop: &mut EventLoop<SenderHandler<S>>, msg: Msg) {
-            if !self.on_msg(msg) {
-                event_loop.shutdown();
-            }
-        }
-    }
-
-    #[test]
-    fn test_sendch() {
-        let mut event_loop = EventLoop::new().unwrap();
-        let ch = SendCh::new(event_loop.channel(), "test");
-        let _ch = ch.clone();
-        let h = thread::spawn(move || {
-            let mut sender = SenderHandler { ch: _ch };
-            event_loop.run(&mut sender).unwrap();
-        });
-
-        ch.try_send(Msg::Stop).unwrap();
-
-        h.join().unwrap();
-    }
-
-    #[test]
-    fn test_sendch_full() {
-        let mut config = EventLoopConfig::new();
-        config.notify_capacity(2);
-        let mut event_loop = EventLoop::configured(config).unwrap();
-        let ch = SendCh::new(event_loop.channel(), "test");
-        let _ch = ch.clone();
-        let h = thread::spawn(move || {
-            let mut sender = SenderHandler { ch: _ch };
-            event_loop.run(&mut sender).unwrap();
-        });
-
-        ch.send(Msg::Sleep(1000)).unwrap();
-        ch.send(Msg::Stop).unwrap();
-        ch.send(Msg::Stop).unwrap();
-        match ch.send(Msg::Stop) {
-            Err(Error::Discard(_)) => {}
-            res => panic!("expect discard error, but found: {:?}", res),
-        }
-
-        h.join().unwrap();
     }
 
     #[test]

--- a/tests/failpoints/cases/test_conf_change.rs
+++ b/tests/failpoints/cases/test_conf_change.rs
@@ -15,8 +15,10 @@ use std::time::Duration;
 
 use fail;
 use futures::Future;
+use raft::eraftpb::ConfChangeType;
 use test_raftstore::*;
 use tikv::pd::PdClient;
+use tikv::util::HandyRwLock;
 
 #[test]
 fn test_destory_local_reader() {
@@ -78,4 +80,75 @@ fn test_destory_local_reader() {
     assert!(resp.unwrap().get_header().has_error());
 
     fail::remove(reader_has_delegate);
+}
+
+#[test]
+fn test_write_after_destroy() {
+    let _guard = ::setup();
+
+    // 3 nodes cluster.
+    let mut cluster = new_server_cluster(0, 3);
+
+    let pd_client = cluster.pd_client.clone();
+    // Disable default max peer count check.
+    pd_client.disable_default_operator();
+
+    let r1 = cluster.run_conf_change();
+
+    // Now region 1 only has peer (1, 1);
+    let (key, value) = (b"k1", b"v1");
+
+    cluster.must_put(key, value);
+    assert_eq!(cluster.get(key), Some(value.to_vec()));
+
+    // add peer (2,2) to region 1.
+    pd_client.must_add_peer(r1, new_peer(2, 2));
+
+    // add peer (3, 3) to region 1.
+    pd_client.must_add_peer(r1, new_peer(3, 3));
+    let engine_3 = cluster.get_engine(3);
+    must_get_equal(&engine_3, b"k1", b"v1");
+
+    let apply_fp = "apply_on_conf_change_1_3_1";
+    fail::cfg(apply_fp, "pause").unwrap();
+
+    cluster.must_transfer_leader(r1, new_peer(1, 1));
+    let conf_change = new_change_peer_request(ConfChangeType::RemoveNode, new_peer(3, 3));
+    let mut epoch = cluster.pd_client.get_region_epoch(r1);
+    let mut admin_req = new_admin_request(r1, &epoch, conf_change);
+    admin_req.mut_header().set_peer(new_peer(1, 1));
+    let (cb1, rx1) = make_cb(&admin_req);
+    let engines_3 = cluster.get_all_engines(3);
+    let region = cluster
+        .pd_client
+        .get_region_by_id(r1)
+        .wait()
+        .unwrap()
+        .unwrap();
+    let reqs = vec![new_put_cmd(b"k5", b"v5")];
+    let new_version = epoch.get_conf_ver() + 1;
+    epoch.set_conf_ver(new_version);
+    let mut put = new_request(r1, epoch, reqs, false);
+    put.mut_header().set_peer(new_peer(1, 1));
+    cluster
+        .sim
+        .rl()
+        .async_command_on_node(1, admin_req, cb1)
+        .unwrap();
+    for _ in 0..100 {
+        let (cb2, _rx2) = make_cb(&put);
+        cluster
+            .sim
+            .rl()
+            .async_command_on_node(1, put.clone(), cb2)
+            .unwrap();
+    }
+    let engine_2 = cluster.get_engine(2);
+    must_get_equal(&engine_2, b"k5", b"v5");
+    fail::remove(apply_fp);
+    let resp = rx1.recv_timeout(Duration::from_secs(2)).unwrap();
+    assert!(!resp.get_header().has_error(), "{:?}", resp);
+    ::std::thread::sleep(Duration::from_secs(3));
+    must_get_none(&engine_3, b"k5");
+    must_region_cleared(&engines_3, &region);
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -164,6 +164,9 @@ fn test_serde_custom_tikv_config() {
         local_read_batch_size: 33,
         apply_max_batch_size: 22,
         apply_pool_size: 4,
+        store_max_batch_size: 21,
+        store_pool_size: 3,
+        future_poll_size: 2,
     };
     value.pd = PdConfig {
         endpoints: vec!["example.com:443".to_owned()],

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -118,6 +118,9 @@ cleanup-import-sst-interval = "12m"
 local-read-batch-size = 33
 apply-max-batch-size = 22
 apply-pool-size = 4
+store-max-batch-size = 21
+store-pool-size = 3
+future-poll-size = 2
 
 [coprocessor]
 split-region-on-table = true

--- a/tests/integrations/raftstore/test_bootstrap.rs
+++ b/tests/integrations/raftstore/test_bootstrap.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use std::path::Path;
-use std::sync::{mpsc, Arc};
+use std::sync::Arc;
 
 use tempdir::TempDir;
 
@@ -22,9 +22,7 @@ use kvproto::raft_serverpb::RegionLocalState;
 use test_raftstore::*;
 use tikv::import::SSTImporter;
 use tikv::raftstore::coprocessor::CoprocessorHost;
-use tikv::raftstore::store::{
-    bootstrap_store, create_event_loop, keys, Engines, Peekable, SnapManager,
-};
+use tikv::raftstore::store::{bootstrap_store, fsm, keys, Engines, Peekable, SnapManager};
 use tikv::server::Node;
 use tikv::storage::{ALL_CFS, CF_RAFT};
 use tikv::util::rocksdb;
@@ -50,7 +48,7 @@ fn test_node_bootstrap_with_prepared_data() {
     let pd_client = Arc::new(TestPdClient::new(0, false));
     let cfg = new_tikv_config(0);
 
-    let mut event_loop = create_event_loop(&cfg.raft_store).unwrap();
+    let (_, system) = fsm::create_raft_batch_system(&cfg.raft_store);
     let simulate_trans = SimulateTransport::new(ChannelTransport::new());
     let tmp_path = TempDir::new("test_cluster").unwrap();
     let engine =
@@ -61,14 +59,8 @@ fn test_node_bootstrap_with_prepared_data() {
     let engines = Engines::new(Arc::clone(&engine), Arc::clone(&raft_engine));
     let tmp_mgr = TempDir::new("test_cluster").unwrap();
 
-    let mut node = Node::new(
-        &mut event_loop,
-        &cfg.server,
-        &cfg.raft_store,
-        Arc::clone(&pd_client),
-    );
+    let mut node = Node::new(system, &cfg.server, &cfg.raft_store, Arc::clone(&pd_client));
     let snap_mgr = SnapManager::new(tmp_mgr.path().to_str().unwrap(), Some(node.get_sendch()));
-    let (_, snapshot_status_receiver) = mpsc::channel();
     let pd_worker = FutureWorker::new("test-pd-worker");
     let local_reader = Worker::new("test-local-reader");
 
@@ -103,11 +95,9 @@ fn test_node_bootstrap_with_prepared_data() {
 
     // try to restart this node, will clear the prepare data
     node.start(
-        event_loop,
         engines,
         simulate_trans,
         snap_mgr,
-        snapshot_status_receiver,
         pd_worker,
         local_reader,
         coprocessor_host,

--- a/tests/integrations/raftstore/test_conf_change.rs
+++ b/tests/integrations/raftstore/test_conf_change.rs
@@ -238,13 +238,6 @@ fn test_pd_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
 }
 
 #[test]
-fn test_node_simple_conf_change() {
-    let count = 5;
-    let mut cluster = new_node_cluster(0, count);
-    test_simple_conf_change(&mut cluster);
-}
-
-#[test]
 fn test_server_simple_conf_change() {
     let count = 5;
     let mut cluster = new_server_cluster(0, count);

--- a/tests/integrations/raftstore/test_snap.rs
+++ b/tests/integrations/raftstore/test_snap.rs
@@ -21,7 +21,7 @@ use kvproto::raft_serverpb::RaftMessage;
 use raft::eraftpb::{Message, MessageType};
 
 use test_raftstore::*;
-use tikv::raftstore::store::Msg;
+use tikv::raftstore::store::*;
 use tikv::raftstore::Result;
 use tikv::util::config::*;
 use tikv::util::HandyRwLock;
@@ -396,7 +396,7 @@ impl Filter<Msg> for SnapshotAppendFilter {
         let mut stale = false;
         for m in msgs.drain(..) {
             let mut should_collect = false;
-            if let Msg::RaftMessage(ref msg) = m {
+            if let Msg::PeerMsg(PeerMsg::RaftMessage(ref msg)) = m {
                 should_collect =
                     !stale && msg.get_message().get_msg_type() == MessageType::MsgSnapshot;
                 stale = !pending_msg.is_empty()


### PR DESCRIPTION
This pr uses the batch/router system introduced in #3972 and #3916
to make raftstore scale.

Note that raft messages can be reordered in current implementation.
But raft-rs is tolerate with it, so this won't be a problem.

# Benchmark results
![default](https://user-images.githubusercontent.com/8407317/51318608-c8091b00-1a95-11e9-9ae4-8e6d92115001.png)
![default](https://user-images.githubusercontent.com/8407317/51318626-cd666580-1a95-11e9-93ef-7c02eb30ff00.png)
