### PR TITLE
import: fix #4257, restrict memory usage by RocksDB

### DIFF
--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -292,7 +292,10 @@ fn tune_dboptions_for_bulk_load(opts: &DbConfig) -> (DBOptions, CFOptions) {
     // RocksDB preserves `max_background_jobs/4` for flush.
     db_opts.set_max_background_jobs(opts.max_background_jobs);
 
-    let block_base_opts = BlockBasedOptions::new();
+    // Put index and filter in block cache to restrict memory usage.
+    let mut block_base_opts = BlockBasedOptions::new();
+    block_base_opts.set_lru_cache(128 * MB as usize, -1, 0, 0.0);
+    block_base_opts.set_cache_index_and_filter_blocks(true);
     let mut cf_opts = ColumnFamilyOptions::new();
     cf_opts.set_block_based_table_factory(&block_base_opts);
     cf_opts.compression_per_level(&opts.defaultcf.compression_per_level);

--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -292,9 +292,7 @@ fn tune_dboptions_for_bulk_load(opts: &DbConfig) -> (DBOptions, CFOptions) {
     // RocksDB preserves `max_background_jobs/4` for flush.
     db_opts.set_max_background_jobs(opts.max_background_jobs);
 
-    let mut block_base_opts = BlockBasedOptions::new();
-    // Use a large block size for sequential access.
-    block_base_opts.set_block_size(MB as usize);
+    let block_base_opts = BlockBasedOptions::new();
     let mut cf_opts = ColumnFamilyOptions::new();
     cf_opts.set_block_based_table_factory(&block_base_opts);
     cf_opts.compression_per_level(&opts.defaultcf.compression_per_level);


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Before this PR, the block size is very large, causing too much memory to be consumed for each iterator. The approximate size was 1 MB × number of files in L0 (829 for a 703 GB engine file) × number of import jobs (32).

This PR removes the block size setting to reduce the memory usage.


## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Tested manually using a data set with size 6.5 TB

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

Part 5/7 split off from #4245.

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

