### PR TITLE
coprocessor: use servo_arc in BatchTopNExecutor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,7 +1567,7 @@ name = "protoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1631,7 +1631,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1968,6 +1968,15 @@ dependencies = [
  "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2366,6 +2375,7 @@ dependencies = [
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo_arc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3131,6 +3141,7 @@ dependencies = [
 "checksum serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfad05c8854584e5f72fb859385ecdfa03af69c3fd0572f0da2d4c95f060bdb"
 "checksum serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)" = "477b13b646f5b5b56fc95bedfc3b550d12141ce84f466f6c44b9a17589923885"
 "checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
+"checksum servo_arc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
 "checksum signal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "106428d9d96840ecdec5208c13ab8a4e28c38da1e0ccf2909fb44e41b992f897"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "09e4f1d0276ac7d448d98db16f0dab0220c24d4842d88ce4dad4b306fa234f1d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ vlog = "0.1.4"
 twoway = "0.2.0"
 ordered-float = "1.0"
 nom = "5.0.0-beta1"
+servo_arc = "0.1.1"
 profiler = { path = "components/profiler" }
 mime = "0.3.13"
 match_template = { path = "components/match_template" }

--- a/src/coprocessor/dag/batch/executors/top_n_executor.rs
+++ b/src/coprocessor/dag/batch/executors/top_n_executor.rs
@@ -3,7 +3,6 @@
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::ptr::NonNull;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use tikv_util::erase_lifetime;
@@ -57,6 +56,9 @@ pub struct BatchTopNExecutor<Src: BatchExecutor> {
     is_ended: bool,
 }
 
+/// All `NonNull` pointers in `BatchTopNExecutor` cannot be accessed out of the struct and
+/// `BatchTopNExecutor` doesn't leak the pointers to other threads. Therefore, with those `NonNull`
+/// pointers, BatchTopNExecutor still remains `Send`.
 unsafe impl<Src: BatchExecutor + Send> Send for BatchTopNExecutor<Src> {}
 
 impl BatchTopNExecutor<Box<dyn BatchExecutor>> {
@@ -160,7 +162,7 @@ impl<Src: BatchExecutor> BatchTopNExecutor<Src> {
             expr.ensure_columns_decoded(&self.context.cfg.tz, src_schema_unbounded, &mut data)?;
         }
 
-        let data = Rc::new(data);
+        let data = servo_arc::Arc::new(data);
 
         let eval_offset = self.eval_columns_buffer_unsafe.len();
         let order_exprs_unbounded = unsafe { erase_lifetime(&*self.order_exprs) };
@@ -304,19 +306,13 @@ impl<Src: BatchExecutor> BatchExecutor for BatchTopNExecutor<Src> {
 struct HeapItemUnsafe {
     /// A pointer to the `order_is_desc` field in `BatchTopNExecutor`.
     order_is_desc_ptr: NonNull<[bool]>,
+
     /// The source columns that evaluated column in this structure is referring to.
-    ///
-    /// Multiple `HeapItemUnsafe` may share the same source column. Thus source columns
-    /// are placed behind a reference counter. However, there won't be a place other than
-    /// `HeapItemUnsafe` holding this reference counter, so Rc won't break
-    /// `BatchTopNExecutor: Send`.
-    ///
-    /// WARN: Actually we cannot ensure that this is still `Send` in future, since `Rc` may
-    /// use something like thread local variables which does not break its API.
-    source_column_data: Rc<LazyBatchColumnVec>,
+    source_column_data: servo_arc::Arc<LazyBatchColumnVec>,
 
     /// A pointer to the `eval_columns_buffer` field in `BatchTopNExecutor`.
     eval_columns_buffer_ptr: NonNull<Vec<RpnStackNode<'static>>>,
+
     /// The begin offset of the evaluated columns stored in the buffer.
     ///
     /// The length of evaluated columns in the buffer is `order_is_desc.len()`.


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Replace `std::rc::Rc` in `BatchTopNExecutor` with `servo_arc::Arc`.

Because we don't need the weak count, it's ok to use `servo_arc::Arc`. This also saves one word in `HeapItemUnsafe`.

`servo_arc::Arc<T: Send>` is `Send`, so we don't need to worry about if `Rc`  may break the `Send` property of `BatchTopNExecutor`.

## What are the type of the changes? (mandatory)

- Improvement

## How has this PR been tested? (mandatory)

CI

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

Top N with lots of rows, few order-bys, few columns and small limit can maximize the impact of changing `Rc` to `Arc`. (Otherwise, evaluating columns or materialization can be the dominant part). Benchmark (run in an IDC machine) shows there's no significant performance impact.

```
top_n_1_order_by_1_column_limit_10/batch/rows=1000000                                                                          
                        time:   [742.10 ms 744.98 ms 746.92 ms]
                        change: [-1.0320% -0.1323% +0.8214%] (p = 0.79 > 0.05)
                        No change in performance detected.

top_n_1_order_by_1_column_limit_4000/batch/rows=1000000                                                                          
                        time:   [777.96 ms 779.94 ms 782.43 ms]
                        change: [-1.5075% -0.2580% +0.8170%] (p = 0.70 > 0.05)
                        No change in performance detected.
```

## Add a few positive/negative examples (optional)

