### PR TITLE
Remove #[inline(always)] and check output offsets to avoid panic

### DIFF
--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -247,7 +247,7 @@ impl MemComparableByteCodec {
     /// descending decoding, which performs better than inlining a flag.
     ///
     /// Please refer to `try_decode_first` for the meaning of return values, panics and errors.
-    #[inline(always)]
+    #[inline]
     fn try_decode_first_internal<T: MemComparableCodecHelper>(
         mut src_ptr: *const u8,
         src_len: usize,

--- a/src/coprocessor/dag/handler.rs
+++ b/src/coprocessor/dag/handler.rs
@@ -71,10 +71,24 @@ impl DAGRequestHandler {
             ranges,
             config.clone(),
         )?;
+
+        // Check output offsets
+        let output_offsets = req.take_output_offsets();
+        let schema_len = out_most_executor.schema().len();
+        for offset in &output_offsets {
+            if (*offset as usize) >= schema_len {
+                return Err(box_err!(
+                    "Invalid output offset (schema has {} columns, access index {})",
+                    schema_len,
+                    offset
+                ));
+            }
+        }
+
         Ok(super::batch_handler::BatchDAGHandler::new(
             deadline,
             out_most_executor,
-            req.take_output_offsets(),
+            output_offsets,
             config,
             ranges_len,
         ))

--- a/src/coprocessor/dag/rpn_expr/function.rs
+++ b/src/coprocessor/dag/rpn_expr/function.rs
@@ -67,7 +67,7 @@ impl Helper {
     /// Evaluates a function without argument to produce a vector value.
     ///
     /// The function will be called multiple times to fill the vector.
-    #[inline(always)]
+    #[inline]
     pub fn eval_0_arg<Ret, F>(
         rows: usize,
         mut f: F,
@@ -90,7 +90,7 @@ impl Helper {
     /// Evaluates a function with 1 scalar or vector argument to produce a vector value.
     ///
     /// The function will be called multiple times to fill the vector.
-    #[inline(always)]
+    #[inline]
     pub fn eval_1_arg<Arg0, Ret, F>(
         rows: usize,
         mut f: F,
@@ -123,7 +123,7 @@ impl Helper {
     /// Evaluates a function with 2 scalar or vector arguments to produce a vector value.
     ///
     /// The function will be called multiple times to fill the vector.
-    #[inline(always)]
+    #[inline]
     pub fn eval_2_args<Arg0, Arg1, Ret, F>(
         rows: usize,
         f: F,
@@ -181,7 +181,7 @@ impl Helper {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn eval_2_args_scalar_scalar<Arg0, Arg1, Ret, F>(
         rows: usize,
         mut f: F,
@@ -205,7 +205,7 @@ impl Helper {
         Ok(Ret::into_vector_value(result))
     }
 
-    #[inline(always)]
+    #[inline]
     fn eval_2_args_scalar_vector<Arg0, Arg1, Ret, F>(
         rows: usize,
         mut f: F,
@@ -230,7 +230,7 @@ impl Helper {
         Ok(Ret::into_vector_value(result))
     }
 
-    #[inline(always)]
+    #[inline]
     fn eval_2_args_vector_scalar<Arg0, Arg1, Ret, F>(
         rows: usize,
         mut f: F,
@@ -255,7 +255,7 @@ impl Helper {
         Ok(Ret::into_vector_value(result))
     }
 
-    #[inline(always)]
+    #[inline]
     fn eval_2_args_vector_vector<Arg0, Arg1, Ret, F>(
         rows: usize,
         mut f: F,
@@ -285,7 +285,7 @@ impl Helper {
     ///
     /// The function will be called multiple times to fill the vector. For each function call,
     /// there will be one indirection to support both scalar and vector arguments.
-    #[inline(always)]
+    #[inline]
     pub fn eval_3_args<Arg0, Arg1, Arg2, Ret, F>(
         rows: usize,
         mut f: F,

--- a/src/coprocessor/dag/rpn_expr/types/expr_builder.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_builder.rs
@@ -306,7 +306,6 @@ mod tests {
     impl_template_fn! { 1 arg @ FnA }
 
     impl FnA {
-        #[inline(always)]
         fn call(
             _ctx: &mut EvalContext,
             _payload: RpnFnCallPayload<'_>,
@@ -323,7 +322,6 @@ mod tests {
     impl_template_fn! { 2 arg @ FnB }
 
     impl FnB {
-        #[inline(always)]
         fn call(
             _ctx: &mut EvalContext,
             _payload: RpnFnCallPayload<'_>,
@@ -341,7 +339,6 @@ mod tests {
     impl_template_fn! { 3 arg @ FnC }
 
     impl FnC {
-        #[inline(always)]
         fn call(
             _ctx: &mut EvalContext,
             _payload: RpnFnCallPayload<'_>,
@@ -360,7 +357,6 @@ mod tests {
     impl_template_fn! { 3 arg @ FnD }
 
     impl FnD {
-        #[inline(always)]
         fn call(
             _ctx: &mut EvalContext,
             _payload: RpnFnCallPayload<'_>,

--- a/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
@@ -379,7 +379,6 @@ mod tests {
         impl_template_fn! { 0 arg @ FnFoo }
 
         impl FnFoo {
-            #[inline(always)]
             fn call(_ctx: &mut EvalContext, _payload: RpnFnCallPayload<'_>) -> Result<Option<i64>> {
                 Ok(Some(42))
             }
@@ -416,7 +415,6 @@ mod tests {
         impl_template_fn! { 1 arg @ FnFoo }
 
         impl FnFoo {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -467,7 +465,6 @@ mod tests {
         impl_template_fn! { 1 arg @ FnFoo }
 
         impl FnFoo {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -525,7 +522,6 @@ mod tests {
         impl_template_fn! { 2 arg @ FnFoo }
 
         impl FnFoo {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -585,7 +581,6 @@ mod tests {
         impl_template_fn! { 2 arg @ FnFoo }
 
         impl FnFoo {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -652,7 +647,6 @@ mod tests {
         impl_template_fn! { 2 arg @ FnFoo }
 
         impl FnFoo {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -719,7 +713,6 @@ mod tests {
         impl_template_fn! { 2 arg @ FnFoo }
 
         impl FnFoo {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -798,7 +791,6 @@ mod tests {
         impl_template_fn! { 3 arg @ FnFoo }
 
         impl FnFoo {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -877,7 +869,6 @@ mod tests {
         impl_template_fn! { 3 arg @ FnA }
 
         impl FnA {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -896,7 +887,6 @@ mod tests {
         impl_template_fn! { 0 arg @ FnB }
 
         impl FnB {
-            #[inline(always)]
             fn call(_ctx: &mut EvalContext, _payload: RpnFnCallPayload<'_>) -> Result<Option<f64>> {
                 Ok(Some(42.0))
             }
@@ -909,7 +899,6 @@ mod tests {
         impl_template_fn! { 2 arg @ FnC }
 
         impl FnC {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -927,7 +916,6 @@ mod tests {
         impl_template_fn! { 2 arg @ FnD }
 
         impl FnD {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -1053,7 +1041,6 @@ mod tests {
         impl_template_fn! { 1 arg @ FnFoo }
 
         impl FnFoo {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -1091,7 +1078,6 @@ mod tests {
         impl_template_fn! { 1 arg @ FnFoo }
 
         impl FnFoo {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -1150,7 +1136,6 @@ mod tests {
         impl_template_fn! { 1 arg @ FnFoo }
 
         impl FnFoo {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -1211,7 +1196,6 @@ mod tests {
         impl_template_fn! { 3 arg @ FnA }
 
         impl FnA {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -1230,7 +1214,6 @@ mod tests {
         impl_template_fn! { 2 arg @ FnB }
 
         impl FnB {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,
@@ -1248,7 +1231,6 @@ mod tests {
         impl_template_fn! { 0 arg @ FnC }
 
         impl FnC {
-            #[inline(always)]
             fn call(_ctx: &mut EvalContext, _payload: RpnFnCallPayload<'_>) -> Result<Option<i64>> {
                 Ok(Some(42))
             }
@@ -1261,7 +1243,6 @@ mod tests {
         impl_template_fn! { 1 arg @ FnD }
 
         impl FnD {
-            #[inline(always)]
             fn call(
                 _ctx: &mut EvalContext,
                 _payload: RpnFnCallPayload<'_>,


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

1. This PR removes those `#[inline(always)]` for the same reason as https://github.com/rust-lang/rust/pull/43367

2. This PR adds check of output offsets to avoid panic when given output offsets are invalid.

Both of the changes are extracted from https://github.com/tikv/tikv/pull/3898

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)
