### PR TITLE
*: turn debuginfo back on

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,7 @@ members = [
 
 [profile.dev]
 opt-level = 0
-debug = false
+debug = true
 codegen-units = 4
 lto = false
 incremental = true
@@ -222,7 +222,7 @@ rpath = false
 
 [profile.test]
 opt-level = 0
-debug = 1 # enable line numbers by default for easy test debugging
+debug = true
 codegen-units = 16
 lto = false
 incremental = true
@@ -233,7 +233,7 @@ rpath = false
 # The benchmark profile is identical to release, except that lto = false
 [profile.bench]
 opt-level = 3
-debug = false
+debug = true
 codegen-units = 1
 lto = 'thin'
 incremental = false

--- a/README.md
+++ b/README.md
@@ -156,13 +156,6 @@ cargo test $TESTNAME
 
 Our CI systems automatically test all the pull requests, so making sure the full suite passes the test before creating your PR is not strictly required. **All merged PRs must have passed CI test.**
 
-Note that, to reduce compilation time, TiKV builds do not include debugging information by default. The easiest way to enable debuginfo is to precede build commands with `RUSTFLAGS=-Cdebuginfo=1` (for line numbers), or `RUSTFLAGS=-Cdebuginfo=2` (for full debuginfo).
-
-```bash
-RUSTFLAGS=-Cdebuginfo=2 make
-RUSTFLAGS=-Cdebuginfo=2 cargo build
-```
-
 ### Getting the rest of the system working
 
 To get other components ([TiDB](https://github.com/pingcap/tidb) and [PD](https://github.com/pingcap/pd)) working, we suggest you follow the [development guide](https://github.com/pingcap/docs/blob/master/dev-guide/development.md), because you need the `pd-server` at least to work alongside `tikv-server` for integration level testing.


### PR DESCRIPTION
Per https://github.com/tikv/tikv/issues/4894, there isn't a simple way
to temporarily turn debuginfo on for both rustc and gcc. So reenabling
debuginfo until I figure that out.

## What have you changed? (mandatory)

Turning debuginfo on for dev, test, bench profiles.

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Please describe the tests that you ran to verify your changes. Have you finished unit tests, integration tests, or manual tests? What additional tests would give you greater confidence in this change?

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/issues/4894

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

