### PR TITLE
engine: fix prefix extractor panic when delete range

### DIFF
--- a/components/engine/src/util.rs
+++ b/components/engine/src/util.rs
@@ -15,7 +15,7 @@ use std::u64;
 
 use crate::rocks;
 use crate::rocks::{Range, TablePropertiesCollection, Writable, WriteBatch, DB};
-use crate::{CF_LOCK, CF_RAFT};
+use crate::{CF_LOCK, CF_RAFT, CF_WRITE};
 
 use super::{Error, Result};
 use super::{IterOption, Iterable};
@@ -72,7 +72,17 @@ pub fn delete_all_in_range_cf(
     // Since CF_RAFT and CF_LOCK is usually small, so using
     // traditional way to cleanup.
     if use_delete_range && cf != CF_RAFT && cf != CF_LOCK {
-        wb.delete_range_cf(handle, start_key, end_key)?;
+        // HACK: TiKV always enable prefix bloom filter for Write CF,
+        // which requires key.len() > 8
+        //
+        // FIXME: It should delete the `start_key` too.
+        if cf == CF_WRITE {
+            let mut start = start_key.to_vec();
+            start.extend_from_slice(&[0; 8]);
+            wb.delete_range_cf(handle, &start, end_key)?;
+        } else {
+            wb.delete_range_cf(handle, start_key, end_key)?;
+        }
     } else {
         let iter_opt = IterOption::new(Some(start_key.to_vec()), Some(end_key.to_vec()), false);
         let mut it = db.new_iterator_cf(cf, iter_opt)?;

--- a/tests/integrations/raftstore/test_single.rs
+++ b/tests/integrations/raftstore/test_single.rs
@@ -137,7 +137,7 @@ fn test_node_use_delete_range() {
 }
 
 #[test]
-fn test_node_not_use_delete_range_write() {
+fn test_node_not_use_delete_range() {
     let mut cluster = new_node_cluster(0, 1);
     cluster.cfg.raft_store.use_delete_range = false;
     cluster.run();

--- a/tests/integrations/raftstore/test_single.rs
+++ b/tests/integrations/raftstore/test_single.rs
@@ -13,6 +13,7 @@
 
 use std::time::Duration;
 
+use engine::{CfName, CF_DEFAULT, CF_WRITE};
 use test_raftstore::*;
 use tikv::util::config::*;
 
@@ -60,13 +61,13 @@ fn test_delete<T: Simulator>(cluster: &mut Cluster<T>) {
     }
 }
 
-fn test_delete_range<T: Simulator>(cluster: &mut Cluster<T>) {
+fn test_delete_range<T: Simulator>(cluster: &mut Cluster<T>, cf: CfName) {
+    // Always enable delete range.
+    cluster.cfg.raft_store.use_delete_range = true;
     cluster.run();
 
-    let cf = "default";
-
     for i in 1..1000 {
-        let (k, v) = (format!("key{}", i), format!("value{}", i));
+        let (k, v) = (format!("key{:08}", i), format!("value{}", i));
         let key = k.as_bytes();
         let value = v.as_bytes();
         cluster.must_put_cf(cf, key, value);
@@ -74,10 +75,11 @@ fn test_delete_range<T: Simulator>(cluster: &mut Cluster<T>) {
         assert_eq!(v, Some(value.to_vec()));
     }
 
-    cluster.must_delete_range_cf(cf, b"key1", b"key9999");
+    // Empty keys means the whole range.
+    cluster.must_delete_range_cf(cf, b"", b"");
 
     for i in 1..1000 {
-        let k = format!("key{}", i);
+        let k = format!("key{:08}", i);
         let key = k.as_bytes();
         assert!(cluster.get_cf(cf, key).is_none());
     }
@@ -129,9 +131,16 @@ fn test_node_delete() {
 }
 
 #[test]
-fn test_node_delete_range() {
+fn test_node_delete_range_default() {
     let mut cluster = new_node_cluster(0, 1);
-    test_delete_range(&mut cluster);
+    test_delete_range(&mut cluster, CF_DEFAULT);
+}
+
+#[test]
+fn test_node_delete_range_write() {
+    let mut cluster = new_node_cluster(0, 1);
+    // Prefix bloom filter is always enabled in the Write CF.
+    test_delete_range(&mut cluster, CF_WRITE);
 }
 
 #[test]
@@ -150,12 +159,6 @@ fn test_server_put() {
 fn test_server_delete() {
     let mut cluster = new_server_cluster(0, 1);
     test_delete(&mut cluster);
-}
-
-#[test]
-fn test_server_delete_range() {
-    let mut cluster = new_server_cluster(0, 1);
-    test_delete_range(&mut cluster);
 }
 
 #[test]

--- a/tests/integrations/raftstore/test_single.rs
+++ b/tests/integrations/raftstore/test_single.rs
@@ -61,9 +61,8 @@ fn test_delete<T: Simulator>(cluster: &mut Cluster<T>) {
     }
 }
 
-fn test_delete_range<T: Simulator>(cluster: &mut Cluster<T>, cf: CfName) {
-    // Always enable delete range.
-    cluster.cfg.raft_store.use_delete_range = true;
+fn test_delete_range<T: Simulator>(cluster: &mut Cluster<T>, cf: CfName, use_delete_range: bool) {
+    cluster.cfg.raft_store.use_delete_range = use_delete_range;
     cluster.run();
 
     for i in 1..1000 {
@@ -133,14 +132,18 @@ fn test_node_delete() {
 #[test]
 fn test_node_delete_range_default() {
     let mut cluster = new_node_cluster(0, 1);
-    test_delete_range(&mut cluster, CF_DEFAULT);
+    test_delete_range(&mut cluster, CF_DEFAULT, false);
+    let mut cluster = new_node_cluster(0, 1);
+    test_delete_range(&mut cluster, CF_DEFAULT, true);
 }
 
 #[test]
 fn test_node_delete_range_write() {
-    let mut cluster = new_node_cluster(0, 1);
     // Prefix bloom filter is always enabled in the Write CF.
-    test_delete_range(&mut cluster, CF_WRITE);
+    let mut cluster = new_node_cluster(0, 1);
+    test_delete_range(&mut cluster, CF_WRITE, false);
+    let mut cluster = new_node_cluster(0, 1);
+    test_delete_range(&mut cluster, CF_WRITE, true);
 }
 
 #[test]


### PR DESCRIPTION
## What have you changed? (mandatory)

Delete range as a kv pair is passed to prefix extractor which causes panic, because the key is less than 8 bytes.

This is a temporary workaround, the long term plan is skipping the prefix extractor for delete range in RocksDB side.

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Unit tests.

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

#4461 