### PR TITLE
raftstore: more check about transferring leader during configuration change

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1716,8 +1716,11 @@ impl Peer {
         }
 
         // Checks if safe to transfer leader.
-        if duration_to_sec(self.recent_conf_change_time.elapsed())
-            < ctx.cfg.raft_reject_transfer_leader_duration.as_secs() as f64
+        // Check `has_pending_conf` is necessary because `recent_conf_change_time` is updated
+        // on applied. TODO: fix the transfer leader issue in Raft.
+        if self.raft_group.raft.has_pending_conf()
+            || duration_to_sec(self.recent_conf_change_time.elapsed())
+                < ctx.cfg.raft_reject_transfer_leader_duration.as_secs() as f64
         {
             debug!(
                 "reject transfer leader due to the region was config changed recently";


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

## What have you changed? (mandatory)
We have add a check about tranferring leader during configuration change in #4684 . However if the configuration change is not applied on the leader, new transferring leader proposal can pass the check. This PR makes the check can still work in this case.

## What are the type of the changes? (mandatory)
Improvement.

## How has this PR been tested? (mandatory)
make dev.