### PR TITLE
test: fix epollex error on macOS

### DIFF
--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -45,7 +45,6 @@ pub fn setup_for_ci() {
 
     // HACK! Always use epollex in tests.
     // See more: https://github.com/grpc/grpc/blob/v1.17.2/src/core/lib/iomgr/ev_posix.cc#L124
-
     #[cfg(target_os = "linux")]
     env::set_var("GRPC_POLL_STRATEGY", "epollex");
 

--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -43,7 +43,7 @@ pub fn setup_for_ci() {
         tikv::util::set_panic_hook(true, "./");
     }
 
-    // HACK! Always use epollex in tests on linux.
+    // HACK! Always use epollex in tests on Linux.
     // See more: https://github.com/grpc/grpc/blob/v1.17.2/src/core/lib/iomgr/ev_posix.cc#L124
     #[cfg(target_os = "linux")]
     env::set_var("GRPC_POLL_STRATEGY", "epollex");

--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -43,7 +43,7 @@ pub fn setup_for_ci() {
         tikv::util::set_panic_hook(true, "./");
     }
 
-    // HACK! Always use epollex in tests.
+    // HACK! Always use epollex in tests on linux.
     // See more: https://github.com/grpc/grpc/blob/v1.17.2/src/core/lib/iomgr/ev_posix.cc#L124
     #[cfg(target_os = "linux")]
     env::set_var("GRPC_POLL_STRATEGY", "epollex");

--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -45,6 +45,8 @@ pub fn setup_for_ci() {
 
     // HACK! Always use epollex in tests.
     // See more: https://github.com/grpc/grpc/blob/v1.17.2/src/core/lib/iomgr/ev_posix.cc#L124
+
+    #[cfg(target_os = "linux")]
     env::set_var("GRPC_POLL_STRATEGY", "epollex");
 
     tikv::util::check_environment_variables();


### PR DESCRIPTION
Signed-off-by: Max <xiahaijiao@hotmail.com>


## What have you changed? (mandatory)
This PR fixes the error which appears on macOS when runs `make test`,
```
E0117 15:57:03.064976000 123145333387264 ev_posix.cc:227]              No event engine could be initialized from epollex
```
by canceling setting `GRPC_POLL_STRATEGY=epollex` to the environment.

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)
manual test.

## Does this PR affect documentation (docs) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No
