### PR TITLE
add update api

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,10 +21,12 @@ use std::io::Error as IoError;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::usize;
+use std::mem;
+use std::collections::HashMap;
 
 use rocksdb::{
     BlockBasedOptions, ColumnFamilyOptions, CompactionPriority, DBCompactionStyle,
-    DBCompressionType, DBOptions, DBRecoveryMode, TitanDBOptions,
+    DBCompressionType, DBOptions, DBRecoveryMode, TitanDBOptions, MergeOperands,
 };
 use slog;
 use sys_info;
@@ -55,6 +57,8 @@ const LOCKCF_MAX_MEM: usize = GB as usize;
 const RAFT_MIN_MEM: usize = 256 * MB as usize;
 const RAFT_MAX_MEM: usize = 2 * GB as usize;
 pub const LAST_CONFIG_FILE: &str = "last_tikv.toml";
+
+const SIZE_LEN: usize = 4 as usize;
 
 fn memory_mb_for_cf(is_raft_db: bool, cf: &str) -> usize {
     let total_mem = sys_info::mem_info().unwrap().total * KB;
@@ -201,6 +205,7 @@ macro_rules! build_cf_opt {
         cf_opts.set_soft_pending_compaction_bytes_limit($opt.soft_pending_compaction_bytes_limit.0);
         cf_opts.set_hard_pending_compaction_bytes_limit($opt.hard_pending_compaction_bytes_limit.0);
         cf_opts.set_optimize_filters_for_hits($opt.optimize_filters_for_hits);
+        cf_opts.add_merge_operator("update operator", update_merge);
 
         cf_opts
     }};
@@ -1274,6 +1279,133 @@ pub fn check_and_persist_critical_config(config: &TiKvConfig) -> Result<(), Stri
 
     Ok(())
 }
+
+/**
+|total_size|key1_size|key1|value1_size|value1|key2_size|key2|value2_size|value2|...
+all size is four bytes.
+existing_value : existing_val
+operand_list   : operands
+new_value      : result
+Note: little endian Coding
+*/
+fn update_merge(_: &[u8], existing_val: Option<&[u8]>, operands: &mut MergeOperands) -> Vec<u8> {
+    let mut result: Vec<u8> = Vec::with_capacity(operands.size_hint().0);
+    let arr : [u8; SIZE_LEN] = [0, 0, 0, 0];
+    result.extend_from_slice(&arr[..]);
+
+    let mut map_index = HashMap::new();
+
+    let mut total_size  = 0;
+    total_size += SIZE_LEN;
+
+    let mut v = Vec::new();
+    for op in operands {
+        v.push(op);
+    }
+    let len = v.len();
+
+    for i in 0..len {
+        let op_value : &[u8] = v.get( len-1-i ).unwrap();
+        let mut begin = 0;
+        begin += SIZE_LEN ;
+
+        let op_len = op_value.len();
+        while begin < op_len {
+            let first = begin;
+            //decode key size
+            let key_size = decode_size(&op_value, begin);
+
+            //decode key
+            begin = begin + SIZE_LEN;
+            let end = begin + key_size;
+            let key = &op_value[begin..end];
+
+            //decode value size
+            begin = end;
+            let value_size = decode_size(&op_value, begin);
+
+            //decode value
+            begin = begin + SIZE_LEN;
+            let end = begin + value_size;
+            //let value = &op_value[begin..end];
+
+            if let None = map_index.get(&key) {
+                map_index.entry(key).or_insert(1);
+
+                if value_size != 0 {
+                    result.extend_from_slice(&op_value[first..end]);
+                    total_size += 2*SIZE_LEN + key_size + value_size;
+                }
+
+            }
+            begin = end;
+        }
+    }
+
+    if let Some(existing_value) = existing_val {
+        let mut begin= 0;
+        let exist_total_size = existing_value.len();
+
+        begin += SIZE_LEN ;
+
+        while begin < exist_total_size {
+            //decode key size
+            let first = begin;
+            //decode key size
+            let key_size = decode_size(&existing_value, begin);
+
+            //decode key
+            begin = begin + SIZE_LEN;
+            let end = begin + key_size;
+            let key = &existing_value[begin..end];
+
+
+            //decode value size
+            begin = end;
+            let value_size = decode_size(&existing_value, begin);
+
+            //decode value
+            begin = end;
+            let end = begin + value_size;
+            //let value = &existing_value[begin..end];
+
+            if let Some(_) = map_index.get(&key) {
+                begin = end;
+                continue;
+            }
+
+            if value_size != 0 {
+                result.extend_from_slice(&existing_value[first..end]);
+                total_size += 2*SIZE_LEN + key_size + value_size;
+            }
+            begin = end;
+        }
+    }
+
+    let res_u8;
+    unsafe {
+        res_u8 = mem::transmute::<u32, [u8; SIZE_LEN]>(total_size as u32);
+    }
+    for i in 0..SIZE_LEN {
+        if let Some(elem) = result.get_mut(i) {
+            *elem = res_u8[i];
+        }
+    }
+
+    result
+}
+
+fn decode_size(value: &[u8], begin: usize) -> usize {
+    //decode key or value size
+    let end = begin + SIZE_LEN;
+    let vv = &value[begin..end];
+    let ptr: *const u8  = vv.as_ptr();
+    let ptr: *const u32 = ptr as *const u32;
+    let key_size = unsafe{ *ptr } as usize;
+    return key_size
+}
+
+
 
 #[cfg(test)]
 mod tests {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1951,7 +1951,7 @@ pub trait RequestInspector {
         for r in req.get_requests() {
             match r.get_cmd_type() {
                 CmdType::Get | CmdType::Snap => has_read = true,
-                CmdType::Delete | CmdType::Put | CmdType::DeleteRange | CmdType::IngestSST => {
+                CmdType::Delete | CmdType::Put | CmdType::Update | CmdType::DeleteRange | CmdType::IngestSST => {
                     has_write = true
                 }
                 CmdType::Prewrite | CmdType::Invalid => {
@@ -2135,6 +2135,7 @@ impl ReadExecutor {
                 }
                 CmdType::Prewrite
                 | CmdType::Put
+                | CmdType::Update
                 | CmdType::Delete
                 | CmdType::DeleteRange
                 | CmdType::IngestSST

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -202,6 +202,7 @@ impl Task {
                             CmdType::Get | CmdType::Snap => (),
                             CmdType::Delete
                             | CmdType::Put
+                            | CmdType::Update
                             | CmdType::DeleteRange
                             | CmdType::Prewrite
                             | CmdType::IngestSST

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -34,6 +34,8 @@ make_static_metric! {
         raw_batch_scan,
         raw_put,
         raw_batch_put,
+        raw_update,
+        raw_batch_update,
         raw_delete,
         raw_delete_range,
         raw_batch_delete,

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -386,6 +386,86 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         ctx.spawn(future);
     }
 
+    fn raw_update(&mut self, ctx: RpcContext, mut req: RawUpdateRequest, sink: UnarySink<RawUpdateResponse>) {
+        let timer = GRPC_MSG_HISTOGRAM_VEC.raw_update.start_coarse_timer();
+
+        let (cb, future) = paired_future_callback();
+        let res = self.storage.async_raw_update(
+            req.take_context(),
+            req.take_cf(),
+            req.take_key(),
+            req.take_value(),
+            cb,
+        );
+
+        if let Err(e) = res {
+            self.send_fail_status(ctx, sink, Error::from(e), RpcStatusCode::ResourceExhausted);
+            return;
+        }
+
+        let future = future
+            .map_err(Error::from)
+            .map(|v|{
+                let mut resp = RawUpdateResponse::new();
+                if let Some(err) = extract_region_error(&v) {
+                    resp.set_region_error(err);
+                } else if let Err(e) = v {
+                    resp.set_error(format!("{}", e));
+                }
+                resp
+            })
+            .and_then(|res| sink.success(res).map_err(Error::from))
+            .map(|_| timer.observe_duration())
+            .map_err(move |e| {
+                debug!("{} failed {:?}", "raw_update", e);
+                GRPC_MSG_FAIL_COUNTER.raw_update.inc();
+            });
+        ctx.spawn(future);
+    }
+
+    fn raw_batch_update(
+        &mut self,
+        ctx: RpcContext,
+        mut req: RawBatchUpdateRequest,
+        sink: UnarySink<RawBatchUpdateResponse>,
+    ) {
+        let timer = GRPC_MSG_HISTOGRAM_VEC.raw_batch_update.start_coarse_timer();
+
+        let pairs = req
+            .take_pairs()
+            .into_iter()
+            .map(|mut x| (x.take_key(), x.take_value()))
+            .collect();
+
+        let (cb, future) = paired_future_callback();
+        let res = self
+            .storage
+            .async_raw_batch_update(req.take_context(), req.take_cf(), pairs, cb);
+        if let Err(e) = res {
+            self.send_fail_status(ctx, sink, Error::from(e), RpcStatusCode::ResourceExhausted);
+            return;
+        }
+
+        let future = future
+            .map_err(Error::from)
+            .map(|v| {
+                let mut resp = RawBatchUpdateResponse::new();
+                if let Some(err) = extract_region_error(&v) {
+                    resp.set_region_error(err);
+                } else if let Err(e) = v {
+                    resp.set_error(format!("{}", e));
+                }
+                resp
+            })
+            .and_then(|res| sink.success(res).map_err(Error::from))
+            .map(|_| timer.observe_duration())
+            .map_err(move |e| {
+                debug!("{} failed: {:?}", "raw_batch_update", e);
+                GRPC_MSG_FAIL_COUNTER.raw_batch_update.inc();
+            });
+        ctx.spawn(future);
+    }
+
     fn raw_delete(
         &mut self,
         ctx: RpcContext,

--- a/src/storage/engine/btree_engine.rs
+++ b/src/storage/engine/btree_engine.rs
@@ -272,6 +272,7 @@ fn write_modifies(engine: &BTreeEngine, modifies: Vec<Modify>) -> EngineResult<(
                 let cf_tree = engine.get_cf(cf);
                 cf_tree.write().unwrap().remove(&k);
             }
+            Modify::Update(_cf, _k, _v) => unimplemented!(), 
             Modify::Put(cf, k, v) => {
                 let cf_tree = engine.get_cf(cf);
                 cf_tree.write().unwrap().insert(k, v);

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -66,6 +66,7 @@ impl CbContext {
 pub enum Modify {
     Delete(CfName, Key),
     Put(CfName, Key, Value),
+    Update(CfName, Key, Value),
     DeleteRange(CfName, Key, Key),
 }
 

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use kvproto::errorpb;
 use kvproto::kvrpcpb::Context;
 use kvproto::raft_cmdpb::{
-    CmdType, DeleteRangeRequest, DeleteRequest, PutRequest, RaftCmdRequest, RaftCmdResponse,
+    CmdType, DeleteRangeRequest, DeleteRequest, PutRequest, UpdateRequest, RaftCmdRequest, RaftCmdResponse,
     RaftRequestHeader, Request, Response,
 };
 use protobuf::RepeatedField;
@@ -291,6 +291,16 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
                     }
                     req.set_cmd_type(CmdType::Put);
                     req.set_put(put);
+                }
+                Modify::Update(cf, k, v) => {
+                    let mut update = UpdateRequest::new();
+                    update.set_key(k.into_encoded());
+                    update.set_value(v);
+                    if cf != CF_DEFAULT {
+                        update.set_cf(cf.to_string());
+                    }
+                    req.set_cmd_type(CmdType::Update);
+                    req.set_update(update);
                 }
                 Modify::DeleteRange(cf, start_key, end_key) => {
                     let mut delete_range = DeleteRangeRequest::new();

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -213,6 +213,14 @@ fn write_modifies(db: &DB, modifies: Vec<Modify>) -> Result<()> {
                 let handle = rocksdb::get_cf_handle(db, cf)?;
                 wb.put_cf(handle, k.as_encoded(), &v)
             },
+            Modify::Update(cf, k, v) => if cf == CF_DEFAULT {
+                trace!("RocksEngine: update {}, {}", k, escape(&v));
+                wb.merge(k.as_encoded(), &v)
+            } else {
+                trace!("RocksEngine: update_cf {}, {}, {}", cf, k, escape(&v));
+                let handle = rocksdb::get_cf_handle(db, cf)?;
+                wb.merge_cf(handle, k.as_encoded(), &v)
+            },
             Modify::DeleteRange(cf, start_key, end_key) => {
                 trace!(
                     "RocksEngine: delete_range_cf {}, {}, {}",


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
Signed-off-by: fredchenbj <cfworking@163.com>

## What have you changed? (mandatory)
Use rocksdb `merge`  to implement tikv's update api. I add update logic in tikv-server layer and add a new merge operator `update_merge` to present a table-style colomn's update.
Other Points: 
- to compile this pr, need to replace kvproto with pr(https://github.com/pingcap/kvproto/pull/342)
- and maybe fix this compile error of rust-rocksdb(https://github.com/pingcap/rust-rocksdb/issues/264)


## What are the type of the changes? (mandatory)
new feature

## How has this PR been tested? (mandatory)
manual tests

## Does this PR affect documentation (docs) update? (mandatory)
no

## Does this PR affect tidb-ansible update? (mandatory)
no


## Refer to a related PR or issue link (optional)
https://github.com/pingcap/kvproto/pull/342

