### PR TITLE
coprocesser: make `TimeIsNull` be compatible with MySQL

### DIFF
--- a/src/coprocessor/dag/expr/builtin_op.rs
+++ b/src/coprocessor/dag/expr/builtin_op.rs
@@ -135,7 +135,7 @@ impl ScalarFunc {
             return Ok(Some(true as i64));
         }
 
-        if self.implicit_args.len() > 0 {
+        if !self.implicit_args.is_empty() {
             let is_not_null_col = self.implicit_args[0].i64();
             if is_not_null_col > 0 && arg.unwrap().is_zero() {
                 // From MySQL document:


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Make `TimeIsNull` be compatible with MySQL (also fix this issue https://github.com/pingcap/tidb/issues/9763).

The description below is from MySQL document, and it's why `TimeIsNull` is not compatible with MySQL now (`NOT NULL` is not considered):
```
For DATE and DATETIME columns that are declared as NOT NULL, 
you can find the special date '0000-00-00' by using a statement like this:
"SELECT * FROM tbl_name WHERE date_column IS NULL"
```

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Please describe the tests that you ran to verify your changes. Have you finished unit tests, integration tests, or manual tests? What additional tests would give you greater confidence in this change?

Unit tests.