### PR TITLE
cop: Support variable number of arguments

### DIFF
--- a/components/cop_codegen/src/lib.rs
+++ b/components/cop_codegen/src/lib.rs
@@ -30,7 +30,7 @@ pub fn aggr_function_derive(input: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn rpn_fn(attr: TokenStream, input: TokenStream) -> TokenStream {
-    match rpn_function::RpnFn::transform(attr.into(), input.into()) {
+    match rpn_function::transform(attr.into(), input.into()) {
         Ok(tokens) => TokenStream::from(tokens),
         Err(e) => TokenStream::from(e.to_compile_error()),
     }

--- a/components/cop_codegen/src/lib.rs
+++ b/components/cop_codegen/src/lib.rs
@@ -14,15 +14,9 @@ extern crate proc_macro;
 mod aggr_function;
 mod rpn_function;
 
-use self::rpn_function::RpnFnGenerator;
-
 use darling::FromDeriveInput;
-use proc_macro::{Diagnostic, TokenStream};
-use syn::parse::Parser;
-use syn::punctuated::Punctuated;
-use syn::{DeriveInput, Ident, ItemFn};
-
-type Result<T> = std::result::Result<T, Diagnostic>;
+use proc_macro::TokenStream;
+use syn::DeriveInput;
 
 #[proc_macro_derive(AggrFunction, attributes(aggr_function))]
 pub fn aggr_function_derive(input: TokenStream) -> TokenStream {
@@ -36,16 +30,8 @@ pub fn aggr_function_derive(input: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn rpn_fn(attr: TokenStream, input: TokenStream) -> TokenStream {
-    let meta_parser = Punctuated::<Ident, Token![,]>::parse_terminated;
-    let meta = meta_parser.parse(attr).unwrap().into_iter().collect();
-    let item_fn = parse_macro_input!(input as ItemFn);
-
-    let input = RpnFnGenerator::new(meta, item_fn);
-    match input.map(RpnFnGenerator::generate) {
+    match rpn_function::RpnFn::transform(attr.into(), input.into()) {
         Ok(tokens) => TokenStream::from(tokens),
-        Err(e) => {
-            e.emit();
-            TokenStream::new()
-        }
+        Err(e) => TokenStream::from(e.to_compile_error()),
     }
 }

--- a/components/cop_codegen/src/rpn_function.rs
+++ b/components/cop_codegen/src/rpn_function.rs
@@ -28,7 +28,10 @@ impl parse::Parse for RpnFnAttr {
                             if let Expr::Array(ExprArray { elems, .. }) = *right {
                                 captures = elems.into_iter().collect();
                             } else {
-                                return Err(Error::new_spanned(right, "Expect array expression"));
+                                return Err(Error::new_spanned(
+                                    right,
+                                    "Expect array expression for `capture`",
+                                ));
                             }
                         }
                         _ => {

--- a/src/coprocessor/codec/data_type/mod.rs
+++ b/src/coprocessor/codec/data_type/mod.rs
@@ -69,6 +69,9 @@ pub trait Evaluable: Clone + std::fmt::Debug + Send + Sync + 'static {
     /// Borrows this concrete type from a `ScalarValue` in the same type.
     fn borrow_scalar_value(v: &ScalarValue) -> &Option<Self>;
 
+    /// Borrows this concrete type from a `ScalarValueRef` in the same type.
+    fn borrow_scalar_value_ref<'a>(v: &'a ScalarValueRef<'a>) -> &'a Option<Self>;
+
     /// Borrows a slice of this concrete type from a `VectorValue` in the same type.
     fn borrow_vector_value(v: &VectorValue) -> &[Option<Self>];
 
@@ -83,6 +86,11 @@ macro_rules! impl_evaluable_type {
 
             #[inline]
             fn borrow_scalar_value(v: &ScalarValue) -> &Option<Self> {
+                v.as_ref()
+            }
+
+            #[inline]
+            fn borrow_scalar_value_ref<'a>(v: &'a ScalarValueRef<'a>) -> &'a Option<Self> {
                 v.as_ref()
             }
 

--- a/src/coprocessor/codec/data_type/scalar.rs
+++ b/src/coprocessor/codec/data_type/scalar.rs
@@ -61,41 +61,6 @@ impl AsMySQLBool for ScalarValue {
     }
 }
 
-macro_rules! impl_as_ref {
-    ($ty:tt, $name:ident) => {
-        impl ScalarValue {
-            #[inline]
-            pub fn $name(&self) -> &Option<$ty> {
-                match self {
-                    ScalarValue::$ty(ref v) => v,
-                    other => panic!(
-                        "Cannot cast {} scalar value into {}",
-                        other.eval_type(),
-                        stringify!($ty),
-                    ),
-                }
-            }
-        }
-
-        impl AsRef<Option<$ty>> for ScalarValue {
-            #[inline]
-            fn as_ref(&self) -> &Option<$ty> {
-                self.$name()
-            }
-        }
-
-        // `AsMut` is not implemented intentionally.
-    };
-}
-
-impl_as_ref! { Int, as_int }
-impl_as_ref! { Real, as_real }
-impl_as_ref! { Decimal, as_decimal }
-impl_as_ref! { Bytes, as_bytes }
-impl_as_ref! { DateTime, as_date_time }
-impl_as_ref! { Duration, as_duration }
-impl_as_ref! { Json, as_json }
-
 macro_rules! impl_from {
     ($ty:tt) => {
         impl From<Option<$ty>> for ScalarValue {
@@ -168,6 +133,62 @@ impl<'a> ScalarValueRef<'a> {
         }
     }
 }
+
+macro_rules! impl_as_ref {
+    ($ty:tt, $name:ident) => {
+        impl ScalarValue {
+            #[inline]
+            pub fn $name(&self) -> &Option<$ty> {
+                match self {
+                    ScalarValue::$ty(v) => v,
+                    other => panic!(
+                        "Cannot cast {} scalar value into {}",
+                        other.eval_type(),
+                        stringify!($ty),
+                    ),
+                }
+            }
+        }
+
+        impl AsRef<Option<$ty>> for ScalarValue {
+            #[inline]
+            fn as_ref(&self) -> &Option<$ty> {
+                self.$name()
+            }
+        }
+
+        impl<'a> ScalarValueRef<'a> {
+            #[inline]
+            pub fn $name(&'a self) -> &'a Option<$ty> {
+                match self {
+                    ScalarValueRef::$ty(v) => v,
+                    other => panic!(
+                        "Cannot cast {} scalar value into {}",
+                        other.eval_type(),
+                        stringify!($ty),
+                    ),
+                }
+            }
+        }
+
+        impl AsRef<Option<$ty>> for ScalarValueRef<'_> {
+            #[inline]
+            fn as_ref(&self) -> &Option<$ty> {
+                self.$name()
+            }
+        }
+
+        // `AsMut` is not implemented intentionally.
+    };
+}
+
+impl_as_ref! { Int, as_int }
+impl_as_ref! { Real, as_real }
+impl_as_ref! { Decimal, as_decimal }
+impl_as_ref! { Bytes, as_bytes }
+impl_as_ref! { DateTime, as_date_time }
+impl_as_ref! { Duration, as_duration }
+impl_as_ref! { Json, as_json }
 
 impl<'a> Ord for ScalarValueRef<'a> {
     fn cmp(&self, other: &Self) -> Ordering {

--- a/src/coprocessor/codec/data_type/vector.rs
+++ b/src/coprocessor/codec/data_type/vector.rs
@@ -126,7 +126,7 @@ impl VectorValue {
     /// The caller must provide an output buffer which is large enough for holding values.
     pub fn eval_as_mysql_bools(
         &self,
-        context: &mut EvalContext,
+        ctx: &mut EvalContext,
         outputs: &mut [bool],
     ) -> crate::coprocessor::Result<()> {
         assert!(outputs.len() >= self.len());
@@ -135,7 +135,7 @@ impl VectorValue {
                 VectorValue::TT(v) => {
                     let l = self.len();
                     for i in 0..l {
-                        outputs[i] = v[i].as_mysql_bool(context)?;
+                        outputs[i] = v[i].as_mysql_bool(ctx)?;
                     }
                 },
             }

--- a/src/coprocessor/dag/aggr_fn/util.rs
+++ b/src/coprocessor/dag/aggr_fn/util.rs
@@ -50,9 +50,9 @@ pub fn rewrite_exp_for_sum_avg(schema: &[FieldType], exp: &mut RpnExpression) ->
             .decimal(cop_datatype::UNSPECIFIED_LENGTH)
             .build(),
     };
-    let (func, implicit_args) = get_cast_fn(ret_field_type, &new_ret_field_type)?;
+    let (func_meta, implicit_args) = get_cast_fn(ret_field_type, &new_ret_field_type)?;
     exp.push(RpnExpressionNode::FnCall {
-        func,
+        func_meta,
         field_type: new_ret_field_type,
         implicit_args,
     });
@@ -72,9 +72,9 @@ pub fn rewrite_exp_for_bit_op(schema: &[FieldType], exp: &mut RpnExpression) -> 
             .flag(FieldTypeFlag::UNSIGNED)
             .build(),
     };
-    let (func, implicit_args) = get_cast_fn(ret_field_type, &new_ret_field_type)?;
+    let (func_meta, implicit_args) = get_cast_fn(ret_field_type, &new_ret_field_type)?;
     exp.push(RpnExpressionNode::FnCall {
-        func,
+        func_meta,
         field_type: new_ret_field_type,
         implicit_args,
     });

--- a/src/coprocessor/dag/aggr_fn/util.rs
+++ b/src/coprocessor/dag/aggr_fn/util.rs
@@ -6,8 +6,7 @@ use cop_datatype::builder::FieldTypeBuilder;
 use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeFlag, FieldTypeTp};
 use tipb::expression::{Expr, FieldType};
 
-use crate::coprocessor::dag::rpn_expr::impl_cast::get_cast_fn;
-use crate::coprocessor::dag::rpn_expr::types::RpnExpressionNode;
+use crate::coprocessor::dag::rpn_expr::impl_cast::get_cast_fn_rpn_node;
 use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
 use crate::coprocessor::Result;
 
@@ -50,12 +49,8 @@ pub fn rewrite_exp_for_sum_avg(schema: &[FieldType], exp: &mut RpnExpression) ->
             .decimal(cop_datatype::UNSPECIFIED_LENGTH)
             .build(),
     };
-    let (func_meta, implicit_args) = get_cast_fn(ret_field_type, &new_ret_field_type)?;
-    exp.push(RpnExpressionNode::FnCall {
-        func_meta,
-        field_type: new_ret_field_type,
-        implicit_args,
-    });
+    let node = get_cast_fn_rpn_node(ret_field_type, new_ret_field_type)?;
+    exp.push(node);
     Ok(())
 }
 
@@ -72,11 +67,7 @@ pub fn rewrite_exp_for_bit_op(schema: &[FieldType], exp: &mut RpnExpression) -> 
             .flag(FieldTypeFlag::UNSIGNED)
             .build(),
     };
-    let (func_meta, implicit_args) = get_cast_fn(ret_field_type, &new_ret_field_type)?;
-    exp.push(RpnExpressionNode::FnCall {
-        func_meta,
-        field_type: new_ret_field_type,
-        implicit_args,
-    });
+    let node = get_cast_fn_rpn_node(ret_field_type, new_ret_field_type)?;
+    exp.push(node);
     Ok(())
 }

--- a/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
@@ -370,7 +370,7 @@ mod tests {
         let group_by_exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
             .push_column_ref(1)
-            .push_fn_call(arithmetic_fn_meta::<RealPlus>(), FieldTypeTp::Double)
+            .push_fn_call(arithmetic_fn_meta::<RealPlus>(), 2, FieldTypeTp::Double)
             .build();
 
         let aggr_definitions = vec![

--- a/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
@@ -14,7 +14,7 @@ use crate::coprocessor::dag::aggr_fn::*;
 use crate::coprocessor::dag::batch::executors::util::aggr_executor::*;
 use crate::coprocessor::dag::batch::interface::*;
 use crate::coprocessor::dag::expr::EvalConfig;
-use crate::coprocessor::dag::rpn_expr::types::RpnStackNode;
+use crate::coprocessor::dag::rpn_expr::RpnStackNode;
 use crate::coprocessor::Result;
 
 pub struct BatchSimpleAggregationExecutor<Src: BatchExecutor>(

--- a/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
@@ -16,7 +16,7 @@ use crate::coprocessor::dag::batch::executors::util::hash_aggr_helper::HashAggre
 use crate::coprocessor::dag::batch::executors::util::*;
 use crate::coprocessor::dag::batch::interface::*;
 use crate::coprocessor::dag::expr::EvalConfig;
-use crate::coprocessor::dag::rpn_expr::types::RpnStackNode;
+use crate::coprocessor::dag::rpn_expr::RpnStackNode;
 use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
 use crate::coprocessor::Result;
 
@@ -397,7 +397,7 @@ mod tests {
             RpnExpressionBuilder::new()
                 .push_column_ref(0)
                 .push_constant(1.0)
-                .push_fn_call(arithmetic_fn_meta::<RealPlus>(), FieldTypeTp::Double)
+                .push_fn_call(arithmetic_fn_meta::<RealPlus>(), 2, FieldTypeTp::Double)
                 .build(),
         ];
 

--- a/src/coprocessor/dag/batch/executors/stream_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/stream_aggr_executor.rs
@@ -14,7 +14,7 @@ use crate::coprocessor::dag::batch::executors::util::aggr_executor::*;
 use crate::coprocessor::dag::batch::executors::util::*;
 use crate::coprocessor::dag::batch::interface::*;
 use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
-use crate::coprocessor::dag::rpn_expr::types::RpnStackNode;
+use crate::coprocessor::dag::rpn_expr::RpnStackNode;
 use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
 use crate::coprocessor::Result;
 
@@ -346,7 +346,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for BatchStreamAggregation
 }
 
 fn update_current_states(
-    context: &mut EvalContext,
+    ctx: &mut EvalContext,
     states: &mut [Box<dyn AggrFunctionState>],
     aggr_fn_len: usize,
     aggr_expr_results: &[RpnStackNode<'_>],
@@ -365,7 +365,7 @@ fn update_current_states(
                         TT, match value {
                             ScalarValue::TT(scalar_value) => {
                                 state.update_repeat(
-                                    context,
+                                    ctx,
                                     scalar_value,
                                     end_logical_row - start_logical_row,
                                 )?;
@@ -380,7 +380,7 @@ fn update_current_states(
                         TT, match physical_vec {
                             VectorValue::TT(vec) => {
                                 state.update_vector(
-                                    context,
+                                    ctx,
                                     vec,
                                     &logical_rows[start_logical_row..end_logical_row],
                                 )?;
@@ -423,7 +423,7 @@ mod tests {
             RpnExpressionBuilder::new()
                 .push_column_ref(1)
                 .push_constant(2.0)
-                .push_fn_call(arithmetic_fn_meta::<RealPlus>(), FieldTypeTp::Double)
+                .push_fn_call(arithmetic_fn_meta::<RealPlus>(), 2, FieldTypeTp::Double)
                 .build(),
         ];
 

--- a/src/coprocessor/dag/batch/executors/top_n_executor.rs
+++ b/src/coprocessor/dag/batch/executors/top_n_executor.rs
@@ -15,7 +15,7 @@ use crate::coprocessor::dag::batch::executors::util::*;
 use crate::coprocessor::dag::batch::interface::*;
 use crate::coprocessor::dag::expr::EvalWarnings;
 use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
-use crate::coprocessor::dag::rpn_expr::types::RpnStackNode;
+use crate::coprocessor::dag::rpn_expr::RpnStackNode;
 use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
 use crate::coprocessor::Result;
 
@@ -717,13 +717,13 @@ mod tests {
             vec![
                 RpnExpressionBuilder::new()
                     .push_column_ref(0)
-                    .push_fn_call(is_null_fn_meta::<Int>(), FieldTypeTp::LongLong)
+                    .push_fn_call(is_null_fn_meta::<Int>(), 1, FieldTypeTp::LongLong)
                     .build(),
                 RpnExpressionBuilder::new().push_column_ref(0).build(),
                 RpnExpressionBuilder::new()
                     .push_column_ref(1)
                     .push_constant(1)
-                    .push_fn_call(arithmetic_fn_meta::<IntIntPlus>(), FieldTypeTp::LongLong)
+                    .push_fn_call(arithmetic_fn_meta::<IntIntPlus>(), 2, FieldTypeTp::LongLong)
                     .build(),
             ],
             vec![false, false, true],

--- a/src/coprocessor/dag/batch/executors/util/hash_aggr_helper.rs
+++ b/src/coprocessor/dag/batch/executors/util/hash_aggr_helper.rs
@@ -5,7 +5,7 @@ use crate::coprocessor::codec::batch::LazyBatchColumnVec;
 use crate::coprocessor::codec::data_type::*;
 use crate::coprocessor::dag::aggr_fn::AggrFunctionState;
 use crate::coprocessor::dag::batch::interface::*;
-use crate::coprocessor::dag::rpn_expr::types::RpnStackNode;
+use crate::coprocessor::dag::rpn_expr::RpnStackNode;
 use crate::coprocessor::Result;
 
 pub struct HashAggregationHelper;

--- a/src/coprocessor/dag/batch/executors/util/mod.rs
+++ b/src/coprocessor/dag/batch/executors/util/mod.rs
@@ -13,8 +13,8 @@ use tipb::expression::FieldType;
 use crate::coprocessor::codec::batch::LazyBatchColumnVec;
 use crate::coprocessor::codec::mysql::Tz;
 use crate::coprocessor::dag::expr::EvalContext;
-use crate::coprocessor::dag::rpn_expr::types::RpnStackNode;
 use crate::coprocessor::dag::rpn_expr::RpnExpression;
+use crate::coprocessor::dag::rpn_expr::RpnStackNode;
 use crate::coprocessor::Result;
 
 /// Decodes all columns that are not decoded.
@@ -34,7 +34,7 @@ pub fn ensure_columns_decoded(
 /// Evaluates expressions and outputs the result into the given Vec. Lifetime of the expressions
 /// are erased.
 pub unsafe fn eval_exprs_decoded_no_lifetime<'a>(
-    context: &mut EvalContext,
+    ctx: &mut EvalContext,
     exprs: &[RpnExpression],
     schema: &[FieldType],
     input_physical_columns: &LazyBatchColumnVec,
@@ -43,7 +43,7 @@ pub unsafe fn eval_exprs_decoded_no_lifetime<'a>(
 ) -> Result<()> {
     for expr in exprs {
         output.push(erase_lifetime(expr).eval_decoded(
-            erase_lifetime_mut(context),
+            erase_lifetime_mut(ctx),
             erase_lifetime(schema),
             erase_lifetime(input_physical_columns),
             erase_lifetime(input_logical_rows),

--- a/src/coprocessor/dag/rpn_expr/function.rs
+++ b/src/coprocessor/dag/rpn_expr/function.rs
@@ -61,7 +61,6 @@
 //!         self,
 //!         ctx: &mut EvalContext,
 //!         payload: &RpnFnCallPayload<'_>,
-
 //!     ) -> Result<VectorValue> {
 //!         let (regex, arg) = self.extract(0);
 //!         let regex = build_regex(regex);
@@ -84,8 +83,8 @@ use crate::coprocessor::codec::data_type::{Evaluable, ScalarValue, VectorValue};
 use crate::coprocessor::dag::expr::EvalContext;
 use crate::coprocessor::Result;
 
-#[derive(Clone, Copy)]
 /// Metadata of an RPN function
+#[derive(Clone, Copy)]
 pub struct RpnFnMeta {
     /// The display name of the function.
     pub name: &'static str,

--- a/src/coprocessor/dag/rpn_expr/impl_arithmetic.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_arithmetic.rs
@@ -321,7 +321,7 @@ mod tests {
     use cop_datatype::{FieldTypeFlag, FieldTypeTp};
     use tipb::expression::ScalarFuncSig;
 
-    use crate::coprocessor::dag::rpn_expr::types::test_util::RpnFnScalarEvaluator;
+    use crate::coprocessor::dag::rpn_expr::test_util::RpnFnScalarEvaluator;
 
     #[test]
     fn test_plus_int() {

--- a/src/coprocessor/dag/rpn_expr/impl_cast.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_cast.rs
@@ -8,18 +8,17 @@ use tipb::expression::FieldType;
 
 use crate::coprocessor::codec::data_type::*;
 use crate::coprocessor::dag::expr::EvalContext;
-use crate::coprocessor::dag::rpn_expr::function::RpnFnMeta;
-use crate::coprocessor::dag::rpn_expr::types::RpnFnCallPayload;
+use crate::coprocessor::dag::rpn_expr::{RpnExpressionNode, RpnFnCallExtra};
 use crate::coprocessor::Result;
 
 /// Gets the cast function between specified data types.
 ///
 /// TODO: This function supports some internal casts performed by TiKV. However it would be better
 /// to be done in TiDB.
-pub fn get_cast_fn(
+pub fn get_cast_fn_rpn_node(
     from_field_type: &FieldType,
-    to_field_type: &FieldType,
-) -> Result<(RpnFnMeta, Vec<ScalarValue>)> {
+    to_field_type: FieldType,
+) -> Result<RpnExpressionNode> {
     let from = box_try!(EvalType::try_from(from_field_type.tp()));
     let to = box_try!(EvalType::try_from(to_field_type.tp()));
     let func_meta = match (from, to) {
@@ -48,9 +47,12 @@ pub fn get_cast_fn(
     // the `inUnion` flag always false in this situation. Ideally,
     // the cast function should be inserted by TiDB and pushed down
     // with all implicit arguments.
-    // **Note**: CAST family functions inserted by `Coprocessor` will
-    // use empty implicit arguments to avoid memory allocation.
-    Ok((func_meta, vec![]))
+    Ok(RpnExpressionNode::FnCall {
+        func_meta,
+        args_len: 1,
+        field_type: to_field_type,
+        implicit_args: Vec::new(),
+    })
 }
 
 fn produce_dec_with_specified_tp(
@@ -67,11 +69,11 @@ fn produce_dec_with_specified_tp(
 }
 
 /// The unsigned int implementation for push down signature `CastIntAsDecimal`.
-#[rpn_fn(ctx, payload)]
+#[rpn_fn(capture = [ctx, extra])]
 #[inline]
 pub fn cast_uint_as_decimal(
     ctx: &mut EvalContext,
-    payload: &RpnFnCallPayload<'_>,
+    extra: &RpnFnCallExtra<'_>,
     val: &Option<i64>,
 ) -> Result<Option<Decimal>> {
     match val {
@@ -81,18 +83,18 @@ pub fn cast_uint_as_decimal(
             Ok(Some(produce_dec_with_specified_tp(
                 ctx,
                 dec,
-                payload.return_field_type(),
+                extra.ret_field_type,
             )?))
         }
     }
 }
 
 /// The signed int implementation for push down signature `CastIntAsDecimal`.
-#[rpn_fn(ctx, payload)]
+#[rpn_fn(capture = [ctx, extra])]
 #[inline]
 pub fn cast_int_as_decimal(
     ctx: &mut EvalContext,
-    payload: &RpnFnCallPayload<'_>,
+    extra: &RpnFnCallExtra<'_>,
     val: &Option<i64>,
 ) -> Result<Option<Decimal>> {
     match val {
@@ -102,14 +104,14 @@ pub fn cast_int_as_decimal(
             Ok(Some(produce_dec_with_specified_tp(
                 ctx,
                 dec,
-                payload.return_field_type(),
+                extra.ret_field_type,
             )?))
         }
     }
 }
 
 /// The implementation for push down signature `CastStringAsReal`.
-#[rpn_fn(ctx)]
+#[rpn_fn(capture = [ctx])]
 #[inline]
 pub fn cast_string_as_real(ctx: &mut EvalContext, val: &Option<Bytes>) -> Result<Option<Real>> {
     use crate::coprocessor::codec::convert::bytes_to_f64;
@@ -151,7 +153,7 @@ fn cast_duration_as_real(val: &Option<Duration>) -> Result<Option<Real>> {
 }
 
 /// The implementation for push down signature `CastJsonAsReal`.
-#[rpn_fn(ctx)]
+#[rpn_fn(capture = [ctx])]
 #[inline]
 fn cast_json_as_real(ctx: &mut EvalContext, val: &Option<Json>) -> Result<Option<Real>> {
     match val {

--- a/src/coprocessor/dag/rpn_expr/impl_cast.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_cast.rs
@@ -22,7 +22,7 @@ pub fn get_cast_fn(
 ) -> Result<(RpnFnMeta, Vec<ScalarValue>)> {
     let from = box_try!(EvalType::try_from(from_field_type.tp()));
     let to = box_try!(EvalType::try_from(to_field_type.tp()));
-    let func = match (from, to) {
+    let func_meta = match (from, to) {
         (EvalType::Int, EvalType::Decimal) => {
             if !from_field_type
                 .as_accessor()
@@ -50,7 +50,7 @@ pub fn get_cast_fn(
     // with all implicit arguments.
     // **Note**: CAST family functions inserted by `Coprocessor` will
     // use empty implicit arguments to avoid memory allocation.
-    Ok((func, vec![]))
+    Ok((func_meta, vec![]))
 }
 
 fn produce_dec_with_specified_tp(

--- a/src/coprocessor/dag/rpn_expr/impl_control.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_control.rs
@@ -18,7 +18,7 @@ fn if_null<T: Evaluable>(lhs: &Option<T>, rhs: &Option<T>) -> Result<Option<T>> 
 mod tests {
     use tipb::expression::ScalarFuncSig;
 
-    use crate::coprocessor::dag::rpn_expr::types::test_util::RpnFnScalarEvaluator;
+    use crate::coprocessor::dag::rpn_expr::test_util::RpnFnScalarEvaluator;
 
     #[test]
     fn test_if_null() {

--- a/src/coprocessor/dag/rpn_expr/impl_like.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_like.rs
@@ -28,7 +28,7 @@ pub fn like(
 mod tests {
     use tipb::expression::ScalarFuncSig;
 
-    use crate::coprocessor::dag::rpn_expr::types::test_util::RpnFnScalarEvaluator;
+    use crate::coprocessor::dag::rpn_expr::test_util::RpnFnScalarEvaluator;
 
     #[test]
     fn test_like() {

--- a/src/coprocessor/dag/rpn_expr/impl_op.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_op.rs
@@ -81,7 +81,7 @@ mod tests {
     use tipb::expression::ScalarFuncSig;
 
     use crate::coprocessor::codec::mysql::{time, Tz};
-    use crate::coprocessor::dag::rpn_expr::types::test_util::RpnFnScalarEvaluator;
+    use crate::coprocessor::dag::rpn_expr::test_util::RpnFnScalarEvaluator;
 
     #[test]
     fn test_logical_and() {

--- a/src/coprocessor/dag/rpn_expr/mod.rs
+++ b/src/coprocessor/dag/rpn_expr/mod.rs
@@ -1,7 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#[macro_use]
-pub mod function;
 pub mod types;
 
 pub mod impl_arithmetic;
@@ -11,19 +9,19 @@ pub mod impl_control;
 pub mod impl_like;
 pub mod impl_op;
 
-pub use self::function::RpnFnMeta;
-pub use self::types::{RpnExpression, RpnExpressionBuilder};
+pub use self::types::*;
 
 use cop_datatype::{FieldTypeAccessor, FieldTypeFlag};
 use tipb::expression::{Expr, ScalarFuncSig};
+
+use crate::coprocessor::codec::data_type::*;
+use crate::coprocessor::Result;
 
 use self::impl_arithmetic::*;
 use self::impl_compare::*;
 use self::impl_control::*;
 use self::impl_like::*;
 use self::impl_op::*;
-use crate::coprocessor::codec::data_type::*;
-use crate::coprocessor::Result;
 
 fn map_int_sig<F>(value: ScalarFuncSig, children: &[Expr], mapper: F) -> Result<RpnFnMeta>
 where
@@ -170,6 +168,13 @@ fn map_pb_sig_to_rpn_func(value: ScalarFuncSig, children: &[Expr]) -> Result<Rpn
         ScalarFuncSig::IfNullTime => if_null_fn_meta::<DateTime>(),
         ScalarFuncSig::IfNullDuration => if_null_fn_meta::<Duration>(),
         ScalarFuncSig::IfNullJson => if_null_fn_meta::<Json>(),
+        ScalarFuncSig::CoalesceInt => coalesce_fn_meta::<Int>(),
+        ScalarFuncSig::CoalesceReal => coalesce_fn_meta::<Real>(),
+        ScalarFuncSig::CoalesceString => coalesce_fn_meta::<Bytes>(),
+        ScalarFuncSig::CoalesceDecimal => coalesce_fn_meta::<Decimal>(),
+        ScalarFuncSig::CoalesceTime => coalesce_fn_meta::<DateTime>(),
+        ScalarFuncSig::CoalesceDuration => coalesce_fn_meta::<Duration>(),
+        ScalarFuncSig::CoalesceJson => coalesce_fn_meta::<Json>(),
         _ => return Err(box_err!(
             "ScalarFunction {:?} is not supported in batch mode",
             value

--- a/src/coprocessor/dag/rpn_expr/types/expr.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr.rs
@@ -11,6 +11,7 @@ pub enum RpnExpressionNode {
     /// Represents a function call.
     FnCall {
         func_meta: RpnFnMeta,
+        args_len: usize,
         field_type: FieldType,
         implicit_args: Vec<ScalarValue>,
     },

--- a/src/coprocessor/dag/rpn_expr/types/expr.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr.rs
@@ -10,7 +10,7 @@ use crate::coprocessor::codec::data_type::ScalarValue;
 pub enum RpnExpressionNode {
     /// Represents a function call.
     FnCall {
-        func: RpnFnMeta,
+        func_meta: RpnFnMeta,
         field_type: FieldType,
         implicit_args: Vec<ScalarValue>,
     },
@@ -40,7 +40,7 @@ impl RpnExpressionNode {
     #[inline]
     pub fn fn_call_func(&self) -> Option<RpnFnMeta> {
         match self {
-            RpnExpressionNode::FnCall { func, .. } => Some(*func),
+            RpnExpressionNode::FnCall { func_meta, .. } => Some(*func_meta),
             _ => None,
         }
     }

--- a/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tipb::expression::FieldType;
 
 use super::expr::{RpnExpression, RpnExpressionNode};
-use super::RpnFnCallPayload;
+use super::RpnFnCallExtra;
 use crate::coprocessor::codec::batch::LazyBatchColumnVec;
 use crate::coprocessor::codec::data_type::{ScalarValue, ScalarValueRef, VectorValue};
 use crate::coprocessor::codec::mysql::time::Tz;
@@ -146,7 +146,7 @@ impl RpnExpression {
     /// Panics when referenced column does not have equal length as specified in `rows`.
     pub fn eval<'a>(
         &'a self,
-        context: &mut EvalContext,
+        ctx: &mut EvalContext,
         schema: &'a [FieldType],
         input_physical_columns: &'a mut LazyBatchColumnVec,
         input_logical_rows: &'a [usize],
@@ -156,13 +156,13 @@ impl RpnExpression {
         // we evaluate. This is to make Rust's borrow checker happy because there will be
         // mutable reference during the first iteration and we can't keep these references.
         self.ensure_columns_decoded(
-            &context.cfg.tz,
+            &ctx.cfg.tz,
             schema,
             input_physical_columns,
             input_logical_rows,
         )?;
         self.eval_decoded(
-            context,
+            ctx,
             schema,
             input_physical_columns,
             input_logical_rows,
@@ -206,7 +206,7 @@ impl RpnExpression {
     /// Panics when referenced column does not have equal length as specified in `rows`.
     pub fn eval_decoded<'a>(
         &'a self,
-        context: &mut EvalContext,
+        ctx: &mut EvalContext,
         schema: &'a [FieldType],
         input_physical_columns: &'a LazyBatchColumnVec,
         input_logical_rows: &'a [usize],
@@ -214,6 +214,7 @@ impl RpnExpression {
     ) -> Result<RpnStackNode<'a>> {
         assert!(output_rows > 0);
         let mut stack = Vec::with_capacity(self.len());
+        let mut vargs_buffer = vec![0; self.len()];
         // Logical rows for generated columns
         // TODO: Eliminate allocation
         let identity_logical_rows: Vec<_> = (0..output_rows).collect();
@@ -241,7 +242,8 @@ impl RpnExpression {
                 }
                 RpnExpressionNode::FnCall {
                     func_meta,
-                    field_type,
+                    args_len,
+                    field_type: ret_field_type,
                     implicit_args,
                 } => {
                     // Suppose that we have function call `Foo(A, B, C)`, the RPN nodes looks like
@@ -249,23 +251,27 @@ impl RpnExpression {
                     // Now we receives a function call `Foo`, so there are `[A, B, C]` in the stack
                     // as the last several elements. We will directly use the last N (N = number of
                     // arguments) elements in the stack as function arguments.
-                    assert!(stack.len() >= func_meta.args_len);
-                    let stack_slice_begin = stack.len() - func_meta.args_len;
+                    assert!(stack.len() >= *args_len);
+                    let stack_slice_begin = stack.len() - *args_len;
                     let stack_slice = &stack[stack_slice_begin..];
-                    let call_info = RpnFnCallPayload {
-                        output_rows,
-                        raw_args: stack_slice,
+                    let mut call_extra = RpnFnCallExtra {
+                        ret_field_type,
                         implicit_args,
-                        ret_field_type: field_type,
                     };
-                    let ret = (func_meta.fn_ptr)(context, &call_info)?;
+                    let ret = (func_meta.fn_ptr)(
+                        ctx,
+                        output_rows,
+                        stack_slice,
+                        &mut call_extra,
+                        &mut vargs_buffer[..*args_len],
+                    )?;
                     stack.truncate(stack_slice_begin);
                     stack.push(RpnStackNode::Vector {
                         value: RpnStackNodeVectorValue::Generated {
                             physical_value: ret,
                             logical_rows: Arc::clone(&identity_logical_rows),
                         },
-                        field_type,
+                        field_type: ret_field_type,
                     });
                 }
             }
@@ -422,7 +428,7 @@ mod tests {
         }
 
         let exp = RpnExpressionBuilder::new()
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::LongLong)
+            .push_fn_call(foo_fn_meta(), 0, FieldTypeTp::LongLong)
             .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
@@ -448,7 +454,7 @@ mod tests {
 
         let exp = RpnExpressionBuilder::new()
             .push_constant(1.5f64)
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::Double)
+            .push_fn_call(foo_fn_meta(), 1, FieldTypeTp::Double)
             .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
@@ -487,7 +493,7 @@ mod tests {
 
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::LongLong)
+            .push_fn_call(foo_fn_meta(), 1, FieldTypeTp::LongLong)
             .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, schema, &mut columns, &[2, 0], 2);
@@ -531,7 +537,7 @@ mod tests {
 
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::LongLong)
+            .push_fn_call(foo_fn_meta(), 1, FieldTypeTp::LongLong)
             .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, schema, &mut columns, &[2, 0, 1], 3);
@@ -557,7 +563,7 @@ mod tests {
         let exp = RpnExpressionBuilder::new()
             .push_constant(1.5f64)
             .push_constant(3i64)
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::Double)
+            .push_fn_call(foo_fn_meta(), 2, FieldTypeTp::Double)
             .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
@@ -597,7 +603,7 @@ mod tests {
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
             .push_constant(1.5f64)
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::Double)
+            .push_fn_call(foo_fn_meta(), 2, FieldTypeTp::Double)
             .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, schema, &mut columns, &[2, 0], 2);
@@ -635,7 +641,7 @@ mod tests {
         let exp = RpnExpressionBuilder::new()
             .push_constant(1.5f64)
             .push_column_ref(0)
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::Double)
+            .push_fn_call(foo_fn_meta(), 2, FieldTypeTp::Double)
             .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, schema, &mut columns, &[1, 2], 2);
@@ -685,7 +691,7 @@ mod tests {
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(1)
             .push_column_ref(0)
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::LongLong)
+            .push_fn_call(foo_fn_meta(), 2, FieldTypeTp::LongLong)
             .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, schema, &mut columns, &[0, 2, 1], 3);
@@ -735,7 +741,7 @@ mod tests {
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
             .push_column_ref(0)
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::LongLong)
+            .push_fn_call(foo_fn_meta(), 2, FieldTypeTp::LongLong)
             .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, schema, &mut columns, &[1], 1);
@@ -771,7 +777,7 @@ mod tests {
             .push_column_ref(0)
             .push_constant(3i64)
             .push_column_ref(0)
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::LongLong)
+            .push_fn_call(foo_fn_meta(), 3, FieldTypeTp::LongLong)
             .build();
         let mut ctx = EvalContext::default();
         let result = exp.eval(&mut ctx, schema, &mut columns, &[1, 0, 2], 3);
@@ -843,13 +849,13 @@ mod tests {
         // Col0, fn_b, Col1, Const0, fn_d, Const1, fn_c, fn_a
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
-            .push_fn_call(fn_b_fn_meta(), FieldTypeTp::Double)
+            .push_fn_call(fn_b_fn_meta(), 0, FieldTypeTp::Double)
             .push_column_ref(1)
             .push_constant(7i64)
-            .push_fn_call(fn_d_fn_meta(), FieldTypeTp::LongLong)
+            .push_fn_call(fn_d_fn_meta(), 2, FieldTypeTp::LongLong)
             .push_constant(11i64)
-            .push_fn_call(fn_c_fn_meta(), FieldTypeTp::Double)
-            .push_fn_call(fn_a_fn_meta(), FieldTypeTp::Double)
+            .push_fn_call(fn_c_fn_meta(), 2, FieldTypeTp::Double)
+            .push_fn_call(fn_a_fn_meta(), 3, FieldTypeTp::Double)
             .build();
 
         //      fn_a(
@@ -883,7 +889,7 @@ mod tests {
         }
 
         let exp = RpnExpressionBuilder::new()
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::LongLong)
+            .push_fn_call(foo_fn_meta(), 1, FieldTypeTp::LongLong)
             .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
@@ -907,7 +913,7 @@ mod tests {
         let exp = RpnExpressionBuilder::new()
             .push_constant(3.0f64)
             .push_constant(1.5f64)
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::Double)
+            .push_fn_call(foo_fn_meta(), 1, FieldTypeTp::Double)
             .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
@@ -929,7 +935,7 @@ mod tests {
 
         let exp = RpnExpressionBuilder::new()
             .push_constant(7i64)
-            .push_fn_call(foo_fn_meta(), FieldTypeTp::Double)
+            .push_fn_call(foo_fn_meta(), 1, FieldTypeTp::Double)
             .build();
         let mut ctx = EvalContext::default();
         let mut columns = LazyBatchColumnVec::empty();
@@ -1118,7 +1124,7 @@ mod tests {
         let exp = RpnExpressionBuilder::new()
             .push_column_ref(0)
             .push_column_ref(0)
-            .push_fn_call(arithmetic_fn_meta::<IntIntPlus>(), FieldTypeTp::LongLong)
+            .push_fn_call(arithmetic_fn_meta::<IntIntPlus>(), 2, FieldTypeTp::LongLong)
             .build();
         let mut ctx = EvalContext::default();
         let logical_rows: Vec<_> = (0..1024).collect();
@@ -1153,6 +1159,7 @@ mod tests {
             .push_column_ref(0)
             .push_fn_call(
                 compare_fn_meta::<BasicComparer<Int, CmpOpLE>>(),
+                2,
                 FieldTypeTp::LongLong,
             )
             .build();
@@ -1189,6 +1196,7 @@ mod tests {
             .push_column_ref(0)
             .push_fn_call(
                 compare_fn_meta::<BasicComparer<Int, CmpOpLE>>(),
+                2,
                 FieldTypeTp::LongLong,
             )
             .build();

--- a/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
@@ -214,7 +214,6 @@ impl RpnExpression {
     ) -> Result<RpnStackNode<'a>> {
         assert!(output_rows > 0);
         let mut stack = Vec::with_capacity(self.len());
-        let mut vargs_buffer = vec![0; self.len()];
         // Logical rows for generated columns
         // TODO: Eliminate allocation
         let identity_logical_rows: Vec<_> = (0..output_rows).collect();
@@ -258,13 +257,7 @@ impl RpnExpression {
                         ret_field_type,
                         implicit_args,
                     };
-                    let ret = (func_meta.fn_ptr)(
-                        ctx,
-                        output_rows,
-                        stack_slice,
-                        &mut call_extra,
-                        &mut vargs_buffer[..*args_len],
-                    )?;
+                    let ret = (func_meta.fn_ptr)(ctx, output_rows, stack_slice, &mut call_extra)?;
                     stack.truncate(stack_slice_begin);
                     stack.push(RpnStackNode::Vector {
                         value: RpnStackNodeVectorValue::Generated {

--- a/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
@@ -221,10 +221,7 @@ impl RpnExpression {
 
         for node in self.as_ref() {
             match node {
-                RpnExpressionNode::Constant {
-                    ref value,
-                    ref field_type,
-                } => {
+                RpnExpressionNode::Constant { value, field_type } => {
                     stack.push(RpnStackNode::Scalar {
                         value: &value,
                         field_type,
@@ -243,17 +240,17 @@ impl RpnExpression {
                     });
                 }
                 RpnExpressionNode::FnCall {
-                    ref func,
-                    ref field_type,
-                    ref implicit_args,
+                    func_meta,
+                    field_type,
+                    implicit_args,
                 } => {
                     // Suppose that we have function call `Foo(A, B, C)`, the RPN nodes looks like
                     // `[A, B, C, Foo]`.
                     // Now we receives a function call `Foo`, so there are `[A, B, C]` in the stack
                     // as the last several elements. We will directly use the last N (N = number of
                     // arguments) elements in the stack as function arguments.
-                    assert!(stack.len() >= func.args_len);
-                    let stack_slice_begin = stack.len() - func.args_len;
+                    assert!(stack.len() >= func_meta.args_len);
+                    let stack_slice_begin = stack.len() - func_meta.args_len;
                     let stack_slice = &stack[stack_slice_begin..];
                     let call_info = RpnFnCallPayload {
                         output_rows,
@@ -261,7 +258,7 @@ impl RpnExpression {
                         implicit_args,
                         ret_field_type: field_type,
                     };
-                    let ret = (func.fn_ptr)(context, &call_info)?;
+                    let ret = (func_meta.fn_ptr)(context, &call_info)?;
                     stack.truncate(stack_slice_begin);
                     stack.push(RpnStackNode::Vector {
                         value: RpnStackNodeVectorValue::Generated {

--- a/src/coprocessor/dag/rpn_expr/types/function.rs
+++ b/src/coprocessor/dag/rpn_expr/types/function.rs
@@ -17,25 +17,17 @@
 //! itself. Instead, it creates a `foo_fn_meta()` function (simply add `_fn_meta` to the original
 //! function name) that generates an `RpnFnMeta` struct.
 //!
-//! If you needs `EvalContext` or the raw `RpnFnCallPayload`, just put it ahead of the function
-//! parameters, and add `ctx` or `payload` argument to the attribute. For example:
+//! In case of needing other parameters:
 //!
 //! ```ignore
 //! // This generates `with_context_fn_meta() -> RpnFnMeta`
-//! #[rpn_fn(ctx)]
+//! #[rpn_fn(capture = [ctx])]
 //! fn with_context(ctx: &mut EvalContext, param: &Option<Decimal>) -> Result<Option<Int>> {
 //!     // Your RPN function logic
 //! }
-//!
-//! // This generates `with_ctx_and_payload_fn_meta() -> RpnFnMeta`
-//! #[rpn_fn(ctx, payload)]
-//! fn with_ctx_and_payload(
-//!     ctx: &mut EvalContext,
-//!     payload: &RpnFnCallPayload<'_>
-//! ) -> Result<Option<Int>> {
-//!     // Your RPN function logic
-//! }
 //! ```
+//!
+//! All available parameters are: `ctx`, `output_rows`, `args`, `extra`.
 //!
 //! A trait whose name looks like `CamelCasedFnName_Fn` is created by the macro. If you need to
 //! customize the execution logic for specific argument type, you may implement it on your own.
@@ -60,13 +52,14 @@
 //!     fn eval(
 //!         self,
 //!         ctx: &mut EvalContext,
-//!         payload: &RpnFnCallPayload<'_>,
+//          output_rows: usize,
+//          args: &[RpnStackNode<'_>],
+//          extra: &mut RpnFnCallExtra<'_>,
 //!     ) -> Result<VectorValue> {
 //!         let (regex, arg) = self.extract(0);
 //!         let regex = build_regex(regex);
-//!         let rows = payload.output_rows();
-//!         let mut result = Vec::with_capacity(rows);
-//!         for row in 0..rows {
+//!         let mut result = Vec::with_capacity(output_rows);
+//!         for row in 0..output_rows {
 //!             let (text, _) = arg.extract(row);
 //!             result.push(regex_match_impl(&regex, text)?);
 //!         }
@@ -78,33 +71,49 @@
 //! If you are curious about what code the macro will generate, check the test code
 //! in `components/cop_codegen/src/rpn_function.rs`.
 
-use super::types::{RpnFnCallPayload, RpnStackNode};
+use tipb::expression::FieldType;
+
+use super::RpnStackNode;
 use crate::coprocessor::codec::data_type::{Evaluable, ScalarValue, VectorValue};
 use crate::coprocessor::dag::expr::EvalContext;
 use crate::coprocessor::Result;
 
-/// Metadata of an RPN function
+/// Metadata of an RPN function.
 #[derive(Clone, Copy)]
 pub struct RpnFnMeta {
-    /// The display name of the function.
+    /// The display name of the RPN function. Mainly used in tests.
     pub name: &'static str,
 
-    /// The accepted argument length of this RPN function.
-    ///
-    /// Currently we do not support variable arguments.
-    pub args_len: usize,
+    /// Validator against input expression tree.
+    // pub validator_ptr: fn(expr: &Expr) -> Result<()>,
 
-    /// The function receiving raw argument.
-    ///
-    /// The first parameter is the evaluation context and the second one is the payload containing
-    /// the output rows count, the argument value and the argument field type.
-    pub fn_ptr: fn(&mut EvalContext, &RpnFnCallPayload<'_>) -> Result<VectorValue>,
+    #[allow(clippy::type_complexity)]
+    /// The RPN function.
+    pub fn_ptr: fn(
+        // Common arguments
+        ctx: &mut EvalContext,
+        output_rows: usize,
+        args: &[RpnStackNode<'_>],
+        // Uncommon arguments are grouped together
+        extra: &mut RpnFnCallExtra<'_>,
+        // Buffer for evaluating vargs.
+        vargs_buffer: &mut [usize],
+    ) -> Result<VectorValue>,
 }
 
 impl std::fmt::Debug for RpnFnMeta {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}({} args)", self.name, self.args_len)
+        write!(f, "{}", self.name)
     }
+}
+
+/// Extra information about an RPN function call.
+pub struct RpnFnCallExtra<'a> {
+    /// The field type of the return value.
+    pub ret_field_type: &'a FieldType,
+
+    /// Implicit constant arguments.
+    pub implicit_args: &'a [ScalarValue],
 }
 
 /// A single argument of an RPN function.
@@ -197,8 +206,10 @@ pub trait Evaluator {
     fn eval(
         self,
         def: impl ArgDef,
-        context: &mut EvalContext,
-        payload: &RpnFnCallPayload<'_>,
+        ctx: &mut EvalContext,
+        output_rows: usize,
+        args: &[RpnStackNode<'_>],
+        extra: &mut RpnFnCallExtra<'_>,
     ) -> Result<VectorValue>;
 }
 
@@ -218,10 +229,12 @@ impl<E: Evaluator> Evaluator for ArgConstructor<E> {
     fn eval(
         self,
         def: impl ArgDef,
-        context: &mut EvalContext,
-        payload: &RpnFnCallPayload<'_>,
+        ctx: &mut EvalContext,
+        output_rows: usize,
+        args: &[RpnStackNode<'_>],
+        extra: &mut RpnFnCallExtra<'_>,
     ) -> Result<VectorValue> {
-        match payload.raw_arg_at(self.arg_index) {
+        match &args[self.arg_index] {
             RpnStackNode::Scalar { value, .. } => {
                 match_template_evaluable! {
                     TT, match value {
@@ -230,7 +243,7 @@ impl<E: Evaluator> Evaluator for ArgConstructor<E> {
                                 arg: ScalarArg(v),
                                 rem: def,
                             };
-                            self.inner.eval(new_def, context, payload)
+                            self.inner.eval(new_def, ctx, output_rows, args, extra)
                         }
                     }
                 }
@@ -247,7 +260,7 @@ impl<E: Evaluator> Evaluator for ArgConstructor<E> {
                                 },
                                 rem: def,
                             };
-                            self.inner.eval(new_def, context, payload)
+                            self.inner.eval(new_def, ctx, output_rows, args, extra)
                         }
                     }
                 }

--- a/src/coprocessor/dag/rpn_expr/types/function.rs
+++ b/src/coprocessor/dag/rpn_expr/types/function.rs
@@ -17,7 +17,7 @@
 //! itself. Instead, it creates a `foo_fn_meta()` function (simply add `_fn_meta` to the original
 //! function name) that generates an `RpnFnMeta` struct.
 //!
-//! In case of needing other parameters:
+//! In case of needing other parameters like `ctx`, `output_rows`, `args` and `extra`:
 //!
 //! ```ignore
 //! // This generates `with_context_fn_meta() -> RpnFnMeta`
@@ -26,8 +26,6 @@
 //!     // Your RPN function logic
 //! }
 //! ```
-//!
-//! All available parameters are: `ctx`, `output_rows`, `args`, `extra`.
 //!
 //! A trait whose name looks like `CamelCasedFnName_Fn` is created by the macro. If you need to
 //! customize the execution logic for specific argument type, you may implement it on your own.
@@ -84,9 +82,9 @@ pub struct RpnFnMeta {
     /// The display name of the RPN function. Mainly used in tests.
     pub name: &'static str,
 
-    /// Validator against input expression tree.
+    // TODO: Use validator ptr to verify input expression.
+    // /// Validator against input expression tree.
     // pub validator_ptr: fn(expr: &Expr) -> Result<()>,
-
     #[allow(clippy::type_complexity)]
     /// The RPN function.
     pub fn_ptr: fn(
@@ -96,8 +94,6 @@ pub struct RpnFnMeta {
         args: &[RpnStackNode<'_>],
         // Uncommon arguments are grouped together
         extra: &mut RpnFnCallExtra<'_>,
-        // Buffer for evaluating vargs.
-        vargs_buffer: &mut [usize],
     ) -> Result<VectorValue>,
 }
 
@@ -267,4 +263,9 @@ impl<E: Evaluator> Evaluator for ArgConstructor<E> {
             }
         }
     }
+}
+
+thread_local! {
+    pub static VARG_PARAM_BUF: std::cell::RefCell<Vec<usize>> =
+        std::cell::RefCell::new(Vec::with_capacity(20));
 }

--- a/src/coprocessor/dag/rpn_expr/types/mod.rs
+++ b/src/coprocessor/dag/rpn_expr/types/mod.rs
@@ -3,72 +3,11 @@
 mod expr;
 mod expr_builder;
 mod expr_eval;
+pub mod function;
 #[cfg(test)]
 pub mod test_util;
-
-use tipb::expression::FieldType;
 
 pub use self::expr::{RpnExpression, RpnExpressionNode};
 pub use self::expr_builder::RpnExpressionBuilder;
 pub use self::expr_eval::RpnStackNode;
-
-use crate::coprocessor::codec::data_type::ScalarValue;
-
-/// A structure for holding argument values and type information of arguments and return values.
-///
-/// It can simplify function signatures without losing performance where only argument values are
-/// needed in most cases.
-///
-/// NOTE: This structure must be very fast to copy because it will be passed by value directly
-/// (i.e. Copy), instead of by reference, for **EACH** function invocation.
-#[derive(Clone, Copy)]
-pub struct RpnFnCallPayload<'a> {
-    output_rows: usize,
-    raw_args: &'a [RpnStackNode<'a>],
-    implicit_args: &'a Vec<ScalarValue>,
-    ret_field_type: &'a FieldType,
-}
-
-impl<'a> RpnFnCallPayload<'a> {
-    /// The number of arguments.
-    #[inline]
-    pub fn args_len(&'a self) -> usize {
-        self.raw_args.len()
-    }
-
-    /// Gets the raw argument at specific position.
-    #[inline]
-    pub fn raw_arg_at(&'a self, position: usize) -> &'a RpnStackNode<'a> {
-        &self.raw_args[position]
-    }
-
-    /// Gets the field type of the argument at specific position.
-    #[inline]
-    pub fn field_type_at(&'a self, position: usize) -> &'a FieldType {
-        self.raw_args[position].field_type()
-    }
-
-    /// Gets the field type of the return value.
-    #[inline]
-    pub fn return_field_type(&'a self) -> &'a FieldType {
-        self.ret_field_type
-    }
-
-    /// Gets expected rows of output.
-    #[inline]
-    pub fn output_rows(&'a self) -> usize {
-        self.output_rows
-    }
-
-    /// Gets the length of implicit arguments
-    #[inline]
-    pub fn implicit_args_len(&'a self) -> usize {
-        self.implicit_args.len()
-    }
-
-    /// Get implicit argument at the special position
-    #[inline]
-    pub fn implicit_args_at(&'a self, position: usize) -> &'a ScalarValue {
-        &self.implicit_args[position]
-    }
-}
+pub use self::function::{RpnFnCallExtra, RpnFnMeta};

--- a/src/coprocessor/dag/rpn_expr/types/test_util.rs
+++ b/src/coprocessor/dag/rpn_expr/types/test_util.rs
@@ -5,8 +5,8 @@ use tipb::expression::{Expr, FieldType, ScalarFuncSig};
 use crate::coprocessor::codec::batch::LazyBatchColumnVec;
 use crate::coprocessor::codec::data_type::{Evaluable, ScalarValue};
 use crate::coprocessor::dag::expr::EvalContext;
-use crate::coprocessor::dag::rpn_expr::types::RpnStackNode;
 use crate::coprocessor::dag::rpn_expr::RpnExpressionBuilder;
+use crate::coprocessor::dag::rpn_expr::RpnStackNode;
 use crate::coprocessor::Result;
 
 /// Helper utility to evaluate RPN function over scalar inputs.
@@ -91,7 +91,7 @@ impl RpnFnScalarEvaluator {
 
         let expr = self
             .rpn_expr_builder
-            .push_fn_call(func, return_field_type)
+            .push_fn_call(func, children_ed.len(), return_field_type)
             .build();
 
         let mut columns = LazyBatchColumnVec::empty();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR adds vargs support to the RPN framework.

It also includes the implementation of `coalesce_xxx` as a demonstration of the vargs support.

## What are the type of the changes? (mandatory)

- New feature (change which adds functionality)

## How has this PR been tested? (mandatory)

New unit tests.
