### PR TITLE
Copr: Implement checked_add and checked_sub for Mysql Time and Duration

### DIFF
--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -245,6 +245,7 @@ impl Duration {
         Ok(self)
     }
 
+    /// Checked duration addition. Computes self + rhs, returning None if overflow occurred.
     pub fn checked_add(self, rhs: &Duration) -> Option<Duration> {
         let add = match self.to_nanos().checked_add(rhs.to_nanos()) {
             Some(result) => result,
@@ -256,6 +257,7 @@ impl Duration {
         }
     }
 
+    /// Checked duration subtraction. Computes self - rhs, returning None if overflow occurred.
     pub fn checked_sub(self, rhs: &Duration) -> Option<Duration> {
         let sub = match self.to_nanos().checked_sub(rhs.to_nanos()) {
             Some(result) => result,

--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -251,10 +251,7 @@ impl Duration {
             Some(result) => result,
             None => return None,
         };
-        match Duration::from_nanos(add, self.fsp().max(rhs.fsp()) as i8) {
-            Ok(res) => Some(res),
-            Err(_) => None,
-        }
+        Duration::from_nanos(add, self.fsp().max(rhs.fsp()) as i8).ok()
     }
 
     /// Checked duration subtraction. Computes self - rhs, returning None if overflow occurred.
@@ -263,10 +260,7 @@ impl Duration {
             Some(result) => result,
             None => return None,
         };
-        match Duration::from_nanos(sub, self.fsp().max(rhs.fsp()) as i8) {
-            Ok(res) => Some(res),
-            Err(_) => None,
-        }
+        Duration::from_nanos(sub, self.fsp().max(rhs.fsp()) as i8).ok()
     }
 }
 

--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -577,10 +577,10 @@ mod tests {
             assert_eq!(res, exp);
         }
 
-        let lhs = Duration::parse("00:00:01".as_bytes(), 6).unwrap();
+        let lhs = Duration::parse(b"00:00:01", 6).unwrap();
         let rhs = Duration::from_nanos(MAX_TIME_IN_SECS as i64 * NANOS_PER_SEC, 6).unwrap();
         assert_eq!(lhs.checked_add(&rhs), None);
-        let lhs = Duration::parse("-00:00:01".as_bytes(), 6).unwrap();
+        let lhs = Duration::parse(b"-00:00:01", 6).unwrap();
         let rhs = Duration::from_nanos(MAX_TIME_IN_SECS as i64 * NANOS_PER_SEC, 6).unwrap();
         assert_eq!(lhs.checked_sub(&rhs), None);
     }

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -735,6 +735,7 @@ impl Time {
         }
     }
 
+    /// Checked time addition. Computes self + rhs, returning None if overflow occurred.
     pub fn checked_add(self, rhs: &MyDuration) -> Option<Time> {
         if let Some(add) = self
             .time
@@ -751,6 +752,7 @@ impl Time {
         }
     }
 
+    /// Checked time subtraction. Computes self - rhs, returning None if overflow occurred.
     pub fn checked_sub(self, rhs: &MyDuration) -> Option<Time> {
         if let Some(sub) = self
             .time
@@ -1568,14 +1570,14 @@ mod tests {
         for (lhs, rhs, exp) in cases.clone() {
             let lhs = Time::parse_utc_datetime(lhs, 6).unwrap();
             let rhs = MyDuration::parse(rhs.as_bytes(), 6).unwrap();
-            let res = lhs.clone().checked_add(&rhs).unwrap();
+            let res = lhs.checked_add(&rhs).unwrap();
             let exp = Time::parse_utc_datetime(exp, 6).unwrap();
             assert_eq!(res, exp);
         }
         for (exp, rhs, lhs) in cases {
             let lhs = Time::parse_utc_datetime(lhs, 6).unwrap();
             let rhs = MyDuration::parse(rhs.as_bytes(), 6).unwrap();
-            let res = lhs.clone().checked_sub(&rhs).unwrap();
+            let res = lhs.checked_sub(&rhs).unwrap();
             let exp = Time::parse_utc_datetime(exp, 6).unwrap();
             assert_eq!(res, exp);
         }

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -732,6 +732,40 @@ impl Time {
             _ => 31,
         }
     }
+
+    pub fn checked_add(self, rhs: &MyDuration) -> Option<Time> {
+        if let Some(add) = self
+            .time
+            .clone()
+            .checked_add_signed(Duration::nanoseconds(rhs.to_nanos()))
+        {
+            if add.year() > 9999 {
+                return None;
+            }
+            let mut res = self;
+            res.set_time(add);
+            Some(res)
+        } else {
+            None
+        }
+    }
+
+    pub fn checked_sub(self, rhs: &MyDuration) -> Option<Time> {
+        if let Some(sub) = self
+            .time
+            .clone()
+            .checked_sub_signed(Duration::nanoseconds(rhs.to_nanos()))
+        {
+            if sub.year() < 0 {
+                return None;
+            }
+            let mut res = self;
+            res.set_time(sub);
+            Some(res)
+        } else {
+            None
+        }
+    }
 }
 
 impl PartialOrd for Time {
@@ -1505,5 +1539,53 @@ mod tests {
             let t = Time::parse_fsp(s);
             assert_eq!(fsp, t);
         }
+    }
+
+    #[test]
+    fn test_checked_add_and_sub_duration() {
+        let cases = vec![
+            (
+                "2018-12-30 11:30:45.123456",
+                "00:00:14.876545",
+                "2018-12-30 11:31:00.000001",
+            ),
+            (
+                "2018-12-30 11:30:45.123456",
+                "00:30:00",
+                "2018-12-30 12:00:45.123456",
+            ),
+            (
+                "2018-12-30 11:30:45.123456",
+                "12:30:00",
+                "2018-12-31 00:00:45.123456",
+            ),
+            (
+                "2018-12-30 11:30:45.123456",
+                "1 12:30:00",
+                "2019-01-01 00:00:45.123456",
+            ),
+        ];
+        for (lhs, rhs, exp) in cases.clone() {
+            let lhs = Time::parse_utc_datetime(lhs, 6).unwrap();
+            let rhs = MyDuration::parse(rhs.as_bytes(), 6).unwrap();
+            let res = lhs.clone().checked_add(&rhs).unwrap();
+            let exp = Time::parse_utc_datetime(exp, 6).unwrap();
+            assert_eq!(res, exp);
+        }
+        for (exp, rhs, lhs) in cases {
+            let lhs = Time::parse_utc_datetime(lhs, 6).unwrap();
+            let rhs = MyDuration::parse(rhs.as_bytes(), 6).unwrap();
+            let res = lhs.clone().checked_sub(&rhs).unwrap();
+            let exp = Time::parse_utc_datetime(exp, 6).unwrap();
+            assert_eq!(res, exp);
+        }
+
+        use coprocessor::codec::mysql::duration::MAX_TIME_IN_SECS;
+        let lhs = Time::parse_utc_datetime("9999-12-31 23:59:59", 6).unwrap();
+        let rhs = MyDuration::from_nanos(MAX_TIME_IN_SECS as i64 * NANOS_PER_SEC, 6).unwrap();
+        assert_eq!(lhs.checked_add(&rhs), None);
+        let lhs = Time::parse_utc_datetime("0000-01-01 00:00:01", 6).unwrap();
+        let rhs = MyDuration::from_nanos(MAX_TIME_IN_SECS as i64 * NANOS_PER_SEC, 6).unwrap();
+        assert_eq!(lhs.checked_sub(&rhs), None);
     }
 }

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -736,7 +736,6 @@ impl Time {
     pub fn checked_add(self, rhs: &MyDuration) -> Option<Time> {
         if let Some(add) = self
             .time
-            .clone()
             .checked_add_signed(Duration::nanoseconds(rhs.to_nanos()))
         {
             if add.year() > 9999 {
@@ -753,7 +752,6 @@ impl Time {
     pub fn checked_sub(self, rhs: &MyDuration) -> Option<Time> {
         if let Some(sub) = self
             .time
-            .clone()
             .checked_sub_signed(Duration::nanoseconds(rhs.to_nanos()))
         {
             if sub.year() < 0 {


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

## What have you changed? (mandatory)

Add `checked_add` and `checked_sub` for Mysql Time and Duration.
Like:

- `Time.checked_add(Duration)`
- `Time.checked_sub(Duration)`
- `Duration.checked_add(Duration)`
- `Duration.checked_sub(Duration)`

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

unit test

## Does this PR affect documentation (docs) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Refer to a related PR or issue link (optional)

#4097 

