### PR TITLE
benches/misc/coprocessor/codec: add bench test for column

### DIFF
--- a/benches/misc/coprocessor/codec/batch/mod.rs
+++ b/benches/misc/coprocessor/codec/batch/mod.rs
@@ -1,0 +1,115 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use test::Bencher;
+use tikv::coprocessor::codec::batch::*;
+use tikv::coprocessor::codec::mysql::*;
+
+#[bench]
+fn bench_column_agg_long(b: &mut Bencher) {
+    let rows = 1024;
+    let mut long_col = VectorValue::with_capacity(rows, cop_datatype::EvalType::Int);
+    for row_id in 0..rows {
+        if row_id & 1 == 0 {
+            long_col.push_int(None);
+            continue;
+        }
+        long_col.push_int(Some(row_id as i64));
+    }
+    b.iter(|| {
+        let slice = long_col.as_int_slice();
+        let mut long_sum = 0;
+        for v in slice {
+            if let Some(t) = v {
+                long_sum += t;
+            }
+        }
+        assert_eq!(262144, long_sum);
+    });
+}
+
+#[bench]
+fn bench_column_agg_str(b: &mut Bencher) {
+    let rows = 1024;
+    let mut str_col = VectorValue::with_capacity(rows, cop_datatype::EvalType::Bytes);
+    let mut total_size = 0;
+    for row_id in 0..rows {
+        if row_id & 1 == 0 {
+            str_col.push_bytes(None);
+            continue;
+        }
+        let dec = Decimal::from(row_id);
+        let s = dec.to_string().into_bytes();
+        total_size = total_size + s.len();
+        str_col.push_bytes(Some(s));
+    }
+
+    b.iter(|| {
+        let mut get_size = 0;
+        let slice = str_col.as_bytes_slice();
+        for v in slice {
+            if let Some(t) = v {
+                get_size = get_size + t.len();
+            }
+        }
+        assert_eq!(get_size, total_size);
+    });
+}
+
+#[bench]
+fn bench_column_agg_dec(b: &mut Bencher) {
+    let rows = 1024;
+    let mut dec_col = VectorValue::with_capacity(rows, cop_datatype::EvalType::Decimal);
+
+    for row_id in 0..rows {
+        if row_id & 1 == 0 {
+            dec_col.push_decimal(None);
+            continue;
+        }
+        dec_col.push_decimal(Some(Decimal::from(row_id)));
+    }
+    b.iter(|| {
+        let mut dec_sum = Decimal::from(0);
+        let slice = dec_col.as_decimal_slice();
+        for v in slice {
+            if let Some(t) = v {
+                dec_sum = (&dec_sum + &t).unwrap();
+            }
+        }
+        assert_eq!(Decimal::from(262144), dec_sum);
+    });
+}
+
+#[bench]
+fn bench_column_agg_dec_null(b: &mut Bencher) {
+    let rows = 1024;
+    let mut dec_col = VectorValue::with_capacity(rows, cop_datatype::EvalType::Decimal);
+
+    for row_id in 0..rows {
+        if row_id & 1 == 0 {
+            dec_col.push_decimal(None);
+            continue;
+        }
+        dec_col.push_decimal(Some(Decimal::from(row_id)));
+    }
+    b.iter(|| {
+        let mut null_cnt = 0;
+        let slice = dec_col.as_decimal_slice();
+        for v in slice {
+            if v.is_none() {
+                null_cnt += 1;
+            }
+        }
+        assert_eq!(null_cnt, 512);
+    });
+}

--- a/benches/misc/coprocessor/codec/batch/mod.rs
+++ b/benches/misc/coprocessor/codec/batch/mod.rs
@@ -50,7 +50,7 @@ fn bench_column_agg_str(b: &mut Bencher) {
         }
         let dec = Decimal::from(row_id);
         let s = dec.to_string().into_bytes();
-        total_size = total_size + s.len();
+        total_size += s.len();
         str_col.push_bytes(Some(s));
     }
 
@@ -59,7 +59,7 @@ fn bench_column_agg_str(b: &mut Bencher) {
         let slice = str_col.as_bytes_slice();
         for v in slice {
             if let Some(t) = v {
-                get_size = get_size + t.len();
+                get_size += t.len();
             }
         }
         assert_eq!(get_size, total_size);
@@ -83,7 +83,7 @@ fn bench_column_agg_dec(b: &mut Bencher) {
         let slice = dec_col.as_decimal_slice();
         for v in slice {
             if let Some(t) = v {
-                dec_sum = (&dec_sum + &t).unwrap();
+                dec_sum = (&dec_sum + t).unwrap();
             }
         }
         assert_eq!(Decimal::from(262144), dec_sum);

--- a/benches/misc/coprocessor/codec/chunk/mod.rs
+++ b/benches/misc/coprocessor/codec/chunk/mod.rs
@@ -201,7 +201,7 @@ fn bench_column_agg_str(b: &mut Bencher) {
         }
         let dec = Decimal::from(row_id);
         let s = dec.to_string().into_bytes();
-        total_size = total_size + s.len();
+        total_size += s.len();
         str_col.append_datum(&Datum::Bytes(s)).unwrap();
     }
 
@@ -211,7 +211,7 @@ fn bench_column_agg_str(b: &mut Bencher) {
             if str_col.is_null(row_id) {
                 continue;
             }
-            get_size = get_size + str_col.get_bytes(row_id).len();
+            get_size += str_col.get_bytes(row_id).len();
         }
         assert_eq!(get_size, total_size);
     });

--- a/benches/misc/coprocessor/codec/mod.rs
+++ b/benches/misc/coprocessor/codec/mod.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod batch;
 mod chunk;
 mod mysql;
 

--- a/src/coprocessor/codec/chunk/column.rs
+++ b/src/coprocessor/codec/chunk/column.rs
@@ -337,6 +337,11 @@ impl Column {
         self.length
     }
 
+    /// Return true when it's empty.
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
     #[cfg(test)]
     pub fn decode(buf: &mut BytesSlice, tp: &FieldTypeAccessor) -> Result<Column> {
         use crate::util::codec::read_slice;

--- a/src/coprocessor/codec/chunk/mod.rs
+++ b/src/coprocessor/codec/chunk/mod.rs
@@ -17,6 +17,7 @@ mod column;
 pub use crate::coprocessor::codec::{Error, Result};
 
 pub use self::chunk::{Chunk, ChunkEncoder};
+pub use self::column::Column;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
This PR add bench test for columns in Chunk and LazyColumn.

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- Engineering (engineering change which doesn't change any feature or fix any issue)


## Does this PR affect documentation (docs) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

```
test coprocessor::codec::batch::bench_column_agg_dec                  ... bench:      25,981 ns/iter (+/- 2,224)
test coprocessor::codec::batch::bench_column_agg_dec_null             ... bench:         494 ns/iter (+/- 51)
test coprocessor::codec::batch::bench_column_agg_long                 ... bench:         414 ns/iter (+/- 29)
test coprocessor::codec::batch::bench_column_agg_str                  ... bench:         510 ns/iter (+/- 26)
test coprocessor::codec::chunk::bench_column_agg_dec                  ... bench:      59,670 ns/iter (+/- 5,897)
test coprocessor::codec::chunk::bench_column_agg_dec_null             ... bench:       2,443 ns/iter (+/- 393)
test coprocessor::codec::chunk::bench_column_agg_long                 ... bench:       3,239 ns/iter (+/- 197)
test coprocessor::codec::chunk::bench_column_agg_str                  ... bench:       3,500 ns/iter (+/- 325)
```
## Add a few positive/negative examples (optional)

