### PR TITLE
Add missing fsync calls in the snapshot module

### DIFF
--- a/components/tikv_util/src/file.rs
+++ b/components/tikv_util/src/file.rs
@@ -46,6 +46,13 @@ pub fn create_dir_if_not_exist<P: AsRef<Path>>(dir: P) -> io::Result<bool> {
     }
 }
 
+/// Call fsync on file or directory by its path
+pub fn fsync_by_path<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    // File::open will not error when opening a directory
+    // because it just call libc::open and do not do the file or dir check
+    fs::File::open(path)?.sync_all()
+}
+
 const DIGEST_BUFFER_SIZE: usize = 1024 * 1024;
 
 /// Calculates the given file's CRC32 checksum.

--- a/components/tikv_util/src/file.rs
+++ b/components/tikv_util/src/file.rs
@@ -202,5 +202,7 @@ mod tests {
     fn test_fsync_by_path() {
         let tmp_dir = TempDir::new("").unwrap();
         fsync_by_path(tmp_dir.path()).unwrap();
+        let non_existent_file = tmp_dir.path().join("non_existent_file");
+        fsync_by_path(non_existent_file).unwrap_err();
     }
 }

--- a/components/tikv_util/src/file.rs
+++ b/components/tikv_util/src/file.rs
@@ -46,8 +46,8 @@ pub fn create_dir_if_not_exist<P: AsRef<Path>>(dir: P) -> io::Result<bool> {
     }
 }
 
-/// Call fsync on file or directory by its path
-pub fn fsync_by_path<P: AsRef<Path>>(path: P) -> io::Result<()> {
+/// Call fsync on directory by its path
+pub fn sync_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     // File::open will not error when opening a directory
     // because it just call libc::open and do not do the file or dir check
     fs::File::open(path)?.sync_all()
@@ -199,10 +199,10 @@ mod tests {
     }
 
     #[test]
-    fn test_fsync_by_path() {
+    fn test_sync_dir() {
         let tmp_dir = TempDir::new("").unwrap();
-        fsync_by_path(tmp_dir.path()).unwrap();
+        sync_dir(tmp_dir.path()).unwrap();
         let non_existent_file = tmp_dir.path().join("non_existent_file");
-        fsync_by_path(non_existent_file).unwrap_err();
+        sync_dir(non_existent_file).unwrap_err();
     }
 }

--- a/components/tikv_util/src/file.rs
+++ b/components/tikv_util/src/file.rs
@@ -197,4 +197,10 @@ mod tests {
         assert!(!create_dir_if_not_exist(&subdir).unwrap());
         assert!(delete_dir_if_exist(&subdir).unwrap());
     }
+
+    #[test]
+    fn test_fsync_by_path() {
+        let tmp_dir = TempDir::new("").unwrap();
+        fsync_by_path(tmp_dir.path()).unwrap();
+    }
 }

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -305,6 +305,7 @@ struct MetaFile {
 
 pub struct Snap {
     key: SnapKey,
+    is_sending: bool,
     display_path: String,
     dir_path: PathBuf,
     cf_files: Vec<CfFile>,
@@ -364,6 +365,7 @@ impl Snap {
 
         let mut s = Snap {
             key: key.clone(),
+            is_sending,
             display_path,
             dir_path,
             cf_files,
@@ -926,7 +928,9 @@ impl Snapshot for Snap {
             {
                 let mut file = cf_file.file.take().unwrap();
                 file.flush()?;
-                file.sync_all()?;
+                if !self.is_sending {
+                    file.sync_all()?;
+                }
             }
             if cf_file.written_size != cf_file.size {
                 return Err(io::Error::new(

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -648,6 +648,7 @@ impl Snap {
             // to indicate if the sst file is empty.
             if cf_file.kv_count > 0 {
                 fs::rename(&cf_file.tmp_path, &cf_file.path)?;
+                sync_dir(&self.dir_path)?;
                 cf_file.size = size;
                 // add size
                 self.size_track.fetch_add(size, Ordering::SeqCst);
@@ -669,6 +670,7 @@ impl Snap {
             f.flush()?;
         }
         fs::rename(&self.meta_file.tmp_path, &self.meta_file.path)?;
+        sync_dir(&self.dir_path)?;
         self.hold_tmp_files = false;
         Ok(())
     }

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -926,6 +926,7 @@ impl Snapshot for Snap {
             {
                 let mut file = cf_file.file.take().unwrap();
                 file.flush()?;
+                file.sync_all()?;
             }
             if cf_file.written_size != cf_file.size {
                 return Err(io::Error::new(
@@ -1046,7 +1047,6 @@ impl Write for Snap {
 
             let left = (cf_file.size - cf_file.written_size) as usize;
             if left == 0 {
-                cf_file.file.as_mut().unwrap().sync_all()?;
                 self.cf_index += 1;
                 continue;
             }
@@ -1058,7 +1058,6 @@ impl Write for Snap {
                 file.write_all(&next_buf[0..left])?;
                 digest.write(&next_buf[0..left]);
                 cf_file.written_size += left as u64;
-                cf_file.file.as_mut().unwrap().sync_all()?;
                 self.cf_index += 1;
                 next_buf = &next_buf[left..];
             } else {

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -963,6 +963,7 @@ impl Snapshot for Snap {
             fs::rename(&cf_file.tmp_path, &cf_file.path)?;
             self.size_track.fetch_add(cf_file.size, Ordering::SeqCst);
         }
+        fsync_by_path(&self.dir_path)?;
         // write meta file
         let mut v = vec![];
         self.meta_file.meta.write_to_vec(&mut v)?;

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -648,7 +648,6 @@ impl Snap {
             // to indicate if the sst file is empty.
             if cf_file.kv_count > 0 {
                 fs::rename(&cf_file.tmp_path, &cf_file.path)?;
-                sync_dir(&self.dir_path)?;
                 cf_file.size = size;
                 // add size
                 self.size_track.fetch_add(size, Ordering::SeqCst);
@@ -670,7 +669,6 @@ impl Snap {
             f.flush()?;
         }
         fs::rename(&self.meta_file.tmp_path, &self.meta_file.path)?;
-        sync_dir(&self.dir_path)?;
         self.hold_tmp_files = false;
         Ok(())
     }


### PR DESCRIPTION
Signed-off-by: Ben Pig Chu <benpichu@gmail.com>

## What have you changed? (mandatory)

Fix #4846 by add some fsync calls in the snapshot module. Also add util used to call fsync by path

## What are the type of the changes? (mandatory)

- Bug fix 

## How has this PR been tested? (mandatory)

Unit test

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No