### PR TITLE
server: bind port lazily when it's configured

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ extern crate serde_json;
     slog_warn,
     slog_info,
     slog_debug,
+    slog_crit,
     slog_log,
     slog_record,
     slog_b,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -132,6 +132,8 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             if let Some(service) = import_service {
                 sb = sb.register_service(create_import_sst(service));
             }
+            // When port is 0, it has to be binded now to get a valid address, which
+            // is then reported to PD before the server is up. 0 is usually used in tests.
             if addr.port() == 0 {
                 let server = sb.build()?;
                 let (ref host, port) = server.bind_addrs()[0];

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -472,12 +472,10 @@ pub fn set_panic_hook(panic_abort: bool, data_dir: &str) {
                 .location()
                 .map(|l| format!("{}:{}", l.file(), l.line()));
             let bt = backtrace::Backtrace::new();
-            error!(
-                "thread '{}' panicked '{}' at {:?}\n{:?}",
-                name,
-                msg,
-                loc.unwrap_or_else(|| "<unknown>".to_owned()),
-                bt
+            crit!("{}", msg;
+                "thread_name" => name,
+                "location" => loc.unwrap_or_else(|| "<unknown>".to_owned()),
+                "backtrace" => format_args!("{:?}", bt),
             );
         } else {
             orig_hook(info);


### PR DESCRIPTION
## What have you changed? (mandatory)

This PR make TiKV only listens to given port when it's started. Note that listening to port before everything is prepared is a mistake and can lead to unexpected bugs like #4224.

Binding port before server is started is required by our tests to avoid port conflict. So this PR delays binding port only when it's configured.

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

manual tests

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

Close #2999
Close #4224