### PR TITLE
Support exec summary for Selection executor

### DIFF
--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -172,6 +172,7 @@ impl DAGBuilder {
                     return Err(box_err!("got too much *scan exec, should be only one"));
                 }
                 ExecType::TypeSelection => Box::new(SelectionExecutor::new(
+                    C::new(summary_slot_index),
                     exec.take_selection(),
                     Arc::clone(&ctx),
                     src,

--- a/src/coprocessor/dag/executor/limit.rs
+++ b/src/coprocessor/dag/executor/limit.rs
@@ -58,17 +58,17 @@ impl<C: ExecSummaryCollector> Executor for LimitExecutor<C> {
         }
     }
 
-    fn take_eval_warnings(&mut self) -> Option<EvalWarnings> {
-        self.src.take_eval_warnings()
+    fn collect_execution_summaries(&mut self, target: &mut [ExecSummary]) {
+        self.src.collect_execution_summaries(target);
+        self.summary_collector.collect_into(target);
     }
 
     fn get_len_of_columns(&self) -> usize {
         self.src.get_len_of_columns()
     }
 
-    fn collect_execution_summaries(&mut self, target: &mut [ExecSummary]) {
-        self.src.collect_execution_summaries(target);
-        self.summary_collector.collect_into(target);
+    fn take_eval_warnings(&mut self) -> Option<EvalWarnings> {
+        self.src.take_eval_warnings()
     }
 }
 

--- a/src/coprocessor/dag/executor/limit.rs
+++ b/src/coprocessor/dag/executor/limit.rs
@@ -27,23 +27,30 @@ impl<C: ExecSummaryCollector> LimitExecutor<C> {
             first_collect: true,
         }
     }
+
+    fn next_impl(&mut self) -> Result<Option<Row>> {
+        if self.cursor >= self.limit {
+            return Ok(None);
+        }
+        if let Some(row) = self.src.next()? {
+            self.cursor += 1;
+            Ok(Some(row))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 impl<C: ExecSummaryCollector> Executor for LimitExecutor<C> {
     fn next(&mut self) -> Result<Option<Row>> {
         let timer = self.summary_collector.on_start_iterate();
-        if self.cursor >= self.limit {
-            self.summary_collector.on_finish_iterate(timer, 0);
-            return Ok(None);
-        }
-        if let Some(row) = self.src.next()? {
-            self.cursor += 1;
+        let ret = self.next_impl();
+        if let Ok(Some(_)) = ret {
             self.summary_collector.on_finish_iterate(timer, 1);
-            Ok(Some(row))
         } else {
             self.summary_collector.on_finish_iterate(timer, 0);
-            Ok(None)
         }
+        ret
     }
 
     fn collect_output_counts(&mut self, _: &mut Vec<i64>) {


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

1. Support exec summary for `Selection` executor
2. Format `Limit` executor to keep the order of the methods in implementation the same as trait declare order.

## What are the type of the changes? (mandatory)

- New feature (change which adds functionality)
- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

Manually

Generate some rand data
```shell
tidiff 'create table selection(a bigint(10) not null auto_increment primary key, b varchar(20))'
tidiff '!! {{$count:=count 1000}} insert into selection (a, b) values {{range $index := $count}}(NULL, "{{varchar 20}}") {{if head $index $count}},{{end}} {{end}}'
```

```
TiDB(127.0.0.1:4000)> explain analyze select * from selection where b like "%a%" limit 10
+------------------------------------------------------------------------------------------------------------------------------------+
| id                       | count | task | operator info                                        | execution info                    |
+------------------------------------------------------------------------------------------------------------------------------------+
| Limit_8                  | 10.00 | root | offset:0, count:10                                   | time:7.242086ms, loops:2, rows:10 |
| └─TableReader_14     | 10.00 | root | data:Limit_13                                        | time:7.240958ms, loops:1, rows:10 |
|   └─Limit_13         | 10.00 | cop  | offset:0, count:10                                   | time:3ms, loops:11, rows:10       |
|     └─Selection_12   | 10.00 | cop  | like(test.selection.b, "%a%", 92)                    | time:3ms, loops:10, rows:10       |
|       └─TableScan_11 | 12.50 | cop  | table:selection, range:[-inf,+inf], keep order:false | time:2ms, loops:50, rows:50       |
+------------------------------------------------------------------------------------------------------------------------------------+
```

