### PR TITLE
*: remove make bench target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,8 @@ test:
 	bash scripts/check-bins-for-jemalloc.sh
 
 bench:
-	LOG_LEVEL=ERROR RUST_BACKTRACE=1 cargo bench --all --no-default-features --features "${ENABLE_FEATURES}" -- --nocapture
+	LOG_LEVEL=ERROR RUST_BACKTRACE=1 cargo bench --all --lib --bins --tests --bench misc --bench channel --no-default-features --features "${ENABLE_FEATURES}" -- --nocapture && \
+	LOG_LEVEL=ERROR RUST_BACKTRACE=1 cargo bench --bench raftstore --bench coprocessor_executors --bench hierarchy --no-default-features --features "${ENABLE_FEATURES}"
 
 unset-override:
 	@# unset first in case of any previous overrides

--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,6 @@ test:
 	fi
 	bash scripts/check-bins-for-jemalloc.sh
 
-bench:
-	LOG_LEVEL=ERROR RUST_BACKTRACE=1 cargo bench --all --lib --bins --tests --bench misc --bench channel --no-default-features --features "${ENABLE_FEATURES}" -- --nocapture && \
-	LOG_LEVEL=ERROR RUST_BACKTRACE=1 cargo bench --bench raftstore --bench coprocessor_executors --bench hierarchy --no-default-features --features "${ENABLE_FEATURES}"
-
 unset-override:
 	@# unset first in case of any previous overrides
 	@if rustup override list | grep `pwd` > /dev/null; then rustup override unset; fi

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -30,9 +30,11 @@ use crate::raftstore::store::fsm::metrics::*;
 use crate::raftstore::store::fsm::peer::{
     maybe_destroy_source, new_admin_request, PeerFsm, PeerFsmDelegate,
 };
+#[cfg(not(feature = "no-fail"))]
+use crate::raftstore::store::fsm::ApplyTaskRes;
 use crate::raftstore::store::fsm::{
     batch, create_apply_batch_system, ApplyBatchSystem, ApplyPollerBuilder, ApplyRouter, ApplyTask,
-    ApplyTaskRes, BasicMailbox, BatchRouter, BatchSystem, HandlerBuilder,
+    BasicMailbox, BatchRouter, BatchSystem, HandlerBuilder,
 };
 use crate::raftstore::store::fsm::{ApplyNotifier, Fsm, PollHandler, RegionProposal};
 use crate::raftstore::store::keys::{self, data_end_key, data_key, enc_end_key, enc_start_key};

--- a/tests/failpoints/mod.rs
+++ b/tests/failpoints/mod.rs
@@ -5,8 +5,10 @@
 
 #[macro_use]
 extern crate lazy_static;
+#[cfg(not(feature = "no-fail"))]
 #[macro_use(slog_kv, slog_debug, slog_log, slog_record, slog_b, slog_record_static)]
 extern crate slog;
+#[cfg(not(feature = "no-fail"))]
 #[macro_use]
 extern crate slog_global;
 


### PR DESCRIPTION
## What have you changed? (mandatory)
Currently, `make bench` will fail due to Criterion cannot recognize `--nocapture`. The way to fix this problem is to remove `--nocapture` or explicitly specify the bench target to decide whether it should use `--nocapture`. I'm not sure which way is better actually.
Also, this PR fixes some warning when running `make build` and `make test`.

Edit: 
According to the comments, I am going to remove this target.

## What are the type of the changes? (mandatory)

- Bug fix

## How has this PR been tested? (mandatory)

make build, make test

## Does this PR affect documentation (docs) or release note? (mandatory)
No.

## Does this PR affect tidb-ansible update? (mandatory)
No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

