### PR TITLE
Rename and move ExecSummary to support non-batch executors

### DIFF
--- a/src/coprocessor/dag/aggr_fn/impl_avg.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_avg.rs
@@ -164,7 +164,7 @@ where
         if self.count == 0 {
             target[1].push(None);
         } else {
-            target[1].push(Some(self.sum.clone()))
+            target[1].push(Some(self.sum.clone()));
         }
         Ok(())
     }

--- a/src/coprocessor/dag/batch/executors/index_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/index_scan_executor.rs
@@ -27,7 +27,7 @@ pub struct BatchIndexScanExecutor<C: ExecSummaryCollector, S: Store>(
 
 impl
     BatchIndexScanExecutor<
-        crate::coprocessor::dag::batch::statistics::ExecSummaryCollectorDisabled,
+        crate::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled,
         FixtureStore,
     >
 {
@@ -252,7 +252,7 @@ mod tests {
 
     use crate::coprocessor::codec::mysql::Tz;
     use crate::coprocessor::codec::{datum, table, Datum};
-    use crate::coprocessor::dag::batch::statistics::*;
+    use crate::coprocessor::dag::exec_summary::*;
     use crate::coprocessor::dag::expr::EvalConfig;
     use crate::coprocessor::util::convert_to_prefix_next;
     use crate::storage::{FixtureStore, Key};

--- a/src/coprocessor/dag/batch/executors/limit.rs
+++ b/src/coprocessor/dag/batch/executors/limit.rs
@@ -34,7 +34,7 @@ impl<C: ExecSummaryCollector, Src: BatchExecutor> BatchExecutor for BatchLimitEx
 
     #[inline]
     fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
-        let timer = self.summary_collector.on_start_batch();
+        let timer = self.summary_collector.on_start_iterate();
 
         let mut result = self.src.next_batch(scan_rows);
         if result.data.rows_len() < self.remaining_rows {
@@ -46,7 +46,7 @@ impl<C: ExecSummaryCollector, Src: BatchExecutor> BatchExecutor for BatchLimitEx
         }
 
         self.summary_collector
-            .on_finish_batch(timer, result.data.rows_len());
+            .on_finish_iterate(timer, result.data.rows_len());
 
         result
     }
@@ -64,9 +64,7 @@ mod tests {
     use super::*;
     use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
     use crate::coprocessor::codec::data_type::VectorValue;
-    use crate::coprocessor::dag::batch::statistics::{
-        ExecSummaryCollectorDisabled, ExecSummaryCollectorEnabled,
-    };
+    use crate::coprocessor::dag::exec_summary::*;
     use crate::coprocessor::dag::expr::EvalConfig;
     use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeTp};
     use tipb::expression::FieldType;

--- a/src/coprocessor/dag/batch/executors/selection_executor.rs
+++ b/src/coprocessor/dag/batch/executors/selection_executor.rs
@@ -7,7 +7,7 @@ use tipb::expression::Expr;
 use tipb::expression::FieldType;
 
 use super::super::interface::*;
-use crate::coprocessor::dag::batch::statistics::ExecSummaryCollectorDisabled;
+use crate::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled;
 use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
 use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
 use crate::coprocessor::{Error, Result};
@@ -126,10 +126,10 @@ impl<C: ExecSummaryCollector, Src: BatchExecutor> BatchExecutor for BatchSelecti
 
     #[inline]
     fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
-        let timer = self.summary_collector.on_start_batch();
+        let timer = self.summary_collector.on_start_iterate();
         let result = self.handle_next_batch(scan_rows);
         self.summary_collector
-            .on_finish_batch(timer, result.data.rows_len());
+            .on_finish_iterate(timer, result.data.rows_len());
         result
     }
 

--- a/src/coprocessor/dag/batch/executors/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/table_scan_executor.rs
@@ -28,7 +28,7 @@ pub struct BatchTableScanExecutor<C: ExecSummaryCollector, S: Store>(
 
 impl
     BatchTableScanExecutor<
-        crate::coprocessor::dag::batch::statistics::ExecSummaryCollectorDisabled,
+        crate::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled,
         FixtureStore,
     >
 {
@@ -321,7 +321,7 @@ mod tests {
     use crate::coprocessor::codec::mysql::Tz;
     use crate::coprocessor::codec::{datum, table, Datum};
     use crate::coprocessor::dag::batch::interface::BatchExecutor;
-    use crate::coprocessor::dag::batch::statistics::*;
+    use crate::coprocessor::dag::exec_summary::*;
     use crate::coprocessor::dag::expr::EvalConfig;
     use crate::coprocessor::util::convert_to_prefix_next;
     use crate::storage::{FixtureStore, Key};

--- a/src/coprocessor/dag/batch/executors/util/scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/util/scan_executor.rs
@@ -219,7 +219,7 @@ impl<C: ExecSummaryCollector, S: Store, I: ScanExecutorImpl, P: PointRangePolicy
         assert!(!self.is_ended);
         assert!(scan_rows > 0);
 
-        let timer = self.summary_collector.on_start_batch();
+        let timer = self.summary_collector.on_start_iterate();
 
         let mut data = self.imp.build_column_vec(scan_rows);
         let is_drained = self.fill_column_vec(scan_rows, &mut data);
@@ -238,7 +238,7 @@ impl<C: ExecSummaryCollector, S: Store, I: ScanExecutorImpl, P: PointRangePolicy
         };
 
         self.summary_collector
-            .on_finish_batch(timer, data.rows_len());
+            .on_finish_iterate(timer, data.rows_len());
 
         BatchExecuteResult {
             data,

--- a/src/coprocessor/dag/batch/interface.rs
+++ b/src/coprocessor/dag/batch/interface.rs
@@ -4,7 +4,8 @@
 
 //! Batch executor common structures.
 
-pub use super::statistics::{BatchExecuteStatistics, ExecSummaryCollector};
+pub use super::super::exec_summary::ExecSummaryCollector;
+pub use super::statistics::BatchExecuteStatistics;
 
 use tipb::expression::FieldType;
 

--- a/src/coprocessor/dag/batch/statistics.rs
+++ b/src/coprocessor/dag/batch/statistics.rs
@@ -1,5 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use crate::coprocessor::dag::exec_summary::ExecSummary;
+
 /// Data to be flowed between parent and child executors at once during `collect_statistics()`
 /// invocation.
 ///
@@ -36,111 +38,4 @@ impl BatchExecuteStatistics {
         }
         self.cf_stats = crate::storage::Statistics::default();
     }
-}
-
-/// Execution summaries to support `EXPLAIN ANALYZE` statements.
-#[derive(Default)]
-pub struct ExecSummary {
-    /// Total time cost in this executor.
-    pub time_processed_ms: usize,
-
-    /// How many rows this executor produced totally.
-    pub num_produced_rows: usize,
-
-    /// How many times executor's `next_batch()` is called.
-    pub num_iterations: usize,
-}
-
-impl ExecSummary {
-    #[inline]
-    pub fn merge_into(self, target: &mut Self) {
-        target.time_processed_ms += self.time_processed_ms;
-        target.num_produced_rows += self.num_produced_rows;
-        target.num_iterations += self.num_iterations;
-    }
-}
-
-/// A trait for all execution summary collectors.
-pub trait ExecSummaryCollector: Send {
-    type DurationRecorder;
-
-    /// Creates a new instance with specified output slot index.
-    fn new(output_index: usize) -> Self
-    where
-        Self: Sized;
-
-    /// Returns an instance that will record elapsed duration and increase
-    /// the iterations counter. The instance should be later passed back to
-    /// `on_finish_batch` when processing of `next_batch` is completed.
-    fn on_start_batch(&mut self) -> Self::DurationRecorder;
-
-    // Increases the process time and produced rows counter.
-    // It should be called when `next_batch` is completed.
-    fn on_finish_batch(&mut self, dr: Self::DurationRecorder, rows: usize);
-
-    /// Takes and appends current execution summary into `target`.
-    fn collect_into(&mut self, target: &mut [Option<ExecSummary>]);
-}
-
-/// A normal `ExecSummaryCollector` that simply collects execution summaries.
-/// It acts like `collect = true`.
-pub struct ExecSummaryCollectorEnabled {
-    output_index: usize,
-    counts: ExecSummary,
-}
-
-impl ExecSummaryCollector for ExecSummaryCollectorEnabled {
-    type DurationRecorder = tikv_util::time::Instant;
-
-    #[inline]
-    fn new(output_index: usize) -> ExecSummaryCollectorEnabled {
-        ExecSummaryCollectorEnabled {
-            output_index,
-            counts: Default::default(),
-        }
-    }
-
-    #[inline]
-    fn on_start_batch(&mut self) -> Self::DurationRecorder {
-        self.counts.num_iterations += 1;
-        tikv_util::time::Instant::now_coarse()
-    }
-
-    #[inline]
-    fn on_finish_batch(&mut self, dr: Self::DurationRecorder, rows: usize) {
-        self.counts.num_produced_rows += rows;
-        let elapsed_time = tikv_util::time::duration_to_ms(dr.elapsed()) as usize;
-        self.counts.time_processed_ms += elapsed_time;
-    }
-
-    #[inline]
-    fn collect_into(&mut self, target: &mut [Option<ExecSummary>]) {
-        let current_summary = std::mem::replace(&mut self.counts, ExecSummary::default());
-        if let Some(t) = &mut target[self.output_index] {
-            current_summary.merge_into(t);
-        } else {
-            target[self.output_index] = Some(current_summary);
-        }
-    }
-}
-
-/// A `ExecSummaryCollector` that does not collect anything. Acts like `collect = false`.
-pub struct ExecSummaryCollectorDisabled;
-
-impl ExecSummaryCollector for ExecSummaryCollectorDisabled {
-    type DurationRecorder = ();
-
-    #[inline]
-    fn new(_output_index: usize) -> ExecSummaryCollectorDisabled {
-        ExecSummaryCollectorDisabled
-    }
-
-    #[inline]
-    fn on_start_batch(&mut self) -> Self::DurationRecorder {}
-
-    #[inline]
-    fn on_finish_batch(&mut self, _dr: Self::DurationRecorder, _rows: usize) {}
-
-    #[inline]
-    fn collect_into(&mut self, _target: &mut [Option<ExecSummary>]) {}
 }

--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -14,7 +14,7 @@ use super::executor::{
     Executor, HashAggExecutor, LimitExecutor, ScanExecutor, SelectionExecutor, StreamAggExecutor,
     TopNExecutor,
 };
-use crate::coprocessor::dag::batch::statistics::*;
+use crate::coprocessor::dag::exec_summary::*;
 use crate::coprocessor::dag::expr::{EvalConfig, Flag, SqlMode};
 use crate::coprocessor::metrics::*;
 use crate::coprocessor::*;

--- a/src/coprocessor/dag/exec_summary.rs
+++ b/src/coprocessor/dag/exec_summary.rs
@@ -1,0 +1,108 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+/// Execution summaries to support `EXPLAIN ANALYZE` statements.
+#[derive(Default)]
+pub struct ExecSummary {
+    /// Total time cost in this executor.
+    pub time_processed_ms: usize,
+
+    /// How many rows this executor produced totally.
+    pub num_produced_rows: usize,
+
+    /// How many times executor's `next_batch()` is called.
+    pub num_iterations: usize,
+}
+
+impl ExecSummary {
+    #[inline]
+    pub fn merge_into(self, target: &mut Self) {
+        target.time_processed_ms += self.time_processed_ms;
+        target.num_produced_rows += self.num_produced_rows;
+        target.num_iterations += self.num_iterations;
+    }
+}
+
+/// A trait for all execution summary collectors.
+pub trait ExecSummaryCollector: Send {
+    type DurationRecorder;
+
+    /// Creates a new instance with specified output slot index.
+    fn new(output_index: usize) -> Self
+    where
+        Self: Sized;
+
+    /// Returns an instance that will record elapsed duration and increase
+    /// the iterations counter. The instance should be later passed back to
+    /// `on_finish_iterate` when processing of `next_batch` is completed.
+    fn on_start_iterate(&mut self) -> Self::DurationRecorder;
+
+    // Increases the process time and produced rows counter.
+    // It should be called when `next_batch` is completed.
+    fn on_finish_iterate(&mut self, dr: Self::DurationRecorder, rows: usize);
+
+    /// Takes and appends current execution summary into `target`.
+    fn collect_into(&mut self, target: &mut [Option<ExecSummary>]);
+}
+
+/// A normal `ExecSummaryCollector` that simply collects execution summaries.
+/// It acts like `collect = true`.
+pub struct ExecSummaryCollectorEnabled {
+    output_index: usize,
+    counts: ExecSummary,
+}
+
+impl ExecSummaryCollector for ExecSummaryCollectorEnabled {
+    type DurationRecorder = tikv_util::time::Instant;
+
+    #[inline]
+    fn new(output_index: usize) -> ExecSummaryCollectorEnabled {
+        ExecSummaryCollectorEnabled {
+            output_index,
+            counts: Default::default(),
+        }
+    }
+
+    #[inline]
+    fn on_start_iterate(&mut self) -> Self::DurationRecorder {
+        self.counts.num_iterations += 1;
+        tikv_util::time::Instant::now_coarse()
+    }
+
+    #[inline]
+    fn on_finish_iterate(&mut self, dr: Self::DurationRecorder, rows: usize) {
+        self.counts.num_produced_rows += rows;
+        let elapsed_time = tikv_util::time::duration_to_ms(dr.elapsed()) as usize;
+        self.counts.time_processed_ms += elapsed_time;
+    }
+
+    #[inline]
+    fn collect_into(&mut self, target: &mut [Option<ExecSummary>]) {
+        let current_summary = std::mem::replace(&mut self.counts, ExecSummary::default());
+        if let Some(t) = &mut target[self.output_index] {
+            current_summary.merge_into(t);
+        } else {
+            target[self.output_index] = Some(current_summary);
+        }
+    }
+}
+
+/// A `ExecSummaryCollector` that does not collect anything. Acts like `collect = false`.
+pub struct ExecSummaryCollectorDisabled;
+
+impl ExecSummaryCollector for ExecSummaryCollectorDisabled {
+    type DurationRecorder = ();
+
+    #[inline]
+    fn new(_output_index: usize) -> ExecSummaryCollectorDisabled {
+        ExecSummaryCollectorDisabled
+    }
+
+    #[inline]
+    fn on_start_iterate(&mut self) -> Self::DurationRecorder {}
+
+    #[inline]
+    fn on_finish_iterate(&mut self, _dr: Self::DurationRecorder, _rows: usize) {}
+
+    #[inline]
+    fn collect_into(&mut self, _target: &mut [Option<ExecSummary>]) {}
+}

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -26,6 +26,7 @@ pub mod aggr_fn;
 pub mod batch;
 pub mod batch_handler;
 pub mod builder;
+pub mod exec_summary;
 pub mod executor;
 pub mod expr;
 pub mod handler;


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

To use `ExecSummary` in normal executors, we need to move it out of `batch` directory.

Also, renamed functions, e.g. "on_start_batch" to "on_start_iterate", so that it is not limited to batch executors.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

No need.
