### PR TITLE
cop: BufferVec::retain_by_array, optimize to move multiple contiguous slots

### DIFF
--- a/src/coprocessor/codec/batch/buffer_vec.rs
+++ b/src/coprocessor/codec/batch/buffer_vec.rs
@@ -213,7 +213,7 @@ impl BufferVec {
 
         let len = self.len();
         assert!(retain_arr.len() >= len);
-        if len <= 0 {
+        if len == 0 {
             return;
         }
         let mut data_write_offset = 0;
@@ -292,7 +292,6 @@ impl std::ops::Index<usize> for BufferVec {
 }
 
 // TODO: Implement Index<XxxRange>
-
 #[derive(Clone, Copy)]
 pub struct Iter<'a> {
     data: &'a [u8],

--- a/src/coprocessor/codec/batch/buffer_vec.rs
+++ b/src/coprocessor/codec/batch/buffer_vec.rs
@@ -208,7 +208,7 @@ impl BufferVec {
                     break;
                 }
             }
-            return (true, left, right);
+            (true, left, right)
         }
 
         let len = self.len();


### PR DESCRIPTION
Signed-off-by: H-ZeX <hzx20112012@gmail.com>

## What have you changed? (mandatory)

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

In BufferVec::retain_by_array, optimize to move multiple contiguous slots.

## What are the type of the changes? (mandatory)

- Improvement (change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Unit test

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.