### PR TITLE
raftstore: adjust leader metircs

### DIFF
--- a/src/raftstore/coprocessor/metrics.rs
+++ b/src/raftstore/coprocessor/metrics.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use prometheus::{exponential_buckets, Histogram};
+use prometheus::{exponential_buckets, Histogram, IntGaugeVec};
 
 lazy_static! {
     pub static ref REGION_SIZE_HISTOGRAM: Histogram = register_histogram!(
@@ -19,9 +19,17 @@ lazy_static! {
         "Bucketed histogram of approximate region size.",
         exponential_buckets(1024.0 * 1024.0, 2.0, 20).unwrap() // max bucket would be 512GB
     ).unwrap();
+
     pub static ref REGION_KEYS_HISTOGRAM: Histogram = register_histogram!(
         "tikv_raftstore_region_keys",
         "Bucketed histogram of approximate region keys.",
         exponential_buckets(1.0, 2.0, 30).unwrap()
+    ).unwrap();
+
+    pub static ref REGION_COLLECTOR_COUNT_GAUGE_VEC: IntGaugeVec =
+    register_int_gauge_vec!(
+        "tikv_raftstore_region_collector_region_count",
+        "Number of regions collected in region_collector",
+        &["type"]
     ).unwrap();
 }

--- a/src/raftstore/coprocessor/metrics.rs
+++ b/src/raftstore/coprocessor/metrics.rs
@@ -26,9 +26,9 @@ lazy_static! {
         exponential_buckets(1.0, 2.0, 30).unwrap()
     ).unwrap();
 
-    pub static ref REGION_COLLECTOR_COUNT_GAUGE_VEC: IntGaugeVec =
+    pub static ref REGION_COUNT_GAUGE_VEC: IntGaugeVec =
     register_int_gauge_vec!(
-        "tikv_raftstore_region_collector_region_count",
+        "tikv_raftstore_region_count",
         "Number of regions collected in region_collector",
         &["type"]
     ).unwrap();

--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -489,7 +489,8 @@ impl RegionInfoAccessor {
 
     /// Starts the `RegionInfoAccessor`. It should be started before raftstore.
     pub fn start(&self) {
-        let timer = Timer::new(METRICS_FLUSH_INTERVAL as usize);
+        let mut timer = Timer::new(1);
+        timer.add_task(Duration::from_secs(METRICS_FLUSH_INTERVAL), ());
         self.worker
             .lock()
             .unwrap()

--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -442,7 +442,7 @@ impl Runnable<RegionCollectorMsg> for RegionCollector {
     }
 }
 
-const METRICS_FLUSH_INTERVAL: u64 = 10; // 10s
+const METRICS_FLUSH_INTERVAL: u64 = 10000; // 10s
 
 impl RunnableWithTimer<RegionCollectorMsg, ()> for RegionCollector {
     fn on_timeout(&mut self, timer: &mut Timer<()>, _: ()) {
@@ -454,13 +454,13 @@ impl RunnableWithTimer<RegionCollectorMsg, ()> for RegionCollector {
                 leader += 1;
             }
         }
-        REGION_COLLECTOR_COUNT_GAUGE_VEC
+        REGION_COUNT_GAUGE_VEC
             .with_label_values(&["region"])
             .set(count);
-        REGION_COLLECTOR_COUNT_GAUGE_VEC
+        REGION_COUNT_GAUGE_VEC
             .with_label_values(&["leader"])
             .set(leader);
-        timer.add_task(Duration::from_secs(METRICS_FLUSH_INTERVAL), ());
+        timer.add_task(Duration::from_millis(METRICS_FLUSH_INTERVAL), ());
     }
 }
 
@@ -490,7 +490,7 @@ impl RegionInfoAccessor {
     /// Starts the `RegionInfoAccessor`. It should be started before raftstore.
     pub fn start(&self) {
         let mut timer = Timer::new(1);
-        timer.add_task(Duration::from_secs(METRICS_FLUSH_INTERVAL), ());
+        timer.add_task(Duration::from_millis(METRICS_FLUSH_INTERVAL), ());
         self.worker
             .lock()
             .unwrap()

--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -442,7 +442,7 @@ impl Runnable<RegionCollectorMsg> for RegionCollector {
     }
 }
 
-const METRICS_FLUSH_INTERVAL: u64 = 10000; // 10s
+const METRICS_FLUSH_INTERVAL: u64 = 10_000; // 10s
 
 impl RunnableWithTimer<RegionCollectorMsg, ()> for RegionCollector {
     fn on_timeout(&mut self, timer: &mut Timer<()>, _: ()) {

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -1504,9 +1504,6 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
             let meta = self.ctx.store_meta.lock().unwrap();
             stats.set_region_count(meta.regions.len() as u32);
         }
-        STORE_PD_HEARTBEAT_GAUGE_VEC
-            .with_label_values(&["region"])
-            .set(i64::from(stats.get_region_count()));
 
         let snap_stats = self.ctx.snap_mgr.stats();
         stats.set_sending_snap_count(snap_stats.sending_count as u32);

--- a/src/raftstore/store/metrics.rs
+++ b/src/raftstore/store/metrics.rs
@@ -70,13 +70,6 @@ lazy_static! {
             &["type"]
         ).unwrap();
 
-    pub static ref STORE_PD_HEARTBEAT_GAUGE_VEC: IntGaugeVec =
-        register_int_gauge_vec!(
-            "tikv_pd_heartbeat_tick_total",
-            "Total number of pd heartbeat ticks.",
-            &["type"]
-        ).unwrap();
-
     pub static ref STORE_SNAPSHOT_TRAFFIC_GAUGE_VEC: IntGaugeVec =
         register_int_gauge_vec!(
             "tikv_raftstore_snapshot_traffic_total",

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -499,7 +499,7 @@ impl<C: Sender<StoreMsg>> Runnable<Task> for LocalReader<C> {
     }
 }
 
-const METRICS_FLUSH_INTERVAL: u64 = 15000; // 15s
+const METRICS_FLUSH_INTERVAL: u64 = 15_000; // 15s
 
 impl<C: Sender<StoreMsg>> RunnableWithTimer<Task, ()> for LocalReader<C> {
     fn on_timeout(&mut self, timer: &mut Timer<()>, _: ()) {

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -499,12 +499,12 @@ impl<C: Sender<StoreMsg>> Runnable<Task> for LocalReader<C> {
     }
 }
 
-const METRICS_FLUSH_INTERVAL: u64 = 15; // 15s
+const METRICS_FLUSH_INTERVAL: u64 = 15000; // 15s
 
 impl<C: Sender<StoreMsg>> RunnableWithTimer<Task, ()> for LocalReader<C> {
     fn on_timeout(&mut self, timer: &mut Timer<()>, _: ()) {
         self.metrics.borrow_mut().flush();
-        timer.add_task(Duration::from_secs(METRICS_FLUSH_INTERVAL), ());
+        timer.add_task(Duration::from_millis(METRICS_FLUSH_INTERVAL), ());
     }
 }
 


### PR DESCRIPTION
## What have you changed? (mandatory)
After adding threaded raftstore, it is hard to collect the leader count in raftstore. So record this metrics in `region_info_accessor` which has a global view of all the regions of this store.

## What are the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
manual-test

## Does this PR affect documentation (docs) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
https://github.com/pingcap/tidb-ansible/pull/668
