### PR TITLE
Upgrade to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "tikv"
 version = "3.0.0-beta"
+edition = "2018"
 keywords = ["KV", "distributed-systems", "raft"]
 publish = false
 

--- a/benches/misc/raftkv/mod.rs
+++ b/benches/misc/raftkv/mod.rs
@@ -13,9 +13,9 @@
 
 use std::sync::Arc;
 
-use rocksdb::DB;
+use ::rocksdb::DB;
 use tempdir::TempDir;
-use test;
+use ::test;
 
 use kvproto::kvrpcpb::Context;
 use kvproto::metapb::Region;

--- a/benches/misc/raftkv/mod.rs
+++ b/benches/misc/raftkv/mod.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use ::rocksdb::DB;
 use tempdir::TempDir;
-use ::test;
+use crate::test;
 
 use kvproto::kvrpcpb::Context;
 use kvproto::metapb::Region;

--- a/benches/misc/raftkv/mod.rs
+++ b/benches/misc/raftkv/mod.rs
@@ -13,9 +13,9 @@
 
 use std::sync::Arc;
 
+use crate::test;
 use ::rocksdb::DB;
 use tempdir::TempDir;
-use crate::test;
 
 use kvproto::kvrpcpb::Context;
 use kvproto::metapb::Region;

--- a/components/codec/Cargo.toml
+++ b/components/codec/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "codec"
 version = "0.0.1"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -795,7 +795,7 @@ mod tests {
 
 #[cfg(test)]
 mod benches {
-    use ::test;
+    use crate::test;
 
     /// A naive implementation of encoding in mem-comparable format.
     /// It does not process non zero-padding groups separately.

--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -795,7 +795,7 @@ mod tests {
 
 #[cfg(test)]
 mod benches {
-    use test;
+    use ::test;
 
     /// A naive implementation of encoding in mem-comparable format.
     /// It does not process non zero-padding groups separately.

--- a/components/codec/src/number.rs
+++ b/components/codec/src/number.rs
@@ -1640,7 +1640,7 @@ mod tests {
 
 #[cfg(test)]
 mod benches {
-    use test;
+    use ::test;
 
     use byteorder;
     use protobuf::CodedOutputStream;

--- a/components/codec/src/number.rs
+++ b/components/codec/src/number.rs
@@ -1552,7 +1552,7 @@ mod tests {
 
                 // Buffer decode with insufficient space
                 for buf_len in 0..len {
-                    let mut payload: Vec<u8> = base_buf[0..buf_len].to_vec();
+                    let payload: Vec<u8> = base_buf[0..buf_len].to_vec();
 
                     // Starting from any position in the buffer
                     for pos in 0usize..buf_len {

--- a/components/codec/src/number.rs
+++ b/components/codec/src/number.rs
@@ -1640,7 +1640,7 @@ mod tests {
 
 #[cfg(test)]
 mod benches {
-    use ::test;
+    use crate::test;
 
     use byteorder;
     use protobuf::CodedOutputStream;

--- a/components/cop_datatype/Cargo.toml
+++ b/components/cop_datatype/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cop_datatype"
 version = "0.0.1"
+edition = "2018"
 publish = false
 description = "TiKV Coprocessor data types"
 

--- a/components/cop_datatype/src/def/eval_type.rs
+++ b/components/cop_datatype/src/def/eval_type.rs
@@ -35,34 +35,34 @@ impl fmt::Display for EvalType {
     }
 }
 
-impl ::std::convert::TryFrom<::FieldTypeTp> for EvalType {
-    type Error = ::DataTypeError;
+impl ::std::convert::TryFrom<crate::FieldTypeTp> for EvalType {
+    type Error = crate::DataTypeError;
 
-    fn try_from(tp: ::FieldTypeTp) -> Result<Self, ::DataTypeError> {
+    fn try_from(tp: crate::FieldTypeTp) -> Result<Self, crate::DataTypeError> {
         let eval_type = match tp {
-            ::FieldTypeTp::Tiny
-            | ::FieldTypeTp::Short
-            | ::FieldTypeTp::Int24
-            | ::FieldTypeTp::Long
-            | ::FieldTypeTp::LongLong
-            | ::FieldTypeTp::Year => EvalType::Int,
-            ::FieldTypeTp::Float | ::FieldTypeTp::Double => EvalType::Real,
-            ::FieldTypeTp::NewDecimal => EvalType::Decimal,
-            ::FieldTypeTp::Timestamp | ::FieldTypeTp::Date | ::FieldTypeTp::DateTime => {
+            crate::FieldTypeTp::Tiny
+            | crate::FieldTypeTp::Short
+            | crate::FieldTypeTp::Int24
+            | crate::FieldTypeTp::Long
+            | crate::FieldTypeTp::LongLong
+            | crate::FieldTypeTp::Year => EvalType::Int,
+            crate::FieldTypeTp::Float | crate::FieldTypeTp::Double => EvalType::Real,
+            crate::FieldTypeTp::NewDecimal => EvalType::Decimal,
+            crate::FieldTypeTp::Timestamp | crate::FieldTypeTp::Date | crate::FieldTypeTp::DateTime => {
                 EvalType::DateTime
             }
-            ::FieldTypeTp::Duration => EvalType::Duration,
-            ::FieldTypeTp::JSON => EvalType::Json,
-            ::FieldTypeTp::VarChar
-            | ::FieldTypeTp::TinyBlob
-            | ::FieldTypeTp::MediumBlob
-            | ::FieldTypeTp::LongBlob
-            | ::FieldTypeTp::Blob
-            | ::FieldTypeTp::VarString
-            | ::FieldTypeTp::String => EvalType::Bytes,
+            crate::FieldTypeTp::Duration => EvalType::Duration,
+            crate::FieldTypeTp::JSON => EvalType::Json,
+            crate::FieldTypeTp::VarChar
+            | crate::FieldTypeTp::TinyBlob
+            | crate::FieldTypeTp::MediumBlob
+            | crate::FieldTypeTp::LongBlob
+            | crate::FieldTypeTp::Blob
+            | crate::FieldTypeTp::VarString
+            | crate::FieldTypeTp::String => EvalType::Bytes,
             _ => {
                 // Note: In TiDB, Bit's eval type is Int, but it is not yet supported in TiKV.
-                return Err(::DataTypeError::UnsupportedType {
+                return Err(crate::DataTypeError::UnsupportedType {
                     name: tp.to_string(),
                 });
             }

--- a/components/cop_datatype/src/def/eval_type.rs
+++ b/components/cop_datatype/src/def/eval_type.rs
@@ -48,9 +48,9 @@ impl ::std::convert::TryFrom<crate::FieldTypeTp> for EvalType {
             | crate::FieldTypeTp::Year => EvalType::Int,
             crate::FieldTypeTp::Float | crate::FieldTypeTp::Double => EvalType::Real,
             crate::FieldTypeTp::NewDecimal => EvalType::Decimal,
-            crate::FieldTypeTp::Timestamp | crate::FieldTypeTp::Date | crate::FieldTypeTp::DateTime => {
-                EvalType::DateTime
-            }
+            crate::FieldTypeTp::Timestamp
+            | crate::FieldTypeTp::Date
+            | crate::FieldTypeTp::DateTime => EvalType::DateTime,
             crate::FieldTypeTp::Duration => EvalType::Duration,
             crate::FieldTypeTp::JSON => EvalType::Json,
             crate::FieldTypeTp::VarChar

--- a/components/log_wrappers/Cargo.toml
+++ b/components/log_wrappers/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "log_wrappers"
 version = "0.0.1"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/components/log_wrappers/src/lib.rs
+++ b/components/log_wrappers/src/lib.rs
@@ -64,7 +64,7 @@ impl<T: ::std::fmt::Debug> ::slog::Value for DebugValue<T> {
 #[cfg(test)]
 #[test]
 fn test_debug() {
-    let buffer = ::test_util::SyncLoggerBuffer::new();
+    let buffer = crate::test_util::SyncLoggerBuffer::new();
     let logger = buffer.build_logger();
 
     slog_info!(logger, "foo"; "bar" => DebugValue(&::std::time::Duration::from_millis(2500)));
@@ -105,7 +105,7 @@ impl<'a> ::slog::Value for Key<'a> {
 #[cfg(test)]
 #[test]
 fn test_log_key() {
-    let buffer = ::test_util::SyncLoggerBuffer::new();
+    let buffer = crate::test_util::SyncLoggerBuffer::new();
     let logger = buffer.build_logger();
     slog_info!(logger, "foo"; "bar" => Key(b"\xAB \xCD"));
     assert_eq!(&buffer.as_string(), "TIME INFO foo, bar: AB20CD\n");
@@ -113,7 +113,7 @@ fn test_log_key() {
 
 pub mod kvproto {
     pub mod kvrpcpb {
-        pub struct KeyRange<'a>(pub &'a ::lib_kvproto::kvrpcpb::KeyRange);
+        pub struct KeyRange<'a>(pub &'a crate::lib_kvproto::kvrpcpb::KeyRange);
 
         impl<'a> ::slog::Value for KeyRange<'a> {
             #[inline]
@@ -137,10 +137,10 @@ pub mod kvproto {
         #[cfg(test)]
         #[test]
         fn test_key_range() {
-            let buffer = ::test_util::SyncLoggerBuffer::new();
+            let buffer = crate::test_util::SyncLoggerBuffer::new();
             let logger = buffer.build_logger();
 
-            let mut range = ::lib_kvproto::kvrpcpb::KeyRange::new();
+            let mut range = crate::lib_kvproto::kvrpcpb::KeyRange::new();
             range.set_start_key(b"\x20\x00".to_vec());
             range.set_end_key(b"\x31\xFF\x12a".to_vec());
             slog_info!(logger, "foo"; "bar" => KeyRange(&range));
@@ -150,13 +150,13 @@ pub mod kvproto {
             );
 
             buffer.clear();
-            let mut range = ::lib_kvproto::kvrpcpb::KeyRange::new();
+            let mut range = crate::lib_kvproto::kvrpcpb::KeyRange::new();
             range.set_end_key(b"\x31".to_vec());
             slog_info!(logger, "foo"; "bar" => KeyRange(&range));
             assert_eq!(&buffer.as_string(), "TIME INFO foo, bar: [, 31)\n");
 
             buffer.clear();
-            let mut range = ::lib_kvproto::kvrpcpb::KeyRange::new();
+            let mut range = crate::lib_kvproto::kvrpcpb::KeyRange::new();
             range.set_start_key(b"\xC0".to_vec());
             slog_info!(logger, "foo"; "bar" => KeyRange(&range));
             assert_eq!(&buffer.as_string(), "TIME INFO foo, bar: [C0, )\n");
@@ -164,7 +164,7 @@ pub mod kvproto {
     }
 
     pub mod coprocessor {
-        pub struct KeyRange<'a>(pub &'a ::lib_kvproto::coprocessor::KeyRange);
+        pub struct KeyRange<'a>(pub &'a crate::lib_kvproto::coprocessor::KeyRange);
 
         // Similar to `kvrpcpb::KeyRange`. Tests are ignored.
         impl<'a> ::slog::Value for KeyRange<'a> {

--- a/components/panic_hook/Cargo.toml
+++ b/components/panic_hook/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
 name = "panic_hook"
 version = "0.0.1"
+edition = "2018"
 publish = false

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "test_coprocessor"
 version = "0.0.1"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/components/test_coprocessor/src/lib.rs
+++ b/components/test_coprocessor/src/lib.rs
@@ -27,9 +27,9 @@ mod store;
 mod table;
 mod util;
 
-pub use column::*;
-pub use dag::*;
-pub use fixture::*;
-pub use store::*;
-pub use table::*;
-pub use util::*;
+pub use crate::column::*;
+pub use crate::dag::*;
+pub use crate::fixture::*;
+pub use crate::store::*;
+pub use crate::table::*;
+pub use crate::util::*;

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "test_raftstore"
 version = "0.0.1"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -52,7 +52,7 @@ pub trait Simulator {
         &mut self,
         node_id: u64,
         cfg: TiKvConfig,
-        Option<Engines>,
+        _: Option<Engines>,
     ) -> (u64, Engines, Option<TempDir>);
     fn stop_node(&mut self, node_id: u64);
     fn get_node_ids(&self) -> HashSet<u64>;

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -17,7 +17,7 @@ use std::time::*;
 use std::{result, thread};
 
 use futures::Future;
-use rocksdb::DB;
+use ::rocksdb::DB;
 use tempdir::TempDir;
 
 use kvproto::errorpb::Error as PbError;

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -16,8 +16,8 @@ use std::sync::{self, Arc, RwLock};
 use std::time::*;
 use std::{result, thread};
 
-use futures::Future;
 use ::rocksdb::DB;
+use futures::Future;
 use tempdir::TempDir;
 
 use kvproto::errorpb::Error as PbError;

--- a/components/test_raftstore/src/lib.rs
+++ b/components/test_raftstore/src/lib.rs
@@ -47,9 +47,9 @@ mod server;
 mod transport_simulate;
 mod util;
 
-pub use cluster::*;
-pub use node::*;
-pub use pd::*;
-pub use server::*;
-pub use transport_simulate::*;
-pub use util::*;
+pub use crate::cluster::*;
+pub use crate::node::*;
+pub use crate::pd::*;
+pub use crate::server::*;
+pub use crate::transport_simulate::*;
+pub use crate::util::*;

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use std::{thread, usize};
 
-use grpc::{EnvBuilder, Error as GrpcError};
+use crate::grpc::{EnvBuilder, Error as GrpcError};
 use kvproto::raft_cmdpb::*;
 use kvproto::raft_serverpb::{self, RaftMessage};
 use tempdir::TempDir;

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -16,9 +16,9 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 use std::{thread, u64};
 
+use ::rocksdb::{CompactionJobInfo, DB};
 use protobuf;
 use rand::Rng;
-use ::rocksdb::{CompactionJobInfo, DB};
 use tempdir::TempDir;
 
 use kvproto::metapb::{self, RegionEpoch};

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -18,7 +18,7 @@ use std::{thread, u64};
 
 use protobuf;
 use rand::Rng;
-use rocksdb::{CompactionJobInfo, DB};
+use ::rocksdb::{CompactionJobInfo, DB};
 use tempdir::TempDir;
 
 use kvproto::metapb::{self, RegionEpoch};

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "test_storage"
 version = "0.0.1"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/components/test_storage/src/lib.rs
+++ b/components/test_storage/src/lib.rs
@@ -24,6 +24,6 @@ mod assert_storage;
 mod sync_storage;
 mod util;
 
-pub use assert_storage::*;
-pub use sync_storage::*;
-pub use util::*;
+pub use crate::assert_storage::*;
+pub use crate::sync_storage::*;
+pub use crate::util::*;

--- a/components/test_util/Cargo.toml
+++ b/components/test_util/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "test_util"
 version = "0.0.1"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -28,10 +28,10 @@ mod security;
 
 use std::env;
 
-pub use kv_generator::*;
-pub use logging::*;
-pub use macros::*;
-pub use security::*;
+pub use crate::kv_generator::*;
+pub use crate::logging::*;
+pub use crate::macros::*;
+pub use crate::security::*;
 
 pub fn setup_for_ci() {
     if env::var("CI").is_ok() {

--- a/components/tikv_alloc/Cargo.toml
+++ b/components/tikv_alloc/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "tikv_alloc"
 version = "0.1.0"
+edition = "2018"
 authors = ["Brian Anderson <andersrb@gmail.com>"]
 publish = false
 

--- a/src/bin/tikv-importer.rs
+++ b/src/bin/tikv-importer.rs
@@ -46,8 +46,8 @@ extern crate toml;
 #[cfg(unix)]
 #[macro_use]
 mod util;
-use util::setup::*;
-use util::signal_handler;
+use crate::util::setup::*;
+use crate::util::signal_handler;
 
 use std::process;
 use std::sync::atomic::Ordering;

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -48,8 +48,8 @@ extern crate toml;
 #[cfg(unix)]
 #[macro_use]
 mod util;
-use util::setup::*;
-use util::signal_handler;
+use crate::util::setup::*;
+use crate::util::signal_handler;
 
 use std::fs::File;
 use std::path::Path;

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,26 +29,26 @@ use rocksdb::{
 use slog;
 use sys_info;
 
-use import::Config as ImportConfig;
-use pd::Config as PdConfig;
-use raftstore::coprocessor::Config as CopConfig;
-use raftstore::store::keys::region_raft_prefix_len;
-use raftstore::store::Config as RaftstoreConfig;
-use server::readpool;
-use server::Config as ServerConfig;
-use storage::{
+use crate::import::Config as ImportConfig;
+use crate::pd::Config as PdConfig;
+use crate::raftstore::coprocessor::Config as CopConfig;
+use crate::raftstore::store::keys::region_raft_prefix_len;
+use crate::raftstore::store::Config as RaftstoreConfig;
+use crate::server::readpool;
+use crate::server::Config as ServerConfig;
+use crate::storage::{
     Config as StorageConfig, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE, DEFAULT_ROCKSDB_SUB_DIR,
 };
-use util::config::{
+use crate::util::config::{
     self, compression_type_level_serde, CompressionType, ReadableDuration, ReadableSize, GB, KB, MB,
 };
-use util::properties::{MvccPropertiesCollectorFactory, RangePropertiesCollectorFactory};
-use util::rocksdb::{
+use crate::util::properties::{MvccPropertiesCollectorFactory, RangePropertiesCollectorFactory};
+use crate::util::rocksdb::{
     db_exist, CFOptions, EventListener, FixedPrefixSliceTransform, FixedSuffixSliceTransform,
     NoopSliceTransform,
 };
-use util::security::SecurityConfig;
-use util::time::duration_to_sec;
+use crate::util::security::SecurityConfig;
+use crate::util::time::duration_to_sec;
 
 const LOCKCF_MIN_MEM: usize = 256 * MB as usize;
 const LOCKCF_MAX_MEM: usize = GB as usize;
@@ -801,7 +801,7 @@ pub mod log_level_serde {
         Deserialize, Deserializer, Serialize, Serializer,
     };
     use slog::Level;
-    use util::logger::{get_level_by_string, get_string_by_level};
+    use crate::util::logger::{get_level_by_string, get_string_by_level};
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Level, D::Error>
     where

--- a/src/config.rs
+++ b/src/config.rs
@@ -796,12 +796,12 @@ impl Default for MetricConfig {
 }
 
 pub mod log_level_serde {
+    use crate::util::logger::{get_level_by_string, get_string_by_level};
     use serde::{
         de::{Error, Unexpected},
         Deserialize, Deserializer, Serialize, Serializer,
     };
     use slog::Level;
-    use crate::util::logger::{get_level_by_string, get_string_by_level};
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Level, D::Error>
     where

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -18,10 +18,10 @@ use kvproto::coprocessor::{KeyRange, Response};
 use protobuf::Message;
 use tipb::checksum::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse, ChecksumScanOn};
 
-use storage::{Snapshot, SnapshotStore};
+use crate::storage::{Snapshot, SnapshotStore};
 
-use coprocessor::dag::executor::{ExecutorMetrics, ScanOn, Scanner};
-use coprocessor::*;
+use crate::coprocessor::dag::executor::{ExecutorMetrics, ScanOn, Scanner};
+use crate::coprocessor::*;
 
 // `ChecksumContext` is used to handle `ChecksumRequest`
 pub struct ChecksumContext<S: Snapshot> {

--- a/src/coprocessor/codec/batch/column.rs
+++ b/src/coprocessor/codec/batch/column.rs
@@ -15,17 +15,17 @@ use std::convert::{TryFrom, TryInto};
 
 use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeTp};
 
-use coprocessor::codec::datum;
-use coprocessor::codec::mysql::Tz;
-use coprocessor::codec::{Error, Result};
-use util::codec::{bytes, number};
+use crate::coprocessor::codec::datum;
+use crate::coprocessor::codec::mysql::Tz;
+use crate::coprocessor::codec::{Error, Result};
+use crate::util::codec::{bytes, number};
 
 // TODO: Move these type alias and re-exports into cop_datatype.
 // These types are ensured to be cheap to move. However clone can be expensive.
 pub type Int = i64;
 pub type Real = f64;
 pub type Bytes = Vec<u8>;
-pub use coprocessor::codec::mysql::{Decimal, Duration, Json, Time as DateTime};
+pub use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time as DateTime};
 
 /// An array of datums in the same data type and is column oriented.
 ///
@@ -824,7 +824,7 @@ mod benches {
 
     #[bench]
     fn bench_push_datum_int(b: &mut test::Bencher) {
-        use coprocessor::codec::datum::{Datum, DatumEncoder};
+        use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
 
         let mut column = BatchColumn::with_capacity(1000, EvalType::Int);
 
@@ -857,9 +857,9 @@ mod benches {
     #[bench]
     fn bench_batch_decode(b: &mut test::Bencher) {
         use cop_datatype::FieldTypeTp;
-        use coprocessor::codec::datum::{Datum, DatumEncoder};
-        use coprocessor::codec::table;
-        use coprocessor::dag::expr::EvalContext;
+        use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
+        use crate::coprocessor::codec::table;
+        use crate::coprocessor::dag::expr::EvalContext;
 
         let mut datum_raw: Vec<u8> = Vec::new();
         DatumEncoder::encode(&mut datum_raw, &[Datum::U64(0xDEADBEEF)], true).unwrap();

--- a/src/coprocessor/codec/batch/column.rs
+++ b/src/coprocessor/codec/batch/column.rs
@@ -818,7 +818,7 @@ mod tests {
 
 #[cfg(test)]
 mod benches {
-    use ::test;
+    use crate::test;
 
     use super::*;
 

--- a/src/coprocessor/codec/batch/column.rs
+++ b/src/coprocessor/codec/batch/column.rs
@@ -818,7 +818,7 @@ mod tests {
 
 #[cfg(test)]
 mod benches {
-    use test;
+    use ::test;
 
     use super::*;
 

--- a/src/coprocessor/codec/batch/column.rs
+++ b/src/coprocessor/codec/batch/column.rs
@@ -856,10 +856,10 @@ mod benches {
     /// Bench performance of naively decoding multiple datums (without pushing into a vector).
     #[bench]
     fn bench_batch_decode(b: &mut test::Bencher) {
-        use cop_datatype::FieldTypeTp;
         use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
         use crate::coprocessor::codec::table;
         use crate::coprocessor::dag::expr::EvalContext;
+        use cop_datatype::FieldTypeTp;
 
         let mut datum_raw: Vec<u8> = Vec::new();
         DatumEncoder::encode(&mut datum_raw, &[Datum::U64(0xDEADBEEF)], true).unwrap();

--- a/src/coprocessor/codec/batch/rows.rs
+++ b/src/coprocessor/codec/batch/rows.rs
@@ -22,8 +22,8 @@ use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeFlag};
 use tipb::schema::ColumnInfo;
 
 use super::BatchColumn;
-use coprocessor::codec::mysql::Tz;
-use coprocessor::codec::{datum, Error, Result};
+use crate::coprocessor::codec::mysql::Tz;
+use crate::coprocessor::codec::{datum, Error, Result};
 
 pub struct BatchRows<E> {
     /// Multiple interested columns. Each column is either decoded, or not decoded.
@@ -341,7 +341,7 @@ impl LazyBatchColumn {
 mod tests {
     use super::*;
 
-    use coprocessor::codec::datum::{Datum, DatumEncoder};
+    use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
 
     /// Helper method to generate raw row ([u8] vector) from datum vector.
     fn raw_row_from_datums(datums: impl AsRef<[Option<Datum>]>, comparable: bool) -> Vec<Vec<u8>> {
@@ -965,7 +965,7 @@ mod benches {
     #[bench]
     fn bench_lazy_batch_column_clone_decoded(b: &mut test::Bencher) {
         use cop_datatype::FieldTypeTp;
-        use coprocessor::codec::datum::{Datum, DatumEncoder};
+        use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
 
         let mut column = LazyBatchColumn::raw_with_capacity(1000);
 
@@ -996,7 +996,7 @@ mod benches {
     #[bench]
     fn bench_lazy_batch_column_clone_and_decode(b: &mut test::Bencher) {
         use cop_datatype::FieldTypeTp;
-        use coprocessor::codec::datum::{Datum, DatumEncoder};
+        use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
 
         let mut column = LazyBatchColumn::raw_with_capacity(1000);
 
@@ -1028,7 +1028,7 @@ mod benches {
     #[bench]
     fn bench_lazy_batch_column_clone_and_decode_decoded(b: &mut test::Bencher) {
         use cop_datatype::FieldTypeTp;
-        use coprocessor::codec::datum::{Datum, DatumEncoder};
+        use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
 
         let mut column = LazyBatchColumn::raw_with_capacity(1000);
 

--- a/src/coprocessor/codec/batch/rows.rs
+++ b/src/coprocessor/codec/batch/rows.rs
@@ -867,7 +867,7 @@ mod tests {
 
 #[cfg(test)]
 mod benches {
-    use ::test;
+    use crate::test;
 
     use super::*;
 

--- a/src/coprocessor/codec/batch/rows.rs
+++ b/src/coprocessor/codec/batch/rows.rs
@@ -964,8 +964,8 @@ mod benches {
     /// Bench performance of cloning a decoded column.
     #[bench]
     fn bench_lazy_batch_column_clone_decoded(b: &mut test::Bencher) {
-        use cop_datatype::FieldTypeTp;
         use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
+        use cop_datatype::FieldTypeTp;
 
         let mut column = LazyBatchColumn::raw_with_capacity(1000);
 
@@ -995,8 +995,8 @@ mod benches {
     /// Note that there is a clone in the bench suite, whose cost should be excluded.
     #[bench]
     fn bench_lazy_batch_column_clone_and_decode(b: &mut test::Bencher) {
-        use cop_datatype::FieldTypeTp;
         use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
+        use cop_datatype::FieldTypeTp;
 
         let mut column = LazyBatchColumn::raw_with_capacity(1000);
 
@@ -1027,8 +1027,8 @@ mod benches {
     /// Note that there is a clone in the bench suite, whose cost should be excluded.
     #[bench]
     fn bench_lazy_batch_column_clone_and_decode_decoded(b: &mut test::Bencher) {
-        use cop_datatype::FieldTypeTp;
         use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
+        use cop_datatype::FieldTypeTp;
 
         let mut column = LazyBatchColumn::raw_with_capacity(1000);
 

--- a/src/coprocessor/codec/batch/rows.rs
+++ b/src/coprocessor/codec/batch/rows.rs
@@ -867,7 +867,7 @@ mod tests {
 
 #[cfg(test)]
 mod benches {
-    use test;
+    use ::test;
 
     use super::*;
 

--- a/src/coprocessor/codec/chunk/chunk.rs
+++ b/src/coprocessor/codec/chunk/chunk.rs
@@ -13,11 +13,11 @@
 
 use super::column::{Column, ColumnEncoder};
 use super::Result;
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::Datum;
 use std::io::Write;
 use tipb::expression::FieldType;
 #[cfg(test)]
-use util::codec::BytesSlice;
+use crate::util::codec::BytesSlice;
 
 /// `Chunk` stores multiple rows of data in Apache Arrow format.
 /// See https://arrow.apache.org/docs/memory_layout.html
@@ -168,9 +168,9 @@ mod tests {
     use cop_datatype::FieldTypeTp;
 
     use super::*;
-    use coprocessor::codec::chunk::tests::*;
-    use coprocessor::codec::datum::Datum;
-    use coprocessor::codec::mysql::*;
+    use crate::coprocessor::codec::chunk::tests::*;
+    use crate::coprocessor::codec::datum::Datum;
+    use crate::coprocessor::codec::mysql::*;
 
     #[test]
     fn test_append_datum() {

--- a/src/coprocessor/codec/chunk/chunk.rs
+++ b/src/coprocessor/codec/chunk/chunk.rs
@@ -14,10 +14,10 @@
 use super::column::{Column, ColumnEncoder};
 use super::Result;
 use crate::coprocessor::codec::Datum;
-use std::io::Write;
-use tipb::expression::FieldType;
 #[cfg(test)]
 use crate::util::codec::BytesSlice;
+use std::io::Write;
+use tipb::expression::FieldType;
 
 /// `Chunk` stores multiple rows of data in Apache Arrow format.
 /// See https://arrow.apache.org/docs/memory_layout.html

--- a/src/coprocessor/codec/chunk/column.rs
+++ b/src/coprocessor/codec/chunk/column.rs
@@ -17,15 +17,15 @@ use cop_datatype::prelude::*;
 use cop_datatype::{FieldTypeFlag, FieldTypeTp};
 
 use super::{Error, Result};
-use coprocessor::codec::mysql::decimal::DECIMAL_STRUCT_SIZE;
-use coprocessor::codec::mysql::{
+use crate::coprocessor::codec::mysql::decimal::DECIMAL_STRUCT_SIZE;
+use crate::coprocessor::codec::mysql::{
     Decimal, DecimalEncoder, Duration, DurationEncoder, Json, JsonEncoder, Time, TimeEncoder,
 };
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::Datum;
 
-use util::codec::number::{self, NumberEncoder};
+use crate::util::codec::number::{self, NumberEncoder};
 #[cfg(test)]
-use util::codec::BytesSlice;
+use crate::util::codec::BytesSlice;
 
 /// `Column` stores the same column data of multi rows in one chunk.
 #[derive(Default)]
@@ -339,7 +339,7 @@ impl Column {
 
     #[cfg(test)]
     pub fn decode(buf: &mut BytesSlice, tp: &FieldTypeAccessor) -> Result<Column> {
-        use util::codec::read_slice;
+        use crate::util::codec::read_slice;
         let length = number::decode_u32_le(buf)? as usize;
         let mut col = Column::new(tp, length);
         col.length = length;
@@ -395,9 +395,9 @@ impl<T: Write> ColumnEncoder for T {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coprocessor::codec::chunk::tests::field_type;
-    use coprocessor::codec::datum::Datum;
-    use coprocessor::codec::mysql::*;
+    use crate::coprocessor::codec::chunk::tests::field_type;
+    use crate::coprocessor::codec::datum::Datum;
+    use crate::coprocessor::codec::mysql::*;
     use std::{f64, u64};
     use tipb::expression::FieldType;
 

--- a/src/coprocessor/codec/chunk/mod.rs
+++ b/src/coprocessor/codec/chunk/mod.rs
@@ -14,7 +14,7 @@
 mod chunk;
 mod column;
 
-pub use coprocessor::codec::{Error, Result};
+pub use crate::coprocessor::codec::{Error, Result};
 
 pub use self::chunk::{Chunk, ChunkEncoder};
 

--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -18,7 +18,7 @@ use cop_datatype::{self, FieldTypeTp};
 
 use super::mysql::Res;
 use super::{Error, Result};
-use coprocessor::dag::expr::EvalContext;
+use crate::coprocessor::dag::expr::EvalContext;
 
 /// `truncate_binary` truncates a buffer to the specified length.
 #[inline]
@@ -342,7 +342,7 @@ mod tests {
     use std::sync::Arc;
     use std::{f64, i64, isize, u64};
 
-    use coprocessor::dag::expr::{EvalConfig, EvalContext};
+    use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
 
     use super::*;
 

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -26,10 +26,10 @@ use super::mysql::{
     PathExpression, RoundMode, Time, DEFAULT_FSP, MAX_FSP,
 };
 use super::{convert, Error, Result};
-use coprocessor::dag::expr::EvalContext;
-use util::codec::bytes::{self, BytesEncoder};
-use util::codec::{number, BytesSlice};
-use util::escape;
+use crate::coprocessor::dag::expr::EvalContext;
+use crate::util::codec::bytes::{self, BytesEncoder};
+use crate::util::codec::{number, BytesSlice};
+use crate::util::escape;
 
 pub const NIL_FLAG: u8 = 0;
 pub const BYTES_FLAG: u8 = 1;
@@ -1045,9 +1045,9 @@ pub fn split_datum(buf: &[u8], desc: bool) -> Result<(&[u8], &[u8])> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coprocessor::codec::mysql::{Decimal, Duration, Time, MAX_FSP};
-    use coprocessor::dag::expr::{EvalConfig, EvalContext};
-    use util::as_slice;
+    use crate::coprocessor::codec::mysql::{Decimal, Duration, Time, MAX_FSP};
+    use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
+    use crate::util::as_slice;
 
     use std::cmp::Ordering;
     use std::sync::Arc;

--- a/src/coprocessor/codec/error.rs
+++ b/src/coprocessor/codec/error.rs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 use crate::coprocessor::dag::expr::EvalContext;
+use crate::util;
 use regex::Error as RegexpError;
 use std::error::Error as StdError;
 use std::io;
@@ -20,7 +21,6 @@ use std::string::FromUtf8Error;
 use std::{error, str};
 use tipb::expression::ScalarFuncSig;
 use tipb::select;
-use crate::util;
 
 pub const ERR_UNKNOWN: i32 = 1105;
 pub const ERR_REGEXP: i32 = 1139;

--- a/src/coprocessor/codec/error.rs
+++ b/src/coprocessor/codec/error.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use coprocessor::dag::expr::EvalContext;
+use crate::coprocessor::dag::expr::EvalContext;
 use regex::Error as RegexpError;
 use std::error::Error as StdError;
 use std::io;
@@ -20,7 +20,7 @@ use std::string::FromUtf8Error;
 use std::{error, str};
 use tipb::expression::ScalarFuncSig;
 use tipb::select;
-use util;
+use crate::util;
 
 pub const ERR_UNKNOWN: i32 = 1105;
 pub const ERR_REGEXP: i32 = 1139;

--- a/src/coprocessor/codec/mod.rs
+++ b/src/coprocessor/codec/mod.rs
@@ -30,11 +30,11 @@ const TEN_POW: &[u32] = &[
 /// A shortcut to box an error.
 macro_rules! invalid_type {
     ($e:expr) => ({
-        use coprocessor::codec::Error;
+        use crate::coprocessor::codec::Error;
         Error::InvalidDataType(($e).into())
     });
     ($f:tt, $($arg:expr),+) => ({
-        use coprocessor::codec::Error;
+        use crate::coprocessor::codec::Error;
         Error::InvalidDataType(format!($f, $($arg),+))
     });
 }

--- a/src/coprocessor/codec/mysql/decimal.rs
+++ b/src/coprocessor/codec/mysql/decimal.rs
@@ -20,12 +20,12 @@ use std::ops::{Add, Deref, DerefMut, Div, Mul, Neg, Rem, Sub};
 use std::str::{self, FromStr};
 use std::{cmp, i32, i64, mem, u32, u64};
 
-use coprocessor::codec::{convert, Error, Result, TEN_POW};
-use coprocessor::dag::expr::EvalContext;
+use crate::coprocessor::codec::{convert, Error, Result, TEN_POW};
+use crate::coprocessor::dag::expr::EvalContext;
 
-use util::codec::number::{self, NumberEncoder};
-use util::codec::BytesSlice;
-use util::escape;
+use crate::util::codec::number::{self, NumberEncoder};
+use crate::util::codec::BytesSlice;
+use crate::util::escape;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Res<T> {

--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -11,14 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::util::codec::number::{self, NumberEncoder};
+use crate::util::codec::BytesSlice;
 use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter};
 use std::io::Write;
 use std::time::Duration as StdDuration;
 use std::{i64, str, u64};
 use time::{self, Tm};
-use crate::util::codec::number::{self, NumberEncoder};
-use crate::util::codec::BytesSlice;
 
 use super::super::Result;
 use super::{check_fsp, parse_frac, Decimal};

--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -17,8 +17,8 @@ use std::io::Write;
 use std::time::Duration as StdDuration;
 use std::{i64, str, u64};
 use time::{self, Tm};
-use util::codec::number::{self, NumberEncoder};
-use util::codec::BytesSlice;
+use crate::util::codec::number::{self, NumberEncoder};
+use crate::util::codec::BytesSlice;
 
 use super::super::Result;
 use super::{check_fsp, parse_frac, Decimal};
@@ -312,8 +312,8 @@ impl Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coprocessor::codec::mysql::MAX_FSP;
-    use util::escape;
+    use crate::coprocessor::codec::mysql::MAX_FSP;
+    use crate::util::escape;
 
     #[test]
     fn test_hours() {

--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -524,7 +524,7 @@ mod tests {
             ("-1 11:59:59.9999", 2),
         ];
         for (input, fsp) in cases {
-            let mut t = Duration::parse(input.as_bytes(), fsp).unwrap();
+            let t = Duration::parse(input.as_bytes(), fsp).unwrap();
             let mut buf = vec![];
             buf.encode_duration(&t).unwrap();
             let got = Duration::decode(&mut buf.as_slice()).unwrap();

--- a/src/coprocessor/codec/mysql/json/binary.rs
+++ b/src/coprocessor/codec/mysql/json/binary.rs
@@ -16,10 +16,10 @@ use std::io::Write;
 use std::{f64, str};
 
 use super::{Json, ERR_CONVERT_FAILED};
-use byteorder::WriteBytesExt;
 use crate::coprocessor::codec::{Error, Result};
 use crate::util::codec::number::{self, NumberEncoder};
 use crate::util::codec::{read_slice, BytesSlice};
+use byteorder::WriteBytesExt;
 const TYPE_CODE_OBJECT: u8 = 0x01;
 const TYPE_CODE_ARRAY: u8 = 0x03;
 const TYPE_CODE_LITERAL: u8 = 0x04;

--- a/src/coprocessor/codec/mysql/json/binary.rs
+++ b/src/coprocessor/codec/mysql/json/binary.rs
@@ -17,9 +17,9 @@ use std::{f64, str};
 
 use super::{Json, ERR_CONVERT_FAILED};
 use byteorder::WriteBytesExt;
-use coprocessor::codec::{Error, Result};
-use util::codec::number::{self, NumberEncoder};
-use util::codec::{read_slice, BytesSlice};
+use crate::coprocessor::codec::{Error, Result};
+use crate::util::codec::number::{self, NumberEncoder};
+use crate::util::codec::{read_slice, BytesSlice};
 const TYPE_CODE_OBJECT: u8 = 0x01;
 const TYPE_CODE_ARRAY: u8 = 0x03;
 const TYPE_CODE_LITERAL: u8 = 0x04;

--- a/src/coprocessor/codec/mysql/json/json_cast.rs
+++ b/src/coprocessor/codec/mysql/json/json_cast.rs
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 use super::{Json, Result};
-use coprocessor::codec::convert;
-use coprocessor::dag::expr::EvalContext;
+use crate::coprocessor::codec::convert;
+use crate::coprocessor::dag::expr::EvalContext;
 
 impl Json {
     pub fn cast_to_int(&self) -> i64 {
@@ -44,7 +44,7 @@ impl Json {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coprocessor::dag::expr::{EvalConfig, EvalContext};
+    use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
     use std::f64;
     use std::sync::Arc;
 

--- a/src/coprocessor/codec/mysql/json/mod.rs
+++ b/src/coprocessor/codec/mysql/json/mod.rs
@@ -34,7 +34,7 @@ use std::collections::BTreeMap;
 
 use super::super::datum::Datum;
 use super::super::{Error, Result};
-use util::is_even;
+use crate::util::is_even;
 
 const ERR_CONVERT_FAILED: &str = "Can not covert from ";
 

--- a/src/coprocessor/codec/mysql/json/path_expr.rs
+++ b/src/coprocessor/codec/mysql/json/path_expr.rs
@@ -35,7 +35,7 @@
 //     select json_extract('{"a": "b", "c": [1, "2"]}', '$.*') -> ["b", [1, "2"]]
 
 use super::json_unquote::unquote_string;
-use coprocessor::codec::Result;
+use crate::coprocessor::codec::Result;
 use regex::Regex;
 use std::ops::Index;
 

--- a/src/coprocessor/codec/mysql/json/serde.rs
+++ b/src/coprocessor/codec/mysql/json/serde.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 use std::{f64, str};
 
 use super::Json;
-use coprocessor::codec::Error;
+use crate::coprocessor::codec::Error;
 
 impl Json {
     pub fn to_string(&self) -> String {

--- a/src/coprocessor/codec/mysql/mod.rs
+++ b/src/coprocessor/codec/mysql/mod.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use super::Result;
-use util::escape;
+use crate::util::escape;
 
 /// `UNSPECIFIED_FSP` is the unspecified fractional seconds part.
 pub const UNSPECIFIED_FSP: i8 = -1;

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -26,7 +26,9 @@ use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike, Utc};
 
 use cop_datatype::FieldTypeTp;
 
-use crate::coprocessor::codec::mysql::duration::{Duration as MyDuration, NANOS_PER_SEC, NANO_WIDTH};
+use crate::coprocessor::codec::mysql::duration::{
+    Duration as MyDuration, NANOS_PER_SEC, NANO_WIDTH,
+};
 use crate::coprocessor::codec::mysql::{self, Decimal};
 use crate::coprocessor::codec::{Error, Result, TEN_POW};
 use crate::util::codec::number::{self, NumberEncoder};

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -26,11 +26,11 @@ use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike, Utc};
 
 use cop_datatype::FieldTypeTp;
 
-use coprocessor::codec::mysql::duration::{Duration as MyDuration, NANOS_PER_SEC, NANO_WIDTH};
-use coprocessor::codec::mysql::{self, Decimal};
-use coprocessor::codec::{Error, Result, TEN_POW};
-use util::codec::number::{self, NumberEncoder};
-use util::codec::BytesSlice;
+use crate::coprocessor::codec::mysql::duration::{Duration as MyDuration, NANOS_PER_SEC, NANO_WIDTH};
+use crate::coprocessor::codec::mysql::{self, Decimal};
+use crate::coprocessor::codec::{Error, Result, TEN_POW};
+use crate::util::codec::number::{self, NumberEncoder};
+use crate::util::codec::BytesSlice;
 
 pub use self::extension::*;
 pub use self::weekmode::WeekMode;
@@ -879,7 +879,7 @@ mod tests {
 
     use chrono::{Duration, Local};
 
-    use coprocessor::codec::mysql::{Duration as MyDuration, MAX_FSP, UNSPECIFIED_FSP};
+    use crate::coprocessor::codec::mysql::{Duration as MyDuration, MAX_FSP, UNSPECIFIED_FSP};
 
     fn for_each_tz<F: FnMut(Tz, i64)>(mut f: F) {
         const MIN_OFFSET: i64 = -60 * 24 + 1;

--- a/src/coprocessor/codec/overflow.rs
+++ b/src/coprocessor/codec/overflow.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use coprocessor::codec::{Error, Result};
+use crate::coprocessor::codec::{Error, Result};
 
 /// `div_i64` divides i64 a with b and returns:
 /// - an Error indicating overflow occurred or the divisor is 0
@@ -76,7 +76,7 @@ pub fn div_i64_with_u64(a: i64, b: u64) -> Result<u64> {
 
 #[cfg(test)]
 mod tests {
-    use coprocessor::codec::error::{ERR_DATA_OUT_OF_RANGE, ERR_DIVISION_BY_ZERO};
+    use crate::coprocessor::codec::error::{ERR_DATA_OUT_OF_RANGE, ERR_DIVISION_BY_ZERO};
     use std::{i64, u64};
 
     macro_rules! do_test {

--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -23,11 +23,11 @@ use tipb::schema::ColumnInfo;
 //use super::datum::DatumDecoder;
 use super::mysql::{Duration, Time};
 use super::{datum, Datum, Error, Result};
-use coprocessor::dag::expr::EvalContext;
-use util::codec::number::{self, NumberEncoder};
-use util::codec::BytesSlice;
-use util::collections::{HashMap, HashSet};
-use util::escape;
+use crate::coprocessor::dag::expr::EvalContext;
+use crate::util::codec::number::{self, NumberEncoder};
+use crate::util::codec::BytesSlice;
+use crate::util::collections::{HashMap, HashSet};
+use crate::util::escape;
 
 // handle or index id
 pub const ID_LEN: usize = 8;
@@ -425,8 +425,8 @@ mod tests {
 
     use tipb::schema::ColumnInfo;
 
-    use coprocessor::codec::datum::{self, Datum};
-    use util::collections::{HashMap, HashSet};
+    use crate::coprocessor::codec::datum::{self, Datum};
+    use crate::util::collections::{HashMap, HashSet};
 
     use super::*;
 

--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -16,14 +16,14 @@ use std::sync::Arc;
 use kvproto::coprocessor::KeyRange;
 use tipb::executor::{self, ExecType};
 
-use storage::Store;
+use crate::storage::Store;
 
 use super::executor::{
     Executor, HashAggExecutor, IndexScanExecutor, LimitExecutor, SelectionExecutor,
     StreamAggExecutor, TableScanExecutor, TopNExecutor,
 };
-use coprocessor::dag::expr::EvalConfig;
-use coprocessor::*;
+use crate::coprocessor::dag::expr::EvalConfig;
+use crate::coprocessor::*;
 
 /// Utilities to build an executor DAG.
 ///

--- a/src/coprocessor/dag/executor/aggregate.rs
+++ b/src/coprocessor/dag/executor/aggregate.rs
@@ -14,9 +14,9 @@
 use std::cmp::Ordering;
 use tipb::expression::ExprType;
 
-use coprocessor::codec::mysql::Decimal;
-use coprocessor::codec::Datum;
-use coprocessor::Result;
+use crate::coprocessor::codec::mysql::Decimal;
+use crate::coprocessor::codec::Datum;
+use crate::coprocessor::Result;
 
 use super::super::expr::{eval_arith, EvalContext};
 
@@ -300,7 +300,7 @@ impl AggrFunc for Extremum {
 
 #[cfg(test)]
 mod tests {
-    use coprocessor::dag::expr::{EvalConfig, EvalContext};
+    use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
     use std::ops::Add;
     use std::sync::Arc;
     use std::{i64, u64};

--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -270,7 +270,7 @@ impl Executor for StreamAggExecutor {
         while let Some(cols) = self.inner.next()? {
             self.has_data = true;
             let new_group = self.meet_new_group(&cols)?;
-            let mut ret = if new_group {
+            let ret = if new_group {
                 Some(self.get_partial_result()?)
             } else {
                 None

--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -18,11 +18,11 @@ use std::sync::Arc;
 use tipb::executor::Aggregation;
 use tipb::expression::{Expr, ExprType};
 
-use util::collections::{OrderMap, OrderMapEntry};
+use crate::util::collections::{OrderMap, OrderMapEntry};
 
-use coprocessor::codec::datum::{self, Datum};
-use coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
-use coprocessor::*;
+use crate::coprocessor::codec::datum::{self, Datum};
+use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
+use crate::coprocessor::*;
 
 use super::aggregate::{self, AggrFunc};
 use super::ExecutorMetrics;
@@ -405,12 +405,12 @@ mod tests {
     use tipb::expression::{Expr, ExprType};
     use tipb::schema::ColumnInfo;
 
-    use coprocessor::codec::datum::{self, Datum};
-    use coprocessor::codec::mysql::decimal::Decimal;
-    use coprocessor::codec::table;
-    use storage::SnapshotStore;
-    use util::codec::number::NumberEncoder;
-    use util::collections::HashMap;
+    use crate::coprocessor::codec::datum::{self, Datum};
+    use crate::coprocessor::codec::mysql::decimal::Decimal;
+    use crate::coprocessor::codec::table;
+    use crate::storage::SnapshotStore;
+    use crate::util::codec::number::NumberEncoder;
+    use crate::util::collections::HashMap;
 
     use super::super::index_scan::tests::IndexTestWrapper;
     use super::super::index_scan::IndexScanExecutor;

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -24,11 +24,11 @@ use kvproto::coprocessor::KeyRange;
 use tipb::executor::IndexScan;
 use tipb::schema::ColumnInfo;
 
-use coprocessor::codec::{datum, table};
-use coprocessor::util;
-use coprocessor::*;
+use crate::coprocessor::codec::{datum, table};
+use crate::coprocessor::util;
+use crate::coprocessor::*;
 
-use storage::{Key, Store};
+use crate::storage::{Key, Store};
 
 use super::scanner::{ScanOn, Scanner};
 use super::ExecutorMetrics;
@@ -283,9 +283,9 @@ pub mod tests {
     use protobuf::RepeatedField;
     use tipb::schema::ColumnInfo;
 
-    use coprocessor::codec::datum::{self, Datum};
-    use storage::SnapshotStore;
-    use util::collections::HashMap;
+    use crate::coprocessor::codec::datum::{self, Datum};
+    use crate::storage::SnapshotStore;
+    use crate::util::collections::HashMap;
 
     use super::super::scanner::tests::{new_col_info, Data, TestStore};
     use super::*;

--- a/src/coprocessor/dag/executor/limit.rs
+++ b/src/coprocessor/dag/executor/limit.rs
@@ -14,9 +14,9 @@
 use tipb::executor::Limit;
 
 use super::ExecutorMetrics;
-use coprocessor::dag::executor::{Executor, Row};
-use coprocessor::dag::expr::EvalWarnings;
-use coprocessor::Result;
+use crate::coprocessor::dag::executor::{Executor, Row};
+use crate::coprocessor::dag::expr::EvalWarnings;
+use crate::coprocessor::Result;
 
 /// Retrieves rows from the source executor and only produces part of the rows.
 pub struct LimitExecutor<'a> {
@@ -78,8 +78,8 @@ mod tests {
     use protobuf::RepeatedField;
     use tipb::executor::TableScan;
 
-    use coprocessor::codec::datum::Datum;
-    use storage::SnapshotStore;
+    use crate::coprocessor::codec::datum::Datum;
+    use crate::storage::SnapshotStore;
 
     use super::super::scanner::tests::{get_range, new_col_info, TestStore};
     use super::super::table_scan::TableScanExecutor;

--- a/src/coprocessor/dag/executor/metrics.rs
+++ b/src/coprocessor/dag/executor/metrics.rs
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use prometheus::local::LocalIntCounterVec;
 use crate::storage::engine::Statistics;
+use prometheus::local::LocalIntCounterVec;
 
 /// `ExecutorMetrics` is metrics collected from executors group by request.
 #[derive(Default, Debug)]

--- a/src/coprocessor/dag/executor/metrics.rs
+++ b/src/coprocessor/dag/executor/metrics.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use prometheus::local::LocalIntCounterVec;
-use storage::engine::Statistics;
+use crate::storage::engine::Statistics;
 
 /// `ExecutorMetrics` is metrics collected from executors group by request.
 #[derive(Default, Debug)]

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -19,14 +19,14 @@ use kvproto::coprocessor::KeyRange;
 use tipb::expression::{Expr, ExprType};
 use tipb::schema::ColumnInfo;
 
-use util::codec::number;
-use util::collections::HashSet;
+use crate::util::codec::number;
+use crate::util::collections::HashSet;
 
-use coprocessor::codec::datum::{self, Datum, DatumEncoder};
-use coprocessor::codec::table::{self, RowColsDict};
-use coprocessor::dag::expr::{EvalContext, EvalWarnings};
-use coprocessor::util;
-use coprocessor::*;
+use crate::coprocessor::codec::datum::{self, Datum, DatumEncoder};
+use crate::coprocessor::codec::table::{self, RowColsDict};
+use crate::coprocessor::dag::expr::{EvalContext, EvalWarnings};
+use crate::coprocessor::util;
+use crate::coprocessor::*;
 
 mod aggregate;
 mod aggregation;

--- a/src/coprocessor/dag/executor/scanner.rs
+++ b/src/coprocessor/dag/executor/scanner.rs
@@ -13,11 +13,11 @@
 
 use kvproto::coprocessor::KeyRange;
 
-use coprocessor::codec::table::truncate_as_row_key;
-use coprocessor::util;
-use storage::txn::Result;
-use storage::{Key, Scanner as KvScanner, Statistics, Store, Value};
-use util::{escape, set_panic_mark};
+use crate::coprocessor::codec::table::truncate_as_row_key;
+use crate::coprocessor::util;
+use crate::storage::txn::Result;
+use crate::storage::{Key, Scanner as KvScanner, Statistics, Store, Value};
+use crate::util::{escape, set_panic_mark};
 
 const MIN_KEY_BUFFER_CAPACITY: usize = 256;
 
@@ -178,13 +178,13 @@ pub mod tests {
     use kvproto::kvrpcpb::{Context, IsolationLevel};
     use tipb::schema::ColumnInfo;
 
-    use coprocessor::codec::datum::{self, Datum};
-    use coprocessor::codec::table;
-    use coprocessor::util;
-    use storage::engine::{Engine, Modify, RocksEngine, RocksSnapshot, TestEngineBuilder};
-    use storage::mvcc::MvccTxn;
-    use storage::{Key, Mutation, Options, SnapshotStore};
-    use util::collections::HashMap;
+    use crate::coprocessor::codec::datum::{self, Datum};
+    use crate::coprocessor::codec::table;
+    use crate::coprocessor::util;
+    use crate::storage::engine::{Engine, Modify, RocksEngine, RocksSnapshot, TestEngineBuilder};
+    use crate::storage::mvcc::MvccTxn;
+    use crate::storage::{Key, Mutation, Options, SnapshotStore};
+    use crate::util::collections::HashMap;
 
     use super::*;
 

--- a/src/coprocessor/dag/executor/selection.rs
+++ b/src/coprocessor/dag/executor/selection.rs
@@ -15,8 +15,8 @@ use std::sync::Arc;
 
 use tipb::executor::Selection;
 
-use coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
-use coprocessor::Result;
+use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
+use crate::coprocessor::Result;
 
 use super::{Executor, ExecutorMetrics, ExprColumnRefVisitor, Row};
 
@@ -102,9 +102,9 @@ mod tests {
     use tipb::executor::TableScan;
     use tipb::expression::{Expr, ExprType, ScalarFuncSig};
 
-    use coprocessor::codec::datum::Datum;
-    use storage::SnapshotStore;
-    use util::codec::number::NumberEncoder;
+    use crate::coprocessor::codec::datum::Datum;
+    use crate::storage::SnapshotStore;
+    use crate::util::codec::number::NumberEncoder;
 
     use super::super::scanner::tests::{get_range, new_col_info, TestStore};
     use super::super::table_scan::TableScanExecutor;

--- a/src/coprocessor/dag/executor/table_scan.rs
+++ b/src/coprocessor/dag/executor/table_scan.rs
@@ -20,12 +20,12 @@ use kvproto::coprocessor::KeyRange;
 use tipb::executor::TableScan;
 use tipb::schema::ColumnInfo;
 
-use storage::{Key, Store};
-use util::collections::HashSet;
+use crate::storage::{Key, Store};
+use crate::util::collections::HashSet;
 
-use coprocessor::codec::table;
-use coprocessor::util;
-use coprocessor::*;
+use crate::coprocessor::codec::table;
+use crate::coprocessor::util;
+use crate::coprocessor::*;
 
 use super::{Executor, ExecutorMetrics, Row};
 use super::{ScanOn, Scanner};
@@ -235,7 +235,7 @@ mod tests {
     use protobuf::RepeatedField;
     use tipb::schema::ColumnInfo;
 
-    use storage::SnapshotStore;
+    use crate::storage::SnapshotStore;
 
     use super::super::scanner::tests::{
         get_point_range, get_range, prepare_table_data, Data, TestStore,

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -146,7 +146,7 @@ impl Executor for TopNExecutor {
 
     fn take_eval_warnings(&mut self) -> Option<EvalWarnings> {
         if let Some(mut warnings) = self.src.take_eval_warnings() {
-            if let Some(mut topn_warnings) = self.eval_warnings.take() {
+            if let Some(topn_warnings) = self.eval_warnings.take() {
                 warnings.merge(topn_warnings);
             }
             Some(warnings)

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -19,9 +19,9 @@ use std::vec::IntoIter;
 use tipb::executor::TopN;
 use tipb::expression::ByItem;
 
-use coprocessor::codec::datum::Datum;
-use coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
-use coprocessor::Result;
+use crate::coprocessor::codec::datum::Datum;
+use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
+use crate::coprocessor::Result;
 
 use super::topn_heap::TopNHeap;
 use super::{Executor, ExecutorMetrics, ExprColumnRefVisitor, Row};
@@ -172,13 +172,13 @@ pub mod tests {
     use tipb::expression::{Expr, ExprType};
     use tipb::schema::ColumnInfo;
 
-    use coprocessor::codec::table::{self, RowColsDict};
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::executor::OriginCols;
-    use util::codec::number::NumberEncoder;
-    use util::collections::HashMap;
+    use crate::coprocessor::codec::table::{self, RowColsDict};
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::executor::OriginCols;
+    use crate::util::codec::number::NumberEncoder;
+    use crate::util::collections::HashMap;
 
-    use storage::SnapshotStore;
+    use crate::storage::SnapshotStore;
 
     use super::super::scanner::tests::{get_range, new_col_info, TestStore};
     use super::super::table_scan::TableScanExecutor;

--- a/src/coprocessor/dag/executor/topn_heap.rs
+++ b/src/coprocessor/dag/executor/topn_heap.rs
@@ -18,9 +18,9 @@ use std::sync::Arc;
 use std::usize;
 use tipb::expression::ByItem;
 
-use coprocessor::codec::datum::Datum;
-use coprocessor::dag::executor::OriginCols;
-use coprocessor::dag::expr::{EvalContext, Result};
+use crate::coprocessor::codec::datum::Datum;
+use crate::coprocessor::dag::executor::OriginCols;
+use crate::coprocessor::dag::expr::{EvalContext, Result};
 
 const HEAP_MAX_CAPACITY: usize = 1024;
 
@@ -186,12 +186,12 @@ mod tests {
 
     use tipb::expression::{ByItem, Expr, ExprType};
 
-    use coprocessor::codec::table::RowColsDict;
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::executor::OriginCols;
-    use coprocessor::dag::expr::EvalContext;
-    use util::codec::number::*;
-    use util::collections::HashMap;
+    use crate::coprocessor::codec::table::RowColsDict;
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::executor::OriginCols;
+    use crate::coprocessor::dag::expr::EvalContext;
+    use crate::util::codec::number::*;
+    use crate::util::collections::HashMap;
 
     use super::*;
 

--- a/src/coprocessor/dag/expr/builtin_arithmetic.rs
+++ b/src/coprocessor/dag/expr/builtin_arithmetic.rs
@@ -15,8 +15,8 @@ use std::borrow::Cow;
 use std::ops::{Add, Mul, Sub};
 use std::{f64, i64, u64};
 
-use coprocessor::codec::mysql::{Decimal, Res};
-use coprocessor::codec::{div_i64, div_i64_with_u64, div_u64_with_i64, Datum};
+use crate::coprocessor::codec::mysql::{Decimal, Res};
+use crate::coprocessor::codec::{div_i64, div_i64_with_u64, div_u64_with_i64, Datum};
 
 use super::{Error, EvalContext, Result, ScalarFunc};
 
@@ -308,13 +308,13 @@ mod tests {
     use cop_datatype::FieldTypeFlag;
     use tipb::expression::ScalarFuncSig;
 
-    use coprocessor::codec::error::ERR_DIVISION_BY_ZERO;
-    use coprocessor::codec::mysql::Decimal;
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::{
+    use crate::coprocessor::codec::error::ERR_DIVISION_BY_ZERO;
+    use crate::coprocessor::codec::mysql::Decimal;
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::{
         check_divide_by_zero, check_overflow, datum_expr, scalar_func_expr, str2dec,
     };
-    use coprocessor::dag::expr::*;
+    use crate::coprocessor::dag::expr::*;
 
     #[test]
     fn test_arithmetic_int() {

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -19,10 +19,10 @@ use cop_datatype::prelude::*;
 use cop_datatype::{self, FieldTypeFlag, FieldTypeTp};
 
 use super::{Error, EvalContext, Result, ScalarFunc};
-use coprocessor::codec::convert::{self, convert_float_to_int, convert_float_to_uint};
-use coprocessor::codec::mysql::decimal::RoundMode;
-use coprocessor::codec::mysql::{charset, Decimal, Duration, Json, Res, Time, TimeType};
-use coprocessor::codec::{mysql, Datum};
+use crate::coprocessor::codec::convert::{self, convert_float_to_int, convert_float_to_uint};
+use crate::coprocessor::codec::mysql::decimal::RoundMode;
+use crate::coprocessor::codec::mysql::{charset, Decimal, Duration, Json, Res, Time, TimeType};
+use crate::coprocessor::codec::{mysql, Datum};
 
 impl ScalarFunc {
     pub fn cast_int_as_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
@@ -733,12 +733,12 @@ mod tests {
 
     use chrono::Utc;
 
-    use coprocessor::codec::error::*;
-    use coprocessor::codec::mysql::{self, charset, Decimal, Duration, Json, Time, TimeType, Tz};
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::ctx::FLAG_OVERFLOW_AS_WARNING;
-    use coprocessor::dag::expr::tests::{col_expr as base_col_expr, scalar_func_expr};
-    use coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
+    use crate::coprocessor::codec::error::*;
+    use crate::coprocessor::codec::mysql::{self, charset, Decimal, Duration, Json, Time, TimeType, Tz};
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::ctx::FLAG_OVERFLOW_AS_WARNING;
+    use crate::coprocessor::dag::expr::tests::{col_expr as base_col_expr, scalar_func_expr};
+    use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
 
     pub fn col_expr(col_id: i64, tp: FieldTypeTp) -> Expr {
         let mut expr = base_col_expr(col_id);

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -869,7 +869,7 @@ mod tests {
         ];
         for (sig, tp, col, expect) in cases {
             let col_expr = col_expr(0, tp);
-            let mut exp = scalar_func_expr(sig, &[col_expr]);
+            let exp = scalar_func_expr(sig, &[col_expr]);
             let e = Expression::build(&ctx, exp).unwrap();
             let res = e.eval_int(&mut ctx, &col).unwrap();
             assert_eq!(res.unwrap(), expect);
@@ -1900,7 +1900,7 @@ mod tests {
             ),
         ];
         for (flag, cols, exp) in cases {
-            let mut col_expr = col_expr(0, FieldTypeTp::NewDecimal);
+            let col_expr = col_expr(0, FieldTypeTp::NewDecimal);
             let mut ex = scalar_func_expr(ScalarFuncSig::CastDecimalAsInt, &[col_expr]);
             ex.mut_field_type().as_mut_accessor().set_flag(flag);
 
@@ -1948,7 +1948,7 @@ mod tests {
         ];
 
         for (flag, cols, exp, warnings_cnt) in cases {
-            let mut col_expr = col_expr(0, FieldTypeTp::String);
+            let col_expr = col_expr(0, FieldTypeTp::String);
             let mut ex = scalar_func_expr(ScalarFuncSig::CastStringAsInt, &[col_expr]);
             ex.mut_field_type().as_mut_accessor().set_flag(flag);
 
@@ -1974,7 +1974,7 @@ mod tests {
         ];
 
         for (cols, exp) in cases {
-            let mut col_expr = col_expr(0, FieldTypeTp::String);
+            let col_expr = col_expr(0, FieldTypeTp::String);
             let ex = scalar_func_expr(ScalarFuncSig::CastStringAsInt, &[col_expr]);
             // test with overflow as warning && in select stmt
             let mut cfg = EvalConfig::new();

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -734,7 +734,9 @@ mod tests {
     use chrono::Utc;
 
     use crate::coprocessor::codec::error::*;
-    use crate::coprocessor::codec::mysql::{self, charset, Decimal, Duration, Json, Time, TimeType, Tz};
+    use crate::coprocessor::codec::mysql::{
+        self, charset, Decimal, Duration, Json, Time, TimeType, Tz,
+    };
     use crate::coprocessor::codec::Datum;
     use crate::coprocessor::dag::expr::ctx::FLAG_OVERFLOW_AS_WARNING;
     use crate::coprocessor::dag::expr::tests::{col_expr as base_col_expr, scalar_func_expr};

--- a/src/coprocessor/dag/expr/builtin_compare.rs
+++ b/src/coprocessor/dag/expr/builtin_compare.rs
@@ -18,9 +18,9 @@ use std::{f64, i64};
 use chrono::TimeZone;
 
 use super::{Error, EvalContext, Result, ScalarFunc};
-use coprocessor::codec::mysql::{Decimal, Duration, Json, Time, TimeType};
-use coprocessor::codec::{datum, mysql, Datum};
-use coprocessor::dag::expr::Expression;
+use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time, TimeType};
+use crate::coprocessor::codec::{datum, mysql, Datum};
+use crate::coprocessor::dag::expr::Expression;
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum CmpOp {
@@ -481,11 +481,11 @@ where
 mod tests {
     use super::super::EvalConfig;
     use super::*;
-    use coprocessor::codec::error::ERR_TRUNCATE_WRONG_VALUE;
-    use coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::{col_expr, datum_expr, str2dec};
-    use coprocessor::dag::expr::{EvalContext, Expression};
+    use crate::coprocessor::codec::error::ERR_TRUNCATE_WRONG_VALUE;
+    use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::{col_expr, datum_expr, str2dec};
+    use crate::coprocessor::dag::expr::{EvalContext, Expression};
     use protobuf::RepeatedField;
     use std::sync::Arc;
     use std::{i64, u64};

--- a/src/coprocessor/dag/expr/builtin_control.rs
+++ b/src/coprocessor/dag/expr/builtin_control.rs
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 use super::{EvalContext, Result, ScalarFunc};
-use coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
-use coprocessor::codec::Datum;
-use coprocessor::dag::expr::Expression;
+use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
+use crate::coprocessor::codec::Datum;
+use crate::coprocessor::dag::expr::Expression;
 use std::borrow::Cow;
 
 fn if_null<F, T>(mut f: F) -> Result<Option<T>>
@@ -232,10 +232,10 @@ mod tests {
     use protobuf::RepeatedField;
     use tipb::expression::{Expr, ExprType, ScalarFuncSig};
 
-    use coprocessor::codec::mysql::{Duration, Json, Time};
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::{col_expr, datum_expr, scalar_func_expr, str2dec};
-    use coprocessor::dag::expr::{EvalContext, Expression};
+    use crate::coprocessor::codec::mysql::{Duration, Json, Time};
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::{col_expr, datum_expr, scalar_func_expr, str2dec};
+    use crate::coprocessor::dag::expr::{EvalContext, Expression};
 
     #[test]
     fn test_if_null() {

--- a/src/coprocessor/dag/expr/builtin_encryption.rs
+++ b/src/coprocessor/dag/expr/builtin_encryption.rs
@@ -14,7 +14,7 @@
 use std::borrow::Cow;
 
 use super::{Error, EvalContext, Result, ScalarFunc};
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::Datum;
 use crypto::{
     digest::Digest,
     md5::Md5,
@@ -179,9 +179,9 @@ impl ScalarFunc {
 
 #[cfg(test)]
 mod tests {
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::{datum_expr, eval_func, scalar_func_expr};
-    use coprocessor::dag::expr::{EvalContext, Expression};
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::{datum_expr, eval_func, scalar_func_expr};
+    use crate::coprocessor::dag::expr::{EvalContext, Expression};
     use hex;
     use tipb::expression::ScalarFuncSig;
 

--- a/src/coprocessor/dag/expr/builtin_json.rs
+++ b/src/coprocessor/dag/expr/builtin_json.rs
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 use super::{Error, EvalContext, Expression, Result, ScalarFunc};
-use coprocessor::codec::mysql::json::{parse_json_path_expr, ModifyType, PathExpression};
-use coprocessor::codec::mysql::Json;
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::mysql::json::{parse_json_path_expr, ModifyType, PathExpression};
+use crate::coprocessor::codec::mysql::Json;
+use crate::coprocessor::codec::Datum;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 
@@ -199,10 +199,10 @@ impl<'a> JsonFuncArgsParser<'a> {
 
 #[cfg(test)]
 mod tests {
-    use coprocessor::codec::mysql::Json;
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::{datum_expr, make_null_datums, scalar_func_expr};
-    use coprocessor::dag::expr::{EvalContext, Expression};
+    use crate::coprocessor::codec::mysql::Json;
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::{datum_expr, make_null_datums, scalar_func_expr};
+    use crate::coprocessor::dag::expr::{EvalContext, Expression};
     use tipb::expression::ScalarFuncSig;
 
     #[test]

--- a/src/coprocessor/dag/expr/builtin_like.rs
+++ b/src/coprocessor/dag/expr/builtin_like.rs
@@ -14,7 +14,7 @@
 use std::slice::Iter;
 
 use super::{EvalContext, Result, ScalarFunc};
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::Datum;
 use regex::{bytes::Regex as BytesRegex, Regex};
 
 const MAX_RECURSE_LEVEL: usize = 1024;
@@ -122,9 +122,9 @@ fn like(target: &[u8], pattern: &[u8], escape: u32, recurse_level: usize) -> Res
 
 #[cfg(test)]
 mod tests {
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
-    use coprocessor::dag::expr::{EvalContext, Expression};
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
+    use crate::coprocessor::dag::expr::{EvalContext, Expression};
     use tipb::expression::ScalarFuncSig;
 
     #[test]

--- a/src/coprocessor/dag/expr/builtin_math.rs
+++ b/src/coprocessor/dag/expr/builtin_math.rs
@@ -579,7 +579,9 @@ mod tests {
     use tipb::expression::ScalarFuncSig;
 
     use crate::coprocessor::codec::Datum;
-    use crate::coprocessor::dag::expr::tests::{check_overflow, eval_func, eval_func_with, str2dec};
+    use crate::coprocessor::dag::expr::tests::{
+        check_overflow, eval_func, eval_func_with, str2dec,
+    };
 
     #[test]
     fn test_abs() {

--- a/src/coprocessor/dag/expr/builtin_math.rs
+++ b/src/coprocessor/dag/expr/builtin_math.rs
@@ -20,8 +20,8 @@ use rand::{Rng, SeedableRng, XorShiftRng};
 use time;
 
 use super::{Error, EvalContext, Result, ScalarFunc};
-use coprocessor::codec::mysql::{Decimal, RoundMode, DEFAULT_FSP};
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::mysql::{Decimal, RoundMode, DEFAULT_FSP};
+use crate::coprocessor::codec::Datum;
 
 impl ScalarFunc {
     #[inline]
@@ -578,8 +578,8 @@ mod tests {
     use cop_datatype::{self, FieldTypeAccessor, FieldTypeFlag};
     use tipb::expression::ScalarFuncSig;
 
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::{check_overflow, eval_func, eval_func_with, str2dec};
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::{check_overflow, eval_func, eval_func_with, str2dec};
 
     #[test]
     fn test_abs() {

--- a/src/coprocessor/dag/expr/builtin_miscellaneous.rs
+++ b/src/coprocessor/dag/expr/builtin_miscellaneous.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use super::{EvalContext, Result, ScalarFunc};
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::Datum;
 use std::borrow::Cow;
 use std::convert::TryInto;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -126,9 +126,9 @@ impl ScalarFunc {
 
 #[cfg(test)]
 mod tests {
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
-    use coprocessor::dag::expr::{EvalContext, Expression};
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
+    use crate::coprocessor::dag::expr::{EvalContext, Expression};
     use tipb::expression::ScalarFuncSig;
 
     #[test]

--- a/src/coprocessor/dag/expr/builtin_op.rs
+++ b/src/coprocessor/dag/expr/builtin_op.rs
@@ -197,7 +197,9 @@ impl ScalarFunc {
 mod tests {
     use crate::coprocessor::codec::mysql::Duration;
     use crate::coprocessor::codec::Datum;
-    use crate::coprocessor::dag::expr::tests::{check_overflow, datum_expr, scalar_func_expr, str2dec};
+    use crate::coprocessor::dag::expr::tests::{
+        check_overflow, datum_expr, scalar_func_expr, str2dec,
+    };
     use crate::coprocessor::dag::expr::{EvalContext, Expression};
     use std::i64;
     use tipb::expression::ScalarFuncSig;

--- a/src/coprocessor/dag/expr/builtin_op.rs
+++ b/src/coprocessor/dag/expr/builtin_op.rs
@@ -15,8 +15,8 @@ use std::borrow::Cow;
 use std::i64;
 
 use super::{Error, EvalContext, Result, ScalarFunc};
-use coprocessor::codec::mysql::Decimal;
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::mysql::Decimal;
+use crate::coprocessor::codec::Datum;
 
 impl ScalarFunc {
     pub fn logical_and(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
@@ -195,10 +195,10 @@ impl ScalarFunc {
 
 #[cfg(test)]
 mod tests {
-    use coprocessor::codec::mysql::Duration;
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::{check_overflow, datum_expr, scalar_func_expr, str2dec};
-    use coprocessor::dag::expr::{EvalContext, Expression};
+    use crate::coprocessor::codec::mysql::Duration;
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::{check_overflow, datum_expr, scalar_func_expr, str2dec};
+    use crate::coprocessor::dag::expr::{EvalContext, Expression};
     use std::i64;
     use tipb::expression::ScalarFuncSig;
 

--- a/src/coprocessor/dag/expr/builtin_other.rs
+++ b/src/coprocessor/dag/expr/builtin_other.rs
@@ -14,7 +14,7 @@
 use std::i64;
 
 use super::{EvalContext, Result, ScalarFunc};
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::Datum;
 
 impl ScalarFunc {
     #[inline]
@@ -41,11 +41,11 @@ impl ScalarFunc {
 
 #[cfg(test)]
 mod tests {
-    use coprocessor::codec::mysql::Decimal;
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::ctx::FLAG_OVERFLOW_AS_WARNING;
-    use coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
-    use coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
+    use crate::coprocessor::codec::mysql::Decimal;
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::ctx::FLAG_OVERFLOW_AS_WARNING;
+    use crate::coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
+    use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
     use std::str::FromStr;
     use std::sync::Arc;
     use tipb::expression::ScalarFuncSig;

--- a/src/coprocessor/dag/expr/builtin_string.rs
+++ b/src/coprocessor/dag/expr/builtin_string.rs
@@ -23,7 +23,7 @@ use cop_datatype;
 use cop_datatype::prelude::*;
 
 use super::{EvalContext, Result, ScalarFunc};
-use coprocessor::codec::{datum, Datum};
+use crate::coprocessor::codec::{datum, Datum};
 use safemem;
 
 const SPACE: u8 = 0o40u8;
@@ -1051,15 +1051,15 @@ fn trim<'a>(s: &str, pat: &str, direction: TrimDirection) -> Result<Option<Cow<'
 mod tests {
     use super::{encoded_size, TrimDirection};
     use cop_datatype::{Collation, FieldTypeFlag, FieldTypeTp, MAX_BLOB_WIDTH};
-    use coprocessor::codec::mysql::charset::CHARSET_BIN;
+    use crate::coprocessor::codec::mysql::charset::CHARSET_BIN;
     use std::{f64, i64};
     use tipb::expression::{Expr, ScalarFuncSig};
 
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::{
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::{
         col_expr, datum_expr, eval_func, scalar_func_expr, string_datum_expr_with_tp,
     };
-    use coprocessor::dag::expr::{EvalContext, Expression};
+    use crate::coprocessor::dag::expr::{EvalContext, Expression};
 
     #[test]
     fn test_length() {

--- a/src/coprocessor/dag/expr/builtin_string.rs
+++ b/src/coprocessor/dag/expr/builtin_string.rs
@@ -1879,7 +1879,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (row, exp) in cases {
             let children: Vec<Expr> = row.iter().map(|d| datum_expr(d.clone())).collect();
-            let mut expr = scalar_func_expr(ScalarFuncSig::Concat, &children);
+            let expr = scalar_func_expr(ScalarFuncSig::Concat, &children);
             let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);
@@ -1934,7 +1934,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (row, exp) in cases {
             let children: Vec<Expr> = row.iter().map(|d| datum_expr(d.clone())).collect();
-            let mut expr = scalar_func_expr(ScalarFuncSig::ConcatWS, &children);
+            let expr = scalar_func_expr(ScalarFuncSig::ConcatWS, &children);
             let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);

--- a/src/coprocessor/dag/expr/builtin_string.rs
+++ b/src/coprocessor/dag/expr/builtin_string.rs
@@ -1050,8 +1050,8 @@ fn trim<'a>(s: &str, pat: &str, direction: TrimDirection) -> Result<Option<Cow<'
 #[cfg(test)]
 mod tests {
     use super::{encoded_size, TrimDirection};
-    use cop_datatype::{Collation, FieldTypeFlag, FieldTypeTp, MAX_BLOB_WIDTH};
     use crate::coprocessor::codec::mysql::charset::CHARSET_BIN;
+    use cop_datatype::{Collation, FieldTypeFlag, FieldTypeTp, MAX_BLOB_WIDTH};
     use std::{f64, i64};
     use tipb::expression::{Expr, ScalarFuncSig};
 

--- a/src/coprocessor/dag/expr/builtin_time.rs
+++ b/src/coprocessor/dag/expr/builtin_time.rs
@@ -12,13 +12,13 @@
 // limitations under the License.
 
 use super::{EvalContext, Result, ScalarFunc};
-use chrono::offset::TimeZone;
-use chrono::{Datelike, Duration};
 use crate::coprocessor::codec::error::Error;
 use crate::coprocessor::codec::mysql::time::extension::DateTimeExtension;
 use crate::coprocessor::codec::mysql::time::weekmode::WeekMode;
 use crate::coprocessor::codec::mysql::{self, Duration as MyDuration, Time, TimeType};
 use crate::coprocessor::codec::Datum;
+use chrono::offset::TimeZone;
+use chrono::{Datelike, Duration};
 use std::borrow::Cow;
 
 fn handle_incorrect_datetime_error(ctx: &mut EvalContext, t: Cow<'_, Time>) -> Result<()> {

--- a/src/coprocessor/dag/expr/builtin_time.rs
+++ b/src/coprocessor/dag/expr/builtin_time.rs
@@ -14,11 +14,11 @@
 use super::{EvalContext, Result, ScalarFunc};
 use chrono::offset::TimeZone;
 use chrono::{Datelike, Duration};
-use coprocessor::codec::error::Error;
-use coprocessor::codec::mysql::time::extension::DateTimeExtension;
-use coprocessor::codec::mysql::time::weekmode::WeekMode;
-use coprocessor::codec::mysql::{self, Duration as MyDuration, Time, TimeType};
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::error::Error;
+use crate::coprocessor::codec::mysql::time::extension::DateTimeExtension;
+use crate::coprocessor::codec::mysql::time::weekmode::WeekMode;
+use crate::coprocessor::codec::mysql::{self, Duration as MyDuration, Time, TimeType};
+use crate::coprocessor::codec::Datum;
 use std::borrow::Cow;
 
 fn handle_incorrect_datetime_error(ctx: &mut EvalContext, t: Cow<'_, Time>) -> Result<()> {
@@ -109,7 +109,7 @@ impl ScalarFunc {
         } else if month == 0 || t.is_zero() {
             return Ok(None);
         }
-        use coprocessor::codec::mysql::time::MONTH_NAMES;
+        use crate::coprocessor::codec::mysql::time::MONTH_NAMES;
         Ok(Some(Cow::Owned(
             MONTH_NAMES[month - 1].to_string().into_bytes(),
         )))
@@ -125,7 +125,7 @@ impl ScalarFunc {
         if t.is_zero() {
             return handle_incorrect_datetime_error(ctx, t).map(|_| None);
         }
-        use coprocessor::codec::mysql::time::WeekdayExtension;
+        use crate::coprocessor::codec::mysql::time::WeekdayExtension;
         let weekday = t.get_time().weekday();
         Ok(Some(Cow::Owned(weekday.name().to_string().into_bytes())))
     }
@@ -422,11 +422,11 @@ impl ScalarFunc {
 
 #[cfg(test)]
 mod tests {
-    use coprocessor::codec::mysql::{Duration, Time};
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
-    use coprocessor::dag::expr::*;
-    use coprocessor::dag::expr::{EvalContext, Expression};
+    use crate::coprocessor::codec::mysql::{Duration, Time};
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
+    use crate::coprocessor::dag::expr::*;
+    use crate::coprocessor::dag::expr::{EvalContext, Expression};
     use std::sync::Arc;
     use tipb::expression::{Expr, ScalarFuncSig};
 

--- a/src/coprocessor/dag/expr/column.rs
+++ b/src/coprocessor/dag/expr/column.rs
@@ -18,8 +18,8 @@ use cop_datatype::prelude::*;
 use cop_datatype::FieldTypeTp;
 
 use super::{Column, EvalContext, Result};
-use coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
+use crate::coprocessor::codec::Datum;
 
 impl Column {
     pub fn eval(&self, row: &[Datum]) -> Datum {
@@ -96,10 +96,10 @@ mod tests {
     use cop_datatype::{FieldTypeAccessor, FieldTypeTp};
     use tipb::expression::FieldType;
 
-    use coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::col_expr;
-    use coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
+    use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::col_expr;
+    use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
 
     #[derive(PartialEq, Debug)]
     struct EvalResults(

--- a/src/coprocessor/dag/expr/constant.rs
+++ b/src/coprocessor/dag/expr/constant.rs
@@ -14,8 +14,8 @@
 use std::borrow::Cow;
 
 use super::{Constant, Result};
-use coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
+use crate::coprocessor::codec::Datum;
 
 impl Datum {
     #[inline]
@@ -126,10 +126,10 @@ impl Constant {
 
 #[cfg(test)]
 mod tests {
-    use coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
-    use coprocessor::codec::Datum;
-    use coprocessor::dag::expr::tests::datum_expr;
-    use coprocessor::dag::expr::{EvalContext, Expression};
+    use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
+    use crate::coprocessor::codec::Datum;
+    use crate::coprocessor::dag::expr::tests::datum_expr;
+    use crate::coprocessor::dag::expr::{EvalContext, Expression};
     use std::u64;
 
     #[derive(PartialEq, Debug)]

--- a/src/coprocessor/dag/expr/ctx.rs
+++ b/src/coprocessor/dag/expr/ctx.rs
@@ -17,7 +17,7 @@ use std::{i64, mem, u64};
 use tipb::select;
 
 use super::{Error, Result};
-use coprocessor::codec::mysql::Tz;
+use crate::coprocessor::codec::mysql::Tz;
 
 /// Flags are used by `DAGRequest.flags` to handle execution mode, like how to handle
 /// truncate error.

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -20,12 +20,12 @@ use rand::XorShiftRng;
 
 use tipb::expression::{Expr, ExprType, FieldType, ScalarFuncSig};
 
-use cop_datatype::prelude::*;
-use cop_datatype::FieldTypeFlag;
 use crate::coprocessor::codec::mysql::charset;
 use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time, MAX_FSP};
 use crate::coprocessor::codec::{self, Datum};
 use crate::util::codec::number;
+use cop_datatype::prelude::*;
+use cop_datatype::FieldTypeFlag;
 
 mod builtin_arithmetic;
 mod builtin_cast;
@@ -332,7 +332,9 @@ mod tests {
     use super::{Error, EvalConfig, EvalContext, Expression};
     use crate::coprocessor::codec::error::{ERR_DATA_OUT_OF_RANGE, ERR_DIVISION_BY_ZERO};
     use crate::coprocessor::codec::mysql::json::JsonEncoder;
-    use crate::coprocessor::codec::mysql::{charset, Decimal, DecimalEncoder, Duration, Json, Time};
+    use crate::coprocessor::codec::mysql::{
+        charset, Decimal, DecimalEncoder, Duration, Json, Time,
+    };
     use crate::coprocessor::codec::{mysql, Datum};
     use crate::util::codec::number::{self, NumberEncoder};
 

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -22,10 +22,10 @@ use tipb::expression::{Expr, ExprType, FieldType, ScalarFuncSig};
 
 use cop_datatype::prelude::*;
 use cop_datatype::FieldTypeFlag;
-use coprocessor::codec::mysql::charset;
-use coprocessor::codec::mysql::{Decimal, Duration, Json, Time, MAX_FSP};
-use coprocessor::codec::{self, Datum};
-use util::codec::number;
+use crate::coprocessor::codec::mysql::charset;
+use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time, MAX_FSP};
+use crate::coprocessor::codec::{self, Datum};
+use crate::util::codec::number;
 
 mod builtin_arithmetic;
 mod builtin_cast;
@@ -46,7 +46,7 @@ mod ctx;
 mod scalar_function;
 
 pub use self::ctx::*;
-pub use coprocessor::codec::{Error, Result};
+pub use crate::coprocessor::codec::{Error, Result};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expression {
@@ -330,11 +330,11 @@ mod tests {
     use tipb::expression::{Expr, ExprType, FieldType, ScalarFuncSig};
 
     use super::{Error, EvalConfig, EvalContext, Expression};
-    use coprocessor::codec::error::{ERR_DATA_OUT_OF_RANGE, ERR_DIVISION_BY_ZERO};
-    use coprocessor::codec::mysql::json::JsonEncoder;
-    use coprocessor::codec::mysql::{charset, Decimal, DecimalEncoder, Duration, Json, Time};
-    use coprocessor::codec::{mysql, Datum};
-    use util::codec::number::{self, NumberEncoder};
+    use crate::coprocessor::codec::error::{ERR_DATA_OUT_OF_RANGE, ERR_DIVISION_BY_ZERO};
+    use crate::coprocessor::codec::mysql::json::JsonEncoder;
+    use crate::coprocessor::codec::mysql::{charset, Decimal, DecimalEncoder, Duration, Json, Time};
+    use crate::coprocessor::codec::{mysql, Datum};
+    use crate::util::codec::number::{self, NumberEncoder};
 
     #[inline]
     pub fn str2dec(s: &str) -> Datum {

--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -20,8 +20,8 @@ use tipb::expression::ScalarFuncSig;
 
 use super::builtin_compare::CmpOp;
 use super::{Error, EvalContext, Result, ScalarFunc};
-use coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
-use coprocessor::codec::Datum;
+use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
+use crate::coprocessor::codec::Datum;
 
 impl ScalarFunc {
     pub fn check_args(sig: ScalarFuncSig, args: usize) -> Result<()> {
@@ -1058,7 +1058,7 @@ dispatch_call! {
 
 #[cfg(test)]
 mod tests {
-    use coprocessor::dag::expr::{Error, ScalarFunc};
+    use crate::coprocessor::dag::expr::{Error, ScalarFunc};
     use std::usize;
     use tipb::expression::ScalarFuncSig;
 

--- a/src/coprocessor/dag/handler.rs
+++ b/src/coprocessor/dag/handler.rs
@@ -17,9 +17,9 @@ use kvproto::coprocessor::{KeyRange, Response};
 use protobuf::{Message, RepeatedField};
 use tipb::select::{Chunk, DAGRequest, SelectResponse, StreamResponse};
 
-use coprocessor::dag::expr::EvalConfig;
-use coprocessor::*;
-use storage::Store;
+use crate::coprocessor::dag::expr::EvalConfig;
+use crate::coprocessor::*;
+use crate::storage::Store;
 
 use super::executor::{Executor, ExecutorMetrics};
 

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -23,16 +23,16 @@ use tipb::checksum::{ChecksumRequest, ChecksumScanOn};
 use tipb::executor::ExecType;
 use tipb::select::DAGRequest;
 
-use server::readpool::{self, ReadPool};
-use server::Config;
-use storage::{self, Engine, SnapshotStore};
-use util::Either;
+use crate::server::readpool::{self, ReadPool};
+use crate::server::Config;
+use crate::storage::{self, Engine, SnapshotStore};
+use crate::util::Either;
 
-use coprocessor::dag::executor::ExecutorMetrics;
-use coprocessor::metrics::*;
-use coprocessor::tracker::Tracker;
-use coprocessor::util as cop_util;
-use coprocessor::*;
+use crate::coprocessor::dag::executor::ExecutorMetrics;
+use crate::coprocessor::metrics::*;
+use crate::coprocessor::tracker::Tracker;
+use crate::coprocessor::util as cop_util;
+use crate::coprocessor::*;
 
 const OUTDATED_ERROR_MSG: &str = "request outdated.";
 const BUSY_ERROR_MSG: &str = "server is busy (coprocessor full).";
@@ -66,7 +66,7 @@ impl<E: Engine> Clone for Endpoint<E> {
     }
 }
 
-impl<E: Engine> ::util::AssertSend for Endpoint<E> {}
+impl<E: Engine> crate::util::AssertSend for Endpoint<E> {}
 
 impl<E: Engine> Endpoint<E> {
     pub fn new(cfg: &Config, engine: E, read_pool: ReadPool<ReadPoolContext>) -> Self {
@@ -228,7 +228,7 @@ impl<E: Engine> Endpoint<E> {
         engine: E,
         ctx: &kvrpcpb::Context,
     ) -> impl Future<Item = E::Snap, Error = Error> {
-        let (callback, future) = ::util::future::paired_future_callback();
+        let (callback, future) = crate::util::future::paired_future_callback();
         let val = engine.async_snapshot(ctx, callback);
         future::result(val)
             .and_then(|_| future.map_err(|cancel| storage::engine::Error::Other(box_err!(cancel))))
@@ -539,8 +539,8 @@ mod tests {
     use tipb::executor::Executor;
     use tipb::expression::Expr;
 
-    use storage::TestEngineBuilder;
-    use util::worker::FutureWorker;
+    use crate::storage::TestEngineBuilder;
+    use crate::util::worker::FutureWorker;
 
     /// A unary `RequestHandler` that always produces a fixture.
     struct UnaryFixture {
@@ -1035,7 +1035,7 @@ mod tests {
 
     #[test]
     fn test_handle_time() {
-        use util::config::ReadableDuration;
+        use crate::util::config::ReadableDuration;
 
         /// Asserted that the snapshot can be retrieved in 500ms.
         const SNAPSHOT_DURATION_MS: i64 = 500;

--- a/src/coprocessor/error.rs
+++ b/src/coprocessor/error.rs
@@ -18,8 +18,8 @@ use std::time::Duration;
 use kvproto::{errorpb, kvrpcpb};
 use tipb;
 
-use coprocessor;
-use storage;
+use crate::coprocessor;
+use crate::storage;
 
 quick_error! {
     #[derive(Debug)]

--- a/src/coprocessor/local_metrics.rs
+++ b/src/coprocessor/local_metrics.rs
@@ -16,10 +16,10 @@ use std::mem;
 use crate::coprocessor::dag::executor::ExecutorMetrics;
 use crate::coprocessor::metrics::*;
 use crate::pd::PdTask;
-use prometheus::local::{LocalHistogramVec, LocalIntCounterVec};
 use crate::storage::engine::{FlowStatistics, Statistics};
 use crate::util::collections::HashMap;
 use crate::util::worker::FutureScheduler;
+use prometheus::local::{LocalHistogramVec, LocalIntCounterVec};
 
 /// `CopFlowStatistics` is for flow statistics, it would be reported to PD by flush.
 pub struct CopFlowStatistics {

--- a/src/coprocessor/local_metrics.rs
+++ b/src/coprocessor/local_metrics.rs
@@ -13,13 +13,13 @@
 
 use std::mem;
 
-use coprocessor::dag::executor::ExecutorMetrics;
-use coprocessor::metrics::*;
-use pd::PdTask;
+use crate::coprocessor::dag::executor::ExecutorMetrics;
+use crate::coprocessor::metrics::*;
+use crate::pd::PdTask;
 use prometheus::local::{LocalHistogramVec, LocalIntCounterVec};
-use storage::engine::{FlowStatistics, Statistics};
-use util::collections::HashMap;
-use util::worker::FutureScheduler;
+use crate::storage::engine::{FlowStatistics, Statistics};
+use crate::util::collections::HashMap;
+use crate::util::worker::FutureScheduler;
 
 /// `CopFlowStatistics` is for flow statistics, it would be reported to PD by flush.
 pub struct CopFlowStatistics {

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -48,7 +48,7 @@ use std::boxed::FnBox;
 
 use kvproto::{coprocessor as coppb, kvrpcpb};
 
-use util::time::{Duration, Instant};
+use crate::util::time::{Duration, Instant};
 
 pub const REQ_TYPE_DAG: i64 = 103;
 pub const REQ_TYPE_ANALYZE: i64 = 104;

--- a/src/coprocessor/readpool_context.rs
+++ b/src/coprocessor/readpool_context.rs
@@ -13,9 +13,9 @@
 
 use std::fmt;
 
-use pd;
-use util::futurepool;
-use util::worker;
+use crate::pd;
+use crate::util::futurepool;
+use crate::util::worker;
 
 use super::dag::executor::ExecutorMetrics;
 use super::local_metrics::{BasicLocalMetrics, ExecLocalMetrics};

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -22,7 +22,9 @@ use tipb::executor::TableScan;
 use crate::storage::{Snapshot, SnapshotStore};
 
 use crate::coprocessor::codec::datum;
-use crate::coprocessor::dag::executor::{Executor, ExecutorMetrics, IndexScanExecutor, TableScanExecutor};
+use crate::coprocessor::dag::executor::{
+    Executor, ExecutorMetrics, IndexScanExecutor, TableScanExecutor,
+};
 use crate::coprocessor::*;
 
 use super::cmsketch::CMSketch;

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -19,11 +19,11 @@ use rand::{thread_rng, Rng, ThreadRng};
 use tipb::analyze::{self, AnalyzeColumnsReq, AnalyzeIndexReq, AnalyzeReq, AnalyzeType};
 use tipb::executor::TableScan;
 
-use storage::{Snapshot, SnapshotStore};
+use crate::storage::{Snapshot, SnapshotStore};
 
-use coprocessor::codec::datum;
-use coprocessor::dag::executor::{Executor, ExecutorMetrics, IndexScanExecutor, TableScanExecutor};
-use coprocessor::*;
+use crate::coprocessor::codec::datum;
+use crate::coprocessor::dag::executor::{Executor, ExecutorMetrics, IndexScanExecutor, TableScanExecutor};
+use crate::coprocessor::*;
 
 use super::cmsketch::CMSketch;
 use super::fmsketch::FMSketch;
@@ -301,8 +301,8 @@ impl SampleCollector {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coprocessor::codec::datum;
-    use coprocessor::codec::datum::Datum;
+    use crate::coprocessor::codec::datum;
+    use crate::coprocessor::codec::datum::Datum;
 
     #[test]
     fn test_sample_collector() {

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -76,12 +76,12 @@ impl CMSketch {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coprocessor::codec::datum;
-    use coprocessor::codec::datum::Datum;
+    use crate::coprocessor::codec::datum;
+    use crate::coprocessor::codec::datum::Datum;
     use rand::{Rng, SeedableRng, StdRng};
     use std::cmp::min;
-    use util::as_slice;
-    use util::collections::HashMap;
+    use crate::util::as_slice;
+    use crate::util::collections::HashMap;
     use zipf::ZipfDistribution;
 
     impl CMSketch {

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -78,10 +78,10 @@ mod tests {
     use super::*;
     use crate::coprocessor::codec::datum;
     use crate::coprocessor::codec::datum::Datum;
-    use rand::{Rng, SeedableRng, StdRng};
-    use std::cmp::min;
     use crate::util::as_slice;
     use crate::util::collections::HashMap;
+    use rand::{Rng, SeedableRng, StdRng};
+    use std::cmp::min;
     use zipf::ZipfDistribution;
 
     impl CMSketch {

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -14,7 +14,7 @@
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
 use tipb::analyze;
-use util::collections::HashSet;
+use crate::util::collections::HashSet;
 
 /// `FMSketch` is used to count the approximate number of distinct
 /// elements in multiset.
@@ -68,11 +68,11 @@ impl FMSketch {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coprocessor::codec::datum;
-    use coprocessor::codec::datum::Datum;
-    use coprocessor::codec::Result;
+    use crate::coprocessor::codec::datum;
+    use crate::coprocessor::codec::datum::Datum;
+    use crate::coprocessor::codec::Result;
     use std::iter::repeat;
-    use util::as_slice;
+    use crate::util::as_slice;
 
     struct TestData {
         samples: Vec<Datum>,

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::util::collections::HashSet;
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
 use tipb::analyze;
-use crate::util::collections::HashSet;
 
 /// `FMSketch` is used to count the approximate number of distinct
 /// elements in multiset.
@@ -71,8 +71,8 @@ mod tests {
     use crate::coprocessor::codec::datum;
     use crate::coprocessor::codec::datum::Datum;
     use crate::coprocessor::codec::Result;
-    use std::iter::repeat;
     use crate::util::as_slice;
+    use std::iter::repeat;
 
     struct TestData {
         samples: Vec<Datum>,

--- a/src/coprocessor/statistics/histogram.rs
+++ b/src/coprocessor/statistics/histogram.rs
@@ -167,8 +167,8 @@ impl Histogram {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coprocessor::codec::datum;
-    use coprocessor::codec::datum::Datum;
+    use crate::coprocessor::codec::datum;
+    use crate::coprocessor::codec::datum::Datum;
     use std::iter::repeat;
 
     #[test]

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -13,12 +13,12 @@
 
 use kvproto::kvrpcpb;
 
-use storage::engine::{PerfStatisticsDelta, PerfStatisticsInstant};
-use util::futurepool;
-use util::time::{self, Duration, Instant};
+use crate::storage::engine::{PerfStatisticsDelta, PerfStatisticsInstant};
+use crate::util::futurepool;
+use crate::util::time::{self, Duration, Instant};
 
-use coprocessor::dag::executor::ExecutorMetrics;
-use coprocessor::*;
+use crate::coprocessor::dag::executor::ExecutorMetrics;
+use crate::coprocessor::*;
 
 // If handle time is larger than the lower bound, the query is considered as slow query.
 const SLOW_QUERY_LOWER_BOUND: f64 = 1.0; // 1 second.

--- a/src/coprocessor/util.rs
+++ b/src/coprocessor/util.rs
@@ -14,8 +14,8 @@
 use kvproto::coprocessor as coppb;
 use tipb::schema::ColumnInfo;
 
-use coprocessor::codec::datum::Datum;
-use coprocessor::*;
+use crate::coprocessor::codec::datum::Datum;
+use crate::coprocessor::*;
 
 /// A `RequestHandler` that always produces errors.
 pub struct ErrorRequestHandler {

--- a/src/import/client.rs
+++ b/src/import/client.rs
@@ -15,9 +15,9 @@ use std::io::{Cursor, Read};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use crate::grpc::{CallOption, Channel, ChannelBuilder, EnvBuilder, Environment, WriteFlags};
 use futures::future;
 use futures::{Async, Future, Poll, Stream};
-use crate::grpc::{CallOption, Channel, ChannelBuilder, EnvBuilder, Environment, WriteFlags};
 
 use kvproto::import_sstpb::*;
 use kvproto::import_sstpb_grpc::*;

--- a/src/import/client.rs
+++ b/src/import/client.rs
@@ -17,17 +17,17 @@ use std::time::Duration;
 
 use futures::future;
 use futures::{Async, Future, Poll, Stream};
-use grpc::{CallOption, Channel, ChannelBuilder, EnvBuilder, Environment, WriteFlags};
+use crate::grpc::{CallOption, Channel, ChannelBuilder, EnvBuilder, Environment, WriteFlags};
 
 use kvproto::import_sstpb::*;
 use kvproto::import_sstpb_grpc::*;
 use kvproto::kvrpcpb::*;
 use kvproto::tikvpb_grpc::*;
 
-use pd::{Config as PdConfig, PdClient, RegionInfo, RpcClient};
-use storage::types::Key;
-use util::collections::{HashMap, HashMapEntry};
-use util::security::SecurityManager;
+use crate::pd::{Config as PdConfig, PdClient, RegionInfo, RpcClient};
+use crate::storage::types::Key;
+use crate::util::collections::{HashMap, HashMapEntry};
+use crate::util::security::SecurityManager;
 
 use super::common::*;
 use super::{Error, Result};

--- a/src/import/common.rs
+++ b/src/import/common.rs
@@ -18,7 +18,7 @@ use kvproto::import_sstpb::*;
 use kvproto::kvrpcpb::*;
 use kvproto::metapb::*;
 
-use pd::RegionInfo;
+use crate::pd::RegionInfo;
 
 use super::client::*;
 
@@ -146,7 +146,7 @@ pub fn find_region_peer(region: &Region, store_id: u64) -> Option<Peer> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use import::test_helpers::*;
+    use crate::import::test_helpers::*;
 
     #[test]
     fn test_before_end() {

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -14,8 +14,8 @@
 use std::error::Error;
 use std::result::Result;
 
-use raftstore::coprocessor::config::SPLIT_SIZE_MB;
-use util::config::{ReadableDuration, ReadableSize};
+use crate::raftstore::coprocessor::config::SPLIT_SIZE_MB;
+use crate::util::config::{ReadableDuration, ReadableSize};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]

--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -28,14 +28,14 @@ use rocksdb::{
     ExternalSstFileInfo, ReadOptions, SstFileWriter, Writable, WriteBatch as RawBatch, DB,
 };
 
-use config::DbConfig;
-use raftstore::store::keys;
-use storage::mvcc::{Write, WriteType};
-use storage::types::Key;
-use storage::{is_short_value, CF_DEFAULT, CF_WRITE};
-use util::config::MB;
-use util::rocksdb::properties::{SizeProperties, SizePropertiesCollectorFactory};
-use util::rocksdb::{new_engine_opt, CFOptions};
+use crate::config::DbConfig;
+use crate::raftstore::store::keys;
+use crate::storage::mvcc::{Write, WriteType};
+use crate::storage::types::Key;
+use crate::storage::{is_short_value, CF_DEFAULT, CF_WRITE};
+use crate::util::config::MB;
+use crate::util::rocksdb::properties::{SizeProperties, SizePropertiesCollectorFactory};
+use crate::util::rocksdb::{new_engine_opt, CFOptions};
 
 use super::common::*;
 use super::Result;
@@ -299,9 +299,9 @@ mod tests {
     use std::io::Write;
     use tempdir::TempDir;
 
-    use raftstore::store::RegionSnapshot;
-    use storage::mvcc::MvccReader;
-    use util::rocksdb::new_engine_opt;
+    use crate::raftstore::store::RegionSnapshot;
+    use crate::storage::mvcc::MvccReader;
+    use crate::util::rocksdb::new_engine_opt;
 
     fn new_engine() -> (TempDir, Engine) {
         let dir = TempDir::new("test_import_engine").unwrap();

--- a/src/import/errors.rs
+++ b/src/import/errors.rs
@@ -16,8 +16,8 @@ use std::num::ParseIntError;
 use std::path::PathBuf;
 use std::result;
 
-use futures::sync::oneshot::Canceled;
 use crate::grpc::Error as GrpcError;
+use futures::sync::oneshot::Canceled;
 use kvproto::errorpb;
 use kvproto::metapb::*;
 use uuid::{ParseError, Uuid};

--- a/src/import/errors.rs
+++ b/src/import/errors.rs
@@ -17,14 +17,14 @@ use std::path::PathBuf;
 use std::result;
 
 use futures::sync::oneshot::Canceled;
-use grpc::Error as GrpcError;
+use crate::grpc::Error as GrpcError;
 use kvproto::errorpb;
 use kvproto::metapb::*;
 use uuid::{ParseError, Uuid};
 
-use pd::{Error as PdError, RegionInfo};
-use raftstore::errors::Error as RaftStoreError;
-use util::codec::Error as CodecError;
+use crate::pd::{Error as PdError, RegionInfo};
+use crate::raftstore::errors::Error as RaftStoreError;
+use crate::util::codec::Error as CodecError;
 
 quick_error! {
     #[derive(Debug)]

--- a/src/import/import.rs
+++ b/src/import/import.rs
@@ -20,7 +20,7 @@ use std::time::{Duration, Instant};
 use kvproto::import_sstpb::*;
 use uuid::Uuid;
 
-use pd::RegionInfo;
+use crate::pd::RegionInfo;
 
 use super::client::*;
 use super::common::*;

--- a/src/import/import_mode.rs
+++ b/src/import/import_mode.rs
@@ -134,7 +134,7 @@ mod tests {
     use super::*;
 
     use tempdir::TempDir;
-    use util::rocksdb::new_engine;
+    use crate::util::rocksdb::new_engine;
 
     fn check_import_options(db: &DB, opts: &ImportModeOptions) {
         for cf_name in db.cf_names() {

--- a/src/import/import_mode.rs
+++ b/src/import/import_mode.rs
@@ -133,8 +133,8 @@ impl ImportModeOptions {
 mod tests {
     use super::*;
 
-    use tempdir::TempDir;
     use crate::util::rocksdb::new_engine;
+    use tempdir::TempDir;
 
     fn check_import_options(db: &DB, opts: &ImportModeOptions) {
         for cf_name in db.cf_names() {

--- a/src/import/kv_importer.rs
+++ b/src/import/kv_importer.rs
@@ -19,8 +19,8 @@ use std::sync::{Arc, Mutex};
 use kvproto::import_kvpb::*;
 use uuid::Uuid;
 
-use config::DbConfig;
-use util::collections::HashMap;
+use crate::config::DbConfig;
+use crate::util::collections::HashMap;
 
 use super::client::*;
 use super::engine::*;

--- a/src/import/kv_server.rs
+++ b/src/import/kv_server.rs
@@ -15,10 +15,10 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use grpc::{ChannelBuilder, EnvBuilder, Server as GrpcServer, ServerBuilder};
+use crate::grpc::{ChannelBuilder, EnvBuilder, Server as GrpcServer, ServerBuilder};
 use kvproto::import_kvpb_grpc::create_import_kv;
 
-use config::TiKvConfig;
+use crate::config::TiKvConfig;
 
 use super::{ImportKVService, KVImporter};
 

--- a/src/import/kv_service.rs
+++ b/src/import/kv_service.rs
@@ -13,10 +13,10 @@
 
 use std::sync::Arc;
 
+use crate::grpc::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
 use futures::sync::mpsc;
 use futures::{Future, Stream};
 use futures_cpupool::{Builder, CpuPool};
-use crate::grpc::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
 use kvproto::import_kvpb::*;
 use kvproto::import_kvpb_grpc::*;
 use uuid::Uuid;

--- a/src/import/kv_service.rs
+++ b/src/import/kv_service.rs
@@ -16,14 +16,14 @@ use std::sync::Arc;
 use futures::sync::mpsc;
 use futures::{Future, Stream};
 use futures_cpupool::{Builder, CpuPool};
-use grpc::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
+use crate::grpc::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
 use kvproto::import_kvpb::*;
 use kvproto::import_kvpb_grpc::*;
 use uuid::Uuid;
 
-use raftstore::store::keys;
-use storage::types::Key;
-use util::time::Instant;
+use crate::raftstore::store::keys;
+use crate::storage::types::Key;
+use crate::util::time::Instant;
 
 use super::client::*;
 use super::metrics::*;

--- a/src/import/prepare.rs
+++ b/src/import/prepare.rs
@@ -19,9 +19,9 @@ use std::time::{Duration, Instant};
 
 use kvproto::metapb::*;
 
-use pd::RegionInfo;
-use util::escape;
-use util::rocksdb::properties::SizeProperties;
+use crate::pd::RegionInfo;
+use crate::util::escape;
+use crate::util::rocksdb::properties::SizeProperties;
 
 use super::client::*;
 use super::common::*;
@@ -280,14 +280,14 @@ impl<Client: ImportClient> PrepareRangeJob<Client> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use import::test_helpers::*;
+    use crate::import::test_helpers::*;
 
     use rocksdb::Writable;
     use tempdir::TempDir;
     use uuid::Uuid;
 
-    use config::DbConfig;
-    use storage::types::Key;
+    use crate::config::DbConfig;
+    use crate::storage::types::Key;
 
     fn new_encoded_key(k: &[u8]) -> Vec<u8> {
         if k.is_empty() {

--- a/src/import/service.rs
+++ b/src/import/service.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use futures::Future;
-use grpc::{RpcContext, RpcStatus, RpcStatusCode, UnarySink};
+use crate::grpc::{RpcContext, RpcStatus, RpcStatusCode, UnarySink};
 
 use super::Error;
 

--- a/src/import/service.rs
+++ b/src/import/service.rs
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::Future;
 use crate::grpc::{RpcContext, RpcStatus, RpcStatusCode, UnarySink};
+use futures::Future;
 
 use super::Error;
 

--- a/src/import/sst_importer.rs
+++ b/src/import/sst_importer.rs
@@ -21,7 +21,7 @@ use kvproto::import_sstpb::*;
 use rocksdb::{IngestExternalFileOptions, DB};
 use uuid::Uuid;
 
-use util::rocksdb::{get_cf_handle, prepare_sst_for_ingestion, validate_sst_for_ingestion};
+use crate::util::rocksdb::{get_cf_handle, prepare_sst_for_ingestion, validate_sst_for_ingestion};
 
 use super::{Error, Result};
 
@@ -329,10 +329,10 @@ fn path_to_sst_meta<P: AsRef<Path>>(path: P) -> Result<SSTMeta> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use import::test_helpers::*;
+    use crate::import::test_helpers::*;
 
     use tempdir::TempDir;
-    use util::rocksdb::new_engine;
+    use crate::util::rocksdb::new_engine;
 
     #[test]
     fn test_import_dir() {

--- a/src/import/sst_importer.rs
+++ b/src/import/sst_importer.rs
@@ -331,8 +331,8 @@ mod tests {
     use super::*;
     use crate::import::test_helpers::*;
 
-    use tempdir::TempDir;
     use crate::util::rocksdb::new_engine;
+    use tempdir::TempDir;
 
     #[test]
     fn test_import_dir() {

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -16,17 +16,17 @@ use std::sync::{Arc, Mutex};
 use futures::sync::mpsc;
 use futures::{future, Future, Stream};
 use futures_cpupool::{Builder, CpuPool};
-use grpc::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
+use crate::grpc::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
 use kvproto::import_sstpb::*;
 use kvproto::import_sstpb_grpc::*;
 use kvproto::raft_cmdpb::*;
 use rocksdb::DB;
 
-use raftstore::store::Callback;
-use server::transport::RaftStoreRouter;
-use util::future::paired_future_callback;
-use util::rocksdb::compact_files_in_range;
-use util::time::Instant;
+use crate::raftstore::store::Callback;
+use crate::server::transport::RaftStoreRouter;
+use crate::util::future::paired_future_callback;
+use crate::util::rocksdb::compact_files_in_range;
+use crate::util::time::Instant;
 
 use super::import_mode::*;
 use super::metrics::*;

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -13,10 +13,10 @@
 
 use std::sync::{Arc, Mutex};
 
+use crate::grpc::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
 use futures::sync::mpsc;
 use futures::{future, Future, Stream};
 use futures_cpupool::{Builder, CpuPool};
-use crate::grpc::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
 use kvproto::import_sstpb::*;
 use kvproto::import_sstpb_grpc::*;
 use kvproto::raft_cmdpb::*;

--- a/src/import/stream.rs
+++ b/src/import/stream.rs
@@ -227,7 +227,7 @@ impl RangeIterator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use import::test_helpers::*;
+    use crate::import::test_helpers::*;
 
     use std::path::Path;
     use std::sync::Arc;
@@ -235,8 +235,8 @@ mod tests {
     use rocksdb::{DBIterator, DBOptions, ReadOptions, Writable, DB};
     use tempdir::TempDir;
 
-    use config::DbConfig;
-    use storage::types::Key;
+    use crate::config::DbConfig;
+    use crate::storage::types::Key;
 
     fn open_db<P: AsRef<Path>>(path: P) -> Arc<DB> {
         let path = path.as_ref().to_str().unwrap();

--- a/src/import/test_helpers.rs
+++ b/src/import/test_helpers.rs
@@ -24,13 +24,13 @@ use kvproto::metapb::*;
 use rocksdb::{ColumnFamilyOptions, EnvOptions, SstFileWriter, DB};
 use uuid::Uuid;
 
-use pd::RegionInfo;
-use raftstore::store::keys;
+use crate::pd::RegionInfo;
+use crate::raftstore::store::keys;
 
 use super::client::*;
 use super::common::*;
 use super::Result;
-use util::collections::HashMap;
+use crate::util::collections::HashMap;
 
 pub fn calc_data_crc32(data: &[u8]) -> u32 {
     let mut digest = crc32::Digest::new(crc32::IEEE);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,4 +141,4 @@ pub mod raftstore;
 pub mod server;
 pub mod storage;
 
-pub use storage::Storage;
+pub use crate::storage::Storage;

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 
 use futures::sync::mpsc;
 use futures::{future, Future, Sink, Stream};
-use grpc::{CallOption, EnvBuilder, WriteFlags};
+use crate::grpc::{CallOption, EnvBuilder, WriteFlags};
 use kvproto::metapb;
 use kvproto::pdpb::{self, Member};
 use protobuf::RepeatedField;
@@ -26,10 +26,10 @@ use protobuf::RepeatedField;
 use super::metrics::*;
 use super::util::{check_resp_header, sync_request, validate_endpoints, Inner, LeaderClient};
 use super::{Error, PdClient, RegionInfo, RegionStat, Result, REQUEST_TIMEOUT};
-use pd::{Config, PdFuture};
-use util::security::SecurityManager;
-use util::time::{duration_to_sec, time_now_sec};
-use util::{Either, HandyRwLock};
+use crate::pd::{Config, PdFuture};
+use crate::util::security::SecurityManager;
+use crate::util::time::{duration_to_sec, time_now_sec};
+use crate::util::{Either, HandyRwLock};
 
 const CQ_COUNT: usize = 1;
 const CLIENT_PREFIX: &str = "pd";

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -16,9 +16,9 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crate::grpc::{CallOption, EnvBuilder, WriteFlags};
 use futures::sync::mpsc;
 use futures::{future, Future, Sink, Stream};
-use crate::grpc::{CallOption, EnvBuilder, WriteFlags};
 use kvproto::metapb;
 use kvproto::pdpb::{self, Member};
 use protobuf::RepeatedField;

--- a/src/pd/errors.rs
+++ b/src/pd/errors.rs
@@ -34,7 +34,7 @@ quick_error! {
             description("compatible error")
             display("feature is not supported in other cluster components")
         }
-        Grpc(err: ::grpc::Error) {
+        Grpc(err: crate::grpc::Error) {
             from()
             cause(err)
             description(err.description())

--- a/src/pd/pd.rs
+++ b/src/pd/pd.rs
@@ -28,7 +28,6 @@ use rocksdb::DB;
 
 use super::metrics::*;
 use crate::pd::{Error, PdClient, RegionStat};
-use prometheus::local::LocalHistogram;
 use crate::raftstore::store::cmd_resp::new_error;
 use crate::raftstore::store::fsm::SendCh;
 use crate::raftstore::store::util::KeysInfoFormatter;
@@ -44,6 +43,7 @@ use crate::util::escape;
 use crate::util::rocksdb::*;
 use crate::util::time::time_now_sec;
 use crate::util::worker::{FutureRunnable as Runnable, FutureScheduler as Scheduler, Stopped};
+use prometheus::local::LocalHistogram;
 
 /// Uses an asynchronous thread to tell PD something.
 pub enum Task {

--- a/src/pd/pd.rs
+++ b/src/pd/pd.rs
@@ -27,23 +27,23 @@ use raft::eraftpb::ConfChangeType;
 use rocksdb::DB;
 
 use super::metrics::*;
-use pd::{Error, PdClient, RegionStat};
+use crate::pd::{Error, PdClient, RegionStat};
 use prometheus::local::LocalHistogram;
-use raftstore::store::cmd_resp::new_error;
-use raftstore::store::fsm::SendCh;
-use raftstore::store::util::KeysInfoFormatter;
-use raftstore::store::util::{
+use crate::raftstore::store::cmd_resp::new_error;
+use crate::raftstore::store::fsm::SendCh;
+use crate::raftstore::store::util::KeysInfoFormatter;
+use crate::raftstore::store::util::{
     get_region_approximate_keys, get_region_approximate_size, is_epoch_stale,
 };
-use raftstore::store::Callback;
-use raftstore::store::StoreInfo;
-use raftstore::store::{Msg, PeerMsg};
-use storage::FlowStatistics;
-use util::collections::HashMap;
-use util::escape;
-use util::rocksdb::*;
-use util::time::time_now_sec;
-use util::worker::{FutureRunnable as Runnable, FutureScheduler as Scheduler, Stopped};
+use crate::raftstore::store::Callback;
+use crate::raftstore::store::StoreInfo;
+use crate::raftstore::store::{Msg, PeerMsg};
+use crate::storage::FlowStatistics;
+use crate::util::collections::HashMap;
+use crate::util::escape;
+use crate::util::rocksdb::*;
+use crate::util::time::time_now_sec;
+use crate::util::worker::{FutureRunnable as Runnable, FutureScheduler as Scheduler, Stopped};
 
 /// Uses an asynchronous thread to tell PD something.
 pub enum Task {

--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -16,13 +16,13 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
 use std::time::Instant;
-use util::collections::HashSet;
+use crate::util::collections::HashSet;
 
 use futures::future::{loop_fn, ok, Loop};
 use futures::sync::mpsc::UnboundedSender;
 use futures::task::Task;
 use futures::{task, Async, Future, Poll, Stream};
-use grpc::{
+use crate::grpc::{
     CallOption, ChannelBuilder, ClientDuplexReceiver, ClientDuplexSender, Environment,
     Result as GrpcResult,
 };
@@ -34,9 +34,9 @@ use kvproto::pdpb_grpc::PdClient;
 use tokio_timer::timer::Handle;
 
 use super::{Config, Error, PdFuture, Result, REQUEST_TIMEOUT};
-use util::security::SecurityManager;
-use util::timer::GLOBAL_TIMER_HANDLE;
-use util::{Either, HandyRwLock};
+use crate::util::security::SecurityManager;
+use crate::util::timer::GLOBAL_TIMER_HANDLE;
+use crate::util::{Either, HandyRwLock};
 
 pub struct Inner {
     env: Arc<Environment>,

--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -11,21 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::util::collections::HashSet;
 use std::result;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
 use std::time::Instant;
-use crate::util::collections::HashSet;
 
-use futures::future::{loop_fn, ok, Loop};
-use futures::sync::mpsc::UnboundedSender;
-use futures::task::Task;
-use futures::{task, Async, Future, Poll, Stream};
 use crate::grpc::{
     CallOption, ChannelBuilder, ClientDuplexReceiver, ClientDuplexSender, Environment,
     Result as GrpcResult,
 };
+use futures::future::{loop_fn, ok, Loop};
+use futures::sync::mpsc::UnboundedSender;
+use futures::task::Task;
+use futures::{task, Async, Future, Poll, Stream};
 use kvproto::pdpb::{
     ErrorType, GetMembersRequest, GetMembersResponse, Member, RegionHeartbeatRequest,
     RegionHeartbeatResponse, ResponseHeader,

--- a/src/raftstore/coprocessor/config.rs
+++ b/src/raftstore/coprocessor/config.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use super::Result;
-use util::config::ReadableSize;
+use crate::util::config::ReadableSize;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]

--- a/src/raftstore/coprocessor/dispatcher.rs
+++ b/src/raftstore/coprocessor/dispatcher.rs
@@ -273,8 +273,8 @@ impl CoprocessorHost {
 
 #[cfg(test)]
 mod tests {
-    use protobuf::RepeatedField;
     use crate::raftstore::coprocessor::*;
+    use protobuf::RepeatedField;
     use std::sync::atomic::*;
     use std::sync::*;
 

--- a/src/raftstore/coprocessor/dispatcher.rs
+++ b/src/raftstore/coprocessor/dispatcher.rs
@@ -17,8 +17,8 @@ use kvproto::metapb::Region;
 use kvproto::pdpb::CheckPolicy;
 use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse};
 
-use raftstore::store::msg::Msg;
-use util::transport::{RetryableSendCh, Sender};
+use crate::raftstore::store::msg::Msg;
+use crate::util::transport::{RetryableSendCh, Sender};
 
 use super::*;
 
@@ -274,7 +274,7 @@ impl CoprocessorHost {
 #[cfg(test)]
 mod tests {
     use protobuf::RepeatedField;
-    use raftstore::coprocessor::*;
+    use crate::raftstore::coprocessor::*;
     use std::sync::atomic::*;
     use std::sync::*;
 

--- a/src/raftstore/coprocessor/mod.rs
+++ b/src/raftstore/coprocessor/mod.rs
@@ -35,7 +35,7 @@ pub use self::split_check::{
     TableCheckObserver,
 };
 
-pub use raftstore::store::KeyEntry;
+pub use crate::raftstore::store::KeyEntry;
 
 /// Coprocessor is used to provide a convient way to inject code to
 /// KV processing.

--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -24,13 +24,13 @@ use super::{
 };
 use kvproto::metapb::Region;
 use raft::StateRole;
-use raftstore::store::keys::{data_end_key, data_key, origin_key, DATA_MAX_KEY};
-use raftstore::store::msg::{SeekRegionCallback, SeekRegionFilter, SeekRegionResult};
-use storage::engine::{RegionInfoProvider, Result as EngineResult};
-use util::collections::HashMap;
-use util::escape;
-use util::timer::Timer;
-use util::worker::{Builder as WorkerBuilder, Runnable, RunnableWithTimer, Scheduler, Worker};
+use crate::raftstore::store::keys::{data_end_key, data_key, origin_key, DATA_MAX_KEY};
+use crate::raftstore::store::msg::{SeekRegionCallback, SeekRegionFilter, SeekRegionResult};
+use crate::storage::engine::{RegionInfoProvider, Result as EngineResult};
+use crate::util::collections::HashMap;
+use crate::util::escape;
+use crate::util::timer::Timer;
+use crate::util::worker::{Builder as WorkerBuilder, Runnable, RunnableWithTimer, Scheduler, Worker};
 
 /// `RegionInfoAccessor` is used to collect all regions' information on this TiKV into a collection
 /// so that other parts of TiKV can get region information from it. It registers a observer to

--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -22,15 +22,17 @@ use super::{
     Coprocessor, CoprocessorHost, ObserverContext, RegionChangeEvent, RegionChangeObserver,
     RoleObserver,
 };
-use kvproto::metapb::Region;
-use raft::StateRole;
 use crate::raftstore::store::keys::{data_end_key, data_key, origin_key, DATA_MAX_KEY};
 use crate::raftstore::store::msg::{SeekRegionCallback, SeekRegionFilter, SeekRegionResult};
 use crate::storage::engine::{RegionInfoProvider, Result as EngineResult};
 use crate::util::collections::HashMap;
 use crate::util::escape;
 use crate::util::timer::Timer;
-use crate::util::worker::{Builder as WorkerBuilder, Runnable, RunnableWithTimer, Scheduler, Worker};
+use crate::util::worker::{
+    Builder as WorkerBuilder, Runnable, RunnableWithTimer, Scheduler, Worker,
+};
+use kvproto::metapb::Region;
+use raft::StateRole;
 
 /// `RegionInfoAccessor` is used to collect all regions' information on this TiKV into a collection
 /// so that other parts of TiKV can get region information from it. It registers a observer to

--- a/src/raftstore/coprocessor/split_check/half.rs
+++ b/src/raftstore/coprocessor/split_check/half.rs
@@ -19,9 +19,9 @@ use crate::util::config::ReadableSize;
 use super::super::error::Result;
 use super::super::{Coprocessor, KeyEntry, ObserverContext, SplitCheckObserver, SplitChecker};
 use super::Host;
+use crate::raftstore::store::util as raftstore_util;
 use kvproto::metapb::Region;
 use kvproto::pdpb::CheckPolicy;
-use crate::raftstore::store::util as raftstore_util;
 
 const BUCKET_NUMBER_LIMIT: usize = 1024;
 const BUCKET_SIZE_LIMIT_MB: u64 = 512;

--- a/src/raftstore/coprocessor/split_check/half.rs
+++ b/src/raftstore/coprocessor/split_check/half.rs
@@ -13,15 +13,15 @@
 
 use rocksdb::DB;
 
-use raftstore::store::keys;
-use util::config::ReadableSize;
+use crate::raftstore::store::keys;
+use crate::util::config::ReadableSize;
 
 use super::super::error::Result;
 use super::super::{Coprocessor, KeyEntry, ObserverContext, SplitCheckObserver, SplitChecker};
 use super::Host;
 use kvproto::metapb::Region;
 use kvproto::pdpb::CheckPolicy;
-use raftstore::store::util as raftstore_util;
+use crate::raftstore::store::util as raftstore_util;
 
 const BUCKET_NUMBER_LIMIT: usize = 1024;
 const BUCKET_SIZE_LIMIT_MB: u64 = 512;
@@ -119,17 +119,17 @@ mod tests {
     use rocksdb::{ColumnFamilyOptions, DBOptions};
     use tempdir::TempDir;
 
-    use raftstore::store::{keys, SplitCheckRunner, SplitCheckTask};
-    use storage::{Key, ALL_CFS, CF_DEFAULT};
-    use util::config::ReadableSize;
-    use util::properties::SizePropertiesCollectorFactory;
-    use util::rocksdb::{new_engine_opt, CFOptions};
-    use util::transport::RetryableSendCh;
-    use util::worker::Runnable;
+    use crate::raftstore::store::{keys, SplitCheckRunner, SplitCheckTask};
+    use crate::storage::{Key, ALL_CFS, CF_DEFAULT};
+    use crate::util::config::ReadableSize;
+    use crate::util::properties::SizePropertiesCollectorFactory;
+    use crate::util::rocksdb::{new_engine_opt, CFOptions};
+    use crate::util::transport::RetryableSendCh;
+    use crate::util::worker::Runnable;
 
     use super::super::size::tests::must_split_at;
     use super::*;
-    use raftstore::coprocessor::{Config, CoprocessorHost};
+    use crate::raftstore::coprocessor::{Config, CoprocessorHost};
 
     #[test]
     fn test_split_check() {

--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -11,12 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use kvproto::pdpb::CheckPolicy;
 use crate::raftstore::store::{keys, util, Msg, PeerMsg};
+use crate::util::transport::{RetryableSendCh, Sender};
+use kvproto::pdpb::CheckPolicy;
 use rocksdb::DB;
 use std::mem;
 use std::sync::Mutex;
-use crate::util::transport::{RetryableSendCh, Sender};
 
 use super::super::metrics::*;
 use super::super::{Coprocessor, KeyEntry, ObserverContext, SplitCheckObserver, SplitChecker};

--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -12,11 +12,11 @@
 // limitations under the License.
 
 use kvproto::pdpb::CheckPolicy;
-use raftstore::store::{keys, util, Msg, PeerMsg};
+use crate::raftstore::store::{keys, util, Msg, PeerMsg};
 use rocksdb::DB;
 use std::mem;
 use std::sync::Mutex;
-use util::transport::{RetryableSendCh, Sender};
+use crate::util::transport::{RetryableSendCh, Sender};
 
 use super::super::metrics::*;
 use super::super::{Coprocessor, KeyEntry, ObserverContext, SplitCheckObserver, SplitChecker};
@@ -189,15 +189,15 @@ mod tests {
     use rocksdb::{ColumnFamilyOptions, DBOptions, Writable, DB};
     use tempdir::TempDir;
 
-    use raftstore::store::{keys, Msg, PeerMsg, SplitCheckRunner, SplitCheckTask};
-    use storage::mvcc::{Write, WriteType};
-    use storage::{Key, ALL_CFS, CF_DEFAULT, CF_WRITE};
-    use util::properties::RangePropertiesCollectorFactory;
-    use util::rocksdb::{new_engine_opt, CFOptions};
-    use util::transport::RetryableSendCh;
-    use util::worker::Runnable;
+    use crate::raftstore::store::{keys, Msg, PeerMsg, SplitCheckRunner, SplitCheckTask};
+    use crate::storage::mvcc::{Write, WriteType};
+    use crate::storage::{Key, ALL_CFS, CF_DEFAULT, CF_WRITE};
+    use crate::util::properties::RangePropertiesCollectorFactory;
+    use crate::util::rocksdb::{new_engine_opt, CFOptions};
+    use crate::util::transport::RetryableSendCh;
+    use crate::util::worker::Runnable;
 
-    use raftstore::coprocessor::{Config, CoprocessorHost};
+    use crate::raftstore::coprocessor::{Config, CoprocessorHost};
 
     use super::super::size::tests::must_split_at;
 

--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -12,14 +12,14 @@
 // limitations under the License.
 
 use super::super::error::Result;
-use kvproto::metapb::Region;
-use kvproto::pdpb::CheckPolicy;
 use crate::raftstore::store::util as raftstore_util;
 use crate::raftstore::store::{keys, util, Msg, PeerMsg};
+use crate::util::transport::{RetryableSendCh, Sender};
+use kvproto::metapb::Region;
+use kvproto::pdpb::CheckPolicy;
 use rocksdb::DB;
 use std::mem;
 use std::sync::Mutex;
-use crate::util::transport::{RetryableSendCh, Sender};
 
 use super::super::metrics::*;
 use super::super::{Coprocessor, KeyEntry, ObserverContext, SplitCheckObserver, SplitChecker};

--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -14,12 +14,12 @@
 use super::super::error::Result;
 use kvproto::metapb::Region;
 use kvproto::pdpb::CheckPolicy;
-use raftstore::store::util as raftstore_util;
-use raftstore::store::{keys, util, Msg, PeerMsg};
+use crate::raftstore::store::util as raftstore_util;
+use crate::raftstore::store::{keys, util, Msg, PeerMsg};
 use rocksdb::DB;
 use std::mem;
 use std::sync::Mutex;
-use util::transport::{RetryableSendCh, Sender};
+use crate::util::transport::{RetryableSendCh, Sender};
 
 use super::super::metrics::*;
 use super::super::{Coprocessor, KeyEntry, ObserverContext, SplitCheckObserver, SplitChecker};
@@ -212,14 +212,14 @@ pub mod tests {
     use tempdir::TempDir;
 
     use super::Checker;
-    use raftstore::coprocessor::{Config, CoprocessorHost, ObserverContext, SplitChecker};
-    use raftstore::store::{keys, KeyEntry, Msg, PeerMsg, SplitCheckRunner, SplitCheckTask};
-    use storage::{ALL_CFS, CF_WRITE};
-    use util::config::ReadableSize;
-    use util::properties::RangePropertiesCollectorFactory;
-    use util::rocksdb::{new_engine_opt, CFOptions};
-    use util::transport::RetryableSendCh;
-    use util::worker::Runnable;
+    use crate::raftstore::coprocessor::{Config, CoprocessorHost, ObserverContext, SplitChecker};
+    use crate::raftstore::store::{keys, KeyEntry, Msg, PeerMsg, SplitCheckRunner, SplitCheckTask};
+    use crate::storage::{ALL_CFS, CF_WRITE};
+    use crate::util::config::ReadableSize;
+    use crate::util::properties::RangePropertiesCollectorFactory;
+    use crate::util::rocksdb::{new_engine_opt, CFOptions};
+    use crate::util::transport::RetryableSendCh;
+    use crate::util::worker::Runnable;
 
     pub fn must_split_at(
         rx: &mpsc::Receiver<Msg>,

--- a/src/raftstore/coprocessor/split_check/table.rs
+++ b/src/raftstore/coprocessor/split_check/table.rs
@@ -17,12 +17,12 @@ use kvproto::metapb::Region;
 use rocksdb::{SeekKey, DB};
 
 use crate::coprocessor::codec::table as table_codec;
-use kvproto::pdpb::CheckPolicy;
 use crate::raftstore::store::engine::{IterOption, Iterable};
 use crate::raftstore::store::keys;
 use crate::storage::types::Key;
 use crate::storage::CF_WRITE;
 use crate::util::escape;
+use kvproto::pdpb::CheckPolicy;
 
 use super::super::{
     Coprocessor, KeyEntry, ObserverContext, Result, SplitCheckObserver, SplitChecker,

--- a/src/raftstore/coprocessor/split_check/table.rs
+++ b/src/raftstore/coprocessor/split_check/table.rs
@@ -16,13 +16,13 @@ use std::cmp::Ordering;
 use kvproto::metapb::Region;
 use rocksdb::{SeekKey, DB};
 
-use coprocessor::codec::table as table_codec;
+use crate::coprocessor::codec::table as table_codec;
 use kvproto::pdpb::CheckPolicy;
-use raftstore::store::engine::{IterOption, Iterable};
-use raftstore::store::keys;
-use storage::types::Key;
-use storage::CF_WRITE;
-use util::escape;
+use crate::raftstore::store::engine::{IterOption, Iterable};
+use crate::raftstore::store::keys;
+use crate::storage::types::Key;
+use crate::storage::CF_WRITE;
+use crate::util::escape;
 
 use super::super::{
     Coprocessor, KeyEntry, ObserverContext, Result, SplitCheckObserver, SplitChecker,
@@ -234,18 +234,18 @@ mod tests {
     use rocksdb::Writable;
     use tempdir::TempDir;
 
-    use coprocessor::codec::table::{TABLE_PREFIX, TABLE_PREFIX_KEY_LEN};
-    use raftstore::store::{Msg, PeerMsg, SplitCheckRunner, SplitCheckTask};
-    use storage::types::Key;
-    use storage::ALL_CFS;
-    use util::codec::number::NumberEncoder;
-    use util::config::ReadableSize;
-    use util::rocksdb::new_engine;
-    use util::transport::RetryableSendCh;
-    use util::worker::Runnable;
+    use crate::coprocessor::codec::table::{TABLE_PREFIX, TABLE_PREFIX_KEY_LEN};
+    use crate::raftstore::store::{Msg, PeerMsg, SplitCheckRunner, SplitCheckTask};
+    use crate::storage::types::Key;
+    use crate::storage::ALL_CFS;
+    use crate::util::codec::number::NumberEncoder;
+    use crate::util::config::ReadableSize;
+    use crate::util::rocksdb::new_engine;
+    use crate::util::transport::RetryableSendCh;
+    use crate::util::worker::Runnable;
 
     use super::*;
-    use raftstore::coprocessor::{Config, CoprocessorHost};
+    use crate::raftstore::coprocessor::{Config, CoprocessorHost};
 
     /// Composes table record and index prefix: `t[table_id]`.
     // Port from TiDB

--- a/src/raftstore/coprocessor/split_observer.rs
+++ b/src/raftstore/coprocessor/split_observer.rs
@@ -12,14 +12,14 @@
 // limitations under the License.
 
 use super::{AdminObserver, Coprocessor, ObserverContext, Result as CopResult};
-use coprocessor::codec::table;
-use util::codec::bytes::{self, encode_bytes};
-use util::escape;
+use crate::coprocessor::codec::table;
+use crate::util::codec::bytes::{self, encode_bytes};
+use crate::util::escape;
 
 use kvproto::metapb::Region;
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, SplitRequest};
 use protobuf::RepeatedField;
-use raftstore::store::util;
+use crate::raftstore::store::util;
 use std::result::Result as StdResult;
 
 /// `SplitObserver` adjusts the split key so that it won't separate
@@ -169,12 +169,12 @@ impl AdminObserver for SplitObserver {
 mod tests {
     use super::*;
     use byteorder::{BigEndian, WriteBytesExt};
-    use coprocessor::codec::{datum, table, Datum};
+    use crate::coprocessor::codec::{datum, table, Datum};
     use kvproto::metapb::Region;
     use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, SplitRequest};
-    use raftstore::coprocessor::AdminObserver;
-    use raftstore::coprocessor::ObserverContext;
-    use util::codec::bytes::encode_bytes;
+    use crate::raftstore::coprocessor::AdminObserver;
+    use crate::raftstore::coprocessor::ObserverContext;
+    use crate::util::codec::bytes::encode_bytes;
 
     fn new_split_request(key: &[u8]) -> AdminRequest {
         let mut req = AdminRequest::new();

--- a/src/raftstore/coprocessor/split_observer.rs
+++ b/src/raftstore/coprocessor/split_observer.rs
@@ -16,10 +16,10 @@ use crate::coprocessor::codec::table;
 use crate::util::codec::bytes::{self, encode_bytes};
 use crate::util::escape;
 
+use crate::raftstore::store::util;
 use kvproto::metapb::Region;
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, SplitRequest};
 use protobuf::RepeatedField;
-use crate::raftstore::store::util;
 use std::result::Result as StdResult;
 
 /// `SplitObserver` adjusts the split key so that it won't separate
@@ -168,13 +168,13 @@ impl AdminObserver for SplitObserver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use byteorder::{BigEndian, WriteBytesExt};
     use crate::coprocessor::codec::{datum, table, Datum};
-    use kvproto::metapb::Region;
-    use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, SplitRequest};
     use crate::raftstore::coprocessor::AdminObserver;
     use crate::raftstore::coprocessor::ObserverContext;
     use crate::util::codec::bytes::encode_bytes;
+    use byteorder::{BigEndian, WriteBytesExt};
+    use kvproto::metapb::Region;
+    use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, SplitRequest};
 
     fn new_split_request(key: &[u8]) -> AdminRequest {
         let mut req = AdminRequest::new();

--- a/src/raftstore/errors.rs
+++ b/src/raftstore/errors.rs
@@ -18,10 +18,10 @@ use std::result;
 
 use protobuf::{ProtobufError, RepeatedField};
 
-use kvproto::{errorpb, metapb};
 use crate::pd;
-use raft;
 use crate::util::codec;
+use kvproto::{errorpb, metapb};
+use raft;
 
 use super::coprocessor::Error as CopError;
 use super::store::SnapError;

--- a/src/raftstore/errors.rs
+++ b/src/raftstore/errors.rs
@@ -19,13 +19,13 @@ use std::result;
 use protobuf::{ProtobufError, RepeatedField};
 
 use kvproto::{errorpb, metapb};
-use pd;
+use crate::pd;
 use raft;
-use util::codec;
+use crate::util::codec;
 
 use super::coprocessor::Error as CopError;
 use super::store::SnapError;
-use util::{escape, transport};
+use crate::util::{escape, transport};
 
 pub const RAFTSTORE_IS_BUSY: &str = "raftstore is busy";
 

--- a/src/raftstore/store/bootstrap.rs
+++ b/src/raftstore/store/bootstrap.rs
@@ -17,10 +17,10 @@ use super::peer_storage::{write_initial_apply_state, write_initial_raft_state};
 use super::util::Engines;
 use kvproto::metapb;
 use kvproto::raft_serverpb::{RegionLocalState, StoreIdent};
-use raftstore::Result;
+use crate::raftstore::Result;
 use rocksdb::{Writable, WriteBatch, DB};
-use storage::{CF_DEFAULT, CF_RAFT};
-use util::rocksdb;
+use crate::storage::{CF_DEFAULT, CF_RAFT};
+use crate::util::rocksdb;
 
 const INIT_EPOCH_VER: u64 = 1;
 const INIT_EPOCH_CONF_VER: u64 = 1;
@@ -131,10 +131,10 @@ mod tests {
     use tempdir::TempDir;
 
     use super::*;
-    use raftstore::store::engine::Peekable;
-    use raftstore::store::{keys, Engines};
-    use storage::CF_DEFAULT;
-    use util::rocksdb;
+    use crate::raftstore::store::engine::Peekable;
+    use crate::raftstore::store::{keys, Engines};
+    use crate::storage::CF_DEFAULT;
+    use crate::util::rocksdb;
 
     #[test]
     fn test_bootstrap() {

--- a/src/raftstore/store/bootstrap.rs
+++ b/src/raftstore/store/bootstrap.rs
@@ -18,7 +18,7 @@ use super::util::Engines;
 use kvproto::metapb;
 use kvproto::raft_serverpb::{RegionLocalState, StoreIdent};
 use crate::raftstore::Result;
-use rocksdb::{Writable, WriteBatch, DB};
+use ::rocksdb::{Writable, WriteBatch, DB};
 use crate::storage::{CF_DEFAULT, CF_RAFT};
 use crate::util::rocksdb;
 

--- a/src/raftstore/store/bootstrap.rs
+++ b/src/raftstore/store/bootstrap.rs
@@ -15,12 +15,12 @@ use super::engine::{Iterable, Mutable};
 use super::keys;
 use super::peer_storage::{write_initial_apply_state, write_initial_raft_state};
 use super::util::Engines;
-use kvproto::metapb;
-use kvproto::raft_serverpb::{RegionLocalState, StoreIdent};
 use crate::raftstore::Result;
-use ::rocksdb::{Writable, WriteBatch, DB};
 use crate::storage::{CF_DEFAULT, CF_RAFT};
 use crate::util::rocksdb;
+use ::rocksdb::{Writable, WriteBatch, DB};
+use kvproto::metapb;
+use kvproto::raft_serverpb::{RegionLocalState, StoreIdent};
 
 const INIT_EPOCH_VER: u64 = 1;
 const INIT_EPOCH_CONF_VER: u64 = 1;

--- a/src/raftstore/store/cmd_resp.rs
+++ b/src/raftstore/store/cmd_resp.rs
@@ -14,7 +14,7 @@
 use std::error;
 
 use kvproto::raft_cmdpb::RaftCmdResponse;
-use raftstore::Error;
+use crate::raftstore::Error;
 
 pub fn bind_term(resp: &mut RaftCmdResponse, term: u64) {
     if term == 0 {

--- a/src/raftstore/store/cmd_resp.rs
+++ b/src/raftstore/store/cmd_resp.rs
@@ -13,8 +13,8 @@
 
 use std::error;
 
-use kvproto::raft_cmdpb::RaftCmdResponse;
 use crate::raftstore::Error;
+use kvproto::raft_cmdpb::RaftCmdResponse;
 
 pub fn bind_term(resp: &mut RaftCmdResponse, term: u64) {
     if term == 0 {

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -16,8 +16,8 @@ use std::u64;
 
 use time::Duration as TimeDuration;
 
-use raftstore::{coprocessor, Result};
-use util::config::{ReadableDuration, ReadableSize};
+use crate::raftstore::{coprocessor, Result};
+use crate::util::config::{ReadableDuration, ReadableSize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
@@ -364,7 +364,7 @@ impl Config {
 mod tests {
     use super::*;
 
-    use util::config::*;
+    use crate::util::config::*;
 
     #[test]
     fn test_config_validate() {

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -20,10 +20,10 @@ use byteorder::{BigEndian, ByteOrder};
 use protobuf;
 use rocksdb::rocksdb_options::UnsafeSnap;
 use rocksdb::{CFHandle, DBIterator, DBVector, ReadOptions, Writable, WriteBatch, DB};
-use util::rocksdb;
+use crate::util::rocksdb;
 
-use raftstore::Error;
-use raftstore::Result;
+use crate::raftstore::Error;
+use crate::raftstore::Result;
 
 pub struct Snapshot {
     db: Arc<DB>,
@@ -267,7 +267,7 @@ impl Default for IterOption {
 // TODO: refactor this trait into rocksdb trait.
 pub trait Iterable {
     fn new_iterator(&self, iter_opt: IterOption) -> DBIterator<&DB>;
-    fn new_iterator_cf(&self, &str, iter_opt: IterOption) -> Result<DBIterator<&DB>>;
+    fn new_iterator_cf(&self, _: &str, iter_opt: IterOption) -> Result<DBIterator<&DB>>;
     // scan scans database using an iterator in range [start_key, end_key), calls function f for
     // each iteration, if f returns false, terminates this scan.
     fn scan<F>(&self, start_key: &[u8], end_key: &[u8], fill_cache: bool, f: F) -> Result<()>

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 
 use byteorder::{BigEndian, ByteOrder};
 use protobuf;
-use rocksdb::rocksdb_options::UnsafeSnap;
-use rocksdb::{CFHandle, DBIterator, DBVector, ReadOptions, Writable, WriteBatch, DB};
+use ::rocksdb::rocksdb_options::UnsafeSnap;
+use ::rocksdb::{CFHandle, DBIterator, DBVector, ReadOptions, Writable, WriteBatch, DB};
 use crate::util::rocksdb;
 
 use crate::raftstore::Error;
@@ -429,7 +429,7 @@ impl Mutable for WriteBatch {}
 mod tests {
     use super::*;
     use kvproto::metapb::Region;
-    use rocksdb::Writable;
+    use ::rocksdb::Writable;
     use std::sync::Arc;
     use tempdir::TempDir;
 

--- a/src/raftstore/store/engine.rs
+++ b/src/raftstore/store/engine.rs
@@ -16,11 +16,11 @@ use std::ops::Deref;
 use std::option::Option;
 use std::sync::Arc;
 
-use byteorder::{BigEndian, ByteOrder};
-use protobuf;
+use crate::util::rocksdb;
 use ::rocksdb::rocksdb_options::UnsafeSnap;
 use ::rocksdb::{CFHandle, DBIterator, DBVector, ReadOptions, Writable, WriteBatch, DB};
-use crate::util::rocksdb;
+use byteorder::{BigEndian, ByteOrder};
+use protobuf;
 
 use crate::raftstore::Error;
 use crate::raftstore::Result;
@@ -428,8 +428,8 @@ impl Mutable for WriteBatch {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kvproto::metapb::Region;
     use ::rocksdb::Writable;
+    use kvproto::metapb::Region;
     use std::sync::Arc;
     use tempdir::TempDir;
 

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -39,25 +39,25 @@ use kvproto::raft_serverpb::{
 use raft::eraftpb::{ConfChange, ConfChangeType, Entry, EntryType};
 
 use crossbeam::channel::{TryRecvError, TrySendError};
-use import::SSTImporter;
+use crate::import::SSTImporter;
 use raft::NO_LIMIT;
-use raftstore::coprocessor::CoprocessorHost;
-use raftstore::store::engine::{Mutable, Peekable, Snapshot};
-use raftstore::store::fsm::{RaftPollerBuilder, RaftRouter};
-use raftstore::store::metrics::*;
-use raftstore::store::msg::{Callback, PeerMsg};
-use raftstore::store::peer::Peer;
-use raftstore::store::peer_storage::{
+use crate::raftstore::coprocessor::CoprocessorHost;
+use crate::raftstore::store::engine::{Mutable, Peekable, Snapshot};
+use crate::raftstore::store::fsm::{RaftPollerBuilder, RaftRouter};
+use crate::raftstore::store::metrics::*;
+use crate::raftstore::store::msg::{Callback, PeerMsg};
+use crate::raftstore::store::peer::Peer;
+use crate::raftstore::store::peer_storage::{
     self, compact_raft_log, write_initial_apply_state, write_peer_state,
 };
-use raftstore::store::util::check_region_epoch;
-use raftstore::store::{cmd_resp, keys, util, Config, Engines};
-use raftstore::{Error, Result};
-use storage::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
-use util::mpsc::{loose_bounded, LooseBoundedSender, Receiver};
-use util::time::{duration_to_sec, Instant, SlowTimer};
-use util::Either;
-use util::{escape, rocksdb, MustConsumeVec};
+use crate::raftstore::store::util::check_region_epoch;
+use crate::raftstore::store::{cmd_resp, keys, util, Config, Engines};
+use crate::raftstore::{Error, Result};
+use crate::storage::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+use crate::util::mpsc::{loose_bounded, LooseBoundedSender, Receiver};
+use crate::util::time::{duration_to_sec, Instant, SlowTimer};
+use crate::util::Either;
+use crate::util::{escape, rocksdb, MustConsumeVec};
 
 use super::metrics::*;
 use super::{
@@ -2666,16 +2666,16 @@ mod tests {
     use kvproto::metapb::{self, RegionEpoch};
     use kvproto::raft_cmdpb::*;
     use protobuf::Message;
-    use raftstore::coprocessor::*;
-    use raftstore::store::msg::WriteResponse;
-    use raftstore::store::peer_storage::RAFT_INIT_LOG_INDEX;
-    use raftstore::store::util::{new_learner_peer, new_peer};
-    use raftstore::store::Config;
+    use crate::raftstore::coprocessor::*;
+    use crate::raftstore::store::msg::WriteResponse;
+    use crate::raftstore::store::peer_storage::RAFT_INIT_LOG_INDEX;
+    use crate::raftstore::store::util::{new_learner_peer, new_peer};
+    use crate::raftstore::store::Config;
     use rocksdb::{Writable, WriteBatch, DB};
     use tempdir::TempDir;
 
     use super::*;
-    use import::test_helpers::*;
+    use crate::import::test_helpers::*;
 
     pub fn create_tmp_engine(path: &str) -> (TempDir, Engines) {
         let path = TempDir::new(path).unwrap();

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -23,8 +23,8 @@ use std::sync::Arc;
 use std::{cmp, usize};
 
 use protobuf::RepeatedField;
-use rocksdb::rocksdb_options::WriteOptions;
-use rocksdb::{Writable, WriteBatch};
+use ::rocksdb::rocksdb_options::WriteOptions;
+use ::rocksdb::{Writable, WriteBatch};
 use uuid::Uuid;
 
 use kvproto::import_sstpb::SSTMeta;
@@ -2671,7 +2671,7 @@ mod tests {
     use crate::raftstore::store::peer_storage::RAFT_INIT_LOG_INDEX;
     use crate::raftstore::store::util::{new_learner_peer, new_peer};
     use crate::raftstore::store::Config;
-    use rocksdb::{Writable, WriteBatch, DB};
+    use ::rocksdb::{Writable, WriteBatch, DB};
     use tempdir::TempDir;
 
     use super::*;

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -22,9 +22,9 @@ use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::{cmp, usize};
 
-use protobuf::RepeatedField;
 use ::rocksdb::rocksdb_options::WriteOptions;
 use ::rocksdb::{Writable, WriteBatch};
+use protobuf::RepeatedField;
 use uuid::Uuid;
 
 use kvproto::import_sstpb::SSTMeta;
@@ -38,9 +38,7 @@ use kvproto::raft_serverpb::{
 };
 use raft::eraftpb::{ConfChange, ConfChangeType, Entry, EntryType};
 
-use crossbeam::channel::{TryRecvError, TrySendError};
 use crate::import::SSTImporter;
-use raft::NO_LIMIT;
 use crate::raftstore::coprocessor::CoprocessorHost;
 use crate::raftstore::store::engine::{Mutable, Peekable, Snapshot};
 use crate::raftstore::store::fsm::{RaftPollerBuilder, RaftRouter};
@@ -58,6 +56,8 @@ use crate::util::mpsc::{loose_bounded, LooseBoundedSender, Receiver};
 use crate::util::time::{duration_to_sec, Instant, SlowTimer};
 use crate::util::Either;
 use crate::util::{escape, rocksdb, MustConsumeVec};
+use crossbeam::channel::{TryRecvError, TrySendError};
+use raft::NO_LIMIT;
 
 use super::metrics::*;
 use super::{
@@ -2663,15 +2663,15 @@ mod tests {
     use std::sync::*;
     use std::time::*;
 
-    use kvproto::metapb::{self, RegionEpoch};
-    use kvproto::raft_cmdpb::*;
-    use protobuf::Message;
     use crate::raftstore::coprocessor::*;
     use crate::raftstore::store::msg::WriteResponse;
     use crate::raftstore::store::peer_storage::RAFT_INIT_LOG_INDEX;
     use crate::raftstore::store::util::{new_learner_peer, new_peer};
     use crate::raftstore::store::Config;
     use ::rocksdb::{Writable, WriteBatch, DB};
+    use kvproto::metapb::{self, RegionEpoch};
+    use kvproto::raft_cmdpb::*;
+    use protobuf::Message;
     use tempdir::TempDir;
 
     use super::*;

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -2341,7 +2341,7 @@ impl ApplyFsm {
             }
             None => {
                 info!("{} all pending logs are applied.", self.delegate.tag);
-                if let Some(mut catch_up_logs) = state.catch_up_logs {
+                if let Some(catch_up_logs) = state.catch_up_logs {
                     // There is a merge cascade, need to notify the source peer.
                     ctx.write_to_db();
                     let region_id = self.delegate.region_id();
@@ -2762,7 +2762,7 @@ mod tests {
     fn fetch_apply_res(receiver: &::std::sync::mpsc::Receiver<PeerMsg>) -> ApplyRes {
         match receiver.recv_timeout(Duration::from_secs(3)) {
             Ok(PeerMsg::ApplyRes { res, .. }) => match res {
-                TaskRes::Apply(mut res) => res,
+                TaskRes::Apply(res) => res,
                 e => panic!("unexpected res {:?}", e),
             },
             e => panic!("unexpected res {:?}", e),

--- a/src/raftstore/store/fsm/batch.rs
+++ b/src/raftstore/store/fsm/batch.rs
@@ -24,7 +24,7 @@ use crossbeam::channel::{self, SendError, TryRecvError};
 use std::borrow::Cow;
 use std::cmp;
 use std::thread::{self, JoinHandle};
-use util::mpsc;
+use crate::util::mpsc;
 
 /// `FsmScheduler` schedules `Fsm` for later handles.
 pub trait FsmScheduler {

--- a/src/raftstore/store/fsm/batch.rs
+++ b/src/raftstore/store/fsm/batch.rs
@@ -20,11 +20,11 @@
 #![allow(dead_code)]
 
 use super::router::{BasicMailbox, Router};
+use crate::util::mpsc;
 use crossbeam::channel::{self, SendError, TryRecvError};
 use std::borrow::Cow;
 use std::cmp;
 use std::thread::{self, JoinHandle};
-use crate::util::mpsc;
 
 /// `FsmScheduler` schedules `Fsm` for later handles.
 pub trait FsmScheduler {

--- a/src/raftstore/store/fsm/batch.rs
+++ b/src/raftstore/store/fsm/batch.rs
@@ -398,7 +398,7 @@ where
         B::Handler: Send + 'static,
     {
         for i in 0..self.pool_size {
-            let mut handler = builder.build();
+            let handler = builder.build();
             let mut poller = Poller {
                 router: self.router.clone(),
                 fsm_receiver: self.receiver.clone(),

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -35,34 +35,34 @@ use raft::eraftpb::ConfChangeType;
 use raft::Ready;
 use raft::{self, SnapshotStatus, INVALID_INDEX, NO_LIMIT};
 
-use pd::{PdClient, PdTask};
-use raftstore::{Error, Result};
-use storage::CF_RAFT;
-use util::mpsc::{self, LooseBoundedSender, Receiver};
-use util::time::duration_to_sec;
-use util::worker::{Scheduler, Stopped};
-use util::{escape, is_zero_duration};
+use crate::pd::{PdClient, PdTask};
+use crate::raftstore::{Error, Result};
+use crate::storage::CF_RAFT;
+use crate::util::mpsc::{self, LooseBoundedSender, Receiver};
+use crate::util::time::duration_to_sec;
+use crate::util::worker::{Scheduler, Stopped};
+use crate::util::{escape, is_zero_duration};
 
-use raftstore::coprocessor::RegionChangeEvent;
-use raftstore::store::cmd_resp::{bind_term, new_error};
-use raftstore::store::engine::{Peekable, Snapshot as EngineSnapshot};
-use raftstore::store::fsm::store::{PollContext, StoreMeta};
-use raftstore::store::fsm::{
+use crate::raftstore::coprocessor::RegionChangeEvent;
+use crate::raftstore::store::cmd_resp::{bind_term, new_error};
+use crate::raftstore::store::engine::{Peekable, Snapshot as EngineSnapshot};
+use crate::raftstore::store::fsm::store::{PollContext, StoreMeta};
+use crate::raftstore::store::fsm::{
     apply, ApplyMetrics, ApplyTask, ApplyTaskRes, BasicMailbox, ChangePeer, ExecResult, Fsm,
     RegionProposal,
 };
-use raftstore::store::keys::{self, enc_end_key, enc_start_key};
-use raftstore::store::metrics::*;
-use raftstore::store::msg::Callback;
-use raftstore::store::peer::{ConsistencyState, Peer, StaleState, WaitApplyResultState};
-use raftstore::store::peer_storage::{ApplySnapResult, InvokeContext};
-use raftstore::store::transport::Transport;
-use raftstore::store::util::KeysInfoFormatter;
-use raftstore::store::worker::{
+use crate::raftstore::store::keys::{self, enc_end_key, enc_start_key};
+use crate::raftstore::store::metrics::*;
+use crate::raftstore::store::msg::Callback;
+use crate::raftstore::store::peer::{ConsistencyState, Peer, StaleState, WaitApplyResultState};
+use crate::raftstore::store::peer_storage::{ApplySnapResult, InvokeContext};
+use crate::raftstore::store::transport::Transport;
+use crate::raftstore::store::util::KeysInfoFormatter;
+use crate::raftstore::store::worker::{
     CleanupSSTTask, ConsistencyCheckTask, RaftlogGcTask, ReadTask, RegionTask, SplitCheckTask,
 };
-use raftstore::store::Engines;
-use raftstore::store::{
+use crate::raftstore::store::Engines;
+use crate::raftstore::store::{
     util, Config, PeerMsg, PeerTick, SignificantMsg, SnapKey, SnapshotDeleter, StoreMsg,
 };
 

--- a/src/raftstore/store/fsm/router.rs
+++ b/src/raftstore/store/fsm/router.rs
@@ -15,15 +15,15 @@
 #![allow(dead_code)]
 
 use super::batch::{Fsm, FsmScheduler};
+use crate::util::collections::HashMap;
+use crate::util::mpsc;
+use crate::util::Either;
 use crossbeam::channel::{SendError, TrySendError};
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::ptr;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use crate::util::collections::HashMap;
-use crate::util::mpsc;
-use crate::util::Either;
 
 // The FSM is notified.
 const NOTIFYSTATE_NOTIFIED: usize = 0;
@@ -474,12 +474,12 @@ impl<N: Fsm, C: Fsm, Ns: Clone, Cs: Clone> Clone for Router<N, C, Ns, Cs> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::util::mpsc;
     use crossbeam::channel::{SendError, TryRecvError, TrySendError};
     use std::sync::atomic::AtomicUsize;
     use std::sync::Arc;
     use std::thread;
     use test::Bencher;
-    use crate::util::mpsc;
 
     pub struct Counter {
         pub counter: Arc<AtomicUsize>,

--- a/src/raftstore/store/fsm/router.rs
+++ b/src/raftstore/store/fsm/router.rs
@@ -21,9 +21,9 @@ use std::cell::Cell;
 use std::ptr;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use util::collections::HashMap;
-use util::mpsc;
-use util::Either;
+use crate::util::collections::HashMap;
+use crate::util::mpsc;
+use crate::util::Either;
 
 // The FSM is notified.
 const NOTIFYSTATE_NOTIFIED: usize = 0;
@@ -479,7 +479,7 @@ pub mod tests {
     use std::sync::Arc;
     use std::thread;
     use test::Bencher;
-    use util::mpsc;
+    use crate::util::mpsc;
 
     pub struct Counter {
         pub counter: Arc<AtomicUsize>,

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -532,7 +532,7 @@ impl<T: Transport, C: PdClient> RaftPoller<T, C> {
         if ready_cnt != 0 {
             let mut batch_pos = 0;
             let mut ready_res = mem::replace(&mut self.poll_ctx.ready_res, Vec::default());
-            for (mut ready, invoke_ctx) in ready_res.drain(..) {
+            for (ready, invoke_ctx) in ready_res.drain(..) {
                 let region_id = invoke_ctx.region_id;
                 if peers[batch_pos].region_id() == region_id {
                 } else {
@@ -1938,7 +1938,7 @@ fn is_range_covered<'a, F: Fn(u64) -> &'a metapb::Region>(
     end: Vec<u8>,
 ) -> bool {
     for (end_key, &id) in region_ranges.range((Excluded(start.clone()), Unbounded::<Key>)) {
-        let mut region = get_region(id);
+        let region = get_region(id);
         // find a missing range
         if start < enc_start_key(region) {
             return false;

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ::rocksdb::{CompactionJobInfo, WriteBatch, WriteOptions, DB};
 use crossbeam::channel::{TryRecvError, TrySendError};
 use futures::Future;
 use kvproto::errorpb;
@@ -21,7 +22,6 @@ use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, RaftCmdResponse};
 use kvproto::raft_serverpb::{PeerState, RaftMessage, RegionLocalState};
 use protobuf;
 use raft::{Ready, StateRole};
-use ::rocksdb::{CompactionJobInfo, WriteBatch, WriteOptions, DB};
 use std::collections::BTreeMap;
 use std::collections::Bound::{Excluded, Included, Unbounded};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -1956,9 +1956,9 @@ mod tests {
     use std::collections::BTreeMap;
     use std::collections::HashMap;
 
-    use protobuf::RepeatedField;
     use crate::util::rocksdb::properties::{IndexHandle, IndexHandles, SizeProperties};
     use crate::util::rocksdb::CompactedEvent;
+    use protobuf::RepeatedField;
 
     use super::*;
 

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -21,7 +21,7 @@ use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, RaftCmdResponse};
 use kvproto::raft_serverpb::{PeerState, RaftMessage, RegionLocalState};
 use protobuf;
 use raft::{Ready, StateRole};
-use rocksdb::{CompactionJobInfo, WriteBatch, WriteOptions, DB};
+use ::rocksdb::{CompactionJobInfo, WriteBatch, WriteOptions, DB};
 use std::collections::BTreeMap;
 use std::collections::Bound::{Excluded, Included, Unbounded};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -31,42 +31,42 @@ use std::{mem, thread, u64};
 use time::{self, Timespec};
 use tokio_threadpool::{Sender as ThreadPoolSender, ThreadPool};
 
-use pd::{PdClient, PdRunner, PdTask};
-use raftstore::coprocessor::split_observer::SplitObserver;
-use raftstore::coprocessor::{CoprocessorHost, RegionChangeEvent};
-use raftstore::store::util::is_initial_msg;
-use raftstore::Result;
-use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
-use util::collections::{HashMap, HashSet};
-use util::mpsc::{self, LooseBoundedSender, Receiver};
-use util::rocksdb::{CompactedEvent, CompactionListener};
-use util::time::{duration_to_sec, SlowTimer};
-use util::timer::SteadyTimer;
-use util::transport::RetryableSendCh;
-use util::worker::{FutureScheduler, FutureWorker, Scheduler, Worker};
-use util::{is_zero_duration, rocksdb, sys as util_sys, Either, RingQueue};
+use crate::pd::{PdClient, PdRunner, PdTask};
+use crate::raftstore::coprocessor::split_observer::SplitObserver;
+use crate::raftstore::coprocessor::{CoprocessorHost, RegionChangeEvent};
+use crate::raftstore::store::util::is_initial_msg;
+use crate::raftstore::Result;
+use crate::storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+use crate::util::collections::{HashMap, HashSet};
+use crate::util::mpsc::{self, LooseBoundedSender, Receiver};
+use crate::util::rocksdb::{CompactedEvent, CompactionListener};
+use crate::util::time::{duration_to_sec, SlowTimer};
+use crate::util::timer::SteadyTimer;
+use crate::util::transport::RetryableSendCh;
+use crate::util::worker::{FutureScheduler, FutureWorker, Scheduler, Worker};
+use crate::util::{is_zero_duration, rocksdb, sys as util_sys, Either, RingQueue};
 
-use import::SSTImporter;
-use raftstore::store::config::Config;
-use raftstore::store::engine::{Iterable, Mutable, Peekable};
-use raftstore::store::fsm::metrics::*;
-use raftstore::store::fsm::peer::{new_admin_request, PeerFsm, PeerFsmDelegate};
-use raftstore::store::fsm::{
+use crate::import::SSTImporter;
+use crate::raftstore::store::config::Config;
+use crate::raftstore::store::engine::{Iterable, Mutable, Peekable};
+use crate::raftstore::store::fsm::metrics::*;
+use crate::raftstore::store::fsm::peer::{new_admin_request, PeerFsm, PeerFsmDelegate};
+use crate::raftstore::store::fsm::{
     batch, create_apply_batch_system, ApplyBatchSystem, ApplyPollerBuilder, ApplyRouter, ApplyTask,
     BasicMailbox, BatchRouter, BatchSystem, HandlerBuilder,
 };
-use raftstore::store::fsm::{ApplyNotifier, Fsm, PollHandler, RegionProposal};
-use raftstore::store::keys::{self, data_end_key, data_key, enc_end_key, enc_start_key};
-use raftstore::store::local_metrics::RaftMetrics;
-use raftstore::store::metrics::*;
-use raftstore::store::peer_storage::{self, HandleRaftReadyContext, InvokeContext};
-use raftstore::store::transport::Transport;
-use raftstore::store::worker::{
+use crate::raftstore::store::fsm::{ApplyNotifier, Fsm, PollHandler, RegionProposal};
+use crate::raftstore::store::keys::{self, data_end_key, data_key, enc_end_key, enc_start_key};
+use crate::raftstore::store::local_metrics::RaftMetrics;
+use crate::raftstore::store::metrics::*;
+use crate::raftstore::store::peer_storage::{self, HandleRaftReadyContext, InvokeContext};
+use crate::raftstore::store::transport::Transport;
+use crate::raftstore::store::worker::{
     CleanupSSTRunner, CleanupSSTTask, CompactRunner, CompactTask, ConsistencyCheckRunner,
     ConsistencyCheckTask, LocalReader, RaftlogGcRunner, RaftlogGcTask, ReadTask, RegionRunner,
     RegionTask, SplitCheckRunner, SplitCheckTask,
 };
-use raftstore::store::{
+use crate::raftstore::store::{
     util, Callback, Engines, Msg, PeerMsg, SignificantMsg, SnapManager, SnapshotDeleter, StoreMsg,
     StoreTick,
 };
@@ -115,7 +115,7 @@ impl StoreMeta {
         host: &CoprocessorHost,
         reader: &Scheduler<ReadTask>,
         region: Region,
-        peer: &mut ::raftstore::store::Peer,
+        peer: &mut crate::raftstore::store::Peer,
     ) {
         let prev = self.regions.insert(region.get_id(), region.clone());
         if prev.map_or(true, |r| r.get_id() != region.get_id()) {
@@ -219,7 +219,7 @@ impl RaftRouter {
 }
 
 // TODO: drop Sender support.
-impl ::util::transport::Sender<Msg> for RaftRouter {
+impl crate::util::transport::Sender<Msg> for RaftRouter {
     fn send(&self, msg: Msg) -> ::std::result::Result<(), TrySendError<Msg>> {
         match msg {
             Msg::PeerMsg(msg) => self.send_peer_msg(msg),
@@ -1957,8 +1957,8 @@ mod tests {
     use std::collections::HashMap;
 
     use protobuf::RepeatedField;
-    use util::rocksdb::properties::{IndexHandle, IndexHandles, SizeProperties};
-    use util::rocksdb::CompactedEvent;
+    use crate::util::rocksdb::properties::{IndexHandle, IndexHandles, SizeProperties};
+    use crate::util::rocksdb::CompactedEvent;
 
     use super::*;
 

--- a/src/raftstore/store/keys.rs
+++ b/src/raftstore/store/keys.rs
@@ -14,9 +14,9 @@
 use byteorder::{BigEndian, ByteOrder};
 
 use kvproto::metapb::Region;
-use raftstore::Result;
+use crate::raftstore::Result;
 use std::mem;
-use util::escape;
+use crate::util::escape;
 
 pub const MIN_KEY: &[u8] = &[];
 pub const MAX_KEY: &[u8] = &[0xFF];

--- a/src/raftstore/store/keys.rs
+++ b/src/raftstore/store/keys.rs
@@ -13,10 +13,10 @@
 
 use byteorder::{BigEndian, ByteOrder};
 
-use kvproto::metapb::Region;
 use crate::raftstore::Result;
-use std::mem;
 use crate::util::escape;
+use kvproto::metapb::Region;
+use std::mem;
 
 pub const MIN_KEY: &[u8] = &[];
 pub const MAX_KEY: &[u8] = &[0xFF];

--- a/src/raftstore/store/local_metrics.rs
+++ b/src/raftstore/store/local_metrics.rs
@@ -14,7 +14,7 @@
 use prometheus::local::LocalHistogram;
 use std::sync::{Arc, Mutex};
 
-use util::collections::HashSet;
+use crate::util::collections::HashSet;
 
 use super::metrics::*;
 

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -23,11 +23,11 @@ use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse};
 use kvproto::raft_serverpb::RaftMessage;
 
 use raft::{SnapshotStatus, StateRole};
-use raftstore::store::fsm::apply::TaskRes as ApplyTaskRes;
-use raftstore::store::util::KeysInfoFormatter;
-use raftstore::store::SnapKey;
-use util::escape;
-use util::rocksdb::CompactedEvent;
+use crate::raftstore::store::fsm::apply::TaskRes as ApplyTaskRes;
+use crate::raftstore::store::util::KeysInfoFormatter;
+use crate::raftstore::store::SnapKey;
+use crate::util::escape;
+use crate::util::rocksdb::CompactedEvent;
 
 use super::RegionSnapshot;
 

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -22,12 +22,12 @@ use kvproto::pdpb::CheckPolicy;
 use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse};
 use kvproto::raft_serverpb::RaftMessage;
 
-use raft::{SnapshotStatus, StateRole};
 use crate::raftstore::store::fsm::apply::TaskRes as ApplyTaskRes;
 use crate::raftstore::store::util::KeysInfoFormatter;
 use crate::raftstore::store::SnapKey;
 use crate::util::escape;
 use crate::util::rocksdb::CompactedEvent;
+use raft::{SnapshotStatus, StateRole};
 
 use super::RegionSnapshot;
 

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -32,10 +32,6 @@ use rocksdb::{WriteBatch, DB};
 use time::Timespec;
 
 use crate::pd::{PdTask, INVALID_ID};
-use raft::{
-    self, Progress, ProgressState, RawNode, Ready, SnapshotStatus, StateRole, INVALID_INDEX,
-    NO_LIMIT,
-};
 use crate::raftstore::coprocessor::{CoprocessorHost, RegionChangeEvent};
 use crate::raftstore::store::engine::{Peekable, Snapshot, SyncSnapshot};
 use crate::raftstore::store::fsm::store::PollContext;
@@ -49,6 +45,10 @@ use crate::util::collections::HashMap;
 use crate::util::time::{duration_to_sec, monotonic_raw_now};
 use crate::util::worker::Scheduler;
 use crate::util::{escape, MustConsumeVec};
+use raft::{
+    self, Progress, ProgressState, RawNode, Ready, SnapshotStatus, StateRole, INVALID_INDEX,
+    NO_LIMIT,
+};
 
 use super::cmd_resp;
 use super::local_metrics::{RaftMessageMetrics, RaftReadyMetrics};

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -31,24 +31,24 @@ use rocksdb::rocksdb_options::WriteOptions;
 use rocksdb::{WriteBatch, DB};
 use time::Timespec;
 
-use pd::{PdTask, INVALID_ID};
+use crate::pd::{PdTask, INVALID_ID};
 use raft::{
     self, Progress, ProgressState, RawNode, Ready, SnapshotStatus, StateRole, INVALID_INDEX,
     NO_LIMIT,
 };
-use raftstore::coprocessor::{CoprocessorHost, RegionChangeEvent};
-use raftstore::store::engine::{Peekable, Snapshot, SyncSnapshot};
-use raftstore::store::fsm::store::PollContext;
-use raftstore::store::fsm::{
+use crate::raftstore::coprocessor::{CoprocessorHost, RegionChangeEvent};
+use crate::raftstore::store::engine::{Peekable, Snapshot, SyncSnapshot};
+use crate::raftstore::store::fsm::store::PollContext;
+use crate::raftstore::store::fsm::{
     apply, Apply, ApplyMetrics, ApplyTask, ApplyTaskRes, Proposal, RegionProposal,
 };
-use raftstore::store::worker::{ReadProgress, ReadTask, RegionTask};
-use raftstore::store::{keys, Callback, Config, Engines, ReadResponse, RegionSnapshot};
-use raftstore::{Error, Result};
-use util::collections::HashMap;
-use util::time::{duration_to_sec, monotonic_raw_now};
-use util::worker::Scheduler;
-use util::{escape, MustConsumeVec};
+use crate::raftstore::store::worker::{ReadProgress, ReadTask, RegionTask};
+use crate::raftstore::store::{keys, Callback, Config, Engines, ReadResponse, RegionSnapshot};
+use crate::raftstore::{Error, Result};
+use crate::util::collections::HashMap;
+use crate::util::time::{duration_to_sec, monotonic_raw_now};
+use crate::util::worker::Scheduler;
+use crate::util::{escape, MustConsumeVec};
 
 use super::cmd_resp;
 use super::local_metrics::{RaftMessageMetrics, RaftReadyMetrics};

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::{cmp, error, u64};
 
+use ::rocksdb::{Writable, WriteBatch, DB};
 use kvproto::metapb::{self, Region};
 use kvproto::raft_serverpb::{
     MergeState, PeerState, RaftApplyState, RaftLocalState, RaftSnapshotData, RegionLocalState,
@@ -26,7 +27,6 @@ use kvproto::raft_serverpb::{
 use protobuf::Message;
 use raft::eraftpb::{ConfState, Entry, HardState, Snapshot};
 use raft::{self, Error as RaftError, RaftState, Ready, Storage, StorageError};
-use ::rocksdb::{Writable, WriteBatch, DB};
 
 use crate::raftstore::store::util::{conf_state_from_region, Engines};
 use crate::raftstore::store::ProposalContext;
@@ -1461,26 +1461,26 @@ impl Storage for PeerStorage {
 
 #[cfg(test)]
 mod tests {
+    use crate::raftstore::store::bootstrap;
+    use crate::raftstore::store::util::Engines;
+    use crate::raftstore::store::worker::RegionRunner;
+    use crate::raftstore::store::worker::RegionTask;
+    use crate::storage::{ALL_CFS, CF_DEFAULT};
+    use crate::util::rocksdb::new_engine;
+    use crate::util::worker::{Scheduler, Worker};
+    use ::rocksdb::WriteBatch;
     use kvproto::raft_serverpb::RaftSnapshotData;
     use protobuf;
     use raft::eraftpb::HardState;
     use raft::eraftpb::{ConfState, Entry};
     use raft::{Error as RaftError, StorageError};
-    use crate::raftstore::store::bootstrap;
-    use crate::raftstore::store::util::Engines;
-    use crate::raftstore::store::worker::RegionRunner;
-    use crate::raftstore::store::worker::RegionTask;
-    use ::rocksdb::WriteBatch;
     use std::cell::RefCell;
     use std::path::Path;
     use std::sync::atomic::*;
     use std::sync::mpsc::*;
     use std::sync::*;
     use std::time::Duration;
-    use crate::storage::{ALL_CFS, CF_DEFAULT};
     use tempdir::*;
-    use crate::util::rocksdb::new_engine;
-    use crate::util::worker::{Scheduler, Worker};
 
     use super::*;
 

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -26,7 +26,7 @@ use kvproto::raft_serverpb::{
 use protobuf::Message;
 use raft::eraftpb::{ConfState, Entry, HardState, Snapshot};
 use raft::{self, Error as RaftError, RaftState, Ready, Storage, StorageError};
-use rocksdb::{Writable, WriteBatch, DB};
+use ::rocksdb::{Writable, WriteBatch, DB};
 
 use crate::raftstore::store::util::{conf_state_from_region, Engines};
 use crate::raftstore::store::ProposalContext;
@@ -1470,7 +1470,7 @@ mod tests {
     use crate::raftstore::store::util::Engines;
     use crate::raftstore::store::worker::RegionRunner;
     use crate::raftstore::store::worker::RegionTask;
-    use rocksdb::WriteBatch;
+    use ::rocksdb::WriteBatch;
     use std::cell::RefCell;
     use std::path::Path;
     use std::sync::atomic::*;

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -28,12 +28,12 @@ use raft::eraftpb::{ConfState, Entry, HardState, Snapshot};
 use raft::{self, Error as RaftError, RaftState, Ready, Storage, StorageError};
 use rocksdb::{Writable, WriteBatch, DB};
 
-use raftstore::store::util::{conf_state_from_region, Engines};
-use raftstore::store::ProposalContext;
-use raftstore::{Error, Result};
-use storage::CF_RAFT;
-use util::worker::Scheduler;
-use util::{self, rocksdb};
+use crate::raftstore::store::util::{conf_state_from_region, Engines};
+use crate::raftstore::store::ProposalContext;
+use crate::raftstore::{Error, Result};
+use crate::storage::CF_RAFT;
+use crate::util::worker::Scheduler;
+use crate::util::{self, rocksdb};
 
 use super::engine::{Iterable, Mutable, Peekable, Snapshot as DbSnapshot};
 use super::keys::{self, enc_end_key, enc_start_key};
@@ -1466,10 +1466,10 @@ mod tests {
     use raft::eraftpb::HardState;
     use raft::eraftpb::{ConfState, Entry};
     use raft::{Error as RaftError, StorageError};
-    use raftstore::store::bootstrap;
-    use raftstore::store::util::Engines;
-    use raftstore::store::worker::RegionRunner;
-    use raftstore::store::worker::RegionTask;
+    use crate::raftstore::store::bootstrap;
+    use crate::raftstore::store::util::Engines;
+    use crate::raftstore::store::worker::RegionRunner;
+    use crate::raftstore::store::worker::RegionTask;
     use rocksdb::WriteBatch;
     use std::cell::RefCell;
     use std::path::Path;
@@ -1477,10 +1477,10 @@ mod tests {
     use std::sync::mpsc::*;
     use std::sync::*;
     use std::time::Duration;
-    use storage::{ALL_CFS, CF_DEFAULT};
+    use crate::storage::{ALL_CFS, CF_DEFAULT};
     use tempdir::*;
-    use util::rocksdb::new_engine;
-    use util::worker::{Scheduler, Worker};
+    use crate::util::rocksdb::new_engine;
+    use crate::util::worker::{Scheduler, Worker};
 
     use super::*;
 

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -332,8 +332,8 @@ mod tests {
     use std::path::Path;
     use std::sync::Arc;
 
-    use kvproto::metapb::{Peer, Region};
     use ::rocksdb::Writable;
+    use kvproto::metapb::{Peer, Region};
     use tempdir::TempDir;
 
     use crate::raftstore::store::engine::*;

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -333,7 +333,7 @@ mod tests {
     use std::sync::Arc;
 
     use kvproto::metapb::{Peer, Region};
-    use rocksdb::Writable;
+    use ::rocksdb::Writable;
     use tempdir::TempDir;
 
     use crate::raftstore::store::engine::*;

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -16,10 +16,10 @@ use rocksdb::{DBIterator, DBVector, SeekKey, TablePropertiesCollection, DB};
 use std::cmp;
 use std::sync::Arc;
 
-use raftstore::store::engine::{IterOption, Peekable, Snapshot, SyncSnapshot};
-use raftstore::store::{keys, util, PeerStorage};
-use raftstore::Result;
-use util::set_panic_mark;
+use crate::raftstore::store::engine::{IterOption, Peekable, Snapshot, SyncSnapshot};
+use crate::raftstore::store::{keys, util, PeerStorage};
+use crate::raftstore::Result;
+use crate::util::set_panic_mark;
 
 /// Snapshot of a region.
 ///
@@ -336,13 +336,13 @@ mod tests {
     use rocksdb::Writable;
     use tempdir::TempDir;
 
-    use raftstore::store::engine::*;
-    use raftstore::store::keys::*;
-    use raftstore::store::{Engines, PeerStorage};
-    use raftstore::Result;
-    use storage::{CFStatistics, Cursor, Key, ScanMode, ALL_CFS, CF_DEFAULT};
-    use util::rocksdb::compact_files_in_range;
-    use util::{escape, rocksdb, worker};
+    use crate::raftstore::store::engine::*;
+    use crate::raftstore::store::keys::*;
+    use crate::raftstore::store::{Engines, PeerStorage};
+    use crate::raftstore::Result;
+    use crate::storage::{CFStatistics, Cursor, Key, ScanMode, ALL_CFS, CF_DEFAULT};
+    use crate::util::rocksdb::compact_files_in_range;
+    use crate::util::{escape, rocksdb, worker};
 
     use super::*;
 

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -972,7 +972,7 @@ impl Snapshot for Snap {
             check_abort(&options.abort)?;
             let cf_handle = box_try!(rocksdb::get_cf_handle(&options.db, cf_file.cf));
             if plain_file_used(cf_file.cf) {
-                let mut file = box_try!(File::open(&cf_file.path));
+                let file = box_try!(File::open(&cf_file.path));
                 apply_plain_cf_file(&mut BufReader::new(file), &options, cf_handle)?;
             } else {
                 let _timer = INGEST_SST_DURATION_SECONDS.start_coarse_timer();

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -24,7 +24,7 @@ use kvproto::metapb::Region;
 use kvproto::raft_serverpb::RaftSnapshotData;
 use protobuf::Message;
 use raft::eraftpb::Snapshot as RaftSnapshot;
-use rocksdb::{CFHandle, Writable, WriteBatch, DB};
+use ::rocksdb::{CFHandle, Writable, WriteBatch, DB};
 
 use crate::raftstore::errors::Error as RaftStoreError;
 use crate::raftstore::store::fsm::SendCh;
@@ -222,7 +222,7 @@ pub fn retry_delete_snapshot(
 use crc::crc32::{self, Digest, Hasher32};
 use kvproto::raft_serverpb::{SnapshotCFFile, SnapshotMeta};
 use protobuf::RepeatedField;
-use rocksdb::{DBCompressionType, EnvOptions, IngestExternalFileOptions, SstFileWriter};
+use ::rocksdb::{DBCompressionType, EnvOptions, IngestExternalFileOptions, SstFileWriter};
 use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
 use std::time::Instant;
@@ -1467,7 +1467,7 @@ pub mod tests {
     use kvproto::raft_serverpb::{
         RaftApplyState, RaftSnapshotData, RegionLocalState, SnapshotMeta,
     };
-    use rocksdb::DB;
+    use ::rocksdb::DB;
     use std::path::PathBuf;
 
     use crate::raftstore::store::engine::{Iterable, Mutable, Peekable, Snapshot as DbSnapshot};

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -26,26 +26,26 @@ use protobuf::Message;
 use raft::eraftpb::Snapshot as RaftSnapshot;
 use rocksdb::{CFHandle, Writable, WriteBatch, DB};
 
-use raftstore::errors::Error as RaftStoreError;
-use raftstore::store::fsm::SendCh;
-use raftstore::store::util::check_key_in_region;
-use raftstore::store::{Msg, StoreMsg};
-use raftstore::Result as RaftStoreResult;
-use storage::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
-use util::codec::bytes::{BytesEncoder, CompactBytesFromFileDecoder};
-use util::collections::{HashMap, HashMapEntry as Entry};
-use util::io_limiter::{IOLimiter, LimitWriter};
-use util::rocksdb::{prepare_sst_for_ingestion, validate_sst_for_ingestion};
-use util::HandyRwLock;
+use crate::raftstore::errors::Error as RaftStoreError;
+use crate::raftstore::store::fsm::SendCh;
+use crate::raftstore::store::util::check_key_in_region;
+use crate::raftstore::store::{Msg, StoreMsg};
+use crate::raftstore::Result as RaftStoreResult;
+use crate::storage::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
+use crate::util::codec::bytes::{BytesEncoder, CompactBytesFromFileDecoder};
+use crate::util::collections::{HashMap, HashMapEntry as Entry};
+use crate::util::io_limiter::{IOLimiter, LimitWriter};
+use crate::util::rocksdb::{prepare_sst_for_ingestion, validate_sst_for_ingestion};
+use crate::util::HandyRwLock;
 
-use raftstore::store::engine::{Iterable, Snapshot as DbSnapshot};
-use raftstore::store::keys::{self, enc_end_key, enc_start_key};
+use crate::raftstore::store::engine::{Iterable, Snapshot as DbSnapshot};
+use crate::raftstore::store::keys::{self, enc_end_key, enc_start_key};
 
-use raftstore::store::metrics::{
+use crate::raftstore::store::metrics::{
     INGEST_SST_DURATION_SECONDS, SNAPSHOT_BUILD_TIME_HISTOGRAM, SNAPSHOT_CF_KV_COUNT,
     SNAPSHOT_CF_SIZE,
 };
-use raftstore::store::peer_storage::JOB_STATUS_CANCELLING;
+use crate::raftstore::store::peer_storage::JOB_STATUS_CANCELLING;
 
 // Data in CF_RAFT should be excluded for a snapshot.
 pub const SNAPSHOT_CFS: &[CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE];
@@ -226,10 +226,10 @@ use rocksdb::{DBCompressionType, EnvOptions, IngestExternalFileOptions, SstFileW
 use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
 use std::time::Instant;
-use util::file::{calc_crc32, delete_file_if_exist, file_exists, get_file_size};
-use util::rocksdb;
-use util::rocksdb::get_fastest_supported_compression_type;
-use util::time::duration_to_sec;
+use crate::util::file::{calc_crc32, delete_file_if_exist, file_exists, get_file_size};
+use crate::util::rocksdb;
+use crate::util::rocksdb::get_fastest_supported_compression_type;
+use crate::util::time::duration_to_sec;
 
 pub const SNAPSHOT_VERSION: u64 = 2;
 const META_FILE_SUFFIX: &str = ".meta";
@@ -1470,12 +1470,12 @@ pub mod tests {
     use rocksdb::DB;
     use std::path::PathBuf;
 
-    use raftstore::store::engine::{Iterable, Mutable, Peekable, Snapshot as DbSnapshot};
-    use raftstore::store::keys;
-    use raftstore::store::peer_storage::JOB_STATUS_RUNNING;
-    use raftstore::Result;
-    use storage::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
-    use util::rocksdb::{self, CFOptions};
+    use crate::raftstore::store::engine::{Iterable, Mutable, Peekable, Snapshot as DbSnapshot};
+    use crate::raftstore::store::keys;
+    use crate::raftstore::store::peer_storage::JOB_STATUS_RUNNING;
+    use crate::raftstore::Result;
+    use crate::storage::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+    use crate::util::rocksdb::{self, CFOptions};
 
     const TEST_STORE_ID: u64 = 1;
     const TEST_KEY: &[u8] = b"akey";

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -20,11 +20,11 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::{error, result, str, thread, time, u64};
 
+use ::rocksdb::{CFHandle, Writable, WriteBatch, DB};
 use kvproto::metapb::Region;
 use kvproto::raft_serverpb::RaftSnapshotData;
 use protobuf::Message;
 use raft::eraftpb::Snapshot as RaftSnapshot;
-use ::rocksdb::{CFHandle, Writable, WriteBatch, DB};
 
 use crate::raftstore::errors::Error as RaftStoreError;
 use crate::raftstore::store::fsm::SendCh;
@@ -219,17 +219,17 @@ pub fn retry_delete_snapshot(
     false
 }
 
-use crc::crc32::{self, Digest, Hasher32};
-use kvproto::raft_serverpb::{SnapshotCFFile, SnapshotMeta};
-use protobuf::RepeatedField;
-use ::rocksdb::{DBCompressionType, EnvOptions, IngestExternalFileOptions, SstFileWriter};
-use std::fs::{File, OpenOptions};
-use std::path::PathBuf;
-use std::time::Instant;
 use crate::util::file::{calc_crc32, delete_file_if_exist, file_exists, get_file_size};
 use crate::util::rocksdb;
 use crate::util::rocksdb::get_fastest_supported_compression_type;
 use crate::util::time::duration_to_sec;
+use ::rocksdb::{DBCompressionType, EnvOptions, IngestExternalFileOptions, SstFileWriter};
+use crc::crc32::{self, Digest, Hasher32};
+use kvproto::raft_serverpb::{SnapshotCFFile, SnapshotMeta};
+use protobuf::RepeatedField;
+use std::fs::{File, OpenOptions};
+use std::path::PathBuf;
+use std::time::Instant;
 
 pub const SNAPSHOT_VERSION: u64 = 2;
 const META_FILE_SUFFIX: &str = ".meta";
@@ -1463,11 +1463,11 @@ pub mod tests {
         SnapshotDeleter, SnapshotStatistics, META_FILE_SUFFIX, SNAPSHOT_CFS, SNAP_GEN_PREFIX,
     };
 
+    use ::rocksdb::DB;
     use kvproto::metapb::{Peer, Region};
     use kvproto::raft_serverpb::{
         RaftApplyState, RaftSnapshotData, RegionLocalState, SnapshotMeta,
     };
-    use ::rocksdb::DB;
     use std::path::PathBuf;
 
     use crate::raftstore::store::engine::{Iterable, Mutable, Peekable, Snapshot as DbSnapshot};

--- a/src/raftstore/store/transport.rs
+++ b/src/raftstore/store/transport.rs
@@ -13,7 +13,7 @@
 
 use kvproto::raft_serverpb::RaftMessage;
 
-use raftstore::Result;
+use crate::raftstore::Result;
 
 /// Transports messages between different Raft peers.
 pub trait Transport: Send + Clone {

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -22,17 +22,17 @@ use kvproto::raft_cmdpb::{AdminCmdType, RaftCmdRequest};
 use protobuf::{self, Message};
 use raft::eraftpb::{self, ConfChangeType, ConfState, MessageType};
 use raft::INVALID_INDEX;
-use raftstore::store::keys;
-use raftstore::{Error, Result};
+use crate::raftstore::store::keys;
+use crate::raftstore::{Error, Result};
 use rocksdb::{Range, TablePropertiesCollection, Writable, WriteBatch, DB};
 use time::{Duration, Timespec};
 
-use storage::{Key, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE, LARGE_CFS};
-use util::escape;
-use util::properties::RangeProperties;
-use util::rocksdb::stats::get_range_entries_and_versions;
-use util::time::monotonic_raw_now;
-use util::{rocksdb as rocksdb_util, Either};
+use crate::storage::{Key, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE, LARGE_CFS};
+use crate::util::escape;
+use crate::util::properties::RangeProperties;
+use crate::util::rocksdb::stats::get_range_entries_and_versions;
+use crate::util::time::monotonic_raw_now;
+use crate::util::{rocksdb as rocksdb_util, Either};
 
 use super::engine::{IterOption, Iterable};
 use super::peer_storage;
@@ -979,13 +979,13 @@ mod tests {
     use tempdir::TempDir;
     use time::Duration as TimeDuration;
 
-    use raftstore::store::peer_storage;
-    use storage::mvcc::{Write, WriteType};
-    use storage::{Key, ALL_CFS, CF_DEFAULT};
-    use util::escape;
-    use util::properties::{MvccPropertiesCollectorFactory, RangePropertiesCollectorFactory};
-    use util::rocksdb::{get_cf_handle, new_engine_opt, CFOptions};
-    use util::time::{monotonic_now, monotonic_raw_now};
+    use crate::raftstore::store::peer_storage;
+    use crate::storage::mvcc::{Write, WriteType};
+    use crate::storage::{Key, ALL_CFS, CF_DEFAULT};
+    use crate::util::escape;
+    use crate::util::properties::{MvccPropertiesCollectorFactory, RangePropertiesCollectorFactory};
+    use crate::util::rocksdb::{get_cf_handle, new_engine_opt, CFOptions};
+    use crate::util::time::{monotonic_now, monotonic_raw_now};
 
     use super::*;
 

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -17,13 +17,13 @@ use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use std::{fmt, u64};
 
+use crate::raftstore::store::keys;
+use crate::raftstore::{Error, Result};
 use kvproto::metapb;
 use kvproto::raft_cmdpb::{AdminCmdType, RaftCmdRequest};
 use protobuf::{self, Message};
 use raft::eraftpb::{self, ConfChangeType, ConfState, MessageType};
 use raft::INVALID_INDEX;
-use crate::raftstore::store::keys;
-use crate::raftstore::{Error, Result};
 use rocksdb::{Range, TablePropertiesCollection, Writable, WriteBatch, DB};
 use time::{Duration, Timespec};
 
@@ -983,7 +983,9 @@ mod tests {
     use crate::storage::mvcc::{Write, WriteType};
     use crate::storage::{Key, ALL_CFS, CF_DEFAULT};
     use crate::util::escape;
-    use crate::util::properties::{MvccPropertiesCollectorFactory, RangePropertiesCollectorFactory};
+    use crate::util::properties::{
+        MvccPropertiesCollectorFactory, RangePropertiesCollectorFactory,
+    };
     use crate::util::rocksdb::{get_cf_handle, new_engine_opt, CFOptions};
     use crate::util::time::{monotonic_now, monotonic_raw_now};
 

--- a/src/raftstore/store/worker/cleanup_sst.rs
+++ b/src/raftstore/store/worker/cleanup_sst.rs
@@ -16,12 +16,12 @@ use std::sync::Arc;
 
 use kvproto::import_sstpb::SSTMeta;
 
-use import::SSTImporter;
-use pd::PdClient;
-use raftstore::store::fsm::SendCh;
-use raftstore::store::util::is_epoch_stale;
-use raftstore::store::{Msg, StoreMsg};
-use util::worker::Runnable;
+use crate::import::SSTImporter;
+use crate::pd::PdClient;
+use crate::raftstore::store::fsm::SendCh;
+use crate::raftstore::store::util::is_epoch_stale;
+use crate::raftstore::store::{Msg, StoreMsg};
+use crate::util::worker::Runnable;
 
 pub enum Task {
     DeleteSST { ssts: Vec<SSTMeta> },

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -18,12 +18,12 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use rocksdb::DB;
-use storage::CF_WRITE;
-use util::escape;
-use util::rocksdb;
-use util::rocksdb::compact_range;
-use util::rocksdb::stats::get_range_entries_and_versions;
-use util::worker::Runnable;
+use crate::storage::CF_WRITE;
+use crate::util::escape;
+use crate::util::rocksdb;
+use crate::util::rocksdb::compact_range;
+use crate::util::rocksdb::stats::get_range_entries_and_versions;
+use crate::util::worker::Runnable;
 
 use super::metrics::COMPACT_RANGE_CF;
 
@@ -259,15 +259,15 @@ mod tests {
 
     use tempdir::TempDir;
 
-    use raftstore::store::keys::data_key;
+    use crate::raftstore::store::keys::data_key;
     use rocksdb::{self, Writable, WriteBatch, DB};
-    use storage::mvcc::{Write, WriteType};
-    use storage::types::Key as MvccKey;
-    use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
-    use util::properties::MvccPropertiesCollectorFactory;
-    use util::rocksdb::new_engine;
-    use util::rocksdb::stats::get_range_entries_and_versions;
-    use util::rocksdb::{get_cf_handle, new_engine_opt, CFOptions};
+    use crate::storage::mvcc::{Write, WriteType};
+    use crate::storage::types::Key as MvccKey;
+    use crate::storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+    use crate::util::properties::MvccPropertiesCollectorFactory;
+    use crate::util::rocksdb::new_engine;
+    use crate::util::rocksdb::stats::get_range_entries_and_versions;
+    use crate::util::rocksdb::{get_cf_handle, new_engine_opt, CFOptions};
 
     use super::*;
 

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -17,13 +17,13 @@ use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
 use std::time::Instant;
 
-use ::rocksdb::DB;
 use crate::storage::CF_WRITE;
 use crate::util::escape;
 use crate::util::rocksdb;
 use crate::util::rocksdb::compact_range;
 use crate::util::rocksdb::stats::get_range_entries_and_versions;
 use crate::util::worker::Runnable;
+use ::rocksdb::DB;
 
 use super::metrics::COMPACT_RANGE_CF;
 
@@ -260,7 +260,6 @@ mod tests {
     use tempdir::TempDir;
 
     use crate::raftstore::store::keys::data_key;
-    use rocksdb::{self, Writable, WriteBatch, DB};
     use crate::storage::mvcc::{Write, WriteType};
     use crate::storage::types::Key as MvccKey;
     use crate::storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
@@ -268,6 +267,7 @@ mod tests {
     use crate::util::rocksdb::new_engine;
     use crate::util::rocksdb::stats::get_range_entries_and_versions;
     use crate::util::rocksdb::{get_cf_handle, new_engine_opt, CFOptions};
+    use rocksdb::{self, Writable, WriteBatch, DB};
 
     use super::*;
 

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -17,7 +17,7 @@ use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
 use std::time::Instant;
 
-use rocksdb::DB;
+use ::rocksdb::DB;
 use crate::storage::CF_WRITE;
 use crate::util::escape;
 use crate::util::rocksdb;

--- a/src/raftstore/store/worker/consistency_check.rs
+++ b/src/raftstore/store/worker/consistency_check.rs
@@ -17,14 +17,14 @@ use byteorder::{BigEndian, WriteBytesExt};
 use crc::crc32::{self, Digest, Hasher32};
 
 use kvproto::metapb::Region;
-use raftstore::store::engine::{Iterable, Peekable, Snapshot};
-use raftstore::store::{keys, Msg, PeerMsg};
-use storage::CF_RAFT;
-use util::worker::Runnable;
+use crate::raftstore::store::engine::{Iterable, Peekable, Snapshot};
+use crate::raftstore::store::{keys, Msg, PeerMsg};
+use crate::storage::CF_RAFT;
+use crate::util::worker::Runnable;
 
 use super::metrics::*;
 use super::MsgSender;
-use raftstore::store::metrics::*;
+use crate::raftstore::store::metrics::*;
 
 /// Consistency checking task.
 pub enum Task {
@@ -159,15 +159,15 @@ mod tests {
     use byteorder::{BigEndian, WriteBytesExt};
     use crc::crc32::{self, Digest, Hasher32};
     use kvproto::metapb::*;
-    use raftstore::store::engine::Snapshot;
-    use raftstore::store::{keys, Msg};
+    use crate::raftstore::store::engine::Snapshot;
+    use crate::raftstore::store::{keys, Msg};
     use rocksdb::Writable;
     use std::sync::{mpsc, Arc};
     use std::time::Duration;
-    use storage::{CF_DEFAULT, CF_RAFT};
+    use crate::storage::{CF_DEFAULT, CF_RAFT};
     use tempdir::TempDir;
-    use util::rocksdb::new_engine;
-    use util::worker::Runnable;
+    use crate::util::rocksdb::new_engine;
+    use crate::util::worker::Runnable;
 
     #[test]
     fn test_consistency_check() {

--- a/src/raftstore/store/worker/consistency_check.rs
+++ b/src/raftstore/store/worker/consistency_check.rs
@@ -16,11 +16,11 @@ use std::fmt::{self, Display, Formatter};
 use byteorder::{BigEndian, WriteBytesExt};
 use crc::crc32::{self, Digest, Hasher32};
 
-use kvproto::metapb::Region;
 use crate::raftstore::store::engine::{Iterable, Peekable, Snapshot};
 use crate::raftstore::store::{keys, Msg, PeerMsg};
 use crate::storage::CF_RAFT;
 use crate::util::worker::Runnable;
+use kvproto::metapb::Region;
 
 use super::metrics::*;
 use super::MsgSender;
@@ -156,18 +156,18 @@ impl<C: MsgSender> Runnable<Task> for Runner<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::raftstore::store::engine::Snapshot;
+    use crate::raftstore::store::{keys, Msg};
+    use crate::storage::{CF_DEFAULT, CF_RAFT};
+    use crate::util::rocksdb::new_engine;
+    use crate::util::worker::Runnable;
     use byteorder::{BigEndian, WriteBytesExt};
     use crc::crc32::{self, Digest, Hasher32};
     use kvproto::metapb::*;
-    use crate::raftstore::store::engine::Snapshot;
-    use crate::raftstore::store::{keys, Msg};
     use rocksdb::Writable;
     use std::sync::{mpsc, Arc};
     use std::time::Duration;
-    use crate::storage::{CF_DEFAULT, CF_RAFT};
     use tempdir::TempDir;
-    use crate::util::rocksdb::new_engine;
-    use crate::util::worker::Runnable;
 
     #[test]
     fn test_consistency_check() {

--- a/src/raftstore/store/worker/mod.rs
+++ b/src/raftstore/store/worker/mod.rs
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use raftstore;
-use raftstore::store::fsm::SendCh;
-use raftstore::store::msg::Msg;
+use crate::raftstore;
+use crate::raftstore::store::fsm::SendCh;
+use crate::raftstore::store::msg::Msg;
 use std::sync::mpsc::Sender;
 
 pub trait MsgSender {

--- a/src/raftstore/store/worker/raftlog_gc.rs
+++ b/src/raftstore/store/worker/raftlog_gc.rs
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use raftstore::store::engine::Iterable;
-use raftstore::store::keys;
-use raftstore::store::util::MAX_DELETE_BATCH_SIZE;
-use util::worker::Runnable;
+use crate::raftstore::store::engine::Iterable;
+use crate::raftstore::store::keys;
+use crate::raftstore::store::util::MAX_DELETE_BATCH_SIZE;
+use crate::util::worker::Runnable;
 
 use rocksdb::{Writable, WriteBatch, DB};
 use std::error;
@@ -143,9 +143,9 @@ mod tests {
     use super::*;
     use std::sync::mpsc;
     use std::time::Duration;
-    use storage::CF_DEFAULT;
+    use crate::storage::CF_DEFAULT;
     use tempdir::TempDir;
-    use util::rocksdb::new_engine;
+    use crate::util::rocksdb::new_engine;
 
     #[test]
     fn test_gc_raft_log() {

--- a/src/raftstore/store/worker/raftlog_gc.rs
+++ b/src/raftstore/store/worker/raftlog_gc.rs
@@ -141,11 +141,11 @@ impl Runnable<Task> for Runner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::CF_DEFAULT;
+    use crate::util::rocksdb::new_engine;
     use std::sync::mpsc;
     use std::time::Duration;
-    use crate::storage::CF_DEFAULT;
     use tempdir::TempDir;
-    use crate::util::rocksdb::new_engine;
 
     #[test]
     fn test_gc_raft_log() {

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -23,20 +23,20 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use time::Timespec;
 
-use raftstore::errors::RAFTSTORE_IS_BUSY;
-use raftstore::store::fsm::{RaftPollerBuilder, RaftRouter};
-use raftstore::store::msg::Callback;
-use raftstore::store::util::{self, LeaseState, RemoteLease};
-use raftstore::store::{
+use crate::raftstore::errors::RAFTSTORE_IS_BUSY;
+use crate::raftstore::store::fsm::{RaftPollerBuilder, RaftRouter};
+use crate::raftstore::store::msg::Callback;
+use crate::raftstore::store::util::{self, LeaseState, RemoteLease};
+use crate::raftstore::store::{
     cmd_resp, Msg as StoreMsg, Peer, PeerMsg, ReadExecutor, ReadResponse, RequestInspector,
     RequestPolicy,
 };
-use raftstore::Result;
-use util::collections::HashMap;
-use util::time::duration_to_sec;
-use util::timer::Timer;
-use util::transport::Sender;
-use util::worker::{Runnable, RunnableWithTimer};
+use crate::raftstore::Result;
+use crate::util::collections::HashMap;
+use crate::util::time::duration_to_sec;
+use crate::util::timer::Timer;
+use crate::util::transport::Sender;
+use crate::util::worker::{Runnable, RunnableWithTimer};
 
 use super::metrics::*;
 
@@ -616,11 +616,11 @@ mod tests {
     use tempdir::TempDir;
     use time::Duration;
 
-    use raftstore::store::util::Lease;
-    use raftstore::store::Callback;
-    use storage::ALL_CFS;
-    use util::rocksdb;
-    use util::time::monotonic_raw_now;
+    use crate::raftstore::store::util::Lease;
+    use crate::raftstore::store::Callback;
+    use crate::storage::ALL_CFS;
+    use crate::util::rocksdb;
+    use crate::util::time::monotonic_raw_now;
 
     use super::*;
 

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -23,23 +23,23 @@ use kvproto::raft_serverpb::{PeerState, RaftApplyState, RegionLocalState};
 use raft::eraftpb::Snapshot as RaftSnapshot;
 use rocksdb::{Writable, WriteBatch};
 
-use raftstore::store::engine::{Mutable, Snapshot};
-use raftstore::store::peer_storage::{
+use crate::raftstore::store::engine::{Mutable, Snapshot};
+use crate::raftstore::store::peer_storage::{
     JOB_STATUS_CANCELLED, JOB_STATUS_CANCELLING, JOB_STATUS_FAILED, JOB_STATUS_FINISHED,
     JOB_STATUS_PENDING, JOB_STATUS_RUNNING,
 };
-use raftstore::store::snap::{plain_file_used, Error, Result, SNAPSHOT_CFS};
-use raftstore::store::util::Engines;
-use raftstore::store::{
+use crate::raftstore::store::snap::{plain_file_used, Error, Result, SNAPSHOT_CFS};
+use crate::raftstore::store::util::Engines;
+use crate::raftstore::store::{
     self, check_abort, keys, ApplyOptions, Peekable, SnapEntry, SnapKey, SnapManager,
 };
-use storage::CF_RAFT;
-use util::rocksdb::get_cf_num_files_at_level;
-use util::threadpool::{DefaultContext, ThreadPool, ThreadPoolBuilder};
-use util::time;
-use util::timer::Timer;
-use util::worker::{Runnable, RunnableWithTimer};
-use util::{escape, rocksdb};
+use crate::storage::CF_RAFT;
+use crate::util::rocksdb::get_cf_num_files_at_level;
+use crate::util::threadpool::{DefaultContext, ThreadPool, ThreadPoolBuilder};
+use crate::util::time;
+use crate::util::timer::Timer;
+use crate::util::worker::{Runnable, RunnableWithTimer};
+use crate::util::{escape, rocksdb};
 
 use super::super::util;
 use super::metrics::*;
@@ -660,18 +660,18 @@ mod tests {
     use std::time::Duration;
 
     use kvproto::raft_serverpb::{PeerState, RegionLocalState};
-    use raftstore::store::engine::{Mutable, Peekable};
-    use raftstore::store::peer_storage::JOB_STATUS_PENDING;
-    use raftstore::store::snap::tests::get_test_db_for_regions;
-    use raftstore::store::worker::RegionRunner;
-    use raftstore::store::{keys, Engines, SnapKey, SnapManager};
+    use crate::raftstore::store::engine::{Mutable, Peekable};
+    use crate::raftstore::store::peer_storage::JOB_STATUS_PENDING;
+    use crate::raftstore::store::snap::tests::get_test_db_for_regions;
+    use crate::raftstore::store::worker::RegionRunner;
+    use crate::raftstore::store::{keys, Engines, SnapKey, SnapManager};
     use rocksdb::{ColumnFamilyOptions, Writable, WriteBatch};
-    use storage::{CF_DEFAULT, CF_RAFT};
+    use crate::storage::{CF_DEFAULT, CF_RAFT};
     use tempdir::TempDir;
-    use util::rocksdb;
-    use util::time;
-    use util::timer::Timer;
-    use util::worker::Worker;
+    use crate::util::rocksdb;
+    use crate::util::time;
+    use crate::util::timer::Timer;
+    use crate::util::worker::Worker;
 
     use super::Event;
     use super::PendingDeleteRanges;

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -21,7 +21,7 @@ use std::u64;
 
 use kvproto::raft_serverpb::{PeerState, RaftApplyState, RegionLocalState};
 use raft::eraftpb::Snapshot as RaftSnapshot;
-use rocksdb::{Writable, WriteBatch};
+use ::rocksdb::{Writable, WriteBatch};
 
 use crate::raftstore::store::engine::{Mutable, Snapshot};
 use crate::raftstore::store::peer_storage::{
@@ -665,7 +665,7 @@ mod tests {
     use crate::raftstore::store::snap::tests::get_test_db_for_regions;
     use crate::raftstore::store::worker::RegionRunner;
     use crate::raftstore::store::{keys, Engines, SnapKey, SnapManager};
-    use rocksdb::{ColumnFamilyOptions, Writable, WriteBatch};
+    use ::rocksdb::{ColumnFamilyOptions, Writable, WriteBatch};
     use crate::storage::{CF_DEFAULT, CF_RAFT};
     use tempdir::TempDir;
     use crate::util::rocksdb;

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::u64;
 
+use ::rocksdb::{Writable, WriteBatch};
 use kvproto::raft_serverpb::{PeerState, RaftApplyState, RegionLocalState};
 use raft::eraftpb::Snapshot as RaftSnapshot;
-use ::rocksdb::{Writable, WriteBatch};
 
 use crate::raftstore::store::engine::{Mutable, Snapshot};
 use crate::raftstore::store::peer_storage::{
@@ -659,19 +659,19 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
-    use kvproto::raft_serverpb::{PeerState, RegionLocalState};
     use crate::raftstore::store::engine::{Mutable, Peekable};
     use crate::raftstore::store::peer_storage::JOB_STATUS_PENDING;
     use crate::raftstore::store::snap::tests::get_test_db_for_regions;
     use crate::raftstore::store::worker::RegionRunner;
     use crate::raftstore::store::{keys, Engines, SnapKey, SnapManager};
-    use ::rocksdb::{ColumnFamilyOptions, Writable, WriteBatch};
     use crate::storage::{CF_DEFAULT, CF_RAFT};
-    use tempdir::TempDir;
     use crate::util::rocksdb;
     use crate::util::time;
     use crate::util::timer::Timer;
     use crate::util::worker::Worker;
+    use ::rocksdb::{ColumnFamilyOptions, Writable, WriteBatch};
+    use kvproto::raft_serverpb::{PeerState, RegionLocalState};
+    use tempdir::TempDir;
 
     use super::Event;
     use super::PendingDeleteRanges;

--- a/src/raftstore/store/worker/split_check.rs
+++ b/src/raftstore/store/worker/split_check.rs
@@ -22,14 +22,14 @@ use kvproto::metapb::RegionEpoch;
 use kvproto::pdpb::CheckPolicy;
 use rocksdb::{DBIterator, DB};
 
-use raftstore::coprocessor::CoprocessorHost;
-use raftstore::coprocessor::SplitCheckerHost;
-use raftstore::store::engine::{IterOption, Iterable};
-use raftstore::store::{keys, Callback, Msg, PeerMsg};
-use raftstore::Result;
-use storage::{CfName, CF_WRITE, LARGE_CFS};
-use util::transport::{RetryableSendCh, Sender};
-use util::worker::Runnable;
+use crate::raftstore::coprocessor::CoprocessorHost;
+use crate::raftstore::coprocessor::SplitCheckerHost;
+use crate::raftstore::store::engine::{IterOption, Iterable};
+use crate::raftstore::store::{keys, Callback, Msg, PeerMsg};
+use crate::raftstore::Result;
+use crate::storage::{CfName, CF_WRITE, LARGE_CFS};
+use crate::util::transport::{RetryableSendCh, Sender};
+use crate::util::worker::Runnable;
 
 use super::metrics::*;
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -14,14 +14,14 @@
 use std::i32;
 
 use super::Result;
-use grpc::CompressionAlgorithms;
+use crate::grpc::CompressionAlgorithms;
 
-use util::collections::HashMap;
-use util::config::{self, ReadableDuration, ReadableSize};
-use util::io_limiter::DEFAULT_SNAP_MAX_BYTES_PER_SEC;
+use crate::util::collections::HashMap;
+use crate::util::config::{self, ReadableDuration, ReadableSize};
+use crate::util::io_limiter::DEFAULT_SNAP_MAX_BYTES_PER_SEC;
 
-pub use raftstore::store::Config as RaftStoreConfig;
-pub use storage::Config as StorageConfig;
+pub use crate::raftstore::store::Config as RaftStoreConfig;
+pub use crate::storage::Config as StorageConfig;
 
 pub const DEFAULT_CLUSTER_ID: u64 = 0;
 pub const DEFAULT_LISTENING_ADDR: &str = "127.0.0.1:20160";
@@ -265,7 +265,7 @@ fn validate_label(s: &str, tp: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use util::config::ReadableDuration;
+    use crate::util::config::ReadableDuration;
 
     #[test]
     fn test_config_validate() {

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -31,7 +31,6 @@ use rocksdb::{
     WriteBatch, WriteOptions, DB,
 };
 
-use raft::{self, RawNode};
 use crate::raftstore::store::engine::{IterOption, Mutable};
 use crate::raftstore::store::util as raftstore_util;
 use crate::raftstore::store::{
@@ -51,6 +50,7 @@ use crate::util::properties::MvccProperties;
 use crate::util::rocksdb::get_cf_handle;
 use crate::util::rocksdb::properties::RangeProperties;
 use crate::util::worker::Worker;
+use raft::{self, RawNode};
 
 pub type Result<T> = result::Result<T, Error>;
 type DBIterator = ::rocksdb::DBIterator<Arc<DB>>;

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -32,25 +32,25 @@ use rocksdb::{
 };
 
 use raft::{self, RawNode};
-use raftstore::store::engine::{IterOption, Mutable};
-use raftstore::store::util as raftstore_util;
-use raftstore::store::{
+use crate::raftstore::store::engine::{IterOption, Mutable};
+use crate::raftstore::store::util as raftstore_util;
+use crate::raftstore::store::{
     init_apply_state, init_raft_state, write_initial_apply_state, write_initial_raft_state,
     write_peer_state,
 };
-use raftstore::store::{keys, Engines, Iterable, Peekable, PeerStorage};
-use storage::mvcc::{Lock, LockType, Write, WriteType};
-use storage::types::Key;
-use storage::Iterator as EngineIterator;
-use storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
-use util::codec::bytes;
-use util::collections::HashSet;
-use util::config::ReadableSize;
-use util::escape;
-use util::properties::MvccProperties;
-use util::rocksdb::get_cf_handle;
-use util::rocksdb::properties::RangeProperties;
-use util::worker::Worker;
+use crate::raftstore::store::{keys, Engines, Iterable, Peekable, PeerStorage};
+use crate::storage::mvcc::{Lock, LockType, Write, WriteType};
+use crate::storage::types::Key;
+use crate::storage::Iterator as EngineIterator;
+use crate::storage::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+use crate::util::codec::bytes;
+use crate::util::collections::HashSet;
+use crate::util::config::ReadableSize;
+use crate::util::escape;
+use crate::util::properties::MvccProperties;
+use crate::util::rocksdb::get_cf_handle;
+use crate::util::rocksdb::properties::RangeProperties;
+use crate::util::worker::Worker;
 
 pub type Result<T> = result::Result<T, Error>;
 type DBIterator = ::rocksdb::DBIterator<Arc<DB>>;
@@ -1305,7 +1305,7 @@ fn set_region_tombstone(db: &DB, store_id: u64, region: Region, wb: &WriteBatch)
     Ok(())
 }
 
-fn divide_db(db: &DB, parts: usize) -> ::raftstore::Result<Vec<Vec<u8>>> {
+fn divide_db(db: &DB, parts: usize) -> crate::raftstore::Result<Vec<Vec<u8>>> {
     let mut fake_region = Region::default();
     fake_region.set_start_key(vec![]);
     fake_region.set_end_key(vec![]);
@@ -1325,7 +1325,7 @@ fn divide_db(db: &DB, parts: usize) -> ::raftstore::Result<Vec<Vec<u8>>> {
     divide_db_cf(db, parts, cf)
 }
 
-fn divide_db_cf(db: &DB, parts: usize, cf: &str) -> ::raftstore::Result<Vec<Vec<u8>>> {
+fn divide_db_cf(db: &DB, parts: usize, cf: &str) -> crate::raftstore::Result<Vec<Vec<u8>>> {
     let cf = get_cf_handle(db, cf)?;
     let start = keys::data_key(b"");
     let end = keys::data_end_key(b"");
@@ -1393,10 +1393,10 @@ mod tests {
     use tempdir::TempDir;
 
     use super::*;
-    use raftstore::store::engine::Mutable;
-    use storage::mvcc::{Lock, LockType};
-    use storage::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
-    use util::rocksdb::{self as rocksdb_util, new_engine_opt, CFOptions};
+    use crate::raftstore::store::engine::Mutable;
+    use crate::storage::mvcc::{Lock, LockType};
+    use crate::storage::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+    use crate::util::rocksdb::{self as rocksdb_util, new_engine_opt, CFOptions};
 
     fn init_region_state(engine: &DB, region_id: u64, stores: &[u64]) -> Region {
         let cf_raft = engine.cf_handle(CF_RAFT).unwrap();

--- a/src/server/errors.rs
+++ b/src/server/errors.rs
@@ -17,17 +17,17 @@ use std::net::AddrParseError;
 use std::result;
 
 use futures::Canceled;
-use grpc::Error as GrpcError;
+use crate::grpc::Error as GrpcError;
 use hyper::Error as HttpError;
 use protobuf::ProtobufError;
 
 use super::snap::Task as SnapTask;
-use pd::Error as PdError;
-use raftstore::Error as RaftServerError;
-use storage::engine::Error as EngineError;
-use storage::Error as StorageError;
-use util::codec::Error as CodecError;
-use util::worker::ScheduleError;
+use crate::pd::Error as PdError;
+use crate::raftstore::Error as RaftServerError;
+use crate::storage::engine::Error as EngineError;
+use crate::storage::Error as StorageError;
+use crate::util::codec::Error as CodecError;
+use crate::util::worker::ScheduleError;
 
 quick_error! {
     #[derive(Debug)]

--- a/src/server/errors.rs
+++ b/src/server/errors.rs
@@ -16,8 +16,8 @@ use std::io::Error as IoError;
 use std::net::AddrParseError;
 use std::result;
 
-use futures::Canceled;
 use crate::grpc::Error as GrpcError;
+use futures::Canceled;
 use hyper::Error as HttpError;
 use protobuf::ProtobufError;
 

--- a/src/server/load_statistics/linux.rs
+++ b/src/server/load_statistics/linux.rs
@@ -17,8 +17,8 @@ use std::time::Instant;
 
 use libc::{getpid, pid_t};
 
-use server::load_statistics::ThreadLoad;
-use util::metrics::{cpu_total, get_thread_ids};
+use crate::server::load_statistics::ThreadLoad;
+use crate::util::metrics::{cpu_total, get_thread_ids};
 
 use procinfo::pid;
 

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -18,22 +18,22 @@ use std::time::Duration;
 
 use super::transport::RaftStoreRouter;
 use super::Result;
-use import::SSTImporter;
+use crate::import::SSTImporter;
 use kvproto::metapb;
 use kvproto::raft_serverpb::StoreIdent;
-use pd::{Error as PdError, PdClient, PdTask, INVALID_ID};
+use crate::pd::{Error as PdError, PdClient, PdTask, INVALID_ID};
 use protobuf::RepeatedField;
-use raftstore::coprocessor::dispatcher::CoprocessorHost;
-use raftstore::store::fsm::{RaftBatchSystem, SendCh};
-use raftstore::store::{
+use crate::raftstore::coprocessor::dispatcher::CoprocessorHost;
+use crate::raftstore::store::fsm::{RaftBatchSystem, SendCh};
+use crate::raftstore::store::{
     self, keys, Config as StoreConfig, Engines, Peekable, ReadTask, SnapManager, Transport,
 };
 use rocksdb::DB;
-use server::readpool::ReadPool;
-use server::Config as ServerConfig;
-use server::ServerRaftStoreRouter;
-use storage::{self, Config as StorageConfig, RaftKv, Storage};
-use util::worker::{FutureWorker, Worker};
+use crate::server::readpool::ReadPool;
+use crate::server::Config as ServerConfig;
+use crate::server::ServerRaftStoreRouter;
+use crate::storage::{self, Config as StorageConfig, RaftKv, Storage};
+use crate::util::worker::{FutureWorker, Worker};
 
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
 const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
@@ -377,7 +377,7 @@ where
 mod tests {
     use super::check_region_epoch;
     use kvproto::metapb;
-    use raftstore::store::keys;
+    use crate::raftstore::store::keys;
 
     #[test]
     fn test_check_region_epoch() {

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -19,21 +19,21 @@ use std::time::Duration;
 use super::transport::RaftStoreRouter;
 use super::Result;
 use crate::import::SSTImporter;
-use kvproto::metapb;
-use kvproto::raft_serverpb::StoreIdent;
 use crate::pd::{Error as PdError, PdClient, PdTask, INVALID_ID};
-use protobuf::RepeatedField;
 use crate::raftstore::coprocessor::dispatcher::CoprocessorHost;
 use crate::raftstore::store::fsm::{RaftBatchSystem, SendCh};
 use crate::raftstore::store::{
     self, keys, Config as StoreConfig, Engines, Peekable, ReadTask, SnapManager, Transport,
 };
-use rocksdb::DB;
 use crate::server::readpool::ReadPool;
 use crate::server::Config as ServerConfig;
 use crate::server::ServerRaftStoreRouter;
 use crate::storage::{self, Config as StorageConfig, RaftKv, Storage};
 use crate::util::worker::{FutureWorker, Worker};
+use kvproto::metapb;
+use kvproto::raft_serverpb::StoreIdent;
+use protobuf::RepeatedField;
+use rocksdb::DB;
 
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
 const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
@@ -376,8 +376,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::check_region_epoch;
-    use kvproto::metapb;
     use crate::raftstore::store::keys;
+    use kvproto::metapb;
 
     #[test]
     fn test_check_region_epoch() {

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -19,7 +19,7 @@ use std::time::Instant;
 
 use crossbeam::channel::SendError;
 use futures::{future, stream, Future, Poll, Sink, Stream};
-use grpc::{ChannelBuilder, Environment, Error as GrpcError, RpcStatus, RpcStatusCode, WriteFlags};
+use crate::grpc::{ChannelBuilder, Environment, Error as GrpcError, RpcStatus, RpcStatusCode, WriteFlags};
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::tikvpb::BatchRaftMessage;
 use kvproto::tikvpb_grpc::TikvClient;
@@ -30,9 +30,9 @@ use tokio::timer::Delay;
 use super::load_statistics::ThreadLoad;
 use super::metrics::*;
 use super::{Config, Result};
-use util::collections::{HashMap, HashMapEntry};
-use util::mpsc::batch::{self, Sender as BatchSender};
-use util::security::SecurityManager;
+use crate::util::collections::{HashMap, HashMapEntry};
+use crate::util::mpsc::batch::{self, Sender as BatchSender};
+use crate::util::security::SecurityManager;
 
 const MAX_GRPC_RECV_MSG_LEN: i32 = 10 * 1024 * 1024;
 const MAX_GRPC_SEND_MSG_LEN: i32 = 10 * 1024 * 1024;

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -17,9 +17,11 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use crate::grpc::{
+    ChannelBuilder, Environment, Error as GrpcError, RpcStatus, RpcStatusCode, WriteFlags,
+};
 use crossbeam::channel::SendError;
 use futures::{future, stream, Future, Poll, Sink, Stream};
-use crate::grpc::{ChannelBuilder, Environment, Error as GrpcError, RpcStatus, RpcStatusCode, WriteFlags};
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::tikvpb::BatchRaftMessage;
 use kvproto::tikvpb_grpc::TikvClient;

--- a/src/server/readpool/config.rs
+++ b/src/server/readpool/config.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use util::config::ReadableSize;
+use crate::util::config::ReadableSize;
 
 // Assume a request can be finished in 1ms, a request at position x will wait about
 // 0.001 * x secs to be actual started. A server-is-busy error will trigger 2 seconds

--- a/src/server/readpool/mod.rs
+++ b/src/server/readpool/mod.rs
@@ -21,8 +21,8 @@ use std::time::Duration;
 use futures::Future;
 use futures_cpupool::CpuFuture;
 
-use util;
-use util::futurepool::{self, FuturePool};
+use crate::util;
+use crate::util::futurepool::{self, FuturePool};
 
 pub use self::config::Config;
 pub use self::priority::Priority;

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -18,9 +18,9 @@ use std::time::Instant;
 
 use kvproto::metapb;
 
-use pd::PdClient;
-use util::collections::HashMap;
-use util::worker::{Runnable, Scheduler, Worker};
+use crate::pd::PdClient;
+use crate::util::collections::HashMap;
+use crate::util::worker::{Runnable, Scheduler, Worker};
 
 use super::metrics::*;
 use super::Result;
@@ -157,9 +157,9 @@ mod tests {
 
     use kvproto::metapb;
     use kvproto::pdpb;
-    use pd::{PdClient, PdFuture, RegionStat, Result};
-    use util;
-    use util::collections::HashMap;
+    use crate::pd::{PdClient, PdFuture, RegionStat, Result};
+    use crate::util;
+    use crate::util::collections::HashMap;
 
     const STORE_ADDRESS_REFRESH_SECONDS: u64 = 60;
 

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -155,11 +155,11 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
 
-    use kvproto::metapb;
-    use kvproto::pdpb;
     use crate::pd::{PdClient, PdFuture, RegionStat, Result};
     use crate::util;
     use crate::util::collections::HashMap;
+    use kvproto::metapb;
+    use kvproto::pdpb;
 
     const STORE_ADDRESS_REFRESH_SECONDS: u64 = 60;
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -18,19 +18,19 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use futures::Stream;
-use grpc::{ChannelBuilder, EnvBuilder, Environment, Server as GrpcServer, ServerBuilder};
+use crate::grpc::{ChannelBuilder, EnvBuilder, Environment, Server as GrpcServer, ServerBuilder};
 use kvproto::debugpb_grpc::create_debug;
 use kvproto::import_sstpb_grpc::create_import_sst;
 use kvproto::tikvpb_grpc::*;
 use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 use tokio::timer::Interval;
 
-use coprocessor::Endpoint;
-use import::ImportSSTService;
-use raftstore::store::{Engines, SnapManager};
-use storage::{Engine, Storage};
-use util::security::SecurityManager;
-use util::worker::Worker;
+use crate::coprocessor::Endpoint;
+use crate::import::ImportSSTService;
+use crate::raftstore::store::{Engines, SnapManager};
+use crate::storage::{Engine, Storage};
+use crate::util::security::SecurityManager;
+use crate::util::worker::Worker;
 
 use super::load_statistics::*;
 use super::raft_client::RaftClient;
@@ -227,16 +227,16 @@ mod tests {
     use super::super::resolve::{Callback as ResolveCallback, StoreAddrResolver};
     use super::super::transport::RaftStoreRouter;
     use super::super::{Config, Result};
-    use coprocessor;
+    use crate::coprocessor;
     use kvproto::raft_serverpb::RaftMessage;
-    use raftstore::store::transport::Transport;
-    use raftstore::store::Msg as StoreMsg;
-    use raftstore::store::*;
-    use raftstore::Result as RaftStoreResult;
-    use server::readpool::{self, ReadPool};
-    use storage::TestStorageBuilder;
-    use util::security::SecurityConfig;
-    use util::worker::FutureWorker;
+    use crate::raftstore::store::transport::Transport;
+    use crate::raftstore::store::Msg as StoreMsg;
+    use crate::raftstore::store::*;
+    use crate::raftstore::Result as RaftStoreResult;
+    use crate::server::readpool::{self, ReadPool};
+    use crate::storage::TestStorageBuilder;
+    use crate::util::security::SecurityConfig;
+    use crate::util::worker::FutureWorker;
 
     #[derive(Clone)]
     struct MockResolver {

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -17,8 +17,8 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
-use futures::Stream;
 use crate::grpc::{ChannelBuilder, EnvBuilder, Environment, Server as GrpcServer, ServerBuilder};
+use futures::Stream;
 use kvproto::debugpb_grpc::create_debug;
 use kvproto::import_sstpb_grpc::create_import_sst;
 use kvproto::tikvpb_grpc::*;
@@ -228,7 +228,6 @@ mod tests {
     use super::super::transport::RaftStoreRouter;
     use super::super::{Config, Result};
     use crate::coprocessor;
-    use kvproto::raft_serverpb::RaftMessage;
     use crate::raftstore::store::transport::Transport;
     use crate::raftstore::store::Msg as StoreMsg;
     use crate::raftstore::store::*;
@@ -237,6 +236,7 @@ mod tests {
     use crate::storage::TestStorageBuilder;
     use crate::util::security::SecurityConfig;
     use crate::util::worker::FutureWorker;
+    use kvproto::raft_serverpb::RaftMessage;
 
     #[derive(Clone)]
     struct MockResolver {

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -15,8 +15,8 @@ use fail;
 use futures::sync::oneshot;
 use futures::{future, stream, Future, Stream};
 use futures_cpupool::{Builder, CpuPool};
-use grpc::{Error as GrpcError, WriteFlags};
-use grpc::{RpcContext, RpcStatus, RpcStatusCode, ServerStreamingSink, UnarySink};
+use crate::grpc::{Error as GrpcError, WriteFlags};
+use crate::grpc::{RpcContext, RpcStatus, RpcStatusCode, ServerStreamingSink, UnarySink};
 use kvproto::debugpb::*;
 use kvproto::debugpb_grpc;
 use kvproto::raft_cmdpb::{
@@ -25,12 +25,12 @@ use kvproto::raft_cmdpb::{
 };
 use protobuf::text_format::print_to_string;
 
-use raftstore::store::msg::Callback;
-use raftstore::store::Engines;
-use server::debug::{Debugger, Error};
-use server::transport::RaftStoreRouter;
+use crate::raftstore::store::msg::Callback;
+use crate::raftstore::store::Engines;
+use crate::server::debug::{Debugger, Error};
+use crate::server::transport::RaftStoreRouter;
 use tikv_alloc;
-use util::{metrics, rocksdb_stats};
+use crate::util::{metrics, rocksdb_stats};
 
 fn error_to_status(e: Error) -> RpcStatus {
     let (code, msg) = match e {

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -11,12 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::grpc::{Error as GrpcError, WriteFlags};
+use crate::grpc::{RpcContext, RpcStatus, RpcStatusCode, ServerStreamingSink, UnarySink};
 use fail;
 use futures::sync::oneshot;
 use futures::{future, stream, Future, Stream};
 use futures_cpupool::{Builder, CpuPool};
-use crate::grpc::{Error as GrpcError, WriteFlags};
-use crate::grpc::{RpcContext, RpcStatus, RpcStatusCode, ServerStreamingSink, UnarySink};
 use kvproto::debugpb::*;
 use kvproto::debugpb_grpc;
 use kvproto::raft_cmdpb::{
@@ -29,8 +29,8 @@ use crate::raftstore::store::msg::Callback;
 use crate::raftstore::store::Engines;
 use crate::server::debug::{Debugger, Error};
 use crate::server::transport::RaftStoreRouter;
-use tikv_alloc;
 use crate::util::{metrics, rocksdb_stats};
+use tikv_alloc;
 
 fn error_to_status(e: Error) -> RpcStatus {
     let (code, msg) = match e {

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -14,11 +14,11 @@ use std::iter::{self, FromIterator};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use futures::{future, Future, Sink, Stream};
 use crate::grpc::{
     ClientStreamingSink, DuplexSink, Error as GrpcError, RequestStream, RpcContext, RpcStatus,
     RpcStatusCode, ServerStreamingSink, UnarySink, WriteFlags,
 };
+use futures::{future, Future, Sink, Stream};
 use kvproto::coprocessor::*;
 use kvproto::errorpb::{Error as RegionError, ServerIsBusy};
 use kvproto::kvrpcpb::{self, *};

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::{future, Future, Sink, Stream};
-use grpc::{
+use crate::grpc::{
     ClientStreamingSink, DuplexSink, Error as GrpcError, RequestStream, RpcContext, RpcStatus,
     RpcStatusCode, ServerStreamingSink, UnarySink, WriteFlags,
 };
@@ -30,21 +30,21 @@ use protobuf::RepeatedField;
 use tokio::runtime::{Runtime, TaskExecutor};
 use tokio::timer::Delay;
 
-use coprocessor::Endpoint;
-use raftstore::store::{Callback, Msg as StoreMessage, PeerMsg};
-use server::load_statistics::ThreadLoad;
-use server::metrics::*;
-use server::snap::Task as SnapTask;
-use server::transport::RaftStoreRouter;
-use server::Error;
-use storage::engine::Error as EngineError;
-use storage::mvcc::{Error as MvccError, LockType, Write as MvccWrite, WriteType};
-use storage::txn::Error as TxnError;
-use storage::{self, Engine, Key, Mutation, Options, Storage, Value};
-use util::collections::HashMap;
-use util::future::{paired_future_callback, AndThenWith};
-use util::mpsc::batch::{unbounded, BatchReceiver, Sender};
-use util::worker::Scheduler;
+use crate::coprocessor::Endpoint;
+use crate::raftstore::store::{Callback, Msg as StoreMessage, PeerMsg};
+use crate::server::load_statistics::ThreadLoad;
+use crate::server::metrics::*;
+use crate::server::snap::Task as SnapTask;
+use crate::server::transport::RaftStoreRouter;
+use crate::server::Error;
+use crate::storage::engine::Error as EngineError;
+use crate::storage::mvcc::{Error as MvccError, LockType, Write as MvccWrite, WriteType};
+use crate::storage::txn::Error as TxnError;
+use crate::storage::{self, Engine, Key, Mutation, Options, Storage, Value};
+use crate::util::collections::HashMap;
+use crate::util::future::{paired_future_callback, AndThenWith};
+use crate::util::mpsc::batch::{unbounded, BatchReceiver, Sender};
+use crate::util::worker::Scheduler;
 
 const SCHEDULER_IS_BUSY: &str = "scheduler is busy";
 const GC_WORKER_IS_BUSY: &str = "gc worker is busy";
@@ -1548,7 +1548,7 @@ fn future_cop<E: Engine>(
 }
 
 fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
-    use storage::Error;
+    use crate::storage::Error;
     match *res {
         // TODO: use `Error::cause` instead.
         Err(Error::Engine(EngineError::Request(ref e)))
@@ -1725,9 +1725,9 @@ fn extract_key_errors(res: storage::Result<Vec<storage::Result<()>>>) -> Vec<Key
 #[cfg(test)]
 mod tests {
     use super::*;
-    use storage;
-    use storage::mvcc::Error as MvccError;
-    use storage::txn::Error as TxnError;
+    use crate::storage;
+    use crate::storage::mvcc::Error as MvccError;
+    use crate::storage::txn::Error as TxnError;
 
     #[test]
     fn test_extract_key_error_write_conflict() {

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant};
 
 use futures::{future, Async, Future, Poll, Stream};
 use futures_cpupool::{Builder as CpuPoolBuilder, CpuPool};
-use grpc::{
+use crate::grpc::{
     ChannelBuilder, ClientStreamingSink, Environment, RequestStream, RpcStatus, RpcStatusCode,
     WriteFlags,
 };
@@ -27,10 +27,10 @@ use kvproto::raft_serverpb::RaftMessage;
 use kvproto::raft_serverpb::{Done, SnapshotChunk};
 use kvproto::tikvpb_grpc::TikvClient;
 
-use raftstore::store::{SnapEntry, SnapKey, SnapManager, Snapshot};
-use util::security::SecurityManager;
-use util::worker::Runnable;
-use util::DeferContext;
+use crate::raftstore::store::{SnapEntry, SnapKey, SnapManager, Snapshot};
+use crate::util::security::SecurityManager;
+use crate::util::worker::Runnable;
+use crate::util::DeferContext;
 
 use super::metrics::*;
 use super::transport::RaftStoreRouter;

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -17,12 +17,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use futures::{future, Async, Future, Poll, Stream};
-use futures_cpupool::{Builder as CpuPoolBuilder, CpuPool};
 use crate::grpc::{
     ChannelBuilder, ClientStreamingSink, Environment, RequestStream, RpcStatus, RpcStatusCode,
     WriteFlags,
 };
+use futures::{future, Async, Future, Poll, Stream};
+use futures_cpupool::{Builder as CpuPoolBuilder, CpuPool};
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::raft_serverpb::{Done, SnapshotChunk};
 use kvproto::tikvpb_grpc::TikvClient;

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -22,7 +22,7 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 
 use super::Result;
-use util::metrics::dump;
+use crate::util::metrics::dump;
 
 pub struct StatusServer {
     thread_pool: ThreadPool,
@@ -104,7 +104,7 @@ impl StatusServer {
 mod tests {
     use futures::future::{lazy, Future};
     use hyper::{Client, StatusCode, Uri};
-    use server::status_server::StatusServer;
+    use crate::server::status_server::StatusServer;
 
     #[test]
     fn test_status_service() {

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -102,9 +102,9 @@ impl StatusServer {
 
 #[cfg(test)]
 mod tests {
+    use crate::server::status_server::StatusServer;
     use futures::future::{lazy, Future};
     use hyper::{Client, StatusCode, Uri};
-    use crate::server::status_server::StatusServer;
 
     #[test]
     fn test_status_service() {

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -20,15 +20,17 @@ use std::sync::{Arc, RwLock};
 use super::metrics::*;
 use super::resolve::StoreAddrResolver;
 use super::snap::Task as SnapTask;
-use raft::SnapshotStatus;
 use crate::raftstore::store::fsm::{RaftRouter, SendCh};
-use crate::raftstore::store::{Callback, Msg as StoreMsg, PeerMsg, ReadTask, SignificantMsg, Transport};
+use crate::raftstore::store::{
+    Callback, Msg as StoreMsg, PeerMsg, ReadTask, SignificantMsg, Transport,
+};
 use crate::raftstore::{Error as RaftStoreError, Result as RaftStoreResult};
 use crate::server::raft_client::RaftClient;
 use crate::server::Result;
 use crate::util::collections::HashSet;
 use crate::util::worker::Scheduler;
 use crate::util::HandyRwLock;
+use raft::SnapshotStatus;
 
 /// Routes messages to the raftstore.
 pub trait RaftStoreRouter: Send + Clone {

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -21,14 +21,14 @@ use super::metrics::*;
 use super::resolve::StoreAddrResolver;
 use super::snap::Task as SnapTask;
 use raft::SnapshotStatus;
-use raftstore::store::fsm::{RaftRouter, SendCh};
-use raftstore::store::{Callback, Msg as StoreMsg, PeerMsg, ReadTask, SignificantMsg, Transport};
-use raftstore::{Error as RaftStoreError, Result as RaftStoreResult};
-use server::raft_client::RaftClient;
-use server::Result;
-use util::collections::HashSet;
-use util::worker::Scheduler;
-use util::HandyRwLock;
+use crate::raftstore::store::fsm::{RaftRouter, SendCh};
+use crate::raftstore::store::{Callback, Msg as StoreMsg, PeerMsg, ReadTask, SignificantMsg, Transport};
+use crate::raftstore::{Error as RaftStoreError, Result as RaftStoreResult};
+use crate::server::raft_client::RaftClient;
+use crate::server::Result;
+use crate::util::collections::HashSet;
+use crate::util::worker::Scheduler;
+use crate::util::HandyRwLock;
 
 /// Routes messages to the raftstore.
 pub trait RaftStoreRouter: Send + Clone {

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -15,7 +15,7 @@ use std::error::Error;
 
 use sys_info;
 
-use util::config::{self, ReadableSize};
+use crate::util::config::{self, ReadableSize};
 
 pub const DEFAULT_DATA_DIR: &str = "";
 pub const DEFAULT_ROCKSDB_SUB_DIR: &str = "db";

--- a/src/storage/engine/btree_engine.rs
+++ b/src/storage/engine/btree_engine.rs
@@ -20,12 +20,12 @@ use std::sync::{Arc, RwLock};
 
 use kvproto::kvrpcpb::Context;
 
-use raftstore::store::engine::IterOption;
-use storage::engine::{
+use crate::raftstore::store::engine::IterOption;
+use crate::storage::engine::{
     Callback as EngineCallback, CbContext, Cursor, Engine, Error as EngineError, Iterator, Modify,
     Result as EngineResult, ScanMode, Snapshot,
 };
-use storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_WRITE};
+use crate::storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_WRITE};
 
 type RwLockTree = RwLock<BTreeMap<Key, Value>>;
 

--- a/src/storage/engine/cursor_builder.rs
+++ b/src/storage/engine/cursor_builder.rs
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use raftstore::store::engine::IterOption;
-use storage::engine::Result;
-use storage::{CfName, Cursor, Key, ScanMode, Snapshot};
+use crate::raftstore::store::engine::IterOption;
+use crate::storage::engine::Result;
+use crate::storage::{CfName, Cursor, Key, ScanMode, Snapshot};
 
 /// A handy utility to build a snapshot cursor according to various configurations.
 pub struct CursorBuilder<'a, S: 'a + Snapshot> {

--- a/src/storage/engine/metrics.rs
+++ b/src/storage/engine/metrics.rs
@@ -14,7 +14,7 @@
 use prometheus::exponential_buckets;
 use prometheus_static_metric::*;
 
-use storage::ErrorHeaderKind;
+use crate::storage::ErrorHeaderKind;
 
 make_static_metric! {
     pub label_enum RequestStatusKind {

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -19,10 +19,10 @@ use std::{error, result};
 
 use kvproto::errorpb::Error as ErrorHeader;
 use kvproto::kvrpcpb::{Context, ScanDetail, ScanInfo};
-use raftstore::store::engine::IterOption;
-use raftstore::store::{SeekRegionFilter, SeekRegionResult};
+use crate::raftstore::store::engine::IterOption;
+use crate::raftstore::store::{SeekRegionFilter, SeekRegionResult};
 use rocksdb::TablePropertiesCollection;
-use storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_WRITE};
+use crate::storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_WRITE};
 
 mod btree_engine;
 mod cursor_builder;
@@ -682,9 +682,9 @@ pub mod tests {
     use super::SEEK_BOUND;
     use super::*;
     use kvproto::kvrpcpb::Context;
-    use storage::{CfName, Key, CF_DEFAULT};
-    use util::codec::bytes;
-    use util::escape;
+    use crate::storage::{CfName, Key, CF_DEFAULT};
+    use crate::util::codec::bytes;
+    use crate::util::escape;
     pub const TEST_ENGINE_CFS: &[CfName] = &["cf"];
 
     pub fn must_put<E: Engine>(engine: &E, key: &[u8], value: &[u8]) {

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -21,7 +21,7 @@ use kvproto::errorpb::Error as ErrorHeader;
 use kvproto::kvrpcpb::{Context, ScanDetail, ScanInfo};
 use crate::raftstore::store::engine::IterOption;
 use crate::raftstore::store::{SeekRegionFilter, SeekRegionResult};
-use rocksdb::TablePropertiesCollection;
+use ::rocksdb::TablePropertiesCollection;
 use crate::storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_WRITE};
 
 mod btree_engine;

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -17,12 +17,12 @@ use std::cmp::Ordering;
 use std::time::Duration;
 use std::{error, result};
 
-use kvproto::errorpb::Error as ErrorHeader;
-use kvproto::kvrpcpb::{Context, ScanDetail, ScanInfo};
 use crate::raftstore::store::engine::IterOption;
 use crate::raftstore::store::{SeekRegionFilter, SeekRegionResult};
-use ::rocksdb::TablePropertiesCollection;
 use crate::storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_WRITE};
+use ::rocksdb::TablePropertiesCollection;
+use kvproto::errorpb::Error as ErrorHeader;
+use kvproto::kvrpcpb::{Context, ScanDetail, ScanInfo};
 
 mod btree_engine;
 mod cursor_builder;
@@ -681,10 +681,10 @@ pub mod tests {
     use super::super::super::raftstore::store::engine::IterOption;
     use super::SEEK_BOUND;
     use super::*;
-    use kvproto::kvrpcpb::Context;
     use crate::storage::{CfName, Key, CF_DEFAULT};
     use crate::util::codec::bytes;
     use crate::util::escape;
+    use kvproto::kvrpcpb::Context;
     pub const TEST_ENGINE_CFS: &[CfName] = &["cf"];
 
     pub fn must_put<E: Engine>(engine: &E, key: &[u8], value: &[u8]) {

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -28,14 +28,14 @@ use super::metrics::*;
 use super::{
     Callback, CbContext, Cursor, Engine, Iterator as EngineIterator, Modify, ScanMode, Snapshot,
 };
-use raftstore::errors::Error as RaftServerError;
-use raftstore::store::engine::IterOption;
-use raftstore::store::engine::Peekable;
-use raftstore::store::{Callback as StoreCallback, ReadResponse, WriteResponse};
-use raftstore::store::{RegionIterator, RegionSnapshot};
+use crate::raftstore::errors::Error as RaftServerError;
+use crate::raftstore::store::engine::IterOption;
+use crate::raftstore::store::engine::Peekable;
+use crate::raftstore::store::{Callback as StoreCallback, ReadResponse, WriteResponse};
+use crate::raftstore::store::{RegionIterator, RegionSnapshot};
 use rocksdb::TablePropertiesCollection;
-use server::transport::RaftStoreRouter;
-use storage::{self, engine, CfName, Key, Value, CF_DEFAULT};
+use crate::server::transport::RaftStoreRouter;
+use crate::storage::{self, engine, CfName, Key, Value, CF_DEFAULT};
 
 quick_error! {
     #[derive(Debug)]

--- a/src/storage/engine/raftkv.rs
+++ b/src/storage/engine/raftkv.rs
@@ -33,9 +33,9 @@ use crate::raftstore::store::engine::IterOption;
 use crate::raftstore::store::engine::Peekable;
 use crate::raftstore::store::{Callback as StoreCallback, ReadResponse, WriteResponse};
 use crate::raftstore::store::{RegionIterator, RegionSnapshot};
-use rocksdb::TablePropertiesCollection;
 use crate::server::transport::RaftStoreRouter;
 use crate::storage::{self, engine, CfName, Key, Value, CF_DEFAULT};
+use rocksdb::TablePropertiesCollection;
 
 quick_error! {
     #[derive(Debug)]

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -19,21 +19,21 @@ use std::sync::{Arc, Mutex};
 use kvproto::kvrpcpb::Context;
 use tempdir::TempDir;
 
-use raftstore::store::engine::{IterOption, Peekable};
+use crate::raftstore::store::engine::{IterOption, Peekable};
 use rocksdb::{DBIterator, SeekKey, Writable, WriteBatch, DB};
-use storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+use crate::storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 
-use util::escape;
-use util::rocksdb;
-use util::rocksdb::CFOptions;
-use util::worker::{Runnable, Scheduler, Worker};
+use crate::util::escape;
+use crate::util::rocksdb;
+use crate::util::rocksdb::CFOptions;
+use crate::util::worker::{Runnable, Scheduler, Worker};
 
 use super::{
     Callback, CbContext, Cursor, Engine, Error, Iterator as EngineIterator, Modify, Result,
     ScanMode, Snapshot,
 };
 
-pub use raftstore::store::engine::SyncSnapshot as RocksSnapshot;
+pub use crate::raftstore::store::engine::SyncSnapshot as RocksSnapshot;
 
 const TEMP_DIR: &str = "";
 
@@ -177,8 +177,8 @@ impl TestEngineBuilder {
             None => TEMP_DIR.to_owned(),
             Some(p) => p.to_str().unwrap().to_owned(),
         };
-        let cfs = self.cfs.unwrap_or_else(|| ::storage::ALL_CFS.to_vec());
-        let cfg_rocksdb = ::config::DbConfig::default();
+        let cfs = self.cfs.unwrap_or_else(|| crate::storage::ALL_CFS.to_vec());
+        let cfg_rocksdb = crate::config::DbConfig::default();
         let cfs_opts = cfs
             .iter()
             .map(|cf| match *cf {

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -20,8 +20,8 @@ use kvproto::kvrpcpb::Context;
 use tempdir::TempDir;
 
 use crate::raftstore::store::engine::{IterOption, Peekable};
-use ::rocksdb::{DBIterator, SeekKey, Writable, WriteBatch, DB};
 use crate::storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+use ::rocksdb::{DBIterator, SeekKey, Writable, WriteBatch, DB};
 
 use crate::util::escape;
 use crate::util::rocksdb;

--- a/src/storage/engine/rocksdb.rs
+++ b/src/storage/engine/rocksdb.rs
@@ -20,7 +20,7 @@ use kvproto::kvrpcpb::Context;
 use tempdir::TempDir;
 
 use crate::raftstore::store::engine::{IterOption, Peekable};
-use rocksdb::{DBIterator, SeekKey, Writable, WriteBatch, DB};
+use ::rocksdb::{DBIterator, SeekKey, Writable, WriteBatch, DB};
 use crate::storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 
 use crate::util::escape;

--- a/src/storage/gc_worker.rs
+++ b/src/storage/gc_worker.rs
@@ -31,7 +31,6 @@ use super::engine::{
 use super::metrics::*;
 use super::mvcc::{MvccReader, MvccTxn};
 use super::{Callback, Error, Key, Result, CF_DEFAULT, CF_LOCK, CF_WRITE};
-use log_wrappers::DisplayValue;
 use crate::pd::PdClient;
 use crate::raftstore::store::keys;
 use crate::raftstore::store::msg::{Msg as RaftStoreMsg, StoreMsg};
@@ -41,6 +40,7 @@ use crate::server::transport::{RaftStoreRouter, ServerRaftStoreRouter};
 use crate::util::rocksdb::get_cf_handle;
 use crate::util::time::{duration_to_sec, SlowTimer};
 use crate::util::worker::{self, Builder as WorkerBuilder, Runnable, ScheduleError, Worker};
+use log_wrappers::DisplayValue;
 
 // TODO: make it configurable.
 pub const GC_BATCH_SIZE: usize = 512;
@@ -1157,13 +1157,13 @@ impl<E: Engine> GCWorker<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::Future;
-    use kvproto::metapb;
     use crate::raftstore::store::SeekRegionFilter;
-    use std::collections::BTreeMap;
-    use std::sync::mpsc::{channel, Receiver, Sender};
     use crate::storage::engine::Result as EngineResult;
     use crate::storage::{Mutation, Options, Storage, TestEngineBuilder, TestStorageBuilder};
+    use futures::Future;
+    use kvproto::metapb;
+    use std::collections::BTreeMap;
+    use std::sync::mpsc::{channel, Receiver, Sender};
 
     struct MockSafePointProvider {
         rx: Receiver<u64>,

--- a/src/storage/gc_worker.rs
+++ b/src/storage/gc_worker.rs
@@ -32,15 +32,15 @@ use super::metrics::*;
 use super::mvcc::{MvccReader, MvccTxn};
 use super::{Callback, Error, Key, Result, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use log_wrappers::DisplayValue;
-use pd::PdClient;
-use raftstore::store::keys;
-use raftstore::store::msg::{Msg as RaftStoreMsg, StoreMsg};
-use raftstore::store::util::{delete_all_in_range_cf, find_peer};
-use raftstore::store::SeekRegionResult;
-use server::transport::{RaftStoreRouter, ServerRaftStoreRouter};
-use util::rocksdb::get_cf_handle;
-use util::time::{duration_to_sec, SlowTimer};
-use util::worker::{self, Builder as WorkerBuilder, Runnable, ScheduleError, Worker};
+use crate::pd::PdClient;
+use crate::raftstore::store::keys;
+use crate::raftstore::store::msg::{Msg as RaftStoreMsg, StoreMsg};
+use crate::raftstore::store::util::{delete_all_in_range_cf, find_peer};
+use crate::raftstore::store::SeekRegionResult;
+use crate::server::transport::{RaftStoreRouter, ServerRaftStoreRouter};
+use crate::util::rocksdb::get_cf_handle;
+use crate::util::time::{duration_to_sec, SlowTimer};
+use crate::util::worker::{self, Builder as WorkerBuilder, Runnable, ScheduleError, Worker};
 
 // TODO: make it configurable.
 pub const GC_BATCH_SIZE: usize = 512;
@@ -1159,11 +1159,11 @@ mod tests {
     use super::*;
     use futures::Future;
     use kvproto::metapb;
-    use raftstore::store::SeekRegionFilter;
+    use crate::raftstore::store::SeekRegionFilter;
     use std::collections::BTreeMap;
     use std::sync::mpsc::{channel, Receiver, Sender};
-    use storage::engine::Result as EngineResult;
-    use storage::{Mutation, Options, Storage, TestEngineBuilder, TestStorageBuilder};
+    use crate::storage::engine::Result as EngineResult;
+    use crate::storage::{Mutation, Options, Storage, TestEngineBuilder, TestStorageBuilder};
 
     struct MockSafePointProvider {
         rx: Receiver<u64>,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -34,12 +34,12 @@ use kvproto::kvrpcpb::{CommandPri, Context, KeyRange, LockInfo};
 
 use rocksdb::DB;
 
-use raftstore::store::engine::IterOption;
-use server::readpool::{self, ReadPool};
-use server::ServerRaftStoreRouter;
-use util;
-use util::collections::HashMap;
-use util::worker::{self, Builder, ScheduleError, Worker};
+use crate::raftstore::store::engine::IterOption;
+use crate::server::readpool::{self, ReadPool};
+use crate::server::ServerRaftStoreRouter;
+use crate::util;
+use crate::util::collections::HashMap;
+use crate::util::worker::{self, Builder, ScheduleError, Worker};
 
 use self::gc_worker::GCWorker;
 use self::metrics::*;
@@ -474,7 +474,7 @@ impl<E: Engine> TestStorageBuilder<E> {
 
     /// Build a `Storage<E>`.
     pub fn build(self) -> Result<Storage<E>> {
-        use util::worker::FutureWorker;
+        use crate::util::worker::FutureWorker;
 
         let read_pool = {
             let pd_worker = FutureWorker::new("test-future–worker");
@@ -1766,7 +1766,7 @@ mod tests {
     use super::*;
     use kvproto::kvrpcpb::{Context, LockInfo};
     use std::sync::mpsc::{channel, Sender};
-    use util::config::ReadableSize;
+    use crate::util::config::ReadableSize;
 
     fn expect_none(x: Result<Option<Value>>) {
         assert_eq!(x.unwrap(), None);
@@ -3695,7 +3695,7 @@ mod tests {
 
     #[test]
     fn test_resolve_lock() {
-        use storage::txn::RESOLVE_LOCK_BATCH_SIZE;
+        use crate::storage::txn::RESOLVE_LOCK_BATCH_SIZE;
 
         let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1764,9 +1764,9 @@ pub fn get_tag_from_header(header: &errorpb::Error) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::config::ReadableSize;
     use kvproto::kvrpcpb::{Context, LockInfo};
     use std::sync::mpsc::{channel, Sender};
-    use crate::util::config::ReadableSize;
 
     fn expect_none(x: Result<Option<Value>>) {
         assert_eq!(x.unwrap(), None);

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -13,10 +13,10 @@
 
 use super::super::types::Value;
 use super::{Error, Result};
-use byteorder::ReadBytesExt;
 use crate::storage::{Mutation, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
 use crate::util::codec::bytes::{self, BytesEncoder};
 use crate::util::codec::number::{self, NumberEncoder, MAX_VAR_U64_LEN};
+use byteorder::ReadBytesExt;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LockType {

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -14,9 +14,9 @@
 use super::super::types::Value;
 use super::{Error, Result};
 use byteorder::ReadBytesExt;
-use storage::{Mutation, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
-use util::codec::bytes::{self, BytesEncoder};
-use util::codec::number::{self, NumberEncoder, MAX_VAR_U64_LEN};
+use crate::storage::{Mutation, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
+use crate::util::codec::bytes::{self, BytesEncoder};
+use crate::util::codec::number::{self, NumberEncoder, MAX_VAR_U64_LEN};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LockType {
@@ -138,7 +138,7 @@ impl Lock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use storage::{Key, Mutation};
+    use crate::storage::{Key, Mutation};
 
     #[test]
     fn test_lock_type() {

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -23,9 +23,9 @@ pub use self::reader::{BackwardScanner, BackwardScannerBuilder};
 pub use self::reader::{ForwardScanner, ForwardScannerBuilder};
 pub use self::txn::{MvccTxn, MAX_TXN_WRITE_SIZE};
 pub use self::write::{Write, WriteType};
+use crate::util::escape;
 use std::error;
 use std::io;
-use crate::util::escape;
 
 quick_error! {
     #[derive(Debug)]

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -25,12 +25,12 @@ pub use self::txn::{MvccTxn, MAX_TXN_WRITE_SIZE};
 pub use self::write::{Write, WriteType};
 use std::error;
 use std::io;
-use util::escape;
+use crate::util::escape;
 
 quick_error! {
     #[derive(Debug)]
     pub enum Error {
-        Engine(err: ::storage::engine::Error) {
+        Engine(err: crate::storage::engine::Error) {
             from()
             cause(err)
             description(err.description())
@@ -40,7 +40,7 @@ quick_error! {
             cause(err)
             description(err.description())
         }
-        Codec(err: ::util::codec::Error) {
+        Codec(err: crate::util::codec::Error) {
             from()
             cause(err)
             description(err.description())
@@ -131,8 +131,8 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 pub mod tests {
     use kvproto::kvrpcpb::{Context, IsolationLevel};
 
-    use storage::CF_WRITE;
-    use storage::{Engine, Key, Modify, Mutation, Options, ScanMode, Snapshot};
+    use crate::storage::CF_WRITE;
+    use crate::storage::{Engine, Key, Modify, Mutation, Options, ScanMode, Snapshot};
 
     use super::*;
 

--- a/src/storage/mvcc/reader/backward_scanner.rs
+++ b/src/storage/mvcc/reader/backward_scanner.rs
@@ -15,11 +15,11 @@ use std::cmp::Ordering;
 
 use kvproto::kvrpcpb::IsolationLevel;
 
-use storage::engine::SEEK_BOUND;
-use storage::mvcc::write::{Write, WriteType};
-use storage::mvcc::Result;
-use storage::{Cursor, CursorBuilder, Key, Lock, ScanMode, Snapshot, Statistics, Value};
-use storage::{CF_DEFAULT, CF_LOCK, CF_WRITE};
+use crate::storage::engine::SEEK_BOUND;
+use crate::storage::mvcc::write::{Write, WriteType};
+use crate::storage::mvcc::Result;
+use crate::storage::{Cursor, CursorBuilder, Key, Lock, ScanMode, Snapshot, Statistics, Value};
+use crate::storage::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 
 use super::util::CheckLockResult;
 
@@ -481,8 +481,8 @@ impl<S: Snapshot> BackwardScanner<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use storage::mvcc::tests::*;
-    use storage::{Engine, Key, TestEngineBuilder};
+    use crate::storage::mvcc::tests::*;
+    use crate::storage::{Engine, Key, TestEngineBuilder};
 
     use kvproto::kvrpcpb::Context;
 

--- a/src/storage/mvcc/reader/forward_scanner.rs
+++ b/src/storage/mvcc/reader/forward_scanner.rs
@@ -15,11 +15,11 @@ use std::cmp::Ordering;
 
 use kvproto::kvrpcpb::IsolationLevel;
 
-use storage::engine::SEEK_BOUND;
-use storage::mvcc::write::{Write, WriteType};
-use storage::mvcc::Result;
-use storage::{Cursor, CursorBuilder, Key, Lock, Snapshot, Statistics, Value};
-use storage::{CF_DEFAULT, CF_LOCK, CF_WRITE};
+use crate::storage::engine::SEEK_BOUND;
+use crate::storage::mvcc::write::{Write, WriteType};
+use crate::storage::mvcc::Result;
+use crate::storage::{Cursor, CursorBuilder, Key, Lock, Snapshot, Statistics, Value};
+use crate::storage::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 
 use super::util::CheckLockResult;
 
@@ -476,8 +476,8 @@ impl<S: Snapshot> ForwardScanner<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use storage::mvcc::tests::*;
-    use storage::{Engine, Key, TestEngineBuilder};
+    use crate::storage::mvcc::tests::*;
+    use crate::storage::{Engine, Key, TestEngineBuilder};
 
     use kvproto::kvrpcpb::Context;
 

--- a/src/storage/mvcc/reader/mod.rs
+++ b/src/storage/mvcc/reader/mod.rs
@@ -19,11 +19,11 @@ use super::lock::{Lock, LockType};
 use super::write::{Write, WriteType};
 use super::{Error, Result};
 use kvproto::kvrpcpb::IsolationLevel;
-use raftstore::store::engine::IterOption;
+use crate::raftstore::store::engine::IterOption;
 use std::u64;
-use storage::engine::{Cursor, ScanMode, Snapshot, Statistics};
-use storage::{Key, Value, CF_LOCK, CF_WRITE};
-use util::properties::MvccProperties;
+use crate::storage::engine::{Cursor, ScanMode, Snapshot, Statistics};
+use crate::storage::{Key, Value, CF_LOCK, CF_WRITE};
+use crate::util::properties::MvccProperties;
 
 pub use self::backward_scanner::{BackwardScanner, BackwardScannerBuilder};
 pub use self::forward_scanner::{ForwardScanner, ForwardScannerBuilder};
@@ -493,18 +493,18 @@ impl<S: Snapshot> MvccReader<S> {
 mod tests {
     use kvproto::kvrpcpb::IsolationLevel;
     use kvproto::metapb::{Peer, Region};
-    use raftstore::store::keys;
-    use raftstore::store::RegionSnapshot;
+    use crate::raftstore::store::keys;
+    use crate::raftstore::store::RegionSnapshot;
     use rocksdb::{self, Writable, WriteBatch, DB};
     use std::sync::Arc;
     use std::u64;
-    use storage::engine::Modify;
-    use storage::mvcc::write::WriteType;
-    use storage::mvcc::{MvccReader, MvccTxn};
-    use storage::{Key, Mutation, Options, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+    use crate::storage::engine::Modify;
+    use crate::storage::mvcc::write::WriteType;
+    use crate::storage::mvcc::{MvccReader, MvccTxn};
+    use crate::storage::{Key, Mutation, Options, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
     use tempdir::TempDir;
-    use util::properties::{MvccProperties, MvccPropertiesCollectorFactory};
-    use util::rocksdb::{self as rocksdb_util, CFOptions};
+    use crate::util::properties::{MvccProperties, MvccPropertiesCollectorFactory};
+    use crate::util::rocksdb::{self as rocksdb_util, CFOptions};
 
     struct RegionEngine {
         db: Arc<DB>,

--- a/src/storage/mvcc/reader/mod.rs
+++ b/src/storage/mvcc/reader/mod.rs
@@ -18,12 +18,12 @@ mod util;
 use super::lock::{Lock, LockType};
 use super::write::{Write, WriteType};
 use super::{Error, Result};
-use kvproto::kvrpcpb::IsolationLevel;
 use crate::raftstore::store::engine::IterOption;
-use std::u64;
 use crate::storage::engine::{Cursor, ScanMode, Snapshot, Statistics};
 use crate::storage::{Key, Value, CF_LOCK, CF_WRITE};
 use crate::util::properties::MvccProperties;
+use kvproto::kvrpcpb::IsolationLevel;
+use std::u64;
 
 pub use self::backward_scanner::{BackwardScanner, BackwardScannerBuilder};
 pub use self::forward_scanner::{ForwardScanner, ForwardScannerBuilder};
@@ -491,20 +491,20 @@ impl<S: Snapshot> MvccReader<S> {
 
 #[cfg(test)]
 mod tests {
-    use kvproto::kvrpcpb::IsolationLevel;
-    use kvproto::metapb::{Peer, Region};
     use crate::raftstore::store::keys;
     use crate::raftstore::store::RegionSnapshot;
-    use rocksdb::{self, Writable, WriteBatch, DB};
-    use std::sync::Arc;
-    use std::u64;
     use crate::storage::engine::Modify;
     use crate::storage::mvcc::write::WriteType;
     use crate::storage::mvcc::{MvccReader, MvccTxn};
     use crate::storage::{Key, Mutation, Options, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
-    use tempdir::TempDir;
     use crate::util::properties::{MvccProperties, MvccPropertiesCollectorFactory};
     use crate::util::rocksdb::{self as rocksdb_util, CFOptions};
+    use kvproto::kvrpcpb::IsolationLevel;
+    use kvproto::metapb::{Peer, Region};
+    use rocksdb::{self, Writable, WriteBatch, DB};
+    use std::sync::Arc;
+    use std::u64;
+    use tempdir::TempDir;
 
     struct RegionEngine {
         db: Arc<DB>,

--- a/src/storage/mvcc/reader/util.rs
+++ b/src/storage/mvcc/reader/util.rs
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use storage::mvcc::{Error, Result};
-use storage::mvcc::{Lock, LockType, Write};
-use storage::{Cursor, Iterator, Key, Statistics, Value};
+use crate::storage::mvcc::{Error, Result};
+use crate::storage::mvcc::{Lock, LockType, Write};
+use crate::storage::{Cursor, Iterator, Key, Statistics, Value};
 
 /// Representing check lock result.
 #[derive(Debug)]

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -18,8 +18,8 @@ use super::write::{Write, WriteType};
 use super::{Error, Result};
 use kvproto::kvrpcpb::IsolationLevel;
 use std::fmt;
-use storage::engine::{Modify, ScanMode, Snapshot};
-use storage::{
+use crate::storage::engine::{Modify, ScanMode, Snapshot};
+use crate::storage::{
     is_short_value, Key, Mutation, Options, Statistics, Value, CF_DEFAULT, CF_LOCK, CF_WRITE,
 };
 
@@ -379,11 +379,11 @@ impl<S: Snapshot> MvccTxn<S> {
 mod tests {
     use kvproto::kvrpcpb::{Context, IsolationLevel};
 
-    use storage::engine::Engine;
-    use storage::mvcc::tests::*;
-    use storage::mvcc::WriteType;
-    use storage::mvcc::{MvccReader, MvccTxn};
-    use storage::{Key, Mutation, Options, ScanMode, TestEngineBuilder, SHORT_VALUE_MAX_LEN};
+    use crate::storage::engine::Engine;
+    use crate::storage::mvcc::tests::*;
+    use crate::storage::mvcc::WriteType;
+    use crate::storage::mvcc::{MvccReader, MvccTxn};
+    use crate::storage::{Key, Mutation, Options, ScanMode, TestEngineBuilder, SHORT_VALUE_MAX_LEN};
 
     fn test_mvcc_txn_read_imp(k: &[u8], v: &[u8]) {
         let engine = TestEngineBuilder::new().build().unwrap();

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -16,12 +16,12 @@ use super::metrics::*;
 use super::reader::MvccReader;
 use super::write::{Write, WriteType};
 use super::{Error, Result};
-use kvproto::kvrpcpb::IsolationLevel;
-use std::fmt;
 use crate::storage::engine::{Modify, ScanMode, Snapshot};
 use crate::storage::{
     is_short_value, Key, Mutation, Options, Statistics, Value, CF_DEFAULT, CF_LOCK, CF_WRITE,
 };
+use kvproto::kvrpcpb::IsolationLevel;
+use std::fmt;
 
 pub const MAX_TXN_WRITE_SIZE: usize = 32 * 1024;
 
@@ -383,7 +383,9 @@ mod tests {
     use crate::storage::mvcc::tests::*;
     use crate::storage::mvcc::WriteType;
     use crate::storage::mvcc::{MvccReader, MvccTxn};
-    use crate::storage::{Key, Mutation, Options, ScanMode, TestEngineBuilder, SHORT_VALUE_MAX_LEN};
+    use crate::storage::{
+        Key, Mutation, Options, ScanMode, TestEngineBuilder, SHORT_VALUE_MAX_LEN,
+    };
 
     fn test_mvcc_txn_read_imp(k: &[u8], v: &[u8]) {
         let engine = TestEngineBuilder::new().build().unwrap();

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -15,8 +15,8 @@ use super::super::types::Value;
 use super::lock::LockType;
 use super::{Error, Result};
 use byteorder::ReadBytesExt;
-use storage::{SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
-use util::codec::number::{self, NumberEncoder, MAX_VAR_U64_LEN};
+use crate::storage::{SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
+use crate::util::codec::number::{self, NumberEncoder, MAX_VAR_U64_LEN};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WriteType {

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -14,9 +14,9 @@
 use super::super::types::Value;
 use super::lock::LockType;
 use super::{Error, Result};
-use byteorder::ReadBytesExt;
 use crate::storage::{SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
 use crate::util::codec::number::{self, NumberEncoder, MAX_VAR_U64_LEN};
+use byteorder::ReadBytesExt;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WriteType {

--- a/src/storage/readpool_context.rs
+++ b/src/storage/readpool_context.rs
@@ -15,12 +15,12 @@ use prometheus::local::{LocalHistogramTimer, LocalHistogramVec, LocalIntCounterV
 use std::fmt;
 use std::mem;
 
-use pd;
-use server::readpool;
-use storage;
-use util::collections::HashMap;
-use util::futurepool;
-use util::worker;
+use crate::pd;
+use crate::server::readpool;
+use crate::storage;
+use crate::util::collections::HashMap;
+use crate::util::futurepool;
+use crate::util::worker;
 
 use super::metrics::*;
 

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -23,17 +23,17 @@ pub use self::process::RESOLVE_LOCK_BATCH_SIZE;
 pub use self::scheduler::{Msg, Scheduler, CMD_BATCH_SIZE};
 pub use self::store::{FixtureStore, FixtureStoreScanner};
 pub use self::store::{Scanner, SnapshotStore, Store, StoreScanner};
-use util::escape;
+use crate::util::escape;
 
 quick_error! {
     #[derive(Debug)]
     pub enum Error {
-        Engine(err: ::storage::engine::Error) {
+        Engine(err: crate::storage::engine::Error) {
             from()
             cause(err)
             description(err.description())
         }
-        Codec(err: ::util::codec::Error) {
+        Codec(err: crate::util::codec::Error) {
             from()
             cause(err)
             description(err.description())
@@ -43,7 +43,7 @@ quick_error! {
             cause(err)
             description(err.description())
         }
-        Mvcc(err: ::storage::mvcc::Error) {
+        Mvcc(err: crate::storage::mvcc::Error) {
             from()
             cause(err)
             description(err.description())

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -19,19 +19,19 @@ use std::u64;
 use kvproto::kvrpcpb::{CommandPri, Context, LockInfo};
 use prometheus::local::LocalHistogramVec;
 
-use storage::engine::{CbContext, Modify, Result as EngineResult};
-use storage::mvcc::{
+use crate::storage::engine::{CbContext, Modify, Result as EngineResult};
+use crate::storage::mvcc::{
     Error as MvccError, Lock as MvccLock, MvccReader, MvccTxn, Write, MAX_TXN_WRITE_SIZE,
 };
-use storage::{
+use crate::storage::{
     Command, Engine, Error as StorageError, Result as StorageResult, ScanMode, Snapshot,
     Statistics, StatisticsSummary, StorageCb,
 };
-use storage::{Key, MvccInfo, Value};
-use util::collections::HashMap;
-use util::threadpool::{self, Context as ThreadContext, ContextFactory as ThreadContextFactory};
-use util::time::SlowTimer;
-use util::worker::{self, ScheduleError};
+use crate::storage::{Key, MvccInfo, Value};
+use crate::util::collections::HashMap;
+use crate::util::threadpool::{self, Context as ThreadContext, ContextFactory as ThreadContextFactory};
+use crate::util::time::SlowTimer;
+use crate::util::worker::{self, ScheduleError};
 
 use super::super::metrics::*;
 use super::scheduler::Msg;

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -29,7 +29,9 @@ use crate::storage::{
 };
 use crate::storage::{Key, MvccInfo, Value};
 use crate::util::collections::HashMap;
-use crate::util::threadpool::{self, Context as ThreadContext, ContextFactory as ThreadContextFactory};
+use crate::util::threadpool::{
+    self, Context as ThreadContext, ContextFactory as ThreadContextFactory,
+};
 use crate::util::time::SlowTimer;
 use crate::util::worker::{self, ScheduleError};
 

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -540,7 +540,7 @@ fn process_write_impl<S: Snapshot>(
         }
         Command::ResolveLock {
             ctx,
-            mut txn_status,
+            txn_status,
             mut scan_key,
             key_locks,
         } => {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -37,12 +37,12 @@ use std::u64;
 use kvproto::kvrpcpb::CommandPri;
 use prometheus::HistogramTimer;
 
-use storage::engine::Result as EngineResult;
-use storage::Key;
-use storage::{Command, Engine, Error as StorageError, StorageCb};
-use util::collections::HashMap;
-use util::threadpool::{ThreadPool, ThreadPoolBuilder};
-use util::worker::{self, Runnable};
+use crate::storage::engine::Result as EngineResult;
+use crate::storage::Key;
+use crate::storage::{Command, Engine, Error as StorageError, StorageCb};
+use crate::util::collections::HashMap;
+use crate::util::threadpool::{ThreadPool, ThreadPoolBuilder};
+use crate::util::worker::{self, Runnable};
 
 use super::super::metrics::*;
 use super::latch::{Latches, Lock};
@@ -499,10 +499,10 @@ fn gen_command_lock(latches: &Latches, cmd: &Command) -> Lock {
 mod tests {
     use super::*;
     use kvproto::kvrpcpb::Context;
-    use storage::mvcc;
-    use storage::txn::latch::*;
-    use storage::{Command, Key, Mutation, Options};
-    use util::collections::HashMap;
+    use crate::storage::mvcc;
+    use crate::storage::txn::latch::*;
+    use crate::storage::{Command, Key, Mutation, Options};
+    use crate::util::collections::HashMap;
 
     #[test]
     fn test_command_latches() {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -400,7 +400,7 @@ impl<E: Engine> Scheduler<E> {
         let pr = match result {
             Ok(()) => pr,
             Err(e) => ProcessResult::Failed {
-                err: ::storage::Error::from(e),
+                err: crate::storage::Error::from(e),
             },
         };
         if let ProcessResult::NextCommand { cmd } = pr {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -498,11 +498,11 @@ fn gen_command_lock(latches: &Latches, cmd: &Command) -> Lock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kvproto::kvrpcpb::Context;
     use crate::storage::mvcc;
     use crate::storage::txn::latch::*;
     use crate::storage::{Command, Key, Mutation, Options};
     use crate::util::collections::HashMap;
+    use kvproto::kvrpcpb::Context;
 
     #[test]
     fn test_command_latches() {

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -947,7 +947,7 @@ mod tests {
 
 #[cfg(test)]
 mod benches {
-    use test;
+    use ::test;
 
     use rand::{self, Rng};
     use std::collections::BTreeMap;

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -947,7 +947,7 @@ mod tests {
 
 #[cfg(test)]
 mod benches {
-    use ::test;
+    use crate::test;
 
     use rand::{self, Rng};
     use std::collections::BTreeMap;

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -13,11 +13,11 @@
 
 use kvproto::kvrpcpb::IsolationLevel;
 
-use storage::mvcc::{
+use crate::storage::mvcc::{
     BackwardScanner, BackwardScannerBuilder, ForwardScanner, ForwardScannerBuilder,
 };
-use storage::mvcc::{Error as MvccError, MvccReader};
-use storage::{Key, KvPair, Snapshot, Statistics, Value};
+use crate::storage::mvcc::{Error as MvccError, MvccReader};
+use crate::storage::{Key, KvPair, Snapshot, Statistics, Value};
 
 use super::{Error, Result};
 
@@ -326,11 +326,11 @@ mod tests {
     use super::{FixtureStore, Scanner, SnapshotStore, Store};
 
     use kvproto::kvrpcpb::{Context, IsolationLevel};
-    use raftstore::store::engine::IterOption;
-    use storage::engine::{Engine, Result as EngineResult, RocksEngine, RocksSnapshot, ScanMode};
-    use storage::mvcc::Error as MvccError;
-    use storage::mvcc::MvccTxn;
-    use storage::{
+    use crate::raftstore::store::engine::IterOption;
+    use crate::storage::engine::{Engine, Result as EngineResult, RocksEngine, RocksSnapshot, ScanMode};
+    use crate::storage::mvcc::Error as MvccError;
+    use crate::storage::mvcc::MvccTxn;
+    use crate::storage::{
         CfName, Cursor, Iterator, Key, KvPair, Mutation, Options, Snapshot, Statistics,
         TestEngineBuilder, Value,
     };
@@ -953,7 +953,7 @@ mod benches {
     use std::collections::BTreeMap;
 
     use super::{FixtureStore, Scanner, Store};
-    use storage::{Key, Statistics};
+    use crate::storage::{Key, Statistics};
 
     fn gen_payload(n: usize) -> Vec<u8> {
         let mut data = vec![0; n];

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -325,15 +325,17 @@ mod tests {
     use super::Error;
     use super::{FixtureStore, Scanner, SnapshotStore, Store};
 
-    use kvproto::kvrpcpb::{Context, IsolationLevel};
     use crate::raftstore::store::engine::IterOption;
-    use crate::storage::engine::{Engine, Result as EngineResult, RocksEngine, RocksSnapshot, ScanMode};
+    use crate::storage::engine::{
+        Engine, Result as EngineResult, RocksEngine, RocksSnapshot, ScanMode,
+    };
     use crate::storage::mvcc::Error as MvccError;
     use crate::storage::mvcc::MvccTxn;
     use crate::storage::{
         CfName, Cursor, Iterator, Key, KvPair, Mutation, Options, Snapshot, Statistics,
         TestEngineBuilder, Value,
     };
+    use kvproto::kvrpcpb::{Context, IsolationLevel};
 
     const KEY_PREFIX: &str = "key_prefix";
     const START_TS: u64 = 10;

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -19,11 +19,11 @@ use std::u64;
 use byteorder::{ByteOrder, NativeEndian};
 use hex::ToHex;
 
-use storage::mvcc::{Lock, Write};
-use util::codec;
-use util::codec::bytes;
-use util::codec::bytes::BytesEncoder;
-use util::codec::number::{self, NumberEncoder};
+use crate::storage::mvcc::{Lock, Write};
+use crate::util::codec;
+use crate::util::codec::bytes;
+use crate::util::codec::bytes::BytesEncoder;
+use crate::util::codec::number::{self, NumberEncoder};
 /// Value type which is essentially raw bytes.
 pub type Value = Vec<u8>;
 

--- a/src/util/codec/bytes.rs
+++ b/src/util/codec/bytes.rs
@@ -16,7 +16,7 @@ use std::io::{BufRead, Write};
 
 use super::{BytesSlice, Error, Result};
 use std::ptr;
-use util::codec::number::{self, NumberEncoder};
+use crate::util::codec::number::{self, NumberEncoder};
 
 const ENC_GROUP_SIZE: usize = 8;
 const ENC_MARKER: u8 = b'\xff';
@@ -293,7 +293,7 @@ pub fn decode_bytes_in_place(data: &mut Vec<u8>, desc: bool) -> Result<()> {
 mod tests {
     use super::*;
     use std::cmp::Ordering;
-    use util::codec::{bytes, number};
+    use crate::util::codec::{bytes, number};
 
     #[test]
     fn test_enc_dec_bytes() {

--- a/src/util/codec/bytes.rs
+++ b/src/util/codec/bytes.rs
@@ -15,8 +15,8 @@ use byteorder::ReadBytesExt;
 use std::io::{BufRead, Write};
 
 use super::{BytesSlice, Error, Result};
-use std::ptr;
 use crate::util::codec::number::{self, NumberEncoder};
+use std::ptr;
 
 const ENC_GROUP_SIZE: usize = 8;
 const ENC_MARKER: u8 = b'\xff';
@@ -292,8 +292,8 @@ pub fn decode_bytes_in_place(data: &mut Vec<u8>, desc: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cmp::Ordering;
     use crate::util::codec::{bytes, number};
+    use std::cmp::Ordering;
 
     #[test]
     fn test_enc_dec_bytes() {

--- a/src/util/codec/number.rs
+++ b/src/util/codec/number.rs
@@ -328,7 +328,7 @@ pub fn read_u8(data: &mut BytesSlice) -> Result<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use util::codec::Error;
+    use crate::util::codec::Error;
 
     use protobuf::CodedOutputStream;
     use std::io::ErrorKind;
@@ -499,7 +499,7 @@ mod tests {
             #[allow(clippy::float_cmp)]
             mod $enc {
                 use super::{F64_TESTS, I64_TESTS, U16_TESTS, U32_TESTS, U64_TESTS};
-                use util::codec::number::*;
+                use crate::util::codec::number::*;
 
                 test_serialize!(serialize, $enc, $dec, $cases);
 

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -24,8 +24,8 @@ use serde::de::{self, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use url;
 
-use rocksdb::DBCompressionType;
 use crate::util;
+use rocksdb::DBCompressionType;
 
 quick_error! {
     #[derive(Debug)]

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use url;
 
 use rocksdb::DBCompressionType;
-use util;
+use crate::util;
 
 quick_error! {
     #[derive(Debug)]

--- a/src/util/future.rs
+++ b/src/util/future.rs
@@ -14,7 +14,7 @@
 use futures::sync::oneshot;
 use futures::{Async, Future, IntoFuture, Poll};
 use std::boxed;
-use util::Either;
+use crate::util::Either;
 
 /// Generates a paired future and callback so that when callback is being called, its result
 /// is automatically passed as a future result.

--- a/src/util/future.rs
+++ b/src/util/future.rs
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::util::Either;
 use futures::sync::oneshot;
 use futures::{Async, Future, IntoFuture, Poll};
 use std::boxed;
-use crate::util::Either;
 
 /// Generates a paired future and callback so that when callback is being called, its result
 /// is automatically passed as a future result.

--- a/src/util/futurepool.rs
+++ b/src/util/futurepool.rs
@@ -25,9 +25,9 @@ use futures::Future;
 use futures_cpupool::{self as cpupool, CpuFuture, CpuPool};
 use prometheus::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 
-use util;
-use util::collections::HashMap;
-use util::time::Instant;
+use crate::util;
+use crate::util::collections::HashMap;
+use crate::util::time::Instant;
 
 lazy_static! {
     pub static ref FUTUREPOOL_PENDING_TASK_VEC: IntGaugeVec = register_int_gauge_vec!(

--- a/src/util/logger/mod.rs
+++ b/src/util/logger/mod.rs
@@ -19,8 +19,8 @@ use std::io::{self, BufWriter};
 use std::path::Path;
 use std::sync::Mutex;
 
-use chrono::{self, Duration};
 use crate::grpc;
+use chrono::{self, Duration};
 use log::{self, SetLoggerError};
 use slog::{self, Drain, Key, OwnedKVList, Record, KV};
 use slog_async::{Async, OverflowStrategy};

--- a/src/util/logger/mod.rs
+++ b/src/util/logger/mod.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use chrono::{self, Duration};
-use grpc;
+use crate::grpc;
 use log::{self, SetLoggerError};
 use slog::{self, Drain, Key, OwnedKVList, Record, KV};
 use slog_async::{Async, OverflowStrategy};

--- a/src/util/rocksdb/engine_metrics.rs
+++ b/src/util/rocksdb/engine_metrics.rs
@@ -18,7 +18,7 @@ use rocksdb::{
     DBStatisticsHistogramType as HistType, DBStatisticsTickerType as TickerType, HistogramData, DB,
 };
 use time;
-use util::rocksdb;
+use crate::util::rocksdb;
 
 pub const ROCKSDB_TOTAL_SST_FILES_SIZE: &str = "rocksdb.total-sst-files-size";
 pub const ROCKSDB_TABLE_READERS_MEM: &str = "rocksdb.estimate-table-readers-mem";
@@ -1248,8 +1248,8 @@ mod tests {
 
     use tempdir::TempDir;
 
-    use storage::ALL_CFS;
-    use util::rocksdb;
+    use crate::storage::ALL_CFS;
+    use crate::util::rocksdb;
 
     #[test]
     fn test_flush() {

--- a/src/util/rocksdb/engine_metrics.rs
+++ b/src/util/rocksdb/engine_metrics.rs
@@ -13,12 +13,12 @@
 
 use std::i64;
 
-use prometheus::{exponential_buckets, GaugeVec, HistogramVec, IntCounterVec, IntGaugeVec};
+use crate::util::rocksdb;
 use ::rocksdb::{
     DBStatisticsHistogramType as HistType, DBStatisticsTickerType as TickerType, HistogramData, DB,
 };
+use prometheus::{exponential_buckets, GaugeVec, HistogramVec, IntCounterVec, IntGaugeVec};
 use time;
-use crate::util::rocksdb;
 
 pub const ROCKSDB_TOTAL_SST_FILES_SIZE: &str = "rocksdb.total-sst-files-size";
 pub const ROCKSDB_TABLE_READERS_MEM: &str = "rocksdb.estimate-table-readers-mem";

--- a/src/util/rocksdb/engine_metrics.rs
+++ b/src/util/rocksdb/engine_metrics.rs
@@ -14,7 +14,7 @@
 use std::i64;
 
 use prometheus::{exponential_buckets, GaugeVec, HistogramVec, IntCounterVec, IntGaugeVec};
-use rocksdb::{
+use ::rocksdb::{
     DBStatisticsHistogramType as HistType, DBStatisticsTickerType as TickerType, HistogramData, DB,
 };
 use time;

--- a/src/util/rocksdb/event_listener.rs
+++ b/src/util/rocksdb/event_listener.rs
@@ -17,9 +17,9 @@ use rocksdb::{
     self, CompactionJobInfo, FlushJobInfo, IngestionInfo, WriteStallCondition, WriteStallInfo,
 };
 
-use util::collections::HashSet;
-use util::properties::RangeProperties;
-use util::rocksdb::engine_metrics::*;
+use crate::util::collections::HashSet;
+use crate::util::properties::RangeProperties;
+use crate::util::rocksdb::engine_metrics::*;
 
 pub struct EventListener {
     db_name: String,

--- a/src/util/rocksdb/metrics_flusher.rs
+++ b/src/util/rocksdb/metrics_flusher.rs
@@ -11,14 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use raftstore::store::Engines;
+use crate::raftstore::store::Engines;
 use rocksdb::DB;
 use std::io;
 use std::sync::mpsc::{self, Sender};
 use std::sync::Arc;
 use std::thread::{Builder, JoinHandle};
 use std::time::{Duration, Instant};
-use util::rocksdb::engine_metrics::*;
+use crate::util::rocksdb::engine_metrics::*;
 
 pub const DEFAULT_FLUSHER_INTERVAL: u64 = 10000;
 pub const DEFAULT_FLUSHER_RESET_INTERVAL: u64 = 60000;
@@ -100,9 +100,9 @@ mod tests {
     use std::sync::Arc;
     use std::thread::sleep;
     use std::time::Duration;
-    use storage::{CF_DEFAULT, CF_LOCK, CF_WRITE};
+    use crate::storage::{CF_DEFAULT, CF_LOCK, CF_WRITE};
     use tempdir::TempDir;
-    use util::rocksdb::{self, CFOptions};
+    use crate::util::rocksdb::{self, CFOptions};
 
     #[test]
     fn test_metrics_flusher() {

--- a/src/util/rocksdb/metrics_flusher.rs
+++ b/src/util/rocksdb/metrics_flusher.rs
@@ -12,13 +12,13 @@
 // limitations under the License.
 
 use crate::raftstore::store::Engines;
+use crate::util::rocksdb::engine_metrics::*;
 use rocksdb::DB;
 use std::io;
 use std::sync::mpsc::{self, Sender};
 use std::sync::Arc;
 use std::thread::{Builder, JoinHandle};
 use std::time::{Duration, Instant};
-use crate::util::rocksdb::engine_metrics::*;
 
 pub const DEFAULT_FLUSHER_INTERVAL: u64 = 10000;
 pub const DEFAULT_FLUSHER_RESET_INTERVAL: u64 = 60000;
@@ -95,14 +95,14 @@ fn flush_metrics(db: &DB, name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::{CF_DEFAULT, CF_LOCK, CF_WRITE};
+    use crate::util::rocksdb::{self, CFOptions};
     use ::rocksdb::{ColumnFamilyOptions, DBOptions};
     use std::path::Path;
     use std::sync::Arc;
     use std::thread::sleep;
     use std::time::Duration;
-    use crate::storage::{CF_DEFAULT, CF_LOCK, CF_WRITE};
     use tempdir::TempDir;
-    use crate::util::rocksdb::{self, CFOptions};
 
     #[test]
     fn test_metrics_flusher() {

--- a/src/util/rocksdb/metrics_flusher.rs
+++ b/src/util/rocksdb/metrics_flusher.rs
@@ -95,7 +95,7 @@ fn flush_metrics(db: &DB, name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rocksdb::{ColumnFamilyOptions, DBOptions};
+    use ::rocksdb::{ColumnFamilyOptions, DBOptions};
     use std::path::Path;
     use std::sync::Arc;
     use std::thread::sleep;

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -26,10 +26,10 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use rocksdb::load_latest_options;
-use rocksdb::rocksdb::supported_compression;
-use rocksdb::set_external_sst_file_global_seq_no;
-use rocksdb::{
+use ::rocksdb::load_latest_options;
+use ::rocksdb::rocksdb::supported_compression;
+use ::rocksdb::set_external_sst_file_global_seq_no;
+use ::rocksdb::{
     CColumnFamilyDescriptor, ColumnFamilyOptions, CompactOptions, CompactionOptions,
     DBCompressionType, DBOptions, Env, Range, SliceTransform, DB,
 };
@@ -42,7 +42,7 @@ use crate::util::rocksdb::engine_metrics::{
     ROCKSDB_NUM_FILES_AT_LEVEL, ROCKSDB_TOTAL_SST_FILES_SIZE,
 };
 
-pub use rocksdb::CFHandle;
+pub use ::rocksdb::CFHandle;
 
 use super::cfs_diff;
 
@@ -581,7 +581,7 @@ pub fn validate_sst_for_ingestion<P: AsRef<Path>>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rocksdb::{
+    use ::rocksdb::{
         ColumnFamilyOptions, DBOptions, EnvOptions, IngestExternalFileOptions, SstFileWriter,
         Writable, DB,
     };

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -26,6 +26,13 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::storage::{ALL_CFS, CF_DEFAULT};
+use crate::util::file::{calc_crc32, copy_and_sync};
+use crate::util::rocksdb;
+use crate::util::rocksdb::engine_metrics::{
+    ROCKSDB_COMPRESSION_RATIO_AT_LEVEL, ROCKSDB_CUR_SIZE_ALL_MEM_TABLES,
+    ROCKSDB_NUM_FILES_AT_LEVEL, ROCKSDB_TOTAL_SST_FILES_SIZE,
+};
 use ::rocksdb::load_latest_options;
 use ::rocksdb::rocksdb::supported_compression;
 use ::rocksdb::set_external_sst_file_global_seq_no;
@@ -33,14 +40,7 @@ use ::rocksdb::{
     CColumnFamilyDescriptor, ColumnFamilyOptions, CompactOptions, CompactionOptions,
     DBCompressionType, DBOptions, Env, Range, SliceTransform, DB,
 };
-use crate::storage::{ALL_CFS, CF_DEFAULT};
 use sys_info;
-use crate::util::file::{calc_crc32, copy_and_sync};
-use crate::util::rocksdb;
-use crate::util::rocksdb::engine_metrics::{
-    ROCKSDB_COMPRESSION_RATIO_AT_LEVEL, ROCKSDB_CUR_SIZE_ALL_MEM_TABLES,
-    ROCKSDB_NUM_FILES_AT_LEVEL, ROCKSDB_TOTAL_SST_FILES_SIZE,
-};
 
 pub use ::rocksdb::CFHandle;
 
@@ -581,11 +581,11 @@ pub fn validate_sst_for_ingestion<P: AsRef<Path>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::CF_DEFAULT;
     use ::rocksdb::{
         ColumnFamilyOptions, DBOptions, EnvOptions, IngestExternalFileOptions, SstFileWriter,
         Writable, DB,
     };
-    use crate::storage::CF_DEFAULT;
     use tempdir::TempDir;
 
     #[test]

--- a/src/util/rocksdb/mod.rs
+++ b/src/util/rocksdb/mod.rs
@@ -33,11 +33,11 @@ use rocksdb::{
     CColumnFamilyDescriptor, ColumnFamilyOptions, CompactOptions, CompactionOptions,
     DBCompressionType, DBOptions, Env, Range, SliceTransform, DB,
 };
-use storage::{ALL_CFS, CF_DEFAULT};
+use crate::storage::{ALL_CFS, CF_DEFAULT};
 use sys_info;
-use util::file::{calc_crc32, copy_and_sync};
-use util::rocksdb;
-use util::rocksdb::engine_metrics::{
+use crate::util::file::{calc_crc32, copy_and_sync};
+use crate::util::rocksdb;
+use crate::util::rocksdb::engine_metrics::{
     ROCKSDB_COMPRESSION_RATIO_AT_LEVEL, ROCKSDB_CUR_SIZE_ALL_MEM_TABLES,
     ROCKSDB_NUM_FILES_AT_LEVEL, ROCKSDB_TOTAL_SST_FILES_SIZE,
 };
@@ -585,7 +585,7 @@ mod tests {
         ColumnFamilyOptions, DBOptions, EnvOptions, IngestExternalFileOptions, SstFileWriter,
         Writable, DB,
     };
-    use storage::CF_DEFAULT;
+    use crate::storage::CF_DEFAULT;
     use tempdir::TempDir;
 
     #[test]

--- a/src/util/rocksdb/properties.rs
+++ b/src/util/rocksdb/properties.rs
@@ -18,14 +18,14 @@ use std::io::Read;
 use std::ops::{Deref, DerefMut};
 use std::u64;
 
-use raftstore::store::keys;
+use crate::raftstore::store::keys;
 use rocksdb::{
     DBEntryType, TablePropertiesCollector, TablePropertiesCollectorFactory, UserCollectedProperties,
 };
-use storage::mvcc::{Write, WriteType};
-use storage::types::Key;
-use util::codec::number::{self, NumberEncoder};
-use util::codec::{Error, Result};
+use crate::storage::mvcc::{Write, WriteType};
+use crate::storage::types::Key;
+use crate::util::codec::number::{self, NumberEncoder};
+use crate::util::codec::{Error, Result};
 
 const PROP_NUM_ERRORS: &str = "tikv.num_errors";
 const PROP_MIN_TS: &str = "tikv.min_ts";
@@ -656,10 +656,10 @@ impl TablePropertiesCollectorFactory for RangePropertiesCollectorFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use raftstore::store::keys;
+    use crate::raftstore::store::keys;
     use rocksdb::{DBEntryType, TablePropertiesCollector};
-    use storage::mvcc::{Write, WriteType};
-    use storage::Key;
+    use crate::storage::mvcc::{Write, WriteType};
+    use crate::storage::Key;
     use test::Bencher;
 
     #[test]

--- a/src/util/rocksdb/properties.rs
+++ b/src/util/rocksdb/properties.rs
@@ -19,13 +19,13 @@ use std::ops::{Deref, DerefMut};
 use std::u64;
 
 use crate::raftstore::store::keys;
-use rocksdb::{
-    DBEntryType, TablePropertiesCollector, TablePropertiesCollectorFactory, UserCollectedProperties,
-};
 use crate::storage::mvcc::{Write, WriteType};
 use crate::storage::types::Key;
 use crate::util::codec::number::{self, NumberEncoder};
 use crate::util::codec::{Error, Result};
+use rocksdb::{
+    DBEntryType, TablePropertiesCollector, TablePropertiesCollectorFactory, UserCollectedProperties,
+};
 
 const PROP_NUM_ERRORS: &str = "tikv.num_errors";
 const PROP_MIN_TS: &str = "tikv.min_ts";
@@ -657,9 +657,9 @@ impl TablePropertiesCollectorFactory for RangePropertiesCollectorFactory {
 mod tests {
     use super::*;
     use crate::raftstore::store::keys;
-    use rocksdb::{DBEntryType, TablePropertiesCollector};
     use crate::storage::mvcc::{Write, WriteType};
     use crate::storage::Key;
+    use rocksdb::{DBEntryType, TablePropertiesCollector};
     use test::Bencher;
 
     #[test]

--- a/src/util/rocksdb/stats.rs
+++ b/src/util/rocksdb/stats.rs
@@ -80,10 +80,10 @@ mod tests {
     use rocksdb::{ColumnFamilyOptions, DBOptions, Writable};
     use tempdir::TempDir;
 
-    use raftstore::store::keys;
-    use storage::{Key, CF_WRITE, LARGE_CFS};
-    use util::properties::MvccPropertiesCollectorFactory;
-    use util::rocksdb::{self, CFOptions};
+    use crate::raftstore::store::keys;
+    use crate::storage::{Key, CF_WRITE, LARGE_CFS};
+    use crate::util::properties::MvccPropertiesCollectorFactory;
+    use crate::util::rocksdb::{self, CFOptions};
 
     use super::*;
 

--- a/src/util/rocksdb/stats.rs
+++ b/src/util/rocksdb/stats.rs
@@ -77,7 +77,7 @@ pub fn get_range_entries_and_versions(
 
 #[cfg(test)]
 mod tests {
-    use rocksdb::{ColumnFamilyOptions, DBOptions, Writable};
+    use ::rocksdb::{ColumnFamilyOptions, DBOptions, Writable};
     use tempdir::TempDir;
 
     use crate::raftstore::store::keys;

--- a/src/util/security.rs
+++ b/src/util/security.rs
@@ -16,7 +16,7 @@ use std::fs::File;
 use std::io::Read;
 use std::ptr;
 
-use grpc::{
+use crate::grpc::{
     Channel, ChannelBuilder, ChannelCredentialsBuilder, ServerBuilder, ServerCredentialsBuilder,
 };
 

--- a/src/util/timer.rs
+++ b/src/util/timer.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::util::time::{monotonic_raw_now, Instant};
 use std::cmp::{Ord, Ordering, Reverse};
 use std::collections::BinaryHeap;
 use std::sync::{mpsc, Arc};
@@ -19,7 +20,6 @@ use std::time::Duration;
 use time::Timespec;
 use tokio_executor::park::ParkThread;
 use tokio_timer::{self, clock::Clock, clock::Now, timer::Handle, Delay};
-use crate::util::time::{monotonic_raw_now, Instant};
 
 pub struct Timer<T> {
     pending: BinaryHeap<Reverse<TimeoutTask<T>>>,
@@ -213,10 +213,10 @@ fn start_global_steady_timer() -> SteadyTimer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::worker::{Builder as WorkerBuilder, Runnable, RunnableWithTimer};
     use futures::Future;
     use std::sync::mpsc::RecvTimeoutError;
     use std::sync::mpsc::{self, Sender};
-    use crate::util::worker::{Builder as WorkerBuilder, Runnable, RunnableWithTimer};
 
     #[derive(Debug, PartialEq, Eq, Copy, Clone)]
     enum Task {

--- a/src/util/timer.rs
+++ b/src/util/timer.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use time::Timespec;
 use tokio_executor::park::ParkThread;
 use tokio_timer::{self, clock::Clock, clock::Now, timer::Handle, Delay};
-use util::time::{monotonic_raw_now, Instant};
+use crate::util::time::{monotonic_raw_now, Instant};
 
 pub struct Timer<T> {
     pending: BinaryHeap<Reverse<TimeoutTask<T>>>,
@@ -216,7 +216,7 @@ mod tests {
     use futures::Future;
     use std::sync::mpsc::RecvTimeoutError;
     use std::sync::mpsc::{self, Sender};
-    use util::worker::{Builder as WorkerBuilder, Runnable, RunnableWithTimer};
+    use crate::util::worker::{Builder as WorkerBuilder, Runnable, RunnableWithTimer};
 
     #[derive(Debug, PartialEq, Eq, Copy, Clone)]
     enum Task {

--- a/src/util/worker/future.rs
+++ b/src/util/worker/future.rs
@@ -197,7 +197,7 @@ mod tests {
     use futures::Future;
     use tokio_core::reactor::Handle;
     use tokio_timer::timer;
-    use util::timer::GLOBAL_TIMER_HANDLE;
+    use crate::util::timer::GLOBAL_TIMER_HANDLE;
 
     use super::*;
 

--- a/src/util/worker/future.rs
+++ b/src/util/worker/future.rs
@@ -194,10 +194,10 @@ mod tests {
     use std::time::Duration;
     use std::time::Instant;
 
+    use crate::util::timer::GLOBAL_TIMER_HANDLE;
     use futures::Future;
     use tokio_core::reactor::Handle;
     use tokio_timer::timer;
-    use crate::util::timer::GLOBAL_TIMER_HANDLE;
 
     use super::*;
 

--- a/src/util/worker/mod.rs
+++ b/src/util/worker/mod.rs
@@ -39,9 +39,9 @@ use std::time::Duration;
 use std::{io, usize};
 
 use self::metrics::*;
-use util::mpsc::{self, Receiver, Sender};
-use util::time::{Instant, SlowTimer};
-use util::timer::Timer;
+use crate::util::mpsc::{self, Receiver, Sender};
+use crate::util::time::{Instant, SlowTimer};
+use crate::util::timer::Timer;
 
 pub use self::future::Runnable as FutureRunnable;
 pub use self::future::Scheduler as FutureScheduler;
@@ -105,7 +105,7 @@ pub trait Runnable<T: Display> {
 }
 
 pub trait RunnableWithTimer<T: Display, U>: Runnable<T> {
-    fn on_timeout(&mut self, &mut Timer<U>, U);
+    fn on_timeout(&mut self, _: &mut Timer<U>, _: U);
 }
 
 struct DefaultRunnerWithTimer<R>(R);

--- a/tests/failpoints/cases/test_conf_change.rs
+++ b/tests/failpoints/cases/test_conf_change.rs
@@ -22,7 +22,7 @@ use tikv::util::HandyRwLock;
 
 #[test]
 fn test_destory_local_reader() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
 
     // 3 nodes cluster.
     let mut cluster = new_node_cluster(0, 3);
@@ -84,7 +84,7 @@ fn test_destory_local_reader() {
 
 #[test]
 fn test_write_after_destroy() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
 
     // 3 nodes cluster.
     let mut cluster = new_server_cluster(0, 3);
@@ -155,7 +155,7 @@ fn test_write_after_destroy() {
 
 #[test]
 fn test_tick_after_destroy() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     // 3 nodes cluster.
     let mut cluster = new_server_cluster(0, 3);
 

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -33,7 +33,7 @@ use tikv::util::HandyRwLock;
 /// Test if merge is rollback as expected.
 #[test]
 fn test_node_merge_rollback() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     let mut cluster = new_node_cluster(0, 3);
     configure_for_merge(&mut cluster);
     let pd_client = Arc::clone(&cluster.pd_client);
@@ -120,7 +120,7 @@ fn test_node_merge_rollback() {
 /// Test if merge is still working when restart a cluster during merge.
 #[test]
 fn test_node_merge_restart() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     let mut cluster = new_node_cluster(0, 3);
     configure_for_merge(&mut cluster);
     cluster.run();
@@ -220,7 +220,7 @@ fn test_node_merge_restart() {
 /// Test if merging state will be removed after accepting a snapshot.
 #[test]
 fn test_node_merge_recover_snapshot() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     let mut cluster = new_node_cluster(0, 3);
     configure_for_merge(&mut cluster);
     cluster.cfg.raft_store.raft_log_gc_threshold = 12;
@@ -279,7 +279,7 @@ fn test_node_merge_multiple_snapshots_together() {
 // }
 
 fn test_node_merge_multiple_snapshots(together: bool) {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     let mut cluster = new_node_cluster(0, 3);
     configure_for_merge(&mut cluster);
     let pd_client = Arc::clone(&cluster.pd_client);

--- a/tests/failpoints/cases/test_pending_peers.rs
+++ b/tests/failpoints/cases/test_pending_peers.rs
@@ -22,7 +22,7 @@ use tikv::util::config::*;
 
 #[test]
 fn test_pending_peers() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     let mut cluster = new_node_cluster(0, 3);
     cluster.cfg.raft_store.pd_heartbeat_tick_interval = ReadableDuration::millis(100);
 

--- a/tests/failpoints/cases/test_snap.rs
+++ b/tests/failpoints/cases/test_snap.rs
@@ -26,7 +26,7 @@ use tikv::util::config::*;
 
 #[test]
 fn test_overlap_cleanup() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     let mut cluster = new_node_cluster(0, 3);
     // Disable raft log gc in this test case.
     cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::secs(60);
@@ -77,7 +77,7 @@ fn test_overlap_cleanup() {
 // stay in Snapshot forever.
 #[test]
 fn test_server_snapshot_on_resolve_failure() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     let mut cluster = new_server_cluster(1, 4);
     configure_for_snapshot(&mut cluster);
 
@@ -152,7 +152,7 @@ fn test_server_snapshot_on_resolve_failure() {
 
 #[test]
 fn test_generate_snapshot() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
 
     let mut cluster = new_server_cluster(1, 5);
     configure_for_snapshot(&mut cluster);

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -25,7 +25,7 @@ use test_raftstore::*;
 
 #[test]
 fn test_follower_slow_split() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     let mut cluster = new_node_cluster(0, 3);
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();

--- a/tests/failpoints/cases/test_stale_peer.rs
+++ b/tests/failpoints/cases/test_stale_peer.rs
@@ -19,7 +19,7 @@ use tikv::util::config::ReadableDuration;
 
 #[test]
 fn test_one_node_leader_missing() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
 
     let mut cluster = new_server_cluster(0, 1);
 
@@ -49,7 +49,7 @@ fn test_one_node_leader_missing() {
 
 #[test]
 fn test_node_update_localreader_after_removed() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
 
     let mut cluster = new_node_cluster(0, 6);
     let pd_client = cluster.pd_client.clone();

--- a/tests/failpoints/cases/test_stale_read.rs
+++ b/tests/failpoints/cases/test_stale_read.rs
@@ -23,7 +23,7 @@ use tikv::pd::PdClient;
 use tikv::raftstore::store::Callback;
 
 fn stale_read_during_splitting(right_derive: bool) {
-    let _guard = ::setup();
+    let _guard = crate::setup();
 
     let count = 3;
     let mut cluster = new_node_cluster(0, count);
@@ -224,7 +224,7 @@ fn test_node_stale_read_during_splitting_right_derive() {
 
 #[test]
 fn test_stale_read_during_merging() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
 
     let count = 3;
     let mut cluster = new_node_cluster(0, count);

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -29,7 +29,7 @@ use tikv::util::HandyRwLock;
 
 #[test]
 fn test_storage_gcworker_busy() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     let snapshot_fp = "raftkv_async_snapshot";
     let (_cluster, engine, ctx) = new_raft_engine(3, "");
     let storage = TestStorageBuilder::from_engine(engine.clone())
@@ -79,7 +79,7 @@ fn test_storage_gcworker_busy() {
 
 #[test]
 fn test_scheduler_leader_change_twice() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     let snapshot_fp = "scheduler_async_snapshot_finish";
     let mut cluster = new_server_cluster(0, 2);
     cluster.run();
@@ -129,7 +129,7 @@ fn test_scheduler_leader_change_twice() {
 
 #[test]
 fn test_server_catching_api_error() {
-    let _guard = ::setup();
+    let _guard = crate::setup();
     let raftkv_fp = "raftkv_early_error_report";
     let mut cluster = new_server_cluster(0, 1);
     cluster.run();

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -1345,7 +1345,7 @@ fn test_handle_truncate() {
 
         // Do NOT ignore truncate error.
         let req = DAGSelect::from(&product).where_expr(cond.clone()).build();
-        let mut resp = handle_select(&endpoint, req);
+        let resp = handle_select(&endpoint, req);
         assert!(resp.has_error());
         assert!(resp.get_warnings().is_empty());
     }

--- a/tests/integrations/import/kv_service.rs
+++ b/tests/integrations/import/kv_service.rs
@@ -18,7 +18,7 @@ use futures::{stream, Future, Stream};
 use tempdir::TempDir;
 use uuid::Uuid;
 
-use grpc::{ChannelBuilder, Environment, Result, WriteFlags};
+use crate::grpc::{ChannelBuilder, Environment, Result, WriteFlags};
 use kvproto::import_kvpb::*;
 use kvproto::import_kvpb_grpc::*;
 

--- a/tests/integrations/import/sst_service.rs
+++ b/tests/integrations/import/sst_service.rs
@@ -19,7 +19,7 @@ use futures::{stream, Future, Stream};
 use tempdir::TempDir;
 use uuid::Uuid;
 
-use grpc::{ChannelBuilder, Environment, Result, WriteFlags};
+use crate::grpc::{ChannelBuilder, Environment, Result, WriteFlags};
 use kvproto::import_sstpb::*;
 use kvproto::import_sstpb_grpc::*;
 use kvproto::kvrpcpb::*;

--- a/tests/integrations/pd/mock/server.rs
+++ b/tests/integrations/pd/mock/server.rs
@@ -16,7 +16,7 @@ use std::thread;
 use std::time::Duration;
 
 use futures::{Future, Sink, Stream};
-use grpc::{
+use crate::grpc::{
     DuplexSink, EnvBuilder, RequestStream, RpcContext, RpcStatus, RpcStatusCode,
     Server as GrpcServer, ServerBuilder, UnarySink, WriteFlags,
 };

--- a/tests/integrations/pd/mock/server.rs
+++ b/tests/integrations/pd/mock/server.rs
@@ -15,11 +15,11 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use futures::{Future, Sink, Stream};
 use crate::grpc::{
     DuplexSink, EnvBuilder, RequestStream, RpcContext, RpcStatus, RpcStatusCode,
     Server as GrpcServer, ServerBuilder, UnarySink, WriteFlags,
 };
+use futures::{Future, Sink, Stream};
 use tikv::pd::Error as PdError;
 use tikv::util::security::*;
 

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use futures::Future;
 use futures_cpupool::Builder;
-use grpc::EnvBuilder;
+use crate::grpc::EnvBuilder;
 use kvproto::metapb;
 use kvproto::pdpb;
 
@@ -203,11 +203,11 @@ fn test_retry<F: Fn(&RpcClient)>(func: F) {
 
 #[test]
 fn test_retry_async() {
-    let async = |client: &RpcClient| {
+    let r#async = |client: &RpcClient| {
         let region = client.get_region_by_id(1);
         region.wait().unwrap();
     };
-    test_retry(async);
+    test_retry(r#async);
 }
 
 #[test]
@@ -232,11 +232,11 @@ fn test_not_retry<F: Fn(&RpcClient)>(func: F) {
 
 #[test]
 fn test_not_retry_async() {
-    let async = |client: &RpcClient| {
+    let r#async = |client: &RpcClient| {
         let region = client.get_region_by_id(1);
         region.wait().unwrap_err();
     };
-    test_not_retry(async);
+    test_not_retry(r#async);
 }
 
 #[test]

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -16,9 +16,9 @@ use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
 
+use crate::grpc::EnvBuilder;
 use futures::Future;
 use futures_cpupool::Builder;
-use crate::grpc::EnvBuilder;
 use kvproto::metapb;
 use kvproto::pdpb;
 

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use futures::{future, Future, Stream};
-use grpc::{ChannelBuilder, Environment, Error, RpcStatusCode};
+use crate::grpc::{ChannelBuilder, Environment, Error, RpcStatusCode};
 use rocksdb::Writable;
 
 use kvproto::coprocessor::*;

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -13,8 +13,8 @@
 
 use std::sync::Arc;
 
-use futures::{future, Future, Stream};
 use crate::grpc::{ChannelBuilder, Environment, Error, RpcStatusCode};
+use futures::{future, Future, Stream};
 use rocksdb::Writable;
 
 use kvproto::coprocessor::*;

--- a/tests/integrations/server/mod.rs
+++ b/tests/integrations/server/mod.rs
@@ -17,7 +17,7 @@ mod raft_client;
 use std::sync::Arc;
 
 use futures::Future;
-use grpc::*;
+use crate::grpc::*;
 use kvproto::coprocessor::*;
 use kvproto::kvrpcpb::*;
 use kvproto::raft_serverpb::{Done, RaftMessage, SnapshotChunk};

--- a/tests/integrations/server/mod.rs
+++ b/tests/integrations/server/mod.rs
@@ -16,8 +16,8 @@ mod raft_client;
 
 use std::sync::Arc;
 
-use futures::Future;
 use crate::grpc::*;
+use futures::Future;
 use kvproto::coprocessor::*;
 use kvproto::kvrpcpb::*;
 use kvproto::raft_serverpb::{Done, RaftMessage, SnapshotChunk};

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -15,8 +15,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::{thread, time};
 
-use futures::{Future, Stream};
 use crate::grpc::*;
+use futures::{Future, Stream};
 use kvproto::raft_serverpb::{Done, RaftMessage};
 use kvproto::tikvpb::BatchRaftMessage;
 use tikv::server::{load_statistics::ThreadLoad, Config, RaftClient};

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::{thread, time};
 
 use futures::{Future, Stream};
-use grpc::*;
+use crate::grpc::*;
 use kvproto::raft_serverpb::{Done, RaftMessage};
 use kvproto::tikvpb::BatchRaftMessage;
 use tikv::server::{load_statistics::ThreadLoad, Config, RaftClient};


### PR DESCRIPTION
This upgrades the tikv package and all of the component packages to 2018.

It does not yet upgrade any of the fuzzing code to 2018, mostly because I didn't want to go through the long process of revalidating the fuzzers. Somebody else can make those changes while they are working on the fuzzers, if they feel like it's important.

The commits are all pretty straightforward at this point.

After this there is still work that can be done to bring tikv up to date with 2018 idioms. I'll file separate bugs on that.

Fixes https://github.com/tikv/tikv/issues/3896