### PR TITLE
[WIP]: Reduce codec::mysql::Duration memory size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,15 +897,13 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git#84f2c621d8e8dce083d62297490217da809bc51a"
+source = "git+https://github.com/pingcap/kvproto.git#a63718839aee85e3315e58d7bd8a49c721a43294"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc-grpcio 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc-rust 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1370,6 +1368,19 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "protobuf-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "grpcio-compiler 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-grpcio 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-rust 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "protobuf-codegen"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,7 +1393,7 @@ name = "protoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1446,7 +1457,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2699,6 +2710,7 @@ dependencies = [
 "checksum prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "760293453bee1de0a12987422d7c4885f7ee933e4417bb828ed23f7d05c3c390"
 "checksum prometheus-static-metric 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1d2b4a6a1ae793e7eb6773a5301a5a08e8929ea5517b677c93e57ce2d0973c02"
 "checksum protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "128a4f37a2df739a567a8685b17f54aa19b9c3c4a6a5b8731e97a419b3db451c"
+"checksum protobuf-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a94ea746889322eb33b6977db6ffe82b1decaac1804958b9179245fc45dc4b6"
 "checksum protobuf-codegen 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3624c0feac7f512de21dbf8b574ae65c6573b1872d3878be951c0912eee4daca"
 "checksum protoc 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8736a41d7c7e321913dd81067fbedf74d037f69999386eba07cc4dd1de7369f0"
 "checksum protoc-grpcio 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a9798b534614b71d780778b1508410826073b5a1ca111a090f1f3fd3ac663ef6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitfield"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,6 +2053,7 @@ dependencies = [
  "arrow 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitfield 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2581,6 +2587,7 @@ dependencies = [
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
 "checksum base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "621fc7ecb8008f86d7fb9b95356cd692ce9514b80a86d85b397f32a22da7b9e2"
+"checksum bitfield 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a260ed6b9f3ca16a4389390b1b1cd15a3bc0a9d3e63b1ef39f4978cec58a4e83"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e4ca3a1755927e5b00c3fe43250053b957b5c074d9f17782b88ef7aa0fb4dfe2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ more-asserts = "0.1"
 hyper = "0.12"
 tokio-threadpool = "0.1"
 vlog = "0.1.4"
+bitfield = "0.13.1"
 twoway = "0.2.0"
 cop_datatype = { path = "components/cop_datatype" }
 panic_hook = { path = "components/panic_hook" }

--- a/src/coprocessor/codec/chunk/column.rs
+++ b/src/coprocessor/codec/chunk/column.rs
@@ -115,7 +115,7 @@ impl Column {
             Datum::F64(v) => self.append_f64(*v),
             Datum::Bytes(ref v) => self.append_bytes(v),
             Datum::Dec(ref v) => self.append_decimal(v),
-            Datum::Dur(ref v) => self.append_duration(v),
+            Datum::Dur(v) => self.append_duration(*v),
             Datum::Time(ref v) => self.append_time(v),
             Datum::Json(ref v) => self.append_json(v),
             _ => Err(box_err!("unsupported datum {:?}", data)),
@@ -291,7 +291,7 @@ impl Column {
     }
 
     /// Append a duration datum to the column.
-    pub fn append_duration(&mut self, d: &Duration) -> Result<()> {
+    pub fn append_duration(&mut self, d: Duration) -> Result<()> {
         self.data.encode_duration(d)?;
         self.finish_append_fixed()
     }

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -133,7 +133,7 @@ impl Datum {
             Datum::U64(u) => self.cmp_u64(ctx, u),
             Datum::F64(f) => self.cmp_f64(ctx, f),
             Datum::Bytes(ref bs) => self.cmp_bytes(ctx, bs),
-            Datum::Dur(ref d) => self.cmp_dur(ctx, d),
+            Datum::Dur(d) => self.cmp_dur(ctx, d),
             Datum::Dec(ref d) => self.cmp_dec(ctx, d),
             Datum::Time(ref t) => self.cmp_time(ctx, t),
             Datum::Json(ref j) => self.cmp_json(j),
@@ -236,12 +236,12 @@ impl Datum {
         }
     }
 
-    fn cmp_dur(&self, ctx: &mut EvalContext, d: &Duration) -> Result<Ordering> {
+    fn cmp_dur(&self, ctx: &mut EvalContext, d: Duration) -> Result<Ordering> {
         match *self {
-            Datum::Dur(ref d2) => Ok(d2.cmp(d)),
+            Datum::Dur(ref d2) => Ok(d2.cmp(&d)),
             Datum::Bytes(ref bs) => {
                 let d2 = Duration::parse(bs, MAX_FSP)?;
-                Ok(d2.cmp(d))
+                Ok(d2.cmp(&d))
             }
             _ => self.cmp_f64(ctx, d.to_secs()),
         }

--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -240,7 +240,7 @@ impl Duration {
         if round_with_fsp {
             let round = u64::from(TEN_POW[NANO_WIDTH as usize - fsp as usize - 1]);
             nano /= round;
-            nano = nano / 10 + if nano % 10 > 4 { 1 } else { 0 };
+            nano = (nano + 5) / 10;
             nano *= round * 10;
         }
 

--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -119,6 +119,10 @@ bitfield! {
 
 }
 
+/// NOTE:
+/// 1. It will automatically round the `nano` field according to `fsp` if round_with_fsp is true.
+/// 2. `nano` field can be greater than `NANOS_PER_SEC`.
+/// 3. Return an `Err` if the result's fields is invalid.
 #[derive(Clone, Copy)]
 struct DurationBuilder {
     neg: bool,
@@ -221,10 +225,6 @@ impl Duration {
     }
 
     /// Try to build a `Duration` via `DurationBuilder`
-    /// NOTE:
-    /// 1. It will automatically round the `nano` field according to `fsp`
-    /// 2. `DurationBuilder.nano` can be greater than `NANOS_PER_SEC`.
-    /// 3. Return an `Err` only if the result's `hour` is invalid(> 838).
     #[inline]
     fn build(builder: DurationBuilder) -> Result<Duration> {
         let DurationBuilder {

--- a/src/coprocessor/codec/mysql/mod.rs
+++ b/src/coprocessor/codec/mysql/mod.rs
@@ -55,11 +55,7 @@ fn parse_frac(frac: &str, fsp: u8) -> Result<u64> {
         frac.parse::<u64>().map_err(mapping)? * u64::from(TEN_POW[fsp - frac.len()])
     } else {
         let result = frac[..=fsp].parse::<u64>().map_err(mapping)?;
-        if result % 10 > 4 {
-            result / 10 + 1
-        } else {
-            result / 10
-        }
+        (result + 5) / 10
     })
 }
 

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -423,7 +423,7 @@ impl Time {
         }
 
         let frac = if has_hhmmss {
-            mysql::parse_frac(frac_str.as_bytes(), fsp)?
+            mysql::parse_frac(frac_str, fsp)?
         } else {
             0
         };
@@ -481,7 +481,7 @@ impl Time {
         Time::new(t, time_type, fsp as i8)
     }
 
-    pub fn from_duration(tz: &Tz, time_type: TimeType, d: &MyDuration) -> Result<Time> {
+    pub fn from_duration(tz: &Tz, time_type: TimeType, d: MyDuration) -> Result<Time> {
         let dur = Duration::nanoseconds(d.to_nanos());
         let t = Utc::now()
             .with_timezone(tz)
@@ -511,7 +511,7 @@ impl Time {
         if self.is_zero() {
             return Ok(MyDuration::zero());
         }
-        let nanos = i64::from(self.time.num_seconds_from_midnight()) * NANOS_PER_SEC
+        let nanos = i64::from(self.time.num_seconds_from_midnight()) * NANOS_PER_SEC as i64
             + i64::from(self.time.nanosecond());
         MyDuration::from_nanos(nanos, self.fsp as i8)
     }
@@ -736,7 +736,7 @@ impl Time {
     }
 
     /// Checked time addition. Computes self + rhs, returning None if overflow occurred.
-    pub fn checked_add(self, rhs: &MyDuration) -> Option<Time> {
+    pub fn checked_add(self, rhs: MyDuration) -> Option<Time> {
         if let Some(add) = self
             .time
             .checked_add_signed(Duration::nanoseconds(rhs.to_nanos()))
@@ -753,7 +753,7 @@ impl Time {
     }
 
     /// Checked time subtraction. Computes self - rhs, returning None if overflow occurred.
-    pub fn checked_sub(self, rhs: &MyDuration) -> Option<Time> {
+    pub fn checked_sub(self, rhs: MyDuration) -> Option<Time> {
         if let Some(sub) = self
             .time
             .checked_sub_signed(Duration::nanoseconds(rhs.to_nanos()))
@@ -1434,7 +1434,7 @@ mod tests {
         let tz = Tz::utc();
         for s in cases {
             let d = MyDuration::parse(s.as_bytes(), MAX_FSP).unwrap();
-            let get = Time::from_duration(&tz, TimeType::DateTime, &d).unwrap();
+            let get = Time::from_duration(&tz, TimeType::DateTime, d).unwrap();
             let get_today = get
                 .time
                 .checked_sub_signed(Duration::nanoseconds(d.to_nanos()))
@@ -1580,23 +1580,23 @@ mod tests {
         for (lhs, rhs, exp) in cases.clone() {
             let lhs = Time::parse_utc_datetime(lhs, 6).unwrap();
             let rhs = MyDuration::parse(rhs.as_bytes(), 6).unwrap();
-            let res = lhs.checked_add(&rhs).unwrap();
+            let res = lhs.checked_add(rhs).unwrap();
             let exp = Time::parse_utc_datetime(exp, 6).unwrap();
             assert_eq!(res, exp);
         }
         for (exp, rhs, lhs) in cases {
             let lhs = Time::parse_utc_datetime(lhs, 6).unwrap();
             let rhs = MyDuration::parse(rhs.as_bytes(), 6).unwrap();
-            let res = lhs.checked_sub(&rhs).unwrap();
+            let res = lhs.checked_sub(rhs).unwrap();
             let exp = Time::parse_utc_datetime(exp, 6).unwrap();
             assert_eq!(res, exp);
         }
 
         let lhs = Time::parse_utc_datetime("9999-12-31 23:59:59", 6).unwrap();
         let rhs = MyDuration::parse(b"01:00:00", 6).unwrap();
-        assert_eq!(lhs.checked_add(&rhs), None);
+        assert_eq!(lhs.checked_add(rhs), None);
         let lhs = Time::parse_utc_datetime("0000-01-01 00:00:01", 6).unwrap();
         let rhs = MyDuration::parse(b"01:00:00", 6).unwrap();
-        assert_eq!(lhs.checked_sub(&rhs), None);
+        assert_eq!(lhs.checked_sub(rhs), None);
     }
 }

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -423,7 +423,7 @@ impl Time {
         }
 
         let frac = if has_hhmmss {
-            mysql::parse_frac(frac_str, fsp)?
+            mysql::parse_frac(frac_str, fsp)? as u32
         } else {
             0
         };

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -419,8 +419,7 @@ impl ScalarFunc {
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, Time>>> {
         let val = try_opt!(self.children[0].eval_duration(ctx, row));
-        let mut val =
-            Time::from_duration(&ctx.cfg.tz, self.field_type.tp().try_into()?, val.as_ref())?;
+        let mut val = Time::from_duration(&ctx.cfg.tz, self.field_type.tp().try_into()?, *val)?;
         val.round_frac(self.field_type.decimal() as i8)?;
         Ok(Some(Cow::Owned(val)))
     }

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -419,7 +419,7 @@ impl ScalarFunc {
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, Time>>> {
         let val = try_opt!(self.children[0].eval_duration(ctx, row));
-        let mut val = Time::from_duration(&ctx.cfg.tz, self.field_type.tp().try_into()?, *val)?;
+        let mut val = Time::from_duration(&ctx.cfg.tz, self.field_type.tp().try_into()?, val)?;
         val.round_frac(self.field_type.decimal() as i8)?;
         Ok(Some(Cow::Owned(val)))
     }
@@ -438,12 +438,12 @@ impl ScalarFunc {
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         let val = try_opt!(self.children[0].eval_int(ctx, row));
         let s = format!("{}", val);
         // TODO: port NumberToDuration from tidb.
         match Duration::parse(s.as_bytes(), self.field_type.decimal() as i8) {
-            Ok(dur) => Ok(Some(Cow::Owned(dur))),
+            Ok(dur) => Ok(Some(dur)),
             Err(e) => {
                 if e.is_overflow() {
                     ctx.handle_overflow(e)?;
@@ -459,68 +459,66 @@ impl ScalarFunc {
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         let val = try_opt!(self.children[0].eval_real(ctx, row));
         let s = format!("{}", val);
         let dur = Duration::parse(s.as_bytes(), self.field_type.decimal() as i8)?;
-        Ok(Some(Cow::Owned(dur)))
+        Ok(Some(dur))
     }
 
     pub fn cast_decimal_as_duration<'a, 'b: 'a>(
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         let val = try_opt!(self.children[0].eval_decimal(ctx, row));
         let s = val.to_string();
         let dur = Duration::parse(s.as_bytes(), self.field_type.decimal() as i8)?;
-        Ok(Some(Cow::Owned(dur)))
+        Ok(Some(dur))
     }
 
     pub fn cast_str_as_duration<'a, 'b: 'a>(
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         let val = try_opt!(self.children[0].eval_string(ctx, row));
         let dur = Duration::parse(val.as_ref(), self.field_type.decimal() as i8)?;
-        Ok(Some(Cow::Owned(dur)))
+        Ok(Some(dur))
     }
 
     pub fn cast_time_as_duration<'a, 'b: 'a>(
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         let val = try_opt!(self.children[0].eval_time(ctx, row));
         let res = val
             .to_duration()?
             .round_frac(self.field_type.decimal() as i8)?;
-        Ok(Some(Cow::Owned(res)))
+        Ok(Some(res))
     }
 
     pub fn cast_duration_as_duration<'a, 'b: 'a>(
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         let val = try_opt!(self.children[0].eval_duration(ctx, row));
-        let res = val
-            .into_owned()
-            .round_frac(self.field_type.decimal() as i8)?;
-        Ok(Some(Cow::Owned(res)))
+        let res = val.round_frac(self.field_type.decimal() as i8)?;
+        Ok(Some(res))
     }
 
     pub fn cast_json_as_duration<'a, 'b: 'a>(
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         let val = try_opt!(self.children[0].eval_json(ctx, row));
         let s = val.unquote()?;
         // TODO: tidb would handle truncate here
         let d = Duration::parse(s.as_bytes(), self.field_type.decimal() as i8)?;
-        Ok(Some(Cow::Owned(d)))
+        Ok(Some(d))
     }
 
     pub fn cast_int_as_json<'a, 'b: 'a>(
@@ -598,8 +596,7 @@ impl ScalarFunc {
         ctx: &mut EvalContext,
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, Json>>> {
-        let val = try_opt!(self.children[0].eval_duration(ctx, row));
-        let mut val = val.into_owned();
+        let mut val = try_opt!(self.children[0].eval_duration(ctx, row));
         val.set_fsp(mysql::MAX_FSP as u8);
         let s = format!("{}", val);
         Ok(Some(Cow::Owned(Json::String(s))))
@@ -1649,7 +1646,7 @@ mod tests {
                 .set_decimal(isize::from(to_fsp));
             let e = Expression::build(&ctx, ex).unwrap();
             let res = e.eval_duration(&mut ctx, col).unwrap();
-            let data = res.unwrap().into_owned();
+            let data = res.unwrap();
             let mut expt = *exp;
             if to_fsp != mysql::UNSPECIFIED_FSP {
                 expt.set_fsp(to_fsp as u8);

--- a/src/coprocessor/dag/expr/builtin_compare.rs
+++ b/src/coprocessor/dag/expr/builtin_compare.rs
@@ -140,7 +140,7 @@ impl ScalarFunc {
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         do_coalesce(self, |v| v.eval_duration(ctx, row))
     }
 

--- a/src/coprocessor/dag/expr/builtin_control.rs
+++ b/src/coprocessor/dag/expr/builtin_control.rs
@@ -106,7 +106,7 @@ impl ScalarFunc {
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         if_null(|i| self.children[i].eval_duration(ctx, row))
     }
 
@@ -162,7 +162,7 @@ impl ScalarFunc {
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         if_condition(self, ctx, row, |i, ctx| {
             self.children[i].eval_duration(ctx, row)
         })
@@ -214,7 +214,7 @@ impl ScalarFunc {
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         case_when(self, ctx, row, |v, ctx| v.eval_duration(ctx, row))
     }
 

--- a/src/coprocessor/dag/expr/builtin_time.rs
+++ b/src/coprocessor/dag/expr/builtin_time.rs
@@ -77,7 +77,7 @@ impl ScalarFunc {
     #[inline]
     pub fn micro_second(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         let dur: Cow<'_, MyDuration> = try_opt!(self.children[0].eval_duration(ctx, row));
-        Ok(Some(i64::from(dur.micro_secs())))
+        Ok(Some(dur.micro_secs() as i64))
     }
 
     #[inline]
@@ -286,7 +286,7 @@ impl ScalarFunc {
         let arg0: Cow<'a, Time> = try_opt!(self.children[0].eval_time(ctx, row));
         let arg1: Cow<'a, MyDuration> = try_opt!(self.children[1].eval_duration(ctx, row));
         let overflow = Error::overflow("TIME", &format!("({} + {})", &arg0, &arg1));
-        let mut res = match arg0.into_owned().checked_add(&arg1) {
+        let mut res = match arg0.into_owned().checked_add(*arg1) {
             Some(res) => res,
             None => return Err(overflow),
         };
@@ -305,7 +305,7 @@ impl ScalarFunc {
         let s = ::std::str::from_utf8(&arg1)?;
         let arg1 = MyDuration::parse(&arg1, Time::parse_fsp(s))?;
         let overflow = Error::overflow("TIME", &format!("({} + {})", &arg0, &arg1));
-        let mut res = match arg0.into_owned().checked_add(&arg1) {
+        let mut res = match arg0.into_owned().checked_add(arg1) {
             Some(res) => res,
             None => return Err(overflow),
         };
@@ -358,7 +358,7 @@ impl ScalarFunc {
         let arg0: Cow<'a, MyDuration> = try_opt!(self.children[0].eval_duration(ctx, row));
         let arg1: Cow<'a, MyDuration> = try_opt!(self.children[1].eval_duration(ctx, row));
         let overflow = Error::overflow("DURATION", &format!("({} + {})", &arg0, &arg1));
-        let res = match arg0.into_owned().checked_add(&arg1) {
+        let res = match arg0.into_owned().checked_add(*arg1) {
             Some(res) => res,
             None => return Err(overflow),
         };
@@ -376,7 +376,7 @@ impl ScalarFunc {
         let s = ::std::str::from_utf8(&arg1)?;
         let arg1 = MyDuration::parse(&arg1, Time::parse_fsp(s))?;
         let overflow = Error::overflow("DURATION", &format!("({} + {})", &arg0, &arg1));
-        let res = match arg0.into_owned().checked_add(&arg1) {
+        let res = match arg0.into_owned().checked_add(arg1) {
             Some(res) => res,
             None => return Err(overflow),
         };
@@ -401,7 +401,7 @@ impl ScalarFunc {
         let arg0: Cow<'a, Time> = try_opt!(self.children[0].eval_time(ctx, row));
         let arg1: Cow<'a, MyDuration> = try_opt!(self.children[1].eval_duration(ctx, row));
         let overflow = Error::overflow("TIME", &format!("({} - {})", &arg0, &arg1));
-        let mut res = match arg0.into_owned().checked_sub(&arg1) {
+        let mut res = match arg0.into_owned().checked_sub(*arg1) {
             Some(res) => res,
             None => return Err(overflow),
         };
@@ -420,7 +420,7 @@ impl ScalarFunc {
         let s = ::std::str::from_utf8(&arg1)?;
         let arg1 = MyDuration::parse(&arg1, Time::parse_fsp(s))?;
         let overflow = Error::overflow("TIME", &format!("({} - {})", &arg0, &arg1));
-        let mut res = match arg0.into_owned().checked_sub(&arg1) {
+        let mut res = match arg0.into_owned().checked_sub(arg1) {
             Some(res) => res,
             None => return Err(overflow),
         };

--- a/src/coprocessor/dag/expr/column.rs
+++ b/src/coprocessor/dag/expr/column.rs
@@ -78,7 +78,7 @@ impl Column {
     }
 
     #[inline]
-    pub fn eval_duration<'a>(&self, row: &'a [Datum]) -> Result<Option<Cow<'a, Duration>>> {
+    pub fn eval_duration<'a>(&self, row: &'a [Datum]) -> Result<Option<Duration>> {
         row[self.offset].as_duration()
     }
 
@@ -184,10 +184,7 @@ mod tests {
                 .eval_time(&mut ctx, &row)
                 .unwrap_or(None)
                 .map(|t| t.into_owned());
-            let dur = e
-                .eval_duration(&mut ctx, &row)
-                .unwrap_or(None)
-                .map(|t| t.into_owned());
+            let dur = e.eval_duration(&mut ctx, &row).unwrap_or(None);
             let j = e
                 .eval_json(&mut ctx, &row)
                 .unwrap_or(None)

--- a/src/coprocessor/dag/expr/constant.rs
+++ b/src/coprocessor/dag/expr/constant.rs
@@ -65,10 +65,10 @@ impl Datum {
     }
 
     #[inline]
-    pub fn as_duration(&self) -> Result<Option<Cow<'_, Duration>>> {
+    pub fn as_duration(&self) -> Result<Option<Duration>> {
         match *self {
             Datum::Null => Ok(None),
-            Datum::Dur(ref d) => Ok(Some(Cow::Borrowed(d))),
+            Datum::Dur(d) => Ok(Some(d)),
             _ => Err(box_err!("Can't eval_duration from Datum")),
         }
     }
@@ -114,7 +114,7 @@ impl Constant {
     }
 
     #[inline]
-    pub fn eval_duration(&self) -> Result<Option<Cow<'_, Duration>>> {
+    pub fn eval_duration(&self) -> Result<Option<Duration>> {
         self.val.as_duration()
     }
 
@@ -187,10 +187,7 @@ mod tests {
                 .eval_time(&mut ctx, &[])
                 .unwrap_or(None)
                 .map(|t| t.into_owned());
-            let dur = e
-                .eval_duration(&mut ctx, &[])
-                .unwrap_or(None)
-                .map(|t| t.into_owned());
+            let dur = e.eval_duration(&mut ctx, &[]).unwrap_or(None);
             let j = e
                 .eval_json(&mut ctx, &[])
                 .unwrap_or(None)

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -190,7 +190,7 @@ impl Expression {
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
-    ) -> Result<Option<Cow<'a, Duration>>> {
+    ) -> Result<Option<Duration>> {
         match *self {
             Expression::Constant(ref constant) => constant.eval_duration(),
             Expression::ColumnRef(ref column) => column.eval_duration(row),

--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -606,7 +606,7 @@ macro_rules! dispatch_call {
                 &'b self,
                 ctx: &mut EvalContext,
                 row: &'a [Datum]
-            ) -> Result<Option<Cow<'a, Duration>>> {
+            ) -> Result<Option<Duration>> {
                 match self.sig {
                     $(ScalarFuncSig::$u_sig => self.$u_func(ctx, row, $($u_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))


### PR DESCRIPTION
- Reduce `codec::mysql::Duration` from 24 bytes to 8 bytes
- Fix the bug of `codec::mysql::Duration::parse`
- Derive `Copy` trait for `codec::mysql::Duration`

Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

## What have you changed? (mandatory)
* Fix https://github.com/tikv/tikv/issues/4025, reduce `Duration` size from 24 bytes to 8 bytes and apply `Copy` semantic to it.
* Additionally, I found a bug in: 
https://github.com/tikv/tikv/blob/1093fcaca79906d930cbd99841c708b8f1902532/src/coprocessor/codec/mysql/duration.rs#L176-L199

which will fail to parse the time string in the format like: 
* `1:2:3` or `1:02:3` (because of the bug of the first `match` arm)
* `12345` => `1:23:45`(MySQL's behavior), `strptime` will output `12:34:05` (because of the bug in last `match` arm)
* `    -.123`
* `  -    1:0.123    `

## What are the type of the changes? (mandatory)
- Improvement (change which is an improvement to an existing feature)
- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)
pass all the test suit. `make test` already.

