### PR TITLE
coprocessor: fix `Duration::parse` while input is empty

### DIFF
--- a/src/coprocessor/codec/mysql/duration.rs
+++ b/src/coprocessor/codec/mysql/duration.rs
@@ -465,11 +465,11 @@ impl Duration {
     /// returns the duration type `Time` value.
     /// See: http://dev.mysql.com/doc/refman/5.7/en/fractional-seconds.html
     pub fn parse(input: &[u8], fsp: i8) -> Result<Duration> {
-        if input.is_empty() {
-            return Err(invalid_type!("invalid time format"));
-        }
-
         let fsp = check_fsp(fsp)?;
+
+        if input.is_empty() {
+            return Ok(Duration::zero());
+        }
 
         let (mut neg, [mut day, mut hour, mut minute, mut second, micros]) =
             self::parser::parse(input, fsp)
@@ -857,7 +857,8 @@ mod tests {
             (b" - 1 : 2 :  3 .123 ", 3, Some("-01:02:03.123")),
             (b" - 1 .123 ", 3, Some("-00:00:01.123")),
             (b"-", 0, None),
-            (b"", 0, None),
+            (b"", 0, Some("00:00:00")),
+            (b"", 7, None),
             (b"18446744073709551615:59:59", 0, None),
             (b"1::2:3", 0, None),
             (b"1.23 3", 0, None),


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

There is different behavior in TiDB and Coprocessor when `Duration::parse` input string is empty.

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Unit tests

