### PR TITLE
Set blob_run_mode=ReadOnly for non-default CFs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -115,6 +115,7 @@ impl TitanCfConfig {
         opts.set_discardable_ratio(self.discardable_ratio);
         opts.set_sample_ratio(self.sample_ratio);
         opts.set_merge_small_file_threshold(self.merge_small_file_threshold.0 as u64);
+        opts.set_blob_run_mode(self.blob_run_mode.into());
         opts
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -404,8 +404,9 @@ cf_config!(WriteCfConfig);
 
 impl Default for WriteCfConfig {
     fn default() -> WriteCfConfig {
+        // Setting blob_run_mode=read_only effectively disable Titan.
         let mut titan = TitanCfConfig::default();
-        titan.min_blob_size = ReadableSize::gb(4).0 as u64;
+        titan.blob_run_mode = BlobRunMode::ReadOnly;
         WriteCfConfig {
             block_size: ReadableSize::kb(64),
             block_cache_size: ReadableSize::mb(memory_mb_for_cf(false, CF_WRITE) as u64),
@@ -478,8 +479,9 @@ cf_config!(LockCfConfig);
 
 impl Default for LockCfConfig {
     fn default() -> LockCfConfig {
+        // Setting blob_run_mode=read_only effectively disable Titan.
         let mut titan = TitanCfConfig::default();
-        titan.min_blob_size = ReadableSize::gb(4).0 as u64;
+        titan.blob_run_mode = BlobRunMode::ReadOnly;
         LockCfConfig {
             block_size: ReadableSize::kb(16),
             block_cache_size: ReadableSize::mb(memory_mb_for_cf(false, CF_LOCK) as u64),
@@ -534,8 +536,9 @@ cf_config!(RaftCfConfig);
 
 impl Default for RaftCfConfig {
     fn default() -> RaftCfConfig {
+        // Setting blob_run_mode=read_only effectively disable Titan.
         let mut titan = TitanCfConfig::default();
-        titan.min_blob_size = ReadableSize::gb(4).0 as u64;
+        titan.blob_run_mode = BlobRunMode::ReadOnly;
         RaftCfConfig {
             block_size: ReadableSize::kb(16),
             block_cache_size: ReadableSize::mb(128),

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -235,7 +235,7 @@ fn test_serde_custom_tikv_config() {
                 discardable_ratio: 0.00156,
                 sample_ratio: 0.982,
                 merge_small_file_threshold: ReadableSize::kb(21),
-                blob_run_mode: BlobRunMode::ReadOnly,
+                blob_run_mode: BlobRunMode::Fallback,
             },
             prop_size_index_distance: 4000000,
             prop_keys_index_distance: 40000,
@@ -279,7 +279,7 @@ fn test_serde_custom_tikv_config() {
             soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
             hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
             titan: TitanCfConfig {
-                min_blob_size: ReadableSize::gb(4).0 as u64, // disable titan default
+                min_blob_size: 1024, // default value
                 blob_file_compression: CompressionType::Lz4,
                 blob_cache_size: ReadableSize::mb(0),
                 min_gc_batch_size: ReadableSize::mb(16),
@@ -287,7 +287,7 @@ fn test_serde_custom_tikv_config() {
                 discardable_ratio: 0.5,
                 sample_ratio: 0.1,
                 merge_small_file_threshold: ReadableSize::mb(8),
-                blob_run_mode: BlobRunMode::Normal,
+                blob_run_mode: BlobRunMode::ReadOnly,
             },
             prop_size_index_distance: 4000000,
             prop_keys_index_distance: 40000,
@@ -331,7 +331,7 @@ fn test_serde_custom_tikv_config() {
             soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
             hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
             titan: TitanCfConfig {
-                min_blob_size: ReadableSize::gb(4).0 as u64, // disable titan default
+                min_blob_size: 1024, // default value
                 blob_file_compression: CompressionType::Lz4,
                 blob_cache_size: ReadableSize::mb(0),
                 min_gc_batch_size: ReadableSize::mb(16),
@@ -339,7 +339,7 @@ fn test_serde_custom_tikv_config() {
                 discardable_ratio: 0.5,
                 sample_ratio: 0.1,
                 merge_small_file_threshold: ReadableSize::mb(8),
-                blob_run_mode: BlobRunMode::Normal,
+                blob_run_mode: BlobRunMode::ReadOnly, // default value
             },
             prop_size_index_distance: 4000000,
             prop_keys_index_distance: 40000,
@@ -383,7 +383,7 @@ fn test_serde_custom_tikv_config() {
             soft_pending_compaction_bytes_limit: ReadableSize::gb(12),
             hard_pending_compaction_bytes_limit: ReadableSize::gb(12),
             titan: TitanCfConfig {
-                min_blob_size: ReadableSize::gb(4).0 as u64, // disable titan default
+                min_blob_size: 1024, // default value
                 blob_file_compression: CompressionType::Lz4,
                 blob_cache_size: ReadableSize::mb(0),
                 min_gc_batch_size: ReadableSize::mb(16),
@@ -391,7 +391,7 @@ fn test_serde_custom_tikv_config() {
                 discardable_ratio: 0.5,
                 sample_ratio: 0.1,
                 merge_small_file_threshold: ReadableSize::mb(8),
-                blob_run_mode: BlobRunMode::Normal,
+                blob_run_mode: BlobRunMode::ReadOnly, // default value
             },
             prop_size_index_distance: 4000000,
             prop_keys_index_distance: 40000,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -224,7 +224,7 @@ max-gc-batch-size = "12MB"
 discardable-ratio = 0.00156
 sample-ratio = 0.982
 merge-small-file-threshold = "21KB"
-blob-run-mode = "read-only"
+blob-run-mode = "fallback"
 
 [rocksdb.writecf]
 block-size = "12KB"


### PR DESCRIPTION
## What have you changed? (mandatory)

Currently titan is disabled for non-default CFs by setting min_blob_size=4GB. Changing to set blob_run_mode=ReadOnly which will disable titan even value size is >4GB (though it will never happen)

## What are the type of the changes? (mandatory)
Improvement

## How has this PR been tested? (mandatory)
Manually start tikv-server and check rocksdb log to set blob_run_mode is set.

## Does this PR affect documentation (docs) or release note? (mandatory)
no

## Does this PR affect tidb-ansible update? (mandatory)
no

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

