### PR TITLE
log_wrappers: add tikv_alloc dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,7 @@ dependencies = [
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
  "slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tikv_alloc 0.1.0",
 ]
 
 [[package]]

--- a/components/log_wrappers/Cargo.toml
+++ b/components/log_wrappers/Cargo.toml
@@ -9,3 +9,4 @@ slog = "2.3"
 slog-term = "2.4"
 hex = "0.3"
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+tikv_alloc = { path = "../tikv_alloc" }

--- a/components/log_wrappers/src/lib.rs
+++ b/components/log_wrappers/src/lib.rs
@@ -18,6 +18,7 @@ extern crate kvproto as lib_kvproto;
 #[macro_use]
 extern crate slog;
 extern crate slog_term;
+extern crate tikv_alloc;
 
 pub mod test_util;
 

--- a/etc/check-bins-for-jemalloc.sh
+++ b/etc/check-bins-for-jemalloc.sh
@@ -64,5 +64,6 @@ done
 
 if [[ "$errors" -ne 0 ]]; then
     echo "some binaries do not link to jemalloc"
+    echo "fix this by adding tikv_alloc as a dependency and importing it with 'extern crate'"
     exit 1
 fi


### PR DESCRIPTION
This fixes the error generated by check-bins-for-jemalloc.sh

I also added more info to the error message in the script,
indicating how to fix the problem.

Fixes https://github.com/tikv/tikv/issues/4220