### PR TITLE
raftstore: Prevent double-panic in PendingCmd dtor

### DIFF
--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::Sender;
 use std::sync::mpsc::SyncSender;
 use std::sync::Arc;
-use std::{cmp, usize};
+use std::{cmp, thread, usize};
 
 use crossbeam::channel::{TryRecvError, TrySendError};
 use engine::rocks;
@@ -81,10 +81,18 @@ impl PendingCmd {
 impl Drop for PendingCmd {
     fn drop(&mut self) {
         if self.cb.is_some() {
-            panic!(
-                "callback of pending command at [index: {}, term: {}] is leak",
-                self.index, self.term
-            );
+            // Double panic leads to an abort, so we need to prevent it.
+            if thread::panicking() {
+                error!(
+                    "callback of pending command at [index: {}, term: {}] leaks while panicking",
+                    self.index, self.term
+                );
+            } else {
+                panic!(
+                    "callback of pending command at [index: {}, term: {}] leaks",
+                    self.index, self.term
+                );
+            }
         }
     }
 }
@@ -3811,5 +3819,23 @@ mod tests {
         checker.check(b"k3", b"k31", 1, &[3, 5, 7], false);
         checker.check(b"k31", b"k32", 24, &[25, 26, 27], true);
         checker.check(b"k32", b"k4", 28, &[29, 30, 31], true);
+    }
+
+    #[test]
+    fn pending_cmd_leak() {
+        let res = panic_hook::recover_safe(|| {
+            let _cmd = PendingCmd::new(1, 1, Callback::None);
+        });
+        res.unwrap_err();
+    }
+
+    #[test]
+    fn pending_cmd_leak_dtor_not_abort() {
+        let res = panic_hook::recover_safe(|| {
+            let _cmd = PendingCmd::new(1, 1, Callback::None);
+            panic!("Don't abort");
+            // It would abort and fail if there was a double-panic in PendingCmd dtor.
+        });
+        res.unwrap_err();
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

It's generally not ok to panic in dtor because of the risk of double-panic. So we log the PendingCmd leak as an error instead of panicking if we detect the thread is unwinding due to panic.

## What are the type of the changes? (mandatory)

Bug fix.

## How has this PR been tested? (mandatory)

Unit test.

## Does this PR affect documentation (docs) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

It fixes #4310 

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

