### PR TITLE
*: replace FnBox with FnOnce

### DIFF
--- a/components/tikv_util/src/future.rs
+++ b/components/tikv_util/src/future.rs
@@ -3,11 +3,10 @@
 use crate::Either;
 use futures::sync::oneshot;
 use futures::{Async, Future, IntoFuture, Poll};
-use std::boxed;
 
 /// Generates a paired future and callback so that when callback is being called, its result
 /// is automatically passed as a future result.
-pub fn paired_future_callback<T>() -> (Box<dyn boxed::FnBox(T) + Send>, oneshot::Receiver<T>)
+pub fn paired_future_callback<T>() -> (Box<dyn FnOnce(T) + Send>, oneshot::Receiver<T>)
 where
     T: Send + 'static,
 {

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![feature(fnbox)]
 #![cfg_attr(test, feature(test))]
 
 #[macro_use]

--- a/components/tikv_util/src/threadpool.rs
+++ b/components/tikv_util/src/threadpool.rs
@@ -1,6 +1,5 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::boxed::FnBox;
 use std::collections::VecDeque;
 use std::fmt::Write;
 use std::marker::PhantomData;
@@ -40,7 +39,7 @@ impl<C: Context + Default> ContextFactory<C> for DefaultContextFactory {
 }
 
 pub struct Task<C> {
-    task: Box<dyn FnBox(&mut C) + Send>,
+    task: Box<dyn FnOnce(&mut C) + Send>,
 }
 
 impl<C: Context> Task<C> {
@@ -326,7 +325,7 @@ where
             };
 
             self.ctx.on_task_started();
-            (task.task).call_box((&mut self.ctx,));
+            (task.task)(&mut self.ctx);
             self.ctx.on_task_finished();
             self.task_count.fetch_sub(1, AtomicOrdering::SeqCst);
             if self.task_counter == self.tasks_per_tick {

--- a/src/coprocessor/dag/batch/executors/selection_executor.rs
+++ b/src/coprocessor/dag/batch/executors/selection_executor.rs
@@ -257,7 +257,7 @@ mod tests {
             BatchSelectionExecutor::new_for_test(src_exec, vec![predicate])
         };
 
-        let executor_builders: Vec<Box<dyn std::boxed::FnBox(MockExecutor) -> _>> =
+        let executor_builders: Vec<Box<dyn FnOnce(MockExecutor) -> _>> =
             vec![Box::new(exec_no_predicate), Box::new(exec_predicate_true)];
 
         for exec_builder in executor_builders {

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -230,7 +230,7 @@ impl<E: Engine> Endpoint<E> {
                     .map(|_| (tracker, snapshot))
             })
             .and_then(move |(tracker, snapshot)| {
-                future::result(handler_builder.call_box((snapshot, &tracker.req_ctx)))
+                future::result(handler_builder(snapshot, &tracker.req_ctx))
                     .map(|handler| (tracker, handler))
             })
             .and_then(|(mut tracker, mut handler)| {
@@ -327,7 +327,7 @@ impl<E: Engine> Endpoint<E> {
                         .map(|_| (tracker, snapshot))
                 })
                 .and_then(move |(tracker, snapshot)| {
-                    future::result(handler_builder.call_box((snapshot, &tracker.req_ctx)))
+                    future::result(handler_builder(snapshot, &tracker.req_ctx))
                         .map(|handler| (tracker, handler))
                 });
 

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -32,8 +32,6 @@ pub mod util;
 pub use self::endpoint::Endpoint;
 pub use self::error::{Error, Result};
 
-use std::boxed::FnBox;
-
 use kvproto::{coprocessor as coppb, kvrpcpb};
 
 use tikv_util::time::{Duration, Instant};
@@ -111,10 +109,8 @@ impl Deadline {
     }
 }
 
-/// Denotes for a function that builds a `RequestHandler`.
-/// Due to rust-lang#23856, we have to make it a type alias of `Box<..>`.
 type RequestHandlerBuilder<Snap> =
-    Box<dyn for<'a> FnBox(Snap, &'a ReqContext) -> Result<Box<dyn RequestHandler>> + Send>;
+    Box<dyn for<'a> FnOnce(Snap, &'a ReqContext) -> Result<Box<dyn RequestHandler>> + Send>;
 
 /// Encapsulate the `kvrpcpb::Context` to provide some extra properties.
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #![cfg_attr(test, feature(test))]
 #![recursion_limit = "200"]
 #![feature(cell_update)]
-#![feature(fnbox)]
 #![feature(proc_macro_hygiene)]
 #![feature(duration_float)]
 #![feature(specialization)]

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -1,8 +1,6 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::borrow::Cow;
-#[cfg(test)]
-use std::boxed::FnBox;
 use std::collections::VecDeque;
 use std::fmt::{self, Debug, Formatter};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -2257,7 +2255,7 @@ pub enum Msg {
     Destroy(Destroy),
     Snapshot(GenSnapTask),
     #[cfg(test)]
-    Validate(u64, Box<dyn FnBox(&ApplyDelegate) + Send>),
+    Validate(u64, Box<dyn FnOnce(&ApplyDelegate) + Send>),
 }
 
 impl Msg {
@@ -2614,7 +2612,7 @@ impl ApplyFsm {
                 Some(Msg::LogsUpToDate(_)) => {}
                 Some(Msg::Snapshot(snap_task)) => self.handle_snapshot(apply_ctx, snap_task),
                 #[cfg(test)]
-                Some(Msg::Validate(_, f)) => f.call_box((&self.delegate,)),
+                Some(Msg::Validate(_, f)) => f(&self.delegate),
                 None => break,
             }
         }

--- a/src/raftstore/store/fsm/batch.rs
+++ b/src/raftstore/store/fsm/batch.rs
@@ -455,11 +455,10 @@ pub mod tests {
     use super::super::router::*;
     use super::*;
     use std::borrow::Cow;
-    use std::boxed::FnBox;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
-    pub type Message = Option<Box<dyn FnBox(&mut Runner) + Send>>;
+    pub type Message = Option<Box<dyn FnOnce(&mut Runner) + Send>>;
 
     pub struct Runner {
         is_stopped: bool,
@@ -517,7 +516,7 @@ pub mod tests {
             self.local.control += 1;
             while let Ok(r) = control.recv.try_recv() {
                 if let Some(r) = r {
-                    r.call_box((control,));
+                    r(control);
                 }
             }
             Some(0)
@@ -527,7 +526,7 @@ pub mod tests {
             self.local.normal += 1;
             while let Ok(r) = normal.recv.try_recv() {
                 if let Some(r) = r {
-                    r.call_box((normal,));
+                    r(normal);
                 }
             }
             Some(0)

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -1,6 +1,5 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::boxed::FnBox;
 use std::fmt;
 use std::time::Instant;
 
@@ -31,8 +30,8 @@ pub struct WriteResponse {
     pub response: RaftCmdResponse,
 }
 
-pub type ReadCallback = Box<dyn FnBox(ReadResponse) + Send>;
-pub type WriteCallback = Box<dyn FnBox(WriteResponse) + Send>;
+pub type ReadCallback = Box<dyn FnOnce(ReadResponse) + Send>;
+pub type WriteCallback = Box<dyn FnOnce(WriteResponse) + Send>;
 
 /// Variants of callbacks for `Msg`.
 ///  - `Read`: a callbak for read only requests including `StatusRequest`,

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -1,6 +1,5 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::boxed::FnBox;
 use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
 use std::time::Instant;
@@ -16,7 +15,7 @@ use super::Result;
 
 const STORE_ADDRESS_REFRESH_SECONDS: u64 = 60;
 
-pub type Callback = Box<dyn FnBox(Result<String>) + Send>;
+pub type Callback = Box<dyn FnOnce(Result<String>) + Send>;
 
 /// A trait for resolving store addresses.
 pub trait StoreAddrResolver: Send + Clone {
@@ -92,7 +91,7 @@ impl<T: PdClient> Runnable<Task> for Runner<T> {
     fn run(&mut self, task: Task) {
         let store_id = task.store_id;
         let resp = self.resolve(store_id);
-        task.cb.call_box((resp,))
+        (task.cb)(resp)
     }
 }
 

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -1,6 +1,5 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::boxed::FnBox;
 use std::fmt::{self, Display, Formatter};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -25,7 +24,7 @@ use super::metrics::*;
 use super::transport::RaftStoreRouter;
 use super::{Config, Error, Result};
 
-pub type Callback = Box<dyn FnBox(Result<()>) + Send>;
+pub type Callback = Box<dyn FnOnce(Result<()>) + Send>;
 
 const DEFAULT_POOL_SIZE: usize = 4;
 

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -1,6 +1,5 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::boxed::FnBox;
 use std::cell::Cell;
 use std::cmp::Ordering;
 use std::time::Duration;
@@ -44,7 +43,7 @@ const STAT_SEEK: &str = "seek";
 const STAT_SEEK_FOR_PREV: &str = "seek_for_prev";
 const STAT_OVER_SEEK_BOUND: &str = "over_seek_bound";
 
-pub type Callback<T> = Box<dyn FnBox((CbContext, Result<T>)) + Send>;
+pub type Callback<T> = Box<dyn FnOnce((CbContext, Result<T>)) + Send>;
 
 #[derive(Debug)]
 pub struct CbContext {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -9,7 +9,6 @@ pub mod readpool_impl;
 pub mod txn;
 pub mod types;
 
-use std::boxed::FnBox;
 use std::cmp;
 use std::error;
 use std::fmt::{self, Debug, Display, Formatter};
@@ -46,7 +45,7 @@ pub use self::readpool_impl::*;
 pub use self::txn::{FixtureStore, FixtureStoreScanner};
 pub use self::txn::{Msg, Scanner, Scheduler, SnapshotStore, Store};
 pub use self::types::{Key, KvPair, MvccInfo, Value};
-pub type Callback<T> = Box<dyn FnBox(Result<T>) + Send>;
+pub type Callback<T> = Box<dyn FnOnce(Result<T>) + Send>;
 
 // Short value max len must <= 255.
 pub const SHORT_VALUE_MAX_LEN: usize = 64;


### PR DESCRIPTION
## What have you changed? (mandatory)

`FnBox` will never be stabilized. Instead, `Box<dyn FnOnce>` is available now, and is fully usable in 1.35. (https://github.com/rust-lang/rust/pull/59500)

So we can replace all FnBox occurrences with `FnOnce` now. Feature gate of fnbox can be removed as well.

## What are the type of the changes? (mandatory)

Engineering

## How has this PR been tested? (mandatory)

`make dev`

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

@kennytm 
