### PR TITLE
improvement(scripts): check sse4.2 with objdump

### DIFF
--- a/scripts/check-sse4_2.sh
+++ b/scripts/check-sse4_2.sh
@@ -17,8 +17,6 @@ if [[ "`uname`" != "Linux" ]]; then
     exit 0
 fi
 
-command -v gdb >/dev/null 2>&1 || { echo "skipping sse4.2 check - gdb is required"; exit 0; }
-
 echo "checking bins for sse4.2"
 
 for dir in $dirs; do
@@ -41,8 +39,7 @@ for dir in $dirs; do
             # f2.*0f 38 is the opcode of `crc32`, see Intel® SSE4 Programming Reference
             found=0
             for sym in $fast_crc32; do
-                echo $sym
-                if [[ `gdb -batch -ex "disass/r $sym" $dirfile 2> /dev/null | grep ">:.*f2.*0f 38.*crc32"` ]]; then
+                if [[ `objdump --disassemble="$sym" $dirfile 2> /dev/null | grep ".*f2.*0f 38.*crc32"` ]]; then
                     found=1
                     break
                 fi
@@ -50,6 +47,8 @@ for dir in $dirs; do
             if [[ "$found" -ne 1 ]]; then
                 echo "error: $dirfile does not enable sse4.2"
                 errors=1
+	    else
+                echo -e "$dirfile sse4.2 \e[32menabled\e[0m"
             fi
         fi
     done


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

The original way to check if sse4.2 is enabled is to load the binary
with gdb and then disassemble the symbol, this is slow because gdb is
a dynamic debugger. Replace gdb with objdump which analysis the static
code. It is 25x faster than the way of using gdb.

Another reason to replace gdb is that some versions of gdb can not
recognize the symbol correctly.

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

* replace gdb with `objdump`
* remove the output of $sym which is a mess of string. I think it is confused.
* output the check result with green color

Please **NOTE** that:
- Do not assume reviewers understand the original issue

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

manually test

## Refer to a related PR or issue link (optional)

- https://github.com/tikv/tikv/issues/4367
- https://github.com/tikv/tikv/pull/4387
- https://github.com/tikv/tikv/issues/4330
- https://github.com/tikv/tikv/pull/4840
- https://github.com/tikv/tikv/pull/4832

## Add a few positive/negative examples (optional)

time cost using objdump

```sh
> time -f "\t%E real,\t%U user,\t%S sys" bash scripts/check-sse4_2.sh  > /dev/null
        0:00.19 real,   0.18 user,      0.02 sys
```

time cost using gdb(which causes an error in my envrionment)

```sh
> time -f "\t%E real,\t%U user,\t%S sys" bash scripts/check-sse4_2_with_gdb.sh   > /dev/nul
Command exited with non-zero status 1
        0:05.12 real,   4.59 user,      0.54 sys
```
