### PR TITLE
Several trivial engineering improvements

### DIFF
--- a/components/cop_datatype/src/def/field_type.rs
+++ b/components/cop_datatype/src/def/field_type.rs
@@ -308,3 +308,19 @@ impl FieldTypeAccessor for ColumnInfo {
         self as &mut dyn FieldTypeAccessor
     }
 }
+
+impl Into<FieldType> for FieldTypeTp {
+    fn into(self) -> FieldType {
+        let mut ft = FieldType::new();
+        ft.as_mut_accessor().set_tp(self);
+        ft
+    }
+}
+
+impl Into<ColumnInfo> for FieldTypeTp {
+    fn into(self) -> ColumnInfo {
+        let mut ft = ColumnInfo::new();
+        ft.as_mut_accessor().set_tp(self);
+        ft
+    }
+}

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -101,6 +101,10 @@ pub fn panic_mark_file_exists<P: AsRef<Path>>(data_dir: P) -> bool {
 
 pub const NO_LIMIT: u64 = u64::MAX;
 
+pub trait AssertClone: Clone {}
+
+pub trait AssertCopy: Copy {}
+
 pub trait AssertSend: Send {}
 
 pub trait AssertSync: Sync {}

--- a/src/coprocessor/codec/data_type/scalar.rs
+++ b/src/coprocessor/codec/data_type/scalar.rs
@@ -17,7 +17,7 @@ use super::*;
 ///
 /// TODO: Once we removed the `Option<..>` wrapper, it will be much like `Datum`. At that time,
 /// we only need to preserve one of them.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ScalarValue {
     Int(Option<super::Int>),
     Real(Option<super::Real>),
@@ -97,3 +97,29 @@ impl_as_ref! { Bytes, as_bytes }
 impl_as_ref! { DateTime, as_date_time }
 impl_as_ref! { Duration, as_duration }
 impl_as_ref! { Json, as_json }
+
+macro_rules! impl_from {
+    ($ty:tt) => {
+        impl From<Option<$ty>> for ScalarValue {
+            #[inline]
+            fn from(s: Option<$ty>) -> ScalarValue {
+                ScalarValue::$ty(s)
+            }
+        }
+
+        impl From<$ty> for ScalarValue {
+            #[inline]
+            fn from(s: $ty) -> ScalarValue {
+                ScalarValue::$ty(Some(s))
+            }
+        }
+    };
+}
+
+impl_from! { Int }
+impl_from! { Real }
+impl_from! { Decimal }
+impl_from! { Bytes }
+impl_from! { DateTime }
+impl_from! { Duration }
+impl_from! { Json }

--- a/src/coprocessor/codec/data_type/vector.rs
+++ b/src/coprocessor/codec/data_type/vector.rs
@@ -726,20 +726,6 @@ impl_ext! { Json, push_json }
 
 macro_rules! impl_from {
     ($ty:tt) => {
-        impl<'a> From<&'a [Option<$ty>]> for VectorValue {
-            #[inline]
-            fn from(s: &'a [Option<$ty>]) -> VectorValue {
-                VectorValue::$ty(s.to_vec())
-            }
-        }
-
-        impl<'a> From<&'a mut [Option<$ty>]> for VectorValue {
-            #[inline]
-            fn from(s: &'a mut [Option<$ty>]) -> VectorValue {
-                VectorValue::$ty(s.to_vec())
-            }
-        }
-
         impl From<Vec<Option<$ty>>> for VectorValue {
             #[inline]
             fn from(s: Vec<Option<$ty>>) -> VectorValue {
@@ -949,10 +935,6 @@ mod tests {
     #[test]
     fn test_from() {
         let slice: &[_] = &[None, Some(1.0)];
-        let column = VectorValue::from(slice);
-        assert_eq!(column.len(), 2);
-        assert_eq!(column.as_real_slice(), slice);
-
         let vec = slice.to_vec();
         let column = VectorValue::from(vec);
         assert_eq!(column.len(), 2);

--- a/src/coprocessor/dag/rpn_expr/types/expr.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr.rs
@@ -6,7 +6,7 @@ use super::super::function::RpnFunction;
 use crate::coprocessor::codec::data_type::ScalarValue;
 
 /// A type for each node in the RPN expression list.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RpnExpressionNode {
     /// Represents a function call.
     FnCall {
@@ -66,7 +66,7 @@ impl RpnExpressionNode {
 /// An expression in Reverse Polish notation, which is simply a list of RPN expression nodes.
 ///
 /// You may want to build it using `RpnExpressionBuilder`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RpnExpression(Vec<RpnExpressionNode>);
 
 impl std::ops::Deref for RpnExpression {

--- a/src/coprocessor/dag/rpn_expr/types/expr_builder.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_builder.rs
@@ -3,6 +3,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use cop_datatype::{EvalType, FieldTypeAccessor};
+use tikv_util::codec::number;
 use tipb::expression::{Expr, ExprType, FieldType};
 
 use super::super::function::RpnFunction;
@@ -11,12 +12,9 @@ use crate::coprocessor::codec::data_type::ScalarValue;
 use crate::coprocessor::codec::mysql::Tz;
 use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time, MAX_FSP};
 use crate::coprocessor::{Error, Result};
-use tikv_util::codec::number;
 
 /// Helper to build an `RpnExpression`.
-///
-/// TODO: Deprecate it in Coprocessor V2 DAG interface.
-pub struct RpnExpressionBuilder;
+pub struct RpnExpressionBuilder(Vec<RpnExpressionNode>);
 
 impl RpnExpressionBuilder {
     /// Builds the RPN expression node list from an expression definition tree.
@@ -55,6 +53,54 @@ impl RpnExpressionBuilder {
             max_columns,
         )?;
         Ok(RpnExpression::from(expr_nodes))
+    }
+
+    /// Creates a new builder instance.
+    ///
+    /// Only used in tests. Normal logic should use `build_from_expr_tree`.
+    #[cfg(test)]
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    #[cfg(test)]
+    pub fn push_fn_call(
+        mut self,
+        func: impl RpnFunction,
+        field_type: impl Into<FieldType>,
+    ) -> Self {
+        let node = RpnExpressionNode::FnCall {
+            func: Box::new(func),
+            field_type: field_type.into(),
+        };
+        self.0.push(node);
+        self
+    }
+
+    #[cfg(test)]
+    pub fn push_constant(
+        mut self,
+        value: impl Into<ScalarValue>,
+        field_type: impl Into<FieldType>,
+    ) -> Self {
+        let node = RpnExpressionNode::Constant {
+            value: value.into(),
+            field_type: field_type.into(),
+        };
+        self.0.push(node);
+        self
+    }
+
+    #[cfg(test)]
+    pub fn push_column_ref(mut self, offset: usize) -> Self {
+        let node = RpnExpressionNode::ColumnRef { offset };
+        self.0.push(node);
+        self
+    }
+
+    #[cfg(test)]
+    pub fn build(self) -> RpnExpression {
+        RpnExpression::from(self.0)
     }
 }
 

--- a/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
@@ -238,6 +238,7 @@ mod tests {
     use super::super::RpnFnCallPayload;
 
     use crate::coprocessor::codec::batch::LazyBatchColumn;
+    use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
     use crate::coprocessor::dag::expr::EvalContext;
     use crate::coprocessor::dag::rpn_expr::RpnExpressionBuilder;
     use crate::coprocessor::Result;
@@ -245,15 +246,9 @@ mod tests {
     /// Single constant node
     #[test]
     fn test_eval_single_constant_node() {
-        let rpn_nodes = vec![RpnExpressionNode::Constant {
-            value: ScalarValue::Real(Some(1.5)),
-            field_type: {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                ft
-            },
-        }];
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_constant(1.5f64, FieldTypeTp::Double)
+            .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
         let result = exp.eval(&mut ctx, 10, &[], &mut columns);
@@ -307,8 +302,7 @@ mod tests {
         let (columns, schema) = new_single_column_node_fixture();
 
         let mut c = columns.clone();
-        let rpn_nodes = vec![RpnExpressionNode::ColumnRef { offset: 1 }];
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new().push_column_ref(1).build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, 5, &schema, &mut c);
         let val = result.unwrap();
@@ -320,8 +314,7 @@ mod tests {
         assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
 
         let mut c = columns.clone();
-        let rpn_nodes = vec![RpnExpressionNode::ColumnRef { offset: 0 }];
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new().push_column_ref(0).build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, 5, &schema, &mut c);
         let val = result.unwrap();
@@ -339,8 +332,7 @@ mod tests {
         let (columns, schema) = new_single_column_node_fixture();
 
         let mut c = columns.clone();
-        let rpn_nodes = vec![RpnExpressionNode::ColumnRef { offset: 1 }];
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new().push_column_ref(1).build();
         let mut ctx = EvalContext::default();
         let hooked_eval = ::panic_hook::recover_safe(|| {
             // smaller row number
@@ -349,8 +341,7 @@ mod tests {
         assert!(hooked_eval.is_err());
 
         let mut c = columns.clone();
-        let rpn_nodes = vec![RpnExpressionNode::ColumnRef { offset: 1 }];
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new().push_column_ref(1).build();
         let mut ctx = EvalContext::default();
         let hooked_eval = ::panic_hook::recover_safe(|| {
             // larger row number
@@ -373,15 +364,9 @@ mod tests {
             }
         }
 
-        let rpn_nodes = vec![RpnExpressionNode::FnCall {
-            func: Box::new(FnFoo),
-            field_type: {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-        }];
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_fn_call(FnFoo, FieldTypeTp::LongLong)
+            .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
         let result = exp.eval(&mut ctx, 4, &[], &mut columns);
@@ -413,25 +398,10 @@ mod tests {
             }
         }
 
-        let rpn_nodes = vec![
-            RpnExpressionNode::Constant {
-                value: ScalarValue::Real(Some(1.5)),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnFoo),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-        ];
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_constant(1.5f64, FieldTypeTp::Double)
+            .push_fn_call(FnFoo, FieldTypeTp::Double)
+            .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
         let result = exp.eval(&mut ctx, 3, &[], &mut columns);
@@ -477,19 +447,10 @@ mod tests {
             ft
         }];
 
-        let rpn_nodes = vec![
-            RpnExpressionNode::ColumnRef { offset: 0 },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnFoo),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                    ft
-                },
-            },
-        ];
-
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_column_ref(0)
+            .push_fn_call(FnFoo, FieldTypeTp::LongLong)
+            .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, 3, schema, &mut columns);
         let val = result.unwrap();
@@ -497,6 +458,64 @@ mod tests {
         assert_eq!(
             val.vector_value().unwrap().as_int_slice(),
             [Some(6), Some(10), None]
+        );
+        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
+    }
+
+    /// Unary function (argument is raw column). The column should be decoded.
+    #[test]
+    fn test_eval_unary_function_raw_column() {
+        /// FnFoo(v) performs v + 5.
+        #[derive(Debug, Clone, Copy)]
+        struct FnFoo;
+
+        impl_template_fn! { 1 arg @ FnFoo }
+
+        impl FnFoo {
+            fn call(
+                _ctx: &mut EvalContext,
+                _payload: RpnFnCallPayload<'_>,
+                v: &Option<i64>,
+            ) -> Result<Option<i64>> {
+                Ok(Some(v.unwrap() + 5))
+            }
+        }
+
+        let mut columns = LazyBatchColumnVec::from(vec![{
+            let mut col = LazyBatchColumn::raw_with_capacity(3);
+
+            let mut datum_raw = Vec::new();
+            DatumEncoder::encode(&mut datum_raw, &[Datum::I64(-5)], false).unwrap();
+            col.push_raw(&datum_raw);
+
+            let mut datum_raw = Vec::new();
+            DatumEncoder::encode(&mut datum_raw, &[Datum::I64(-7)], false).unwrap();
+            col.push_raw(&datum_raw);
+
+            let mut datum_raw = Vec::new();
+            DatumEncoder::encode(&mut datum_raw, &[Datum::I64(3)], false).unwrap();
+            col.push_raw(&datum_raw);
+
+            col
+        }]);
+
+        let schema = &[{
+            let mut ft = FieldType::new();
+            ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
+            ft
+        }];
+
+        let exp = RpnExpressionBuilder::new()
+            .push_column_ref(0)
+            .push_fn_call(FnFoo, FieldTypeTp::LongLong)
+            .build();
+        let mut ctx = EvalContext::default();
+        let result = exp.eval(&mut ctx, 3, schema, &mut columns);
+        let val = result.unwrap();
+        assert!(val.is_vector());
+        assert_eq!(
+            val.vector_value().unwrap().as_int_slice(),
+            [Some(0), Some(-2), Some(8)]
         );
         assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
     }
@@ -521,33 +540,11 @@ mod tests {
             }
         }
 
-        let rpn_nodes = vec![
-            RpnExpressionNode::Constant {
-                value: ScalarValue::Real(Some(1.5)),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-            RpnExpressionNode::Constant {
-                value: ScalarValue::Int(Some(3)),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                    ft
-                },
-            },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnFoo),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-        ];
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_constant(1.5f64, FieldTypeTp::Double)
+            .push_constant(3i64, FieldTypeTp::LongLong)
+            .push_fn_call(FnFoo, FieldTypeTp::Double)
+            .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
         let result = exp.eval(&mut ctx, 3, &[], &mut columns);
@@ -594,27 +591,11 @@ mod tests {
             ft
         }];
 
-        let rpn_nodes = vec![
-            RpnExpressionNode::ColumnRef { offset: 0 },
-            RpnExpressionNode::Constant {
-                value: ScalarValue::Real(Some(1.5)),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnFoo),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-        ];
-
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_column_ref(0)
+            .push_constant(1.5f64, FieldTypeTp::Double)
+            .push_fn_call(FnFoo, FieldTypeTp::Double)
+            .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, 3, schema, &mut columns);
         let val = result.unwrap();
@@ -660,27 +641,11 @@ mod tests {
             ft
         }];
 
-        let rpn_nodes = vec![
-            RpnExpressionNode::Constant {
-                value: ScalarValue::Real(Some(1.5)),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-            RpnExpressionNode::ColumnRef { offset: 0 },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnFoo),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-        ];
-
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_constant(1.5f64, FieldTypeTp::Double)
+            .push_column_ref(0)
+            .push_fn_call(FnFoo, FieldTypeTp::Double)
+            .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, 3, schema, &mut columns);
         let val = result.unwrap();
@@ -745,20 +710,11 @@ mod tests {
         ];
 
         // FnFoo(col1, col0)
-        let rpn_nodes = vec![
-            RpnExpressionNode::ColumnRef { offset: 1 },
-            RpnExpressionNode::ColumnRef { offset: 0 },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnFoo),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                    ft
-                },
-            },
-        ];
-
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_column_ref(1)
+            .push_column_ref(0)
+            .push_fn_call(FnFoo, FieldTypeTp::LongLong)
+            .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, 3, schema, &mut columns);
         let val = result.unwrap();
@@ -766,6 +722,74 @@ mod tests {
         assert_eq!(
             val.vector_value().unwrap().as_int_slice(),
             [Some(-2), Some(-17), Some(22)]
+        );
+        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
+    }
+
+    /// Binary function (arguments are both raw columns). The same column is referred multiple times
+    /// and it should be Ok.
+    #[test]
+    fn test_eval_binary_function_raw_column() {
+        /// FnFoo(v1, v2) performs v1 * v2.
+        #[derive(Debug, Clone, Copy)]
+        struct FnFoo;
+
+        impl_template_fn! { 2 arg @ FnFoo }
+
+        impl FnFoo {
+            fn call(
+                _ctx: &mut EvalContext,
+                _payload: RpnFnCallPayload<'_>,
+                v1: &Option<i64>,
+                v2: &Option<i64>,
+            ) -> Result<Option<i64>> {
+                Ok(Some(v1.unwrap() * v2.unwrap()))
+            }
+        }
+
+        let mut columns = LazyBatchColumnVec::from(vec![{
+            let mut col = LazyBatchColumn::raw_with_capacity(3);
+
+            let mut datum_raw = Vec::new();
+            DatumEncoder::encode(&mut datum_raw, &[Datum::I64(-5)], false).unwrap();
+            col.push_raw(&datum_raw);
+
+            let mut datum_raw = Vec::new();
+            DatumEncoder::encode(&mut datum_raw, &[Datum::I64(-7)], false).unwrap();
+            col.push_raw(&datum_raw);
+
+            let mut datum_raw = Vec::new();
+            DatumEncoder::encode(&mut datum_raw, &[Datum::I64(3)], false).unwrap();
+            col.push_raw(&datum_raw);
+
+            col
+        }]);
+
+        let schema = &[
+            {
+                let mut ft = FieldType::new();
+                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
+                ft
+            },
+            {
+                let mut ft = FieldType::new();
+                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
+                ft
+            },
+        ];
+
+        let exp = RpnExpressionBuilder::new()
+            .push_column_ref(0)
+            .push_column_ref(0)
+            .push_fn_call(FnFoo, FieldTypeTp::LongLong)
+            .build();
+        let mut ctx = EvalContext::default();
+        let result = exp.eval(&mut ctx, 3, schema, &mut columns);
+        let val = result.unwrap();
+        assert!(val.is_vector());
+        assert_eq!(
+            val.vector_value().unwrap().as_int_slice(),
+            [Some(25), Some(49), Some(9)]
         );
         assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
     }
@@ -799,34 +823,14 @@ mod tests {
             col
         }]);
 
-        let schema = &[{
-            let mut ft = FieldType::new();
-            ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-            ft
-        }];
+        let schema = &[FieldTypeTp::LongLong.into()];
 
-        let rpn_nodes = vec![
-            RpnExpressionNode::ColumnRef { offset: 0 },
-            RpnExpressionNode::Constant {
-                value: ScalarValue::Int(Some(3)),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                    ft
-                },
-            },
-            RpnExpressionNode::ColumnRef { offset: 0 },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnFoo),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                    ft
-                },
-            },
-        ];
-
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_column_ref(0)
+            .push_constant(3i64, FieldTypeTp::LongLong)
+            .push_column_ref(0)
+            .push_fn_call(FnFoo, FieldTypeTp::LongLong)
+            .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, 3, schema, &mut columns);
         let val = result.unwrap();
@@ -946,59 +950,16 @@ mod tests {
         ];
 
         // Col0, FnB, Col1, Const0, FnD, Const1, FnC, FnA
-
-        let rpn_nodes = vec![
-            RpnExpressionNode::ColumnRef { offset: 0 },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnB),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-            RpnExpressionNode::ColumnRef { offset: 1 },
-            RpnExpressionNode::Constant {
-                value: ScalarValue::Int(Some(7)),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                    ft
-                },
-            },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnD),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                    ft
-                },
-            },
-            RpnExpressionNode::Constant {
-                value: ScalarValue::Int(Some(11)),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                    ft
-                },
-            },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnC),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnA),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-        ];
+        let exp = RpnExpressionBuilder::new()
+            .push_column_ref(0)
+            .push_fn_call(FnB, FieldTypeTp::Double)
+            .push_column_ref(1)
+            .push_constant(7i64, FieldTypeTp::LongLong)
+            .push_fn_call(FnD, FieldTypeTp::LongLong)
+            .push_constant(11i64, FieldTypeTp::LongLong)
+            .push_fn_call(FnC, FieldTypeTp::Double)
+            .push_fn_call(FnA, FieldTypeTp::Double)
+            .build();
 
         //      FnA(
         //          [0.5, -0.1, 3.5],
@@ -1009,7 +970,7 @@ mod tests {
         //          )
         //      )
         //      => [25.0, 3.8, 146.0]
-        let exp = RpnExpression::from(rpn_nodes);
+
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, 3, schema, &mut columns);
         let val = result.unwrap();
@@ -1039,15 +1000,9 @@ mod tests {
             }
         }
 
-        let rpn_nodes = vec![RpnExpressionNode::FnCall {
-            func: Box::new(FnFoo),
-            field_type: {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-        }];
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_fn_call(FnFoo, FieldTypeTp::LongLong)
+            .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
         let hooked_eval = ::panic_hook::recover_safe(|| {
@@ -1078,33 +1033,11 @@ mod tests {
 
         // FnFoo only accepts 1 parameter but we will give 2.
 
-        let rpn_nodes = vec![
-            RpnExpressionNode::Constant {
-                value: ScalarValue::Real(Some(3.0)),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-            RpnExpressionNode::Constant {
-                value: ScalarValue::Real(Some(1.5)),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnFoo),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-        ];
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_constant(3.0f64, FieldTypeTp::Double)
+            .push_constant(1.5f64, FieldTypeTp::Double)
+            .push_fn_call(FnFoo, FieldTypeTp::Double)
+            .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
         let hooked_eval = ::panic_hook::recover_safe(|| {
@@ -1134,25 +1067,10 @@ mod tests {
             }
         }
 
-        let rpn_nodes = vec![
-            RpnExpressionNode::Constant {
-                value: ScalarValue::Int(Some(7)),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                    ft
-                },
-            },
-            RpnExpressionNode::FnCall {
-                func: Box::new(FnFoo),
-                field_type: {
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-            },
-        ];
-        let exp = RpnExpression::from(rpn_nodes);
+        let exp = RpnExpressionBuilder::new()
+            .push_constant(7i64, FieldTypeTp::LongLong)
+            .push_fn_call(FnFoo, FieldTypeTp::Double)
+            .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
         let hooked_eval = ::panic_hook::recover_safe(|| {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR extracts some engineering changes from https://github.com/tikv/tikv/pull/3898 where each of them is pretty small.

- Further simplify the building of `ColumnInfo` and `FieldType`.
- Simplify the building of `RpnExpression`.
- Add two additional RpnExpression tests:
  - `test_eval_unary_function_raw_column`
  - `test_eval_binary_function_raw_column`
- Implement `Clone` for `RpnFunction`

- [x] Merge https://github.com/tikv/tikv/pull/4546 first.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

No.