### PR TITLE
[DNM] Reduce memory copy for IterOptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.3.0 (git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options)",
+ "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
  "slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
  "sys-info 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options#75b51c8aa2b232241464c57e8fb7f1f7a2d0a78a"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#4f8c6b3a48c7acb0c81f9bb91e7d8493b1c5a73e"
 dependencies = [
  "bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1640,11 +1640,11 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options#75b51c8aa2b232241464c57e8fb7f1f7a2d0a78a"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#4f8c6b3a48c7acb0c81f9bb91e7d8493b1c5a73e"
 dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb_sys 0.1.0 (git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options)",
+ "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
 ]
 
 [[package]]
@@ -2683,7 +2683,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
 "checksum libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)" = "<none>"
-"checksum librocksdb_sys 0.1.0 (git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options)" = "<none>"
+"checksum librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)" = "<none>"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
@@ -2758,7 +2758,7 @@ dependencies = [
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum rocksdb 0.3.0 (git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options)" = "<none>"
+"checksum rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)" = "<none>"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
+ "rocksdb 0.3.0 (git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options)",
  "slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
  "sys-info 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#263b82e81a90d0f9c6162b921f16610af58d195a"
+source = "git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options#75b51c8aa2b232241464c57e8fb7f1f7a2d0a78a"
 dependencies = [
  "bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1640,11 +1640,11 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#263b82e81a90d0f9c6162b921f16610af58d195a"
+source = "git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options#75b51c8aa2b232241464c57e8fb7f1f7a2d0a78a"
 dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
+ "librocksdb_sys 0.1.0 (git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options)",
 ]
 
 [[package]]
@@ -2683,7 +2683,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
 "checksum libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)" = "<none>"
-"checksum librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git)" = "<none>"
+"checksum librocksdb_sys 0.1.0 (git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options)" = "<none>"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
@@ -2758,7 +2758,7 @@ dependencies = [
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)" = "<none>"
+"checksum rocksdb 0.3.0 (git+https://github.com/zhangjinpeng1987/rust-rocksdb.git?branch=read-options)" = "<none>"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -27,7 +27,8 @@ default-features = false
 features = ["nightly"]
 
 [dependencies.engine_rocksdb]
-git = "https://github.com/pingcap/rust-rocksdb.git"
+git = "https://github.com/zhangjinpeng1987/rust-rocksdb.git"
+branch = "read-options"
 package = "rocksdb"
 
 [dev-dependencies]

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -27,8 +27,7 @@ default-features = false
 features = ["nightly"]
 
 [dependencies.engine_rocksdb]
-git = "https://github.com/zhangjinpeng1987/rust-rocksdb.git"
-branch = "read-options"
+git = "https://github.com/pingcap/rust-rocksdb.git"
 package = "rocksdb"
 
 [dev-dependencies]

--- a/components/engine/src/lib.rs
+++ b/components/engine/src/lib.rs
@@ -232,7 +232,7 @@ impl IterOption {
         if let Some(u) = upper_bound {
             read_options.set_iterate_upper_bound(u);
         }
-        IterOption(read_options)
+        IterOption(read_options).use_total_order_seek()
     }
 
     #[inline]
@@ -280,8 +280,6 @@ impl IterOption {
 impl Default for IterOption {
     fn default() -> IterOption {
         IterOption::new(None, None, true)
-            .set_prefix_same_as_start(false)
-            .use_total_order_seek()
     }
 }
 

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -289,9 +289,9 @@ impl Debugger {
         let cf_handle = get_cf_handle(db, cf).unwrap();
         let mut read_opt = ReadOptions::new();
         read_opt.set_total_order_seek(true);
-        read_opt.set_iterate_lower_bound(start);
+        read_opt.set_iterate_lower_bound(keys::data_key(start));
         if !end.is_empty() {
-            read_opt.set_iterate_upper_bound(end);
+            read_opt.set_iterate_upper_bound(keys::data_key(end));
         }
         let mut iter = db.iter_cf_opt(cf_handle, read_opt);
         if !iter.seek_to_first() {

--- a/src/storage/kv/btree_engine.rs
+++ b/src/storage/kv/btree_engine.rs
@@ -124,14 +124,16 @@ pub struct BTreeEngineIterator {
 
 impl BTreeEngineIterator {
     pub fn new(tree: Arc<RwLockTree>, iter_opt: IterOption) -> BTreeEngineIterator {
-        let lower_bound = match iter_opt.lower_bound() {
-            None => Unbounded,
-            Some(key) => Included(Key::from_raw(key)),
+        let lower_bound = if iter_opt.lower_bound().is_empty() {
+            Unbounded
+        } else {
+            Included(Key::from_raw(iter_opt.lower_bound()))
         };
 
-        let upper_bound = match iter_opt.upper_bound() {
-            None => Unbounded,
-            Some(key) => Excluded(Key::from_raw(key)),
+        let upper_bound = if iter_opt.upper_bound().is_empty() {
+            Unbounded
+        } else {
+            Excluded(Key::from_raw(iter_opt.upper_bound()))
         };
         let bounds = (lower_bound.clone(), upper_bound.clone());
         Self {

--- a/src/storage/kv/cursor_builder.rs
+++ b/src/storage/kv/cursor_builder.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::raftstore::store::keys;
 use crate::storage::kv::Result;
 use crate::storage::{Cursor, Key, ScanMode, Snapshot};
 use engine::CfName;
@@ -84,8 +85,8 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
     /// Build `Cursor` from the current configuration.
     pub fn build(self) -> Result<Cursor<S::Iter>> {
         let mut iter_opt = IterOption::new(
-            self.lower_bound.map(|k| k.into_encoded()),
-            self.upper_bound.map(|k| k.into_encoded()),
+            self.lower_bound.map(|k| keys::data_key(k.as_encoded())),
+            self.upper_bound.map(|k| keys::data_key(k.as_encoded())),
             self.fill_cache,
         );
         if self.prefix_seek {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -34,6 +34,7 @@ use futures::{future, Future};
 use kvproto::errorpb;
 use kvproto::kvrpcpb::{CommandPri, Context, KeyRange, LockInfo};
 
+use crate::raftstore::store::keys;
 use crate::server::readpool::{self, ReadPool};
 use crate::server::ServerRaftStoreRouter;
 use crate::util;
@@ -1324,7 +1325,7 @@ impl<E: Engine> Storage<E> {
     ) -> Result<Vec<Result<KvPair>>> {
         let mut option = IterOption::default();
         if let Some(end) = end_key {
-            option.set_upper_bound(end.into_encoded());
+            option.set_upper_bound(keys::data_key(end.as_encoded()));
         }
         let mut cursor = snapshot.iter_cf(Self::rawkv_cf(cf)?, option, ScanMode::Forward)?;
         let statistics = statistics.mut_cf_statistics(cf);
@@ -1362,7 +1363,7 @@ impl<E: Engine> Storage<E> {
     ) -> Result<Vec<Result<KvPair>>> {
         let mut option = IterOption::default();
         if let Some(end) = end_key {
-            option.set_lower_bound(end.into_encoded());
+            option.set_lower_bound(keys::data_key(end.as_encoded()));
         }
         let mut cursor = snapshot.iter_cf(Self::rawkv_cf(cf)?, option, ScanMode::Backward)?;
         let statistics = statistics.mut_cf_statistics(cf);

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::raftstore::store::keys;
 use crate::storage::kv::{Cursor, ScanMode, Snapshot, Statistics};
 use crate::storage::mvcc::default_not_found_error;
 use crate::storage::mvcc::lock::{Lock, LockType};
@@ -282,8 +283,12 @@ impl<S: Snapshot> MvccReader<S> {
     fn create_data_cursor(&mut self) -> Result<()> {
         if self.data_cursor.is_none() {
             let iter_opt = IterOption::new(
-                self.lower_bound.as_ref().cloned(),
-                self.upper_bound.as_ref().cloned(),
+                self.lower_bound
+                    .as_ref()
+                    .map(|ref bound| keys::data_key(bound.as_slice())),
+                self.upper_bound
+                    .as_ref()
+                    .map(|ref bound| keys::data_key(bound.as_slice())),
                 self.fill_cache,
             );
             let iter = self.snapshot.iter(iter_opt, self.get_scan_mode(true))?;
@@ -295,8 +300,12 @@ impl<S: Snapshot> MvccReader<S> {
     fn create_write_cursor(&mut self) -> Result<()> {
         if self.write_cursor.is_none() {
             let iter_opt = IterOption::new(
-                self.lower_bound.as_ref().cloned(),
-                self.upper_bound.as_ref().cloned(),
+                self.lower_bound
+                    .as_ref()
+                    .map(|ref bound| keys::data_key(bound.as_slice())),
+                self.upper_bound
+                    .as_ref()
+                    .map(|ref bound| keys::data_key(bound.as_slice())),
                 self.fill_cache,
             );
             let iter = self
@@ -310,8 +319,12 @@ impl<S: Snapshot> MvccReader<S> {
     fn create_lock_cursor(&mut self) -> Result<()> {
         if self.lock_cursor.is_none() {
             let iter_opt = IterOption::new(
-                self.lower_bound.as_ref().cloned(),
-                self.upper_bound.as_ref().cloned(),
+                self.lower_bound
+                    .as_ref()
+                    .map(|ref bound| keys::data_key(bound.as_slice())),
+                self.upper_bound
+                    .as_ref()
+                    .map(|ref bound| keys::data_key(bound.as_slice())),
                 true,
             );
             let iter = self


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>


## What have you changed? (mandatory)

Reduce one time memory copy for IterOptions' lower_bound and upper_bound.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

UT

## Does this PR affect documentation (docs) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

NO

## Refer to a related PR or issue link (optional)

- [ ] https://github.com/pingcap/rust-rocksdb/pull/287 is required.

