### PR TITLE
Reuse ScalarFunc::find_str in ScalarFunc::instr

### DIFF
--- a/src/coprocessor/dag/expr/builtin_string.rs
+++ b/src/coprocessor/dag/expr/builtin_string.rs
@@ -907,18 +907,9 @@ impl ScalarFunc {
     ) -> Result<Option<i64>> {
         let s = try_opt!(self.children[0].eval_string_and_decode(ctx, row));
         let substr = try_opt!(self.children[1].eval_string_and_decode(ctx, row));
-        if substr.is_empty() {
-            return Ok(Some(1));
-        }
-        if s.is_empty() {
-            return Ok(Some(0));
-        }
-        let s = s.to_lowercase();
-        let substr = substr.to_lowercase();
-        match s.find(&substr) {
-            Some(x) => Ok(Some(1 + s[..x].chars().count() as i64)),
-            None => Ok(Some(0)),
-        }
+        Ok(Self::find_str(&s.to_lowercase(), &substr.to_lowercase())
+            .map(|i| 1 + i as i64)
+            .or(Some(0)))
     }
 
     #[inline]


### PR DESCRIPTION
## What have you changed? (mandatory)
`ScalarFunc::find_str` is a wrapper of `twoway::find_str` which have an optional SSE4.2 accelerated version (if detected at runtime) which is even faster.

## What are the type of changes? (mandatory)
- Improvement (a change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
pass all the test suit. `make test` already.
