### PR TITLE
Implements AsMySQLBool

### DIFF
--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -55,7 +55,6 @@ pub fn truncate_f64(mut f: f64, flen: u8, decimal: u8) -> Res<f64> {
 }
 
 /// `overflow` returns an overflowed error.
-#[macro_export]
 macro_rules! overflow {
     ($val:ident, $bound:ident) => {{
         Err(box_err!("constant {} overflows {}", $val, $bound))

--- a/src/coprocessor/codec/data_type/mod.rs
+++ b/src/coprocessor/codec/data_type/mod.rs
@@ -13,6 +13,7 @@
 
 mod scalar;
 mod vector;
+mod vector_like;
 
 // Concrete eval types without a nullable wrapper.
 pub type Int = i64;
@@ -23,3 +24,4 @@ pub use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time as Date
 // Dynamic eval types.
 pub use self::scalar::ScalarValue;
 pub use self::vector::VectorValue;
+pub use self::vector_like::{VectorLikeValueRef, VectorLikeValueRefSpecialized};

--- a/src/coprocessor/codec/data_type/scalar.rs
+++ b/src/coprocessor/codec/data_type/scalar.rs
@@ -52,6 +52,26 @@ impl ScalarValue {
             ScalarValue::Json(_) => EvalType::Json,
         }
     }
+
+    #[inline]
+    pub fn as_vector_like(&self) -> VectorLikeValueRef {
+        VectorLikeValueRef::Scalar(self)
+    }
+}
+
+impl AsMySQLBool for ScalarValue {
+    #[inline]
+    fn as_mysql_bool(&self) -> bool {
+        match self {
+            ScalarValue::Int(ref v) => v.as_mysql_bool(),
+            ScalarValue::Real(ref v) => v.as_mysql_bool(),
+            ScalarValue::Decimal(ref v) => v.as_mysql_bool(),
+            ScalarValue::Bytes(ref v) => v.as_mysql_bool(),
+            ScalarValue::DateTime(ref v) => v.as_mysql_bool(),
+            ScalarValue::Duration(ref v) => v.as_mysql_bool(),
+            ScalarValue::Json(ref v) => v.as_mysql_bool(),
+        }
+    }
 }
 
 macro_rules! impl_as_ref {

--- a/src/coprocessor/codec/data_type/vector.rs
+++ b/src/coprocessor/codec/data_type/vector.rs
@@ -222,6 +222,24 @@ impl VectorValue {
         }
     }
 
+    #[inline]
+    pub fn as_vector_like(&self) -> VectorLikeValueRef {
+        VectorLikeValueRef::Vector(self)
+    }
+
+    /// Evaluates values into MySQL logic values.
+    ///
+    /// The caller must provide an output buffer which is large enough for holding values.
+    pub fn eval_as_mysql_bools(&self, outputs: &mut [bool]) {
+        assert!(outputs.len() >= self.len());
+        match_self!(ref self, v, {
+            let l = self.len();
+            for i in 0..l {
+                outputs[i] = v[i].as_mysql_bool();
+            }
+        });
+    }
+
     /// Pushes a value into the column by decoding the datum and converting to current
     /// column's type.
     ///

--- a/src/coprocessor/codec/data_type/vector_like.rs
+++ b/src/coprocessor/codec/data_type/vector_like.rs
@@ -1,0 +1,91 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Index;
+
+use super::*;
+
+/// A vector-like value reference container, for all concrete eval types.
+///
+/// Vector-like: This type contains either a vector reference or a scalar reference. When inner
+/// reference is a scalar value, it acts like a vector that containing arbitrary amount of same
+/// elements. This capability is provided via specialized version.
+///
+/// This type is similar to a trait object but is faster due to function inlining.
+// TODO: Switch to use trait object when trait object is faster.
+#[derive(Copy, Clone)]
+pub enum VectorLikeValueRef<'a> {
+    Vector(&'a VectorValue),
+    Scalar(&'a ScalarValue),
+}
+
+macro_rules! impl_specialize {
+    ($ty:tt, $name:ident) => {
+        impl<'a> VectorLikeValueRef<'a> {
+            /// Converts this reference container to a concrete type specialized reference
+            /// container.
+            #[inline]
+            pub fn $name(self) -> VectorLikeValueRefSpecialized<'a, Option<$ty>> {
+                match self {
+                    VectorLikeValueRef::Vector(v) => {
+                        VectorLikeValueRefSpecialized::Vector(v.as_ref())
+                    }
+                    VectorLikeValueRef::Scalar(s) => {
+                        VectorLikeValueRefSpecialized::Scalar(s.as_ref())
+                    }
+                }
+            }
+        }
+
+        impl<'a> From<VectorLikeValueRef<'a>> for VectorLikeValueRefSpecialized<'a, Option<$ty>> {
+            #[inline]
+            fn from(v: VectorLikeValueRef<'a>) -> Self {
+                v.$name()
+            }
+        }
+    };
+}
+
+impl_specialize! { Int, specialize_as_int }
+impl_specialize! { Real, specialize_as_real }
+impl_specialize! { Decimal, specialize_as_decimal }
+impl_specialize! { Bytes, specialize_as_bytes }
+impl_specialize! { DateTime, specialize_as_date_time }
+impl_specialize! { Duration, specialize_as_duration }
+impl_specialize! { Json, specialize_as_json }
+
+/// A concrete eval type specialized vector-like value reference container.
+///
+/// Vector-like: This type contains either a concrete vector reference or a concrete scalar
+/// reference. When inner reference is a concrete scalar value, it acts like a concrete vector that
+/// containing arbitrary amount of same elements.
+///
+/// When the concrete type of `VectorLikeValueRef` is known, it can be converted (specialized) into
+/// this type so that repeated access over this type later won't pay for type checks.
+#[derive(Copy, Clone)]
+pub enum VectorLikeValueRefSpecialized<'a, T> {
+    Vector(&'a [T]),
+    Scalar(&'a T),
+}
+
+impl<'a, T> Index<usize> for VectorLikeValueRefSpecialized<'a, T> {
+    type Output = T;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        match self {
+            VectorLikeValueRefSpecialized::Vector(ref v) => &v[index],
+            VectorLikeValueRefSpecialized::Scalar(ref v) => &v,
+        }
+    }
+}

--- a/src/coprocessor/codec/mysql/decimal.rs
+++ b/src/coprocessor/codec/mysql/decimal.rs
@@ -1791,6 +1791,13 @@ impl Display for Decimal {
     }
 }
 
+impl crate::coprocessor::codec::data_type::AsMySQLBool for Decimal {
+    #[inline]
+    fn as_mysql_bool(&self) -> bool {
+        self.as_f64().unwrap_or(0.0).round() != 0f64
+    }
+}
+
 macro_rules! write_u8 {
     ($writer:ident, $b:expr, $written:ident) => {{
         let mut b = $b;

--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -327,6 +327,13 @@ impl Duration {
     }
 }
 
+impl crate::coprocessor::codec::data_type::AsMySQLBool for Duration {
+    #[inline]
+    fn as_mysql_bool(&self) -> bool {
+        !self.is_zero()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/coprocessor/codec/mysql/json/mod.rs
+++ b/src/coprocessor/codec/mysql/json/mod.rs
@@ -95,6 +95,14 @@ pub fn json_object(kvs: Vec<Datum>) -> Result<Json> {
     Ok(Json::Object(map))
 }
 
+impl crate::coprocessor::codec::data_type::AsMySQLBool for Json {
+    #[inline]
+    fn as_mysql_bool(&self) -> bool {
+        // FIXME: Is it correct?
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -907,6 +907,13 @@ impl Time {
     }
 }
 
+impl crate::coprocessor::codec::data_type::AsMySQLBool for Time {
+    #[inline]
+    fn as_mysql_bool(&self) -> bool {
+        !self.is_zero()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

AsMySQLBool is a newly added trait that provides interface "as_mysql_bool" for different data types. For selection, we need predicates which is bools from arbitrary data types. This is where AsMySQLBool will be used.

This PR also carries some other data structures needed by vectorization framework, like `Evaluable`.

This is extracted from #3898.

- [x] Merge #4320 first.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)
