### PR TITLE
raftstore: mark read delegate as invalid correctly

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1270,29 +1270,21 @@ impl Peer {
     fn post_pending_read_index_on_replica<T, C>(&mut self, ctx: &mut PollContext<T, C>) {
         if self.pending_reads.ready_cnt > 0 {
             for _ in 0..self.pending_reads.ready_cnt {
-                let (read_index, is_read_index_request) = {
-                    let read = self.pending_reads.reads.front().unwrap();
-                    if read.cmds.len() == 1
-                        && read.cmds[0].0.get_requests().len() == 1
-                        && read.cmds[0].0.get_requests()[0].get_cmd_type() == CmdType::ReadIndex
-                    {
-                        (read.read_index, true)
-                    } else {
-                        (read.read_index, false)
-                    }
-                };
-
                 let mut read = self.pending_reads.reads.pop_front().unwrap();
+                let is_read_index_request = read.cmds.len() == 1
+                    && read.cmds[0].0.get_requests().len() == 1
+                    && read.cmds[0].0.get_requests()[0].get_cmd_type() == CmdType::ReadIndex;
+
                 if !is_read_index_request {
                     let term = self.term();
                     // Only read index request is valid.
                     for (_, cb) in read.cmds.drain(..) {
                         apply::notify_stale_req(term, cb);
                     }
-                    continue;
-                }
-                for (req, cb) in read.cmds.drain(..) {
-                    cb.invoke_read(self.handle_read(ctx, req, true, read_index));
+                } else {
+                    for (req, cb) in read.cmds.drain(..) {
+                        cb.invoke_read(self.handle_read(ctx, req, true, read.read_index));
+                    }
                 }
                 self.pending_reads.ready_cnt -= 1;
             }

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -2,8 +2,8 @@
 
 use std::cell::{Cell, RefCell};
 use std::fmt::{self, Display, Formatter};
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crossbeam::TrySendError;

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -683,6 +683,7 @@ mod tests {
                 applied_index_term: term6 - 1,
                 leader_lease: Some(remote),
                 last_valid_ts: RefCell::new(Timespec::new(0, 0)),
+                invalid: Arc::new(AtomicBool::new(false)),
             };
             meta.readers.insert(1, read_delegate);
         }

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -3,6 +3,7 @@
 use std::cell::{Cell, RefCell};
 use std::fmt::{self, Display, Formatter};
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crossbeam::TrySendError;
@@ -38,6 +39,7 @@ pub struct ReadDelegate {
     last_valid_ts: RefCell<Timespec>,
 
     tag: String,
+    invalid: Arc<AtomicBool>,
 }
 
 impl ReadDelegate {
@@ -53,7 +55,12 @@ impl ReadDelegate {
             leader_lease: None,
             last_valid_ts: RefCell::new(Timespec::new(0, 0)),
             tag: format!("[region {}] {}", region_id, peer_id),
+            invalid: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    pub fn mark_invalid(&self) {
+        self.invalid.store(true, Ordering::Release);
     }
 
     pub fn update(&mut self, progress: Progress) {
@@ -237,6 +244,12 @@ impl<C: ProposalRouter> LocalReader<C> {
                 return Ok(None);
             }
         };
+
+        if delegate.invalid.load(Ordering::Acquire) {
+            self.delegates.borrow_mut().remove(&region_id);
+            return Ok(None);
+        }
+
         // Check peer id.
         if let Err(e) = util::check_peer_id(req, delegate.peer_id) {
             self.metrics.borrow_mut().rejected_by_peer_id_mismatch += 1;

--- a/tests/integrations/raftstore/test_lease_read.rs
+++ b/tests/integrations/raftstore/test_lease_read.rs
@@ -414,16 +414,19 @@ fn test_local_read_cache() {
     must_get_equal(&cluster.get_engine(1), b"k1", b"v1");
     must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
     must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
-    must_get_equal(&cluster.get_engine(4), b"k1", b"v1");
 
     let r1 = cluster.get_region(b"k1");
     let leader = cluster.leader_of_region(r1.get_id()).unwrap();
     let new_leader = new_peer(3 - leader.get_id(), 3 - leader.get_id());
     cluster.must_transfer_leader(r1.get_id(), new_leader);
 
-    cluster.pd_client.must_remove_peer(r1.get_id(), leader);
-    let replace_peer = new_peer(1, 10000);
-    cluster.pd_client.must_add_peer(r1.get_id(), replace_peer);
+    cluster
+        .pd_client
+        .must_remove_peer(r1.get_id(), leader.clone());
+    let replace_peer = new_peer(leader.get_store_id(), 10000);
+    cluster
+        .pd_client
+        .must_add_peer(r1.get_id(), replace_peer.clone());
     cluster.must_transfer_leader(r1.get_id(), replace_peer);
 
     cluster.must_put(b"k1", b"v2");

--- a/tests/integrations/raftstore/test_lease_read.rs
+++ b/tests/integrations/raftstore/test_lease_read.rs
@@ -427,9 +427,9 @@ fn test_local_read_cache() {
     let replace_peer = new_peer(leader.get_store_id(), 10000);
     pd_client.must_add_peer(r1.get_id(), replace_peer.clone());
     cluster.must_put(b"k2", b"v2");
-    must_get_equal(&cluster.get_engine(1), b"k2", b"v2");
+    must_get_equal(&cluster.get_engine(leader.get_store_id()), b"k2", b"v2");
 
     cluster.must_transfer_leader(r1.get_id(), replace_peer);
     cluster.must_put(b"k3", b"v3");
-    must_get_equal(&cluster.get_engine(1), b"k3", b"v3");
+    must_get_equal(&cluster.get_engine(leader.get_store_id()), b"k3", b"v3");
 }

--- a/tests/integrations/raftstore/test_lease_read.rs
+++ b/tests/integrations/raftstore/test_lease_read.rs
@@ -403,3 +403,29 @@ fn test_read_index_when_transfer_leader() {
     );
     drop(cluster);
 }
+
+#[test]
+fn test_local_read_cache() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_lease_read(&mut cluster, Some(50), None);
+    cluster.pd_client.disable_default_operator();
+    cluster.run();
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(1), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(4), b"k1", b"v1");
+
+    let r1 = cluster.get_region(b"k1");
+    let leader = cluster.leader_of_region(r1.get_id()).unwrap();
+    let new_leader = new_peer(3 - leader.get_id(), 3 - leader.get_id());
+    cluster.must_transfer_leader(r1.get_id(), new_leader);
+
+    cluster.pd_client.must_remove_peer(r1.get_id(), leader);
+    let replace_peer = new_peer(1, 10000);
+    cluster.pd_client.must_add_peer(r1.get_id(), replace_peer);
+    cluster.must_transfer_leader(r1.get_id(), replace_peer);
+
+    cluster.must_put(b"k1", b"v2");
+    must_get_equal(&cluster.get_engine(1), b"k1", b"v2");
+}


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

## What have you changed? (mandatory)
LocalReader uses local caches for read delegates. After a region is destroyed in raftstore thread,  the local caches are not cleared correctly. This PR fix this.

## What are the type of the changes? (mandatory)
Bug fix.

## Benchmarks
master：
![图片](https://user-images.githubusercontent.com/8407317/58322767-81b53580-7e54-11e9-9366-ea38487f4d76.png)
the patch:
![图片](https://user-images.githubusercontent.com/8407317/58322792-9396d880-7e54-11e9-8a50-e29446520232.png)
Almost same. So this PR won't introduce any performance drop.