### PR TITLE
Adds /config endpoint to status server that returns the tikv config

### DIFF
--- a/src/binutil/server.rs
+++ b/src/binutil/server.rs
@@ -344,7 +344,8 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     let mut status_enabled = cfg.metric.address.is_empty() && !server_cfg.status_addr.is_empty();
 
     // Create a status server.
-    let mut status_server = StatusServer::new(server_cfg.status_thread_pool_size);
+    // TODO: How to keep cfg updated?
+    let mut status_server = StatusServer::new(server_cfg.status_thread_pool_size, cfg.clone());
     if status_enabled {
         // Start the status server.
         if let Err(e) = status_server.start(server_cfg.status_addr) {

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -218,11 +218,10 @@ impl StatusServer {
         let config = self.config.clone();
 
         // Start to serve.
-        let server =
-            builder.serve(move || {
-                let config = config.clone();
-                // Create a status service.
-                service_fn(
+        let server = builder.serve(move || {
+            let config = config.clone();
+            // Create a status service.
+            service_fn(
                     move |req: Request<Body>| -> Box<
                         dyn Future<Item = Response<Body>, Error = hyper::Error> + Send,
                     > {
@@ -248,7 +247,7 @@ impl StatusServer {
                         }
                     },
                 )
-            });
+        });
         self.addr = Some(server.local_addr());
         let graceful = server
             .with_graceful_shutdown(self.rx.take().unwrap())

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -198,7 +198,6 @@ impl StatusServer {
         let res = match serde_json::to_string(config.as_ref()) {
             Ok(json) => {
                 Response::builder()
-//                    .status(StatusCode::OK)
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(Body::from(json))
                     .unwrap()

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -1,12 +1,13 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::sync::Arc;
 use futures::future::{err, ok};
 use futures::sync::oneshot::{Receiver, Sender};
 #[cfg(not(feature = "no-fail"))]
 use futures::Stream;
 use futures::{self, Future};
 use hyper::service::service_fn;
-use hyper::{self, Body, Method, Request, Response, Server, StatusCode};
+use hyper::{self, Body, Method, Request, Response, Server, StatusCode, header};
 use tempfile::TempDir;
 use tokio_threadpool::{Builder, ThreadPool};
 
@@ -18,6 +19,7 @@ use tikv_alloc::error::ProfError;
 use tikv_util::collections::HashMap;
 use tikv_util::metrics::dump;
 use tikv_util::timer::GLOBAL_TIMER_HANDLE;
+use crate::config::TiKvConfig;
 
 mod profiler_guard {
     use tikv_alloc::error::ProfResult;
@@ -73,10 +75,11 @@ pub struct StatusServer {
     tx: Sender<()>,
     rx: Option<Receiver<()>>,
     addr: Option<SocketAddr>,
+    config: Arc<TiKvConfig>,
 }
 
 impl StatusServer {
-    pub fn new(status_thread_pool_size: usize) -> Self {
+    pub fn new(status_thread_pool_size: usize, tikv_config: TiKvConfig) -> Self {
         let thread_pool = Builder::new()
             .pool_size(status_thread_pool_size)
             .name_prefix("status-server-")
@@ -93,10 +96,11 @@ impl StatusServer {
             tx,
             rx: Some(rx),
             addr: None,
+            config: Arc::new(tikv_config),
         }
     }
 
-    pub fn dump_prof(seconds: u64) -> Box<dyn Future<Item = Vec<u8>, Error = ProfError> + Send> {
+    pub fn dump_prof(seconds: u64) -> Box<dyn Future<Item=Vec<u8>, Error=ProfError> + Send> {
         let lock = match profiler_guard::ProfLock::new() {
             Err(e) => return Box::new(err(e)),
             Ok(lock) => lock,
@@ -108,7 +112,7 @@ impl StatusServer {
             timer
                 .delay(std::time::Instant::now() + std::time::Duration::from_secs(seconds))
                 .then(
-                    move |_| -> Box<dyn Future<Item = Vec<u8>, Error = ProfError> + Send> {
+                    move |_| -> Box<dyn Future<Item=Vec<u8>, Error=ProfError> + Send> {
                         let tmp_dir = match TempDir::new() {
                             Ok(tmp_dir) => tmp_dir,
                             Err(e) => return Box::new(err(e.into())),
@@ -142,7 +146,7 @@ impl StatusServer {
 
     pub fn dump_prof_to_resp(
         req: Request<Body>,
-    ) -> Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send> {
+    ) -> Box<dyn Future<Item=Response<Body>, Error=hyper::Error> + Send> {
         let query = match req.uri().query() {
             Some(query) => query,
             None => {
@@ -190,39 +194,62 @@ impl StatusServer {
         )
     }
 
+    fn config_handler(config: Arc<TiKvConfig>) -> Box<dyn Future<Item=Response<Body>, Error=hyper::Error> + Send> {
+        let res = match serde_json::to_string(config.as_ref()) {
+            Ok(json) => {
+                Response::builder()
+//                    .status(StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(json))
+                    .unwrap()
+            }
+            Err(_) => {
+                Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(Body::from("Internal Server Error"))
+                    .unwrap()
+            }
+        };
+        Box::new(ok(res))
+    }
+
     pub fn start(&mut self, status_addr: String) -> Result<()> {
         let addr = SocketAddr::from_str(&status_addr)?;
 
         // TODO: support TLS for the status server.
         let builder = Server::try_bind(&addr)?;
-
-        // Create a status service.
-        let service = |req: Request<Body>| -> Box<dyn Future<Item=Response<Body>, Error=hyper::Error> + Send> {
-            let path = req.uri().path().to_owned();
-            let method = req.method().to_owned();
-
-            #[cfg(not(feature = "no-fail"))]
-                {
-                    if path.starts_with(FAIL_POINTS_REQUEST_PATH) {
-                        return handle_fail_points_request(req);
-                    }
-                }
-
-            match (method, path.as_ref()) {
-                (Method::GET, "/metrics") => Box::new(ok(Response::new(dump().into()))),
-                (Method::GET, "/status") => Box::new(ok(Response::default())),
-                (Method::GET, "/pprof/profile") => Self::dump_prof_to_resp(req),
-                _ => {
-                    Box::new(ok(Response::builder()
-                        .status(StatusCode::NOT_FOUND)
-                        .body(Body::empty())
-                        .unwrap()))
-                }
-            }
-        };
+        let config = self.config.clone();
 
         // Start to serve.
-        let server = builder.serve(move || service_fn(service));
+        let server = builder.serve(move || {
+            let config = config.clone();
+            // Create a status service.
+            service_fn(
+                move |req: Request<Body>| -> Box<dyn Future<Item=Response<Body>, Error=hyper::Error> + Send> {
+                    let path = req.uri().path().to_owned();
+                    let method = req.method().to_owned();
+
+                    #[cfg(not(feature = "no-fail"))]
+                        {
+                            if path.starts_with(FAIL_POINTS_REQUEST_PATH) {
+                                return handle_fail_points_request(req);
+                            }
+                        }
+
+                    match (method, path.as_ref()) {
+                        (Method::GET, "/metrics") => Box::new(ok(Response::new(dump().into()))),
+                        (Method::GET, "/status") => Box::new(ok(Response::default())),
+                        (Method::GET, "/pprof/profile") => Self::dump_prof_to_resp(req),
+                        (Method::GET, "/config") => Self::config_handler(config.clone()),
+                        _ => {
+                            Box::new(ok(Response::builder()
+                                .status(StatusCode::NOT_FOUND)
+                                .body(Body::empty())
+                                .unwrap()))
+                        }
+                    }
+                })
+        });
         self.addr = Some(server.local_addr());
         let graceful = server
             .with_graceful_shutdown(self.rx.take().unwrap())
@@ -251,7 +278,7 @@ impl StatusServer {
 #[cfg(not(feature = "no-fail"))]
 fn handle_fail_points_request(
     req: Request<Body>,
-) -> Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send> {
+) -> Box<dyn Future<Item=Response<Body>, Error=hyper::Error> + Send> {
     let path = req.uri().path().to_owned();
     let method = req.method().to_owned();
     let fail_path = format!("{}/", FAIL_POINTS_REQUEST_PATH);
@@ -332,6 +359,7 @@ mod tests {
     #[cfg(not(feature = "no-fail"))]
     use futures::Stream;
     use hyper::{Body, Client, Method, Request, StatusCode, Uri};
+    use crate::config::TiKvConfig;
 
     lazy_static! {
         static ref LOCK: Mutex<()> = Mutex::new(());
@@ -346,7 +374,8 @@ mod tests {
 
     #[test]
     fn test_status_service() {
-        let mut status_server = StatusServer::new(1);
+        let config = TiKvConfig::default();
+        let mut status_server = StatusServer::new(1, config);
         let _ = status_server.start("127.0.0.1:0".to_string());
         let client = Client::new();
         let uri = Uri::builder()
@@ -370,11 +399,48 @@ mod tests {
         status_server.stop();
     }
 
+    #[test]
+    fn test_config_endpoint() {
+        let config = TiKvConfig::default();
+        let mut status_server = StatusServer::new(1, config);
+        let _ = status_server.start("127.0.0.1:0".to_string());
+        let client = Client::new();
+        let uri = Uri::builder()
+            .scheme("http")
+            .authority(status_server.listening_addr().to_string().as_str())
+            .path_and_query("/config")
+            .build()
+            .unwrap();
+        let handle = status_server.thread_pool.spawn_handle(lazy(move || {
+            client
+                .get(uri)
+                .and_then(|resp| {
+                    assert_eq!(resp.status(), StatusCode::OK);
+                    resp.into_body().concat2()
+                })
+                .map(|body| {
+                    let v = body.to_vec();
+                    let resp_json = String::from_utf8_lossy(&v).to_string();
+                    let cfg = TiKvConfig::default();
+                    serde_json::to_string(&cfg)
+                        .map(|cfg_json| {
+                            assert_eq!(resp_json, cfg_json);
+                        }).expect("Could not convert TiKvConfig to string");
+                })
+                .map_err(|err| {
+                    panic!("response status is not OK: {:?}", err)
+                })
+        }));
+        handle.wait().unwrap();
+        status_server.stop();
+    }
+
     #[cfg(not(feature = "no-fail"))]
     #[test]
     fn test_status_service_fail_endpoints() {
         let _gaurd = setup();
-        let mut status_server = StatusServer::new(1);
+        let config = TiKvConfig::default();
+        let mut status_server = StatusServer::new(1, config);
         let _ = status_server.start("127.0.0.1:0".to_string());
         let client = Client::new();
         let addr = status_server.listening_addr().to_string();
@@ -506,7 +572,8 @@ mod tests {
     #[test]
     fn test_status_service_fail_endpoints_can_trigger_fails() {
         let _gaurd = setup();
-        let mut status_server = StatusServer::new(1);
+        let config = TiKvConfig::default();
+        let mut status_server = StatusServer::new(1, config);
         let _ = status_server.start("127.0.0.1:0".to_string());
         let client = Client::new();
         let addr = status_server.listening_addr().to_string();
@@ -547,7 +614,8 @@ mod tests {
     #[test]
     fn test_status_service_fail_endpoints_should_give_404_when_feature_no_fail_exists() {
         let _gaurd = setup();
-        let mut status_server = StatusServer::new(1);
+        let config = TiKvConfig::default();
+        let mut status_server = StatusServer::new(1, config);
         let _ = status_server.start("127.0.0.1:0".to_string());
         let client = Client::new();
         let addr = status_server.listening_addr().to_string();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
* Adds a `/config` endpoint to `StatusServer` that returns the `TiKvConfig` as json
* Adds a unit test that checks if a `StatusServer` created with a default `TiKvConfig` returns a json string that is the same as serializing a default `TiKvConfig` to a json string directly.

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- New feature (change which adds functionality)


## How has this PR been tested? (mandatory)

- Manual testing (`curl http://status.server.addr:20180/config`)
- Unit test

## Refer to a related PR or issue link (optional)
#4901 