### PR TITLE
the panic's param may be `$ty` but not `$tt`

### DIFF
--- a/src/coprocessor/codec/data_type/scalar.rs
+++ b/src/coprocessor/codec/data_type/scalar.rs
@@ -73,7 +73,7 @@ macro_rules! impl_as_ref {
                     other => panic!(
                         "Cannot cast {} scalar value into {}",
                         other.eval_type(),
-                        stringify!($tt),
+                        stringify!($ty),
                     ),
                 }
             }


### PR DESCRIPTION
Signed-off-by: H-ZeX <hzx20112012@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- in `coprocessors::codec::data_type::scalars::impl_as_ref::ScalarValue::$name`, the `stringify!($tt)`  may be changed to `stringify!($ty)`   

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)
- test using this demo
   ```rust
   macro_rules! my_macro_2 {
       ($ty: tt) => {
           println!("{}", stringify!($ty));
           println!("{}", stringify!($tt));
       };
   }
   ``` 
- use `rustc -Z unstable-options --pretty expanded scalar.rs > /tmp/3.rs` and analysis the expanded code

## Does this PR affect documentation (docs) or release note? (mandatory)
no 

## Does this PR affect tidb-ansible update? (mandatory)
no 
