### PR TITLE
service/kv: do not return retryable error when tikv is closing

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1136,10 +1136,6 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
             warn!("txn conflicts: {:?}", err);
             key_error.set_retryable(format!("{:?}", err));
         }
-        storage::Error::Closed => {
-            warn!("tikv server is closing");
-            key_error.set_retryable(format!("{:?}", err));
-        }
         _ => {
             error!("txn aborts: {:?}", err);
             key_error.set_abort(format!("{:?}", err));


### PR DESCRIPTION
## What have you changed? (mandatory)

This reverts commit 211d4287915d2f3793911e76e466bea13dcbfd9f temporarily because it may cause `Duplicate entry` error in TiDB.

## What are the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

Manually

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

#3908 