### PR TITLE
pessimistic-txn: add metrics

### DIFF
--- a/src/storage/lock_manager/metrics.rs
+++ b/src/storage/lock_manager/metrics.rs
@@ -1,0 +1,55 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use prometheus::*;
+use prometheus_static_metric::*;
+
+make_static_metric! {
+    pub struct TaskCounterVec: IntCounter {
+        "type" => {
+            wait_for,
+            wake_up,
+            dump,
+            deadlock,
+            detect,
+            clean_up_wait_for,
+            clean_up,
+        },
+    }
+
+    pub struct ErrorCounterVec: IntCounter {
+        "type" => {
+            dropped,
+            not_leader,
+            reconnect_leader,
+        },
+    }
+}
+
+lazy_static! {
+    pub static ref TASK_COUNTER_VEC: TaskCounterVec = register_static_int_counter_vec!(
+        TaskCounterVec,
+        "tikv_lock_manager_task_counter",
+        "Total number of tasks received",
+        &["type"]
+    )
+    .unwrap();
+    pub static ref ERROR_COUNTER_VEC: ErrorCounterVec = register_static_int_counter_vec!(
+        ErrorCounterVec,
+        "tikv_lock_manager_error_counter",
+        "Total number of errors",
+        &["type"]
+    )
+    .unwrap();
+    pub static ref WAITER_LIFETIME_HISTOGRAM: Histogram = register_histogram!(
+        "tikv_lock_manager_waiter_lifetime_duration",
+        "Duration of waiters' lifetime in seconds",
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref DETECT_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "tikv_lock_manager_detect_duration",
+        "Duration of handling detect requests",
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+}

--- a/src/storage/lock_manager/mod.rs
+++ b/src/storage/lock_manager/mod.rs
@@ -3,6 +3,7 @@
 mod client;
 mod config;
 pub mod deadlock;
+mod metrics;
 mod util;
 pub mod waiter_manager;
 

--- a/src/storage/lock_manager/waiter_manager.rs
+++ b/src/storage/lock_manager/waiter_manager.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::deadlock::Scheduler as DetectorScheduler;
+use super::metrics::*;
 use super::Lock;
 use crate::storage::mvcc::Error as MvccError;
 use crate::storage::txn::Error as TxnError;
@@ -10,6 +11,7 @@ use crate::tikv_util::collections::HashMap;
 use crate::tikv_util::worker::{FutureRunnable, FutureScheduler, Stopped};
 use futures::Future;
 use kvproto::deadlock::WaitForEntry;
+use prometheus::HistogramTimer;
 use std::cell::RefCell;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::rc::Rc;
@@ -70,6 +72,7 @@ struct Waiter {
     cb: StorageCb,
     pr: ProcessResult,
     lock: Lock,
+    _lifetime_timer: HistogramTimer,
 }
 
 type Waiters = Vec<Waiter>;
@@ -326,8 +329,10 @@ impl FutureRunnable<Task> for WaiterManager {
                         cb,
                         pr,
                         lock,
+                        _lifetime_timer: WAITER_LIFETIME_HISTOGRAM.start_coarse_timer(),
                     },
                 );
+                TASK_COUNTER_VEC.wait_for.inc();
             }
             Task::WakeUp {
                 lock_ts,
@@ -335,9 +340,11 @@ impl FutureRunnable<Task> for WaiterManager {
                 commit_ts,
             } => {
                 self.handle_wake_up(handle, lock_ts, hashes, commit_ts);
+                TASK_COUNTER_VEC.wake_up.inc();
             }
             Task::Dump { cb } => {
                 self.handle_dump(cb);
+                TASK_COUNTER_VEC.dump.inc();
             }
             Task::Deadlock {
                 start_ts,
@@ -345,6 +352,7 @@ impl FutureRunnable<Task> for WaiterManager {
                 deadlock_key_hash,
             } => {
                 self.handle_deadlock(start_ts, lock, deadlock_key_hash);
+                TASK_COUNTER_VEC.deadlock.inc();
             }
         }
     }
@@ -384,6 +392,7 @@ mod tests {
             cb: StorageCb::Boolean(Box::new(|_| ())),
             pr: ProcessResult::Res,
             lock: Lock { ts: lock_ts, hash },
+            _lifetime_timer: WAITER_LIFETIME_HISTOGRAM.start_coarse_timer(),
         }
     }
 


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
Added metrics:
* `TASK_COUNTER_VEC`:   count tasks handled.
* ` ERROR_COUNTER_VEC`: count errors.
* ` WAITER_LIFETIME_HISTOGRAM`:  measure how long a waiter is waked up.
* ` DETECT_DURATION_HISTOGRAM`: measure how long detect requests cost, and it can reflect which node is the leader of deadlock detector.

## What are the type of the changes? (mandatory)
- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
manual test
![image](https://user-images.githubusercontent.com/14819777/59029218-44a76500-8890-11e9-8f23-5ac718ab8bc9.png)
![image](https://user-images.githubusercontent.com/14819777/59029250-5ab52580-8890-11e9-8399-a9a11b8b87c5.png)


## Does this PR affect documentation (docs) or release note? (mandatory)
no

## Does this PR affect tidb-ansible update? (mandatory)
yes. https://github.com/pingcap/tidb-ansible/pull/772
