### PR TITLE
storage/mvcc: Handle collisions between start_ts and commit_ts properly

### DIFF
--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -413,6 +413,7 @@ pub mod tests {
         let (ts, write_type) = reader
             .get_txn_commit_info(&Key::from_raw(key), start_ts)
             .unwrap()
+            .0
             .unwrap();
         assert_ne!(write_type, WriteType::Rollback);
         assert_eq!(ts, commit_ts);
@@ -424,7 +425,7 @@ pub mod tests {
 
         let ret = reader.get_txn_commit_info(&Key::from_raw(key), start_ts);
         assert!(ret.is_ok());
-        match ret.unwrap() {
+        match ret.unwrap().0 {
             None => {}
             Some((_, write_type)) => {
                 assert_eq!(write_type, WriteType::Rollback);
@@ -439,6 +440,7 @@ pub mod tests {
         let (ts, write_type) = reader
             .get_txn_commit_info(&Key::from_raw(key), start_ts)
             .unwrap()
+            .0
             .unwrap();
         assert_eq!(ts, start_ts);
         assert_eq!(write_type, WriteType::Rollback);
@@ -450,7 +452,8 @@ pub mod tests {
 
         let ret = reader
             .get_txn_commit_info(&Key::from_raw(key), start_ts)
-            .unwrap();
+            .unwrap()
+            .0;
         assert_eq!(ret, None);
     }
 

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -413,7 +413,6 @@ pub mod tests {
         let (ts, write_type) = reader
             .get_txn_commit_info(&Key::from_raw(key), start_ts)
             .unwrap()
-            .0
             .unwrap();
         assert_ne!(write_type, WriteType::Rollback);
         assert_eq!(ts, commit_ts);
@@ -425,7 +424,7 @@ pub mod tests {
 
         let ret = reader.get_txn_commit_info(&Key::from_raw(key), start_ts);
         assert!(ret.is_ok());
-        match ret.unwrap().0 {
+        match ret.unwrap() {
             None => {}
             Some((_, write_type)) => {
                 assert_eq!(write_type, WriteType::Rollback);
@@ -440,7 +439,6 @@ pub mod tests {
         let (ts, write_type) = reader
             .get_txn_commit_info(&Key::from_raw(key), start_ts)
             .unwrap()
-            .0
             .unwrap();
         assert_eq!(ts, start_ts);
         assert_eq!(write_type, WriteType::Rollback);
@@ -452,8 +450,7 @@ pub mod tests {
 
         let ret = reader
             .get_txn_commit_info(&Key::from_raw(key), start_ts)
-            .unwrap()
-            .0;
+            .unwrap();
         assert_eq!(ret, None);
     }
 

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -256,22 +256,15 @@ impl<S: Snapshot> MvccReader<S> {
         }
     }
 
-    /// Gets `commit_ts` and `WriteType` of the transaction with specified `start_ts`.
-    /// The second return value indicates whether there is a write value with commit_ts equals to
-    /// the given `start_ts`.
     pub fn get_txn_commit_info(
         &mut self,
         key: &Key,
         start_ts: u64,
-    ) -> Result<(Option<(u64, WriteType)>, bool)> {
+    ) -> Result<Option<(u64, WriteType)>> {
         let mut seek_ts = start_ts;
-        let mut write_ts_collision = false;
         while let Some((commit_ts, write)) = self.reverse_seek_write(key, seek_ts)? {
-            if commit_ts == start_ts {
-                write_ts_collision = true;
-            }
             if write.start_ts == start_ts {
-                return Ok((Some((commit_ts, write.write_type)), write_ts_collision));
+                return Ok(Some((commit_ts, write.write_type)));
             }
 
             // If we reach a commit version whose type is not Rollback and start ts is
@@ -282,7 +275,7 @@ impl<S: Snapshot> MvccReader<S> {
 
             seek_ts = commit_ts + 1;
         }
-        Ok((None, write_ts_collision))
+        Ok(None)
     }
 
     fn create_data_cursor(&mut self) -> Result<()> {
@@ -790,28 +783,28 @@ mod tests {
         // is 40.
         // Commit versions: [40_35 PUT, 30_25 PUT, 20_20 Rollback, 10_1 PUT, 5_5 Rollback].
         let key = Key::from_raw(k);
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 35).unwrap().0.unwrap();
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 35).unwrap().unwrap();
         assert_eq!(commit_ts, 40);
         assert_eq!(write_type, WriteType::Put);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 25).unwrap().0.unwrap();
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 25).unwrap().unwrap();
         assert_eq!(commit_ts, 30);
         assert_eq!(write_type, WriteType::Put);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 20).unwrap().0.unwrap();
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 20).unwrap().unwrap();
         assert_eq!(commit_ts, 20);
         assert_eq!(write_type, WriteType::Rollback);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 1).unwrap().0.unwrap();
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 1).unwrap().unwrap();
         assert_eq!(commit_ts, 10);
         assert_eq!(write_type, WriteType::Put);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 5).unwrap().0.unwrap();
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 5).unwrap().unwrap();
         assert_eq!(commit_ts, 5);
         assert_eq!(write_type, WriteType::Rollback);
 
         let seek_for_prev_old = reader.get_statistics().write.seek_for_prev;
-        assert!(reader.get_txn_commit_info(&key, 15).unwrap().0.is_none());
+        assert!(reader.get_txn_commit_info(&key, 15).unwrap().is_none());
         let seek_for_prev_new = reader.get_statistics().write.seek_for_prev;
 
         // `get_txn_commit_info(&key, 15)` stopped at `30_25 PUT`.

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -256,15 +256,22 @@ impl<S: Snapshot> MvccReader<S> {
         }
     }
 
+    /// Gets `commit_ts` and `WriteType` of the transaction with specified `start_ts`.
+    /// The second return value indicates whether there is a write value with commit_ts equals to
+    /// the given `start_ts`.
     pub fn get_txn_commit_info(
         &mut self,
         key: &Key,
         start_ts: u64,
-    ) -> Result<Option<(u64, WriteType)>> {
+    ) -> Result<(Option<(u64, WriteType)>, bool)> {
         let mut seek_ts = start_ts;
+        let mut write_ts_collision = false;
         while let Some((commit_ts, write)) = self.reverse_seek_write(key, seek_ts)? {
+            if commit_ts == start_ts {
+                write_ts_collision = true;
+            }
             if write.start_ts == start_ts {
-                return Ok(Some((commit_ts, write.write_type)));
+                return Ok((Some((commit_ts, write.write_type)), write_ts_collision));
             }
 
             // If we reach a commit version whose type is not Rollback and start ts is
@@ -275,7 +282,7 @@ impl<S: Snapshot> MvccReader<S> {
 
             seek_ts = commit_ts + 1;
         }
-        Ok(None)
+        Ok((None, write_ts_collision))
     }
 
     fn create_data_cursor(&mut self) -> Result<()> {
@@ -783,28 +790,28 @@ mod tests {
         // is 40.
         // Commit versions: [40_35 PUT, 30_25 PUT, 20_20 Rollback, 10_1 PUT, 5_5 Rollback].
         let key = Key::from_raw(k);
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 35).unwrap().unwrap();
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 35).unwrap().0.unwrap();
         assert_eq!(commit_ts, 40);
         assert_eq!(write_type, WriteType::Put);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 25).unwrap().unwrap();
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 25).unwrap().0.unwrap();
         assert_eq!(commit_ts, 30);
         assert_eq!(write_type, WriteType::Put);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 20).unwrap().unwrap();
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 20).unwrap().0.unwrap();
         assert_eq!(commit_ts, 20);
         assert_eq!(write_type, WriteType::Rollback);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 1).unwrap().unwrap();
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 1).unwrap().0.unwrap();
         assert_eq!(commit_ts, 10);
         assert_eq!(write_type, WriteType::Put);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 5).unwrap().unwrap();
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 5).unwrap().0.unwrap();
         assert_eq!(commit_ts, 5);
         assert_eq!(write_type, WriteType::Rollback);
 
         let seek_for_prev_old = reader.get_statistics().write.seek_for_prev;
-        assert!(reader.get_txn_commit_info(&key, 15).unwrap().is_none());
+        assert!(reader.get_txn_commit_info(&key, 15).unwrap().0.is_none());
         let seek_for_prev_new = reader.get_statistics().write.seek_for_prev;
 
         // `get_txn_commit_info(&key, 15)` stopped at `30_25 PUT`.

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -1151,11 +1151,13 @@ mod tests {
 
         let mut expected_result = Vec::new();
 
+        let read_ts = 6;
+
         for (i, ts) in [5u64, 6, 7, 5, 7, 6, 5].iter().enumerate() {
             let i = i as u8;
             must_prewrite_put(&engine, &[i], &[i], &[i], ts - 1);
             must_commit(&engine, &[i], ts - 1, *ts);
-            if *ts <= 6 {
+            if *ts <= read_ts {
                 expected_result.push((Key::from_raw(&[i]), vec![i]));
             }
         }
@@ -1165,7 +1167,7 @@ mod tests {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
 
         // Test both bound specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 6, true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), read_ts, true)
             .build()
             .unwrap();
 

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -659,4 +659,35 @@ mod tests {
         );
         assert_eq!(scanner.next().unwrap(), None);
     }
+
+    #[test]
+    fn test_scan_ts_visibility() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+
+        let mut expected_result = Vec::new();
+
+        for (i, ts) in [5u64, 6, 7, 5, 7, 6, 5].iter().enumerate() {
+            let i = i as u8;
+            must_prewrite_put(&engine, &[i], &[i], &[i], ts - 1);
+            must_commit(&engine, &[i], ts - 1, *ts);
+            if *ts <= 6 {
+                expected_result.push((Key::from_raw(&[i]), vec![i]));
+            }
+        }
+
+        let snapshot = engine.snapshot(&Context::new()).unwrap();
+
+        // Test both bound specified.
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 6, false)
+            .build()
+            .unwrap();
+
+        let mut result = Vec::new();
+
+        while let Some((k, v)) = scanner.next().unwrap() {
+            result.push((k, v));
+        }
+
+        assert_eq!(result, expected_result);
+    }
 }

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -666,11 +666,13 @@ mod tests {
 
         let mut expected_result = Vec::new();
 
+        let read_ts = 6;
+
         for (i, ts) in [5u64, 6, 7, 5, 7, 6, 5].iter().enumerate() {
             let i = i as u8;
             must_prewrite_put(&engine, &[i], &[i], &[i], ts - 1);
             must_commit(&engine, &[i], ts - 1, *ts);
-            if *ts <= 6 {
+            if *ts <= read_ts {
                 expected_result.push((Key::from_raw(&[i]), vec![i]));
             }
         }
@@ -678,7 +680,7 @@ mod tests {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
 
         // Test both bound specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 6, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), read_ts, false)
             .build()
             .unwrap();
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -303,6 +303,8 @@ impl<S: Snapshot> MvccTxn<S> {
                 };
             }
         }
+        // If the key "key{self.start_ts}" is already occupied, it should not be replaced by a
+        // Rollback record.
         if self
             .reader
             .seek_write(&key, self.start_ts)?

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -263,7 +263,9 @@ impl<S: Snapshot> MvccTxn<S> {
     /// We allow a transaction's commit_ts be the same as another transaction's start_ts. The
     /// rollback records are inserted into write_cf with the start_ts appended to the key, but the
     /// start_ts might also be another transaction's commit_ts. In this case the rollback record
-    /// will not be inserted if it will overwrite another write record.
+    /// will not be inserted if it will overwrite another write record. Prewrite will meet conflict
+    /// if its start_ts is the same as the timestamp of a record in write cf, no matter whether it's
+    /// a rollback record or not.
     pub fn rollback(&mut self, key: Key) -> Result<()> {
         match self.reader.load_lock(&key)? {
             Some(ref lock) if lock.ts == self.start_ts => {

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -263,9 +263,9 @@ impl<S: Snapshot> MvccTxn<S> {
     /// We allow a transaction's commit_ts be the same as another transaction's start_ts. The
     /// rollback records are inserted into write_cf with the start_ts appended to the key, but the
     /// start_ts might also be another transaction's commit_ts. In this case the rollback record
-    /// will not be inserted if it will overwrite another write record. Prewrite will meet conflict
-    /// if its start_ts is the same as the timestamp of a record in write cf, no matter whether it's
-    /// a rollback record or not.
+    /// will not be inserted if it will overwrite another write record. And it's safe to skip
+    /// writing the rollback record, because prewrite will still not succeed since its start_ts is
+    /// the same as another transaction's commit_ts.
     pub fn rollback(&mut self, key: Key) -> Result<()> {
         match self.reader.load_lock(&key)? {
             Some(ref lock) if lock.ts == self.start_ts => {

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -333,10 +333,10 @@ impl<S: Snapshot> MvccTxn<S> {
             let ts = self.start_ts;
             self.put_write(key.clone(), ts, write.to_bytes());
             if self.collapse_rollback {
-                self.collapse_prev_rollback(key)?;
+                self.collapse_prev_rollback(key.clone())?;
             }
         }
-        self.unlock_key(key.clone());
+        self.unlock_key(key);
         Ok(())
     }
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -456,6 +456,11 @@ mod tests {
         must_prewrite_delete(&engine, k, k, 13);
         must_rollback(&engine, k, 13);
         must_unlocked(&engine, k);
+
+        // The same start_ts and another transaction's commit_ts is considered conflicting.
+        must_prewrite_put(&engine, k, v, k, 15);
+        must_commit(&engine, k, 15, 16);
+        must_prewrite_lock_err(&engine, k, k, 16);
     }
 
     #[test]


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

A part of #4290 .

This PR addes some test to ensure:

* A transaction committed with commit_ts `t1` is visible by another transaction with start_ts `t1`
* A transaction trying to prewrite with start_ts `t1` on a key who has a committed version with commit_ts `t1` will cause WriteConflict

And also updated logic of rollback so that rollback records will not overwrite other commit records in write cf.

Previously we didn't care TiKV's behavior when a start_ts is the same as another transaction's commit_ts, because there will never be two same timestamps. However we are now working on a optimization that calculates the commit_ts instead of allocating it from PD. This PR tries to ensure TiKV's behavior is well defined in this case.

**20190828 Reopen:**
The current design of large transaction's support will also meet the condition that transaction's commit_ts collides with other timestamps.I think it's time to reopen this PR.

## What are the type of the changes? (mandatory)

- Improvement

## How has this PR been tested? (mandatory)

By CI

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No