### PR TITLE
config: add metrics pushgateway addr parameter

### DIFF
--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -455,6 +455,14 @@ fn main() {
                 .long("print-sample-config")
                 .help("Print a sample config to stdout"),
         )
+        .arg(
+            Arg::with_name("metrics-addr")
+                .long("metrics-addr")
+                .value_name("IP:PORT")
+                .help(
+                    "prometheus pushgateway address, leaves it empty will disable prometheus push",
+                ),
+        )
         .get_matches();
 
     if matches.is_present("print-sample-config") {

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -459,8 +459,10 @@ fn main() {
             Arg::with_name("metrics-addr")
                 .long("metrics-addr")
                 .value_name("IP:PORT")
-                .help(
-                    "prometheus pushgateway address, leaves it empty will disable prometheus push",
+                .help("Sets Prometheus Pushgateway address")
+                .long_help(
+                    "Sets push address to the Prometheus Pushgateway, \
+                     leaves it empty will disable Prometheus push",
                 ),
         )
         .get_matches();

--- a/src/bin/util/setup.rs
+++ b/src/bin/util/setup.rs
@@ -140,4 +140,8 @@ pub fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatc
     if let Some(import_dir) = matches.value_of("import-dir") {
         config.import.import_dir = import_dir.to_owned();
     }
+
+    if let Some(metrics_addr) = matches.value_of("metrics-addr") {
+        config.metric.address = metrics_addr.to_owned()
+    }
 }


### PR DESCRIPTION
In the local test, if you want to specify the address of pushgateway, you can only manually create a config file, which is not very convenient. By adding this parameter, you can specify it directly on the command line. This behavior is also consistent with tidb-server and pd-server

Signed-off-by: dongxu <huang@pingcap.com>
