### PR TITLE
coprocessor: reduce the size of 'RpnFn' from 32 bytes to 16 bytes

### DIFF
--- a/components/cop_codegen/src/lib.rs
+++ b/components/cop_codegen/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(proc_macro_diagnostic)]
-#![recursion_limit = "128"]
+#![recursion_limit = "256"]
 
 #[macro_use]
 extern crate darling;


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

The `RpnFn` has implemented the `Copy`, we should keep it as small as possible.

## What are the type of the changes? (mandatory)

This PR reduces the size of `RpnFn` from 32 bytes to 16 bytes.

See: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=3aed47a2f557473677826ca70f769bac

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Unit tests
