### PR TITLE
Cherry-pick: import: use memory to cache split sst instead of disk file (#4566)

### DIFF
--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -221,7 +221,7 @@ pub struct SSTWriter {
 
 impl SSTWriter {
     pub fn new(cfg: &DbConfig, path: &str) -> Result<SSTWriter> {
-        let env = Arc::new(Env::default());
+        let env = Arc::new(Env::new_mem());
         let uuid = Uuid::new_v4().to_string();
 
         let mut default_opts = cfg.defaultcf.build_opt();

--- a/src/import/import.rs
+++ b/src/import/import.rs
@@ -86,6 +86,12 @@ impl<Client: ImportClient> ImportJob<Client> {
                 "[{}] still has ranges need to retry, retry_count:{}, current_count:{}",
                 self.tag, retry_count, i,
             );
+            if i == MAX_RETRY_TIMES - 1 {
+                res = Err(Error::ImportJobFailed(format!(
+                    "retry {} times still {} ranges failed",
+                    i, retry_count
+                )))
+            }
         }
         IMPORT_EACH_PHASE.with_label_values(&["import"]).set(0.0);
 


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Cherry-pick: #4566