### PR TITLE
Replace all `Into` with `From`

### DIFF
--- a/components/cop_datatype/src/builder/field_type.rs
+++ b/components/cop_datatype/src/builder/field_type.rs
@@ -42,8 +42,8 @@ impl FieldTypeBuilder {
     }
 }
 
-impl Into<FieldType> for FieldTypeBuilder {
-    fn into(self) -> FieldType {
-        self.build()
+impl From<FieldTypeBuilder> for FieldType {
+    fn from(fp_builder: FieldTypeBuilder) -> FieldType {
+        fp_builder.build()
     }
 }

--- a/components/cop_datatype/src/def/field_type.rs
+++ b/components/cop_datatype/src/def/field_type.rs
@@ -309,18 +309,18 @@ impl FieldTypeAccessor for ColumnInfo {
     }
 }
 
-impl Into<FieldType> for FieldTypeTp {
-    fn into(self) -> FieldType {
+impl From<FieldTypeTp> for FieldType {
+    fn from(fp: FieldTypeTp) -> FieldType {
         let mut ft = FieldType::new();
-        ft.as_mut_accessor().set_tp(self);
+        ft.as_mut_accessor().set_tp(fp);
         ft
     }
 }
 
-impl Into<ColumnInfo> for FieldTypeTp {
-    fn into(self) -> ColumnInfo {
+impl From<FieldTypeTp> for ColumnInfo {
+    fn from(fp: FieldTypeTp) -> ColumnInfo {
         let mut ft = ColumnInfo::new();
-        ft.as_mut_accessor().set_tp(self);
+        ft.as_mut_accessor().set_tp(fp);
         ft
     }
 }

--- a/components/engine/src/rocks/util/config.rs
+++ b/components/engine/src/rocks/util/config.rs
@@ -15,9 +15,9 @@ pub enum CompressionType {
     ZstdNotFinal,
 }
 
-impl Into<DBCompressionType> for CompressionType {
-    fn into(self) -> DBCompressionType {
-        match self {
+impl From<CompressionType> for DBCompressionType {
+    fn from(compression_type: CompressionType) -> DBCompressionType {
+        match compression_type {
             CompressionType::No => DBCompressionType::No,
             CompressionType::Snappy => DBCompressionType::Snappy,
             CompressionType::Zlib => DBCompressionType::Zlib,

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -221,9 +221,9 @@ impl<'de> Deserialize<'de> for ReadableSize {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ReadableDuration(pub Duration);
 
-impl Into<Duration> for ReadableDuration {
-    fn into(self) -> Duration {
-        self.0
+impl From<ReadableDuration> for Duration {
+    fn from(readable: ReadableDuration) -> Duration {
+        readable.0
     }
 }
 

--- a/components/tipb_helper/src/expr_def_builder.rs
+++ b/components/tipb_helper/src/expr_def_builder.rs
@@ -90,8 +90,8 @@ impl ExprDefBuilder {
     }
 }
 
-impl Into<Expr> for ExprDefBuilder {
-    fn into(self) -> Expr {
-        self.build()
+impl From<ExprDefBuilder> for Expr {
+    fn from(expr_def_builder: ExprDefBuilder) -> Expr {
+        expr_def_builder.build()
     }
 }

--- a/src/coprocessor/codec/error.rs
+++ b/src/coprocessor/codec/error.rs
@@ -147,11 +147,11 @@ impl Error {
     }
 }
 
-impl Into<select::Error> for Error {
-    fn into(self) -> select::Error {
+impl From<Error> for select::Error {
+    fn from(error: Error) -> select::Error {
         let mut err = select::Error::new();
-        err.set_code(self.code());
-        err.set_msg(format!("{:?}", self));
+        err.set_code(error.code());
+        err.set_msg(format!("{:?}", error));
         err
     }
 }

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -189,9 +189,9 @@ pub enum TimeType {
     Timestamp,
 }
 
-impl Into<FieldTypeTp> for TimeType {
-    fn into(self) -> FieldTypeTp {
-        match self {
+impl From<TimeType> for FieldTypeTp {
+    fn from(time_type: TimeType) -> FieldTypeTp {
+        match time_type {
             TimeType::Date => FieldTypeTp::Date,
             TimeType::DateTime => FieldTypeTp::DateTime,
             TimeType::Timestamp => FieldTypeTp::Timestamp,

--- a/src/raftstore/errors.rs
+++ b/src/raftstore/errors.rs
@@ -142,12 +142,12 @@ quick_error! {
 
 pub type Result<T> = result::Result<T, Error>;
 
-impl Into<errorpb::Error> for Error {
-    fn into(self) -> errorpb::Error {
+impl From<Error> for errorpb::Error {
+    fn from(err: Error) -> errorpb::Error {
         let mut errorpb = errorpb::Error::new();
-        errorpb.set_message(error::Error::description(&self).to_owned());
+        errorpb.set_message(error::Error::description(&err).to_owned());
 
-        match self {
+        match err {
             Error::RegionNotFound(region_id) => {
                 errorpb.mut_region_not_found().set_region_id(region_id);
             }

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -116,9 +116,9 @@ impl From<debugpb::BottommostLevelCompaction> for BottommostLevelCompaction {
     }
 }
 
-impl Into<debugpb::BottommostLevelCompaction> for BottommostLevelCompaction {
-    fn into(self) -> debugpb::BottommostLevelCompaction {
-        match self.0 {
+impl From<BottommostLevelCompaction> for debugpb::BottommostLevelCompaction {
+    fn from(bottommost: BottommostLevelCompaction) -> debugpb::BottommostLevelCompaction {
+        match bottommost.0 {
             DBBottommostLevelCompaction::Skip => debugpb::BottommostLevelCompaction::Skip,
             DBBottommostLevelCompaction::Force => debugpb::BottommostLevelCompaction::Force,
             DBBottommostLevelCompaction::IfHaveCompactionFilter => {


### PR DESCRIPTION
Signed-off-by: Iosmanthus Teng <myosmanthustree@gmail.com>


## What have you changed? (mandatory)
Lots of code in `TiKV` implement `Into<SomeType>` for AnotherType but not `From<AnotherType>` for SomeType which will automatically implement `Into<SomeType>` and allow more explicitly construction.

## What are the type of changes? (mandatory)
- Improvement (a change which is an improvement to an existing feature)
