### PR TITLE
pd: execlude tombstone stores when getting all stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#7f2fc73ef562be1b0a6100ccfce13ec01bae79be"
+source = "git+https://github.com/pingcap/kvproto.git#84f2c621d8e8dce083d62297490217da809bc51a"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1388,7 +1388,7 @@ name = "protoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1452,7 +1452,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -220,6 +220,7 @@ impl PdClient for RpcClient {
 
         let mut req = pdpb::GetAllStoresRequest::new();
         req.set_header(self.header());
+        req.set_exclude_tombstone_stores(true);
 
         let mut resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
             client.get_all_stores_opt(&req, Self::call_option())


### PR DESCRIPTION
## What have you changed? (mandatory)

The `GetAllStores` API in PD returns tombstone stores, which is not expected for TiKV.
This PR specifies the option to exclude tombstone stores from the result, please consider this as a bug fix.

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Can't think of a good way to test, it totally depends on the server behavior.

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

Fixes #4221 
Conflicts https://github.com/tikv/tikv/pull/4223
Relates to https://github.com/pingcap/pd/pull/1440