### PR TITLE
Cherry-pick 4 PRs related to tikv-importer to release-2.1

### DIFF
--- a/etc/tikv-importer.toml
+++ b/etc/tikv-importer.toml
@@ -46,7 +46,7 @@ num-import-jobs = 24
 # maximum duration to prepare regions.
 # max-prepare-duration = "5m"
 # split regions into this size according to the importing data.
-# region-split-size = "96MB"
+# region-split-size = "512MB"
 # stream channel window size, stream will be blocked on channel full.
 # stream-channel-window = 128
 # maximum number of open engines

--- a/src/import/client.rs
+++ b/src/import/client.rs
@@ -52,6 +52,10 @@ pub trait ImportClient: Send + Sync + Clone + 'static {
     fn ingest_sst(&self, _: u64, _: IngestRequest) -> Result<IngestResponse> {
         unimplemented!()
     }
+
+    fn has_region_id(&self, _: u64) -> Result<bool> {
+        unimplemented!()
+    }
 }
 
 pub struct Client {
@@ -208,6 +212,10 @@ impl ImportClient for Client {
         let client = ImportSstClient::new(ch);
         let res = client.ingest_opt(&req, self.option(Duration::from_secs(30)));
         self.post_resolve(store_id, res.map_err(Error::from))
+    }
+
+    fn has_region_id(&self, id: u64) -> Result<bool> {
+        Ok(self.pd.get_region_by_id(id).wait()?.is_some())
     }
 }
 

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -14,7 +14,6 @@
 use std::error::Error;
 use std::result::Result;
 
-use raftstore::coprocessor::config::SPLIT_SIZE_MB;
 use util::config::{ReadableDuration, ReadableSize};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -39,7 +38,7 @@ impl Default for Config {
             num_import_jobs: 8,
             num_import_sst_jobs: 2,
             max_prepare_duration: ReadableDuration::minutes(5),
-            region_split_size: ReadableSize::mb(SPLIT_SIZE_MB),
+            region_split_size: ReadableSize::mb(512),
             stream_channel_window: 128,
             max_open_engines: 8,
         }

--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -257,9 +257,10 @@ fn tune_dboptions_for_bulk_load(opts: &DbConfig) -> (DBOptions, CFOptions) {
     // RocksDB preserves `max_background_jobs/4` for flush.
     db_opts.set_max_background_jobs(opts.max_background_jobs);
 
+    // Put index and filter in block cache to restrict memory usage.
     let mut block_base_opts = BlockBasedOptions::new();
-    // Use a large block size for sequential access.
-    block_base_opts.set_block_size(MB as usize);
+    block_base_opts.set_lru_cache(128 * MB as usize, -1, 0, 0.0);
+    block_base_opts.set_cache_index_and_filter_blocks(true);
     let mut cf_opts = ColumnFamilyOptions::new();
     cf_opts.set_block_based_table_factory(&block_base_opts);
     cf_opts.compression_per_level(&opts.defaultcf.compression_per_level);

--- a/src/import/test_helpers.rs
+++ b/src/import/test_helpers.rs
@@ -162,4 +162,9 @@ impl ImportClient for MockClient {
         regions.insert(region.get_id(), region.region.clone());
         Ok(())
     }
+
+    fn has_region_id(&self, region_id: u64) -> Result<bool> {
+        let regions = self.regions.lock().unwrap();
+        Ok(regions.contains_key(&region_id))
+    }
 }


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>
Signed-off-by: kennytm <kennytm@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Cherry-picks the following 4 PRs for 2.1.6 release:

* #4347 (increase default region-split-size to 512 MiB)
* #4348 (store intermediate SST files on disk instead of memory)
* #4350 (restrict memory usage by RocksDB)
* #4352 (wait after split before scatter)

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)
- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Tested manually using a data set with size 6.5 TB

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

Yes (will be filed separately, together with Lightning changes)

## Refer to a related PR or issue link (optional)

See above

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

