### PR TITLE
coprocessor: RPN function UnaryNot

### DIFF
--- a/src/coprocessor/dag/rpn_expr/impl_op.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_op.rs
@@ -244,8 +244,7 @@ mod tests {
         ];
         for (arg, expect_output) in test_cases {
             let output = RpnFnScalarEvaluator::new()
-                .push_param(arg0)
-                .push_param(arg1)
+                .push_param(arg)
                 .evaluate(ScalarFuncSig::UnaryNot)
                 .unwrap();
             assert_eq!(output, expect_output);

--- a/src/coprocessor/dag/rpn_expr/impl_op.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_op.rs
@@ -54,6 +54,21 @@ impl RpnFnLogicalOr {
     }
 }
 
+#[derive(Debug, Clone, Copy, RpnFunction)]
+#[rpn_function(args = 1)]
+pub struct RpnFnUnaryNot;
+
+impl RpnFnUnaryNot {
+    #[inline]
+    fn call(
+        _ctx: &mut EvalContext,
+        _payload: RpnFnCallPayload<'_>,
+        arg: &Option<i64>,
+    ) -> Result<Option<i64>> {
+        Ok(arg.map(|v| (v == 0) as i64))
+    }
+}
+
 #[derive(Clone, Debug, RpnFunction)]
 #[rpn_function(args = 1)]
 pub struct RpnFnIsNull<T: Evaluable> {
@@ -213,6 +228,25 @@ mod tests {
                 .push_param(arg0)
                 .push_param(arg1)
                 .evaluate(ScalarFuncSig::LogicalOr)
+                .unwrap();
+            assert_eq!(output, expect_output);
+        }
+    }
+
+    #[test]
+    fn test_unary_not() {
+        let test_cases = vec![
+            (Some(0), Some(1)),
+            (Some(1), Some(0)),
+            (Some(2), Some(0)),
+            (Some(-1), Some(0)),
+            (None, None),
+        ];
+        for (arg, expect_output) in test_cases {
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(arg0)
+                .push_param(arg1)
+                .evaluate(ScalarFuncSig::UnaryNot)
                 .unwrap();
             assert_eq!(output, expect_output);
         }

--- a/src/coprocessor/dag/rpn_expr/mod.rs
+++ b/src/coprocessor/dag/rpn_expr/mod.rs
@@ -151,6 +151,7 @@ fn map_pb_sig_to_rpn_func(value: ScalarFuncSig, children: &[Expr]) -> Result<Box
         ScalarFuncSig::DecimalIsFalse => Box::new(RpnFnDecimalIsFalse),
         ScalarFuncSig::LogicalAnd => Box::new(RpnFnLogicalAnd),
         ScalarFuncSig::LogicalOr => Box::new(RpnFnLogicalOr),
+        ScalarFuncSig::UnaryNot => Box::new(RpnFnUnaryNot),
         ScalarFuncSig::PlusInt => map_int_sig(value, children, plus_mapper)?,
         ScalarFuncSig::PlusReal => Box::new(RpnFnArithmetic::<RealPlus>::new()),
         ScalarFuncSig::PlusDecimal => Box::new(RpnFnArithmetic::<DecimalPlus>::new()),


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR adds UnaryNot RPN function.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

New unit test.