### PR TITLE
coprocessor: add batch aggregate function Max/Min

### DIFF
--- a/src/coprocessor/dag/aggr_fn/impl_max_min.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_max_min.rs
@@ -80,7 +80,7 @@ impl<T: Extremum> super::AggrDefinitionParser for AggrFnDefinitionParserExtremum
     }
 }
 
-/// The bit operation aggregate functions.
+/// The MAX/MIN aggregate functions.
 #[derive(Debug, AggrFunction)]
 #[aggr_function(state = AggFnStateExtremum::<T>::new(self.ord))]
 pub struct AggFnExtremum<T, E>
@@ -327,8 +327,8 @@ mod tests {
         {
             let max_result = exp[0].eval(&mut ctx, 6, &src_schema, &mut columns).unwrap();
             assert!(max_result.is_vector());
-            let bit_and_slice: &[Option<Int>] = max_result.vector_value().unwrap().as_ref();
-            max_state.update_vector(&mut ctx, bit_and_slice).unwrap();
+            let max_slice: &[Option<Int>] = max_result.vector_value().unwrap().as_ref();
+            max_state.update_vector(&mut ctx, max_slice).unwrap();
             max_state.push_result(&mut ctx, &mut aggr_result).unwrap();
         }
 
@@ -336,8 +336,8 @@ mod tests {
         {
             let min_result = exp[1].eval(&mut ctx, 6, &src_schema, &mut columns).unwrap();
             assert!(min_result.is_vector());
-            let bit_or_slice: &[Option<Int>] = min_result.vector_value().unwrap().as_ref();
-            min_state.update_vector(&mut ctx, bit_or_slice).unwrap();
+            let min_slice: &[Option<Int>] = min_result.vector_value().unwrap().as_ref();
+            min_state.update_vector(&mut ctx, min_slice).unwrap();
             min_state.push_result(&mut ctx, &mut aggr_result).unwrap();
         }
 

--- a/src/coprocessor/dag/aggr_fn/impl_max_min.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_max_min.rs
@@ -19,19 +19,21 @@ pub trait Extremum: Clone + std::fmt::Debug + Send + Sync + 'static {
     const ORD: Ordering;
 }
 
-macro_rules! extremum {
-    ($e:ident, $ord:path) => {
-        #[derive(Debug, Clone, Copy)]
-        pub struct $e;
-        impl Extremum for $e {
-            const TP: ExprType = ExprType::$e;
-            const ORD: Ordering = $ord;
-        }
-    };
+#[derive(Debug, Clone, Copy)]
+pub struct Max;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Min;
+
+impl Extremum for Max {
+    const TP: ExprType = ExprType::Max;
+    const ORD: Ordering = Ordering::Less;
 }
 
-extremum!(Max, Ordering::Less);
-extremum!(Min, Ordering::Greater);
+impl Extremum for Min {
+    const TP: ExprType = ExprType::Min;
+    const ORD: Ordering = Ordering::Greater;
+}
 
 /// The parser for `MAX/MIN` aggregate functions.
 pub struct AggrFnDefinitionParserExtremum<T: Extremum>(std::marker::PhantomData<T>);

--- a/src/coprocessor/dag/aggr_fn/impl_max_min.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_max_min.rs
@@ -1,0 +1,350 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::cmp::Ordering;
+use std::convert::TryFrom;
+
+use cop_codegen::AggrFunction;
+use cop_datatype::{EvalType, FieldTypeAccessor};
+use tipb::expression::{Expr, ExprType, FieldType};
+
+use crate::coprocessor::codec::data_type::*;
+use crate::coprocessor::codec::mysql::Tz;
+use crate::coprocessor::dag::expr::EvalContext;
+use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
+use crate::coprocessor::Result;
+
+pub enum Extremum {
+    Min,
+    Max,
+}
+
+impl Extremum {
+    pub fn tp(&self) -> ExprType {
+        match self {
+            Extremum::Max => ExprType::Max,
+            Extremum::Min => ExprType::Min,
+        }
+    }
+
+    pub fn ord(&self) -> Ordering {
+        match self {
+            Extremum::Max => Ordering::Less,
+            Extremum::Min => Ordering::Greater,
+        }
+    }
+}
+
+/// The parser for `MAX/MIN` aggregate functions.
+pub struct AggrFnDefinitionParserExtremum(pub Extremum);
+
+impl super::AggrDefinitionParser for AggrFnDefinitionParserExtremum {
+    fn check_supported(&self, aggr_def: &Expr) -> Result<()> {
+        assert_eq!(aggr_def.get_tp(), self.0.tp());
+        super::util::check_aggr_exp_supported_one_child(aggr_def)
+    }
+
+    fn parse(
+        &self,
+        mut aggr_def: Expr,
+        time_zone: &Tz,
+        // We use the same structure for all data types, so this parameter is not needed.
+        src_schema: &[FieldType],
+        out_schema: &mut Vec<FieldType>,
+        out_exp: &mut Vec<RpnExpression>,
+    ) -> Result<Box<dyn super::AggrFunction>> {
+        assert_eq!(aggr_def.get_tp(), self.0.tp());
+
+        // `MAX/MIN` outputs one column which has the same type with its child
+        out_schema.push(aggr_def.take_field_type());
+
+        let child = aggr_def.take_children().into_iter().next().unwrap();
+        let eval_type = EvalType::try_from(child.get_field_type().tp()).unwrap();
+        out_exp.push(RpnExpressionBuilder::build_from_expr_tree(
+            child,
+            time_zone,
+            src_schema.len(),
+        )?);
+
+        match_template_evaluable! {
+            TT, match eval_type {
+                EvalType::TT => Ok(Box::new(AggFnExtremum::<TT>::new(self.0.ord())))
+            }
+        }
+    }
+}
+
+/// The bit operation aggregate functions.
+#[derive(Debug, AggrFunction)]
+#[aggr_function(state = AggFnStateExtremum::<T>::new(self.ord))]
+pub struct AggFnExtremum<T>
+where
+    T: Evaluable + Ord,
+    VectorValue: VectorValueExt<T>,
+{
+    _phantom: std::marker::PhantomData<T>,
+    ord: Ordering,
+}
+
+impl<T> AggFnExtremum<T>
+where
+    T: Evaluable + Ord,
+    VectorValue: VectorValueExt<T>,
+{
+    fn new(ord: Ordering) -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+            ord,
+        }
+    }
+}
+
+/// The state of the MAX/MIN aggregate function.
+#[derive(Debug)]
+pub struct AggFnStateExtremum<T>
+where
+    T: Evaluable + Ord,
+    VectorValue: VectorValueExt<T>,
+{
+    _phantom: std::marker::PhantomData<T>,
+    ord: Ordering,
+    extremum: Option<T>,
+}
+
+impl<T> AggFnStateExtremum<T>
+where
+    T: Evaluable + Ord,
+    VectorValue: VectorValueExt<T>,
+{
+    pub fn new(ord: Ordering) -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+            ord,
+            extremum: None,
+        }
+    }
+}
+
+impl<T> super::ConcreteAggrFunctionState for AggFnStateExtremum<T>
+where
+    T: Evaluable + Ord,
+    VectorValue: VectorValueExt<T>,
+{
+    type ParameterType = T;
+
+    #[inline]
+    fn update_concrete(
+        &mut self,
+        _ctx: &mut EvalContext,
+        value: &Option<Self::ParameterType>,
+    ) -> Result<()> {
+        match value {
+            None => Ok(()),
+            Some(value) => {
+                // TODO: is there a way to eliminate the clone?
+                match &self.extremum {
+                    Some(lhs) => {
+                        if lhs.cmp(value) == self.ord {
+                            self.extremum = Some(value.clone());
+                        }
+                    }
+                    None => self.extremum = Some(value.clone()),
+                }
+                Ok(())
+            }
+        }
+    }
+
+    #[inline]
+    fn push_result(&self, _ctx: &mut EvalContext, target: &mut [VectorValue]) -> Result<()> {
+        target[0].push(self.extremum.clone());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cop_datatype::EvalType;
+    use tipb_helper::ExprDefBuilder;
+
+    use super::*;
+    use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
+    use crate::coprocessor::dag::aggr_fn::parser::AggrDefinitionParser;
+    use crate::coprocessor::dag::aggr_fn::AggrFunction;
+    use cop_datatype::{FieldTypeAccessor, FieldTypeTp};
+
+    #[test]
+    fn test_max() {
+        let mut ctx = EvalContext::default();
+        let function = AggFnExtremum::<Int>::new(Extremum::Max.ord());
+        let mut state = function.create_state();
+
+        let mut result = [VectorValue::with_capacity(0, EvalType::Int)];
+
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[None]);
+
+        state.update(&mut ctx, &Option::<Int>::None).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[None]);
+
+        state.update(&mut ctx, &Some(7i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(7)]);
+
+        state.update(&mut ctx, &Some(4i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(7)]);
+
+        state.update_repeat(&mut ctx, &Some(20), 10).unwrap();
+        state
+            .update_repeat(&mut ctx, &Option::<Int>::None, 7)
+            .unwrap();
+
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(20)]);
+
+        // update vector
+        state.update(&mut ctx, &Some(7i64)).unwrap();
+        state
+            .update_vector(&mut ctx, &[Some(21i64), None, Some(22i64)])
+            .unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(22)]);
+
+        state.update(&mut ctx, &Some(40i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(40)]);
+    }
+
+    #[test]
+    fn test_min() {
+        let mut ctx = EvalContext::default();
+        let function = AggFnExtremum::<Int>::new(Extremum::Min.ord());
+        let mut state = function.create_state();
+
+        let mut result = [VectorValue::with_capacity(0, EvalType::Int)];
+
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[None]);
+
+        state.update(&mut ctx, &Option::<Int>::None).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[None]);
+
+        state.update(&mut ctx, &Some(100i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(100)]);
+
+        state.update(&mut ctx, &Some(90i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(90)]);
+
+        state.update_repeat(&mut ctx, &Some(80), 10).unwrap();
+        state
+            .update_repeat(&mut ctx, &Option::<Int>::None, 10)
+            .unwrap();
+
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(80)]);
+
+        // update vector
+        state.update(&mut ctx, &Some(70i64)).unwrap();
+        state
+            .update_vector(&mut ctx, &[Some(69i64), None, Some(68i64)])
+            .unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(68)]);
+
+        state.update(&mut ctx, &Some(2i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(2)]);
+
+        state.update(&mut ctx, &Some(-1i64)).unwrap();
+        result[0].clear();
+        state.push_result(&mut ctx, &mut result).unwrap();
+        assert_eq!(result[0].as_int_slice(), &[Some(-1i64)]);
+    }
+
+    #[test]
+    fn test_integration() {
+        let max_parser = AggrFnDefinitionParserExtremum(Extremum::Max);
+        let min_parser = AggrFnDefinitionParserExtremum(Extremum::Min);
+
+        let max = ExprDefBuilder::aggr_func(ExprType::Max, FieldTypeTp::LongLong)
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+            .build();
+        max_parser.check_supported(&max).unwrap();
+
+        let min = ExprDefBuilder::aggr_func(ExprType::Min, FieldTypeTp::LongLong)
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+            .build();
+        min_parser.check_supported(&min).unwrap();
+
+        let src_schema = [FieldTypeTp::LongLong.into()];
+        let mut columns = LazyBatchColumnVec::from(vec![{
+            let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(0, EvalType::Int);
+            col.mut_decoded().push_int(Some(1));
+            col.mut_decoded().push_int(Some(23));
+            col.mut_decoded().push_int(Some(42));
+            col.mut_decoded().push_int(None);
+            col.mut_decoded().push_int(Some(99));
+            col.mut_decoded().push_int(Some(-1));
+            col
+        }]);
+
+        let mut schema = vec![];
+        let mut exp = vec![];
+
+        let max_fn = max_parser
+            .parse(max, &Tz::utc(), &src_schema, &mut schema, &mut exp)
+            .unwrap();
+        assert_eq!(schema.len(), 1);
+        assert_eq!(schema[0].tp(), FieldTypeTp::LongLong);
+        assert_eq!(exp.len(), 1);
+
+        let min_fn = min_parser
+            .parse(min, &Tz::utc(), &src_schema, &mut schema, &mut exp)
+            .unwrap();
+        assert_eq!(schema.len(), 2);
+        assert_eq!(schema[1].tp(), FieldTypeTp::LongLong);
+        assert_eq!(exp.len(), 2);
+
+        let mut ctx = EvalContext::default();
+        let mut max_state = max_fn.create_state();
+        let mut min_state = min_fn.create_state();
+
+        let mut aggr_result = [VectorValue::with_capacity(0, EvalType::Int)];
+
+        // max
+        {
+            let max_result = exp[0].eval(&mut ctx, 6, &src_schema, &mut columns).unwrap();
+            assert!(max_result.is_vector());
+            let bit_and_slice: &[Option<Int>] = max_result.vector_value().unwrap().as_ref();
+            max_state.update_vector(&mut ctx, bit_and_slice).unwrap();
+            max_state.push_result(&mut ctx, &mut aggr_result).unwrap();
+        }
+
+        // min
+        {
+            let min_result = exp[1].eval(&mut ctx, 6, &src_schema, &mut columns).unwrap();
+            assert!(min_result.is_vector());
+            let bit_or_slice: &[Option<Int>] = min_result.vector_value().unwrap().as_ref();
+            min_state.update_vector(&mut ctx, bit_or_slice).unwrap();
+            min_state.push_result(&mut ctx, &mut aggr_result).unwrap();
+        }
+
+        assert_eq!(aggr_result[0].as_int_slice(), &[Some(99), Some(-1i64),]);
+    }
+}

--- a/src/coprocessor/dag/aggr_fn/mod.rs
+++ b/src/coprocessor/dag/aggr_fn/mod.rs
@@ -6,6 +6,7 @@ mod impl_avg;
 mod impl_bit_op;
 mod impl_count;
 mod impl_first;
+mod impl_max_min;
 mod impl_sum;
 mod parser;
 mod summable;

--- a/src/coprocessor/dag/aggr_fn/parser.rs
+++ b/src/coprocessor/dag/aggr_fn/parser.rs
@@ -4,6 +4,7 @@ use tipb::expression::{Expr, ExprType, FieldType};
 
 use crate::coprocessor::codec::mysql::Tz;
 use crate::coprocessor::dag::aggr_fn::impl_bit_op::*;
+use crate::coprocessor::dag::aggr_fn::impl_max_min::*;
 use crate::coprocessor::dag::aggr_fn::AggrFunction;
 use crate::coprocessor::dag::rpn_expr::RpnExpression;
 use crate::coprocessor::{Error, Result};
@@ -50,6 +51,8 @@ fn map_pb_sig_to_aggr_func_parser(value: ExprType) -> Result<Box<dyn AggrDefinit
         ExprType::Agg_BitAnd => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitAnd>::new())),
         ExprType::Agg_BitOr => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitOr>::new())),
         ExprType::Agg_BitXor => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitXor>::new())),
+        ExprType::Max => Ok(Box::new(AggrFnDefinitionParserExtremum(Extremum::Max))),
+        ExprType::Min => Ok(Box::new(AggrFnDefinitionParserExtremum(Extremum::Min))),
         v => Err(box_err!(
             "Aggregation function expr type {:?} is not supported in batch mode",
             v

--- a/src/coprocessor/dag/aggr_fn/parser.rs
+++ b/src/coprocessor/dag/aggr_fn/parser.rs
@@ -51,8 +51,8 @@ fn map_pb_sig_to_aggr_func_parser(value: ExprType) -> Result<Box<dyn AggrDefinit
         ExprType::Agg_BitAnd => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitAnd>::new())),
         ExprType::Agg_BitOr => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitOr>::new())),
         ExprType::Agg_BitXor => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitXor>::new())),
-        ExprType::Max => Ok(Box::new(AggrFnDefinitionParserExtremum(Extremum::Max))),
-        ExprType::Min => Ok(Box::new(AggrFnDefinitionParserExtremum(Extremum::Min))),
+        ExprType::Max => Ok(Box::new(AggrFnDefinitionParserExtremum::<Max>::new())),
+        ExprType::Min => Ok(Box::new(AggrFnDefinitionParserExtremum::<Min>::new())),
         v => Err(box_err!(
             "Aggregation function expr type {:?} is not supported in batch mode",
             v


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR adds MAX/MIN aggregation functions for batch aggregation framework.

- [x] Merge #4824 first

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- New feature (change which adds functionality)

## How has this PR been tested? (mandatory)

Unit tests
