### PR TITLE
generate build info in cargo's build script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,9 @@ features = ["nightly", "push", "process"]
 [dependencies.prometheus-static-metric]
 version = "0.1.4"
 
+[build-dependencies]
+chrono = "0.4"
+
 [dev-dependencies]
 test_util = { path = "components/test_util" }
 test_raftstore = { path = "components/test_raftstore" }

--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,6 @@ BIN_PATH = $(CURDIR)/bin
 GOROOT ?= $(DEPS_PATH)/go
 CARGO_TARGET_DIR ?= $(CURDIR)/target
 
-BUILD_INFO_GIT_FALLBACK := "Unknown (no git or not git repo)"
-BUILD_INFO_RUSTC_FALLBACK := "Unknown"
-export TIKV_BUILD_TIME := $(shell date -u '+%Y-%m-%d %I:%M:%S')
-export TIKV_BUILD_GIT_HASH := $(shell git rev-parse HEAD 2> /dev/null || echo ${BUILD_INFO_GIT_FALLBACK})
-export TIKV_BUILD_GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null || echo ${BUILD_INFO_GIT_FALLBACK})
-export TIKV_BUILD_RUSTC_VERSION := $(shell rustc --version 2> /dev/null || echo ${BUILD_INFO_RUSTC_FALLBACK})
-
 default: release
 
 .PHONY: all

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,38 @@
+use std::process::Command;
+
+use chrono::Utc;
+
+const BUILD_INFO_FALLBACK: &str = "Unknown";
+
+fn run_command(program: &str, args: &[&str]) -> String {
+    if let Ok(o) = Command::new(program).args(args).output() {
+        let raw_output = String::from_utf8_lossy(&o.stdout).into_owned();
+        raw_output.trim().to_string()
+    } else {
+        BUILD_INFO_FALLBACK.to_string()
+    }
+}
+
+fn set_env(var: &str, value: String) {
+    println!("cargo:rustc-env={}={}", var, value);
+}
+
+fn main() {
+    set_env(
+        "TIKV_BUILD_TIME",
+        Utc::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+    );
+    set_env(
+        "TIKV_BUILD_GIT_HASH",
+        run_command("git", &["rev-parse", "HEAD"]),
+    );
+    set_env(
+        "TIKV_BUILD_GIT_BRANCH",
+        run_command("git", &["rev-parse", "--abbrev-ref", "HEAD"]),
+    );
+    set_env(
+        "TIKV_BUILD_RUSTC_VERSION",
+        run_command("rustc", &["--version"]),
+    );
+    println!("cargo:rerun-if-changed=.git/HEAD");
+}


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

## What have you changed? (mandatory)

Generate build info in cargo's build script instead of Makefile.

## What are the type of the changes? (mandatory)

- New feature

## How has this PR been tested? (mandatory)

manual test.

result: 
```
[2019/04/14 22:32:05.824 +08:00] [INFO] [mod.rs:25] ["Welcome to TiKV."]
[2019/04/14 22:32:05.825 +08:00] [INFO] [mod.rs:27] []
[2019/04/14 22:32:05.826 +08:00] [INFO] [mod.rs:27] ["Release Version:   3.0.0-beta.1"]
[2019/04/14 22:32:05.827 +08:00] [INFO] [mod.rs:27] ["Git Commit Hash:   545e47950c4c84c74e59a7127e7359703d84800d"]
[2019/04/14 22:32:05.828 +08:00] [INFO] [mod.rs:27] ["Git Commit Branch: build_env"]
[2019/04/14 22:32:05.828 +08:00] [INFO] [mod.rs:27] ["UTC Build Time:    2019-04-14 14:23:32"]
[2019/04/14 22:32:05.829 +08:00] [INFO] [mod.rs:27] ["Rust Version:      rustc 1.35.0-nightly (a9da8fc9c 2019-03-04)"]
```

## Does this PR affect documentation (docs) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Refer to a related PR or issue link (optional)

#4051 
