### PR TITLE
raftstore: write tombstone state with writes in one batch when catching up logs for merge [release-2.1]

### DIFF
--- a/components/test_raftstore/cluster.rs
+++ b/components/test_raftstore/cluster.rs
@@ -645,6 +645,30 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
+    pub fn must_put_kvs(&mut self, kvs: &Vec<(Vec<u8>, Vec<u8>)>) {
+        self.must_put_kvs_cf("default", kvs);
+    }
+
+    pub fn must_put_kvs_cf(&mut self, cf: &str, kvs: &Vec<(Vec<u8>, Vec<u8>)>) {
+        let mut cmds = vec![];
+        for (key, value) in kvs {
+            cmds.push(new_put_cf_cmd(cf, key, value))
+        }
+
+        let resp = self.request(
+            &kvs[0].0,
+            cmds,
+            false,
+            Duration::from_secs(5),
+        );
+        if resp.get_header().has_error() {
+            panic!("response {:?} has error", resp);
+        }
+        assert_eq!(resp.get_responses().len(), kvs.len());
+        assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::Put);
+    }
+
+
     pub fn must_put(&mut self, key: &[u8], value: &[u8]) {
         self.must_put_cf("default", key, value);
     }

--- a/components/test_raftstore/cluster.rs
+++ b/components/test_raftstore/cluster.rs
@@ -645,29 +645,23 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
-    pub fn must_put_kvs(&mut self, kvs: &Vec<(Vec<u8>, Vec<u8>)>) {
+    pub fn must_put_kvs(&mut self, kvs: &[(Vec<u8>, Vec<u8>)]) {
         self.must_put_kvs_cf("default", kvs);
     }
 
-    pub fn must_put_kvs_cf(&mut self, cf: &str, kvs: &Vec<(Vec<u8>, Vec<u8>)>) {
+    pub fn must_put_kvs_cf(&mut self, cf: &str, kvs: &[(Vec<u8>, Vec<u8>)]) {
         let mut cmds = vec![];
         for (key, value) in kvs {
             cmds.push(new_put_cf_cmd(cf, key, value))
         }
 
-        let resp = self.request(
-            &kvs[0].0,
-            cmds,
-            false,
-            Duration::from_secs(5),
-        );
+        let resp = self.request(&kvs[0].0, cmds, false, Duration::from_secs(5));
         if resp.get_header().has_error() {
             panic!("response {:?} has error", resp);
         }
         assert_eq!(resp.get_responses().len(), kvs.len());
         assert_eq!(resp.get_responses()[0].get_cmd_type(), CmdType::Put);
     }
-
 
     pub fn must_put(&mut self, key: &[u8], value: &[u8]) {
         self.must_put_cf("default", key, value);

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1704,7 +1704,9 @@ impl Peer {
             if cmd.has_admin_request() {
                 let cmd_type = cmd.get_admin_request().get_cmd_type();
                 match cmd_type {
-                    AdminCmdType::TransferLeader | AdminCmdType::InvalidAdmin => {}
+                    AdminCmdType::TransferLeader
+                    | AdminResponse::VerifyHash
+                    | AdminCmdType::InvalidAdmin => {}
                     _ => {
                         // Any command that can change epoch or log gap should be rejected.
                         return Err(box_err!(

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1705,7 +1705,7 @@ impl Peer {
                 let cmd_type = cmd.get_admin_request().get_cmd_type();
                 match cmd_type {
                     AdminCmdType::TransferLeader
-                    | AdminResponse::VerifyHash
+                    | AdminCmdType::VerifyHash
                     | AdminCmdType::InvalidAdmin => {}
                     _ => {
                         // Any command that can change epoch or log gap should be rejected.

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -252,6 +252,8 @@ struct ApplyContextCore<'a> {
     sync_log_hint: bool,
     exec_ctx: Option<ExecContext>,
     use_delete_range: bool,
+    // indicates it is catching up logs for merge.
+    for_merge_source: bool,
 }
 
 impl<'a> ApplyContextCore<'a> {
@@ -271,6 +273,7 @@ impl<'a> ApplyContextCore<'a> {
             sync_log_hint: false,
             exec_ctx: None,
             use_delete_range: false,
+            for_merge_source: false,
         }
     }
 
@@ -363,6 +366,7 @@ impl<'a> ApplyContextCore<'a> {
     /// the context is ready to switch to apply other `ApplyDelegate`.
     pub fn stash(&mut self, delegate: &mut ApplyDelegate) -> Stash {
         self.commit_opt(delegate, false);
+        self.for_merge_source = true;
         Stash {
             // last cbs should not be popped, because if the ApplyContext
             // is flushed, the callbacks can be flushed too.
@@ -378,6 +382,7 @@ impl<'a> ApplyContextCore<'a> {
         if let Some(region) = stash.region {
             self.cbs.push(ApplyCallback::new(region));
         }
+        self.for_merge_source = false;
         self.exec_ctx = stash.exec_ctx;
         self.last_applied_index = stash.last_applied_index;
     }
@@ -459,7 +464,7 @@ pub fn notify_stale_req(term: u64, cb: Callback) {
 }
 
 /// Check if a write is needed to be issued before handle the command.
-fn should_write_to_engine(cmd: &RaftCmdRequest, wb_keys: usize) -> bool {
+fn should_write_to_engine(cmd: &RaftCmdRequest, wb_keys: usize, for_merge_source: bool) -> bool {
     if cmd.has_admin_request() {
         match cmd.get_admin_request().get_cmd_type() {
             // ComputeHash require an up to date snapshot.
@@ -472,7 +477,7 @@ fn should_write_to_engine(cmd: &RaftCmdRequest, wb_keys: usize) -> bool {
     }
 
     // When write batch contains more than `recommended` keys, write the batch to engine.
-    if wb_keys >= WRITE_BATCH_MAX_KEYS {
+    if wb_keys >= WRITE_BATCH_MAX_KEYS && !for_merge_source {
         return true;
     }
 
@@ -624,7 +629,7 @@ impl ApplyDelegate {
         if !data.is_empty() {
             let cmd = util::parse_data_at(data, index, &self.tag);
 
-            if should_write_to_engine(&cmd, apply_ctx.wb().count()) {
+            if should_write_to_engine(&cmd, apply_ctx.wb().count(), apply_ctx.for_merge_source) {
                 apply_ctx.commit(self);
             }
 
@@ -2103,7 +2108,7 @@ impl Runner {
                 fail_point!(
                     "skip_merge_tombstone_persist",
                     { delegate.id() == 3 && delegate.region_id() == 1 },
-                    |_| { 
+                    |_| {
                         ctx.delegates.remove(&region_id);
                         ctx.cbs.drain(..);
                         ()
@@ -2307,7 +2312,7 @@ mod tests {
         req.mut_admin_request()
             .set_cmd_type(AdminCmdType::ComputeHash);
         let wb = WriteBatch::new();
-        assert_eq!(should_write_to_engine(&req, wb.count()), true);
+        assert_eq!(should_write_to_engine(&req, wb.count(), false), true);
 
         // IngestSST command
         let mut req = Request::new();
@@ -2316,7 +2321,7 @@ mod tests {
         let mut cmd = RaftCmdRequest::new();
         cmd.mut_requests().push(req);
         let wb = WriteBatch::new();
-        assert_eq!(should_write_to_engine(&cmd, wb.count()), true);
+        assert_eq!(should_write_to_engine(&cmd, wb.count(), false), true);
 
         // Write batch keys reach WRITE_BATCH_MAX_KEYS
         let req = RaftCmdRequest::new();
@@ -2325,7 +2330,7 @@ mod tests {
             let key = format!("key_{}", i);
             wb.put(key.as_bytes(), b"value").unwrap();
         }
-        assert_eq!(should_write_to_engine(&req, wb.count()), true);
+        assert_eq!(should_write_to_engine(&req, wb.count(), false), true);
 
         // Write batch keys not reach WRITE_BATCH_MAX_KEYS
         let req = RaftCmdRequest::new();
@@ -2334,7 +2339,7 @@ mod tests {
             let key = format!("key_{}", i);
             wb.put(key.as_bytes(), b"value").unwrap();
         }
-        assert_eq!(should_write_to_engine(&req, wb.count()), false);
+        assert_eq!(should_write_to_engine(&req, wb.count(), false), false);
     }
 
     #[test]


### PR DESCRIPTION
## What have you changed? (mandatory)
There are two bugs of #4581 and #4560 in master which fixed by https://github.com/tikv/tikv/pull/4595. But release-2.1 doesn't suffer from #4581, and to make changes as less as possible, this PR just write tombstone state with writes in one batch when catching up logs for merge instead of catching up logs through raft.

## What are the type of the changes? (mandatory)
- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)
unit-test


