### PR TITLE
Simplify some code using field type converts

### DIFF
--- a/src/coprocessor/codec/batch/lazy_column.rs
+++ b/src/coprocessor/codec/batch/lazy_column.rs
@@ -288,9 +288,6 @@ mod tests {
     fn test_lazy_batch_column_clone() {
         use cop_datatype::FieldTypeTp;
 
-        let mut ft = FieldType::new();
-        ft.as_mut_accessor().set_tp(FieldTypeTp::Long);
-
         let mut col = LazyBatchColumn::raw_with_capacity(5);
         assert!(col.is_raw());
         assert_eq!(col.len(), 0);
@@ -307,7 +304,7 @@ mod tests {
         {
             // Empty raw to empty decoded.
             let mut col = col.clone();
-            col.decode(&Tz::utc(), &ft).unwrap();
+            col.decode(&Tz::utc(), &FieldTypeTp::Long.into()).unwrap();
             assert!(col.is_decoded());
             assert_eq!(col.len(), 0);
             assert_eq!(col.capacity(), 5);
@@ -347,7 +344,7 @@ mod tests {
             assert_eq!(col.raw()[1].as_slice(), datum_raw_2.as_slice());
         }
         // Non-empty raw to non-empty decoded.
-        col.decode(&Tz::utc(), &ft).unwrap();
+        col.decode(&Tz::utc(), &FieldTypeTp::Long.into()).unwrap();
         assert!(col.is_decoded());
         assert_eq!(col.len(), 2);
         assert_eq!(col.capacity(), 5);
@@ -472,11 +469,9 @@ mod benches {
             column.push_raw(datum_raw.as_slice());
         }
 
-        let mut ft = tipb::expression::FieldType::new();
-        ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-        let tz = Tz::utc();
-
-        column.decode(&tz, &ft).unwrap();
+        column
+            .decode(&Tz::utc(), &FieldTypeTp::LongLong.into())
+            .unwrap();
 
         b.iter(|| {
             test::black_box(test::black_box(&column).clone());
@@ -500,8 +495,7 @@ mod benches {
             column.push_raw(datum_raw.as_slice());
         }
 
-        let mut ft = tipb::expression::FieldType::new();
-        ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
+        let ft = FieldTypeTp::LongLong.into();
         let tz = Tz::utc();
 
         b.iter(|| {
@@ -529,8 +523,7 @@ mod benches {
             column.push_raw(datum_raw.as_slice());
         }
 
-        let mut ft = tipb::expression::FieldType::new();
-        ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
+        let ft = FieldTypeTp::LongLong.into();
         let tz = Tz::utc();
 
         column.decode(&tz, &ft).unwrap();

--- a/src/coprocessor/codec/batch/lazy_column_vec.rs
+++ b/src/coprocessor/codec/batch/lazy_column_vec.rs
@@ -215,7 +215,7 @@ impl std::ops::DerefMut for LazyBatchColumnVec {
 mod tests {
     use super::*;
 
-    use cop_datatype::{EvalType, FieldTypeAccessor};
+    use cop_datatype::EvalType;
 
     use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
 
@@ -268,26 +268,10 @@ mod tests {
 
         for comparable in &[true, false] {
             let schema = [
-                {
-                    // Column 1: Long
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Long);
-                    ft
-                },
-                {
-                    // Column 2: Double
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                    ft
-                },
-                {
-                    // Column 3: VarChar
-                    let mut ft = FieldType::new();
-                    ft.as_mut_accessor().set_tp(FieldTypeTp::VarChar);
-                    ft
-                },
+                FieldTypeTp::Long.into(),
+                FieldTypeTp::Double.into(),
+                FieldTypeTp::VarChar.into(),
             ];
-
             let values = vec![
                 vec![Datum::U64(1), Datum::F64(1.0), Datum::Null],
                 vec![Datum::Null, Datum::Null, Datum::Bytes(vec![0u8, 2u8])],
@@ -355,21 +339,7 @@ mod tests {
     fn test_retain_rows_by_index() {
         use cop_datatype::FieldTypeTp;
 
-        let schema = [
-            {
-                // Column 1: Long
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::Long);
-                ft
-            },
-            {
-                // Column 2: Double
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                ft
-            },
-        ];
-
+        let schema = [FieldTypeTp::Long.into(), FieldTypeTp::Double.into()];
         let mut columns = LazyBatchColumnVec::with_raw_columns(2);
         assert_eq!(columns.rows_len(), 0);
         assert_eq!(columns.columns_len(), 2);

--- a/src/coprocessor/codec/data_type/vector.rs
+++ b/src/coprocessor/codec/data_type/vector.rs
@@ -957,8 +957,7 @@ mod benches {
         let mut datum_raw: Vec<u8> = Vec::new();
         DatumEncoder::encode(&mut datum_raw, &[Datum::U64(0xDEADBEEF)], true).unwrap();
 
-        let mut field_type = tipb::expression::FieldType::new();
-        field_type.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
+        let field_type = FieldTypeTp::LongLong.into();
         let tz = Tz::utc();
 
         b.iter(move || {

--- a/src/coprocessor/dag/batch/executors/index_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/index_scan_executor.rs
@@ -247,7 +247,6 @@ mod tests {
 
     use cop_datatype::{FieldTypeAccessor, FieldTypeTp};
     use kvproto::coprocessor::KeyRange;
-    use tipb::expression::FieldType;
     use tipb::schema::ColumnInfo;
 
     use crate::coprocessor::codec::mysql::Tz;
@@ -293,21 +292,9 @@ mod tests {
 
         // The schema of these columns. Used to check executor output.
         let schema = vec![
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                ft
-            },
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::Double.into(),
+            FieldTypeTp::LongLong.into(),
         ];
 
         // Case 1. Normal index.

--- a/src/coprocessor/dag/batch/executors/limit_executor.rs
+++ b/src/coprocessor/dag/batch/executors/limit_executor.rs
@@ -66,7 +66,7 @@ mod tests {
     use crate::coprocessor::codec::data_type::VectorValue;
     use crate::coprocessor::dag::exec_summary::*;
     use crate::coprocessor::dag::expr::EvalConfig;
-    use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeTp};
+    use cop_datatype::{EvalType, FieldTypeTp};
     use tipb::expression::FieldType;
 
     struct MockExecutor {
@@ -75,12 +75,6 @@ mod tests {
         field_types: Vec<FieldType>,
         offset: usize,
         cfg: EvalConfig,
-    }
-
-    fn field_type(ft: FieldTypeTp) -> FieldType {
-        let mut f = FieldType::new();
-        f.as_mut_accessor().set_tp(ft);
-        f
     }
 
     impl MockExecutor {
@@ -93,11 +87,10 @@ mod tests {
                 (5, None, Some(0.1)),
                 (6, None, Some(4.5)),
             ];
-
             let field_types = vec![
-                field_type(FieldTypeTp::LongLong),
-                field_type(FieldTypeTp::LongLong),
-                field_type(FieldTypeTp::Double),
+                FieldTypeTp::LongLong.into(),
+                FieldTypeTp::LongLong.into(),
+                FieldTypeTp::Double.into(),
             ];
 
             MockExecutor {

--- a/src/coprocessor/dag/batch/executors/mod.rs
+++ b/src/coprocessor/dag/batch/executors/mod.rs
@@ -1,12 +1,12 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 mod index_scan_executor;
-mod limit;
+mod limit_executor;
 mod selection_executor;
 mod table_scan_executor;
 mod util;
 
 pub use self::index_scan_executor::BatchIndexScanExecutor;
-pub use self::limit::BatchLimitExecutor;
+pub use self::limit_executor::BatchLimitExecutor;
 pub use self::selection_executor::BatchSelectionExecutor;
 pub use self::table_scan_executor::BatchTableScanExecutor;

--- a/src/coprocessor/dag/batch/executors/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/table_scan_executor.rs
@@ -326,12 +326,6 @@ mod tests {
     use crate::coprocessor::util::convert_to_prefix_next;
     use crate::storage::{FixtureStore, Key};
 
-    fn field_type(ft: FieldTypeTp) -> FieldType {
-        let mut f = FieldType::new();
-        f.as_mut_accessor().set_tp(ft);
-        f
-    }
-
     /// Test Helper for normal test with fixed schema and data.
     /// Table Schema: ID (INT, PK), Foo (INT), Bar (FLOAT, Default 4.5)
     /// Column id:    1,            2,         4
@@ -429,9 +423,9 @@ mod tests {
             ];
 
             let field_types = vec![
-                field_type(FieldTypeTp::LongLong),
-                field_type(FieldTypeTp::LongLong),
-                field_type(FieldTypeTp::Double),
+                FieldTypeTp::LongLong.into(),
+                FieldTypeTp::LongLong.into(),
+                FieldTypeTp::Double.into(),
             ];
 
             let store = {
@@ -725,23 +719,10 @@ mod tests {
                 ci
             },
         ];
-
         let schema = vec![
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::LongLong.into(),
         ];
 
         let mut kv = vec![];
@@ -843,19 +824,7 @@ mod tests {
                 ci
             },
         ];
-
-        let schema = vec![
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-        ];
+        let schema = vec![FieldTypeTp::LongLong.into(), FieldTypeTp::LongLong.into()];
 
         let mut kv = vec![];
         {

--- a/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
@@ -282,18 +282,7 @@ mod tests {
                 col
             },
         ]);
-        let schema = [
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                ft
-            },
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-        ];
+        let schema = [FieldTypeTp::Double.into(), FieldTypeTp::LongLong.into()];
         (columns, schema)
     }
 
@@ -438,12 +427,7 @@ mod tests {
             col.mut_decoded().push_int(None);
             col
         }]);
-
-        let schema = &[{
-            let mut ft = FieldType::new();
-            ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-            ft
-        }];
+        let schema = &[FieldTypeTp::LongLong.into()];
 
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
@@ -495,12 +479,7 @@ mod tests {
 
             col
         }]);
-
-        let schema = &[{
-            let mut ft = FieldType::new();
-            ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-            ft
-        }];
+        let schema = &[FieldTypeTp::LongLong.into()];
 
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
@@ -579,12 +558,7 @@ mod tests {
             col.mut_decoded().push_real(Some(-4.3));
             col
         }]);
-
-        let schema = &[{
-            let mut ft = FieldType::new();
-            ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-            ft
-        }];
+        let schema = &[FieldTypeTp::Double.into()];
 
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
@@ -628,12 +602,7 @@ mod tests {
             col.mut_decoded().push_int(Some(-4));
             col
         }]);
-
-        let schema = &[{
-            let mut ft = FieldType::new();
-            ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-            ft
-        }];
+        let schema = &[FieldTypeTp::LongLong.into()];
 
         let exp = RpnExpressionBuilder::new()
             .push_constant(1.5f64)
@@ -688,19 +657,7 @@ mod tests {
                 col
             },
         ]);
-
-        let schema = &[
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                ft
-            },
-        ];
+        let schema = &[FieldTypeTp::LongLong.into(), FieldTypeTp::Double.into()];
 
         // FnFoo(col1, col0)
         let exp = RpnExpressionBuilder::new()
@@ -756,19 +713,7 @@ mod tests {
 
             col
         }]);
-
-        let schema = &[
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-        ];
+        let schema = &[FieldTypeTp::LongLong.into(), FieldTypeTp::LongLong.into()];
 
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
@@ -813,7 +758,6 @@ mod tests {
             col.mut_decoded().push_int(Some(-4));
             col
         }]);
-
         let schema = &[FieldTypeTp::LongLong.into()];
 
         let exp = RpnExpressionBuilder::new()
@@ -922,19 +866,7 @@ mod tests {
                 col
             },
         ]);
-
-        let schema = &[
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                ft
-            },
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-        ];
+        let schema = &[FieldTypeTp::Double.into(), FieldTypeTp::LongLong.into()];
 
         // Col0, FnB, Col1, Const0, FnD, Const1, FnC, FnA
         let exp = RpnExpressionBuilder::new()
@@ -1249,19 +1181,7 @@ mod tests {
                 col
             },
         ]);
-
-        let schema = &[
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
-                ft
-            },
-            {
-                let mut ft = FieldType::new();
-                ft.as_mut_accessor().set_tp(FieldTypeTp::Double);
-                ft
-            },
-        ];
+        let schema = &[FieldTypeTp::LongLong.into(), FieldTypeTp::Double.into()];
 
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, 3, schema, &mut columns);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Thanks to some recent merged PRs, we can now just write `FieldTypeTp::Xxx.into()` in test codes where we want a `FieldType` 

This PR also renames limit.rs to limit_executor.rs to be more unified with others.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

No need.
