### PR TITLE
cop: Support empty aggr fn in batch aggr executor

### DIFF
--- a/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
@@ -94,6 +94,10 @@ impl BatchFastHashAggregationExecutor<Box<dyn BatchExecutor>> {
         }
 
         let aggr_definitions = descriptor.get_agg_func();
+        if aggr_definitions.is_empty() {
+            return Err(box_err!("Aggregation expression is empty"));
+        }
+
         for def in aggr_definitions {
             AllAggrDefinitionParser.check_supported(def)?;
         }

--- a/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
@@ -94,10 +94,6 @@ impl BatchFastHashAggregationExecutor<Box<dyn BatchExecutor>> {
         }
 
         let aggr_definitions = descriptor.get_agg_func();
-        if aggr_definitions.is_empty() {
-            return Err(box_err!("Aggregation expression is empty"));
-        }
-
         for def in aggr_definitions {
             AllAggrDefinitionParser.check_supported(def)?;
         }
@@ -535,6 +531,74 @@ mod tests {
             let r = exec.next_batch(1);
             assert_eq!(r.data.rows_len(), 0);
             assert!(r.is_drained.unwrap());
+        }
+    }
+
+    /// Only have GROUP BY columns but no Aggregate Functions.
+    ///
+    /// E.g. SELECT 1 FROM t GROUP BY x
+    #[test]
+    fn test_no_aggr_fn() {
+        let group_by_exp = RpnExpressionBuilder::new().push_column_ref(0).build();
+
+        let exec_fast = |src_exec| {
+            Box::new(BatchFastHashAggregationExecutor::new_for_test(
+                src_exec,
+                group_by_exp.clone(),
+                vec![],
+                AllAggrDefinitionParser,
+            )) as Box<dyn BatchExecutor>
+        };
+
+        let exec_slow = |src_exec| {
+            Box::new(BatchSlowHashAggregationExecutor::new_for_test(
+                src_exec,
+                vec![group_by_exp.clone()],
+                vec![],
+                AllAggrDefinitionParser,
+            )) as Box<dyn BatchExecutor>
+        };
+
+        let executor_builders: Vec<Box<dyn FnOnce(MockExecutor) -> _>> =
+            vec![Box::new(exec_fast), Box::new(exec_slow)];
+
+        for exec_builder in executor_builders {
+            let src_exec = make_src_executor_1();
+            let mut exec = exec_builder(src_exec);
+
+            let r = exec.next_batch(1);
+            assert_eq!(r.data.rows_len(), 0);
+            assert!(!r.is_drained.unwrap());
+
+            let r = exec.next_batch(1);
+            assert_eq!(r.data.rows_len(), 0);
+            assert!(!r.is_drained.unwrap());
+
+            let mut r = exec.next_batch(1);
+            assert_eq!(r.data.rows_len(), 3);
+            assert_eq!(r.data.columns_len(), 1); // 0 result column, 1 group by column
+            r.data[0].decode(&Tz::utc(), &exec.schema()[0]).unwrap();
+            let mut sort_column: Vec<(usize, _)> = r.data[0]
+                .decoded()
+                .as_real_slice()
+                .iter()
+                .map(|v| {
+                    use std::hash::{Hash, Hasher};
+                    let mut s = std::collections::hash_map::DefaultHasher::new();
+                    v.hash(&mut s);
+                    s.finish()
+                })
+                .enumerate()
+                .collect();
+            sort_column.sort_by(|a, b| a.1.cmp(&b.1));
+            let ordered_column: Vec<_> = sort_column
+                .iter()
+                .map(|(idx, _)| r.data[0].decoded().as_real_slice()[*idx])
+                .collect();
+            assert_eq!(
+                &ordered_column,
+                &[Real::new(1.5).ok(), None, Real::new(7.0).ok()]
+            );
         }
     }
 }

--- a/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
@@ -61,6 +61,10 @@ impl BatchSimpleAggregationExecutor<Box<dyn BatchExecutor>> {
     pub fn check_supported(descriptor: &Aggregation) -> Result<()> {
         assert_eq!(descriptor.get_group_by().len(), 0);
         let aggr_definitions = descriptor.get_agg_func();
+        if aggr_definitions.is_empty() {
+            return Err(box_err!("Aggregation expression is empty"));
+        }
+
         for def in aggr_definitions {
             AllAggrDefinitionParser.check_supported(def)?;
         }

--- a/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
@@ -77,6 +77,10 @@ impl BatchSlowHashAggregationExecutor<Box<dyn BatchExecutor>> {
         }
 
         let aggr_definitions = descriptor.get_agg_func();
+        if aggr_definitions.is_empty() {
+            return Err(box_err!("Aggregation expression is empty"));
+        }
+
         for def in aggr_definitions {
             AllAggrDefinitionParser.check_supported(def)?;
         }

--- a/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
@@ -77,10 +77,6 @@ impl BatchSlowHashAggregationExecutor<Box<dyn BatchExecutor>> {
         }
 
         let aggr_definitions = descriptor.get_agg_func();
-        if aggr_definitions.is_empty() {
-            return Err(box_err!("Aggregation expression is empty"));
-        }
-
         for def in aggr_definitions {
             AllAggrDefinitionParser.check_supported(def)?;
         }

--- a/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
@@ -116,8 +116,6 @@ impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> AggregationExecutor<Sr
         aggr_def_parser: impl AggrDefinitionParser,
     ) -> Result<Self> {
         let aggr_fn_len = aggr_defs.len();
-        assert!(aggr_fn_len > 0);
-
         let src_schema = src.schema();
         let src_schema_len = src_schema.len();
 


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR allows no aggr fn in the aggregation request.

This scenario happens for SQLs like:

```sql
SELECT 1 FROM t GROUP BY a
```

However, for simple aggregation executor it is still disallowed (since we now have no group bys as well as no aggregations).

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)
