### PR TITLE
coprocessor: add batch aggregate function BitAnd/BitOr/BitXor

### DIFF
--- a/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
@@ -1,0 +1,466 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use cop_codegen::AggrFunction;
+use cop_datatype::builder::FieldTypeBuilder;
+use cop_datatype::{FieldTypeFlag, FieldTypeTp};
+use tipb::expression::{Expr, ExprType, FieldType};
+
+use crate::coprocessor::codec::data_type::*;
+use crate::coprocessor::codec::mysql::Tz;
+use crate::coprocessor::dag::expr::EvalContext;
+use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
+use crate::coprocessor::Result;
+
+/// A trait for all bit operations
+pub trait BitOp: Clone + std::fmt::Debug + Send + Sync + 'static {
+    /// Returns the bit operation type
+    fn tp() -> ExprType;
+
+    /// Returns the bit operation initial state
+    fn init_state() -> usize;
+
+    /// Executes the special bit operation
+    fn op(lhs: &mut usize, rhs: usize);
+}
+
+macro_rules! bit_op {
+    ($name:ident, $tp:path, $init:tt, $op:tt) => {
+        #[derive(Debug, Clone, Copy)]
+        pub struct $name;
+        impl BitOp for $name {
+            fn tp() -> ExprType {
+                $tp
+            }
+
+            fn init_state() -> usize {
+                $init
+            }
+
+            fn op(lhs: &mut usize, rhs: usize) {
+                *lhs $op rhs
+            }
+        }
+    };
+}
+
+bit_op!(BitAnd, ExprType::Agg_BitAnd, 0xffffffffffffffff, &=);
+bit_op!(BitOr, ExprType::Agg_BitOr, 0, |=);
+bit_op!(BitXor, ExprType::Agg_BitXor, 0, ^=);
+
+/// The parser for bit operation aggregate functions.
+pub struct AggrFnDefinitionParserBitOp<T: BitOp> {
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: BitOp> AggrFnDefinitionParserBitOp<T> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T: BitOp> super::AggrDefinitionParser for AggrFnDefinitionParserBitOp<T> {
+    fn check_supported(&self, aggr_def: &Expr) -> Result<()> {
+        assert_eq!(aggr_def.get_tp(), T::tp());
+        super::util::check_aggr_exp_supported_one_child(aggr_def)
+    }
+
+    fn parse(
+        &self,
+        mut aggr_def: Expr,
+        time_zone: &Tz,
+        // We use the same structure for all data types, so this parameter is not needed.
+        src_schema: &[FieldType],
+        out_schema: &mut Vec<FieldType>,
+        out_exp: &mut Vec<RpnExpression>,
+    ) -> Result<Box<dyn super::AggrFunction>> {
+        assert_eq!(aggr_def.get_tp(), T::tp());
+
+        // bit operation outputs one column.
+        out_schema.push(
+            FieldTypeBuilder::new()
+                .tp(FieldTypeTp::LongLong)
+                .flag(FieldTypeFlag::UNSIGNED)
+                .build(),
+        );
+
+        // Rewrite expression to insert CAST() if needed.
+        let child = aggr_def.take_children().into_iter().next().unwrap();
+        let mut exp =
+            RpnExpressionBuilder::build_from_expr_tree(child, time_zone, src_schema.len())?;
+        super::util::rewrite_exp_for_bit_op(src_schema, &mut exp).unwrap();
+        out_exp.push(exp);
+
+        Ok(Box::new(AggrFnBitOp::<T>::new()))
+    }
+}
+
+/// The bit operation aggregate functions.
+#[derive(Debug, AggrFunction)]
+#[aggr_function(state = AggrFnStateBitOp::<T>::new())]
+pub struct AggrFnBitOp<T: BitOp> {
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: BitOp> AggrFnBitOp<T> {
+    fn new() -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+/// The state of the BitAnd aggregate function.
+#[derive(Debug)]
+pub struct AggrFnStateBitOp<T: BitOp> {
+    c: usize,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: BitOp> AggrFnStateBitOp<T> {
+    pub fn new() -> Self {
+        Self {
+            c: T::init_state(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T: BitOp> super::ConcreteAggrFunctionState for AggrFnStateBitOp<T> {
+    type ParameterType = Int;
+
+    #[inline]
+    fn update_concrete(
+        &mut self,
+        _ctx: &mut EvalContext,
+        value: &Option<Self::ParameterType>,
+    ) -> Result<()> {
+        match value {
+            None => Ok(()),
+            Some(value) => {
+                T::op(&mut self.c, *value as usize);
+                Ok(())
+            }
+        }
+    }
+
+    #[inline]
+    fn push_result(&self, _ctx: &mut EvalContext, target: &mut [VectorValue]) -> Result<()> {
+        target[0].push_int(Some(self.c as Int));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cop_datatype::EvalType;
+    use tipb_helper::ExprDefBuilder;
+
+    use super::super::AggrFunction;
+    use super::*;
+    use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
+    use crate::coprocessor::dag::aggr_fn::parser::AggrDefinitionParser;
+    use cop_datatype::FieldTypeAccessor;
+
+    #[test]
+    fn test_bit_and() {
+        let mut ctx = EvalContext::default();
+        let function = AggrFnBitOp::<BitAnd>::new();
+        let mut state = function.create_state();
+
+        let mut result = [VectorValue::with_capacity(0, EvalType::Int)];
+
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(
+            result[0].as_int_slice(),
+            &[Some(0xffffffffffffffff as u64 as i64)]
+        );
+
+        state.update(&mut ctx, &Option::<Int>::None).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(
+            result[0].as_int_slice(),
+            &[Some(0xffffffffffffffff as u64 as i64)]
+        );
+
+        // 7 & 4 == 4
+        state.update(&mut ctx, &Some(7i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(7)]);
+
+        state.update(&mut ctx, &Some(4i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(4)]);
+
+        state.update_repeat(&mut ctx, &Some(4), 10).unwrap();
+        state
+            .update_repeat(&mut ctx, &Option::<Int>::None, 7)
+            .unwrap();
+
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(4)]);
+
+        // Reset the state
+        let mut state = function.create_state();
+        // 7 & 1 == 1
+        state.update(&mut ctx, &Some(7i64)).unwrap();
+        state
+            .update_vector(&mut ctx, &[Some(1i64), None, Some(1i64)])
+            .unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(1)]);
+
+        // 7 & 1 & 2 == 0
+        state.update(&mut ctx, &Some(2i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(0)]);
+    }
+
+    #[test]
+    fn test_bit_or() {
+        let mut ctx = EvalContext::default();
+        let function = AggrFnBitOp::<BitOr>::new();
+        let mut state = function.create_state();
+
+        let mut result = [VectorValue::with_capacity(0, EvalType::Int)];
+
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(0)]);
+
+        state.update(&mut ctx, &Option::<Int>::None).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(0)]);
+
+        // 1 | 4 == 5
+        state.update(&mut ctx, &Some(1i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(1)]);
+
+        state.update(&mut ctx, &Some(4i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(5)]);
+
+        state.update_repeat(&mut ctx, &Some(8), 10).unwrap();
+        state
+            .update_repeat(&mut ctx, &Option::<Int>::None, 7)
+            .unwrap();
+
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(13)]);
+
+        // 13 | 2 == 15
+        state.update(&mut ctx, &Some(2i64)).unwrap();
+        state
+            .update_vector(&mut ctx, &[Some(2i64), None, Some(1i64)])
+            .unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(15)]);
+
+        // 15 | 2 == 15
+        state.update(&mut ctx, &Some(2i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(15)]);
+
+        // 15 | 2 | -1 == 18446744073709551615
+        state.update(&mut ctx, &Some(-1i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(
+            result[0].as_int_slice(),
+            &[Some(18446744073709551615 as u64 as i64)]
+        );
+    }
+
+    #[test]
+    fn test_bit_xor() {
+        let mut ctx = EvalContext::default();
+        let function = AggrFnBitOp::<BitXor>::new();
+        let mut state = function.create_state();
+
+        let mut result = [VectorValue::with_capacity(0, EvalType::Int)];
+
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(0)]);
+
+        state.update(&mut ctx, &Option::<Int>::None).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(0)]);
+
+        // 1 ^ 5 == 4
+        state.update(&mut ctx, &Some(1i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(1)]);
+
+        state.update(&mut ctx, &Some(5i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(4)]);
+
+        // 1 ^ 5 ^ 8 == 12
+        state.update_repeat(&mut ctx, &Some(8), 9).unwrap();
+        state
+            .update_repeat(&mut ctx, &Option::<Int>::None, 7)
+            .unwrap();
+
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(12)]);
+
+        // Will not change due to xor even times
+        state.update_repeat(&mut ctx, &Some(9), 10).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(12)]);
+
+        // 1 ^ 5 ^ 8 ^ ^ 2 ^ 2 ^ 1 == 13
+        state.update(&mut ctx, &Some(2i64)).unwrap();
+        state
+            .update_vector(&mut ctx, &[Some(2i64), None, Some(1i64)])
+            .unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(13)]);
+
+        // 13 ^ 2 == 15
+        state.update(&mut ctx, &Some(2i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(15)]);
+
+        // 15 ^ 2 ^ -1 == 18446744073709551602
+        state.update(&mut ctx, &Some(2i64)).unwrap();
+        state.update(&mut ctx, &Some(-1i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(
+            result[0].as_int_slice(),
+            &[Some(18446744073709551602 as u64 as i64)]
+        );
+    }
+
+    #[test]
+    fn test_integration() {
+        let bit_and_parser = AggrFnDefinitionParserBitOp::<BitAnd>::new();
+        let bit_or_parser = AggrFnDefinitionParserBitOp::<BitOr>::new();
+        let bit_xor_parser = AggrFnDefinitionParserBitOp::<BitXor>::new();
+
+        let bit_and = ExprDefBuilder::aggr_func(ExprType::Agg_BitAnd, FieldTypeTp::LongLong)
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+            .build();
+        bit_and_parser.check_supported(&bit_and).unwrap();
+
+        let bit_or = ExprDefBuilder::aggr_func(ExprType::Agg_BitOr, FieldTypeTp::LongLong)
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+            .build();
+        bit_or_parser.check_supported(&bit_or).unwrap();
+
+        let bit_xor = ExprDefBuilder::aggr_func(ExprType::Agg_BitXor, FieldTypeTp::LongLong)
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+            .build();
+        bit_xor_parser.check_supported(&bit_xor).unwrap();
+
+        let src_schema = [FieldTypeTp::LongLong.into()];
+        let mut columns = LazyBatchColumnVec::from(vec![{
+            let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(0, EvalType::Int);
+            col.mut_decoded().push_int(Some(1));
+            col.mut_decoded().push_int(Some(23));
+            col.mut_decoded().push_int(Some(42));
+            col.mut_decoded().push_int(None);
+            col.mut_decoded().push_int(Some(99));
+            col.mut_decoded().push_int(Some(-1));
+            col
+        }]);
+
+        let mut schema = vec![];
+        let mut exp = vec![];
+
+        let bit_and_fn = bit_and_parser
+            .parse(bit_and, &Tz::utc(), &src_schema, &mut schema, &mut exp)
+            .unwrap();
+        assert_eq!(schema.len(), 1);
+        assert_eq!(schema[0].tp(), FieldTypeTp::LongLong);
+        assert_eq!(exp.len(), 1);
+
+        let bit_or_fn = bit_or_parser
+            .parse(bit_or, &Tz::utc(), &src_schema, &mut schema, &mut exp)
+            .unwrap();
+        assert_eq!(schema.len(), 2);
+        assert_eq!(schema[1].tp(), FieldTypeTp::LongLong);
+        assert_eq!(exp.len(), 2);
+
+        let bit_xor_fn = bit_xor_parser
+            .parse(bit_xor, &Tz::utc(), &src_schema, &mut schema, &mut exp)
+            .unwrap();
+        assert_eq!(schema.len(), 3);
+        assert_eq!(schema[2].tp(), FieldTypeTp::LongLong);
+        assert_eq!(exp.len(), 3);
+
+        let mut ctx = EvalContext::default();
+        let mut bit_and_state = bit_and_fn.create_state();
+        let mut bit_or_state = bit_or_fn.create_state();
+        let mut bit_xor_state = bit_xor_fn.create_state();
+
+        let mut aggr_result = [VectorValue::with_capacity(0, EvalType::Int)];
+
+        // bit and
+        {
+            let bit_and_result = exp[0].eval(&mut ctx, 6, &src_schema, &mut columns).unwrap();
+            assert!(bit_and_result.is_vector());
+            let bit_and_slice: &[Option<Int>] = bit_and_result.vector_value().unwrap().as_ref();
+            bit_and_state
+                .update_vector(&mut ctx, bit_and_slice)
+                .unwrap();
+            bit_and_state
+                .push_result(&mut ctx, &mut aggr_result)
+                .unwrap();
+        }
+
+        // bit or
+        {
+            let bit_or_result = exp[1].eval(&mut ctx, 6, &src_schema, &mut columns).unwrap();
+            assert!(bit_or_result.is_vector());
+            let bit_or_slice: &[Option<Int>] = bit_or_result.vector_value().unwrap().as_ref();
+            bit_or_state.update_vector(&mut ctx, bit_or_slice).unwrap();
+            bit_or_state
+                .push_result(&mut ctx, &mut aggr_result)
+                .unwrap();
+        }
+
+        // bit xor
+        {
+            let bit_xor_result = exp[2].eval(&mut ctx, 6, &src_schema, &mut columns).unwrap();
+            assert!(bit_xor_result.is_vector());
+            let bit_xor_slice: &[Option<Int>] = bit_xor_result.vector_value().unwrap().as_ref();
+            bit_xor_state
+                .update_vector(&mut ctx, bit_xor_slice)
+                .unwrap();
+            bit_xor_state
+                .push_result(&mut ctx, &mut aggr_result)
+                .unwrap();
+        }
+
+        assert_eq!(
+            aggr_result[0].as_int_slice(),
+            &[
+                Some(0),
+                Some(18446744073709551615 as u64 as i64),
+                Some(18446744073709551520 as u64 as i64)
+            ]
+        );
+    }
+}

--- a/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
@@ -19,10 +19,10 @@ pub trait BitOp: Clone + std::fmt::Debug + Send + Sync + 'static {
     fn tp() -> ExprType;
 
     /// Returns the bit operation initial state
-    fn init_state() -> usize;
+    fn init_state() -> u64;
 
     /// Executes the special bit operation
-    fn op(lhs: &mut usize, rhs: usize);
+    fn op(lhs: &mut u64, rhs: u64);
 }
 
 macro_rules! bit_op {
@@ -34,11 +34,11 @@ macro_rules! bit_op {
                 $tp
             }
 
-            fn init_state() -> usize {
+            fn init_state() -> u64 {
                 $init
             }
 
-            fn op(lhs: &mut usize, rhs: usize) {
+            fn op(lhs: &mut u64, rhs: u64) {
                 *lhs $op rhs
             }
         }
@@ -115,7 +115,7 @@ pub struct AggrFnBitOp<T: BitOp>(std::marker::PhantomData<T>);
 /// The state of the BitAnd aggregate function.
 #[derive(Debug)]
 pub struct AggrFnStateBitOp<T: BitOp> {
-    c: usize,
+    c: u64,
     _phantom: std::marker::PhantomData<T>,
 }
 
@@ -140,7 +140,7 @@ impl<T: BitOp> super::ConcreteAggrFunctionState for AggrFnStateBitOp<T> {
         match value {
             None => Ok(()),
             Some(value) => {
-                T::op(&mut self.c, *value as usize);
+                T::op(&mut self.c, *value as u64);
                 Ok(())
             }
         }

--- a/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
@@ -50,17 +50,7 @@ bit_op!(BitOr, ExprType::Agg_BitOr, 0, |=);
 bit_op!(BitXor, ExprType::Agg_BitXor, 0, ^=);
 
 /// The parser for bit operation aggregate functions.
-pub struct AggrFnDefinitionParserBitOp<T: BitOp> {
-    _phantom: std::marker::PhantomData<T>,
-}
-
-impl<T: BitOp> AggrFnDefinitionParserBitOp<T> {
-    pub fn new() -> Self {
-        Self {
-            _phantom: std::marker::PhantomData,
-        }
-    }
-}
+pub struct AggrFnDefinitionParserBitOp<T: BitOp>(pub std::marker::PhantomData<T>);
 
 impl<T: BitOp> super::AggrDefinitionParser for AggrFnDefinitionParserBitOp<T> {
     fn check_supported(&self, aggr_def: &Expr) -> Result<()> {
@@ -106,24 +96,14 @@ impl<T: BitOp> super::AggrDefinitionParser for AggrFnDefinitionParserBitOp<T> {
         super::util::rewrite_exp_for_bit_op(src_schema, &mut exp).unwrap();
         out_exp.push(exp);
 
-        Ok(Box::new(AggrFnBitOp::<T>::new()))
+        Ok(Box::new(AggrFnBitOp::<T>(std::marker::PhantomData)))
     }
 }
 
 /// The bit operation aggregate functions.
 #[derive(Debug, AggrFunction)]
 #[aggr_function(state = AggrFnStateBitOp::<T>::new())]
-pub struct AggrFnBitOp<T: BitOp> {
-    _phantom: std::marker::PhantomData<T>,
-}
-
-impl<T: BitOp> AggrFnBitOp<T> {
-    fn new() -> Self {
-        Self {
-            _phantom: std::marker::PhantomData,
-        }
-    }
-}
+pub struct AggrFnBitOp<T: BitOp>(std::marker::PhantomData<T>);
 
 /// The state of the BitAnd aggregate function.
 #[derive(Debug)]
@@ -180,7 +160,7 @@ mod tests {
     #[test]
     fn test_bit_and() {
         let mut ctx = EvalContext::default();
-        let function = AggrFnBitOp::<BitAnd>::new();
+        let function = AggrFnBitOp::<BitAnd>(std::marker::PhantomData);
         let mut state = function.create_state();
 
         let mut result = [VectorValue::with_capacity(0, EvalType::Int)];
@@ -240,7 +220,7 @@ mod tests {
     #[test]
     fn test_bit_or() {
         let mut ctx = EvalContext::default();
-        let function = AggrFnBitOp::<BitOr>::new();
+        let function = AggrFnBitOp::<BitOr>(std::marker::PhantomData);
         let mut state = function.create_state();
 
         let mut result = [VectorValue::with_capacity(0, EvalType::Int)];
@@ -301,7 +281,7 @@ mod tests {
     #[test]
     fn test_bit_xor() {
         let mut ctx = EvalContext::default();
-        let function = AggrFnBitOp::<BitXor>::new();
+        let function = AggrFnBitOp::<BitXor>(std::marker::PhantomData);
         let mut state = function.create_state();
 
         let mut result = [VectorValue::with_capacity(0, EvalType::Int)];
@@ -369,9 +349,9 @@ mod tests {
 
     #[test]
     fn test_integration() {
-        let bit_and_parser = AggrFnDefinitionParserBitOp::<BitAnd>::new();
-        let bit_or_parser = AggrFnDefinitionParserBitOp::<BitOr>::new();
-        let bit_xor_parser = AggrFnDefinitionParserBitOp::<BitXor>::new();
+        let bit_and_parser = AggrFnDefinitionParserBitOp::<BitAnd>(std::marker::PhantomData);
+        let bit_or_parser = AggrFnDefinitionParserBitOp::<BitOr>(std::marker::PhantomData);
+        let bit_xor_parser = AggrFnDefinitionParserBitOp::<BitXor>(std::marker::PhantomData);
 
         let bit_and = ExprDefBuilder::aggr_func(ExprType::Agg_BitAnd, FieldTypeTp::LongLong)
             .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))

--- a/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
@@ -45,7 +45,7 @@ macro_rules! bit_op {
     };
 }
 
-bit_op!(BitAnd, ExprType::Agg_BitAnd, 0xffffffffffffffff, &=);
+bit_op!(BitAnd, ExprType::Agg_BitAnd, 0xffff_ffff_ffff_ffff, &=);
 bit_op!(BitOr, ExprType::Agg_BitOr, 0, |=);
 bit_op!(BitXor, ExprType::Agg_BitXor, 0, ^=);
 
@@ -89,12 +89,7 @@ impl<T: BitOp> super::AggrDefinitionParser for AggrFnDefinitionParserBitOp<T> {
         assert_eq!(aggr_def.get_tp(), T::tp());
 
         // bit operation outputs one column.
-        out_schema.push(
-            FieldTypeBuilder::new()
-                .tp(FieldTypeTp::LongLong)
-                .flag(FieldTypeFlag::UNSIGNED)
-                .build(),
-        );
+        out_schema.push(aggr_def.take_field_type());
 
         // Rewrite expression to insert CAST() if needed.
         let child = aggr_def.take_children().into_iter().next().unwrap();
@@ -175,7 +170,7 @@ mod tests {
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(
             result[0].as_int_slice(),
-            &[Some(0xffffffffffffffffu64 as i64)]
+            &[Some(0xffff_ffff_ffff_ffff_u64 as i64)]
         );
 
         state.update(&mut ctx, &Option::<Int>::None).unwrap();
@@ -183,7 +178,7 @@ mod tests {
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(
             result[0].as_int_slice(),
-            &[Some(0xffffffffffffffffu64 as i64)]
+            &[Some(0xffff_ffff_ffff_ffff_u64 as i64)]
         );
 
         // 7 & 4 == 4

--- a/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
@@ -175,7 +175,7 @@ mod tests {
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(
             result[0].as_int_slice(),
-            &[Some(0xffffffffffffffff as u64 as i64)]
+            &[Some(0xffffffffffffffffu64 as i64)]
         );
 
         state.update(&mut ctx, &Option::<Int>::None).unwrap();
@@ -183,7 +183,7 @@ mod tests {
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(
             result[0].as_int_slice(),
-            &[Some(0xffffffffffffffff as u64 as i64)]
+            &[Some(0xffffffffffffffffu64 as i64)]
         );
 
         // 7 & 4 == 4
@@ -281,7 +281,7 @@ mod tests {
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(
             result[0].as_int_slice(),
-            &[Some(18446744073709551615 as u64 as i64)]
+            &[Some(18446744073709551615u64 as i64)]
         );
     }
 
@@ -350,7 +350,7 @@ mod tests {
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(
             result[0].as_int_slice(),
-            &[Some(18446744073709551602 as u64 as i64)]
+            &[Some(18446744073709551602u64 as i64)]
         );
     }
 
@@ -459,8 +459,8 @@ mod tests {
             aggr_result[0].as_int_slice(),
             &[
                 Some(0),
-                Some(18446744073709551615 as u64 as i64),
-                Some(18446744073709551520 as u64 as i64)
+                Some(18446744073709551615u64 as i64),
+                Some(18446744073709551520u64 as i64)
             ]
         );
     }

--- a/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_bit_op.rs
@@ -3,8 +3,7 @@
 use std::convert::TryFrom;
 
 use cop_codegen::AggrFunction;
-use cop_datatype::builder::FieldTypeBuilder;
-use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeFlag, FieldTypeTp};
+use cop_datatype::{EvalType, FieldTypeAccessor};
 use tipb::expression::{Expr, ExprType, FieldType};
 
 use crate::coprocessor::codec::data_type::*;
@@ -157,7 +156,7 @@ mod tests {
     use super::*;
     use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
     use crate::coprocessor::dag::aggr_fn::parser::AggrDefinitionParser;
-    use cop_datatype::FieldTypeAccessor;
+    use cop_datatype::{FieldTypeAccessor, FieldTypeTp};
 
     #[test]
     fn test_bit_and() {

--- a/src/coprocessor/dag/aggr_fn/mod.rs
+++ b/src/coprocessor/dag/aggr_fn/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides aggregate functions for batch executors.
 
 mod impl_avg;
+mod impl_bit_op;
 mod impl_count;
 mod impl_first;
 mod impl_sum;

--- a/src/coprocessor/dag/aggr_fn/parser.rs
+++ b/src/coprocessor/dag/aggr_fn/parser.rs
@@ -42,14 +42,15 @@ pub trait AggrDefinitionParser {
 
 #[inline]
 fn map_pb_sig_to_aggr_func_parser(value: ExprType) -> Result<Box<dyn AggrDefinitionParser>> {
+    use std::marker::PhantomData;
     match value {
         ExprType::Count => Ok(Box::new(super::impl_count::AggrFnDefinitionParserCount)),
         ExprType::Sum => Ok(Box::new(super::impl_sum::AggrFnDefinitionParserSum)),
         ExprType::Avg => Ok(Box::new(super::impl_avg::AggrFnDefinitionParserAvg)),
         ExprType::First => Ok(Box::new(super::impl_first::AggrFnDefinitionParserFirst)),
-        ExprType::Agg_BitAnd => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitAnd>::new())),
-        ExprType::Agg_BitOr => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitOr>::new())),
-        ExprType::Agg_BitXor => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitXor>::new())),
+        ExprType::Agg_BitAnd => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitAnd>(PhantomData))),
+        ExprType::Agg_BitOr => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitOr>(PhantomData))),
+        ExprType::Agg_BitXor => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitXor>(PhantomData))),
         v => Err(box_err!(
             "Aggregation function expr type {:?} is not supported in batch mode",
             v

--- a/src/coprocessor/dag/aggr_fn/parser.rs
+++ b/src/coprocessor/dag/aggr_fn/parser.rs
@@ -3,6 +3,7 @@
 use tipb::expression::{Expr, ExprType, FieldType};
 
 use crate::coprocessor::codec::mysql::Tz;
+use crate::coprocessor::dag::aggr_fn::impl_bit_op::*;
 use crate::coprocessor::dag::aggr_fn::AggrFunction;
 use crate::coprocessor::dag::rpn_expr::RpnExpression;
 use crate::coprocessor::{Error, Result};
@@ -46,6 +47,9 @@ fn map_pb_sig_to_aggr_func_parser(value: ExprType) -> Result<Box<dyn AggrDefinit
         ExprType::Sum => Ok(Box::new(super::impl_sum::AggrFnDefinitionParserSum)),
         ExprType::Avg => Ok(Box::new(super::impl_avg::AggrFnDefinitionParserAvg)),
         ExprType::First => Ok(Box::new(super::impl_first::AggrFnDefinitionParserFirst)),
+        ExprType::Agg_BitAnd => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitAnd>::new())),
+        ExprType::Agg_BitOr => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitOr>::new())),
+        ExprType::Agg_BitXor => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitXor>::new())),
         v => Err(box_err!(
             "Aggregation function expr type {:?} is not supported in batch mode",
             v

--- a/src/coprocessor/dag/aggr_fn/parser.rs
+++ b/src/coprocessor/dag/aggr_fn/parser.rs
@@ -42,15 +42,14 @@ pub trait AggrDefinitionParser {
 
 #[inline]
 fn map_pb_sig_to_aggr_func_parser(value: ExprType) -> Result<Box<dyn AggrDefinitionParser>> {
-    use std::marker::PhantomData;
     match value {
         ExprType::Count => Ok(Box::new(super::impl_count::AggrFnDefinitionParserCount)),
         ExprType::Sum => Ok(Box::new(super::impl_sum::AggrFnDefinitionParserSum)),
         ExprType::Avg => Ok(Box::new(super::impl_avg::AggrFnDefinitionParserAvg)),
         ExprType::First => Ok(Box::new(super::impl_first::AggrFnDefinitionParserFirst)),
-        ExprType::Agg_BitAnd => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitAnd>(PhantomData))),
-        ExprType::Agg_BitOr => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitOr>(PhantomData))),
-        ExprType::Agg_BitXor => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitXor>(PhantomData))),
+        ExprType::Agg_BitAnd => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitAnd>::new())),
+        ExprType::Agg_BitOr => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitOr>::new())),
+        ExprType::Agg_BitXor => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitXor>::new())),
         v => Err(box_err!(
             "Aggregation function expr type {:?} is not supported in batch mode",
             v

--- a/src/coprocessor/dag/aggr_fn/util.rs
+++ b/src/coprocessor/dag/aggr_fn/util.rs
@@ -3,7 +3,7 @@
 use std::convert::TryFrom;
 
 use cop_datatype::builder::FieldTypeBuilder;
-use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeTp};
+use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeFlag, FieldTypeTp};
 use tipb::expression::{Expr, FieldType};
 
 use crate::coprocessor::dag::rpn_expr::impl_cast::get_cast_fn;
@@ -48,6 +48,27 @@ pub fn rewrite_exp_for_sum_avg(schema: &[FieldType], exp: &mut RpnExpression) ->
             .tp(FieldTypeTp::Double)
             .flen(cop_datatype::MAX_REAL_WIDTH)
             .decimal(cop_datatype::UNSPECIFIED_LENGTH)
+            .build(),
+    };
+    let func = get_cast_fn(ret_field_type, &new_ret_field_type)?;
+    exp.push(RpnExpressionNode::FnCall {
+        func,
+        field_type: new_ret_field_type,
+    });
+    Ok(())
+}
+
+/// Rewrites the expression to insert necessary cast functions for Bit operation family functions.
+pub fn rewrite_exp_for_bit_op(schema: &[FieldType], exp: &mut RpnExpression) -> Result<()> {
+    let ret_field_type = exp.ret_field_type(schema);
+    let ret_eval_type = box_try!(EvalType::try_from(ret_field_type.tp()));
+    let new_ret_field_type = match ret_eval_type {
+        EvalType::Int => {
+            return Ok(());
+        }
+        _ => FieldTypeBuilder::new()
+            .tp(FieldTypeTp::LongLong)
+            .flag(FieldTypeFlag::UNSIGNED)
             .build(),
     };
     let func = get_cast_fn(ret_field_type, &new_ret_field_type)?;


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Add batch aggregate function BitAnd/BitOr/BitXor. All related CAST functions don't contain in this PR.

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- New feature (change which adds functionality)

## How has this PR been tested? (mandatory)

- unit tests

