### PR TITLE
Share block cache among column families (#4563)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "glob"
-version = "0.2.11"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -976,7 +976,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#44d2a52a469c2db43cb998a983bfc09f57ea21ff"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#0826c1f101a5b1c18acd945decab91c8da0c85d9"
 dependencies = [
  "bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -985,7 +985,7 @@ dependencies = [
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4-sys 1.8.0 (git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build)",
  "snappy-sys 0.1.0 (git+https://github.com/busyjay/rust-snappy.git?branch=static-link)",
- "zstd-sys 1.4.9+zstd.1.3.8 (git+https://github.com/gyscos/zstd-rs.git)",
+ "zstd-sys 1.4.10+zstd.1.4.0 (git+https://github.com/gyscos/zstd-rs.git)",
 ]
 
 [[package]]
@@ -1686,7 +1686,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#44d2a52a469c2db43cb998a983bfc09f57ea21ff"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#0826c1f101a5b1c18acd945decab91c8da0c85d9"
 dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2694,11 +2694,11 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.9+zstd.1.3.8"
-source = "git+https://github.com/gyscos/zstd-rs.git#d51f87c668932670b9aced48d1b750506c211f11"
+version = "1.4.10+zstd.1.4.0"
+source = "git+https://github.com/gyscos/zstd-rs.git#071020d16b6fd58d496e389495a8de06f769d808"
 dependencies = [
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2770,7 +2770,7 @@ dependencies = [
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
-"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum grpcio 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5cef8e7d071d3e48349528932590b2a4c6fc8b3e20cec1e3bdc52c4d831e89a"
 "checksum grpcio-compiler 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373a14f0f994d4c235770f4bb5558be00626844db130a82a70142b8fc5996fc3"
 "checksum grpcio-sys 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "456f8b46b47028e75726587987ead25144ac14c7c9e79f28bbb71436eca67d68"
@@ -2978,4 +2978,4 @@ dependencies = [
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 "checksum zipf 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4b6916023b585291387096ec195b2f2d372344993dfceed51c8efb6cde84b12"
-"checksum zstd-sys 1.4.9+zstd.1.3.8 (git+https://github.com/gyscos/zstd-rs.git)" = "<none>"
+"checksum zstd-sys 1.4.10+zstd.1.4.0 (git+https://github.com/gyscos/zstd-rs.git)" = "<none>"

--- a/components/engine/src/rocks/mod.rs
+++ b/components/engine/src/rocks/mod.rs
@@ -10,15 +10,15 @@ pub use engine_rocksdb::rocksdb_options::UnsafeSnap;
 pub use engine_rocksdb::{
     load_latest_options, rocksdb::supported_compression, run_ldb_tool,
     set_external_sst_file_global_seq_no, BlockBasedOptions, CColumnFamilyDescriptor, CFHandle,
-    ColumnFamilyOptions, CompactOptions, CompactionJobInfo, CompactionOptions, CompactionPriority,
-    DBBottommostLevelCompaction, DBCompactionStyle, DBCompressionType, DBEntryType, DBIterator,
-    DBOptions, DBRateLimiterMode, DBRecoveryMode, DBStatisticsHistogramType,
-    DBStatisticsTickerType, DBVector, Env, EnvOptions, EventListener, ExternalSstFileInfo,
-    FlushJobInfo, HistogramData, IngestExternalFileOptions, IngestionInfo, Kv, PerfContext, Range,
-    RateLimiter, ReadOptions, SeekKey, SequentialFile, SliceTransform, SstFileWriter,
-    TablePropertiesCollection, TablePropertiesCollector, TablePropertiesCollectorFactory,
-    TitanBlobIndex, TitanDBOptions, UserCollectedProperties, Writable, WriteBatch, WriteOptions,
-    WriteStallCondition, WriteStallInfo, DB,
+    Cache, ColumnFamilyOptions, CompactOptions, CompactionJobInfo, CompactionOptions,
+    CompactionPriority, DBBottommostLevelCompaction, DBCompactionStyle, DBCompressionType,
+    DBEntryType, DBIterator, DBOptions, DBRateLimiterMode, DBRecoveryMode,
+    DBStatisticsHistogramType, DBStatisticsTickerType, DBVector, Env, EnvOptions, EventListener,
+    ExternalSstFileInfo, FlushJobInfo, HistogramData, IngestExternalFileOptions, IngestionInfo, Kv,
+    LRUCacheOptions, PerfContext, Range, RateLimiter, ReadOptions, SeekKey, SequentialFile,
+    SliceTransform, SstFileWriter, TablePropertiesCollection, TablePropertiesCollector,
+    TablePropertiesCollectorFactory, TitanBlobIndex, TitanDBOptions, UserCollectedProperties,
+    Writable, WriteBatch, WriteOptions, WriteStallCondition, WriteStallInfo, DB,
 };
 
 #[cfg(test)]

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -130,8 +130,9 @@ impl<T: Simulator> Cluster<T> {
         for _ in 0..self.count {
             let dir = TempDir::new("test_cluster").unwrap();
             let kv_path = dir.path().join("kv");
+            let cache = self.cfg.storage.block_cache.build_shared_cache();
             let kv_db_opt = self.cfg.rocksdb.build_opt();
-            let kv_cfs_opt = self.cfg.rocksdb.build_cf_opts();
+            let kv_cfs_opt = self.cfg.rocksdb.build_cf_opts(&cache);
             let engine = Arc::new(
                 rocks::util::new_engine_opt(kv_path.to_str().unwrap(), kv_db_opt, kv_cfs_opt)
                     .unwrap(),

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -495,7 +495,8 @@ pub fn create_test_engine(
                 cmpacted_handler,
                 Some(dummpy_filter),
             ));
-            let kv_cfs_opt = cfg.rocksdb.build_cf_opts();
+            let cache = cfg.storage.block_cache.build_shared_cache();
+            let kv_cfs_opt = cfg.rocksdb.build_cf_opts(&cache);
             let engine = Arc::new(
                 rocks::util::new_engine_opt(
                     path.as_ref().unwrap().path().to_str().unwrap(),

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -134,6 +134,30 @@
 ## When the pending write bytes exceeds this threshold, the "scheduler too busy" error is displayed.
 # scheduler-pending-write-threshold = "100MB"
 
+[storage.block-cache]
+## Whether to create a shared block cache for all RocksDB column families.
+##
+## Block cache is used by RocksDB to cache uncompressed blocks. Big block cache can speed up read.
+## It is recommended to turn on shared block cache. Since only the total cache size need to be
+## set, it is easier to config. In most cases it should be able to auto-balance cache usage
+## between column families with standard LRU algorithm.
+##
+## The rest of config in the storage.block-cache session is effective only when shared block cache
+## is on.
+# shared = true
+
+## Size of the shared block cache. Normally it should be tuned to 30%-50% of system's total memory.
+## When the config is not set, it is decided by the sum of the following fields or their default
+## value:
+##   * rocksdb.defaultcf.block-cache-size or 25% of system's total memory
+##   * rocksdb.writecf.block-cache-size   or 15% of system's total memory
+##   * rocksdb.lockcf.block-cache-size    or  2% of system's total memory
+##   * raftdb.defaultcf.block-cache-size  or  2% of system's total memory
+##
+## To deploy multiple TiKV nodes on a single physical machine, configure this parameter explicitly.
+## Otherwise, the OOM problem might occur in TiKV.
+# capacity = "1GB"
+
 [pd]
 ## PD endpoints.
 # endpoints = []
@@ -509,13 +533,6 @@
 ## 3 : MinOverlappingRatio
 # compaction-pri = 3
 
-## Block cache used to cache uncompressed blocks.
-## Big block-cache can speed up read. Normally it should be tuned to 30%-50% system's total memory.
-## When the config is not set, TiKV sets the value to 40% of the system memory size.
-## To deploy multiple TiKV nodes on one physical machine, configure this parameter explicitly.
-## Otherwise, the OOM problem might occur in TiKV.
-# block-cache-size = "1GB"
-
 ## Indicating if we'd put index/filter blocks to the block cache.
 ## If not specified, each "table reader" object will pre-load index/filter block during table
 ## initialization.
@@ -605,13 +622,6 @@
 # max-bytes-for-level-base = "512MB"
 # target-file-size-base = "8MB"
 
-## In normal cases, this config should be tuned to 10%-30% of the system's total memory.
-## When this config is not set, TiKV sets it to 15% of the system memory size.
-## To deploy multiple TiKV nodes on a single physical machine, configure this parameter explicitly.
-## The related data of the version information (MVCC) and the index-related data are recorded in
-## Write CF. In scenarios that include many single table indexes, set this parameter value higher.
-# block-cache-size = "256MB"
-
 # level0-file-num-compaction-trigger = 4
 # level0-slowdown-writes-trigger = 20
 # level0-stop-writes-trigger = 36
@@ -630,7 +640,6 @@
 # min-write-buffer-number-to-merge = 1
 # max-bytes-for-level-base = "128MB"
 # target-file-size-base = "8MB"
-# block-cache-size = "256MB"
 # level0-file-num-compaction-trigger = 1
 # level0-slowdown-writes-trigger = 20
 # level0-stop-writes-trigger = 36
@@ -678,10 +687,6 @@
 ## Recommend to set it the same as `rocksdb.defaultcf.max-bytes-for-level-base`.
 # max-bytes-for-level-base = "512MB"
 # target-file-size-base = "8MB"
-
-## Generally, you can set it from 256MB to 2GB. In most cases, you can use the default value. But
-## if the system resources are adequate, you can set it higher.
-# block-cache-size = "256MB"
 
 # level0-file-num-compaction-trigger = 4
 # level0-slowdown-writes-trigger = 20

--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -76,8 +76,9 @@ fn new_debug_executor(
 ) -> Box<dyn DebugExecutor> {
     match (host, db) {
         (None, Some(kv_path)) => {
+            let cache = cfg.storage.block_cache.build_shared_cache();
             let mut kv_db_opts = cfg.rocksdb.build_opt();
-            let kv_cfs_opts = cfg.rocksdb.build_cf_opts();
+            let kv_cfs_opts = cfg.rocksdb.build_cf_opts(&cache);
 
             if !mgr.cipher_file().is_empty() {
                 let encrypted_env =
@@ -90,7 +91,7 @@ fn new_debug_executor(
                 .map(ToString::to_string)
                 .unwrap_or_else(|| format!("{}/../raft", kv_path));
             let mut raft_db_opts = cfg.raftdb.build_opt();
-            let raft_db_cf_opts = cfg.raftdb.build_cf_opts();
+            let raft_db_cf_opts = cfg.raftdb.build_cf_opts(&cache);
 
             if !mgr.cipher_file().is_empty() {
                 let encrypted_env =

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,8 +9,9 @@ use std::path::Path;
 use std::usize;
 
 use engine::rocks::{
-    BlockBasedOptions, ColumnFamilyOptions, CompactionPriority, DBCompactionStyle,
-    DBCompressionType, DBOptions, DBRateLimiterMode, DBRecoveryMode, TitanDBOptions,
+    BlockBasedOptions, Cache, ColumnFamilyOptions, CompactionPriority, DBCompactionStyle,
+    DBCompressionType, DBOptions, DBRateLimiterMode, DBRecoveryMode, LRUCacheOptions,
+    TitanDBOptions,
 };
 use slog;
 use sys_info;
@@ -99,7 +100,7 @@ impl TitanCfConfig {
         let mut opts = TitanDBOptions::new();
         opts.set_min_blob_size(self.min_blob_size);
         opts.set_blob_file_compression(self.blob_file_compression.into());
-        opts.set_blob_cache(self.blob_cache_size.0 as usize, -1, 0, 0.0);
+        opts.set_blob_cache(self.blob_cache_size.0 as usize, -1, false, 0.0);
         opts.set_min_gc_batch_size(self.min_gc_batch_size.0 as u64);
         opts.set_max_gc_batch_size(self.max_gc_batch_size.0 as u64);
         opts.set_discardable_ratio(self.discardable_ratio);
@@ -263,11 +264,17 @@ macro_rules! write_into_metrics {
 }
 
 macro_rules! build_cf_opt {
-    ($opt:ident) => {{
+    ($opt:ident, $cache:ident) => {{
         let mut block_base_opts = BlockBasedOptions::new();
         block_base_opts.set_block_size($opt.block_size.0 as usize);
         block_base_opts.set_no_block_cache($opt.disable_block_cache);
-        block_base_opts.set_lru_cache($opt.block_cache_size.0 as usize, -1, 0, 0.0);
+        if let Some(cache) = $cache {
+            block_base_opts.set_block_cache(cache);
+        } else {
+            let mut cache_opts = LRUCacheOptions::new();
+            cache_opts.set_capacity($opt.block_cache_size.0 as usize);
+            block_base_opts.set_block_cache(&Cache::new_lru_cache(cache_opts));
+        }
         block_base_opts.set_cache_index_and_filter_blocks($opt.cache_index_and_filter_blocks);
         block_base_opts
             .set_pin_l0_filter_and_index_blocks_in_cache($opt.pin_l0_filter_and_index_blocks);
@@ -357,8 +364,8 @@ impl Default for DefaultCfConfig {
 }
 
 impl DefaultCfConfig {
-    pub fn build_opt(&self) -> ColumnFamilyOptions {
-        let mut cf_opts = build_cf_opt!(self);
+    pub fn build_opt(&self, cache: &Option<Cache>) -> ColumnFamilyOptions {
+        let mut cf_opts = build_cf_opt!(self, cache);
         let f = Box::new(RangePropertiesCollectorFactory {
             prop_size_index_distance: self.prop_size_index_distance,
             prop_keys_index_distance: self.prop_keys_index_distance,
@@ -421,8 +428,8 @@ impl Default for WriteCfConfig {
 }
 
 impl WriteCfConfig {
-    pub fn build_opt(&self) -> ColumnFamilyOptions {
-        let mut cf_opts = build_cf_opt!(self);
+    pub fn build_opt(&self, cache: &Option<Cache>) -> ColumnFamilyOptions {
+        let mut cf_opts = build_cf_opt!(self, cache);
         // Prefix extractor(trim the timestamp at tail) for write cf.
         let e = Box::new(FixedSuffixSliceTransform::new(8));
         cf_opts
@@ -487,8 +494,8 @@ impl Default for LockCfConfig {
 }
 
 impl LockCfConfig {
-    pub fn build_opt(&self) -> ColumnFamilyOptions {
-        let mut cf_opts = build_cf_opt!(self);
+    pub fn build_opt(&self, cache: &Option<Cache>) -> ColumnFamilyOptions {
+        let mut cf_opts = build_cf_opt!(self, cache);
         let f = Box::new(NoopSliceTransform);
         cf_opts
             .set_prefix_extractor("NoopSliceTransform", f)
@@ -543,8 +550,8 @@ impl Default for RaftCfConfig {
 }
 
 impl RaftCfConfig {
-    pub fn build_opt(&self) -> ColumnFamilyOptions {
-        let mut cf_opts = build_cf_opt!(self);
+    pub fn build_opt(&self, cache: &Option<Cache>) -> ColumnFamilyOptions {
+        let mut cf_opts = build_cf_opt!(self, cache);
         let f = Box::new(NoopSliceTransform);
         cf_opts
             .set_prefix_extractor("NoopSliceTransform", f)
@@ -715,22 +722,22 @@ impl DbConfig {
         opts
     }
 
-    pub fn build_cf_opts(&self) -> Vec<CFOptions<'_>> {
+    pub fn build_cf_opts(&self, cache: &Option<Cache>) -> Vec<CFOptions<'_>> {
         vec![
-            CFOptions::new(CF_DEFAULT, self.defaultcf.build_opt()),
-            CFOptions::new(CF_LOCK, self.lockcf.build_opt()),
-            CFOptions::new(CF_WRITE, self.writecf.build_opt()),
+            CFOptions::new(CF_DEFAULT, self.defaultcf.build_opt(cache)),
+            CFOptions::new(CF_LOCK, self.lockcf.build_opt(cache)),
+            CFOptions::new(CF_WRITE, self.writecf.build_opt(cache)),
             // TODO: rmeove CF_RAFT.
-            CFOptions::new(CF_RAFT, self.raftcf.build_opt()),
+            CFOptions::new(CF_RAFT, self.raftcf.build_opt(cache)),
         ]
     }
 
-    pub fn build_cf_opts_v2(&self) -> Vec<CFOptions<'_>> {
+    pub fn build_cf_opts_v2(&self, cache: &Option<Cache>) -> Vec<CFOptions<'_>> {
         vec![
-            CFOptions::new(CF_DEFAULT, self.defaultcf.build_opt()),
-            CFOptions::new(CF_LOCK, self.lockcf.build_opt()),
-            CFOptions::new(CF_WRITE, self.writecf.build_opt()),
-            CFOptions::new(CF_RAFT, self.raftcf.build_opt()),
+            CFOptions::new(CF_DEFAULT, self.defaultcf.build_opt(cache)),
+            CFOptions::new(CF_LOCK, self.lockcf.build_opt(cache)),
+            CFOptions::new(CF_WRITE, self.writecf.build_opt(cache)),
+            CFOptions::new(CF_RAFT, self.raftcf.build_opt(cache)),
         ]
     }
 
@@ -796,8 +803,8 @@ impl Default for RaftDefaultCfConfig {
 }
 
 impl RaftDefaultCfConfig {
-    pub fn build_opt(&self) -> ColumnFamilyOptions {
-        let mut cf_opts = build_cf_opt!(self);
+    pub fn build_opt(&self, cache: &Option<Cache>) -> ColumnFamilyOptions {
+        let mut cf_opts = build_cf_opt!(self, cache);
         let f = Box::new(FixedPrefixSliceTransform::new(region_raft_prefix_len()));
         cf_opts
             .set_memtable_insert_hint_prefix_extractor("RaftPrefixSliceTransform", f)
@@ -916,8 +923,8 @@ impl RaftDbConfig {
         opts
     }
 
-    pub fn build_cf_opts(&self) -> Vec<CFOptions<'_>> {
-        vec![CFOptions::new(CF_DEFAULT, self.defaultcf.build_opt())]
+    pub fn build_cf_opts(&self, cache: &Option<Cache>) -> Vec<CFOptions<'_>> {
+        vec![CFOptions::new(CF_DEFAULT, self.defaultcf.build_opt(cache))]
     }
 }
 
@@ -1326,6 +1333,18 @@ impl TiKvConfig {
             let delay_secs = self.raft_store.clean_stale_peer_delay.as_secs()
                 + self.server.end_point_request_max_handle_duration.as_secs();
             self.raft_store.clean_stale_peer_delay = ReadableDuration::secs(delay_secs);
+        }
+        // When shared block cache is enabled, if its capacity is set, it overrides individual
+        // block cache sizes. Otherwise use the sum of block cache size of all column families
+        // as the shared cache size.
+        let cache_cfg = &mut self.storage.block_cache;
+        if cache_cfg.shared && cache_cfg.capacity.is_none() {
+            cache_cfg.capacity = Some(ReadableSize {
+                0: self.rocksdb.defaultcf.block_cache_size.0
+                    + self.rocksdb.writecf.block_cache_size.0
+                    + self.rocksdb.lockcf.block_cache_size.0
+                    + self.raftdb.defaultcf.block_cache_size.0,
+            });
         }
     }
 

--- a/src/import/engine.rs
+++ b/src/import/engine.rs
@@ -23,8 +23,8 @@ use crate::storage::mvcc::{Write, WriteType};
 use crate::storage::types::Key;
 use engine::rocks::util::{new_engine_opt, CFOptions};
 use engine::rocks::{
-    BlockBasedOptions, ColumnFamilyOptions, DBIterator, DBOptions, Env, EnvOptions,
-    ExternalSstFileInfo, ReadOptions, SequentialFile, SstFileWriter, Writable,
+    BlockBasedOptions, Cache, ColumnFamilyOptions, DBIterator, DBOptions, Env, EnvOptions,
+    ExternalSstFileInfo, LRUCacheOptions, ReadOptions, SequentialFile, SstFileWriter, Writable,
     WriteBatch as RawBatch, DB,
 };
 use engine::{CF_DEFAULT, CF_WRITE};
@@ -229,17 +229,19 @@ impl SSTWriter {
             env = encrypted_env_from_cipher_file(&security_cfg.cipher_file, Some(env))?;
         }
         let uuid = Uuid::new_v4().to_string();
+        // Placeholder. SstFileWriter don't actually use block cache.
+        let cache = None;
 
         // Creates a writer for default CF
         // Here is where we set table_properties_collector_factory, so that we can collect
         // some properties about SST
-        let mut default_opts = db_cfg.defaultcf.build_opt();
+        let mut default_opts = db_cfg.defaultcf.build_opt(&cache);
         default_opts.set_env(Arc::clone(&env));
         let mut default = SstFileWriter::new(EnvOptions::new(), default_opts);
         default.open(&format!("{}{}.{}:default", path, MAIN_SEPARATOR, uuid))?;
 
         // Creates a writer for write CF
-        let mut write_opts = db_cfg.writecf.build_opt();
+        let mut write_opts = db_cfg.writecf.build_opt(&cache);
         write_opts.set_env(Arc::clone(&env));
         let mut write = SstFileWriter::new(EnvOptions::new(), write_opts);
         write.open(&format!("{}{}.{}:write", path, MAIN_SEPARATOR, uuid))?;
@@ -339,8 +341,10 @@ fn tune_dboptions_for_bulk_load(opts: &DbConfig) -> (DBOptions, CFOptions<'_>) {
     db_opts.set_max_background_jobs(opts.max_background_jobs);
 
     // Put index and filter in block cache to restrict memory usage.
+    let mut cache_opts = LRUCacheOptions::new();
+    cache_opts.set_capacity(128 * MB as usize);
     let mut block_base_opts = BlockBasedOptions::new();
-    block_base_opts.set_lru_cache(128 * MB as usize, -1, 0, 0.0);
+    block_base_opts.set_block_cache(&Cache::new_lru_cache(cache_opts));
     block_base_opts.set_cache_index_and_filter_blocks(true);
     let mut cf_opts = ColumnFamilyOptions::new();
     cf_opts.set_block_based_table_factory(&block_base_opts);
@@ -376,6 +380,7 @@ mod tests {
 
     use crate::raftstore::store::RegionSnapshot;
     use crate::storage::mvcc::MvccReader;
+    use crate::storage::BlockCacheConfig;
     use engine::rocks::util::security::encrypted_env_from_cipher_file;
     use tikv_util::file::file_exists;
 
@@ -451,7 +456,8 @@ mod tests {
             let env = encrypted_env_from_cipher_file(&security_cfg.cipher_file, None).unwrap();
             db_opts.set_env(env);
         }
-        let cfs_opts = cfg.build_cf_opts();
+        let cache = BlockCacheConfig::default().build_shared_cache();
+        let cfs_opts = cfg.build_cf_opts(&cache);
         let db = new_engine_opt(temp_dir.path().to_str().unwrap(), db_opts, cfs_opts).unwrap();
         let db = Arc::new(db);
 

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -9,8 +9,8 @@ use std::time::Instant;
 use std::{cmp, error, u64};
 
 use engine::rocks;
+use engine::rocks::{Cache, Snapshot as DbSnapshot, WriteBatch, DB};
 use engine::rocks::{DBOptions, Writable};
-use engine::rocks::{Snapshot as DbSnapshot, WriteBatch, DB};
 use engine::Engines;
 use engine::CF_RAFT;
 use engine::{Iterable, Mutable, Peekable};
@@ -1473,6 +1473,7 @@ pub fn maybe_upgrade_from_2_to_3(
     kv_path: &str,
     kv_db_opts: DBOptions,
     kv_cfg: &config::DbConfig,
+    cache: &Option<Cache>,
 ) -> Result<()> {
     use engine::WriteOptions;
 
@@ -1495,7 +1496,7 @@ pub fn maybe_upgrade_from_2_to_3(
     let t = Instant::now();
 
     // Create v2.0.x kv engine.
-    let kv_cfs_opts = kv_cfg.build_cf_opts_v2();
+    let kv_cfs_opts = kv_cfg.build_cf_opts_v2(cache);
     let mut kv_engine = rocks::util::new_engine_opt(kv_path, kv_db_opts, kv_cfs_opts)?;
 
     // Move meta data from kv engine to raft engine.

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -4,7 +4,11 @@ use std::error::Error;
 
 use sys_info;
 
-use tikv_util::config::{self, ReadableSize};
+use tikv_util::config::{self, ReadableSize, KB};
+
+use engine::rocks::{Cache, LRUCacheOptions};
+
+use libc::c_int;
 
 pub const DEFAULT_DATA_DIR: &str = "./";
 pub const DEFAULT_ROCKSDB_SUB_DIR: &str = "db";
@@ -30,6 +34,7 @@ pub struct Config {
     pub scheduler_concurrency: usize,
     pub scheduler_worker_pool_size: usize,
     pub scheduler_pending_write_threshold: ReadableSize,
+    pub block_cache: BlockCacheConfig,
 }
 
 impl Default for Config {
@@ -43,6 +48,7 @@ impl Default for Config {
             scheduler_concurrency: DEFAULT_SCHED_CONCURRENCY,
             scheduler_worker_pool_size: if total_cpu >= 16 { 8 } else { 4 },
             scheduler_pending_write_threshold: ReadableSize::mb(DEFAULT_SCHED_PENDING_WRITE_MB),
+            block_cache: BlockCacheConfig::default(),
         }
     }
 }
@@ -53,5 +59,49 @@ impl Config {
             self.data_dir = config::canonicalize_path(&self.data_dir)?
         }
         Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+#[serde(rename_all = "kebab-case")]
+pub struct BlockCacheConfig {
+    pub shared: bool,
+    pub capacity: Option<ReadableSize>,
+    pub num_shard_bits: i32,
+    pub strict_capacity_limit: bool,
+    pub high_pri_pool_ratio: f64,
+}
+
+impl Default for BlockCacheConfig {
+    fn default() -> BlockCacheConfig {
+        BlockCacheConfig {
+            shared: true,
+            capacity: None,
+            num_shard_bits: 6,
+            strict_capacity_limit: false,
+            high_pri_pool_ratio: 0.0,
+        }
+    }
+}
+
+impl BlockCacheConfig {
+    pub fn build_shared_cache(&self) -> Option<Cache> {
+        if !self.shared {
+            return None;
+        }
+        let capacity = match self.capacity {
+            None => {
+                let total_mem = sys_info::mem_info().unwrap().total * KB;
+                ((total_mem as f64) * 0.45) as usize
+            }
+            Some(c) => c.0 as usize,
+        };
+        let mut cache_opts = LRUCacheOptions::new();
+        cache_opts.set_capacity(capacity);
+        cache_opts.set_num_shard_bits(self.num_shard_bits as c_int);
+        cache_opts.set_strict_capacity_limit(self.strict_capacity_limit);
+        cache_opts.set_high_pri_pool_ratio(self.high_pri_pool_ratio);
+        Some(Cache::new_lru_cache(cache_opts))
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -33,7 +33,7 @@ use self::metrics::*;
 use self::mvcc::Lock;
 use self::txn::CMD_BATCH_SIZE;
 
-pub use self::config::{Config, DEFAULT_DATA_DIR, DEFAULT_ROCKSDB_SUB_DIR};
+pub use self::config::{BlockCacheConfig, Config, DEFAULT_DATA_DIR, DEFAULT_ROCKSDB_SUB_DIR};
 pub use self::gc_worker::{AutoGCConfig, GCSafePointProvider};
 pub use self::kv::raftkv::RaftKv;
 pub use self::kv::{

--- a/tests/failpoints/cases/test_upgrade.rs
+++ b/tests/failpoints/cases/test_upgrade.rs
@@ -17,6 +17,7 @@ use tikv::raftstore::store::{
 use tikv::storage::kv::{DBOptions, Writable, DB};
 use tikv::storage::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use tikv_util::rocksdb_util;
+use tikv_util::config::MB;
 
 const CLUSTER_ID: u64 = 1_000_000_000;
 const STOER_ID: u64 = 1;
@@ -126,6 +127,8 @@ fn test_upgrade_from_v2_to_v3(fp: &str) {
     let tmp_path_raft = tmp_dir.path().join(Path::new("raft"));
     let raft_engine =
         rocksdb_util::new_engine(tmp_path_raft.to_str().unwrap(), None, &[], None).unwrap();
+    let mut cache_opts = LRUCacheOptions::new();
+    cache_opts.set_capacity(8 * MB);
 
     // No need to upgrade an empty node.
     tikv::raftstore::store::maybe_upgrade_from_2_to_3(
@@ -133,6 +136,7 @@ fn test_upgrade_from_v2_to_v3(fp: &str) {
         tmp_path_kv.to_str().unwrap(),
         DBOptions::new(),
         &DbConfig::default(),
+        Some(Cache::new_lru_cache(cache_opts)),
     )
     .unwrap();
     // Check whether there is a kv engine.

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -17,7 +17,7 @@ use tikv::raftstore::coprocessor::Config as CopConfig;
 use tikv::raftstore::store::Config as RaftstoreConfig;
 use tikv::server::config::GrpcCompressionType;
 use tikv::server::Config as ServerConfig;
-use tikv::storage::Config as StorageConfig;
+use tikv::storage::{BlockCacheConfig, Config as StorageConfig};
 use tikv_util::config::{ReadableDuration, ReadableSize};
 use tikv_util::security::SecurityConfig;
 
@@ -475,6 +475,13 @@ fn test_serde_custom_tikv_config() {
         scheduler_concurrency: 123,
         scheduler_worker_pool_size: 1,
         scheduler_pending_write_threshold: ReadableSize::kb(123),
+        block_cache: BlockCacheConfig {
+            shared: true,
+            capacity: Some(ReadableSize::gb(40)),
+            num_shard_bits: 10,
+            strict_capacity_limit: true,
+            high_pri_pool_ratio: 0.8,
+        },
     };
     value.coprocessor = CopConfig {
         split_region_on_table: true,
@@ -533,4 +540,21 @@ fn test_readpool_default_config() {
     let mut expected = TiKvConfig::default();
     expected.readpool.storage.high_concurrency = 1;
     assert_eq!(cfg, expected);
+}
+
+#[test]
+fn test_block_cache_backward_compatible() {
+    let content = read_file_in_project_dir("tests/integrations/config/test-cache-compatible.toml");
+    let mut cfg: TiKvConfig = toml::from_str(&content).unwrap();
+    assert!(cfg.storage.block_cache.shared);
+    assert!(cfg.storage.block_cache.capacity.is_none());
+    cfg.compatible_adjust();
+    assert!(cfg.storage.block_cache.capacity.is_some());
+    assert_eq!(
+        cfg.storage.block_cache.capacity.unwrap().0,
+        cfg.rocksdb.defaultcf.block_cache_size.0
+            + cfg.rocksdb.writecf.block_cache_size.0
+            + cfg.rocksdb.lockcf.block_cache_size.0
+            + cfg.raftdb.defaultcf.block_cache_size.0
+    );
 }

--- a/tests/integrations/config/test-cache-compatible.toml
+++ b/tests/integrations/config/test-cache-compatible.toml
@@ -21,16 +21,20 @@
 [rocksdb.titan]
 
 [rocksdb.defaultcf]
+block-cache-size = "1GB"
 
 [rocksdb.defaultcf.titan]
 
 [rocksdb.writecf]
+block-cache-size = "1GB"
 
 [rocksdb.lockcf]
+block-cache-size = "128MB"
 
 [raftdb]
 
 [raftdb.defaultcf]
+block-cache-size = "128MB"
 
 [security]
 

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -59,6 +59,13 @@ scheduler-concurrency = 123
 scheduler-worker-pool-size = 1
 scheduler-pending-write-threshold = "123KB"
 
+[storage.block-cache]
+shared = true
+capacity = "40GB"
+num-shard-bits = 10
+strict-capacity-limit = true
+high-pri-pool-ratio = 0.8
+
 [pd]
 endpoints = [
     "example.com:443",


### PR DESCRIPTION
## What have you changed? (mandatory)
Add option to share block cache between column families. The goal is to simplify config. It may also improve cache performance if previous config fail to balance cache size well. A previous benchmark indeed show read throughput and latency increases in the specific test scenario (see benchmark result link).

The new config provide a flag to enable sharing block cache, and it is default true. Cache capacity is optional. If it is not provided, it is decided by 
* the sum of cache size of individual column families. and
* In the particular case when cache sizes for all column families are not set, the shared cache size is ~45% of total physical memory.

We also expose more block cache options through the new block cache config.

Config example:
```
[storage.block-cache]
shared = true
capacity = "10G"
num-shard-bits = -1
strict-capacity-limit = false
high-pri-pool-ratio = 0.0
```

## What are the type of the changes? (mandatory)
New feature

## How has this PR been tested? (mandatory)
Run tikv-server from command line. Change tikv config with the following scenario. Check the cache address and detailed cache options in rocksdb log.
* case 1: shared=false. Expect: block cache is not shared, and their individual sizes respect individual block-cache-size setting.
* case 2: shared=true and capacity is not provided. block cache size is provided for individual column families. Expect: Cache is shared and with size equal to sum of individual cache sizes.
* case 3: shared=true and capacity is not provided. block cache size is not provided for individual column families. Expect: Cache is shared and with size ~=45% total physical memory.
* case 4: shared=true and capacity is provided. Expect: cache is shared and with size equal to capacity.

## Does this PR affect documentation (docs) update? (mandatory)
Yes. We will need to update our tuning guide to suggest users to set shared cache instead.

## Does this PR affect tidb-ansible update? (mandatory)
Yes. We need to update config template.

## Benchmark result if necessary (optional)
Test with The following YCSB with steps against TiKV transaction API.

Load 30M records into empty TiKV instance, with workload A.
Run workload C (point lookup only) with 30M operations, from 500 threads.
Run workload E (95% small scan + 5% updates) with 3M operations, from 500 threads.
The resulting DB size is ~36G. 

Details test script:

./bin/go-ycsb load tikv -P workloads/workloada -p tikv.pd="172.16.30.40:2379" -p tikv.type="txn" -p recordcount=30000000
./bin/go-ycsb run tikv -P workloads/workloadc -p tikv.pd="172.16.30.40:2379" -p tikv.type="txn" -p recordcount=30000000 -p threadcount=500 -p operationcount=30000000

Testing the following versions:
Master: default CF 10G, lock CF 1G, write CF 10G, Raft CF 128M, Raft RocksDB: 1G
Test 1: KV RocksDB: shared block cache with total size 21G. Raft RocksDB: 1G
Test 2: KV RocksDB: shared block cache with total size 14G. Raft RocksDB: 1G

Result: 
Master (block cache hit rate: 95.4%)
READ - Takes(s): 442.3, Count: 29999994, OPS: 67821.4, Avg(us): 7366, Min(us): 326, Max(us): 91756, 95th(us): 9000, 99th(us): 11000

Test 1 (throughput +16%, average latency -14%, block cache hit rate: 97.7%):

READ - Takes(s): 380.1, Count: 29999994, OPS: 78930.5, Avg(us): 6329, Min(us): 311, Max(us): 90951, 95th(us): 8000, 99th(us): 11000

Test 2 (throughput +4.6%, average latency -4.4%, block cache hit rate: 96.1%):

READ - Takes(s): 422.8, Count: 29999999, OPS: 70958.6, Avg(us): 7040, Min(us): 257, Max(us): 85152, 95th(us): 9000, 99th(us): 11000
