### PR TITLE
Export jemalloc stats to prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,15 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "jemalloc-ctl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jemalloc-sys"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,6 +2115,8 @@ dependencies = [
 name = "tikv_alloc"
 version = "0.1.0"
 dependencies = [
+ "jemalloc-ctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2615,6 +2626,7 @@ dependencies = [
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itertools-num 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d78fa608383e6e608ba36f962ac991d5d6878d7203eb93b4711b14fa6717813"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
+"checksum jemalloc-ctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e93b0f37e7d735c6b610176d5b1bde8e1621ff3f6f7ac23cdfa4e7f7d0111b5"
 "checksum jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "bfc62c8e50e381768ce8ee0428ee53741929f7ebd73e4d83f669bcf7693e00ae"
 "checksum jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0cd42ac65f758063fea55126b0148b1ce0a6354ff78e07a4d6806bc65c4ab3"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/components/tikv_alloc/Cargo.toml
+++ b/components/tikv_alloc/Cargo.toml
@@ -23,7 +23,13 @@ log = "0.3"
 tempdir = "0.3"
 
 [dependencies.jemallocator]
+version = "0.1.9"
 optional = true
 features = ["unprefixed_malloc_on_supported_platforms"]
-version = "0.1.9"
 
+[dependencies.jemalloc-sys]
+version = "0.1.8"
+features = ["stats"]
+
+[dependencies.jemalloc-ctl]
+version = "0.2.0"

--- a/components/tikv_alloc/src/lib.rs
+++ b/components/tikv_alloc/src/lib.rs
@@ -109,9 +109,10 @@ pub use self::imp::*;
 // The implementation of this crate when jemalloc is turned on
 #[cfg(all(unix, not(fuzzing), not(feature = "no-jemalloc")))]
 mod imp {
+    use jemalloc_ctl::{stats, Epoch as JeEpoch};
     use jemallocator::ffi::malloc_stats_print;
     use libc::{self, c_char, c_void};
-    use std::{ptr, slice};
+    use std::{io, ptr, slice};
 
     pub use self::profiling::dump_prof;
 
@@ -125,6 +126,29 @@ mod imp {
             )
         }
         String::from_utf8_lossy(&buf).into_owned()
+    }
+
+    pub struct JemallocStats {
+        pub allocated: usize,
+        pub active: usize,
+        pub metadata: usize,
+        pub resident: usize,
+        pub mapped: usize,
+        pub retained: usize,
+    }
+
+    pub fn fetch_stats() -> io::Result<JemallocStats> {
+        // Stats are cached. Need to advance epoch to refresh.
+        JeEpoch::new()?.advance()?;
+
+        Ok(JemallocStats {
+            allocated: stats::allocated()?,
+            active: stats::active()?,
+            metadata: stats::metadata()?,
+            resident: stats::resident()?,
+            mapped: stats::mapped()?,
+            retained: stats::retained()?,
+        })
     }
 
     #[allow(clippy::cast_ptr_alignment)]

--- a/src/bin/util/setup.rs
+++ b/src/bin/util/setup.rs
@@ -68,6 +68,8 @@ pub fn initial_logger(config: &TiKvConfig) {
 pub fn initial_metric(cfg: &MetricConfig, node_id: Option<u64>) {
     util::metrics::monitor_threads("tikv")
         .unwrap_or_else(|e| fatal!("failed to start monitor thread: {}", e));
+    util::metrics::monitor_jemalloc_stats("tikv")
+        .unwrap_or_else(|e| fatal!("failed to monitor jemalloc stats: {}", e));
 
     if cfg.interval.as_secs() == 0 || cfg.address.is_empty() {
         return;

--- a/src/util/metrics/jemalloc_metrics.rs
+++ b/src/util/metrics/jemalloc_metrics.rs
@@ -1,0 +1,70 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use prometheus::core::{Collector, Desc};
+use prometheus::proto::MetricFamily;
+use prometheus::{IntGaugeVec, Opts, Result};
+
+use tikv_alloc;
+
+pub fn monitor_jemalloc_stats<S: Into<String>>(namespace: S) -> Result<()> {
+    prometheus::register(Box::new(JemallocStatsCollector::new(namespace)?))
+}
+
+struct JemallocStatsCollector {
+    descs: Vec<Desc>,
+    metrics: IntGaugeVec,
+}
+
+impl JemallocStatsCollector {
+    fn new<S: Into<String>>(namespace: S) -> Result<JemallocStatsCollector> {
+        let stats = IntGaugeVec::new(
+            Opts::new("jemalloc_stats", "Jemalloc stats").namespace(namespace.into()),
+            &["type"],
+        )?;
+        Ok(JemallocStatsCollector {
+            descs: stats.desc().into_iter().cloned().collect(),
+            metrics: stats,
+        })
+    }
+}
+
+impl Collector for JemallocStatsCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        self.descs.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        if let Ok(stats) = tikv_alloc::fetch_stats() {
+            self.metrics
+                .with_label_values(&["allocated"])
+                .set(stats.allocated as i64);
+            self.metrics
+                .with_label_values(&["active"])
+                .set(stats.active as i64);
+            self.metrics
+                .with_label_values(&["metadata"])
+                .set(stats.metadata as i64);
+            self.metrics
+                .with_label_values(&["resident"])
+                .set(stats.resident as i64);
+            self.metrics
+                .with_label_values(&["mapped"])
+                .set(stats.mapped as i64);
+            self.metrics
+                .with_label_values(&["retained"])
+                .set(stats.retained as i64);
+        }
+        self.metrics.collect()
+    }
+}

--- a/src/util/metrics/mod.rs
+++ b/src/util/metrics/mod.rs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod jemalloc_metrics;
+
 use std::thread;
 use std::time::Duration;
 
@@ -25,6 +27,9 @@ pub use self::threads_linux::{cpu_total, get_thread_ids, monitor_threads};
 mod threads_dummy;
 #[cfg(not(target_os = "linux"))]
 pub use self::threads_dummy::monitor_threads;
+
+#[cfg(all(unix, not(fuzzing), not(feature = "no-jemalloc")))]
+pub use self::jemalloc_metrics::monitor_jemalloc_stats;
 
 /// Runs a background Prometheus client.
 pub fn run_prometheus(


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
Exporting 6 jemalloc stats to prometheus. Details of these counters can be found in http://jemalloc.net/jemalloc.3.html (search for, e.g. "stats.allocated"). Rough meaning of them are:
* allocated: how much memory user code (the whole tikv in this case) requested.
* active: how much jemalloc allocated to satisfy the allocation requests (because jemalloc has size classes, e.g. user request for 3.9k memory, and the closest size class is 4k, so jemalloc end up allocate 4k).
* metadata: extra usage by jemalloc itself, e.g. to keep track of allocation size of each item
* resident: close to actual memory used by jemalloc.

These counters should be useful to monitor jemalloc memory fragmentation ratio.

## What are the type of the changes? (mandatory)
Improvement

## How has this PR been tested? (mandatory)
Run the code in IDC.
Grafana snapshot:
<img width="1953" alt="screen shot 2019-03-07 at 10 21 24 pm" src="https://user-images.githubusercontent.com/2606959/54012068-a50bf680-4129-11e9-9e94-09c3aae55bc3.png">

## Does this PR affect documentation (docs) update? (mandatory)
Not sure if we document exported metrics.

## Does this PR affect tidb-ansible update? (mandatory)
No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

