### PR TITLE
import: tune SstFileWriter options to reduce CPU usage

### DIFF
--- a/etc/tikv-importer.toml
+++ b/etc/tikv-importer.toml
@@ -34,7 +34,11 @@ max-write-buffer-number = 8
 # the algorithm at level-0 is using to compress KV data.
 # the algorithm at level-6 is using to compress SST files.
 # the algorithms at level-1 ~ level-5 are not used for now.
-compression-per-level = ["lz4", "no", "no", "no", "no", "no", "zstd"]
+compression-per-level = ["lz4", "no", "no", "no", "no", "no", "lz4"]
+
+[rocksdb.writecf]
+compression-per-level = ["lz4", "no", "no", "no", "no", "no", "lz4"]
+
 
 [import]
 # the directory to store importing kv data.

--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -36,8 +36,6 @@ use crate::import::stream::SSTFile;
 use engine::rocks::util::security::encrypted_env_from_cipher_file;
 use tikv_util::security::SecurityConfig;
 
-const DISABLED: i32 = i32::MAX;
-
 /// Engine wraps rocksdb::DB with customized options to support efficient bulk
 /// write.
 pub struct Engine {
@@ -339,6 +337,8 @@ pub fn get_approximate_ranges(
 }
 
 fn tune_dboptions_for_bulk_load(opts: &DbConfig) -> (DBOptions, CFOptions<'_>) {
+    const DISABLED: i32 = i32::MAX;
+
     let mut db_opts = DBOptions::new();
     db_opts.create_if_missing(true);
     db_opts.enable_statistics(false);

--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -23,9 +23,9 @@ use crate::storage::mvcc::{Write, WriteType};
 use crate::storage::types::Key;
 use engine::rocks::util::{new_engine_opt, CFOptions};
 use engine::rocks::{
-    BlockBasedOptions, Cache, ColumnFamilyOptions, CompactionPriority, DBCompressionType,
-    DBIterator, DBOptions, Env, EnvOptions, ExternalSstFileInfo, LRUCacheOptions, ReadOptions,
-    SequentialFile, SstFileWriter, Writable, WriteBatch as RawBatch, DB,
+    BlockBasedOptions, Cache, ColumnFamilyOptions, DBCompressionType, DBIterator, DBOptions, Env,
+    EnvOptions, ExternalSstFileInfo, LRUCacheOptions, ReadOptions, SequentialFile, SstFileWriter,
+    Writable, WriteBatch as RawBatch, DB,
 };
 use engine::{CF_DEFAULT, CF_WRITE};
 use tikv_util::config::MB;

--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -243,7 +243,6 @@ impl SSTWriter {
         // Creates a writer for write CF
         let mut write_opts = db_cfg.writecf.build_opt(&cache);
         Self::tune_config(Arc::clone(&env), &mut write_opts);
-
         let mut write = SstFileWriter::new(EnvOptions::new(), write_opts);
         write.open(&format!("{}{}.{}:write", path, MAIN_SEPARATOR, uuid))?;
 
@@ -258,9 +257,9 @@ impl SSTWriter {
     }
 
     fn tune_config(env: Arc<Env>, cf_opts: &mut ColumnFamilyOptions) {
-        use DBCompressionType::Lz4;
+        use DBCompressionType::{Lz4, No};
         cf_opts.set_env(env);
-        cf_opts.compression_per_level(&[Lz4, Lz4, Lz4, Lz4, Lz4, Lz4, Lz4]);
+        cf_opts.compression_per_level(&[No, No, No, No, No, No, Lz4]);
     }
 
     pub fn put(&mut self, key: &[u8], value: &[u8]) -> Result<()> {


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

The `zstd` is a CPU-tense compaction algorithm, which makes other workers have less chance to do some works. CPU will become the bottleneck of TiKV-Importer.

## What are the type of the changes? (mandatory)

Change the compaction algorithm to `lz4` to make a balance between CPU and bandwidth.

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

11T test case, index engine file import throughput increase 250MB/s to 1GB/s in our 10G network card.
