### PR TITLE
tikv/src/bin: clean up early errors and logging

### DIFF
--- a/src/bin/tikv-importer.rs
+++ b/src/bin/tikv-importer.rs
@@ -108,7 +108,7 @@ fn main() {
     tikv_util::set_panic_hook(false, &config.storage.data_dir);
 
     initial_metric(&config.metric, None);
-    util::print_tikv_info();
+    util::log_tikv_info();
     check_environment_variables();
 
     if tikv_util::panic_mark_file_exists(&config.storage.data_dir) {

--- a/src/bin/tikv-importer.rs
+++ b/src/bin/tikv-importer.rs
@@ -113,8 +113,8 @@ fn main() {
 
     if tikv_util::panic_mark_file_exists(&config.storage.data_dir) {
         fatal!(
-            "panic_mark_file {:?} exists, there must be something wrong with the db.",
-            tikv_util::panic_mark_file_path(&config.storage.data_dir)
+            "panic_mark_file {} exists, there must be something wrong with the db.",
+            tikv_util::panic_mark_file_path(&config.storage.data_dir).display()
         );
     }
 

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -440,7 +440,7 @@ fn main() {
     overwrite_config_with_cmd_args(&mut config, &matches);
 
     if let Err(e) = check_and_persist_critical_config(&config) {
-        fatal!("check critical config failed, error {:?}", e);
+        fatal!("critical config check failed: {}", e);
     }
 
     // Sets the global logger ASAP.
@@ -450,11 +450,11 @@ fn main() {
     tikv_util::set_panic_hook(false, &config.storage.data_dir);
 
     // Print version information.
-    util::print_tikv_info();
+    util::log_tikv_info();
 
     config.compatible_adjust();
     if let Err(e) = config.validate() {
-        fatal!("invalid configuration: {:?}", e);
+        fatal!("invalid configuration: {}", e.description());
     }
     info!(
         "using config";
@@ -468,13 +468,13 @@ fn main() {
 
     let security_mgr = Arc::new(
         SecurityManager::new(&config.security)
-            .unwrap_or_else(|e| fatal!("failed to create security manager: {:?}", e)),
+            .unwrap_or_else(|e| fatal!("failed to create security manager: {}", e.description())),
     );
     let pd_client = RpcClient::new(&config.pd, Arc::clone(&security_mgr))
-        .unwrap_or_else(|e| fatal!("failed to create rpc client: {:?}", e));
+        .unwrap_or_else(|e| fatal!("failed to create rpc client: {}", e));
     let cluster_id = pd_client
         .get_cluster_id()
-        .unwrap_or_else(|e| fatal!("failed to get cluster id: {:?}", e));
+        .unwrap_or_else(|e| fatal!("failed to get cluster id: {}", e));
     if cluster_id == DEFAULT_CLUSTER_ID {
         fatal!("cluster id can't be {}", DEFAULT_CLUSTER_ID);
     }

--- a/src/bin/util/mod.rs
+++ b/src/bin/util/mod.rs
@@ -21,6 +21,10 @@ pub fn tikv_version_info() -> String {
 
 /// Prints the tikv version information to the standard output.
 #[allow(dead_code)]
-pub fn print_tikv_info() {
-    info!("Welcome to TiKV. {}", tikv_version_info());
+pub fn log_tikv_info() {
+    info!("Welcome to TiKV.");
+    for line in tikv_version_info().lines() {
+        info!("{}", line);
+    }
+    info!("");
 }

--- a/src/bin/util/setup.rs
+++ b/src/bin/util/setup.rs
@@ -44,20 +44,20 @@ pub fn initial_logger(config: &TiKvConfig) {
         let drainer = logger::term_drainer();
         // use async drainer and init std log.
         logger::init_log(drainer, config.log_level, true, true).unwrap_or_else(|e| {
-            fatal!("failed to initialize log: {:?}", e);
+            fatal!("failed to initialize log: {}", e);
         });
     } else {
         let drainer =
             logger::file_drainer(&config.log_file, log_rotation_timespan).unwrap_or_else(|e| {
                 fatal!(
-                    "failed to initialize log with file {:?}: {:?}",
+                    "failed to initialize log with file {}: {}",
                     config.log_file,
                     e
                 );
             });
         // use async drainer and init std log.
         logger::init_log(drainer, config.log_level, true, true).unwrap_or_else(|e| {
-            fatal!("failed to initialize log: {:?}", e);
+            fatal!("failed to initialize log: {}", e);
         });
     };
     LOG_INITIALIZED.store(true, Ordering::SeqCst);
@@ -66,7 +66,7 @@ pub fn initial_logger(config: &TiKvConfig) {
 #[allow(dead_code)]
 pub fn initial_metric(cfg: &MetricConfig, node_id: Option<u64>) {
     util::metrics::monitor_threads("tikv")
-        .unwrap_or_else(|e| fatal!("failed to start monitor thread: {:?}", e));
+        .unwrap_or_else(|e| fatal!("failed to start monitor thread: {}", e));
 
     if cfg.interval.as_secs() == 0 || cfg.address.is_empty() {
         return;
@@ -118,11 +118,11 @@ pub fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatc
                 let mut parts = s.split('=');
                 let key = parts.next().unwrap().to_owned();
                 let value = match parts.next() {
-                    None => fatal!("invalid label: {:?}", s),
+                    None => fatal!("invalid label: {}", s),
                     Some(v) => v.to_owned(),
                 };
                 if parts.next().is_some() {
-                    fatal!("invalid label: {:?}", s);
+                    fatal!("invalid label: {}", s);
                 }
                 labels.insert(key, value);
             })

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -161,7 +161,10 @@ impl Config {
         if !self.advertise_addr.is_empty() {
             box_try!(config::check_addr(&self.advertise_addr));
         } else {
-            info!("no advertise-addr is specified, fall back to addr.");
+            info!(
+                "no advertise-addr is specified, falling back to {}.",
+                self.addr
+            );
             self.advertise_addr = self.addr.clone();
         }
         if self.advertise_addr.starts_with("0.") {


### PR DESCRIPTION
This makes a run of 'tikv-sever' with no args look like

```
ubuntu@ip-172-30-0-238:~/tikv2$ cargo run --bin tikv-server --
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
     Running `target/debug/tikv-server`
[2019/02/01 21:54:14.575 +00:00] [INFO] [mod.rs:25] ["Welcome to TiKV."]
[2019/02/01 21:54:14.575 +00:00] [INFO] [mod.rs:27] []
[2019/02/01 21:54:14.575 +00:00] [INFO] [mod.rs:27] ["Release Version:   3.0.0-beta"]
[2019/02/01 21:54:14.575 +00:00] [INFO] [mod.rs:27] ["Git Commit Hash:   Unknown (env var does not exist when building)"]
[2019/02/01 21:54:14.576 +00:00] [INFO] [mod.rs:27] ["Git Commit Branch: Unknown (env var does not exist when building)"]
[2019/02/01 21:54:14.576 +00:00] [INFO] [mod.rs:27] ["UTC Build Time:    Unknown (env var does not exist when building)"]
[2019/02/01 21:54:14.576 +00:00] [INFO] [mod.rs:27] ["Rust Version:      Unknown (env var does not exist when building)"]
[2019/02/01 21:54:14.576 +00:00] [INFO] [mod.rs:29] []
[2019/02/01 21:54:14.576 +00:00] [INFO] [config.rs:164] ["no advertise-addr is specified, falling back to 127.0.0.1:20160."]
[2019/02/01 21:54:14.577 +00:00] [ERROR] [tikv-server.rs:457] ["invalid configuration: please specify pd.endpoints."]
```

Instead of

```
ubuntu@ip-172-30-0-238:~/tikv$ cargo run --bin tikv-server
    Finished dev [unoptimized + debuginfo] target(s) in 0.46s
     Running `target/debug/tikv-server`
[2019/02/01 21:53:08.332 +00:00] [INFO] [mod.rs:25] ["Welcome to TiKV. \nRelease Version:   3.0.0-beta\nGit Commit Hash:   Unknown (env var does not exist when building)\nGit Commit Branch: Unknown (env var does not exist when building)\nUTC Build Time:    Unknown (env var does not exist when building)\nRust Version:      Unknown (env var does not exist when building)"]
[2019/02/01 21:53:08.332 +00:00] [INFO] [config.rs:164] ["no advertise-addr is specified, fall back to addr."]
[2019/02/01 21:53:08.333 +00:00] [ERROR] [tikv-server.rs:457] ["invalid configuration: StringError(\"please specify pd.endpoints.\")"]
```

It is primarily changing the print_tikv_info function to log_tikv_info
and doing so a line at a time. it also puts the fallback IP into the error mesage,
and replaces several uses of "{:?}" with "{}" such that tikv doesn't print
raw type representations, but error messages.

It also remove one extra case of "wrapping" an error string
in more error srings:

```
if let Err(e) = config.check_critical_cfg_with(&last_cfg) {
    return Err(format!("check critical config failed, err {:?}", e));
}
```

This adds no new info and that exact string, "check critical ..."
is again printed the next level up the stack. This kind of pattern -
creating nested errors by printing errors into new errors -
is an anti-pattern, because it makes errors that are very hard to read.
This would be better done with error chaining.

Finally, it wraps strings embedded in error messages in quotes -
this way, when the string is equal to "", it is clear that there's
an empty value there, not just a mis-typed extra quote.


