### PR TITLE
gc_worker: Change logs about plenty versions to debug level

### DIFF
--- a/src/storage/gc_worker.rs
+++ b/src/storage/gc_worker.rs
@@ -223,7 +223,7 @@ impl<E: Engine> GCRunner<E> {
             let gc_info = txn.gc(k.clone(), safe_point)?;
 
             if gc_info.found_versions >= GC_LOG_FOUND_VERSION_THRESHOLD {
-                info!(
+                debug!(
                     "GC found plenty versions for a key";
                     "region_id" => ctx.get_region_id(),
                     "versions" => gc_info.found_versions,
@@ -233,7 +233,7 @@ impl<E: Engine> GCRunner<E> {
             // TODO: we may delete only part of the versions in a batch, which may not beyond
             // the logging threshold `GC_LOG_DELETED_VERSION_THRESHOLD`.
             if gc_info.deleted_versions as usize >= GC_LOG_DELETED_VERSION_THRESHOLD {
-                info!(
+                debug!(
                     "GC deleted plenty versions for a key";
                     "region_id" => ctx.get_region_id(),
                     "versions" => gc_info.deleted_versions,


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR is moved from #4485 , originally authored by @kolbe

The logs complaining about too many version is printed too frequently and is annoying. So move it to debug level.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

No.

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.
