### PR TITLE
coprocessor:make end-point-enable-batch-if-possible configurable

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -50,6 +50,7 @@ pub struct Endpoint<E: Engine> {
     batch_row_limit: usize,
     stream_batch_row_limit: usize,
     stream_channel_size: usize,
+    enable_batch_if_possible: bool,
 
     /// The soft time limit of handling Coprocessor requests.
     max_handle_duration: Duration,
@@ -74,6 +75,7 @@ impl<E: Engine> Endpoint<E> {
             read_pool,
             recursion_limit: cfg.end_point_recursion_limit,
             batch_row_limit: cfg.end_point_batch_row_limit,
+            enable_batch_if_possible: cfg.end_point_enable_batch_if_possible,
             stream_batch_row_limit: cfg.end_point_stream_batch_row_limit,
             stream_channel_size: cfg.end_point_stream_channel_size,
             max_handle_duration: cfg.end_point_request_max_handle_duration.0,
@@ -128,6 +130,7 @@ impl<E: Engine> Endpoint<E> {
                     Some(dag.get_start_ts()),
                 );
                 let batch_row_limit = self.get_batch_row_limit(is_streaming);
+                let enable_batch_if_possible = self.enable_batch_if_possible;
                 builder = Box::new(move |snap, req_ctx: &ReqContext| {
                     // TODO: Remove explicit type once rust-lang#41078 is resolved
                     let store = SnapshotStore::new(
@@ -143,7 +146,7 @@ impl<E: Engine> Endpoint<E> {
                         req_ctx.deadline,
                         batch_row_limit,
                         is_streaming,
-                        true,
+                        enable_batch_if_possible,
                     )
                 });
             }

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -86,6 +86,7 @@ pub struct Config {
     pub end_point_stream_channel_size: usize,
     pub end_point_batch_row_limit: usize,
     pub end_point_stream_batch_row_limit: usize,
+    pub end_point_enable_batch_if_possible: bool,
     pub end_point_request_max_handle_duration: ReadableDuration,
     pub snap_max_write_bytes_per_sec: ReadableSize,
     pub snap_max_total_size: ReadableSize,
@@ -139,6 +140,7 @@ impl Default for Config {
             end_point_stream_channel_size: 8,
             end_point_batch_row_limit: DEFAULT_ENDPOINT_BATCH_ROW_LIMIT,
             end_point_stream_batch_row_limit: DEFAULT_ENDPOINT_STREAM_BATCH_ROW_LIMIT,
+            end_point_enable_batch_if_possible: true,
             end_point_request_max_handle_duration: ReadableDuration::secs(
                 DEFAULT_ENDPOINT_REQUEST_MAX_HANDLE_SECS,
             ),

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -80,6 +80,7 @@ fn test_serde_custom_tikv_config() {
         end_point_stream_channel_size: 16,
         end_point_batch_row_limit: 64,
         end_point_stream_batch_row_limit: 4096,
+        end_point_enable_batch_if_possible: true,
         end_point_request_max_handle_duration: ReadableDuration::secs(12),
         snap_max_write_bytes_per_sec: ReadableSize::mb(10),
         snap_max_total_size: ReadableSize::gb(10),

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -39,6 +39,7 @@ end-point-recursion-limit = 100
 end-point-stream-channel-size = 16
 end-point-batch-row-limit = 64
 end-point-stream-batch-row-limit = 4096
+end-point-enable-batch-if-possible = true
 end-point-request-max-handle-duration = "12s"
 snap-max-write-bytes-per-sec = "10MB"
 snap-max-total-size = "10GB"


### PR DESCRIPTION
Signed-off-by: Shirly <AndreMouche@126.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR makes `end-point-enable-batch-if-possible` configurable. However, This config will be removed once the batch computation is stable.


Please **NOTE** that:
- Do not assume reviewers understand the original issue

## How has this PR been tested? (mandatory)

unit tests, integration tests, or manual tests

## Does this PR affect documentation (docs) update? (mandatory)

no, we don't want the users to know this config. 
and once the batch computation is ready, this config will be removed.

## Does this PR affect tidb-ansible update? (mandatory)

no

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

