### PR TITLE
coprocessor: Refine LazyBatchColumn to use BufferVec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,6 +2301,7 @@ dependencies = [
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono-tz 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codec 0.0.1",
  "cop_codegen 0.0.1",
  "cop_datatype 0.0.1",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ profiler = { path = "components/profiler" }
 match_template = { path = "components/match_template" }
 cop_datatype = { path = "components/cop_datatype" }
 cop_codegen = { path = "components/cop_codegen" }
+codec = { path = "components/codec" }
 tipb_helper = { path = "components/tipb_helper" }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
 # TODO: use master branch after the next version is released.

--- a/src/coprocessor/codec/batch/buffer_vec.rs
+++ b/src/coprocessor/codec/batch/buffer_vec.rs
@@ -187,7 +187,7 @@ impl BufferVec {
         }
     }
 
-    /// Retain the elements according to a boolean array.
+    /// Retains the elements according to a boolean array.
     ///
     /// # Panics
     ///

--- a/src/coprocessor/codec/batch/buffer_vec.rs
+++ b/src/coprocessor/codec/batch/buffer_vec.rs
@@ -1,0 +1,800 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+#![allow(dead_code)]
+
+use std::iter::*;
+
+/// A vector like container storing multiple buffers. Each buffer is a `[u8]` slice in
+/// arbitrary length.
+#[derive(Default)]
+pub struct BufferVec {
+    data: Vec<u8>,
+    offsets: Vec<usize>,
+}
+
+impl Clone for BufferVec {
+    fn clone(&self) -> Self {
+        Self {
+            data: tikv_util::vec_clone_with_capacity(&self.data),
+            offsets: tikv_util::vec_clone_with_capacity(&self.offsets),
+        }
+    }
+}
+
+impl std::fmt::Debug for BufferVec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use hex::ToHex;
+
+        write!(f, "[")?;
+        let len = self.len();
+        if len > 0 {
+            for i in 0..len - 1 {
+                if self[i].is_empty() {
+                    write!(f, "null")?;
+                } else {
+                    self[i].as_ref().write_hex_upper(f)?;
+                }
+                write!(f, ", ")?;
+            }
+            if self[len - 1].is_empty() {
+                write!(f, "null")?;
+            } else {
+                self[len - 1].as_ref().write_hex_upper(f)?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+
+impl BufferVec {
+    /// Constructs a new, empty `BufferVec`.
+    ///
+    /// The `BufferVec` will not allocate until buffers are pushed onto it.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Constructs a new, empty `BufferVec` with the specified element capacity and data capacity.
+    #[inline]
+    pub fn with_capacity(elements_capacity: usize, data_capacity: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(data_capacity),
+            offsets: Vec::with_capacity(elements_capacity),
+        }
+    }
+
+    /// Returns the number of buffers this `BufferVec` can hold without reallocating the
+    /// offsets array.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.offsets.capacity()
+    }
+
+    /// Returns the number of buffers this `BufferVec` can hold without reallocating the
+    /// data array.
+    #[inline]
+    pub fn data_capacity(&self) -> usize {
+        self.data.capacity()
+    }
+
+    /// Returns the number of contained buffers.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.offsets.len()
+    }
+
+    /// Returns `true` if there is no contained buffer.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the total length of all contained buffers.
+    #[inline]
+    pub fn total_len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Appends a buffer to the back.
+    #[inline]
+    pub fn push(&mut self, buffer: impl AsRef<[u8]>) {
+        self.offsets.push(self.data.len());
+        self.data.extend_from_slice(buffer.as_ref());
+    }
+
+    /// Removes the last buffer if there is any.
+    #[inline]
+    pub fn pop(&mut self) {
+        let len = self.len();
+        if len > 0 {
+            self.data.truncate(self.offsets[len - 1]);
+            self.offsets.pop();
+        }
+    }
+
+    /// Removes the first `n` buffers.
+    ///
+    /// If `n` >= current length, all buffers will be removed.
+    pub fn shift(&mut self, n: usize) {
+        let len = self.len();
+        if n == 0 {
+            return;
+        }
+
+        // Suppose we want to shift by 2 and we have the following data:
+        // data:   [AABB, 00, , CACCAA]
+        // offset: [0,    2,  3,3     ]
+        //                    ^             : data_offset  = 3
+        //                   >|      |<     : data_len     = 3
+        //                   >|      |<     : n_len        = 2
+        //
+        // 1. Move valid data and offset forward
+        // data:   [, CACCAA, XX, XX]   XX is the outdated data
+        // offset: [3,3     , XX, XX]
+        //
+        // 2. Update offset
+        // data:   [, CACCAA, XX, XX]
+        // offset: [0,0     , XX, XX]
+        //
+        // 3. Shrink
+        // data:   [, CACCAA]
+        // offset: [0,0     ]
+
+        if n < len {
+            unsafe {
+                let data_offset = self.offsets[n];
+                let data_len = self.data.len() - data_offset;
+                let n_len = len - n;
+                // 1
+                std::ptr::copy(
+                    self.data.as_ptr().add(data_offset),
+                    self.data.as_mut_ptr(),
+                    data_len,
+                );
+                std::ptr::copy(
+                    self.offsets.as_ptr().add(n),
+                    self.offsets.as_mut_ptr(),
+                    n_len,
+                );
+                // 2
+                for i in 0..n_len {
+                    self.offsets[i] -= data_offset;
+                }
+                assert_eq!(self.offsets[0], 0);
+                // 3
+                self.data.set_len(data_len);
+                self.offsets.set_len(n_len);
+            }
+        } else {
+            self.clear();
+        }
+    }
+
+    /// Shortens the `BufferVec`, keeping the first `n` buffers and dropping the rest.
+    ///
+    /// If `n` >= current length, this has no effect.
+    #[inline]
+    pub fn truncate(&mut self, n: usize) {
+        let len = self.len();
+        if n < len {
+            self.data.truncate(self.offsets[n]);
+            self.offsets.truncate(n);
+        }
+    }
+
+    /// Removes all buffers.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.data.clear();
+        self.offsets.clear();
+    }
+
+    /// Copies all buffers from `other` to `self`.
+    pub fn extend(&mut self, other: &BufferVec) {
+        let base_offset = self.data.len();
+        self.data.extend_from_slice(&other.data);
+        self.offsets.reserve(other.offsets.len());
+        for offset in &other.offsets {
+            self.offsets.push(*offset + base_offset);
+        }
+    }
+
+    /// Copies first `n` buffers from `other` to `self`.
+    ///
+    /// If `n > other.len()`, only `other.len()` buffers will be copied.
+    pub fn extend_n(&mut self, other: &BufferVec, n: usize) {
+        if n >= other.len() {
+            self.extend(other);
+        } else if n > 0 {
+            let base_offset = self.data.len();
+            self.data.extend_from_slice(&other.data[..other.offsets[n]]);
+            self.offsets.reserve(n);
+            for i in 0..n {
+                self.offsets.push(other.offsets[i] + base_offset);
+            }
+        }
+    }
+
+    /// Retain the elements according to a boolean array.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `retain_arr` is not long enough.
+    pub fn retain_by_array(&mut self, retain_arr: &[bool]) {
+        unsafe {
+            let len = self.len();
+            assert!(retain_arr.len() >= len);
+
+            if len > 0 {
+                let mut data_write_offset = 0;
+                let mut offsets_write_offset = 0;
+                for i in 0..len - 1 {
+                    if retain_arr[i] {
+                        let write_len = self.offsets[i + 1] - self.offsets[i];
+                        std::ptr::copy(
+                            self.data.as_ptr().add(self.offsets[i]),
+                            self.data.as_mut_ptr().add(data_write_offset),
+                            write_len,
+                        );
+                        self.offsets[offsets_write_offset] = data_write_offset;
+                        offsets_write_offset += 1;
+                        data_write_offset += write_len;
+                    }
+                }
+                // The last buffer does not have an ending offset
+                if retain_arr[len - 1] {
+                    let write_len = self.data.len() - self.offsets[len - 1];
+                    std::ptr::copy(
+                        self.data.as_ptr().add(self.offsets[len - 1]),
+                        self.data.as_mut_ptr().add(data_write_offset),
+                        write_len,
+                    );
+                    self.offsets[offsets_write_offset] = data_write_offset;
+                    offsets_write_offset += 1;
+                    data_write_offset += write_len;
+                }
+                self.offsets.set_len(offsets_write_offset);
+                self.data.set_len(data_write_offset);
+            }
+        }
+    }
+
+    /// Returns an iterator over the `BufferVec`.
+    pub fn iter(&self) -> Iter<'_> {
+        Iter {
+            data: &self.data,
+            offsets: &self.offsets,
+        }
+    }
+}
+
+impl std::ops::Index<usize> for BufferVec {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: usize) -> &[u8] {
+        assert!(index < self.offsets.len());
+        if index < self.offsets.len() - 1 {
+            &self.data[self.offsets[index]..self.offsets[index + 1]]
+        } else {
+            &self.data[self.offsets[index]..]
+        }
+    }
+}
+
+// TODO: Implement Index<XxxRange>
+
+#[derive(Clone, Copy)]
+pub struct Iter<'a> {
+    data: &'a [u8],
+    offsets: &'a [usize],
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.nth(0)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.offsets.len();
+        (len, Some(len))
+    }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.offsets.len()
+    }
+
+    fn last(mut self) -> Option<Self::Item> {
+        let l = self.offsets.len();
+        if l == 0 {
+            None
+        } else {
+            self.nth(l - 1)
+        }
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if n + 1 < self.offsets.len() {
+            let begin_offset = self.offsets[n];
+            let end_offset = self.offsets[n + 1];
+            self.offsets = &self.offsets[n + 1..];
+            Some(&self.data[begin_offset..end_offset])
+        } else if n + 1 == self.offsets.len() {
+            let begin_offset = self.offsets[n];
+            self.offsets = &[];
+            Some(&self.data[begin_offset..])
+        } else {
+            self.offsets = &[];
+            None
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for Iter<'a> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let mut v = BufferVec::new();
+        assert_eq!(format!("{:?}", v), "[]");
+        assert!(v.is_empty());
+
+        v.pop();
+        assert_eq!(format!("{:?}", v), "[]");
+        assert!(v.is_empty());
+
+        v.shift(0);
+        assert_eq!(format!("{:?}", v), "[]");
+        assert!(v.is_empty());
+
+        v.push(&[0xAA, 0x0, 0xB]);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xAA, 0x0, 0xB]);
+        assert_eq!(format!("{:?}", v), "[AA000B]");
+
+        v.truncate(1);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xAA, 0x0, 0xB]);
+        assert_eq!(format!("{:?}", v), "[AA000B]");
+
+        v.truncate(2);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xAA, 0x0, 0xB]);
+        assert_eq!(format!("{:?}", v), "[AA000B]");
+
+        v.shift(0);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xAA, 0x0, 0xB]);
+        assert_eq!(format!("{:?}", v), "[AA000B]");
+
+        v.pop();
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.total_len(), 0);
+        assert!(v.is_empty());
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.truncate(1);
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.total_len(), 0);
+        assert!(v.is_empty());
+        assert_eq!(format!("{:?}", v), "[]");
+        assert!(v.is_empty());
+
+        v.pop();
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.total_len(), 0);
+        assert!(v.is_empty());
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.push(&[0xCA, 0xB]);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 2);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xCA, 0xB]);
+        assert_eq!(format!("{:?}", v), "[CA0B]");
+
+        v.shift(1);
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.total_len(), 0);
+        assert!(v.is_empty());
+        assert_eq!(format!("{:?}", v), "[]");
+        assert!(v.is_empty());
+
+        v.push(&[0xCA, 0xB]);
+        v.push(&[]);
+        assert_eq!(v.len(), 2);
+        assert_eq!(v.total_len(), 2);
+        assert!(!v.is_empty());
+        assert!(v[1].is_empty()); // To avoid "cannot infer type" bug..
+        assert_eq!(format!("{:?}", v), "[CA0B, null]");
+
+        v.pop();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 2);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xCA, 0xB]);
+        assert_eq!(format!("{:?}", v), "[CA0B]");
+
+        v.push(&[]);
+        v.push(&[]);
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.total_len(), 2);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xCA, 0xB]);
+        assert!(v[1].is_empty());
+        assert!(v[2].is_empty());
+        assert_eq!(format!("{:?}", v), "[CA0B, null, null]");
+
+        v.push(&[0xC]);
+        assert_eq!(v.len(), 4);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xCA, 0xB]);
+        assert!(v[1].is_empty());
+        assert!(v[2].is_empty());
+        assert_eq!(v[3], [0xC]);
+        assert_eq!(format!("{:?}", v), "[CA0B, null, null, 0C]");
+
+        v.pop();
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.total_len(), 2);
+        assert!(!v.is_empty());
+        assert_eq!(v[0], [0xCA, 0xB]);
+        assert!(v[1].is_empty());
+        assert!(v[2].is_empty());
+        assert_eq!(format!("{:?}", v), "[CA0B, null, null]");
+
+        v.shift(1);
+        assert_eq!(v.len(), 2);
+        assert_eq!(v.total_len(), 0);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert!(v[1].is_empty());
+        assert_eq!(format!("{:?}", v), "[null, null]");
+
+        v.push(&[0xAC, 0xBB, 0x00]);
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert!(v[1].is_empty());
+        assert_eq!(v[2], [0xAC, 0xBB, 0x00]);
+        assert_eq!(format!("{:?}", v), "[null, null, ACBB00]");
+
+        v.shift(0);
+        assert!(!v.is_empty());
+        assert_eq!(format!("{:?}", v), "[null, null, ACBB00]");
+
+        v.shift(1);
+        assert_eq!(v.len(), 2);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert_eq!(v[1], [0xAC, 0xBB, 0x00]);
+        assert_eq!(format!("{:?}", v), "[null, ACBB00]");
+
+        v.push(&[]);
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.total_len(), 3);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert_eq!(v[1], [0xAC, 0xBB, 0x00]);
+        assert!(v[2].is_empty());
+        assert_eq!(format!("{:?}", v), "[null, ACBB00, null]");
+
+        v.shift(2);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 0);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert_eq!(format!("{:?}", v), "[null]");
+
+        v.shift(0);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 0);
+        assert!(!v.is_empty());
+        assert!(v[0].is_empty());
+        assert_eq!(format!("{:?}", v), "[null]");
+
+        v.shift(2);
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.total_len(), 0);
+        assert!(v.is_empty());
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.push(&[0xA]);
+        v.push(&[0xB]);
+        v.push(&[0xC]);
+        v.push(&[0xD, 0xE]);
+        v.push(&[]);
+        v.push(&[]);
+        assert_eq!(v.len(), 6);
+        assert_eq!(v.total_len(), 5);
+        assert!(!v.is_empty());
+        assert_eq!(format!("{:?}", v), "[0A, 0B, 0C, 0D0E, null, null]");
+
+        v.truncate(5);
+        assert_eq!(v.len(), 5);
+        assert_eq!(v.total_len(), 5);
+        assert!(!v.is_empty());
+        assert_eq!(format!("{:?}", v), "[0A, 0B, 0C, 0D0E, null]");
+
+        v.shift(4);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v.total_len(), 0);
+        assert!(!v.is_empty());
+        assert_eq!(format!("{:?}", v), "[null]");
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut v1 = BufferVec::new();
+        v1.push(&[]);
+        v1.push(&[0xAA, 0xBB, 0x0C]);
+        v1.push(&[]);
+        v1.push(&[0x00]);
+
+        let mut v2 = BufferVec::new();
+        v2.push(&[]);
+        v2.push(&[]);
+
+        let mut v3 = v1.clone();
+        v3.extend(&v2);
+        assert_eq!(v3.len(), 6);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, null, 00, null, null]");
+
+        v3.truncate(3);
+        assert_eq!(v3.len(), 3);
+        assert_eq!(v3.total_len(), 3);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, null]");
+
+        v3.push(&[]);
+        v3.push(&[0x00]);
+        assert_eq!(v3.len(), 5);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, null, null, 00]");
+
+        let mut v3 = v2.clone();
+        v3.extend(&v1);
+        assert_eq!(v3.len(), 6);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[null, null, null, AABB0C, null, 00]");
+
+        v3.pop();
+        v3.shift(0);
+        assert_eq!(v3.len(), 5);
+        assert_eq!(v3.total_len(), 3);
+        assert_eq!(format!("{:?}", v3), "[null, null, null, AABB0C, null]");
+
+        let mut v3 = v2.clone();
+        v3.shift(2);
+        v3.extend(&v1);
+        assert_eq!(v3.len(), 4);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, null, 00]");
+
+        v3.shift(4);
+        assert_eq!(v3.len(), 0);
+        assert_eq!(v3.total_len(), 0);
+        assert_eq!(format!("{:?}", v3), "[]");
+
+        let mut v1 = BufferVec::new();
+        v1.push(&[]);
+        v1.push(&[0xAA, 0xBB, 0x0C]);
+
+        let mut v2 = BufferVec::new();
+        v2.push(&[0x0C, 0x00]);
+        v2.push(&[]);
+
+        let mut v3 = v2.clone();
+        v3.extend_n(&v1, 0);
+        assert_eq!(v3.len(), 2);
+        assert_eq!(v3.total_len(), 2);
+        assert_eq!(format!("{:?}", v3), "[0C00, null]");
+
+        v3.push(&[0xAA]);
+        assert_eq!(v3.len(), 3);
+        assert_eq!(v3.total_len(), 3);
+        assert_eq!(format!("{:?}", v3), "[0C00, null, AA]");
+
+        let mut v3 = v2.clone();
+        v3.extend_n(&v1, 1);
+        assert_eq!(v3.len(), 3);
+        assert_eq!(v3.total_len(), 2);
+        assert_eq!(format!("{:?}", v3), "[0C00, null, null]");
+
+        v3.push(&[0xAA]);
+        assert_eq!(v3.len(), 4);
+        assert_eq!(v3.total_len(), 3);
+        assert_eq!(format!("{:?}", v3), "[0C00, null, null, AA]");
+
+        let mut v3 = v1.clone();
+        v3.extend_n(&v2, 1);
+        assert_eq!(v3.len(), 3);
+        assert_eq!(v3.total_len(), 5);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, 0C00]");
+
+        v3.pop();
+        assert_eq!(v3.len(), 2);
+        assert_eq!(v3.total_len(), 3);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C]");
+
+        let mut v3 = v1.clone();
+        v3.extend_n(&v2, 2);
+        assert_eq!(v3.len(), 4);
+        assert_eq!(v3.total_len(), 5);
+        assert_eq!(format!("{:?}", v3), "[null, AABB0C, 0C00, null]");
+
+        v3.shift(2);
+        assert_eq!(v3.len(), 2);
+        assert_eq!(v3.total_len(), 2);
+        assert_eq!(format!("{:?}", v3), "[0C00, null]");
+
+        v3.extend_n(&v2, 5);
+        assert_eq!(v3.len(), 4);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[0C00, null, 0C00, null]");
+
+        v3.pop();
+        assert_eq!(v3.len(), 3);
+        assert_eq!(v3.total_len(), 4);
+        assert_eq!(format!("{:?}", v3), "[0C00, null, 0C00]");
+    }
+
+    #[test]
+    fn test_retain() {
+        let mut v = BufferVec::new();
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.retain_by_array(&[]);
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.push(&[]);
+        assert_eq!(format!("{:?}", v), "[null]");
+
+        v.retain_by_array(&[true]);
+        assert_eq!(format!("{:?}", v), "[null]");
+
+        v.retain_by_array(&[false]);
+        assert_eq!(format!("{:?}", v), "[]");
+
+        v.push(&[0xAA, 0x00]);
+        v.push(&[]);
+        assert_eq!(format!("{:?}", v), "[AA00, null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[true, true]);
+        assert_eq!(format!("{:?}", v2), "[AA00, null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[true, false]);
+        assert_eq!(format!("{:?}", v2), "[AA00]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[false, true]);
+        assert_eq!(format!("{:?}", v2), "[null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[false, false]);
+        assert_eq!(format!("{:?}", v2), "[]");
+
+        v.push(&[]);
+        v.push(&[0xBB, 0x00, 0xA0]);
+        assert_eq!(format!("{:?}", v), "[AA00, null, null, BB00A0]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[true, true, false, true]);
+        assert_eq!(format!("{:?}", v2), "[AA00, null, BB00A0]");
+
+        v2.extend_n(&v, 2);
+        assert_eq!(format!("{:?}", v2), "[AA00, null, BB00A0, AA00, null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[true, false, false, true]);
+        assert_eq!(format!("{:?}", v2), "[AA00, BB00A0]");
+
+        v2.shift(1);
+        assert_eq!(format!("{:?}", v2), "[BB00A0]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[false, false, true, true]);
+        assert_eq!(format!("{:?}", v2), "[null, BB00A0]");
+
+        v2.push(&[]);
+        assert_eq!(format!("{:?}", v2), "[null, BB00A0, null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[true, true, true, false]);
+        assert_eq!(format!("{:?}", v2), "[AA00, null, null]");
+
+        v2.shift(2);
+        assert_eq!(format!("{:?}", v2), "[null]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[false, true, true, false]);
+        assert_eq!(format!("{:?}", v2), "[null, null]");
+
+        v2.pop();
+        v2.extend(&v);
+        assert_eq!(format!("{:?}", v2), "[null, AA00, null, null, BB00A0]");
+
+        let mut v2 = v.clone();
+        v2.retain_by_array(&[false, false, false, true]);
+        assert_eq!(format!("{:?}", v2), "[BB00A0]");
+
+        v2.pop();
+        assert_eq!(format!("{:?}", v2), "[]");
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut v = BufferVec::new();
+        v.push(&[]);
+        v.push(&[0xAA, 0xBB, 0x0C]);
+        v.push(&[]);
+        v.push(&[]);
+        v.push(&[0x00]);
+        v.push(&[]);
+
+        let mut it = v.iter();
+        assert_eq!(it.count(), 6);
+        assert!(it.next().unwrap().is_empty());
+        assert_eq!(it.count(), 5);
+        assert!(it.last().unwrap().is_empty());
+
+        let mut it = v.iter();
+        assert!(it.nth(0).unwrap().is_empty());
+        assert_eq!(it.count(), 5);
+        assert_eq!(it.nth(0).unwrap(), &[0xAA, 0xBB, 0x0C]);
+        assert_eq!(it.count(), 4);
+        assert_eq!(it.nth(2).unwrap(), &[0x00]);
+        assert_eq!(it.count(), 1);
+        assert!(it.next().unwrap().is_empty());
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.next(), None);
+        assert_eq!(it.last(), None);
+
+        let mut it = v.iter();
+        assert!(it.nth(3).unwrap().is_empty());
+        assert_eq!(it.count(), 2);
+        assert_eq!(it.next().unwrap(), &[0x00]);
+        assert_eq!(it.count(), 1);
+        assert!(it.next().unwrap().is_empty());
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.next(), None);
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.nth(0), None);
+        assert_eq!(it.last(), None);
+
+        let mut it = v.iter();
+        assert!(it.nth(5).unwrap().is_empty());
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.next(), None);
+        assert_eq!(it.nth(3), None);
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.last(), None);
+
+        let mut it = v.iter();
+        assert_eq!(it.nth(6), None);
+        assert_eq!(it.count(), 0);
+        assert_eq!(it.next(), None);
+        assert_eq!(it.nth(1), None);
+    }
+}

--- a/src/coprocessor/codec/batch/buffer_vec.rs
+++ b/src/coprocessor/codec/batch/buffer_vec.rs
@@ -1,7 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![allow(dead_code)]
-
 use std::iter::*;
 
 /// A vector like container storing multiple buffers. Each buffer is a `[u8]` slice in

--- a/src/coprocessor/codec/batch/buffer_vec.rs
+++ b/src/coprocessor/codec/batch/buffer_vec.rs
@@ -26,20 +26,14 @@ impl std::fmt::Debug for BufferVec {
         use hex::ToHex;
 
         write!(f, "[")?;
-        let len = self.len();
-        if len > 0 {
-            for i in 0..len - 1 {
-                if self[i].is_empty() {
-                    write!(f, "null")?;
-                } else {
-                    self[i].as_ref().write_hex_upper(f)?;
-                }
+        for (i, item) in self.iter().enumerate() {
+            if i != 0 {
                 write!(f, ", ")?;
             }
-            if self[len - 1].is_empty() {
+            if item.is_empty() {
                 write!(f, "null")?;
             } else {
-                self[len - 1].as_ref().write_hex_upper(f)?;
+                item.write_hex_upper(f)?;
             }
         }
         write!(f, "]")
@@ -106,10 +100,8 @@ impl BufferVec {
     /// Removes the last buffer if there is any.
     #[inline]
     pub fn pop(&mut self) {
-        let len = self.len();
-        if len > 0 {
-            self.data.truncate(self.offsets[len - 1]);
-            self.offsets.pop();
+        if let Some(offset) = self.offsets.pop() {
+            self.data.truncate(offset);
         }
     }
 
@@ -117,7 +109,6 @@ impl BufferVec {
     ///
     /// If `n` >= current length, all buffers will be removed.
     pub fn shift(&mut self, n: usize) {
-        let len = self.len();
         if n == 0 {
             return;
         }
@@ -130,42 +121,24 @@ impl BufferVec {
         //                   >|      |<     : n_len        = 2
         //
         // 1. Move valid data and offset forward
-        // data:   [, CACCAA, XX, XX]   XX is the outdated data
-        // offset: [3,3     , XX, XX]
+        // data:   [, CACCAA]
+        // offset: [3,3     ]
         //
         // 2. Update offset
-        // data:   [, CACCAA, XX, XX]
-        // offset: [0,0     , XX, XX]
-        //
-        // 3. Shrink
         // data:   [, CACCAA]
         // offset: [0,0     ]
 
+        let len = self.len();
         if n < len {
-            unsafe {
-                let data_offset = self.offsets[n];
-                let data_len = self.data.len() - data_offset;
-                let n_len = len - n;
-                // 1
-                std::ptr::copy(
-                    self.data.as_ptr().add(data_offset),
-                    self.data.as_mut_ptr(),
-                    data_len,
-                );
-                std::ptr::copy(
-                    self.offsets.as_ptr().add(n),
-                    self.offsets.as_mut_ptr(),
-                    n_len,
-                );
-                // 2
-                for i in 0..n_len {
-                    self.offsets[i] -= data_offset;
-                }
-                assert_eq!(self.offsets[0], 0);
-                // 3
-                self.data.set_len(data_len);
-                self.offsets.set_len(n_len);
+            let data_offset = self.offsets[n];
+            // 1
+            self.data.drain(..data_offset);
+            self.offsets.drain(..n);
+            // 2
+            for offset in &mut self.offsets {
+                *offset -= data_offset;
             }
+            assert_eq!(self.offsets[0], 0);
         } else {
             self.clear();
         }
@@ -210,8 +183,8 @@ impl BufferVec {
             let base_offset = self.data.len();
             self.data.extend_from_slice(&other.data[..other.offsets[n]]);
             self.offsets.reserve(n);
-            for i in 0..n {
-                self.offsets.push(other.offsets[i] + base_offset);
+            for offset in &other.offsets[..n] {
+                self.offsets.push(*offset + base_offset);
             }
         }
     }
@@ -222,6 +195,7 @@ impl BufferVec {
     ///
     /// Panics if `retain_arr` is not long enough.
     pub fn retain_by_array(&mut self, retain_arr: &[bool]) {
+        // TODO: Optimize to move multiple contiguous slots.
         unsafe {
             let len = self.len();
             assert!(retain_arr.len() >= len);
@@ -269,17 +243,30 @@ impl BufferVec {
     }
 }
 
+impl<A: AsRef<[u8]>> Extend<A> for BufferVec {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = A>,
+    {
+        for i in iter.into_iter() {
+            self.push(i);
+        }
+    }
+}
+
 impl std::ops::Index<usize> for BufferVec {
     type Output = [u8];
 
     #[inline]
     fn index(&self, index: usize) -> &[u8] {
         assert!(index < self.offsets.len());
-        if index < self.offsets.len() - 1 {
-            &self.data[self.offsets[index]..self.offsets[index + 1]]
-        } else {
-            &self.data[self.offsets[index]..]
-        }
+        let start = self.offsets[index];
+        let end = self
+            .offsets
+            .get(index + 1)
+            .copied()
+            .unwrap_or_else(|| self.data.len());
+        &self.data[start..end]
     }
 }
 
@@ -394,7 +381,6 @@ mod tests {
         assert_eq!(v.total_len(), 0);
         assert!(v.is_empty());
         assert_eq!(format!("{:?}", v), "[]");
-        assert!(v.is_empty());
 
         v.pop();
         assert_eq!(v.len(), 0);
@@ -414,7 +400,6 @@ mod tests {
         assert_eq!(v.total_len(), 0);
         assert!(v.is_empty());
         assert_eq!(format!("{:?}", v), "[]");
-        assert!(v.is_empty());
 
         v.push(&[0xCA, 0xB]);
         v.push(&[]);

--- a/src/coprocessor/codec/batch/lazy_column.rs
+++ b/src/coprocessor/codec/batch/lazy_column.rs
@@ -2,11 +2,10 @@
 
 use std::convert::TryFrom;
 
-use smallvec::SmallVec;
-
 use cop_datatype::{EvalType, FieldTypeAccessor};
 use tipb::expression::FieldType;
 
+use super::BufferVec;
 use crate::coprocessor::codec::data_type::VectorValue;
 use crate::coprocessor::codec::mysql::Tz;
 use crate::coprocessor::codec::Result;
@@ -19,27 +18,10 @@ use crate::coprocessor::codec::Result;
 /// to avoid unnecessary repeated serialization / deserialization. In future, Coprocessor will
 /// respond all data in Arrow format which is different to the format in storage. At that time,
 /// this structure is no longer useful and should be removed.
+#[derive(Clone, Debug)]
 pub enum LazyBatchColumn {
-    /// Ensure that small datum values (i.e. Int, Real, Time) are stored compactly.
-    /// When using VarInt encoding there are 9 bytes. Plus 1 extra byte to store the datum flag.
-    /// Thus totally there are 10 bytes.
-    Raw(Vec<SmallVec<[u8; 10]>>),
+    Raw(BufferVec),
     Decoded(VectorValue),
-}
-
-impl std::fmt::Debug for LazyBatchColumn {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LazyBatchColumn::Raw(ref v) => {
-                let vec_display: Vec<_> = v
-                    .iter()
-                    .map(|item| tikv_util::escape(item.as_slice()))
-                    .collect();
-                f.debug_tuple("Raw").field(&vec_display).finish()
-            }
-            LazyBatchColumn::Decoded(ref v) => f.debug_tuple("Decoded").field(v).finish(),
-        }
-    }
 }
 
 impl From<VectorValue> for LazyBatchColumn {
@@ -49,28 +31,12 @@ impl From<VectorValue> for LazyBatchColumn {
     }
 }
 
-impl Clone for LazyBatchColumn {
-    #[inline]
-    fn clone(&self) -> Self {
-        match self {
-            LazyBatchColumn::Raw(v) => {
-                // This is much more efficient than `SmallVec::clone`.
-                let mut raw_vec = Vec::with_capacity(v.capacity());
-                for d in v {
-                    raw_vec.push(SmallVec::from_slice(d.as_slice()));
-                }
-                LazyBatchColumn::Raw(raw_vec)
-            }
-            LazyBatchColumn::Decoded(v) => LazyBatchColumn::Decoded(v.clone()),
-        }
-    }
-}
-
 impl LazyBatchColumn {
     /// Creates a new `LazyBatchColumn::Raw` with specified capacity.
     #[inline]
     pub fn raw_with_capacity(capacity: usize) -> Self {
-        LazyBatchColumn::Raw(Vec::with_capacity(capacity))
+        // 11 = MAX_VAR_INT_LEN(10) + Datum Flag(1)
+        LazyBatchColumn::Raw(BufferVec::with_capacity(capacity, capacity * 11))
     }
 
     /// Creates a new `LazyBatchColumn::Decoded` with specified capacity and eval type.
@@ -99,7 +65,7 @@ impl LazyBatchColumn {
     pub fn decoded(&self) -> &VectorValue {
         match self {
             LazyBatchColumn::Raw(_) => panic!("LazyBatchColumn is not decoded"),
-            LazyBatchColumn::Decoded(ref v) => v,
+            LazyBatchColumn::Decoded(v) => v,
         }
     }
 
@@ -107,22 +73,22 @@ impl LazyBatchColumn {
     pub fn mut_decoded(&mut self) -> &mut VectorValue {
         match self {
             LazyBatchColumn::Raw(_) => panic!("LazyBatchColumn is not decoded"),
-            LazyBatchColumn::Decoded(ref mut v) => v,
+            LazyBatchColumn::Decoded(v) => v,
         }
     }
 
     #[inline]
-    pub fn raw(&self) -> &Vec<SmallVec<[u8; 10]>> {
+    pub fn raw(&self) -> &BufferVec {
         match self {
-            LazyBatchColumn::Raw(ref v) => v,
+            LazyBatchColumn::Raw(v) => v,
             LazyBatchColumn::Decoded(_) => panic!("LazyBatchColumn is already decoded"),
         }
     }
 
     #[inline]
-    pub fn mut_raw(&mut self) -> &mut Vec<SmallVec<[u8; 10]>> {
+    pub fn mut_raw(&mut self) -> &mut BufferVec {
         match self {
-            LazyBatchColumn::Raw(ref mut v) => v,
+            LazyBatchColumn::Raw(v) => v,
             LazyBatchColumn::Decoded(_) => panic!("LazyBatchColumn is already decoded"),
         }
     }
@@ -130,22 +96,25 @@ impl LazyBatchColumn {
     #[inline]
     pub fn len(&self) -> usize {
         match self {
-            LazyBatchColumn::Raw(ref v) => v.len(),
-            LazyBatchColumn::Decoded(ref v) => v.len(),
+            LazyBatchColumn::Raw(v) => v.len(),
+            LazyBatchColumn::Decoded(v) => v.len(),
         }
     }
 
     #[inline]
     pub fn truncate(&mut self, len: usize) {
         match self {
-            LazyBatchColumn::Raw(ref mut v) => v.truncate(len),
-            LazyBatchColumn::Decoded(ref mut v) => v.truncate(len),
+            LazyBatchColumn::Raw(v) => v.truncate(len),
+            LazyBatchColumn::Decoded(v) => v.truncate(len),
         };
     }
 
     #[inline]
     pub fn clear(&mut self) {
-        self.truncate(0)
+        match self {
+            LazyBatchColumn::Raw(v) => v.clear(),
+            LazyBatchColumn::Decoded(v) => v.clear(),
+        };
     }
 
     #[inline]
@@ -156,28 +125,16 @@ impl LazyBatchColumn {
     #[inline]
     pub fn capacity(&self) -> usize {
         match self {
-            LazyBatchColumn::Raw(ref v) => v.capacity(),
-            LazyBatchColumn::Decoded(ref v) => v.capacity(),
+            LazyBatchColumn::Raw(v) => v.capacity(),
+            LazyBatchColumn::Decoded(v) => v.capacity(),
         }
     }
 
     #[inline]
-    pub fn retain_by_index<F>(&mut self, mut f: F)
-    where
-        F: FnMut(usize) -> bool,
-    {
+    pub fn retain_by_array(&mut self, retain_arr: &[bool]) {
         match self {
-            LazyBatchColumn::Raw(ref mut v) => {
-                let mut idx = 0;
-                v.retain(|_| {
-                    let r = f(idx);
-                    idx += 1;
-                    r
-                });
-            }
-            LazyBatchColumn::Decoded(ref mut v) => {
-                v.retain_by_index(f);
-            }
+            LazyBatchColumn::Raw(v) => v.retain_by_array(retain_arr),
+            LazyBatchColumn::Decoded(v) => v.retain_by_array(retain_arr),
         }
     }
 
@@ -186,7 +143,7 @@ impl LazyBatchColumn {
     /// The field type is needed because we use the same `DateTime` structure when handling
     /// Date, Time or Timestamp.
     // TODO: Maybe it's a better idea to assign different eval types for different date types.
-    pub fn decode(&mut self, time_zone: &Tz, field_type: &FieldType) -> Result<()> {
+    pub fn ensure_decoded(&mut self, time_zone: &Tz, field_type: &FieldType) -> Result<()> {
         if self.is_decoded() {
             return Ok(());
         }
@@ -195,10 +152,8 @@ impl LazyBatchColumn {
 
         let mut decoded_column = VectorValue::with_capacity(self.capacity(), eval_type);
         {
-            let raw_values = self.raw();
-            for raw_value in raw_values {
-                let raw_datum = raw_value.as_slice();
-                decoded_column.push_datum(raw_datum, time_zone, field_type)?;
+            for value in self.raw().iter() {
+                decoded_column.push_datum(value, time_zone, field_type)?;
             }
         }
         *self = LazyBatchColumn::Decoded(decoded_column);
@@ -206,56 +161,11 @@ impl LazyBatchColumn {
         Ok(())
     }
 
-    /// Push a raw datum which is not yet decoded.
-    ///
-    /// `raw_datum.len()` can be 0, indicating a missing value for corresponding cell.
-    ///
-    /// # Panics
-    ///
-    /// Panics when current column is already decoded.
-    // TODO: Deprecate this function. mut_raw should be preferred so that there won't be repeated
-    // match for each iteration.
-    #[inline]
-    pub fn push_raw(&mut self, raw_datum: impl AsRef<[u8]>) {
-        match self {
-            LazyBatchColumn::Raw(ref mut v) => {
-                v.push(SmallVec::from_slice(raw_datum.as_ref()));
-            }
-            LazyBatchColumn::Decoded(_) => panic!("LazyBatchColumn is already decoded"),
-        }
-    }
-
-    /// Moves all elements of `other` into `Self`, leaving `other` empty.
-    ///
-    /// # Panics
-    ///
-    /// Panics when `other` and `Self` does not have identical decoded status or identical
-    /// `EvalType`, i.e. one is `decoded` but another is `raw`, or one is `decoded(Int)` but
-    /// another is `decoded(Real)`.
-    pub fn append(&mut self, other: &mut Self) {
-        match self {
-            LazyBatchColumn::Raw(ref mut dest) => match other {
-                LazyBatchColumn::Raw(ref mut src) => dest.append(src),
-                _ => panic!("Cannot append decoded LazyBatchColumn into raw LazyBatchColumn"),
-            },
-            LazyBatchColumn::Decoded(ref mut dest) => match other {
-                LazyBatchColumn::Decoded(ref mut src) => dest.append(src),
-                _ => panic!("Cannot append raw LazyBatchColumn into decoded LazyBatchColumn"),
-            },
-        }
-    }
-
     /// Returns maximum encoded size.
     pub fn maximum_encoded_size(&self) -> Result<usize> {
         match self {
-            LazyBatchColumn::Raw(ref v) => {
-                let mut size = 0;
-                for s in v {
-                    size += s.len();
-                }
-                Ok(size)
-            }
-            LazyBatchColumn::Decoded(ref v) => v.maximum_encoded_size(),
+            LazyBatchColumn::Raw(v) => Ok(v.total_len()),
+            LazyBatchColumn::Decoded(v) => v.maximum_encoded_size(),
         }
     }
 
@@ -268,8 +178,8 @@ impl LazyBatchColumn {
         output: &mut Vec<u8>,
     ) -> Result<()> {
         match self {
-            LazyBatchColumn::Raw(ref v) => {
-                output.extend_from_slice(v[row_index].as_slice());
+            LazyBatchColumn::Raw(v) => {
+                output.extend_from_slice(&v[row_index]);
                 Ok(())
             }
             LazyBatchColumn::Decoded(ref v) => v.encode(row_index, field_type, output),
@@ -303,7 +213,8 @@ mod tests {
         {
             // Empty raw to empty decoded.
             let mut col = col.clone();
-            col.decode(&Tz::utc(), &FieldTypeTp::Long.into()).unwrap();
+            col.ensure_decoded(&Tz::utc(), &FieldTypeTp::Long.into())
+                .unwrap();
             assert!(col.is_decoded());
             assert_eq!(col.len(), 0);
             assert_eq!(col.capacity(), 5);
@@ -320,18 +231,18 @@ mod tests {
 
         let mut datum_raw_1 = Vec::new();
         DatumEncoder::encode(&mut datum_raw_1, &[Datum::U64(32)], false).unwrap();
-        col.push_raw(&datum_raw_1);
+        col.mut_raw().push(&datum_raw_1);
 
         let mut datum_raw_2 = Vec::new();
         DatumEncoder::encode(&mut datum_raw_2, &[Datum::U64(7)], true).unwrap();
-        col.push_raw(&datum_raw_2);
+        col.mut_raw().push(&datum_raw_2);
 
         assert!(col.is_raw());
         assert_eq!(col.len(), 2);
         assert_eq!(col.capacity(), 5);
         assert_eq!(col.raw().len(), 2);
-        assert_eq!(col.raw()[0].as_slice(), datum_raw_1.as_slice());
-        assert_eq!(col.raw()[1].as_slice(), datum_raw_2.as_slice());
+        assert_eq!(&col.raw()[0], datum_raw_1.as_slice());
+        assert_eq!(&col.raw()[1], datum_raw_2.as_slice());
         {
             // Clone non-empty raw LazyBatchColumn.
             let col = col.clone();
@@ -339,11 +250,12 @@ mod tests {
             assert_eq!(col.len(), 2);
             assert_eq!(col.capacity(), 5);
             assert_eq!(col.raw().len(), 2);
-            assert_eq!(col.raw()[0].as_slice(), datum_raw_1.as_slice());
-            assert_eq!(col.raw()[1].as_slice(), datum_raw_2.as_slice());
+            assert_eq!(&col.raw()[0], datum_raw_1.as_slice());
+            assert_eq!(&col.raw()[1], datum_raw_2.as_slice());
         }
         // Non-empty raw to non-empty decoded.
-        col.decode(&Tz::utc(), &FieldTypeTp::Long.into()).unwrap();
+        col.ensure_decoded(&Tz::utc(), &FieldTypeTp::Long.into())
+            .unwrap();
         assert!(col.is_decoded());
         assert_eq!(col.len(), 2);
         assert_eq!(col.capacity(), 5);
@@ -370,87 +282,12 @@ mod benches {
         b.iter(|| {
             let column = test::black_box(&mut column);
             for _ in 0..1000 {
-                column.push_raw(test::black_box(&val))
+                column.mut_raw().push(test::black_box(&val))
             }
             test::black_box(&column);
             column.clear();
             test::black_box(&column);
         });
-    }
-
-    #[bench]
-    fn bench_lazy_batch_column_push_raw_9bytes(b: &mut test::Bencher) {
-        let mut column = LazyBatchColumn::raw_with_capacity(1000);
-        let val = vec![0; 9];
-        b.iter(|| {
-            let column = test::black_box(&mut column);
-            for _ in 0..1000 {
-                column.push_raw(test::black_box(&val))
-            }
-            test::black_box(&column);
-            column.clear();
-            test::black_box(&column);
-        });
-    }
-
-    /// 10 bytes > inline size for LazyBatchColumn, which will be slower.
-    /// This benchmark shows how slow it will be.
-    #[bench]
-    fn bench_lazy_batch_column_push_raw_10bytes(b: &mut test::Bencher) {
-        let mut column = LazyBatchColumn::raw_with_capacity(1000);
-        let val = vec![0; 10];
-        b.iter(|| {
-            let column = test::black_box(&mut column);
-            for _ in 0..1000 {
-                column.push_raw(test::black_box(&val))
-            }
-            test::black_box(&column);
-            column.clear();
-            test::black_box(&column);
-        });
-    }
-
-    /// Bench performance of cloning a raw column which size <= inline size.
-    #[bench]
-    fn bench_lazy_batch_column_clone(b: &mut test::Bencher) {
-        let mut column = LazyBatchColumn::raw_with_capacity(1000);
-        let val = vec![0; 9];
-        for _ in 0..1000 {
-            column.push_raw(&val);
-        }
-        b.iter(|| {
-            test::black_box(test::black_box(&column).clone());
-        });
-    }
-
-    /// Bench performance of cloning a raw column which size > inline size.
-    #[bench]
-    fn bench_lazy_batch_column_clone_10bytes(b: &mut test::Bencher) {
-        let mut column = LazyBatchColumn::raw_with_capacity(1000);
-        let val = vec![0; 10];
-        for _ in 0..1000 {
-            column.push_raw(&val);
-        }
-        b.iter(|| {
-            test::black_box(test::black_box(&column).clone());
-        });
-    }
-
-    /// Bench performance of naively cloning a raw column
-    /// (which uses `SmallVec::clone()` instead of our own)
-    #[bench]
-    fn bench_lazy_batch_column_clone_naive(b: &mut test::Bencher) {
-        let mut column = LazyBatchColumn::raw_with_capacity(1000);
-        let val = vec![0; 10];
-        for _ in 0..1000 {
-            column.push_raw(&val);
-        }
-        b.iter(|| match test::black_box(&column) {
-            LazyBatchColumn::Raw(raw_vec) => {
-                test::black_box(raw_vec.clone());
-            }
-            _ => panic!(),
-        })
     }
 
     /// Bench performance of cloning a decoded column.
@@ -465,11 +302,11 @@ mod benches {
         DatumEncoder::encode(&mut datum_raw, &[Datum::U64(0xDEADBEEF)], true).unwrap();
 
         for _ in 0..1000 {
-            column.push_raw(datum_raw.as_slice());
+            column.mut_raw().push(datum_raw.as_slice());
         }
 
         column
-            .decode(&Tz::utc(), &FieldTypeTp::LongLong.into())
+            .ensure_decoded(&Tz::utc(), &FieldTypeTp::LongLong.into())
             .unwrap();
 
         b.iter(|| {
@@ -491,7 +328,7 @@ mod benches {
         DatumEncoder::encode(&mut datum_raw, &[Datum::U64(0xDEADBEEF)], true).unwrap();
 
         for _ in 0..1000 {
-            column.push_raw(datum_raw.as_slice());
+            column.mut_raw().push(datum_raw.as_slice());
         }
 
         let ft = FieldTypeTp::LongLong.into();
@@ -499,7 +336,7 @@ mod benches {
 
         b.iter(|| {
             let mut col = test::black_box(&column).clone();
-            col.decode(test::black_box(&tz), test::black_box(&ft))
+            col.ensure_decoded(test::black_box(&tz), test::black_box(&ft))
                 .unwrap();
             test::black_box(&col);
         });
@@ -519,17 +356,17 @@ mod benches {
         DatumEncoder::encode(&mut datum_raw, &[Datum::U64(0xDEADBEEF)], true).unwrap();
 
         for _ in 0..1000 {
-            column.push_raw(datum_raw.as_slice());
+            column.mut_raw().push(datum_raw.as_slice());
         }
 
         let ft = FieldTypeTp::LongLong.into();
         let tz = Tz::utc();
 
-        column.decode(&tz, &ft).unwrap();
+        column.ensure_decoded(&tz, &ft).unwrap();
 
         b.iter(|| {
             let mut col = test::black_box(&column).clone();
-            col.decode(test::black_box(&tz), test::black_box(&ft))
+            col.ensure_decoded(test::black_box(&tz), test::black_box(&ft))
                 .unwrap();
             test::black_box(&col);
         });

--- a/src/coprocessor/codec/batch/lazy_column.rs
+++ b/src/coprocessor/codec/batch/lazy_column.rs
@@ -35,8 +35,12 @@ impl LazyBatchColumn {
     /// Creates a new `LazyBatchColumn::Raw` with specified capacity.
     #[inline]
     pub fn raw_with_capacity(capacity: usize) -> Self {
-        // 11 = MAX_VAR_INT_LEN(10) + Datum Flag(1)
-        LazyBatchColumn::Raw(BufferVec::with_capacity(capacity, capacity * 11))
+        use codec::number::MAX_VARINT64_LENGTH;
+        // We assume that each element *may* has a size of MAX_VAR_INT_LEN + Datum Flag (1 byte).
+        LazyBatchColumn::Raw(BufferVec::with_capacity(
+            capacity,
+            capacity * (MAX_VARINT64_LENGTH + 1),
+        ))
     }
 
     /// Creates a new `LazyBatchColumn::Decoded` with specified capacity and eval type.
@@ -130,6 +134,11 @@ impl LazyBatchColumn {
         }
     }
 
+    /// Retains the elements according to a boolean array.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `retain_arr` is not long enough.
     #[inline]
     pub fn retain_by_array(&mut self, retain_arr: &[bool]) {
         match self {

--- a/src/coprocessor/codec/batch/lazy_column_vec.rs
+++ b/src/coprocessor/codec/batch/lazy_column_vec.rs
@@ -4,7 +4,6 @@ use tipb::expression::FieldType;
 
 use super::LazyBatchColumn;
 use crate::coprocessor::codec::data_type::VectorValue;
-use crate::coprocessor::codec::mysql::Tz;
 use crate::coprocessor::codec::Result;
 
 /// Stores multiple `LazyBatchColumn`s. Each column has an equal length.
@@ -48,7 +47,6 @@ impl LazyBatchColumnVec {
     }
 
     /// Creates a new `LazyBatchColumnVec`, which contains `columns_count` number of raw columns.
-    #[inline]
     #[cfg(test)]
     pub fn with_raw_columns(columns_count: usize) -> Self {
         let mut columns = Vec::with_capacity(columns_count);
@@ -57,46 +55,6 @@ impl LazyBatchColumnVec {
             columns.push(column);
         }
         Self { columns }
-    }
-
-    /// Moves all elements of `other` into `Self`, leaving `other` empty.
-    ///
-    /// # Panics
-    ///
-    /// Panics when `other` and `Self` does not have same column schemas.
-    #[inline]
-    pub fn append(&mut self, other: &mut Self) {
-        let len = self.columns_len();
-        assert_eq!(len, other.columns_len());
-        for i in 0..len {
-            self.columns[i].append(&mut other[i]);
-        }
-
-        self.assert_columns_equal_length();
-    }
-
-    /// Ensures that a column at specified `column_index` is decoded and returns a reference
-    /// to the decoded column.
-    ///
-    /// If the column is already decoded, this function does nothing.
-    #[inline]
-    pub fn ensure_column_decoded(
-        &mut self,
-        column_index: usize,
-        time_zone: &Tz,
-        field_type: &FieldType,
-    ) -> Result<&VectorValue> {
-        let number_of_rows = self.rows_len();
-        let col = &mut self.columns[column_index];
-        assert_eq!(col.len(), number_of_rows);
-        col.decode(time_zone, field_type)?;
-        Ok(col.decoded())
-    }
-
-    /// Returns whether column at specified `column_index` is decoded.
-    #[inline]
-    pub fn is_column_decoded(&self, column_index: usize) -> bool {
-        self.columns[column_index].is_decoded()
     }
 
     /// Returns the number of columns.
@@ -125,14 +83,12 @@ impl LazyBatchColumnVec {
         }
     }
 
-    /// Retains only the rows specified by the predicate, which accepts index only.
+    /// Retain the elements according to a boolean array.
     ///
-    /// In other words, remove all rows such that `f(row_index)` returns `false`.
-    #[inline]
-    pub fn retain_rows_by_index<F>(&mut self, mut f: F)
-    where
-        F: FnMut(usize) -> bool,
-    {
+    /// # Panics
+    ///
+    /// Panics if `retain_arr` is not long enough.
+    pub fn retain_rows_by_array(&mut self, retain_arr: &[bool]) {
         if self.rows_len() == 0 {
             return;
         }
@@ -142,7 +98,7 @@ impl LazyBatchColumnVec {
         // We retain column by column to be efficient.
         for col in &mut self.columns {
             assert_eq!(col.len(), current_rows_len);
-            col.retain_by_index(&mut f);
+            col.retain_by_array(retain_arr);
         }
 
         self.assert_columns_equal_length();
@@ -219,6 +175,7 @@ mod tests {
 
     use crate::coprocessor::codec::data_type::Real;
     use crate::coprocessor::codec::datum::{Datum, DatumEncoder};
+    use crate::coprocessor::codec::mysql::Tz;
 
     /// Pushes a raw row. There must be no empty datum.
     ///
@@ -239,7 +196,7 @@ mod tests {
         for (col_index, raw_datum) in raw_row_slice.iter().enumerate() {
             let lazy_col = &mut columns.columns[col_index];
             assert!(lazy_col.is_raw());
-            lazy_col.push_raw(raw_datum);
+            lazy_col.mut_raw().push(raw_datum);
         }
 
         columns.assert_columns_equal_length();
@@ -263,6 +220,8 @@ mod tests {
         push_raw_row(columns, raw_row);
     }
 
+    // TODO: Move to VectorValue
+    /*
     #[test]
     fn test_ensure_column_decoded() {
         use cop_datatype::FieldTypeTp;
@@ -289,65 +248,61 @@ mod tests {
             assert_eq!(columns.rows_len(), values.len());
 
             // Decode Column Index 2
-            assert!(!columns.is_column_decoded(2));
+            assert!(!columns[2].is_decoded());
             {
-                let col = columns
-                    .ensure_column_decoded(2, &Tz::utc(), &schema[2])
-                    .unwrap();
+                let col = columns[2].ensure_decoded(&Tz::utc(), &schema[2]).unwrap();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Bytes);
                 assert_eq!(col.as_bytes_slice(), &[None, Some(vec![0u8, 2u8])]);
             }
             // Decode a decoded column
-            assert!(columns.is_column_decoded(2));
+            assert!(columns[2].is_decoded());
             {
-                let col = columns
-                    .ensure_column_decoded(2, &Tz::utc(), &schema[2])
-                    .unwrap();
+                let col = columns[2].ensure_decoded(&Tz::utc(), &schema[2]).unwrap();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Bytes);
                 assert_eq!(col.as_bytes_slice(), &[None, Some(vec![0u8, 2u8])]);
             }
-            assert!(columns.is_column_decoded(2));
+            assert!(columns[2].is_decoded());
 
             // Decode Column Index 0
-            assert!(!columns.is_column_decoded(0));
+            assert!(!columns[0].is_decoded());
             {
-                let col = columns
-                    .ensure_column_decoded(0, &Tz::utc(), &schema[0])
-                    .unwrap();
+                let col = columns[0].ensure_decoded(&Tz::utc(), &schema[0]).unwrap();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Int);
                 assert_eq!(col.as_int_slice(), &[Some(1), None]);
             }
-            assert!(columns.is_column_decoded(0));
+            assert!(columns[0].is_decoded());
 
             // Decode Column Index 1
-            assert!(!columns.is_column_decoded(1));
+            assert!(!columns[1].is_decoded());
             {
-                let col = columns
-                    .ensure_column_decoded(1, &Tz::utc(), &schema[1])
-                    .unwrap();
+                let col = columns[1].ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Real);
                 assert_eq!(col.as_real_slice(), &[Real::new(1.0).ok(), None]);
             }
-            assert!(columns.is_column_decoded(1));
+            assert!(columns[1].is_decoded());
         }
     }
+    */
 
     #[test]
-    fn test_retain_rows_by_index() {
+    fn test_retain_rows_by_array() {
         use cop_datatype::FieldTypeTp;
 
         let schema = [FieldTypeTp::Long.into(), FieldTypeTp::Double.into()];
         let mut columns = LazyBatchColumnVec::with_raw_columns(2);
         assert_eq!(columns.rows_len(), 0);
         assert_eq!(columns.columns_len(), 2);
-        columns.retain_rows_by_index(|_| true);
+        columns.retain_rows_by_array(&[]);
         assert_eq!(columns.rows_len(), 0);
         assert_eq!(columns.columns_len(), 2);
-        columns.retain_rows_by_index(|_| false);
+        columns.retain_rows_by_array(&[true]);
+        assert_eq!(columns.rows_len(), 0);
+        assert_eq!(columns.columns_len(), 2);
+        columns.retain_rows_by_array(&[false]);
         assert_eq!(columns.rows_len(), 0);
         assert_eq!(columns.columns_len(), 2);
 
@@ -358,15 +313,14 @@ mod tests {
         push_raw_row_from_datums(&mut columns, &[Datum::U64(11), Datum::F64(7.5)], true);
         push_raw_row_from_datums(&mut columns, &[Datum::Null, Datum::F64(13.1)], true);
 
-        let retain_map = &[true, true, false, false, true, false];
-        columns.retain_rows_by_index(|idx| retain_map[idx]);
+        columns.retain_rows_by_array(&[true, true, false, false, true, false]);
 
         assert_eq!(columns.rows_len(), 3);
         assert_eq!(columns.columns_len(), 2);
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(&Tz::utc(), &schema[0]).unwrap();
+            column0.ensure_decoded(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 3);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(column0.decoded().as_int_slice(), &[None, None, Some(11)]);
@@ -374,7 +328,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(&Tz::utc(), &schema[1]).unwrap();
+            column1.ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 3);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -393,7 +347,7 @@ mod tests {
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(&Tz::utc(), &schema[0]).unwrap();
+            column0.ensure_decoded(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 7);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(
@@ -404,7 +358,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(&Tz::utc(), &schema[1]).unwrap();
+            column1.ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 7);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -421,15 +375,14 @@ mod tests {
             );
         }
 
-        let retain_map = &[true, false, true, false, false, true, true];
-        columns.retain_rows_by_index(|idx| retain_map[idx]);
+        columns.retain_rows_by_array(&[true, false, true, false, false, true, true]);
 
         assert_eq!(columns.rows_len(), 4);
         assert_eq!(columns.columns_len(), 2);
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(&Tz::utc(), &schema[0]).unwrap();
+            column0.ensure_decoded(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 4);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(
@@ -440,7 +393,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(&Tz::utc(), &schema[1]).unwrap();
+            column1.ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 4);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -454,14 +407,14 @@ mod tests {
             );
         }
 
-        columns.retain_rows_by_index(|_| true);
+        columns.retain_rows_by_array(&[true, true, true, true]);
 
         assert_eq!(columns.rows_len(), 4);
         assert_eq!(columns.columns_len(), 2);
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(&Tz::utc(), &schema[0]).unwrap();
+            column0.ensure_decoded(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 4);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(
@@ -472,7 +425,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(&Tz::utc(), &schema[1]).unwrap();
+            column1.ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 4);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -486,14 +439,14 @@ mod tests {
             );
         }
 
-        columns.retain_rows_by_index(|_| false);
+        columns.retain_rows_by_array(&[false, false, false, false]);
 
         assert_eq!(columns.rows_len(), 0);
         assert_eq!(columns.columns_len(), 2);
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(&Tz::utc(), &schema[0]).unwrap();
+            column0.ensure_decoded(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 0);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(column0.decoded().as_int_slice(), &[]);
@@ -501,7 +454,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(&Tz::utc(), &schema[1]).unwrap();
+            column1.ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 0);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(column1.decoded().as_real_slice(), &[]);
@@ -516,7 +469,7 @@ mod tests {
         {
             let mut column0 = columns[0].clone();
             assert!(column0.is_raw());
-            column0.decode(&Tz::utc(), &schema[0]).unwrap();
+            column0.ensure_decoded(&Tz::utc(), &schema[0]).unwrap();
             assert_eq!(column0.decoded().len(), 3);
             assert_eq!(column0.decoded().eval_type(), EvalType::Int);
             assert_eq!(column0.decoded().as_int_slice(), &[None, Some(5), Some(1)]);
@@ -524,7 +477,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(&Tz::utc(), &schema[1]).unwrap();
+            column1.ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 3);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -534,11 +487,9 @@ mod tests {
         }
 
         // Let's change a column from lazy to decoded and test whether retain works
-        columns
-            .ensure_column_decoded(0, &Tz::utc(), &schema[0])
-            .unwrap();
+        columns[0].ensure_decoded(&Tz::utc(), &schema[0]).unwrap();
 
-        columns.retain_rows_by_index(|_| true);
+        columns.retain_rows_by_array(&[true, true, true]);
 
         assert_eq!(columns.rows_len(), 3);
         assert_eq!(columns.columns_len(), 2);
@@ -552,7 +503,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(&Tz::utc(), &schema[1]).unwrap();
+            column1.ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 3);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -561,8 +512,7 @@ mod tests {
             );
         }
 
-        let retain_map = &[true, false, true];
-        columns.retain_rows_by_index(|idx| retain_map[idx]);
+        columns.retain_rows_by_array(&[true, false, true]);
 
         assert_eq!(columns.rows_len(), 2);
         assert_eq!(columns.columns_len(), 2);
@@ -576,7 +526,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(&Tz::utc(), &schema[1]).unwrap();
+            column1.ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 2);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(
@@ -585,7 +535,7 @@ mod tests {
             );
         }
 
-        columns.retain_rows_by_index(|_| false);
+        columns.retain_rows_by_array(&[false, false]);
 
         assert_eq!(columns.rows_len(), 0);
         assert_eq!(columns.columns_len(), 2);
@@ -599,7 +549,7 @@ mod tests {
         {
             let mut column1 = columns[1].clone();
             assert!(column1.is_raw());
-            column1.decode(&Tz::utc(), &schema[1]).unwrap();
+            column1.ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
             assert_eq!(column1.decoded().len(), 0);
             assert_eq!(column1.decoded().eval_type(), EvalType::Real);
             assert_eq!(column1.decoded().as_real_slice(), &[]);

--- a/src/coprocessor/codec/batch/lazy_column_vec.rs
+++ b/src/coprocessor/codec/batch/lazy_column_vec.rs
@@ -83,7 +83,7 @@ impl LazyBatchColumnVec {
         }
     }
 
-    /// Retain the elements according to a boolean array.
+    /// Retains the elements according to a boolean array.
     ///
     /// # Panics
     ///
@@ -220,8 +220,6 @@ mod tests {
         push_raw_row(columns, raw_row);
     }
 
-    // TODO: Move to VectorValue
-    /*
     #[test]
     fn test_ensure_column_decoded() {
         use cop_datatype::FieldTypeTp;
@@ -250,7 +248,8 @@ mod tests {
             // Decode Column Index 2
             assert!(!columns[2].is_decoded());
             {
-                let col = columns[2].ensure_decoded(&Tz::utc(), &schema[2]).unwrap();
+                columns[2].ensure_decoded(&Tz::utc(), &schema[2]).unwrap();
+                let col = columns[2].decoded();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Bytes);
                 assert_eq!(col.as_bytes_slice(), &[None, Some(vec![0u8, 2u8])]);
@@ -258,7 +257,8 @@ mod tests {
             // Decode a decoded column
             assert!(columns[2].is_decoded());
             {
-                let col = columns[2].ensure_decoded(&Tz::utc(), &schema[2]).unwrap();
+                columns[2].ensure_decoded(&Tz::utc(), &schema[2]).unwrap();
+                let col = columns[2].decoded();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Bytes);
                 assert_eq!(col.as_bytes_slice(), &[None, Some(vec![0u8, 2u8])]);
@@ -268,7 +268,8 @@ mod tests {
             // Decode Column Index 0
             assert!(!columns[0].is_decoded());
             {
-                let col = columns[0].ensure_decoded(&Tz::utc(), &schema[0]).unwrap();
+                columns[0].ensure_decoded(&Tz::utc(), &schema[0]).unwrap();
+                let col = columns[0].decoded();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Int);
                 assert_eq!(col.as_int_slice(), &[Some(1), None]);
@@ -278,7 +279,8 @@ mod tests {
             // Decode Column Index 1
             assert!(!columns[1].is_decoded());
             {
-                let col = columns[1].ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
+                columns[1].ensure_decoded(&Tz::utc(), &schema[1]).unwrap();
+                let col = columns[1].decoded();
                 assert_eq!(col.len(), 2);
                 assert_eq!(col.eval_type(), EvalType::Real);
                 assert_eq!(col.as_real_slice(), &[Real::new(1.0).ok(), None]);
@@ -286,7 +288,6 @@ mod tests {
             assert!(columns[1].is_decoded());
         }
     }
-    */
 
     #[test]
     fn test_retain_rows_by_array() {

--- a/src/coprocessor/codec/batch/mod.rs
+++ b/src/coprocessor/codec/batch/mod.rs
@@ -1,7 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+mod buffer_vec;
 mod lazy_column;
 mod lazy_column_vec;
 
+pub use self::buffer_vec::BufferVec;
 pub use self::lazy_column::LazyBatchColumn;
 pub use self::lazy_column_vec::LazyBatchColumnVec;

--- a/src/coprocessor/codec/data_type/vector.rs
+++ b/src/coprocessor/codec/data_type/vector.rs
@@ -107,7 +107,7 @@ impl VectorValue {
         }
     }
 
-    /// Retain the elements according to a boolean array.
+    /// Retains the elements according to a boolean array.
     ///
     /// # Panics
     ///

--- a/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
@@ -410,7 +410,9 @@ mod tests {
 
             // Let's check group by column first. Group by column is decoded in fast hash agg,
             // but not decoded in slow hash agg. So decode it anyway.
-            r.data[4].decode(&Tz::utc(), &exec.schema()[4]).unwrap();
+            r.data[4]
+                .ensure_decoded(&Tz::utc(), &exec.schema()[4])
+                .unwrap();
 
             // The row order is not defined. Let's sort it by the group by column before asserting.
             let mut sort_column: Vec<(usize, _)> = r.data[4]
@@ -577,7 +579,9 @@ mod tests {
             let mut r = exec.next_batch(1);
             assert_eq!(r.data.rows_len(), 3);
             assert_eq!(r.data.columns_len(), 1); // 0 result column, 1 group by column
-            r.data[0].decode(&Tz::utc(), &exec.schema()[0]).unwrap();
+            r.data[0]
+                .ensure_decoded(&Tz::utc(), &exec.schema()[0])
+                .unwrap();
             let mut sort_column: Vec<(usize, _)> = r.data[0]
                 .decoded()
                 .as_real_slice()

--- a/src/coprocessor/dag/batch/executors/index_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/index_scan_executor.rs
@@ -180,7 +180,7 @@ impl super::util::scan_executor::ScanExecutorImpl for IndexScanExecutorImpl {
 
         for i in 0..self.columns_len_without_handle {
             let (val, remaining) = datum::split_datum(key_payload, false)?;
-            columns[i].push_raw(val);
+            columns[i].mut_raw().push(val);
             key_payload = remaining;
         }
 
@@ -336,13 +336,17 @@ mod tests {
             assert_eq!(result.data.columns_len(), 2);
             assert_eq!(result.data.rows_len(), 3);
             assert!(result.data[0].is_raw());
-            result.data[0].decode(&Tz::utc(), &schema[0]).unwrap();
+            result.data[0]
+                .ensure_decoded(&Tz::utc(), &schema[0])
+                .unwrap();
             assert_eq!(
                 result.data[0].decoded().as_int_slice(),
                 &[Some(5), Some(5), Some(-5)]
             );
             assert!(result.data[1].is_raw());
-            result.data[1].decode(&Tz::utc(), &schema[1]).unwrap();
+            result.data[1]
+                .ensure_decoded(&Tz::utc(), &schema[1])
+                .unwrap();
             assert_eq!(
                 result.data[1].decoded().as_real_slice(),
                 &[
@@ -386,10 +390,14 @@ mod tests {
             assert_eq!(result.data.columns_len(), 3);
             assert_eq!(result.data.rows_len(), 2);
             assert!(result.data[0].is_raw());
-            result.data[0].decode(&Tz::utc(), &schema[0]).unwrap();
+            result.data[0]
+                .ensure_decoded(&Tz::utc(), &schema[0])
+                .unwrap();
             assert_eq!(result.data[0].decoded().as_int_slice(), &[Some(5), Some(5)]);
             assert!(result.data[1].is_raw());
-            result.data[1].decode(&Tz::utc(), &schema[1]).unwrap();
+            result.data[1]
+                .ensure_decoded(&Tz::utc(), &schema[1])
+                .unwrap();
             assert_eq!(
                 result.data[1].decoded().as_real_slice(),
                 &[Real::new(5.1).ok(), Real::new(10.5).ok()]
@@ -452,10 +460,14 @@ mod tests {
             assert_eq!(result.data.columns_len(), 3);
             assert_eq!(result.data.rows_len(), 2);
             assert!(result.data[0].is_raw());
-            result.data[0].decode(&Tz::utc(), &schema[0]).unwrap();
+            result.data[0]
+                .ensure_decoded(&Tz::utc(), &schema[0])
+                .unwrap();
             assert_eq!(result.data[0].decoded().as_int_slice(), &[Some(5), Some(5)]);
             assert!(result.data[1].is_raw());
-            result.data[1].decode(&Tz::utc(), &schema[1]).unwrap();
+            result.data[1]
+                .ensure_decoded(&Tz::utc(), &schema[1])
+                .unwrap();
             assert_eq!(
                 result.data[1].decoded().as_real_slice(),
                 &[Real::new(5.1).ok(), Real::new(10.5).ok()]
@@ -496,10 +508,14 @@ mod tests {
             assert_eq!(result.data.columns_len(), 3);
             assert_eq!(result.data.rows_len(), 1);
             assert!(result.data[0].is_raw());
-            result.data[0].decode(&Tz::utc(), &schema[0]).unwrap();
+            result.data[0]
+                .ensure_decoded(&Tz::utc(), &schema[0])
+                .unwrap();
             assert_eq!(result.data[0].decoded().as_int_slice(), &[Some(5)]);
             assert!(result.data[1].is_raw());
-            result.data[1].decode(&Tz::utc(), &schema[1]).unwrap();
+            result.data[1]
+                .ensure_decoded(&Tz::utc(), &schema[1])
+                .unwrap();
             assert_eq!(
                 result.data[1].decoded().as_real_slice(),
                 &[Real::new(5.1).ok()]

--- a/src/coprocessor/dag/batch/executors/selection_executor.rs
+++ b/src/coprocessor/dag/batch/executors/selection_executor.rs
@@ -101,10 +101,7 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSelectionExecutor<Src> {
             }
 
             // TODO: When there are many conditions, it would be better to filter column each time.
-
-            src_result
-                .data
-                .retain_rows_by_index(|idx| base_retain_map[idx]);
+            src_result.data.retain_rows_by_array(&base_retain_map);
         }
 
         // Only append warnings when there is no error during filtering because we clear the data

--- a/src/coprocessor/dag/batch/executors/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/table_scan_executor.rs
@@ -243,7 +243,7 @@ impl super::util::scan_executor::ScanExecutorImpl for TableScanExecutorImpl {
                 if let Some(index) = some_index {
                     let index = *index;
                     if !self.is_column_filled[index] {
-                        columns[index].push_raw(val);
+                        columns[index].mut_raw().push(val);
                         decoded_columns += 1;
                         self.is_column_filled[index] = true;
                     } else {
@@ -285,7 +285,7 @@ impl super::util::scan_executor::ScanExecutorImpl for TableScanExecutorImpl {
                     ));
                 };
 
-                columns[i].push_raw(default_value);
+                columns[i].mut_raw().push(default_value);
             } else {
                 // Reset to not-filled, prepare for next function call.
                 self.is_column_filled[i] = false;
@@ -541,7 +541,7 @@ mod tests {
                 } else {
                     assert!(columns[id].is_raw());
                     columns[id]
-                        .decode(&Tz::utc(), self.get_field_type(col_idx))
+                        .ensure_decoded(&Tz::utc(), self.get_field_type(col_idx))
                         .unwrap();
                 }
                 assert_eq!(columns[id].decoded(), &values[col_idx]);
@@ -786,10 +786,14 @@ mod tests {
             assert!(result.data[0].is_decoded());
             assert_eq!(result.data[0].decoded().as_int_slice(), &[Some(0), Some(1)]);
             assert!(result.data[1].is_raw());
-            result.data[1].decode(&Tz::utc(), &schema[1]).unwrap();
+            result.data[1]
+                .ensure_decoded(&Tz::utc(), &schema[1])
+                .unwrap();
             assert_eq!(result.data[1].decoded().as_int_slice(), &[Some(5), None]);
             assert!(result.data[2].is_raw());
-            result.data[2].decode(&Tz::utc(), &schema[2]).unwrap();
+            result.data[2]
+                .ensure_decoded(&Tz::utc(), &schema[2])
+                .unwrap();
             assert_eq!(result.data[2].decoded().as_int_slice(), &[Some(7), None]);
         }
     }
@@ -881,7 +885,9 @@ mod tests {
             assert!(result.data[0].is_decoded());
             assert_eq!(result.data[0].decoded().as_int_slice(), &[Some(0)]);
             assert!(result.data[1].is_raw());
-            result.data[1].decode(&Tz::utc(), &schema[1]).unwrap();
+            result.data[1]
+                .ensure_decoded(&Tz::utc(), &schema[1])
+                .unwrap();
             assert_eq!(result.data[1].decoded().as_int_slice(), &[Some(7)]);
         }
 
@@ -907,7 +913,9 @@ mod tests {
             assert!(result.data[0].is_decoded());
             assert_eq!(result.data[0].decoded().as_int_slice(), &[Some(0)]);
             assert!(result.data[1].is_raw());
-            result.data[1].decode(&Tz::utc(), &schema[1]).unwrap();
+            result.data[1]
+                .ensure_decoded(&Tz::utc(), &schema[1])
+                .unwrap();
             assert_eq!(result.data[1].decoded().as_int_slice(), &[Some(7)]);
 
             let result = executor.next_batch(1);
@@ -953,7 +961,9 @@ mod tests {
             assert!(result.data[0].is_decoded());
             assert_eq!(result.data[0].decoded().as_int_slice(), &[Some(2), Some(0)]);
             assert!(result.data[1].is_raw());
-            result.data[1].decode(&Tz::utc(), &schema[1]).unwrap();
+            result.data[1]
+                .ensure_decoded(&Tz::utc(), &schema[1])
+                .unwrap();
             assert_eq!(result.data[1].decoded().as_int_slice(), &[Some(5), Some(7)]);
         }
 

--- a/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
@@ -139,7 +139,7 @@ impl RpnExpression {
 
         for node in self.as_ref() {
             if let RpnExpressionNode::ColumnRef { ref offset, .. } = node {
-                columns.ensure_column_decoded(*offset, &context.cfg.tz, &schema[*offset])?;
+                columns[*offset].ensure_decoded(&context.cfg.tz, &schema[*offset])?;
             }
         }
 
@@ -472,15 +472,15 @@ mod tests {
 
             let mut datum_raw = Vec::new();
             DatumEncoder::encode(&mut datum_raw, &[Datum::I64(-5)], false).unwrap();
-            col.push_raw(&datum_raw);
+            col.mut_raw().push(&datum_raw);
 
             let mut datum_raw = Vec::new();
             DatumEncoder::encode(&mut datum_raw, &[Datum::I64(-7)], false).unwrap();
-            col.push_raw(&datum_raw);
+            col.mut_raw().push(&datum_raw);
 
             let mut datum_raw = Vec::new();
             DatumEncoder::encode(&mut datum_raw, &[Datum::I64(3)], false).unwrap();
-            col.push_raw(&datum_raw);
+            col.mut_raw().push(&datum_raw);
 
             col
         }]);
@@ -718,15 +718,15 @@ mod tests {
 
             let mut datum_raw = Vec::new();
             DatumEncoder::encode(&mut datum_raw, &[Datum::I64(-5)], false).unwrap();
-            col.push_raw(&datum_raw);
+            col.mut_raw().push(&datum_raw);
 
             let mut datum_raw = Vec::new();
             DatumEncoder::encode(&mut datum_raw, &[Datum::I64(-7)], false).unwrap();
-            col.push_raw(&datum_raw);
+            col.mut_raw().push(&datum_raw);
 
             let mut datum_raw = Vec::new();
             DatumEncoder::encode(&mut datum_raw, &[Datum::I64(3)], false).unwrap();
-            col.push_raw(&datum_raw);
+            col.mut_raw().push(&datum_raw);
 
             col
         }]);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR utilizes `BufferVec` in `LazyBatchColumn`, which was added in https://github.com/tikv/tikv/pull/4790 . Also some useless interfaces are removed.

It fixes the performance regression when there are large integers, as well as other cases where datum is small but larger than 10 bytes.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Existing tests.
