### PR TITLE
*: report unreachable in more cases

### DIFF
--- a/benches/misc/raftkv/mod.rs
+++ b/benches/misc/raftkv/mod.rs
@@ -79,6 +79,8 @@ impl RaftStoreRouter for SyncBenchRouter {
     fn casual_send(&self, _: u64, _: CasualMessage) -> Result<()> {
         Ok(())
     }
+
+    fn broadcast_unreachable(&self, _: u64) {}
 }
 
 fn new_engine() -> (TempDir, Arc<DB>) {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -21,8 +21,8 @@ use tikv::raftstore::Result;
 use tikv::server::load_statistics::ThreadLoad;
 use tikv::server::readpool;
 use tikv::server::resolve::{self, Task as ResolveTask};
-use tikv::server::transport::RaftStoreRouter;
 use tikv::server::transport::ServerRaftStoreRouter;
+use tikv::server::transport::{RaftStoreBlackHole, RaftStoreRouter};
 use tikv::server::Result as ServerResult;
 use tikv::server::{
     create_raft_storage, Config, Error, Node, PdStoreAddrResolver, RaftClient, Server,
@@ -58,7 +58,7 @@ pub struct ServerCluster {
     pub region_info_accessors: HashMap<u64, RegionInfoAccessor>,
     snap_paths: HashMap<u64, TempDir>,
     pd_client: Arc<TestPdClient>,
-    raft_client: RaftClient,
+    raft_client: RaftClient<RaftStoreBlackHole>,
     _stats_pool: tokio_threadpool::ThreadPool,
 }
 
@@ -76,6 +76,7 @@ impl ServerCluster {
             env,
             Arc::new(Config::default()),
             security_mgr,
+            RaftStoreBlackHole,
             Arc::new(ThreadLoad::with_threshold(usize::MAX)),
             stats_pool.sender().clone(),
         );

--- a/components/test_raftstore/src/transport_simulate.rs
+++ b/components/test_raftstore/src/transport_simulate.rs
@@ -200,6 +200,10 @@ impl<C: RaftStoreRouter> RaftStoreRouter for SimulateTransport<C> {
         self.ch.casual_send(region_id, msg)
     }
 
+    fn broadcast_unreachable(&self, store_id: u64) {
+        self.ch.broadcast_unreachable(store_id)
+    }
+
     fn significant_send(&self, region_id: u64, msg: SignificantMsg) -> Result<()> {
         self.ch.significant_send(region_id, msg)
     }

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -516,7 +516,9 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 self.report_snapshot_status(to_peer_id, status);
             }
             SignificantMsg::Unreachable { to_peer_id, .. } => {
-                self.fsm.peer.raft_group.report_unreachable(to_peer_id);
+                if self.fsm.peer.is_leader() {
+                    self.fsm.peer.raft_group.report_unreachable(to_peer_id);
+                }
             }
             SignificantMsg::StoreUnreachable { store_id } => {
                 if let Some(peer_id) = util::find_peer(self.region(), store_id).map(|p| p.get_id())

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -518,6 +518,12 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             SignificantMsg::Unreachable { to_peer_id, .. } => {
                 self.fsm.peer.raft_group.report_unreachable(to_peer_id);
             }
+            SignificantMsg::StoreUnreachable { store_id } => {
+                if let Some(peer_id) = util::find_peer(self.region(), store_id).map(|p| p.get_id())
+                {
+                    self.fsm.peer.raft_group.report_unreachable(peer_id);
+                }
+            }
         }
     }
 
@@ -571,6 +577,10 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         if let Some(apply_res) = res {
             self.on_ready_apply_snapshot(apply_res);
             has_snapshot = true;
+        }
+        if self.fsm.peer.leader_unreachable {
+            // TODO: handle unreachable.
+            self.fsm.peer.leader_unreachable = false;
         }
         if is_merging && has_snapshot {
             // After applying a snapshot, merge is rollbacked implicitly.

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -521,7 +521,9 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             SignificantMsg::StoreUnreachable { store_id } => {
                 if let Some(peer_id) = util::find_peer(self.region(), store_id).map(|p| p.get_id())
                 {
-                    self.fsm.peer.raft_group.report_unreachable(peer_id);
+                    if self.fsm.peer.is_leader() {
+                        self.fsm.peer.raft_group.report_unreachable(peer_id);
+                    }
                 }
             }
         }

--- a/src/raftstore/store/fsm/router.rs
+++ b/src/raftstore/store/fsm/router.rs
@@ -419,6 +419,14 @@ where
         }
     }
 
+    /// Try to notify all normal fsm a message.
+    pub fn broadcast_normal(&self, mut msg_gen: impl FnMut() -> N::Message) {
+        let mailboxes = self.normals.lock().unwrap();
+        for mailbox in mailboxes.values() {
+            let _ = mailbox.force_send(msg_gen(), &self.normal_scheduler);
+        }
+    }
+
     /// Try to notify all fsm that the cluster is being shutdown.
     pub fn broadcast_shutdown(&self) {
         info!("broadcasting shutdown");

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -66,6 +66,7 @@ type Key = Vec<u8>;
 const KV_WB_SHRINK_SIZE: usize = 256 * 1024;
 const RAFT_WB_SHRINK_SIZE: usize = 1024 * 1024;
 const PENDING_VOTES_CAP: usize = 20;
+const UNREACHABLE_BACKOFF: Duration = Duration::from_secs(10);
 
 pub struct StoreInfo {
     pub engine: Arc<DB>,
@@ -1915,8 +1916,8 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
             .store
             .last_unreachable_report
             .get(&store_id)
-            .map_or(10, |t| now.duration_since(*t).as_secs())
-            < 10
+            .map_or(UNREACHABLE_BACKOFF, |t| now.duration_since(*t))
+            < UNREACHABLE_BACKOFF
         {
             return;
         }

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -144,8 +144,14 @@ pub enum SignificantMsg {
         to_peer_id: u64,
         status: SnapshotStatus,
     },
+    StoreUnreachable {
+        store_id: u64,
+    },
     /// Reports `to_peer_id` is unreachable.
-    Unreachable { region_id: u64, to_peer_id: u64 },
+    Unreachable {
+        region_id: u64,
+        to_peer_id: u64,
+    },
 }
 
 /// Message that will be sent to a peer.
@@ -317,6 +323,9 @@ pub enum StoreMsg {
         start_key: Vec<u8>,
         end_key: Vec<u8>,
     },
+    StoreUnreachable {
+        store_id: u64,
+    },
 
     // Compaction finished event
     CompactedEvent(CompactedEvent),
@@ -331,6 +340,9 @@ impl fmt::Debug for StoreMsg {
         match *self {
             StoreMsg::RaftMessage(_) => write!(fmt, "Raft Message"),
             StoreMsg::SnapshotStats => write!(fmt, "Snapshot stats"),
+            StoreMsg::StoreUnreachable { store_id } => {
+                write!(fmt, "Store {}  is unreachable", store_id)
+            }
             StoreMsg::CompactedEvent(ref event) => write!(fmt, "CompactedEvent cf {}", event.cf),
             StoreMsg::ValidateSSTResult { .. } => write!(fmt, "Validate SST Result"),
             StoreMsg::ClearRegionSizeInRange {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -254,6 +254,8 @@ pub struct Peer {
     leader_lease: Lease,
     pending_reads: ReadIndexQueue,
 
+    /// If it fails to send messages to leader.
+    pub leader_unreachable: bool,
     /// Whether this peer is destroyed asynchronously.
     pub pending_remove: bool,
     /// If a snapshot is being applied asynchronously, messages should not be sent.
@@ -358,6 +360,7 @@ impl Peer {
             approximate_size: None,
             approximate_keys: None,
             compaction_declined_bytes: 0,
+            leader_unreachable: false,
             pending_remove: false,
             pending_merge_state: None,
             last_committed_prepare_merge_idx: 0,
@@ -2087,7 +2090,9 @@ impl Peer {
                 "target_store_id" => to_store_id,
                 "err" => ?e,
             );
-
+            if to_peer_id == self.leader_id() {
+                self.leader_unreachable = true;
+            }
             // unreachable store
             self.raft_group.report_unreachable(to_peer_id);
             if msg_type == eraftpb::MessageType::MsgSnapshot {

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -136,6 +136,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             Arc::clone(&env),
             Arc::clone(cfg),
             Arc::clone(security_mgr),
+            raft_router.clone(),
             Arc::clone(&thread_load),
             stats_pool.sender().clone(),
         )));
@@ -291,6 +292,10 @@ mod tests {
         fn casual_send(&self, _: u64, _: CasualMessage) -> RaftStoreResult<()> {
             self.tx.send(1).unwrap();
             Ok(())
+        }
+
+        fn broadcast_unreachable(&self, _: u64) {
+            let _ = self.tx.send(1);
         }
     }
 

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -8,12 +8,13 @@ use futures::{Future, Stream};
 use grpcio::*;
 use kvproto::raft_serverpb::{Done, RaftMessage};
 use kvproto::tikvpb::BatchRaftMessage;
+use tikv::server::transport::RaftStoreBlackHole;
 use tikv::server::{load_statistics::ThreadLoad, Config, RaftClient};
 use tikv_util::security::{SecurityConfig, SecurityManager};
 
 use super::{mock_kv_service, MockKv, MockKvService};
 
-pub fn get_raft_client(pool: &tokio_threadpool::ThreadPool) -> RaftClient {
+pub fn get_raft_client(pool: &tokio_threadpool::ThreadPool) -> RaftClient<RaftStoreBlackHole> {
     let env = Arc::new(Environment::new(2));
     let cfg = Arc::new(Config::default());
     let security_mgr = Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap());
@@ -22,6 +23,7 @@ pub fn get_raft_client(pool: &tokio_threadpool::ThreadPool) -> RaftClient {
         env,
         cfg,
         security_mgr,
+        RaftStoreBlackHole,
         grpc_thread_load,
         pool.sender().clone(),
     )


### PR DESCRIPTION

## What have you changed? (mandatory)

Unreachable report is used to perform traffic control and potential down
node detection. This PR adds more unreachable report by hooking the
connection state and send error in raftstore layer. These can also be
useful when implementing hibernate regions as peers can be woken up when
failure is detected.

## What are the type of the changes? (mandatory)

- Improvement

## How has this PR been tested? (mandatory)

unit tests

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.
