### PR TITLE
Add PerfContext for Kv Operations

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -87,6 +87,14 @@
 # should be set based on your disk performance
 # snap-max-write-bytes-per-sec = "100MB"
 
+# How long will a KV read request be treated as slow and print slow log.
+# Setting to 0s will print slow log for all requests.
+# kv-read-slow-log-threshold = "1s"
+
+# How long will a Coprocessor end-point request be treated as slow and print slow log.
+# Setting to 0s will print slow log for all requests.
+# end-point-slow-log-threshold = "1s"
+
 # set attributes about this server, e.g. { zone = "us-west-1", disk = "ssd" }.
 # labels = {}
 

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -87,10 +87,6 @@
 # should be set based on your disk performance
 # snap-max-write-bytes-per-sec = "100MB"
 
-# How long will a KV read request be treated as slow and print slow log.
-# Setting to 0s will print slow log for all requests.
-# kv-read-slow-log-threshold = "1s"
-
 # How long will a Coprocessor end-point request be treated as slow and print slow log.
 # Setting to 0s will print slow log for all requests.
 # end-point-slow-log-threshold = "1s"
@@ -118,6 +114,10 @@
 # When the pending write bytes exceeds this threshold,
 # the "scheduler too busy" error is displayed.
 # scheduler-pending-write-threshold = "100MB"
+
+# How long will a KV read request be treated as slow and print slow log.
+# Setting to 0s will print slow log for all requests.
+# kv-read-slow-log-threshold = "1s"
 
 [pd]
 # pd endpoints

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -45,6 +45,7 @@ pub struct Endpoint<E: Engine> {
     stream_batch_row_limit: usize,
     stream_channel_size: usize,
     max_handle_duration: Duration,
+    slow_log_threshold: Duration,
 }
 
 impl<E: Engine> Clone for Endpoint<E> {
@@ -69,6 +70,7 @@ impl<E: Engine> Endpoint<E> {
             stream_batch_row_limit: cfg.end_point_stream_batch_row_limit,
             stream_channel_size: cfg.end_point_stream_channel_size,
             max_handle_duration: cfg.end_point_request_max_handle_duration.0,
+            slow_log_threshold: cfg.end_point_slow_log_threshold.clone().into(),
         }
     }
 
@@ -279,7 +281,7 @@ impl<E: Engine> Endpoint<E> {
     ) -> impl Future<Item = coppb::Response, Error = ()> {
         let engine = self.engine.clone();
         let priority = readpool::Priority::from(req_ctx.context.get_priority());
-        let mut tracker = box Tracker::new(req_ctx);
+        let mut tracker = box Tracker::new(req_ctx, self.slow_log_threshold);
 
         let result = self.read_pool.future_execute(priority, move |ctxd| {
             tracker.attach_ctxd(ctxd);
@@ -409,7 +411,7 @@ impl<E: Engine> Endpoint<E> {
         let engine = self.engine.clone();
         let priority = readpool::Priority::from(req_ctx.context.get_priority());
         // Must be created befure `future_execute`, otherwise wait time is not tracked.
-        let mut tracker = box Tracker::new(req_ctx);
+        let mut tracker = box Tracker::new(req_ctx, self.slow_log_threshold);
 
         let tx1 = tx.clone();
         let result = self.read_pool.future_execute(priority, move |ctxd| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 #![feature(ascii_ctype)]
 #![feature(const_int_ops)]
 #![feature(use_extern_macros)]
+#![feature(optin_builtin_traits)]
 #![recursion_limit = "200"]
 // Currently this raises some false positives, so we allow it:
 // https://github.com/rust-lang-nursery/rust-clippy/issues/2638

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -82,7 +82,6 @@ pub struct Config {
     pub end_point_request_max_handle_duration: ReadableDuration,
     pub snap_max_write_bytes_per_sec: ReadableSize,
     pub snap_max_total_size: ReadableSize,
-    pub kv_read_slow_log_threshold: ReadableDuration,
     pub end_point_slow_log_threshold: ReadableDuration,
 
     // Server labels to specify some attributes about this server.
@@ -134,7 +133,6 @@ impl Default for Config {
             ),
             snap_max_write_bytes_per_sec: ReadableSize(DEFAULT_SNAP_MAX_BYTES_PER_SEC),
             snap_max_total_size: ReadableSize(0),
-            kv_read_slow_log_threshold: ReadableDuration::secs(1),
             end_point_slow_log_threshold: ReadableDuration::secs(1),
         }
     }

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -82,6 +82,8 @@ pub struct Config {
     pub end_point_request_max_handle_duration: ReadableDuration,
     pub snap_max_write_bytes_per_sec: ReadableSize,
     pub snap_max_total_size: ReadableSize,
+    pub kv_read_slow_log_threshold: ReadableDuration,
+    pub end_point_slow_log_threshold: ReadableDuration,
 
     // Server labels to specify some attributes about this server.
     pub labels: HashMap<String, String>,
@@ -132,6 +134,8 @@ impl Default for Config {
             ),
             snap_max_write_bytes_per_sec: ReadableSize(DEFAULT_SNAP_MAX_BYTES_PER_SEC),
             snap_max_total_size: ReadableSize(0),
+            kv_read_slow_log_threshold: ReadableDuration::secs(1),
+            end_point_slow_log_threshold: ReadableDuration::secs(1),
         }
     }
 }

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -15,7 +15,7 @@ use std::error::Error;
 
 use sys_info;
 
-use util::config::{self, ReadableSize};
+use util::config::{self, ReadableDuration, ReadableSize};
 
 pub const DEFAULT_DATA_DIR: &str = "";
 pub const DEFAULT_ROCKSDB_SUB_DIR: &str = "db";
@@ -41,6 +41,7 @@ pub struct Config {
     pub scheduler_concurrency: usize,
     pub scheduler_worker_pool_size: usize,
     pub scheduler_pending_write_threshold: ReadableSize,
+    pub kv_read_slow_log_threshold: ReadableDuration,
 }
 
 impl Default for Config {
@@ -54,6 +55,7 @@ impl Default for Config {
             scheduler_concurrency: DEFAULT_SCHED_CONCURRENCY,
             scheduler_worker_pool_size: if total_cpu >= 16 { 8 } else { 4 },
             scheduler_pending_write_threshold: ReadableSize::mb(DEFAULT_SCHED_PENDING_WRITE_MB),
+            kv_read_slow_log_threshold: ReadableDuration::secs(1),
         }
     }
 }

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -19,6 +19,11 @@ lazy_static! {
         "Total number of commands received.",
         &["type"]
     ).unwrap();
+    pub static ref KV_ROCKSDB_PERF_COUNTER: IntCounterVec = register_int_counter_vec!(
+        "tikv_storage_rocksdb_perf",
+        "Total number of RocksDB internal operations from PerfContext",
+        &["type", "metric"]
+    ).unwrap();
     pub static ref SCHED_STAGE_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
         "tikv_scheduler_stage_total",
         "Total number of commands on each stage.",

--- a/src/storage/perf_tracker.rs
+++ b/src/storage/perf_tracker.rs
@@ -1,0 +1,68 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use storage::engine::{PerfStatisticsDelta, PerfStatisticsInstant};
+use util::time::{Duration, Instant};
+
+/// A PerfContext tracker for Storage.
+///
+/// It records PerfContext statistics when created, and logs delta PerfContext statistics as slow
+/// operation when `track()` is called or it is dropped after specified slow threshold.
+pub struct PerfTracker {
+    cmd: &'static str,
+    slow_log_threshold: Duration,
+    time_start: Instant,
+    perf_start: PerfStatisticsInstant,
+    perf_delta: Option<PerfStatisticsDelta>,
+}
+
+impl PerfTracker {
+    pub fn new(cmd: &'static str, slow_log_threshold: Duration) -> Self {
+        Self {
+            cmd,
+            slow_log_threshold,
+            time_start: Instant::now_coarse(),
+            perf_start: PerfStatisticsInstant::new(),
+            perf_delta: None,
+        }
+    }
+
+    /// Records and returns the delta PerfContext. If elapsed time is larger than specified slow
+    /// log threshold, a slow log will be printed.
+    pub fn record(mut self) -> PerfStatisticsDelta {
+        let perf_delta = self.perf_start.delta();
+        self.perf_delta = Some(perf_delta);
+        drop(self);
+        perf_delta
+    }
+}
+
+impl Drop for PerfTracker {
+    /// Similar to `record()`, but does not return the delta PerfContext.
+    fn drop(&mut self) {
+        if self.perf_delta.is_none() {
+            self.perf_delta = Some(self.perf_start.delta());
+        }
+        let elapsed = self.time_start.elapsed();
+        if elapsed > self.slow_log_threshold {
+            info!(
+                "[slow-kv] cmd {:?} process takes {:?}, perf: {:?}",
+                self.cmd,
+                elapsed,
+                self.perf_delta.take().unwrap(),
+            );
+        }
+    }
+}
+
+impl !Send for PerfTracker {}

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -79,6 +79,8 @@ fn test_serde_custom_tikv_config() {
         end_point_request_max_handle_duration: ReadableDuration::secs(12),
         snap_max_write_bytes_per_sec: ReadableSize::mb(10),
         snap_max_total_size: ReadableSize::gb(10),
+        kv_read_slow_log_threshold: ReadableDuration::secs(2),
+        end_point_slow_log_threshold: ReadableDuration::secs(4),
     };
     value.readpool = ReadPoolConfig {
         storage: StorageReadPoolConfig {

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -79,7 +79,6 @@ fn test_serde_custom_tikv_config() {
         end_point_request_max_handle_duration: ReadableDuration::secs(12),
         snap_max_write_bytes_per_sec: ReadableSize::mb(10),
         snap_max_total_size: ReadableSize::gb(10),
-        kv_read_slow_log_threshold: ReadableDuration::secs(2),
         end_point_slow_log_threshold: ReadableDuration::secs(4),
     };
     value.readpool = ReadPoolConfig {
@@ -410,6 +409,7 @@ fn test_serde_custom_tikv_config() {
         scheduler_concurrency: 123,
         scheduler_worker_pool_size: 1,
         scheduler_pending_write_threshold: ReadableSize::kb(123),
+        kv_read_slow_log_threshold: ReadableDuration::secs(2),
     };
     value.coprocessor = CopConfig {
         split_region_on_table: true,

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -38,6 +38,8 @@ end-point-stream-batch-row-limit = 4096
 end-point-request-max-handle-duration = "12s"
 snap-max-write-bytes-per-sec = "10MB"
 snap-max-total-size = "10GB"
+kv-read-slow-log-threshold = "2s"
+end-point-slow-log-threshold = "4s"
 
 [server.labels]
 a = "b"

--- a/tests/config/test-custom.toml
+++ b/tests/config/test-custom.toml
@@ -38,7 +38,6 @@ end-point-stream-batch-row-limit = 4096
 end-point-request-max-handle-duration = "12s"
 snap-max-write-bytes-per-sec = "10MB"
 snap-max-total-size = "10GB"
-kv-read-slow-log-threshold = "2s"
 end-point-slow-log-threshold = "4s"
 
 [server.labels]
@@ -52,6 +51,7 @@ scheduler-notify-capacity = 123
 scheduler-concurrency = 123
 scheduler-worker-pool-size = 1
 scheduler-pending-write-threshold = "123KB"
+kv-read-slow-log-threshold = "2s"
 
 [pd]
 endpoints = [

--- a/tests/coprocessor/test_select.rs
+++ b/tests/coprocessor/test_select.rs
@@ -1483,41 +1483,10 @@ fn test_exec_details() {
 
     let product = ProductTable::new();
     let (_, endpoint) = init_with_data(&product, &data);
-
-    // get none
-    let req = DAGSelect::from(&product.table).build();
-    let resp = handle_request(&endpoint, req);
-    assert!(resp.has_exec_details());
-    let exec_details = resp.get_exec_details();
-    assert!(!exec_details.has_handle_time());
-    assert!(!exec_details.has_scan_detail());
-
     let flags = &[0];
 
-    // get handle_time
-    let mut ctx = Context::new();
-    ctx.set_handle_time(true);
-    let req = DAGSelect::from(&product.table).build_with(ctx, flags);
-    let resp = handle_request(&endpoint, req);
-    assert!(resp.has_exec_details());
-    let exec_details = resp.get_exec_details();
-    assert!(exec_details.has_handle_time());
-    assert!(!exec_details.has_scan_detail());
-
-    // get scan detail
-    let mut ctx = Context::new();
-    ctx.set_scan_detail(true);
-    let req = DAGSelect::from(&product.table).build_with(ctx, flags);
-    let resp = handle_request(&endpoint, req);
-    assert!(resp.has_exec_details());
-    let exec_details = resp.get_exec_details();
-    assert!(!exec_details.has_handle_time());
-    assert!(exec_details.has_scan_detail());
-
     // get both
-    let mut ctx = Context::new();
-    ctx.set_scan_detail(true);
-    ctx.set_handle_time(true);
+    let ctx = Context::new();
     let req = DAGSelect::from(&product.table).build_with(ctx, flags);
     let resp = handle_request(&endpoint, req);
     assert!(resp.has_exec_details());


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR adds PerfContext and slow log for Kv read operations. (release-2.1)

Additionally, this PR allows adjusting the threshold of outputting slow log.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

WIP
