### PR TITLE
tests: tiny refactor

### DIFF
--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -200,6 +200,7 @@ impl<T: Simulator> Cluster<T> {
         debug!("starting node {}", node_id);
         let engines = self.engines[&node_id].clone();
         let (router, system) = create_raft_batch_system(&self.cfg.raft_store);
+        debug!("calling run node"; "node_id" => node_id);
         // FIXME: rocksdb event listeners may not work, because we change the router.
         self.sim
             .wl()
@@ -268,7 +269,7 @@ impl<T: Simulator> Cluster<T> {
         mut request: RaftCmdRequest,
         timeout: Duration,
     ) -> Result<RaftCmdResponse> {
-        let mut retry_cnt = 0;
+        let timer = Instant::now();
         let region_id = request.get_header().get_region_id();
         loop {
             let leader = match self.leader_of_region(region_id) {
@@ -280,8 +281,7 @@ impl<T: Simulator> Cluster<T> {
                 e @ Err(_) => return e,
                 Ok(resp) => resp,
             };
-            if self.refresh_leader_if_needed(&resp, region_id) && retry_cnt < 10 {
-                retry_cnt += 1;
+            if self.refresh_leader_if_needed(&resp, region_id) && timer.elapsed() < timeout {
                 warn!(
                     "{:?} is no longer leader, let's retry",
                     request.get_header().get_peer()
@@ -350,33 +350,38 @@ impl<T: Simulator> Cluster<T> {
         }
         self.reset_leader_of_region(region_id);
         let mut leader = None;
-        let mut retry_cnt = 500;
+        let mut leaders = HashMap::new();
 
         let node_ids = self.sim.rl().get_node_ids();
-        let mut count = 0;
-        while (leader.is_none() || count < store_ids.len()) && retry_cnt > 0 {
-            count = 0;
-            leader = None;
-            for store_id in &store_ids {
-                // For some tests, we stop the node but pd still has this information,
-                // and we must skip this.
-                if !node_ids.contains(store_id) {
-                    count += 1;
-                    continue;
-                }
-                let l = self.query_leader(*store_id, region_id, Duration::from_secs(1));
-                if l.is_none() {
-                    continue;
-                }
-                if leader.is_none() {
-                    leader = l;
-                    count += 1;
-                } else if l == leader {
-                    count += 1;
+        // For some tests, we stop the node but pd still has this information,
+        // and we must skip this.
+        let alive_store_ids: Vec<_> = store_ids
+            .iter()
+            .filter(|id| node_ids.contains(id))
+            .cloned()
+            .collect();
+        for _ in 0..500 {
+            for store_id in &alive_store_ids {
+                let l = match self.query_leader(*store_id, region_id, Duration::from_secs(1)) {
+                    None => continue,
+                    Some(l) => l,
+                };
+                leaders
+                    .entry(l.get_id())
+                    .or_insert_with(|| (l, vec![]))
+                    .1
+                    .push(*store_id);
+            }
+            if let Some((_, (l, c))) = leaders.drain().max_by_key(|(_, (_, c))| c.len()) {
+                // It may be a step down leader.
+                if c.contains(&l.get_store_id()) {
+                    leader = Some(l);
+                    if c.len() > store_ids.len() / 2 {
+                        break;
+                    }
                 }
             }
             sleep_ms(10);
-            retry_cnt -= 1;
         }
 
         if let Some(l) = leader {
@@ -534,6 +539,10 @@ impl<T: Simulator> Cluster<T> {
             self.reset_leader_of_region(region_id);
             return true;
         }
+        // Not match epoch can be introduced by wrong leader.
+        if err.has_epoch_not_match() {
+            self.reset_leader_of_region(region_id);
+        }
         if !err.has_not_leader() {
             return false;
         }
@@ -554,7 +563,10 @@ impl<T: Simulator> Cluster<T> {
         read_quorum: bool,
         timeout: Duration,
     ) -> RaftCmdResponse {
-        for _ in 0..20 {
+        let timer = Instant::now();
+        let mut tried_times = 0;
+        while tried_times < 10 || timer.elapsed() < timeout {
+            tried_times += 1;
             let mut region = self.get_region(key);
             let region_id = region.get_id();
             let req = new_request(
@@ -589,7 +601,7 @@ impl<T: Simulator> Cluster<T> {
             }
             return resp;
         }
-        panic!("request failed after retry for 20 times");
+        panic!("request timeout");
     }
 
     // Get region when the `filter` returns true.
@@ -778,19 +790,16 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn must_transfer_leader(&mut self, region_id: u64, leader: metapb::Peer) {
-        let mut try_cnt = 0;
+        let timer = Instant::now();
         loop {
             self.reset_leader_of_region(region_id);
             if self.leader_of_region(region_id) == Some(leader.clone()) {
                 return;
             }
-            if try_cnt > 250 {
+            if timer.elapsed() > Duration::from_secs(5) {
                 panic!("failed to transfer leader to [{}] {:?}", region_id, leader);
             }
-            if try_cnt % 50 == 0 {
-                self.transfer_leader(region_id, leader.clone());
-            }
-            try_cnt += 1;
+            self.transfer_leader(region_id, leader.clone());
         }
     }
 
@@ -932,8 +941,8 @@ impl<T: Simulator> Cluster<T> {
 
             if try_cnt > 250 {
                 panic!(
-                    "region {} doesn't exist on store {} after {} tries",
-                    region_id, store_id, try_cnt
+                    "region {} doesn't exist on store {} after {} tries: {:?}",
+                    region_id, store_id, try_cnt, resp
                 );
             }
             try_cnt += 1;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -515,7 +515,7 @@ impl<E: Engine> Clone for Storage<E> {
     fn clone(&self) -> Self {
         let refs = self.refs.fetch_add(1, atomic::Ordering::SeqCst);
 
-        debug!(
+        trace!(
             "Storage referenced"; "original_ref" => refs
         );
 
@@ -536,7 +536,7 @@ impl<E: Engine> Drop for Storage<E> {
     fn drop(&mut self) {
         let refs = self.refs.fetch_sub(1, atomic::Ordering::SeqCst);
 
-        debug!(
+        trace!(
             "Storage de-referenced"; "original_ref" => refs
         );
 

--- a/tests/failpoints/cases/test_snap.rs
+++ b/tests/failpoints/cases/test_snap.rs
@@ -32,11 +32,13 @@ fn test_overlap_cleanup() {
     cluster.must_put(b"k1", b"v1");
     must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
 
+    cluster.must_transfer_leader(region_id, new_peer(2, 2));
     // This will only pause the bootstrapped region, so the split region
     // can still work as expected.
     fail::cfg(gen_snapshot_fp, "pause").unwrap();
     pd_client.must_add_peer(region_id, new_peer(3, 3));
     cluster.must_put(b"k3", b"v3");
+    assert_snapshot(&cluster.get_snap_dir(2), region_id, true);
     let region1 = cluster.get_region(b"k1");
     cluster.must_split(&region1, b"k2");
     // Wait till the snapshot of split region is applied, whose range is ["", "k2").
@@ -44,18 +46,8 @@ fn test_overlap_cleanup() {
     // Resume the fail point and pause it again. So only the paused snapshot is generated.
     // And the paused snapshot's range is ["", ""), hence overlap.
     fail::cfg(gen_snapshot_fp, "pause").unwrap();
-    // Wait a little bit for the message being sent out.
-    thread::sleep(Duration::from_secs(1));
     // Overlap snapshot should be deleted.
-    let snap_dir = cluster.get_snap_dir(3);
-    for p in fs::read_dir(&snap_dir).unwrap() {
-        let name = p.unwrap().file_name().into_string().unwrap();
-        let mut parts = name.split('_');
-        parts.next();
-        if parts.next().unwrap() == "1" {
-            panic!("snapshot of region 1 should be deleted.");
-        }
-    }
+    assert_snapshot(&cluster.get_snap_dir(3), region_id, false);
     fail::remove(gen_snapshot_fp);
 }
 
@@ -149,6 +141,7 @@ fn test_generate_snapshot() {
     pd_client.disable_default_operator();
 
     cluster.run();
+    cluster.must_transfer_leader(1, new_peer(1, 1));
     cluster.stop_node(4);
     cluster.stop_node(5);
     (0..10).for_each(|_| cluster.must_put(b"k2", b"v2"));
@@ -195,5 +188,32 @@ fn must_empty_dir(path: String) {
             "the directory {:?} should be empty, but has entries: {:?}",
             path, entries
         );
+    }
+}
+
+fn assert_snapshot(snap_dir: &str, region_id: u64, exist: bool) {
+    let region_id = format!("{}", region_id);
+    let timer = Instant::now();
+    loop {
+        for p in fs::read_dir(&snap_dir).unwrap() {
+            let name = p.unwrap().file_name().into_string().unwrap();
+            let mut parts = name.split('_');
+            parts.next();
+            if parts.next().unwrap() == region_id && exist {
+                return;
+            }
+        }
+        if !exist {
+            return;
+        }
+
+        if timer.elapsed() < Duration::from_secs(6) {
+            thread::sleep(Duration::from_millis(20));
+        } else {
+            panic!(
+                "assert snapshot [exist: {}, region: {}] fail",
+                exist, region_id
+            );
+        }
     }
 }

--- a/tests/integrations/raftstore/test_conf_change.rs
+++ b/tests/integrations/raftstore/test_conf_change.rs
@@ -650,6 +650,9 @@ fn test_learner_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     pd_client.region_leader_must_be(r1, new_peer(1, 1));
     // To avoid using stale leader.
     cluster.reset_leader_of_region(r1);
+    // Put a new kv to ensure leader has applied to newest log, so that to avoid
+    // false warning about pending conf change.
+    cluster.must_put(b"k4", b"v4");
 
     let mut add_peer = |peer: metapb::Peer| {
         let conf_type = if peer.get_is_learner() {
@@ -715,6 +718,9 @@ fn test_conf_change_remove_leader() {
 
     // Transfer leader to the first peer.
     cluster.must_transfer_leader(r1, new_peer(1, 1));
+    // Put a new kv to ensure leader has applied to newest log, so that to avoid
+    // false warning about pending conf change.
+    cluster.must_put(b"k1", b"v1");
 
     // Try to remove leader, which should be ignored.
     let res =

--- a/tests/integrations/raftstore/test_conf_change.rs
+++ b/tests/integrations/raftstore/test_conf_change.rs
@@ -620,7 +620,7 @@ fn test_learner_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     )
     .unwrap();
     let err_msg = resp.get_header().get_error().get_message();
-    assert!(err_msg.contains("duplicated"));
+    assert!(err_msg.contains("duplicated"), "{:?}", resp);
 
     // Remove learner (4, 10) from region 1.
     pd_client.must_remove_peer(r1, new_learner_peer(4, 10));
@@ -663,7 +663,7 @@ fn test_learner_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
     // Add learner on store which already has peer.
     let resp = add_peer(new_learner_peer(4, 13));
     let err_msg = resp.get_header().get_error().get_message();
-    assert!(err_msg.contains("duplicated"));
+    assert!(err_msg.contains("duplicated"), "{:?}", err_msg);
     pd_client.must_have_peer(r1, new_peer(4, 12));
 
     // Add peer with different id on store which already has learner.
@@ -672,12 +672,12 @@ fn test_learner_conf_change<T: Simulator>(cluster: &mut Cluster<T>) {
 
     let resp = add_peer(new_learner_peer(4, 14));
     let err_msg = resp.get_header().get_error().get_message();
-    assert!(err_msg.contains("duplicated"));
+    assert!(err_msg.contains("duplicated"), "{:?}", resp);
     pd_client.must_none_peer(r1, new_learner_peer(4, 14));
 
     let resp = add_peer(new_peer(4, 15));
     let err_msg = resp.get_header().get_error().get_message();
-    assert!(err_msg.contains("duplicated"));
+    assert!(err_msg.contains("duplicated"), "{:?}", resp);
     pd_client.must_none_peer(r1, new_peer(4, 15));
 }
 

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -260,7 +260,19 @@ impl Filter for EraseHeartbeatCommit {
 
 fn check_cluster(cluster: &mut Cluster<impl Simulator>, k: &[u8], v: &[u8], all_committed: bool) {
     let region = cluster.pd_client.get_region(k).unwrap();
-    let leader = cluster.leader_of_region(region.get_id()).unwrap();
+    let mut tried_cnt = 0;
+    let leader = loop {
+        match cluster.leader_of_region(region.get_id()) {
+            None => {
+                tried_cnt += 1;
+                if tried_cnt >= 3 {
+                    panic!("leader should be elected");
+                }
+                continue;
+            }
+            Some(l) => break l,
+        }
+    };
     for i in 1..=region.get_peers().len() as u64 {
         let engine = cluster.get_engine(i);
         if all_committed || i == leader.get_store_id() {
@@ -307,10 +319,9 @@ fn test_delay_split_region() {
     // the log.
     check_cluster(&mut cluster, b"k4", b"v4", false);
 
-    cluster.stop_node(1);
+    cluster.must_transfer_leader(region.get_id(), new_peer(3, 3));
     // New leader should flush old committed entries eagerly.
     check_cluster(&mut cluster, b"k4", b"v4", true);
-    cluster.run_node(1).unwrap();
     cluster.must_put(b"k5", b"v5");
     // New committed entries should be broadcast lazily.
     check_cluster(&mut cluster, b"k5", b"v5", false);


### PR DESCRIPTION
## What have you changed? (mandatory)

This PR changes noisy logs to trace from storage module and updates the
way to refresh leader in tests. The new method only counts quorum and is
expected to return early than before, which counts all the nodes.

## What are the type of the changes? (mandatory)

- Engineering

## How has this PR been tested? (mandatory)

unit tests

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.
