### PR TITLE
Add option to decide panic or not when key exceed bound

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -113,6 +113,17 @@ fn check_system_config(config: &TiKvConfig) {
     }
 }
 
+fn pre_start(cfg: &TiKvConfig) {
+    // Before any startup, check system configuration and environment variables.
+    check_system_config(&cfg);
+    check_environment_variables();
+
+    if cfg.panic_when_key_exceed_bound {
+        info!("panic-when-key-exceed-bound is on");
+        tikv_util::set_panic_when_key_exceed_bound(true);
+    }
+}
+
 fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<SecurityManager>) {
     let store_path = Path::new(&cfg.storage.data_dir);
     let lock_path = store_path.join(Path::new("LOCK"));
@@ -480,10 +491,8 @@ fn main() {
         "config" => serde_json::to_string(&config).unwrap(),
     );
 
-    // Before any startup, check system configuration.
-    check_system_config(&config);
-
-    check_environment_variables();
+    // Do some prepare works before start.
+    pre_start(&config);
 
     let security_mgr = Arc::new(
         SecurityManager::new(&config.security)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1036,6 +1036,7 @@ pub struct TiKvConfig {
     pub raftdb: RaftDbConfig,
     pub security: SecurityConfig,
     pub import: ImportConfig,
+    pub panic_when_key_exceed_bound: bool,
 }
 
 impl Default for TiKvConfig {
@@ -1055,6 +1056,7 @@ impl Default for TiKvConfig {
             storage: StorageConfig::default(),
             security: SecurityConfig::default(),
             import: ImportConfig::default(),
+            panic_when_key_exceed_bound: false,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1242,11 +1242,7 @@ impl TiKvConfig {
     }
 
     pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), IoError> {
-        let content = match toml::to_string(&self) {
-            Ok(content) => content,
-            Err(e) => panic!("toml to string error: {:?}", e),
-        };
-        //let content = toml::to_string(&self).unwrap();
+        let content = toml::to_string(&self).unwrap();
         let mut f = fs::File::create(&path)?;
         f.write_all(content.as_bytes())?;
         f.sync_all()?;

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use crate::raftstore::store::engine::{IterOption, Peekable, Snapshot, SyncSnapshot};
 use crate::raftstore::store::{keys, util, PeerStorage};
 use crate::raftstore::Result;
-use crate::util::set_panic_mark;
+use crate::util::{panic_when_key_exceed_bound, set_panic_mark};
 
 /// Snapshot of a region.
 ///
@@ -154,7 +154,6 @@ pub struct RegionIterator {
     region: Arc<Region>,
     start_key: Vec<u8>,
     end_key: Vec<u8>,
-    panic_when_exceed_bound: bool,
 }
 
 fn set_lower_bound(iter_opt: &mut IterOption, region: &Region) {
@@ -195,7 +194,6 @@ impl RegionIterator {
             start_key,
             end_key,
             region,
-            panic_when_exceed_bound: true,
         }
     }
 
@@ -216,13 +214,7 @@ impl RegionIterator {
             start_key,
             end_key,
             region,
-            panic_when_exceed_bound: true,
         }
-    }
-
-    // Set false only in test.
-    pub fn panic_when_exceed_bound(&mut self, panic: bool) {
-        self.panic_when_exceed_bound = panic;
     }
 
     pub fn seek_to_first(&mut self) -> bool {
@@ -316,7 +308,7 @@ impl RegionIterator {
     #[inline]
     pub fn should_seekable(&self, key: &[u8]) -> Result<()> {
         if let Err(e) = util::check_key_in_region_inclusive(key, &self.region) {
-            if self.panic_when_exceed_bound {
+            if panic_when_key_exceed_bound() {
                 set_panic_mark();
                 panic!("key exceed bound: {:?}", e);
             } else {
@@ -487,7 +479,6 @@ mod tests {
                 true,
             );
             let mut iter = snap.iter(iter_opt);
-            iter.panic_when_exceed_bound(false);
             for (seek_key, in_range, seek_exp, prev_exp) in seek_table.clone() {
                 let check_res =
                     |iter: &RegionIterator, res: Result<bool>, exp: Option<(&[u8], &[u8])>| {
@@ -657,8 +648,7 @@ mod tests {
 
         let snap = RegionSnapshot::new(&store);
         let mut statistics = CFStatistics::default();
-        let mut it = snap.iter(IterOption::default());
-        it.panic_when_exceed_bound(false);
+        let it = snap.iter(IterOption::default());
         let mut iter = Cursor::new(it, ScanMode::Mixed);
         assert!(!iter
             .reverse_seek(&Key::from_encoded_slice(b"a2"), &mut statistics)
@@ -709,8 +699,7 @@ mod tests {
         region.mut_peers().push(Peer::new());
         let store = new_peer_storage(engines, &region);
         let snap = RegionSnapshot::new(&store);
-        let mut it = snap.iter(IterOption::default());
-        it.panic_when_exceed_bound(false);
+        let it = snap.iter(IterOption::default());
         let mut iter = Cursor::new(it, ScanMode::Mixed);
         assert!(!iter
             .reverse_seek(&Key::from_encoded_slice(b"a1"), &mut statistics)
@@ -763,7 +752,6 @@ mod tests {
         let mut iter_opt = IterOption::default();
         iter_opt.set_lower_bound(b"a3".to_vec());
         let mut iter = snap.iter(iter_opt);
-        iter.panic_when_exceed_bound(false);
         assert!(iter.seek_to_last());
         let mut res = vec![];
         loop {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -45,6 +45,16 @@ pub mod timer;
 pub mod transport;
 pub mod worker;
 
+static PANIC_WHEN_KEY_EXCEED_BOUND: AtomicBool = AtomicBool::new(false);
+
+pub fn panic_when_key_exceed_bound() -> bool {
+    PANIC_WHEN_KEY_EXCEED_BOUND.load(Ordering::SeqCst)
+}
+
+pub fn set_panic_when_key_exceed_bound(flag: bool) {
+    PANIC_WHEN_KEY_EXCEED_BOUND.store(flag, Ordering::SeqCst);
+}
+
 static PANIC_MARK: AtomicBool = AtomicBool::new(false);
 
 pub fn set_panic_mark() {

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -497,6 +497,7 @@ fn test_serde_custom_tikv_config() {
         stream_channel_window: 123,
         max_open_engines: 2,
     };
+    value.panic_when_key_exceed_bound = true;
 
     let custom = read_file_in_project_dir("tests/integrations/config/test-custom.toml");
     let load = toml::from_str(&custom).unwrap();

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -9,6 +9,7 @@ max-tasks-per-worker-high = 1000
 max-tasks-per-worker-normal = 1500
 max-tasks-per-worker-low = 2500
 stack-size = "20MB"
+panic-when-key-exceed-bound = true
 
 [readpool.coprocessor]
 high-concurrency = 2

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -1,6 +1,8 @@
 log-level = "debug"
 log-file = "foo"
 log-rotation-timespan = "1d"
+panic-when-key-exceed-bound = true
+
 [readpool.storage]
 high-concurrency = 1
 normal-concurrency = 3
@@ -9,7 +11,6 @@ max-tasks-per-worker-high = 1000
 max-tasks-per-worker-normal = 1500
 max-tasks-per-worker-low = 2500
 stack-size = "20MB"
-panic-when-key-exceed-bound = true
 
 [readpool.coprocessor]
 high-concurrency = 2


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Previously TiKV will panic when encounter key exceed bound error, add a configuration to control panic or return error in this condition.

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Unit test

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

