### PR TITLE
[release-3.0] engine: add titan key only option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#94d50c897e8a289e1e1bf43661096b78920eadc9"
+source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#4d2381ec21bc8982db96e7e81e5b640ad7164001"
 dependencies = [
  "bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#94d50c897e8a289e1e1bf43661096b78920eadc9"
+source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#4d2381ec21bc8982db96e7e81e5b640ad7164001"
 dependencies = [
  "bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#94d50c897e8a289e1e1bf43661096b78920eadc9"
+source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#4d2381ec21bc8982db96e7e81e5b640ad7164001"
 dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/engine/src/iterable.rs
+++ b/components/engine/src/iterable.rs
@@ -16,6 +16,8 @@ pub struct IterOption {
     upper_bound: Option<KeyBuilder>,
     prefix_same_as_start: bool,
     fill_cache: bool,
+    // only supported when Titan enabled, otherwise it doesn't take effect.
+    titan_key_only: bool,
     seek_mode: SeekMode,
 }
 
@@ -30,6 +32,7 @@ impl IterOption {
             upper_bound,
             prefix_same_as_start: false,
             fill_cache,
+            titan_key_only: false,
             seek_mode: SeekMode::TotalOrder,
         }
     }
@@ -48,6 +51,11 @@ impl IterOption {
     #[inline]
     pub fn fill_cache(&mut self, v: bool) {
         self.fill_cache = v;
+    }
+
+    #[inline]
+    pub fn titan_key_only(&mut self, v: bool) {
+        self.titan_key_only = v;
     }
 
     #[inline]
@@ -101,6 +109,9 @@ impl IterOption {
     pub fn build_read_opts(self) -> ReadOptions {
         let mut opts = ReadOptions::new();
         opts.fill_cache(self.fill_cache);
+        if self.titan_key_only {
+            opts.set_titan_key_only(true);
+        }
         if self.total_order_seek_used() {
             opts.set_total_order_seek(true);
         } else if self.prefix_same_as_start {
@@ -123,6 +134,7 @@ impl Default for IterOption {
             upper_bound: None,
             prefix_same_as_start: false,
             fill_cache: true,
+            titan_key_only: false,
             seek_mode: SeekMode::TotalOrder,
         }
     }

--- a/components/engine/src/util.rs
+++ b/components/engine/src/util.rs
@@ -64,7 +64,12 @@ pub fn delete_all_in_range_cf(
     } else {
         let start = KeyBuilder::from_slice(start_key, 0, 0);
         let end = KeyBuilder::from_slice(end_key, 0, 0);
-        let iter_opt = IterOption::new(Some(start), Some(end), false);
+        let mut iter_opt = IterOption::new(Some(start), Some(end), false);
+        if db.is_titan() {
+            // Cause DeleteFilesInRange may expose old blob index keys, setting key only for Titan
+            // to avoid referring to missing blob files.
+            iter_opt.titan_key_only(true);
+        }
         let mut it = db.new_iterator_cf(cf, iter_opt)?;
         it.seek(start_key.into());
         while it.valid() {

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -227,7 +227,7 @@ fn test_serde_custom_tikv_config() {
             soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
             hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
             titan: TitanCfConfig {
-                min_blob_size: 2018,
+                min_blob_size: ReadableSize(2018),
                 blob_file_compression: CompressionType::Zstd,
                 blob_cache_size: ReadableSize::gb(12),
                 min_gc_batch_size: ReadableSize::kb(12),
@@ -278,7 +278,7 @@ fn test_serde_custom_tikv_config() {
             soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
             hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
             titan: TitanCfConfig {
-                min_blob_size: ReadableSize::gb(4).0 as u64, // disable titan default
+                min_blob_size: ReadableSize::gb(4), // disable titan default
                 blob_file_compression: CompressionType::Lz4,
                 blob_cache_size: ReadableSize::mb(0),
                 min_gc_batch_size: ReadableSize::mb(16),
@@ -329,7 +329,7 @@ fn test_serde_custom_tikv_config() {
             soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
             hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
             titan: TitanCfConfig {
-                min_blob_size: ReadableSize::gb(4).0 as u64, // disable titan default
+                min_blob_size: ReadableSize::gb(4), // disable titan default
                 blob_file_compression: CompressionType::Lz4,
                 blob_cache_size: ReadableSize::mb(0),
                 min_gc_batch_size: ReadableSize::mb(16),
@@ -380,7 +380,7 @@ fn test_serde_custom_tikv_config() {
             soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
             hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
             titan: TitanCfConfig {
-                min_blob_size: ReadableSize::gb(4).0 as u64, // disable titan default
+                min_blob_size: ReadableSize::gb(4), // disable titan default
                 blob_file_compression: CompressionType::Lz4,
                 blob_cache_size: ReadableSize::mb(0),
                 min_gc_batch_size: ReadableSize::mb(16),
@@ -397,6 +397,7 @@ fn test_serde_custom_tikv_config() {
             dirname: "bar".to_owned(),
             disable_gc: false,
             max_background_gc: 9,
+            purge_obsolete_files_period: ReadableDuration::secs(1),
         },
     };
     value.raftdb = RaftDbConfig {

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -173,6 +173,7 @@ enabled = true
 dirname = "bar"
 disable-gc = false
 max-background-gc = 9
+purge-obsolete-files-period = "1s"
 
 [rocksdb.defaultcf]
 block-size = "12KB"
@@ -216,7 +217,7 @@ prop-size-index-distance = 4000000
 prop-keys-index-distance = 40000
 
 [rocksdb.defaultcf.titan]
-min-blob-size = 2018
+min-blob-size = "2018B"
 blob-file-compression = "zstd"
 blob-cache-size = "12GB"
 min-gc-batch-size = "12KB"


### PR DESCRIPTION
## What have you changed? (mandatory)
Cause DeleteFilesInRange may expose old blob index keys, setting key only for Titan to avoid referring to missing blob files.

## What are the type of the changes? (mandatory)
- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)
unit-test by https://github.com/tikv/tikv/pull/4946

## Does this PR affect documentation (docs) or release note? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No

