### PR TITLE
copr: Demo of new RPN function framework

### DIFF
--- a/src/coprocessor/dag/rpn_expr/function.rs
+++ b/src/coprocessor/dag/rpn_expr/function.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::types::RpnFnCallPayload;
+use super::types::{RpnFnCallPayload, RpnStackNode};
 use crate::coprocessor::codec::data_type::{Evaluable, ScalarValue, VectorValue};
 use crate::coprocessor::dag::expr::EvalContext;
 use crate::coprocessor::Result;
@@ -343,5 +343,173 @@ impl Helper {
             result.push(f(context, payload, &arg0[i], &arg1[i], &arg2[i])?);
         }
         Ok(Ret::into_vector_value(result))
+    }
+}
+
+#[derive(Clone, Copy)]
+/// A RPN function
+pub struct RpnFn {
+    /// The display name of the function.
+    pub name: &'static str,
+
+    /// The accepted argument length of this RPN function.
+    ///
+    /// Currently we do not support variable arguments.
+    pub args_len: usize,
+
+    /// The function receiving raw argument.
+    ///
+    /// The first parameter is the number of rows.
+    /// The second and the third are the evaluation context and the payload containing the
+    /// argument value and the argument field type.
+    pub fn_ptr: fn(usize, &mut EvalContext, RpnFnCallPayload<'_>) -> Result<VectorValue>,
+}
+
+impl std::fmt::Debug for RpnFn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}({} args)", self.name, self.args_len)
+    }
+}
+
+/// A single argument of an RPN function.
+pub trait RpnFnArg: std::fmt::Debug {
+    type Type;
+
+    /// Gets the value in the given row.
+    fn get(&self, row: usize) -> Self::Type;
+}
+
+/// Represents an RPN function argument of a `ScalarValue`.
+#[derive(Clone, Copy, Debug)]
+pub struct ScalarArg<'a, T: Evaluable>(&'a Option<T>);
+
+impl<'a, T: Evaluable> RpnFnArg for ScalarArg<'a, T> {
+    type Type = &'a Option<T>;
+
+    /// Gets the value in the given row. All rows of a `ScalarArg` share the same value.
+    #[inline]
+    fn get(&self, _row: usize) -> &'a Option<T> {
+        self.0
+    }
+}
+
+/// Represents an RPN function argument of a `VectorValue`.
+#[derive(Clone, Copy, Debug)]
+pub struct VectorArg<'a, T: Evaluable>(&'a [Option<T>]);
+
+impl<'a, T: Evaluable> RpnFnArg for VectorArg<'a, T> {
+    type Type = &'a Option<T>;
+
+    #[inline]
+    fn get(&self, row: usize) -> &'a Option<T> {
+        &self.0[row]
+    }
+}
+
+/// Partial or complete argument definition of an RPN function.
+///
+/// `ArgDef` is constructed at the beginning of evaluating an RPN function. The types of
+/// `RpnFnArg`s are determined at this stage. So there won't be dynamic dispatch or enum matches
+/// when the function is applied to each row of the input.
+pub trait ArgDef: std::fmt::Debug {}
+
+/// RPN function argument definitions in the form of a linked list.
+///
+/// For example, if an RPN function foo(Int, Real, Decimal) is applied to input of a scalar of
+/// integer, a vector of reals and a vector of decimals, the constructed `ArgDef` will be
+/// `Arg<ScalarArg<Int>, Arg<VectorValue<Real>, Arg<VectorValue<Decimal>, Null>>>`. `Null`
+/// indicates the end of the argument list.
+#[derive(Debug)]
+pub struct Arg<A: RpnFnArg, Rem: ArgDef> {
+    arg: A,
+    rem: Rem,
+}
+
+impl<A: RpnFnArg, Rem: ArgDef> ArgDef for Arg<A, Rem> {}
+
+impl<A: RpnFnArg, Rem: ArgDef> Arg<A, Rem> {
+    /// Gets the value of the head argument in the given row and returns the remaining argument
+    /// list.
+    #[inline]
+    pub fn extract(&self, row: usize) -> (A::Type, &Rem) {
+        (self.arg.get(row), &self.rem)
+    }
+}
+
+/// Represents the end of the argument list.
+#[derive(Debug)]
+pub struct Null;
+
+impl ArgDef for Null {}
+
+/// A generic evaluator of an RPN function.
+///
+/// For every RPN function, the evaluator should be created first. Then, call its `eval` method
+/// with the input to get the result vector.
+///
+/// There are two kinds of evaluators in general:
+/// - `ArgConstructor`: It's a provided `Evaluator`. It is used in the `rpn_fn` attribute macro
+///   to generate the `ArgDef`. The `def` parameter of its eval method is the already constructed
+///   `ArgDef`. If it is the outmost evaluator, `def` should be `Null`.
+/// - Custom evaluators which do the actual execution of the RPN function. The `def` parameter of
+///   its eval method is the constructed `ArgDef`. Implementors can then extract values from the
+///   arguments, execute the RPN function and fill the result vector.
+pub trait Evaluator {
+    fn eval<D: ArgDef>(
+        self,
+        def: D,
+        rows: usize,
+        context: &mut EvalContext,
+        payload: RpnFnCallPayload<'_>,
+    ) -> Result<VectorValue>;
+}
+
+pub struct ArgConstructor<E: Evaluator> {
+    arg_index: usize,
+    inner: E,
+}
+
+impl<E: Evaluator> ArgConstructor<E> {
+    pub fn new(arg_index: usize, inner: E) -> Self {
+        ArgConstructor { arg_index, inner }
+    }
+}
+
+impl<E: Evaluator> Evaluator for ArgConstructor<E> {
+    fn eval<D: ArgDef>(
+        self,
+        def: D,
+        rows: usize,
+        context: &mut EvalContext,
+        payload: RpnFnCallPayload<'_>,
+    ) -> Result<VectorValue> {
+        match payload.raw_arg_at(self.arg_index) {
+            RpnStackNode::Scalar { value, .. } => {
+                match_template_evaluable! {
+                    TT, match value {
+                        ScalarValue::TT(v) => {
+                            let new_def = Arg {
+                                arg: ScalarArg(v),
+                                rem: def,
+                            };
+                            self.inner.eval(new_def, rows, context, payload)
+                        }
+                    }
+                }
+            }
+            RpnStackNode::Vector { value, .. } => {
+                match_template_evaluable! {
+                    TT, match **value {
+                        VectorValue::TT(ref v) => {
+                            let new_def = Arg {
+                                arg: VectorArg(v),
+                                rem: def,
+                            };
+                            self.inner.eval(new_def, rows, context, payload)
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 #![feature(proc_macro_hygiene)]
 #![feature(duration_float)]
 #![feature(specialization)]
+#![feature(const_fn)]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

I want to introduce a new RPN function framework. This one uses `RpnFn` struct instead of `Box<dyn RpnFunction` to represent an RPN function. Then, we can avoid dynamic dispatch and heap allocations.

This is just a demonstration of how the code looks like using compare functions as an example. Next, I will add a macro to generate this code.

## What are the type of the changes? (mandatory)

Engineering

## How has this PR been tested? (mandatory)

CI

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
