### PR TITLE
More friendly error messages in Coprocessor

### DIFF
--- a/src/coprocessor/codec/error.rs
+++ b/src/coprocessor/codec/error.rs
@@ -61,7 +61,7 @@ quick_error! {
             from()
             cause(err.as_ref())
             description(err.description())
-            display("unknown error {:?}", err)
+            display("{}", err)
         }
     }
 }

--- a/src/coprocessor/error.rs
+++ b/src/coprocessor/error.rs
@@ -41,13 +41,13 @@ quick_error! {
         Eval(err: tipb::select::Error) {
             from()
             description("eval failed")
-            display("eval error {:?}", err)
+            display("Eval error: {}", err.get_msg())
         }
         Other(err: Box<dyn error::Error + Send + Sync>) {
             from()
             cause(err.as_ref())
             description(err.description())
-            display("unknown error {:?}", err)
+            display("{}", err)
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR makes error messages in Coprocessor more user friendly. More technically, prining as `Display` is enough, `Debug` is not necessary.

Before change:

TiDB output to MySQL clients:

```
ERROR 1105 (HY000): other error: unknown error StringError("[src/coprocessor/dag/executor/mod.rs:241]: unknown error StringError(\"[src/coprocessor/codec/mysql/time/mod.rs:104]: \\\'2019-0-0 0:0:0.000000000\\\' is not a valid datetime in specified time zone\")")
```

TiKV output to log:

```
[2019/04/04 17:56:14.780 +08:00] [ERROR] [endpoint.rs:470] [error-response] [err="unknown error StringError(\"[src/coprocessor/dag/executor/mod.rs:241]: unknown error StringError(\\\"[src/coprocessor/codec/mysql/time/mod.rs:104]: \\\\\\'2019-0-0 0:0:0.000000000\\\\\\' is not a valid datetime in specified time zone\\\")\")"]
```

After change:

TiDB output to MySQL clients:

```
ERROR 1105 (HY000): other error: [src/coprocessor/dag/executor/mod.rs:241]: [src/coprocessor/codec/mysql/time/mod.rs:104]: '2019-0-0 0:0:0.000000000' is not a valid datetime in specified time zone
```

TiKV output to log:

```
[2019/04/04 17:53:15.389 +08:00] [ERROR] [endpoint.rs:470] [error-response] [err="[src/coprocessor/dag/executor/mod.rs:241]: [src/coprocessor/codec/mysql/time/mod.rs:104]: '2019-0-0 0:0:0.000000000' is not a valid datetime in specified time zone"]
```

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)
