### PR TITLE
config: enlarge max-manifest-file-size to 128MB

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -282,7 +282,7 @@
 
 ## Max size of RocksDB's MANIFEST file.
 ## For detailed explanation, please refer to https://github.com/facebook/rocksdb/wiki/MANIFEST
-# max-manifest-file-size = "20MB"
+# max-manifest-file-size = "128MB"
 
 ## If the value is `true`, the database will be created if it is missing.
 # create-if-missing = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -515,7 +515,7 @@ impl Default for DbConfig {
             wal_size_limit: ReadableSize::kb(0),
             max_total_wal_size: ReadableSize::gb(4),
             max_background_jobs: 6,
-            max_manifest_file_size: ReadableSize::mb(20),
+            max_manifest_file_size: ReadableSize::mb(128),
             create_if_missing: true,
             max_open_files: 40960,
             enable_statistics: true,


### PR DESCRIPTION
## What have you changed? (mandatory)

There two benefits:
1. Save more versions for debugging when necessary.
2. Avoid rewritting the whole manifest file frequently.

However, a larger manifest file needs more time to recover.
According to test, a 128MB manifest file takes about 4s to recover.

More information about the manifest file: https://github.com/facebook/rocksdb/wiki/MANIFEST

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Unit test

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No