### PR TITLE
coprocessor: add support exec summary for TopN executor

### DIFF
--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -187,9 +187,12 @@ impl DAGBuilder {
                     src,
                     exec.take_aggregation(),
                 )?),
-                ExecType::TypeTopN => {
-                    Box::new(TopNExecutor::new(exec.take_topN(), Arc::clone(&ctx), src)?)
-                }
+                ExecType::TypeTopN => Box::new(TopNExecutor::new(
+                    C::new(summary_slot_index),
+                    exec.take_topN(),
+                    Arc::clone(&ctx),
+                    src,
+                )?),
                 ExecType::TypeLimit => Box::new(LimitExecutor::new(
                     C::new(summary_slot_index),
                     exec.take_limit(),

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -82,7 +82,9 @@ impl InnerExecutor for IndexInnerExecutor {
     }
 }
 
-impl<C: ExecSummaryCollector, S: Store> ScanExecutor<C, S, IndexInnerExecutor> {
+pub type IndexScanExecutor<C, S> = ScanExecutor<C, S, IndexInnerExecutor>;
+
+impl<C: ExecSummaryCollector, S: Store> IndexScanExecutor<C, S> {
     pub fn index_scan(
         summary_collector: C,
         mut meta: IndexScan,
@@ -127,8 +129,6 @@ impl<C: ExecSummaryCollector, S: Store> ScanExecutor<C, S, IndexInnerExecutor> {
         )
     }
 }
-
-pub type IndexScanExecutor<C, S> = ScanExecutor<C, S, IndexInnerExecutor>;
 
 #[cfg(test)]
 pub mod tests {

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -65,9 +65,7 @@ impl ExprColumnRefVisitor {
             }
             self.cols_offset.insert(offset);
         } else {
-            for sub_expr in expr.get_children() {
-                self.visit(sub_expr)?;
-            }
+            self.batch_visit(expr.get_children())?;
         }
         Ok(())
     }

--- a/src/coprocessor/dag/executor/table_scan.rs
+++ b/src/coprocessor/dag/executor/table_scan.rs
@@ -56,7 +56,9 @@ impl InnerExecutor for TableInnerExecutor {
     }
 }
 
-impl<C: ExecSummaryCollector, S: Store> ScanExecutor<C, S, TableInnerExecutor> {
+pub type TableScanExecutor<C, S> = ScanExecutor<C, S, TableInnerExecutor>;
+
+impl<C: ExecSummaryCollector, S: Store> TableScanExecutor<C, S> {
     pub fn table_scan(
         summary_collector: C,
         mut meta: TableScan,
@@ -76,8 +78,6 @@ impl<C: ExecSummaryCollector, S: Store> ScanExecutor<C, S, TableInnerExecutor> {
         )
     }
 }
-
-pub type TableScanExecutor<C, S> = ScanExecutor<C, S, TableInnerExecutor>;
 
 #[cfg(test)]
 mod tests {

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -116,10 +116,7 @@ impl<C: ExecSummaryCollector> TopNExecutor<C> {
             self.fetch_all()?;
         }
         let iter = self.iter.as_mut().unwrap();
-        match iter.next() {
-            Some(sort_row) => Ok(Some(sort_row)),
-            None => Ok(None),
-        }
+        Ok(iter.next())
     }
 }
 

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -114,11 +114,11 @@ impl<C: ExecSummaryCollector> TopNExecutor<C> {
 
 impl<C: ExecSummaryCollector> Executor for TopNExecutor<C> {
     fn next(&mut self) -> Result<Option<Row>> {
+        let timer = self.summary_collector.on_start_iterate();
         if self.iter.is_none() {
             self.fetch_all()?;
         }
         let iter = self.iter.as_mut().unwrap();
-        let timer = self.summary_collector.on_start_iterate();
         match iter.next() {
             Some(sort_row) => {
                 self.summary_collector.on_finish_iterate(timer, 1);

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -11,7 +11,7 @@ use tipb::expression::ByItem;
 use super::topn_heap::TopNHeap;
 use super::{Executor, ExecutorMetrics, ExprColumnRefVisitor, Row};
 use crate::coprocessor::codec::datum::Datum;
-use crate::coprocessor::dag::exec_summary::ExecSummary;
+use crate::coprocessor::dag::exec_summary::{ExecSummary, ExecSummaryCollector};
 use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
 use crate::coprocessor::Result;
 
@@ -43,7 +43,8 @@ impl OrderBy {
 
 /// Retrieves rows from the source executor, orders rows according to expressions and produces part
 /// of the rows.
-pub struct TopNExecutor {
+pub struct TopNExecutor<C: ExecSummaryCollector> {
+    summary_collector: C,
     order_by: OrderBy,
     related_cols_offset: Vec<usize>, // offset of related columns
     iter: Option<IntoIter<Row>>,
@@ -54,12 +55,13 @@ pub struct TopNExecutor {
     first_collect: bool,
 }
 
-impl TopNExecutor {
+impl<C: ExecSummaryCollector> TopNExecutor<C> {
     pub fn new(
+        summary_collector: C,
         mut meta: TopN,
         eval_cfg: Arc<EvalConfig>,
         src: Box<dyn Executor + Send>,
-    ) -> Result<TopNExecutor> {
+    ) -> Result<Self> {
         let order_by = meta.take_order_by().into_vec();
 
         let mut visitor = ExprColumnRefVisitor::new(src.get_len_of_columns());
@@ -69,6 +71,7 @@ impl TopNExecutor {
         let mut eval_ctx = EvalContext::new(Arc::clone(&eval_cfg));
         let order_by = OrderBy::new(&mut eval_ctx, order_by)?;
         Ok(TopNExecutor {
+            summary_collector,
             order_by,
             related_cols_offset: visitor.column_offsets(),
             iter: None,
@@ -109,15 +112,22 @@ impl TopNExecutor {
     }
 }
 
-impl Executor for TopNExecutor {
+impl<C: ExecSummaryCollector> Executor for TopNExecutor<C> {
     fn next(&mut self) -> Result<Option<Row>> {
         if self.iter.is_none() {
             self.fetch_all()?;
         }
         let iter = self.iter.as_mut().unwrap();
+        let timer = self.summary_collector.on_start_iterate();
         match iter.next() {
-            Some(sort_row) => Ok(Some(sort_row)),
-            None => Ok(None),
+            Some(sort_row) => {
+                self.summary_collector.on_finish_iterate(timer, 1);
+                Ok(Some(sort_row))
+            }
+            None => {
+                self.summary_collector.on_finish_iterate(timer, 0);
+                Ok(None)
+            }
         }
     }
 
@@ -133,6 +143,15 @@ impl Executor for TopNExecutor {
         }
     }
 
+    fn collect_execution_summaries(&mut self, target: &mut [ExecSummary]) {
+        self.src.collect_execution_summaries(target);
+        self.summary_collector.collect_into(target);
+    }
+
+    fn get_len_of_columns(&self) -> usize {
+        self.src.get_len_of_columns()
+    }
+
     fn take_eval_warnings(&mut self) -> Option<EvalWarnings> {
         if let Some(mut warnings) = self.src.take_eval_warnings() {
             if let Some(mut topn_warnings) = self.eval_warnings.take() {
@@ -142,14 +161,6 @@ impl Executor for TopNExecutor {
         } else {
             self.eval_warnings.take()
         }
-    }
-
-    fn get_len_of_columns(&self) -> usize {
-        self.src.get_len_of_columns()
-    }
-
-    fn collect_execution_summaries(&mut self, target: &mut [ExecSummary]) {
-        self.src.collect_execution_summaries(target);
     }
 }
 
@@ -170,6 +181,7 @@ pub mod tests {
 
     use super::super::tests::*;
     use super::*;
+    use crate::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled;
 
     fn new_order_by(offset: i64, desc: bool) -> ByItem {
         let mut item = ByItem::new();
@@ -399,8 +411,13 @@ pub mod tests {
         let limit = 4;
         topn.set_limit(limit);
         // init topn executor
-        let mut topn_ect =
-            TopNExecutor::new(topn, Arc::new(EvalConfig::default()), ts_ect).unwrap();
+        let mut topn_ect = TopNExecutor::new(
+            ExecSummaryCollectorDisabled,
+            topn,
+            Arc::new(EvalConfig::default()),
+            ts_ect,
+        )
+        .unwrap();
         let mut topn_rows = Vec::with_capacity(limit as usize);
         while let Some(row) = topn_ect.next().unwrap() {
             topn_rows.push(row.take_origin());
@@ -444,8 +461,13 @@ pub mod tests {
         topn.set_order_by(RepeatedField::from_vec(ob_vec));
         // test with limit=0
         topn.set_limit(0);
-        let mut topn_ect =
-            TopNExecutor::new(topn, Arc::new(EvalConfig::default()), ts_ect).unwrap();
+        let mut topn_ect = TopNExecutor::new(
+            ExecSummaryCollectorDisabled,
+            topn,
+            Arc::new(EvalConfig::default()),
+            ts_ect,
+        )
+        .unwrap();
         assert!(topn_ect.next().unwrap().is_none());
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Add support exec summary for TopN executor

## What are the type of the changes? (mandatory)

- New feature (change which adds functionality)

## How has this PR been tested? (mandatory)

Manually

Generate random data
```shell
tidiff 'create table topn(a bigint(10) not null auto_increment primary key, b varchar(20), c bigint(20))'
tififf '!! {{$count:=count 1000}} insert into topn (a, b, c) values {{range $index := $count}}(NULL, "{{varchar 20}}", {{int 1 1000}}) {{if head $index $count}},{{end}} {{end}}'
```

```
TiDB(127.0.0.1:4000)> explain analyze select * from topn where b like "%a%" order by c limit 10
+------------------------------------------------------------------------------------------------------------------------------------------------+
| id                       | count    | task | operator info                                                 | execution info                    |
+------------------------------------------------------------------------------------------------------------------------------------------------+
| TopN_8                   | 10.00    | root | test.topn.c:asc, offset:0, count:10                           | time:2.064582ms, loops:2, rows:10 |
| └─TableReader_17     | 10.00    | root | data:TopN_16                                                  | time:2.049292ms, loops:2, rows:10 |
|   └─TopN_16          | 10.00    | cop  | test.topn.c:asc, offset:0, count:10                           | time:0s, loops:11, rows:10        |
|     └─Selection_15   | 8000.00  | cop  | like(test.topn.b, "%a%", 92)                                  | time:1ms, loops:201, rows:200     |
|       └─TableScan_14 | 10000.00 | cop  | table:topn, range:[-inf,+inf], keep order:false, stats:pseudo | time:1ms, loops:1001, rows:1000   |
+------------------------------------------------------------------------------------------------------------------------------------------------+
5 row in set (0.007 sec)
```