### PR TITLE
Impl Eq and Hash for all evaluable

### DIFF
--- a/src/coprocessor/codec/data_type/mod.rs
+++ b/src/coprocessor/codec/data_type/mod.rs
@@ -65,7 +65,9 @@ where
 }
 
 /// A trait of all types that can be used during evaluation (eval type).
-pub trait Evaluable: Clone + std::fmt::Debug + Send + Sync + 'static {
+pub trait Evaluable:
+    Clone + std::fmt::Debug + Send + Sync + Eq + std::hash::Hash + 'static
+{
     const EVAL_TYPE: EvalType;
 
     /// Borrows this concrete type from a `ScalarValue` in the same type.

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -1834,7 +1834,6 @@ mod tests {
             ),
             (Datum::Bytes(b"[1, 2, 3]".to_vec()), "[1, 2, 3]"),
             (Datum::Bytes(b"{}".to_vec()), "{}"),
-            (Datum::I64(1), "true"),
         ];
 
         for (d, json) in tests {

--- a/src/coprocessor/codec/mysql/decimal.rs
+++ b/src/coprocessor/codec/mysql/decimal.rs
@@ -2113,6 +2113,15 @@ impl PartialOrd for Decimal {
     }
 }
 
+impl std::hash::Hash for Decimal {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.int_cnt.hash(state);
+        self.frac_cnt.hash(state);
+        self.negative.hash(state);
+        self.word_buf.hash(state);
+    }
+}
+
 impl Eq for Decimal {}
 
 impl Ord for Decimal {

--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -280,6 +280,13 @@ impl PartialEq for Duration {
     }
 }
 
+impl std::hash::Hash for Duration {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.neg.hash(state);
+        self.dur.hash(state);
+    }
+}
+
 impl PartialOrd for Duration {
     fn partial_cmp(&self, dur: &Duration) -> Option<Ordering> {
         Some(match (self.neg, dur.neg) {

--- a/src/coprocessor/codec/mysql/json/comparison.rs
+++ b/src/coprocessor/codec/mysql/json/comparison.rs
@@ -63,17 +63,14 @@ impl PartialEq for Json {
 }
 
 impl PartialOrd for Json {
+    // FIXME: The following logic is not exactly the same as MySQL.
     fn partial_cmp(&self, right: &Json) -> Option<Ordering> {
         let precedence_diff = self.get_precedence() - right.get_precedence();
         if precedence_diff == 0 {
             if self.get_precedence() == PRECEDENCE_NUMBER {
                 let left_data = self.as_f64().unwrap();
                 let right_data = right.as_f64().unwrap();
-                if (left_data - right_data).abs() < f64::EPSILON {
-                    return Some(Ordering::Equal);
-                } else {
-                    return left_data.partial_cmp(&right_data);
-                }
+                return left_data.partial_cmp(&right_data);
             }
 
             return match (self, right) {
@@ -97,20 +94,30 @@ impl PartialOrd for Json {
             };
         }
 
-        let left_data = self.as_f64();
-        let right_data = right.as_f64();
-        // tidb treats boolean as integer, but boolean is different from integer in JSON.
-        // so we need convert them to same type and then compare.
-        if left_data.is_ok() && right_data.is_ok() {
-            let left = left_data.unwrap();
-            let right = right_data.unwrap();
-            return left.partial_cmp(&right);
-        }
-
         if precedence_diff > 0 {
             Some(Ordering::Greater)
         } else {
             Some(Ordering::Less)
+        }
+    }
+}
+
+impl std::hash::Hash for Json {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let p = self.get_precedence();
+        if p == PRECEDENCE_NUMBER {
+            let f = ordered_float::NotNan::new(self.as_f64().unwrap()).unwrap();
+            f.hash(state);
+        } else {
+            p.hash(state);
+            match self {
+                Json::Boolean(v) => v.hash(state),
+                Json::String(v) => v.hash(state),
+                Json::Array(v) => v.hash(state),
+                Json::Object(v) => v.hash(state),
+                Json::None => {}
+                _ => unreachable!(),
+            }
         }
     }
 }
@@ -144,8 +151,6 @@ mod tests {
         let test_cases = vec![
             ("1.5", "2"),
             ("1.5", "false"),
-            ("true", "1.5"),
-            ("true", "2"),
             ("null", r#"{"a": "b"}"#),
             ("2", r#""hello, world""#),
             (r#""hello, world""#, r#"{"a": "b"}"#),
@@ -158,7 +163,5 @@ mod tests {
             let right: Json = right_str.parse().unwrap();
             assert!(left < right);
         }
-
-        assert_eq!(Json::I64(2), Json::Boolean(false));
     }
 }

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -771,6 +771,12 @@ impl PartialEq for Time {
     }
 }
 
+impl std::hash::Hash for Time {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.time.hash(state);
+    }
+}
+
 impl Eq for Time {}
 
 impl Ord for Time {


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR implements Eq and Hash for all evaluable types, so that they can be used in HashMaps.

About the change in JSON:

- According to https://github.com/pingcap/tidb/issues/10461 MySQL does not do epsilon aware comparing.
- According to [TiDB's implementation](https://github.com/pingcap/tidb/blob/545afc5a3a0fc806b02324c39d6dd01387a04b80/types/json/binary_functions.go#L638) and my own experiment, we should not cast data to f64 any more when data is not numeric. We should only do precedence compare.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Existing unit tests (some incorrect cases are dropped).
