### PR TITLE
[DNM] use abort instead of exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.
 
 ## [Unreleased]
 
++ Engine
+  - Fix Titan portable build
+
 ## [3.0.0]
 
 + Engine


### PR DESCRIPTION
## What have you changed? (mandatory)
When calling exit90 in panic_hook, it triggers global static to destroy, like c++ static dtors, which may cause other threads encounter `pure virtual method call`. So using abort instead of exit.

## What are the type of the changes? (mandatory)
- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)


