### PR TITLE
raftstore: learners should be considered when check progresses before merge

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1724,16 +1724,13 @@ impl Peer {
 
     pub fn get_min_progress(&self) -> u64 {
         let status = self.raft_group.status();
-        let voters_min = status
+        status
             .progress
             .values()
+            .chain(status.learner_progress.values())
             .map(|pr| pr.matched)
             .min()
-            .unwrap_or_default();
-        match status.learner_progress.values().map(|pr| pr.matched).min() {
-            Some(learners_min) => cmp::min(voters_min, learners_min),
-            None => voters_min,
-        }
+            .unwrap_or_default()
     }
 
     fn pre_propose_prepare_merge<T, C>(

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1730,13 +1730,10 @@ impl Peer {
             .map(|pr| pr.matched)
             .min()
             .unwrap_or_default();
-        let learners_min = status
-            .learner_progress
-            .values()
-            .map(|pr| pr.matched)
-            .min()
-            .unwrap_or_default();
-        cmp::min(voters_min, learners_min)
+        match status.learner_progress.values().map(|pr| pr.matched).min() {
+            Some(learners_min) => cmp::min(voters_min, learners_min),
+            None => voters_min,
+        }
     }
 
     fn pre_propose_prepare_merge<T, C>(

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1723,13 +1723,20 @@ impl Peer {
     }
 
     pub fn get_min_progress(&self) -> u64 {
-        self.raft_group
-            .status()
+        let status = self.raft_group.status();
+        let voters_min = status
             .progress
             .values()
             .map(|pr| pr.matched)
             .min()
-            .unwrap_or_default()
+            .unwrap_or_default();
+        let learners_min = status
+            .learner_progress
+            .values()
+            .map(|pr| pr.matched)
+            .min()
+            .unwrap_or_default();
+        cmp::min(voters_min, learners_min)
     }
 
     fn pre_propose_prepare_merge<T, C>(

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -2,8 +2,8 @@
 
 use std::iter::*;
 use std::sync::Arc;
-use std::thread;
 use std::time::Duration;
+use std::{panic, thread};
 
 use kvproto::raft_cmdpb::CmdType;
 use kvproto::raft_serverpb::{PeerState, RegionLocalState};
@@ -100,6 +100,44 @@ fn test_node_base_merge() {
     }
 
     cluster.must_put(b"k4", b"v4");
+}
+
+#[test]
+fn test_node_merge_with_slow_learner() {
+    let mut cluster = new_node_cluster(0, 2);
+    configure_for_merge(&mut cluster);
+
+    // Create a cluster with peer 1 as leader and peer 2 as learner.
+    let r1 = cluster.run_conf_change();
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.must_add_peer(r1, new_learner_peer(2, 2));
+
+    // Make sure the leader has received the learner's last index.
+    cluster.must_put(b"k1", b"v1");
+    cluster.must_put(b"k3", b"v3");
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(2), b"k3", b"v3");
+
+    // Split the region.
+    let pd_client = Arc::clone(&cluster.pd_client);
+    let region = pd_client.get_region(b"k1").unwrap();
+    cluster.must_split(&region, b"k2");
+    let left = pd_client.get_region(b"k1").unwrap();
+    let right = pd_client.get_region(b"k2").unwrap();
+    assert_eq!(region.get_id(), right.get_id());
+    assert_eq!(left.get_end_key(), right.get_start_key());
+    assert_eq!(right.get_start_key(), b"k2");
+
+    // Merge 2 regions under isolation should fail.
+    cluster.add_send_filter(IsolationFilterFactory::new(2));
+    (0..100).for_each(|_| cluster.must_put(b"k1", b"v1"));
+    let do_merge = || pd_client.must_merge(left.get_id(), right.get_id());
+    if panic::catch_unwind(panic::AssertUnwindSafe(do_merge)).is_ok() {
+        panic!("merge with slow learner should fail");
+    }
+
+    cluster.clear_send_filters();
+    pd_client.must_merge(left.get_id(), right.get_id());
 }
 
 /// Test whether merge will be aborted if prerequisites is not met.

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -2,8 +2,8 @@
 
 use std::iter::*;
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
-use std::{panic, thread};
 
 use kvproto::raft_cmdpb::CmdType;
 use kvproto::raft_serverpb::{PeerState, RegionLocalState};

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -138,6 +138,7 @@ fn test_node_merge_with_slow_learner() {
 
     cluster.clear_send_filters();
     cluster.must_put(b"k11", b"v100");
+    must_get_equal(&cluster.get_engine(1), b"k11", b"v100");
     must_get_equal(&cluster.get_engine(2), b"k11", b"v100");
     pd_client.must_merge(left.get_id(), right.get_id());
 }


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

## What have you changed? (mandatory)
Fix a bug about merge with learner, which is when we check the log gap in all replications, learners should also be considered, otherwise learners could panic.
close #4551 .

## What are the type of the changes? (mandatory)
Bug fix.

## How has this PR been tested? (mandatory)
Unit tests.