### PR TITLE
raftstore: remove local reader cache

### DIFF
--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -25,7 +25,6 @@ use tikv_util::collections::{HashMap, HashSet};
 use tikv_util::worker::FutureWorker;
 
 use super::*;
-use tikv::raftstore::store::fsm::store::{StoreMeta, PENDING_VOTES_CAP};
 
 pub struct ChannelTransportCore {
     snap_paths: HashMap<u64, (SnapManager, TempDir)>,
@@ -203,7 +202,7 @@ impl Simulator for NodeCluster {
             Arc::new(SSTImporter::new(dir).unwrap())
         };
 
-        let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_VOTES_CAP)));
+        let store_meta = Arc::new(StoreMeta::new());
         let local_reader = LocalReader::new(engines.kv.clone(), store_meta.clone(), router.clone());
         node.start(
             engines.clone(),

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -1,7 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::path::Path;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use std::{thread, usize};
 
@@ -16,7 +16,7 @@ use tikv::coprocessor;
 use tikv::import::{ImportSSTService, SSTImporter};
 use tikv::raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor};
 use tikv::raftstore::store::fsm::{RaftBatchSystem, RaftRouter};
-use tikv::raftstore::store::{Callback, LocalReader, SnapManager};
+use tikv::raftstore::store::{Callback, LocalReader, SnapManager, StoreMeta};
 use tikv::raftstore::Result;
 use tikv::server::load_statistics::ThreadLoad;
 use tikv::server::resolve::{self, Task as ResolveTask};
@@ -34,7 +34,6 @@ use tikv_util::security::SecurityManager;
 use tikv_util::worker::{FutureWorker, Worker};
 
 use super::*;
-use tikv::raftstore::store::fsm::store::{StoreMeta, PENDING_VOTES_CAP};
 
 type SimulateStoreTransport = SimulateTransport<ServerRaftStoreRouter>;
 type SimulateServerTransport =
@@ -120,7 +119,7 @@ impl Simulator for ServerCluster {
             cfg.server.addr = addr.clone();
         }
 
-        let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_VOTES_CAP)));
+        let store_meta = Arc::new(StoreMeta::new());
         let local_reader = LocalReader::new(engines.kv.clone(), store_meta.clone(), router.clone());
         let raft_router = ServerRaftStoreRouter::new(router.clone(), local_reader);
         let sim_router = SimulateTransport::new(raft_router);

--- a/src/binutil/server.rs
+++ b/src/binutil/server.rs
@@ -9,8 +9,7 @@ use crate::fatal;
 use crate::import::{ImportSSTService, SSTImporter};
 use crate::pd::{PdClient, RpcClient};
 use crate::raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor};
-use crate::raftstore::store::fsm::store::{StoreMeta, PENDING_VOTES_CAP};
-use crate::raftstore::store::{fsm, LocalReader};
+use crate::raftstore::store::{fsm, LocalReader, StoreMeta};
 use crate::raftstore::store::{new_compaction_listener, SnapManagerBuilder};
 use crate::server::resolve;
 use crate::server::status_server::StatusServer;
@@ -28,7 +27,7 @@ use engine::Engines;
 use fs2::FileExt;
 use std::fs::File;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Duration;
 use tikv_util::check_environment_variables;
@@ -176,7 +175,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
         .unwrap_or_else(|s| fatal!("failed to create kv engine: {}", s));
 
     let engines = Engines::new(Arc::new(kv_engine), Arc::new(raft_engine), cache.is_some());
-    let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_VOTES_CAP)));
+    let store_meta = Arc::new(StoreMeta::new());
     let local_reader = LocalReader::new(engines.kv.clone(), store_meta.clone(), router.clone());
     let raft_router = ServerRaftStoreRouter::new(router.clone(), local_reader);
 

--- a/src/raftstore/store/meta.rs
+++ b/src/raftstore/store/meta.rs
@@ -1,0 +1,146 @@
+// Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::collections::BTreeMap;
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::{Arc, Mutex, RwLock};
+
+use crate::raftstore::coprocessor::CoprocessorHost;
+use crate::raftstore::store::worker::ReadDelegate;
+use crate::raftstore::store::Peer;
+use kvproto::metapb::{Region, RegionEpoch};
+use kvproto::raft_serverpb::RaftMessage;
+
+use tikv_util::collections::HashMap;
+use tikv_util::{HandyRwLock, RingQueue};
+
+const PENDING_VOTES_CAP: usize = 20;
+const READERS_SLOT_COUNT: usize = 1 << 6; // 64 slots.
+
+type SharedReader = Arc<RwLock<ReadDelegate>>;
+
+pub struct StoreMeta {
+    pub(super) inner: Mutex<StoreMetaInner>,
+    /// store id
+    pub store_id: AtomicU64,
+    /// region_id -> reader
+    readers: Vec<RwLock<HashMap<u64, SharedReader>>>,
+}
+
+impl StoreMeta {
+    pub fn new() -> Self {
+        let mut readers = Vec::with_capacity(READERS_SLOT_COUNT);
+        for _ in 0..READERS_SLOT_COUNT {
+            readers.push(RwLock::new(HashMap::new()));
+        }
+        StoreMeta {
+            inner: Mutex::new(StoreMetaInner::default()),
+            store_id: AtomicU64::new(0),
+            readers,
+        }
+    }
+
+    pub(super) fn insert_reader(&self, region_id: u64, reader: ReadDelegate) {
+        let slot = region_id as usize % READERS_SLOT_COUNT;
+        let mut readers = self.readers[slot].write().unwrap();
+        readers.insert(region_id, Arc::new(RwLock::new(reader)));
+    }
+
+    pub(super) fn remove_reader(&self, region_id: u64) {
+        let slot = region_id as usize % READERS_SLOT_COUNT;
+        let mut readers = self.readers[slot].write().unwrap();
+        readers.remove(&region_id);
+    }
+
+    pub fn with_reader<F, R>(&self, region_id: u64, f: F) -> R
+    where
+        F: FnOnce(Option<&ReadDelegate>) -> R,
+    {
+        let slot = region_id as usize % READERS_SLOT_COUNT;
+        match self.readers[slot].rl().get(&region_id).map(Arc::clone) {
+            Some(reader) => f(Some(reader.read().unwrap().deref())),
+            None => f(None),
+        }
+    }
+
+    pub(super) fn with_mut_reader<F, R>(&self, region_id: u64, f: F) -> R
+    where
+        F: FnOnce(Option<&mut ReadDelegate>) -> R,
+    {
+        let slot = region_id as usize % READERS_SLOT_COUNT;
+        match self.readers[slot].rl().get(&region_id).map(Arc::clone) {
+            Some(reader) => f(Some(reader.write().unwrap().deref_mut())),
+            None => f(None),
+        }
+    }
+
+    pub(super) fn set_region(&self, host: &CoprocessorHost, region: Region, peer: &mut Peer) {
+        let region_id = region.get_id();
+        let mut inner = self.inner.lock().unwrap();
+        let prev = inner.regions.insert(region_id, region.clone());
+        drop(inner);
+        if prev.map_or(true, |r| r.get_id() != region_id) {
+            // TODO: may not be a good idea to panic when holding a lock.
+            panic!("{} region corrupted", peer.tag);
+        }
+        self.with_mut_reader(region_id, |reader| {
+            peer.set_region(host, reader.unwrap(), region);
+        });
+    }
+
+    /// Sometimes `set_region` needs to be called with a locked `inner`.
+    pub(super) fn set_region_with_inner(
+        &self,
+        inner: &mut StoreMetaInner,
+        host: &CoprocessorHost,
+        region: Region,
+        peer: &mut Peer,
+    ) {
+        let region_id = region.get_id();
+        let prev = inner.regions.insert(region_id, region.clone());
+        if prev.map_or(true, |r| r.get_id() != region_id) {
+            // TODO: may not be a good idea to panic when holding a lock.
+            panic!("{} region corrupted", peer.tag);
+        }
+        self.with_mut_reader(region_id, |reader| {
+            peer.set_region(host, reader.unwrap(), region);
+        });
+    }
+}
+
+pub(super) struct StoreMetaInner {
+    /// region_end_key -> region_id
+    pub region_ranges: BTreeMap<Vec<u8>, u64>,
+    /// region_id -> region
+    pub regions: HashMap<u64, Region>,
+    /// `MsgRequestPreVote` or `MsgRequestVote` messages from newly split Regions shouldn't be dropped if there is no
+    /// such Region in this store now. So the messages are recorded temporarily and will be handled later.
+    pub pending_votes: RingQueue<RaftMessage>,
+    /// The regions with pending snapshots.
+    pub pending_snapshot_regions: Vec<Region>,
+    /// A marker used to indicate the peer of a Region has received a merge target message and waits to be destroyed.
+    /// target_region_id -> (source_region_id -> merge_target_epoch)
+    pub pending_merge_targets: HashMap<u64, HashMap<u64, RegionEpoch>>,
+    /// An inverse mapping of `pending_merge_targets` used to let source peer help target peer to clean up related entry.
+    /// source_region_id -> target_region_id
+    pub targets_map: HashMap<u64, u64>,
+    /// In raftstore, the execute order of `PrepareMerge` and `CommitMerge` is not certain because of the messages
+    /// belongs two regions. To make them in order, `PrepareMerge` will set this structure and `CommitMerge` will retry
+    /// later if there is no related lock.
+    /// source_region_id -> (version, BiLock).
+    pub merge_locks: HashMap<u64, (u64, Option<Arc<AtomicBool>>)>,
+}
+
+impl Default for StoreMetaInner {
+    fn default() -> StoreMetaInner {
+        StoreMetaInner {
+            region_ranges: BTreeMap::default(),
+            regions: HashMap::default(),
+            pending_votes: RingQueue::with_capacity(PENDING_VOTES_CAP),
+            pending_snapshot_regions: Vec::default(),
+            pending_merge_targets: HashMap::default(),
+            targets_map: HashMap::default(),
+            merge_locks: HashMap::default(),
+        }
+    }
+}

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -10,6 +10,7 @@ pub mod util;
 
 mod bootstrap;
 mod local_metrics;
+mod meta;
 mod metrics;
 mod peer;
 mod peer_storage;
@@ -23,6 +24,7 @@ pub use self::bootstrap::{
 };
 pub use self::config::Config;
 pub use self::fsm::{new_compaction_listener, DestroyPeerJob, RaftRouter, StoreInfo};
+pub use self::meta::StoreMeta;
 pub use self::msg::{
     Callback, CasualMessage, PeerMsg, PeerTicks, RaftCommand, ReadCallback, ReadResponse,
     SignificantMsg, StoreMsg, StoreTick, WriteCallback, WriteResponse,

--- a/tests/integrations/raftstore/test_bootstrap.rs
+++ b/tests/integrations/raftstore/test_bootstrap.rs
@@ -1,7 +1,7 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use tempdir::TempDir;
 
@@ -14,7 +14,7 @@ use engine::*;
 use test_raftstore::*;
 use tikv::import::SSTImporter;
 use tikv::raftstore::coprocessor::CoprocessorHost;
-use tikv::raftstore::store::fsm::store::StoreMeta;
+use tikv::raftstore::store::StoreMeta;
 use tikv::raftstore::store::{bootstrap_store, fsm, keys, SnapManager};
 use tikv::server::Node;
 use tikv_util::worker::FutureWorker;
@@ -92,7 +92,7 @@ fn test_node_bootstrap_with_prepared_data() {
         simulate_trans,
         snap_mgr,
         pd_worker,
-        Arc::new(Mutex::new(StoreMeta::new(0))),
+        Arc::new(StoreMeta::new()),
         coprocessor_host,
         importer,
     )


### PR DESCRIPTION
#4558 introduces a thread-local cache for `ReadDelegate`s, because with that PR we can do lease read in many threads. However there is still one issue about the cache: if a region is removed from raftstore, and then no more read requests come to the store, the delegate in all thread local caches can't be cleared correctly.

This PR resolves the problem by remove thread local caches. All threads can get the read delegate singleton by `RwLock`s. Seems it's more simple and clear, but we need to prove no performance drops.

## Benchmarks
### oltp_point_select
*the left is master, the right is the patch*
![图片](https://user-images.githubusercontent.com/8407317/58701462-9013cc00-83d5-11e9-86a9-5da0231b1a88.png)

### oltp_update_index
*the left is the patch, the right is master*
![图片](https://user-images.githubusercontent.com/8407317/58801397-07976480-863d-11e9-80d8-4fef9bf24117.png)

