### PR TITLE
service: handle BatchCommandsEmptyRequest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.0#1962e47a393b43c78096bc43991f732134cac27a"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.0#7809473e1b70f4bed152e685716d683de30a1de0"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1263,7 +1263,27 @@ fn handle_batch_commands_request<E: Engine>(
                 .map_err(|_| GRPC_MSG_FAIL_COUNTER.kv_pessimistic_rollback.inc());
             response_batch_commands_request(id, resp, tx, timer);
         }
+        Some(BatchCommandsRequest_Request_oneof_cmd::Empty(req)) => {
+            let timer = GRPC_MSG_HISTOGRAM_VEC.invalid.start_coarse_timer();
+            let resp = future_handle_empty(req)
+                .map(oneof!(BatchCommandsResponse_Response_oneof_cmd::Empty))
+                .map_err(|_| GRPC_MSG_FAIL_COUNTER.invalid.inc());
+            response_batch_commands_request(id, resp, tx, timer);
+        }
     }
+}
+
+fn future_handle_empty(
+    req: BatchCommandsEmptyRequest,
+) -> impl Future<Item = BatchCommandsEmptyResponse, Error = Error> {
+    tikv_util::timer::GLOBAL_TIMER_HANDLE
+        .delay(std::time::Instant::now() + std::time::Duration::from_millis(req.get_delay_time()))
+        .map(move |_| {
+            let mut res = BatchCommandsEmptyResponse::new();
+            res.set_test_id(req.get_test_id());
+            res
+        })
+        .map_err(|_| unreachable!())
 }
 
 fn future_get<E: Engine>(


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

## What have you changed? (mandatory)
Handle `BatchCommandsRequst::Empty`. This message is generally for tests, make us can focus on transport layer instead of backend logics.

## Relative works
- I suggeste to cherry pick it to release-3.0, so that we can do more tests for release-3.0.