### PR TITLE
tests: update to new fail-rs logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,12 +599,12 @@ dependencies = [
 
 [[package]]
 name = "fail"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2366,7 +2366,7 @@ dependencies = [
  "crossbeam 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "engine 0.0.1",
- "fail 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fail 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "farmhash 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2466,7 +2466,7 @@ dependencies = [
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fail 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fail 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3028,7 +3028,7 @@ dependencies = [
 "checksum enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"
-"checksum fail 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd2e1a22c616c8c8c96b6e07c243014551f3ba77291d24c22e0bfea6830c0b4e"
+"checksum fail 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f63eec71a3013ee912a0ecb339ff0c5fa5ed9660df04bfefa10c250b885d018c"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum farmhash 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f35ce9c8fb9891c75ceadbc330752951a4e369b50af10775955aeb9af3eee34b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ portable = ["engine/portable"]
 sse = ["engine/sse"]
 mem-profiling = ["tikv_alloc/mem-profiling"]
 profiling = ["profiler/profiling"]
-no-fail = ["fail/no_fail"]
+failpoints = ["fail/failpoints"]
 
 [lib]
 name = "tikv"
@@ -34,6 +34,7 @@ name = "tikv-ctl"
 [[test]]
 name = "failpoints"
 path = "tests/failpoints/mod.rs"
+required-features = ["failpoints"]
 
 [[test]]
 name = "integrations"
@@ -100,7 +101,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 zipf = "5.0.1"
 bitflags = "1.0.1"
-fail = "0.2"
+fail = "0.3"
 uuid = { version = "0.6", features = [ "serde", "v4" ] }
 grpcio = { version = "0.4", features = [ "secure" ] }
 raft = "0.4.3"

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ ifneq ($(ROCKSDB_SYS_SSE),0)
 ENABLE_FEATURES += sse
 endif
 
-ifneq ($(FAIL_POINT),1)
-ENABLE_FEATURES += no-fail
+ifeq ($(FAIL_POINT),1)
+ENABLE_FEATURES += failpoints
 endif
 
 PROJECT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2018"
 publish = false
 
+[features]
+failpoints = ["fail/failpoints"]
+
 [dependencies]
 log = { version = "0.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
@@ -38,7 +41,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 grpcio = { version = "0.4", features = [ "secure" ] }
 crossbeam = "0.5"
-fail = "0.2"
+fail = "0.3"
 fxhash = "0.2.1"
 
 [dependencies.prometheus]

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -2,6 +2,8 @@
 
 #![cfg_attr(test, feature(test))]
 
+#[macro_use(fail_point)]
+extern crate fail;
 #[macro_use]
 extern crate futures;
 #[macro_use]
@@ -29,8 +31,6 @@ extern crate slog;
 extern crate slog_global;
 #[cfg(test)]
 extern crate test;
-#[macro_use]
-extern crate fail;
 
 use std::collections::hash_map::Entry;
 use std::collections::vec_deque::{Iter, VecDeque};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
+#[macro_use(fail_point)]
 extern crate fail;
 #[macro_use]
 extern crate lazy_static;

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -1585,13 +1585,11 @@ impl ApplyDelegate {
         ctx: &mut ApplyContext,
         req: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult)> {
-        (|| {
-            fail_point!(
-                "apply_before_split_1_3",
-                { self.id == 3 && self.region_id() == 1 },
-                |_| {}
-            );
-        })();
+        fail_point!(
+            "apply_before_split_1_3",
+            { self.id == 3 && self.region_id() == 1 },
+            |_| {}
+        );
 
         PEER_ADMIN_CMD_COUNTER_VEC
             .with_label_values(&["batch-split", "all"])
@@ -2641,9 +2639,7 @@ impl ApplyFsm {
             .iter()
             .any(|res| res.region_id == self.delegate.region_id())
             && self.delegate.last_sync_apply_index != applied_index;
-        (|| {
-            fail_point!("apply_on_handle_snapshot_sync", |_| { need_sync = true });
-        })();
+        fail_point!("apply_on_handle_snapshot_sync", |_| { need_sync = true });
         if need_sync {
             if apply_ctx.timer.is_none() {
                 apply_ctx.timer = Some(SlowTimer::new());

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -30,7 +30,7 @@ use crate::raftstore::store::fsm::metrics::*;
 use crate::raftstore::store::fsm::peer::{
     maybe_destroy_source, new_admin_request, PeerFsm, PeerFsmDelegate,
 };
-#[cfg(not(feature = "no-fail"))]
+#[cfg(feature = "failpoints")]
 use crate::raftstore::store::fsm::ApplyTaskRes;
 use crate::raftstore::store::fsm::{
     batch, create_apply_batch_system, ApplyBatchSystem, ApplyPollerBuilder, ApplyRouter, ApplyTask,

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -2,7 +2,7 @@
 
 use futures::future::{err, ok};
 use futures::sync::oneshot::{Receiver, Sender};
-#[cfg(not(feature = "no-fail"))]
+#[cfg(feature = "failpoints")]
 use futures::Stream;
 use futures::{self, Future};
 use hyper::service::service_fn;
@@ -63,11 +63,11 @@ mod profiler_guard {
     }
 }
 
-#[cfg(not(feature = "no-fail"))]
+#[cfg(feature = "failpoints")]
 static MISSING_NAME: &[u8] = b"Missing param name";
-#[cfg(not(feature = "no-fail"))]
+#[cfg(feature = "failpoints")]
 static MISSING_ACTIONS: &[u8] = b"Missing param actions";
-#[cfg(not(feature = "no-fail"))]
+#[cfg(feature = "failpoints")]
 static FAIL_POINTS_REQUEST_PATH: &str = "/fail";
 
 pub struct StatusServer {
@@ -228,7 +228,7 @@ impl StatusServer {
                         let path = req.uri().path().to_owned();
                         let method = req.method().to_owned();
 
-                        #[cfg(not(feature = "no-fail"))]
+                        #[cfg(feature = "failpoints")]
                         {
                             if path.starts_with(FAIL_POINTS_REQUEST_PATH) {
                                 return handle_fail_points_request(req);
@@ -273,7 +273,7 @@ impl StatusServer {
 }
 
 // For handling fail points related requests
-#[cfg(not(feature = "no-fail"))]
+#[cfg(feature = "failpoints")]
 fn handle_fail_points_request(
     req: Request<Body>,
 ) -> Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send> {
@@ -350,25 +350,11 @@ fn handle_fail_points_request(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
-
     use crate::config::TiKvConfig;
     use crate::server::status_server::StatusServer;
     use futures::future::{lazy, Future};
-    #[cfg(not(feature = "no-fail"))]
     use futures::Stream;
     use hyper::{Body, Client, Method, Request, StatusCode, Uri};
-
-    lazy_static! {
-        static ref LOCK: Mutex<()> = Mutex::new(());
-    }
-
-    fn setup<'a>() -> MutexGuard<'a, ()> {
-        let guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        fail::teardown();
-        fail::setup();
-        guard
-    }
 
     #[test]
     fn test_status_service() {
@@ -432,10 +418,10 @@ mod tests {
         status_server.stop();
     }
 
-    #[cfg(not(feature = "no-fail"))]
+    #[cfg(feature = "failpoints")]
     #[test]
     fn test_status_service_fail_endpoints() {
-        let _gaurd = setup();
+        let _guard = fail::FailScenario::setup();
         let config = TiKvConfig::default();
         let mut status_server = StatusServer::new(1, config);
         let _ = status_server.start("127.0.0.1:0".to_string());
@@ -565,10 +551,10 @@ mod tests {
         status_server.stop();
     }
 
-    #[cfg(not(feature = "no-fail"))]
+    #[cfg(feature = "failpoints")]
     #[test]
     fn test_status_service_fail_endpoints_can_trigger_fails() {
-        let _gaurd = setup();
+        let _guard = fail::FailScenario::setup();
         let config = TiKvConfig::default();
         let mut status_server = StatusServer::new(1, config);
         let _ = status_server.start("127.0.0.1:0".to_string());
@@ -607,10 +593,10 @@ mod tests {
         assert!(true_only_if_fail_point_triggered());
     }
 
-    #[cfg(feature = "no-fail")]
+    #[cfg(not(feature = "failpoints"))]
     #[test]
-    fn test_status_service_fail_endpoints_should_give_404_when_feature_no_fail_exists() {
-        let _gaurd = setup();
+    fn test_status_service_fail_endpoints_should_give_404_when_failpoints_are_disable() {
+        let _guard = fail::FailScenario::setup();
         let config = TiKvConfig::default();
         let mut status_server = StatusServer::new(1, config);
         let _ = status_server.start("127.0.0.1:0".to_string());
@@ -632,7 +618,8 @@ mod tests {
             client
                 .request(req)
                 .map(|res| {
-                    assert_eq!(res.status(), StatusCode::NOT_FOUND); // with feature no-fail, this PUT endpoint should return 404
+                    // without feature "failpoints", this PUT endpoint should return 404
+                    assert_eq!(res.status(), StatusCode::NOT_FOUND);
                 })
                 .map_err(|err| {
                     panic!("response status is not OK: {:?}", err);

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -259,8 +259,8 @@ impl<T: RaftStoreRouter + 'static, S: StoreAddrResolver + 'static> ServerTranspo
     }
 
     // TODO: remove allow unused mut.
-    // Compiler warns `mut addr ` and `mut transport_on_resolve_fp`, when we enable
-    // the `no-fail` feature.
+    // Compiler warns `mut addr ` and `mut transport_on_resolve_fp`, when we disable
+    // the `failpoints` feature.
     #[allow(unused_mut)]
     fn resolve(&self, store_id: u64, msg: RaftMessage) {
         let trans = self.clone();

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -12,7 +12,7 @@ use engine::Engines;
 use engine::Error as EngineError;
 use engine::{CfName, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use engine::{IterOption, Peekable};
-#[cfg(not(feature = "no-fail"))]
+#[cfg(feature = "failpoints")]
 use kvproto::errorpb::Error as ErrorHeader;
 use kvproto::kvrpcpb::Context;
 use tempfile::{Builder, TempDir};

--- a/tests/failpoints/mod.rs
+++ b/tests/failpoints/mod.rs
@@ -1,43 +1,23 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![recursion_limit = "100"]
-#![cfg_attr(feature = "no-fail", allow(dead_code))]
 
-#[macro_use]
-extern crate lazy_static;
-#[cfg(not(feature = "no-fail"))]
 #[macro_use(slog_kv, slog_debug, slog_log, slog_record, slog_b, slog_record_static)]
 extern crate slog;
-#[cfg(not(feature = "no-fail"))]
 #[macro_use]
 extern crate slog_global;
 
-#[cfg(not(feature = "no-fail"))]
 mod cases;
 
-use std::sync::*;
-use std::thread;
-
-lazy_static! {
-    /// Failpoints are global structs, hence rules set in different cases
-    /// may affect each other. So use a global lock to synchronize them.
-    static ref LOCK: Mutex<()> = {
-        test_util::setup_for_ci();
-        Mutex::new(())
-    };
-}
-
-fn setup<'a>() -> MutexGuard<'a, ()> {
-    // We don't want a failed test breaks others.
-    let guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    fail::teardown();
-    fail::setup();
+fn setup<'a>() -> fail::FailScenario<'a> {
+    let guard = fail::FailScenario::setup();
+    test_util::setup_for_ci();
     guard
 }
 
 #[test]
 fn test_setup() {
-    let _ = thread::spawn(move || {
+    let _ = std::thread::spawn(move || {
         panic_hook::mute();
         let _g = setup();
         panic!("Poison!");

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -706,7 +706,7 @@ fn test_debug_region_size() {
 }
 
 #[test]
-#[cfg(not(feature = "no-fail"))]
+#[cfg(feature = "failpoints")]
 fn test_debug_fail_point() {
     let (_cluster, debug_client, _) = must_new_cluster_and_debug_client();
 


### PR DESCRIPTION
## What have you changed? (mandatory)
    
This updates tests logic and build helpers to use new logic and
features from latest `fail`.

## What are the type of the changes? (mandatory)

 * Update to `fail` 0.3
 * Rename feature to `failpoints`
 * Serialize tests via `fail::FailScenario`

## How has this PR been tested? (mandatory)

```
$ cargo test --test failpoints --features failpoints
...
test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

