### PR TITLE
scripts: Skip sse4.2 check when not enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ ENABLE_FEATURES += portable
 endif
 
 # Enable sse4.2 by default unless disable explicitly
+# Note this env var is also tested by scripts/check-sse4_2.sh
 ifneq ($(ROCKSDB_SYS_SSE),0)
 ENABLE_FEATURES += sse
 endif

--- a/scripts/check-sse4_2.sh
+++ b/scripts/check-sse4_2.sh
@@ -17,6 +17,11 @@ if [[ "`uname`" != "Linux" ]]; then
     exit 0
 fi
 
+if [[ "$ROCKSDB_SYS_SSE" == "0" ]]; then
+	echo "skipping sse4.2 check - sse4.2 disabled"
+	exit 0
+fi
+
 echo "checking bins for sse4.2"
 
 for dir in $dirs; do


### PR DESCRIPTION
## What have you changed? (mandatory)

Don't run check-sse4_2.sh when SSE4.2 optimizations are disabled.

Fixes https://github.com/tikv/tikv/issues/4900

Note that [encountered an unrelated bug](https://github.com/tikv/tikv/issues/4367#issuecomment-503332664) in this script during testing. cc @shafreeck 

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Manual

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

Fixes https://github.com/tikv/tikv/issues/4900

Related to https://github.com/tikv/tikv/issues/4367#issuecomment-503332664

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

