### PR TITLE
coprocessor: Support all data types for AVG()

### DIFF
--- a/components/cop_datatype/src/def/mod.rs
+++ b/components/cop_datatype/src/def/mod.rs
@@ -14,3 +14,4 @@ pub const UNSPECIFIED_LENGTH: isize = -1;
 /// MySQL type maximum length
 pub const MAX_BLOB_WIDTH: i32 = 16_777_216; // FIXME: Should be isize
 pub const MAX_DECIMAL_WIDTH: isize = 65;
+pub const MAX_REAL_WIDTH: isize = 23;

--- a/components/cop_datatype/src/def/mod.rs
+++ b/components/cop_datatype/src/def/mod.rs
@@ -12,4 +12,5 @@ pub use self::field_type::{Collation, FieldTypeAccessor, FieldTypeFlag, FieldTyp
 pub const UNSPECIFIED_LENGTH: isize = -1;
 
 /// MySQL type maximum length
-pub const MAX_BLOB_WIDTH: i32 = 16_777_216;
+pub const MAX_BLOB_WIDTH: i32 = 16_777_216; // FIXME: Should be isize
+pub const MAX_DECIMAL_WIDTH: isize = 65;

--- a/src/coprocessor/dag/aggr_fn/impl_avg.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_avg.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use cop_codegen::AggrFunction;
+use cop_datatype::builder::FieldTypeBuilder;
 use cop_datatype::{EvalType, FieldTypeFlag, FieldTypeTp};
 use tipb::expression::{Expr, ExprType, FieldType};
 
@@ -9,45 +10,22 @@ use crate::coprocessor::codec::data_type::*;
 use crate::coprocessor::codec::mysql::Tz;
 use crate::coprocessor::dag::expr::EvalContext;
 use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
-use crate::coprocessor::{Error, Result};
+use crate::coprocessor::Result;
 
 /// The parser for AVG aggregate function.
 pub struct AggrFnDefinitionParserAvg;
 
 impl super::AggrDefinitionParser for AggrFnDefinitionParserAvg {
     fn check_supported(&self, aggr_def: &Expr) -> Result<()> {
-        use cop_datatype::FieldTypeAccessor;
-        use std::convert::TryFrom;
-
         assert_eq!(aggr_def.get_tp(), ExprType::Avg);
-        if aggr_def.get_children().len() != 1 {
-            return Err(box_err!(
-                "Expect 1 parameter, but got {}",
-                aggr_def.get_children().len()
-            ));
-        }
-
-        // Check whether or not the children's field type is supported. Currently we only support
-        // Double and Decimal and does not support other types (which need casting).
-        let child = &aggr_def.get_children()[0];
-        let eval_type = EvalType::try_from(child.get_field_type().tp())
-            .map_err(|e| Error::Other(box_err!(e)))?;
-        match eval_type {
-            EvalType::Real | EvalType::Decimal => {}
-            _ => return Err(box_err!("Cast from {:?} is not supported", eval_type)),
-        }
-
-        // Check whether parameter expression is supported.
-        RpnExpressionBuilder::check_expr_tree_supported(child)?;
-
-        Ok(())
+        super::util::check_aggr_exp_supported_one_child(aggr_def)
     }
 
     fn parse(
         &self,
         mut aggr_def: Expr,
         time_zone: &Tz,
-        max_columns: usize,
+        schema: &[FieldType],
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn super::AggrFunction>> {
@@ -55,33 +33,29 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserAvg {
         use std::convert::TryFrom;
 
         assert_eq!(aggr_def.get_tp(), ExprType::Avg);
-        let child = aggr_def.take_children().into_iter().next().unwrap();
-        let eval_type = EvalType::try_from(child.get_field_type().tp()).unwrap();
 
         // AVG outputs two columns.
-        out_schema.push({
-            let mut ft = FieldType::new();
-            ft.as_mut_accessor()
-                .set_tp(FieldTypeTp::LongLong)
-                .set_flag(FieldTypeFlag::UNSIGNED);
-            ft
-        });
+        out_schema.push(
+            FieldTypeBuilder::new()
+                .tp(FieldTypeTp::LongLong)
+                .flag(FieldTypeFlag::UNSIGNED)
+                .build(),
+        );
         out_schema.push(aggr_def.take_field_type());
 
-        // Currently we don't support casting in `check_supported`, so we can directly use the
-        // built expression.
-        out_exp.push(RpnExpressionBuilder::build_from_expr_tree(
-            child,
-            time_zone,
-            max_columns,
-        )?);
+        // Rewrite expression to insert CAST() if needed.
+        let child = aggr_def.take_children().into_iter().next().unwrap();
+        let mut exp = RpnExpressionBuilder::build_from_expr_tree(child, time_zone, schema.len())?;
+        super::util::rewrite_exp_for_sum_avg(schema, &mut exp).unwrap();
 
-        // Choose a type-aware AVG implementation based on eval type.
-        match eval_type {
-            EvalType::Real => Ok(Box::new(AggrFnAvg::<Real>::new())),
-            EvalType::Decimal => Ok(Box::new(AggrFnAvg::<Decimal>::new())),
+        let rewritten_eval_type = EvalType::try_from(exp.ret_field_type(schema).tp()).unwrap();
+        out_exp.push(exp);
+
+        Ok(match rewritten_eval_type {
+            EvalType::Decimal => Box::new(AggrFnAvg::<Decimal>::new()),
+            EvalType::Real => Box::new(AggrFnAvg::<Real>::new()),
             _ => unreachable!(),
-        }
+        })
     }
 }
 
@@ -172,6 +146,12 @@ mod tests {
     use super::super::AggrFunction;
     use super::*;
 
+    use cop_datatype::FieldTypeAccessor;
+    use tipb_helper::ExprDefBuilder;
+
+    use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
+    use crate::coprocessor::dag::aggr_fn::parser::AggrDefinitionParser;
+
     #[test]
     fn test_update() {
         let mut ctx = EvalContext::default();
@@ -215,6 +195,58 @@ mod tests {
         assert_eq!(
             result[1].as_real_slice(),
             &[None, None, Real::new(15.0).ok(), Real::new(10.5).ok()]
+        );
+    }
+
+    /// AVG(IntColumn) should produce (Int, Decimal).
+    #[test]
+    fn test_integration() {
+        let expr = ExprDefBuilder::aggr_func(ExprType::Avg, FieldTypeTp::NewDecimal)
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+            .build();
+        AggrFnDefinitionParserAvg.check_supported(&expr).unwrap();
+
+        let src_schema = [FieldTypeTp::LongLong.into()];
+        let mut columns = LazyBatchColumnVec::from(vec![{
+            // this column is not referenced
+            let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(5, EvalType::Int);
+            col.mut_decoded().push_int(Some(1));
+            col.mut_decoded().push_int(None);
+            col.mut_decoded().push_int(Some(42));
+            col.mut_decoded().push_int(None);
+            col
+        }]);
+
+        let mut schema = vec![];
+        let mut exp = vec![];
+
+        let aggr_fn = AggrFnDefinitionParserAvg
+            .parse(expr, &Tz::utc(), &src_schema, &mut schema, &mut exp)
+            .unwrap();
+        assert_eq!(schema.len(), 2);
+        assert_eq!(schema[0].tp(), FieldTypeTp::LongLong);
+        assert_eq!(schema[1].tp(), FieldTypeTp::NewDecimal);
+
+        assert_eq!(exp.len(), 1);
+
+        let mut state = aggr_fn.create_state();
+        let mut ctx = EvalContext::default();
+
+        let exp_result = exp[0].eval(&mut ctx, 4, &src_schema, &mut columns).unwrap();
+        assert!(exp_result.is_vector());
+        let slice: &[Option<Decimal>] = exp_result.vector_value().unwrap().as_ref();
+        state.update_vector(&mut ctx, slice).unwrap();
+
+        let mut aggr_result = [
+            VectorValue::with_capacity(0, EvalType::Int),
+            VectorValue::with_capacity(0, EvalType::Decimal),
+        ];
+        state.push_result(&mut ctx, &mut aggr_result).unwrap();
+
+        assert_eq!(aggr_result[0].as_int_slice(), &[Some(2)]);
+        assert_eq!(
+            aggr_result[1].as_decimal_slice(),
+            &[Some(Decimal::from(43u64))]
         );
     }
 }

--- a/src/coprocessor/dag/aggr_fn/impl_avg.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_avg.rs
@@ -208,8 +208,7 @@ mod tests {
 
         let src_schema = [FieldTypeTp::LongLong.into()];
         let mut columns = LazyBatchColumnVec::from(vec![{
-            // this column is not referenced
-            let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(5, EvalType::Int);
+            let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(0, EvalType::Int);
             col.mut_decoded().push_int(Some(1));
             col.mut_decoded().push_int(None);
             col.mut_decoded().push_int(Some(42));

--- a/src/coprocessor/dag/aggr_fn/impl_avg.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_avg.rs
@@ -25,7 +25,7 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserAvg {
         &self,
         mut aggr_def: Expr,
         time_zone: &Tz,
-        schema: &[FieldType],
+        src_schema: &[FieldType],
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn super::AggrFunction>> {
@@ -45,10 +45,11 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserAvg {
 
         // Rewrite expression to insert CAST() if needed.
         let child = aggr_def.take_children().into_iter().next().unwrap();
-        let mut exp = RpnExpressionBuilder::build_from_expr_tree(child, time_zone, schema.len())?;
-        super::util::rewrite_exp_for_sum_avg(schema, &mut exp).unwrap();
+        let mut exp =
+            RpnExpressionBuilder::build_from_expr_tree(child, time_zone, src_schema.len())?;
+        super::util::rewrite_exp_for_sum_avg(src_schema, &mut exp).unwrap();
 
-        let rewritten_eval_type = EvalType::try_from(exp.ret_field_type(schema).tp()).unwrap();
+        let rewritten_eval_type = EvalType::try_from(exp.ret_field_type(src_schema).tp()).unwrap();
         out_exp.push(exp);
 
         Ok(match rewritten_eval_type {

--- a/src/coprocessor/dag/aggr_fn/impl_count.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_count.rs
@@ -25,7 +25,7 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserCount {
         mut aggr_def: Expr,
         time_zone: &Tz,
         // We use the same structure for all data types, so this parameter is not needed.
-        schema: &[FieldType],
+        src_schema: &[FieldType],
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn super::AggrFunction>> {
@@ -44,7 +44,7 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserCount {
         out_exp.push(RpnExpressionBuilder::build_from_expr_tree(
             child,
             time_zone,
-            schema.len(),
+            src_schema.len(),
         )?);
 
         Ok(Box::new(AggrFnCount))

--- a/src/coprocessor/dag/aggr_fn/impl_count.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_count.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use cop_codegen::AggrFunction;
+use cop_datatype::builder::FieldTypeBuilder;
 use cop_datatype::{FieldTypeFlag, FieldTypeTp};
 use tipb::expression::{Expr, ExprType, FieldType};
 
@@ -16,47 +17,34 @@ pub struct AggrFnDefinitionParserCount;
 impl super::AggrDefinitionParser for AggrFnDefinitionParserCount {
     fn check_supported(&self, aggr_def: &Expr) -> Result<()> {
         assert_eq!(aggr_def.get_tp(), ExprType::Count);
-        if aggr_def.get_children().len() != 1 {
-            return Err(box_err!(
-                "Expect 1 parameter, but got {}",
-                aggr_def.get_children().len()
-            ));
-        }
-
-        // Only check whether or not the children expr is supported.
-        let child = &aggr_def.get_children()[0];
-        RpnExpressionBuilder::check_expr_tree_supported(child)?;
-
-        Ok(())
+        super::util::check_aggr_exp_supported_one_child(aggr_def)
     }
 
     fn parse(
         &self,
         mut aggr_def: Expr,
         time_zone: &Tz,
-        max_columns: usize,
+        // We use the same structure for all data types, so this parameter is not needed.
+        schema: &[FieldType],
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn super::AggrFunction>> {
-        use cop_datatype::FieldTypeAccessor;
-
         assert_eq!(aggr_def.get_tp(), ExprType::Count);
         let child = aggr_def.take_children().into_iter().next().unwrap();
 
         // COUNT outputs one column.
-        out_schema.push({
-            let mut ft = FieldType::new();
-            ft.as_mut_accessor()
-                .set_tp(FieldTypeTp::LongLong)
-                .set_flag(FieldTypeFlag::UNSIGNED);
-            ft
-        });
+        out_schema.push(
+            FieldTypeBuilder::new()
+                .tp(FieldTypeTp::LongLong)
+                .flag(FieldTypeFlag::UNSIGNED)
+                .build(),
+        );
 
         // COUNT doesn't need to cast, so using the expression directly.
         out_exp.push(RpnExpressionBuilder::build_from_expr_tree(
             child,
             time_zone,
-            max_columns,
+            schema.len(),
         )?);
 
         Ok(Box::new(AggrFnCount))

--- a/src/coprocessor/dag/aggr_fn/mod.rs
+++ b/src/coprocessor/dag/aggr_fn/mod.rs
@@ -6,6 +6,7 @@ mod impl_avg;
 mod impl_count;
 mod parser;
 mod summable;
+mod util;
 
 pub use self::parser::{AggrDefinitionParser, AllAggrDefinitionParser};
 

--- a/src/coprocessor/dag/aggr_fn/parser.rs
+++ b/src/coprocessor/dag/aggr_fn/parser.rs
@@ -23,6 +23,9 @@ pub trait AggrDefinitionParser {
     /// RPN expression (maybe wrapped by some casting according to types) will be appended in
     /// `out_exp`.
     ///
+    /// The parser may choose particular aggregate function implementation based on the data
+    /// type, so `schema` is also needed in case of data type depending on the column.
+    ///
     /// # Panic
     ///
     /// May panic if the aggregate function definition is not supported by this parser.
@@ -30,7 +33,7 @@ pub trait AggrDefinitionParser {
         &self,
         aggr_def: Expr,
         time_zone: &Tz,
-        max_columns: usize,
+        schema: &[FieldType],
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn AggrFunction>>;
@@ -76,11 +79,11 @@ impl AggrDefinitionParser for AllAggrDefinitionParser {
         &self,
         aggr_def: Expr,
         time_zone: &Tz,
-        max_columns: usize,
+        schema: &[FieldType],
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn AggrFunction>> {
         let parser = map_pb_sig_to_aggr_func_parser(aggr_def.get_tp()).unwrap();
-        parser.parse(aggr_def, time_zone, max_columns, out_schema, out_exp)
+        parser.parse(aggr_def, time_zone, schema, out_schema, out_exp)
     }
 }

--- a/src/coprocessor/dag/aggr_fn/parser.rs
+++ b/src/coprocessor/dag/aggr_fn/parser.rs
@@ -33,7 +33,7 @@ pub trait AggrDefinitionParser {
         &self,
         aggr_def: Expr,
         time_zone: &Tz,
-        schema: &[FieldType],
+        src_schema: &[FieldType],
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn AggrFunction>>;
@@ -79,11 +79,11 @@ impl AggrDefinitionParser for AllAggrDefinitionParser {
         &self,
         aggr_def: Expr,
         time_zone: &Tz,
-        schema: &[FieldType],
+        src_schema: &[FieldType],
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn AggrFunction>> {
         let parser = map_pb_sig_to_aggr_func_parser(aggr_def.get_tp()).unwrap();
-        parser.parse(aggr_def, time_zone, schema, out_schema, out_exp)
+        parser.parse(aggr_def, time_zone, src_schema, out_schema, out_exp)
     }
 }

--- a/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
@@ -475,7 +475,7 @@ mod tests {
                 &self,
                 _aggr_def: Expr,
                 _time_zone: &Tz,
-                _schema: &[FieldType],
+                _src_schema: &[FieldType],
                 out_schema: &mut Vec<FieldType>,
                 out_exp: &mut Vec<RpnExpression>,
             ) -> Result<Box<dyn AggrFunction>> {

--- a/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
@@ -475,7 +475,7 @@ mod tests {
                 &self,
                 _aggr_def: Expr,
                 _time_zone: &Tz,
-                _max_columns: usize,
+                _schema: &[FieldType],
                 out_schema: &mut Vec<FieldType>,
                 out_exp: &mut Vec<RpnExpression>,
             ) -> Result<Box<dyn AggrFunction>> {

--- a/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
@@ -323,7 +323,7 @@ mod tests {
                 &self,
                 aggr_def: Expr,
                 _time_zone: &Tz,
-                _max_columns: usize,
+                _schema: &[FieldType],
                 out_schema: &mut Vec<FieldType>,
                 out_exp: &mut Vec<RpnExpression>,
             ) -> Result<Box<dyn AggrFunction>> {
@@ -560,7 +560,7 @@ mod tests {
                 &self,
                 _aggr_def: Expr,
                 _time_zone: &Tz,
-                _max_columns: usize,
+                _schema: &[FieldType],
                 out_schema: &mut Vec<FieldType>,
                 out_exp: &mut Vec<RpnExpression>,
             ) -> Result<Box<dyn AggrFunction>> {

--- a/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
@@ -327,7 +327,7 @@ mod tests {
                 &self,
                 aggr_def: Expr,
                 _time_zone: &Tz,
-                _schema: &[FieldType],
+                _src_schema: &[FieldType],
                 out_schema: &mut Vec<FieldType>,
                 out_exp: &mut Vec<RpnExpression>,
             ) -> Result<Box<dyn AggrFunction>> {
@@ -564,7 +564,7 @@ mod tests {
                 &self,
                 _aggr_def: Expr,
                 _time_zone: &Tz,
-                _schema: &[FieldType],
+                _src_schema: &[FieldType],
                 out_schema: &mut Vec<FieldType>,
                 out_exp: &mut Vec<RpnExpression>,
             ) -> Result<Box<dyn AggrFunction>> {

--- a/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
@@ -119,7 +119,6 @@ impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> AggregationExecutor<Sr
         assert!(aggr_fn_len > 0);
 
         let src_schema = src.schema();
-        let src_schema_len = src_schema.len();
 
         let mut schema = Vec::with_capacity(aggr_fn_len * 2);
         let mut each_aggr_fn = Vec::with_capacity(aggr_fn_len);
@@ -133,7 +132,7 @@ impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> AggregationExecutor<Sr
             let aggr_fn = aggr_def_parser.parse(
                 aggr_def,
                 &config.tz,
-                src_schema_len,
+                src_schema,
                 &mut schema,
                 &mut each_aggr_exprs,
             )?;

--- a/src/coprocessor/dag/rpn_expr/impl_cast.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_cast.rs
@@ -1,0 +1,203 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::convert::TryFrom;
+
+use cop_codegen::RpnFunction;
+use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeFlag};
+use tipb::expression::FieldType;
+
+use crate::coprocessor::codec::data_type::*;
+use crate::coprocessor::dag::expr::EvalContext;
+use crate::coprocessor::dag::rpn_expr::function::RpnFunction;
+use crate::coprocessor::dag::rpn_expr::types::RpnFnCallPayload;
+use crate::coprocessor::Result;
+
+/// Gets the cast function between specified data types.
+///
+/// TODO: This function supports some internal casts performed by TiKV. However it would be better
+/// to be done in TiDB.
+pub fn get_cast_fn(
+    from_field_type: &FieldType,
+    to_field_type: &FieldType,
+) -> Result<Box<dyn RpnFunction>> {
+    let from = box_try!(EvalType::try_from(from_field_type.tp()));
+    let to = box_try!(EvalType::try_from(to_field_type.tp()));
+    Ok(match (from, to) {
+        (EvalType::Int, EvalType::Decimal) => {
+            if !from_field_type
+                .as_accessor()
+                .flag()
+                .contains(FieldTypeFlag::UNSIGNED)
+                && !to_field_type
+                    .as_accessor()
+                    .flag()
+                    .contains(FieldTypeFlag::UNSIGNED)
+            {
+                Box::new(RpnFnCastIntAsDecimal)
+            } else {
+                Box::new(RpnFnCastUintAsDecimal)
+            }
+        }
+        (EvalType::Bytes, EvalType::Real) => Box::new(RpnFnCastStringAsReal),
+        (EvalType::DateTime, EvalType::Real) => Box::new(RpnFnCastTimeAsReal),
+        (EvalType::Duration, EvalType::Real) => Box::new(RpnFnCastDurationAsReal),
+        (EvalType::Json, EvalType::Real) => Box::new(RpnFnCastJsonAsReal),
+        _ => return Err(box_err!("Unsupported cast from {} to {}", from, to)),
+    })
+}
+
+fn produce_dec_with_specified_tp(
+    ctx: &mut EvalContext,
+    dec: Decimal,
+    ft: &FieldType,
+) -> Result<Decimal> {
+    // FIXME: The implementation is not exactly the same as TiDB's `ProduceDecWithSpecifiedTp`.
+    let (flen, decimal) = (ft.flen(), ft.decimal());
+    if flen == cop_datatype::UNSPECIFIED_LENGTH || decimal == cop_datatype::UNSPECIFIED_LENGTH {
+        return Ok(dec);
+    }
+    Ok(dec.convert_to(ctx, flen as u8, decimal as u8)?)
+}
+
+/// The unsigned int implementation for push down signature `CastIntAsDecimal`.
+#[derive(Debug, Clone, Copy, RpnFunction)]
+#[rpn_function(args = 1)]
+pub struct RpnFnCastUintAsDecimal;
+
+impl RpnFnCastUintAsDecimal {
+    #[inline]
+    fn call(
+        ctx: &mut EvalContext,
+        payload: RpnFnCallPayload<'_>,
+        val: &Option<i64>,
+    ) -> Result<Option<Decimal>> {
+        match val {
+            None => Ok(None),
+            Some(val) => {
+                let dec = Decimal::from(*val as u64);
+                Ok(Some(produce_dec_with_specified_tp(
+                    ctx,
+                    dec,
+                    payload.return_field_type(),
+                )?))
+            }
+        }
+    }
+}
+
+/// The signed int implementation for push down signature `CastIntAsDecimal`.
+#[derive(Debug, Clone, Copy, RpnFunction)]
+#[rpn_function(args = 1)]
+pub struct RpnFnCastIntAsDecimal;
+
+impl RpnFnCastIntAsDecimal {
+    #[inline]
+    fn call(
+        ctx: &mut EvalContext,
+        payload: RpnFnCallPayload<'_>,
+        val: &Option<i64>,
+    ) -> Result<Option<Decimal>> {
+        match val {
+            None => Ok(None),
+            Some(val) => {
+                let dec = Decimal::from(*val);
+                Ok(Some(produce_dec_with_specified_tp(
+                    ctx,
+                    dec,
+                    payload.return_field_type(),
+                )?))
+            }
+        }
+    }
+}
+
+/// The implementation for push down signature `CastStringAsReal`.
+#[derive(Debug, Clone, Copy, RpnFunction)]
+#[rpn_function(args = 1)]
+pub struct RpnFnCastStringAsReal;
+
+impl RpnFnCastStringAsReal {
+    #[inline]
+    fn call(
+        ctx: &mut EvalContext,
+        _payload: RpnFnCallPayload<'_>,
+        val: &Option<Bytes>,
+    ) -> Result<Option<Real>> {
+        use crate::coprocessor::codec::convert::bytes_to_f64;
+
+        match val {
+            None => Ok(None),
+            Some(val) => {
+                let val = bytes_to_f64(ctx, val.as_slice())?;
+                // FIXME: There is an additional step `ProduceFloatWithSpecifiedTp` in TiDB.
+                Ok(Real::new(val).ok())
+            }
+        }
+    }
+}
+
+/// The implementation for push down signature `CastTimeAsReal`.
+#[derive(Debug, Clone, Copy, RpnFunction)]
+#[rpn_function(args = 1)]
+pub struct RpnFnCastTimeAsReal;
+
+impl RpnFnCastTimeAsReal {
+    #[inline]
+    fn call(
+        _ctx: &mut EvalContext,
+        _payload: RpnFnCallPayload<'_>,
+        val: &Option<DateTime>,
+    ) -> Result<Option<Real>> {
+        match val {
+            None => Ok(None),
+            Some(val) => {
+                let val = val.to_decimal()?.as_f64()?;
+                Ok(Real::new(val).ok())
+            }
+        }
+    }
+}
+
+/// The implementation for push down signature `CastDurationAsReal`.
+#[derive(Debug, Clone, Copy, RpnFunction)]
+#[rpn_function(args = 1)]
+pub struct RpnFnCastDurationAsReal;
+
+impl RpnFnCastDurationAsReal {
+    #[inline]
+    fn call(
+        _ctx: &mut EvalContext,
+        _payload: RpnFnCallPayload<'_>,
+        val: &Option<Duration>,
+    ) -> Result<Option<Real>> {
+        match val {
+            None => Ok(None),
+            Some(val) => {
+                let val = val.to_decimal()?.as_f64()?;
+                Ok(Real::new(val).ok())
+            }
+        }
+    }
+}
+
+/// The implementation for push down signature `CastJsonAsReal`.
+#[derive(Debug, Clone, Copy, RpnFunction)]
+#[rpn_function(args = 1)]
+pub struct RpnFnCastJsonAsReal;
+
+impl RpnFnCastJsonAsReal {
+    #[inline]
+    fn call(
+        ctx: &mut EvalContext,
+        _payload: RpnFnCallPayload<'_>,
+        val: &Option<Json>,
+    ) -> Result<Option<Real>> {
+        match val {
+            None => Ok(None),
+            Some(val) => {
+                let val = val.cast_to_real(ctx)?;
+                Ok(Real::new(val).ok())
+            }
+        }
+    }
+}

--- a/src/coprocessor/dag/rpn_expr/mod.rs
+++ b/src/coprocessor/dag/rpn_expr/mod.rs
@@ -5,6 +5,7 @@ pub mod function;
 pub mod types;
 
 pub mod impl_arithmetic;
+pub mod impl_cast;
 pub mod impl_compare;
 pub mod impl_op;
 

--- a/src/coprocessor/dag/rpn_expr/types/expr.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr.rs
@@ -95,6 +95,12 @@ impl AsRef<[RpnExpressionNode]> for RpnExpression {
     }
 }
 
+impl AsMut<[RpnExpressionNode]> for RpnExpression {
+    fn as_mut(&mut self) -> &mut [RpnExpressionNode] {
+        self.0.as_mut()
+    }
+}
+
 impl RpnExpression {
     /// Gets the field type of the return value.
     pub fn ret_field_type<'a>(&'a self, schema: &'a [FieldType]) -> &'a FieldType {


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR adds supports of using all data types in AVG(), by half-implementing CAST functions necessary for these data types. 

Note: These implementations are not fully TiDB compatible. It is only ensured that the behaviour is not worse than existing cast behaviour in non-batch aggregation functions.

## What are the type of the changes? (mandatory)

- New feature (change which adds functionality)

## How has this PR been tested? (mandatory)

New unit tests.
