### PR TITLE
tikv_util: call _exit instead of exit in panic hook

### DIFF
--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -528,7 +528,13 @@ pub fn set_panic_hook(panic_abort: bool, data_dir: &str) {
         if panic_abort {
             process::abort();
         } else {
-            process::exit(1);
+            unsafe {
+                // Calling process::exit would trigger global static to destroy, like C++
+                // static variables of RocksDB, which may cause other threads encounter
+                // pure virtual method call. So calling libc::_exit() instead to skip the
+                // cleanup process.
+                libc::_exit(1);
+            }
         }
     }))
 }


### PR DESCRIPTION
## What have you changed? (mandatory)
When calling exit() in panic_hook, it triggers global static to destroy, like c++ static dtors, which may cause other threads encounter `pure virtual method call`. So using `_exit` instead of `exit`.

## What are the type of the changes? (mandatory)
- Bug fix (change which fixes an issue)
