### PR TITLE
fix test_node_request_snapshot_reject_merge

### DIFF
--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -467,4 +467,5 @@ fn test_node_request_snapshot_reject_merge() {
     let target = cluster.get_region(target_region.get_start_key());
     assert_eq!(target, target_region);
     fail::remove(region_gen_snap_fp);
+    drop(cluster);
 }

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -467,5 +467,6 @@ fn test_node_request_snapshot_reject_merge() {
     let target = cluster.get_region(target_region.get_start_key());
     assert_eq!(target, target_region);
     fail::remove(region_gen_snap_fp);
+    // Drop cluster to ensure notifier will not send any message after rx is dropped.
     drop(cluster);
 }


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

test cases::test_merge::test_node_request_snapshot_reject_merge failed while running CI (see https://github.com/tikv/tikv/issues/5054).
I found it may be caused by the variable `notifier` https://github.com/tikv/tikv/blob/c3a8f2152164abe7c2285ee836d087146c7c9422/tests/failpoints/cases/test_merge.rs#L444-L451  sends a message after the variable `rx` was deconstructed. https://github.com/tikv/tikv/blob/c3a8f2152164abe7c2285ee836d087146c7c9422/tests/failpoints/cases/test_merge.rs#L454
Deconstructing `cluster` before the function returns could fix this problem.

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)
