### PR TITLE
config: increase raftdb max-background-job and max sub compactions

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -651,8 +651,8 @@
 # optimize-filters-for-hits = false
 
 [raftdb]
-# max-background-jobs = 2
-# max-sub-compactions = 1
+# max-background-jobs = 4
+# max-sub-compactions = 2
 # max-open-files = 40960
 # max-manifest-file-size = "20MB"
 # create-if-missing = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,7 +156,7 @@ macro_rules! cf_config {
 }
 
 macro_rules! write_into_metrics {
-    ($cf:expr, $tag:expr,$metrics:expr) => {{
+    ($cf:expr, $tag:expr, $metrics:expr) => {{
         $metrics
             .with_label_values(&[$tag, "block_size"])
             .set($cf.block_size.0 as f64);
@@ -856,7 +856,7 @@ impl Default for RaftDbConfig {
             wal_ttl_seconds: 0,
             wal_size_limit: ReadableSize::kb(0),
             max_total_wal_size: ReadableSize::gb(4),
-            max_background_jobs: 2,
+            max_background_jobs: 4,
             max_manifest_file_size: ReadableSize::mb(20),
             create_if_missing: true,
             max_open_files: 40960,
@@ -867,7 +867,7 @@ impl Default for RaftDbConfig {
             info_log_roll_time: ReadableDuration::secs(0),
             info_log_keep_log_file_num: 10,
             info_log_dir: "".to_owned(),
-            max_sub_compactions: 1,
+            max_sub_compactions: 2,
             writable_file_max_buffer_size: ReadableSize::mb(1),
             use_direct_io_for_flush_and_compaction: false,
             enable_pipelined_write: true,

--- a/tests/integrations/config/test-default.toml
+++ b/tests/integrations/config/test-default.toml
@@ -29,8 +29,6 @@
 [rocksdb.lockcf]
 
 [raftdb]
-max-background-jobs = 4
-max-sub-compactions = 2
 
 [raftdb.defaultcf]
 

--- a/tests/integrations/config/test-default.toml
+++ b/tests/integrations/config/test-default.toml
@@ -29,6 +29,8 @@
 [rocksdb.lockcf]
 
 [raftdb]
+max-background-jobs = 4
+max-sub-compactions = 2
 
 [raftdb.defaultcf]
 


### PR DESCRIPTION
## What have you changed? (mandatory)

Increase raftdb max-background-job from 2 to 4 and max-sub-compactions from 1 to 2.
It helps to reduce write stall in high-pressure workload.

From raft RocksDB log we find only two threads are not enough, there is no worker to compact level 0 while others are busy with bottom level compaction and flush memtable. This leads to write-stall even if IO usage is not reaching 100%.

## What are the type of the changes? (mandatory)

- Misc (other changes)

## How has this PR been tested? (mandatory)

Unit tests.

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

Yes.
