### PR TITLE
Dockerfile use the Makefile to build tikv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN sed -i '/fuzz/d' Cargo.toml && \
     sed -i '/test\_/d' Cargo.toml && \
     sed -i '/profiler/d' Cargo.toml
 
+# Use Makefile to build
+COPY Makefile ./
+
 # Add components Cargo files
 # Notice: every time we add a new component, we must regenerate the dockerfile
 COPY ./components/codec/Cargo.toml ./components/codec/Cargo.toml
@@ -44,7 +47,7 @@ RUN mkdir -p ./src/bin && \
     mkdir ./components/tikv_alloc/src && echo '' > ./components/tikv_alloc/src/lib.rs && \
     mkdir ./components/tikv_util/src && echo '' > ./components/tikv_util/src/lib.rs && \
     mkdir ./components/tipb_helper/src && echo '' > ./components/tipb_helper/src/lib.rs && \
-    cargo build --no-default-features --release --features "jemalloc portable sse no-fail" && \
+    make build_release && \
     rm -rf ./target/release/.fingerprint/codec-* && \
     rm -rf ./target/release/.fingerprint/cop_codegen-* && \
     rm -rf ./target/release/.fingerprint/cop_datatype-* && \
@@ -61,7 +64,7 @@ RUN mkdir -p ./src/bin && \
 COPY ./src ./src
 COPY ./components ./components
 
-RUN make build
+RUN make build_release
 
 # Strip debug info to reduce the docker size, may strip later?
 # RUN strip --strip-debug /tikv/target/release/tikv-server && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN mkdir -p ./src/bin && \
 COPY ./src ./src
 COPY ./components ./components
 
-RUN cargo build --no-default-features --release --features "jemalloc portable sse no-fail" 
+RUN make build
 
 # Strip debug info to reduce the docker size, may strip later?
 # RUN strip --strip-debug /tikv/target/release/tikv-server && \

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ fail_release:
 # Individual developers should only need to use the `dist_` rules when working
 # on the CI/CD system.
 dist_release:
-	cargo build --no-default-features --release --features "${ENABLE_FEATURES}"
+	make build_release
 	@mkdir -p ${BIN_PATH}
 	@cp -f ${CARGO_TARGET_DIR}/release/tikv-ctl ${CARGO_TARGET_DIR}/release/tikv-server ${CARGO_TARGET_DIR}/release/tikv-importer ${BIN_PATH}/
 	bash scripts/check-sse4_2.sh
@@ -118,6 +118,10 @@ dist_prof_release:
 # This is used for schrodinger chaos testing.
 dist_fail_release:
 	FAIL_POINT=1 make release
+
+# Build with release flag
+build_release:
+	cargo build --no-default-features --release --features "${ENABLE_FEATURES}"
 
 # unlike test, this target will trace tests and output logs when fail test is detected.
 trace_test:

--- a/scripts/gen-dockerfile.sh
+++ b/scripts/gen-dockerfile.sh
@@ -66,7 +66,7 @@ cat <<EOT >> ${output}
 COPY ${dir}/src ./src
 COPY ${dir}/components ./components
 
-RUN cargo build --no-default-features --release --features "jemalloc portable sse no-fail" 
+RUN make build
 
 # Strip debug info to reduce the docker size, may strip later?
 # RUN strip --strip-debug /tikv/target/release/tikv-server && \\

--- a/scripts/gen-dockerfile.sh
+++ b/scripts/gen-dockerfile.sh
@@ -23,6 +23,9 @@ RUN sed -i '/fuzz/d' Cargo.toml && \\
     sed -i '/test\_/d' Cargo.toml && \\
     sed -i '/profiler/d' Cargo.toml
 
+# Use Makefile to build
+COPY Makefile ./
+
 EOT
 
 # Get components, remove test and profiler components
@@ -52,7 +55,7 @@ for i in ${components}; do
     echo "    mkdir ./components/${i}/src && echo '' > ./components/${i}/src/lib.rs && \\" >> ${output}
 done
 
-echo '    cargo build --no-default-features --release --features "jemalloc portable sse no-fail" && \' >> ${output}
+echo '    make build_release && \' >> ${output}
 
 for i in ${components}; do 
     echo "    rm -rf ./target/release/.fingerprint/${i}-* && \\" >> ${output}
@@ -66,7 +69,7 @@ cat <<EOT >> ${output}
 COPY ${dir}/src ./src
 COPY ${dir}/components ./components
 
-RUN make build
+RUN make build_release
 
 # Strip debug info to reduce the docker size, may strip later?
 # RUN strip --strip-debug /tikv/target/release/tikv-server && \\


### PR DESCRIPTION
## What have you changed? (mandatory)
1. Add a new rule `build_release` to Makefile
2. Replace `RUN cargo build --no-default-features --release --features "jemalloc portable sse no-fail"` with `RUN make build_release` in script `scripts/gen-dockerfile.sh`  and execute the script to generate a new Dockerfile.

## What are the type of the changes? (mandatory)
- Improvement

## How has this PR been tested? (mandatory)
Run `docker build .` on my local MacOS.

## Does this PR affect documentation (docs) or release note? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No

## Refer to a related PR or issue link (optional)
[#4845](https://github.com/tikv/tikv/issues/4845)