### PR TITLE
[DNM] 2.1: return region error when TiKV is closing

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1087,6 +1087,13 @@ fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
             err.set_server_is_busy(server_is_busy_err);
             Some(err)
         }
+        Err(storage::Error::Closed) => {
+            // TiKV is closing, return an RegionError to tell the client that this region is unavailable
+            // temporarily, the client should retry the request in other TiKVs.
+            let mut err = RegionError::new();
+            err.set_message("TiKV is Closing".to_string());
+            Some(err)
+        }
         _ => None,
     }
 }

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1087,7 +1087,7 @@ fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
             err.set_server_is_busy(server_is_busy_err);
             Some(err)
         }
-        Err(storage::Error::Closed) => {
+        Err(Error::Closed) => {
             // TiKV is closing, return an RegionError to tell the client that this region is unavailable
             // temporarily, the client should retry the request in other TiKVs.
             let mut err = RegionError::new();


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

## What have you changed? (mandatory)

Return an RegionError when TiKV is closing to tell the client that this region is unavailable temporarily, the client should retry the request in other TiKVs.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

- [x] killing test

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
