### PR TITLE
coprocessor: add minus(Int, Real, Decimal) RPN functions

### DIFF
--- a/src/coprocessor/dag/rpn_expr/impl_arithmetic.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_arithmetic.rs
@@ -140,6 +140,97 @@ impl ArithmeticOp for DecimalPlus {
 }
 
 #[derive(Debug)]
+pub struct IntIntMinus;
+
+impl ArithmeticOp for IntIntMinus {
+    type T = Int;
+
+    fn calc(lhs: &Int, rhs: &Int) -> Result<Option<Int>> {
+        lhs.checked_sub(*rhs)
+            .ok_or_else(|| Error::overflow("BIGINT", &format!("({} - {})", lhs, rhs)).into())
+            .map(Some)
+    }
+}
+
+#[derive(Debug)]
+pub struct IntUintMinus;
+
+impl ArithmeticOp for IntUintMinus {
+    type T = Int;
+
+    fn calc(lhs: &Int, rhs: &Int) -> Result<Option<Int>> {
+        if *lhs >= 0 {
+            (*lhs as u64)
+                .checked_sub(*rhs as u64)
+                .ok_or_else(|| Error::overflow("BIGINT", &format!("({} - {})", lhs, rhs)).into())
+                .map(|v| Some(v as i64))
+        } else {
+            Err(Error::overflow("BIGINT", &format!("({} - {})", lhs, rhs)))?
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct UintIntMinus;
+
+impl ArithmeticOp for UintIntMinus {
+    type T = Int;
+
+    fn calc(lhs: &Int, rhs: &Int) -> Result<Option<Int>> {
+        let res = if *rhs >= 0 {
+            (*lhs as u64).checked_sub(*rhs as u64)
+        } else {
+            (*lhs as u64).checked_add(rhs.overflowing_neg().0 as u64)
+        };
+        res.ok_or_else(|| Error::overflow("BIGINT", &format!("({} - {})", lhs, rhs)).into())
+            .map(|v| Some(v as i64))
+    }
+}
+
+#[derive(Debug)]
+pub struct UintUintMinus;
+
+impl ArithmeticOp for UintUintMinus {
+    type T = Int;
+
+    fn calc(lhs: &Int, rhs: &Int) -> Result<Option<Int>> {
+        (*lhs as u64)
+            .checked_sub(*rhs as u64)
+            .ok_or_else(|| {
+                Error::overflow("BIGINT UNSIGNED", &format!("({} - {})", lhs, rhs)).into()
+            })
+            .map(|v| Some(v as i64))
+    }
+}
+
+#[derive(Debug)]
+pub struct RealMinus;
+
+impl ArithmeticOp for RealMinus {
+    type T = Real;
+
+    fn calc(lhs: &Real, rhs: &Real) -> Result<Option<Real>> {
+        let res = *lhs - *rhs;
+        if res.is_infinite() {
+            Err(Error::overflow("DOUBLE", &format!("({} - {})", lhs, rhs)))?;
+        }
+        Ok(Some(res))
+    }
+}
+
+#[derive(Debug)]
+pub struct DecimalMinus;
+
+impl ArithmeticOp for DecimalMinus {
+    type T = Decimal;
+
+    fn calc(lhs: &Decimal, rhs: &Decimal) -> Result<Option<Decimal>> {
+        let res: codec::Result<Decimal> = (lhs - rhs).into();
+        Ok(Some(res?))
+    }
+}
+
+#[derive(Debug)]
 pub struct IntIntMod;
 
 impl ArithmeticOp for IntIntMod {
@@ -246,7 +337,7 @@ mod tests {
     use crate::coprocessor::dag::rpn_expr::types::test_util::RpnFnScalarEvaluator;
 
     #[test]
-    fn test_arithmetic_int() {
+    fn test_plus_int() {
         let test_cases = vec![
             (None, false, Some(1), false, None),
             (Some(1), false, None, false, None),
@@ -286,7 +377,7 @@ mod tests {
     }
 
     #[test]
-    fn test_arithmetic_real() {
+    fn test_plus_real() {
         let test_cases = vec![
             (
                 Real::new(1.01001).ok(),
@@ -311,7 +402,7 @@ mod tests {
     }
 
     #[test]
-    fn test_arithmetic_decimal() {
+    fn test_plus_decimal() {
         let test_cases = vec![("1.1", "2.2", "3.3")];
         for (lhs, rhs, expected) in test_cases {
             let expected: Option<Decimal> = expected.parse().ok();
@@ -319,6 +410,113 @@ mod tests {
                 .push_param(lhs.parse::<Decimal>().ok())
                 .push_param(rhs.parse::<Decimal>().ok())
                 .evaluate(ScalarFuncSig::PlusDecimal)
+                .unwrap();
+            assert_eq!(output, expected, "lhs={:?}, rhs={:?}", lhs, rhs);
+        }
+    }
+
+    #[test]
+    fn test_minus_int() {
+        let test_cases = vec![
+            (None, false, Some(1), false, None, false),
+            (Some(1), false, None, false, None, false),
+            (Some(12), false, Some(1), false, Some(11), false),
+            (
+                Some(0),
+                true,
+                Some(std::i64::MIN),
+                false,
+                Some((std::i64::MAX as u64 + 1) as i64),
+                false,
+            ),
+            (
+                Some(std::i64::MIN),
+                false,
+                Some(std::i64::MAX),
+                false,
+                None,
+                true,
+            ),
+            (
+                Some(std::i64::MAX),
+                false,
+                Some(std::i64::MIN),
+                false,
+                None,
+                true,
+            ),
+            (Some(-1), false, Some(2), true, None, true),
+            (Some(1), true, Some(2), false, None, true),
+        ];
+        for (lhs, lhs_is_unsigned, rhs, rhs_is_unsigned, expected, is_err) in test_cases {
+            let lhs_field_type = FieldTypeBuilder::new()
+                .tp(FieldTypeTp::LongLong)
+                .flag(if lhs_is_unsigned {
+                    FieldTypeFlag::UNSIGNED
+                } else {
+                    FieldTypeFlag::empty()
+                })
+                .build();
+            let rhs_field_type = FieldTypeBuilder::new()
+                .tp(FieldTypeTp::LongLong)
+                .flag(if rhs_is_unsigned {
+                    FieldTypeFlag::UNSIGNED
+                } else {
+                    FieldTypeFlag::empty()
+                })
+                .build();
+            let output = RpnFnScalarEvaluator::new()
+                .push_param_with_field_type(lhs, lhs_field_type)
+                .push_param_with_field_type(rhs, rhs_field_type)
+                .evaluate(ScalarFuncSig::MinusInt);
+            if is_err {
+                assert!(output.is_err())
+            } else {
+                let output = output.unwrap();
+                assert_eq!(output, expected, "lhs={:?}, rhs={:?}", lhs, rhs);
+            }
+        }
+    }
+
+    #[test]
+    fn test_minus_real() {
+        let test_cases = vec![
+            (
+                Real::new(1.01001).ok(),
+                Real::new(-0.01).ok(),
+                Real::new(1.02001).ok(),
+                false,
+            ),
+            (
+                Real::new(std::f64::MIN).ok(),
+                Real::new(std::f64::MAX).ok(),
+                None,
+                true,
+            ),
+        ];
+        for (lhs, rhs, expected, is_err) in test_cases {
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(lhs)
+                .push_param(rhs)
+                .evaluate(ScalarFuncSig::MinusReal);
+            if is_err {
+                assert!(output.is_err())
+            } else {
+                let output = output.unwrap();
+                assert_eq!(output, expected, "lhs={:?}, rhs={:?}", lhs, rhs);
+            }
+        }
+    }
+
+    #[test]
+    fn test_minus_decimal() {
+        let test_cases = vec![("1.1", "2.2", "-1.1")];
+        for (lhs, rhs, expected) in test_cases {
+            let expected: Option<Decimal> = expected.parse().ok();
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(lhs.parse::<Decimal>().ok())
+                .push_param(rhs.parse::<Decimal>().ok())
+                .evaluate(ScalarFuncSig::MinusDecimal)
                 .unwrap();
             assert_eq!(output, expected, "lhs={:?}, rhs={:?}", lhs, rhs);
         }

--- a/src/coprocessor/dag/rpn_expr/mod.rs
+++ b/src/coprocessor/dag/rpn_expr/mod.rs
@@ -65,6 +65,15 @@ fn plus_mapper(lhs_is_unsigned: bool, rhs_is_unsigned: bool) -> Box<dyn RpnFunct
     }
 }
 
+fn minus_mapper(lhs_is_unsigned: bool, rhs_is_unsigned: bool) -> Box<dyn RpnFunction> {
+    match (lhs_is_unsigned, rhs_is_unsigned) {
+        (false, false) => Box::new(RpnFnArithmetic::<IntIntMinus>::new()),
+        (false, true) => Box::new(RpnFnArithmetic::<IntUintMinus>::new()),
+        (true, false) => Box::new(RpnFnArithmetic::<UintIntMinus>::new()),
+        (true, true) => Box::new(RpnFnArithmetic::<UintUintMinus>::new()),
+    }
+}
+
 fn mod_mapper(lhs_is_unsigned: bool, rhs_is_unsigned: bool) -> Box<dyn RpnFunction> {
     match (lhs_is_unsigned, rhs_is_unsigned) {
         (false, false) => Box::new(RpnFnArithmetic::<IntIntMod>::new()),
@@ -144,6 +153,9 @@ fn map_pb_sig_to_rpn_func(value: ScalarFuncSig, children: &[Expr]) -> Result<Box
         ScalarFuncSig::PlusInt => map_int_sig(value, children, plus_mapper)?,
         ScalarFuncSig::PlusReal => Box::new(RpnFnArithmetic::<RealPlus>::new()),
         ScalarFuncSig::PlusDecimal => Box::new(RpnFnArithmetic::<DecimalPlus>::new()),
+        ScalarFuncSig::MinusInt => map_int_sig(value, children, minus_mapper)?,
+        ScalarFuncSig::MinusReal => Box::new(RpnFnArithmetic::<RealMinus>::new()),
+        ScalarFuncSig::MinusDecimal => Box::new(RpnFnArithmetic::<DecimalMinus>::new()),
         ScalarFuncSig::ModReal => Box::new(RpnFnArithmetic::<RealMod>::new()),
         ScalarFuncSig::ModDecimal => Box::new(RpnFnArithmetic::<DecimalMod>::new()),
         ScalarFuncSig::ModInt => map_int_sig(value, children, mod_mapper)?,


### PR DESCRIPTION
## What have you changed? (mandatory)
This PR adds minus RPN functions for Int, Real, and Decimal. Code and tests are mainly adapted from `builtin_arithmetic.rs.`

## What are the type of the changes? (mandatory)

- Improvement 

## How has this PR been tested? (mandatory)

make dev

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

