### PR TITLE
Makefile: check sse4.2 only in release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ release:
 	cargo build --release --features "${ENABLE_FEATURES}"
 	@mkdir -p ${BIN_PATH}
 	@cp -f ${CARGO_TARGET_DIR}/release/tikv-ctl ${CARGO_TARGET_DIR}/release/tikv-server ${CARGO_TARGET_DIR}/release/tikv-importer ${BIN_PATH}/
+	bash etc/check-sse4_2.sh
 
 unportable_release:
 	ROCKSDB_SYS_PORTABLE=0 make release
@@ -105,7 +106,6 @@ test:
 		cargo test --features "${ENABLE_FEATURES},mem-profiling" ${EXTRA_CARGO_ARGS} --bin tikv-server -- --nocapture --ignored; \
 	fi
 	bash etc/check-bins-for-jemalloc.sh
-	bash etc/check-sse4_2.sh
 
 bench:
 	LOG_LEVEL=ERROR RUST_BACKTRACE=1 cargo bench --all --features "${ENABLE_FEATURES}" -- --nocapture

--- a/etc/check-sse4_2.sh
+++ b/etc/check-sse4_2.sh
@@ -4,7 +4,8 @@
 # directory enables intel® sse4.2 extensions. It is suitable to run as part of
 # CI.
 
-dirs="./target/debug ./target/release"
+# Check release only.
+dirs="./target/release"
 
 errors=0
 
@@ -20,12 +21,12 @@ echo "checking bins for sse4.2"
 
 for dir in $dirs; do
     for file in $targets; do
-        
+
         dirfile="$dir/$file"
         if [[ -x "$dirfile" && ! -d "$dirfile" ]]; then
-            
+
             echo "checking binary $dirfile for sse4.2"
-            
+
             # RocksDB uses sse4.2 in the `Fast_CRC32` function
             fast_crc32=$(nm "$dirfile" | grep -o " _.*Fast_CRC32.*")
             if [[ ! $fast_crc32 ]]; then
@@ -33,7 +34,7 @@ for dir in $dirs; do
                 errors=1
                 continue
             fi
-            
+
             # Make sure the `Fast_CRC32` uses the sse4.2 instruction `crc32`
             # f2.*0f 38 is the opcode of `crc32`, see Intel® SSE4 Programming Reference
             found=0


### PR DESCRIPTION
## What have you changed? (mandatory)

Check sse4.2 only in the release build, so that `make dev` does not require gdb.

## What are the type of the changes? (mandatory)

- Misc (other changes)

## Refer to a related PR or issue link (optional)

#4330 #4314 
