### PR TITLE
Dockerfile use the Makefile to build tikv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN mkdir -p ./src/bin && \
 COPY ./src ./src
 COPY ./components ./components
 
-RUN cargo build --no-default-features --release --features "jemalloc portable sse no-fail" 
+RUN make build
 
 # Strip debug info to reduce the docker size, may strip later?
 # RUN strip --strip-debug /tikv/target/release/tikv-server && \

--- a/scripts/gen-dockerfile.sh
+++ b/scripts/gen-dockerfile.sh
@@ -66,7 +66,7 @@ cat <<EOT >> ${output}
 COPY ${dir}/src ./src
 COPY ${dir}/components ./components
 
-RUN cargo build --no-default-features --release --features "jemalloc portable sse no-fail" 
+RUN make build
 
 # Strip debug info to reduce the docker size, may strip later?
 # RUN strip --strip-debug /tikv/target/release/tikv-server && \\


### PR DESCRIPTION
## What have you changed? (mandatory)
Replace `RUN cargo build --no-default-features --release --features "jemalloc portable sse no-fail"` with `RUN make build` in script `scripts/gen-dockerfile.sh`  and execute the script to generate a new Dockerfile.

## What are the type of the changes? (mandatory)
- Improvement

## How has this PR been tested? (mandatory)
N/A

## Does this PR affect documentation (docs) or release note? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No

## Refer to a related PR or issue link (optional)
[#4845](https://github.com/tikv/tikv/issues/4845)