### PR TITLE
raftstore/region_info_accessor: Stale checking only compares conf_ver only when versions are equal

### DIFF
--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -950,10 +950,10 @@ mod tests {
     fn test_merge_impl(to_left: bool, update_first: bool) {
         let mut c = RegionCollector::new();
         let init_regions = &[
-            new_region(1, b"", b"k1", 1),
-            new_region(2, b"k1", b"k2", 1),
-            new_region(3, b"k2", b"k3", 1),
-            new_region(4, b"k3", b"", 1),
+            region_with_conf(1, b"", b"k1", 1, 1),
+            region_with_conf(2, b"k1", b"k2", 1, 100),
+            region_with_conf(3, b"k2", b"k3", 1, 1),
+            region_with_conf(4, b"k3", b"", 1, 100),
         ];
         must_load_regions(&mut c, init_regions);
 
@@ -975,9 +975,9 @@ mod tests {
         }
 
         let final_regions = &[
-            (new_region(1, b"", b"k1", 1), StateRole::Follower),
+            (region_with_conf(1, b"", b"k1", 1, 1), StateRole::Follower),
             (updating_region, StateRole::Follower),
-            (new_region(4, b"k3", b"", 1), StateRole::Follower),
+            (region_with_conf(4, b"k3", b"", 1, 100), StateRole::Follower),
         ];
         check_collection(&c, final_regions);
     }

--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -280,8 +280,13 @@ impl RegionCollector {
         let epoch = region_to_check.get_region_epoch();
         let current_epoch = current.get_region_epoch();
 
+        // Only compare conf_ver when they have the same version.
+        // When a region A merges region B, region B may have a greater conf_ver. Then, the new
+        // merged region meta has larger version but smaller conf_ver than the original B's. In this
+        // case, the incoming region meta has a smaller conf_ver but is not stale.
         epoch.get_version() < current_epoch.get_version()
-            || epoch.get_conf_ver() < current_epoch.get_conf_ver()
+            || (epoch.get_version() == current_epoch.get_version()
+                && epoch.get_conf_ver() < current_epoch.get_conf_ver())
     }
 
     /// For all regions whose range overlaps with the given `region` or region_id is the same as


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

In function `is_region_epoch_stale`, only compares `conf_ver` when they have the same version.
When a region A merges region B, region B may have a greater conf_ver. Then, the new merged region meta has larger version but smaller conf_ver than the original B's. In this case, the incoming region meta has a smaller conf_ver but is not stale.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

- By unit tests

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

NO