### PR TITLE
Don't make users worry about logs

### DIFF
--- a/src/coprocessor/dag/aggr_fn/parser.rs
+++ b/src/coprocessor/dag/aggr_fn/parser.rs
@@ -54,7 +54,7 @@ fn map_pb_sig_to_aggr_func_parser(value: ExprType) -> Result<Box<dyn AggrDefinit
         ExprType::Max => Ok(Box::new(AggrFnDefinitionParserExtremum::<Max>::new())),
         ExprType::Min => Ok(Box::new(AggrFnDefinitionParserExtremum::<Min>::new())),
         v => Err(box_err!(
-            "Aggregation function expr type {:?} is not supported in batch mode",
+            "Aggregation function meet blacklist aggr function {:?}",
             v
         )),
     }
@@ -70,7 +70,7 @@ impl AggrDefinitionParser for AllAggrDefinitionParser {
         let parser = map_pb_sig_to_aggr_func_parser(aggr_def.get_tp())?;
         parser.check_supported(aggr_def).map_err(|e| {
             Error::Other(box_err!(
-                "Aggregation function for expr type {:?} is not supported: {}",
+                "Aggregation function meet blacklist expr type {:?}: {}",
                 aggr_def.get_tp(),
                 e
             ))

--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -36,43 +36,32 @@ impl DAGBuilder {
             match ed.get_tp() {
                 ExecType::TypeTableScan => {
                     let descriptor = ed.get_tbl_scan();
-                    BatchTableScanExecutor::check_supported(&descriptor).map_err(|e| {
-                        Error::Other(box_err!("Unable to use BatchTableScanExecutor: {}", e))
-                    })?;
+                    BatchTableScanExecutor::check_supported(&descriptor)
+                        .map_err(|e| Error::Other(box_err!("BatchTableScanExecutor: {}", e)))?;
                 }
                 ExecType::TypeIndexScan => {
                     let descriptor = ed.get_idx_scan();
-                    BatchIndexScanExecutor::check_supported(&descriptor).map_err(|e| {
-                        Error::Other(box_err!("Unable to use BatchIndexScanExecutor: {}", e))
-                    })?;
+                    BatchIndexScanExecutor::check_supported(&descriptor)
+                        .map_err(|e| Error::Other(box_err!("BatchIndexScanExecutor: {}", e)))?;
                 }
                 ExecType::TypeSelection => {
                     let descriptor = ed.get_selection();
-                    BatchSelectionExecutor::check_supported(&descriptor).map_err(|e| {
-                        Error::Other(box_err!("Unable to use BatchSelectionExecutor: {}", e))
-                    })?;
+                    BatchSelectionExecutor::check_supported(&descriptor)
+                        .map_err(|e| Error::Other(box_err!("BatchSelectionExecutor: {}", e)))?;
                 }
                 ExecType::TypeAggregation | ExecType::TypeStreamAgg
                     if ed.get_aggregation().get_group_by().is_empty() =>
                 {
                     let descriptor = ed.get_aggregation();
                     BatchSimpleAggregationExecutor::check_supported(&descriptor).map_err(|e| {
-                        Error::Other(box_err!(
-                            "Unable to use BatchSimpleAggregationExecutor: {}",
-                            e
-                        ))
+                        Error::Other(box_err!("BatchSimpleAggregationExecutor: {}", e))
                     })?;
                 }
                 ExecType::TypeAggregation => {
                     let descriptor = ed.get_aggregation();
                     if BatchFastHashAggregationExecutor::check_supported(&descriptor).is_err() {
                         BatchSlowHashAggregationExecutor::check_supported(&descriptor).map_err(
-                            |e| {
-                                Error::Other(box_err!(
-                                    "Unable to use BatchSlowHashAggregationExecutor: {}",
-                                    e
-                                ))
-                            },
+                            |e| Error::Other(box_err!("BatchSlowHashAggregationExecutor: {}", e)),
                         )?;
                     }
                 }
@@ -81,18 +70,14 @@ impl DAGBuilder {
                     //       It is undefined behavior if the source is unordered.
                     let descriptor = ed.get_aggregation();
                     BatchStreamAggregationExecutor::check_supported(&descriptor).map_err(|e| {
-                        Error::Other(box_err!(
-                            "Unable to use BatchStreamAggregationExecutor: {}",
-                            e
-                        ))
+                        Error::Other(box_err!("BatchStreamAggregationExecutor: {}", e))
                     })?;
                 }
                 ExecType::TypeLimit => {}
                 ExecType::TypeTopN => {
                     let descriptor = ed.get_topN();
-                    BatchTopNExecutor::check_supported(&descriptor).map_err(|e| {
-                        Error::Other(box_err!("Unable to use BatchTopNExecutor: {}", e))
-                    })?;
+                    BatchTopNExecutor::check_supported(&descriptor)
+                        .map_err(|e| Error::Other(box_err!("BatchTopNExecutor: {}", e)))?;
                 }
             }
         }
@@ -508,7 +493,7 @@ impl DAGBuilder {
             let build_batch_result =
                 super::builder::DAGBuilder::check_build_batch(req.get_executors());
             if let Err(e) = build_batch_result {
-                info!("Coprocessor request cannot be batched"; "start_ts" => req.get_start_ts(), "reason" => %e);
+                debug!("Successfully use normal Coprocessor query engine"; "start_ts" => req.get_start_ts(), "reason" => %e);
             } else {
                 is_batch = true;
             }

--- a/src/coprocessor/dag/rpn_expr/types/expr_builder.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_builder.rs
@@ -44,7 +44,7 @@ impl RpnExpressionBuilder {
             ExprType::MysqlDecimal => {}
             ExprType::MysqlJson => {}
             ExprType::ColumnRef => {}
-            _ => return Err(box_err!("Unsupported expression type {:?}", c.get_tp())),
+            _ => return Err(box_err!("Blacklist expression type {:?}", c.get_tp())),
         }
 
         Ok(())


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Logs when batch execution cannot be utilized is not a big deal. This PR adjusts the level and the wording of batch execution log outputs, so that user will won't be worried when seeing these logs.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)
