### PR TITLE
 Move the logic of checking the availability of batch execution to the executor

### DIFF
--- a/src/coprocessor/dag/batch/executors/util/scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/util/scan_executor.rs
@@ -11,7 +11,7 @@ use crate::coprocessor::codec::batch::LazyBatchColumnVec;
 use crate::coprocessor::dag::batch::interface::*;
 use crate::coprocessor::dag::expr::EvalContext;
 use crate::coprocessor::dag::Scanner;
-use crate::coprocessor::Result;
+use crate::coprocessor::{Error, Result};
 
 /// Common interfaces for table scan and index scan implementations.
 pub trait ScanExecutorImpl: Send {
@@ -192,6 +192,18 @@ pub fn field_type_from_column_info(ci: &ColumnInfo) -> FieldType {
     field_type.set_collate(ci.get_collation());
     // Note: Charset is not provided in column info.
     field_type
+}
+
+/// Checks whether the given columns info are supported.
+pub fn check_columns_info_supported(columns_info: &[ColumnInfo]) -> Result<()> {
+    use cop_datatype::EvalType;
+    use cop_datatype::FieldTypeAccessor;
+    use std::convert::TryFrom;
+
+    for column in columns_info {
+        EvalType::try_from(column.tp()).map_err(|e| Error::Other(box_err!(e)))?;
+    }
+    Ok(())
 }
 
 impl<C: ExecSummaryCollector, S: Store, I: ScanExecutorImpl, P: PointRangePolicy> BatchExecutor

--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -59,7 +59,6 @@ impl DAGBuilder {
         ranges: Vec<KeyRange>,
         config: Arc<EvalConfig>,
     ) -> Result<Box<dyn BatchExecutor>> {
-        // Shared in multiple executors, so wrap with Rc.
         let mut executor_descriptors = executor_descriptors.into_iter();
         let mut first_ed = executor_descriptors
             .next()

--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -305,7 +305,7 @@ impl DAGBuilder {
             let build_batch_result =
                 super::builder::DAGBuilder::check_build_batch(req.get_executors());
             if let Err(e) = build_batch_result {
-                info!("Coprocessor request cannot be batched"; "reason" => %e);
+                debug!("Coprocessor request cannot be batched"; "reason" => %e);
             } else {
                 is_batch = true;
             }

--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -28,52 +28,27 @@ use crate::coprocessor::*;
 pub struct DAGBuilder;
 
 impl DAGBuilder {
-    /// Given a list of executor descriptors and returns whether all executor descriptors can
+    /// Given a list of executor descriptors and checks whether all executor descriptors can
     /// be used to build batch executors.
-    pub fn can_build_batch(exec_descriptors: &[executor::Executor]) -> bool {
-        use cop_datatype::EvalType;
-        use cop_datatype::FieldTypeAccessor;
-        use std::convert::TryFrom;
-
+    pub fn check_build_batch(exec_descriptors: &[executor::Executor]) -> Result<()> {
         for ed in exec_descriptors {
             match ed.get_tp() {
                 ExecType::TypeTableScan => {
                     let descriptor = ed.get_tbl_scan();
-                    for column in descriptor.get_columns() {
-                        let eval_type = EvalType::try_from(column.tp());
-                        if eval_type.is_err() {
-                            debug!(
-                                "Coprocessor request cannot be batched";
-                                "unsupported_column_tp" => ?column.tp(),
-                            );
-                            return false;
-                        }
-                    }
+                    BatchTableScanExecutor::check_supported(&descriptor)?;
                 }
                 ExecType::TypeIndexScan => {
                     let descriptor = ed.get_idx_scan();
-                    for column in descriptor.get_columns() {
-                        let eval_type = EvalType::try_from(column.tp());
-                        if eval_type.is_err() {
-                            debug!(
-                                "Coprocessor request cannot be batched";
-                                "unsupported_column_tp" => ?column.tp(),
-                            );
-                            return false;
-                        }
-                    }
+                    BatchIndexScanExecutor::check_supported(&descriptor)?;
                 }
                 ExecType::TypeLimit => {}
                 _ => {
-                    debug!(
-                        "Coprocessor request cannot be batched";
-                        "unsupported_executor_tp" => ?ed.get_tp(),
-                    );
-                    return false;
+                    return Err(box_err!("Unsupported executor {:?}", ed.get_tp()));
                 }
             }
         }
-        true
+
+        Ok(())
     }
 
     // Note: `S` is `'static` because we have trait objects `Executor`.
@@ -83,6 +58,7 @@ impl DAGBuilder {
         ranges: Vec<KeyRange>,
         config: Arc<EvalConfig>,
     ) -> Result<Box<dyn BatchExecutor>> {
+        // Shared in multiple executors, so wrap with Rc.
         let mut executor_descriptors = executor_descriptors.into_iter();
         let mut first_ed = executor_descriptors
             .next()

--- a/src/coprocessor/dag/handler.rs
+++ b/src/coprocessor/dag/handler.rs
@@ -111,9 +111,16 @@ impl DAGRequestHandler {
             eval_cfg.set_sql_mode(SqlMode::from_bits_truncate(req.get_sql_mode()));
         }
 
-        let is_batch = enable_batch_if_possible
-            && !is_streaming
-            && super::builder::DAGBuilder::can_build_batch(req.get_executors());
+        let mut is_batch = false;
+        if enable_batch_if_possible && !is_streaming {
+            let build_batch_result =
+                super::builder::DAGBuilder::check_build_batch(req.get_executors());
+            if let Err(e) = build_batch_result {
+                debug!("Coprocessor request cannot be batched"; "reason" => %e);
+            } else {
+                is_batch = true;
+            }
+        }
 
         if is_batch {
             Ok(Self::build_batch_dag(deadline, eval_cfg, req, ranges, store)?.into_boxed())


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

We have some really complicated checking logic in aggregation executors, so it is no longer suitable to put them together in one function. This PR moves them back to places near the executor itself. This makes it more cohesive.

Additionally, this PR also changes the checking logic from returning a bool to returning a Result, so that the reasons that batch cannot be used can be outputted by simply return the Error.

Extracted from #3898

- [x] Merge #4482 first

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)