### PR TITLE
coprocessor: reduce allocations in slow hash aggregation

### DIFF
--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -569,6 +569,10 @@ pub fn is_zero_duration(d: &Duration) -> bool {
     d.as_secs() == 0 && d.subsec_nanos() == 0
 }
 
+pub unsafe fn erase_lifetime_mut<'a, T: ?Sized>(v: &mut T) -> &'a mut T {
+    &mut *(v as *mut T)
+}
+
 pub unsafe fn erase_lifetime<'a, T: ?Sized>(v: &T) -> &'a T {
     &*(v as *const T)
 }

--- a/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
@@ -1,20 +1,22 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::hash::{Hash, Hasher};
+use std::ptr::NonNull;
 use std::sync::Arc;
 
 use hashbrown::hash_map::Entry;
-use smallvec::SmallVec;
 
 use tikv_util::collections::HashMap;
 use tipb::executor::Aggregation;
 use tipb::expression::{Expr, FieldType};
 
 use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
+use crate::coprocessor::codec::data_type::{ScalarValue, VectorValue};
 use crate::coprocessor::dag::aggr_fn::*;
 use crate::coprocessor::dag::batch::executors::util::aggr_executor::*;
-use crate::coprocessor::dag::batch::executors::util::hash_aggr_helper::HashAggregationHelper;
 use crate::coprocessor::dag::batch::interface::*;
 use crate::coprocessor::dag::expr::EvalConfig;
+use crate::coprocessor::dag::rpn_expr::types::RpnStackNode;
 use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
 use crate::coprocessor::Result;
 
@@ -116,13 +118,15 @@ impl<Src: BatchExecutor> BatchSlowHashAggregationExecutor<Src> {
         aggr_defs: Vec<Expr>,
         aggr_def_parser: impl AggrDefinitionParser,
     ) -> Result<Self> {
+        let group_by_len = group_by_exps.len();
         let aggr_impl = SlowHashAggregationImpl {
             states: Vec::with_capacity(1024),
             groups: HashMap::default(),
             group_by_exps,
-            states_offset_each_row: Vec::with_capacity(
-                crate::coprocessor::dag::batch_handler::BATCH_MAX_SIZE,
-            ),
+            group_key_buffer: Box::new(Vec::new()),
+            group_key_offsets: vec![0],
+            group_by_results: Vec::with_capacity(group_by_len),
+            aggr_expr_results: Vec::with_capacity(aggr_defs.len()),
         };
 
         Ok(Self(AggregationExecutor::new(
@@ -137,39 +141,28 @@ impl<Src: BatchExecutor> BatchSlowHashAggregationExecutor<Src> {
 
 pub struct SlowHashAggregationImpl {
     states: Vec<Box<dyn AggrFunctionState>>,
-    groups: HashMap<Vec<u8>, GroupInfo>,
+
+    /// The value is the group index. `states` and `group_key_offsets` are stored in
+    /// the order of group index.
+    groups: HashMap<GroupKeyRefUnsafe, usize>,
     group_by_exps: Vec<RpnExpression>,
-    states_offset_each_row: Vec<usize>,
+
+    #[allow(clippy::box_vec)]
+    group_key_buffer: Box<Vec<u8>>,
+    group_key_offsets: Vec<usize>,
+
+    /// Stores evaluation results of group by expressions.
+    /// It is just used to reduce allocations. The lifetime is not really 'static. The elements
+    /// are only valid in the same batch where they are added.
+    group_by_results: Vec<RpnStackNode<'static>>,
+
+    /// Stores evaluation results of aggregate expressions.
+    /// It is just used to reduce allocations. The lifetime is not really 'static. The elements
+    /// are only valid in the same batch where they are added.
+    aggr_expr_results: Vec<RpnStackNode<'static>>,
 }
 
-#[derive(Debug)]
-struct GroupInfo {
-    /// The start offset of the states of this group stored in
-    /// `SlowHashAggregationImpl::states`.
-    states_start_offset: usize,
-
-    /// The offset of each GROUP BY column in the group key. There will be an additional offset
-    /// at the end, which equals to the group key length.
-    ///
-    /// For example, if the group key `AaaFfffff` is composed by two group column `[Aaa, Ffffff]`,
-    /// then the value of this field is `[0, 3, 9]`.
-    ///
-    /// Note 1:
-    /// We want aggregation executor to provide each GROUP BY column independently, which will be
-    /// useful in future executors (like Projection executor). However, currently this segmentation
-    /// is not useful because we return data by row and columns will be always pasted together.
-    /// Thus segmentation or not doesn't make any differences.
-    ///
-    /// Note 2:
-    /// We use `SmallVec<[..; 6]>` so that when group by columns <= 5 SmallVec avoids allocation.
-    /// We think the case that there are more than 5 group by columns are rare.
-    ///
-    /// Note 3:
-    /// We use `SmallVec<[u32; ..]>` instead of `SmallVec<[usize; ..]>` because the length of the
-    /// group key will not exceed `u32`. Using `u32` instead of `usize` makes this field small
-    /// and can be fit into the cache line better.
-    group_key_offsets: SmallVec<[u32; 6]>,
-}
+unsafe impl Send for SlowHashAggregationImpl {}
 
 impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SlowHashAggregationImpl {
     #[inline]
@@ -188,63 +181,108 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SlowHashAggregationImp
         entities: &mut Entities<Src>,
         mut input: LazyBatchColumnVec,
     ) -> Result<()> {
-        let rows_len = input.rows_len();
-
-        // 1. Calculate which group each src row belongs to.
-        self.states_offset_each_row.clear();
-
+        let context = &mut entities.context;
         let src_schema = entities.src.schema();
+        let rows_len = input.rows_len();
+        let group_by_len = self.group_by_exps.len();
+        let aggr_fn_len = entities.each_aggr_fn.len();
 
-        // TODO: Eliminate these allocations using an allocator.
-        let mut group_by_keys = Vec::with_capacity(rows_len);
-        let mut group_by_keys_offsets = Vec::with_capacity(rows_len);
-        for _ in 0..rows_len {
-            group_by_keys.push(Vec::with_capacity(32));
-            group_by_keys_offsets.push(SmallVec::new());
+        // Decode columns with mutable input first, so subsequent access to input can be immutable
+        // (and the borrow checker will be happy)
+        ensure_columns_decoded(&context.cfg.tz, &self.group_by_exps, src_schema, &mut input)?;
+        ensure_columns_decoded(
+            &context.cfg.tz,
+            &entities.each_aggr_exprs,
+            src_schema,
+            &mut input,
+        )?;
+        assert!(self.group_by_results.is_empty());
+        assert!(self.aggr_expr_results.is_empty());
+        unsafe {
+            eval_exprs_no_lifetime(
+                context,
+                &self.group_by_exps,
+                src_schema,
+                &input,
+                &mut self.group_by_results,
+            )?;
+            eval_exprs_no_lifetime(
+                context,
+                &entities.each_aggr_exprs,
+                src_schema,
+                &input,
+                &mut self.aggr_expr_results,
+            )?;
         }
-        for group_by_exp in &self.group_by_exps {
-            let group_by_result =
-                group_by_exp.eval(&mut entities.context, rows_len, src_schema, &mut input)?;
-            // Unwrap is fine because we have verified the group by expression before.
-            let group_column = group_by_result.vector_value().unwrap();
-            let field_type = group_by_result.field_type();
-            for row_index in 0..rows_len {
-                group_by_keys_offsets[row_index].push(group_by_keys[row_index].len() as u32);
-                group_column.encode(row_index, field_type, &mut group_by_keys[row_index])?;
-            }
-        }
-        // One extra offset, to be used as the end offset.
+
         for row_index in 0..rows_len {
-            group_by_keys_offsets[row_index].push(group_by_keys[row_index].len() as u32);
-        }
-
-        for (group_key, group_key_offsets) in group_by_keys.into_iter().zip(group_by_keys_offsets) {
-            match self.groups.entry(group_key) {
+            let offset_begin = self.group_key_buffer.len();
+            for group_by_result in &self.group_by_results {
+                match group_by_result {
+                    RpnStackNode::Vector { value, field_type } => {
+                        value.encode(row_index, field_type, &mut self.group_key_buffer)?;
+                        self.group_key_offsets.push(self.group_key_buffer.len());
+                    }
+                    // we have checked that group by cannot be a scalar
+                    _ => unreachable!(),
+                }
+            }
+            let group_key_ref_unsafe = GroupKeyRefUnsafe {
+                buffer: (&*self.group_key_buffer).into(),
+                begin: offset_begin,
+                end: self.group_key_buffer.len(),
+            };
+            let group_len = self.groups.len();
+            let group_index = match self.groups.entry(group_key_ref_unsafe) {
                 Entry::Vacant(entry) => {
-                    let offset = self.states.len();
-                    self.states_offset_each_row.push(offset);
-                    entry.insert(GroupInfo {
-                        states_start_offset: offset,
-                        group_key_offsets,
-                    });
+                    // if it's a new group, the group index is the current group count
+                    entry.insert(group_len);
                     for aggr_fn in &entities.each_aggr_fn {
                         self.states.push(aggr_fn.create_state());
                     }
+                    group_len
                 }
                 Entry::Occupied(entry) => {
-                    self.states_offset_each_row
-                        .push(entry.get().states_start_offset);
+                    // remove the duplicated group key
+                    self.group_key_buffer.truncate(offset_begin);
+                    self.group_key_offsets
+                        .truncate(self.group_key_offsets.len() - group_by_len);
+                    *entry.get()
+                }
+            };
+            let state_begin = group_index * aggr_fn_len;
+            for (aggr_expr_result, state) in self
+                .aggr_expr_results
+                .iter()
+                .zip(&mut self.states[state_begin..state_begin + aggr_fn_len])
+            {
+                match aggr_expr_result {
+                    RpnStackNode::Scalar { value, .. } => {
+                        match_template_evaluable! {
+                            TT, match value {
+                                ScalarValue::TT(scalar_value) => {
+                                    state.update(context, scalar_value)?;
+                                },
+                            }
+                        }
+                    }
+                    RpnStackNode::Vector { value, .. } => {
+                        match_template_evaluable! {
+                            TT, match &**value {
+                                VectorValue::TT(vector_value) => {
+                                    state.update(context, &vector_value[row_index])?;
+                                },
+                            }
+                        }
+                    }
                 }
             }
         }
 
-        // 2. Update states according to the group.
-        HashAggregationHelper::update_each_row_states_by_offset(
-            entities,
-            &mut input,
-            &mut self.states,
-            &self.states_offset_each_row,
-        )?;
+        // Remember to remove expression results of the current batch. They are invalid
+        // in the next batch.
+        self.group_by_results.clear();
+        self.aggr_expr_results.clear();
 
         Ok(())
     }
@@ -273,20 +311,21 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SlowHashAggregationImp
         let aggr_fns_len = entities.each_aggr_fn.len();
 
         let groups = std::mem::replace(&mut self.groups, HashMap::default());
-        for (group_key, group_info) in groups {
+        for (_, group_index) in groups {
+            let states_start_offset = group_index * aggr_fns_len;
             iteratee(
                 entities,
-                &self.states
-                    [group_info.states_start_offset..group_info.states_start_offset + aggr_fns_len],
+                &self.states[states_start_offset..states_start_offset + aggr_fns_len],
             )?;
 
             // Extract group column from group key for each group
+            let group_key_offsets = &self.group_key_offsets[group_index * group_by_exps_len..];
             for group_index in 0..group_by_exps_len {
-                let offset_begin = group_info.group_key_offsets[group_index] as usize;
-                let offset_end = group_info.group_key_offsets[group_index + 1] as usize;
+                let offset_begin = group_key_offsets[group_index];
+                let offset_end = group_key_offsets[group_index + 1];
                 group_by_columns[group_index]
                     .mut_raw()
-                    .push(&group_key[offset_begin..offset_end]);
+                    .push(&self.group_key_buffer[offset_begin..offset_end]);
             }
         }
 
@@ -299,6 +338,34 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SlowHashAggregationImp
         false
     }
 }
+
+/// A reference to a group key slice in the `group_key_buffer` of `SlowHashAggregationImpl`.
+///
+/// It is safe as soon as it doesn't outlive the `SlowHashAggregationImpl` that creates this
+/// reference.
+struct GroupKeyRefUnsafe {
+    /// Points to the `group_key_buffer` of `SlowHashAggregationImpl`
+    buffer: NonNull<Vec<u8>>,
+    begin: usize,
+    end: usize,
+}
+
+impl Hash for GroupKeyRefUnsafe {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        unsafe { self.buffer.as_ref()[self.begin..self.end].hash(state) }
+    }
+}
+
+impl PartialEq for GroupKeyRefUnsafe {
+    fn eq(&self, other: &GroupKeyRefUnsafe) -> bool {
+        unsafe {
+            self.buffer.as_ref()[self.begin..self.end]
+                == other.buffer.as_ref()[other.begin..other.end]
+        }
+    }
+}
+
+impl Eq for GroupKeyRefUnsafe {}
 
 #[cfg(test)]
 mod tests {

--- a/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
@@ -5,7 +5,6 @@ use std::ptr::NonNull;
 use std::sync::Arc;
 
 use hashbrown::hash_map::Entry;
-
 use tikv_util::collections::HashMap;
 use tipb::executor::Aggregation;
 use tipb::expression::{Expr, FieldType};
@@ -131,7 +130,6 @@ impl<Src: BatchExecutor> BatchSlowHashAggregationExecutor<Src> {
                 crate::coprocessor::dag::batch_handler::BATCH_MAX_SIZE,
             ),
             group_by_results_unsafe: Vec::with_capacity(group_by_len),
-            aggr_expr_results_unsafe: Vec::with_capacity(aggr_defs.len()),
         };
 
         Ok(Self(AggregationExecutor::new(
@@ -172,11 +170,6 @@ pub struct SlowHashAggregationImpl {
     /// It is just used to reduce allocations. The lifetime is not really 'static. The elements
     /// are only valid in the same batch where they are added.
     group_by_results_unsafe: Vec<RpnStackNode<'static>>,
-
-    /// Stores evaluation results of aggregate expressions.
-    /// It is just used to reduce allocations. The lifetime is not really 'static. The elements
-    /// are only valid in the same batch where they are added.
-    aggr_expr_results_unsafe: Vec<RpnStackNode<'static>>,
 }
 
 unsafe impl Send for SlowHashAggregationImpl {}
@@ -275,7 +268,6 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SlowHashAggregationImp
         // Remember to remove expression results of the current batch. They are invalid
         // in the next batch.
         self.group_by_results_unsafe.clear();
-        self.aggr_expr_results_unsafe.clear();
 
         Ok(())
     }

--- a/src/coprocessor/dag/batch/executors/stream_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/stream_aggr_executor.rs
@@ -9,7 +9,6 @@ use tipb::expression::{Expr, FieldType};
 
 use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::coprocessor::codec::data_type::*;
-use crate::coprocessor::codec::mysql::time::Tz;
 use crate::coprocessor::dag::aggr_fn::*;
 use crate::coprocessor::dag::batch::executors::util::aggr_executor::*;
 use crate::coprocessor::dag::batch::interface::*;
@@ -79,14 +78,27 @@ impl BatchStreamAggregationExecutor<Box<dyn BatchExecutor>> {
 
 pub struct BatchStreamAggregationImpl {
     group_by_exps: Vec<RpnExpression>,
+
     /// used in the `iterate_each_group_for_aggregation` method
     group_by_exps_types: Vec<EvalType>,
+
     /// Stores all group keys for the current result partial.
     /// The last `group_by_exps.len()` elements are the keys of the last group.
     keys: Vec<ScalarValue>,
+
     /// Stores all group states for the current result partial.
     /// The last `each_aggr_fn.len()` elements are the states of the last group.
     states: Vec<Box<dyn AggrFunctionState>>,
+
+    /// Stores evaluation results of group by expressions.
+    /// It is just used to reduce allocations. The lifetime is not really 'static. The elements
+    /// are only valid in the same batch where they are added.
+    group_by_results: Vec<RpnStackNode<'static>>,
+
+    /// Stores evaluation results of aggregate expressions.
+    /// It is just used to reduce allocations. The lifetime is not really 'static. The elements
+    /// are only valid in the same batch where they are added.
+    aggr_expr_results: Vec<RpnStackNode<'static>>,
 }
 
 impl<Src: BatchExecutor> BatchStreamAggregationExecutor<Src> {
@@ -131,11 +143,14 @@ impl<Src: BatchExecutor> BatchStreamAggregationExecutor<Src> {
             })
             .collect();
 
+        let group_by_len = group_by_exps.len();
         let aggr_impl = BatchStreamAggregationImpl {
             group_by_exps,
             group_by_exps_types,
             keys: Vec::new(),
             states: Vec::new(),
+            group_by_results: Vec::with_capacity(group_by_len),
+            aggr_expr_results: Vec::with_capacity(aggr_defs.len()),
         };
 
         Ok(Self(AggregationExecutor::new(
@@ -181,14 +196,30 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for BatchStreamAggregation
             src_schema,
             &mut input,
         )?;
-        let group_by_results = eval_exprs(context, &self.group_by_exps, src_schema, &input)?;
-        let aggr_expr_results = eval_exprs(context, &entities.each_aggr_exprs, src_schema, &input)?;
+        assert!(self.group_by_results.is_empty());
+        assert!(self.aggr_expr_results.is_empty());
+        unsafe {
+            eval_exprs_no_lifetime(
+                context,
+                &self.group_by_exps,
+                src_schema,
+                &input,
+                &mut self.group_by_results,
+            )?;
+            eval_exprs_no_lifetime(
+                context,
+                &entities.each_aggr_exprs,
+                src_schema,
+                &input,
+                &mut self.aggr_expr_results,
+            )?;
+        }
 
         // Stores input references, clone them when needed
         let mut group_key_ref = Vec::with_capacity(group_by_len);
         let mut group_start_row = 0;
         for row_index in 0..rows_len {
-            for group_by_result in &group_by_results {
+            for group_by_result in &self.group_by_results {
                 group_key_ref.push(group_by_result.get_scalar_ref(row_index));
             }
             match self.keys.rchunks_exact(group_by_len).next() {
@@ -202,7 +233,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for BatchStreamAggregation
                             context,
                             &mut self.states,
                             aggr_fn_len,
-                            &aggr_expr_results,
+                            &self.aggr_expr_results,
                             group_start_row,
                             row_index,
                         )?;
@@ -223,10 +254,15 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for BatchStreamAggregation
             context,
             &mut self.states,
             aggr_fn_len,
-            &aggr_expr_results,
+            &self.aggr_expr_results,
             group_start_row,
             rows_len,
         )?;
+
+        // Remember to remove expression results of the current batch. They are invalid
+        // in the next batch.
+        self.group_by_results.clear();
+        self.aggr_expr_results.clear();
 
         Ok(())
     }
@@ -296,30 +332,6 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for BatchStreamAggregation
     fn is_partial_results_ready(&self) -> bool {
         AggregationExecutorImpl::<Src>::groups_len(self) >= 2
     }
-}
-
-fn ensure_columns_decoded(
-    tz: &Tz,
-    exprs: &[RpnExpression],
-    schema: &[FieldType],
-    input: &mut LazyBatchColumnVec,
-) -> Result<()> {
-    for expr in exprs {
-        expr.ensure_columns_decoded(tz, schema, input)?;
-    }
-    Ok(())
-}
-
-fn eval_exprs<'a, 'b>(
-    context: &'a mut EvalContext,
-    exprs: &'b [RpnExpression],
-    schema: &'b [FieldType],
-    input: &'b LazyBatchColumnVec,
-) -> Result<Vec<RpnStackNode<'b>>> {
-    exprs
-        .iter()
-        .map(|expr| expr.eval_unchecked(context, input.rows_len(), schema, &input))
-        .collect()
 }
 
 fn update_current_states(

--- a/src/coprocessor/dag/batch/executors/top_n_executor.rs
+++ b/src/coprocessor/dag/batch/executors/top_n_executor.rs
@@ -169,7 +169,7 @@ impl<Src: BatchExecutor> BatchTopNExecutor<Src> {
         let data_unbounded = unsafe { erase_lifetime(&*data) };
         for expr_unbounded in order_exprs_unbounded.iter() {
             self.eval_columns_buffer_unsafe
-                .push(expr_unbounded.eval_unchecked(
+                .push(expr_unbounded.eval_decoded(
                     &mut self.context,
                     data.rows_len(),
                     src_schema_unbounded,

--- a/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
@@ -330,7 +330,7 @@ pub unsafe fn eval_exprs_no_lifetime<'a>(
     output: &mut Vec<RpnStackNode<'a>>,
 ) -> Result<()> {
     for expr in exprs {
-        output.push(erase_lifetime(expr).eval_unchecked(
+        output.push(erase_lifetime(expr).eval_decoded(
             erase_lifetime_mut(context),
             input.rows_len(),
             erase_lifetime(schema),

--- a/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
@@ -149,7 +149,7 @@ impl RpnExpression {
         // we evaluate. This is to make Rust's borrow checker happy because there will be
         // mutable reference during the first iteration and we can't keep these references.
         self.ensure_columns_decoded(&context.cfg.tz, schema, columns)?;
-        self.eval_unchecked(context, rows, schema, columns)
+        self.eval_decoded(context, rows, schema, columns)
     }
 
     /// Evaluates the expression into a boolean vector.
@@ -202,10 +202,10 @@ impl RpnExpression {
         Ok(())
     }
 
-    /// Evaluates the expression into a vector.
+    /// Evaluates the expression into a vector. The input columns must be already decoded.
     ///
-    /// It differs from `eval` in that `eval_unchecked` needn't receive a mutable reference
-    /// to `LazyBatchColumnVec`. However, since `eval_unchecked` doesn't decode columns,
+    /// It differs from `eval` in that `eval_decoded` needn't receive a mutable reference
+    /// to `LazyBatchColumnVec`. However, since `eval_decoded` doesn't decode columns,
     /// it will panic if referred columns are not decoded.
     ///
     /// # Panics
@@ -215,7 +215,7 @@ impl RpnExpression {
     /// Panics if referred columns are not decoded.
     ///
     /// Panics when referenced column does not have equal length as specified in `rows`.
-    pub fn eval_unchecked<'a>(
+    pub fn eval_decoded<'a>(
         &'a self,
         context: &mut EvalContext,
         rows: usize,


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

In this PR, slow hash aggregation uses a single `Vec` to store all encoded keys. Then, allocations are largely reduced.

`unsafe` is used in this PR. Please carefully review it.

Fix #4756 

## What are the type of the changes? (mandatory)

Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

make dev

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

```
hash_aggr_count_1_first_group_by_int_col_real_col/batch/rows=5000                                                                           
                        time:   [1.6607 ms 1.6980 ms 1.7284 ms]
                        change: [-19.420% -17.570% -15.802%] (p = 0.00 < 0.05)
                        Performance has improved.

hash_aggr_count_1_first_group_by_int_col_real_col_2_groups/batch/rows=5000                                                                           
                        time:   [690.97 us 695.09 us 699.15 us]
                        change: [-31.231% -30.194% -29.013%] (p = 0.00 < 0.05)
                        Performance has improved.

hash_aggr_count_1_group_by_decimal_col/batch/rows=5000                                                                           
                        time:   [1.3481 ms 1.3629 ms 1.3787 ms]
                        change: [-25.587% -24.749% -23.894%] (p = 0.00 < 0.05)
                        Performance has improved.

hash_aggr_count_1_group_by_decimal_col_2_groups/batch/rows=5000                                                                           
                        time:   [915.59 us 923.36 us 932.60 us]
                        change: [-26.320% -25.347% -24.311%] (p = 0.00 < 0.05)
                        Performance has improved.

hash_aggr_count_1_group_by_int_col_real_col/batch/rows=5000                                                                           
                        time:   [1.2434 ms 1.2698 ms 1.2876 ms]
                        change: [-25.898% -24.440% -22.928%] (p = 0.00 < 0.05)
                        Performance has improved.

hash_aggr_count_1_group_by_int_col_real_col_2_groups/batch/rows=5000                                                                           
                        time:   [541.36 us 547.85 us 552.46 us]
                        change: [-39.517% -38.309% -37.239%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## Add a few positive/negative examples (optional)

