### PR TITLE
Makefile: make sure gdb is installed before sse4.2 check

### DIFF
--- a/scripts/check-sse4_2.sh
+++ b/scripts/check-sse4_2.sh
@@ -17,6 +17,11 @@ if [[ "`uname`" != "Linux" ]]; then
     exit 0
 fi
 
+if [[ ! `command -v gdb >/dev/null 2>&1` ]]; then
+    echo "skipping sse4.2 check - gdb is required"
+    exit 0
+fi
+
 echo "checking bins for sse4.2"
 
 for dir in $dirs; do


### PR DESCRIPTION
Signed-off-by: Kaige Ye <ye@kaige.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

I got the same issue with https://github.com/tikv/tikv/issues/4330 when I run `make release`, and I found mine is also caused by missing `gdb`. The message generated by [`scripts/check-sse4_2.sh`](https://github.com/tikv/tikv/blob/3458a0eb46fae8a7f37dca86f4ae07c7911238a8/scripts/check-sse4_2.sh#L43) is **misleading** in this case, so it's better to check if gdb is installed first.

## What have you changed? (mandatory)

Make sure `gdb` is installed before SSE4.2 check.

## What are the type of the changes? (mandatory)

Improvement

## How has this PR been tested? (mandatory)

Manual tests finished

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/issues/4330


@overvenus PTAL