### PR TITLE
Add make audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ export TIKV_BUILD_TIME := $(shell date -u '+%Y-%m-%d %I:%M:%S')
 export TIKV_BUILD_GIT_HASH := $(shell git rev-parse HEAD 2> /dev/null || echo ${BUILD_INFO_GIT_FALLBACK})
 export TIKV_BUILD_GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null || echo ${BUILD_INFO_GIT_FALLBACK})
 export TIKV_BUILD_RUSTC_VERSION := $(shell rustc --version 2> /dev/null || echo ${BUILD_INFO_RUSTC_FALLBACK})
+LATEST_AUDIT_VERSION = $(strip $(shell cargo search cargo-audit | head -n 1 | awk '{ gsub(/"/, "", $$3); print $$3 }'))
+CURRENT_AUDIT_VERSION = $(strip $(shell (cargo audit --version 2> /dev/null || echo "noop 0") | awk '{ print $$2 }'))
 
 default: release
 
@@ -117,8 +119,6 @@ format: pre-format
 	@cargo fmt --all -- --check >/dev/null || \
 	cargo fmt --all
 
-LATEST_AUDIT_VERSION = $(strip $(shell cargo search cargo-audit | head -n 1 | awk '{ gsub(/"/, "", $$3); print $$3 }'))
-CURRENT_AUDIT_VERSION = $(strip $(shell (cargo audit --version 2> /dev/null || echo "noop 0") | awk '{ print $$2 }'))
 pre-audit:
 ifneq ($(LATEST_AUDIT_VERSION),$(CURRENT_AUDIT_VERSION))
 	cargo install cargo-audit --force

--- a/Makefile
+++ b/Makefile
@@ -117,15 +117,14 @@ format: pre-format
 	@cargo fmt --all -- --check >/dev/null || \
 	cargo fmt --all
 
-pre-audit:
-	@cargo install cargo-audit --force
-
 LATEST_AUDIT_VERSION = $(strip $(shell cargo search cargo-audit | head -n 1 | awk '{ gsub(/"/, "", $$3); print $$3 }'))
 CURRENT_AUDIT_VERSION = $(strip $(shell (cargo audit --version 2> /dev/null || echo "noop 0") | awk '{ print $$2 }'))
-audit:
+pre-audit:
 ifneq ($(LATEST_AUDIT_VERSION),$(CURRENT_AUDIT_VERSION))
 	cargo install cargo-audit --force
 endif
+
+audit: pre-audit
 	cargo audit
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,19 @@ format: pre-format
 	@cargo fmt --all -- --check >/dev/null || \
 	cargo fmt --all
 
+pre-audit:
+	@cargo install cargo-audit --force
+
+LATEST_AUDIT_VERSION = $(strip $(shell cargo search cargo-audit | head -n 1 | awk '{ gsub(/"/, "", $$3); print $$3 }'))
+CURRENT_AUDIT_VERSION = $(strip $(shell (cargo audit --version 2> /dev/null || echo "noop 0") | awk '{ print $$2 }'))
+audit:
+	echo "$(strip $(LATEST_AUDIT_VERSION))"
+	echo "$(strip $(CURRENT_AUDIT_VERSION))"
+ifneq ($(LATEST_AUDIT_VERSION),$(CURRENT_AUDIT_VERSION))
+	cargo install cargo-audit --force
+endif
+	@cargo audit
+
 clean:
 	@cargo clean
 

--- a/Makefile
+++ b/Makefile
@@ -123,15 +123,13 @@ pre-audit:
 LATEST_AUDIT_VERSION = $(strip $(shell cargo search cargo-audit | head -n 1 | awk '{ gsub(/"/, "", $$3); print $$3 }'))
 CURRENT_AUDIT_VERSION = $(strip $(shell (cargo audit --version 2> /dev/null || echo "noop 0") | awk '{ print $$2 }'))
 audit:
-	echo "$(strip $(LATEST_AUDIT_VERSION))"
-	echo "$(strip $(CURRENT_AUDIT_VERSION))"
 ifneq ($(LATEST_AUDIT_VERSION),$(CURRENT_AUDIT_VERSION))
 	cargo install cargo-audit --force
 endif
-	@cargo audit
+	cargo audit
 
 clean:
-	@cargo clean
+	cargo clean
 
 expression: format clippy
 	LOG_LEVEL=ERROR RUST_BACKTRACE=1 cargo test --features "${ENABLE_FEATURES}" "coprocessor::dag::expr" -- --nocapture


### PR DESCRIPTION
Add an audit command as part of #4264 .

Test by running `make audit`, regardless of a `cargo-audit` version being installed. It will install (or update to) the latest, then run audit.

A follow up PR will add this to our CI builds in the SRE repo.

## Test locally

```rust
make audit
```

You can test with or without cargo-audit installed.