### PR TITLE
coprocessor: refine the 'convert_*_to_int' functions

### DIFF
--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -110,7 +110,7 @@ macro_rules! overflow {
     }};
 }
 
-/// Converts an int value to a diferent int value.
+/// Converts an int value to a different int value.
 #[inline]
 pub fn convert_int_to_int(ctx: &mut EvalContext, val: i64, tp: FieldTypeTp) -> Result<i64> {
     let lower_bound = integer_signed_lower_bound(tp);
@@ -495,7 +495,7 @@ fn float_str_to_int_string<'a, 'b: 'a>(
     let e_idx = e_idx.unwrap();
     let exp = box_try!((&valid_float[e_idx + 1..]).parse::<i64>());
     if exp > 0 && int_cnt > (i64::MAX - exp) {
-        // (exp + inc_cnt) overflows MaxInt64. Add warning and return original float string
+        // (exp + int_cnt) overflows MaxInt64. Add warning and return original float string
         ctx.warnings
             .append_warning(Error::overflow("BIGINT", &valid_float));
         return Ok(Cow::Owned(valid_float.to_owned()));
@@ -562,7 +562,7 @@ mod tests {
     use std::sync::Arc;
     use std::{f64, i64, isize, u64};
 
-    use crate::coprocessor::codec::error::{ERR_DATA_OUT_OF_RANGE,WARN_DATA_TRUNCATED};
+    use crate::coprocessor::codec::error::{ERR_DATA_OUT_OF_RANGE, WARN_DATA_TRUNCATED};
     use crate::coprocessor::dag::expr::Flag;
     use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
 
@@ -862,14 +862,18 @@ mod tests {
         let val = convert_bytes_to_int(&mut ctx, bs, FieldTypeTp::LongLong);
         assert_eq!(val.unwrap(), 123i64);
         assert_eq!(ctx.warnings.warning_cnt, 1);
-        
+
         let mut ctx = EvalContext::new(Arc::new(EvalConfig::from_flag(Flag::TRUNCATE_AS_WARNING)));
         let val = convert_bytes_to_int(&mut ctx, &invalid_utf8, FieldTypeTp::LongLong);
         assert_eq!(val.unwrap(), 123i64);
-        // note: 
+        // note:
         // warning 1: vec!['1' as u8, '2' as u8, '3' as u8, 0, 159, 146, 150] -> utf8
         // warning 2: vec!['1' as u8, '2' as u8, '3' as u8, 0] -> float
-        assert_eq!(ctx.warnings.warning_cnt, 2, "unexpected warning: {:?}", ctx.warnings.warnings);
+        assert_eq!(
+            ctx.warnings.warning_cnt, 2,
+            "unexpected warning: {:?}",
+            ctx.warnings.warnings
+        );
     }
 
     #[test]

--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -205,7 +205,6 @@ pub fn convert_duration_to_int(
     dur: Duration,
     tp: FieldTypeTp,
 ) -> Result<i64> {
-    // It's OK to clone because duration only occupies 8 bytes after #4858 merged
     let dur = dur.round_frac(DEFAULT_FSP)?;
     let val = Decimal::try_from(dur)?.as_i64_with_ctx(ctx)?;
     convert_int_to_int(ctx, val, tp)

--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -852,7 +852,7 @@ mod tests {
         assert_eq!(ctx.warnings.warning_cnt, 0);
 
         let mut ctx = EvalContext::new(Arc::new(EvalConfig::from_flag(Flag::IGNORE_TRUNCATE)));
-        let invalid_utf8 = vec!['1' as u8, '2' as u8, '3' as u8, 0, 159, 146, 150];
+        let invalid_utf8 = vec![b'1', b'2', b'3', 0, 159, 146, 150];
         let val = convert_bytes_to_int(&mut ctx, &invalid_utf8, FieldTypeTp::LongLong);
         assert_eq!(val.unwrap(), 123i64);
         assert_eq!(ctx.warnings.warning_cnt, 0);

--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -10,6 +10,7 @@ use super::{Error, Result};
 use crate::coprocessor::dag::expr::EvalContext;
 
 /// `integer_unsigned_upper_bound` returns the max u64 values of different mysql types
+#[inline]
 pub fn integer_unsigned_upper_bound(tp: FieldTypeTp) -> u64 {
     match tp {
         FieldTypeTp::Tiny => u64::from(u8::MAX),
@@ -22,6 +23,7 @@ pub fn integer_unsigned_upper_bound(tp: FieldTypeTp) -> u64 {
 }
 
 /// `integer_signed_upper_bound` returns the max i64 values of different mysql types
+#[inline]
 pub fn integer_signed_upper_bound(tp: FieldTypeTp) -> i64 {
     match tp {
         FieldTypeTp::Tiny => i64::from(i8::MAX),
@@ -34,6 +36,7 @@ pub fn integer_signed_upper_bound(tp: FieldTypeTp) -> i64 {
 }
 
 /// `integer_signed_lower_bound` returns the min i64 values of different mysql types
+#[inline]
 pub fn integer_signed_lower_bound(tp: FieldTypeTp) -> i64 {
     match tp {
         FieldTypeTp::Tiny => i64::from(i8::MIN),
@@ -87,6 +90,7 @@ macro_rules! overflow {
 }
 
 /// `convert_int_to_int` converts an int value to a diferent int value.
+#[inline]
 pub fn convert_int_to_int(val: i64, tp: FieldTypeTp) -> Result<i64> {
     let lower_bound = integer_signed_lower_bound(tp);
     if val < lower_bound {
@@ -111,6 +115,7 @@ pub fn convert_uint_to_int(val: u64, tp: FieldTypeTp) -> Result<i64> {
 
 /// `convert_float_to_int` converts an f64 value to an i64 value.
 ///  Returns the overflow error if the value exceeds the boundary.
+#[inline]
 pub fn convert_float_to_int(fval: f64, tp: FieldTypeTp) -> Result<i64> {
     // TODO any performance problem to use round directly?
     let val = fval.round();
@@ -128,6 +133,7 @@ pub fn convert_float_to_int(fval: f64, tp: FieldTypeTp) -> Result<i64> {
 
 /// `convert_float_to_uint` converts a f64 value to a u64 value.
 /// Returns the overflow error if the value exceeds the boundary.
+#[inline]
 pub fn convert_float_to_uint(fval: f64, tp: FieldTypeTp) -> Result<u64> {
     // TODO any performance problem to use round directly?
     let val = fval.round();

--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -416,7 +416,7 @@ fn round_int_str(num_next_dot: char, s: &str) -> Cow<'_, str> {
         return Cow::Borrowed(s);
     }
 
-    let mut int_str = String::with_capacity(s.len());
+    let mut int_str = String::with_capacity(s.len() + 1);
     match s.rfind(|c| c != '9' && c != '+' && c != '-') {
         Some(idx) => {
             int_str.push_str(&s[..idx]);

--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -417,7 +417,7 @@ fn round_int_str(num_next_dot: char, s: &str) -> Cow<'_, str> {
         return Cow::Borrowed(s);
     }
 
-    let mut int_str = String::new();
+    let mut int_str = String::with_capacity(s.len());
     match s.rfind(|c| c != '9' && c != '+' && c != '-') {
         Some(idx) => {
             int_str.push_str(&s[..idx]);

--- a/src/coprocessor/codec/data_type/mod.rs
+++ b/src/coprocessor/codec/data_type/mod.rs
@@ -16,8 +16,9 @@ pub use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time as Date
 pub use self::scalar::{ScalarValue, ScalarValueRef};
 pub use self::vector::{VectorValue, VectorValueExt};
 
-use cop_datatype::EvalType;
+use cop_datatype::{EvalType, FieldTypeTp};
 
+use crate::coprocessor::codec::convert::convert_bytes_to_int;
 use crate::coprocessor::dag::expr::EvalContext;
 use crate::coprocessor::Result;
 
@@ -45,8 +46,7 @@ impl AsMySQLBool for Real {
 impl AsMySQLBool for Bytes {
     #[inline]
     fn as_mysql_bool(&self, context: &mut EvalContext) -> Result<bool> {
-        Ok(!self.is_empty()
-            && crate::coprocessor::codec::convert::bytes_to_int(context, self)? != 0)
+        Ok(!self.is_empty() && convert_bytes_to_int(context, self, FieldTypeTp::LongLong)? != 0)
     }
 }
 

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -349,8 +349,8 @@ impl Datum {
         let tp = FieldTypeTp::LongLong;
         match self {
             Datum::I64(i) => Ok(i),
-            Datum::U64(u) => convert::convert_uint_to_int(u, tp),
-            Datum::F64(f) => convert::convert_float_to_int(f, tp),
+            Datum::U64(u) => convert::convert_uint_to_int(ctx, u, tp),
+            Datum::F64(f) => convert::convert_float_to_int(ctx, f, tp),
             Datum::Bytes(bs) => convert::convert_bytes_to_int(ctx, &bs, FieldTypeTp::LongLong),
             Datum::Time(mut t) => {
                 t.round_frac(mysql::DEFAULT_FSP)?;

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -1669,7 +1669,7 @@ mod tests {
             (Datum::F64(-0.4), Some(false)),
             (Datum::Null, None),
             (b"".as_ref().into(), Some(false)),
-            (b"0.5".as_ref().into(), Some(false)),
+            (b"0.5".as_ref().into(), Some(true)),
             (b"0".as_ref().into(), Some(false)),
             (b"2".as_ref().into(), Some(true)),
             (b"abc".as_ref().into(), Some(false)),

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -281,7 +281,10 @@ impl Datum {
             Datum::I64(i) => Some(i != 0),
             Datum::U64(u) => Some(u != 0),
             Datum::F64(f) => Some(f.round() != 0f64),
-            Datum::Bytes(ref bs) => Some(!bs.is_empty() && convert::bytes_to_int(ctx, bs)? != 0),
+            Datum::Bytes(ref bs) => Some(
+                !bs.is_empty()
+                    && convert::convert_bytes_to_int(ctx, bs, FieldTypeTp::LongLong)? != 0,
+            ),
             Datum::Time(t) => Some(!t.is_zero()),
             Datum::Dur(d) => Some(!d.is_zero()),
             Datum::Dec(d) => Some(d.as_f64()?.round() != 0f64),
@@ -348,7 +351,7 @@ impl Datum {
             Datum::I64(i) => Ok(i),
             Datum::U64(u) => convert::convert_uint_to_int(u, tp),
             Datum::F64(f) => convert::convert_float_to_int(f, tp),
-            Datum::Bytes(bs) => convert::bytes_to_int(ctx, &bs),
+            Datum::Bytes(bs) => convert::convert_bytes_to_int(ctx, &bs, FieldTypeTp::LongLong),
             Datum::Time(mut t) => {
                 t.round_frac(mysql::DEFAULT_FSP)?;
                 let d = t.to_decimal()?;

--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -343,13 +343,11 @@ impl Datum {
     /// `into_i64` converts self into i64.
     /// source function name is `ToInt64`.
     pub fn into_i64(self, ctx: &mut EvalContext) -> Result<i64> {
-        let (lower_bound, upper_bound) = (i64::MIN, i64::MAX);
         let tp = FieldTypeTp::LongLong;
         match self {
             Datum::I64(i) => Ok(i),
-            Datum::U64(u) => convert::convert_uint_to_int(u, upper_bound, tp),
-
-            Datum::F64(f) => convert::convert_float_to_int(f, lower_bound, upper_bound, tp),
+            Datum::U64(u) => convert::convert_uint_to_int(u, tp),
+            Datum::F64(f) => convert::convert_float_to_int(f, tp),
             Datum::Bytes(bs) => convert::bytes_to_int(ctx, &bs),
             Datum::Time(mut t) => {
                 t.round_frac(mysql::DEFAULT_FSP)?;

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -22,10 +22,10 @@ impl ScalarFunc {
     pub fn cast_real_as_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         let val = try_opt!(self.children[0].eval_real(ctx, row));
         if self.field_type.flag().contains(FieldTypeFlag::UNSIGNED) {
-            let uval = convert_float_to_uint(val, u64::MAX, FieldTypeTp::Double)?;
+            let uval = convert_float_to_uint(val, FieldTypeTp::LongLong)?;
             Ok(Some(uval as i64))
         } else {
-            let res = convert_float_to_int(val, i64::MIN, i64::MAX, FieldTypeTp::Double)?;
+            let res = convert_float_to_int(val, FieldTypeTp::LongLong)?;
             Ok(Some(res))
         }
     }

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -8,7 +8,9 @@ use cop_datatype::prelude::*;
 use cop_datatype::{self, FieldTypeFlag, FieldTypeTp};
 
 use super::{Error, EvalContext, Result, ScalarFunc};
-use crate::coprocessor::codec::convert::{self, convert_float_to_int, convert_float_to_uint};
+use crate::coprocessor::codec::convert::{
+    self, convert_bytes_to_int, convert_float_to_int, convert_float_to_uint,
+};
 use crate::coprocessor::codec::mysql::decimal::RoundMode;
 use crate::coprocessor::codec::mysql::{charset, Decimal, Duration, Json, Res, Time, TimeType};
 use crate::coprocessor::codec::{mysql, Datum};
@@ -61,7 +63,7 @@ impl ScalarFunc {
             _ => false,
         };
         let res = if is_negative {
-            convert::bytes_to_int(ctx, &val).map(|v| {
+            convert_bytes_to_int(ctx, &val, FieldTypeTp::LongLong).map(|v| {
                 ctx.warnings
                     .append_warning(Error::cast_neg_int_as_unsigned());
                 v

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -24,10 +24,10 @@ impl ScalarFunc {
     pub fn cast_real_as_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         let val = try_opt!(self.children[0].eval_real(ctx, row));
         if self.field_type.flag().contains(FieldTypeFlag::UNSIGNED) {
-            let uval = convert_float_to_uint(val, FieldTypeTp::LongLong)?;
+            let uval = convert_float_to_uint(ctx, val, FieldTypeTp::LongLong)?;
             Ok(Some(uval as i64))
         } else {
-            let res = convert_float_to_int(val, FieldTypeTp::LongLong)?;
+            let res = convert_float_to_int(ctx, val, FieldTypeTp::LongLong)?;
             Ok(Some(res))
         }
     }

--- a/src/coprocessor/dag/expr/ctx.rs
+++ b/src/coprocessor/dag/expr/ctx.rs
@@ -47,6 +47,8 @@ bitflags! {
 
         /// DIVIDED_BY_ZERO_AS_WARNING indicates if DividedByZero should be returned as warning.
         const DIVIDED_BY_ZERO_AS_WARNING = 1 << 8;
+        /// `IN_LOAD_DATA_STMT` indicates if this is a LOAD DATA statement.
+        const IN_LOAD_DATA_STMT = 1 << 10;
     }
 }
 
@@ -289,6 +291,15 @@ impl EvalContext {
             &mut self.warnings,
             EvalWarnings::new(self.cfg.max_warning_cnt),
         )
+    }
+
+    /// Indicates whether values less than 0 should be clipped to 0 for unsigned
+    /// integer types. This is the case for `insert`, `update`, `alter table` and
+    /// `load data infile` statements, when not in strict SQL mode.
+    /// see https://dev.mysql.com/doc/refman/5.7/en/out-of-range-and-overflow.html
+    pub fn should_clip_to_zero(&self) -> bool {
+        self.cfg.flag.contains(Flag::IN_INSERT_STMT)
+            || self.cfg.flag.contains(Flag::IN_LOAD_DATA_STMT)
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

1. add functions to retrieve boundary of integer types.
2. add function `convert_*_to_int` and related tests.
3. `convert_json_to_int` directly use `Json::cast_as_int` which behavior is not correct. This will be fixed in the next PR.

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- New feature (change which adds functionality)
- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Unit tests

