### PR TITLE
coprocessor: move ExecSummaryCollector out of Executors into a wrapper struct

### DIFF
--- a/benches/coprocessor_executors/mod.rs
+++ b/benches/coprocessor_executors/mod.rs
@@ -10,7 +10,6 @@ use tipb::executor::{IndexScan, TableScan};
 
 use test_coprocessor::*;
 use tikv::coprocessor::codec::Datum;
-use tikv::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled;
 use tikv::coprocessor::dag::executor::Executor;
 use tikv::storage::RocksEngine;
 
@@ -25,7 +24,6 @@ fn bench_table_scan_next(
     b.iter_with_setup(
         || {
             let mut executor = TableScanExecutor::table_scan(
-                ExecSummaryCollectorDisabled,
                 meta.clone(),
                 ranges.to_vec(),
                 store.to_fixture_store(),
@@ -416,7 +414,6 @@ fn bench_table_scan_multi_point_range(c: &mut Criterion) {
                     ranges.push(table.get_record_range_one(i));
                 }
                 let mut executor = TableScanExecutor::table_scan(
-                    ExecSummaryCollectorDisabled,
                     meta.clone(),
                     ranges,
                     store.to_fixture_store(),
@@ -473,7 +470,6 @@ fn bench_table_scan_multi_rows(c: &mut Criterion) {
         b.iter_with_setup(
             || {
                 let mut executor = TableScanExecutor::table_scan(
-                    ExecSummaryCollectorDisabled,
                     meta.clone(),
                     vec![table.get_record_range_all()],
                     store.to_fixture_store(),
@@ -507,7 +503,6 @@ fn bench_index_scan_next(
     b.iter_with_setup(
         || {
             let mut executor = IndexScanExecutor::index_scan(
-                ExecSummaryCollectorDisabled,
                 meta.clone(),
                 ranges.to_vec(),
                 store.to_fixture_store(),

--- a/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
@@ -14,7 +14,6 @@ use crate::coprocessor::dag::aggr_fn::*;
 use crate::coprocessor::dag::batch::executors::util::aggr_executor::*;
 use crate::coprocessor::dag::batch::executors::util::hash_aggr_helper::HashAggregationHelper;
 use crate::coprocessor::dag::batch::interface::*;
-use crate::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled;
 use crate::coprocessor::dag::expr::EvalConfig;
 use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
 use crate::coprocessor::Result;
@@ -30,13 +29,11 @@ macro_rules! match_template_hashable {
 
 /// Fast Hash Aggregation Executor uses hash when comparing group key. It only supports one
 /// group by column.
-pub struct BatchFastHashAggregationExecutor<C: ExecSummaryCollector, Src: BatchExecutor>(
-    AggregationExecutor<C, Src, FastHashAggregationImpl>,
+pub struct BatchFastHashAggregationExecutor<Src: BatchExecutor>(
+    AggregationExecutor<Src, FastHashAggregationImpl>,
 );
 
-impl<C: ExecSummaryCollector, Src: BatchExecutor> BatchExecutor
-    for BatchFastHashAggregationExecutor<C, Src>
-{
+impl<Src: BatchExecutor> BatchExecutor for BatchFastHashAggregationExecutor<Src> {
     #[inline]
     fn schema(&self) -> &[FieldType] {
         self.0.schema()
@@ -53,7 +50,7 @@ impl<C: ExecSummaryCollector, Src: BatchExecutor> BatchExecutor
     }
 }
 
-impl<Src: BatchExecutor> BatchFastHashAggregationExecutor<ExecSummaryCollectorDisabled, Src> {
+impl<Src: BatchExecutor> BatchFastHashAggregationExecutor<Src> {
     #[cfg(test)]
     pub fn new_for_test(
         src: Src,
@@ -62,7 +59,6 @@ impl<Src: BatchExecutor> BatchFastHashAggregationExecutor<ExecSummaryCollectorDi
         aggr_def_parser: impl AggrDefinitionParser,
     ) -> Self {
         Self::new_impl(
-            ExecSummaryCollectorDisabled,
             Arc::new(EvalConfig::default()),
             src,
             group_by_exp,
@@ -73,7 +69,7 @@ impl<Src: BatchExecutor> BatchFastHashAggregationExecutor<ExecSummaryCollectorDi
     }
 }
 
-impl BatchFastHashAggregationExecutor<ExecSummaryCollectorDisabled, Box<dyn BatchExecutor>> {
+impl BatchFastHashAggregationExecutor<Box<dyn BatchExecutor>> {
     /// Checks whether this executor can be used.
     #[inline]
     pub fn check_supported(descriptor: &Aggregation) -> Result<()> {
@@ -105,9 +101,8 @@ impl BatchFastHashAggregationExecutor<ExecSummaryCollectorDisabled, Box<dyn Batc
     }
 }
 
-impl<C: ExecSummaryCollector, Src: BatchExecutor> BatchFastHashAggregationExecutor<C, Src> {
+impl<Src: BatchExecutor> BatchFastHashAggregationExecutor<Src> {
     pub fn new(
-        summary_collector: C,
         config: Arc<EvalConfig>,
         src: Src,
         group_by_exp_defs: Vec<Expr>,
@@ -120,7 +115,6 @@ impl<C: ExecSummaryCollector, Src: BatchExecutor> BatchFastHashAggregationExecut
             src.schema().len(),
         )?;
         Self::new_impl(
-            summary_collector,
             config,
             src,
             group_by_exp,
@@ -131,7 +125,6 @@ impl<C: ExecSummaryCollector, Src: BatchExecutor> BatchFastHashAggregationExecut
 
     #[inline]
     fn new_impl(
-        summary_collector: C,
         config: Arc<EvalConfig>,
         src: Src,
         group_by_exp: RpnExpression,
@@ -158,7 +151,6 @@ impl<C: ExecSummaryCollector, Src: BatchExecutor> BatchFastHashAggregationExecut
         };
 
         Ok(Self(AggregationExecutor::new(
-            summary_collector,
             aggr_impl,
             src,
             config,

--- a/src/coprocessor/dag/batch/executors/index_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/index_scan_executor.rs
@@ -16,21 +16,15 @@ use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
 use crate::coprocessor::dag::Scanner;
 use crate::coprocessor::{Error, Result};
 
-pub struct BatchIndexScanExecutor<C: ExecSummaryCollector, S: Store>(
+pub struct BatchIndexScanExecutor<S: Store>(
     super::util::scan_executor::ScanExecutor<
-        C,
         S,
         IndexScanExecutorImpl,
         super::util::ranges_iter::PointRangeConditional,
     >,
 );
 
-impl
-    BatchIndexScanExecutor<
-        crate::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled,
-        FixtureStore,
-    >
-{
+impl BatchIndexScanExecutor<FixtureStore> {
     /// Checks whether this executor can be used.
     #[inline]
     pub fn check_supported(descriptor: &IndexScan) -> Result<()> {
@@ -38,9 +32,8 @@ impl
     }
 }
 
-impl<C: ExecSummaryCollector, S: Store> BatchIndexScanExecutor<C, S> {
+impl<S: Store> BatchIndexScanExecutor<S> {
     pub fn new(
-        summary_collector: C,
         store: S,
         config: Arc<EvalConfig>,
         columns_info: Vec<ColumnInfo>,
@@ -79,7 +72,6 @@ impl<C: ExecSummaryCollector, S: Store> BatchIndexScanExecutor<C, S> {
             decode_handle,
         };
         let wrapper = super::util::scan_executor::ScanExecutor::new(
-            summary_collector,
             imp,
             store,
             desc,
@@ -90,7 +82,7 @@ impl<C: ExecSummaryCollector, S: Store> BatchIndexScanExecutor<C, S> {
     }
 }
 
-impl<C: ExecSummaryCollector, S: Store> BatchExecutor for BatchIndexScanExecutor<C, S> {
+impl<S: Store> BatchExecutor for BatchIndexScanExecutor<S> {
     #[inline]
     fn schema(&self) -> &[FieldType] {
         self.0.schema()
@@ -251,7 +243,6 @@ mod tests {
     use crate::coprocessor::codec::data_type::Real;
     use crate::coprocessor::codec::mysql::Tz;
     use crate::coprocessor::codec::{datum, table, Datum};
-    use crate::coprocessor::dag::exec_summary::*;
     use crate::coprocessor::dag::expr::EvalConfig;
     use crate::coprocessor::util::convert_to_prefix_next;
     use crate::storage::{FixtureStore, Key};
@@ -331,7 +322,6 @@ mod tests {
             }];
 
             let mut executor = BatchIndexScanExecutor::new(
-                ExecSummaryCollectorDisabled,
                 store.clone(),
                 Arc::new(EvalConfig::default()),
                 vec![columns_info[0].clone(), columns_info[1].clone()],
@@ -378,7 +368,6 @@ mod tests {
             }];
 
             let mut executor = BatchIndexScanExecutor::new(
-                ExecSummaryCollectorDisabled,
                 store.clone(),
                 Arc::new(EvalConfig::default()),
                 vec![
@@ -445,7 +434,6 @@ mod tests {
             }];
 
             let mut executor = BatchIndexScanExecutor::new(
-                ExecSummaryCollectorDisabled,
                 store.clone(),
                 Arc::new(EvalConfig::default()),
                 vec![
@@ -490,7 +478,6 @@ mod tests {
             }];
 
             let mut executor = BatchIndexScanExecutor::new(
-                ExecSummaryCollectorDisabled,
                 store.clone(),
                 Arc::new(EvalConfig::default()),
                 vec![

--- a/src/coprocessor/dag/batch/executors/selection_executor.rs
+++ b/src/coprocessor/dag/batch/executors/selection_executor.rs
@@ -58,9 +58,17 @@ impl<Src: BatchExecutor> BatchSelectionExecutor<Src> {
             conditions,
         })
     }
+}
+
+impl<Src: BatchExecutor> BatchExecutor for BatchSelectionExecutor<Src> {
+    #[inline]
+    fn schema(&self) -> &[FieldType] {
+        // The selection executor's schema comes from its child.
+        self.src.schema()
+    }
 
     #[inline]
-    fn handle_next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
+    fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
         let mut src_result = self.src.next_batch(scan_rows);
 
         // When there are errors during the `next_batch()` in the src executor, it means that the
@@ -103,19 +111,6 @@ impl<Src: BatchExecutor> BatchSelectionExecutor<Src> {
         // when there are errors.
         src_result.warnings.merge(&mut self.context.warnings);
         src_result
-    }
-}
-
-impl<Src: BatchExecutor> BatchExecutor for BatchSelectionExecutor<Src> {
-    #[inline]
-    fn schema(&self) -> &[FieldType] {
-        // The selection executor's schema comes from its child.
-        self.src.schema()
-    }
-
-    #[inline]
-    fn next_batch(&mut self, scan_rows: usize) -> BatchExecuteResult {
-        self.handle_next_batch(scan_rows)
     }
 
     #[inline]

--- a/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
@@ -85,7 +85,6 @@ impl<Src: BatchExecutor> BatchSimpleAggregationExecutor<Src> {
         let aggr_impl = SimpleAggregationImpl { states: Vec::new() };
 
         Ok(Self(AggregationExecutor::new(
-            summary_collector,
             aggr_impl,
             src,
             config,

--- a/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
@@ -101,22 +101,14 @@ pub struct Entities<Src: BatchExecutor> {
 
 /// A shared executor implementation for simple aggregation, hash aggregation and
 /// stream aggregation. Implementation differences are further given via `AggregationExecutorImpl`.
-pub struct AggregationExecutor<
-    C: ExecSummaryCollector,
-    Src: BatchExecutor,
-    I: AggregationExecutorImpl<Src>,
-> {
-    summary_collector: C,
+pub struct AggregationExecutor<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> {
     imp: I,
     is_ended: bool,
     entities: Entities<Src>,
 }
 
-impl<C: ExecSummaryCollector, Src: BatchExecutor, I: AggregationExecutorImpl<Src>>
-    AggregationExecutor<C, Src, I>
-{
+impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> AggregationExecutor<Src, I> {
     pub fn new(
-        summary_collector: C,
         mut imp: I,
         src: Src,
         config: Arc<EvalConfig>,
@@ -176,7 +168,6 @@ impl<C: ExecSummaryCollector, Src: BatchExecutor, I: AggregationExecutorImpl<Src
         imp.prepare_entities(&mut entities);
 
         Ok(Self {
-            summary_collector,
             imp,
             is_ended: false,
             entities,
@@ -261,8 +252,8 @@ impl<C: ExecSummaryCollector, Src: BatchExecutor, I: AggregationExecutorImpl<Src
     }
 }
 
-impl<C: ExecSummaryCollector, Src: BatchExecutor, I: AggregationExecutorImpl<Src>> BatchExecutor
-    for AggregationExecutor<C, Src, I>
+impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> BatchExecutor
+    for AggregationExecutor<Src, I>
 {
     #[inline]
     fn schema(&self) -> &[FieldType] {
@@ -273,10 +264,9 @@ impl<C: ExecSummaryCollector, Src: BatchExecutor, I: AggregationExecutorImpl<Src
     fn next_batch(&mut self, _scan_rows: usize) -> BatchExecuteResult {
         assert!(!self.is_ended);
 
-        let timer = self.summary_collector.on_start_iterate();
         let result = self.handle_next_batch();
 
-        let ret = match result {
+        match result {
             Err(e) => {
                 // When there are error, we can just return empty data.
                 self.is_ended = true;
@@ -303,18 +293,12 @@ impl<C: ExecSummaryCollector, Src: BatchExecutor, I: AggregationExecutorImpl<Src
                     is_drained: Ok(true),
                 }
             }
-        };
-
-        self.summary_collector
-            .on_finish_iterate(timer, ret.data.rows_len());
-        ret
+        }
     }
 
     #[inline]
     fn collect_statistics(&mut self, destination: &mut BatchExecuteStatistics) {
         self.entities.src.collect_statistics(destination);
-        self.summary_collector
-            .collect_into(&mut destination.summary_per_executor);
     }
 }
 

--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -95,29 +95,33 @@ impl DAGBuilder {
 
                 let mut descriptor = first_ed.take_tbl_scan();
                 let columns_info = descriptor.take_columns().into_vec();
-                executor = Box::new(BatchTableScanExecutor::new(
-                    C::new(summary_slot_index),
-                    store,
-                    config.clone(),
-                    columns_info,
-                    ranges,
-                    descriptor.get_desc(),
-                )?);
+                executor = Box::new(
+                    BatchTableScanExecutor::new(
+                        store,
+                        config.clone(),
+                        columns_info,
+                        ranges,
+                        descriptor.get_desc(),
+                    )?
+                    .with_summary_collector(C::new(summary_slot_index)),
+                );
             }
             ExecType::TypeIndexScan => {
                 COPR_EXECUTOR_COUNT.with_label_values(&["idxscan"]).inc();
 
                 let mut descriptor = first_ed.take_idx_scan();
                 let columns_info = descriptor.take_columns().into_vec();
-                executor = Box::new(BatchIndexScanExecutor::new(
-                    C::new(summary_slot_index),
-                    store,
-                    config.clone(),
-                    columns_info,
-                    ranges,
-                    descriptor.get_desc(),
-                    descriptor.get_unique(),
-                )?);
+                executor = Box::new(
+                    BatchIndexScanExecutor::new(
+                        store,
+                        config.clone(),
+                        columns_info,
+                        ranges,
+                        descriptor.get_desc(),
+                        descriptor.get_unique(),
+                    )?
+                    .with_summary_collector(C::new(summary_slot_index)),
+                );
             }
             _ => {
                 return Err(Error::Other(box_err!(
@@ -134,12 +138,14 @@ impl DAGBuilder {
                 ExecType::TypeSelection => {
                     COPR_EXECUTOR_COUNT.with_label_values(&["selection"]).inc();
 
-                    Box::new(BatchSelectionExecutor::new(
-                        C::new(summary_slot_index),
-                        config.clone(),
-                        executor,
-                        ed.take_selection().take_conditions().into_vec(),
-                    )?)
+                    Box::new(
+                        BatchSelectionExecutor::new(
+                            config.clone(),
+                            executor,
+                            ed.take_selection().take_conditions().into_vec(),
+                        )?
+                        .with_summary_collector(C::new(summary_slot_index)),
+                    )
                 }
                 ExecType::TypeAggregation | ExecType::TypeStreamAgg
                     if ed.get_aggregation().get_group_by().is_empty() =>
@@ -148,21 +154,22 @@ impl DAGBuilder {
                         .with_label_values(&["simple_aggregation"])
                         .inc();
 
-                    Box::new(BatchSimpleAggregationExecutor::new(
-                        C::new(summary_slot_index),
-                        config.clone(),
-                        executor,
-                        ed.mut_aggregation().take_agg_func().into_vec(),
-                    )?)
+                    Box::new(
+                        BatchSimpleAggregationExecutor::new(
+                            config.clone(),
+                            executor,
+                            ed.mut_aggregation().take_agg_func().into_vec(),
+                        )?
+                        .with_summary_collector(C::new(summary_slot_index)),
+                    )
                 }
                 ExecType::TypeLimit => {
                     COPR_EXECUTOR_COUNT.with_label_values(&["limit"]).inc();
 
-                    Box::new(BatchLimitExecutor::new(
-                        C::new(summary_slot_index),
-                        executor,
-                        ed.get_limit().get_limit() as usize,
-                    )?)
+                    Box::new(
+                        BatchLimitExecutor::new(executor, ed.get_limit().get_limit() as usize)?
+                            .with_summary_collector(C::new(summary_slot_index)),
+                    )
                 }
                 _ => {
                     return Err(Error::Other(box_err!(
@@ -202,35 +209,26 @@ impl DAGBuilder {
                 ExecType::TypeTableScan | ExecType::TypeIndexScan => {
                     return Err(box_err!("got too much *scan exec, should be only one"));
                 }
-                ExecType::TypeSelection => Box::new(SelectionExecutor::new(
-                    C::new(summary_slot_index),
-                    exec.take_selection(),
-                    Arc::clone(&ctx),
-                    src,
-                )?),
-                ExecType::TypeAggregation => Box::new(HashAggExecutor::new(
-                    C::new(summary_slot_index),
-                    exec.take_aggregation(),
-                    Arc::clone(&ctx),
-                    src,
-                )?),
-                ExecType::TypeStreamAgg => Box::new(StreamAggExecutor::new(
-                    C::new(summary_slot_index),
-                    Arc::clone(&ctx),
-                    src,
-                    exec.take_aggregation(),
-                )?),
-                ExecType::TypeTopN => Box::new(TopNExecutor::new(
-                    C::new(summary_slot_index),
-                    exec.take_topN(),
-                    Arc::clone(&ctx),
-                    src,
-                )?),
-                ExecType::TypeLimit => Box::new(LimitExecutor::new(
-                    C::new(summary_slot_index),
-                    exec.take_limit(),
-                    src,
-                )),
+                ExecType::TypeSelection => Box::new(
+                    SelectionExecutor::new(exec.take_selection(), Arc::clone(&ctx), src)?
+                        .with_summary_collector(C::new(summary_slot_index)),
+                ),
+                ExecType::TypeAggregation => Box::new(
+                    HashAggExecutor::new(exec.take_aggregation(), Arc::clone(&ctx), src)?
+                        .with_summary_collector(C::new(summary_slot_index)),
+                ),
+                ExecType::TypeStreamAgg => Box::new(
+                    StreamAggExecutor::new(Arc::clone(&ctx), src, exec.take_aggregation())?
+                        .with_summary_collector(C::new(summary_slot_index)),
+                ),
+                ExecType::TypeTopN => Box::new(
+                    TopNExecutor::new(exec.take_topN(), Arc::clone(&ctx), src)?
+                        .with_summary_collector(C::new(summary_slot_index)),
+                ),
+                ExecType::TypeLimit => Box::new(
+                    LimitExecutor::new(exec.take_limit(), src)
+                        .with_summary_collector(C::new(summary_slot_index)),
+                ),
             };
             src = curr;
         }
@@ -249,25 +247,24 @@ impl DAGBuilder {
     ) -> Result<Box<dyn Executor + Send>> {
         match first.get_tp() {
             ExecType::TypeTableScan => {
-                let ex = Box::new(ScanExecutor::table_scan(
-                    C::new(0),
-                    first.take_tbl_scan(),
-                    ranges,
-                    store,
-                    collect,
-                )?);
+                let ex = Box::new(
+                    ScanExecutor::table_scan(first.take_tbl_scan(), ranges, store, collect)?
+                        .with_summary_collector(C::new(0)),
+                );
                 Ok(ex)
             }
             ExecType::TypeIndexScan => {
                 let unique = first.get_idx_scan().get_unique();
-                let ex = Box::new(ScanExecutor::index_scan(
-                    C::new(0),
-                    first.take_idx_scan(),
-                    ranges,
-                    store,
-                    unique,
-                    collect,
-                )?);
+                let ex = Box::new(
+                    ScanExecutor::index_scan(
+                        first.take_idx_scan(),
+                        ranges,
+                        store,
+                        unique,
+                        collect,
+                    )?
+                    .with_summary_collector(C::new(0)),
+                );
                 Ok(ex)
             }
             _ => Err(box_err!(

--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -184,25 +184,29 @@ impl DAGBuilder {
                             .with_label_values(&["fast_hash_aggregation"])
                             .inc();
 
-                        Box::new(BatchFastHashAggregationExecutor::new(
-                            C::new(summary_slot_index),
-                            config.clone(),
-                            executor,
-                            ed.mut_aggregation().take_group_by().into_vec(),
-                            ed.mut_aggregation().take_agg_func().into_vec(),
-                        )?)
+                        Box::new(
+                            BatchFastHashAggregationExecutor::new(
+                                config.clone(),
+                                executor,
+                                ed.mut_aggregation().take_group_by().into_vec(),
+                                ed.mut_aggregation().take_agg_func().into_vec(),
+                            )?
+                            .with_summary_collector(C::new(summary_slot_index)),
+                        )
                     } else {
                         COPR_EXECUTOR_COUNT
                             .with_label_values(&["slow_hash_aggregation"])
                             .inc();
 
-                        Box::new(BatchSlowHashAggregationExecutor::new(
-                            C::new(summary_slot_index),
-                            config.clone(),
-                            executor,
-                            ed.mut_aggregation().take_group_by().into_vec(),
-                            ed.mut_aggregation().take_agg_func().into_vec(),
-                        )?)
+                        Box::new(
+                            BatchSlowHashAggregationExecutor::new(
+                                config.clone(),
+                                executor,
+                                ed.mut_aggregation().take_group_by().into_vec(),
+                                ed.mut_aggregation().take_agg_func().into_vec(),
+                            )?
+                            .with_summary_collector(C::new(summary_slot_index)),
+                        )
                     }
                 }
                 ExecType::TypeLimit => {

--- a/src/coprocessor/dag/exec_summary.rs
+++ b/src/coprocessor/dag/exec_summary.rs
@@ -94,3 +94,11 @@ impl ExecSummaryCollector for ExecSummaryCollectorDisabled {
     #[inline]
     fn collect_into(&mut self, _target: &mut [ExecSummary]) {}
 }
+
+/// Combines an `ExecSummaryCollector` with another type. This inner type `T`
+/// typically `Executor`/`BatchExecutor`, such that `WithSummaryCollector<C, T>`
+/// would implement the same trait and collects the statistics into `C`.
+pub struct WithSummaryCollector<C: ExecSummaryCollector, T> {
+    pub(super) summary_collector: C,
+    pub(super) inner: T,
+}

--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -10,7 +10,7 @@ use tipb::expression::{Expr, ExprType};
 use tikv_util::collections::{OrderMap, OrderMapEntry};
 
 use crate::coprocessor::codec::datum::{self, Datum};
-use crate::coprocessor::dag::exec_summary::{ExecSummary, ExecSummaryCollector};
+use crate::coprocessor::dag::exec_summary::ExecSummary;
 use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
 use crate::coprocessor::*;
 
@@ -64,8 +64,7 @@ impl dyn AggrFunc {
     }
 }
 
-struct AggExecutor<C: ExecSummaryCollector> {
-    summary_collector: C,
+struct AggExecutor {
     group_by: Vec<Expression>,
     aggr_func: Vec<AggFuncExpr>,
     executed: bool,
@@ -75,9 +74,8 @@ struct AggExecutor<C: ExecSummaryCollector> {
     first_collect: bool,
 }
 
-impl<C: ExecSummaryCollector> AggExecutor<C> {
+impl AggExecutor {
     fn new(
-        summary_collector: C,
         group_by: Vec<Expr>,
         aggr_func: Vec<Expr>,
         eval_config: Arc<EvalConfig>,
@@ -89,7 +87,6 @@ impl<C: ExecSummaryCollector> AggExecutor<C> {
         visitor.batch_visit(&aggr_func)?;
         let ctx = EvalContext::new(eval_config);
         Ok(AggExecutor {
-            summary_collector,
             group_by: Expression::batch_build(&ctx, group_by)?,
             aggr_func: AggFuncExpr::batch_build(&ctx, aggr_func)?,
             executed: false,
@@ -154,22 +151,21 @@ impl<C: ExecSummaryCollector> AggExecutor<C> {
 // HashAggExecutor deals with the aggregate functions.
 // When Next() is called, it reads all the data from src
 // and updates all the values in group_key_aggrs, then returns a result.
-pub struct HashAggExecutor<C: ExecSummaryCollector> {
-    inner: AggExecutor<C>,
+pub struct HashAggExecutor {
+    inner: AggExecutor,
     group_key_aggrs: OrderMap<Vec<u8>, Vec<Box<dyn AggrFunc>>>,
     cursor: usize,
 }
 
-impl<C: ExecSummaryCollector> HashAggExecutor<C> {
+impl HashAggExecutor {
     pub fn new(
-        summary_collector: C,
         mut meta: Aggregation,
         eval_config: Arc<EvalConfig>,
         src: Box<dyn Executor + Send>,
     ) -> Result<Self> {
         let group_bys = meta.take_group_by().into_vec();
         let aggs = meta.take_agg_func().into_vec();
-        let inner = AggExecutor::new(summary_collector, group_bys, aggs, eval_config, src)?;
+        let inner = AggExecutor::new(group_bys, aggs, eval_config, src)?;
         Ok(HashAggExecutor {
             inner,
             group_key_aggrs: OrderMap::new(),
@@ -241,16 +237,9 @@ impl<C: ExecSummaryCollector> HashAggExecutor<C> {
     }
 }
 
-impl<C: ExecSummaryCollector> Executor for HashAggExecutor<C> {
+impl Executor for HashAggExecutor {
     fn next(&mut self) -> Result<Option<Row>> {
-        let timer = self.inner.summary_collector.on_start_iterate();
-        let ret = self.next_impl();
-        if let Ok(Some(_)) = ret {
-            self.inner.summary_collector.on_finish_iterate(timer, 1)
-        } else {
-            self.inner.summary_collector.on_finish_iterate(timer, 0)
-        }
-        ret
+        self.next_impl()
     }
 
     fn collect_output_counts(&mut self, counts: &mut Vec<i64>) {
@@ -274,16 +263,9 @@ impl<C: ExecSummaryCollector> Executor for HashAggExecutor<C> {
     }
 }
 
-impl<C: ExecSummaryCollector> Executor for StreamAggExecutor<C> {
+impl Executor for StreamAggExecutor {
     fn next(&mut self) -> Result<Option<Row>> {
-        let timer = self.inner.summary_collector.on_start_iterate();
-        let ret = self.next_impl();
-        if let Ok(Some(_)) = ret {
-            self.inner.summary_collector.on_finish_iterate(timer, 1)
-        } else {
-            self.inner.summary_collector.on_finish_iterate(timer, 0)
-        }
-        ret
+        self.next_impl()
     }
 
     fn collect_output_counts(&mut self, counts: &mut Vec<i64>) {
@@ -310,8 +292,8 @@ impl<C: ExecSummaryCollector> Executor for StreamAggExecutor<C> {
 // StreamAggExecutor deals with the aggregation functions.
 // It assumes all the input data is sorted by group by key.
 // When next() is called, it finds a group and returns a result for the same group.
-pub struct StreamAggExecutor<C: ExecSummaryCollector> {
-    inner: AggExecutor<C>,
+pub struct StreamAggExecutor {
+    inner: AggExecutor,
     // save partial agg result
     agg_funcs: Vec<Box<dyn AggrFunc>>,
     cur_group_row: Vec<Datum>,
@@ -320,9 +302,8 @@ pub struct StreamAggExecutor<C: ExecSummaryCollector> {
     has_data: bool,
 }
 
-impl<C: ExecSummaryCollector> StreamAggExecutor<C> {
+impl StreamAggExecutor {
     pub fn new(
-        summary_collector: C,
         eval_config: Arc<EvalConfig>,
         src: Box<dyn Executor + Send>,
         mut meta: Aggregation,
@@ -330,7 +311,7 @@ impl<C: ExecSummaryCollector> StreamAggExecutor<C> {
         let group_bys = meta.take_group_by().into_vec();
         let aggs = meta.take_agg_func().into_vec();
         let group_len = group_bys.len();
-        let inner = AggExecutor::new(summary_collector, group_bys, aggs, eval_config, src)?;
+        let inner = AggExecutor::new(group_bys, aggs, eval_config, src)?;
         // Get aggregation functions.
         let mut funcs = Vec::with_capacity(inner.aggr_func.len());
         for expr in &inner.aggr_func {
@@ -440,7 +421,6 @@ mod tests {
     use crate::coprocessor::codec::datum::{self, Datum};
     use crate::coprocessor::codec::mysql::decimal::Decimal;
     use crate::coprocessor::codec::table;
-    use crate::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled;
     use crate::coprocessor::dag::scanner::tests::Data;
     use crate::storage::SnapshotStore;
     use tikv_util::collections::HashMap;
@@ -534,18 +514,11 @@ mod tests {
         let mut wrapper = IndexTestWrapper::new(unique, idx_data);
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let is_executor = IndexScanExecutor::index_scan(
-            ExecSummaryCollectorDisabled,
-            wrapper.scan,
-            wrapper.ranges,
-            store,
-            unique,
-            true,
-        )
-        .unwrap();
+        let is_executor =
+            IndexScanExecutor::index_scan(wrapper.scan, wrapper.ranges, store, unique, true)
+                .unwrap();
         // init the stream aggregation executor
         let mut agg_ect = StreamAggExecutor::new(
-            ExecSummaryCollectorDisabled,
             Arc::new(EvalConfig::default()),
             Box::new(is_executor),
             aggregation.clone(),
@@ -573,18 +546,11 @@ mod tests {
         let mut wrapper = IndexTestWrapper::new(unique, idx_data);
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let is_executor = IndexScanExecutor::index_scan(
-            ExecSummaryCollectorDisabled,
-            wrapper.scan,
-            wrapper.ranges,
-            store,
-            unique,
-            true,
-        )
-        .unwrap();
+        let is_executor =
+            IndexScanExecutor::index_scan(wrapper.scan, wrapper.ranges, store, unique, true)
+                .unwrap();
         // init the stream aggregation executor
         let mut agg_ect = StreamAggExecutor::new(
-            ExecSummaryCollectorDisabled,
             Arc::new(EvalConfig::default()),
             Box::new(is_executor),
             aggregation.clone(),
@@ -630,18 +596,11 @@ mod tests {
         let mut wrapper = IndexTestWrapper::new(unique, idx_data);
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let is_executor = IndexScanExecutor::index_scan(
-            ExecSummaryCollectorDisabled,
-            wrapper.scan,
-            wrapper.ranges,
-            store,
-            unique,
-            true,
-        )
-        .unwrap();
+        let is_executor =
+            IndexScanExecutor::index_scan(wrapper.scan, wrapper.ranges, store, unique, true)
+                .unwrap();
         // init the stream aggregation executor
         let mut agg_ect = StreamAggExecutor::new(
-            ExecSummaryCollectorDisabled,
             Arc::new(EvalConfig::default()),
             Box::new(is_executor),
             aggregation,
@@ -782,13 +741,8 @@ mod tests {
         let aggr_funcs = build_aggr_func(&aggr_funcs);
         aggregation.set_agg_func(RepeatedField::from_vec(aggr_funcs));
         // init the hash aggregation executor
-        let mut aggr_ect = HashAggExecutor::new(
-            ExecSummaryCollectorDisabled,
-            aggregation,
-            Arc::new(EvalConfig::default()),
-            ts_ect,
-        )
-        .unwrap();
+        let mut aggr_ect =
+            HashAggExecutor::new(aggregation, Arc::new(EvalConfig::default()), ts_ect).unwrap();
         let expect_row_cnt = 4;
         let mut row_data = Vec::with_capacity(expect_row_cnt);
         while let Some(Row::Agg(row)) = aggr_ect.next().unwrap() {

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use super::{scan::InnerExecutor, Row, ScanExecutor};
 use crate::coprocessor::codec::table;
-use crate::coprocessor::dag::exec_summary::ExecSummaryCollector;
 use crate::coprocessor::{util, Result};
 use crate::storage::Store;
 use kvproto::coprocessor::KeyRange;
@@ -82,11 +81,10 @@ impl InnerExecutor for IndexInnerExecutor {
     }
 }
 
-pub type IndexScanExecutor<C, S> = ScanExecutor<C, S, IndexInnerExecutor>;
+pub type IndexScanExecutor<S> = ScanExecutor<S, IndexInnerExecutor>;
 
-impl<C: ExecSummaryCollector, S: Store> IndexScanExecutor<C, S> {
+impl<S: Store> IndexScanExecutor<S> {
     pub fn index_scan(
-        summary_collector: C,
         mut meta: IndexScan,
         key_ranges: Vec<KeyRange>,
         store: S,
@@ -95,19 +93,10 @@ impl<C: ExecSummaryCollector, S: Store> IndexScanExecutor<C, S> {
     ) -> Result<Self> {
         let columns = meta.get_columns().to_vec();
         let inner = IndexInnerExecutor::new(&mut meta, unique);
-        Self::new(
-            summary_collector,
-            inner,
-            meta.get_desc(),
-            columns,
-            key_ranges,
-            store,
-            collect,
-        )
+        Self::new(inner, meta.get_desc(), columns, key_ranges, store, collect)
     }
 
     pub fn index_scan_with_cols_len(
-        summary_collector: C,
         cols: i64,
         key_ranges: Vec<KeyRange>,
         store: S,
@@ -118,15 +107,7 @@ impl<C: ExecSummaryCollector, S: Store> IndexScanExecutor<C, S> {
             pk_col: None,
             unique: false,
         };
-        Self::new(
-            summary_collector,
-            inner,
-            false,
-            vec![],
-            key_ranges,
-            store,
-            false,
-        )
+        Self::new(inner, false, vec![], key_ranges, store, false)
     }
 }
 
@@ -146,7 +127,6 @@ pub mod tests {
 
     use super::super::tests::*;
     use super::*;
-    use crate::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled;
     use crate::coprocessor::dag::executor::Executor;
     use crate::coprocessor::dag::scanner::tests::Data;
 
@@ -312,15 +292,9 @@ pub mod tests {
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
 
-        let mut scanner = IndexScanExecutor::index_scan(
-            ExecSummaryCollectorDisabled,
-            wrapper.scan,
-            wrapper.ranges,
-            store,
-            false,
-            false,
-        )
-        .unwrap();
+        let mut scanner =
+            IndexScanExecutor::index_scan(wrapper.scan, wrapper.ranges, store, false, false)
+                .unwrap();
 
         for handle in 0..KEY_NUMBER / 2 {
             let row = scanner.next().unwrap().unwrap().take_origin();
@@ -373,15 +347,9 @@ pub mod tests {
 
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let mut scanner = IndexScanExecutor::index_scan(
-            ExecSummaryCollectorDisabled,
-            wrapper.scan,
-            wrapper.ranges,
-            store,
-            unique,
-            true,
-        )
-        .unwrap();
+        let mut scanner =
+            IndexScanExecutor::index_scan(wrapper.scan, wrapper.ranges, store, unique, true)
+                .unwrap();
         for handle in 0..KEY_NUMBER {
             let row = scanner.next().unwrap().unwrap().take_origin();
             assert_eq!(row.handle, handle as i64);
@@ -432,15 +400,9 @@ pub mod tests {
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
 
-        let mut scanner = IndexScanExecutor::index_scan(
-            ExecSummaryCollectorDisabled,
-            wrapper.scan,
-            wrapper.ranges,
-            store,
-            unique,
-            false,
-        )
-        .unwrap();
+        let mut scanner =
+            IndexScanExecutor::index_scan(wrapper.scan, wrapper.ranges, store, unique, false)
+                .unwrap();
 
         for tid in 0..KEY_NUMBER {
             let handle = KEY_NUMBER - tid - 1;
@@ -463,15 +425,9 @@ pub mod tests {
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
 
-        let mut scanner = IndexScanExecutor::index_scan(
-            ExecSummaryCollectorDisabled,
-            wrapper.scan,
-            wrapper.ranges,
-            store,
-            false,
-            false,
-        )
-        .unwrap();
+        let mut scanner =
+            IndexScanExecutor::index_scan(wrapper.scan, wrapper.ranges, store, false, false)
+                .unwrap();
 
         for handle in 0..KEY_NUMBER {
             let row = scanner.next().unwrap().unwrap().take_origin();

--- a/src/coprocessor/dag/executor/limit.rs
+++ b/src/coprocessor/dag/executor/limit.rs
@@ -25,8 +25,10 @@ impl LimitExecutor {
             first_collect: true,
         }
     }
+}
 
-    fn next_impl(&mut self) -> Result<Option<Row>> {
+impl Executor for LimitExecutor {
+    fn next(&mut self) -> Result<Option<Row>> {
         if self.cursor >= self.limit {
             return Ok(None);
         }
@@ -36,12 +38,6 @@ impl LimitExecutor {
         } else {
             Ok(None)
         }
-    }
-}
-
-impl Executor for LimitExecutor {
-    fn next(&mut self) -> Result<Option<Row>> {
-        self.next_impl()
     }
 
     fn collect_output_counts(&mut self, _: &mut Vec<i64>) {

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -13,7 +13,9 @@ use tikv_util::collections::HashSet;
 
 use crate::coprocessor::codec::datum::{self, Datum, DatumEncoder};
 use crate::coprocessor::codec::table::{self, RowColsDict};
-use crate::coprocessor::dag::exec_summary::ExecSummary;
+use crate::coprocessor::dag::exec_summary::{
+    ExecSummary, ExecSummaryCollector, WithSummaryCollector,
+};
 use crate::coprocessor::dag::expr::{EvalContext, EvalWarnings};
 use crate::coprocessor::util;
 use crate::coprocessor::*;
@@ -255,13 +257,67 @@ pub trait Executor {
     fn stop_scan(&mut self) -> Option<KeyRange> {
         None
     }
+
+    fn with_summary_collector<C: ExecSummaryCollector>(
+        self,
+        summary_collector: C,
+    ) -> WithSummaryCollector<C, Self>
+    where
+        Self: Sized,
+    {
+        WithSummaryCollector {
+            summary_collector,
+            inner: self,
+        }
+    }
+}
+
+impl<C: ExecSummaryCollector, T: Executor> Executor for WithSummaryCollector<C, T> {
+    fn next(&mut self) -> Result<Option<Row>> {
+        let timer = self.summary_collector.on_start_iterate();
+        let ret = self.inner.next();
+        if let Ok(Some(_)) = ret {
+            self.summary_collector.on_finish_iterate(timer, 1);
+        } else {
+            self.summary_collector.on_finish_iterate(timer, 0);
+        }
+        ret
+    }
+
+    fn collect_output_counts(&mut self, counts: &mut Vec<i64>) {
+        self.inner.collect_output_counts(counts);
+    }
+
+    fn collect_metrics_into(&mut self, metrics: &mut ExecutorMetrics) {
+        self.inner.collect_metrics_into(metrics);
+    }
+
+    fn collect_execution_summaries(&mut self, target: &mut [ExecSummary]) {
+        self.inner.collect_execution_summaries(target);
+        self.summary_collector.collect_into(target);
+    }
+
+    fn get_len_of_columns(&self) -> usize {
+        self.inner.get_len_of_columns()
+    }
+
+    fn take_eval_warnings(&mut self) -> Option<EvalWarnings> {
+        self.inner.take_eval_warnings()
+    }
+
+    fn start_scan(&mut self) {
+        self.inner.start_scan();
+    }
+
+    fn stop_scan(&mut self) -> Option<KeyRange> {
+        self.inner.stop_scan()
+    }
 }
 
 #[cfg(test)]
 pub mod tests {
     use super::{Executor, TableScanExecutor};
     use crate::coprocessor::codec::{table, Datum};
-    use crate::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled;
     use crate::storage::kv::{Engine, Modify, RocksEngine, RocksSnapshot, TestEngineBuilder};
     use crate::storage::mvcc::MvccTxn;
     use crate::storage::SnapshotStore;
@@ -408,15 +464,6 @@ pub mod tests {
 
         let (snapshot, start_ts) = test_store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        Box::new(
-            TableScanExecutor::table_scan(
-                ExecSummaryCollectorDisabled,
-                table_scan,
-                key_ranges,
-                store,
-                true,
-            )
-            .unwrap(),
-        )
+        Box::new(TableScanExecutor::table_scan(table_scan, key_ranges, store, true).unwrap())
     }
 }

--- a/src/coprocessor/dag/executor/scan.rs
+++ b/src/coprocessor/dag/executor/scan.rs
@@ -116,8 +116,10 @@ impl<S: Store, T: InnerExecutor> ScanExecutor<S, T> {
         )
         .map_err(Error::from)
     }
+}
 
-    fn next_impl(&mut self) -> Result<Option<Row>> {
+impl<S: Store, T: InnerExecutor> Executor for ScanExecutor<S, T> {
+    fn next(&mut self) -> Result<Option<Row>> {
         loop {
             if let Some(row) = self.get_row_from_range_scanner()? {
                 self.inc_last_count();
@@ -146,12 +148,6 @@ impl<S: Store, T: InnerExecutor> ScanExecutor<S, T> {
             }
             return Ok(None);
         }
-    }
-}
-
-impl<S: Store, T: InnerExecutor> Executor for ScanExecutor<S, T> {
-    fn next(&mut self) -> Result<Option<Row>> {
-        self.next_impl()
     }
 
     fn collect_output_counts(&mut self, counts: &mut Vec<i64>) {

--- a/src/coprocessor/dag/executor/scan.rs
+++ b/src/coprocessor/dag/executor/scan.rs
@@ -7,7 +7,7 @@ use tipb::schema::ColumnInfo;
 
 use super::{Executor, ExecutorMetrics, Row};
 use crate::coprocessor::codec::table;
-use crate::coprocessor::dag::exec_summary::{ExecSummary, ExecSummaryCollector};
+use crate::coprocessor::dag::exec_summary::ExecSummary;
 use crate::coprocessor::{Error, Result};
 use crate::storage::{Key, Store};
 
@@ -31,8 +31,7 @@ pub trait InnerExecutor {
 }
 
 // Executor for table scan and index scan
-pub struct ScanExecutor<C: ExecSummaryCollector, S: Store, T: InnerExecutor> {
-    summary_collector: C,
+pub struct ScanExecutor<S: Store, T: InnerExecutor> {
     store: S,
     desc: bool,
     key_ranges: Peekable<IntoIter<KeyRange>>,
@@ -46,9 +45,8 @@ pub struct ScanExecutor<C: ExecSummaryCollector, S: Store, T: InnerExecutor> {
     first_collect: bool,
 }
 
-impl<C: ExecSummaryCollector, S: Store, T: InnerExecutor> ScanExecutor<C, S, T> {
+impl<S: Store, T: InnerExecutor> ScanExecutor<S, T> {
     pub fn new(
-        summary_collector: C,
         inner: T,
         desc: bool,
         columns: Vec<ColumnInfo>,
@@ -63,7 +61,6 @@ impl<C: ExecSummaryCollector, S: Store, T: InnerExecutor> ScanExecutor<C, S, T> 
         let counts = if collect { Some(Vec::default()) } else { None };
 
         Ok(Self {
-            summary_collector,
             inner,
             store,
             desc,
@@ -152,16 +149,9 @@ impl<C: ExecSummaryCollector, S: Store, T: InnerExecutor> ScanExecutor<C, S, T> 
     }
 }
 
-impl<C: ExecSummaryCollector, S: Store, T: InnerExecutor> Executor for ScanExecutor<C, S, T> {
+impl<S: Store, T: InnerExecutor> Executor for ScanExecutor<S, T> {
     fn next(&mut self) -> Result<Option<Row>> {
-        let timer = self.summary_collector.on_start_iterate();
-        let ret = self.next_impl();
-        if let Ok(Some(_)) = ret {
-            self.summary_collector.on_finish_iterate(timer, 1);
-        } else {
-            self.summary_collector.on_finish_iterate(timer, 0);
-        }
-        ret
+        self.next_impl()
     }
 
     fn collect_output_counts(&mut self, counts: &mut Vec<i64>) {
@@ -186,9 +176,7 @@ impl<C: ExecSummaryCollector, S: Store, T: InnerExecutor> Executor for ScanExecu
         }
     }
 
-    fn collect_execution_summaries(&mut self, target: &mut [ExecSummary]) {
-        self.summary_collector.collect_into(target);
-    }
+    fn collect_execution_summaries(&mut self, _: &mut [ExecSummary]) {}
 
     fn get_len_of_columns(&self) -> usize {
         self.columns.len()

--- a/src/coprocessor/dag/executor/selection.rs
+++ b/src/coprocessor/dag/executor/selection.rs
@@ -37,8 +37,10 @@ impl SelectionExecutor {
             first_collect: true,
         })
     }
+}
 
-    fn next_impl(&mut self) -> Result<Option<Row>> {
+impl Executor for SelectionExecutor {
+    fn next(&mut self) -> Result<Option<Row>> {
         'next: while let Some(row) = self.src.next()? {
             let row = row.take_origin();
             let cols = row.inflate_cols_with_offsets(&self.ctx, &self.related_cols_offset)?;
@@ -51,12 +53,6 @@ impl SelectionExecutor {
             return Ok(Some(Row::Origin(row)));
         }
         Ok(None)
-    }
-}
-
-impl Executor for SelectionExecutor {
-    fn next(&mut self) -> Result<Option<Row>> {
-        self.next_impl()
     }
 
     fn collect_output_counts(&mut self, counts: &mut Vec<i64>) {

--- a/src/coprocessor/dag/executor/table_scan.rs
+++ b/src/coprocessor/dag/executor/table_scan.rs
@@ -5,7 +5,6 @@ use tikv_util::collections::HashSet;
 
 use super::{scan::InnerExecutor, Row, ScanExecutor};
 use crate::coprocessor::codec::table;
-use crate::coprocessor::dag::exec_summary::ExecSummaryCollector;
 use crate::coprocessor::{util, Result};
 use crate::storage::Store;
 use kvproto::coprocessor::KeyRange;
@@ -56,11 +55,10 @@ impl InnerExecutor for TableInnerExecutor {
     }
 }
 
-pub type TableScanExecutor<C, S> = ScanExecutor<C, S, TableInnerExecutor>;
+pub type TableScanExecutor<S> = ScanExecutor<S, TableInnerExecutor>;
 
-impl<C: ExecSummaryCollector, S: Store> TableScanExecutor<C, S> {
+impl<S: Store> TableScanExecutor<S> {
     pub fn table_scan(
-        summary_collector: C,
         mut meta: TableScan,
         key_ranges: Vec<KeyRange>,
         store: S,
@@ -68,7 +66,6 @@ impl<C: ExecSummaryCollector, S: Store> TableScanExecutor<C, S> {
     ) -> Result<Self> {
         let inner = TableInnerExecutor::new(&meta);
         Self::new(
-            summary_collector,
             inner,
             meta.get_desc(),
             meta.take_columns().to_vec(),
@@ -94,7 +91,6 @@ mod tests {
         tests::{get_range, TestStore},
         Executor,
     };
-    use crate::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled;
 
     const TABLE_ID: i64 = 1;
     const KEY_NUMBER: usize = 10;
@@ -147,14 +143,9 @@ mod tests {
 
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let mut table_scanner = super::TableScanExecutor::table_scan(
-            ExecSummaryCollectorDisabled,
-            wrapper.table_scan,
-            wrapper.ranges,
-            store,
-            true,
-        )
-        .unwrap();
+        let mut table_scanner =
+            super::TableScanExecutor::table_scan(wrapper.table_scan, wrapper.ranges, store, true)
+                .unwrap();
 
         let row = table_scanner.next().unwrap().unwrap().take_origin();
         assert_eq!(row.handle, handle as i64);
@@ -189,14 +180,9 @@ mod tests {
 
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let mut table_scanner = super::TableScanExecutor::table_scan(
-            ExecSummaryCollectorDisabled,
-            wrapper.table_scan,
-            wrapper.ranges,
-            store,
-            true,
-        )
-        .unwrap();
+        let mut table_scanner =
+            super::TableScanExecutor::table_scan(wrapper.table_scan, wrapper.ranges, store, true)
+                .unwrap();
 
         for handle in 0..KEY_NUMBER {
             let row = table_scanner.next().unwrap().unwrap().take_origin();
@@ -230,14 +216,9 @@ mod tests {
 
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
         let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        let mut table_scanner = super::TableScanExecutor::table_scan(
-            ExecSummaryCollectorDisabled,
-            wrapper.table_scan,
-            wrapper.ranges,
-            store,
-            true,
-        )
-        .unwrap();
+        let mut table_scanner =
+            super::TableScanExecutor::table_scan(wrapper.table_scan, wrapper.ranges, store, true)
+                .unwrap();
 
         for tid in 0..KEY_NUMBER {
             let handle = KEY_NUMBER - tid - 1;

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -11,7 +11,7 @@ use tipb::expression::ByItem;
 use super::topn_heap::TopNHeap;
 use super::{Executor, ExecutorMetrics, ExprColumnRefVisitor, Row};
 use crate::coprocessor::codec::datum::Datum;
-use crate::coprocessor::dag::exec_summary::{ExecSummary, ExecSummaryCollector};
+use crate::coprocessor::dag::exec_summary::ExecSummary;
 use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
 use crate::coprocessor::Result;
 
@@ -43,8 +43,7 @@ impl OrderBy {
 
 /// Retrieves rows from the source executor, orders rows according to expressions and produces part
 /// of the rows.
-pub struct TopNExecutor<C: ExecSummaryCollector> {
-    summary_collector: C,
+pub struct TopNExecutor {
     order_by: OrderBy,
     related_cols_offset: Vec<usize>, // offset of related columns
     iter: Option<IntoIter<Row>>,
@@ -55,9 +54,8 @@ pub struct TopNExecutor<C: ExecSummaryCollector> {
     first_collect: bool,
 }
 
-impl<C: ExecSummaryCollector> TopNExecutor<C> {
+impl TopNExecutor {
     pub fn new(
-        summary_collector: C,
         mut meta: TopN,
         eval_cfg: Arc<EvalConfig>,
         src: Box<dyn Executor + Send>,
@@ -71,7 +69,6 @@ impl<C: ExecSummaryCollector> TopNExecutor<C> {
         let mut eval_ctx = EvalContext::new(Arc::clone(&eval_cfg));
         let order_by = OrderBy::new(&mut eval_ctx, order_by)?;
         Ok(TopNExecutor {
-            summary_collector,
             order_by,
             related_cols_offset: visitor.column_offsets(),
             iter: None,
@@ -120,16 +117,9 @@ impl<C: ExecSummaryCollector> TopNExecutor<C> {
     }
 }
 
-impl<C: ExecSummaryCollector> Executor for TopNExecutor<C> {
+impl Executor for TopNExecutor {
     fn next(&mut self) -> Result<Option<Row>> {
-        let timer = self.summary_collector.on_start_iterate();
-        let ret = self.next_impl();
-        if let Ok(Some(_)) = ret {
-            self.summary_collector.on_finish_iterate(timer, 1);
-        } else {
-            self.summary_collector.on_finish_iterate(timer, 0);
-        }
-        ret
+        self.next_impl()
     }
 
     fn collect_output_counts(&mut self, counts: &mut Vec<i64>) {
@@ -146,7 +136,6 @@ impl<C: ExecSummaryCollector> Executor for TopNExecutor<C> {
 
     fn collect_execution_summaries(&mut self, target: &mut [ExecSummary]) {
         self.src.collect_execution_summaries(target);
-        self.summary_collector.collect_into(target);
     }
 
     fn get_len_of_columns(&self) -> usize {
@@ -182,7 +171,6 @@ pub mod tests {
 
     use super::super::tests::*;
     use super::*;
-    use crate::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled;
 
     fn new_order_by(offset: i64, desc: bool) -> ByItem {
         let mut item = ByItem::new();
@@ -412,13 +400,8 @@ pub mod tests {
         let limit = 4;
         topn.set_limit(limit);
         // init topn executor
-        let mut topn_ect = TopNExecutor::new(
-            ExecSummaryCollectorDisabled,
-            topn,
-            Arc::new(EvalConfig::default()),
-            ts_ect,
-        )
-        .unwrap();
+        let mut topn_ect =
+            TopNExecutor::new(topn, Arc::new(EvalConfig::default()), ts_ect).unwrap();
         let mut topn_rows = Vec::with_capacity(limit as usize);
         while let Some(row) = topn_ect.next().unwrap() {
             topn_rows.push(row.take_origin());
@@ -462,13 +445,8 @@ pub mod tests {
         topn.set_order_by(RepeatedField::from_vec(ob_vec));
         // test with limit=0
         topn.set_limit(0);
-        let mut topn_ect = TopNExecutor::new(
-            ExecSummaryCollectorDisabled,
-            topn,
-            Arc::new(EvalConfig::default()),
-            ts_ect,
-        )
-        .unwrap();
+        let mut topn_ect =
+            TopNExecutor::new(topn, Arc::new(EvalConfig::default()), ts_ect).unwrap();
         assert!(topn_ect.next().unwrap().is_none());
     }
 }

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -107,19 +107,15 @@ impl TopNExecutor {
         self.eval_warnings = Some(ctx.borrow_mut().take_warnings());
         Ok(())
     }
+}
 
-    fn next_impl(&mut self) -> Result<Option<Row>> {
+impl Executor for TopNExecutor {
+    fn next(&mut self) -> Result<Option<Row>> {
         if self.iter.is_none() {
             self.fetch_all()?;
         }
         let iter = self.iter.as_mut().unwrap();
         Ok(iter.next())
-    }
-}
-
-impl Executor for TopNExecutor {
-    fn next(&mut self) -> Result<Option<Row>> {
-        self.next_impl()
     }
 
     fn collect_output_counts(&mut self, counts: &mut Vec<i64>) {


### PR DESCRIPTION
Signed-off-by: kennytm <kennytm@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Removed the `ExecSummaryCollector` field from *all* Executors and BatchExecutors. Instead, introduced a `WithSummaryCollector<C, T>` struct as a wrapper of the concrete executors, and implement the traits on it.

The main purpose is to factor out the repetition of the pattern `on_start_iterate() ... on_finish_iterate()`.

Note: Currently `WithSummaryCollector` will _always_ execute `summary_collector.collect_into()` inside `collect_statistics()`, but it was not always the case in the original implementation. I'm not sure if this is dedicated or just an oversight. We could add a flag to control this behavior if the omission is indeed dedicated.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

```
cargo test -- coprocessor
```

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

