### PR TITLE
test: fix no region contains key error

### DIFF
--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -817,9 +817,9 @@ impl TestPdClient {
                 .wait()
                 .unwrap()
                 .unwrap();
-            if  (now.get_start_key() != region.get_start_key() 
+            if (now.get_start_key() != region.get_start_key()
                 && self.get_region(region.get_start_key()).is_ok())
-                || (now.get_end_key() != region.get_end_key() 
+                || (now.get_end_key() != region.get_end_key()
                     && self.get_region(now.get_end_key()).is_ok())
             {
                 assert!(

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -820,9 +820,11 @@ impl TestPdClient {
             if (now.get_start_key() != region.get_start_key()
                 && self.get_region(region.get_start_key()).is_ok())
                 || (now.get_end_key() != region.get_end_key()
-                    && !now.get_end_key().is_empty()
                     && self.get_region(now.get_end_key()).is_ok())
             {
+                if now.get_end_key() != region.get_end_key() {
+                    assert!(now.get_end_key().is_empty());
+                }
                 assert!(
                     now.get_region_epoch().get_version() > region.get_region_epoch().get_version()
                 );

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -817,8 +817,10 @@ impl TestPdClient {
                 .wait()
                 .unwrap()
                 .unwrap();
-            if now.get_start_key() != region.get_start_key()
-                || now.get_end_key() != region.get_end_key()
+            if  (now.get_start_key() != region.get_start_key() 
+                && self.get_region(region.get_start_key()).is_ok())
+                || (now.get_end_key() != region.get_end_key() 
+                    && self.get_region(now.get_end_key()).is_ok())
             {
                 assert!(
                     now.get_region_epoch().get_version() > region.get_region_epoch().get_version()

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -819,7 +819,8 @@ impl TestPdClient {
                 .unwrap();
             if (now.get_start_key() != region.get_start_key()
                 && self.get_region(region.get_start_key()).is_ok())
-                || (now.get_end_key() != region.get_end_key()
+                || (now.get_end_key() != region.get_end_key() 
+                    && !now.get_end_key().is_empty()
                     && self.get_region(now.get_end_key()).is_ok())
             {
                 assert!(

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -819,7 +819,7 @@ impl TestPdClient {
                 .unwrap();
             if (now.get_start_key() != region.get_start_key()
                 && self.get_region(region.get_start_key()).is_ok())
-                || (now.get_end_key() != region.get_end_key() 
+                || (now.get_end_key() != region.get_end_key()
                     && !now.get_end_key().is_empty()
                     && self.get_region(now.get_end_key()).is_ok())
             {


### PR DESCRIPTION
## What have you changed? (mandatory)
the test is failed because the heartbeat of the other region generated from split may not received in time.
```
test raftstore::test_split_region::test_node_half_split_region ... thread 'raftstore::test_split_region::test_node_half_split_region' panicked at 'called `Result::unwrap()` on an `Err` value: Other(StringError("[components/test_raftstore/src/pd.rs:982]: no region contains key \"\""))', src/libcore/result.rs:1009:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at src/libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:71
   2: std::panicking::default_hook::{{closure}}
             at src/libstd/sys_common/backtrace.rs:59
             at src/libstd/panicking.rs:211
   3: std::panicking::default_hook
             at src/libstd/panicking.rs:227
   4: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:491
   5: std::panicking::continue_panic_fmt
             at src/libstd/panicking.rs:398
   6: rust_begin_unwind
             at src/libstd/panicking.rs:325
   7: core::panicking::panic_fmt
             at src/libcore/panicking.rs:95
   8: core::result::unwrap_failed
             at /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/libcore/macros.rs:26
   9: <core::result::Result<T, E>>::unwrap
             at /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/libcore/result.rs:808
  10: integrations::raftstore::test_split_region::test_half_split_region
             at tests/integrations/raftstore/test_split_region.rs:740
  11: integrations::raftstore::test_split_region::test_node_half_split_region
             at tests/integrations/raftstore/test_split_region.rs:715
  12: integrations::raftstore::test_split_region::test_node_half_split_region::{{closure}}
             at tests/integrations/raftstore/test_split_region.rs:712
  13: core::ops::function::FnOnce::call_once
             at /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/libcore/ops/function.rs:238
  14: <F as alloc::boxed::FnBox<A>>::call_box
             at src/libtest/lib.rs:1471
             at /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/libcore/ops/function.rs:238
             at /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/liballoc/boxed.rs:673
  15: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:102
```

## What are the type of the changes? (mandatory)
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)
unit-test

## Does this PR affect documentation (docs) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No 