### PR TITLE
raftstore: generate snapshot after applying the current commit idx

### DIFF
--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -2633,6 +2633,7 @@ impl ApplyFsm {
             self.delegate.pending_snaps.tasks.push_back(task);
         }
         while let Some(task) = self.delegate.pending_snaps.tasks.pop_front() {
+            // Handle the task if its commit index has been applied.
             if task.commit_index() > applied_index {
                 self.delegate.pending_snaps.tasks.push_front(task);
                 break;
@@ -2663,11 +2664,11 @@ impl ApplyFsm {
                 apply_ctx.flush();
                 // For now, it's more like last_flush_apply_index.
                 // TODO: Update it only when `flush()` returns true.
-                self.delegate.last_sync_apply_index = self.delegate.apply_state.get_applied_index();
+                self.delegate.last_sync_apply_index = applied_index;
             }
 
-            if let Err(e) = task
-                .generate_and_schedule_snapshot(&apply_ctx.engines, &apply_ctx.region_scheduler)
+            if let Err(e) =
+                task.generate_and_schedule_snapshot(&apply_ctx.engines, &apply_ctx.region_scheduler)
             {
                 error!(
                     "schedule snapshot failed";

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -2633,7 +2633,7 @@ impl ApplyFsm {
             self.delegate
                 .write_apply_state(&apply_ctx.engines, apply_ctx.kv_wb());
             fail_point!(
-                "apply_on_handle_snapshot_finish_1_1",
+                "apply_on_handle_snapshot_1_1",
                 self.delegate.id == 1 && self.delegate.region_id() == 1,
                 |_| unimplemented!()
             );

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -587,31 +587,6 @@ impl Debug for WaitSourceMergeState {
     }
 }
 
-#[derive(Debug)]
-struct PendingSnapshot {
-    tasks: VecDeque<GenSnapTask>,
-    /// The counter of pending request snapshots. See more in `Peer`.
-    pending_count: Arc<AtomicUsize>,
-}
-
-impl PendingSnapshot {
-    const SHRINK_TASKS_CAPACITY: usize = 3;
-
-    fn gc(&mut self) {
-        if self.tasks.capacity() > Self::SHRINK_TASKS_CAPACITY
-            && self.tasks.len() < Self::SHRINK_TASKS_CAPACITY
-        {
-            self.tasks.shrink_to_fit();
-        }
-    }
-
-    fn has_ready_snap(&self, applied_index: u64) -> bool {
-        self.tasks
-            .front()
-            .map_or(false, |task| task.commit_index() <= applied_index)
-    }
-}
-
 /// The apply delegate of a Region which is responsible for handling committed
 /// raft log entries of a Region.
 ///
@@ -645,8 +620,8 @@ pub struct ApplyDelegate {
 
     /// The commands waiting to be committed and applied
     pending_cmds: PendingCmdQueue,
-    /// The generate snapshot tasks waiting to be handled.
-    pending_snaps: PendingSnapshot,
+    /// The counter of pending request snapshots. See more in `Peer`.
+    pending_request_snapshot_count: Arc<AtomicUsize>,
 
     /// Marks the delegate as merged by CommitMerge.
     merged: bool,
@@ -677,10 +652,6 @@ pub struct ApplyDelegate {
 
 impl ApplyDelegate {
     fn from_registration(reg: Registration) -> ApplyDelegate {
-        let pending_snaps = PendingSnapshot {
-            tasks: VecDeque::new(),
-            pending_count: reg.pending_request_snapshot_count,
-        };
         ApplyDelegate {
             id: reg.id,
             tag: format!("[region {}] {}", reg.region.get_id(), reg.id),
@@ -698,7 +669,7 @@ impl ApplyDelegate {
             pending_cmds: Default::default(),
             metrics: Default::default(),
             last_merge_version: 0,
-            pending_snaps,
+            pending_request_snapshot_count: reg.pending_request_snapshot_count,
         }
     }
 
@@ -2638,22 +2609,12 @@ impl ApplyFsm {
     }
 
     #[allow(unused_mut)]
-    fn maybe_handle_snapshot(
-        &mut self,
-        apply_ctx: &mut ApplyContext,
-        snap_task: Option<GenSnapTask>,
-    ) {
+    fn handle_snapshot(&mut self, apply_ctx: &mut ApplyContext, snap_task: GenSnapTask) {
         if self.delegate.pending_remove || self.delegate.stopped {
             return;
         }
-        if let Some(task) = snap_task {
-            self.delegate.pending_snaps.tasks.push_back(task);
-        }
         let applied_index = self.delegate.apply_state.get_applied_index();
-        if !self.delegate.pending_snaps.has_ready_snap(applied_index) {
-            return;
-        }
-
+        assert!(snap_task.commit_index() <= applied_index);
         let mut need_sync = apply_ctx
             .apply_res
             .iter()
@@ -2683,39 +2644,28 @@ impl ApplyFsm {
             self.delegate.last_sync_apply_index = applied_index;
         }
 
-        while let Some(task) = self.delegate.pending_snaps.tasks.pop_front() {
-            // Handle the task if its commit index has been applied.
-            if task.commit_index() > applied_index {
-                self.delegate.pending_snaps.tasks.push_front(task);
-                break;
-            }
-
-            if let Err(e) =
-                task.generate_and_schedule_snapshot(&apply_ctx.engines, &apply_ctx.region_scheduler)
-            {
-                error!(
-                    "schedule snapshot failed";
-                    "error" => ?e,
-                    "region_id" => self.delegate.region_id(),
-                    "peer_id" => self.delegate.id()
-                );
-            }
-            self.delegate
-                .pending_snaps
-                .pending_count
-                .fetch_sub(1, Ordering::SeqCst);
-            fail_point!(
-                "apply_on_handle_snapshot_finish_1_1",
-                self.delegate.id == 1 && self.delegate.region_id() == 1,
-                |_| unimplemented!()
+        if let Err(e) = snap_task
+            .generate_and_schedule_snapshot(&apply_ctx.engines, &apply_ctx.region_scheduler)
+        {
+            error!(
+                "schedule snapshot failed";
+                "error" => ?e,
+                "region_id" => self.delegate.region_id(),
+                "peer_id" => self.delegate.id()
             );
         }
-        self.delegate.pending_snaps.gc();
+        self.delegate
+            .pending_request_snapshot_count
+            .fetch_sub(1, Ordering::SeqCst);
+        fail_point!(
+            "apply_on_handle_snapshot_finish_1_1",
+            self.delegate.id == 1 && self.delegate.region_id() == 1,
+            |_| unimplemented!()
+        );
     }
 
     fn handle_tasks(&mut self, apply_ctx: &mut ApplyContext, msgs: &mut Vec<Msg>) {
         let mut channel_timer = None;
-        let mut snap_task = None;
         let mut drainer = msgs.drain(..);
         loop {
             match drainer.next() {
@@ -2734,15 +2684,12 @@ impl ApplyFsm {
                 Some(Msg::Destroy(d)) => self.handle_destroy(apply_ctx, d),
                 Some(Msg::CatchUpLogs(cul)) => self.catch_up_logs_for_merge(apply_ctx, cul),
                 Some(Msg::LogsUpToDate(_)) => {}
-                Some(Msg::Snapshot(task)) => {
-                    snap_task = Some(task);
-                }
+                Some(Msg::Snapshot(snap_task)) => self.handle_snapshot(apply_ctx, snap_task),
                 #[cfg(test)]
                 Some(Msg::Validate(_, f)) => f(&self.delegate),
                 None => break,
             }
         }
-        self.maybe_handle_snapshot(apply_ctx, snap_task);
         if let Some(timer) = channel_timer {
             let elapsed = duration_to_sec(timer.elapsed());
             APPLY_TASK_WAIT_TIME_HISTOGRAM.observe(elapsed);
@@ -3973,76 +3920,4 @@ mod tests {
         checker.check(b"k31", b"k32", 24, &[25, 26, 27], true);
         checker.check(b"k32", b"k4", 28, &[29, 30, 31], true);
     }
-
-    #[test]
-    fn test_snapshot() {
-        let (_path, engines) = create_tmp_engine("test-delegate");
-        let (_import_dir, importer) = create_tmp_importer("test-delegate");
-        let mut host = CoprocessorHost::default();
-        let obs = ApplyObserver::default();
-        host.registry
-            .register_query_observer(1, Box::new(obs.clone()));
-
-        let (tx, rx) = mpsc::channel();
-        let (region_scheduler, snapshot_rx) = dummy_scheduler();
-        let sender = Notifier::Sender(tx);
-        let cfg = Arc::new(Config::default());
-        let (router, mut system) = create_apply_batch_system(&cfg);
-        let builder = super::Builder {
-            tag: "test-store".to_owned(),
-            cfg,
-            sender,
-            region_scheduler,
-            coprocessor_host: Arc::new(host),
-            importer: importer.clone(),
-            engines: engines.clone(),
-            router: router.clone(),
-        };
-        system.spawn("test-handle-raft".to_owned(), builder);
-
-        let mut reg = Registration::default();
-        reg.id = 3;
-        reg.region.set_id(1);
-        reg.region.mut_peers().push(new_peer(2, 3));
-        reg.region.set_end_key(b"k5".to_vec());
-        reg.region.mut_region_epoch().set_conf_ver(1);
-        reg.region.mut_region_epoch().set_version(3);
-        router.schedule_task(1, Msg::Registration(reg));
-
-        let apply_entry = |index| {
-            let (capture_tx, capture_rx) = mpsc::channel();
-            let put_entry = EntryBuilder::new(index, 1)
-                .put(b"k1", b"v1")
-                .epoch(1, 3)
-                .capture_resp(&router, 3, 1, capture_tx.clone())
-                .build();
-            router.schedule_task(1, Msg::apply(Apply::new(1, 1, vec![put_entry])));
-            let resp = capture_rx.recv_timeout(Duration::from_secs(3)).unwrap();
-            assert!(!resp.get_header().has_error(), "{:?}", resp);
-            assert_eq!(resp.get_responses().len(), 1);
-            validate(&router, 1, move |delegate| {
-                assert_eq!(delegate.applied_index_term, 1);
-                assert_eq!(delegate.apply_state.get_applied_index(), index);
-            });
-            fetch_apply_res(&rx);
-        };
-
-        // Snapshot needs applied index = 2.
-        let (tx, _) = mpsc::sync_channel(0);
-        router.schedule_task(1, Msg::Snapshot(GenSnapTask::new(1, 2, tx)));
-
-        // Apply entry at index 1.
-        apply_entry(1);
-
-        // Must wait applied index = 2.
-        snapshot_rx.try_recv().unwrap_err();
-
-        // Apply entry at index 2.
-        apply_entry(2);
-
-        snapshot_rx.recv_timeout(Duration::from_secs(3)).unwrap();
-
-        system.shutdown();
-    }
-
 }

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1241,7 +1241,7 @@ impl Peer {
                     .schedule_task(self.region_id, ApplyTask::apply(apply));
             }
             // Check whether there is a pending generate snapshot task, the task
-            // needs to be sent the apply system.
+            // needs to be sent to the apply system.
             // Always sending snapshot task behind apply task, so it gets latest
             // snapshot.
             if let Some(gen_task) = self.mut_store().take_gen_snap_task() {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1073,15 +1073,6 @@ impl Peer {
             }
         }
 
-        // Check whether there is a pending generate snapshot task, the task
-        // needs to be sent the apply system.
-        if let Some(gen_task) = self.mut_store().take_gen_snap_task() {
-            self.pending_request_snapshot_count
-                .fetch_add(1, Ordering::SeqCst);
-            ctx.apply_router
-                .schedule_task(self.region_id, ApplyTask::Snapshot(gen_task));
-        }
-
         if !self
             .raft_group
             .has_ready_since(Some(self.last_applying_idx))
@@ -1248,6 +1239,16 @@ impl Peer {
                 let apply = Apply::new(self.region_id, self.term(), committed_entries);
                 ctx.apply_router
                     .schedule_task(self.region_id, ApplyTask::apply(apply));
+            }
+            // Check whether there is a pending generate snapshot task, the task
+            // needs to be sent the apply system.
+            // Always sending snapshot task behind apply task, so it gets latest
+            // snapshot.
+            if let Some(gen_task) = self.mut_store().take_gen_snap_task() {
+                self.pending_request_snapshot_count
+                    .fetch_add(1, Ordering::SeqCst);
+                ctx.apply_router
+                    .schedule_task(self.region_id, ApplyTask::Snapshot(gen_task));
             }
         }
 

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -794,7 +794,7 @@ impl PeerStorage {
         let (tx, rx) = mpsc::sync_channel(1);
         *snap_state = SnapState::Generating(rx);
 
-        let task = GenSnapTask::new(self.region.get_id(), tx);
+        let task = GenSnapTask::new(self.region.get_id(), self.committed_index(), tx);
         let mut gen_snap_task = self.gen_snap_task.borrow_mut();
         assert!(gen_snap_task.is_none());
         *gen_snap_task = Some(task);


### PR DESCRIPTION
## What have you changed? (mandatory)

Wait for the current commit index being applied before generating snapshots. It is useful in the request-snapshot scenario, followers always get the latest snapshot.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

Unit tests.

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.
