### PR TITLE
server: use {} instead of {:?}.

### DIFF
--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -59,11 +59,11 @@ quick_error! {
     pub enum Error {
         InvalidArgument(msg: String) {
             description(msg)
-            display("Invalid Argument {:?}", msg)
+            display("Invalid Argument {}", msg)
         }
         NotFound(msg: String) {
             description(msg)
-            display("Not Found {:?}", msg)
+            display("Not Found {}", msg)
         }
         Other(err: Box<error::Error + Sync + Send>) {
             from()


### PR DESCRIPTION
## What have you changed?
Use ```{}``` instead of ```{:?}``` when displaying a ```String```.

## What are the type of the changes?
Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? 
Unit test.

## Does this PR affect documentation (docs) update? 
No.

## Does this PR affect tidb-ansible update? 
No.