### PR TITLE
Remove unnecessary ::

### DIFF
--- a/components/codec/src/buffer.rs
+++ b/components/codec/src/buffer.rs
@@ -29,7 +29,7 @@ pub trait BufferReader {
     fn advance(&mut self, count: usize);
 }
 
-impl<T: AsRef<[u8]>> BufferReader for ::std::io::Cursor<T> {
+impl<T: AsRef<[u8]>> BufferReader for std::io::Cursor<T> {
     fn bytes(&self) -> &[u8] {
         let pos = self.position() as usize;
         let slice = self.get_ref().as_ref();
@@ -109,7 +109,7 @@ pub trait BufferWriter {
     unsafe fn advance_mut(&mut self, count: usize);
 }
 
-impl<T: AsMut<[u8]>> BufferWriter for ::std::io::Cursor<T> {
+impl<T: AsMut<[u8]>> BufferWriter for std::io::Cursor<T> {
     unsafe fn bytes_mut(&mut self, _size: usize) -> &mut [u8] {
         // `size` is ignored since this buffer is not capable to grow.
         let pos = self.position() as usize;
@@ -133,7 +133,7 @@ impl<'a> BufferWriter for &'a mut [u8] {
     }
 
     unsafe fn advance_mut(&mut self, count: usize) {
-        let original_self = ::std::mem::replace(self, &mut []);
+        let original_self = std::mem::replace(self, &mut []);
         *self = &mut original_self[count..];
     }
 }
@@ -146,7 +146,7 @@ impl BufferWriter for Vec<u8> {
         // Ensure returned slice has enough space
         self.reserve(size);
         let ptr = self.as_mut_ptr();
-        &mut ::std::slice::from_raw_parts_mut(ptr, self.capacity())[self.len()..]
+        &mut std::slice::from_raw_parts_mut(ptr, self.capacity())[self.len()..]
     }
 
     unsafe fn advance_mut(&mut self, count: usize) {
@@ -188,7 +188,7 @@ mod tests {
             base.push(rand::random());
         }
 
-        let mut buffer = ::std::io::Cursor::new(base.clone());
+        let mut buffer = std::io::Cursor::new(base.clone());
 
         assert_eq!(buffer.bytes(), &base[0..40]);
         buffer.advance(13);
@@ -264,7 +264,7 @@ mod tests {
                 base_write.push(rand::random());
             }
 
-            let mut buffer = ::std::io::Cursor::new(base.clone());
+            let mut buffer = std::io::Cursor::new(base.clone());
 
             buffer.bytes_mut(13)[..13].clone_from_slice(&base_write[0..13]);
             buffer.advance_mut(13);

--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -54,7 +54,7 @@ impl MemComparableByteCodec {
 
             // Let's first write these zero padding groups.
             for _ in 0..zero_padding_groups {
-                ::std::ptr::copy_nonoverlapping(src_ptr, dest_ptr, MEMCMP_GROUP_SIZE);
+                std::ptr::copy_nonoverlapping(src_ptr, dest_ptr, MEMCMP_GROUP_SIZE);
                 src_ptr = src_ptr.add(MEMCMP_GROUP_SIZE);
                 dest_ptr = dest_ptr.add(MEMCMP_GROUP_SIZE);
 
@@ -66,8 +66,8 @@ impl MemComparableByteCodec {
             let remaining_size = src_ptr_end.offset_from(src_ptr) as usize;
             let padding_size = MEMCMP_GROUP_SIZE - remaining_size;
             let padding_marker = !(padding_size as u8);
-            ::std::ptr::copy_nonoverlapping(src_ptr, dest_ptr, remaining_size);
-            ::std::ptr::write_bytes(dest_ptr.add(remaining_size), MEMCMP_PAD_BYTE, padding_size);
+            std::ptr::copy_nonoverlapping(src_ptr, dest_ptr, remaining_size);
+            std::ptr::write_bytes(dest_ptr.add(remaining_size), MEMCMP_PAD_BYTE, padding_size);
             dest_ptr = dest_ptr.add(MEMCMP_GROUP_SIZE);
             dest_ptr.write(padding_marker);
             (dest_ptr.offset_from(dest.as_mut_ptr()) + 1) as usize
@@ -266,22 +266,22 @@ impl MemComparableByteCodec {
 
             loop {
                 let src_ptr_next = src_ptr.add(MEMCMP_GROUP_SIZE + 1);
-                if ::std::intrinsics::unlikely(src_ptr_next > src_ptr_end) {
+                if std::intrinsics::unlikely(src_ptr_next > src_ptr_end) {
                     return Err(Error::UnexpectedEOF);
                 }
 
                 // Copy `MEMCMP_GROUP_SIZE` bytes any way. However we will truncate the returned
                 // length according to padding size if it is the last block.
-                ::std::ptr::copy(src_ptr, dest_ptr, MEMCMP_GROUP_SIZE);
+                std::ptr::copy(src_ptr, dest_ptr, MEMCMP_GROUP_SIZE);
 
                 let padding_size = T::parse_padding_size(*src_ptr.add(MEMCMP_GROUP_SIZE));
                 src_ptr = src_ptr_next;
                 dest_ptr = dest_ptr.add(MEMCMP_GROUP_SIZE);
 
                 // If there is a padding, check whether or not it is correct.
-                if ::std::intrinsics::unlikely(padding_size > 0) {
+                if std::intrinsics::unlikely(padding_size > 0) {
                     // First check padding size.
-                    if ::std::intrinsics::unlikely(padding_size > MEMCMP_GROUP_SIZE) {
+                    if std::intrinsics::unlikely(padding_size > MEMCMP_GROUP_SIZE) {
                         return Err(Error::BadPadding);
                     }
 
@@ -290,12 +290,12 @@ impl MemComparableByteCodec {
                     // bytes at once.
                     let base_padding_ptr = dest_ptr.sub(padding_size);
                     let expected_padding_ptr = T::get_raw_padding_ptr();
-                    let cmp_result = ::libc::memcmp(
-                        base_padding_ptr as *const ::libc::c_void,
-                        expected_padding_ptr as *const ::libc::c_void,
+                    let cmp_result = libc::memcmp(
+                        base_padding_ptr as *const libc::c_void,
+                        expected_padding_ptr as *const libc::c_void,
                         padding_size,
                     );
-                    if ::std::intrinsics::unlikely(cmp_result != 0) {
+                    if std::intrinsics::unlikely(cmp_result != 0) {
                         return Err(Error::BadPadding);
                     }
 
@@ -531,7 +531,7 @@ mod tests {
         for (src_len, dest_len) in cases {
             let src = vec![0; src_len];
             let mut dest = vec![0; dest_len];
-            let result = ::panic_hook::recover_safe(move || {
+            let result = panic_hook::recover_safe(move || {
                 let _ = MemComparableByteCodec::encode_all(src.as_slice(), dest.as_mut_slice());
             });
             assert!(result.is_err());
@@ -615,8 +615,8 @@ mod tests {
             let output_len = unsafe {
                 let src_ptr = buffer.as_mut_ptr().add(encoded_prefix_len);
                 let slice_len = buffer.len() - encoded_prefix_len;
-                let src = ::std::slice::from_raw_parts(src_ptr, slice_len);
-                let dest = ::std::slice::from_raw_parts_mut(src_ptr, slice_len);
+                let src = std::slice::from_raw_parts(src_ptr, slice_len);
+                let dest = std::slice::from_raw_parts_mut(src_ptr, slice_len);
                 if is_desc {
                     MemComparableByteCodec::try_decode_first_desc(src, dest).unwrap()
                 } else {
@@ -716,7 +716,7 @@ mod tests {
             {
                 let src = src.clone();
                 let mut dest = vec![0; src.len() - 1];
-                let result = ::panic_hook::recover_safe(move || {
+                let result = panic_hook::recover_safe(move || {
                     let _ = MemComparableByteCodec::try_decode_first(
                         src.as_slice(),
                         dest.as_mut_slice(),
@@ -816,11 +816,11 @@ mod benches {
                 let padding_size;
                 if remaining_size > super::MEMCMP_GROUP_SIZE {
                     padding_size = 0;
-                    ::std::ptr::copy_nonoverlapping(src_ptr, dest_ptr, super::MEMCMP_GROUP_SIZE);
+                    std::ptr::copy_nonoverlapping(src_ptr, dest_ptr, super::MEMCMP_GROUP_SIZE);
                 } else {
                     padding_size = super::MEMCMP_GROUP_SIZE - remaining_size;
-                    ::std::ptr::copy_nonoverlapping(src_ptr, dest_ptr, remaining_size);
-                    ::std::ptr::write_bytes(
+                    std::ptr::copy_nonoverlapping(src_ptr, dest_ptr, remaining_size);
+                    std::ptr::write_bytes(
                         dest_ptr.add(remaining_size),
                         super::MEMCMP_PAD_BYTE,
                         padding_size,
@@ -844,7 +844,7 @@ mod benches {
     const ENC_DESC_PADDING: [u8; ENC_GROUP_SIZE] = [!0; ENC_GROUP_SIZE];
 
     /// The original implementation of `encode_bytes` in TiKV.
-    trait OldBytesEncoder: ::std::io::Write {
+    trait OldBytesEncoder: std::io::Write {
         fn encode_bytes(&mut self, key: &[u8], desc: bool) -> super::Result<()> {
             let len = key.len();
             let mut index = 0;
@@ -896,7 +896,7 @@ mod benches {
         }
     }
 
-    impl<T: ::std::io::Write> OldBytesEncoder for T {}
+    impl<T: std::io::Write> OldBytesEncoder for T {}
 
     /// The original implementation of `decode_bytes` in TiKV.
     fn original_decode_bytes(data: &mut &[u8], desc: bool) -> super::Result<Vec<u8>> {
@@ -963,7 +963,7 @@ mod benches {
                 // it is semantically equivalent to C's memmove()
                 // and the src and dest may overlap
                 // if src == dest do nothing
-                ::std::ptr::copy(
+                std::ptr::copy(
                     data.as_ptr().add(read_offset),
                     data.as_mut_ptr().add(write_offset),
                     ENC_GROUP_SIZE,

--- a/components/codec/src/error.rs
+++ b/components/codec/src/error.rs
@@ -26,4 +26,4 @@ quick_error! {
     }
 }
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/components/cop_datatype/src/def/eval_type.rs
+++ b/components/cop_datatype/src/def/eval_type.rs
@@ -35,7 +35,7 @@ impl fmt::Display for EvalType {
     }
 }
 
-impl ::std::convert::TryFrom<crate::FieldTypeTp> for EvalType {
+impl std::convert::TryFrom<crate::FieldTypeTp> for EvalType {
     type Error = crate::DataTypeError;
 
     fn try_from(tp: crate::FieldTypeTp) -> Result<Self, crate::DataTypeError> {

--- a/components/log_wrappers/src/lib.rs
+++ b/components/log_wrappers/src/lib.rs
@@ -27,16 +27,16 @@ pub mod test_util;
 ///
 /// If your type `val: T` is directly used as a field value, you may use `"key" => %value` syntax
 /// instead.
-pub struct DisplayValue<T: ::std::fmt::Display>(pub T);
+pub struct DisplayValue<T: std::fmt::Display>(pub T);
 
-impl<T: ::std::fmt::Display> ::slog::Value for DisplayValue<T> {
+impl<T: std::fmt::Display> slog::Value for DisplayValue<T> {
     #[inline]
     fn serialize(
         &self,
         _record: &::slog::Record,
-        key: ::slog::Key,
-        serializer: &mut ::slog::Serializer,
-    ) -> ::slog::Result {
+        key: slog::Key,
+        serializer: &mut slog::Serializer,
+    ) -> slog::Result {
         serializer.emit_arguments(key, &format_args!("{}", self.0))
     }
 }
@@ -47,16 +47,16 @@ impl<T: ::std::fmt::Display> ::slog::Value for DisplayValue<T> {
 ///
 /// If your type `val: T` is directly used as a field value, you may use `"key" => ?value` syntax
 /// instead.
-pub struct DebugValue<T: ::std::fmt::Debug>(pub T);
+pub struct DebugValue<T: std::fmt::Debug>(pub T);
 
-impl<T: ::std::fmt::Debug> ::slog::Value for DebugValue<T> {
+impl<T: std::fmt::Debug> slog::Value for DebugValue<T> {
     #[inline]
     fn serialize(
         &self,
         _record: &::slog::Record,
-        key: ::slog::Key,
-        serializer: &mut ::slog::Serializer,
-    ) -> ::slog::Result {
+        key: slog::Key,
+        serializer: &mut slog::Serializer,
+    ) -> slog::Result {
         serializer.emit_arguments(key, &format_args!("{:?}", self.0))
     }
 }
@@ -90,15 +90,15 @@ fn test_debug() {
 
 pub struct Key<'a>(pub &'a [u8]);
 
-impl<'a> ::slog::Value for Key<'a> {
+impl<'a> slog::Value for Key<'a> {
     #[inline]
     fn serialize(
         &self,
         _record: &::slog::Record,
-        key: ::slog::Key,
-        serializer: &mut ::slog::Serializer,
-    ) -> ::slog::Result {
-        serializer.emit_arguments(key, &format_args!("{}", ::hex::encode_upper(self.0)))
+        key: slog::Key,
+        serializer: &mut slog::Serializer,
+    ) -> slog::Result {
+        serializer.emit_arguments(key, &format_args!("{}", hex::encode_upper(self.0)))
     }
 }
 
@@ -115,20 +115,20 @@ pub mod kvproto {
     pub mod kvrpcpb {
         pub struct KeyRange<'a>(pub &'a crate::lib_kvproto::kvrpcpb::KeyRange);
 
-        impl<'a> ::slog::Value for KeyRange<'a> {
+        impl<'a> slog::Value for KeyRange<'a> {
             #[inline]
             fn serialize(
                 &self,
                 _record: &::slog::Record,
-                key: ::slog::Key,
-                serializer: &mut ::slog::Serializer,
-            ) -> ::slog::Result {
+                key: slog::Key,
+                serializer: &mut slog::Serializer,
+            ) -> slog::Result {
                 serializer.emit_arguments(
                     key,
                     &format_args!(
                         "[{}, {})",
-                        ::hex::encode_upper(self.0.get_start_key()),
-                        ::hex::encode_upper(self.0.get_end_key())
+                        hex::encode_upper(self.0.get_start_key()),
+                        hex::encode_upper(self.0.get_end_key())
                     ),
                 )
             }
@@ -167,20 +167,20 @@ pub mod kvproto {
         pub struct KeyRange<'a>(pub &'a crate::lib_kvproto::coprocessor::KeyRange);
 
         // Similar to `kvrpcpb::KeyRange`. Tests are ignored.
-        impl<'a> ::slog::Value for KeyRange<'a> {
+        impl<'a> slog::Value for KeyRange<'a> {
             #[inline]
             fn serialize(
                 &self,
                 _record: &::slog::Record,
-                key: ::slog::Key,
-                serializer: &mut ::slog::Serializer,
-            ) -> ::slog::Result {
+                key: slog::Key,
+                serializer: &mut slog::Serializer,
+            ) -> slog::Result {
                 serializer.emit_arguments(
                     key,
                     &format_args!(
                         "[{}, {})",
-                        ::hex::encode_upper(self.0.get_start()),
-                        ::hex::encode_upper(self.0.get_end())
+                        hex::encode_upper(self.0.get_start()),
+                        hex::encode_upper(self.0.get_end())
                     ),
                 )
             }

--- a/components/log_wrappers/src/test_util.rs
+++ b/components/log_wrappers/src/test_util.rs
@@ -29,15 +29,15 @@ impl SyncLoggerBuffer {
 
     /// Builds a `slog::Logger` over this buffer which uses compact format and always output `TIME`
     /// in the time field.
-    pub fn build_logger(&self) -> ::slog::Logger {
+    pub fn build_logger(&self) -> slog::Logger {
         use slog::Drain;
 
-        let decorator = ::slog_term::PlainDecorator::new(self.clone());
-        let drain = ::slog_term::CompactFormat::new(decorator)
+        let decorator = slog_term::PlainDecorator::new(self.clone());
+        let drain = slog_term::CompactFormat::new(decorator)
             .use_custom_timestamp(|w: &mut io::Write| w.write(b"TIME").map(|_| ()))
             .build();
         let drain = sync::Mutex::new(drain).fuse();
-        ::slog::Logger::root(drain, o!())
+        slog::Logger::root(drain, o!())
     }
 
     fn lock(&self) -> sync::MutexGuard<Vec<u8>> {

--- a/components/panic_hook/src/lib.rs
+++ b/components/panic_hook/src/lib.rs
@@ -65,7 +65,7 @@ fn track_hook(p: &PanicInfo) {
 /// This function assumes the closure is able to be forced to implement `UnwindSafe`.
 ///
 /// Also see [`AssertUnwindSafe`](https://doc.rust-lang.org/std/panic/struct.AssertUnwindSafe.html).
-pub fn recover_safe<F, R>(f: F) -> ::std::thread::Result<R>
+pub fn recover_safe<F, R>(f: F) -> std::thread::Result<R>
 where
     F: FnOnce() -> R,
 {

--- a/components/test_coprocessor/src/dag.rs
+++ b/components/test_coprocessor/src/dag.rs
@@ -277,7 +277,7 @@ impl Iterator for DAGChunkSpliter {
             }
             assert_eq!(self.datums.len() >= self.col_cnt, true);
             let mut cols = self.datums.split_off(self.col_cnt);
-            ::std::mem::swap(&mut self.datums, &mut cols);
+            std::mem::swap(&mut self.datums, &mut cols);
             return Some(cols);
         }
     }

--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -50,7 +50,7 @@ impl ProductTable {
     }
 }
 
-impl ::std::ops::Deref for ProductTable {
+impl std::ops::Deref for ProductTable {
     type Target = Table;
 
     fn deref(&self) -> &Table {

--- a/components/test_coprocessor/src/table.rs
+++ b/components/test_coprocessor/src/table.rs
@@ -34,7 +34,7 @@ pub struct Table {
     pub(crate) idxs: BTreeMap<i64, Vec<i64>>,
 }
 
-fn normalize_column_name(name: impl ::std::borrow::Borrow<str>) -> String {
+fn normalize_column_name(name: impl std::borrow::Borrow<str>) -> String {
     name.borrow().to_lowercase()
 }
 
@@ -46,7 +46,7 @@ impl Table {
     }
 
     /// Get a column reference in the table by column name (case insensitive).
-    pub fn column_by_name(&self, name: impl ::std::borrow::Borrow<str>) -> Option<&Column> {
+    pub fn column_by_name(&self, name: impl std::borrow::Borrow<str>) -> Option<&Column> {
         let normalized_name = normalize_column_name(name);
         let idx = self.column_index_by_name.get(&normalized_name);
         idx.map(|idx| &self.columns[*idx].1)
@@ -98,8 +98,8 @@ impl Table {
     /// Create a `KeyRange` which select all records in current table.
     pub fn get_record_range_all(&self) -> KeyRange {
         let mut range = KeyRange::new();
-        range.set_start(table::encode_row_key(self.id, ::std::i64::MIN));
-        range.set_end(table::encode_row_key(self.id, ::std::i64::MAX));
+        range.set_start(table::encode_row_key(self.id, std::i64::MIN));
+        range.set_end(table::encode_row_key(self.id, std::i64::MAX));
         range
     }
 
@@ -127,7 +127,7 @@ impl Table {
     }
 }
 
-impl<T: ::std::borrow::Borrow<str>> ::std::ops::Index<T> for Table {
+impl<T: std::borrow::Borrow<str>> std::ops::Index<T> for Table {
     type Output = Column;
 
     fn index(&self, key: T) -> &Column {
@@ -148,7 +148,7 @@ impl TableBuilder {
         }
     }
 
-    pub fn add_col(mut self, name: impl ::std::borrow::Borrow<str>, col: Column) -> TableBuilder {
+    pub fn add_col(mut self, name: impl std::borrow::Borrow<str>, col: Column) -> TableBuilder {
         if col.index == 0 {
             if self.handle_id > 0 {
                 self.handle_id = 0;

--- a/fuzz/targets/mod.rs
+++ b/fuzz/targets/mod.rs
@@ -106,9 +106,9 @@ trait ReadAsDecimalRoundMode: ReadLiteralExt {
         &mut self,
     ) -> Result<::tikv::coprocessor::codec::mysql::decimal::RoundMode, Error> {
         Ok(match self.read_as_u8()? % 3 {
-            0 => ::tikv::coprocessor::codec::mysql::decimal::RoundMode::HalfEven,
-            1 => ::tikv::coprocessor::codec::mysql::decimal::RoundMode::Truncate,
-            _ => ::tikv::coprocessor::codec::mysql::decimal::RoundMode::Ceiling,
+            0 => tikv::coprocessor::codec::mysql::decimal::RoundMode::HalfEven,
+            1 => tikv::coprocessor::codec::mysql::decimal::RoundMode::Truncate,
+            _ => tikv::coprocessor::codec::mysql::decimal::RoundMode::Ceiling,
         })
     }
 }
@@ -160,9 +160,9 @@ pub fn fuzz_coprocessor_codec_decimal(data: &[u8]) -> Result<(), Error> {
 trait ReadAsTimeType: ReadLiteralExt {
     fn read_as_time_type(&mut self) -> Result<::tikv::coprocessor::codec::mysql::TimeType, Error> {
         Ok(match self.read_as_u8()? % 3 {
-            0 => ::tikv::coprocessor::codec::mysql::TimeType::Date,
-            1 => ::tikv::coprocessor::codec::mysql::TimeType::DateTime,
-            _ => ::tikv::coprocessor::codec::mysql::TimeType::Timestamp,
+            0 => tikv::coprocessor::codec::mysql::TimeType::Date,
+            1 => tikv::coprocessor::codec::mysql::TimeType::DateTime,
+            _ => tikv::coprocessor::codec::mysql::TimeType::Timestamp,
         })
     }
 }
@@ -170,7 +170,7 @@ trait ReadAsTimeType: ReadLiteralExt {
 impl<T: ReadLiteralExt> ReadAsTimeType for T {}
 
 fn fuzz_time(
-    t: ::tikv::coprocessor::codec::mysql::Time,
+    t: tikv::coprocessor::codec::mysql::Time,
     mut cursor: Cursor<&[u8]>,
 ) -> Result<(), Error> {
     use tikv::coprocessor::codec::mysql::TimeEncoder;

--- a/src/coprocessor/codec/batch/column.rs
+++ b/src/coprocessor/codec/batch/column.rs
@@ -832,7 +832,7 @@ mod benches {
         DatumEncoder::encode(&mut datum_raw, &[Datum::U64(0xDEADBEEF)], true).unwrap();
 
         let col_info = {
-            let mut col_info = ::tipb::schema::ColumnInfo::new();
+            let mut col_info = tipb::schema::ColumnInfo::new();
             col_info.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
             col_info
         };
@@ -865,7 +865,7 @@ mod benches {
         DatumEncoder::encode(&mut datum_raw, &[Datum::U64(0xDEADBEEF)], true).unwrap();
 
         let col_info = {
-            let mut col_info = ::tipb::schema::ColumnInfo::new();
+            let mut col_info = tipb::schema::ColumnInfo::new();
             col_info.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
             col_info
         };

--- a/src/coprocessor/codec/batch/rows.rs
+++ b/src/coprocessor/codec/batch/rows.rs
@@ -977,7 +977,7 @@ mod benches {
         }
 
         let col_info = {
-            let mut col_info = ::tipb::schema::ColumnInfo::new();
+            let mut col_info = tipb::schema::ColumnInfo::new();
             col_info.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
             col_info
         };
@@ -1008,7 +1008,7 @@ mod benches {
         }
 
         let col_info = {
-            let mut col_info = ::tipb::schema::ColumnInfo::new();
+            let mut col_info = tipb::schema::ColumnInfo::new();
             col_info.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
             col_info
         };
@@ -1040,7 +1040,7 @@ mod benches {
         }
 
         let col_info = {
-            let mut col_info = ::tipb::schema::ColumnInfo::new();
+            let mut col_info = tipb::schema::ColumnInfo::new();
             col_info.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
             col_info
         };

--- a/src/coprocessor/codec/error.rs
+++ b/src/coprocessor/codec/error.rs
@@ -191,4 +191,4 @@ impl From<RegexpError> for Error {
     }
 }
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/coprocessor/dag/expr/builtin_math.rs
+++ b/src/coprocessor/dag/expr/builtin_math.rs
@@ -537,7 +537,7 @@ fn format_radix(mut x: u64, radix: u32) -> String {
         let m = x % u64::from(radix);
         x /= u64::from(radix);
         r.push(
-            ::std::char::from_digit(m as u32, radix)
+            std::char::from_digit(m as u32, radix)
                 .unwrap()
                 .to_ascii_uppercase(),
         );

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -81,8 +81,8 @@ struct CusRng {
     rng: RefCell<Option<XorShiftRng>>,
 }
 
-impl ::std::fmt::Debug for CusRng {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl std::fmt::Debug for CusRng {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "()")
     }
 }

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -1065,7 +1065,7 @@ mod tests {
 
         let cop = Endpoint::new(&config, engine, read_pool);
 
-        let (tx, rx) = ::std::sync::mpsc::channel();
+        let (tx, rx) = std::sync::mpsc::channel();
 
         // A request that requests execution details.
         let mut req_with_exec_detail = ReqContext::default_for_test();

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -190,7 +190,7 @@ impl Tracker {
         }
 
         let total_exec_metrics =
-            ::std::mem::replace(&mut self.total_exec_metrics, ExecutorMetrics::default());
+            std::mem::replace(&mut self.total_exec_metrics, ExecutorMetrics::default());
         let mut thread_ctx = self.ctxd.as_ref().unwrap().current_thread_context_mut();
         thread_ctx
             .basic_local_metrics

--- a/src/pd/errors.rs
+++ b/src/pd/errors.rs
@@ -17,7 +17,7 @@ use std::result;
 quick_error! {
     #[derive(Debug)]
     pub enum Error {
-        Io(err: ::std::io::Error) {
+        Io(err: std::io::Error) {
             from()
             cause(err)
             description(err.description())

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -132,7 +132,7 @@ impl RaftRouter {
     pub fn send_raft_message(
         &self,
         mut msg: RaftMessage,
-    ) -> ::std::result::Result<(), TrySendError<RaftMessage>> {
+    ) -> std::result::Result<(), TrySendError<RaftMessage>> {
         let id = msg.get_region_id();
         match self.try_send(id, PeerMsg::RaftMessage(msg)) {
             Either::Left(Ok(())) => return Ok(()),
@@ -155,7 +155,7 @@ impl RaftRouter {
         }
     }
 
-    pub fn send_peer_msg(&self, msg: PeerMsg) -> ::std::result::Result<(), TrySendError<Msg>> {
+    pub fn send_peer_msg(&self, msg: PeerMsg) -> std::result::Result<(), TrySendError<Msg>> {
         let region_id = match msg {
             PeerMsg::RaftMessage(msg) => {
                 return match self.send_raft_message(msg) {
@@ -209,7 +209,7 @@ impl RaftRouter {
         }
     }
 
-    fn send_store_msg(&self, msg: StoreMsg) -> ::std::result::Result<(), TrySendError<Msg>> {
+    fn send_store_msg(&self, msg: StoreMsg) -> std::result::Result<(), TrySendError<Msg>> {
         match self.send_control(msg) {
             Ok(()) => Ok(()),
             Err(TrySendError::Full(m)) => Err(TrySendError::Full(Msg::StoreMsg(m))),
@@ -220,7 +220,7 @@ impl RaftRouter {
 
 // TODO: drop Sender support.
 impl crate::util::transport::Sender<Msg> for RaftRouter {
-    fn send(&self, msg: Msg) -> ::std::result::Result<(), TrySendError<Msg>> {
+    fn send(&self, msg: Msg) -> std::result::Result<(), TrySendError<Msg>> {
         match msg {
             Msg::PeerMsg(msg) => self.send_peer_msg(msg),
             Msg::StoreMsg(msg) => self.send_store_msg(msg),
@@ -982,7 +982,7 @@ impl RaftBatchSystem {
             consistency_check_worker: Worker::new("consistency-check"),
             cleanup_sst_worker: Worker::new("cleanup-sst"),
             coprocessor_host: Arc::new(coprocessor_host),
-            future_poller: ::tokio_threadpool::Builder::new()
+            future_poller: tokio_threadpool::Builder::new()
                 .name_prefix("future-poller")
                 .pool_size(cfg.future_poll_size)
                 .build(),

--- a/src/raftstore/store/keys.rs
+++ b/src/raftstore/store/keys.rs
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn test_region_id_key() {
-        let region_ids = vec![0, 1, 1024, ::std::u64::MAX];
+        let region_ids = vec![0, 1, 1024, std::u64::MAX];
         for region_id in region_ids {
             let prefix = region_raft_prefix(region_id);
 

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -2167,7 +2167,7 @@ mod tests {
         s.snap_state = RefCell::new(SnapState::Applying(Arc::new(AtomicUsize::new(
             JOB_STATUS_FAILED,
         ))));
-        let res = ::panic_hook::recover_safe(|| s.cancel_applying_snap());
+        let res = panic_hook::recover_safe(|| s.cancel_applying_snap());
         assert!(res.is_err());
     }
 
@@ -2216,7 +2216,7 @@ mod tests {
         s.snap_state = RefCell::new(SnapState::Applying(Arc::new(AtomicUsize::new(
             JOB_STATUS_FAILED,
         ))));
-        let res = ::panic_hook::recover_safe(|| s.check_applying_snap());
+        let res = panic_hook::recover_safe(|| s.check_applying_snap());
         assert!(res.is_err());
     }
 

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -169,8 +169,8 @@ impl Runnable<Task> for Runner {
                             ) {
                                 error!(
                                     "compact range failed";
-                                    "range_start" => ::log_wrappers::Key(&start),
-                                    "range_end" => ::log_wrappers::Key(&end),
+                                    "range_start" => log_wrappers::Key(&start),
+                                    "range_end" => log_wrappers::Key(&end),
                                     "cf" => cf,
                                     "err" => %e,
                                 );

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -393,8 +393,8 @@ impl SnapContext {
                 error!(
                     "failed to delete files in range";
                     "region_id" => region_id,
-                    "start_key" => ::log_wrappers::Key(start_key),
-                    "end_key" => ::log_wrappers::Key(end_key),
+                    "start_key" => log_wrappers::Key(start_key),
+                    "end_key" => log_wrappers::Key(end_key),
                     "err" => %e,
                 );
                 return;
@@ -406,16 +406,16 @@ impl SnapContext {
             error!(
                 "failed to delete data in range";
                 "region_id" => region_id,
-                "start_key" => ::log_wrappers::Key(start_key),
-                "end_key" => ::log_wrappers::Key(end_key),
+                "start_key" => log_wrappers::Key(start_key),
+                "end_key" => log_wrappers::Key(end_key),
                 "err" => %e,
             );
         } else {
             info!(
                 "succeed in deleting data in range";
                 "region_id" => region_id,
-                "start_key" => ::log_wrappers::Key(start_key),
-                "end_key" => ::log_wrappers::Key(end_key),
+                "start_key" => log_wrappers::Key(start_key),
+                "end_key" => log_wrappers::Key(end_key),
             );
         }
     }
@@ -447,8 +447,8 @@ impl SnapContext {
         info!(
             "register deleting data in range";
             "region_id" => region_id,
-            "start_key" => ::log_wrappers::Key(start_key),
-            "end_key" => ::log_wrappers::Key(end_key),
+            "start_key" => log_wrappers::Key(start_key),
+            "end_key" => log_wrappers::Key(end_key),
         );
         let timeout = time::Instant::now() + self.clean_stale_peer_delay;
         self.pending_delete_ranges

--- a/src/raftstore/store/worker/split_check.rs
+++ b/src/raftstore/store/worker/split_check.rs
@@ -183,8 +183,8 @@ impl<C: Sender<Msg>> Runner<C> {
         debug!(
             "executing task";
             "region_id" => region_id,
-            "start_key" => ::log_wrappers::Key(&start_key),
-            "end_key" => ::log_wrappers::Key(&end_key),
+            "start_key" => log_wrappers::Key(&start_key),
+            "end_key" => log_wrappers::Key(&end_key),
         );
         CHECK_SPILT_COUNTER_VEC.with_label_values(&["all"]).inc();
 

--- a/src/storage/engine/perf_context.rs
+++ b/src/storage/engine/perf_context.rs
@@ -29,13 +29,13 @@ pub struct PerfStatisticsFields {
 #[derive(Debug, Clone, Copy)]
 pub struct PerfStatisticsInstant(pub PerfStatisticsFields);
 
-impl ::slog::KV for PerfStatisticsInstant {
+impl slog::KV for PerfStatisticsInstant {
     fn serialize(
         &self,
         record: &::slog::Record,
-        serializer: &mut ::slog::Serializer,
-    ) -> ::slog::Result {
-        ::slog::KV::serialize(&self.0, record, serializer)
+        serializer: &mut slog::Serializer,
+    ) -> slog::Result {
+        slog::KV::serialize(&self.0, record, serializer)
     }
 }
 
@@ -78,13 +78,13 @@ impl DerefMut for PerfStatisticsInstant {
 #[derive(Default, Debug, Clone, Copy, Add, AddAssign, Sub, SubAssign)]
 pub struct PerfStatisticsDelta(pub PerfStatisticsFields);
 
-impl ::slog::KV for PerfStatisticsDelta {
+impl slog::KV for PerfStatisticsDelta {
     fn serialize(
         &self,
         record: &::slog::Record,
-        serializer: &mut ::slog::Serializer,
-    ) -> ::slog::Result {
-        ::slog::KV::serialize(&self.0, record, serializer)
+        serializer: &mut slog::Serializer,
+    ) -> slog::Result {
+        slog::KV::serialize(&self.0, record, serializer)
     }
 }
 

--- a/src/storage/gc_worker.rs
+++ b/src/storage/gc_worker.rs
@@ -539,7 +539,7 @@ enum GCManagerError {
     Stopped,
 }
 
-type GCManagerResult<T> = ::std::result::Result<T, GCManagerError>;
+type GCManagerResult<T> = std::result::Result<T, GCManagerError>;
 
 /// Used to check if `GCManager` should be stopped.
 ///

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1697,7 +1697,7 @@ quick_error! {
     }
 }
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 pub enum ErrorHeaderKind {
     NotLeader,

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -125,7 +125,7 @@ impl Error {
     }
 }
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[cfg(test)]
 pub mod tests {

--- a/src/storage/mvcc/reader/backward_scanner.rs
+++ b/src/storage/mvcc/reader/backward_scanner.rs
@@ -164,7 +164,7 @@ pub struct BackwardScanner<S: Snapshot> {
 impl<S: Snapshot> BackwardScanner<S> {
     /// Take out and reset the statistics collected so far.
     pub fn take_statistics(&mut self) -> Statistics {
-        ::std::mem::replace(&mut self.statistics, Statistics::default())
+        std::mem::replace(&mut self.statistics, Statistics::default())
     }
 
     /// Get the next key-value pair, in backward order.

--- a/src/storage/mvcc/reader/forward_scanner.rs
+++ b/src/storage/mvcc/reader/forward_scanner.rs
@@ -153,7 +153,7 @@ pub struct ForwardScanner<S: Snapshot> {
 impl<S: Snapshot> ForwardScanner<S> {
     /// Take out and reset the statistics collected so far.
     pub fn take_statistics(&mut self) -> Statistics {
-        ::std::mem::replace(&mut self.statistics, Statistics::default())
+        std::mem::replace(&mut self.statistics, Statistics::default())
     }
 
     /// Get the next key-value pair, in forward order.

--- a/src/storage/mvcc/reader/util.rs
+++ b/src/storage/mvcc/reader/util.rs
@@ -40,7 +40,7 @@ pub fn check_lock(key: &Key, ts: u64, lock: &Lock) -> Result<CheckLockResult> {
 
     let raw_key = key.to_raw()?;
 
-    if ts == ::std::u64::MAX && raw_key == lock.primary {
+    if ts == std::u64::MAX && raw_key == lock.primary {
         // When `ts == u64::MAX` (which means to get latest committed version for
         // primary key), and current key is the primary key, we return the latest
         // committed version.

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -38,7 +38,7 @@ quick_error! {
             cause(err)
             description(err.description())
         }
-        ProtoBuf(err: ::protobuf::error::ProtobufError) {
+        ProtoBuf(err: protobuf::error::ProtobufError) {
             from()
             cause(err)
             description(err.description())
@@ -108,4 +108,4 @@ impl Error {
     }
 }
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -215,11 +215,11 @@ impl<S: Snapshot> Scanner for StoreScanner<S> {
 
 /// A Store that reads on fixtures.
 pub struct FixtureStore {
-    data: ::std::collections::BTreeMap<Key, Result<Vec<u8>>>,
+    data: std::collections::BTreeMap<Key, Result<Vec<u8>>>,
 }
 
 impl FixtureStore {
-    pub fn new(data: ::std::collections::BTreeMap<Key, Result<Vec<u8>>>) -> Self {
+    pub fn new(data: std::collections::BTreeMap<Key, Result<Vec<u8>>>) -> Self {
         FixtureStore { data }
     }
 }
@@ -300,7 +300,7 @@ impl Store for FixtureStore {
 
 /// A Scanner that scans on fixtures.
 pub struct FixtureStoreScanner {
-    data: ::std::vec::IntoIter<(Key, Result<Vec<u8>>)>,
+    data: std::vec::IntoIter<(Key, Result<Vec<u8>>)>,
 }
 
 impl Scanner for FixtureStoreScanner {

--- a/src/util/codec/mod.rs
+++ b/src/util/codec/mod.rs
@@ -57,4 +57,4 @@ impl Error {
     }
 }
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/util/collections.rs
+++ b/src/util/collections.rs
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub type HashMap<K, V> = ::hashbrown::HashMap<K, V, ::hashbrown::hash_map::DefaultHashBuilder>;
-pub type HashSet<T> = ::hashbrown::HashSet<T, ::hashbrown::hash_map::DefaultHashBuilder>;
+pub type HashMap<K, V> = hashbrown::HashMap<K, V, hashbrown::hash_map::DefaultHashBuilder>;
+pub type HashSet<T> = hashbrown::HashSet<T, hashbrown::hash_map::DefaultHashBuilder>;
 pub use hashbrown::hash_map::Entry as HashMapEntry;
 
 pub use indexmap::map::Entry as OrderMapEntry;

--- a/src/util/logger/mod.rs
+++ b/src/util/logger/mod.rs
@@ -46,7 +46,7 @@ pub fn init_log<D>(
 ) -> Result<(), SetLoggerError>
 where
     D: Drain + Send + 'static,
-    <D as Drain>::Err: ::std::fmt::Debug,
+    <D as Drain>::Err: std::fmt::Debug,
 {
     let logger = if use_async {
         let drain = Async::new(drain.fuse())
@@ -62,9 +62,9 @@ where
         slog::Logger::root(drain, slog_o!())
     };
 
-    ::slog_global::set_global(logger);
+    slog_global::set_global(logger);
     if init_stdlog {
-        ::slog_global::redirect_std_log(Some(level))?;
+        slog_global::redirect_std_log(Some(level))?;
         grpc::redirect_log();
     }
 
@@ -367,9 +367,9 @@ mod tests {
         );
 
         slog_warn!(logger, "Type";
-            "Counter" => ::std::f64::NAN,
-            "Score" => ::std::f64::INFINITY,
-            "Other" => ::std::f64::NEG_INFINITY
+            "Counter" => std::f64::NAN,
+            "Score" => std::f64::INFINITY,
+            "Other" => std::f64::NEG_INFINITY
         );
 
         let none: Option<u8> = None;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -458,7 +458,7 @@ pub fn set_panic_hook(panic_abort: bool, data_dir: &str) {
     let orig_hook = panic::take_hook();
     panic::set_hook(box move |info: &panic::PanicInfo| {
         use slog::Drain;
-        if ::slog_global::borrow_global().is_enabled(::slog::Level::Error) {
+        if slog_global::borrow_global().is_enabled(::slog::Level::Error) {
             let msg = match info.payload().downcast_ref::<&'static str>() {
                 Some(s) => *s,
                 None => match info.payload().downcast_ref::<String>() {
@@ -471,7 +471,7 @@ pub fn set_panic_hook(panic_abort: bool, data_dir: &str) {
             let loc = info
                 .location()
                 .map(|l| format!("{}:{}", l.file(), l.line()));
-            let bt = ::backtrace::Backtrace::new();
+            let bt = backtrace::Backtrace::new();
             error!(
                 "thread '{}' panicked '{}' at {:?}\n{:?}",
                 name,
@@ -486,7 +486,7 @@ pub fn set_panic_hook(panic_abort: bool, data_dir: &str) {
         // There might be remaining logs in the async logger.
         // To collect remaining logs and also collect future logs, replace the old one with a
         // terminal logger.
-        if let Some(level) = ::log::max_log_level().to_log_level() {
+        if let Some(level) = log::max_log_level().to_log_level() {
             let drainer = logger::term_drainer();
             let _ = logger::init_log(
                 drainer,
@@ -702,7 +702,7 @@ mod tests {
 
     #[test]
     fn test_resource_leak() {
-        let res = ::panic_hook::recover_safe(|| {
+        let res = panic_hook::recover_safe(|| {
             let mut v = MustConsumeVec::new("test");
             v.push(2);
         });

--- a/src/util/timer.rs
+++ b/src/util/timer.rs
@@ -118,7 +118,7 @@ struct TimeZero {
     ///
     /// Note that `zero` doesn't have to be related to `steady_time_point`, as what's
     /// observed here is elapsed time instead of time point.
-    zero: ::std::time::Instant,
+    zero: std::time::Instant,
     /// A base time point.
     ///
     /// The source of time point should grow steady.
@@ -140,7 +140,7 @@ pub struct SteadyClock {
 lazy_static! {
     static ref STEADY_CLOCK: SteadyClock = SteadyClock {
         zero: Arc::new(TimeZero {
-            zero: ::std::time::Instant::now(),
+            zero: std::time::Instant::now(),
             steady_time_point: monotonic_raw_now(),
         }),
     };
@@ -155,7 +155,7 @@ impl Default for SteadyClock {
 
 impl Now for SteadyClock {
     #[inline]
-    fn now(&self) -> ::std::time::Instant {
+    fn now(&self) -> std::time::Instant {
         let n = monotonic_raw_now();
         let dur = Instant::elapsed_duration(n, self.zero.steady_time_point);
         self.zero.zero + dur
@@ -324,7 +324,7 @@ mod tests {
     fn test_global_timer() {
         let handle = super::GLOBAL_TIMER_HANDLE.clone();
         let delay =
-            handle.delay(::std::time::Instant::now() + ::std::time::Duration::from_millis(100));
+            handle.delay(::std::time::Instant::now() + std::time::Duration::from_millis(100));
         let timer = Instant::now();
         delay.wait().unwrap();
         assert!(timer.elapsed() >= Duration::from_millis(100));

--- a/tests/failpoints/cases/test_conf_change.rs
+++ b/tests/failpoints/cases/test_conf_change.rs
@@ -148,7 +148,7 @@ fn test_write_after_destroy() {
     fail::remove(apply_fp);
     let resp = rx1.recv_timeout(Duration::from_secs(2)).unwrap();
     assert!(!resp.get_header().has_error(), "{:?}", resp);
-    ::std::thread::sleep(Duration::from_secs(3));
+    std::thread::sleep(Duration::from_secs(3));
     must_get_none(&engine_3, b"k5");
     must_region_cleared(&engines_3, &region);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Since we have upgraded to Rust 2018, adding `::` prefix to refer a 3rd-party crate is no longer needed.

## What are the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

CI
