### PR TITLE
import: increase default region-split-size to 512 MiB

### DIFF
--- a/etc/tikv-importer.toml
+++ b/etc/tikv-importer.toml
@@ -46,7 +46,7 @@ num-import-jobs = 24
 # maximum duration to prepare regions.
 # max-prepare-duration = "5m"
 # split regions into this size according to the importing data.
-# region-split-size = "96MB"
+# region-split-size = "512MB"
 # stream channel window size, stream will be blocked on channel full.
 # stream-channel-window = 128
 # maximum number of open engines

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -14,7 +14,6 @@
 use std::error::Error;
 use std::result::Result;
 
-use crate::raftstore::coprocessor::config::SPLIT_SIZE_MB;
 use crate::util::config::{ReadableDuration, ReadableSize};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -39,7 +38,7 @@ impl Default for Config {
             num_import_jobs: 8,
             num_import_sst_jobs: 2,
             max_prepare_duration: ReadableDuration::minutes(5),
-            region_split_size: ReadableSize::mb(SPLIT_SIZE_MB),
+            region_split_size: ReadableSize::mb(512),
             stream_channel_window: 128,
             max_open_engines: 8,
         }


### PR DESCRIPTION
Signed-off-by: kennytm <kennytm@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This makes the SST size to upload larger, which reduces the number of SST
files needed to ingested, and improve overall speed.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Tested manually using a data set with size 6.5 TB

## Does this PR affect documentation (docs) update? (mandatory)

No (config for importer isn't documented in this repo 🤔)

## Does this PR affect tidb-ansible update? (mandatory)

Yes (will be filed separately, together with Lightning changes)

## Refer to a related PR or issue link (optional)

Part 1/7 split off from #4245

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

