### PR TITLE
storage: waking up pending transactions shouldn't be done in apply threads

### DIFF
--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -5,8 +5,7 @@ use super::*;
 use kvproto::kvrpcpb::Context;
 
 use tikv::coprocessor::codec::Datum;
-use tikv::coprocessor::Endpoint;
-use tikv::server::readpool;
+use tikv::coprocessor::{readpool_impl, Endpoint};
 use tikv::server::Config;
 use tikv::storage::kv::RocksEngine;
 use tikv::storage::{Engine, TestEngineBuilder};
@@ -79,8 +78,8 @@ pub fn init_data_with_details<E: Engine>(
         store.commit_with_ctx(ctx);
     }
 
-    let pool = readpool::Builder::build_for_test();
-    let cop = Endpoint::new(cfg, store.get_engine(), pool);
+    let pool = readpool_impl::build_read_pool_for_test(store.get_engine());
+    let cop = Endpoint::new(cfg, pool);
     (store, cop)
 }
 

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -131,7 +131,7 @@ impl Simulator for ServerCluster {
         let pd_worker = FutureWorker::new("test-pd-worker");
         let storage_read_pool = readpool::Builder::build_for_test();
         let store = create_raft_storage(
-            sim_router.clone(),
+            RaftKv::new(sim_router.clone()),
             &cfg.storage,
             storage_read_pool,
             None,

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -158,8 +158,9 @@ impl Simulator for ServerCluster {
         let snap_mgr = SnapManager::new(tmp_str, Some(router.clone()));
         let server_cfg = Arc::new(cfg.server.clone());
         let security_mgr = Arc::new(SecurityManager::new(&cfg.security).unwrap());
-        let cop_read_pool = readpool::Builder::build_for_test();
-        let cop = coprocessor::Endpoint::new(&server_cfg, store.get_engine(), cop_read_pool);
+        let cop_read_pool =
+            coprocessor::readpool_impl::build_read_pool_for_test(store.get_engine());
+        let cop = coprocessor::Endpoint::new(&server_cfg, cop_read_pool);
         let mut server = None;
         for _ in 0..100 {
             server = Some(Server::new(

--- a/src/binutil/server.rs
+++ b/src/binutil/server.rs
@@ -16,6 +16,7 @@ use crate::server::status_server::StatusServer;
 use crate::server::transport::ServerRaftStoreRouter;
 use crate::server::DEFAULT_CLUSTER_ID;
 use crate::server::{create_raft_storage, Node, Server};
+use crate::storage::kv::raftkv::RaftKv;
 use crate::storage::lock_manager::{
     Detector, DetectorScheduler, Service as DeadlockService, WaiterManager, WaiterMgrScheduler,
 };
@@ -185,9 +186,12 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
 
     let engines = Engines::new(Arc::new(kv_engine), Arc::new(raft_engine), cache.is_some());
 
+    let engine = RaftKv::new(raft_router.clone());
+
     let storage_read_pool = storage::readpool_impl::build_read_pool(
         &cfg.readpool.storage.build_config(),
         pd_sender.clone(),
+        engine.clone(),
     );
 
     // Create waiter manager worker and deadlock detector worker if pessimistic-txn is enabled
@@ -211,7 +215,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     };
 
     let storage = create_raft_storage(
-        raft_router.clone(),
+        engine.clone(),
         &cfg.storage,
         storage_read_pool,
         Some(engines.kv.clone()),
@@ -247,8 +251,9 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     let cop_read_pool = coprocessor::readpool_impl::build_read_pool(
         &cfg.readpool.coprocessor.build_config(),
         pd_sender.clone(),
+        engine.clone(),
     );
-    let cop = coprocessor::Endpoint::new(&server_cfg, storage.get_engine(), cop_read_pool);
+    let cop = coprocessor::Endpoint::new(&server_cfg, engine.clone(), cop_read_pool);
     let mut server = Server::new(
         &server_cfg,
         &security_mgr,

--- a/src/binutil/server.rs
+++ b/src/binutil/server.rs
@@ -253,7 +253,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
         pd_sender.clone(),
         engine.clone(),
     );
-    let cop = coprocessor::Endpoint::new(&server_cfg, engine.clone(), cop_read_pool);
+    let cop = coprocessor::Endpoint::new(&server_cfg, cop_read_pool);
     let mut server = Server::new(
         &server_cfg,
         &security_mgr,

--- a/src/coprocessor/readpool_impl.rs
+++ b/src/coprocessor/readpool_impl.rs
@@ -1,9 +1,12 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::cell::RefCell;
+use std::sync::{Arc, Mutex};
 
 use crate::pd::PdTask;
-use crate::server::readpool::{self, Builder, ReadPool};
+use crate::server::readpool::{self, Builder, Config, ReadPool};
+use crate::storage::kv::{destroy_tls_engine, set_tls_engine};
+use crate::storage::Engine;
 use tikv_util::collections::HashMap;
 use tikv_util::worker::FutureScheduler;
 
@@ -55,13 +58,31 @@ thread_local! {
     );
 }
 
-pub fn build_read_pool(config: &readpool::Config, pd_sender: FutureScheduler<PdTask>) -> ReadPool {
+pub fn build_read_pool<E: Engine>(
+    config: &readpool::Config,
+    pd_sender: FutureScheduler<PdTask>,
+    engine: E,
+) -> ReadPool {
     let pd_sender2 = pd_sender.clone();
+    let engine = Arc::new(Mutex::new(engine));
 
     Builder::from_config(config)
         .name_prefix("cop")
         .on_tick(move || tls_flush(&pd_sender))
-        .before_stop(move || tls_flush(&pd_sender2))
+        .after_start(move || set_tls_engine(engine.lock().unwrap().clone()))
+        .before_stop(move || {
+            destroy_tls_engine::<E>();
+            tls_flush(&pd_sender2)
+        })
+        .build()
+}
+
+pub fn build_read_pool_for_test<E: Engine>(engine: E) -> ReadPool {
+    let engine = Arc::new(Mutex::new(engine));
+
+    Builder::from_config(&Config::default_for_test())
+        .after_start(move || set_tls_engine(engine.lock().unwrap().clone()))
+        .before_stop(|| destroy_tls_engine::<E>())
         .build()
 }
 

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -32,7 +32,7 @@ const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
 /// Creates a new storage engine which is backed by the Raft consensus
 /// protocol.
 pub fn create_raft_storage<S>(
-    router: S,
+    engine: RaftKv<S>,
     cfg: &StorageConfig,
     read_pool: ReadPool,
     local_storage: Option<Arc<DB>>,
@@ -43,7 +43,6 @@ pub fn create_raft_storage<S>(
 where
     S: RaftStoreRouter + 'static,
 {
-    let engine = RaftKv::new(router);
     let store = Storage::from_engine(
         engine,
         cfg,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -247,9 +247,9 @@ mod tests {
     use crate::raftstore::store::transport::Transport;
     use crate::raftstore::store::*;
     use crate::raftstore::Result as RaftStoreResult;
-    use crate::server::readpool;
     use crate::storage::TestStorageBuilder;
 
+    use crate::coprocessor::readpool_impl;
     use kvproto::raft_cmdpb::RaftCmdRequest;
     use kvproto::raft_serverpb::RaftMessage;
     use tikv_util::security::SecurityConfig;
@@ -332,8 +332,8 @@ mod tests {
         let cfg = Arc::new(cfg);
         let security_mgr = Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap());
 
-        let cop_read_pool = readpool::Builder::build_for_test();
-        let cop = coprocessor::Endpoint::new(&cfg, storage.get_engine(), cop_read_pool);
+        let cop_read_pool = readpool_impl::build_read_pool_for_test(storage.get_engine());
+        let cop = coprocessor::Endpoint::new(&cfg, cop_read_pool);
 
         let addr = Arc::new(Mutex::new(None));
         let mut server = Server::new(

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -1,9 +1,9 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::cell::Cell;
+use std::cell::{Cell, UnsafeCell};
 use std::cmp::Ordering;
 use std::time::Duration;
-use std::{error, result};
+use std::{error, ptr, result};
 
 use crate::raftstore::coprocessor::SeekRegionCallback;
 use crate::storage::{Key, Value};
@@ -681,6 +681,36 @@ impl Error {
 }
 
 pub type Result<T> = result::Result<T, Error>;
+
+thread_local! {
+    // A pointer to thread local engine. Use raw pointer and `UnsafeCell` to reduce runtime check.
+    static TLS_ENGINE_ANY: UnsafeCell<*mut ()> = UnsafeCell::new(ptr::null_mut());
+}
+
+/// Execute the closure on the thread local engine.
+pub fn with_tls_engine<E: Engine, F, R>(f: F) -> R
+where
+    F: FnOnce(&E) -> R,
+{
+    TLS_ENGINE_ANY.with(|e| {
+        let engine = unsafe { &*(*e.get() as *const E) };
+        f(engine)
+    })
+}
+
+/// Set the thread local engine.
+pub fn set_tls_engine<E: Engine>(engine: E) {
+    let engine = Box::into_raw(Box::new(engine)) as *mut ();
+    TLS_ENGINE_ANY.with(|e| unsafe { *e.get() = engine });
+}
+
+/// Destroy the thread local engine.
+pub fn destroy_tls_engine<E: Engine>() {
+    TLS_ENGINE_ANY.with(|e| unsafe {
+        drop(Box::from_raw(*e.get() as *mut E));
+        *e.get() = ptr::null_mut();
+    });
+}
 
 #[cfg(test)]
 pub mod tests {

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -133,6 +133,10 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
         self.sched_pool.take().unwrap()
     }
 
+    fn clone_pool(&mut self) -> SchedPool<E> {
+        self.sched_pool.clone().unwrap()
+    }
+
     fn take_scheduler(&mut self) -> S {
         self.scheduler.take().unwrap()
     }
@@ -166,7 +170,7 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
                     .inc();
 
                 error!("get snapshot failed"; "cid" => task.cid, "err" => ?err);
-                notify_scheduler(
+                wakeup_scheduler(
                     self.take_scheduler(),
                     Msg::FinishedWithErr {
                         cid: task.cid,
@@ -191,7 +195,7 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
         if let Some(term) = cb_ctx.term {
             task.cmd.mut_context().set_term(term);
         }
-        let sched_pool = self.take_pool();
+        let sched_pool = self.clone_pool();
         let engine = sched_pool.engine;
         let readonly = task.cmd.readonly();
         sched_pool.pool.spawn(move || {
@@ -234,7 +238,7 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
             Err(e) => ProcessResult::Failed { err: e.into() },
             Ok(pr) => pr,
         };
-        notify_scheduler(self.take_scheduler(), Msg::ReadFinished { cid, pr, tag });
+        wakeup_scheduler(self.take_scheduler(), Msg::ReadFinished { cid, pr, tag });
         statistics
     }
 
@@ -287,20 +291,24 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
                     }
                 } else {
                     let sched = scheduler.clone();
+                    let sched_pool = self.take_pool();
                     // The callback to receive async results of write prepare from the storage engine.
                     let engine_cb = Box::new(move |(_, result)| {
-                        notify_scheduler(
-                            sched,
-                            Msg::WriteFinished {
-                                cid,
-                                pr,
-                                result,
-                                tag,
-                            },
-                        );
-                        KV_COMMAND_KEYWRITE_HISTOGRAM_VEC
-                            .with_label_values(&[tag])
-                            .observe(rows as f64);
+                        sched_pool.pool.spawn(move || {
+                            wakeup_scheduler(
+                                sched,
+                                Msg::WriteFinished {
+                                    cid,
+                                    pr,
+                                    result,
+                                    tag,
+                                },
+                            );
+                            KV_COMMAND_KEYWRITE_HISTOGRAM_VEC
+                                .with_label_values(&[tag])
+                                .observe(rows as f64);
+                            future::ok::<_, ()>(())
+                        })
                     });
 
                     if let Err(e) = engine.async_write(&ctx, to_be_write, engine_cb) {
@@ -327,7 +335,7 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
                 Msg::FinishedWithErr { cid, err, tag }
             }
         };
-        notify_scheduler(scheduler, msg);
+        wakeup_scheduler(scheduler, msg);
         statistics
     }
 }
@@ -768,7 +776,7 @@ fn process_write_impl<S: Snapshot>(
     })
 }
 
-pub fn notify_scheduler<S: MsgScheduler>(scheduler: S, msg: Msg) {
+pub fn wakeup_scheduler<S: MsgScheduler>(scheduler: S, msg: Msg) {
     scheduler.on_msg(msg);
 }
 

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -1,11 +1,13 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::marker::PhantomData;
 use std::time::Duration;
 use std::{mem, thread, u64};
 
 use futures::future;
 use kvproto::kvrpcpb::{CommandPri, Context, LockInfo};
 
+use crate::storage::kv::with_tls_engine;
 use crate::storage::kv::{CbContext, Modify, Result as EngineResult};
 use crate::storage::lock_manager::{self, DetectorScheduler, WaiterMgrScheduler};
 use crate::storage::mvcc::{
@@ -106,18 +108,20 @@ pub trait MsgScheduler: Clone + Send + 'static {
 
 pub struct Executor<E: Engine, S: MsgScheduler> {
     // We put time consuming tasks to the thread pool.
-    sched_pool: Option<SchedPool<E>>,
+    sched_pool: Option<SchedPool>,
     // And the tasks completes we post a completion to the `Scheduler`.
     scheduler: Option<S>,
     // If the task releases some locks, we wake up waiters waiting for them.
     waiter_mgr_scheduler: Option<WaiterMgrScheduler>,
     detector_scheduler: Option<DetectorScheduler>,
+
+    _phantom: PhantomData<E>,
 }
 
 impl<E: Engine, S: MsgScheduler> Executor<E, S> {
     pub fn new(
         scheduler: S,
-        pool: SchedPool<E>,
+        pool: SchedPool,
         waiter_mgr_scheduler: Option<WaiterMgrScheduler>,
         detector_scheduler: Option<DetectorScheduler>,
     ) -> Self {
@@ -126,14 +130,15 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
             scheduler: Some(scheduler),
             waiter_mgr_scheduler,
             detector_scheduler,
+            _phantom: Default::default(),
         }
     }
 
-    fn take_pool(&mut self) -> SchedPool<E> {
+    fn take_pool(&mut self) -> SchedPool {
         self.sched_pool.take().unwrap()
     }
 
-    fn clone_pool(&mut self) -> SchedPool<E> {
+    fn clone_pool(&mut self) -> SchedPool {
         self.sched_pool.clone().unwrap()
     }
 
@@ -196,7 +201,6 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
             task.cmd.mut_context().set_term(term);
         }
         let sched_pool = self.clone_pool();
-        let engine = sched_pool.engine;
         let readonly = task.cmd.readonly();
         sched_pool.pool.spawn(move || {
             fail_point!("scheduler_async_snapshot_finish");
@@ -210,7 +214,7 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
             let statistics = if readonly {
                 self.process_read(snapshot, task)
             } else {
-                self.process_write(engine, snapshot, task)
+                with_tls_engine(|engine| self.process_write(engine, snapshot, task))
             };
             tls_add_statistics(tag, &statistics);
             slow_log!(
@@ -244,7 +248,7 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
 
     /// Processes a write command within a worker thread, then posts either a `WriteFinished`
     /// message if successful or a `FinishedWithErr` message back to the `Scheduler`.
-    fn process_write(mut self, engine: E, snapshot: E::Snap, task: Task) -> Statistics {
+    fn process_write(mut self, engine: &E, snapshot: E::Snap, task: Task) -> Statistics {
         fail_point!("txn_before_process_write");
         let tag = task.tag;
         let cid = task.cid;

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -176,7 +176,7 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
 
                 error!("get snapshot failed"; "cid" => task.cid, "err" => ?err);
                 self.take_pool().pool.spawn(move || {
-                    wakeup_scheduler(
+                    notify_scheduler(
                         self.take_scheduler(),
                         Msg::FinishedWithErr {
                             cid: task.cid,
@@ -245,7 +245,7 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
             Err(e) => ProcessResult::Failed { err: e.into() },
             Ok(pr) => pr,
         };
-        wakeup_scheduler(self.take_scheduler(), Msg::ReadFinished { cid, pr, tag });
+        notify_scheduler(self.take_scheduler(), Msg::ReadFinished { cid, pr, tag });
         statistics
     }
 
@@ -302,7 +302,7 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
                     // The callback to receive async results of write prepare from the storage engine.
                     let engine_cb = Box::new(move |(_, result)| {
                         sched_pool.pool.spawn(move || {
-                            wakeup_scheduler(
+                            notify_scheduler(
                                 sched,
                                 Msg::WriteFinished {
                                     cid,
@@ -342,7 +342,7 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
                 Msg::FinishedWithErr { cid, err, tag }
             }
         };
-        wakeup_scheduler(scheduler, msg);
+        notify_scheduler(scheduler, msg);
         statistics
     }
 }
@@ -784,7 +784,7 @@ fn process_write_impl<S: Snapshot>(
     })
 }
 
-pub fn wakeup_scheduler<S: MsgScheduler>(scheduler: S, msg: Msg) {
+pub fn notify_scheduler<S: MsgScheduler>(scheduler: S, msg: Msg) {
     scheduler.on_msg(msg);
 }
 

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -145,10 +145,6 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
         self.detector_scheduler.take()
     }
 
-    pub fn clone_pool(&self) -> SchedPool<E> {
-        self.sched_pool.clone().unwrap()
-    }
-
     /// Start the execution of the task.
     pub fn execute(mut self, cb_ctx: CbContext, snapshot: EngineResult<E::Snap>, task: Task) {
         debug!(

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -38,7 +38,7 @@ use crate::storage::txn::Error;
 use crate::storage::{metrics::*, Key};
 use crate::storage::{Command, Engine, Error as StorageError, StorageCb};
 
-const TASKS_SLOTS_NUM: usize = 1 << 10; // 1024 slots.
+const TASKS_SLOTS_NUM: usize = 1 << 12; // 4096 slots.
 
 /// Message types for the scheduler event loop.
 pub enum Msg {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -29,7 +29,7 @@ use kvproto::kvrpcpb::CommandPri;
 use prometheus::HistogramTimer;
 use tikv_util::collections::HashMap;
 
-use crate::storage::kv::Result as EngineResult;
+use crate::storage::kv::{with_tls_engine, Result as EngineResult};
 use crate::storage::lock_manager::{self, DetectorScheduler, WaiterMgrScheduler};
 use crate::storage::txn::latch::{Latches, Lock};
 use crate::storage::txn::process::{execute_callback, Executor, MsgScheduler, ProcessResult, Task};
@@ -137,7 +137,7 @@ impl TaskContext {
     }
 }
 
-struct SchedulerInner<E: Engine> {
+struct SchedulerInner {
     // slot_id -> { cid -> `TaskContext` } in the slot.
     task_contexts: Vec<Mutex<HashMap<u64, TaskContext>>>,
 
@@ -150,10 +150,10 @@ struct SchedulerInner<E: Engine> {
     sched_pending_write_threshold: usize,
 
     // worker pool
-    worker_pool: SchedPool<E>,
+    worker_pool: SchedPool,
 
     // high priority commands and system commands will be delivered to this pool
-    high_priority_pool: SchedPool<E>,
+    high_priority_pool: SchedPool,
 
     // used to control write flow
     running_write_bytes: AtomicUsize,
@@ -168,7 +168,7 @@ fn id_index(cid: u64) -> usize {
     cid as usize % TASKS_SLOTS_NUM
 }
 
-impl<E: Engine> SchedulerInner<E> {
+impl SchedulerInner {
     /// Generates the next command ID.
     #[inline]
     fn gen_id(&self) -> u64 {
@@ -237,8 +237,9 @@ impl<E: Engine> SchedulerInner<E> {
 /// Scheduler which schedules the execution of `storage::Command`s.
 #[derive(Clone)]
 pub struct Scheduler<E: Engine> {
-    engine: E,
-    inner: Arc<SchedulerInner<E>>,
+    // `engine` is `None` means currently the program is in scheduler worker threads.
+    engine: Option<E>,
+    inner: Arc<SchedulerInner>,
 }
 
 unsafe impl<E: Engine> Send for Scheduler<E> {}
@@ -278,7 +279,10 @@ impl<E: Engine> Scheduler<E> {
         });
 
         info!("Scheduler::new is finished, the transaction scheduler is initialized");
-        Scheduler { engine, inner }
+        Scheduler {
+            engine: Some(engine),
+            inner,
+        }
     }
 
     pub fn run_cmd(&self, cmd: Command, callback: StorageCb) {
@@ -293,8 +297,12 @@ impl<E: Engine> Scheduler<E> {
         } else {
             self.inner.worker_pool.clone()
         };
+        let scheduler = Scheduler {
+            engine: None,
+            inner: Arc::clone(&self.inner),
+        };
         Executor::new(
-            self.clone(),
+            scheduler,
             pool,
             self.inner.waiter_mgr_scheduler.clone(),
             self.inner.detector_scheduler.clone(),
@@ -364,17 +372,27 @@ impl<E: Engine> Scheduler<E> {
         let cb = Box::new(move |(cb_ctx, snapshot)| {
             executor.execute(cb_ctx, snapshot, task);
         });
-        if let Err(e) = self.engine.async_snapshot(&ctx, cb) {
-            SCHED_STAGE_COUNTER_VEC
-                .with_label_values(&[tag, "async_snapshot_err"])
-                .inc();
 
-            error!("engine async_snapshot failed"; "err" => ?e);
-            self.finish_with_err(cid, e.into());
+        let f = |engine: &E| {
+            if let Err(e) = engine.async_snapshot(&ctx, cb) {
+                SCHED_STAGE_COUNTER_VEC
+                    .with_label_values(&[tag, "async_snapshot_err"])
+                    .inc();
+
+                error!("engine async_snapshot failed"; "err" => ?e);
+                self.finish_with_err(cid, e.into());
+            } else {
+                SCHED_STAGE_COUNTER_VEC
+                    .with_label_values(&[tag, "snapshot"])
+                    .inc();
+            }
+        };
+
+        if let Some(engine) = self.engine.as_ref() {
+            f(engine)
         } else {
-            SCHED_STAGE_COUNTER_VEC
-                .with_label_values(&[tag, "snapshot"])
-                .inc();
+            // The program is currently in scheduler worker threads.
+            with_tls_engine(f)
         }
     }
 


### PR DESCRIPTION
## What have you changed? (mandatory)
#4098 introduces a problem that pending transactions are woken up in apply threads, which causes performance drop. This PR changes the behavior. With the patch pending transactions will be woken up in scheduler workers.

## What are the type of the changes? (mandatory)
Improvement.

## How has this PR been tested? (mandatory)
Make dev.

## Benchmark result if necessary (optional)
### Old:
![图片](https://user-images.githubusercontent.com/8407317/58090528-fe000c80-7bf9-11e9-85d7-a6f8a967b7f9.png)
### New:
![图片](https://user-images.githubusercontent.com/8407317/58090565-0e17ec00-7bfa-11e9-9b62-f75463085a2a.png)
### Master branch without #4098 
![图片](https://user-images.githubusercontent.com/8407317/58090614-2e47ab00-7bfa-11e9-8dec-670d446c19a2.png)

We can see the second and the third results are almost same and better than the latest master.