### PR TITLE
[DNM] switch encode part  to use  component/codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,7 @@ name = "fuzz-targets"
 version = "0.0.1"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codec 0.0.1",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tikv 3.0.0-beta",
 ]
@@ -1973,6 +1974,7 @@ dependencies = [
 name = "test_coprocessor"
 version = "0.0.1"
 dependencies = [
+ "codec 0.0.1",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2053,6 +2055,7 @@ dependencies = [
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono-tz 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codec 0.0.1",
  "cop_datatype 0.0.1",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ panic_hook = { path = "components/panic_hook" }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 log_wrappers = { path = "components/log_wrappers" }
+codec = { path = "components/codec" }
 
 [dependencies.murmur3]
 git = "https://github.com/pingcap/murmur3.git"

--- a/components/codec/src/lib.rs
+++ b/components/codec/src/lib.rs
@@ -30,7 +30,7 @@ mod number;
 
 pub mod prelude {
     pub use super::buffer::{BufferReader, BufferWriter};
-    pub use super::byte::MemComparableByteCodec;
+    pub use super::byte::{BufferByteEncoder, MemComparableByteCodec};
     pub use super::number::{BufferNumberDecoder, BufferNumberEncoder};
 }
 

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 tikv = { path = "../../" }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+codec = { path = "../codec"}
 protobuf = "~2.0"
 test_storage = { path = "../test_storage" }
 futures = "0.1"

--- a/components/test_coprocessor/src/dag.rs
+++ b/components/test_coprocessor/src/dag.rs
@@ -25,9 +25,9 @@ use tipb::expression::{ByItem, Expr, ExprType};
 use tipb::schema::ColumnInfo;
 use tipb::select::{Chunk, DAGRequest};
 
+use codec::prelude::BufferNumberEncoder;
 use tikv::coprocessor::codec::{datum, Datum};
 use tikv::coprocessor::REQ_TYPE_DAG;
-use tikv::util::codec::number::NumberEncoder;
 
 pub struct DAGSelect {
     pub execs: Vec<Executor>,
@@ -99,7 +99,7 @@ impl DAGSelect {
         let mut item = ByItem::new();
         let mut expr = Expr::new();
         expr.set_tp(ExprType::ColumnRef);
-        expr.mut_val().encode_i64(col_offset).unwrap();
+        expr.mut_val().write_i64(col_offset).unwrap();
         item.set_expr(expr);
         item.set_desc(desc);
         self.order_by.push(item);
@@ -117,7 +117,7 @@ impl DAGSelect {
         let col_offset = offset_for_column(&self.cols, col.id);
         let mut col_expr = Expr::new();
         col_expr.set_tp(ExprType::ColumnRef);
-        col_expr.mut_val().encode_i64(col_offset).unwrap();
+        col_expr.mut_val().write_i64(col_offset).unwrap();
         let mut expr = Expr::new();
         expr.set_tp(aggr_t);
         expr.mut_children().push(col_expr);
@@ -162,7 +162,7 @@ impl DAGSelect {
             let offset = offset_for_column(&self.cols, col.id);
             let mut expr = Expr::new();
             expr.set_tp(ExprType::ColumnRef);
-            expr.mut_val().encode_i64(offset).unwrap();
+            expr.mut_val().write_i64(offset).unwrap();
             self.group_by.push(expr);
         }
         self

--- a/components/test_coprocessor/src/table.rs
+++ b/components/test_coprocessor/src/table.rs
@@ -20,9 +20,9 @@ use tipb::schema::{self, ColumnInfo};
 
 use protobuf::RepeatedField;
 
+use codec::prelude::BufferNumberEncoder;
 use tikv::coprocessor;
 use tikv::coprocessor::codec::table;
-use tikv::util::codec::number::NumberEncoder;
 
 #[derive(Clone)]
 pub struct Table {
@@ -118,10 +118,10 @@ impl Table {
     pub fn get_index_range_all(&self, idx: i64) -> KeyRange {
         let mut range = KeyRange::new();
         let mut buf = Vec::with_capacity(8);
-        buf.encode_i64(::std::i64::MIN).unwrap();
+        buf.write_i64(::std::i64::MIN).unwrap();
         range.set_start(table::encode_index_seek_key(self.id, idx, &buf));
         buf.clear();
-        buf.encode_i64(::std::i64::MAX).unwrap();
+        buf.write_i64(::std::i64::MAX).unwrap();
         range.set_end(table::encode_index_seek_key(self.id, idx, &buf));
         range
     }

--- a/fuzz/targets/Cargo.toml
+++ b/fuzz/targets/Cargo.toml
@@ -10,3 +10,4 @@ path = "mod.rs"
 byteorder = "1"
 failure = "0.1"
 tikv = {path = "../.."}
+codec = {path = "../../components/codec"}

--- a/fuzz/targets/mod.rs
+++ b/fuzz/targets/mod.rs
@@ -14,6 +14,7 @@
 //! DO NOT MOVE THIS FILE. IT WILL BE PARSED BY `fuzz/cli.rs`. SEE `discover_fuzz_targets()`.
 
 extern crate byteorder;
+extern crate codec;
 extern crate failure;
 extern crate tikv;
 
@@ -34,52 +35,52 @@ pub fn fuzz_codec_bytes(data: &[u8]) -> Result<(), Error> {
 
 #[inline(always)]
 pub fn fuzz_codec_number(data: &[u8]) -> Result<(), Error> {
-    use tikv::util::codec::number::NumberEncoder;
+    use codec::prelude::BufferNumberEncoder;
     {
         let mut cursor = Cursor::new(data);
         let n = cursor.read_as_u64()?;
         let mut buf = vec![];
-        let _ = buf.encode_u64(n);
-        let _ = buf.encode_u64_le(n);
-        let _ = buf.encode_u64_desc(n);
-        let _ = buf.encode_var_u64(n);
+        let _ = buf.write_u64(n);
+        let _ = buf.write_u64_le(n);
+        let _ = buf.write_u64_desc(n);
+        let _ = buf.write_var_u64(n);
     }
     {
         let mut cursor = Cursor::new(data);
         let n = cursor.read_as_i64()?;
         let mut buf = vec![];
-        let _ = buf.encode_i64(n);
-        let _ = buf.encode_i64_le(n);
-        let _ = buf.encode_i64_desc(n);
-        let _ = buf.encode_var_i64(n);
+        let _ = buf.write_i64(n);
+        let _ = buf.write_i64_le(n);
+        let _ = buf.write_i64_desc(n);
+        let _ = buf.write_var_i64(n);
     }
     {
         let mut cursor = Cursor::new(data);
         let n = cursor.read_as_f64()?;
         let mut buf = vec![];
-        let _ = buf.encode_f64(n);
-        let _ = buf.encode_f64_le(n);
-        let _ = buf.encode_f64_desc(n);
+        let _ = buf.write_f64(n);
+        let _ = buf.write_f64_le(n);
+        let _ = buf.write_f64_desc(n);
     }
     {
         let mut cursor = Cursor::new(data);
         let n = cursor.read_as_u32()?;
         let mut buf = vec![];
-        let _ = buf.encode_u32(n);
-        let _ = buf.encode_u32_le(n);
+        let _ = buf.write_u32(n);
+        let _ = buf.write_u32_le(n);
     }
     {
         let mut cursor = Cursor::new(data);
         let n = cursor.read_as_i32()?;
         let mut buf = vec![];
-        let _ = buf.encode_i32_le(n);
+        let _ = buf.write_i32_le(n);
     }
     {
         let mut cursor = Cursor::new(data);
         let n = cursor.read_as_u16()?;
         let mut buf = vec![];
-        let _ = buf.encode_u16(n);
-        let _ = buf.encode_u16_le(n);
+        let _ = buf.write_u16(n);
+        let _ = buf.write_u16_le(n);
     }
     {
         let buf = data.to_owned();

--- a/src/coprocessor/codec/chunk/chunk.rs
+++ b/src/coprocessor/codec/chunk/chunk.rs
@@ -16,7 +16,6 @@ use super::Result;
 use crate::coprocessor::codec::Datum;
 #[cfg(test)]
 use crate::util::codec::BytesSlice;
-use std::io::Write;
 use tipb::expression::FieldType;
 
 /// `Chunk` stores multiple rows of data in Apache Arrow format.
@@ -105,7 +104,7 @@ pub trait ChunkEncoder: ColumnEncoder {
     }
 }
 
-impl<T: Write> ChunkEncoder for T {}
+impl<T: ColumnEncoder> ChunkEncoder for T {}
 
 /// `Row` represents one row in the chunk.
 pub struct Row<'a> {

--- a/src/coprocessor/codec/data_type/vector.rs
+++ b/src/coprocessor/codec/data_type/vector.rs
@@ -536,8 +536,7 @@ impl VectorValue {
     ) -> Result<()> {
         use crate::coprocessor::codec::mysql::DecimalEncoder;
         use crate::coprocessor::codec::mysql::JsonEncoder;
-        use crate::util::codec::bytes::BytesEncoder;
-        use crate::util::codec::number::NumberEncoder;
+        use codec::prelude::{BufferByteEncoder, BufferNumberEncoder};
 
         match self {
             VectorValue::Int(ref vec) => {
@@ -549,10 +548,10 @@ impl VectorValue {
                         // Always encode to INT / UINT instead of VAR INT to be efficient.
                         if field_type.flag().contains(FieldTypeFlag::UNSIGNED) {
                             output.push(datum::UINT_FLAG);
-                            output.encode_u64(val as u64)?;
+                            output.write_u64(val as u64)?;
                         } else {
                             output.push(datum::INT_FLAG);
-                            output.encode_i64(val)?;
+                            output.write_i64(val)?;
                         }
                     }
                 }
@@ -565,7 +564,7 @@ impl VectorValue {
                     }
                     Some(val) => {
                         output.push(datum::FLOAT_FLAG);
-                        output.encode_f64(val)?;
+                        output.write_f64(val)?;
                     }
                 }
                 Ok(())
@@ -590,7 +589,7 @@ impl VectorValue {
                     }
                     Some(ref val) => {
                         output.push(datum::COMPACT_BYTES_FLAG);
-                        output.encode_compact_bytes(val)?;
+                        output.write_compact_bytes(val)?;
                     }
                 }
                 Ok(())
@@ -602,7 +601,7 @@ impl VectorValue {
                     }
                     Some(ref val) => {
                         output.push(datum::UINT_FLAG);
-                        output.encode_u64(val.to_packed_u64())?;
+                        output.write_u64(val.to_packed_u64())?;
                     }
                 }
                 Ok(())
@@ -614,7 +613,7 @@ impl VectorValue {
                     }
                     Some(ref val) => {
                         output.push(datum::DURATION_FLAG);
-                        output.encode_i64(val.to_nanos())?;
+                        output.write_i64(val.to_nanos())?;
                     }
                 }
                 Ok(())

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -11,14 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use byteorder::WriteBytesExt;
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::{self, Debug, Display, Formatter};
-use std::io::Write;
 use std::str::FromStr;
 use std::{i64, str};
 
+use codec::prelude::{BufferByteEncoder, BufferNumberEncoder};
 use cop_datatype::FieldTypeTp;
 
 use super::mysql::{
@@ -27,7 +26,7 @@ use super::mysql::{
 };
 use super::{convert, Error, Result};
 use crate::coprocessor::dag::expr::EvalContext;
-use crate::util::codec::bytes::{self, BytesEncoder};
+use crate::util::codec::bytes;
 use crate::util::codec::{number, BytesSlice};
 use crate::util::escape;
 
@@ -861,7 +860,7 @@ pub fn decode(data: &mut BytesSlice<'_>) -> Result<Vec<Datum>> {
 }
 
 /// `DatumEncoder` encodes the datum.
-pub trait DatumEncoder: BytesEncoder + DecimalEncoder + JsonEncoder {
+pub trait DatumEncoder: DecimalEncoder + JsonEncoder + BufferByteEncoder {
     /// Encode values to buf slice.
     fn encode(&mut self, values: &[Datum], comparable: bool) -> Result<()> {
         let mut find_min = false;
@@ -875,33 +874,34 @@ pub trait DatumEncoder: BytesEncoder + DecimalEncoder + JsonEncoder {
                 Datum::I64(i) => {
                     if comparable {
                         self.write_u8(INT_FLAG)?;
-                        self.encode_i64(i)?;
+                        self.write_i64(i)?;
                     } else {
                         self.write_u8(VAR_INT_FLAG)?;
-                        self.encode_var_i64(i)?;
+                        self.write_var_i64(i)?;
                     }
                 }
                 Datum::U64(u) => {
                     if comparable {
                         self.write_u8(UINT_FLAG)?;
-                        self.encode_u64(u)?;
+                        self.write_u64(u)?;
                     } else {
                         self.write_u8(VAR_UINT_FLAG)?;
-                        self.encode_var_u64(u)?;
+                        self.write_var_u64(u)?;
                     }
                 }
                 Datum::Bytes(ref bs) => {
                     if comparable {
                         self.write_u8(BYTES_FLAG)?;
-                        self.encode_bytes(bs, false)?;
+                        self.write_bytes(bs, false)?;
                     } else {
                         self.write_u8(COMPACT_BYTES_FLAG)?;
-                        self.encode_compact_bytes(bs)?;
+                        self.write_var_i64(bs.len() as i64)?;
+                        self.write_all(bs)?;
                     }
                 }
                 Datum::F64(f) => {
                     self.write_u8(FLOAT_FLAG)?;
-                    self.encode_f64(f)?;
+                    self.write_f64(f)?;
                 }
                 Datum::Null => self.write_u8(NIL_FLAG)?,
                 Datum::Min => {
@@ -911,11 +911,11 @@ pub trait DatumEncoder: BytesEncoder + DecimalEncoder + JsonEncoder {
                 Datum::Max => self.write_u8(MAX_FLAG)?,
                 Datum::Time(ref t) => {
                     self.write_u8(UINT_FLAG)?;
-                    self.encode_u64(t.to_packed_u64())?;
+                    self.write_u64(t.to_packed_u64())?;
                 }
                 Datum::Dur(ref d) => {
                     self.write_u8(DURATION_FLAG)?;
-                    self.encode_i64(d.to_nanos())?;
+                    self.write_i64(d.to_nanos())?;
                 }
                 Datum::Dec(ref d) => {
                     self.write_u8(DECIMAL_FLAG)?;
@@ -932,7 +932,7 @@ pub trait DatumEncoder: BytesEncoder + DecimalEncoder + JsonEncoder {
     }
 }
 
-impl<T: Write> DatumEncoder for T {}
+impl<T> DatumEncoder for T where T: BufferNumberEncoder {}
 
 /// Get the approximate needed buffer size of values.
 ///

--- a/src/coprocessor/codec/error.rs
+++ b/src/coprocessor/codec/error.rs
@@ -177,6 +177,12 @@ impl From<util::codec::Error> for Error {
     }
 }
 
+impl From<codec::Error> for Error {
+    fn from(err: codec::Error) -> Error {
+        box_err!("codec:{:?}", err)
+    }
+}
+
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
         let uerr: util::codec::Error = err.into();

--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -11,8 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::util::codec::number::{self, NumberEncoder};
-use crate::util::codec::BytesSlice;
+use crate::util::codec::{number, BytesSlice};
 use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter};
 use std::io::Write;
@@ -22,6 +21,7 @@ use time::{self, Tm};
 
 use super::super::Result;
 use super::{check_fsp, parse_frac, Decimal};
+use codec::prelude::BufferNumberEncoder;
 
 pub const NANOS_PER_SEC: i64 = 1_000_000_000;
 pub const NANO_WIDTH: u32 = 9;
@@ -310,11 +310,11 @@ impl Ord for Duration {
     }
 }
 
-impl<T: Write> DurationEncoder for T {}
-pub trait DurationEncoder: NumberEncoder {
+impl<T: BufferNumberEncoder> DurationEncoder for T {}
+pub trait DurationEncoder: BufferNumberEncoder {
     fn encode_duration(&mut self, v: &Duration) -> Result<()> {
-        self.encode_i64(v.to_nanos())?;
-        self.encode_i64(i64::from(v.fsp)).map_err(From::from)
+        self.write_i64(v.to_nanos())?;
+        self.write_i64(i64::from(v.fsp)).map_err(From::from)
     }
 }
 

--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 use std::convert::TryInto;
-use std::io::Write;
 use std::{cmp, u8};
 
 use cop_datatype::prelude::*;
@@ -24,10 +23,10 @@ use tipb::schema::ColumnInfo;
 use super::mysql::{Duration, Time};
 use super::{datum, Datum, Error, Result};
 use crate::coprocessor::dag::expr::EvalContext;
-use crate::util::codec::number::{self, NumberEncoder};
-use crate::util::codec::BytesSlice;
+use crate::util::codec::{number, BytesSlice};
 use crate::util::collections::{HashMap, HashSet};
 use crate::util::escape;
+use codec::prelude::BufferNumberEncoder;
 
 // handle or index id
 pub const ID_LEN: usize = 8;
@@ -41,21 +40,21 @@ pub const TABLE_PREFIX_LEN: usize = 1;
 pub const TABLE_PREFIX_KEY_LEN: usize = TABLE_PREFIX_LEN + ID_LEN;
 
 /// `TableEncoder` encodes the table record/index prefix.
-trait TableEncoder: NumberEncoder {
+trait TableEncoder: BufferNumberEncoder {
     fn append_table_record_prefix(&mut self, table_id: i64) -> Result<()> {
         self.write_all(TABLE_PREFIX)?;
-        self.encode_i64(table_id)?;
+        self.write_i64(table_id)?;
         self.write_all(RECORD_PREFIX_SEP).map_err(Error::from)
     }
 
     fn append_table_index_prefix(&mut self, table_id: i64) -> Result<()> {
         self.write_all(TABLE_PREFIX)?;
-        self.encode_i64(table_id)?;
+        self.write_i64(table_id)?;
         self.write_all(INDEX_PREFIX_SEP).map_err(Error::from)
     }
 }
 
-impl<T: Write> TableEncoder for T {}
+impl<T: BufferNumberEncoder> TableEncoder for T {}
 
 /// Extracts table prefix from table record or index.
 #[inline]
@@ -136,7 +135,7 @@ pub fn encode_row_key(table_id: i64, handle: i64) -> Vec<u8> {
     let mut key = Vec::with_capacity(RECORD_ROW_KEY_LEN);
     // can't panic
     key.append_table_record_prefix(table_id).unwrap();
-    key.encode_i64(handle).unwrap();
+    key.write_i64(handle).unwrap();
     key
 }
 
@@ -144,8 +143,8 @@ pub fn encode_row_key(table_id: i64, handle: i64) -> Vec<u8> {
 pub fn encode_column_key(table_id: i64, handle: i64, column_id: i64) -> Vec<u8> {
     let mut key = Vec::with_capacity(RECORD_ROW_KEY_LEN + ID_LEN);
     key.append_table_record_prefix(table_id).unwrap();
-    key.encode_i64(handle).unwrap();
-    key.encode_i64(column_id).unwrap();
+    key.write_i64(handle).unwrap();
+    key.write_i64(column_id).unwrap();
     key
 }
 
@@ -182,7 +181,7 @@ pub fn truncate_as_row_key(key: &[u8]) -> Result<&[u8]> {
 pub fn encode_index_seek_key(table_id: i64, idx_id: i64, encoded: &[u8]) -> Vec<u8> {
     let mut key = Vec::with_capacity(PREFIX_LEN + ID_LEN + encoded.len());
     key.append_table_index_prefix(table_id).unwrap();
-    key.encode_i64(idx_id).unwrap();
+    key.write_i64(idx_id).unwrap();
     key.write_all(encoded).unwrap();
     key
 }

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -278,7 +278,7 @@ pub mod tests {
     use crate::storage::mvcc::MvccTxn;
     use crate::storage::SnapshotStore;
     use crate::storage::{Key, Mutation, Options};
-    use crate::util::codec::number::NumberEncoder;
+    use codec::prelude::BufferNumberEncoder;
     use cop_datatype::{FieldTypeAccessor, FieldTypeTp};
     use kvproto::{
         coprocessor::KeyRange,
@@ -295,7 +295,7 @@ pub mod tests {
         let mut expr = Expr::new();
         expr.set_tp(tp);
         if tp == ExprType::ColumnRef {
-            expr.mut_val().encode_i64(id.unwrap()).unwrap();
+            expr.mut_val().write_i64(id.unwrap()).unwrap();
         } else {
             expr.mut_children().push(child.unwrap());
         }

--- a/src/coprocessor/dag/executor/selection.rs
+++ b/src/coprocessor/dag/executor/selection.rs
@@ -100,7 +100,7 @@ mod tests {
     use tipb::expression::{Expr, ExprType, ScalarFuncSig};
 
     use crate::coprocessor::codec::datum::Datum;
-    use crate::util::codec::number::NumberEncoder;
+    use codec::prelude::BufferNumberEncoder;
 
     use super::super::tests::{gen_table_scan_executor, new_col_info};
     use super::*;
@@ -129,13 +129,13 @@ mod tests {
         expr.mut_children().push({
             let mut lhs = Expr::new();
             lhs.set_tp(ExprType::ColumnRef);
-            lhs.mut_val().encode_i64(offset).unwrap();
+            lhs.mut_val().write_i64(offset).unwrap();
             lhs
         });
         expr.mut_children().push({
             let mut rhs = Expr::new();
             rhs.set_tp(ExprType::Uint64);
-            rhs.mut_val().encode_u64(val).unwrap();
+            rhs.mut_val().write_u64(val).unwrap();
             rhs
         });
         expr

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -172,8 +172,8 @@ pub mod tests {
     use crate::coprocessor::codec::table::RowColsDict;
     use crate::coprocessor::codec::Datum;
     use crate::coprocessor::dag::executor::OriginCols;
-    use crate::util::codec::number::NumberEncoder;
     use crate::util::collections::HashMap;
+    use codec::prelude::BufferNumberEncoder;
 
     use super::super::tests::{gen_table_scan_executor, get_range, new_col_info};
     use super::*;
@@ -182,7 +182,7 @@ pub mod tests {
         let mut item = ByItem::new();
         let mut expr = Expr::new();
         expr.set_tp(ExprType::ColumnRef);
-        expr.mut_val().encode_i64(offset).unwrap();
+        expr.mut_val().write_i64(offset).unwrap();
         item.set_expr(expr);
         item.set_desc(desc);
         item

--- a/src/coprocessor/dag/executor/topn_heap.rs
+++ b/src/coprocessor/dag/executor/topn_heap.rs
@@ -190,8 +190,8 @@ mod tests {
     use crate::coprocessor::codec::Datum;
     use crate::coprocessor::dag::executor::OriginCols;
     use crate::coprocessor::dag::expr::EvalContext;
-    use crate::util::codec::number::*;
     use crate::util::collections::HashMap;
+    use codec::prelude::BufferNumberEncoder;
 
     use super::*;
 
@@ -199,7 +199,7 @@ mod tests {
         let mut item = ByItem::new();
         let mut expr = Expr::new();
         expr.set_tp(ExprType::ColumnRef);
-        expr.mut_val().encode_i64(col_id).unwrap();
+        expr.mut_val().write_i64(col_id).unwrap();
         item.set_expr(expr);
         item.set_desc(desc);
         item

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -336,7 +336,8 @@ mod tests {
         charset, Decimal, DecimalEncoder, Duration, Json, Time,
     };
     use crate::coprocessor::codec::{mysql, Datum};
-    use crate::util::codec::number::{self, NumberEncoder};
+    use crate::util::codec::number;
+    use codec::prelude::BufferNumberEncoder;
 
     #[inline]
     pub fn str2dec(s: &str) -> Datum {
@@ -381,7 +382,7 @@ mod tests {
         let mut expr = Expr::new();
         expr.set_tp(ExprType::ColumnRef);
         let mut buf = Vec::with_capacity(8);
-        buf.encode_i64(col_id).unwrap();
+        buf.write_i64(col_id).unwrap();
         expr.set_val(buf);
         expr
     }
@@ -419,13 +420,13 @@ mod tests {
             Datum::I64(i) => {
                 expr.set_tp(ExprType::Int64);
                 let mut buf = Vec::with_capacity(number::I64_SIZE);
-                buf.encode_i64(i).unwrap();
+                buf.write_i64(i).unwrap();
                 expr.set_val(buf);
             }
             Datum::U64(u) => {
                 expr.set_tp(ExprType::Uint64);
                 let mut buf = Vec::with_capacity(number::U64_SIZE);
-                buf.encode_u64(u).unwrap();
+                buf.write_u64(u).unwrap();
                 expr.set_val(buf);
                 expr.mut_field_type()
                     .as_mut_accessor()
@@ -440,13 +441,13 @@ mod tests {
             Datum::F64(f) => {
                 expr.set_tp(ExprType::Float64);
                 let mut buf = Vec::with_capacity(number::F64_SIZE);
-                buf.encode_f64(f).unwrap();
+                buf.write_f64(f).unwrap();
                 expr.set_val(buf);
             }
             Datum::Dur(d) => {
                 expr.set_tp(ExprType::MysqlDuration);
                 let mut buf = Vec::with_capacity(number::I64_SIZE);
-                buf.encode_i64(d.to_nanos()).unwrap();
+                buf.write_i64(d.to_nanos()).unwrap();
                 expr.set_val(buf);
             }
             Datum::Dec(d) => {
@@ -465,7 +466,7 @@ mod tests {
                 expr.set_field_type(ft);
                 let u = t.to_packed_u64();
                 let mut buf = Vec::with_capacity(number::U64_SIZE);
-                buf.encode_u64(u).unwrap();
+                buf.write_u64(u).unwrap();
                 expr.set_val(buf);
             }
             Datum::Json(j) => {

--- a/src/coprocessor/dag/rpn_expr/types/expr_builder.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_builder.rs
@@ -309,8 +309,7 @@ mod tests {
     #[test]
     #[allow(clippy::float_cmp)]
     fn test_append_rpn_nodes_recursively() {
-        use crate::util::codec::number::NumberEncoder;
-
+        use codec::prelude::BufferNumberEncoder;
         // Input:
         // FnD(a, FnA(FnC(b, c, d)), FnA(FnB(e, f))
         //
@@ -334,7 +333,7 @@ mod tests {
                 .mut_field_type()
                 .as_mut_accessor()
                 .set_tp(FieldTypeTp::LongLong);
-            node_b.mut_val().encode_i64(7).unwrap();
+            node_b.mut_val().write_i64(7).unwrap();
 
             // node c
             let mut node_c = Expr::new();
@@ -343,7 +342,7 @@ mod tests {
                 .mut_field_type()
                 .as_mut_accessor()
                 .set_tp(FieldTypeTp::LongLong);
-            node_c.mut_val().encode_i64(3).unwrap();
+            node_c.mut_val().write_i64(3).unwrap();
 
             // node d
             let mut node_d = Expr::new();
@@ -352,7 +351,7 @@ mod tests {
                 .mut_field_type()
                 .as_mut_accessor()
                 .set_tp(FieldTypeTp::LongLong);
-            node_d.mut_val().encode_i64(11).unwrap();
+            node_d.mut_val().write_i64(11).unwrap();
 
             // FnC
             let mut node_fn_c = Expr::new();
@@ -386,7 +385,7 @@ mod tests {
                 .mut_field_type()
                 .as_mut_accessor()
                 .set_tp(FieldTypeTp::Double);
-            node_e.mut_val().encode_f64(-1.5).unwrap();
+            node_e.mut_val().write_f64(-1.5).unwrap();
 
             // node f
             let mut node_f = Expr::new();
@@ -395,7 +394,7 @@ mod tests {
                 .mut_field_type()
                 .as_mut_accessor()
                 .set_tp(FieldTypeTp::Double);
-            node_f.mut_val().encode_f64(100.12).unwrap();
+            node_f.mut_val().write_f64(100.12).unwrap();
 
             // FnB
             let mut node_fn_b = Expr::new();

--- a/src/raftstore/coprocessor/split_check/table.rs
+++ b/src/raftstore/coprocessor/split_check/table.rs
@@ -225,10 +225,10 @@ fn is_same_table(left_key: &[u8], right_key: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
     use std::sync::mpsc;
     use std::sync::Arc;
 
+    use codec::prelude::BufferNumberEncoder;
     use kvproto::metapb::Peer;
     use kvproto::pdpb::CheckPolicy;
     use rocksdb::Writable;
@@ -238,7 +238,6 @@ mod tests {
     use crate::raftstore::store::{CasualMessage, SplitCheckRunner, SplitCheckTask};
     use crate::storage::types::Key;
     use crate::storage::ALL_CFS;
-    use crate::util::codec::number::NumberEncoder;
     use crate::util::config::ReadableSize;
     use crate::util::rocksdb_util::new_engine;
     use crate::util::worker::Runnable;
@@ -251,7 +250,7 @@ mod tests {
     fn gen_table_prefix(table_id: i64) -> Vec<u8> {
         let mut buf = Vec::with_capacity(TABLE_PREFIX_KEY_LEN);
         buf.write_all(TABLE_PREFIX).unwrap();
-        buf.encode_i64(table_id).unwrap();
+        buf.write_i64(table_id).unwrap();
         buf
     }
 

--- a/src/raftstore/errors.rs
+++ b/src/raftstore/errors.rs
@@ -20,7 +20,7 @@ use crossbeam::TrySendError;
 use protobuf::{ProtobufError, RepeatedField};
 
 use crate::pd;
-use crate::util::codec;
+use crate::util;
 use kvproto::{errorpb, metapb};
 use raft;
 
@@ -98,6 +98,13 @@ quick_error! {
             cause(err)
             description(err.description())
             display("Protobuf {}", err)
+        }
+        // TOOD: this will be removed when switch to component/codec finished
+        CodecDeprecated(err: util::codec::Error) {
+            from()
+            cause(err)
+            description(err.description())
+            display("Codec {}", err)
         }
         Codec(err: codec::Error) {
             from()

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -14,9 +14,10 @@
 use super::super::types::Value;
 use super::{Error, Result};
 use crate::storage::{Mutation, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
-use crate::util::codec::bytes::{self, BytesEncoder};
-use crate::util::codec::number::{self, NumberEncoder, MAX_VAR_U64_LEN};
+use crate::util::codec::bytes;
+use crate::util::codec::number::{self, MAX_VAR_U64_LEN};
 use byteorder::ReadBytesExt;
+use codec::prelude::{BufferByteEncoder, BufferNumberEncoder};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LockType {
@@ -87,9 +88,9 @@ impl Lock {
             1 + MAX_VAR_U64_LEN + self.primary.len() + MAX_VAR_U64_LEN + SHORT_VALUE_MAX_LEN + 2,
         );
         b.push(self.lock_type.to_u8());
-        b.encode_compact_bytes(&self.primary).unwrap();
-        b.encode_var_u64(self.ts).unwrap();
-        b.encode_var_u64(self.ttl).unwrap();
+        b.write_compact_bytes(&self.primary).unwrap();
+        b.write_var_u64(self.ts).unwrap();
+        b.write_var_u64(self.ttl).unwrap();
         if let Some(ref v) = self.short_value {
             b.push(SHORT_VALUE_PREFIX);
             b.push(v.len() as u8);

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -15,8 +15,9 @@ use super::super::types::Value;
 use super::lock::LockType;
 use super::{Error, Result};
 use crate::storage::{SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
-use crate::util::codec::number::{self, NumberEncoder, MAX_VAR_U64_LEN};
+use crate::util::codec::number::{self, MAX_VAR_U64_LEN};
 use byteorder::ReadBytesExt;
+use codec::prelude::BufferNumberEncoder;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WriteType {
@@ -79,7 +80,7 @@ impl Write {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut b = Vec::with_capacity(1 + MAX_VAR_U64_LEN + SHORT_VALUE_MAX_LEN + 2);
         b.push(self.write_type.to_u8());
-        b.encode_var_u64(self.start_ts).unwrap();
+        b.write_var_u64(self.start_ts).unwrap();
         if let Some(ref v) = self.short_value {
             b.push(SHORT_VALUE_PREFIX);
             b.push(v.len() as u8);


### PR DESCRIPTION
## What have you changed? (mandatory)

switch the `encode` part to using `component/codec` instead of `util/codec`.
since most encode part in TiKV is for test, this PR is simplely replace the methods call. Except:
1. I add `write_u8` and `write_all` to `BufferNumberEncoder` (no document and test yet).  `write_all` maybe a conflict method name when `std::io::Write` is imported, maybe `encode_all` or `batch_write_u8` is better

2. I add `BufferByteEncoder` for `write_bytes` and `write_compact_bytes`(no ducuments and tests yet)

3.  `raftstore/store/snap` using `write_compact_bytes` on `std::io::File`. since  `component/codec` is not implemented over `std::io::Write`, should I impl `BufferByteEncoder` on `std::io::File` ? (currently I use a `Vec` to hold content,  then write it to the file)

## What are the type of the changes? (mandatory)

Improvement

## How has this PR been tested? (mandatory)

unit test

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

#4040 

## Benchmark result if necessary (optional)
the encode part in TiKV is mostly used for test,  there will be benchmark when switch the decode part


