### PR TITLE
engine: skip check raft cf in delete range

### DIFF
--- a/components/engine/src/mutable.rs
+++ b/components/engine/src/mutable.rs
@@ -10,7 +10,7 @@ pub trait Mutable: Writable {
         Ok(())
     }
 
-    // TOOD: change CFHandle to str.
+    // TODO: change CFHandle to str.
     fn put_msg_cf<M: protobuf::Message>(&self, cf: &CFHandle, key: &[u8], m: &M) -> Result<()> {
         let value = m.write_to_bytes()?;
         self.put_cf(cf, key, &value)?;

--- a/components/engine/src/util.rs
+++ b/components/engine/src/util.rs
@@ -4,7 +4,7 @@ use std::u64;
 
 use crate::rocks;
 use crate::rocks::{Range, TablePropertiesCollection, Writable, WriteBatch, DB};
-use crate::{CF_LOCK, CF_RAFT};
+use crate::CF_LOCK;
 
 use super::{Error, Result};
 use super::{IterOption, Iterable};
@@ -59,9 +59,7 @@ pub fn delete_all_in_range_cf(
 ) -> Result<()> {
     let handle = rocks::util::get_cf_handle(db, cf)?;
     let wb = WriteBatch::new();
-    // Since CF_RAFT and CF_LOCK is usually small, so using
-    // traditional way to cleanup.
-    if use_delete_range && cf != CF_RAFT && cf != CF_LOCK {
+    if use_delete_range && cf != CF_LOCK {
         wb.delete_range_cf(handle, start_key, end_key)?;
     } else {
         let start = KeyBuilder::from_slice(start_key, 0, 0);


### PR DESCRIPTION
## What have you changed? (mandatory)

Skip deleting range check on raftcf, because the encoding of keys in raftcf is different from others, and there is no such usage in TiKV.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

No.

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.
