### PR TITLE
scripts: Don't cp -b

### DIFF
--- a/scripts/run-cargo.sh
+++ b/scripts/run-cargo.sh
@@ -44,7 +44,7 @@ if [[ -n "$X_CARGO_CONFIG_FILE" ]]; then
     args="$args -Zunstable-options -Zconfig-profile"
     mkdir .cargo 2> /dev/null || true
     set -x
-    cp -b "$X_CARGO_CONFIG_FILE" .cargo/config
+    cp "$X_CARGO_CONFIG_FILE" .cargo/config
     set +x
 fi
 


### PR DESCRIPTION
The -b backs up .cargo/config in case there is some custom config there.
-b doesn't work on macos though so just remove it. The risk of somebody
having their own config there, while also using these custom configs
is low.

