### PR TITLE
*: simplify seek region interface

### DIFF
--- a/src/raftstore/coprocessor/mod.rs
+++ b/src/raftstore/coprocessor/mod.rs
@@ -29,7 +29,7 @@ pub mod split_observer;
 pub use self::config::Config;
 pub use self::dispatcher::{CoprocessorHost, Registry};
 pub use self::error::{Error, Result};
-pub use self::region_info_accessor::{RegionInfo, RegionInfoAccessor};
+pub use self::region_info_accessor::{RegionInfo, RegionInfoAccessor, SeekRegionCallback};
 pub use self::split_check::{
     HalfCheckObserver, Host as SplitCheckerHost, KeysCheckObserver, SizeCheckObserver,
     TableCheckObserver,

--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -22,8 +22,7 @@ use super::{
     Coprocessor, CoprocessorHost, ObserverContext, RegionChangeEvent, RegionChangeObserver,
     RoleObserver,
 };
-use crate::raftstore::store::keys::{data_end_key, data_key, origin_key, DATA_MAX_KEY};
-use crate::raftstore::store::msg::{SeekRegionCallback, SeekRegionFilter, SeekRegionResult};
+use crate::raftstore::store::keys::{data_end_key, data_key};
 use crate::storage::engine::{RegionInfoProvider, Result as EngineResult};
 use crate::util::collections::HashMap;
 use crate::util::escape;
@@ -84,28 +83,28 @@ impl RegionInfo {
 type RegionsMap = HashMap<u64, RegionInfo>;
 type RegionRangesMap = BTreeMap<Vec<u8>, u64>;
 
+pub type SeekRegionCallback = Box<dyn Fn(&mut dyn Iterator<Item = &RegionInfo>) + Send>;
+
 /// `RegionInfoAccessor` has its own thread. Queries and updates are done by sending commands to the
 /// thread.
-enum RegionCollectorMsg {
+enum RegionInfoQuery {
     RaftStoreEvent(RaftStoreEvent),
     SeekRegion {
         from: Vec<u8>,
-        filter: SeekRegionFilter,
-        limit: u32,
         callback: SeekRegionCallback,
     },
     /// Gets all contents from the collection. Only used for testing.
     DebugDump(mpsc::Sender<(RegionsMap, RegionRangesMap)>),
 }
 
-impl Display for RegionCollectorMsg {
+impl Display for RegionInfoQuery {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            RegionCollectorMsg::RaftStoreEvent(e) => write!(f, "RaftStoreEvent({:?})", e),
-            RegionCollectorMsg::SeekRegion { from, limit, .. } => {
-                write!(f, "SeekRegion(from: {}, limit: {})", escape(from), limit)
+            RegionInfoQuery::RaftStoreEvent(e) => write!(f, "RaftStoreEvent({:?})", e),
+            RegionInfoQuery::SeekRegion { from, .. } => {
+                write!(f, "SeekRegion(from: {})", escape(from))
             }
-            RegionCollectorMsg::DebugDump(_) => write!(f, "DebugDump"),
+            RegionInfoQuery::DebugDump(_) => write!(f, "DebugDump"),
         }
     }
 }
@@ -114,7 +113,7 @@ impl Display for RegionCollectorMsg {
 /// through the `scheduler`.
 #[derive(Clone)]
 struct RegionEventListener {
-    scheduler: Scheduler<RegionCollectorMsg>,
+    scheduler: Scheduler<RegionInfoQuery>,
 }
 
 impl Coprocessor for RegionEventListener {}
@@ -133,7 +132,7 @@ impl RegionChangeObserver for RegionEventListener {
             RegionChangeEvent::Destroy => RaftStoreEvent::DestroyRegion { region },
         };
         self.scheduler
-            .schedule(RegionCollectorMsg::RaftStoreEvent(event))
+            .schedule(RegionInfoQuery::RaftStoreEvent(event))
             .unwrap();
     }
 }
@@ -143,7 +142,7 @@ impl RoleObserver for RegionEventListener {
         let region = context.region().clone();
         let event = RaftStoreEvent::RoleChange { region, role };
         self.scheduler
-            .schedule(RegionCollectorMsg::RaftStoreEvent(event))
+            .schedule(RegionInfoQuery::RaftStoreEvent(event))
             .unwrap();
     }
 }
@@ -151,7 +150,7 @@ impl RoleObserver for RegionEventListener {
 /// Creates an `RegionEventListener` and register it to given coprocessor host.
 fn register_region_event_listener(
     host: &mut CoprocessorHost,
-    scheduler: Scheduler<RegionCollectorMsg>,
+    scheduler: Scheduler<RegionInfoQuery>,
 ) {
     let listener = RegionEventListener { scheduler };
 
@@ -355,38 +354,13 @@ impl RegionCollector {
         true
     }
 
-    fn handle_seek_region(
-        &self,
-        from_key: Vec<u8>,
-        filter: SeekRegionFilter,
-        mut limit: u32,
-        callback: SeekRegionCallback,
-    ) {
-        assert!(limit > 0);
-
+    fn handle_seek_region(&self, from_key: Vec<u8>, callback: SeekRegionCallback) {
         let from_key = data_key(&from_key);
-        for (end_key, region_id) in self.region_ranges.range((Excluded(from_key), Unbounded)) {
-            let RegionInfo { region, role } = &self.regions[region_id];
-            if filter(region, *role) {
-                callback(SeekRegionResult::Found(region.clone()));
-                return;
-            }
-
-            limit -= 1;
-            if limit == 0 {
-                // `origin_key` does not handle `DATA_MAX_KEY`, but we can return `Ended` rather
-                // than `LimitExceeded`.
-                if end_key.as_slice() >= DATA_MAX_KEY {
-                    break;
-                }
-
-                callback(SeekRegionResult::LimitExceeded {
-                    next_key: origin_key(end_key).to_vec(),
-                });
-                return;
-            }
-        }
-        callback(SeekRegionResult::Ended);
+        let mut iter = self
+            .region_ranges
+            .range((Excluded(from_key), Unbounded))
+            .map(|(_, region_id)| &self.regions[region_id]);
+        callback(&mut iter)
     }
 
     fn handle_raftstore_event(&mut self, event: RaftStoreEvent) {
@@ -430,21 +404,16 @@ impl RegionCollector {
     }
 }
 
-impl Runnable<RegionCollectorMsg> for RegionCollector {
-    fn run(&mut self, task: RegionCollectorMsg) {
+impl Runnable<RegionInfoQuery> for RegionCollector {
+    fn run(&mut self, task: RegionInfoQuery) {
         match task {
-            RegionCollectorMsg::RaftStoreEvent(event) => {
+            RegionInfoQuery::RaftStoreEvent(event) => {
                 self.handle_raftstore_event(event);
             }
-            RegionCollectorMsg::SeekRegion {
-                from,
-                filter,
-                limit,
-                callback,
-            } => {
-                self.handle_seek_region(from, filter, limit, callback);
+            RegionInfoQuery::SeekRegion { from, callback } => {
+                self.handle_seek_region(from, callback);
             }
-            RegionCollectorMsg::DebugDump(tx) => {
+            RegionInfoQuery::DebugDump(tx) => {
                 tx.send((self.regions.clone(), self.region_ranges.clone()))
                     .unwrap();
             }
@@ -454,7 +423,7 @@ impl Runnable<RegionCollectorMsg> for RegionCollector {
 
 const METRICS_FLUSH_INTERVAL: u64 = 10_000; // 10s
 
-impl RunnableWithTimer<RegionCollectorMsg, ()> for RegionCollector {
+impl RunnableWithTimer<RegionInfoQuery, ()> for RegionCollector {
     fn on_timeout(&mut self, timer: &mut Timer<()>, _: ()) {
         let mut count = 0;
         let mut leader = 0;
@@ -477,8 +446,8 @@ impl RunnableWithTimer<RegionCollectorMsg, ()> for RegionCollector {
 /// `RegionInfoAccessor` keeps all region information separately from raftstore itself.
 #[derive(Clone)]
 pub struct RegionInfoAccessor {
-    worker: Arc<Mutex<Worker<RegionCollectorMsg>>>,
-    scheduler: Scheduler<RegionCollectorMsg>,
+    worker: Arc<Mutex<Worker<RegionInfoQuery>>>,
+    scheduler: Scheduler<RegionInfoQuery>,
 }
 
 impl RegionInfoAccessor {
@@ -517,41 +486,21 @@ impl RegionInfoAccessor {
     pub fn debug_dump(&self) -> (RegionsMap, RegionRangesMap) {
         let (tx, rx) = mpsc::channel();
         self.scheduler
-            .schedule(RegionCollectorMsg::DebugDump(tx))
+            .schedule(RegionInfoQuery::DebugDump(tx))
             .unwrap();
         rx.recv().unwrap()
     }
 }
 
 impl RegionInfoProvider for RegionInfoAccessor {
-    fn seek_region(
-        &self,
-        from: &[u8],
-        filter: SeekRegionFilter,
-        limit: u32,
-    ) -> EngineResult<SeekRegionResult> {
-        let (tx, rx) = mpsc::channel();
-        let msg = RegionCollectorMsg::SeekRegion {
+    fn seek_region(&self, from: &[u8], callback: SeekRegionCallback) -> EngineResult<()> {
+        let msg = RegionInfoQuery::SeekRegion {
             from: from.to_vec(),
-            filter,
-            limit,
-            callback: Box::new(move |res| {
-                tx.send(res).unwrap_or_else(|e| {
-                    panic!("failed to send seek_region result back to caller: {:?}", e)
-                })
-            }),
+            callback,
         };
         self.scheduler
             .schedule(msg)
             .map_err(|e| box_err!("failed to send request to region collector: {:?}", e))
-            .and_then(|_| {
-                rx.recv().map_err(|e| {
-                    box_err!(
-                        "failed to receive seek region result from region collector: {:?}",
-                        e
-                    )
-                })
-            })
     }
 }
 

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -38,8 +38,7 @@ pub use self::engine::{Iterable, Mutable, Peekable};
 pub use self::fsm::{new_compaction_listener, DestroyPeerJob, RaftRouter, StoreInfo};
 pub use self::msg::{
     Callback, CasualMessage, PeerMsg, PeerTick, RaftCommand, ReadCallback, ReadResponse,
-    SeekRegionCallback, SeekRegionFilter, SeekRegionResult, SignificantMsg, StoreMsg, StoreTick,
-    WriteCallback, WriteResponse,
+    SignificantMsg, StoreMsg, StoreTick, WriteCallback, WriteResponse,
 };
 pub use self::peer::{
     Peer, PeerStat, ProposalContext, ReadExecutor, RequestInspector, RequestPolicy,

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -27,7 +27,7 @@ use crate::raftstore::store::util::KeysInfoFormatter;
 use crate::raftstore::store::SnapKey;
 use crate::util::escape;
 use crate::util::rocksdb_util::CompactedEvent;
-use raft::{SnapshotStatus, StateRole};
+use raft::SnapshotStatus;
 
 use super::RegionSnapshot;
 
@@ -42,18 +42,8 @@ pub struct WriteResponse {
     pub response: RaftCmdResponse,
 }
 
-#[derive(Debug)]
-pub enum SeekRegionResult {
-    Found(metapb::Region),
-    LimitExceeded { next_key: Vec<u8> },
-    Ended,
-}
-
 pub type ReadCallback = Box<dyn FnBox(ReadResponse) + Send>;
 pub type WriteCallback = Box<dyn FnBox(WriteResponse) + Send>;
-
-pub type SeekRegionCallback = Box<dyn FnBox(SeekRegionResult) + Send>;
-pub type SeekRegionFilter = Box<dyn Fn(&metapb::Region, StateRole) -> bool + Send>;
 
 /// Variants of callbacks for `Msg`.
 ///  - `Read`: a callbak for read only requests including `StatusRequest`,

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -17,8 +17,8 @@ use std::cmp::Ordering;
 use std::time::Duration;
 use std::{error, result};
 
+use crate::raftstore::coprocessor::SeekRegionCallback;
 use crate::raftstore::store::engine::IterOption;
-use crate::raftstore::store::{SeekRegionFilter, SeekRegionResult};
 use crate::storage::{CfName, Key, Value, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::errorpb::Error as ErrorHeader;
 use kvproto::kvrpcpb::{Context, ScanDetail, ScanInfo};
@@ -158,12 +158,7 @@ pub trait Iterator: Send {
 pub trait RegionInfoProvider: Send + Clone + 'static {
     /// Find the first region `r` whose range contains or greater than `from_key` and the peer on
     /// this TiKV satisfies `filter(peer)` returns true.
-    fn seek_region(
-        &self,
-        from: &[u8],
-        filter: SeekRegionFilter,
-        limit: u32,
-    ) -> Result<SeekRegionResult>;
+    fn seek_region(&self, from: &[u8], filter: SeekRegionCallback) -> Result<()>;
 }
 
 macro_rules! near_loop {

--- a/tests/integrations/storage/test_seek_region.rs
+++ b/tests/integrations/storage/test_seek_region.rs
@@ -17,7 +17,6 @@ use std::time::Duration;
 
 use test_raftstore::*;
 use tikv::raftstore::coprocessor::RegionInfoAccessor;
-use tikv::raftstore::store::SeekRegionResult;
 use tikv::storage::engine::RegionInfoProvider;
 use tikv::util::collections::HashMap;
 use tikv::util::HandyRwLock;
@@ -77,110 +76,51 @@ fn test_seek_region_impl<T: Simulator, R: RegionInfoProvider>(
         let engine = &region_info_providers[&node_id];
 
         // Test traverse all regions
-        let mut sought_regions = Vec::new();
-        let mut key = b"".to_vec();
-        loop {
-            let res = engine
-                .seek_region(&key, Box::new(|_, _| true), 100)
-                .unwrap();
-            match res {
-                SeekRegionResult::Found(region) => {
-                    key = region.get_end_key().to_vec();
-                    sought_regions.push(region);
-                    // Break on the last region
-                    if key.is_empty() {
-                        break;
-                    }
-                }
-                SeekRegionResult::Ended => break,
-                r => panic!("expect getting a region or Ended, but got {:?}", r),
-            }
-        }
+        let key = b"".to_vec();
+        let (tx, rx) = channel();
+        let tx_ = tx.clone();
+        engine
+            .seek_region(
+                &key,
+                Box::new(move |infos| {
+                    tx_.send(infos.map(|i| i.region.clone()).collect()).unwrap();
+                }),
+            )
+            .unwrap();
+        let sought_regions: Vec<_> = rx.recv_timeout(Duration::from_secs(3)).unwrap();
         assert_eq!(sought_regions, regions);
 
         // Test end_key is exclusive
-        let res = engine
-            .seek_region(b"k1", Box::new(|_, _| true), 100)
-            .unwrap();
-        match res {
-            SeekRegionResult::Found(region) => {
-                assert_eq!(region, regions[1]);
-            }
-            r => panic!("expect getting a region, but got {:?}", r),
-        }
-
-        // Test exactly reaches limit
-        let res = engine
-            .seek_region(b"", Box::new(|r, _| r.get_end_key() == b"k9"), 5)
-            .unwrap();
-        match res {
-            SeekRegionResult::Found(region) => {
-                assert_eq!(region, regions[4]);
-            }
-            r => panic!("expect getting a region, but got {:?}", r),
-        }
-
-        // Test exactly exceeds limit
-        let res = engine
-            .seek_region(b"", Box::new(|r, _| r.get_end_key() == b"k9"), 4)
-            .unwrap();
-        match res {
-            SeekRegionResult::LimitExceeded { next_key } => {
-                assert_eq!(&next_key, b"k7");
-            }
-            r => panic!("expect getting LimitExceeded, but got {:?}", r),
-        }
-
-        // Test seek to the end
-        let res = engine
-            .seek_region(b"", Box::new(|_, _| false), 100)
-            .unwrap();
-        match res {
-            SeekRegionResult::Ended => {}
-            r => panic!("expect getting Ended, but got {:?}", r),
-        }
-
-        // Test exactly to the end
-        let res = engine
-            .seek_region(b"", Box::new(|r, _| r.get_end_key().is_empty()), 6)
-            .unwrap();
-        match res {
-            SeekRegionResult::Found(region) => {
-                assert_eq!(region, regions[5]);
-            }
-            r => panic!("expect getting a region, but got {:?}", r),
-        }
-
-        // Test limit exactly reaches end
-        let res = engine.seek_region(b"", Box::new(|_, _| false), 6).unwrap();
-        match res {
-            SeekRegionResult::Ended => {}
-            r => panic!("expect getting Ended, but got {:?}", r),
-        }
-
-        // Test seek from non-starting key
-        let res = engine
-            .seek_region(b"k6\xff\xff\xff\xff\xff", Box::new(|_, _| true), 1)
-            .unwrap();
-        match res {
-            SeekRegionResult::Found(region) => {
-                assert_eq!(region, regions[3]);
-            }
-            r => panic!("expect getting a region, but got {:?}", r),
-        }
-        let res = engine
+        let (tx, rx) = channel();
+        let tx_ = tx.clone();
+        engine
             .seek_region(
-                b"\xff\xff\xff\xff\xff\xff\xff\xff",
-                Box::new(|_, _| true),
-                1,
+                b"k1",
+                Box::new(move |infos| tx_.send(infos.next().unwrap().region.clone()).unwrap()),
             )
             .unwrap();
-        match res {
-            SeekRegionResult::Found(region) => {
-                assert_eq!(region, regions[5]);
-            }
-            r => panic!("expect getting a region, but got {:?}", r),
-        }
+        let region = rx.recv_timeout(Duration::from_secs(3)).unwrap();
+        assert_eq!(region, regions[1]);
+
+        // Test seek from non-starting key
+        let tx_ = tx.clone();
+        engine
+            .seek_region(
+                b"k6\xff\xff\xff\xff\xff",
+                Box::new(move |infos| tx_.send(infos.next().unwrap().region.clone()).unwrap()),
+            )
+            .unwrap();
+        let region = rx.recv_timeout(Duration::from_secs(3)).unwrap();
+        assert_eq!(region, regions[3]);
+        let tx_ = tx.clone();
+        engine
+            .seek_region(
+                b"\xff\xff\xff\xff\xff\xff\xff\xff",
+                Box::new(move |infos| tx_.send(infos.next().unwrap().region.clone()).unwrap()),
+            )
+            .unwrap();
+        let region = rx.recv_timeout(Duration::from_secs(3)).unwrap();
+        assert_eq!(region, regions[5]);
     }
 }
 


### PR DESCRIPTION
## What have you changed? (mandatory)

Seek region required two callbacks and returned an additional result to indicate whether it exceeded the limit or reached the end. It's too complicated and limited. This PR makes it accept an arbitrary closure so that users can do whatever they want without touching RegionInfoAccessor.

## What are the type of the changes? (mandatory)

- Improvement

## How has this PR been tested? (mandatory)

unit tests.

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.
