### PR TITLE
pessimistic-txn: resolve all optimistic locks when non-pessimistic lock conflict occurs

### DIFF
--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -189,13 +189,13 @@ impl<S: Snapshot> MvccTxn<S> {
         for_update_ts: u64,
         lock: Lock,
     ) -> Result<()> {
-        // Optimistic lock's for_update_ts is its start_ts.
-        let lock_for_update_ts = if lock.for_update_ts > 0 {
-            lock.for_update_ts
-        } else {
-            lock.ts
-        };
-        if for_update_ts > lock_for_update_ts {
+        // The previous pessimistic transaction has been committed or aborted.
+        // Resolve it immediately.
+        //
+        // Because the row key is locked, the optimistic transaction will
+        // abort. Resolve it immediately.
+        // Optimistic lock's for_update_ts is zero.
+        if for_update_ts > lock.for_update_ts {
             Err(Error::KeyIsLocked {
                 key: key.into_raw()?,
                 primary: lock.primary,


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
Resolve all optimistic locks when non-pessimistic lock conflict occurs.

## What are the type of the changes? (mandatory)
- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)
manual tests

## Does this PR affect documentation (docs) or release note? (mandatory)
no

## Does this PR affect tidb-ansible update? (mandatory)
no