### PR TITLE
coprocessor: returns error instead of panic when unexpected take origin

### DIFF
--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -99,7 +99,7 @@ impl AggExecutor {
 
     fn next(&mut self) -> Result<Option<Vec<Datum>>> {
         if let Some(row) = self.src.next()? {
-            let row = row.take_origin();
+            let row = row.take_origin()?;
             row.inflate_cols_with_offsets(&self.ctx, &self.related_cols_offset)
                 .map(Some)
         } else {

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -297,7 +297,7 @@ pub mod tests {
                 .unwrap();
 
         for handle in 0..KEY_NUMBER / 2 {
-            let row = scanner.next().unwrap().unwrap().take_origin();
+            let row = scanner.next().unwrap().unwrap().take_origin().unwrap();
             assert_eq!(row.handle, handle as i64);
             assert_eq!(row.data.len(), wrapper.cols.len());
             let expect_row = &wrapper.data.expect_rows[handle];
@@ -351,7 +351,7 @@ pub mod tests {
             IndexScanExecutor::index_scan(wrapper.scan, wrapper.ranges, store, unique, true)
                 .unwrap();
         for handle in 0..KEY_NUMBER {
-            let row = scanner.next().unwrap().unwrap().take_origin();
+            let row = scanner.next().unwrap().unwrap().take_origin().unwrap();
             assert_eq!(row.handle, handle as i64);
             assert_eq!(row.data.len(), 2);
             let expect_row = &wrapper.data.expect_rows[handle];
@@ -406,7 +406,7 @@ pub mod tests {
 
         for tid in 0..KEY_NUMBER {
             let handle = KEY_NUMBER - tid - 1;
-            let row = scanner.next().unwrap().unwrap().take_origin();
+            let row = scanner.next().unwrap().unwrap().take_origin().unwrap();
             assert_eq!(row.handle, handle as i64);
             assert_eq!(row.data.len(), 2);
             let expect_row = &wrapper.data.expect_rows[handle];
@@ -430,7 +430,7 @@ pub mod tests {
                 .unwrap();
 
         for handle in 0..KEY_NUMBER {
-            let row = scanner.next().unwrap().unwrap().take_origin();
+            let row = scanner.next().unwrap().unwrap().take_origin().unwrap();
             assert_eq!(row.handle, handle as i64);
             assert_eq!(row.data.len(), wrapper.cols.len());
             let expect_row = &wrapper.data.expect_rows[handle];

--- a/src/coprocessor/dag/executor/limit.rs
+++ b/src/coprocessor/dag/executor/limit.rs
@@ -104,7 +104,7 @@ mod tests {
         let mut limit_ect = LimitExecutor::new(limit_meta, ts_ect);
         let mut limit_rows = Vec::with_capacity(limit as usize);
         while let Some(row) = limit_ect.next().unwrap() {
-            limit_rows.push(row.take_origin());
+            limit_rows.push(row.take_origin().unwrap());
         }
         assert_eq!(limit_rows.len(), limit as usize);
         let expect_row_handles = vec![1, 2, 3, 5, 6];

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -126,10 +126,12 @@ impl Row {
         Row::Agg(AggCols { suffix, value })
     }
 
-    pub fn take_origin(self) -> OriginCols {
+    pub fn take_origin(self) -> Result<OriginCols> {
         match self {
-            Row::Origin(row) => row,
-            _ => unreachable!(),
+            Row::Origin(row) => Ok(row),
+            _ => Err(box_err!(
+                "unexpected: aggregation columns cannot take origin"
+            )),
         }
     }
 

--- a/src/coprocessor/dag/executor/selection.rs
+++ b/src/coprocessor/dag/executor/selection.rs
@@ -42,7 +42,7 @@ impl SelectionExecutor {
 impl Executor for SelectionExecutor {
     fn next(&mut self) -> Result<Option<Row>> {
         'next: while let Some(row) = self.src.next()? {
-            let row = row.take_origin();
+            let row = row.take_origin()?;
             let cols = row.inflate_cols_with_offsets(&self.ctx, &self.related_cols_offset)?;
             for filter in &self.conditions {
                 let val = filter.eval(&mut self.ctx, &cols)?;
@@ -193,7 +193,7 @@ mod tests {
 
         let mut selection_rows = Vec::with_capacity(raw_data.len());
         while let Some(row) = selection_executor.next().unwrap() {
-            selection_rows.push(row.take_origin());
+            selection_rows.push(row.take_origin().unwrap());
         }
 
         assert_eq!(selection_rows.len(), raw_data.len());
@@ -232,7 +232,7 @@ mod tests {
 
         let mut selection_rows = Vec::with_capacity(raw_data.len());
         while let Some(row) = selection_executor.next().unwrap() {
-            selection_rows.push(row.take_origin());
+            selection_rows.push(row.take_origin().unwrap());
         }
 
         let expect_row_handles = raw_data

--- a/src/coprocessor/dag/executor/table_scan.rs
+++ b/src/coprocessor/dag/executor/table_scan.rs
@@ -147,7 +147,12 @@ mod tests {
             super::TableScanExecutor::table_scan(wrapper.table_scan, wrapper.ranges, store, true)
                 .unwrap();
 
-        let row = table_scanner.next().unwrap().unwrap().take_origin();
+        let row = table_scanner
+            .next()
+            .unwrap()
+            .unwrap()
+            .take_origin()
+            .unwrap();
         assert_eq!(row.handle, handle as i64);
         assert_eq!(row.data.len(), wrapper.cols.len());
 
@@ -185,7 +190,12 @@ mod tests {
                 .unwrap();
 
         for handle in 0..KEY_NUMBER {
-            let row = table_scanner.next().unwrap().unwrap().take_origin();
+            let row = table_scanner
+                .next()
+                .unwrap()
+                .unwrap()
+                .take_origin()
+                .unwrap();
             assert_eq!(row.handle, handle as i64);
             assert_eq!(row.data.len(), wrapper.cols.len());
             let expect_row = &wrapper.data.expect_rows[handle];
@@ -222,7 +232,12 @@ mod tests {
 
         for tid in 0..KEY_NUMBER {
             let handle = KEY_NUMBER - tid - 1;
-            let row = table_scanner.next().unwrap().unwrap().take_origin();
+            let row = table_scanner
+                .next()
+                .unwrap()
+                .unwrap()
+                .take_origin()
+                .unwrap();
             assert_eq!(row.handle, handle as i64);
             assert_eq!(row.data.len(), wrapper.cols.len());
             let expect_row = &wrapper.data.expect_rows[handle];

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -93,7 +93,7 @@ impl TopNExecutor {
         let ctx = Arc::new(RefCell::new(self.eval_ctx.take().unwrap()));
         let mut heap = TopNHeap::new(self.limit, Arc::clone(&ctx))?;
         while let Some(row) = self.src.next()? {
-            let row = row.take_origin();
+            let row = row.take_origin()?;
             let cols = row.inflate_cols_with_offsets(&ctx.borrow(), &self.related_cols_offset)?;
             let ob_values = self.order_by.eval(&mut ctx.borrow_mut(), &cols)?;
             heap.try_add_row(row, ob_values, Arc::clone(&self.order_by.items))?;
@@ -400,7 +400,7 @@ pub mod tests {
             TopNExecutor::new(topn, Arc::new(EvalConfig::default()), ts_ect).unwrap();
         let mut topn_rows = Vec::with_capacity(limit as usize);
         while let Some(row) = topn_ect.next().unwrap() {
-            topn_rows.push(row.take_origin());
+            topn_rows.push(row.take_origin().unwrap());
         }
         assert_eq!(topn_rows.len(), limit as usize);
         let expect_row_handles = vec![1, 3, 2, 6];

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -81,7 +81,7 @@ impl<S: Snapshot> AnalyzeContext<S> {
             req.get_cmsketch_width() as usize,
         );
         while let Some(row) = scanner.next()? {
-            let row = row.take_origin();
+            let row = row.take_origin()?;
             let (bytes, end_offsets) = row.data.get_column_values_and_end_offsets();
             hist.append(bytes);
             if let Some(c) = cms.as_mut() {
@@ -206,7 +206,7 @@ impl<S: Snapshot> SampleBuilder<S> {
             self.col_len
         ];
         while let Some(row) = self.data.next()? {
-            let row = row.take_origin();
+            let row = row.take_origin()?;
             let cols = row.get_binary_cols()?;
             let retrieve_len = cols.len();
             let mut cols_iter = cols.into_iter();


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Returns error instead of panic when unexpected take origin

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

unit tests

