### PR TITLE
coprocessor: add unit tests to coverage `parse_frac` all path

### DIFF
--- a/src/coprocessor/codec/mysql/mod.rs
+++ b/src/coprocessor/codec/mysql/mod.rs
@@ -63,18 +63,26 @@ pub use self::time::{Time, TimeEncoder, TimeType, Tz};
 mod tests {
     #[test]
     fn test_parse_frac() {
-        let cases = vec![
-            ("1234567", 0, 0),
-            ("1234567", 1, 1),
-            ("0000567", 5, 6),
-            ("1234567", 5, 12346),
-            ("1234567", 6, 123457),
-            ("9999999", 6, 1000000),
+        let cases: Vec<(&'static [u8], u8, u32)> = vec![
+            (b"", 0, 0),
+            (b"", 10, 0),
+            (b"1234567", 0, 0),
+            (b"1234567", 1, 1),
+            (b"0000567", 5, 6),
+            (b"1234567", 5, 12346),
+            (b"1234567", 6, 123457),
+            (b"9999999", 6, 1000000),
+            (b"9999999", 8, 99999990),
         ];
 
         for (s, fsp, exp) in cases {
-            let res = super::parse_frac(s.as_bytes(), fsp).unwrap();
+            let res = super::parse_frac(s, fsp).unwrap();
             assert_eq!(res, exp);
         }
+
+        assert!(
+            super::parse_frac(b"00x", 6).is_err(),
+            "00x should invalid for `parse_frac`"
+        );
     }
 }

--- a/src/coprocessor/codec/mysql/mod.rs
+++ b/src/coprocessor/codec/mysql/mod.rs
@@ -72,7 +72,7 @@ mod tests {
             (b"1234567", 5, 12346),
             (b"1234567", 6, 123457),
             (b"9999999", 6, 1000000),
-            (b"9999999", 8, 99999990),
+            (b"12", 5, 12000),
         ];
 
         for (s, fsp, exp) in cases {
@@ -82,7 +82,7 @@ mod tests {
 
         assert!(
             super::parse_frac(b"00x", 6).is_err(),
-            "00x should invalid for `parse_frac`"
+            "00x should be invalid for `parse_frac`"
         );
     }
 }


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Add unit tests for `coprocessor::codec::mysql::parse_frac` to coverage all path

## What are the type of the changes? (mandatory)

- Misc (other changes)
