### PR TITLE
Convert `FieldTypeTp` to `FieldType` explicitly

### DIFF
--- a/components/cop_datatype/src/def/field_type.rs
+++ b/components/cop_datatype/src/def/field_type.rs
@@ -309,18 +309,18 @@ impl FieldTypeAccessor for ColumnInfo {
     }
 }
 
-impl Into<FieldType> for FieldTypeTp {
-    fn into(self) -> FieldType {
+impl From<FieldTypeTp> for FieldType {
+    fn from(tp: FieldTypeTp) -> Self {
         let mut ft = FieldType::new();
-        ft.as_mut_accessor().set_tp(self);
+        ft.as_mut_accessor().set_tp(tp);
         ft
     }
 }
 
-impl Into<ColumnInfo> for FieldTypeTp {
-    fn into(self) -> ColumnInfo {
+impl From<FieldTypeTp> for ColumnInfo {
+    fn from(tp: FieldTypeTp) -> ColumnInfo {
         let mut ft = ColumnInfo::new();
-        ft.as_mut_accessor().set_tp(self);
+        ft.as_mut_accessor().set_tp(tp);
         ft
     }
 }

--- a/src/coprocessor/codec/batch/lazy_column.rs
+++ b/src/coprocessor/codec/batch/lazy_column.rs
@@ -303,7 +303,8 @@ mod tests {
         {
             // Empty raw to empty decoded.
             let mut col = col.clone();
-            col.decode(&Tz::utc(), &FieldTypeTp::Long.into()).unwrap();
+            col.decode(&Tz::utc(), &FieldType::from(FieldTypeTp::Long))
+                .unwrap();
             assert!(col.is_decoded());
             assert_eq!(col.len(), 0);
             assert_eq!(col.capacity(), 5);
@@ -343,7 +344,8 @@ mod tests {
             assert_eq!(col.raw()[1].as_slice(), datum_raw_2.as_slice());
         }
         // Non-empty raw to non-empty decoded.
-        col.decode(&Tz::utc(), &FieldTypeTp::Long.into()).unwrap();
+        col.decode(&Tz::utc(), &FieldType::from(FieldTypeTp::Long))
+            .unwrap();
         assert!(col.is_decoded());
         assert_eq!(col.len(), 2);
         assert_eq!(col.capacity(), 5);
@@ -469,7 +471,7 @@ mod benches {
         }
 
         column
-            .decode(&Tz::utc(), &FieldTypeTp::LongLong.into())
+            .decode(&Tz::utc(), &FieldType::from(FieldTypeTp::LongLong))
             .unwrap();
 
         b.iter(|| {
@@ -494,7 +496,7 @@ mod benches {
             column.push_raw(datum_raw.as_slice());
         }
 
-        let ft = FieldTypeTp::LongLong.into();
+        let ft = FieldType::from(FieldTypeTp::LongLong);
         let tz = Tz::utc();
 
         b.iter(|| {
@@ -522,7 +524,7 @@ mod benches {
             column.push_raw(datum_raw.as_slice());
         }
 
-        let ft = FieldTypeTp::LongLong.into();
+        let ft = FieldType::from(FieldTypeTp::LongLong);
         let tz = Tz::utc();
 
         column.decode(&tz, &ft).unwrap();

--- a/src/coprocessor/codec/batch/lazy_column_vec.rs
+++ b/src/coprocessor/codec/batch/lazy_column_vec.rs
@@ -267,11 +267,10 @@ mod tests {
         use cop_datatype::FieldTypeTp;
 
         for comparable in &[true, false] {
-            let schema = [
-                FieldTypeTp::Long.into(),
-                FieldTypeTp::Double.into(),
-                FieldTypeTp::VarChar.into(),
-            ];
+            let schema = vec![FieldTypeTp::Long, FieldTypeTp::Double, FieldTypeTp::VarChar]
+                .into_iter()
+                .map(FieldType::from)
+                .collect::<Vec<_>>();
             let values = vec![
                 vec![Datum::U64(1), Datum::F64(1.0), Datum::Null],
                 vec![Datum::Null, Datum::Null, Datum::Bytes(vec![0u8, 2u8])],
@@ -339,7 +338,10 @@ mod tests {
     fn test_retain_rows_by_index() {
         use cop_datatype::FieldTypeTp;
 
-        let schema = [FieldTypeTp::Long.into(), FieldTypeTp::Double.into()];
+        let schema = vec![FieldTypeTp::Long, FieldTypeTp::Double]
+            .into_iter()
+            .map(FieldType::from)
+            .collect::<Vec<_>>();
         let mut columns = LazyBatchColumnVec::with_raw_columns(2);
         assert_eq!(columns.rows_len(), 0);
         assert_eq!(columns.columns_len(), 2);

--- a/src/coprocessor/codec/data_type/vector.rs
+++ b/src/coprocessor/codec/data_type/vector.rs
@@ -957,7 +957,7 @@ mod benches {
         let mut datum_raw: Vec<u8> = Vec::new();
         DatumEncoder::encode(&mut datum_raw, &[Datum::U64(0xDEADBEEF)], true).unwrap();
 
-        let field_type = FieldTypeTp::LongLong.into();
+        let field_type = FieldType::from(FieldTypeTp::LongLong);
         let tz = Tz::utc();
 
         b.iter(move || {

--- a/src/coprocessor/dag/batch/executors/index_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/index_scan_executor.rs
@@ -292,10 +292,13 @@ mod tests {
 
         // The schema of these columns. Used to check executor output.
         let schema = vec![
-            FieldTypeTp::LongLong.into(),
-            FieldTypeTp::Double.into(),
-            FieldTypeTp::LongLong.into(),
-        ];
+            FieldTypeTp::LongLong,
+            FieldTypeTp::Double,
+            FieldTypeTp::LongLong,
+        ]
+        .into_iter()
+        .map(FieldType::from)
+        .collect::<Vec<_>>();
 
         // Case 1. Normal index.
 

--- a/src/coprocessor/dag/batch/executors/limit_executor.rs
+++ b/src/coprocessor/dag/batch/executors/limit_executor.rs
@@ -88,10 +88,13 @@ mod tests {
                 (6, None, Some(4.5)),
             ];
             let field_types = vec![
-                FieldTypeTp::LongLong.into(),
-                FieldTypeTp::LongLong.into(),
-                FieldTypeTp::Double.into(),
-            ];
+                FieldTypeTp::LongLong,
+                FieldTypeTp::LongLong,
+                FieldTypeTp::Double,
+            ]
+            .into_iter()
+            .map(FieldType::from)
+            .collect::<Vec<_>>();
 
             MockExecutor {
                 data: expect_rows,

--- a/src/coprocessor/dag/batch/executors/selection_executor.rs
+++ b/src/coprocessor/dag/batch/executors/selection_executor.rs
@@ -216,7 +216,10 @@ mod tests {
     /// (drained)
     fn make_src_executor_using_fixture_1() -> MockExecutor {
         MockExecutor::new(
-            vec![FieldTypeTp::LongLong.into(), FieldTypeTp::Double.into()],
+            vec![FieldTypeTp::LongLong, FieldTypeTp::Double]
+                .into_iter()
+                .map(FieldType::from)
+                .collect(),
             vec![
                 BatchExecuteResult {
                     data: LazyBatchColumnVec::from(vec![
@@ -351,10 +354,13 @@ mod tests {
     fn make_src_executor_using_fixture_2() -> MockExecutor {
         MockExecutor::new(
             vec![
-                FieldTypeTp::LongLong.into(),
-                FieldTypeTp::LongLong.into(),
-                FieldTypeTp::LongLong.into(),
-            ],
+                FieldTypeTp::LongLong,
+                FieldTypeTp::LongLong,
+                FieldTypeTp::LongLong,
+            ]
+            .into_iter()
+            .map(FieldType::from)
+            .collect::<Vec<_>>(),
             vec![
                 BatchExecuteResult {
                     data: LazyBatchColumnVec::from(vec![
@@ -557,7 +563,10 @@ mod tests {
         // == Call #2 ==
         // (drained)
         let src_exec = MockExecutor::new(
-            vec![FieldTypeTp::LongLong.into(), FieldTypeTp::LongLong.into()],
+            vec![FieldTypeTp::LongLong, FieldTypeTp::LongLong]
+                .into_iter()
+                .map(FieldType::from)
+                .collect::<Vec<_>>(),
             vec![
                 BatchExecuteResult {
                     data: LazyBatchColumnVec::from(vec![

--- a/src/coprocessor/dag/batch/executors/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/table_scan_executor.rs
@@ -423,10 +423,13 @@ mod tests {
             ];
 
             let field_types = vec![
-                FieldTypeTp::LongLong.into(),
-                FieldTypeTp::LongLong.into(),
-                FieldTypeTp::Double.into(),
-            ];
+                FieldTypeTp::LongLong,
+                FieldTypeTp::LongLong,
+                FieldTypeTp::Double,
+            ]
+            .into_iter()
+            .map(FieldType::from)
+            .collect::<Vec<_>>();
 
             let store = {
                 let kv = data
@@ -720,10 +723,13 @@ mod tests {
             },
         ];
         let schema = vec![
-            FieldTypeTp::LongLong.into(),
-            FieldTypeTp::LongLong.into(),
-            FieldTypeTp::LongLong.into(),
-        ];
+            FieldTypeTp::LongLong,
+            FieldTypeTp::LongLong,
+            FieldTypeTp::LongLong,
+        ]
+        .into_iter()
+        .map(FieldType::from)
+        .collect::<Vec<_>>();
 
         let mut kv = vec![];
         {
@@ -824,7 +830,10 @@ mod tests {
                 ci
             },
         ];
-        let schema = vec![FieldTypeTp::LongLong.into(), FieldTypeTp::LongLong.into()];
+        let schema = vec![FieldTypeTp::LongLong, FieldTypeTp::LongLong]
+            .into_iter()
+            .map(FieldType::from)
+            .collect::<Vec<_>>();
 
         let mut kv = vec![];
         {

--- a/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
@@ -260,7 +260,7 @@ mod tests {
     }
 
     /// Creates fixture to be used in `test_eval_single_column_node_xxx`.
-    fn new_single_column_node_fixture() -> (LazyBatchColumnVec, [FieldType; 2]) {
+    fn new_single_column_node_fixture() -> (LazyBatchColumnVec, Vec<FieldType>) {
         let columns = LazyBatchColumnVec::from(vec![
             {
                 // this column is not referenced
@@ -282,7 +282,10 @@ mod tests {
                 col
             },
         ]);
-        let schema = [FieldTypeTp::Double.into(), FieldTypeTp::LongLong.into()];
+        let schema = vec![FieldTypeTp::Double, FieldTypeTp::LongLong]
+            .into_iter()
+            .map(FieldType::from)
+            .collect::<Vec<_>>();
         (columns, schema)
     }
 
@@ -427,7 +430,7 @@ mod tests {
             col.mut_decoded().push_int(None);
             col
         }]);
-        let schema = &[FieldTypeTp::LongLong.into()];
+        let schema = &[FieldType::from(FieldTypeTp::LongLong)];
 
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
@@ -479,7 +482,7 @@ mod tests {
 
             col
         }]);
-        let schema = &[FieldTypeTp::LongLong.into()];
+        let schema = &[FieldType::from(FieldTypeTp::LongLong)];
 
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
@@ -558,7 +561,7 @@ mod tests {
             col.mut_decoded().push_real(Some(-4.3));
             col
         }]);
-        let schema = &[FieldTypeTp::Double.into()];
+        let schema = &[FieldType::from(FieldTypeTp::Double)];
 
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
@@ -602,7 +605,7 @@ mod tests {
             col.mut_decoded().push_int(Some(-4));
             col
         }]);
-        let schema = &[FieldTypeTp::LongLong.into()];
+        let schema = &[FieldType::from(FieldTypeTp::LongLong)];
 
         let exp = RpnExpressionBuilder::new()
             .push_constant(1.5f64)
@@ -657,7 +660,10 @@ mod tests {
                 col
             },
         ]);
-        let schema = &[FieldTypeTp::LongLong.into(), FieldTypeTp::Double.into()];
+        let schema = vec![FieldTypeTp::LongLong, FieldTypeTp::Double]
+            .into_iter()
+            .map(FieldType::from)
+            .collect::<Vec<_>>();
 
         // FnFoo(col1, col0)
         let exp = RpnExpressionBuilder::new()
@@ -666,7 +672,7 @@ mod tests {
             .push_fn_call(FnFoo, FieldTypeTp::LongLong)
             .build();
         let mut ctx = EvalContext::default();
-        let result = exp.eval(&mut ctx, 3, schema, &mut columns);
+        let result = exp.eval(&mut ctx, 3, &schema, &mut columns);
         let val = result.unwrap();
         assert!(val.is_vector());
         assert_eq!(
@@ -713,7 +719,10 @@ mod tests {
 
             col
         }]);
-        let schema = &[FieldTypeTp::LongLong.into(), FieldTypeTp::LongLong.into()];
+        let schema = vec![FieldTypeTp::LongLong, FieldTypeTp::LongLong]
+            .into_iter()
+            .map(FieldType::from)
+            .collect::<Vec<_>>();
 
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
@@ -721,7 +730,7 @@ mod tests {
             .push_fn_call(FnFoo, FieldTypeTp::LongLong)
             .build();
         let mut ctx = EvalContext::default();
-        let result = exp.eval(&mut ctx, 3, schema, &mut columns);
+        let result = exp.eval(&mut ctx, 3, &schema, &mut columns);
         let val = result.unwrap();
         assert!(val.is_vector());
         assert_eq!(
@@ -758,7 +767,7 @@ mod tests {
             col.mut_decoded().push_int(Some(-4));
             col
         }]);
-        let schema = &[FieldTypeTp::LongLong.into()];
+        let schema = &[FieldType::from(FieldTypeTp::LongLong)];
 
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
@@ -866,7 +875,10 @@ mod tests {
                 col
             },
         ]);
-        let schema = &[FieldTypeTp::Double.into(), FieldTypeTp::LongLong.into()];
+        let schema = vec![FieldTypeTp::Double, FieldTypeTp::LongLong]
+            .into_iter()
+            .map(FieldType::from)
+            .collect::<Vec<_>>();
 
         // Col0, FnB, Col1, Const0, FnD, Const1, FnC, FnA
         let exp = RpnExpressionBuilder::new()
@@ -891,7 +903,7 @@ mod tests {
         //      => [25.0, 3.8, 146.0]
 
         let mut ctx = EvalContext::default();
-        let result = exp.eval(&mut ctx, 3, schema, &mut columns);
+        let result = exp.eval(&mut ctx, 3, &schema, &mut columns);
         let val = result.unwrap();
         assert!(val.is_vector());
         assert_eq!(
@@ -1181,10 +1193,13 @@ mod tests {
                 col
             },
         ]);
-        let schema = &[FieldTypeTp::LongLong.into(), FieldTypeTp::Double.into()];
+        let schema = vec![FieldTypeTp::LongLong, FieldTypeTp::Double]
+            .into_iter()
+            .map(FieldType::from)
+            .collect::<Vec<_>>();
 
         let mut ctx = EvalContext::default();
-        let result = exp.eval(&mut ctx, 3, schema, &mut columns);
+        let result = exp.eval(&mut ctx, 3, &schema, &mut columns);
         let val = result.unwrap();
         assert!(val.is_vector());
         assert_eq!(


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

## What have you changed? (mandatory)
Improve https://github.com/tikv/tikv/pull/4649, use `FieldType::From(FieldTypeTp::xxx)` to convert `FieldTypeTp` to `FieldType` which is more explicit than `FieldTypeTp.into`. 

- Improvement (a change which is an improvement to an existing feature)


## How has this PR been tested? (mandatory)
No test needed if the code passed compiling.
