### PR TITLE
Cherry-pick #4850 to release-2.1

### DIFF
--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -226,7 +226,7 @@ use rocksdb::{DBCompressionType, EnvOptions, IngestExternalFileOptions, SstFileW
 use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
 use std::time::Instant;
-use util::file::{calc_crc32, delete_file_if_exist, file_exists, get_file_size};
+use util::file::{calc_crc32, delete_file_if_exist, file_exists, get_file_size, sync_dir};
 use util::rocksdb;
 use util::rocksdb::get_fastest_supported_compression_type;
 use util::time::duration_to_sec;
@@ -316,7 +316,9 @@ struct MetaFile {
 
 pub struct Snap {
     key: SnapKey,
+    is_sending: bool,
     display_path: String,
+    dir_path: PathBuf,
     cf_files: Vec<CfFile>,
     cf_index: usize,
     meta_file: MetaFile,
@@ -374,7 +376,9 @@ impl Snap {
 
         let mut s = Snap {
             key: key.clone(),
+            is_sending,
             display_path,
+            dir_path,
             cf_files,
             cf_index: 0,
             meta_file,
@@ -914,6 +918,9 @@ impl Snapshot for Snap {
             {
                 let mut file = cf_file.file.take().unwrap();
                 file.flush()?;
+                if !self.is_sending {
+                    file.sync_all()?;
+                }
             }
             if cf_file.written_size != cf_file.size {
                 return Err(io::Error::new(
@@ -947,6 +954,7 @@ impl Snapshot for Snap {
             fs::rename(&cf_file.tmp_path, &cf_file.path)?;
             self.size_track.fetch_add(cf_file.size, Ordering::SeqCst);
         }
+        sync_dir(&self.dir_path)?;
         // write meta file
         let mut v = vec![];
         self.meta_file.meta.write_to_vec(&mut v)?;
@@ -956,6 +964,7 @@ impl Snapshot for Snap {
             meta_file.sync_all()?;
         }
         fs::rename(&self.meta_file.tmp_path, &self.meta_file.path)?;
+        sync_dir(&self.dir_path)?;
         self.hold_tmp_files = false;
         Ok(())
     }
@@ -1032,7 +1041,6 @@ impl Write for Snap {
 
             let left = (cf_file.size - cf_file.written_size) as usize;
             if left == 0 {
-                cf_file.file.as_mut().unwrap().sync_all()?;
                 self.cf_index += 1;
                 continue;
             }


### PR DESCRIPTION
Signed-off-by: Ben Pig Chu <benpichu@gmail.com>

## What have you changed? (mandatory)

Cherry-pick #4850 to release-2.1, fix #4846 on 2.1.x branch by add some fsync calls in the snapshot module. Also add util used to call fsync by path.

## What are the type of the changes? (mandatory)

- Bug fix

## How has this PR been tested? (mandatory)

unit-test

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No