### PR TITLE
coprocesser: make `TimeIsNull` be compatible with MySQL

### DIFF
--- a/src/coprocessor/dag/expr/builtin_op.rs
+++ b/src/coprocessor/dag/expr/builtin_op.rs
@@ -138,22 +138,19 @@ impl ScalarFunc {
         }
 
         if !self.children.is_empty() {
-            match self.children[0] {
-                Expression::ColumnRef(_) => {
-                    //	Description below are from MySQL document:
-                    //		For DATE and DATETIME columns that are declared as NOT NULL,
-                    //		you can find the special date '0000-00-00' by using a statement like this:
-                    //		"SELECT * FROM tbl_name WHERE date_column IS NULL"
-                    if self.children[0]
-                        .field_type()
-                        .flag()
-                        .contains(FieldTypeFlag::NOT_NULL)
-                        && arg.unwrap().is_zero()
-                    {
-                        return Ok(Some(true as i64));
-                    }
+            if let Expression::ColumnRef(_) = self.children[0] {
+                //	Description below are from MySQL document:
+                //		For DATE and DATETIME columns that are declared as NOT NULL,
+                //		you can find the special date '0000-00-00' by using a statement like this:
+                //		"SELECT * FROM tbl_name WHERE date_column IS NULL"
+                if self.children[0]
+                    .field_type()
+                    .flag()
+                    .contains(FieldTypeFlag::NOT_NULL)
+                    && arg.unwrap().is_zero()
+                {
+                    return Ok(Some(true as i64));
                 }
-                _ => {}
             }
         }
 

--- a/src/coprocessor/dag/expr/builtin_op.rs
+++ b/src/coprocessor/dag/expr/builtin_op.rs
@@ -6,8 +6,8 @@ use std::i64;
 use super::{Error, EvalContext, Result, ScalarFunc};
 use crate::coprocessor::codec::mysql::Decimal;
 use crate::coprocessor::codec::Datum;
-use cop_datatype::{FieldTypeAccessor, FieldTypeFlag};
 use crate::coprocessor::dag::expr::Expression;
+use cop_datatype::{FieldTypeAccessor, FieldTypeFlag};
 
 impl ScalarFunc {
     pub fn logical_and(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
@@ -136,7 +136,7 @@ impl ScalarFunc {
         if arg.is_none() {
             return Ok(Some(true as i64));
         }
-        
+
         if !self.children.is_empty() {
             match self.children[0] {
                 Expression::ColumnRef(_) => {
@@ -144,15 +144,19 @@ impl ScalarFunc {
                     //		For DATE and DATETIME columns that are declared as NOT NULL,
                     //		you can find the special date '0000-00-00' by using a statement like this:
                     //		"SELECT * FROM tbl_name WHERE date_column IS NULL"
-                    if self.children[0].field_type().flag().contains(FieldTypeFlag::NOT_NULL) &&
-                        arg.unwrap().is_zero() {
+                    if self.children[0]
+                        .field_type()
+                        .flag()
+                        .contains(FieldTypeFlag::NOT_NULL)
+                        && arg.unwrap().is_zero()
+                    {
                         return Ok(Some(true as i64));
                     }
                 }
                 _ => {}
             }
         }
-        
+
         Ok(Some(false as i64))
     }
 
@@ -207,13 +211,15 @@ impl ScalarFunc {
 #[cfg(test)]
 mod tests {
     use crate::coprocessor::codec::mysql::Duration;
+    use crate::coprocessor::codec::mysql::{time::zero_datetime, Time, Tz, UNSPECIFIED_FSP};
     use crate::coprocessor::codec::Datum;
-    use crate::coprocessor::dag::expr::tests::{check_overflow, datum_expr, scalar_func_expr, str2dec, col_expr};
+    use crate::coprocessor::dag::expr::tests::{
+        check_overflow, col_expr, datum_expr, scalar_func_expr, str2dec,
+    };
     use crate::coprocessor::dag::expr::{EvalContext, Expression};
+    use cop_datatype::{FieldTypeAccessor, FieldTypeFlag};
     use std::i64;
     use tipb::expression::ScalarFuncSig;
-    use cop_datatype::{FieldTypeAccessor, FieldTypeFlag};
-    use crate::coprocessor::codec::mysql::{Time, time::zero_datetime, Tz, UNSPECIFIED_FSP};
     use tipb::expression::ScalarFuncSig::TimeIsNull;
 
     #[test]
@@ -455,25 +461,35 @@ mod tests {
             assert!(check_overflow(got).is_ok());
         }
     }
-    
+
     #[test]
     fn test_time_is_null() {
         let tests = vec![
-            (Datum::Time(Time::parse_utc_datetime("17011801101", UNSPECIFIED_FSP).unwrap()), true, Some(0)),
-            (Datum::Time(Time::parse_utc_datetime("17011801101", UNSPECIFIED_FSP).unwrap()), false, Some(0)),
+            (
+                Datum::Time(Time::parse_utc_datetime("17011801101", UNSPECIFIED_FSP).unwrap()),
+                true,
+                Some(0),
+            ),
+            (
+                Datum::Time(Time::parse_utc_datetime("17011801101", UNSPECIFIED_FSP).unwrap()),
+                false,
+                Some(0),
+            ),
             (Datum::Time(zero_datetime(&Tz::utc())), true, Some(1)),
             (Datum::Time(zero_datetime(&Tz::utc())), false, Some(0)),
             (Datum::Null, true, Some(1)),
             (Datum::Null, false, Some(1)),
         ];
-        
+
         let mut ctx = EvalContext::default();
         for (argument, not_null, exp) in tests {
             let mut col = col_expr(0);
             if not_null {
-                col.mut_field_type().as_mut_accessor().set_flag(FieldTypeFlag::NOT_NULL);
+                col.mut_field_type()
+                    .as_mut_accessor()
+                    .set_flag(FieldTypeFlag::NOT_NULL);
             }
-            
+
             let op = Expression::build(&ctx, scalar_func_expr(TimeIsNull, &[col])).unwrap();
             let got = op.eval_int(&mut ctx, &[argument]).unwrap();
             assert_eq!(got, exp);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Make `TimeIsNull` be compatible with MySQL (also fix this issue https://github.com/pingcap/tidb/issues/9763).

The description below is from MySQL document, and it's why `TimeIsNull` is not compatible with MySQL now (`NOT NULL` is not considered):
```
For DATE and DATETIME columns that are declared as NOT NULL, 
you can find the special date '0000-00-00' by using a statement like this:
"SELECT * FROM tbl_name WHERE date_column IS NULL"
```

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Please describe the tests that you ran to verify your changes. Have you finished unit tests, integration tests, or manual tests? What additional tests would give you greater confidence in this change?

Unit tests.