### PR TITLE
remove unnecessary Copy trait of Tz and EvalConfig

### DIFF
--- a/fuzz/targets/mod.rs
+++ b/fuzz/targets/mod.rs
@@ -198,7 +198,7 @@ pub fn fuzz_coprocessor_codec_time_from_parse(data: &[u8]) -> Result<(), Error> 
     let fsp = cursor.read_as_i8()?;
     let mut buf: [u8; 32] = [b' '; 32];
     cursor.read_exact(&mut buf)?;
-    let t = Time::parse_datetime(::std::str::from_utf8(&buf)?, fsp, tz)?;
+    let t = Time::parse_datetime(::std::str::from_utf8(&buf)?, fsp, &tz)?;
     fuzz_time(t, cursor)
 }
 
@@ -209,6 +209,6 @@ pub fn fuzz_coprocessor_codec_time_from_u64(data: &[u8]) -> Result<(), Error> {
     let time_type = cursor.read_as_time_type()?;
     let tz = Tz::from_offset(cursor.read_as_i64()?).unwrap_or_else(Tz::utc);
     let fsp = cursor.read_as_i8()?;
-    let t = Time::from_packed_u64(u, time_type, fsp, tz)?;
+    let t = Time::from_packed_u64(u, time_type, fsp, &tz)?;
     fuzz_time(t, cursor)
 }

--- a/src/coprocessor/codec/batch/lazy_column.rs
+++ b/src/coprocessor/codec/batch/lazy_column.rs
@@ -190,7 +190,7 @@ impl LazyBatchColumn {
     /// The field type is needed because we use the same `DateTime` structure when handling
     /// Date, Time or Timestamp.
     // TODO: Maybe it's a better idea to assign different eval types for different date types.
-    pub fn decode(&mut self, time_zone: Tz, field_type: &FieldType) -> Result<()> {
+    pub fn decode(&mut self, time_zone: &Tz, field_type: &FieldType) -> Result<()> {
         if self.is_decoded() {
             return Ok(());
         }
@@ -311,7 +311,7 @@ mod tests {
         {
             // Empty raw to empty decoded.
             let mut col = col.clone();
-            col.decode(Tz::utc(), &ft).unwrap();
+            col.decode(&Tz::utc(), &ft).unwrap();
             assert!(col.is_decoded());
             assert_eq!(col.len(), 0);
             assert_eq!(col.capacity(), 5);
@@ -351,7 +351,7 @@ mod tests {
             assert_eq!(col.raw()[1].as_slice(), datum_raw_2.as_slice());
         }
         // Non-empty raw to non-empty decoded.
-        col.decode(Tz::utc(), &ft).unwrap();
+        col.decode(&Tz::utc(), &ft).unwrap();
         assert!(col.is_decoded());
         assert_eq!(col.len(), 2);
         assert_eq!(col.capacity(), 5);
@@ -480,7 +480,7 @@ mod benches {
         ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
         let tz = Tz::utc();
 
-        column.decode(tz, &ft).unwrap();
+        column.decode(&tz, &ft).unwrap();
 
         b.iter(|| {
             test::black_box(test::black_box(&column).clone());
@@ -510,7 +510,7 @@ mod benches {
 
         b.iter(|| {
             let mut col = test::black_box(&column).clone();
-            col.decode(test::black_box(tz), test::black_box(&ft))
+            col.decode(test::black_box(&tz), test::black_box(&ft))
                 .unwrap();
             test::black_box(&col);
         });
@@ -537,11 +537,11 @@ mod benches {
         ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
         let tz = Tz::utc();
 
-        column.decode(tz, &ft).unwrap();
+        column.decode(&tz, &ft).unwrap();
 
         b.iter(|| {
             let mut col = test::black_box(&column).clone();
-            col.decode(test::black_box(tz), test::black_box(&ft))
+            col.decode(test::black_box(&tz), test::black_box(&ft))
                 .unwrap();
             test::black_box(&col);
         });

--- a/src/coprocessor/codec/batch/lazy_column_vec.rs
+++ b/src/coprocessor/codec/batch/lazy_column_vec.rs
@@ -72,7 +72,7 @@ impl LazyBatchColumnVec {
     pub fn ensure_column_decoded(
         &mut self,
         column_index: usize,
-        time_zone: Tz,
+        time_zone: &Tz,
         field_type: &FieldType,
     ) -> Result<&VectorValue> {
         let number_of_rows = self.rows_len();
@@ -289,7 +289,7 @@ mod tests {
             assert!(!columns.is_column_decoded(2));
             {
                 let col = columns
-                    .ensure_column_decoded(2, Tz::utc(), &schema[2])
+                    .ensure_column_decoded(2, &Tz::utc(), &schema[2])
                     .unwrap();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Bytes);
@@ -299,7 +299,7 @@ mod tests {
             assert!(columns.is_column_decoded(2));
             {
                 let col = columns
-                    .ensure_column_decoded(2, Tz::utc(), &schema[2])
+                    .ensure_column_decoded(2, &Tz::utc(), &schema[2])
                     .unwrap();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Bytes);
@@ -311,7 +311,7 @@ mod tests {
             assert!(!columns.is_column_decoded(0));
             {
                 let col = columns
-                    .ensure_column_decoded(0, Tz::utc(), &schema[0])
+                    .ensure_column_decoded(0, &Tz::utc(), &schema[0])
                     .unwrap();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Int);
@@ -323,7 +323,7 @@ mod tests {
             assert!(!columns.is_column_decoded(1));
             {
                 let col = columns
-                    .ensure_column_decoded(1, Tz::utc(), &schema[1])
+                    .ensure_column_decoded(1, &Tz::utc(), &schema[1])
                     .unwrap();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Real);
@@ -381,7 +381,7 @@ mod tests {
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(Tz::utc(), &schema[0]).unwrap();
+            column0.decode(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 3);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(column0.decoded().as_int_slice(), &[None, None, Some(11)]);
@@ -389,7 +389,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(Tz::utc(), &schema[1]).unwrap();
+            column1.decode(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 3);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -408,7 +408,7 @@ mod tests {
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(Tz::utc(), &schema[0]).unwrap();
+            column0.decode(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 7);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(
@@ -419,7 +419,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(Tz::utc(), &schema[1]).unwrap();
+            column1.decode(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 7);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -444,7 +444,7 @@ mod tests {
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(Tz::utc(), &schema[0]).unwrap();
+            column0.decode(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 4);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(
@@ -455,7 +455,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(Tz::utc(), &schema[1]).unwrap();
+            column1.decode(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 4);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -471,7 +471,7 @@ mod tests {
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(Tz::utc(), &schema[0]).unwrap();
+            column0.decode(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 4);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(
@@ -482,7 +482,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(Tz::utc(), &schema[1]).unwrap();
+            column1.decode(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 4);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -498,7 +498,7 @@ mod tests {
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(Tz::utc(), &schema[0]).unwrap();
+            column0.decode(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 0);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(column0.decoded().as_int_slice(), &[]);
@@ -506,7 +506,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(Tz::utc(), &schema[1]).unwrap();
+            column1.decode(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 0);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(column1.decoded().as_real_slice(), &[]);
@@ -521,7 +521,7 @@ mod tests {
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(Tz::utc(), &schema[0]).unwrap();
+            column0.decode(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 3);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(column0.decoded().as_int_slice(), &[None, Some(5), Some(1)]);
@@ -529,7 +529,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(Tz::utc(), &schema[1]).unwrap();
+            column1.decode(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 3);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -540,7 +540,7 @@ mod tests {
 
         // Let's change a column from lazy to decoded and test whether retain works
         columns
-            .ensure_column_decoded(0, Tz::utc(), &schema[0])
+            .ensure_column_decoded(0, &Tz::utc(), &schema[0])
             .unwrap();
 
         columns.retain_rows_by_index(|_| true);
@@ -557,7 +557,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(Tz::utc(), &schema[1]).unwrap();
+            column1.decode(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 3);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -581,7 +581,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(Tz::utc(), &schema[1]).unwrap();
+            column1.decode(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 2);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(column1.decoded().as_real_slice(), &[Some(7.77), Some(7.17)]);
@@ -601,7 +601,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(Tz::utc(), &schema[1]).unwrap();
+            column1.decode(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 0);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(column1.decoded().as_real_slice(), &[]);

--- a/src/coprocessor/codec/data_type/vector.rs
+++ b/src/coprocessor/codec/data_type/vector.rs
@@ -261,7 +261,7 @@ impl VectorValue {
     pub fn push_datum(
         &mut self,
         mut raw_datum: &[u8],
-        time_zone: Tz,
+        time_zone: &Tz,
         field_type: &FieldType,
     ) -> Result<()> {
         #[inline]
@@ -328,7 +328,7 @@ impl VectorValue {
         #[inline]
         fn decode_date_time_from_uint(
             v: u64,
-            time_zone: Tz,
+            time_zone: &Tz,
             field_type: &FieldType,
         ) -> Result<DateTime> {
             let fsp = field_type.decimal() as i8;
@@ -966,7 +966,7 @@ mod benches {
                 column
                     .push_datum(
                         test::black_box(&datum_raw),
-                        test::black_box(tz),
+                        test::black_box(&tz),
                         test::black_box(&field_type),
                     )
                     .unwrap();

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -207,7 +207,7 @@ impl Datum {
             }
             Datum::Time(ref t) => {
                 let s = str::from_utf8(bs)?;
-                let t2 = Time::parse_datetime(s, DEFAULT_FSP, ctx.cfg.tz)?;
+                let t2 = Time::parse_datetime(s, DEFAULT_FSP, &ctx.cfg.tz)?;
                 Ok(t.cmp(&t2))
             }
             Datum::Dur(ref d) => {
@@ -251,7 +251,7 @@ impl Datum {
         match *self {
             Datum::Bytes(ref bs) => {
                 let s = str::from_utf8(bs)?;
-                let t = Time::parse_datetime(s, DEFAULT_FSP, ctx.cfg.tz)?;
+                let t = Time::parse_datetime(s, DEFAULT_FSP, &ctx.cfg.tz)?;
                 Ok(t.cmp(time))
             }
             Datum::Time(ref t) => Ok(t.cmp(time)),

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -70,19 +70,19 @@ const MONTH_NAMES_ABBR: &[&str] = &[
 ];
 
 #[inline]
-fn zero_time(tz: Tz) -> DateTime<Tz> {
+fn zero_time(tz: &Tz) -> DateTime<Tz> {
     tz.timestamp(ZERO_TIMESTAMP, 0)
 }
 
 #[inline]
-pub fn zero_datetime(tz: Tz) -> Time {
+pub fn zero_datetime(tz: &Tz) -> Time {
     Time::new(zero_time(tz), TimeType::DateTime, mysql::DEFAULT_FSP).unwrap()
 }
 
 #[allow(clippy::too_many_arguments)]
 #[inline]
 fn ymd_hms_nanos<T: TimeZone>(
-    tz: T,
+    tz: &T,
     year: i32,
     month: u32,
     day: u32,
@@ -341,22 +341,22 @@ impl Time {
     }
 
     pub fn parse_utc_datetime(s: &str, fsp: i8) -> Result<Time> {
-        Time::parse_datetime(s, fsp, Tz::utc())
+        Time::parse_datetime(s, fsp, &Tz::utc())
     }
 
     pub fn parse_utc_datetime_from_float_string(s: &str, fsp: i8) -> Result<Time> {
-        Time::parse_datetime_from_float_string(s, fsp, Tz::utc())
+        Time::parse_datetime_from_float_string(s, fsp, &Tz::utc())
     }
 
-    pub fn parse_datetime(s: &str, fsp: i8, tz: Tz) -> Result<Time> {
+    pub fn parse_datetime(s: &str, fsp: i8, tz: &Tz) -> Result<Time> {
         Time::parse_datetime_internal(s, fsp, tz, false)
     }
 
-    pub fn parse_datetime_from_float_string(s: &str, fsp: i8, tz: Tz) -> Result<Time> {
+    pub fn parse_datetime_from_float_string(s: &str, fsp: i8, tz: &Tz) -> Result<Time> {
         Time::parse_datetime_internal(s, fsp, tz, true)
     }
 
-    fn parse_datetime_internal(s: &str, fsp: i8, tz: Tz, is_float: bool) -> Result<Time> {
+    fn parse_datetime_internal(s: &str, fsp: i8, tz: &Tz, is_float: bool) -> Result<Time> {
         let fsp = mysql::check_fsp(fsp)?;
         let mut need_adjust = false;
         let mut has_hhmmss = false;
@@ -456,7 +456,7 @@ impl Time {
     /// Get time from packed u64. When `tp` is `TIMESTAMP`, the packed time should
     /// be a UTC time; otherwise the packed time should be in the same timezone as `tz`
     /// specified.
-    pub fn from_packed_u64(u: u64, time_type: TimeType, fsp: i8, tz: Tz) -> Result<Time> {
+    pub fn from_packed_u64(u: u64, time_type: TimeType, fsp: i8, tz: &Tz) -> Result<Time> {
         if u == 0 {
             return Time::new(zero_time(tz), time_type, fsp);
         }
@@ -473,7 +473,7 @@ impl Time {
         let hour = (hms >> 12) as u32;
         let nanosec = ((u & ((1 << 24) - 1)) * 1000) as u32;
         let t = if time_type == TimeType::Timestamp {
-            let t = ymd_hms_nanos(Utc, year, month, day, hour, minute, second, nanosec)?;
+            let t = ymd_hms_nanos(&Utc, year, month, day, hour, minute, second, nanosec)?;
             tz.from_utc_datetime(&t.naive_utc())
         } else {
             ymd_hms_nanos(tz, year, month, day, hour, minute, second, nanosec)?
@@ -481,10 +481,10 @@ impl Time {
         Time::new(t, time_type, fsp as i8)
     }
 
-    pub fn from_duration(tz: Tz, time_type: TimeType, d: &MyDuration) -> Result<Time> {
+    pub fn from_duration(tz: &Tz, time_type: TimeType, d: &MyDuration) -> Result<Time> {
         let dur = Duration::nanoseconds(d.to_nanos());
         let t = Utc::now()
-            .with_timezone(&tz)
+            .with_timezone(tz)
             .date()
             .and_hms(0, 0, 0) // TODO: might panic!
             .checked_add_signed(dur);
@@ -886,14 +886,14 @@ impl Time {
             && second == 0
             && nanoseconds == 0
         {
-            return Ok(zero_datetime(tz));
+            return Ok(zero_datetime(&tz));
         }
         let t = if tp == FieldTypeTp::Timestamp {
-            let t = ymd_hms_nanos(Utc, year, month, day, hour, minute, second, nanoseconds)?;
+            let t = ymd_hms_nanos(&Utc, year, month, day, hour, minute, second, nanoseconds)?;
             tz.from_utc_datetime(&t.naive_utc())
         } else {
             ymd_hms_nanos(
-                Tz::utc(),
+                &Tz::utc(),
                 year,
                 month,
                 day,
@@ -1021,7 +1021,7 @@ mod tests {
             assert_eq!(format!("{}", utc_t), exp);
 
             for_each_tz(move |tz, offset| {
-                let t = Time::parse_datetime(input, fsp, tz).unwrap();
+                let t = Time::parse_datetime(input, fsp, &tz).unwrap();
                 if utc_t.is_zero() {
                     assert_eq!(t, utc_t);
                 } else {
@@ -1083,7 +1083,7 @@ mod tests {
 
         for t in fail_tbl {
             let tz = Tz::utc();
-            assert!(Time::parse_datetime(t, 0, tz).is_err(), t);
+            assert!(Time::parse_datetime(t, 0, &tz).is_err(), t);
         }
     }
 
@@ -1109,7 +1109,7 @@ mod tests {
 
         for (tz_name, time_str, utc_timestamp) in ok_tables {
             let tz = Tz::from_tz_name(tz_name).unwrap();
-            let t = Time::parse_datetime(time_str, UNSPECIFIED_FSP, tz).unwrap();
+            let t = Time::parse_datetime(time_str, UNSPECIFIED_FSP, &tz).unwrap();
             assert_eq!(t.time.timestamp(), utc_timestamp);
         }
 
@@ -1127,7 +1127,7 @@ mod tests {
 
         for (tz_name, time_str) in fail_tables {
             let tz = Tz::from_tz_name(tz_name).unwrap();
-            assert!(Time::parse_datetime(time_str, UNSPECIFIED_FSP, tz).is_err());
+            assert!(Time::parse_datetime(time_str, UNSPECIFIED_FSP, &tz).is_err());
         }
     }
 
@@ -1167,7 +1167,7 @@ mod tests {
                 if let Some(local_time) = local_time {
                     let time_str =
                         format!("{}-{}-{} {}:{}:{}", year, month, day, hour, minute, second);
-                    let t = Time::parse_datetime(&time_str, UNSPECIFIED_FSP, *tz).unwrap();
+                    let t = Time::parse_datetime(&time_str, UNSPECIFIED_FSP, tz).unwrap();
                     assert_eq!(t.time, local_time);
                 }
             }
@@ -1187,15 +1187,15 @@ mod tests {
         ];
         for (s, fsp) in cases {
             for_each_tz(move |tz, offset| {
-                let t = Time::parse_datetime(s, fsp, tz).unwrap();
+                let t = Time::parse_datetime(s, fsp, &tz).unwrap();
                 let packed = t.to_packed_u64();
                 let reverted_datetime =
-                    Time::from_packed_u64(packed, TimeType::DateTime, fsp, tz).unwrap();
+                    Time::from_packed_u64(packed, TimeType::DateTime, fsp, &tz).unwrap();
                 assert_eq!(reverted_datetime, t);
                 assert_eq!(reverted_datetime.to_packed_u64(), packed);
 
                 let reverted_timestamp =
-                    Time::from_packed_u64(packed, TimeType::Timestamp, fsp, tz).unwrap();
+                    Time::from_packed_u64(packed, TimeType::Timestamp, fsp, &tz).unwrap();
                 assert_eq!(
                     reverted_timestamp.time,
                     reverted_datetime.time + Duration::seconds(offset)
@@ -1246,11 +1246,11 @@ mod tests {
 
         for (t_str, fsp, datetime_dec, date_dec) in cases {
             for_each_tz(move |tz, _offset| {
-                let mut t = Time::parse_datetime(t_str, fsp, tz).unwrap();
+                let mut t = Time::parse_datetime(t_str, fsp, &tz).unwrap();
                 let mut res = format!("{}", t.to_decimal().unwrap());
                 assert_eq!(res, datetime_dec);
 
-                t = Time::parse_datetime(t_str, 0, tz).unwrap();
+                t = Time::parse_datetime(t_str, 0, &tz).unwrap();
                 t.set_time_type(TimeType::Date).unwrap();
                 res = format!("{}", t.to_decimal().unwrap());
                 assert_eq!(res, date_dec);
@@ -1286,8 +1286,8 @@ mod tests {
 
         for (l, r, exp) in cases {
             for_each_tz(move |tz, _offset| {
-                let l_t = Time::parse_datetime(l, MAX_FSP, tz).unwrap();
-                let r_t = Time::parse_datetime(r, MAX_FSP, tz).unwrap();
+                let l_t = Time::parse_datetime(l, MAX_FSP, &tz).unwrap();
+                let r_t = Time::parse_datetime(r, MAX_FSP, &tz).unwrap();
                 assert_eq!(exp, l_t.cmp(&r_t));
             });
         }
@@ -1398,9 +1398,9 @@ mod tests {
             );
 
             for_each_tz(move |tz, offset| {
-                let mut t = Time::parse_datetime(input, UNSPECIFIED_FSP, tz).unwrap();
+                let mut t = Time::parse_datetime(input, UNSPECIFIED_FSP, &tz).unwrap();
                 t.round_frac(fsp).unwrap();
-                let expect = Time::parse_datetime(exp, UNSPECIFIED_FSP, tz).unwrap();
+                let expect = Time::parse_datetime(exp, UNSPECIFIED_FSP, &tz).unwrap();
                 assert_eq!(
                     t, expect,
                     "tz:{:?},input:{:?}, exp:{:?}, utc_t:{:?}, expect:{:?}",
@@ -1434,7 +1434,7 @@ mod tests {
         let tz = Tz::utc();
         for s in cases {
             let d = MyDuration::parse(s.as_bytes(), MAX_FSP).unwrap();
-            let get = Time::from_duration(tz, TimeType::DateTime, &d).unwrap();
+            let get = Time::from_duration(&tz, TimeType::DateTime, &d).unwrap();
             let get_today = get
                 .time
                 .checked_sub_signed(Duration::nanoseconds(d.to_nanos()))

--- a/src/coprocessor/codec/mysql/time/tz.rs
+++ b/src/coprocessor/codec/mysql/time/tz.rs
@@ -19,7 +19,7 @@ use chrono_tz;
 
 /// A time zone represented by either offset (i.e. +8) or name (i.e. Asia/Shanghai). In addition,
 /// local time zone is also valid.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub enum Tz {
     /// A time zone specified by offset seconds.
     Offset(FixedOffset),

--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -218,7 +218,7 @@ fn unflatten(ctx: &EvalContext, datum: Datum, field_type: &dyn FieldTypeAccessor
         FieldTypeTp::Float => Ok(Datum::F64(f64::from(datum.f64() as f32))),
         FieldTypeTp::Date | FieldTypeTp::DateTime | FieldTypeTp::Timestamp => {
             let fsp = field_type.decimal() as i8;
-            let t = Time::from_packed_u64(datum.u64(), tp.try_into()?, fsp, ctx.cfg.tz)?;
+            let t = Time::from_packed_u64(datum.u64(), tp.try_into()?, fsp, &ctx.cfg.tz)?;
             Ok(Datum::Time(t))
         }
         FieldTypeTp::Duration => Duration::from_nanos(datum.i64(), 0).map(Datum::Dur),

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -420,7 +420,7 @@ impl ScalarFunc {
     ) -> Result<Option<Cow<'a, Time>>> {
         let val = try_opt!(self.children[0].eval_duration(ctx, row));
         let mut val =
-            Time::from_duration(ctx.cfg.tz, self.field_type.tp().try_into()?, val.as_ref())?;
+            Time::from_duration(&ctx.cfg.tz, self.field_type.tp().try_into()?, val.as_ref())?;
         val.round_frac(self.field_type.decimal() as i8)?;
         Ok(Some(Cow::Owned(val)))
     }
@@ -690,14 +690,17 @@ impl ScalarFunc {
     }
 
     fn produce_time_with_str(&self, ctx: &mut EvalContext, s: &str) -> Result<Cow<'_, Time>> {
-        let mut t = Time::parse_datetime(s, self.field_type.decimal() as i8, ctx.cfg.tz)?;
+        let mut t = Time::parse_datetime(s, self.field_type.decimal() as i8, &ctx.cfg.tz)?;
         t.set_time_type(self.field_type.tp().try_into()?)?;
         Ok(Cow::Owned(t))
     }
 
     fn produce_time_with_float_str(&self, ctx: &mut EvalContext, s: &str) -> Result<Cow<'_, Time>> {
-        let mut t =
-            Time::parse_datetime_from_float_string(s, self.field_type.decimal() as i8, ctx.cfg.tz)?;
+        let mut t = Time::parse_datetime_from_float_string(
+            s,
+            self.field_type.decimal() as i8,
+            &ctx.cfg.tz,
+        )?;
         t.set_time_type(self.field_type.tp().try_into()?)?;
         Ok(Cow::Owned(t))
     }
@@ -1795,7 +1798,7 @@ mod tests {
         let time = Time::parse_utc_datetime(time_str, mysql::DEFAULT_FSP).unwrap();
         let time_stamp = {
             let t = time.to_packed_u64();
-            Time::from_packed_u64(t, TimeType::Timestamp, mysql::DEFAULT_FSP, tz).unwrap()
+            Time::from_packed_u64(t, TimeType::Timestamp, mysql::DEFAULT_FSP, &tz).unwrap()
         };
         let date = {
             let mut t = time.clone();

--- a/src/coprocessor/dag/expr/builtin_compare.rs
+++ b/src/coprocessor/dag/expr/builtin_compare.rs
@@ -181,11 +181,11 @@ impl ScalarFunc {
         ctx: &mut EvalContext,
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, [u8]>>> {
-        let mut greatest = mysql::time::zero_datetime(ctx.cfg.tz);
+        let mut greatest = mysql::time::zero_datetime(&ctx.cfg.tz);
 
         for exp in &self.children {
             let s = try_opt!(exp.eval_string_and_decode(ctx, row));
-            match Time::parse_datetime(&s, Time::parse_fsp(&s), ctx.cfg.tz) {
+            match Time::parse_datetime(&s, Time::parse_fsp(&s), &ctx.cfg.tz) {
                 Ok(t) => greatest = max(greatest, t),
                 Err(_) => {
                     if let Err(e) = ctx.handle_invalid_time_error(Error::invalid_time_format(&s)) {
@@ -241,7 +241,7 @@ impl ScalarFunc {
 
         for exp in &self.children {
             let s = try_opt!(exp.eval_string_and_decode(ctx, row));
-            match Time::parse_datetime(&s, Time::parse_fsp(&s), ctx.cfg.tz) {
+            match Time::parse_datetime(&s, Time::parse_fsp(&s), &ctx.cfg.tz) {
                 Ok(t) => least = min(least, t),
                 Err(_) => match ctx.handle_invalid_time_error(Error::invalid_time_format(&s)) {
                     Err(e) => return Err(e),

--- a/src/coprocessor/dag/expr/ctx.rs
+++ b/src/coprocessor/dag/expr/ctx.rs
@@ -50,7 +50,7 @@ pub const MODE_ERROR_FOR_DIVISION_BY_ZERO: u64 = 27;
 
 const DEFAULT_MAX_WARNING_CNT: usize = 64;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct EvalConfig {
     /// timezone to use when parse/calculate time.
     pub tz: Tz,

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -262,7 +262,7 @@ impl Expression {
                 .map_err(Error::from)
                 .and_then(|i| {
                     let fsp = field_type.decimal() as i8;
-                    Time::from_packed_u64(i, field_type.tp().try_into()?, fsp, ctx.cfg.tz)
+                    Time::from_packed_u64(i, field_type.tp().try_into()?, fsp, &ctx.cfg.tz)
                 })
                 .map(|t| Expression::new_const(Datum::Time(t), field_type)),
             ExprType::MysqlDuration => number::decode_i64(&mut expr.get_val())


### PR DESCRIPTION
## What have you changed? (mandatory)

Fix issue: https://github.com/tikv/tikv/issues/4341
plenty of functions read `Tz` and use it to construct a correct `Time` by copying them so does `EvalConfig`. No need to copy, just take ownership or use references. But using reference is hard now...
There are too many signatures to modify and it is likely to break lots of API.

## What are the type of changes? (mandatory)
- Improvement (a change which is an improvement to an existing feature)
reduce the number of `Tz` copy in the stack.

## How has this PR been tested? (mandatory)
`make test` already. 