### PR TITLE
Support adjusting log level dynamically through HTTP API (#4033)

### DIFF
--- a/components/tikv_util/src/logger/mod.rs
+++ b/components/tikv_util/src/logger/mod.rs
@@ -34,9 +34,7 @@ const SLOG_CHANNEL_SIZE: usize = 10240;
 const SLOG_CHANNEL_OVERFLOW_STRATEGY: OverflowStrategy = OverflowStrategy::Block;
 const TIMESTAMP_FORMAT: &str = "%Y/%m/%d %H:%M:%S%.3f %:z";
 
-lazy_static! {
-    static ref LOG_LEVEL: AtomicUsize = AtomicUsize::new(usize::max_value());
-}
+static LOG_LEVEL: AtomicUsize = AtomicUsize::new(usize::max_value());
 
 pub fn init_log<D>(
     drain: D,

--- a/components/tikv_util/src/logger/mod.rs
+++ b/components/tikv_util/src/logger/mod.rs
@@ -7,6 +7,7 @@ use std::env;
 use std::fmt;
 use std::io::{self, BufWriter};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 use std::thread;
 
@@ -33,6 +34,10 @@ const SLOG_CHANNEL_SIZE: usize = 10240;
 const SLOG_CHANNEL_OVERFLOW_STRATEGY: OverflowStrategy = OverflowStrategy::Block;
 const TIMESTAMP_FORMAT: &str = "%Y/%m/%d %H:%M:%S%.3f %:z";
 
+lazy_static! {
+    static ref LOG_LEVEL: AtomicUsize = AtomicUsize::new(usize::max_value());
+}
+
 pub fn init_log<D>(
     drain: D,
     level: Level,
@@ -45,6 +50,9 @@ where
     D: Drain + Send + 'static,
     <D as Drain>::Err: std::fmt::Display,
 {
+    // Set the initial log level used by the Drains
+    LOG_LEVEL.store(level.as_usize(), Ordering::Relaxed);
+
     // Only for debug purpose, so use environment instead of configuration file.
     if let Ok(extra_modules) = env::var("TIKV_DISABLE_LOG_TARGETS") {
         disabled_targets.extend(extra_modules.split(',').map(ToOwned::to_owned));
@@ -235,6 +243,14 @@ pub fn convert_log_level_to_slog_level(lv: log::Level) -> Level {
     }
 }
 
+pub fn get_log_level() -> Option<Level> {
+    Level::from_usize(LOG_LEVEL.load(Ordering::Relaxed))
+}
+
+pub fn set_log_level(new_level: Level) {
+    LOG_LEVEL.store(new_level.as_usize(), Ordering::SeqCst)
+}
+
 pub struct TikvFormat<D>
 where
     D: Decorator,
@@ -259,18 +275,22 @@ where
     type Err = io::Error;
 
     fn log(&self, record: &Record<'_>, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
-        self.decorator.with_record(record, values, |decorator| {
-            write_log_header(decorator, record)?;
-            write_log_msg(decorator, record)?;
-            write_log_fields(decorator, record, values)?;
+        if record.level().as_usize() <= LOG_LEVEL.load(Ordering::Relaxed) {
+            self.decorator.with_record(record, values, |decorator| {
+                write_log_header(decorator, record)?;
+                write_log_msg(decorator, record)?;
+                write_log_fields(decorator, record, values)?;
 
-            decorator.start_whitespace()?;
-            writeln!(decorator)?;
+                decorator.start_whitespace()?;
+                writeln!(decorator)?;
 
-            decorator.flush()?;
+                decorator.flush()?;
 
-            Ok(())
-        })
+                Ok(())
+            })?;
+        }
+
+        Ok(())
     }
 }
 
@@ -336,15 +356,17 @@ where
     type Err = slog::Never;
 
     fn log(&self, record: &Record<'_>, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
-        if let Err(e) = self.0.log(record, values) {
-            let fatal_drainer = Mutex::new(text_format(term_writer())).ignore_res();
-            fatal_drainer.log(record, values).unwrap();
-            let fatal_logger = slog::Logger::root(fatal_drainer, slog_o!());
-            slog::slog_crit!(
-                fatal_logger,
-                "logger encountered error";
-                "err" => %e,
-            );
+        if record.level().as_usize() <= LOG_LEVEL.load(Ordering::Relaxed) {
+            if let Err(e) = self.0.log(record, values) {
+                let fatal_drainer = Mutex::new(text_format(term_writer())).ignore_res();
+                fatal_drainer.log(record, values).unwrap();
+                let fatal_logger = slog::Logger::root(fatal_drainer, slog_o!());
+                slog::slog_crit!(
+                    fatal_logger,
+                    "logger encountered error";
+                    "err" => %e,
+                );
+            }
         }
         Ok(())
     }

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -38,12 +38,13 @@ use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
 use super::Result;
-use crate::config::ConfigController;
+use crate::config::{log_level_serde, ConfigController};
 use configuration::Configuration;
 use pd_client::RpcClient;
 use security::{self, SecurityConfig};
 use tikv_alloc::error::ProfError;
 use tikv_util::collections::HashMap;
+use tikv_util::logger::set_log_level;
 use tikv_util::metrics::dump;
 use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 
@@ -87,6 +88,13 @@ static MISSING_NAME: &[u8] = b"Missing param name";
 static MISSING_ACTIONS: &[u8] = b"Missing param actions";
 #[cfg(feature = "failpoints")]
 static FAIL_POINTS_REQUEST_PATH: &str = "/fail";
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct LogLevelRequest {
+    #[serde(with = "log_level_serde")]
+    pub log_level: slog::Level,
+}
 
 pub struct StatusServer<E, R> {
     thread_pool: Runtime,
@@ -398,6 +406,30 @@ where
                     err.to_string(),
                 )),
             }
+        }
+    }
+
+    async fn change_log_level(req: Request<Body>) -> hyper::Result<Response<Body>> {
+        let mut body = Vec::new();
+        req.into_body()
+            .try_for_each(|bytes| {
+                body.extend(bytes);
+                ok(())
+            })
+            .await?;
+
+        let log_level_request: std::result::Result<LogLevelRequest, serde_json::error::Error> =
+            serde_json::from_slice(&body);
+
+        match log_level_request {
+            Ok(req) => {
+                set_log_level(req.log_level);
+                Ok(Response::new(Body::empty()))
+            }
+            Err(err) => Ok(StatusServer::err_response(
+                StatusCode::BAD_REQUEST,
+                err.to_string(),
+            )),
         }
     }
 
@@ -720,6 +752,9 @@ where
                             (Method::GET, path) if path.starts_with("/region") => {
                                 Self::dump_region_meta(req, router).await
                             }
+                            (Method::PUT, path) if path.starts_with("/log-level") => {
+                                Self::change_log_level(req).await
+                            }
                             _ => Ok(StatusServer::err_response(
                                 StatusCode::NOT_FOUND,
                                 "path not found",
@@ -978,7 +1013,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::config::{ConfigController, TiKvConfig};
-    use crate::server::status_server::StatusServer;
+    use crate::server::status_server::{LogLevelRequest, StatusServer};
     use configuration::Configuration;
     use engine_rocks::RocksEngine;
     use raftstore::store::transport::CasualRouter;
@@ -986,6 +1021,7 @@ mod tests {
     use security::SecurityConfig;
     use test_util::new_security_cfg;
     use tikv_util::collections::HashSet;
+    use tikv_util::logger::get_log_level;
 
     #[derive(Clone)]
     struct MockRouter;
@@ -1433,6 +1469,54 @@ mod tests {
         let resp = block_on(handle).unwrap();
 
         assert_eq!(resp.status(), StatusCode::OK);
+        status_server.stop();
+    }
+
+    #[test]
+    fn test_change_log_level() {
+        let mut status_server = StatusServer::new(
+            1,
+            None,
+            ConfigController::default(),
+            Arc::new(SecurityConfig::default()),
+            MockRouter,
+        )
+        .unwrap();
+        let addr = "127.0.0.1:0".to_owned();
+        let _ = status_server.start(addr.clone(), addr);
+
+        let uri = Uri::builder()
+            .scheme("http")
+            .authority(status_server.listening_addr().to_string().as_str())
+            .path_and_query("/log-level")
+            .build()
+            .unwrap();
+
+        let new_log_level = slog::Level::Debug;
+        let mut log_level_request = Request::new(Body::from(
+            serde_json::to_string(&LogLevelRequest {
+                log_level: new_log_level,
+            })
+            .unwrap(),
+        ));
+        *log_level_request.method_mut() = Method::PUT;
+        *log_level_request.uri_mut() = uri;
+        log_level_request.headers_mut().insert(
+            hyper::header::CONTENT_TYPE,
+            hyper::header::HeaderValue::from_static("application/json"),
+        );
+
+        let handle = status_server.thread_pool.spawn(async move {
+            Client::new()
+                .request(log_level_request)
+                .await
+                .map(move |res| {
+                    assert_eq!(res.status(), StatusCode::OK);
+                    assert_eq!(get_log_level(), Some(new_log_level));
+                })
+                .unwrap()
+        });
+        block_on(handle).unwrap();
         status_server.stop();
     }
 }


### PR DESCRIPTION
Signed-off-by: andrisak <andrisak@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

A new endpoint was added to the StatusServer API that can be called using HTTP to change the log level during runtime. The new endpoint path is `/log-level`. Example invocation:

`curl -X PUT -H "Content-Type: application/json" -d '{"log-level":"debug"}' http://127.0.0.1:20180/log-level`

## What are the type of the changes? (mandatory)

New feature.

## How has this PR been tested? (mandatory)

The unit test `test_change_log_level` in `status_server` was extended to also test this endpoint.

Also ran basic integration tests by running pd-server, the updated tikv-server, and tidb-server and calling the endpoint. Monitored the tikv-server log to see if the entries had the expected level.

## Does this PR affect documentation (docs) or release note? (mandatory)

This change should be documented but it's not included in this PR.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

