### PR TITLE
Allow logger cleanup on fatal!()

### DIFF
--- a/src/bin/util/setup.rs
+++ b/src/bin/util/setup.rs
@@ -32,6 +32,7 @@ macro_rules! fatal {
         } else {
             eprintln!($lvl, $($arg)+);
         }
+        slog_global::clear_global();
         process::exit(1)
     })
 }


### PR DESCRIPTION
This clears the slog_global logger before exiting. It should prevent the
process from exiting prior logs all being flushed.

Related to #3387, #4328, #4358
