### PR TITLE
Cargo: disable procinfo on non-Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,6 @@ rust-crypto = "^0.2"
 base64 = "0.10"
 safemem = "0.3"
 smallvec = { version = "0.6", features = ["union"] }
-procinfo = { git = "https://github.com/tikv/procinfo-rs" }
 flate2 = { version = "1.0", features = ["zlib"], default-features = false }
 more-asserts = "0.1"
 hyper = "0.12"
@@ -143,6 +142,9 @@ arrow = "0.10.0"
 
 [target.'cfg(unix)'.dependencies]
 signal = "0.6"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+procinfo = { git = "https://github.com/tikv/procinfo-rs" }
 
 [workspace]
 members = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ extern crate num;
 extern crate num_traits;
 #[macro_use]
 extern crate prometheus;
+#[cfg(target_os = "linux")]
 extern crate procinfo;
 extern crate prometheus_static_metric;
 extern crate protobuf;


### PR DESCRIPTION
## What have you changed? (mandatory)

Fix complie error on non-Linux by disable the procinfo crate.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

Manually, maybe we should test macOS build on CircleCI?

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

Close #4130.
