### PR TITLE
Upgrade sys-info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ dependencies = [
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
- "sys-info 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sys-info 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tikv_alloc 0.1.0",
  "tikv_util 0.1.0",
@@ -2118,10 +2118,10 @@ dependencies = [
 
 [[package]]
 name = "sys-info"
-version = "0.5.1"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2319,7 +2319,7 @@ dependencies = [
  "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "sys-info 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sys-info 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_coprocessor 0.0.1",
  "test_raftstore 0.0.1",
@@ -3085,7 +3085,7 @@ dependencies = [
 "checksum syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)" = "ec52cd796e5f01d0067225a5392e70084acc4c0013fa71d55166d38a8b307836"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
-"checksum sys-info 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6e0c80518e54ce6bd40e8262b386395f2154dcfaf22ff8102380dc5c7bed3683"
+"checksum sys-info 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "617f594d3869801871433390254b4a79f2a18176d7f4ad5784fa990bc8c12986"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tcmalloc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "375205113d84a1c5eeed67beaa0ce08e41be1a9d5acc3425ad2381fddd9d819b"
 "checksum tcmalloc-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7ad73e635dd232c2c2106d59269f59a61de421cc6b95252d2d932094ff1f40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ backtrace = "0.2.3"
 clap = "2.32"
 url = "1.7.2"
 regex = "1.0"
-sys-info = "0.5.1"
+sys-info = "0.5.6"
 indexmap = { version = "1.0", features = ["serde-1"] }
 futures = "0.1"
 futures-cpupool = "0.1"

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "0.2.1"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "91904ade" }
 time = "0.1"
-sys-info = "0.5.1"
+sys-info = "0.5.6"
 tikv_alloc = { path = "../tikv_alloc", default-features = false }
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
This fixes a regression linking to the native get_mem_info function when upgrading the next toolchain.

## What have you changed? (mandatory)

Bumped sys-info from 0.5.1 to 0.5.6.

While testing cargo pipelining I needed to use a newer toolchain. That toolchain failed to link the native parts of the sys-info crate. Upgrading sys-info fixes it for whatever reason. Doesn't seem worth investigating.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

cargo build

## Does this PR affect documentation (docs) or release note? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

