### PR TITLE
Fix incorrect default value handling in batch table scan executor

### DIFF
--- a/src/coprocessor/dag/batch_executor/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch_executor/table_scan_executor.rs
@@ -280,8 +280,6 @@ impl super::scan_executor::ScanExecutorImpl for TableScanExecutorImpl {
                     // NULL is allowed, use NULL
                     datum::DATUM_DATA_NULL
                 } else {
-                    // default_value is not provided && flag contains NOT NULL:
-                    // for a normal request this will never happen, so let's return an error.
                     return Err(box_err!(
                         "Data is corrupted, missing data for NOT NULL column (offset = {})",
                         i

--- a/src/coprocessor/dag/batch_executor/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch_executor/table_scan_executor.rs
@@ -56,22 +56,7 @@ impl<S: Store> BatchTableScanExecutor<S> {
             schema.push(super::scan_executor::field_type_from_column_info(&ci));
 
             // - Prepare column default value (will be used to fill missing column later).
-            if !ci.get_default_val().is_empty() {
-                columns_default_value.push(ci.take_default_val());
-            } else if !ci.flag().contains(cop_datatype::FieldTypeFlag::NOT_NULL)
-                || ci.get_pk_handle()
-            {
-                // Empty slice in default value means that we need to use NULL as the default value
-                // (except for PK).
-                columns_default_value.push(Vec::new());
-            } else {
-                // default_value is not provided && flag contains NOT NULL:
-                // for a normal request this will never happen, so let's return an error.
-                return Err(box_err!(
-                    "Invalid request: default value must be provided for NOT NULL column (offset = {})",
-                    index
-                ));
-            }
+            columns_default_value.push(ci.take_default_val());
 
             // - Store the index of the PK handle.
             // - Check whether or not we don't need KV values (iff PK handle is given).
@@ -133,8 +118,7 @@ struct TableScanExecutorImpl {
     schema: Vec<FieldType>,
 
     /// The default value of corresponding columns in the schema. When column data is missing,
-    /// the default value will be used to fill the output. If corresponding slot is empty, it means
-    /// NULL should be used.
+    /// the default value will be used to fill the output.
     columns_default_value: Vec<Vec<u8>>,
 
     /// The output position in the schema giving the column id.
@@ -286,11 +270,24 @@ impl super::scan_executor::ScanExecutorImpl for TableScanExecutorImpl {
                 // Missing fields must not be a primary key, so it must be
                 // `LazyBatchColumn::raw`.
 
-                let default_value = if self.columns_default_value[i].is_empty() {
+                let default_value = if !self.columns_default_value[i].is_empty() {
+                    // default value is provided, use the default value
+                    self.columns_default_value[i].as_slice()
+                } else if !self.schema[i]
+                    .flag()
+                    .contains(cop_datatype::FieldTypeFlag::NOT_NULL)
+                {
+                    // NULL is allowed, use NULL
                     datum::DATUM_DATA_NULL
                 } else {
-                    self.columns_default_value[i].as_slice()
+                    // default_value is not provided && flag contains NOT NULL:
+                    // for a normal request this will never happen, so let's return an error.
+                    return Err(box_err!(
+                        "Invalid request: default value must be provided for NOT NULL column (offset = {})",
+                        i
+                    ));
                 };
+
                 columns[i].push_raw(default_value);
             } else {
                 // Reset to not-filled, prepare for next function call.

--- a/src/coprocessor/dag/batch_executor/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch_executor/table_scan_executor.rs
@@ -58,8 +58,11 @@ impl<S: Store> BatchTableScanExecutor<S> {
             // - Prepare column default value (will be used to fill missing column later).
             if !ci.get_default_val().is_empty() {
                 columns_default_value.push(ci.take_default_val());
-            } else if !ci.flag().contains(cop_datatype::FieldTypeFlag::NOT_NULL) {
-                // Empty value means that we need to use NULL as the default value.
+            } else if !ci.flag().contains(cop_datatype::FieldTypeFlag::NOT_NULL)
+                || ci.get_pk_handle()
+            {
+                // Empty slice in default value means that we need to use NULL as the default value
+                // (except for PK).
                 columns_default_value.push(Vec::new());
             } else {
                 // default_value is not provided && flag contains NOT NULL:

--- a/src/coprocessor/dag/batch_executor/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch_executor/table_scan_executor.rs
@@ -283,7 +283,7 @@ impl super::scan_executor::ScanExecutorImpl for TableScanExecutorImpl {
                     // default_value is not provided && flag contains NOT NULL:
                     // for a normal request this will never happen, so let's return an error.
                     return Err(box_err!(
-                        "Invalid request: default value must be provided for NOT NULL column (offset = {})",
+                        "Data is corrupted, missing data for NOT NULL column (offset = {})",
                         i
                     ));
                 };

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -143,7 +143,7 @@ impl<E: Engine> Endpoint<E> {
                         req_ctx.deadline,
                         batch_row_limit,
                         is_streaming,
-                        false, // TODO:fix it when batch executor is ready.
+                        true,
                     )
                 });
             }


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR reverts our optimization in the batch table scan executor for default values, because we cannot identify invalid requests actually. For NOT NULL columns created by CREATE TABLE statement, they don't have default values. So when we got a NOT NULL column without default value, it is valid. We should return error only when we additionally indeed got missing data.

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

CI