### PR TITLE
Adds BufferVec

### DIFF
--- a/src/coprocessor/codec/batch/buffer_vec.rs
+++ b/src/coprocessor/codec/batch/buffer_vec.rs
@@ -1,0 +1,800 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+#![allow(dead_code)]
+
+use std::iter::*;
+
+/// A vector like container storing multiple buffers. Each buffer is a `[u8]` slice in
+/// arbitrary length.
+#[derive(Default)]
+pub struct BufferVec {
+    data: Vec<u8>,
+    offsets: Vec<usize>,
+}
+
+impl Clone for BufferVec {
+    fn clone(&self) -> Self {
+        Self {
+            data: tikv_util::vec_clone_with_capacity(&self.data),
+            offsets: tikv_util::vec_clone_with_capacity(&self.offsets),
+        }
+    }
+}
+
+impl std::fmt::Debug for BufferVec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use hex::ToHex;
+
+        write!(f, "[")?;
+        let len = self.len();
+        if len > 0 {
+            for i in 0..len - 1 {
+                if self[i].is_empty() {
+                    write!(f, "null")?;
+                } else {
+                    self[i].as_ref().write_hex_upper(f)?;
+                }
+                write!(f, ", ")?;
+            }
+            if self[len - 1].is_empty() {
+                write!(f, "null")?;
+            } else {
+                self[len - 1].as_ref().write_hex_upper(f)?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+
+impl BufferVec {
+    /// Constructs a new, empty `BufferVec`.
+    ///
+    /// The `BufferVec` will not allocate until buffers are pushed onto it.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Constructs a new, empty `BufferVec` with the specified element capacity and data capacity.
+    #[inline]
+    pub fn with_capacity(elements_capacity: usize, data_capacity: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(data_capacity),
+            offsets: Vec::with_capacity(elements_capacity),
+        }
+    }
+
+    /// Returns the number of buffers this `BufferVec` can hold without reallocating the
+    /// offsets array.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.offsets.capacity()
+    }
+
+    /// Returns the number of buffers this `BufferVec` can hold without reallocating the
+    /// data array.
+    #[inline]
+    pub fn data_capacity(&self) -> usize {
+        self.data.capacity()
+    }
+
+    /// Returns the number of contained buffers.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.offsets.len()
+    }
+
+    /// Returns `true` if there is no contained buffer.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the total length of all contained buffers.
+    #[inline]
+    pub fn total_len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Appends a buffer to the back.
+    #[inline]
+    pub fn push(&mut self, buffer: impl AsRef<[u8]>) {
+        self.offsets.push(self.data.len());
+        self.data.extend_from_slice(buffer.as_ref());
+    }
+
+    /// Removes the last buffer if there is any.
+    #[inline]
+    pub fn pop(&mut self) {
+        let len = self.len();
+        if len > 0 {
+            self.data.truncate(self.offsets[len - 1]);
+            self.offsets.pop();
+        }
+    }
+
+    /// Removes the first `n` buffers.
+    ///
+    /// If `n` >= current length, all buffers will be removed.
+    pub fn shift(&mut self, n: usize) {
+        let len = self.len();
+        if n == 0 {
+            return;
+        }
+
+        // Suppose we want to shift by 2 and we have the following data:
+        // data:   [AABB, 00, , CACCAA]
+        // offset: [0,    2,  3,3     ]
+        //                    ^             : data_offset  = 3
+        //                   >|      |<     : data_len     = 3
+        //                   >|      |<     : n_len        = 2
+        //
+        // 1. Move valid data and offset forward
+        // data:   [, CACCAA, XX, XX]   XX is the outdated data
+        // offset: [3,3     , XX, XX]
+        //
+        // 2. Update offset
+        // data:   [, CACCAA, XX, XX]
+        // offset: [0,0     , XX, XX]
+        //
+        // 3. Shrink
+        // data:   [, CACCAA]
+        // offset: [0,0     ]
+
+        if n < len {
+            unsafe {
+                let data_offset = self.offsets[n];
+                let data_len = self.data.len() - data_offset;
+                let n_len = len - n;
+                // 1
+                std::ptr::copy(
+                    self.data.as_ptr().add(data_offset),
+                    self.data.as_mut_ptr(),
+                    data_len,
+                );
+                std::ptr::copy(
+                    self.offsets.as_ptr().add(n),
+                    self.offsets.as_mut_ptr(),
+                    n_len,
+                );
+                // 2
+                for i in 0..n_len {
+                    self.offsets[i] -= data_offset;
+                }
+                assert_eq!(self.offsets[0], 0);
+                // 3
+                self.data.set_len(data_len);
+                self.offsets.set_len(n_len);
+            }
+        } else {
+            self.clear();
+        }
+    }
+
+    /// Shortens the `BufferVec`, keeping the first `n` buffers and dropping the rest.
+    ///
+    /// If `n` >= current length, this has no effect.
+    #[inline]
+    pub fn truncate(&mut self, n: usize) {
+        let len = self.len();
+        if n < len {
+            self.data.truncate(self.offsets[n]);
+            self.offsets.truncate(n);
+        }
+    }
+
+    /// Removes all buffers.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.data.clear();
+        self.offsets.clear();
+    }
+
+    /// Copies all buffers from `other` to `self`.
+    pub fn extend(&mut self, other: &BufferVec) {
+        let base_offset = self.data.len();
+        self.data.extend_from_slice(&other.data);
+        self.offsets.reserve(other.offsets.len());
+        for offset in &other.offsets {
+            self.offsets.push(*offset + base_offset);
+        }
+    }
+
+    /// Copies first `n` buffers from `other` to `self`.
+    ///
+    /// If `n > other.len()`, only `other.len()` buffers will be copied.
+    pub fn extend_n(&mut self, other: &BufferVec, n: usize) {
+        if n >= other.len() {
+            self.extend(other);
+        } else if n > 0 {
+            let base_offset = self.data.len();
+            self.data.extend_from_slice(&other.data[..other.offsets[n]]);
+            self.offsets.reserve(n);
+            for i in 0..n {
+                self.offsets.push(other.offsets[i] + base_offset);
+            }
+        }
+    }
+
+    /// Retain the elements according to a boolean array.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `retain_arr` is not long enough.
+    pub fn retain_by_array(&mut self, retain_arr: &[bool]) {
+        unsafe {
+            let len = self.len();
+            assert!(retain_arr.len() >= len);
+
+            if len > 0 {
+                let mut data_write_offset = 0;
+                let mut offsets_write_offset = 0;
+                for i in 0..len - 1 {
+                    if retain_arr[i] {
+                        let write_len = self.offsets[i + 1] - self.offsets[i];
+                        std::ptr::copy(
+                            self.data.as_ptr().add(self.offsets[i]),
+                            self.data.as_mut_ptr().add(data_write_offset),
+                            write_len,
+                        );
+                        self.offsets[offsets_write_offset] = data_write_offset;
+                        offsets_write_offset += 1;
+                        data_write_offset += write_len;
+                    }
+                }
+                // The last buffer does not have an ending offset
+                if retain_arr[len - 1] {
+                    let write_len = self.data.len() - self.offsets[len - 1];
+                    std::ptr::copy(
+                        self.data.as_ptr().add(self.offsets[len - 1]),
+                        self.data.as_mut_ptr().add(data_write_offset),
+                        write_len,
+                    );
+                    self.offsets[offsets_write_offset] = data_write_offset;
+                    offsets_write_offset += 1;
+                    data_write_offset += write_len;
+                }
+                self.offsets.set_len(offsets_write_offset);
+                self.data.set_len(data_write_offset);
+            }
+        }
+    }
+
+    /// Returns an iterator over the `BufferVec`.
+    pub fn iter(&self) -> Iter<'_> {
+        Iter {
+            data: &self.data,
+            offsets: &self.offsets,
+        }
+    }
+}
+
+impl std::ops::Index<usize> for BufferVec {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: usize) -> &[u8] {
+        assert!(index < self.offsets.len());
+        if index < self.offsets.len() - 1 {
+            &self.data[self.offsets[index]..self.offsets[index + 1]]
+        } else {
+            &self.data[self.offsets[index]..]
+        }
+    }
+}
+
+// TODO: Implement Index<XxxRange>
+
+#[derive(Clone, Copy)]
+pub struct Iter<'a> {
+    data: &'a [u8],
+    offsets: &'a [usize],
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.nth(0)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.offsets.len();
+        (len, Some(len))
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.offsets.len()
+    }
+
+    fn last(mut self) -> Option<Self::Item> {
+        let l = self.offsets.len();
+        if l == 0 {
+            None
+        } else {
+            self.nth(l - 1)
+        }
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if n + 1 < self.offsets.len() {
+            let begin_offset = self.offsets[n];
+            let end_offset = self.offsets[n + 1];
+            self.offsets = &self.offsets[n + 1..];
+            Some(&self.data[begin_offset..end_offset])
+        } else if n + 1 == self.offsets.len() {
+            let begin_offset = self.offsets[n];
+            self.offsets = &[];
+            Some(&self.data[begin_offset..])
+        } else {
+            self.offsets = &[];
+            None
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for Iter<'a> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let mut v = BufferVec::new();
+        assert_eq!(format!("{:?}", v), "[]");
+        assert!(v.is_empty());
+
+        v.pop();
+        assert_eq!(format!("{:?}", v), "[]");
+        assert!(v.is_empty());
+
+        v.shift(0);
+        assert_eq!(format!("{:?}", v), "[]");
+        assert!(v.is_empty());
+
+        v.push(&[0xAA, 0x0, 0xB]);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xAA, 0x0, 0xB]);
+        assert_eq!(format!("{:?}", v), "[AA000B]");
+
+        v.truncate(1);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xAA, 0x0, 0xB]);
+        assert_eq!(format!("{:?}", v), "[AA000B]");
+
+        v.truncate(2);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xAA, 0x0, 0xB]);
+        assert_eq!(format!("{:?}", v), "[AA000B]");
+
+        v.shift(0);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xAA, 0x0, 0xB]);
+        assert_eq!(format!("{:?}", v), "[AA000B]");
+
+        v.pop();
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.total_len(), 0);
+        assert!(v.is_empty());
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.truncate(1);
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.total_len(), 0);
+        assert!(v.is_empty());
+        assert_eq!(format!("{:?}", v), "[]");
+        assert!(v.is_empty());
+
+        v.pop();
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.total_len(), 0);
+        assert!(v.is_empty());
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.push(&[0xCA, 0xB]);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 2);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xCA, 0xB]);
+        assert_eq!(format!("{:?}", v), "[CA0B]");
+
+        v.shift(1);
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.total_len(), 0);
+        assert!(v.is_empty());
+        assert_eq!(format!("{:?}", v), "[]");
+        assert!(v.is_empty());
+
+        v.push(&[0xCA, 0xB]);
+        v.push(&[]);
+        assert_eq!(v.len(), 2);
+        assert_eq!(v.total_len(), 2);
+        assert!(!v.is_empty());
+        assert!(v[1].is_empty()); // To avoid "cannot infer type" bug..
+        assert_eq!(format!("{:?}", v), "[CA0B, null]");
+
+        v.pop();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 2);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xCA, 0xB]);
+        assert_eq!(format!("{:?}", v), "[CA0B]");
+
+        v.push(&[]);
+        v.push(&[]);
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.total_len(), 2);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xCA, 0xB]);
+        assert!(v[1].is_empty());
+        assert!(v[2].is_empty());
+        assert_eq!(format!("{:?}", v), "[CA0B, null, null]");
+
+        v.push(&[0xC]);
+        assert_eq!(v.len(), 4);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xCA, 0xB]);
+        assert!(v[1].is_empty());
+        assert!(v[2].is_empty());
+        assert_eq!(v[3], [0xC]);
+        assert_eq!(format!("{:?}", v), "[CA0B, null, null, 0C]");
+
+        v.pop();
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.total_len(), 2);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xCA, 0xB]);
+        assert!(v[1].is_empty());
+        assert!(v[2].is_empty());
+        assert_eq!(format!("{:?}", v), "[CA0B, null, null]");
+
+        v.shift(1);
+        assert_eq!(v.len(), 2);
+        assert_eq!(v.total_len(), 0);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert!(v[1].is_empty());
+        assert_eq!(format!("{:?}", v), "[null, null]");
+
+        v.push(&[0xAC, 0xBB, 0x00]);
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert!(v[1].is_empty());
+        assert_eq!(v[2], [0xAC, 0xBB, 0x00]);
+        assert_eq!(format!("{:?}", v), "[null, null, ACBB00]");
+
+        v.shift(0);
+        assert!(!v.is_empty());
+        assert_eq!(format!("{:?}", v), "[null, null, ACBB00]");
+
+        v.shift(1);
+        assert_eq!(v.len(), 2);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert_eq!(v[1], [0xAC, 0xBB, 0x00]);
+        assert_eq!(format!("{:?}", v), "[null, ACBB00]");
+
+        v.push(&[]);
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert_eq!(v[1], [0xAC, 0xBB, 0x00]);
+        assert!(v[2].is_empty());
+        assert_eq!(format!("{:?}", v), "[null, ACBB00, null]");
+
+        v.shift(2);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 0);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert_eq!(format!("{:?}", v), "[null]");
+
+        v.shift(0);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 0);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert_eq!(format!("{:?}", v), "[null]");
+
+        v.shift(2);
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.total_len(), 0);
+        assert!(v.is_empty());
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.push(&[0xA]);
+        v.push(&[0xB]);
+        v.push(&[0xC]);
+        v.push(&[0xD, 0xE]);
+        v.push(&[]);
+        v.push(&[]);
+        assert_eq!(v.len(), 6);
+        assert_eq!(v.total_len(), 5);
+        assert!(!v.is_empty());
+        assert_eq!(format!("{:?}", v), "[0A, 0B, 0C, 0D0E, null, null]");
+
+        v.truncate(5);
+        assert_eq!(v.len(), 5);
+        assert_eq!(v.total_len(), 5);
+        assert!(!v.is_empty());
+        assert_eq!(format!("{:?}", v), "[0A, 0B, 0C, 0D0E, null]");
+
+        v.shift(4);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 0);
+        assert!(!v.is_empty());
+        assert_eq!(format!("{:?}", v), "[null]");
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut v1 = BufferVec::new();
+        v1.push(&[]);
+        v1.push(&[0xAA, 0xBB, 0x0C]);
+        v1.push(&[]);
+        v1.push(&[0x00]);
+
+        let mut v2 = BufferVec::new();
+        v2.push(&[]);
+        v2.push(&[]);
+
+        let mut v3 = v1.clone();
+        v3.extend(&v2);
+        assert_eq!(v3.len(), 6);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, null, 00, null, null]");
+
+        v3.truncate(3);
+        assert_eq!(v3.len(), 3);
+        assert_eq!(v3.total_len(), 3);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, null]");
+
+        v3.push(&[]);
+        v3.push(&[0x00]);
+        assert_eq!(v3.len(), 5);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, null, null, 00]");
+
+        let mut v3 = v2.clone();
+        v3.extend(&v1);
+        assert_eq!(v3.len(), 6);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[null, null, null, AABB0C, null, 00]");
+
+        v3.pop();
+        v3.shift(0);
+        assert_eq!(v3.len(), 5);
+        assert_eq!(v3.total_len(), 3);
+        assert_eq!(format!("{:?}", v3), "[null, null, null, AABB0C, null]");
+
+        let mut v3 = v2.clone();
+        v3.shift(2);
+        v3.extend(&v1);
+        assert_eq!(v3.len(), 4);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, null, 00]");
+
+        v3.shift(4);
+        assert_eq!(v3.len(), 0);
+        assert_eq!(v3.total_len(), 0);
+        assert_eq!(format!("{:?}", v3), "[]");
+
+        let mut v1 = BufferVec::new();
+        v1.push(&[]);
+        v1.push(&[0xAA, 0xBB, 0x0C]);
+
+        let mut v2 = BufferVec::new();
+        v2.push(&[0x0C, 0x00]);
+        v2.push(&[]);
+
+        let mut v3 = v2.clone();
+        v3.extend_n(&v1, 0);
+        assert_eq!(v3.len(), 2);
+        assert_eq!(v3.total_len(), 2);
+        assert_eq!(format!("{:?}", v3), "[0C00, null]");
+
+        v3.push(&[0xAA]);
+        assert_eq!(v3.len(), 3);
+        assert_eq!(v3.total_len(), 3);
+        assert_eq!(format!("{:?}", v3), "[0C00, null, AA]");
+
+        let mut v3 = v2.clone();
+        v3.extend_n(&v1, 1);
+        assert_eq!(v3.len(), 3);
+        assert_eq!(v3.total_len(), 2);
+        assert_eq!(format!("{:?}", v3), "[0C00, null, null]");
+
+        v3.push(&[0xAA]);
+        assert_eq!(v3.len(), 4);
+        assert_eq!(v3.total_len(), 3);
+        assert_eq!(format!("{:?}", v3), "[0C00, null, null, AA]");
+
+        let mut v3 = v1.clone();
+        v3.extend_n(&v2, 1);
+        assert_eq!(v3.len(), 3);
+        assert_eq!(v3.total_len(), 5);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, 0C00]");
+
+        v3.pop();
+        assert_eq!(v3.len(), 2);
+        assert_eq!(v3.total_len(), 3);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C]");
+
+        let mut v3 = v1.clone();
+        v3.extend_n(&v2, 2);
+        assert_eq!(v3.len(), 4);
+        assert_eq!(v3.total_len(), 5);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, 0C00, null]");
+
+        v3.shift(2);
+        assert_eq!(v3.len(), 2);
+        assert_eq!(v3.total_len(), 2);
+        assert_eq!(format!("{:?}", v3), "[0C00, null]");
+
+        v3.extend_n(&v2, 5);
+        assert_eq!(v3.len(), 4);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[0C00, null, 0C00, null]");
+
+        v3.pop();
+        assert_eq!(v3.len(), 3);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[0C00, null, 0C00]");
+    }
+
+    #[test]
+    fn test_retain() {
+        let mut v = BufferVec::new();
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.retain_by_array(&[]);
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.push(&[]);
+        assert_eq!(format!("{:?}", v), "[null]");
+
+        v.retain_by_array(&[true]);
+        assert_eq!(format!("{:?}", v), "[null]");
+
+        v.retain_by_array(&[false]);
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.push(&[0xAA, 0x00]);
+        v.push(&[]);
+        assert_eq!(format!("{:?}", v), "[AA00, null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[true, true]);
+        assert_eq!(format!("{:?}", v2), "[AA00, null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[true, false]);
+        assert_eq!(format!("{:?}", v2), "[AA00]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[false, true]);
+        assert_eq!(format!("{:?}", v2), "[null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[false, false]);
+        assert_eq!(format!("{:?}", v2), "[]");
+
+        v.push(&[]);
+        v.push(&[0xBB, 0x00, 0xA0]);
+        assert_eq!(format!("{:?}", v), "[AA00, null, null, BB00A0]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[true, true, false, true]);
+        assert_eq!(format!("{:?}", v2), "[AA00, null, BB00A0]");
+
+        v2.extend_n(&v, 2);
+        assert_eq!(format!("{:?}", v2), "[AA00, null, BB00A0, AA00, null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[true, false, false, true]);
+        assert_eq!(format!("{:?}", v2), "[AA00, BB00A0]");
+
+        v2.shift(1);
+        assert_eq!(format!("{:?}", v2), "[BB00A0]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[false, false, true, true]);
+        assert_eq!(format!("{:?}", v2), "[null, BB00A0]");
+
+        v2.push(&[]);
+        assert_eq!(format!("{:?}", v2), "[null, BB00A0, null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[true, true, true, false]);
+        assert_eq!(format!("{:?}", v2), "[AA00, null, null]");
+
+        v2.shift(2);
+        assert_eq!(format!("{:?}", v2), "[null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[false, true, true, false]);
+        assert_eq!(format!("{:?}", v2), "[null, null]");
+
+        v2.pop();
+        v2.extend(&v);
+        assert_eq!(format!("{:?}", v2), "[null, AA00, null, null, BB00A0]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[false, false, false, true]);
+        assert_eq!(format!("{:?}", v2), "[BB00A0]");
+
+        v2.pop();
+        assert_eq!(format!("{:?}", v2), "[]");
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut v = BufferVec::new();
+        v.push(&[]);
+        v.push(&[0xAA, 0xBB, 0x0C]);
+        v.push(&[]);
+        v.push(&[]);
+        v.push(&[0x00]);
+        v.push(&[]);
+
+        let mut it = v.iter();
+        assert_eq!(it.count(), 6);
+        assert!(it.next().unwrap().is_empty());
+        assert_eq!(it.count(), 5);
+        assert!(it.last().unwrap().is_empty());
+
+        let mut it = v.iter();
+        assert!(it.nth(0).unwrap().is_empty());
+        assert_eq!(it.count(), 5);
+        assert_eq!(it.nth(0).unwrap(), &[0xAA, 0xBB, 0x0C]);
+        assert_eq!(it.count(), 4);
+        assert_eq!(it.nth(2).unwrap(), &[0x00]);
+        assert_eq!(it.count(), 1);
+        assert!(it.next().unwrap().is_empty());
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.next(), None);
+        assert_eq!(it.last(), None);
+
+        let mut it = v.iter();
+        assert!(it.nth(3).unwrap().is_empty());
+        assert_eq!(it.count(), 2);
+        assert_eq!(it.next().unwrap(), &[0x00]);
+        assert_eq!(it.count(), 1);
+        assert!(it.next().unwrap().is_empty());
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.next(), None);
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.nth(0), None);
+        assert_eq!(it.last(), None);
+
+        let mut it = v.iter();
+        assert!(it.nth(5).unwrap().is_empty());
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.next(), None);
+        assert_eq!(it.nth(3), None);
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.last(), None);
+
+        let mut it = v.iter();
+        assert_eq!(it.nth(6), None);
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.next(), None);
+        assert_eq!(it.nth(1), None);
+    }
+}

--- a/src/coprocessor/codec/batch/buffer_vec.rs
+++ b/src/coprocessor/codec/batch/buffer_vec.rs
@@ -26,20 +26,14 @@ impl std::fmt::Debug for BufferVec {
         use hex::ToHex;
 
         write!(f, "[")?;
-        let len = self.len();
-        if len > 0 {
-            for i in 0..len - 1 {
-                if self[i].is_empty() {
-                    write!(f, "null")?;
-                } else {
-                    self[i].as_ref().write_hex_upper(f)?;
-                }
+        for (i, item) in self.iter().enumerate() {
+            if i != 0 {
                 write!(f, ", ")?;
             }
-            if self[len - 1].is_empty() {
+            if item.is_empty() {
                 write!(f, "null")?;
             } else {
-                self[len - 1].as_ref().write_hex_upper(f)?;
+                item.write_hex_upper(f)?;
             }
         }
         write!(f, "]")
@@ -106,10 +100,8 @@ impl BufferVec {
     /// Removes the last buffer if there is any.
     #[inline]
     pub fn pop(&mut self) {
-        let len = self.len();
-        if len > 0 {
-            self.data.truncate(self.offsets[len - 1]);
-            self.offsets.pop();
+        if let Some(offset) = self.offsets.pop() {
+            self.data.truncate(offset);
         }
     }
 
@@ -117,7 +109,6 @@ impl BufferVec {
     ///
     /// If `n` >= current length, all buffers will be removed.
     pub fn shift(&mut self, n: usize) {
-        let len = self.len();
         if n == 0 {
             return;
         }
@@ -130,42 +121,24 @@ impl BufferVec {
         //                   >|      |<     : n_len        = 2
         //
         // 1. Move valid data and offset forward
-        // data:   [, CACCAA, XX, XX]   XX is the outdated data
-        // offset: [3,3     , XX, XX]
+        // data:   [, CACCAA]
+        // offset: [3,3     ]
         //
         // 2. Update offset
-        // data:   [, CACCAA, XX, XX]
-        // offset: [0,0     , XX, XX]
-        //
-        // 3. Shrink
         // data:   [, CACCAA]
         // offset: [0,0     ]
 
+        let len = self.len();
         if n < len {
-            unsafe {
-                let data_offset = self.offsets[n];
-                let data_len = self.data.len() - data_offset;
-                let n_len = len - n;
-                // 1
-                std::ptr::copy(
-                    self.data.as_ptr().add(data_offset),
-                    self.data.as_mut_ptr(),
-                    data_len,
-                );
-                std::ptr::copy(
-                    self.offsets.as_ptr().add(n),
-                    self.offsets.as_mut_ptr(),
-                    n_len,
-                );
-                // 2
-                for i in 0..n_len {
-                    self.offsets[i] -= data_offset;
-                }
-                assert_eq!(self.offsets[0], 0);
-                // 3
-                self.data.set_len(data_len);
-                self.offsets.set_len(n_len);
+            let data_offset = self.offsets[n];
+            // 1
+            self.data.drain(..data_offset);
+            self.offsets.drain(..n);
+            // 2
+            for offset in &mut self.offsets {
+                *offset -= data_offset;
             }
+            assert_eq!(self.offsets[0], 0);
         } else {
             self.clear();
         }
@@ -210,8 +183,8 @@ impl BufferVec {
             let base_offset = self.data.len();
             self.data.extend_from_slice(&other.data[..other.offsets[n]]);
             self.offsets.reserve(n);
-            for i in 0..n {
-                self.offsets.push(other.offsets[i] + base_offset);
+            for offset in &other.offsets[..n] {
+                self.offsets.push(*offset + base_offset);
             }
         }
     }
@@ -222,6 +195,7 @@ impl BufferVec {
     ///
     /// Panics if `retain_arr` is not long enough.
     pub fn retain_by_array(&mut self, retain_arr: &[bool]) {
+        // TODO: Optimize to move multiple contiguous slots.
         unsafe {
             let len = self.len();
             assert!(retain_arr.len() >= len);
@@ -269,17 +243,30 @@ impl BufferVec {
     }
 }
 
+impl<A: AsRef<[u8]>> Extend<A> for BufferVec {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = A>,
+    {
+        for i in iter.into_iter() {
+            self.push(i);
+        }
+    }
+}
+
 impl std::ops::Index<usize> for BufferVec {
     type Output = [u8];
 
     #[inline]
     fn index(&self, index: usize) -> &[u8] {
         assert!(index < self.offsets.len());
-        if index < self.offsets.len() - 1 {
-            &self.data[self.offsets[index]..self.offsets[index + 1]]
-        } else {
-            &self.data[self.offsets[index]..]
-        }
+        let start = self.offsets[index];
+        let end = self
+            .offsets
+            .get(index + 1)
+            .copied()
+            .unwrap_or_else(|| self.data.len());
+        &self.data[start..end]
     }
 }
 
@@ -394,7 +381,6 @@ mod tests {
         assert_eq!(v.total_len(), 0);
         assert!(v.is_empty());
         assert_eq!(format!("{:?}", v), "[]");
-        assert!(v.is_empty());
 
         v.pop();
         assert_eq!(v.len(), 0);
@@ -414,7 +400,6 @@ mod tests {
         assert_eq!(v.total_len(), 0);
         assert!(v.is_empty());
         assert_eq!(format!("{:?}", v), "[]");
-        assert!(v.is_empty());
 
         v.push(&[0xCA, 0xB]);
         v.push(&[]);

--- a/src/coprocessor/codec/batch/mod.rs
+++ b/src/coprocessor/codec/batch/mod.rs
@@ -1,7 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+mod buffer_vec;
 mod lazy_column;
 mod lazy_column_vec;
 
+pub use self::buffer_vec::BufferVec;
 pub use self::lazy_column::LazyBatchColumn;
 pub use self::lazy_column_vec::LazyBatchColumnVec;


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

`BufferVec` is a data structure for efficiently holding multiple binary strings (like `Vec<Vec<u8>>`). Each binary string can be in different length.

`BufferVec` supports random read and sequential write. `BufferVec` does not support random write.

`BufferVec` will be used to support `LazyBatchColumn`, as well as `VectorValue::Bytes` in future may be.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

New unit tests.
