### PR TITLE
raftclient: add test case for server reconnection (#5030)

### DIFF
--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -204,7 +204,7 @@ impl<T: RaftStoreRouter> RaftClient<T> {
             .stream
             .send(msg)
         {
-            error!("RaftClient fails to send");
+            error!("send to {} fail, the gRPC connection could be broken", addr);
             let index = msg.region_id as usize % self.cfg.grpc_raft_conn_num;
             self.conns.remove(&(addr.to_owned(), index));
 
@@ -213,6 +213,7 @@ impl<T: RaftStoreRouter> RaftClient<T> {
                     self.addrs.insert(store_id, current_addr);
                 }
             }
+            return Err(box_err!("RaftClient send fail"));
         }
         Ok(())
     }

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use std::{thread, time};
 
 use futures::{Future, Stream};
-use grpcio::*;
+use grpcio::{
+    ClientStreamingSink, Environment, RequestStream, RpcContext, RpcStatus, RpcStatusCode, Server,
+};
 use kvproto::raft_serverpb::{Done, RaftMessage};
 use kvproto::tikvpb::BatchRaftMessage;
 use tikv::server::transport::RaftStoreBlackHole;
@@ -67,25 +69,120 @@ fn test_batch_raft_fallback() {
     let mut raft_client = get_raft_client(&pool);
     let counter = Arc::new(AtomicUsize::new(0));
 
-    // Try to bind the mock server on a TCP port, and then do test.
-    for i in 0..100 {
-        let kv_service = MockKv(MockKvForRaft(Arc::clone(&counter)));
-        let port = 60000 + i;
-        let mut mock_server = match mock_kv_service(kv_service, "localhost", port) {
+    let service = MockKvForRaft(Arc::clone(&counter));
+    let (mock_server, port) = create_mock_server(service, 60000, 60100).unwrap();
+
+    let addr = format!("localhost:{}", port);
+    (0..100).for_each(|_| {
+        raft_client.send(1, &addr, RaftMessage::new()).unwrap();
+        thread::sleep(time::Duration::from_millis(10));
+        raft_client.flush();
+    });
+
+    assert!(counter.load(Ordering::SeqCst) > 0);
+    pool.shutdown().wait().unwrap();
+    drop(mock_server)
+}
+
+#[test]
+// Test raft_client auto reconnect to servers after connection break.
+fn test_raft_client_reconnect() {
+    #[derive(Clone)]
+    struct MockKvForRaft(Arc<AtomicUsize>);
+
+    impl MockKvService for MockKvForRaft {
+        fn batch_raft(
+            &mut self,
+            ctx: RpcContext<'_>,
+            stream: RequestStream<BatchRaftMessage>,
+            sink: ClientStreamingSink<Done>,
+        ) {
+            let counter = Arc::clone(&self.0);
+            ctx.spawn(
+                stream
+                    .for_each(move |msgs| {
+                        let len = msgs.msgs.len();
+                        counter.fetch_add(len, Ordering::SeqCst);
+                        Ok(())
+                    })
+                    .map_err(|_| drop(sink)),
+            );
+        }
+    }
+
+    let pool = tokio_threadpool::Builder::new().pool_size(1).build();
+    let mut raft_client = get_raft_client(&pool);
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    let service = MockKvForRaft(Arc::clone(&counter));
+    let (mock_server, port) = create_mock_server(service, 50000, 50300).unwrap();
+    let addr = format!("localhost:{}", port);
+
+    // `send` should success.
+    (0..50).for_each(|_| raft_client.send(1, &addr, RaftMessage::new()).unwrap());
+    raft_client.flush();
+
+    check_f(300, || counter.load(Ordering::SeqCst) == 50);
+
+    // `send` should fail after the mock server stopped.
+    drop(mock_server);
+
+    assert!((0..100)
+        .map(|_| raft_client.send(1, &addr, RaftMessage::new()))
+        .collect::<Result<(), _>>()
+        .is_err());
+
+    // `send` should success after the mock server restarted.
+    let service = MockKvForRaft(Arc::clone(&counter));
+    let mock_server = create_mock_server_on(service, port);
+    (0..50).for_each(|_| raft_client.send(1, &addr, RaftMessage::new()).unwrap());
+    raft_client.flush();
+
+    check_f(300, || counter.load(Ordering::SeqCst) == 100);
+    assert_eq!(counter.load(Ordering::SeqCst), 100);
+
+    drop(mock_server);
+    pool.shutdown().wait().unwrap();
+}
+
+// Try to create a mock server with `service`. The server will be binded wiht a random
+// port chosen between [`min_port`, `max_port`]. Return `None` if no port is available.
+fn create_mock_server<T>(service: T, min_port: u16, max_port: u16) -> Option<(Server, u16)>
+where
+    T: MockKvService + Clone + Send + 'static,
+{
+    for port in min_port..=max_port {
+        let kv = MockKv(service.clone());
+        let mut mock_server = match mock_kv_service(kv, "localhost", port) {
             Ok(s) => s,
             Err(_) => continue,
         };
         mock_server.start();
-
-        let addr = format!("localhost:{}", port);
-        (0..100).for_each(|_| {
-            raft_client.send(1, &addr, RaftMessage::new()).unwrap();
-            thread::sleep(time::Duration::from_millis(10));
-            raft_client.flush();
-        });
-
-        assert!(counter.load(Ordering::SeqCst) > 0);
-        break;
+        return Some((mock_server, port));
     }
-    pool.shutdown().wait().unwrap();
+    None
+}
+
+// Try to create a mock server with `service` and bind it with `port`.
+// Return `None` is the port is unavailable.
+fn create_mock_server_on<T>(service: T, port: u16) -> Option<Server>
+where
+    T: MockKvService + Clone + Send + 'static,
+{
+    let mut mock_server = match mock_kv_service(MockKv(service), "localhost", port) {
+        Ok(s) => s,
+        Err(_) => return None,
+    };
+    mock_server.start();
+    Some(mock_server)
+}
+
+fn check_f<F: Fn() -> bool>(max_delay_ms: u64, f: F) {
+    for _delay_ms in 0..max_delay_ms / 10 {
+        if f() {
+            return;
+        }
+        thread::sleep(time::Duration::from_millis(10));
+    }
+    panic!("raftclient flush time out");
 }


### PR DESCRIPTION
Signed-off-by: zhouyuanhui <zhouyuanhui@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Add a test code，test raft_client auto reconnect to servers after connection break

## What are the type of the changes? (mandatory)

Engineering (engineering change which doesn't change any feature or fix any issue) 

## How has this PR been tested? (mandatory)

CI

## Does this PR affect documentation (docs) or release note? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no
