### PR TITLE
mvcc/txn: use raw_key in Error and reduce copy.

### DIFF
--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -159,7 +159,7 @@ impl<S: Snapshot> MvccTxn<S> {
                             start_ts: self.start_ts,
                             conflict_start_ts: write.start_ts,
                             conflict_commit_ts: commit,
-                            key: key.to_raw()?,
+                            key: key.into_raw()?,
                             primary: primary.to_vec(),
                         });
                     }
@@ -168,7 +168,9 @@ impl<S: Snapshot> MvccTxn<S> {
                             || (write.write_type != WriteType::Delete
                                 && self.key_exist(&key, write.start_ts - 1)?)
                         {
-                            return Err(Error::AlreadyExist { key: key.to_raw()? });
+                            return Err(Error::AlreadyExist {
+                                key: key.into_raw()?,
+                            });
                         }
                     }
                 }
@@ -177,7 +179,7 @@ impl<S: Snapshot> MvccTxn<S> {
             if let Some(lock) = self.reader.load_lock(&key)? {
                 if lock.ts != self.start_ts {
                     return Err(Error::KeyIsLocked {
-                        key: key.to_raw()?,
+                        key: key.into_raw()?,
                         primary: lock.primary,
                         ts: lock.ts,
                         ttl: lock.ttl,
@@ -223,7 +225,7 @@ impl<S: Snapshot> MvccTxn<S> {
                         Err(Error::TxnLockNotFound {
                             start_ts: self.start_ts,
                             commit_ts,
-                            key: key.as_encoded().to_owned(),
+                            key: key.into_raw()?,
                         })
                     }
                     // Committed by concurrent transaction.


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
Use raw key in `Error::TxnLockNotFound` and use `into_raw()` to reduce copy.

## What are the type of the changes? (mandatory)
- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
unit tests, intergration tests

## Does this PR affect documentation (docs) or release note? (mandatory)
no

## Does this PR affect tidb-ansible update? (mandatory)
no

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

