### PR TITLE
.github: ask for the TiKV instead of rustc version in bug-report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -6,8 +6,8 @@ about: Something isn't working as expected
 
 ## Bug Report
 
-**What version of Rust are you using?**
-<!-- You can run `rustc --version` -->
+**What version of TiKV are you using?**
+<!-- You can run `tikv-server --version` -->
 
 **What operating system and CPU are you using?**
 <!-- You can run `cat /proc/cpuinfo` -->


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

The bug report issue template asked for the version of rustc 🙄. I think it  really means the version of TiKV instead.

## What are the type of the changes? (mandatory)

- Misc (other changes)

## How has this PR been tested? (mandatory)

No code.

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

