### PR TITLE
DNM: Use Prost instead off rust-protobuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -231,7 +231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -243,7 +243,7 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -263,7 +263,6 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_hook 0.0.1",
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tikv_alloc 0.1.0",
@@ -293,7 +292,7 @@ dependencies = [
 name = "cop_datatype"
 version = "0.0.1"
 dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -532,6 +531,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,12 +561,12 @@ version = "0.0.1"
 dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.0)",
+ "kvproto 0.0.2",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "raft 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raft 0.4.3 (git+https://github.com/pingcap/raft-rs?rev=eeaee89a4eba7aa17abd630388df2f1c3a0f76ad)",
  "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -633,6 +642,11 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "flate2"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,7 +695,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -778,28 +792,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grpcio"
-version = "0.4.2"
+version = "0.5.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio-sys 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-sys 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grpcio-compiler"
-version = "0.4.3"
+version = "0.5.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf-codegen 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grpcio-sys"
-version = "0.4.2"
+version = "0.5.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1012,15 +1033,16 @@ dependencies = [
 
 [[package]]
 name = "kvproto"
-version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.0#7809473e1b70f4bed152e685716d683de30a1de0"
+version = "0.0.2"
 dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "raft 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.5.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)",
+ "prost-derive 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)",
+ "protobuf-build 0.7.0",
+ "raft-proto 0.4.3 (git+https://github.com/pingcap/raft-rs?rev=eeaee89a4eba7aa17abd630388df2f1c3a0f76ad)",
 ]
 
 [[package]]
@@ -1152,7 +1174,7 @@ name = "log_wrappers"
 version = "0.0.1"
 dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.0)",
+ "kvproto 0.0.2",
  "slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tikv_alloc 0.1.0",
@@ -1285,6 +1307,11 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "multimap"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "murmur3"
 version = "0.4.0"
 source = "git+https://github.com/pingcap/murmur3.git#4af9e1a8f2d4206d90d81f11e513fb03c87208bf"
@@ -1307,7 +1334,7 @@ name = "nix"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1458,6 +1485,14 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "petgraph"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,7 +1557,7 @@ dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "procinfo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1539,18 +1574,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.5.0"
+source = "git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77#1944c27c3029d01ff216e7b126d846b6cf8c7d77"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)",
+]
+
+[[package]]
+name = "prost"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+replace = "prost 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)"
+
+[[package]]
+name = "prost-build"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.5.0"
+source = "git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77#1944c27c3029d01ff216e7b126d846b6cf8c7d77"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "protobuf"
-version = "2.0.4"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "protobuf-build"
-version = "0.1.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "grpcio-compiler 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc-grpcio 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc-rust 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-compiler 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-grpcio 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-rust 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "protobuf-build"
+version = "0.7.0"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-compiler 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-grpcio 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-rust 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1558,42 +1673,42 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.0.4"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "protoc"
-version = "2.0.4"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "protoc-grpcio"
-version = "0.3.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio-compiler 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf-codegen 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-compiler 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "protoc-rust"
-version = "2.0.4"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf-codegen 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1630,20 +1745,30 @@ dependencies = [
 [[package]]
 name = "raft"
 version = "0.4.3"
-source = "git+https://github.com/pingcap/raft-rs/?branch=0.4.x#fe10576720a3ad3b35def3686ebaea2b1ebb4d85"
+source = "git+https://github.com/pingcap/raft-rs?rev=eeaee89a4eba7aa17abd630388df2f1c3a0f76ad#eeaee89a4eba7aa17abd630388df2f1c3a0f76ad"
 dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)",
+ "prost-derive 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raft-proto 0.4.3 (git+https://github.com/pingcap/raft-rs?rev=eeaee89a4eba7aa17abd630388df2f1c3a0f76ad)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "raft"
+name = "raft-proto"
 version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-replace = "raft 0.4.3 (git+https://github.com/pingcap/raft-rs/?branch=0.4.x)"
+source = "git+https://github.com/pingcap/raft-rs?rev=eeaee89a4eba7aa17abd630388df2f1c3a0f76ad#eeaee89a4eba7aa17abd630388df2f1c3a0f76ad"
+dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)",
+ "prost-derive 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)",
+ "protobuf-build 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -1698,7 +1823,7 @@ name = "rand_chacha"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1728,7 +1853,7 @@ name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1776,7 +1901,7 @@ name = "rand_xorshift"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2216,14 +2341,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "tempdir"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,8 +2377,8 @@ name = "test_coprocessor"
 version = "0.0.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.0)",
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvproto 0.0.2",
+ "prost 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)",
  "test_storage 0.0.1",
  "tikv 4.0.0-alpha",
  "tikv_util 0.1.0",
@@ -2274,11 +2391,10 @@ version = "0.0.1"
 dependencies = [
  "engine 0.0.1",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.5.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.0)",
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "raft 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvproto 0.0.2",
+ "raft 0.4.3 (git+https://github.com/pingcap/raft-rs?rev=eeaee89a4eba7aa17abd630388df2f1c3a0f76ad)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
@@ -2294,7 +2410,7 @@ name = "test_storage"
 version = "0.0.1"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.0)",
+ "kvproto 0.0.2",
  "test_raftstore 0.0.1",
  "tikv 4.0.0-alpha",
  "tikv_util 0.1.0",
@@ -2336,7 +2452,7 @@ dependencies = [
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitfield 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono-tz 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2357,11 +2473,11 @@ dependencies = [
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-locks 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.5.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.0)",
+ "kvproto 0.0.2",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2380,9 +2496,9 @@ dependencies = [
  "profiler 0.0.1",
  "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus-static-metric 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "raft 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raft 0.4.3 (git+https://github.com/pingcap/raft-rs?rev=eeaee89a4eba7aa17abd630388df2f1c3a0f76ad)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2452,7 +2568,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.5.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2461,9 +2577,9 @@ dependencies = [
  "procinfo 0.4.2 (git+https://github.com/tikv/procinfo-rs)",
  "prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus-static-metric 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "raft 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raft 0.4.3 (git+https://github.com/pingcap/raft-rs?rev=eeaee89a4eba7aa17abd630388df2f1c3a0f76ad)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2508,9 +2624,14 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#833c2ffd2fe7aad5224dd7c2b05fb24bc109e969"
+source = "git+https://github.com/pingcap/tipb.git#0c0ce040d91b2feaed2eebe76a8fb3c3ebd304d3"
 dependencies = [
- "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-build 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2882,6 +3003,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,7 +3097,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
 "checksum base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "621fc7ecb8008f86d7fb9b95356cd692ce9514b80a86d85b397f32a22da7b9e2"
 "checksum bitfield 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
-"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e4ca3a1755927e5b00c3fe43250053b957b5c074d9f17782b88ef7aa0fb4dfe2"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
@@ -3005,6 +3135,7 @@ dependencies = [
 "checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
 "checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
+"checksum derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ca414e896ae072546f4d789f452daaecf60ddee4c9df5dc6d5936d769e3d87c"
 "checksum derive_more 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46c7f14685a20f5dd08e7f754f2ea8cc064d8f4214ae21116c106a2768ba7b9b"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
@@ -3014,6 +3145,7 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum farmhash 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f35ce9c8fb9891c75ceadbc330752951a4e369b50af10775955aeb9af3eee34b"
+"checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96971e4fc2737f211ec8236fe16ac67695838ca3e25567c07b4f837d1f8f829c"
 "checksum flate2-crc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8a792245eaed7747984647ce20582507985d69ccfacdddcb60bd5f451f21cbc5"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -3028,9 +3160,9 @@ dependencies = [
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-"checksum grpcio 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5cef8e7d071d3e48349528932590b2a4c6fc8b3e20cec1e3bdc52c4d831e89a"
-"checksum grpcio-compiler 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373a14f0f994d4c235770f4bb5558be00626844db130a82a70142b8fc5996fc3"
-"checksum grpcio-sys 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "456f8b46b47028e75726587987ead25144ac14c7c9e79f28bbb71436eca67d68"
+"checksum grpcio 0.5.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f06ce97d149a7e9c5cb0bbc4ab014f2500e478e584ac97bb577658b834842232"
+"checksum grpcio-compiler 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)" = "9a135632fa82163b355fd629acfc07e4521166a87ad4b0716e148203735fa450"
+"checksum grpcio-sys 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)" = "1e85ec75a9091220c12695560c63ace432481d8a3014812bd7f897f977a3f47c"
 "checksum h2 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1ac030ae20dee464c5d0f36544d8b914a6bc606da44a57e052d2b0f5dae129e0"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -3051,7 +3183,6 @@ dependencies = [
 "checksum jemalloc-sys 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "bfc62c8e50e381768ce8ee0428ee53741929f7ebd73e4d83f669bcf7693e00ae"
 "checksum jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0cd42ac65f758063fea55126b0148b1ce0a6354ff78e07a4d6806bc65c4ab3"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.0)" = "<none>"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
@@ -3080,6 +3211,7 @@ dependencies = [
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum more-asserts 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf21d96e87e5d48e3b50ab1512142f2fbe06fc48b7b032dead87fbfcb83f9a89"
+"checksum multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
 "checksum murmur3 0.4.0 (git+https://github.com/pingcap/murmur3.git)" = "<none>"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
@@ -3101,6 +3233,7 @@ dependencies = [
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
 "checksum parse-zoneinfo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "089a398ccdcdd77b8c38909d5a1e4b67da1bc4c9dbfe6d5b536c828eddb779e5"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
+"checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)" = "64c827cea7a7ab30ce4593e5e04d7a11617ad6ece2fa230605a78b00ff965316"
@@ -3108,19 +3241,25 @@ dependencies = [
 "checksum procinfo 0.4.2 (git+https://github.com/tikv/procinfo-rs)" = "<none>"
 "checksum prometheus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "760293453bee1de0a12987422d7c4885f7ee933e4417bb828ed23f7d05c3c390"
 "checksum prometheus-static-metric 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1d2b4a6a1ae793e7eb6773a5301a5a08e8929ea5517b677c93e57ce2d0973c02"
-"checksum protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "128a4f37a2df739a567a8685b17f54aa19b9c3c4a6a5b8731e97a419b3db451c"
-"checksum protobuf-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a94ea746889322eb33b6977db6ffe82b1decaac1804958b9179245fc45dc4b6"
-"checksum protobuf-codegen 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3624c0feac7f512de21dbf8b574ae65c6573b1872d3878be951c0912eee4daca"
-"checksum protoc 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8736a41d7c7e321913dd81067fbedf74d037f69999386eba07cc4dd1de7369f0"
-"checksum protoc-grpcio 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a9798b534614b71d780778b1508410826073b5a1ca111a090f1f3fd3ac663ef6"
-"checksum protoc-rust 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25cba75872da640d0a9a78a9e0cf4b32c98b2f1b26c926aa384a2075ec522c37"
+"checksum prost 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)" = "<none>"
+"checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
+"checksum prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
+"checksum prost-derive 0.5.0 (git+https://github.com/danburkert/prost?rev=1944c27c3029d01ff216e7b126d846b6cf8c7d77)" = "<none>"
+"checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
+"checksum prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
+"checksum protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f00e4a3cb64ecfeac2c0a73c74c68ae3439d7a6bead3870be56ad5dd2620a6f"
+"checksum protobuf-build 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6051c2c827f2c51ea06ef68574c2ca38d0272960c5d98ebda0f5d44d7e7308fb"
+"checksum protobuf-codegen 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2c6e555166cdb646306f599da020e01548e9f4d6ec2fd39802c6db2347cbd3e"
+"checksum protoc 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f26e88abedb402073b87981faecc3b973dd5b19b7002821ed47c457bc5b367a4"
+"checksum protoc-grpcio 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "da4389258ed4b768438edec1e1e813cc7fa29e70c1b1cb4eb2f8fc341dc562dd"
+"checksum protoc-rust 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94ce06ff9a4fbc3a695f8e8ed0b2455744d79108110ac70cb8a091f25d3d3c09"
 "checksum quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ac990ab4e038dd8481a5e3fd00641067fcfc674ad663f3222752ed5284e05d4"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
-"checksum raft 0.4.3 (git+https://github.com/pingcap/raft-rs/?branch=0.4.x)" = "<none>"
-"checksum raft 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "43648985159f2c4c25f934182a63b0dd4c5cc06a5ae96e5d40e12c3a3785abde"
+"checksum raft 0.4.3 (git+https://github.com/pingcap/raft-rs?rev=eeaee89a4eba7aa17abd630388df2f1c3a0f76ad)" = "<none>"
+"checksum raft-proto 0.4.3 (git+https://github.com/pingcap/raft-rs?rev=eeaee89a4eba7aa17abd630388df2f1c3a0f76ad)" = "<none>"
 "checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
@@ -3191,7 +3330,6 @@ dependencies = [
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tcmalloc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "375205113d84a1c5eeed67beaa0ce08e41be1a9d5acc3425ad2381fddd9d819b"
 "checksum tcmalloc-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7ad73e635dd232c2c2106d59269f59a61de421cc6b95252d2d932094ff1f40"
-"checksum tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0b62933a3f96cd559700662c34f8bab881d9e3540289fb4f368419c7f13a5aa9"
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
@@ -3241,6 +3379,7 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
+"checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ libc = "0.2"
 crc = "1.8"
 fs2 = "0.4"
 spin = "0.5"
-protobuf = "2"
+prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
 nix = "0.11"
 utime = "0.2"
 chrono = "0.4"
@@ -101,8 +101,8 @@ zipf = "5.0.1"
 bitflags = "1.0.1"
 fail = "0.2"
 uuid = { version = "0.6", features = [ "serde", "v4" ] }
-grpcio = { version = "0.4", features = [ "secure" ] }
-raft = "0.4.3"
+grpcio = { version = "0.5.0-alpha.1", features = [ "secure", "prost-codec" ], default-features = false }
+raft = { git = "https://github.com/pingcap/raft-rs", rev = "eeaee89a4eba7aa17abd630388df2f1c3a0f76ad" }
 crossbeam = "0.5"
 derive_more = "0.11.0"
 num = { version = "0.2", default-features = false }
@@ -124,16 +124,15 @@ ordered-float = "1.0"
 nom = "5.0.0-beta1"
 servo_arc = "0.1.1"
 bitfield = "0.13.2"
-profiler = { path = "components/profiler" }
+tipb = { git = "https://github.com/pingcap/tipb.git", features = ["prost-codec"] }
+kvproto = { path = "../kvproto" }
 mime = "0.3.13"
+profiler = { path = "components/profiler" }
 match_template = { path = "components/match_template" }
 cop_datatype = { path = "components/cop_datatype" }
 cop_codegen = { path = "components/cop_codegen" }
 codec = { path = "components/codec" }
 tipb_helper = { path = "components/tipb_helper" }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
-# TODO: use master branch after the next version is released.
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-3.0" }
 log_wrappers = { path = "components/log_wrappers" }
 engine = { path = "components/engine" }
 tikv_util = { path = "components/tikv_util" }
@@ -156,7 +155,7 @@ default-features = false
 [replace]
 "log:0.3.9" = { git = "https://github.com/busyjay/log", branch = "use-static-module" }
 "log:0.4.6" = { git = "https://github.com/busyjay/log", branch = "revert-to-static" }
-"raft:0.4.3" = { git = "https://github.com/pingcap/raft-rs/", branch = "0.4.x" }
+"prost:0.5.0" = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
 
 [dev-dependencies]
 panic_hook = { path = "components/panic_hook" }

--- a/benches/coprocessor_executors/hash_aggr/mod.rs
+++ b/benches/coprocessor_executors/hash_aggr/mod.rs
@@ -3,7 +3,7 @@
 mod util;
 
 use cop_datatype::FieldTypeTp;
-use tipb::expression::{ExprType, ScalarFuncSig};
+use tipb::{ExprType, ScalarFuncSig};
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::{BenchCase, FixtureBuilder};
@@ -36,7 +36,7 @@ fn bench_hash_aggr_count_1_group_by_int_col_2_groups(b: &mut criterion::Bencher,
 fn bench_hash_aggr_count_1_group_by_fn_2_groups(b: &mut criterion::Bencher, input: &Input) {
     let fb = FixtureBuilder::new(input.src_rows).push_column_i64_0_n();
     let group_by = vec![
-        ExprDefBuilder::scalar_func(ScalarFuncSig::GTInt, FieldTypeTp::LongLong)
+        ExprDefBuilder::scalar_func(ScalarFuncSig::GtInt, FieldTypeTp::LongLong)
             .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
             .push_child(ExprDefBuilder::constant_int((input.src_rows / 2) as i64))
             .build(),

--- a/benches/coprocessor_executors/hash_aggr/util.rs
+++ b/benches/coprocessor_executors/hash_aggr/util.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use tipb::executor::Aggregation;
-use tipb::expression::Expr;
+use tipb::Aggregation;
+use tipb::Expr;
 
 use tikv::coprocessor::dag::batch::executors::BatchFastHashAggregationExecutor;
 use tikv::coprocessor::dag::batch::executors::BatchSlowHashAggregationExecutor;
@@ -91,7 +91,7 @@ impl HashAggrBencher for BatchBencher {
     ) {
         crate::util::bencher::BatchNextAllBencher::new(|| {
             let src = fb.clone().build_batch_fixture_executor();
-            let mut meta = Aggregation::new();
+            let mut meta = Aggregation::default();
             meta.set_agg_func(aggr_expr.to_vec().into());
             meta.set_group_by(group_by_expr.to_vec().into());
             if BatchFastHashAggregationExecutor::check_supported(&meta).is_ok() {

--- a/benches/coprocessor_executors/index_scan/util.rs
+++ b/benches/coprocessor_executors/index_scan/util.rs
@@ -5,11 +5,9 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use protobuf::RepeatedField;
-
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::IndexScan;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::IndexScan;
 
 use test_coprocessor::*;
 use tikv::coprocessor::dag::batch::executors::BatchIndexScanExecutor;
@@ -41,8 +39,8 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
         store: &Store<RocksEngine>,
         unique: bool,
     ) -> Self::E {
-        let mut req = IndexScan::new();
-        req.set_columns(RepeatedField::from_slice(columns));
+        let mut req = IndexScan::default();
+        req.set_columns(columns.to_owned());
 
         let mut executor = IndexScanExecutor::index_scan(
             black_box(req),

--- a/benches/coprocessor_executors/integrated/mod.rs
+++ b/benches/coprocessor_executors/integrated/mod.rs
@@ -4,7 +4,7 @@ mod fixture;
 mod util;
 
 use cop_datatype::FieldTypeTp;
-use tipb::expression::{ExprType, ScalarFuncSig};
+use tipb::{ExprType, ScalarFuncSig};
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::executor_descriptor::*;
@@ -70,7 +70,7 @@ fn bench_select_col_where_fn_impl(selectivity: f64, b: &mut criterion::Bencher, 
     let executors = &[
         table_scan(&[table["foo"].as_column_info()]),
         selection(&[
-            ExprDefBuilder::scalar_func(ScalarFuncSig::GTInt, FieldTypeTp::LongLong)
+            ExprDefBuilder::scalar_func(ScalarFuncSig::GtInt, FieldTypeTp::LongLong)
                 .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
                 .push_child(ExprDefBuilder::constant_int(
                     (input.rows as f64 * selectivity) as i64,
@@ -105,7 +105,7 @@ fn bench_select_count_1_where_fn_impl(selectivity: f64, b: &mut criterion::Bench
     let executors = &[
         table_scan(&[table["foo"].as_column_info()]),
         selection(&[
-            ExprDefBuilder::scalar_func(ScalarFuncSig::GTInt, FieldTypeTp::LongLong)
+            ExprDefBuilder::scalar_func(ScalarFuncSig::GtInt, FieldTypeTp::LongLong)
                 .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
                 .push_child(ExprDefBuilder::constant_int(
                     (input.rows as f64 * selectivity) as i64,
@@ -350,7 +350,7 @@ fn bench_select_count_1_where_fn_group_by_int_col_group_few_sel_l(
     let executors = &[
         table_scan(&[table["id"].as_column_info(), table["foo"].as_column_info()]),
         selection(&[
-            ExprDefBuilder::scalar_func(ScalarFuncSig::GTInt, FieldTypeTp::LongLong)
+            ExprDefBuilder::scalar_func(ScalarFuncSig::GtInt, FieldTypeTp::LongLong)
                 .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
                 .push_child(ExprDefBuilder::constant_int(
                     (input.rows as f64 * 0.05) as i64,
@@ -383,7 +383,7 @@ fn bench_select_count_1_where_fn_group_by_int_col_group_few_sel_l_stream(
     let executors = &[
         table_scan(&[table["id"].as_column_info(), table["foo"].as_column_info()]),
         selection(&[
-            ExprDefBuilder::scalar_func(ScalarFuncSig::GTInt, FieldTypeTp::LongLong)
+            ExprDefBuilder::scalar_func(ScalarFuncSig::GtInt, FieldTypeTp::LongLong)
                 .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
                 .push_child(ExprDefBuilder::constant_int(
                     (input.rows as f64 * 0.05) as i64,
@@ -461,7 +461,7 @@ fn bench_select_where_fn_order_by_3_col_impl(
             table["col2"].as_column_info(),
         ]),
         selection(&[
-            ExprDefBuilder::scalar_func(ScalarFuncSig::GTInt, FieldTypeTp::LongLong)
+            ExprDefBuilder::scalar_func(ScalarFuncSig::GtInt, FieldTypeTp::LongLong)
                 .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
                 .push_child(ExprDefBuilder::constant_int(0))
                 .build(),

--- a/benches/coprocessor_executors/integrated/util.rs
+++ b/benches/coprocessor_executors/integrated/util.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use criterion::black_box;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::Executor as PbExecutor;
+use tipb::Executor as PbExecutor;
 
 use test_coprocessor::*;
 use tikv::coprocessor::dag::exec_summary::ExecSummaryCollectorDisabled;

--- a/benches/coprocessor_executors/selection/mod.rs
+++ b/benches/coprocessor_executors/selection/mod.rs
@@ -3,7 +3,7 @@
 mod util;
 
 use cop_datatype::FieldTypeTp;
-use tipb::expression::ScalarFuncSig;
+use tipb::ScalarFuncSig;
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::{BenchCase, FixtureBuilder};
@@ -20,7 +20,7 @@ fn bench_selection_binary_func_column_column(b: &mut criterion::Bencher, input: 
     let fb = FixtureBuilder::new(input.src_rows)
         .push_column_f64_random()
         .push_column_f64_random();
-    let expr = ExprDefBuilder::scalar_func(ScalarFuncSig::GTReal, FieldTypeTp::LongLong)
+    let expr = ExprDefBuilder::scalar_func(ScalarFuncSig::GtReal, FieldTypeTp::LongLong)
         .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::Double))
         .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::Double))
         .build();
@@ -30,7 +30,7 @@ fn bench_selection_binary_func_column_column(b: &mut criterion::Bencher, input: 
 /// For SQLS like `WHERE a > 1`.
 fn bench_selection_binary_func_column_constant(b: &mut criterion::Bencher, input: &Input) {
     let fb = FixtureBuilder::new(input.src_rows).push_column_f64_random();
-    let expr = ExprDefBuilder::scalar_func(ScalarFuncSig::GTReal, FieldTypeTp::LongLong)
+    let expr = ExprDefBuilder::scalar_func(ScalarFuncSig::GtReal, FieldTypeTp::LongLong)
         .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::Double))
         .push_child(ExprDefBuilder::constant_real(0.42))
         .build();
@@ -43,11 +43,11 @@ fn bench_selection_multiple_predicate(b: &mut criterion::Bencher, input: &Input)
         .push_column_i64_random()
         .push_column_f64_random();
     let exprs = [
-        ExprDefBuilder::scalar_func(ScalarFuncSig::GTReal, FieldTypeTp::LongLong)
+        ExprDefBuilder::scalar_func(ScalarFuncSig::GtReal, FieldTypeTp::LongLong)
             .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::Double))
             .push_child(ExprDefBuilder::constant_real(0.63))
             .build(),
-        ExprDefBuilder::scalar_func(ScalarFuncSig::LEInt, FieldTypeTp::LongLong)
+        ExprDefBuilder::scalar_func(ScalarFuncSig::LeInt, FieldTypeTp::LongLong)
             .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
             .push_child(ExprDefBuilder::constant_int(0x10FF10))
             .build(),

--- a/benches/coprocessor_executors/selection/util.rs
+++ b/benches/coprocessor_executors/selection/util.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use tipb::expression::Expr;
+use tipb::Expr;
 
 use tikv::coprocessor::dag::batch::executors::BatchSelectionExecutor;
 use tikv::coprocessor::dag::batch::interface::BatchExecutor;

--- a/benches/coprocessor_executors/simple_aggr/mod.rs
+++ b/benches/coprocessor_executors/simple_aggr/mod.rs
@@ -3,7 +3,7 @@
 mod util;
 
 use cop_datatype::FieldTypeTp;
-use tipb::expression::ExprType;
+use tipb::ExprType;
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::{BenchCase, FixtureBuilder};

--- a/benches/coprocessor_executors/simple_aggr/util.rs
+++ b/benches/coprocessor_executors/simple_aggr/util.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use tipb::expression::Expr;
+use tipb::Expr;
 
 use tikv::coprocessor::dag::batch::executors::BatchSimpleAggregationExecutor;
 use tikv::coprocessor::dag::batch::interface::BatchExecutor;

--- a/benches/coprocessor_executors/stream_aggr/mod.rs
+++ b/benches/coprocessor_executors/stream_aggr/mod.rs
@@ -3,7 +3,7 @@
 mod util;
 
 use cop_datatype::FieldTypeTp;
-use tipb::expression::ExprType;
+use tipb::ExprType;
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::{BenchCase, FixtureBuilder};

--- a/benches/coprocessor_executors/stream_aggr/util.rs
+++ b/benches/coprocessor_executors/stream_aggr/util.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use tipb::expression::Expr;
+use tipb::Expr;
 
 use tikv::coprocessor::dag::batch::executors::BatchStreamAggregationExecutor;
 use tikv::coprocessor::dag::batch::interface::BatchExecutor;

--- a/benches/coprocessor_executors/table_scan/util.rs
+++ b/benches/coprocessor_executors/table_scan/util.rs
@@ -5,11 +5,9 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use protobuf::RepeatedField;
-
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::TableScan;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::TableScan;
 
 use test_coprocessor::*;
 use tikv::coprocessor::dag::batch::executors::BatchTableScanExecutor;
@@ -42,8 +40,8 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
         store: &Store<RocksEngine>,
         _: (),
     ) -> Self::E {
-        let mut req = TableScan::new();
-        req.set_columns(RepeatedField::from_slice(columns));
+        let mut req = TableScan::default();
+        req.set_columns(columns.to_vec());
 
         let mut executor = TableScanExecutor::table_scan(
             black_box(req),

--- a/benches/coprocessor_executors/top_n/mod.rs
+++ b/benches/coprocessor_executors/top_n/mod.rs
@@ -3,7 +3,7 @@
 mod util;
 
 use cop_datatype::FieldTypeTp;
-use tipb::expression::ScalarFuncSig;
+use tipb::ScalarFuncSig;
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::{BenchCase, FixtureBuilder};

--- a/benches/coprocessor_executors/top_n/util.rs
+++ b/benches/coprocessor_executors/top_n/util.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use tipb::expression::Expr;
+use tipb::Expr;
 
 use tikv::coprocessor::dag::batch::executors::BatchTopNExecutor;
 use tikv::coprocessor::dag::executor::{Executor, TopNExecutor};
@@ -55,7 +55,7 @@ impl TopNBencher for NormalBencher {
     ) {
         crate::util::bencher::NormalNextAllBencher::new(|| {
             assert_eq!(order_by_expr.len(), order_is_desc.len());
-            let meta = top_n(order_by_expr, order_is_desc, n).take_topN();
+            let meta = top_n(order_by_expr, order_is_desc, n).take_top_n();
             let src = fb.clone().build_normal_fixture_executor();
             Box::new(
                 TopNExecutor::new(

--- a/benches/coprocessor_executors/util/executor_descriptor.rs
+++ b/benches/coprocessor_executors/util/executor_descriptor.rs
@@ -1,12 +1,12 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::executor::{ExecType, Executor as PbExecutor, TopN};
-use tipb::expression::{ByItem, Expr};
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::{ByItem, Expr};
+use tipb::{ExecType, Executor as PbExecutor, TopN};
 
 /// Builds a table scan executor descriptor.
 pub fn table_scan(columns_info: &[ColumnInfo]) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeTableScan);
     exec.mut_tbl_scan()
         .set_columns(columns_info.to_vec().into());
@@ -15,7 +15,7 @@ pub fn table_scan(columns_info: &[ColumnInfo]) -> PbExecutor {
 
 /// Builds a index scan executor descriptor.
 pub fn index_scan(columns_info: &[ColumnInfo], unique: bool) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeIndexScan);
     exec.mut_idx_scan()
         .set_columns(columns_info.to_vec().into());
@@ -25,7 +25,7 @@ pub fn index_scan(columns_info: &[ColumnInfo], unique: bool) -> PbExecutor {
 
 /// Builds a selection executor descriptor.
 pub fn selection(exprs: &[Expr]) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeSelection);
     exec.mut_selection().set_conditions(exprs.to_vec().into());
     exec
@@ -33,7 +33,7 @@ pub fn selection(exprs: &[Expr]) -> PbExecutor {
 
 /// Builds a simple aggregation executor descriptor.
 pub fn simple_aggregate(aggr_exprs: &[Expr]) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeStreamAgg);
     exec.mut_aggregation()
         .set_agg_func(aggr_exprs.to_vec().into());
@@ -42,7 +42,7 @@ pub fn simple_aggregate(aggr_exprs: &[Expr]) -> PbExecutor {
 
 /// Builds a hash aggregation executor descriptor.
 pub fn hash_aggregate(aggr_exprs: &[Expr], group_bys: &[Expr]) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeAggregation);
     exec.mut_aggregation()
         .set_agg_func(aggr_exprs.to_vec().into());
@@ -53,7 +53,7 @@ pub fn hash_aggregate(aggr_exprs: &[Expr], group_bys: &[Expr]) -> PbExecutor {
 
 /// Builds a stream aggregation executor descriptor.
 pub fn stream_aggregate(aggr_exprs: &[Expr], group_bys: &[Expr]) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeStreamAgg);
     exec.mut_aggregation()
         .set_agg_func(aggr_exprs.to_vec().into());
@@ -63,22 +63,22 @@ pub fn stream_aggregate(aggr_exprs: &[Expr], group_bys: &[Expr]) -> PbExecutor {
 }
 
 pub fn top_n(order_by_expr: &[Expr], order_is_desc: &[bool], n: usize) -> PbExecutor {
-    let mut meta = TopN::new();
+    let mut meta = TopN::default();
     meta.set_limit(n as u64);
     meta.set_order_by(
         order_by_expr
             .iter()
             .zip(order_is_desc)
             .map(|(expr, desc)| {
-                let mut item = ByItem::new();
+                let mut item = ByItem::default();
                 item.set_expr(expr.clone());
                 item.set_desc(*desc);
                 item
             })
             .collect(),
     );
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeTopN);
-    exec.set_topN(meta);
+    exec.set_top_n(meta);
     exec
 }

--- a/benches/coprocessor_executors/util/fixture.rs
+++ b/benches/coprocessor_executors/util/fixture.rs
@@ -10,8 +10,8 @@ use rand_xorshift::XorShiftRng;
 use cop_datatype::{FieldTypeAccessor, FieldTypeTp};
 use test_coprocessor::*;
 use tikv_util::collections::HashMap;
-use tipb::expression::FieldType;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::FieldType;
 
 use tikv::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use tikv::coprocessor::codec::data_type::Decimal;
@@ -276,14 +276,14 @@ impl FixtureBuilder {
             .into_iter()
             .enumerate()
             .map(|(index, ft)| {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.set_column_id(index as i64);
                 ci.as_mut_accessor()
-                    .set_tp(ft.tp())
-                    .set_flag(ft.flag())
-                    .set_flen(ft.flen())
-                    .set_decimal(ft.decimal())
-                    .set_collation(ft.collation());
+                    .set_tp(FieldTypeAccessor::tp(&ft))
+                    .set_flag(FieldTypeAccessor::flag(&ft))
+                    .set_flen(FieldTypeAccessor::flen(&ft))
+                    .set_decimal(FieldTypeAccessor::decimal(&ft))
+                    .set_collation(FieldTypeAccessor::collation(&ft));
                 ci
             })
             .collect();

--- a/benches/coprocessor_executors/util/mod.rs
+++ b/benches/coprocessor_executors/util/mod.rs
@@ -10,10 +10,8 @@ pub use self::fixture::FixtureBuilder;
 
 use criterion::black_box;
 
-use protobuf::RepeatedField;
-
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::Executor as PbExecutor;
+use tipb::Executor as PbExecutor;
 
 use test_coprocessor::*;
 use tikv::coprocessor::RequestHandler;
@@ -38,10 +36,10 @@ pub fn build_dag_handler<TargetTxnStore: TxnStore + 'static>(
 ) -> Box<dyn RequestHandler> {
     use tikv::coprocessor::dag::builder::DAGBuilder;
     use tikv::coprocessor::Deadline;
-    use tipb::select::DAGRequest;
+    use tipb::DagRequest;
 
-    let mut dag = DAGRequest::new();
-    dag.set_executors(RepeatedField::from_vec(executors.to_vec()));
+    let mut dag = DagRequest::default();
+    dag.set_executors(executors.to_vec());
 
     DAGBuilder::build(
         black_box(dag),

--- a/benches/coprocessor_executors/util/scan_bencher.rs
+++ b/benches/coprocessor_executors/util/scan_bencher.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
 
 use test_coprocessor::*;
 use tikv::coprocessor::dag::batch::interface::*;

--- a/benches/hierarchy/engine/mod.rs
+++ b/benches/hierarchy/engine/mod.rs
@@ -13,7 +13,7 @@ fn bench_engine_put<E: Engine, F: EngineFactory<E>>(
     config: &BenchConfig<F>,
 ) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     bencher.iter_batched(
         || {
             let test_kvs: Vec<(Key, Value)> = KvGenerator::with_seed(
@@ -41,7 +41,7 @@ fn bench_engine_snapshot<E: Engine, F: EngineFactory<E>>(
     config: &BenchConfig<F>,
 ) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     bencher.iter(|| black_box(&engine).snapshot(black_box(&ctx)).unwrap());
 }
 
@@ -51,7 +51,7 @@ fn bench_engine_get<E: Engine, F: EngineFactory<E>>(
     config: &BenchConfig<F>,
 ) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     let test_kvs: Vec<Key> = KvGenerator::with_seed(
         config.key_length,
         config.value_length,

--- a/benches/hierarchy/mvcc/mod.rs
+++ b/benches/hierarchy/mvcc/mod.rs
@@ -11,7 +11,7 @@ use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS, DEFAULT_KV_GENERATOR
 
 fn mvcc_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     let option = Options::default();
     b.iter_batched(
         || {
@@ -39,7 +39,7 @@ fn mvcc_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Bench
 
 fn mvcc_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     let snapshot = engine.snapshot(&ctx).unwrap();
     let option = Options::default();
     b.iter_batched(
@@ -102,7 +102,7 @@ fn mvcc_reader_load_lock<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config
                     true,
                     None,
                     None,
-                    ctx.isolation_level,
+                    ctx.get_isolation_level(),
                 );
                 black_box(reader.load_lock(&key).unwrap());
             }
@@ -139,7 +139,7 @@ fn mvcc_reader_seek_write<E: Engine, F: EngineFactory<E>>(
                     true,
                     None,
                     None,
-                    ctx.isolation_level,
+                    ctx.get_isolation_level(),
                 );
                 black_box(reader.seek_write(&key, u64::max_value()).unwrap());
             }

--- a/benches/hierarchy/storage/mod.rs
+++ b/benches/hierarchy/storage/mod.rs
@@ -19,7 +19,7 @@ fn storage_raw_get<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Ben
                 .generate(DEFAULT_ITERATIONS);
             let data: Vec<(Context, Vec<u8>)> = kvs
                 .iter()
-                .map(|(k, _)| (Context::new(), k.clone()))
+                .map(|(k, _)| (Context::default(), k.clone()))
                 .collect();
             (data, &store)
         },
@@ -44,7 +44,7 @@ fn storage_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Be
                 .iter()
                 .map(|(k, v)| {
                     (
-                        Context::new(),
+                        Context::default(),
                         vec![Mutation::Put((Key::from_raw(&k), v.clone()))],
                         k.clone(),
                     )
@@ -72,7 +72,7 @@ fn storage_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Benc
             for (k, v) in &kvs {
                 store
                     .prewrite(
-                        Context::new(),
+                        Context::default(),
                         vec![Mutation::Put((Key::from_raw(&k), v.clone()))],
                         k.clone(),
                         1,
@@ -84,7 +84,7 @@ fn storage_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Benc
         },
         |(kvs, store)| {
             for (k, _) in &kvs {
-                black_box(store.commit(Context::new(), vec![Key::from_raw(k)], 1, 2)).unwrap();
+                black_box(store.commit(Context::default(), vec![Key::from_raw(k)], 1, 2)).unwrap();
             }
         },
         BatchSize::SmallInput,

--- a/benches/hierarchy/txn/mod.rs
+++ b/benches/hierarchy/txn/mod.rs
@@ -11,7 +11,7 @@ use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS};
 
 fn txn_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     let option = Options::default();
     b.iter_batched(
         || {
@@ -38,7 +38,7 @@ fn txn_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchC
 
 fn txn_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     let option = Options::default();
     b.iter_batched(
         || {

--- a/benches/misc/coprocessor/codec/chunk/arrow.rs
+++ b/benches/misc/coprocessor/codec/chunk/arrow.rs
@@ -9,7 +9,7 @@ use arrow::record_batch::RecordBatch;
 use cop_datatype::prelude::*;
 use cop_datatype::{FieldTypeFlag, FieldTypeTp};
 use tikv::coprocessor::codec::Datum;
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 pub struct Chunk {
     pub data: RecordBatch,
@@ -23,14 +23,14 @@ impl Chunk {
             }
         }
 
-        match field_type.tp() {
+        match FieldTypeAccessor::tp(field_type) {
             FieldTypeTp::Tiny
             | FieldTypeTp::Short
             | FieldTypeTp::Int24
             | FieldTypeTp::Long
             | FieldTypeTp::LongLong
             | FieldTypeTp::Year => {
-                if field_type.flag().contains(FieldTypeFlag::UNSIGNED) {
+                if FieldTypeAccessor::flag(field_type).contains(FieldTypeFlag::UNSIGNED) {
                     let data = self
                         .data
                         .column(col_id)
@@ -79,14 +79,14 @@ impl ChunkBuilder {
         let mut fields = Vec::with_capacity(tps.len());
         let mut arrays: Vec<Arc<dyn array::Array>> = Vec::with_capacity(tps.len());
         for (field_type, column) in tps.iter().zip(self.columns.into_iter()) {
-            let (field, data) = match field_type.tp() {
+            let (field, data) = match FieldTypeAccessor::tp(field_type) {
                 FieldTypeTp::Tiny
                 | FieldTypeTp::Short
                 | FieldTypeTp::Int24
                 | FieldTypeTp::Long
                 | FieldTypeTp::LongLong
                 | FieldTypeTp::Year => {
-                    if field_type.flag().contains(FieldTypeFlag::UNSIGNED) {
+                    if FieldTypeAccessor::flag(field_type).contains(FieldTypeFlag::UNSIGNED) {
                         column.into_u64_array()
                     } else {
                         column.into_i64_array()

--- a/benches/misc/coprocessor/codec/chunk/mod.rs
+++ b/benches/misc/coprocessor/codec/chunk/mod.rs
@@ -5,14 +5,14 @@ mod arrow;
 use test::Bencher;
 
 use cop_datatype::{FieldTypeAccessor, FieldTypeTp};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use tikv::coprocessor::codec::chunk::{Chunk, ChunkEncoder};
 use tikv::coprocessor::codec::datum::Datum;
 use tikv::coprocessor::codec::mysql::*;
 
 fn field_type(tp: FieldTypeTp) -> FieldType {
-    let mut fp = FieldType::new();
+    let mut fp = FieldType::default();
     fp.as_mut_accessor().set_tp(tp);
     fp
 }

--- a/benches/misc/coprocessor/dag/expr/scalar.rs
+++ b/benches/misc/coprocessor/dag/expr/scalar.rs
@@ -1,12 +1,12 @@
 use std::usize;
 use test::{black_box, Bencher};
 use tikv_util::collections::HashMap;
-use tipb::expression::ScalarFuncSig;
+use tipb::ScalarFuncSig;
 
 fn get_scalar_args_with_match(sig: ScalarFuncSig) -> (usize, usize) {
     // Only select some functions to benchmark
     let (min_args, max_args) = match sig {
-        ScalarFuncSig::LTInt => (2, 2),
+        ScalarFuncSig::LtInt => (2, 2),
         ScalarFuncSig::CastIntAsInt => (1, 1),
         ScalarFuncSig::IfInt => (3, 3),
         ScalarFuncSig::JsonArraySig => (0, usize::MAX),
@@ -23,7 +23,7 @@ fn init_scalar_args_map() -> HashMap<ScalarFuncSig, (usize, usize)> {
     let mut m: HashMap<ScalarFuncSig, (usize, usize)> = HashMap::default();
 
     let tbls = vec![
-        (ScalarFuncSig::LTInt, (2, 2)),
+        (ScalarFuncSig::LtInt, (2, 2)),
         (ScalarFuncSig::CastIntAsInt, (1, 1)),
         (ScalarFuncSig::IfInt, (3, 3)),
         (ScalarFuncSig::JsonArraySig, (0, usize::MAX)),

--- a/benches/misc/raftkv/mod.rs
+++ b/benches/misc/raftkv/mod.rs
@@ -39,7 +39,7 @@ impl SyncBenchRouter {
 
 impl SyncBenchRouter {
     fn invoke(&self, cmd: RaftCommand) {
-        let mut response = RaftCmdResponse::new();
+        let mut response = RaftCmdResponse::default();
         cmd_resp::bind_term(&mut response, 1);
         match cmd.callback {
             Callback::Read(cb) => {
@@ -51,7 +51,7 @@ impl SyncBenchRouter {
                 })
             }
             Callback::Write(cb) => {
-                let mut resp = Response::new();
+                let mut resp = Response::default();
                 let cmd_type = cmd.request.get_requests()[0].get_cmd_type();
                 resp.set_cmd_type(cmd_type);
                 response.mut_responses().push(resp);
@@ -96,10 +96,10 @@ fn bench_async_snapshots_noop(b: &mut test::Bencher) {
     let (_dir, db) = new_engine();
     let snapshot = engine::Snapshot::new(Arc::clone(&db));
     let resp = ReadResponse {
-        response: RaftCmdResponse::new(),
+        response: RaftCmdResponse::default(),
         snapshot: Some(RegionSnapshot::from_snapshot(
             snapshot.into_sync(),
-            Region::new(),
+            Region::default(),
         )),
     };
 
@@ -125,7 +125,7 @@ fn bench_async_snapshots_noop(b: &mut test::Bencher) {
 #[bench]
 fn bench_async_snapshot(b: &mut test::Bencher) {
     let leader = util::new_peer(2, 3);
-    let mut region = Region::new();
+    let mut region = Region::default();
     region.set_id(1);
     region.set_start_key(vec![]);
     region.set_end_key(vec![]);
@@ -135,7 +135,7 @@ fn bench_async_snapshot(b: &mut test::Bencher) {
     let (_tmp, db) = new_engine();
     let kv = RaftKv::new(SyncBenchRouter::new(region.clone(), db));
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());
@@ -150,7 +150,7 @@ fn bench_async_snapshot(b: &mut test::Bencher) {
 #[bench]
 fn bench_async_write(b: &mut test::Bencher) {
     let leader = util::new_peer(2, 3);
-    let mut region = Region::new();
+    let mut region = Region::default();
     region.set_id(1);
     region.set_start_key(vec![]);
     region.set_end_key(vec![]);
@@ -160,7 +160,7 @@ fn bench_async_write(b: &mut test::Bencher) {
     let (_tmp, db) = new_engine();
     let kv = RaftKv::new(SyncBenchRouter::new(region.clone(), db));
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());

--- a/benches/misc/storage/scan.rs
+++ b/benches/misc/storage/scan.rs
@@ -22,7 +22,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
         let mut ts = ts_generator.next().unwrap();
         store
             .prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(&k), v))],
                 k.clone(),
                 ts,
@@ -30,7 +30,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
             .expect("");
         store
             .commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(&k)],
                 ts,
                 ts_generator.next().unwrap(),
@@ -40,7 +40,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
         ts = ts_generator.next().unwrap();
         store
             .prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Delete(Key::from_raw(&k))],
                 k.clone(),
                 ts,
@@ -48,7 +48,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
             .expect("");
         store
             .commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(&k)],
                 ts,
                 ts_generator.next().unwrap(),
@@ -61,7 +61,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
         let (k, _) = kvs.next().unwrap();
         assert!(store
             .scan(
-                Context::new(),
+                Context::default(),
                 Key::from_raw(&k),
                 None,
                 1,

--- a/components/codec/Cargo.toml
+++ b/components/codec/Cargo.toml
@@ -13,6 +13,5 @@ tikv_alloc = { path = "../tikv_alloc", default-features = false }
 
 [dev-dependencies]
 panic_hook = { path = "../panic_hook" }
-protobuf = "2.0"
 bytes = "0.4.10"
 rand = "0.6.5"

--- a/components/cop_codegen/src/rpn_function.rs
+++ b/components/cop_codegen/src/rpn_function.rs
@@ -189,7 +189,7 @@ impl ValidatorFnGenerator {
         let inners = self.tokens;
         quote! {
             fn validate #impl_generics (
-                expr: &tipb::expression::Expr
+                expr: &tipb::Expr
             ) -> crate::coprocessor::Result<()> #where_clause {
                 use crate::coprocessor::codec::data_type::Evaluable;
                 use crate::coprocessor::dag::rpn_expr::function;
@@ -892,7 +892,7 @@ mod tests_normal {
                     )
                     .eval(Null, ctx, output_rows, args, extra)
                 }
-                fn validate(expr: &tipb::expression::Expr) -> crate::coprocessor::Result<()> {
+                fn validate(expr: &tipb::Expr) -> crate::coprocessor::Result<()> {
                     use crate::coprocessor::codec::data_type::Evaluable;
                     use crate::coprocessor::dag::rpn_expr::function;
                     function::validate_expr_return_type(expr, Decimal::EVAL_TYPE)?;
@@ -1061,7 +1061,7 @@ mod tests_normal {
                         extra
                     )
                 }
-                fn validate<A: M, B>(expr: &tipb::expression::Expr) -> crate::coprocessor::Result<()>
+                fn validate<A: M, B>(expr: &tipb::Expr) -> crate::coprocessor::Result<()>
                 where
                     B: N<M>
                 {

--- a/components/cop_datatype/Cargo.toml
+++ b/components/cop_datatype/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 description = "TiKV Coprocessor data types"
 
 [dependencies]
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/pingcap/tipb.git", features = ["prost-codec"] }
 bitflags = "1.0"
 enum-primitive-derive = "0.1"
 num-traits = "0.2"

--- a/components/cop_datatype/src/builder/field_type.rs
+++ b/components/cop_datatype/src/builder/field_type.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use crate::FieldTypeAccessor;
 
@@ -9,7 +9,7 @@ pub struct FieldTypeBuilder(FieldType);
 
 impl FieldTypeBuilder {
     pub fn new() -> Self {
-        Self(FieldType::new())
+        Self(FieldType::default())
     }
 
     pub fn tp(mut self, v: crate::FieldTypeTp) -> Self {

--- a/components/cop_datatype/src/def/field_type.rs
+++ b/components/cop_datatype/src/def/field_type.rs
@@ -2,12 +2,12 @@
 
 use std::fmt;
 
-use tipb::expression::FieldType;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::FieldType;
 
 use num_traits::FromPrimitive;
 
-/// Valid values of `tipb::expression::FieldType::tp` and `tipb::schema::ColumnInfo::tp`.
+/// Valid values of `tipb::FieldType::tp` and `tipb::ColumnInfo::tp`.
 ///
 /// `FieldType` is the field type of a column defined by schema.
 ///
@@ -54,8 +54,8 @@ impl fmt::Display for FieldTypeTp {
     }
 }
 
-/// Valid values of `tipb::expression::FieldType::collate` and
-/// `tipb::schema::ColumnInfo::collation`.
+/// Valid values of `tipb::FieldType::collate` and
+/// `tipb::ColumnInfo::collation`.
 ///
 /// The default value if `UTF8Bin`.
 #[derive(Primitive, PartialEq, Debug, Clone, Copy)]
@@ -277,12 +277,12 @@ impl FieldTypeAccessor for ColumnInfo {
 
     #[inline]
     fn flen(&self) -> isize {
-        self.get_columnLen() as isize
+        self.get_column_len() as isize
     }
 
     #[inline]
     fn set_flen(&mut self, flen: isize) -> &mut dyn FieldTypeAccessor {
-        ColumnInfo::set_columnLen(self, flen as i32);
+        ColumnInfo::set_column_len(self, flen as i32);
         self as &mut dyn FieldTypeAccessor
     }
 
@@ -311,7 +311,7 @@ impl FieldTypeAccessor for ColumnInfo {
 
 impl From<FieldTypeTp> for FieldType {
     fn from(fp: FieldTypeTp) -> FieldType {
-        let mut ft = FieldType::new();
+        let mut ft = FieldType::default();
         ft.as_mut_accessor().set_tp(fp);
         ft
     }
@@ -319,7 +319,7 @@ impl From<FieldTypeTp> for FieldType {
 
 impl From<FieldTypeTp> for ColumnInfo {
     fn from(fp: FieldTypeTp) -> ColumnInfo {
-        let mut ft = ColumnInfo::new();
+        let mut ft = ColumnInfo::default();
         ft.as_mut_accessor().set_tp(fp);
         ft
     }

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -9,9 +9,9 @@ portable = ["engine_rocksdb/portable"]
 sse = ["engine_rocksdb/sse"]
 
 [dependencies]
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-3.0" }
-protobuf = "2"
-raft = "0.4"
+kvproto = { path = "../../../kvproto" }
+prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
+raft = { git = "https://github.com/pingcap/raft-rs", rev = "eeaee89a4eba7aa17abd630388df2f1c3a0f76ad" }
 quick-error = "1.2.2"
 crc = "1.8"
 lazy_static = "1.3"

--- a/components/engine/src/errors.rs
+++ b/components/engine/src/errors.rs
@@ -19,11 +19,17 @@ quick_error! {
                 hex::encode_upper(&key), regoin_id, hex::encode_upper(&start), hex::encode_upper(&end)
             )
         }
-        Protobuf(err: protobuf::ProtobufError) {
+        ProstDecode(err: prost::DecodeError) {
             from()
             cause(err)
             description(err.description())
-            display("Protobuf {}", err)
+            display("Prost Decode {}", err)
+        }
+        ProstEncode(err: prost::EncodeError) {
+            from()
+            cause(err)
+            description(err.description())
+            display("Prost Encode {}", err)
         }
         Io(err: std::io::Error) {
             from()
@@ -51,7 +57,7 @@ impl From<Error> for raft::Error {
 
 impl From<Error> for kvproto::errorpb::Error {
     fn from(err: Error) -> kvproto::errorpb::Error {
-        let mut errorpb = kvproto::errorpb::Error::new();
+        let mut errorpb = kvproto::errorpb::Error::default();
         errorpb.set_message(error::Error::description(&err).to_owned());
 
         if let Error::NotInRange(key, region_id, start_key, end_key) = err {

--- a/components/engine/src/mutable.rs
+++ b/components/engine/src/mutable.rs
@@ -3,16 +3,18 @@
 use crate::rocks::{CFHandle, Writable};
 use crate::Result;
 
+use tikv_util::write_to_bytes;
+
 pub trait Mutable: Writable {
-    fn put_msg<M: protobuf::Message>(&self, key: &[u8], m: &M) -> Result<()> {
-        let value = m.write_to_bytes()?;
+    fn put_msg<M: prost::Message>(&self, key: &[u8], m: &M) -> Result<()> {
+        let value = write_to_bytes(m)?;
         self.put(key, &value)?;
         Ok(())
     }
 
     // TODO: change CFHandle to str.
-    fn put_msg_cf<M: protobuf::Message>(&self, cf: &CFHandle, key: &[u8], m: &M) -> Result<()> {
-        let value = m.write_to_bytes()?;
+    fn put_msg_cf<M: prost::Message>(&self, cf: &CFHandle, key: &[u8], m: &M) -> Result<()> {
+        let value = write_to_bytes(m)?;
         self.put_cf(cf, key, &value)?;
         Ok(())
     }

--- a/components/engine/src/peekable.rs
+++ b/components/engine/src/peekable.rs
@@ -8,27 +8,27 @@ pub trait Peekable {
     fn get_value(&self, key: &[u8]) -> Result<Option<DBVector>>;
     fn get_value_cf(&self, cf: &str, key: &[u8]) -> Result<Option<DBVector>>;
 
-    fn get_msg<M: protobuf::Message>(&self, key: &[u8]) -> Result<Option<M>> {
+    fn get_msg<M: prost::Message + Default>(&self, key: &[u8]) -> Result<Option<M>> {
         let value = self.get_value(key)?;
 
         if value.is_none() {
             return Ok(None);
         }
 
-        let mut m = M::new();
-        m.merge_from_bytes(&value.unwrap())?;
+        let mut m = M::default();
+        m.merge(&*value.unwrap())?;
         Ok(Some(m))
     }
 
-    fn get_msg_cf<M: protobuf::Message>(&self, cf: &str, key: &[u8]) -> Result<Option<M>> {
+    fn get_msg_cf<M: prost::Message + Default>(&self, cf: &str, key: &[u8]) -> Result<Option<M>> {
         let value = self.get_value_cf(cf, key)?;
 
         if value.is_none() {
             return Ok(None);
         }
 
-        let mut m = M::new();
-        m.merge_from_bytes(&value.unwrap())?;
+        let mut m = M::default();
+        m.merge(&*value.unwrap())?;
         Ok(Some(m))
     }
 }

--- a/components/engine/src/rocks/mod.rs
+++ b/components/engine/src/rocks/mod.rs
@@ -38,7 +38,7 @@ mod tests {
         let engine =
             Arc::new(util::new_engine(path.path().to_str().unwrap(), None, &[cf], None).unwrap());
 
-        let mut r = Region::new();
+        let mut r = Region::default();
         r.set_id(10);
 
         let key = b"key";

--- a/components/log_wrappers/Cargo.toml
+++ b/components/log_wrappers/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 slog = "2.3"
 slog-term = "2.4"
 hex = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-3.0" }
+kvproto = { path = "../../../kvproto" }
 tikv_alloc = { path = "../tikv_alloc", default-features = false }

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 tikv_util = { path = "../tikv_util" }
 tikv = { path = "../../", default-features = false }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-3.0" }
-protobuf = "2"
+tipb = { git = "https://github.com/pingcap/tipb.git", features = ["prost-codec"] }
+kvproto = { path = "../../../kvproto" }
 test_storage = { path = "../test_storage" }
 futures = "0.1"
+prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }

--- a/components/test_coprocessor/src/column.rs
+++ b/components/test_coprocessor/src/column.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 use tikv::coprocessor::codec::{datum, Datum};
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
 
 pub const TYPE_VAR_CHAR: i32 = 1;
 pub const TYPE_LONG: i32 = 2;
@@ -19,7 +19,7 @@ pub struct Column {
 
 impl Column {
     pub fn as_column_info(&self) -> ColumnInfo {
-        let mut c_info = ColumnInfo::new();
+        let mut c_info = ColumnInfo::default();
         c_info.set_column_id(self.id);
         c_info.set_tp(self.col_type);
         c_info.set_pk_handle(self.index == 0);

--- a/components/test_coprocessor/src/dag.rs
+++ b/components/test_coprocessor/src/dag.rs
@@ -2,21 +2,17 @@
 
 use super::*;
 
-use protobuf::Message;
-use protobuf::RepeatedField;
-
 use kvproto::coprocessor::{KeyRange, Request};
 use kvproto::kvrpcpb::Context;
-use tipb::executor::{
-    Aggregation, ExecType, Executor, IndexScan, Limit, Selection, TableScan, TopN,
-};
-use tipb::expression::{ByItem, Expr, ExprType};
-use tipb::schema::ColumnInfo;
-use tipb::select::{Chunk, DAGRequest};
+use tipb::ColumnInfo;
+use tipb::{Aggregation, ExecType, Executor, IndexScan, Limit, Selection, TableScan, TopN};
+use tipb::{ByItem, Expr, ExprType};
+use tipb::{Chunk, DagRequest};
 
 use tikv::coprocessor::codec::{datum, Datum};
 use tikv::coprocessor::REQ_TYPE_DAG;
 use tikv_util::codec::number::NumberEncoder;
+use tikv_util::write_to_bytes;
 
 pub struct DAGSelect {
     pub execs: Vec<Executor>,
@@ -31,9 +27,9 @@ pub struct DAGSelect {
 
 impl DAGSelect {
     pub fn from(table: &Table) -> DAGSelect {
-        let mut exec = Executor::new();
-        exec.set_tp(ExecType::TypeTableScan);
-        let mut tbl_scan = TableScan::new();
+        let mut exec = Executor::default();
+        exec.set_tp_(ExecType::TypeTableScan);
+        let mut tbl_scan = TableScan::default();
         let mut table_info = table.table_info();
         tbl_scan.set_table_id(table_info.get_table_id());
         let columns_info = table_info.take_columns();
@@ -54,9 +50,9 @@ impl DAGSelect {
 
     pub fn from_index(table: &Table, index: &Column) -> DAGSelect {
         let idx = index.index;
-        let mut exec = Executor::new();
-        exec.set_tp(ExecType::TypeIndexScan);
-        let mut scan = IndexScan::new();
+        let mut exec = Executor::default();
+        exec.set_tp_(ExecType::TypeIndexScan);
+        let mut scan = IndexScan::default();
         let mut index_info = table.index_info(idx, true);
         scan.set_table_id(index_info.get_table_id());
         scan.set_index_id(idx);
@@ -85,9 +81,9 @@ impl DAGSelect {
 
     pub fn order_by(mut self, col: &Column, desc: bool) -> DAGSelect {
         let col_offset = offset_for_column(&self.cols, col.id);
-        let mut item = ByItem::new();
-        let mut expr = Expr::new();
-        expr.set_tp(ExprType::ColumnRef);
+        let mut item = ByItem::default();
+        let mut expr = Expr::default();
+        expr.set_tp_(ExprType::ColumnRef);
         expr.mut_val().encode_i64(col_offset).unwrap();
         item.set_expr(expr);
         item.set_desc(desc);
@@ -96,19 +92,19 @@ impl DAGSelect {
     }
 
     pub fn count(mut self) -> DAGSelect {
-        let mut expr = Expr::new();
-        expr.set_tp(ExprType::Count);
+        let mut expr = Expr::default();
+        expr.set_tp_(ExprType::Count);
         self.aggregate.push(expr);
         self
     }
 
     pub fn aggr_col(mut self, col: &Column, aggr_t: ExprType) -> DAGSelect {
         let col_offset = offset_for_column(&self.cols, col.id);
-        let mut col_expr = Expr::new();
-        col_expr.set_tp(ExprType::ColumnRef);
+        let mut col_expr = Expr::default();
+        col_expr.set_tp_(ExprType::ColumnRef);
         col_expr.mut_val().encode_i64(col_offset).unwrap();
-        let mut expr = Expr::new();
-        expr.set_tp(aggr_t);
+        let mut expr = Expr::default();
+        expr.set_tp_(aggr_t);
         expr.mut_children().push(col_expr);
         self.aggregate.push(expr);
         self
@@ -135,22 +131,22 @@ impl DAGSelect {
     }
 
     pub fn bit_and(self, col: &Column) -> DAGSelect {
-        self.aggr_col(col, ExprType::Agg_BitAnd)
+        self.aggr_col(col, ExprType::AggBitAnd)
     }
 
     pub fn bit_or(self, col: &Column) -> DAGSelect {
-        self.aggr_col(col, ExprType::Agg_BitOr)
+        self.aggr_col(col, ExprType::AggBitOr)
     }
 
     pub fn bit_xor(self, col: &Column) -> DAGSelect {
-        self.aggr_col(col, ExprType::Agg_BitXor)
+        self.aggr_col(col, ExprType::AggBitXor)
     }
 
     pub fn group_by(mut self, cols: &[&Column]) -> DAGSelect {
         for col in cols {
             let offset = offset_for_column(&self.cols, col.id);
-            let mut expr = Expr::new();
-            expr.set_tp(ExprType::ColumnRef);
+            let mut expr = Expr::default();
+            expr.set_tp_(ExprType::ColumnRef);
             expr.mut_val().encode_i64(offset).unwrap();
             self.group_by.push(expr);
         }
@@ -163,9 +159,9 @@ impl DAGSelect {
     }
 
     pub fn where_expr(mut self, expr: Expr) -> DAGSelect {
-        let mut exec = Executor::new();
-        exec.set_tp(ExecType::TypeSelection);
-        let mut selection = Selection::new();
+        let mut exec = Executor::default();
+        exec.set_tp_(ExecType::TypeSelection);
+        let mut selection = Selection::default();
         selection.mut_conditions().push(expr);
         exec.set_selection(selection);
         self.execs.push(exec);
@@ -173,48 +169,48 @@ impl DAGSelect {
     }
 
     pub fn build(self) -> Request {
-        self.build_with(Context::new(), &[0])
+        self.build_with(Context::default(), &[0])
     }
 
     pub fn build_with(mut self, ctx: Context, flags: &[u64]) -> Request {
         if !self.aggregate.is_empty() || !self.group_by.is_empty() {
-            let mut exec = Executor::new();
-            exec.set_tp(ExecType::TypeAggregation);
-            let mut aggr = Aggregation::new();
+            let mut exec = Executor::default();
+            exec.set_tp_(ExecType::TypeAggregation);
+            let mut aggr = Aggregation::default();
             if !self.aggregate.is_empty() {
-                aggr.set_agg_func(RepeatedField::from_vec(self.aggregate));
+                aggr.set_agg_func(self.aggregate);
             }
 
             if !self.group_by.is_empty() {
-                aggr.set_group_by(RepeatedField::from_vec(self.group_by));
+                aggr.set_group_by(self.group_by);
             }
             exec.set_aggregation(aggr);
             self.execs.push(exec);
         }
 
         if !self.order_by.is_empty() {
-            let mut exec = Executor::new();
-            exec.set_tp(ExecType::TypeTopN);
-            let mut topn = TopN::new();
-            topn.set_order_by(RepeatedField::from_vec(self.order_by));
+            let mut exec = Executor::default();
+            exec.set_tp_(ExecType::TypeTopN);
+            let mut topn = TopN::default();
+            topn.set_order_by(self.order_by);
             if let Some(limit) = self.limit.take() {
                 topn.set_limit(limit);
             }
-            exec.set_topN(topn);
+            exec.set_top_n(topn);
             self.execs.push(exec);
         }
 
         if let Some(l) = self.limit.take() {
-            let mut exec = Executor::new();
-            exec.set_tp(ExecType::TypeLimit);
-            let mut limit = Limit::new();
+            let mut exec = Executor::default();
+            exec.set_tp_(ExecType::TypeLimit);
+            let mut limit = Limit::default();
             limit.set_limit(l);
             exec.set_limit(limit);
             self.execs.push(exec);
         }
 
-        let mut dag = DAGRequest::new();
-        dag.set_executors(RepeatedField::from_vec(self.execs));
+        let mut dag = DagRequest::default();
+        dag.set_executors(self.execs);
         dag.set_start_ts(next_id() as u64);
         dag.set_flags(flags.iter().fold(0, |acc, f| acc | *f));
         dag.set_collect_range_counts(true);
@@ -226,10 +222,10 @@ impl DAGSelect {
         };
         dag.set_output_offsets(output_offsets);
 
-        let mut req = Request::new();
+        let mut req = Request::default();
         req.set_tp(REQ_TYPE_DAG);
-        req.set_data(dag.write_to_bytes().unwrap());
-        req.set_ranges(RepeatedField::from_vec(vec![self.key_range]));
+        req.set_data(write_to_bytes(&dag).unwrap());
+        req.set_ranges(vec![self.key_range]);
         req.set_context(ctx);
         req
     }

--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -89,7 +89,7 @@ pub fn init_data_with_commit(
     commit: bool,
 ) -> (Store<RocksEngine>, Endpoint<RocksEngine>) {
     let engine = TestEngineBuilder::new().build().unwrap();
-    init_data_with_engine_and_commit(Context::new(), engine, tbl, vals, commit)
+    init_data_with_engine_and_commit(Context::default(), engine, tbl, vals, commit)
 }
 
 // This function will create a Product table and initialize with the specified data.

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -35,7 +35,7 @@ impl<'a, E: Engine> Insert<'a, E> {
     }
 
     pub fn execute(self) -> i64 {
-        self.execute_with_ctx(Context::new())
+        self.execute_with_ctx(Context::default())
     }
 
     pub fn execute_with_ctx(self, ctx: Context) -> i64 {
@@ -73,7 +73,7 @@ impl<'a, E: Engine> Delete<'a, E> {
     }
 
     pub fn execute(self, id: i64, row: Vec<Datum>) {
-        self.execute_with_ctx(Context::new(), id, row)
+        self.execute_with_ctx(Context::default(), id, row)
     }
 
     pub fn execute_with_ctx(self, ctx: Context, id: i64, row: Vec<Datum>) {
@@ -169,7 +169,7 @@ impl<E: Engine> Store<E> {
     }
 
     pub fn commit(&mut self) {
-        self.commit_with_ctx(Context::new());
+        self.commit_with_ctx(Context::default());
     }
 
     pub fn get_engine(&self) -> E {
@@ -183,7 +183,7 @@ impl<E: Engine> Store<E> {
     pub fn export(&self) -> Vec<(Vec<u8>, Vec<u8>)> {
         self.store
             .scan(
-                Context::new(),
+                Context::default(),
                 Key::from_encoded(vec![]),
                 None,
                 100_000,
@@ -199,8 +199,8 @@ impl<E: Engine> Store<E> {
 
     /// Directly creates a `SnapshotStore` over current committed data.
     pub fn to_snapshot_store(&self) -> SnapshotStore<E::Snap> {
-        let snapshot = self.get_engine().snapshot(&Context::new()).unwrap();
-        SnapshotStore::new(snapshot, self.last_committed_ts, IsolationLevel::SI, true)
+        let snapshot = self.get_engine().snapshot(&Context::default()).unwrap();
+        SnapshotStore::new(snapshot, self.last_committed_ts, IsolationLevel::Si, true)
     }
 
     /// Strip off committed MVCC information to create a `FixtureStore`.
@@ -246,9 +246,15 @@ mod tests {
     fn test_export() {
         let mut store = Store::new();
         store.begin();
-        store.put(Context::new(), vec![(b"key1".to_vec(), b"value1".to_vec())]);
-        store.put(Context::new(), vec![(b"key2".to_vec(), b"foo".to_vec())]);
-        store.delete(Context::new(), vec![b"key0".to_vec()]);
+        store.put(
+            Context::default(),
+            vec![(b"key1".to_vec(), b"value1".to_vec())],
+        );
+        store.put(
+            Context::default(),
+            vec![(b"key2".to_vec(), b"foo".to_vec())],
+        );
+        store.delete(Context::default(), vec![b"key0".to_vec()]);
         store.commit();
 
         assert_eq!(
@@ -260,9 +266,15 @@ mod tests {
         );
 
         store.begin();
-        store.put(Context::new(), vec![(b"key1".to_vec(), b"value2".to_vec())]);
-        store.put(Context::new(), vec![(b"key2".to_vec(), b"foo".to_vec())]);
-        store.delete(Context::new(), vec![b"key0".to_vec()]);
+        store.put(
+            Context::default(),
+            vec![(b"key1".to_vec(), b"value2".to_vec())],
+        );
+        store.put(
+            Context::default(),
+            vec![(b"key2".to_vec(), b"foo".to_vec())],
+        );
+        store.delete(Context::default(), vec![b"key0".to_vec()]);
         store.commit();
 
         assert_eq!(
@@ -274,21 +286,27 @@ mod tests {
         );
 
         store.begin();
-        store.delete(Context::new(), vec![b"key0".to_vec(), b"key2".to_vec()]);
+        store.delete(Context::default(), vec![b"key0".to_vec(), b"key2".to_vec()]);
         store.commit();
 
         assert_eq!(store.export(), vec![(b"key1".to_vec(), b"value2".to_vec())]);
 
         store.begin();
-        store.delete(Context::new(), vec![b"key1".to_vec()]);
+        store.delete(Context::default(), vec![b"key1".to_vec()]);
         store.commit();
 
         assert_eq!(store.export(), vec![]);
 
         store.begin();
-        store.put(Context::new(), vec![(b"key2".to_vec(), b"bar".to_vec())]);
-        store.put(Context::new(), vec![(b"key1".to_vec(), b"foo".to_vec())]);
-        store.put(Context::new(), vec![(b"k".to_vec(), b"box".to_vec())]);
+        store.put(
+            Context::default(),
+            vec![(b"key2".to_vec(), b"bar".to_vec())],
+        );
+        store.put(
+            Context::default(),
+            vec![(b"key1".to_vec(), b"foo".to_vec())],
+        );
+        store.put(Context::default(), vec![(b"k".to_vec(), b"box".to_vec())]);
         store.commit();
 
         assert_eq!(
@@ -301,7 +319,7 @@ mod tests {
         );
 
         store.begin();
-        store.delete(Context::new(), vec![b"key1".to_vec(), b"key1".to_vec()]);
+        store.delete(Context::default(), vec![b"key1".to_vec(), b"key1".to_vec()]);
         store.commit();
 
         assert_eq!(
@@ -313,7 +331,7 @@ mod tests {
         );
 
         store.begin();
-        store.delete(Context::new(), vec![b"key2".to_vec()]);
+        store.delete(Context::default(), vec![b"key2".to_vec()]);
 
         assert_eq!(
             store.export(),
@@ -328,8 +346,8 @@ mod tests {
         assert_eq!(store.export(), vec![(b"k".to_vec(), b"box".to_vec())]);
 
         store.begin();
-        store.put(Context::new(), vec![(b"key1".to_vec(), b"v1".to_vec())]);
-        store.put(Context::new(), vec![(b"key2".to_vec(), b"v2".to_vec())]);
+        store.put(Context::default(), vec![(b"key1".to_vec(), b"v1".to_vec())]);
+        store.put(Context::default(), vec![(b"key2".to_vec(), b"v2".to_vec())]);
 
         assert_eq!(store.export(), vec![(b"k".to_vec(), b"box".to_vec())]);
 

--- a/components/test_coprocessor/src/table.rs
+++ b/components/test_coprocessor/src/table.rs
@@ -5,9 +5,7 @@ use super::*;
 use std::collections::BTreeMap;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::schema::{self, ColumnInfo};
-
-use protobuf::RepeatedField;
+use tipb::{self, ColumnInfo};
 
 use tikv::coprocessor;
 use tikv::coprocessor::codec::table;
@@ -41,11 +39,11 @@ impl Table {
         idx.map(|idx| &self.columns[*idx].1)
     }
 
-    /// Create `schema::TableInfo` from current table.
-    pub fn table_info(&self) -> schema::TableInfo {
-        let mut info = schema::TableInfo::new();
+    /// Create `tipb::TableInfo` from current table.
+    pub fn table_info(&self) -> tipb::TableInfo {
+        let mut info = tipb::TableInfo::default();
         info.set_table_id(self.id);
-        info.set_columns(RepeatedField::from_vec(self.columns_info()));
+        info.set_columns(self.columns_info());
         info
     }
 
@@ -57,15 +55,15 @@ impl Table {
             .collect()
     }
 
-    /// Create `schema::IndexInfo` from current table.
-    pub fn index_info(&self, index: i64, store_handle: bool) -> schema::IndexInfo {
-        let mut idx_info = schema::IndexInfo::new();
+    /// Create `tipb::IndexInfo` from current table.
+    pub fn index_info(&self, index: i64, store_handle: bool) -> tipb::IndexInfo {
+        let mut idx_info = tipb::IndexInfo::default();
         idx_info.set_table_id(self.id);
         idx_info.set_index_id(index);
         let mut has_pk = false;
         for col_id in &self.idxs[&index] {
             let col = self.column_by_id(*col_id).unwrap();
-            let mut c_info = ColumnInfo::new();
+            let mut c_info = ColumnInfo::default();
             c_info.set_tp(col.col_type);
             c_info.set_column_id(col.id);
             if col.id == self.handle_id {
@@ -75,7 +73,7 @@ impl Table {
             idx_info.mut_columns().push(c_info);
         }
         if !has_pk && store_handle {
-            let mut handle_info = ColumnInfo::new();
+            let mut handle_info = ColumnInfo::default();
             handle_info.set_tp(TYPE_LONG);
             handle_info.set_column_id(-1);
             handle_info.set_pk_handle(true);
@@ -86,7 +84,7 @@ impl Table {
 
     /// Create a `KeyRange` which select all records in current table.
     pub fn get_record_range_all(&self) -> KeyRange {
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         range.set_start(table::encode_row_key(self.id, std::i64::MIN));
         range.set_end(table::encode_row_key(self.id, std::i64::MAX));
         range
@@ -97,7 +95,7 @@ impl Table {
         let start_key = table::encode_row_key(self.id, handle_id);
         let mut end_key = start_key.clone();
         coprocessor::util::convert_to_prefix_next(&mut end_key);
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         range.set_start(start_key);
         range.set_end(end_key);
         range
@@ -105,7 +103,7 @@ impl Table {
 
     /// Create a `KeyRange` which select all index records of a specified index in current table.
     pub fn get_index_range_all(&self, idx: i64) -> KeyRange {
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         let mut buf = Vec::with_capacity(8);
         buf.encode_i64(::std::i64::MIN).unwrap();
         range.set_start(table::encode_index_seek_key(self.id, idx, &buf));

--- a/components/test_coprocessor/src/util.rs
+++ b/components/test_coprocessor/src/util.rs
@@ -3,11 +3,11 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use futures::{Future, Stream};
-use protobuf::Message;
+use prost::Message;
 
 use kvproto::coprocessor::{Request, Response};
-use tipb::schema::ColumnInfo;
-use tipb::select::{SelectResponse, StreamResponse};
+use tipb::ColumnInfo;
+use tipb::{SelectResponse, StreamResponse};
 
 use tikv::coprocessor::Endpoint;
 use tikv::storage::Engine;
@@ -33,8 +33,8 @@ where
 {
     let resp = handle_request(cop, req);
     assert!(!resp.get_data().is_empty(), "{:?}", resp);
-    let mut sel_resp = SelectResponse::new();
-    sel_resp.merge_from_bytes(resp.get_data()).unwrap();
+    let mut sel_resp = SelectResponse::default();
+    sel_resp.merge(resp.get_data()).unwrap();
     sel_resp
 }
 
@@ -53,8 +53,8 @@ where
             let resp = resp.unwrap();
             check_range(&resp);
             assert!(!resp.get_data().is_empty());
-            let mut stream_resp = StreamResponse::new();
-            stream_resp.merge_from_bytes(resp.get_data()).unwrap();
+            let mut stream_resp = StreamResponse::default();
+            stream_resp.merge(resp.get_data()).unwrap();
             stream_resp
         })
         .collect()

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -7,14 +7,13 @@ publish = false
 [dependencies]
 tikv_util = { path = "../tikv_util" }
 tikv = { path = "../../", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-3.0" }
-protobuf = "2"
 tempfile = "3.0"
-raft = "0.4"
+kvproto = { path = "../../../kvproto" }
+raft = { git = "https://github.com/pingcap/raft-rs", rev = "eeaee89a4eba7aa17abd630388df2f1c3a0f76ad" }
 futures = "0.1"
 tokio-timer = "0.2"
 tokio-threadpool = "0.1"
-grpcio = { version = "0.4", features = [ "secure" ] }
+grpcio = { version = "0.5.0-alpha.1", features = [ "secure", "prost-codec" ] }
 rand = "0.6.5"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 # better to not use slog-global, but pass in the logger

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -79,7 +79,7 @@ pub trait Simulator {
         match self.async_command_on_node(node_id, request, cb) {
             Ok(()) => {}
             Err(e) => {
-                let mut resp = RaftCmdResponse::new();
+                let mut resp = RaftCmdResponse::default();
                 resp.mut_header().set_error(e.into());
                 return Ok(resp);
             }
@@ -400,7 +400,7 @@ impl<T: Simulator> Cluster<T> {
     // But another node may request bootstrap at same time and get is_bootstrap false
     // Add Region but not set bootstrap to true
     pub fn add_first_region(&self) -> Result<()> {
-        let mut region = metapb::Region::new();
+        let mut region = metapb::Region::default();
         let region_id = self.pd_client.alloc_id().unwrap();
         let peer_id = self.pd_client.alloc_id().unwrap();
         region.set_id(region_id);
@@ -423,7 +423,7 @@ impl<T: Simulator> Cluster<T> {
             self.engines.insert(id, engines.clone());
         }
 
-        let mut region = metapb::Region::new();
+        let mut region = metapb::Region::default();
         region.set_id(1);
         region.set_start_key(keys::EMPTY_KEY.to_vec());
         region.set_end_key(keys::EMPTY_KEY.to_vec());

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -113,7 +113,7 @@ impl Operator {
                     };
                     new_pd_change_peer(conf_change_type, peer.clone())
                 } else {
-                    pdpb::RegionHeartbeatResponse::new()
+                    pdpb::RegionHeartbeatResponse::default()
                 }
             }
             Operator::RemovePeer { ref peer, .. } => {
@@ -124,7 +124,7 @@ impl Operator {
                 target_region_id, ..
             } => {
                 if target_region_id == region_id {
-                    pdpb::RegionHeartbeatResponse::new()
+                    pdpb::RegionHeartbeatResponse::default()
                 } else {
                     let region = cluster
                         .get_region_by_id(target_region_id)
@@ -227,7 +227,7 @@ struct Cluster {
 
 impl Cluster {
     fn new(cluster_id: u64) -> Cluster {
-        let mut meta = metapb::Cluster::new();
+        let mut meta = metapb::Cluster::default();
         meta.set_id(cluster_id);
         meta.set_max_peer_count(5);
 
@@ -460,7 +460,7 @@ impl Cluster {
         let resp = self
             .poll_heartbeat_responses(region.clone(), leader.clone())
             .unwrap_or_else(|| {
-                let mut resp = pdpb::RegionHeartbeatResponse::new();
+                let mut resp = pdpb::RegionHeartbeatResponse::default();
                 resp.set_region_id(region.get_id());
                 resp.set_region_epoch(region.take_region_epoch());
                 resp.set_target_peer(leader);
@@ -631,7 +631,7 @@ fn setdiff_peers(left: &metapb::Region, right: &metapb::Region) -> Vec<metapb::P
 
 // For test when a node is already bootstraped the cluster with the first region
 pub fn bootstrap_with_first_region(pd_client: Arc<TestPdClient>) -> Result<()> {
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(1);
     region.set_start_key(keys::EMPTY_KEY.to_vec());
     region.set_end_key(keys::EMPTY_KEY.to_vec());
@@ -1068,7 +1068,7 @@ impl PdClient for TestPdClient {
             return Box::new(err(e));
         }
 
-        let mut resp = pdpb::AskSplitResponse::new();
+        let mut resp = pdpb::AskSplitResponse::default();
         resp.set_new_region_id(self.alloc_id().unwrap());
         let mut peer_ids = vec![];
         for _ in region.get_peers() {
@@ -1103,9 +1103,9 @@ impl PdClient for TestPdClient {
             return Box::new(err(e));
         }
 
-        let mut resp = pdpb::AskBatchSplitResponse::new();
+        let mut resp = pdpb::AskBatchSplitResponse::default();
         for _ in 0..count {
-            let mut id = pdpb::SplitID::new();
+            let mut id = pdpb::SplitId::default();
             id.set_new_region_id(self.alloc_id().unwrap());
             for _ in region.get_peers() {
                 id.mut_new_peer_ids().push(self.alloc_id().unwrap());
@@ -1156,9 +1156,9 @@ impl PdClient for TestPdClient {
     }
 
     fn get_operator(&self, region_id: u64) -> Result<pdpb::GetOperatorResponse> {
-        let mut header = pdpb::ResponseHeader::new();
+        let mut header = pdpb::ResponseHeader::default();
         header.set_cluster_id(self.cluster_id);
-        let mut resp = pdpb::GetOperatorResponse::new();
+        let mut resp = pdpb::GetOperatorResponse::default();
         resp.set_header(header);
         resp.set_region_id(region_id);
         Ok(resp)

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -5,7 +5,6 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 use std::{thread, u64};
 
-use protobuf;
 use rand::RngCore;
 use tempfile::{Builder, TempDir};
 
@@ -184,7 +183,7 @@ pub fn new_tikv_config(cluster_id: u64) -> TiKvConfig {
 
 // Create a base request.
 pub fn new_base_request(region_id: u64, epoch: RegionEpoch, read_quorum: bool) -> RaftCmdRequest {
-    let mut req = RaftCmdRequest::new();
+    let mut req = RaftCmdRequest::default();
     req.mut_header().set_region_id(region_id);
     req.mut_header().set_region_epoch(epoch);
     req.mut_header().set_read_quorum(read_quorum);
@@ -198,12 +197,12 @@ pub fn new_request(
     read_quorum: bool,
 ) -> RaftCmdRequest {
     let mut req = new_base_request(region_id, epoch, read_quorum);
-    req.set_requests(protobuf::RepeatedField::from_vec(requests));
+    req.set_requests(requests);
     req
 }
 
 pub fn new_put_cmd(key: &[u8], value: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::Put);
     cmd.mut_put().set_key(key.to_vec());
     cmd.mut_put().set_value(value.to_vec());
@@ -211,7 +210,7 @@ pub fn new_put_cmd(key: &[u8], value: &[u8]) -> Request {
 }
 
 pub fn new_put_cf_cmd(cf: &str, key: &[u8], value: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::Put);
     cmd.mut_put().set_key(key.to_vec());
     cmd.mut_put().set_value(value.to_vec());
@@ -220,20 +219,20 @@ pub fn new_put_cf_cmd(cf: &str, key: &[u8], value: &[u8]) -> Request {
 }
 
 pub fn new_get_cmd(key: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::Get);
     cmd.mut_get().set_key(key.to_vec());
     cmd
 }
 
 pub fn new_read_index_cmd() -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::ReadIndex);
     cmd
 }
 
 pub fn new_get_cf_cmd(cf: &str, key: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::Get);
     cmd.mut_get().set_key(key.to_vec());
     cmd.mut_get().set_cf(cf.to_string());
@@ -241,7 +240,7 @@ pub fn new_get_cf_cmd(cf: &str, key: &[u8]) -> Request {
 }
 
 pub fn new_delete_cmd(cf: &str, key: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::Delete);
     cmd.mut_delete().set_key(key.to_vec());
     cmd.mut_delete().set_cf(cf.to_string());
@@ -249,7 +248,7 @@ pub fn new_delete_cmd(cf: &str, key: &[u8]) -> Request {
 }
 
 pub fn new_delete_range_cmd(cf: &str, start: &[u8], end: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::DeleteRange);
     cmd.mut_delete_range().set_start_key(start.to_vec());
     cmd.mut_delete_range().set_end_key(end.to_vec());
@@ -262,20 +261,20 @@ pub fn new_status_request(
     peer: metapb::Peer,
     request: StatusRequest,
 ) -> RaftCmdRequest {
-    let mut req = new_base_request(region_id, RegionEpoch::new(), false);
+    let mut req = new_base_request(region_id, RegionEpoch::default(), false);
     req.mut_header().set_peer(peer);
     req.set_status_request(request);
     req
 }
 
 pub fn new_region_detail_cmd() -> StatusRequest {
-    let mut cmd = StatusRequest::new();
+    let mut cmd = StatusRequest::default();
     cmd.set_cmd_type(StatusCmdType::RegionDetail);
     cmd
 }
 
 pub fn new_region_leader_cmd() -> StatusRequest {
-    let mut cmd = StatusRequest::new();
+    let mut cmd = StatusRequest::default();
     cmd.set_cmd_type(StatusCmdType::RegionLeader);
     cmd
 }
@@ -291,7 +290,7 @@ pub fn new_admin_request(
 }
 
 pub fn new_change_peer_request(change_type: ConfChangeType, peer: metapb::Peer) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::ChangePeer);
     req.mut_change_peer().set_change_type(change_type);
     req.mut_change_peer().set_peer(peer);
@@ -299,7 +298,7 @@ pub fn new_change_peer_request(change_type: ConfChangeType, peer: metapb::Peer) 
 }
 
 pub fn new_compact_log_request(index: u64, term: u64) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::CompactLog);
     req.mut_compact_log().set_compact_index(index);
     req.mut_compact_log().set_compact_term(term);
@@ -307,7 +306,7 @@ pub fn new_compact_log_request(index: u64, term: u64) -> AdminRequest {
 }
 
 pub fn new_transfer_leader_cmd(peer: metapb::Peer) -> AdminRequest {
-    let mut cmd = AdminRequest::new();
+    let mut cmd = AdminRequest::default();
     cmd.set_cmd_type(AdminCmdType::TransferLeader);
     cmd.mut_transfer_leader().set_peer(peer);
     cmd
@@ -315,14 +314,14 @@ pub fn new_transfer_leader_cmd(peer: metapb::Peer) -> AdminRequest {
 
 #[allow(dead_code)]
 pub fn new_prepare_merge(target_region: metapb::Region) -> AdminRequest {
-    let mut cmd = AdminRequest::new();
+    let mut cmd = AdminRequest::default();
     cmd.set_cmd_type(AdminCmdType::PrepareMerge);
     cmd.mut_prepare_merge().set_target(target_region);
     cmd
 }
 
 pub fn new_store(store_id: u64, addr: String) -> metapb::Store {
-    let mut store = metapb::Store::new();
+    let mut store = metapb::Store::default();
     store.set_id(store_id);
     store.set_address(addr);
 
@@ -341,36 +340,36 @@ pub fn new_pd_change_peer(
     change_type: ConfChangeType,
     peer: metapb::Peer,
 ) -> RegionHeartbeatResponse {
-    let mut change_peer = ChangePeer::new();
+    let mut change_peer = ChangePeer::default();
     change_peer.set_change_type(change_type);
     change_peer.set_peer(peer);
 
-    let mut resp = RegionHeartbeatResponse::new();
+    let mut resp = RegionHeartbeatResponse::default();
     resp.set_change_peer(change_peer);
     resp
 }
 
 pub fn new_half_split_region() -> RegionHeartbeatResponse {
-    let split_region = SplitRegion::new();
-    let mut resp = RegionHeartbeatResponse::new();
+    let split_region = SplitRegion::default();
+    let mut resp = RegionHeartbeatResponse::default();
     resp.set_split_region(split_region);
     resp
 }
 
 pub fn new_pd_transfer_leader(peer: metapb::Peer) -> RegionHeartbeatResponse {
-    let mut transfer_leader = TransferLeader::new();
+    let mut transfer_leader = TransferLeader::default();
     transfer_leader.set_peer(peer);
 
-    let mut resp = RegionHeartbeatResponse::new();
+    let mut resp = RegionHeartbeatResponse::default();
     resp.set_transfer_leader(transfer_leader);
     resp
 }
 
 pub fn new_pd_merge_region(target_region: metapb::Region) -> RegionHeartbeatResponse {
-    let mut merge = Merge::new();
+    let mut merge = Merge::default();
     merge.set_target(target_region);
 
-    let mut resp = RegionHeartbeatResponse::new();
+    let mut resp = RegionHeartbeatResponse::default();
     resp.set_merge(merge);
     resp
 }
@@ -383,7 +382,7 @@ pub fn make_cb(cmd: &RaftCmdRequest) -> (Callback, mpsc::Receiver<RaftCmdRespons
     for req in cmd.get_requests() {
         match req.get_cmd_type() {
             CmdType::Get | CmdType::Snap | CmdType::ReadIndex => is_read = true,
-            CmdType::Put | CmdType::Delete | CmdType::DeleteRange | CmdType::IngestSST => {
+            CmdType::Put | CmdType::Delete | CmdType::DeleteRange | CmdType::IngestSst => {
                 is_write = true
             }
             CmdType::Invalid | CmdType::Prewrite => panic!("Invalid RaftCmdRequest: {:?}", cmd),

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 tikv_util = { path = "../tikv_util" }
 tikv = { path = "../../", default-features = false }
 test_raftstore = { path = "../test_raftstore" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-3.0" }
+kvproto = { path = "../../../kvproto" }
 futures = "0.1"

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -20,7 +20,7 @@ pub struct AssertionStorage<E: Engine> {
 impl Default for AssertionStorage<RocksEngine> {
     fn default() -> Self {
         AssertionStorage {
-            ctx: Context::new(),
+            ctx: Context::default(),
             store: SyncTestStorageBuilder::new().build().unwrap(),
         }
     }

--- a/components/test_storage/src/util.rs
+++ b/components/test_storage/src/util.rs
@@ -18,7 +18,7 @@ pub fn new_raft_engine(
     let region = cluster.get_region(key.as_bytes());
     let leader = cluster.leader_of_region(region.get_id()).unwrap();
     let engine = cluster.sim.rl().storages[&leader.get_id()].clone();
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -18,7 +18,7 @@ time = "0.1"
 toml = "0.4"
 libc = "0.2"
 crc = "1.8"
-protobuf = "2"
+prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
 utime = "0.2"
 chrono = "0.4"
 lazy_static = "1.3"
@@ -36,7 +36,7 @@ tokio-threadpool = "0.1.13"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-grpcio = { version = "0.4", features = [ "secure" ] }
+grpcio = { version = "0.5.0-alpha.1", features = [ "secure", "prost-codec" ] }
 crossbeam = "0.5"
 fail = "0.2"
 fxhash = "0.2.1"
@@ -54,7 +54,7 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs" }
 
 [dev-dependencies]
 panic_hook = { path = "../panic_hook" }
-raft = "0.4"
+raft = { git = "https://github.com/pingcap/raft-rs", rev = "eeaee89a4eba7aa17abd630388df2f1c3a0f76ad" }
 
 [[bench]]
 name = "channel"

--- a/components/tikv_util/src/codec/number.rs
+++ b/components/tikv_util/src/codec/number.rs
@@ -319,7 +319,6 @@ mod tests {
     use super::*;
     use crate::codec::Error;
 
-    use protobuf::CodedOutputStream;
     use std::io::ErrorKind;
     use std::{f32, f64, i16, i32, i64, u16, u32, u64};
 
@@ -555,24 +554,6 @@ mod tests {
             buf.encode_f64_le(v).unwrap();
             let value = decode_f64_le(&mut buf.as_slice()).unwrap();
             assert_eq!(v, value);
-        }
-    }
-
-    #[test]
-    fn test_var_u64_codec() {
-        for &v in U64_TESTS {
-            let mut buf = vec![];
-            let mut p_buf = vec![];
-            {
-                let mut writer = CodedOutputStream::new(&mut p_buf);
-                writer.write_uint64_no_tag(v).unwrap();
-                writer.flush().unwrap();
-            }
-            buf.encode_var_u64(v).unwrap();
-            assert!(buf.len() <= MAX_VAR_I64_LEN);
-            assert_eq!(buf, p_buf);
-            let decoded = decode_var_u64(&mut buf.as_slice()).unwrap();
-            assert_eq!(v, decoded);
         }
     }
 

--- a/components/tipb_helper/Cargo.toml
+++ b/components/tipb_helper/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/pingcap/tipb.git", features = ["prost-codec"] }
 codec = { path = "../codec" }
 cop_datatype = { path = "../cop_datatype" }

--- a/components/tipb_helper/src/expr_def_builder.rs
+++ b/components/tipb_helper/src/expr_def_builder.rs
@@ -2,14 +2,14 @@
 
 use codec::prelude::NumberEncoder;
 use cop_datatype::{FieldTypeAccessor, FieldTypeFlag, FieldTypeTp};
-use tipb::expression::{Expr, ExprType, FieldType, ScalarFuncSig};
+use tipb::{Expr, ExprType, FieldType, ScalarFuncSig};
 
-/// A helper utility to build `tipb::expression::Expr` (a.k.a. expression definition) easily.
+/// A helper utility to build `tipb::Expr` (a.k.a. expression definition) easily.
 pub struct ExprDefBuilder(Expr);
 
 impl ExprDefBuilder {
     pub fn constant_int(v: i64) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::Int64);
         expr.mut_val().write_i64(v).unwrap();
         expr.mut_field_type()
@@ -19,7 +19,7 @@ impl ExprDefBuilder {
     }
 
     pub fn constant_uint(v: u64) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::Uint64);
         expr.mut_val().write_u64(v).unwrap();
         expr.mut_field_type()
@@ -30,7 +30,7 @@ impl ExprDefBuilder {
     }
 
     pub fn constant_real(v: f64) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::Float64);
         expr.mut_val().write_f64(v).unwrap();
         expr.mut_field_type()
@@ -40,7 +40,7 @@ impl ExprDefBuilder {
     }
 
     pub fn constant_bytes(v: Vec<u8>) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::String);
         expr.set_val(v);
         expr.mut_field_type()
@@ -50,14 +50,14 @@ impl ExprDefBuilder {
     }
 
     pub fn constant_null(field_type: impl Into<FieldType>) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::Null);
         expr.set_field_type(field_type.into());
         Self(expr)
     }
 
     pub fn column_ref(offset: usize, field_type: impl Into<FieldType>) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ColumnRef);
         expr.mut_val().write_i64(offset as i64).unwrap();
         expr.set_field_type(field_type.into());
@@ -65,7 +65,7 @@ impl ExprDefBuilder {
     }
 
     pub fn scalar_func(sig: ScalarFuncSig, field_type: impl Into<FieldType>) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ScalarFunc);
         expr.set_sig(sig);
         expr.set_field_type(field_type.into());
@@ -73,7 +73,7 @@ impl ExprDefBuilder {
     }
 
     pub fn aggr_func(tp: ExprType, field_type: impl Into<FieldType>) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(tp);
         expr.set_field_type(field_type.into());
         Self(expr)

--- a/src/config.rs
+++ b/src/config.rs
@@ -661,7 +661,7 @@ pub struct DbConfig {
     pub writable_file_max_buffer_size: ReadableSize,
     pub use_direct_io_for_flush_and_compaction: bool,
     pub enable_pipelined_write: bool,
-    pub defaultcf: DefaultCfConfig,
+    pub new_cf: DefaultCfConfig,
     pub writecf: WriteCfConfig,
     pub lockcf: LockCfConfig,
     pub raftcf: RaftCfConfig,
@@ -696,7 +696,7 @@ impl Default for DbConfig {
             writable_file_max_buffer_size: ReadableSize::mb(1),
             use_direct_io_for_flush_and_compaction: false,
             enable_pipelined_write: true,
-            defaultcf: DefaultCfConfig::default(),
+            new_cf: DefaultCfConfig::default(),
             writecf: WriteCfConfig::default(),
             lockcf: LockCfConfig::default(),
             raftcf: RaftCfConfig::default(),
@@ -761,7 +761,7 @@ impl DbConfig {
 
     pub fn build_cf_opts(&self, cache: &Option<Cache>) -> Vec<CFOptions<'_>> {
         vec![
-            CFOptions::new(CF_DEFAULT, self.defaultcf.build_opt(cache)),
+            CFOptions::new(CF_DEFAULT, self.new_cf.build_opt(cache)),
             CFOptions::new(CF_LOCK, self.lockcf.build_opt(cache)),
             CFOptions::new(CF_WRITE, self.writecf.build_opt(cache)),
             // TODO: rmeove CF_RAFT.
@@ -771,7 +771,7 @@ impl DbConfig {
 
     pub fn build_cf_opts_v2(&self, cache: &Option<Cache>) -> Vec<CFOptions<'_>> {
         vec![
-            CFOptions::new(CF_DEFAULT, self.defaultcf.build_opt(cache)),
+            CFOptions::new(CF_DEFAULT, self.new_cf.build_opt(cache)),
             CFOptions::new(CF_LOCK, self.lockcf.build_opt(cache)),
             CFOptions::new(CF_WRITE, self.writecf.build_opt(cache)),
             CFOptions::new(CF_RAFT, self.raftcf.build_opt(cache)),
@@ -779,7 +779,7 @@ impl DbConfig {
     }
 
     fn validate(&mut self) -> Result<(), Box<dyn Error>> {
-        self.defaultcf.validate()?;
+        self.new_cf.validate()?;
         self.lockcf.validate()?;
         self.writecf.validate()?;
         self.raftcf.validate()?;
@@ -788,7 +788,7 @@ impl DbConfig {
     }
 
     fn write_into_metrics(&self) {
-        write_into_metrics!(self.defaultcf, CF_DEFAULT, CONFIG_ROCKSDB_GAUGE);
+        write_into_metrics!(self.new_cf, CF_DEFAULT, CONFIG_ROCKSDB_GAUGE);
         write_into_metrics!(self.lockcf, CF_LOCK, CONFIG_ROCKSDB_GAUGE);
         write_into_metrics!(self.writecf, CF_WRITE, CONFIG_ROCKSDB_GAUGE);
         write_into_metrics!(self.raftcf, CF_RAFT, CONFIG_ROCKSDB_GAUGE);
@@ -887,7 +887,7 @@ pub struct RaftDbConfig {
     pub allow_concurrent_memtable_write: bool,
     pub bytes_per_sync: ReadableSize,
     pub wal_bytes_per_sync: ReadableSize,
-    pub defaultcf: RaftDefaultCfConfig,
+    pub new_cf: RaftDefaultCfConfig,
 }
 
 impl Default for RaftDbConfig {
@@ -916,7 +916,7 @@ impl Default for RaftDbConfig {
             allow_concurrent_memtable_write: false,
             bytes_per_sync: ReadableSize::mb(1),
             wal_bytes_per_sync: ReadableSize::kb(512),
-            defaultcf: RaftDefaultCfConfig::default(),
+            new_cf: RaftDefaultCfConfig::default(),
         }
     }
 }
@@ -966,11 +966,11 @@ impl RaftDbConfig {
     }
 
     pub fn build_cf_opts(&self, cache: &Option<Cache>) -> Vec<CFOptions<'_>> {
-        vec![CFOptions::new(CF_DEFAULT, self.defaultcf.build_opt(cache))]
+        vec![CFOptions::new(CF_DEFAULT, self.new_cf.build_opt(cache))]
     }
 
     fn validate(&mut self) -> Result<(), Box<dyn Error>> {
-        self.defaultcf.validate()?;
+        self.new_cf.validate()?;
         Ok(())
     }
 }
@@ -1391,10 +1391,10 @@ impl TiKvConfig {
         let cache_cfg = &mut self.storage.block_cache;
         if cache_cfg.shared && cache_cfg.capacity.is_none() {
             cache_cfg.capacity = Some(ReadableSize {
-                0: self.rocksdb.defaultcf.block_cache_size.0
+                0: self.rocksdb.new_cf.block_cache_size.0
                     + self.rocksdb.writecf.block_cache_size.0
                     + self.rocksdb.lockcf.block_cache_size.0
-                    + self.raftdb.defaultcf.block_cache_size.0,
+                    + self.raftdb.new_cf.block_cache_size.0,
             });
         }
     }
@@ -1601,17 +1601,17 @@ mod tests {
     fn test_block_size() {
         let mut tikv_cfg = TiKvConfig::default();
         tikv_cfg.pd.endpoints = vec!["".to_owned()];
-        tikv_cfg.rocksdb.defaultcf.block_size = ReadableSize::gb(10);
+        tikv_cfg.rocksdb.new_cf.block_size = ReadableSize::gb(10);
         tikv_cfg.rocksdb.lockcf.block_size = ReadableSize::gb(10);
         tikv_cfg.rocksdb.writecf.block_size = ReadableSize::gb(10);
         tikv_cfg.rocksdb.raftcf.block_size = ReadableSize::gb(10);
-        tikv_cfg.raftdb.defaultcf.block_size = ReadableSize::gb(10);
+        tikv_cfg.raftdb.new_cf.block_size = ReadableSize::gb(10);
         assert!(tikv_cfg.validate().is_err());
-        tikv_cfg.rocksdb.defaultcf.block_size = ReadableSize::kb(10);
+        tikv_cfg.rocksdb.new_cf.block_size = ReadableSize::kb(10);
         tikv_cfg.rocksdb.lockcf.block_size = ReadableSize::kb(10);
         tikv_cfg.rocksdb.writecf.block_size = ReadableSize::kb(10);
         tikv_cfg.rocksdb.raftcf.block_size = ReadableSize::kb(10);
-        tikv_cfg.raftdb.defaultcf.block_size = ReadableSize::kb(10);
+        tikv_cfg.raftdb.new_cf.block_size = ReadableSize::kb(10);
         tikv_cfg.validate().unwrap();
     }
 

--- a/src/coprocessor/codec/batch/lazy_column.rs
+++ b/src/coprocessor/codec/batch/lazy_column.rs
@@ -3,7 +3,7 @@
 use std::convert::TryFrom;
 
 use cop_datatype::{EvalType, FieldTypeAccessor};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::BufferVec;
 use crate::coprocessor::codec::data_type::VectorValue;
@@ -161,8 +161,7 @@ impl LazyBatchColumn {
         if self.is_decoded() {
             return Ok(());
         }
-
-        let eval_type = box_try!(EvalType::try_from(field_type.tp()));
+        let eval_type = box_try!(EvalType::try_from(FieldTypeAccessor::tp(field_type)));
         let raw_vec = self.raw();
         let raw_vec_len = raw_vec.len();
 

--- a/src/coprocessor/codec/batch/lazy_column_vec.rs
+++ b/src/coprocessor/codec/batch/lazy_column_vec.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::LazyBatchColumn;
 use crate::coprocessor::codec::data_type::VectorValue;

--- a/src/coprocessor/codec/chunk/chunk.rs
+++ b/src/coprocessor/codec/chunk/chunk.rs
@@ -6,7 +6,7 @@ use crate::coprocessor::codec::Datum;
 use std::io::Write;
 #[cfg(test)]
 use tikv_util::codec::BytesSlice;
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 /// `Chunk` stores multiple rows of data in Apache Arrow format.
 /// See https://arrow.apache.org/docs/memory_layout.html

--- a/src/coprocessor/codec/chunk/column.rs
+++ b/src/coprocessor/codec/chunk/column.rs
@@ -388,7 +388,7 @@ mod tests {
     use crate::coprocessor::codec::datum::Datum;
     use crate::coprocessor::codec::mysql::*;
     use std::{f64, u64};
-    use tipb::expression::FieldType;
+    use tipb::FieldType;
 
     #[test]
     fn test_column_i64() {

--- a/src/coprocessor/codec/chunk/mod.rs
+++ b/src/coprocessor/codec/chunk/mod.rs
@@ -11,10 +11,10 @@ pub use self::chunk::{Chunk, ChunkEncoder};
 mod tests {
     use cop_datatype::FieldTypeAccessor;
     use cop_datatype::FieldTypeTp;
-    use tipb::expression::FieldType;
+    use tipb::FieldType;
 
     pub fn field_type(tp: FieldTypeTp) -> FieldType {
-        let mut fp = FieldType::new();
+        let mut fp = FieldType::default();
         fp.as_mut_accessor().set_tp(tp);
         fp
     }

--- a/src/coprocessor/codec/data_type/vector.rs
+++ b/src/coprocessor/codec/data_type/vector.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeFlag};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::*;
 use crate::coprocessor::codec::data_type::scalar::ScalarValueRef;
@@ -239,7 +239,7 @@ impl VectorValue {
                     }
                     Some(val) => {
                         // Always encode to INT / UINT instead of VAR INT to be efficient.
-                        if field_type.flag().contains(FieldTypeFlag::UNSIGNED) {
+                        if FieldTypeAccessor::flag(field_type).contains(FieldTypeFlag::UNSIGNED) {
                             output.push(datum::UINT_FLAG);
                             output.encode_u64(val as u64)?;
                         } else {

--- a/src/coprocessor/codec/error.rs
+++ b/src/coprocessor/codec/error.rs
@@ -6,8 +6,7 @@ use std::io;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 use std::{error, str};
-use tipb::expression::ScalarFuncSig;
-use tipb::select;
+use tipb::{self, ScalarFuncSig};
 
 pub const ERR_UNKNOWN: i32 = 1105;
 pub const ERR_REGEXP: i32 = 1139;
@@ -132,9 +131,9 @@ impl Error {
     }
 }
 
-impl From<Error> for select::Error {
-    fn from(error: Error) -> select::Error {
-        let mut err = select::Error::new();
+impl From<Error> for tipb::Error {
+    fn from(error: Error) -> tipb::Error {
+        let mut err = tipb::Error::default();
         err.set_code(error.code());
         err.set_msg(format!("{:?}", error));
         err

--- a/src/coprocessor/codec/raw_datum.rs
+++ b/src/coprocessor/codec/raw_datum.rs
@@ -4,7 +4,7 @@
 
 use cop_datatype::{FieldTypeAccessor, FieldTypeTp};
 use tikv_util::codec::{bytes, number};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::data_type::*;
 use crate::coprocessor::codec::datum;
@@ -75,7 +75,7 @@ fn decode_date_time_from_uint(v: u64, time_zone: &Tz, field_type: &FieldType) ->
     use std::convert::TryInto;
 
     let fsp = field_type.decimal() as i8;
-    let time_type = field_type.tp().try_into()?;
+    let time_type = FieldTypeAccessor::tp(field_type).try_into()?;
     DateTime::from_packed_u64(v, time_type, fsp, time_zone)
 }
 
@@ -114,7 +114,7 @@ pub fn decode_real_datum(mut raw_datum: &[u8], field_type: &FieldType) -> Result
         // In both index and record, it's flag is `FLOAT`. See TiDB's `encode()`.
         datum::FLOAT_FLAG => {
             let mut v = decode_float(&mut raw_datum)?;
-            if field_type.tp() == FieldTypeTp::Float {
+            if FieldTypeAccessor::tp(field_type) == FieldTypeTp::Float {
                 v = (v as f32) as f64;
             }
             Ok(Real::new(v).ok()) // NaN to None

--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -7,7 +7,7 @@ use std::{cmp, u8};
 use cop_datatype::prelude::*;
 use cop_datatype::FieldTypeTp;
 use kvproto::coprocessor::KeyRange;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
 
 //use super::datum::DatumDecoder;
 use super::mysql::{Duration, Time};
@@ -411,7 +411,7 @@ pub fn cut_idx_key(key: Vec<u8>, col_ids: &[i64]) -> Result<(RowColsDict, Option
 mod tests {
     use std::i64;
 
-    use tipb::schema::ColumnInfo;
+    use tipb::ColumnInfo;
 
     use crate::coprocessor::codec::datum::{self, Datum};
     use tikv_util::collections::{HashMap, HashSet};
@@ -442,7 +442,7 @@ mod tests {
     }
 
     fn new_col_info(tp: FieldTypeTp) -> ColumnInfo {
-        let mut col_info = ColumnInfo::new();
+        let mut col_info = ColumnInfo::default();
         col_info.as_mut_accessor().set_tp(tp);
         col_info
     }
@@ -620,18 +620,18 @@ mod tests {
     fn test_check_table_range() {
         let small_key = b"t\x80\x00\x00\x00\x00\x00\x00\x01a".to_vec();
         let large_key = b"t\x80\x00\x00\x00\x00\x00\x00\x01b".to_vec();
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         range.set_start(small_key.clone());
         range.set_end(large_key.clone());
         assert!(check_table_ranges(&[range]).is_ok());
         //test range.start > range.end
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         range.set_end(small_key.clone());
         range.set_start(large_key);
         assert!(check_table_ranges(&[range]).is_err());
 
         // test invalid end
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         range.set_start(small_key);
         range.set_end(b"xx".to_vec());
         assert!(check_table_ranges(&[range]).is_err());

--- a/src/coprocessor/dag/aggr_fn/impl_avg.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_avg.rs
@@ -3,7 +3,7 @@
 use cop_codegen::AggrFunction;
 use cop_datatype::builder::FieldTypeBuilder;
 use cop_datatype::{EvalType, FieldTypeFlag, FieldTypeTp};
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use super::summable::Summable;
 use crate::coprocessor::codec::data_type::*;
@@ -49,7 +49,8 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserAvg {
             RpnExpressionBuilder::build_from_expr_tree(child, time_zone, src_schema.len())?;
         super::util::rewrite_exp_for_sum_avg(src_schema, &mut exp).unwrap();
 
-        let rewritten_eval_type = EvalType::try_from(exp.ret_field_type(src_schema).tp()).unwrap();
+        let rewritten_eval_type =
+            EvalType::try_from(FieldTypeAccessor::tp(exp.ret_field_type(src_schema))).unwrap();
         out_exp.push(exp);
 
         Ok(match rewritten_eval_type {
@@ -229,8 +230,8 @@ mod tests {
             .parse(expr, &Tz::utc(), &src_schema, &mut schema, &mut exp)
             .unwrap();
         assert_eq!(schema.len(), 2);
-        assert_eq!(schema[0].tp(), FieldTypeTp::LongLong);
-        assert_eq!(schema[1].tp(), FieldTypeTp::NewDecimal);
+        assert_eq!(FieldTypeAccessor::tp(&schema[0]), FieldTypeTp::LongLong);
+        assert_eq!(FieldTypeAccessor::tp(&schema[1]), FieldTypeTp::NewDecimal);
 
         assert_eq!(exp.len(), 1);
 

--- a/src/coprocessor/dag/aggr_fn/impl_count.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_count.rs
@@ -3,7 +3,7 @@
 use cop_codegen::AggrFunction;
 use cop_datatype::builder::FieldTypeBuilder;
 use cop_datatype::{FieldTypeFlag, FieldTypeTp};
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use crate::coprocessor::codec::data_type::*;
 use crate::coprocessor::codec::mysql::Tz;

--- a/src/coprocessor/dag/aggr_fn/impl_first.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_first.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use cop_codegen::AggrFunction;
 use cop_datatype::EvalType;
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use crate::coprocessor::codec::data_type::*;
 use crate::coprocessor::codec::mysql::Tz;
@@ -33,7 +33,7 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserFirst {
         use std::convert::TryFrom;
         assert_eq!(aggr_def.get_tp(), ExprType::First);
         let child = aggr_def.take_children().into_iter().next().unwrap();
-        let eval_type = EvalType::try_from(child.get_field_type().tp()).unwrap();
+        let eval_type = EvalType::try_from(FieldTypeAccessor::tp(child.get_field_type())).unwrap();
 
         // FIRST outputs one column with the same type as its child
         out_schema.push(aggr_def.take_field_type());

--- a/src/coprocessor/dag/aggr_fn/impl_max_min.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_max_min.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 
 use cop_codegen::AggrFunction;
 use cop_datatype::{EvalType, FieldTypeAccessor};
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use crate::coprocessor::codec::data_type::*;
 use crate::coprocessor::codec::mysql::Tz;
@@ -65,7 +65,7 @@ impl<T: Extremum> super::AggrDefinitionParser for AggrFnDefinitionParserExtremum
         out_schema.push(aggr_def.take_field_type());
 
         let child = aggr_def.take_children().into_iter().next().unwrap();
-        let eval_type = EvalType::try_from(child.get_field_type().tp()).unwrap();
+        let eval_type = EvalType::try_from(FieldTypeAccessor::tp(child.get_field_type())).unwrap();
         out_exp.push(RpnExpressionBuilder::build_from_expr_tree(
             child,
             time_zone,
@@ -310,14 +310,14 @@ mod tests {
             .parse(max, &Tz::utc(), &src_schema, &mut schema, &mut exp)
             .unwrap();
         assert_eq!(schema.len(), 1);
-        assert_eq!(schema[0].tp(), FieldTypeTp::LongLong);
+        assert_eq!(FieldTypeAccessor::tp(&schema[0]), FieldTypeTp::LongLong);
         assert_eq!(exp.len(), 1);
 
         let min_fn = min_parser
             .parse(min, &Tz::utc(), &src_schema, &mut schema, &mut exp)
             .unwrap();
         assert_eq!(schema.len(), 2);
-        assert_eq!(schema[1].tp(), FieldTypeTp::LongLong);
+        assert_eq!(FieldTypeAccessor::tp(&schema[1]), FieldTypeTp::LongLong);
         assert_eq!(exp.len(), 2);
 
         let mut ctx = EvalContext::default();

--- a/src/coprocessor/dag/aggr_fn/impl_sum.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_sum.rs
@@ -2,7 +2,7 @@
 
 use cop_codegen::AggrFunction;
 use cop_datatype::EvalType;
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use super::summable::Summable;
 use crate::coprocessor::codec::data_type::*;
@@ -43,7 +43,8 @@ impl super::parser::AggrDefinitionParser for AggrFnDefinitionParserSum {
         // The rewrite should always success.
         super::util::rewrite_exp_for_sum_avg(src_schema, &mut exp).unwrap();
 
-        let rewritten_eval_type = EvalType::try_from(exp.ret_field_type(src_schema).tp()).unwrap();
+        let rewritten_eval_type =
+            EvalType::try_from(FieldTypeAccessor::tp(exp.ret_field_type(src_schema))).unwrap();
         out_exp.push(exp);
 
         // Choose a type-aware SUM implementation based on the eval type after rewriting exp.
@@ -172,7 +173,7 @@ mod tests {
             .parse(expr, &Tz::utc(), &src_schema, &mut schema, &mut exp)
             .unwrap();
         assert_eq!(schema.len(), 1);
-        assert_eq!(schema[0].tp(), FieldTypeTp::Double);
+        assert_eq!(FieldTypeAccessor::tp(&schema[0]), FieldTypeTp::Double);
 
         assert_eq!(exp.len(), 1);
 

--- a/src/coprocessor/dag/aggr_fn/parser.rs
+++ b/src/coprocessor/dag/aggr_fn/parser.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use crate::coprocessor::codec::mysql::Tz;
 use crate::coprocessor::dag::aggr_fn::impl_bit_op::*;
@@ -48,9 +48,9 @@ fn map_pb_sig_to_aggr_func_parser(value: ExprType) -> Result<Box<dyn AggrDefinit
         ExprType::Sum => Ok(Box::new(super::impl_sum::AggrFnDefinitionParserSum)),
         ExprType::Avg => Ok(Box::new(super::impl_avg::AggrFnDefinitionParserAvg)),
         ExprType::First => Ok(Box::new(super::impl_first::AggrFnDefinitionParserFirst)),
-        ExprType::Agg_BitAnd => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitAnd>::new())),
-        ExprType::Agg_BitOr => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitOr>::new())),
-        ExprType::Agg_BitXor => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitXor>::new())),
+        ExprType::AggBitAnd => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitAnd>::new())),
+        ExprType::AggBitOr => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitOr>::new())),
+        ExprType::AggBitXor => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitXor>::new())),
         ExprType::Max => Ok(Box::new(AggrFnDefinitionParserExtremum::<Max>::new())),
         ExprType::Min => Ok(Box::new(AggrFnDefinitionParserExtremum::<Min>::new())),
         v => Err(box_err!(

--- a/src/coprocessor/dag/aggr_fn/util.rs
+++ b/src/coprocessor/dag/aggr_fn/util.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 
 use cop_datatype::builder::FieldTypeBuilder;
 use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeFlag, FieldTypeTp};
-use tipb::expression::{Expr, FieldType};
+use tipb::{Expr, FieldType};
 
 use crate::coprocessor::dag::rpn_expr::impl_cast::get_cast_fn_rpn_node;
 use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
@@ -33,7 +33,7 @@ pub fn check_aggr_exp_supported_one_child(aggr_def: &Expr) -> Result<()> {
 /// TODO: This logic should be performed by TiDB.
 pub fn rewrite_exp_for_sum_avg(schema: &[FieldType], exp: &mut RpnExpression) -> Result<()> {
     let ret_field_type = exp.ret_field_type(schema);
-    let ret_eval_type = box_try!(EvalType::try_from(ret_field_type.tp()));
+    let ret_eval_type = box_try!(EvalType::try_from(FieldTypeAccessor::tp(ret_field_type)));
     let new_ret_field_type = match ret_eval_type {
         EvalType::Decimal | EvalType::Real => {
             // No need to cast. Return directly without changing anything.
@@ -57,7 +57,7 @@ pub fn rewrite_exp_for_sum_avg(schema: &[FieldType], exp: &mut RpnExpression) ->
 /// Rewrites the expression to insert necessary cast functions for Bit operation family functions.
 pub fn rewrite_exp_for_bit_op(schema: &[FieldType], exp: &mut RpnExpression) -> Result<()> {
     let ret_field_type = exp.ret_field_type(schema);
-    let ret_eval_type = box_try!(EvalType::try_from(ret_field_type.tp()));
+    let ret_eval_type = box_try!(EvalType::try_from(FieldTypeAccessor::tp(ret_field_type)));
     let new_ret_field_type = match ret_eval_type {
         EvalType::Int => {
             return Ok(());

--- a/src/coprocessor/dag/batch/executors/index_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/index_scan_executor.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 
 use cop_datatype::EvalType;
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::IndexScan;
-use tipb::expression::FieldType;
-use tipb::schema::ColumnInfo;
+use tipb::{ColumnInfo, FieldType, IndexScan};
 
 use crate::storage::{FixtureStore, Store};
 
@@ -238,7 +236,7 @@ mod tests {
 
     use cop_datatype::{FieldTypeAccessor, FieldTypeTp};
     use kvproto::coprocessor::KeyRange;
-    use tipb::schema::ColumnInfo;
+    use tipb::ColumnInfo;
 
     use crate::coprocessor::codec::data_type::*;
     use crate::coprocessor::codec::mysql::Tz;
@@ -264,17 +262,17 @@ mod tests {
         // The column info for each column in `data`. Used to build the executor.
         let columns_info = vec![
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci
             },
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::Double);
                 ci
             },
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_pk_handle(true);
                 ci
@@ -311,7 +309,7 @@ mod tests {
             // Case 1.1. Normal index, without PK, scan total index in reverse order.
 
             let key_ranges = vec![{
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 let start_data = datum::encode_key(&[Datum::Min]).unwrap();
                 let start_key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &start_data);
                 range.set_start(start_key);
@@ -361,7 +359,7 @@ mod tests {
             // Case 1.2. Normal index, with PK, scan index prefix.
 
             let key_ranges = vec![{
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 let start_data = datum::encode_key(&[Datum::I64(2)]).unwrap();
                 let start_key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &start_data);
                 range.set_start(start_key);
@@ -438,7 +436,7 @@ mod tests {
             // Case 2.1. Unique index, prefix range scan.
 
             let key_ranges = vec![{
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 let start_data = datum::encode_key(&[Datum::I64(5)]).unwrap();
                 let start_key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &start_data);
                 range.set_start(start_key);
@@ -492,7 +490,7 @@ mod tests {
             // Case 2.2. Unique index, point scan.
 
             let key_ranges = vec![{
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 let start_data = datum::encode_key(&[Datum::I64(5), Datum::F64(5.1)]).unwrap();
                 let start_key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &start_data);
                 range.set_start(start_key);

--- a/src/coprocessor/dag/batch/executors/limit_executor.rs
+++ b/src/coprocessor/dag/batch/executors/limit_executor.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use crate::coprocessor::dag::batch::interface::*;
 use crate::coprocessor::Result;

--- a/src/coprocessor/dag/batch/executors/selection_executor.rs
+++ b/src/coprocessor/dag/batch/executors/selection_executor.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 
-use tipb::executor::Selection;
-use tipb::expression::Expr;
-use tipb::expression::FieldType;
+use tipb::Expr;
+use tipb::FieldType;
+use tipb::Selection;
 
 use super::super::interface::*;
 use crate::coprocessor::codec::data_type::*;

--- a/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
@@ -5,8 +5,8 @@
 
 use std::sync::Arc;
 
-use tipb::executor::Aggregation;
-use tipb::expression::{Expr, FieldType};
+use tipb::Aggregation;
+use tipb::{Expr, FieldType};
 
 use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::coprocessor::codec::data_type::*;
@@ -330,7 +330,7 @@ mod tests {
 
         let aggr_definitions: Vec<_> = (0..6)
             .map(|index| {
-                let mut exp = Expr::new();
+                let mut exp = Expr::default();
                 exp.mut_val().push(index as u8);
                 exp
             })
@@ -453,7 +453,7 @@ mod tests {
 
     #[test]
     fn test_it_works_integration() {
-        use tipb::expression::ExprType;
+        use tipb::ExprType;
         use tipb_helper::ExprDefBuilder;
 
         // This test creates a simple aggregation executor with the following aggregate functions:
@@ -607,7 +607,7 @@ mod tests {
         }
 
         let mut exec =
-            BatchSimpleAggregationExecutor::new_for_test(src_exec, vec![Expr::new()], MyParser);
+            BatchSimpleAggregationExecutor::new_for_test(src_exec, vec![Expr::default()], MyParser);
 
         let r = exec.next_batch(1);
         assert!(r.logical_rows.is_empty());

--- a/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/slow_hash_aggr_executor.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use tikv_util::collections::HashMap;
 use tikv_util::collections::HashMapEntry;
-use tipb::executor::Aggregation;
-use tipb::expression::{Expr, FieldType};
+use tipb::Aggregation;
+use tipb::{Expr, FieldType};
 
 use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::coprocessor::dag::aggr_fn::*;
@@ -372,7 +372,7 @@ mod tests {
     use super::*;
 
     use cop_datatype::FieldTypeTp;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::coprocessor::codec::data_type::*;
     use crate::coprocessor::codec::mysql::Tz;
@@ -382,7 +382,7 @@ mod tests {
 
     #[test]
     fn test_it_works_integration() {
-        use tipb::expression::ExprType;
+        use tipb::ExprType;
         use tipb_helper::ExprDefBuilder;
 
         // This test creates a hash aggregation executor with the following aggregate functions:

--- a/src/coprocessor/dag/batch/executors/stream_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/stream_aggr_executor.rs
@@ -4,8 +4,8 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 use cop_datatype::{EvalType, FieldTypeAccessor};
-use tipb::executor::Aggregation;
-use tipb::expression::{Expr, FieldType};
+use tipb::Aggregation;
+use tipb::{Expr, FieldType};
 
 use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::coprocessor::codec::data_type::*;
@@ -140,7 +140,7 @@ impl<Src: BatchExecutor> BatchStreamAggregationExecutor<Src> {
                 // The unwrap is fine because aggregate function parser should never return an
                 // eval type that we cannot process later. If we made a mistake there, then we
                 // should panic.
-                EvalType::try_from(exp.ret_field_type(src.schema()).tp()).unwrap()
+                EvalType::try_from(FieldTypeAccessor::tp(exp.ret_field_type(src.schema()))).unwrap()
             })
             .collect();
 
@@ -399,7 +399,7 @@ mod tests {
     use super::*;
 
     use cop_datatype::FieldTypeTp;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::coprocessor::dag::batch::executors::util::mock_executor::MockExecutor;
     use crate::coprocessor::dag::expr::EvalWarnings;
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_it_works_integration() {
-        use tipb::expression::ExprType;
+        use tipb::ExprType;
         use tipb_helper::ExprDefBuilder;
 
         // This test creates a stream aggregation executor with the following aggregate functions:

--- a/src/coprocessor/dag/batch/executors/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/table_scan_executor.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 
 use cop_datatype::{EvalType, FieldTypeAccessor};
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::TableScan;
-use tipb::expression::FieldType;
-use tipb::schema::ColumnInfo;
+use tipb::{ColumnInfo, FieldType, TableScan};
 
 use crate::storage::{FixtureStore, Store};
 use tikv_util::collections::HashMap;
@@ -272,8 +270,7 @@ impl super::util::scan_executor::ScanExecutorImpl for TableScanExecutorImpl {
                 let default_value = if !self.columns_default_value[i].is_empty() {
                     // default value is provided, use the default value
                     self.columns_default_value[i].as_slice()
-                } else if !self.schema[i]
-                    .flag()
+                } else if !FieldTypeAccessor::flag(&self.schema[i])
                     .contains(cop_datatype::FieldTypeFlag::NOT_NULL)
                 {
                     // NULL is allowed, use NULL
@@ -304,8 +301,8 @@ mod tests {
 
     use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeTp};
     use kvproto::coprocessor::KeyRange;
-    use tipb::expression::FieldType;
-    use tipb::schema::ColumnInfo;
+    use tipb::ColumnInfo;
+    use tipb::FieldType;
 
     use crate::coprocessor::codec::batch::LazyBatchColumnVec;
     use crate::coprocessor::codec::data_type::*;
@@ -391,20 +388,20 @@ mod tests {
             // The column info for each column in `data`.
             let columns_info = vec![
                 {
-                    let mut ci = ColumnInfo::new();
+                    let mut ci = ColumnInfo::default();
                     ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                     ci.set_pk_handle(true);
                     ci.set_column_id(1);
                     ci
                 },
                 {
-                    let mut ci = ColumnInfo::new();
+                    let mut ci = ColumnInfo::default();
                     ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                     ci.set_column_id(2);
                     ci
                 },
                 {
-                    let mut ci = ColumnInfo::new();
+                    let mut ci = ColumnInfo::default();
                     ci.as_mut_accessor().set_tp(FieldTypeTp::Double);
                     ci.set_column_id(4);
                     ci.set_default_val(datum::encode_value(&[Datum::F64(4.5)]).unwrap());
@@ -448,7 +445,7 @@ mod tests {
             self.data
                 .iter()
                 .map(|(row_id, _, _)| {
-                    let mut r = KeyRange::new();
+                    let mut r = KeyRange::default();
                     r.set_start(table::encode_row_key(self.table_id, *row_id));
                     r.set_end(r.get_start().to_vec());
                     convert_to_prefix_next(r.mut_end());
@@ -462,7 +459,7 @@ mod tests {
             vec![
                 self.table_range(std::i64::MIN, 3),
                 {
-                    let mut r = KeyRange::new();
+                    let mut r = KeyRange::default();
                     r.set_start(table::encode_row_key(self.table_id, 3));
                     r.set_end(r.get_start().to_vec());
                     convert_to_prefix_next(r.mut_end());
@@ -495,7 +492,7 @@ mod tests {
 
         /// Returns the range for handle in [start_id,end_id)
         fn table_range(&self, start_id: i64, end_id: i64) -> KeyRange {
-            let mut range = KeyRange::new();
+            let mut range = KeyRange::default();
             range.set_start(table::encode_row_key(self.table_id, start_id));
             range.set_end(table::encode_row_key(self.table_id, end_id));
             range
@@ -689,20 +686,20 @@ mod tests {
 
         let columns_info = vec![
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_pk_handle(true);
                 ci.set_column_id(1);
                 ci
             },
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_column_id(2);
                 ci
             },
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_column_id(3);
                 ci
@@ -753,7 +750,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(index, _)| {
-                let mut r = KeyRange::new();
+                let mut r = KeyRange::default();
                 r.set_start(table::encode_row_key(TABLE_ID, index as i64));
                 r.set_end(r.get_start().to_vec());
                 convert_to_prefix_next(r.mut_end());
@@ -812,14 +809,14 @@ mod tests {
 
         let columns_info = vec![
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_pk_handle(true);
                 ci.set_column_id(1);
                 ci
             },
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_column_id(2);
                 ci
@@ -859,7 +856,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(index, _)| {
-                let mut r = KeyRange::new();
+                let mut r = KeyRange::default();
                 r.set_start(table::encode_row_key(TABLE_ID, index as i64));
                 r.set_end(r.get_start().to_vec());
                 convert_to_prefix_next(r.mut_end());

--- a/src/coprocessor/dag/batch/executors/top_n_executor.rs
+++ b/src/coprocessor/dag/batch/executors/top_n_executor.rs
@@ -6,8 +6,7 @@ use std::ptr::NonNull;
 
 use servo_arc::Arc;
 
-use tipb::executor::TopN;
-use tipb::expression::{Expr, FieldType};
+use tipb::{Expr, FieldType, TopN};
 
 use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::coprocessor::codec::data_type::*;

--- a/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
@@ -30,7 +30,7 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 use cop_datatype::{EvalType, FieldTypeAccessor};
-use tipb::expression::{Expr, FieldType};
+use tipb::{Expr, FieldType};
 
 use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::coprocessor::codec::data_type::*;
@@ -162,7 +162,7 @@ impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> AggregationExecutor<Sr
                 // The unwrap is fine because aggregate function parser should never return an
                 // eval type that we cannot process later. If we made a mistake there, then we
                 // should panic.
-                EvalType::try_from(ft.tp()).unwrap()
+                EvalType::try_from(FieldTypeAccessor::tp(ft)).unwrap()
             })
             .collect();
 

--- a/src/coprocessor/dag/batch/executors/util/mock_executor.rs
+++ b/src/coprocessor/dag/batch/executors/util/mock_executor.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use crate::coprocessor::dag::batch::interface::*;
 

--- a/src/coprocessor/dag/batch/executors/util/mod.rs
+++ b/src/coprocessor/dag/batch/executors/util/mod.rs
@@ -8,7 +8,7 @@ pub mod ranges_iter;
 pub mod scan_executor;
 
 use tikv_util::{erase_lifetime, erase_lifetime_mut};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use crate::coprocessor::codec::batch::LazyBatchColumnVec;
 use crate::coprocessor::codec::mysql::Tz;

--- a/src/coprocessor/dag/batch/executors/util/ranges_iter.rs
+++ b/src/coprocessor/dag/batch/executors/util/ranges_iter.rs
@@ -129,7 +129,7 @@ mod tests {
         use byteorder::{BigEndian, WriteBytesExt};
 
         let v = RANGE_INDEX.fetch_add(1, atomic::Ordering::SeqCst);
-        let mut r = KeyRange::new();
+        let mut r = KeyRange::default();
         r.mut_start().write_u64::<BigEndian>(v).unwrap();
         // Enough to pass `util::is_point`.
         r.mut_end().write_u64::<BigEndian>(v + 1).unwrap();
@@ -140,7 +140,7 @@ mod tests {
         use byteorder::{BigEndian, WriteBytesExt};
 
         let v = RANGE_INDEX.fetch_add(2, atomic::Ordering::SeqCst);
-        let mut r = KeyRange::new();
+        let mut r = KeyRange::default();
         r.mut_start().write_u64::<BigEndian>(v).unwrap();
         // Enough to not pass `util::is_point`.
         r.mut_end().write_u64::<BigEndian>(v + 2).unwrap();

--- a/src/coprocessor/dag/batch/interface.rs
+++ b/src/coprocessor/dag/batch/interface.rs
@@ -7,7 +7,7 @@
 pub use super::super::exec_summary::{ExecSummaryCollector, WithSummaryCollector};
 pub use super::statistics::BatchExecuteStatistics;
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use crate::coprocessor::codec::batch::LazyBatchColumnVec;
 use crate::coprocessor::dag::expr::EvalWarnings;

--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -3,8 +3,7 @@
 use std::sync::Arc;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::{self, ExecType};
-use tipb::select::DAGRequest;
+use tipb::{self, DagRequest, ExecType};
 
 use crate::storage::Store;
 
@@ -31,7 +30,7 @@ pub struct DAGBuilder;
 impl DAGBuilder {
     /// Given a list of executor descriptors and checks whether all executor descriptors can
     /// be used to build batch executors.
-    pub fn check_build_batch(exec_descriptors: &[executor::Executor]) -> Result<()> {
+    pub fn check_build_batch(exec_descriptors: &[tipb::Executor]) -> Result<()> {
         for ed in exec_descriptors {
             match ed.get_tp() {
                 ExecType::TypeTableScan => {
@@ -75,7 +74,7 @@ impl DAGBuilder {
                 }
                 ExecType::TypeLimit => {}
                 ExecType::TypeTopN => {
-                    let descriptor = ed.get_topN();
+                    let descriptor = ed.get_top_n();
                     BatchTopNExecutor::check_supported(&descriptor)
                         .map_err(|e| Error::Other(box_err!("BatchTopNExecutor: {}", e)))?;
                 }
@@ -87,7 +86,7 @@ impl DAGBuilder {
 
     // Note: `S` is `'static` because we have trait objects `Executor`.
     pub fn build_batch<S: Store + 'static, C: ExecSummaryCollector + 'static>(
-        executor_descriptors: Vec<executor::Executor>,
+        executor_descriptors: Vec<tipb::Executor>,
         store: S,
         ranges: Vec<KeyRange>,
         config: Arc<EvalConfig>,
@@ -108,7 +107,7 @@ impl DAGBuilder {
                     .inc();
 
                 let mut descriptor = first_ed.take_tbl_scan();
-                let columns_info = descriptor.take_columns().into_vec();
+                let columns_info = descriptor.take_columns();
                 executor = Box::new(
                     BatchTableScanExecutor::new(
                         store,
@@ -126,7 +125,7 @@ impl DAGBuilder {
                     .inc();
 
                 let mut descriptor = first_ed.take_idx_scan();
-                let columns_info = descriptor.take_columns().into_vec();
+                let columns_info = descriptor.take_columns();
                 executor = Box::new(
                     BatchIndexScanExecutor::new(
                         store,
@@ -160,7 +159,7 @@ impl DAGBuilder {
                         BatchSelectionExecutor::new(
                             config.clone(),
                             executor,
-                            ed.take_selection().take_conditions().into_vec(),
+                            ed.take_selection().take_conditions(),
                         )?
                         .with_summary_collector(C::new(summary_slot_index)),
                     )
@@ -176,7 +175,7 @@ impl DAGBuilder {
                         BatchSimpleAggregationExecutor::new(
                             config.clone(),
                             executor,
-                            ed.mut_aggregation().take_agg_func().into_vec(),
+                            ed.mut_aggregation().take_agg_func(),
                         )?
                         .with_summary_collector(C::new(summary_slot_index)),
                     )
@@ -193,8 +192,8 @@ impl DAGBuilder {
                             BatchFastHashAggregationExecutor::new(
                                 config.clone(),
                                 executor,
-                                ed.mut_aggregation().take_group_by().into_vec(),
-                                ed.mut_aggregation().take_agg_func().into_vec(),
+                                ed.mut_aggregation().take_group_by(),
+                                ed.mut_aggregation().take_agg_func(),
                             )?
                             .with_summary_collector(C::new(summary_slot_index)),
                         )
@@ -207,8 +206,8 @@ impl DAGBuilder {
                             BatchSlowHashAggregationExecutor::new(
                                 config.clone(),
                                 executor,
-                                ed.mut_aggregation().take_group_by().into_vec(),
-                                ed.mut_aggregation().take_agg_func().into_vec(),
+                                ed.mut_aggregation().take_group_by(),
+                                ed.mut_aggregation().take_agg_func(),
                             )?
                             .with_summary_collector(C::new(summary_slot_index)),
                         )
@@ -223,8 +222,8 @@ impl DAGBuilder {
                         BatchStreamAggregationExecutor::new(
                             config.clone(),
                             executor,
-                            ed.mut_aggregation().take_group_by().into_vec(),
-                            ed.mut_aggregation().take_agg_func().into_vec(),
+                            ed.mut_aggregation().take_group_by(),
+                            ed.mut_aggregation().take_agg_func(),
                         )?
                         .with_summary_collector(C::new(summary_slot_index)),
                     )
@@ -244,7 +243,7 @@ impl DAGBuilder {
                         .with_label_values(&["batch_top_n"])
                         .inc();
 
-                    let mut d = ed.take_topN();
+                    let mut d = ed.take_top_n();
                     let order_bys = d.get_order_by().len();
                     let mut order_exprs_def = Vec::with_capacity(order_bys);
                     let mut order_is_desc = Vec::with_capacity(order_bys);
@@ -281,7 +280,7 @@ impl DAGBuilder {
     ///
     /// Normal executors iterate rows one by one.
     pub fn build_normal<S: Store + 'static, C: ExecSummaryCollector + 'static>(
-        exec_descriptors: Vec<executor::Executor>,
+        exec_descriptors: Vec<tipb::Executor>,
         store: S,
         ranges: Vec<KeyRange>,
         ctx: Arc<EvalConfig>,
@@ -315,7 +314,7 @@ impl DAGBuilder {
                         .with_summary_collector(C::new(summary_slot_index)),
                 ),
                 ExecType::TypeTopN => Box::new(
-                    TopNExecutor::new(exec.take_topN(), Arc::clone(&ctx), src)?
+                    TopNExecutor::new(exec.take_top_n(), Arc::clone(&ctx), src)?
                         .with_summary_collector(C::new(summary_slot_index)),
                 ),
                 ExecType::TypeLimit => Box::new(
@@ -333,7 +332,7 @@ impl DAGBuilder {
     ///
     /// The inner-most executor must be a table scan executor or an index scan executor.
     fn build_normal_first_executor<S: Store + 'static, C: ExecSummaryCollector + 'static>(
-        mut first: executor::Executor,
+        mut first: tipb::Executor,
         store: S,
         ranges: Vec<KeyRange>,
         collect: bool,
@@ -369,7 +368,7 @@ impl DAGBuilder {
 
     fn build_dag<S: Store + 'static>(
         eval_cfg: EvalConfig,
-        mut req: DAGRequest,
+        mut req: DagRequest,
         ranges: Vec<KeyRange>,
         store: S,
         deadline: Deadline,
@@ -379,7 +378,7 @@ impl DAGBuilder {
 
         let executor = if req.get_collect_execution_summaries() {
             Self::build_normal::<_, ExecSummaryCollectorEnabled>(
-                req.take_executors().into_vec(),
+                req.take_executors(),
                 store,
                 ranges,
                 Arc::new(eval_cfg),
@@ -387,7 +386,7 @@ impl DAGBuilder {
             )?
         } else {
             Self::build_normal::<_, ExecSummaryCollectorDisabled>(
-                req.take_executors().into_vec(),
+                req.take_executors(),
                 store,
                 ranges,
                 Arc::new(eval_cfg),
@@ -407,7 +406,7 @@ impl DAGBuilder {
     fn build_batch_dag<S: Store + 'static>(
         deadline: Deadline,
         config: EvalConfig,
-        mut req: DAGRequest,
+        mut req: DagRequest,
         ranges: Vec<KeyRange>,
         store: S,
     ) -> Result<super::batch_handler::BatchDAGHandler> {
@@ -418,14 +417,14 @@ impl DAGBuilder {
         let config = Arc::new(config);
         let out_most_executor = if collect_exec_summary {
             super::builder::DAGBuilder::build_batch::<_, ExecSummaryCollectorEnabled>(
-                req.take_executors().into_vec(),
+                req.take_executors(),
                 store,
                 ranges,
                 config.clone(),
             )?
         } else {
             super::builder::DAGBuilder::build_batch::<_, ExecSummaryCollectorDisabled>(
-                req.take_executors().into_vec(),
+                req.take_executors(),
                 store,
                 ranges,
                 config.clone(),
@@ -463,7 +462,7 @@ impl DAGBuilder {
     }
 
     pub fn build<S: Store + 'static>(
-        req: DAGRequest,
+        req: DagRequest,
         ranges: Vec<KeyRange>,
         store: S,
         deadline: Deadline,

--- a/src/coprocessor/dag/executor/aggregate.rs
+++ b/src/coprocessor/dag/executor/aggregate.rs
@@ -1,7 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::cmp::Ordering;
-use tipb::expression::ExprType;
+use tipb::ExprType;
 
 use crate::coprocessor::codec::mysql::Decimal;
 use crate::coprocessor::codec::Datum;
@@ -11,11 +11,11 @@ use super::super::expr::{eval_arith, EvalContext};
 
 pub fn build_aggr_func(tp: ExprType) -> Result<Box<dyn AggrFunc>> {
     match tp {
-        ExprType::Agg_BitAnd => Ok(Box::new(AggBitAnd {
+        ExprType::AggBitAnd => Ok(Box::new(AggBitAnd {
             c: 0xffffffffffffffff,
         })),
-        ExprType::Agg_BitOr => Ok(Box::new(AggBitOr { c: 0 })),
-        ExprType::Agg_BitXor => Ok(Box::new(AggBitXor { c: 0 })),
+        ExprType::AggBitOr => Ok(Box::new(AggBitOr { c: 0 })),
+        ExprType::AggBitXor => Ok(Box::new(AggBitXor { c: 0 })),
         ExprType::Count => Ok(Box::new(Count { c: 0 })),
         ExprType::First => Ok(Box::new(First { e: None })),
         ExprType::Sum => Ok(Box::new(Sum { res: None })),

--- a/src/coprocessor/dag/executor/limit.rs
+++ b/src/coprocessor/dag/executor/limit.rs
@@ -1,6 +1,6 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::executor::Limit;
+use tipb::Limit;
 
 use super::ExecutorMetrics;
 use crate::coprocessor::dag::exec_summary::ExecSummary;

--- a/src/coprocessor/dag/executor/scan.rs
+++ b/src/coprocessor/dag/executor/scan.rs
@@ -3,7 +3,7 @@
 use std::{iter::Peekable, mem, sync::Arc, vec::IntoIter};
 
 use kvproto::coprocessor::KeyRange;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
 
 use super::{Executor, ExecutorMetrics, Row};
 use crate::coprocessor::codec::table;

--- a/src/coprocessor/dag/executor/selection.rs
+++ b/src/coprocessor/dag/executor/selection.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use tipb::executor::Selection;
+use tipb::Selection;
 
 use crate::coprocessor::dag::exec_summary::ExecSummary;
 use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
@@ -24,8 +24,8 @@ impl SelectionExecutor {
         mut meta: Selection,
         eval_cfg: Arc<EvalConfig>,
         src: Box<dyn Executor + Send>,
-    ) -> Result<Self> {
-        let conditions = meta.take_conditions().into_vec();
+    ) -> Result<SelectionExecutor> {
+        let conditions = meta.take_conditions();
         let mut visitor = ExprColumnRefVisitor::new(src.get_len_of_columns());
         visitor.batch_visit(&conditions)?;
         let ctx = EvalContext::new(eval_cfg);
@@ -91,7 +91,7 @@ mod tests {
     use std::sync::Arc;
 
     use cop_datatype::FieldTypeTp;
-    use tipb::expression::{Expr, ExprType, ScalarFuncSig};
+    use tipb::{Expr, ExprType, ScalarFuncSig};
 
     use crate::coprocessor::codec::datum::Datum;
     use tikv_util::codec::number::NumberEncoder;
@@ -100,16 +100,16 @@ mod tests {
     use super::*;
 
     fn new_const_expr() -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ScalarFunc);
-        expr.set_sig(ScalarFuncSig::NullEQInt);
+        expr.set_sig(ScalarFuncSig::NullEqInt);
         expr.mut_children().push({
-            let mut lhs = Expr::new();
+            let mut lhs = Expr::default();
             lhs.set_tp(ExprType::Null);
             lhs
         });
         expr.mut_children().push({
-            let mut rhs = Expr::new();
+            let mut rhs = Expr::default();
             rhs.set_tp(ExprType::Null);
             rhs
         });
@@ -117,17 +117,17 @@ mod tests {
     }
 
     fn new_col_gt_u64_expr(offset: i64, val: u64) -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ScalarFunc);
-        expr.set_sig(ScalarFuncSig::GTInt);
+        expr.set_sig(ScalarFuncSig::GtInt);
         expr.mut_children().push({
-            let mut lhs = Expr::new();
+            let mut lhs = Expr::default();
             lhs.set_tp(ExprType::ColumnRef);
             lhs.mut_val().encode_i64(offset).unwrap();
             lhs
         });
         expr.mut_children().push({
-            let mut rhs = Expr::new();
+            let mut rhs = Expr::default();
             rhs.set_tp(ExprType::Uint64);
             rhs.mut_val().encode_u64(val).unwrap();
             rhs
@@ -183,7 +183,7 @@ mod tests {
         let inner_table_scan = gen_table_scan_executor(1, cis, &raw_data, None);
 
         // selection executor
-        let mut selection = Selection::new();
+        let mut selection = Selection::default();
         let expr = new_const_expr();
         selection.mut_conditions().push(expr);
 
@@ -222,7 +222,7 @@ mod tests {
         let inner_table_scan = gen_table_scan_executor(1, cis, &raw_data, None);
 
         // selection executor
-        let mut selection = Selection::new();
+        let mut selection = Selection::default();
         let expr = new_col_gt_u64_expr(2, 5);
         selection.mut_conditions().push(expr);
 

--- a/src/coprocessor/dag/executor/table_scan.rs
+++ b/src/coprocessor/dag/executor/table_scan.rs
@@ -8,8 +8,8 @@ use crate::coprocessor::codec::table;
 use crate::coprocessor::{util, Result};
 use crate::storage::Store;
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::TableScan;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::TableScan;
 
 pub struct TableInnerExecutor {
     col_ids: HashSet<i64>,
@@ -81,8 +81,7 @@ mod tests {
     use std::i64;
 
     use kvproto::{coprocessor::KeyRange, kvrpcpb::IsolationLevel};
-    use protobuf::RepeatedField;
-    use tipb::{executor::TableScan, schema::ColumnInfo};
+    use tipb::{ColumnInfo, TableScan};
 
     use crate::storage::SnapshotStore;
 
@@ -113,10 +112,10 @@ mod tests {
         fn default() -> TableScanTestWrapper {
             let test_data = prepare_table_data(KEY_NUMBER, TABLE_ID);
             let test_store = TestStore::new(&test_data.kv_data);
-            let mut table_scan = TableScan::new();
+            let mut table_scan = TableScan::default();
             // prepare cols
             let cols = test_data.get_prev_2_cols();
-            let col_req = RepeatedField::from_vec(cols.clone());
+            let col_req = cols.clone();
             table_scan.set_columns(col_req);
             // prepare range
             let range = get_range(TABLE_ID, i64::MIN, i64::MAX);
@@ -142,7 +141,7 @@ mod tests {
         wrapper.ranges = vec![r1, r2];
 
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
-        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
+        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::Si, true);
         let mut table_scanner =
             super::TableScanExecutor::table_scan(wrapper.table_scan, wrapper.ranges, store, true)
                 .unwrap();
@@ -184,7 +183,7 @@ mod tests {
         wrapper.ranges = vec![r1, r2, r3, r4];
 
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
-        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
+        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::Si, true);
         let mut table_scanner =
             super::TableScanExecutor::table_scan(wrapper.table_scan, wrapper.ranges, store, true)
                 .unwrap();
@@ -225,7 +224,7 @@ mod tests {
         wrapper.ranges = vec![r1, r2, r3, r4];
 
         let (snapshot, start_ts) = wrapper.store.get_snapshot();
-        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
+        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::Si, true);
         let mut table_scanner =
             super::TableScanExecutor::table_scan(wrapper.table_scan, wrapper.ranges, store, true)
                 .unwrap();

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::usize;
 use std::vec::IntoIter;
 
-use tipb::executor::TopN;
-use tipb::expression::ByItem;
+use tipb::ByItem;
+use tipb::TopN;
 
 use super::topn_heap::TopNHeap;
 use super::{Executor, ExecutorMetrics, ExprColumnRefVisitor, Row};
@@ -59,8 +59,8 @@ impl TopNExecutor {
         mut meta: TopN,
         eval_cfg: Arc<EvalConfig>,
         src: Box<dyn Executor + Send>,
-    ) -> Result<Self> {
-        let order_by = meta.take_order_by().into_vec();
+    ) -> Result<TopNExecutor> {
+        let order_by = meta.take_order_by();
 
         let mut visitor = ExprColumnRefVisitor::new(src.get_len_of_columns());
         for by_item in &order_by {
@@ -156,8 +156,7 @@ pub mod tests {
     use std::sync::Arc;
 
     use cop_datatype::FieldTypeTp;
-    use protobuf::RepeatedField;
-    use tipb::expression::{Expr, ExprType};
+    use tipb::{Expr, ExprType};
 
     use crate::coprocessor::codec::table::RowColsDict;
     use crate::coprocessor::codec::Datum;
@@ -169,8 +168,8 @@ pub mod tests {
     use super::*;
 
     fn new_order_by(offset: i64, desc: bool) -> ByItem {
-        let mut item = ByItem::new();
-        let mut expr = Expr::new();
+        let mut item = ByItem::default();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ColumnRef);
         expr.mut_val().encode_i64(offset).unwrap();
         item.set_expr(expr);
@@ -392,7 +391,7 @@ pub mod tests {
         ob_vec.push(new_order_by(1, false));
         ob_vec.push(new_order_by(2, true));
         let mut topn = TopN::default();
-        topn.set_order_by(RepeatedField::from_vec(ob_vec));
+        topn.set_order_by(ob_vec);
         let limit = 4;
         topn.set_limit(limit);
         // init topn executor
@@ -438,7 +437,7 @@ pub mod tests {
         ob_vec.push(new_order_by(1, false));
         ob_vec.push(new_order_by(2, true));
         let mut topn = TopN::default();
-        topn.set_order_by(RepeatedField::from_vec(ob_vec));
+        topn.set_order_by(ob_vec);
         // test with limit=0
         topn.set_limit(0);
         let mut topn_ect =

--- a/src/coprocessor/dag/executor/topn_heap.rs
+++ b/src/coprocessor/dag/executor/topn_heap.rs
@@ -5,7 +5,7 @@ use std::cmp::{self, Ordering};
 use std::collections::BinaryHeap;
 use std::sync::Arc;
 use std::usize;
-use tipb::expression::ByItem;
+use tipb::ByItem;
 
 use crate::coprocessor::codec::datum::Datum;
 use crate::coprocessor::dag::executor::OriginCols;
@@ -173,7 +173,7 @@ mod tests {
     use std::cell::RefCell;
     use std::sync::Arc;
 
-    use tipb::expression::{ByItem, Expr, ExprType};
+    use tipb::{ByItem, Expr, ExprType};
 
     use crate::coprocessor::codec::table::RowColsDict;
     use crate::coprocessor::codec::Datum;
@@ -185,8 +185,8 @@ mod tests {
     use super::*;
 
     fn new_order_by(col_id: i64, desc: bool) -> ByItem {
-        let mut item = ByItem::new();
-        let mut expr = Expr::new();
+        let mut item = ByItem::default();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ColumnRef);
         expr.mut_val().encode_i64(col_id).unwrap();
         item.set_expr(expr);

--- a/src/coprocessor/dag/expr/builtin_arithmetic.rs
+++ b/src/coprocessor/dag/expr/builtin_arithmetic.rs
@@ -59,7 +59,7 @@ impl ScalarFunc {
             (false, false) => lhs.checked_add(rhs),
         };
         let data_type = if lus | rus {
-            "BIGINT UNSIGNED"
+            "BIGINT Unsigned"
         } else {
             "BIGINT"
         };
@@ -94,7 +94,7 @@ impl ScalarFunc {
         let lus = self.children[0].is_unsigned();
         let rus = self.children[1].is_unsigned();
         let data_type = if lus | rus {
-            "BIGINT UNSIGNED"
+            "BIGINT Unsigned"
         } else {
             "BIGINT"
         };
@@ -161,7 +161,7 @@ impl ScalarFunc {
             (true, false) => u64_mul_i64(lhs, rhs),
             (false, true) => u64_mul_i64(rhs, lhs),
         };
-        res.ok_or_else(|| Error::overflow("BIGINT UNSIGNED", &format!("({} * {})", lhs, rhs)))
+        res.ok_or_else(|| Error::overflow("BIGINT Unsigned", &format!("({} * {})", lhs, rhs)))
             .map(Some)
     }
 
@@ -174,7 +174,7 @@ impl ScalarFunc {
         let rhs = try_opt!(self.children[1].eval_int(ctx, row));
         let res = (lhs as u64).checked_mul(rhs as u64).map(|t| t as i64);
         // TODO: output expression in error when column's name pushed down.
-        res.ok_or_else(|| Error::overflow("BIGINT UNSIGNED", &format!("({} * {})", lhs, rhs)))
+        res.ok_or_else(|| Error::overflow("BIGINT Unsigned", &format!("({} * {})", lhs, rhs)))
             .map(Some)
     }
 
@@ -295,7 +295,7 @@ mod tests {
     use std::{f64, i64, u64};
 
     use cop_datatype::FieldTypeFlag;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::coprocessor::codec::error::ERR_DIVISION_BY_ZERO;
     use crate::coprocessor::codec::mysql::Decimal;
@@ -536,14 +536,10 @@ mod tests {
             let lhs = datum_expr(tt.1);
             let rhs = datum_expr(tt.2);
 
-            let lus = lhs
-                .get_field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED);
-            let rus = rhs
-                .get_field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED);
+            let lus =
+                FieldTypeAccessor::flag(lhs.get_field_type()).contains(FieldTypeFlag::UNSIGNED);
+            let rus =
+                FieldTypeAccessor::flag(rhs.get_field_type()).contains(FieldTypeFlag::UNSIGNED);
             let unsigned = lus | rus;
 
             let mut op = Expression::build(&ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();
@@ -950,14 +946,10 @@ mod tests {
             let lhs = datum_expr(tt.1);
             let rhs = datum_expr(tt.2);
 
-            let lus = lhs
-                .get_field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED);
-            let rus = rhs
-                .get_field_type()
-                .flag()
-                .contains(FieldTypeFlag::UNSIGNED);
+            let lus =
+                FieldTypeAccessor::flag(lhs.get_field_type()).contains(FieldTypeFlag::UNSIGNED);
+            let rus =
+                FieldTypeAccessor::flag(rhs.get_field_type()).contains(FieldTypeFlag::UNSIGNED);
             let unsigned = lus | rus;
 
             let mut op = Expression::build(&ctx, scalar_func_expr(tt.0, &[lhs, rhs])).unwrap();

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -23,7 +23,7 @@ impl ScalarFunc {
 
     pub fn cast_real_as_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         let val = try_opt!(self.children[0].eval_real(ctx, row));
-        if self.field_type.flag().contains(FieldTypeFlag::UNSIGNED) {
+        if FieldTypeAccessor::flag(&self.field_type).contains(FieldTypeFlag::UNSIGNED) {
             let uval = convert_float_to_uint(ctx, val, FieldTypeTp::LongLong)?;
             Ok(Some(uval as i64))
         } else {
@@ -35,13 +35,14 @@ impl ScalarFunc {
     pub fn cast_decimal_as_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         let val = try_opt!(self.children[0].eval_decimal(ctx, row));
         let val = val.into_owned().round(0, RoundMode::HalfEven).unwrap();
-        let (overflow, res) = if self.field_type.flag().contains(FieldTypeFlag::UNSIGNED) {
-            let uint = val.as_u64();
-            (uint.is_overflow(), uint.unwrap() as i64)
-        } else {
-            let val = val.as_i64();
-            (val.is_overflow(), val.unwrap())
-        };
+        let (overflow, res) =
+            if FieldTypeAccessor::flag(&self.field_type).contains(FieldTypeFlag::UNSIGNED) {
+                let uint = val.as_u64();
+                (uint.is_overflow(), uint.unwrap() as i64)
+            } else {
+                let val = val.as_i64();
+                (val.is_overflow(), val.unwrap())
+            };
 
         if overflow {
             if !ctx.cfg.flag.contains(Flag::OVERFLOW_AS_WARNING) {
@@ -65,7 +66,7 @@ impl ScalarFunc {
         let res = if is_negative {
             convert_bytes_to_int(ctx, &val, FieldTypeTp::LongLong).map(|v| {
                 // TODO: handle inUion flag
-                if self.field_type.flag().contains(FieldTypeFlag::UNSIGNED) {
+                if FieldTypeAccessor::flag(&self.field_type).contains(FieldTypeFlag::UNSIGNED) {
                     ctx.warnings
                         .append_warning(Error::cast_neg_int_as_unsigned());
                 }
@@ -73,7 +74,7 @@ impl ScalarFunc {
             })
         } else {
             convert::bytes_to_uint(ctx, &val).map(|urs| {
-                if !self.field_type.flag().contains(FieldTypeFlag::UNSIGNED)
+                if !FieldTypeAccessor::flag(&self.field_type).contains(FieldTypeFlag::UNSIGNED)
                     && urs > (i64::MAX as u64)
                 {
                     ctx.warnings
@@ -192,8 +193,8 @@ impl ScalarFunc {
         row: &[Datum],
     ) -> Result<Option<Cow<'a, Decimal>>> {
         let val = try_opt!(self.children[0].eval_int(ctx, row));
-        let field_type = &self.children[0].field_type();
-        let res = if !field_type.flag().contains(FieldTypeFlag::UNSIGNED) {
+        let field_type = self.children[0].field_type();
+        let res = if !FieldTypeAccessor::flag(field_type).contains(FieldTypeFlag::UNSIGNED) {
             Cow::Owned(Decimal::from(val))
         } else {
             let uval = val as u64;
@@ -404,7 +405,7 @@ impl ScalarFunc {
         let mut val = val.into_owned();
         val.round_frac(self.field_type.decimal() as i8)?;
         // TODO: tidb only update tp when tp is Date
-        val.set_time_type(self.field_type.tp().try_into()?)?;
+        val.set_time_type(FieldTypeAccessor::tp(&self.field_type).try_into()?)?;
         Ok(Some(Cow::Owned(val)))
     }
 
@@ -414,7 +415,11 @@ impl ScalarFunc {
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, Time>>> {
         let val = try_opt!(self.children[0].eval_duration(ctx, row));
-        let mut val = Time::from_duration(&ctx.cfg.tz, self.field_type.tp().try_into()?, val)?;
+        let mut val = Time::from_duration(
+            &ctx.cfg.tz,
+            FieldTypeAccessor::tp(&self.field_type).try_into()?,
+            val,
+        )?;
         val.round_frac(self.field_type.decimal() as i8)?;
         Ok(Some(Cow::Owned(val)))
     }
@@ -522,7 +527,7 @@ impl ScalarFunc {
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, Json>>> {
         let val = try_opt!(self.children[0].eval_int(ctx, row));
-        let flag = self.children[0].field_type().flag();
+        let flag = FieldTypeAccessor::flag(self.children[0].field_type());
         let j = if flag.contains(FieldTypeFlag::IS_BOOLEAN) {
             Json::Boolean(val != 0)
         } else if flag.contains(FieldTypeFlag::UNSIGNED) {
@@ -560,11 +565,7 @@ impl ScalarFunc {
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, Json>>> {
         let val = try_opt!(self.children[0].eval_string_and_decode(ctx, row));
-        if self
-            .field_type
-            .flag()
-            .contains(FieldTypeFlag::PARSE_TO_JSON)
-        {
+        if FieldTypeAccessor::flag(&self.field_type).contains(FieldTypeFlag::PARSE_TO_JSON) {
             let j: Json = val.parse()?;
             Ok(Some(Cow::Owned(j)))
         } else {
@@ -610,8 +611,8 @@ impl ScalarFunc {
         ctx: &mut EvalContext,
         val: Cow<'a, Decimal>,
     ) -> Result<Cow<'a, Decimal>> {
-        let flen = self.field_type.flen();
-        let decimal = self.field_type.decimal();
+        let flen = FieldTypeAccessor::flen(&self.field_type);
+        let decimal = FieldTypeAccessor::decimal(&self.field_type);
         if flen == cop_datatype::UNSPECIFIED_LENGTH || decimal == cop_datatype::UNSPECIFIED_LENGTH {
             return Ok(val);
         }
@@ -672,7 +673,7 @@ impl ScalarFunc {
             return Ok(Cow::Owned(res));
         }
 
-        if self.field_type.tp() == FieldTypeTp::String && s.len() < flen {
+        if FieldTypeAccessor::tp(&self.field_type) == FieldTypeTp::String && s.len() < flen {
             let mut s = s.into_owned();
             s.resize(flen, 0);
             return Ok(Cow::Owned(s));
@@ -682,7 +683,7 @@ impl ScalarFunc {
 
     fn produce_time_with_str(&self, ctx: &mut EvalContext, s: &str) -> Result<Cow<'_, Time>> {
         let mut t = Time::parse_datetime(s, self.field_type.decimal() as i8, &ctx.cfg.tz)?;
-        t.set_time_type(self.field_type.tp().try_into()?)?;
+        t.set_time_type(FieldTypeAccessor::tp(&self.field_type).try_into()?)?;
         Ok(Cow::Owned(t))
     }
 
@@ -692,7 +693,7 @@ impl ScalarFunc {
             self.field_type.decimal() as i8,
             &ctx.cfg.tz,
         )?;
-        t.set_time_type(self.field_type.tp().try_into()?)?;
+        t.set_time_type(FieldTypeAccessor::tp(&self.field_type).try_into()?)?;
         Ok(Cow::Owned(t))
     }
 
@@ -700,8 +701,8 @@ impl ScalarFunc {
     /// a new float64 according to `flen` and `decimal` in `self.tp`.
     /// TODO port tests from tidb(tidb haven't implemented now)
     fn produce_float_with_specified_tp(&self, ctx: &mut EvalContext, f: f64) -> Result<f64> {
-        let flen = self.field_type.flen();
-        let decimal = self.field_type.decimal();
+        let flen = FieldTypeAccessor::flen(&self.field_type);
+        let decimal = FieldTypeAccessor::decimal(&self.field_type);
         if flen == cop_datatype::UNSPECIFIED_LENGTH || decimal == cop_datatype::UNSPECIFIED_LENGTH {
             return Ok(f);
         }
@@ -723,7 +724,7 @@ mod tests {
     use std::{i64, u64};
 
     use cop_datatype::{self, FieldTypeAccessor, FieldTypeFlag, FieldTypeTp};
-    use tipb::expression::{Expr, FieldType, ScalarFuncSig};
+    use tipb::{Expr, FieldType, ScalarFuncSig};
 
     use chrono::Utc;
 
@@ -738,7 +739,7 @@ mod tests {
 
     pub fn col_expr(col_id: i64, tp: FieldTypeTp) -> Expr {
         let mut expr = base_col_expr(col_id);
-        let mut fp = FieldType::new();
+        let mut fp = FieldType::default();
         fp.as_mut_accessor().set_tp(tp);
         if tp == FieldTypeTp::String {
             fp.set_charset(charset::CHARSET_UTF8.to_owned());
@@ -1765,7 +1766,7 @@ mod tests {
             let col_expr = col_expr(0, FieldTypeTp::String);
             let mut ex = scalar_func_expr(ScalarFuncSig::CastStringAsJson, &[col_expr]);
             if by_parse {
-                let mut flag = ex.get_field_type().flag();
+                let mut flag = FieldTypeAccessor::flag(ex.get_field_type());
                 flag |= FieldTypeFlag::PARSE_TO_JSON;
                 ex.mut_field_type().as_mut_accessor().set_flag(flag);
             }

--- a/src/coprocessor/dag/expr/builtin_compare.rs
+++ b/src/coprocessor/dag/expr/builtin_compare.rs
@@ -475,10 +475,10 @@ mod tests {
     use crate::coprocessor::codec::Datum;
     use crate::coprocessor::dag::expr::tests::{col_expr, datum_expr, str2dec};
     use crate::coprocessor::dag::expr::{EvalContext, Expression, Flag, SqlMode};
-    use protobuf::RepeatedField;
+
     use std::sync::Arc;
     use std::{i64, u64};
-    use tipb::expression::{Expr, ExprType, ScalarFuncSig};
+    use tipb::{Expr, ExprType, ScalarFuncSig};
 
     #[test]
     fn test_cmp_i64_with_unsigned_flag() {
@@ -571,11 +571,11 @@ mod tests {
 
         for (sig, row, exp) in cases {
             let children: Vec<Expr> = (0..row.len()).map(|id| col_expr(id as i64)).collect();
-            let mut expr = Expr::new();
+            let mut expr = Expr::default();
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(sig);
 
-            expr.set_children(RepeatedField::from_vec(children));
+            expr.set_children(children);
             let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &row).unwrap();
             assert_eq!(res, exp);
@@ -702,11 +702,11 @@ mod tests {
 
         for (sig, row, exp) in cases {
             let children: Vec<Expr> = (0..row.len()).map(|id| col_expr(id as i64)).collect();
-            let mut expr = Expr::new();
+            let mut expr = Expr::default();
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(sig);
 
-            expr.set_children(RepeatedField::from_vec(children));
+            expr.set_children(children);
             let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &row).unwrap();
             assert_eq!(res, exp);
@@ -890,10 +890,10 @@ mod tests {
                 // Evaluate and test greatest
                 {
                     let children: Vec<Expr> = row.iter().map(|d| datum_expr(d.clone())).collect();
-                    let mut expr = Expr::new();
+                    let mut expr = Expr::default();
                     expr.set_tp(ExprType::ScalarFunc);
                     expr.set_sig(greatest_sig);
-                    expr.set_children(RepeatedField::from_vec(children));
+                    expr.set_children(children);
                     let e = Expression::build(&ctx, expr).unwrap();
                     let res = e.eval(&mut ctx, &[]).unwrap();
                     assert_eq!(res, greatest_exp);
@@ -901,10 +901,10 @@ mod tests {
                 // Evaluate and test least
                 {
                     let children: Vec<Expr> = row.iter().map(|d| datum_expr(d.clone())).collect();
-                    let mut expr = Expr::new();
+                    let mut expr = Expr::default();
                     expr.set_tp(ExprType::ScalarFunc);
                     expr.set_sig(least_sig);
-                    expr.set_children(RepeatedField::from_vec(children));
+                    expr.set_children(children);
                     let e = Expression::build(&ctx, expr).unwrap();
                     let res = e.eval(&mut ctx, &[]).unwrap();
                     assert_eq!(res, least_exp);
@@ -951,10 +951,10 @@ mod tests {
                 Datum::Bytes(t4.clone()),
             ];
             let children: Vec<Expr> = row.iter().map(|d| datum_expr(d.clone())).collect();
-            let mut expr = Expr::new();
+            let mut expr = Expr::default();
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(ScalarFuncSig::GreatestTime);
-            expr.set_children(RepeatedField::from_vec(children));
+            expr.set_children(children);
             let e = Expression::build(&ctx, expr).unwrap();
             let err = e.eval(&mut ctx, &[]).unwrap_err();
             assert_eq!(err.code(), ERR_TRUNCATE_WRONG_VALUE);

--- a/src/coprocessor/dag/expr/builtin_control.rs
+++ b/src/coprocessor/dag/expr/builtin_control.rs
@@ -218,8 +218,8 @@ impl ScalarFunc {
 
 #[cfg(test)]
 mod tests {
-    use protobuf::RepeatedField;
-    use tipb::expression::{Expr, ExprType, ScalarFuncSig};
+
+    use tipb::{Expr, ExprType, ScalarFuncSig};
 
     use crate::coprocessor::codec::mysql::{Duration, Json, Time};
     use crate::coprocessor::codec::Datum;
@@ -522,11 +522,11 @@ mod tests {
 
         for (sig, row, exp) in cases {
             let children: Vec<Expr> = (0..row.len()).map(|id| col_expr(id as i64)).collect();
-            let mut expr = Expr::new();
+            let mut expr = Expr::default();
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(sig);
 
-            expr.set_children(RepeatedField::from_vec(children));
+            expr.set_children(children);
             let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &row).unwrap();
             assert_eq!(res, exp);

--- a/src/coprocessor/dag/expr/builtin_encryption.rs
+++ b/src/coprocessor/dag/expr/builtin_encryption.rs
@@ -172,7 +172,7 @@ mod tests {
     use crate::coprocessor::dag::expr::tests::{datum_expr, eval_func, scalar_func_expr};
     use crate::coprocessor::dag::expr::{EvalContext, Expression};
     use hex;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_md5() {
@@ -187,7 +187,7 @@ mod tests {
 
         for (input_str, exp_str) in cases {
             let input = datum_expr(Datum::Bytes(input_str.as_bytes().to_vec()));
-            let op = scalar_func_expr(ScalarFuncSig::MD5, &[input]);
+            let op = scalar_func_expr(ScalarFuncSig::Md5, &[input]);
             let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::Bytes(exp_str.as_bytes().to_vec());
@@ -196,7 +196,7 @@ mod tests {
 
         // test NULL case
         let input = datum_expr(Datum::Null);
-        let op = scalar_func_expr(ScalarFuncSig::MD5, &[input]);
+        let op = scalar_func_expr(ScalarFuncSig::Md5, &[input]);
         let op = Expression::build(&ctx, op).unwrap();
         let got = op.eval(&mut ctx, &[]).unwrap();
         let exp = Datum::Null;
@@ -216,7 +216,7 @@ mod tests {
 
         for (input_str, exp_str) in cases {
             let input = datum_expr(Datum::Bytes(input_str.as_bytes().to_vec()));
-            let op = scalar_func_expr(ScalarFuncSig::SHA1, &[input]);
+            let op = scalar_func_expr(ScalarFuncSig::Sha1, &[input]);
             let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::Bytes(exp_str.as_bytes().to_vec());
@@ -225,7 +225,7 @@ mod tests {
 
         // test NULL case
         let input = datum_expr(Datum::Null);
-        let op = scalar_func_expr(ScalarFuncSig::SHA1, &[input]);
+        let op = scalar_func_expr(ScalarFuncSig::Sha1, &[input]);
         let op = Expression::build(&ctx, op).unwrap();
         let got = op.eval(&mut ctx, &[]).unwrap();
         let exp = Datum::Null;
@@ -253,7 +253,7 @@ mod tests {
             let input = datum_expr(Datum::Bytes(input_str.as_bytes().to_vec()));
             let hash_length = datum_expr(Datum::I64(hash_length_i64));
 
-            let op = scalar_func_expr(ScalarFuncSig::SHA2, &[input, hash_length]);
+            let op = scalar_func_expr(ScalarFuncSig::Sha2, &[input, hash_length]);
             let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             let exp = Datum::Bytes(exp_str.as_bytes().to_vec());
@@ -273,7 +273,7 @@ mod tests {
 
         for (input, hash_length, exp) in null_cases {
             let op = scalar_func_expr(
-                ScalarFuncSig::SHA2,
+                ScalarFuncSig::Sha2,
                 &[datum_expr(input.clone()), datum_expr(hash_length.clone())],
             );
             let op = Expression::build(&ctx, op).unwrap();

--- a/src/coprocessor/dag/expr/builtin_json.rs
+++ b/src/coprocessor/dag/expr/builtin_json.rs
@@ -192,7 +192,7 @@ mod tests {
     use crate::coprocessor::codec::Datum;
     use crate::coprocessor::dag::expr::tests::{datum_expr, make_null_datums, scalar_func_expr};
     use crate::coprocessor::dag::expr::{EvalContext, Expression};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_json_type() {

--- a/src/coprocessor/dag/expr/builtin_like.rs
+++ b/src/coprocessor/dag/expr/builtin_like.rs
@@ -43,7 +43,7 @@ mod tests {
     use crate::coprocessor::codec::Datum;
     use crate::coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
     use crate::coprocessor::dag::expr::{EvalContext, Expression};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_like() {

--- a/src/coprocessor/dag/expr/builtin_math.rs
+++ b/src/coprocessor/dag/expr/builtin_math.rs
@@ -558,7 +558,7 @@ mod tests {
     use std::{f64, i64, u64};
 
     use cop_datatype::{self, FieldTypeAccessor, FieldTypeFlag};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::coprocessor::codec::Datum;
     use crate::coprocessor::dag::expr::tests::{
@@ -657,9 +657,7 @@ mod tests {
         // for ceil decimal to int.
         for (sig, arg, exp) in tests {
             let got = eval_func_with(sig, &[arg], |op, args| {
-                if args[0]
-                    .get_field_type()
-                    .flag()
+                if FieldTypeAccessor::flag(args[0].get_field_type())
                     .contains(FieldTypeFlag::UNSIGNED)
                 {
                     op.mut_field_type()
@@ -731,9 +729,7 @@ mod tests {
         // for ceil decimal to int.
         for (sig, arg, exp) in tests {
             let got = eval_func_with(sig, &[arg], |op, args| {
-                if args[0]
-                    .get_field_type()
-                    .flag()
+                if FieldTypeAccessor::flag(args[0].get_field_type())
                     .contains(FieldTypeFlag::UNSIGNED)
                 {
                     op.mut_field_type()
@@ -852,7 +848,7 @@ mod tests {
 
     #[test]
     fn test_pi() {
-        let got = eval_func(ScalarFuncSig::PI, &[]).unwrap();
+        let got = eval_func(ScalarFuncSig::Pi, &[]).unwrap();
         assert_eq!(got, Datum::F64(f64::consts::PI));
     }
 
@@ -916,7 +912,7 @@ mod tests {
 
         for (arg, exp) in cases {
             let arg = Datum::Bytes(arg.as_bytes().to_vec());
-            let got = eval_func(ScalarFuncSig::CRC32, &[arg]).unwrap();
+            let got = eval_func(ScalarFuncSig::Crc32, &[arg]).unwrap();
             let exp = Datum::I64(exp);
             assert_eq!(got, exp);
         }
@@ -1350,9 +1346,7 @@ mod tests {
         ];
         for (x, d, exp) in tests {
             let got = eval_func_with(ScalarFuncSig::TruncateInt, &[x, d], |op, args| {
-                if args[0]
-                    .get_field_type()
-                    .flag()
+                if FieldTypeAccessor::flag(args[0].get_field_type())
                     .contains(FieldTypeFlag::UNSIGNED)
                 {
                     op.mut_field_type()

--- a/src/coprocessor/dag/expr/builtin_miscellaneous.rs
+++ b/src/coprocessor/dag/expr/builtin_miscellaneous.rs
@@ -228,7 +228,7 @@ mod tests {
     use crate::coprocessor::codec::Datum;
     use crate::coprocessor::dag::expr::tests::{datum_expr, scalar_func_expr};
     use crate::coprocessor::dag::expr::{EvalContext, Expression};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     macro_rules! test_any_value {
         ($cases: expr, $case_type: ty, Datum::$type_of_datum: ident, $maker_for_case_ele: expr, ScalarFuncSig::$sig_of_scalar_func: ident) => {{
@@ -323,7 +323,7 @@ mod tests {
             Vec<(Json, Json, Json, Json, Json)>,
             Datum::Json,
             |x| x,
-            ScalarFuncSig::JSONAnyValue
+            ScalarFuncSig::JsonAnyValue
         );
     }
 

--- a/src/coprocessor/dag/expr/builtin_op.rs
+++ b/src/coprocessor/dag/expr/builtin_op.rs
@@ -191,7 +191,7 @@ mod tests {
     };
     use crate::coprocessor::dag::expr::{EvalContext, Expression};
     use std::i64;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_logic_op() {

--- a/src/coprocessor/dag/expr/builtin_other.rs
+++ b/src/coprocessor/dag/expr/builtin_other.rs
@@ -37,7 +37,7 @@ mod tests {
     use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, Expression};
     use std::str::FromStr;
     use std::sync::Arc;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_bit_count() {

--- a/src/coprocessor/dag/expr/builtin_string.rs
+++ b/src/coprocessor/dag/expr/builtin_string.rs
@@ -1063,7 +1063,7 @@ mod tests {
     use crate::coprocessor::codec::mysql::charset::CHARSET_BIN;
     use cop_datatype::{Collation, FieldTypeFlag, FieldTypeTp, MAX_BLOB_WIDTH};
     use std::{f64, i64};
-    use tipb::expression::{Expr, ScalarFuncSig};
+    use tipb::{Expr, ScalarFuncSig};
 
     use crate::coprocessor::codec::Datum;
     use crate::coprocessor::dag::expr::tests::{
@@ -1646,7 +1646,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (input, exp) in cases {
             let input = datum_expr(input);
-            let op = scalar_func_expr(ScalarFuncSig::ASCII, &[input]);
+            let op = scalar_func_expr(ScalarFuncSig::Ascii, &[input]);
             let op = Expression::build(&ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
@@ -1953,7 +1953,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (row, exp) in cases {
             let children: Vec<Expr> = row.iter().map(|d| datum_expr(d.clone())).collect();
-            let expr = scalar_func_expr(ScalarFuncSig::ConcatWS, &children);
+            let expr = scalar_func_expr(ScalarFuncSig::ConcatWs, &children);
             let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &[]).unwrap();
             assert_eq!(res, exp);

--- a/src/coprocessor/dag/expr/builtin_time.rs
+++ b/src/coprocessor/dag/expr/builtin_time.rs
@@ -584,7 +584,7 @@ fn month_to_period(month: u64) -> u64 {
 mod tests {
     use std::sync::Arc;
 
-    use tipb::expression::{Expr, ScalarFuncSig};
+    use tipb::{Expr, ScalarFuncSig};
 
     use crate::coprocessor::codec::mysql::{Duration, Time};
     use crate::coprocessor::codec::Datum;

--- a/src/coprocessor/dag/expr/column.rs
+++ b/src/coprocessor/dag/expr/column.rs
@@ -46,7 +46,7 @@ impl Column {
         }
 
         if !ctx.cfg.flag.contains(Flag::PAD_CHAR_TO_FULL_LENGTH)
-            || self.field_type.tp() != FieldTypeTp::String
+            || FieldTypeAccessor::tp(&self.field_type) != FieldTypeTp::String
         {
             return row[self.offset].as_string();
         }
@@ -86,7 +86,7 @@ mod tests {
     use std::{str, u64};
 
     use cop_datatype::{FieldTypeAccessor, FieldTypeTp};
-    use tipb::expression::FieldType;
+    use tipb::FieldType;
 
     use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time};
     use crate::coprocessor::codec::Datum;
@@ -112,7 +112,7 @@ mod tests {
         let mut pad_char_ctx = EvalContext::new(Arc::new(cfg));
 
         let mut c = col_expr(0);
-        let mut field_tp = FieldType::new();
+        let mut field_tp = FieldType::default();
         let flen = 16;
         field_tp
             .as_mut_accessor()
@@ -199,7 +199,7 @@ mod tests {
         ];
         for tp in hybrid_cases {
             let mut c = col_expr(0);
-            let mut field_tp = FieldType::new();
+            let mut field_tp = FieldType::default();
             field_tp.as_mut_accessor().set_tp(tp);
             c.set_field_type(field_tp);
             let e = Expression::build(&ctx, c).unwrap();
@@ -209,7 +209,7 @@ mod tests {
 
         for tp in in_hybrid_cases {
             let mut c = col_expr(0);
-            let mut field_tp = FieldType::new();
+            let mut field_tp = FieldType::default();
             field_tp.as_mut_accessor().set_tp(tp);
             c.set_field_type(field_tp);
             let e = Expression::build(&ctx, c).unwrap();

--- a/src/coprocessor/dag/expr/ctx.rs
+++ b/src/coprocessor/dag/expr/ctx.rs
@@ -3,8 +3,6 @@
 use std::sync::Arc;
 use std::{i64, mem, u64};
 
-use tipb::select;
-
 use super::{Error, Result};
 use crate::coprocessor::codec::mysql::Tz;
 
@@ -149,7 +147,7 @@ pub struct EvalWarnings {
     // number of warnings
     pub warning_cnt: usize,
     // details of previous max_warning_cnt warnings
-    pub warnings: Vec<select::Error>,
+    pub warnings: Vec<tipb::Error>,
 }
 
 impl EvalWarnings {

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -7,7 +7,7 @@ use std::str;
 
 use rand_xorshift::XorShiftRng;
 
-use tipb::expression::{Expr, ExprType, FieldType, ScalarFuncSig};
+use tipb::{Expr, ExprType, FieldType, ScalarFuncSig};
 
 use crate::coprocessor::codec::mysql::charset;
 use crate::coprocessor::codec::mysql::{Decimal, Duration, Json, Time, MAX_FSP};
@@ -202,7 +202,7 @@ impl Expression {
 
     #[inline]
     pub fn is_unsigned(&self) -> bool {
-        self.field_type().flag().contains(FieldTypeFlag::UNSIGNED)
+        FieldTypeAccessor::flag(self.field_type()).contains(FieldTypeFlag::UNSIGNED)
     }
 }
 
@@ -252,7 +252,12 @@ impl Expression {
                 .map_err(Error::from)
                 .and_then(|i| {
                     let fsp = field_type.decimal() as i8;
-                    Time::from_packed_u64(i, field_type.tp().try_into()?, fsp, &ctx.cfg.tz)
+                    Time::from_packed_u64(
+                        i,
+                        FieldTypeAccessor::tp(&field_type).try_into()?,
+                        fsp,
+                        &ctx.cfg.tz,
+                    )
                 })
                 .map(|t| Expression::new_const(Datum::Time(t), field_type)),
             ExprType::MysqlDuration => number::decode_i64(&mut expr.get_val())
@@ -319,7 +324,7 @@ mod tests {
     use std::{i64, u64};
 
     use cop_datatype::{self, Collation, FieldTypeAccessor, FieldTypeFlag, FieldTypeTp};
-    use tipb::expression::{Expr, ExprType, FieldType, ScalarFuncSig};
+    use tipb::{Expr, ExprType, FieldType, ScalarFuncSig};
 
     use super::{Error, EvalConfig, EvalContext, Expression};
     use crate::coprocessor::codec::error::{ERR_DATA_OUT_OF_RANGE, ERR_DIVISION_BY_ZERO};
@@ -359,10 +364,10 @@ mod tests {
     }
 
     pub fn scalar_func_expr(sig: ScalarFuncSig, children: &[Expr]) -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ScalarFunc);
         expr.set_sig(sig);
-        expr.set_field_type(FieldType::new());
+        expr.set_field_type(FieldType::default());
         for child in children {
             expr.mut_children().push(child.clone());
         }
@@ -370,7 +375,7 @@ mod tests {
     }
 
     pub fn col_expr(col_id: i64) -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ColumnRef);
         let mut buf = Vec::with_capacity(8);
         buf.encode_i64(col_id).unwrap();
@@ -386,7 +391,7 @@ mod tests {
         charset: String,
         collate: Collation,
     ) -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         match datum {
             Datum::Bytes(bs) => {
                 expr.set_tp(ExprType::Bytes);
@@ -406,7 +411,7 @@ mod tests {
     }
 
     pub fn datum_expr(datum: Datum) -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         match datum {
             Datum::I64(i) => {
                 expr.set_tp(ExprType::Int64);
@@ -450,7 +455,7 @@ mod tests {
             }
             Datum::Time(t) => {
                 expr.set_tp(ExprType::MysqlTime);
-                let mut ft = FieldType::new();
+                let mut ft = FieldType::default();
                 ft.as_mut_accessor()
                     .set_tp(t.get_time_type().into())
                     .set_decimal(isize::from(t.get_fsp()));

--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -5,7 +5,7 @@ use std::usize;
 
 use cop_datatype::prelude::*;
 use cop_datatype::FieldTypeFlag;
-use tipb::expression::ScalarFuncSig;
+use tipb::ScalarFuncSig;
 
 use super::builtin_compare::CmpOp;
 use super::{Error, EvalContext, Result, ScalarFunc};
@@ -15,55 +15,55 @@ use crate::coprocessor::codec::Datum;
 impl ScalarFunc {
     pub fn check_args(sig: ScalarFuncSig, args: usize) -> Result<()> {
         let (min_args, max_args) = match sig {
-            ScalarFuncSig::LTInt
-            | ScalarFuncSig::LEInt
-            | ScalarFuncSig::GTInt
-            | ScalarFuncSig::GEInt
-            | ScalarFuncSig::EQInt
-            | ScalarFuncSig::NEInt
-            | ScalarFuncSig::NullEQInt
-            | ScalarFuncSig::LTReal
-            | ScalarFuncSig::LEReal
-            | ScalarFuncSig::GTReal
-            | ScalarFuncSig::GEReal
-            | ScalarFuncSig::EQReal
-            | ScalarFuncSig::NEReal
-            | ScalarFuncSig::NullEQReal
-            | ScalarFuncSig::LTDecimal
-            | ScalarFuncSig::LEDecimal
-            | ScalarFuncSig::GTDecimal
-            | ScalarFuncSig::GEDecimal
-            | ScalarFuncSig::EQDecimal
-            | ScalarFuncSig::NEDecimal
-            | ScalarFuncSig::NullEQDecimal
-            | ScalarFuncSig::LTString
-            | ScalarFuncSig::LEString
-            | ScalarFuncSig::GTString
-            | ScalarFuncSig::GEString
-            | ScalarFuncSig::EQString
-            | ScalarFuncSig::NEString
-            | ScalarFuncSig::NullEQString
-            | ScalarFuncSig::LTTime
-            | ScalarFuncSig::LETime
-            | ScalarFuncSig::GTTime
-            | ScalarFuncSig::GETime
-            | ScalarFuncSig::EQTime
-            | ScalarFuncSig::NETime
-            | ScalarFuncSig::NullEQTime
-            | ScalarFuncSig::LTDuration
-            | ScalarFuncSig::LEDuration
-            | ScalarFuncSig::GTDuration
-            | ScalarFuncSig::GEDuration
-            | ScalarFuncSig::EQDuration
-            | ScalarFuncSig::NEDuration
-            | ScalarFuncSig::NullEQDuration
-            | ScalarFuncSig::LTJson
-            | ScalarFuncSig::LEJson
-            | ScalarFuncSig::GTJson
-            | ScalarFuncSig::GEJson
-            | ScalarFuncSig::EQJson
-            | ScalarFuncSig::NEJson
-            | ScalarFuncSig::NullEQJson
+            ScalarFuncSig::LtInt
+            | ScalarFuncSig::LeInt
+            | ScalarFuncSig::GtInt
+            | ScalarFuncSig::GeInt
+            | ScalarFuncSig::EqInt
+            | ScalarFuncSig::NeInt
+            | ScalarFuncSig::NullEqInt
+            | ScalarFuncSig::LtReal
+            | ScalarFuncSig::LeReal
+            | ScalarFuncSig::GtReal
+            | ScalarFuncSig::GeReal
+            | ScalarFuncSig::EqReal
+            | ScalarFuncSig::NeReal
+            | ScalarFuncSig::NullEqReal
+            | ScalarFuncSig::LtDecimal
+            | ScalarFuncSig::LeDecimal
+            | ScalarFuncSig::GtDecimal
+            | ScalarFuncSig::GeDecimal
+            | ScalarFuncSig::EqDecimal
+            | ScalarFuncSig::NeDecimal
+            | ScalarFuncSig::NullEqDecimal
+            | ScalarFuncSig::LtString
+            | ScalarFuncSig::LeString
+            | ScalarFuncSig::GtString
+            | ScalarFuncSig::GeString
+            | ScalarFuncSig::EqString
+            | ScalarFuncSig::NeString
+            | ScalarFuncSig::NullEqString
+            | ScalarFuncSig::LtTime
+            | ScalarFuncSig::LeTime
+            | ScalarFuncSig::GtTime
+            | ScalarFuncSig::GeTime
+            | ScalarFuncSig::EqTime
+            | ScalarFuncSig::NeTime
+            | ScalarFuncSig::NullEqTime
+            | ScalarFuncSig::LtDuration
+            | ScalarFuncSig::LeDuration
+            | ScalarFuncSig::GtDuration
+            | ScalarFuncSig::GeDuration
+            | ScalarFuncSig::EqDuration
+            | ScalarFuncSig::NeDuration
+            | ScalarFuncSig::NullEqDuration
+            | ScalarFuncSig::LtJson
+            | ScalarFuncSig::LeJson
+            | ScalarFuncSig::GtJson
+            | ScalarFuncSig::GeJson
+            | ScalarFuncSig::EqJson
+            | ScalarFuncSig::NeJson
+            | ScalarFuncSig::NullEqJson
             | ScalarFuncSig::PlusReal
             | ScalarFuncSig::PlusDecimal
             | ScalarFuncSig::PlusInt
@@ -109,7 +109,7 @@ impl ScalarFunc {
             | ScalarFuncSig::RoundWithFracInt
             | ScalarFuncSig::RoundWithFracReal
             | ScalarFuncSig::DateFormatSig
-            | ScalarFuncSig::SHA2
+            | ScalarFuncSig::Sha2
             | ScalarFuncSig::TruncateInt
             | ScalarFuncSig::WeekWithMode
             | ScalarFuncSig::YearWeekWithMode
@@ -232,7 +232,7 @@ impl ScalarFunc {
             | ScalarFuncSig::FloorDecToInt
             | ScalarFuncSig::Rand
             | ScalarFuncSig::RandWithSeed
-            | ScalarFuncSig::CRC32
+            | ScalarFuncSig::Crc32
             | ScalarFuncSig::Sign
             | ScalarFuncSig::Sqrt
             | ScalarFuncSig::Atan1Arg
@@ -246,7 +246,7 @@ impl ScalarFunc {
             | ScalarFuncSig::Log10
             | ScalarFuncSig::Log1Arg
             | ScalarFuncSig::Log2
-            | ScalarFuncSig::ASCII
+            | ScalarFuncSig::Ascii
             | ScalarFuncSig::CharLength
             | ScalarFuncSig::Reverse
             | ScalarFuncSig::ReverseBinary
@@ -275,8 +275,8 @@ impl ScalarFunc {
             | ScalarFuncSig::UnHex
             | ScalarFuncSig::Cot
             | ScalarFuncSig::Degrees
-            | ScalarFuncSig::SHA1
-            | ScalarFuncSig::MD5
+            | ScalarFuncSig::Sha1
+            | ScalarFuncSig::Md5
             | ScalarFuncSig::Radians
             | ScalarFuncSig::Exp
             | ScalarFuncSig::Trim1Arg
@@ -317,7 +317,7 @@ impl ScalarFunc {
             | ScalarFuncSig::StringAnyValue
             | ScalarFuncSig::TimeAnyValue
             | ScalarFuncSig::DecimalAnyValue
-            | ScalarFuncSig::JSONAnyValue
+            | ScalarFuncSig::JsonAnyValue
             | ScalarFuncSig::DurationAnyValue
             | ScalarFuncSig::JsonObjectSig => (0, usize::MAX),
 
@@ -335,7 +335,7 @@ impl ScalarFunc {
             | ScalarFuncSig::CaseWhenReal
             | ScalarFuncSig::CaseWhenString
             | ScalarFuncSig::Concat
-            | ScalarFuncSig::ConcatWS
+            | ScalarFuncSig::ConcatWs
             | ScalarFuncSig::FieldInt
             | ScalarFuncSig::FieldReal
             | ScalarFuncSig::FieldString
@@ -374,7 +374,7 @@ impl ScalarFunc {
             | ScalarFuncSig::AddTimeStringNull
             | ScalarFuncSig::SubTimeDateTimeNull
             | ScalarFuncSig::SubTimeDurationNull
-            | ScalarFuncSig::PI => (0, 0),
+            | ScalarFuncSig::Pi => (0, 0),
 
             // unimplemented signature
             ScalarFuncSig::AddDateAndDuration
@@ -391,7 +391,7 @@ impl ScalarFunc {
             | ScalarFuncSig::AesDecrypt
             | ScalarFuncSig::AesEncrypt
             | ScalarFuncSig::Char
-            | ScalarFuncSig::ConnectionID
+            | ScalarFuncSig::ConnectionId
             | ScalarFuncSig::Convert
             | ScalarFuncSig::ConvertTz
             | ScalarFuncSig::CurrentDate
@@ -419,8 +419,8 @@ impl ScalarFunc {
             | ScalarFuncSig::GetVar
             | ScalarFuncSig::Insert
             | ScalarFuncSig::InsertBinary
-            | ScalarFuncSig::LastInsertID
-            | ScalarFuncSig::LastInsertIDWithID
+            | ScalarFuncSig::LastInsertId
+            | ScalarFuncSig::LastInsertIdWithId
             | ScalarFuncSig::Lock
             | ScalarFuncSig::MakeDate
             | ScalarFuncSig::MakeSet
@@ -462,7 +462,7 @@ impl ScalarFunc {
             | ScalarFuncSig::SubTimeStringNull
             | ScalarFuncSig::SysDateWithFsp
             | ScalarFuncSig::SysDateWithoutFsp
-            | ScalarFuncSig::TiDBVersion
+            | ScalarFuncSig::TiDbVersion
             | ScalarFuncSig::Time
             | ScalarFuncSig::TimeFormat
             | ScalarFuncSig::TimeLiteral
@@ -479,16 +479,16 @@ impl ScalarFunc {
             | ScalarFuncSig::UnixTimestampDec
             | ScalarFuncSig::UnixTimestampInt
             | ScalarFuncSig::User
-            | ScalarFuncSig::UTCDate
-            | ScalarFuncSig::UTCTimestampWithArg
-            | ScalarFuncSig::UTCTimestampWithoutArg
-            | ScalarFuncSig::UTCTimeWithArg
-            | ScalarFuncSig::UTCTimeWithoutArg
-            | ScalarFuncSig::UUID
+            | ScalarFuncSig::UtcDate
+            | ScalarFuncSig::UtcTimestampWithArg
+            | ScalarFuncSig::UtcTimestampWithoutArg
+            | ScalarFuncSig::UtcTimeWithArg
+            | ScalarFuncSig::UtcTimeWithoutArg
+            | ScalarFuncSig::Uuid
             | ScalarFuncSig::ValuesDecimal
             | ScalarFuncSig::ValuesDuration
             | ScalarFuncSig::ValuesInt
-            | ScalarFuncSig::ValuesJSON
+            | ScalarFuncSig::ValuesJson
             | ScalarFuncSig::ValuesReal
             | ScalarFuncSig::ValuesString
             | ScalarFuncSig::ValuesTime
@@ -619,7 +619,7 @@ macro_rules! dispatch_call {
                     $(ScalarFuncSig::$i_sig => {
                         match self.$i_func(ctx, row, $($i_arg)*) {
                             Ok(Some(i)) => {
-                                if self.field_type.flag().contains(FieldTypeFlag::UNSIGNED) {
+                                if FieldTypeAccessor::flag(&self.field_type).contains(FieldTypeFlag::UNSIGNED) {
                                     Ok(Datum::U64(i as u64))
                                 } else {
                                     Ok(Datum::I64(i))
@@ -656,61 +656,61 @@ macro_rules! dispatch_call {
 
 dispatch_call! {
     INT_CALLS {
-        LTInt => compare_int CmpOp::LT,
-        LEInt => compare_int CmpOp::LE,
-        GTInt => compare_int CmpOp::GT,
-        GEInt => compare_int CmpOp::GE,
-        EQInt => compare_int CmpOp::EQ,
-        NEInt => compare_int CmpOp::NE,
-        NullEQInt => compare_int CmpOp::NullEQ,
+        LtInt => compare_int CmpOp::LT,
+        LeInt => compare_int CmpOp::LE,
+        GtInt => compare_int CmpOp::GT,
+        GeInt => compare_int CmpOp::GE,
+        EqInt => compare_int CmpOp::EQ,
+        NeInt => compare_int CmpOp::NE,
+        NullEqInt => compare_int CmpOp::NullEQ,
 
-        LTReal => compare_real CmpOp::LT,
-        LEReal => compare_real CmpOp::LE,
-        GTReal => compare_real CmpOp::GT,
-        GEReal => compare_real CmpOp::GE,
-        EQReal => compare_real CmpOp::EQ,
-        NEReal => compare_real CmpOp::NE,
-        NullEQReal => compare_real CmpOp::NullEQ,
+        LtReal => compare_real CmpOp::LT,
+        LeReal => compare_real CmpOp::LE,
+        GtReal => compare_real CmpOp::GT,
+        GeReal => compare_real CmpOp::GE,
+        EqReal => compare_real CmpOp::EQ,
+        NeReal => compare_real CmpOp::NE,
+        NullEqReal => compare_real CmpOp::NullEQ,
 
-        LTDecimal => compare_decimal CmpOp::LT,
-        LEDecimal => compare_decimal CmpOp::LE,
-        GTDecimal => compare_decimal CmpOp::GT,
-        GEDecimal => compare_decimal CmpOp::GE,
-        EQDecimal => compare_decimal CmpOp::EQ,
-        NEDecimal => compare_decimal CmpOp::NE,
-        NullEQDecimal => compare_decimal CmpOp::NullEQ,
+        LtDecimal => compare_decimal CmpOp::LT,
+        LeDecimal => compare_decimal CmpOp::LE,
+        GtDecimal => compare_decimal CmpOp::GT,
+        GeDecimal => compare_decimal CmpOp::GE,
+        EqDecimal => compare_decimal CmpOp::EQ,
+        NeDecimal => compare_decimal CmpOp::NE,
+        NullEqDecimal => compare_decimal CmpOp::NullEQ,
 
-        LTString => compare_string CmpOp::LT,
-        LEString => compare_string CmpOp::LE,
-        GTString => compare_string CmpOp::GT,
-        GEString => compare_string CmpOp::GE,
-        EQString => compare_string CmpOp::EQ,
-        NEString => compare_string CmpOp::NE,
-        NullEQString => compare_string CmpOp::NullEQ,
+        LtString => compare_string CmpOp::LT,
+        LeString => compare_string CmpOp::LE,
+        GtString => compare_string CmpOp::GT,
+        GeString => compare_string CmpOp::GE,
+        EqString => compare_string CmpOp::EQ,
+        NeString => compare_string CmpOp::NE,
+        NullEqString => compare_string CmpOp::NullEQ,
 
-        LTTime => compare_time CmpOp::LT,
-        LETime => compare_time CmpOp::LE,
-        GTTime => compare_time CmpOp::GT,
-        GETime => compare_time CmpOp::GE,
-        EQTime => compare_time CmpOp::EQ,
-        NETime => compare_time CmpOp::NE,
-        NullEQTime => compare_time CmpOp::NullEQ,
+        LtTime => compare_time CmpOp::LT,
+        LeTime => compare_time CmpOp::LE,
+        GtTime => compare_time CmpOp::GT,
+        GeTime => compare_time CmpOp::GE,
+        EqTime => compare_time CmpOp::EQ,
+        NeTime => compare_time CmpOp::NE,
+        NullEqTime => compare_time CmpOp::NullEQ,
 
-        LTDuration => compare_duration CmpOp::LT,
-        LEDuration => compare_duration CmpOp::LE,
-        GTDuration => compare_duration CmpOp::GT,
-        GEDuration => compare_duration CmpOp::GE,
-        EQDuration => compare_duration CmpOp::EQ,
-        NEDuration => compare_duration CmpOp::NE,
-        NullEQDuration => compare_duration CmpOp::NullEQ,
+        LtDuration => compare_duration CmpOp::LT,
+        LeDuration => compare_duration CmpOp::LE,
+        GtDuration => compare_duration CmpOp::GT,
+        GeDuration => compare_duration CmpOp::GE,
+        EqDuration => compare_duration CmpOp::EQ,
+        NeDuration => compare_duration CmpOp::NE,
+        NullEqDuration => compare_duration CmpOp::NullEQ,
 
-        LTJson => compare_json CmpOp::LT,
-        LEJson => compare_json CmpOp::LE,
-        GTJson => compare_json CmpOp::GT,
-        GEJson => compare_json CmpOp::GE,
-        EQJson => compare_json CmpOp::EQ,
-        NEJson => compare_json CmpOp::NE,
-        NullEQJson => compare_json CmpOp::NullEQ,
+        LtJson => compare_json CmpOp::LT,
+        LeJson => compare_json CmpOp::LE,
+        GtJson => compare_json CmpOp::GT,
+        GeJson => compare_json CmpOp::GE,
+        EqJson => compare_json CmpOp::EQ,
+        NeJson => compare_json CmpOp::NE,
+        NullEqJson => compare_json CmpOp::NullEQ,
 
         CastIntAsInt => cast_int_as_int,
         CastRealAsInt => cast_real_as_int,
@@ -785,7 +785,7 @@ dispatch_call! {
         CeilDecToInt => ceil_dec_to_int,
         FloorIntToInt => floor_int_to_int,
         FloorDecToInt => floor_dec_to_int,
-        CRC32 => crc32,
+        Crc32 => crc32,
         Sign => sign,
 
         RoundInt => round_int,
@@ -823,7 +823,7 @@ dispatch_call! {
         BitLength => bit_length,
         LeftShift => left_shift,
         RightShift => right_shift,
-        ASCII => ascii,
+        Ascii => ascii,
         IsIPv4 => is_ipv4,
         IsIPv4Compat => is_ipv4_compat,
         IsIPv4Mapped => is_ipv4_mapped,
@@ -856,7 +856,7 @@ dispatch_call! {
         FloorReal => floor_real,
         RoundReal => round_real,
         RoundWithFracReal => round_with_frac_real,
-        PI => pi,
+        Pi => pi,
         Rand => rand,
         RandWithSeed => rand_with_seed,
         TruncateReal => truncate_real,
@@ -957,7 +957,7 @@ dispatch_call! {
         Bin => bin,
         Concat => concat,
         Replace => replace,
-        ConcatWS => concat_ws,
+        ConcatWs => concat_ws,
         LTrim => ltrim,
         RTrim => rtrim,
         Reverse => reverse,
@@ -968,9 +968,9 @@ dispatch_call! {
         InetNtoa => inet_ntoa,
         Inet6Aton => inet6_aton,
         Inet6Ntoa => inet6_ntoa,
-        MD5 => md5,
-        SHA1 => sha1,
-        SHA2 => sha2,
+        Md5 => md5,
+        Sha1 => sha1,
+        Sha2 => sha2,
         Elt => elt,
         FromBase64 => from_base64,
         ToBase64 => to_base64,
@@ -1069,7 +1069,7 @@ dispatch_call! {
         JsonMergeSig => json_merge,
         JsonArraySig => json_array,
         JsonObjectSig => json_object,
-        JSONAnyValue => json_any_value,
+        JsonAnyValue => json_any_value,
     }
 }
 
@@ -1077,62 +1077,62 @@ dispatch_call! {
 mod tests {
     use crate::coprocessor::dag::expr::{Error, ScalarFunc};
     use std::usize;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_check_args() {
         let cases = vec![
             (
                 vec![
-                    ScalarFuncSig::LTInt,
-                    ScalarFuncSig::LEInt,
-                    ScalarFuncSig::GTInt,
-                    ScalarFuncSig::GEInt,
-                    ScalarFuncSig::EQInt,
-                    ScalarFuncSig::NEInt,
-                    ScalarFuncSig::NullEQInt,
-                    ScalarFuncSig::LTReal,
-                    ScalarFuncSig::LEReal,
-                    ScalarFuncSig::GTReal,
-                    ScalarFuncSig::GEReal,
-                    ScalarFuncSig::EQReal,
-                    ScalarFuncSig::NEReal,
-                    ScalarFuncSig::NullEQReal,
-                    ScalarFuncSig::LTDecimal,
-                    ScalarFuncSig::LEDecimal,
-                    ScalarFuncSig::GTDecimal,
-                    ScalarFuncSig::GEDecimal,
-                    ScalarFuncSig::EQDecimal,
-                    ScalarFuncSig::NEDecimal,
-                    ScalarFuncSig::NullEQDecimal,
-                    ScalarFuncSig::LTString,
-                    ScalarFuncSig::LEString,
-                    ScalarFuncSig::GTString,
-                    ScalarFuncSig::GEString,
-                    ScalarFuncSig::EQString,
-                    ScalarFuncSig::NEString,
-                    ScalarFuncSig::NullEQString,
-                    ScalarFuncSig::LTTime,
-                    ScalarFuncSig::LETime,
-                    ScalarFuncSig::GTTime,
-                    ScalarFuncSig::GETime,
-                    ScalarFuncSig::EQTime,
-                    ScalarFuncSig::NETime,
-                    ScalarFuncSig::NullEQTime,
-                    ScalarFuncSig::LTDuration,
-                    ScalarFuncSig::LEDuration,
-                    ScalarFuncSig::GTDuration,
-                    ScalarFuncSig::GEDuration,
-                    ScalarFuncSig::EQDuration,
-                    ScalarFuncSig::NEDuration,
-                    ScalarFuncSig::NullEQDuration,
-                    ScalarFuncSig::LTJson,
-                    ScalarFuncSig::LEJson,
-                    ScalarFuncSig::GTJson,
-                    ScalarFuncSig::GEJson,
-                    ScalarFuncSig::EQJson,
-                    ScalarFuncSig::NEJson,
-                    ScalarFuncSig::NullEQJson,
+                    ScalarFuncSig::LtInt,
+                    ScalarFuncSig::LeInt,
+                    ScalarFuncSig::GtInt,
+                    ScalarFuncSig::GeInt,
+                    ScalarFuncSig::EqInt,
+                    ScalarFuncSig::NeInt,
+                    ScalarFuncSig::NullEqInt,
+                    ScalarFuncSig::LtReal,
+                    ScalarFuncSig::LeReal,
+                    ScalarFuncSig::GtReal,
+                    ScalarFuncSig::GeReal,
+                    ScalarFuncSig::EqReal,
+                    ScalarFuncSig::NeReal,
+                    ScalarFuncSig::NullEqReal,
+                    ScalarFuncSig::LtDecimal,
+                    ScalarFuncSig::LeDecimal,
+                    ScalarFuncSig::GtDecimal,
+                    ScalarFuncSig::GeDecimal,
+                    ScalarFuncSig::EqDecimal,
+                    ScalarFuncSig::NeDecimal,
+                    ScalarFuncSig::NullEqDecimal,
+                    ScalarFuncSig::LtString,
+                    ScalarFuncSig::LeString,
+                    ScalarFuncSig::GtString,
+                    ScalarFuncSig::GeString,
+                    ScalarFuncSig::EqString,
+                    ScalarFuncSig::NeString,
+                    ScalarFuncSig::NullEqString,
+                    ScalarFuncSig::LtTime,
+                    ScalarFuncSig::LeTime,
+                    ScalarFuncSig::GtTime,
+                    ScalarFuncSig::GeTime,
+                    ScalarFuncSig::EqTime,
+                    ScalarFuncSig::NeTime,
+                    ScalarFuncSig::NullEqTime,
+                    ScalarFuncSig::LtDuration,
+                    ScalarFuncSig::LeDuration,
+                    ScalarFuncSig::GtDuration,
+                    ScalarFuncSig::GeDuration,
+                    ScalarFuncSig::EqDuration,
+                    ScalarFuncSig::NeDuration,
+                    ScalarFuncSig::NullEqDuration,
+                    ScalarFuncSig::LtJson,
+                    ScalarFuncSig::LeJson,
+                    ScalarFuncSig::GtJson,
+                    ScalarFuncSig::GeJson,
+                    ScalarFuncSig::EqJson,
+                    ScalarFuncSig::NeJson,
+                    ScalarFuncSig::NullEqJson,
                     ScalarFuncSig::PlusReal,
                     ScalarFuncSig::PlusDecimal,
                     ScalarFuncSig::PlusInt,
@@ -1303,7 +1303,7 @@ mod tests {
                     ScalarFuncSig::RoundInt,
                     ScalarFuncSig::Rand,
                     ScalarFuncSig::RandWithSeed,
-                    ScalarFuncSig::CRC32,
+                    ScalarFuncSig::Crc32,
                     ScalarFuncSig::Sign,
                     ScalarFuncSig::Sqrt,
                     ScalarFuncSig::Atan1Arg,
@@ -1314,7 +1314,7 @@ mod tests {
                     ScalarFuncSig::Sin,
                     ScalarFuncSig::JsonTypeSig,
                     ScalarFuncSig::JsonUnquoteSig,
-                    ScalarFuncSig::ASCII,
+                    ScalarFuncSig::Ascii,
                     ScalarFuncSig::Bin,
                     ScalarFuncSig::Log10,
                     ScalarFuncSig::Log1Arg,
@@ -1334,8 +1334,8 @@ mod tests {
                     ScalarFuncSig::IsIPv4Compat,
                     ScalarFuncSig::IsIPv4Mapped,
                     ScalarFuncSig::IsIPv6,
-                    ScalarFuncSig::MD5,
-                    ScalarFuncSig::SHA1,
+                    ScalarFuncSig::Md5,
+                    ScalarFuncSig::Sha1,
                     ScalarFuncSig::Cot,
                     ScalarFuncSig::Degrees,
                     ScalarFuncSig::Radians,
@@ -1383,7 +1383,7 @@ mod tests {
                     ScalarFuncSig::IntAnyValue,
                     ScalarFuncSig::StringAnyValue,
                     ScalarFuncSig::RealAnyValue,
-                    ScalarFuncSig::JSONAnyValue,
+                    ScalarFuncSig::JsonAnyValue,
                     ScalarFuncSig::DurationAnyValue,
                     ScalarFuncSig::TimeAnyValue,
                     ScalarFuncSig::DecimalAnyValue,
@@ -1408,7 +1408,7 @@ mod tests {
                     ScalarFuncSig::CaseWhenString,
                     ScalarFuncSig::CaseWhenTime,
                     ScalarFuncSig::Concat,
-                    ScalarFuncSig::ConcatWS,
+                    ScalarFuncSig::ConcatWs,
                     ScalarFuncSig::FieldInt,
                     ScalarFuncSig::FieldReal,
                     ScalarFuncSig::FieldString,
@@ -1461,7 +1461,7 @@ mod tests {
                     ScalarFuncSig::AddTimeStringNull,
                     ScalarFuncSig::SubTimeDateTimeNull,
                     ScalarFuncSig::SubTimeDurationNull,
-                    ScalarFuncSig::PI,
+                    ScalarFuncSig::Pi,
                 ],
                 0,
                 0,
@@ -1500,7 +1500,7 @@ mod tests {
             ScalarFuncSig::AesDecrypt,
             ScalarFuncSig::AesEncrypt,
             ScalarFuncSig::Char,
-            ScalarFuncSig::ConnectionID,
+            ScalarFuncSig::ConnectionId,
             ScalarFuncSig::Convert,
             ScalarFuncSig::ConvertTz,
             ScalarFuncSig::CurrentDate,
@@ -1528,8 +1528,8 @@ mod tests {
             ScalarFuncSig::GetVar,
             ScalarFuncSig::Insert,
             ScalarFuncSig::InsertBinary,
-            ScalarFuncSig::LastInsertID,
-            ScalarFuncSig::LastInsertIDWithID,
+            ScalarFuncSig::LastInsertId,
+            ScalarFuncSig::LastInsertIdWithId,
             ScalarFuncSig::Lock,
             ScalarFuncSig::MakeDate,
             ScalarFuncSig::MakeSet,
@@ -1571,7 +1571,7 @@ mod tests {
             ScalarFuncSig::SubTimeStringNull,
             ScalarFuncSig::SysDateWithFsp,
             ScalarFuncSig::SysDateWithoutFsp,
-            ScalarFuncSig::TiDBVersion,
+            ScalarFuncSig::TiDbVersion,
             ScalarFuncSig::Time,
             ScalarFuncSig::TimeFormat,
             ScalarFuncSig::TimeLiteral,
@@ -1588,16 +1588,16 @@ mod tests {
             ScalarFuncSig::UnixTimestampDec,
             ScalarFuncSig::UnixTimestampInt,
             ScalarFuncSig::User,
-            ScalarFuncSig::UTCDate,
-            ScalarFuncSig::UTCTimestampWithArg,
-            ScalarFuncSig::UTCTimestampWithoutArg,
-            ScalarFuncSig::UTCTimeWithArg,
-            ScalarFuncSig::UTCTimeWithoutArg,
-            ScalarFuncSig::UUID,
+            ScalarFuncSig::UtcDate,
+            ScalarFuncSig::UtcTimestampWithArg,
+            ScalarFuncSig::UtcTimestampWithoutArg,
+            ScalarFuncSig::UtcTimeWithArg,
+            ScalarFuncSig::UtcTimeWithoutArg,
+            ScalarFuncSig::Uuid,
             ScalarFuncSig::ValuesDecimal,
             ScalarFuncSig::ValuesDuration,
             ScalarFuncSig::ValuesInt,
-            ScalarFuncSig::ValuesJSON,
+            ScalarFuncSig::ValuesJson,
             ScalarFuncSig::ValuesReal,
             ScalarFuncSig::ValuesString,
             ScalarFuncSig::ValuesTime,

--- a/src/coprocessor/dag/rpn_expr/impl_arithmetic.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_arithmetic.rs
@@ -407,7 +407,7 @@ mod tests {
 
     use cop_datatype::builder::FieldTypeBuilder;
     use cop_datatype::{FieldTypeFlag, FieldTypeTp};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::coprocessor::dag::rpn_expr::test_util::RpnFnScalarEvaluator;
 

--- a/src/coprocessor/dag/rpn_expr/impl_compare.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_compare.rs
@@ -239,7 +239,7 @@ mod tests {
 
     use cop_datatype::builder::FieldTypeBuilder;
     use cop_datatype::{FieldTypeFlag, FieldTypeTp};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::coprocessor::dag::rpn_expr::test_util::RpnFnScalarEvaluator;
 
@@ -468,13 +468,13 @@ mod tests {
     fn test_compare_real() {
         for (arg0, arg1, cmp_op, expect_output) in generate_numeric_compare_cases() {
             let sig = match cmp_op {
-                TestCaseCmpOp::GT => ScalarFuncSig::GTReal,
-                TestCaseCmpOp::GE => ScalarFuncSig::GEReal,
-                TestCaseCmpOp::LT => ScalarFuncSig::LTReal,
-                TestCaseCmpOp::LE => ScalarFuncSig::LEReal,
-                TestCaseCmpOp::EQ => ScalarFuncSig::EQReal,
-                TestCaseCmpOp::NE => ScalarFuncSig::NEReal,
-                TestCaseCmpOp::NullEQ => ScalarFuncSig::NullEQReal,
+                TestCaseCmpOp::GT => ScalarFuncSig::GtReal,
+                TestCaseCmpOp::GE => ScalarFuncSig::GeReal,
+                TestCaseCmpOp::LT => ScalarFuncSig::LtReal,
+                TestCaseCmpOp::LE => ScalarFuncSig::LeReal,
+                TestCaseCmpOp::EQ => ScalarFuncSig::EqReal,
+                TestCaseCmpOp::NE => ScalarFuncSig::NeReal,
+                TestCaseCmpOp::NullEQ => ScalarFuncSig::NullEqReal,
             };
             let output = RpnFnScalarEvaluator::new()
                 .push_param(arg0)
@@ -493,13 +493,13 @@ mod tests {
 
         for (arg0, arg1, cmp_op, expect_output) in generate_numeric_compare_cases() {
             let sig = match cmp_op {
-                TestCaseCmpOp::GT => ScalarFuncSig::GTDuration,
-                TestCaseCmpOp::GE => ScalarFuncSig::GEDuration,
-                TestCaseCmpOp::LT => ScalarFuncSig::LTDuration,
-                TestCaseCmpOp::LE => ScalarFuncSig::LEDuration,
-                TestCaseCmpOp::EQ => ScalarFuncSig::EQDuration,
-                TestCaseCmpOp::NE => ScalarFuncSig::NEDuration,
-                TestCaseCmpOp::NullEQ => ScalarFuncSig::NullEQDuration,
+                TestCaseCmpOp::GT => ScalarFuncSig::GtDuration,
+                TestCaseCmpOp::GE => ScalarFuncSig::GeDuration,
+                TestCaseCmpOp::LT => ScalarFuncSig::LtDuration,
+                TestCaseCmpOp::LE => ScalarFuncSig::LeDuration,
+                TestCaseCmpOp::EQ => ScalarFuncSig::EqDuration,
+                TestCaseCmpOp::NE => ScalarFuncSig::NeDuration,
+                TestCaseCmpOp::NullEQ => ScalarFuncSig::NullEqDuration,
             };
             let output = RpnFnScalarEvaluator::new()
                 .push_param(arg0.map(map_double_to_duration))
@@ -514,13 +514,13 @@ mod tests {
     fn test_compare_decimal() {
         for (arg0, arg1, cmp_op, expect_output) in generate_numeric_compare_cases() {
             let sig = match cmp_op {
-                TestCaseCmpOp::GT => ScalarFuncSig::GTDecimal,
-                TestCaseCmpOp::GE => ScalarFuncSig::GEDecimal,
-                TestCaseCmpOp::LT => ScalarFuncSig::LTDecimal,
-                TestCaseCmpOp::LE => ScalarFuncSig::LEDecimal,
-                TestCaseCmpOp::EQ => ScalarFuncSig::EQDecimal,
-                TestCaseCmpOp::NE => ScalarFuncSig::NEDecimal,
-                TestCaseCmpOp::NullEQ => ScalarFuncSig::NullEQDecimal,
+                TestCaseCmpOp::GT => ScalarFuncSig::GtDecimal,
+                TestCaseCmpOp::GE => ScalarFuncSig::GeDecimal,
+                TestCaseCmpOp::LT => ScalarFuncSig::LtDecimal,
+                TestCaseCmpOp::LE => ScalarFuncSig::LeDecimal,
+                TestCaseCmpOp::EQ => ScalarFuncSig::EqDecimal,
+                TestCaseCmpOp::NE => ScalarFuncSig::NeDecimal,
+                TestCaseCmpOp::NullEQ => ScalarFuncSig::NullEqDecimal,
             };
             let output = RpnFnScalarEvaluator::new()
                 .push_param(arg0.map(|v| Decimal::from_f64(v.into_inner()).unwrap()))
@@ -535,13 +535,13 @@ mod tests {
     fn test_compare_signed_int() {
         for (arg0, arg1, cmp_op, expect_output) in generate_numeric_compare_cases() {
             let sig = match cmp_op {
-                TestCaseCmpOp::GT => ScalarFuncSig::GTInt,
-                TestCaseCmpOp::GE => ScalarFuncSig::GEInt,
-                TestCaseCmpOp::LT => ScalarFuncSig::LTInt,
-                TestCaseCmpOp::LE => ScalarFuncSig::LEInt,
-                TestCaseCmpOp::EQ => ScalarFuncSig::EQInt,
-                TestCaseCmpOp::NE => ScalarFuncSig::NEInt,
-                TestCaseCmpOp::NullEQ => ScalarFuncSig::NullEQInt,
+                TestCaseCmpOp::GT => ScalarFuncSig::GtInt,
+                TestCaseCmpOp::GE => ScalarFuncSig::GeInt,
+                TestCaseCmpOp::LT => ScalarFuncSig::LtInt,
+                TestCaseCmpOp::LE => ScalarFuncSig::LeInt,
+                TestCaseCmpOp::EQ => ScalarFuncSig::EqInt,
+                TestCaseCmpOp::NE => ScalarFuncSig::NeInt,
+                TestCaseCmpOp::NullEQ => ScalarFuncSig::NullEqInt,
             };
             let output = RpnFnScalarEvaluator::new()
                 .push_param(arg0.map(|v| v.into_inner() as i64))
@@ -615,18 +615,18 @@ mod tests {
                 .build();
 
             for (sig, accept_orderings) in &[
-                (ScalarFuncSig::EQInt, vec![Ordering::Equal]),
+                (ScalarFuncSig::EqInt, vec![Ordering::Equal]),
                 (
-                    ScalarFuncSig::NEInt,
+                    ScalarFuncSig::NeInt,
                     vec![Ordering::Greater, Ordering::Less],
                 ),
-                (ScalarFuncSig::GTInt, vec![Ordering::Greater]),
+                (ScalarFuncSig::GtInt, vec![Ordering::Greater]),
                 (
-                    ScalarFuncSig::GEInt,
+                    ScalarFuncSig::GeInt,
                     vec![Ordering::Greater, Ordering::Equal],
                 ),
-                (ScalarFuncSig::LTInt, vec![Ordering::Less]),
-                (ScalarFuncSig::LEInt, vec![Ordering::Less, Ordering::Equal]),
+                (ScalarFuncSig::LtInt, vec![Ordering::Less]),
+                (ScalarFuncSig::LeInt, vec![Ordering::Less, Ordering::Equal]),
             ] {
                 let output = RpnFnScalarEvaluator::new()
                     .push_param_with_field_type(lhs, lhs_field_type.clone())

--- a/src/coprocessor/dag/rpn_expr/impl_control.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_control.rs
@@ -32,7 +32,7 @@ pub fn case_when<T: Evaluable>(args: &[ScalarValueRef<'_>]) -> Result<Option<T>>
     Ok(None)
 }
 
-fn case_when_validator<T: Evaluable>(expr: &tipb::expression::Expr) -> Result<()> {
+fn case_when_validator<T: Evaluable>(expr: &tipb::Expr) -> Result<()> {
     for chunk in expr.get_children().chunks(2) {
         if chunk.len() == 1 {
             super::function::validate_expr_return_type(&chunk[0], T::EVAL_TYPE)?;
@@ -48,7 +48,7 @@ fn case_when_validator<T: Evaluable>(expr: &tipb::expression::Expr) -> Result<()
 mod tests {
     use super::*;
 
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::coprocessor::dag::rpn_expr::test_util::RpnFnScalarEvaluator;
 

--- a/src/coprocessor/dag/rpn_expr/impl_like.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_like.rs
@@ -26,7 +26,7 @@ pub fn like(
 
 #[cfg(test)]
 mod tests {
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::coprocessor::dag::rpn_expr::test_util::RpnFnScalarEvaluator;
 

--- a/src/coprocessor/dag/rpn_expr/impl_math.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_math.rs
@@ -47,7 +47,7 @@ fn abs_decimal(arg: &Option<Decimal>) -> Result<Option<Decimal>> {
 mod tests {
     use super::*;
 
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::coprocessor::dag::rpn_expr::types::test_util::RpnFnScalarEvaluator;
 

--- a/src/coprocessor/dag/rpn_expr/impl_op.rs
+++ b/src/coprocessor/dag/rpn_expr/impl_op.rs
@@ -78,7 +78,7 @@ fn decimal_is_false(arg: &Option<Decimal>) -> Result<Option<i64>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::coprocessor::codec::mysql::{time, Tz};
     use crate::coprocessor::dag::rpn_expr::test_util::RpnFnScalarEvaluator;

--- a/src/coprocessor/dag/rpn_expr/mod.rs
+++ b/src/coprocessor/dag/rpn_expr/mod.rs
@@ -13,7 +13,7 @@ pub mod impl_op;
 pub use self::types::*;
 
 use cop_datatype::{FieldTypeAccessor, FieldTypeFlag};
-use tipb::expression::{Expr, ScalarFuncSig};
+use tipb::{Expr, ScalarFuncSig};
 
 use crate::coprocessor::codec::data_type::*;
 use crate::coprocessor::Result;
@@ -37,14 +37,10 @@ where
             children.len()
         ));
     }
-    let lhs_is_unsigned = children[0]
-        .get_field_type()
-        .flag()
-        .contains(FieldTypeFlag::UNSIGNED);
-    let rhs_is_unsigned = children[1]
-        .get_field_type()
-        .flag()
-        .contains(FieldTypeFlag::UNSIGNED);
+    let lhs_is_unsigned =
+        FieldTypeAccessor::flag(children[0].get_field_type()).contains(FieldTypeFlag::UNSIGNED);
+    let rhs_is_unsigned =
+        FieldTypeAccessor::flag(children[1].get_field_type()).contains(FieldTypeFlag::UNSIGNED);
     Ok(mapper(lhs_is_unsigned, rhs_is_unsigned))
 }
 
@@ -96,55 +92,55 @@ fn divide_mapper(lhs_is_unsigned: bool, rhs_is_unsigned: bool) -> RpnFnMeta {
 #[rustfmt::skip]
 fn map_pb_sig_to_rpn_func(value: ScalarFuncSig, children: &[Expr]) -> Result<RpnFnMeta> {
     Ok(match value {
-        ScalarFuncSig::LTInt => map_int_sig(value, children, compare_mapper::<CmpOpLT>)?,
-        ScalarFuncSig::LTReal => compare_fn_meta::<BasicComparer<Real, CmpOpLT>>(),
-        ScalarFuncSig::LTDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpLT>>(),
-        ScalarFuncSig::LTString => compare_fn_meta::<BasicComparer<Bytes, CmpOpLT>>(),
-        ScalarFuncSig::LTTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpLT>>(),
-        ScalarFuncSig::LTDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpLT>>(),
-        ScalarFuncSig::LTJson => compare_fn_meta::<BasicComparer<Json, CmpOpLT>>(),
-        ScalarFuncSig::LEInt => map_int_sig(value, children, compare_mapper::<CmpOpLE>)?,
-        ScalarFuncSig::LEReal => compare_fn_meta::<BasicComparer<Real, CmpOpLE>>(),
-        ScalarFuncSig::LEDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpLE>>(),
-        ScalarFuncSig::LEString => compare_fn_meta::<BasicComparer<Bytes, CmpOpLE>>(),
-        ScalarFuncSig::LETime => compare_fn_meta::<BasicComparer<DateTime, CmpOpLE>>(),
-        ScalarFuncSig::LEDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpLE>>(),
-        ScalarFuncSig::LEJson => compare_fn_meta::<BasicComparer<Json, CmpOpLE>>(),
-        ScalarFuncSig::GTInt => map_int_sig(value, children, compare_mapper::<CmpOpGT>)?,
-        ScalarFuncSig::GTReal => compare_fn_meta::<BasicComparer<Real, CmpOpGT>>(),
-        ScalarFuncSig::GTDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpGT>>(),
-        ScalarFuncSig::GTString => compare_fn_meta::<BasicComparer<Bytes, CmpOpGT>>(),
-        ScalarFuncSig::GTTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpGT>>(),
-        ScalarFuncSig::GTDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpGT>>(),
-        ScalarFuncSig::GTJson => compare_fn_meta::<BasicComparer<Json, CmpOpGT>>(),
-        ScalarFuncSig::GEInt => map_int_sig(value, children, compare_mapper::<CmpOpGE>)?,
-        ScalarFuncSig::GEReal => compare_fn_meta::<BasicComparer<Real, CmpOpGE>>(),
-        ScalarFuncSig::GEDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpGE>>(),
-        ScalarFuncSig::GEString => compare_fn_meta::<BasicComparer<Bytes, CmpOpGE>>(),
-        ScalarFuncSig::GETime => compare_fn_meta::<BasicComparer<DateTime, CmpOpGE>>(),
-        ScalarFuncSig::GEDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpGE>>(),
-        ScalarFuncSig::GEJson => compare_fn_meta::<BasicComparer<Json, CmpOpGE>>(),
-        ScalarFuncSig::NEInt => map_int_sig(value, children, compare_mapper::<CmpOpNE>)?,
-        ScalarFuncSig::NEReal => compare_fn_meta::<BasicComparer<Real, CmpOpNE>>(),
-        ScalarFuncSig::NEDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpNE>>(),
-        ScalarFuncSig::NEString => compare_fn_meta::<BasicComparer<Bytes, CmpOpNE>>(),
-        ScalarFuncSig::NETime => compare_fn_meta::<BasicComparer<DateTime, CmpOpNE>>(),
-        ScalarFuncSig::NEDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpNE>>(),
-        ScalarFuncSig::NEJson => compare_fn_meta::<BasicComparer<Json, CmpOpNE>>(),
-        ScalarFuncSig::EQInt => map_int_sig(value, children, compare_mapper::<CmpOpEQ>)?,
-        ScalarFuncSig::EQReal => compare_fn_meta::<BasicComparer<Real, CmpOpEQ>>(),
-        ScalarFuncSig::EQDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpEQ>>(),
-        ScalarFuncSig::EQString => compare_fn_meta::<BasicComparer<Bytes, CmpOpEQ>>(),
-        ScalarFuncSig::EQTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpEQ>>(),
-        ScalarFuncSig::EQDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpEQ>>(),
-        ScalarFuncSig::EQJson => compare_fn_meta::<BasicComparer<Json, CmpOpEQ>>(),
-        ScalarFuncSig::NullEQInt => map_int_sig(value, children, compare_mapper::<CmpOpNullEQ>)?,
-        ScalarFuncSig::NullEQReal => compare_fn_meta::<BasicComparer<Real, CmpOpNullEQ>>(),
-        ScalarFuncSig::NullEQDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpNullEQ>>(),
-        ScalarFuncSig::NullEQString => compare_fn_meta::<BasicComparer<Bytes, CmpOpNullEQ>>(),
-        ScalarFuncSig::NullEQTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpNullEQ>>(),
-        ScalarFuncSig::NullEQDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpNullEQ>>(),
-        ScalarFuncSig::NullEQJson => compare_fn_meta::<BasicComparer<Json, CmpOpNullEQ>>(),
+        ScalarFuncSig::LtInt => map_int_sig(value, children, compare_mapper::<CmpOpLT>)?,
+        ScalarFuncSig::LtReal => compare_fn_meta::<BasicComparer<Real, CmpOpLT>>(),
+        ScalarFuncSig::LtDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpLT>>(),
+        ScalarFuncSig::LtString => compare_fn_meta::<BasicComparer<Bytes, CmpOpLT>>(),
+        ScalarFuncSig::LtTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpLT>>(),
+        ScalarFuncSig::LtDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpLT>>(),
+        ScalarFuncSig::LtJson => compare_fn_meta::<BasicComparer<Json, CmpOpLT>>(),
+        ScalarFuncSig::LeInt => map_int_sig(value, children, compare_mapper::<CmpOpLE>)?,
+        ScalarFuncSig::LeReal => compare_fn_meta::<BasicComparer<Real, CmpOpLE>>(),
+        ScalarFuncSig::LeDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpLE>>(),
+        ScalarFuncSig::LeString => compare_fn_meta::<BasicComparer<Bytes, CmpOpLE>>(),
+        ScalarFuncSig::LeTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpLE>>(),
+        ScalarFuncSig::LeDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpLE>>(),
+        ScalarFuncSig::LeJson => compare_fn_meta::<BasicComparer<Json, CmpOpLE>>(),
+        ScalarFuncSig::GtInt => map_int_sig(value, children, compare_mapper::<CmpOpGT>)?,
+        ScalarFuncSig::GtReal => compare_fn_meta::<BasicComparer<Real, CmpOpGT>>(),
+        ScalarFuncSig::GtDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpGT>>(),
+        ScalarFuncSig::GtString => compare_fn_meta::<BasicComparer<Bytes, CmpOpGT>>(),
+        ScalarFuncSig::GtTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpGT>>(),
+        ScalarFuncSig::GtDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpGT>>(),
+        ScalarFuncSig::GtJson => compare_fn_meta::<BasicComparer<Json, CmpOpGT>>(),
+        ScalarFuncSig::GeInt => map_int_sig(value, children, compare_mapper::<CmpOpGE>)?,
+        ScalarFuncSig::GeReal => compare_fn_meta::<BasicComparer<Real, CmpOpGE>>(),
+        ScalarFuncSig::GeDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpGE>>(),
+        ScalarFuncSig::GeString => compare_fn_meta::<BasicComparer<Bytes, CmpOpGE>>(),
+        ScalarFuncSig::GeTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpGE>>(),
+        ScalarFuncSig::GeDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpGE>>(),
+        ScalarFuncSig::GeJson => compare_fn_meta::<BasicComparer<Json, CmpOpGE>>(),
+        ScalarFuncSig::NeInt => map_int_sig(value, children, compare_mapper::<CmpOpNE>)?,
+        ScalarFuncSig::NeReal => compare_fn_meta::<BasicComparer<Real, CmpOpNE>>(),
+        ScalarFuncSig::NeDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpNE>>(),
+        ScalarFuncSig::NeString => compare_fn_meta::<BasicComparer<Bytes, CmpOpNE>>(),
+        ScalarFuncSig::NeTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpNE>>(),
+        ScalarFuncSig::NeDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpNE>>(),
+        ScalarFuncSig::NeJson => compare_fn_meta::<BasicComparer<Json, CmpOpNE>>(),
+        ScalarFuncSig::EqInt => map_int_sig(value, children, compare_mapper::<CmpOpEQ>)?,
+        ScalarFuncSig::EqReal => compare_fn_meta::<BasicComparer<Real, CmpOpEQ>>(),
+        ScalarFuncSig::EqDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpEQ>>(),
+        ScalarFuncSig::EqString => compare_fn_meta::<BasicComparer<Bytes, CmpOpEQ>>(),
+        ScalarFuncSig::EqTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpEQ>>(),
+        ScalarFuncSig::EqDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpEQ>>(),
+        ScalarFuncSig::EqJson => compare_fn_meta::<BasicComparer<Json, CmpOpEQ>>(),
+        ScalarFuncSig::NullEqInt => map_int_sig(value, children, compare_mapper::<CmpOpNullEQ>)?,
+        ScalarFuncSig::NullEqReal => compare_fn_meta::<BasicComparer<Real, CmpOpNullEQ>>(),
+        ScalarFuncSig::NullEqDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpNullEQ>>(),
+        ScalarFuncSig::NullEqString => compare_fn_meta::<BasicComparer<Bytes, CmpOpNullEQ>>(),
+        ScalarFuncSig::NullEqTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpNullEQ>>(),
+        ScalarFuncSig::NullEqDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpNullEQ>>(),
+        ScalarFuncSig::NullEqJson => compare_fn_meta::<BasicComparer<Json, CmpOpNullEQ>>(),
         ScalarFuncSig::IntIsNull => is_null_fn_meta::<Int>(),
         ScalarFuncSig::RealIsNull => is_null_fn_meta::<Real>(),
         ScalarFuncSig::DecimalIsNull => is_null_fn_meta::<Decimal>(),

--- a/src/coprocessor/dag/rpn_expr/types/expr.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::super::function::RpnFnMeta;
 use crate::coprocessor::codec::data_type::ScalarValue;

--- a/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
+++ b/src/coprocessor/dag/rpn_expr/types/expr_eval.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::expr::{RpnExpression, RpnExpressionNode};
 use super::RpnFnCallExtra;
@@ -283,7 +283,7 @@ mod tests {
 
     use cop_codegen::rpn_fn;
     use cop_datatype::{EvalType, FieldTypeAccessor, FieldTypeTp};
-    use tipb::expression::FieldType;
+    use tipb::FieldType;
     use tipb_helper::ExprDefBuilder;
 
     use crate::coprocessor::codec::batch::LazyBatchColumn;
@@ -306,7 +306,7 @@ mod tests {
         let val = result.unwrap();
         assert!(val.is_scalar());
         assert_eq!(*val.scalar_value().unwrap().as_real(), Real::new(1.5).ok());
-        assert_eq!(val.field_type().tp(), FieldTypeTp::Double);
+        assert_eq!(FieldTypeAccessor::tp(val.field_type()), FieldTypeTp::Double);
     }
 
     /// Creates fixture to be used in `test_eval_single_column_node_xxx`.
@@ -356,7 +356,10 @@ mod tests {
             val.vector_value().unwrap().logical_rows(),
             logical_rows.as_slice()
         );
-        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
+        assert_eq!(
+            FieldTypeAccessor::tp(val.field_type()),
+            FieldTypeTp::LongLong
+        );
 
         let mut c = columns.clone();
         let exp = RpnExpressionBuilder::new().push_column_ref(1).build();
@@ -370,7 +373,7 @@ mod tests {
             [Some(1), Some(5), None, None, Some(42)]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[2, 0, 1]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong as i32);
 
         let mut c = columns.clone();
         let exp = RpnExpressionBuilder::new().push_column_ref(0).build();
@@ -386,7 +389,7 @@ mod tests {
             val.vector_value().unwrap().logical_rows(),
             logical_rows.as_slice()
         );
-        assert_eq!(val.field_type().tp(), FieldTypeTp::Double);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::Double as i32);
     }
 
     /// Single column node but row numbers in `eval()` does not match column length, should panic.
@@ -434,7 +437,7 @@ mod tests {
             [Some(42), Some(42), Some(42), Some(42)]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0, 1, 2, 3]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong as i32);
     }
 
     /// Unary function (argument is scalar)
@@ -464,7 +467,7 @@ mod tests {
             ]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0, 1, 2]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::Double);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::Double as i32);
     }
 
     /// Unary function (argument is vector)
@@ -498,7 +501,7 @@ mod tests {
             [None, Some(6)]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0, 1]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong as i32);
     }
 
     /// Unary function (argument is raw column). The column should be decoded.
@@ -542,7 +545,10 @@ mod tests {
             [Some(8), Some(0), Some(-2)]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0, 1, 2]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
+        assert_eq!(
+            FieldTypeAccessor::tp(val.field_type()),
+            FieldTypeTp::LongLong
+        );
     }
 
     /// Binary function (arguments are scalar, scalar)
@@ -573,7 +579,7 @@ mod tests {
             ]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0, 1, 2]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::Double);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::Double as i32);
     }
 
     /// Binary function (arguments are vector, scalar)
@@ -611,7 +617,7 @@ mod tests {
             ]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0, 1]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::Double);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::Double as i32);
     }
 
     /// Binary function (arguments are scalar, vector)
@@ -649,7 +655,7 @@ mod tests {
             ]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0, 1]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::Double);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::Double as i32);
     }
 
     /// Binary function (arguments are vector, vector)
@@ -700,7 +706,10 @@ mod tests {
             ]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0, 1, 2]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
+        assert_eq!(
+            FieldTypeAccessor::tp(val.field_type()),
+            FieldTypeTp::LongLong
+        );
     }
 
     /// Binary function (arguments are both raw columns). The same column is referred multiple times
@@ -746,7 +755,7 @@ mod tests {
             [Some(49)]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong as i32);
     }
 
     /// Ternary function (arguments are vector, scalar, vector)
@@ -782,7 +791,7 @@ mod tests {
             [Some(-10), Some(-2), Some(8)]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0, 1, 2]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong as i32);
     }
 
     // Comprehensive expression:
@@ -871,7 +880,7 @@ mod tests {
             [Real::new(146.0).ok(), Real::new(25.0).ok(),]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0, 1]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::Double);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::Double as i32);
     }
 
     /// Unary function, but supplied zero arguments. Should panic.
@@ -942,7 +951,8 @@ mod tests {
     /// Parse from an expression tree then evaluate.
     #[test]
     fn test_parse_and_eval() {
-        use tipb::expression::{Expr, ScalarFuncSig};
+        use tipb::Expr;
+        use tipb::ScalarFuncSig;
 
         // We will build an expression tree from:
         //      fn_d(
@@ -1042,7 +1052,7 @@ mod tests {
             [Some(574), Some(-13)]
         );
         assert_eq!(val.vector_value().unwrap().logical_rows(), &[0, 1]);
-        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong);
+        assert_eq!(val.field_type().tp(), FieldTypeTp::LongLong as i32);
     }
 
     #[bench]

--- a/src/coprocessor/dag/rpn_expr/types/function.rs
+++ b/src/coprocessor/dag/rpn_expr/types/function.rs
@@ -93,7 +93,7 @@
 use std::convert::TryFrom;
 
 use cop_datatype::{EvalType, FieldTypeAccessor};
-use tipb::expression::{Expr, FieldType};
+use tipb::{Expr, FieldType};
 
 use super::RpnStackNode;
 use crate::coprocessor::codec::data_type::{Evaluable, ScalarValue, ScalarValueRef, VectorValue};
@@ -291,7 +291,9 @@ impl<E: Evaluator> Evaluator for ArgConstructor<E> {
 
 /// Validates whether the return type of an expression node meets expectation.
 pub fn validate_expr_return_type(expr: &Expr, et: EvalType) -> Result<()> {
-    let received_et = box_try!(EvalType::try_from(expr.get_field_type().tp()));
+    let received_et = box_try!(EvalType::try_from(FieldTypeAccessor::tp(
+        expr.get_field_type()
+    )));
     if et == received_et {
         Ok(())
     } else {

--- a/src/coprocessor/dag/rpn_expr/types/test_util.rs
+++ b/src/coprocessor/dag/rpn_expr/types/test_util.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::{Expr, FieldType, ScalarFuncSig};
+use tipb::{Expr, FieldType, ScalarFuncSig};
 
 use crate::coprocessor::codec::batch::LazyBatchColumnVec;
 use crate::coprocessor::codec::data_type::{Evaluable, ScalarValue};
@@ -89,7 +89,7 @@ impl RpnFnScalarEvaluator {
             .as_ref()
             .iter()
             .map(|expr_node| {
-                let mut ed = Expr::new();
+                let mut ed = Expr::default();
                 ed.set_field_type(expr_node.field_type().clone());
                 ed
             })

--- a/src/coprocessor/dag/scanner.rs
+++ b/src/coprocessor/dag/scanner.rs
@@ -165,7 +165,7 @@ pub mod tests {
 
     use cop_datatype::FieldTypeTp;
     use kvproto::kvrpcpb::IsolationLevel;
-    use tipb::schema::ColumnInfo;
+    use tipb::ColumnInfo;
 
     use super::super::executor::tests::{get_range, new_col_info, TestStore};
     use crate::coprocessor::codec::datum::{self, Datum};
@@ -241,7 +241,7 @@ pub mod tests {
         let start_key = table::encode_row_key(table_id, handle);
         let mut end = start_key.clone();
         util::convert_to_prefix_next(&mut end);
-        let mut key_range = KeyRange::new();
+        let mut key_range = KeyRange::default();
         key_range.set_start(start_key);
         key_range.set_end(end);
         key_range
@@ -258,7 +258,7 @@ pub mod tests {
         ];
         let mut test_store = TestStore::new(&test_data);
         let (snapshot, start_ts) = test_store.get_snapshot();
-        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
+        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::Si, true);
         let range = get_range(table_id, i64::MIN, i64::MAX);
         let mut scanner = Scanner::new(&store, ScanOn::Table, false, false, range).unwrap();
         for &(ref k, ref v) in &test_data {
@@ -276,7 +276,7 @@ pub mod tests {
         let mut data = prepare_table_data(key_number, table_id);
         let mut test_store = TestStore::new(&data.kv_data);
         let (snapshot, start_ts) = test_store.get_snapshot();
-        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
+        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::Si, true);
         let range = get_range(table_id, i64::MIN, i64::MAX);
         let mut scanner = Scanner::new(&store, ScanOn::Table, true, false, range).unwrap();
         data.kv_data.reverse();
@@ -299,7 +299,7 @@ pub mod tests {
         ];
         let mut test_store = TestStore::new(&test_data);
         let (snapshot, start_ts) = test_store.get_snapshot();
-        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
+        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::Si, true);
         let range = get_range(table_id, i64::MIN, i64::MAX);
         let mut scanner = Scanner::new(&store, ScanOn::Table, false, true, range).unwrap();
         let (_, value) = scanner.next_row().unwrap().unwrap();
@@ -321,13 +321,13 @@ pub mod tests {
             .collect();
         let mut test_store = TestStore::new(&test_data);
         let (snapshot, start_ts) = test_store.get_snapshot();
-        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
+        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::Si, true);
 
         // `test_take` is used to take `count` keys from the scanner. It calls `start_scan` at
         // beginning, `stop_scan` in the end, producing a range. the range will be checked against
         // `expect_start_pk` and `expect_end_pk`. Pass -1 as pk means the end.
         let test_take = |scanner: &mut Scanner<_>, count, expect_start_pk, expect_end_pk| {
-            let mut range = KeyRange::new();
+            let mut range = KeyRange::default();
             scanner.start_scan(&mut range);
 
             let mut keys = Vec::new();

--- a/src/coprocessor/error.rs
+++ b/src/coprocessor/error.rs
@@ -27,7 +27,7 @@ quick_error! {
         Full {
             description("Coprocessor end-point thread pool is full")
         }
-        Eval(err: tipb::select::Error) {
+        Eval(err: tipb::Error) {
             from()
             description("eval failed")
             display("Eval error: {}", err.get_msg())
@@ -68,7 +68,7 @@ impl From<storage::txn::Error> for Error {
                 ttl,
                 txn_size,
             }) => {
-                let mut info = kvrpcpb::LockInfo::new();
+                let mut info = kvrpcpb::LockInfo::default();
                 info.set_primary_lock(primary);
                 info.set_lock_version(ts);
                 info.set_key(key);

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -172,7 +172,7 @@ impl ReqContext {
     pub fn default_for_test() -> Self {
         Self::new(
             "test",
-            kvrpcpb::Context::new(),
+            kvrpcpb::Context::default(),
             &[],
             Duration::from_secs(100),
             None,

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -2,8 +2,8 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
-use protobuf::RepeatedField;
-use tipb::analyze;
+
+use tipb;
 
 /// `CMSketch` is used to estimate point queries.
 /// Refer:[Count-Min Sketch](https://en.wikipedia.org/wiki/Count-min_sketch)
@@ -51,13 +51,13 @@ impl CMSketch {
         }
     }
 
-    pub fn into_proto(self) -> analyze::CMSketch {
-        let mut proto = analyze::CMSketch::new();
-        let mut rows = vec![analyze::CMSketchRow::default(); self.depth];
+    pub fn into_proto(self) -> tipb::CmSketch {
+        let mut proto = tipb::CmSketch::default();
+        let mut rows = vec![tipb::CmSketchRow::default(); self.depth];
         for (i, row) in self.table.iter().enumerate() {
             rows[i].set_counters(row.to_vec());
         }
-        proto.set_rows(RepeatedField::from_vec(rows));
+        proto.set_rows(rows);
         proto
     }
 }

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -3,7 +3,7 @@
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
 use tikv_util::collections::HashSet;
-use tipb::analyze;
+use tipb;
 
 /// `FMSketch` is used to count the approximate number of distinct
 /// elements in multiset.
@@ -33,8 +33,8 @@ impl FMSketch {
         self.insert_hash_value(hash);
     }
 
-    pub fn into_proto(self) -> analyze::FMSketch {
-        let mut proto = analyze::FMSketch::new();
+    pub fn into_proto(self) -> tipb::FmSketch {
+        let mut proto = tipb::FmSketch::default();
         proto.set_mask(self.mask);
         let hash = self.hash_set.into_iter().collect();
         proto.set_hashset(hash);

--- a/src/coprocessor/statistics/histogram.rs
+++ b/src/coprocessor/statistics/histogram.rs
@@ -1,8 +1,7 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use protobuf::RepeatedField;
 use std::mem;
-use tipb::analyze;
+use tipb;
 
 /// Bucket is an element of histogram.
 struct Bucket {
@@ -40,8 +39,8 @@ impl Bucket {
         self.repeats = 1;
     }
 
-    fn into_proto(self) -> analyze::Bucket {
-        let mut bucket = analyze::Bucket::new();
+    fn into_proto(self) -> tipb::Bucket {
+        let mut bucket = tipb::Bucket::default();
         bucket.set_repeats(self.repeats as i64);
         bucket.set_count(self.count as i64);
         bucket.set_lower_bound(self.lower_bound);
@@ -72,15 +71,15 @@ impl Histogram {
         }
     }
 
-    pub fn into_proto(self) -> analyze::Histogram {
-        let mut hist = analyze::Histogram::new();
+    pub fn into_proto(self) -> tipb::Histogram {
+        let mut hist = tipb::Histogram::default();
         hist.set_ndv(self.ndv as i64);
-        let buckets: Vec<analyze::Bucket> = self
+        let buckets: Vec<tipb::Bucket> = self
             .buckets
             .into_iter()
             .map(|bucket| bucket.into_proto())
             .collect();
-        hist.set_buckets(RepeatedField::from_vec(buckets));
+        hist.set_buckets(buckets);
         hist
     }
 

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -112,9 +112,9 @@ impl Tracker {
     pub fn get_item_exec_details(&self) -> kvrpcpb::ExecDetails {
         assert_eq!(self.current_stage, TrackerState::ItemFinished);
         let is_slow_query = time::duration_to_sec(self.item_process_time) > SLOW_QUERY_LOWER_BOUND;
-        let mut exec_details = kvrpcpb::ExecDetails::new();
+        let mut exec_details = kvrpcpb::ExecDetails::default();
         if self.req_ctx.context.get_handle_time() || is_slow_query {
-            let mut handle = kvrpcpb::HandleTime::new();
+            let mut handle = kvrpcpb::HandleTime::default();
             handle.set_process_ms((time::duration_to_sec(self.item_process_time) * 1000.0) as i64);
             handle.set_wait_ms((time::duration_to_sec(self.wait_time) * 1000.0) as i64);
             exec_details.set_handle_time(handle);

--- a/src/coprocessor/util.rs
+++ b/src/coprocessor/util.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use kvproto::coprocessor as coppb;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
 
 use crate::coprocessor::codec::datum::Datum;
 
@@ -95,7 +95,7 @@ pub fn is_point(range: &coppb::KeyRange) -> bool {
 pub fn get_pk(col: &ColumnInfo, h: i64) -> Datum {
     use cop_datatype::{FieldTypeAccessor, FieldTypeFlag};
 
-    if col.flag().contains(FieldTypeFlag::UNSIGNED) {
+    if FieldTypeAccessor::flag(col).contains(FieldTypeFlag::UNSIGNED) {
         // PK column is unsigned
         Datum::U64(h as u64)
     } else {

--- a/src/import/sst_importer.rs
+++ b/src/import/sst_importer.rs
@@ -26,7 +26,7 @@ impl SSTImporter {
         })
     }
 
-    pub fn create(&self, meta: &SSTMeta) -> Result<ImportFile> {
+    pub fn create(&self, meta: &SstMeta) -> Result<ImportFile> {
         match self.dir.create(meta) {
             Ok(f) => {
                 info!("create"; "file" => ?f);
@@ -39,7 +39,7 @@ impl SSTImporter {
         }
     }
 
-    pub fn delete(&self, meta: &SSTMeta) -> Result<()> {
+    pub fn delete(&self, meta: &SstMeta) -> Result<()> {
         match self.dir.delete(meta) {
             Ok(path) => {
                 info!("delete"; "path" => ?path);
@@ -52,7 +52,7 @@ impl SSTImporter {
         }
     }
 
-    pub fn ingest(&self, meta: &SSTMeta, db: &DB) -> Result<()> {
+    pub fn ingest(&self, meta: &SstMeta, db: &DB) -> Result<()> {
         match self.dir.ingest(meta, db) {
             Ok(_) => {
                 info!("ingest"; "meta" => ?meta);
@@ -65,7 +65,7 @@ impl SSTImporter {
         }
     }
 
-    pub fn list_ssts(&self) -> Result<Vec<SSTMeta>> {
+    pub fn list_ssts(&self) -> Result<Vec<SstMeta>> {
         self.dir.list_ssts()
     }
 }
@@ -107,7 +107,7 @@ impl ImportDir {
         })
     }
 
-    fn join(&self, meta: &SSTMeta) -> Result<ImportPath> {
+    fn join(&self, meta: &SstMeta) -> Result<ImportPath> {
         let file_name = sst_meta_to_path(meta)?;
         let save_path = self.root_dir.join(&file_name);
         let temp_path = self.temp_dir.join(&file_name);
@@ -119,7 +119,7 @@ impl ImportDir {
         })
     }
 
-    fn create(&self, meta: &SSTMeta) -> Result<ImportFile> {
+    fn create(&self, meta: &SstMeta) -> Result<ImportFile> {
         let path = self.join(meta)?;
         if path.save.exists() {
             return Err(Error::FileExists(path.save));
@@ -127,7 +127,7 @@ impl ImportDir {
         ImportFile::create(meta.clone(), path)
     }
 
-    fn delete(&self, meta: &SSTMeta) -> Result<ImportPath> {
+    fn delete(&self, meta: &SstMeta) -> Result<ImportPath> {
         let path = self.join(meta)?;
         if path.save.exists() {
             fs::remove_file(&path.save)?;
@@ -141,7 +141,7 @@ impl ImportDir {
         Ok(path)
     }
 
-    fn ingest(&self, meta: &SSTMeta, db: &DB) -> Result<()> {
+    fn ingest(&self, meta: &SstMeta, db: &DB) -> Result<()> {
         let path = self.join(meta)?;
         let cf = meta.get_cf_name();
         prepare_sst_for_ingestion(&path.save, &path.clone)?;
@@ -154,7 +154,7 @@ impl ImportDir {
         Ok(())
     }
 
-    fn list_ssts(&self) -> Result<Vec<SSTMeta>> {
+    fn list_ssts(&self) -> Result<Vec<SstMeta>> {
         let mut ssts = Vec::new();
         for e in fs::read_dir(&self.root_dir)? {
             let e = e?;
@@ -195,14 +195,14 @@ impl fmt::Debug for ImportPath {
 
 /// ImportFile is used to handle the writing and verification of SST files.
 pub struct ImportFile {
-    meta: SSTMeta,
+    meta: SstMeta,
     path: ImportPath,
     file: Option<File>,
     digest: crc32::Digest,
 }
 
 impl ImportFile {
-    fn create(meta: SSTMeta, path: ImportPath) -> Result<ImportFile> {
+    fn create(meta: SstMeta, path: ImportPath) -> Result<ImportFile> {
         let file = OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -277,7 +277,7 @@ impl fmt::Debug for ImportFile {
 
 const SST_SUFFIX: &str = ".sst";
 
-fn sst_meta_to_path(meta: &SSTMeta) -> Result<PathBuf> {
+fn sst_meta_to_path(meta: &SstMeta) -> Result<PathBuf> {
     Ok(PathBuf::from(format!(
         "{}_{}_{}_{}{}",
         Uuid::from_bytes(meta.get_uuid())?,
@@ -288,7 +288,7 @@ fn sst_meta_to_path(meta: &SSTMeta) -> Result<PathBuf> {
     )))
 }
 
-fn path_to_sst_meta<P: AsRef<Path>>(path: P) -> Result<SSTMeta> {
+fn path_to_sst_meta<P: AsRef<Path>>(path: P) -> Result<SstMeta> {
     let path = path.as_ref();
     let file_name = match path.file_name().and_then(|n| n.to_str()) {
         Some(name) => name,
@@ -305,7 +305,7 @@ fn path_to_sst_meta<P: AsRef<Path>>(path: P) -> Result<SSTMeta> {
         return Err(Error::InvalidSSTPath(path.to_owned()));
     }
 
-    let mut meta = SSTMeta::new();
+    let mut meta = SstMeta::default();
     let uuid = Uuid::parse_str(elems[0])?;
     meta.set_uuid(uuid.as_bytes().to_vec());
     meta.set_region_id(elems[1].parse()?);
@@ -327,7 +327,7 @@ mod tests {
         let temp_dir = Builder::new().prefix("test_import_dir").tempdir().unwrap();
         let dir = ImportDir::new(temp_dir.path()).unwrap();
 
-        let mut meta = SSTMeta::new();
+        let mut meta = SstMeta::default();
         meta.set_uuid(Uuid::new_v4().as_bytes().to_vec());
 
         let path = dir.join(&meta).unwrap();
@@ -401,7 +401,7 @@ mod tests {
         let data = b"test_data";
         let crc32 = calc_data_crc32(data);
 
-        let mut meta = SSTMeta::new();
+        let mut meta = SstMeta::default();
 
         {
             let mut f = ImportFile::create(meta.clone(), path.clone()).unwrap();
@@ -436,7 +436,7 @@ mod tests {
 
     #[test]
     fn test_sst_meta_to_path() {
-        let mut meta = SSTMeta::new();
+        let mut meta = SstMeta::default();
         let uuid = Uuid::new_v4();
         meta.set_uuid(uuid.as_bytes().to_vec());
         meta.set_region_id(1);

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -9,7 +9,6 @@ use futures::{future, Future, Stream};
 use futures_cpupool::{Builder, CpuPool};
 use grpcio::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
 use kvproto::import_sstpb::*;
-use kvproto::import_sstpb_grpc::*;
 use kvproto::raft_cmdpb::*;
 
 use crate::raftstore::store::Callback;
@@ -82,7 +81,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
 
         ctx.spawn(
             future::result(res)
-                .map(|_| SwitchModeResponse::new())
+                .map(|_| SwitchModeResponse::default())
                 .then(move |res| send_rpc_response!(res, sink, label, timer)),
         )
     }
@@ -132,7 +131,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
                             })
                             .and_then(|mut file| file.finish())
                     })
-                    .map(|_| UploadResponse::new())
+                    .map(|_| UploadResponse::default())
                     .then(move |res| send_rpc_response!(res, sink, label, timer)),
             ),
         )
@@ -153,15 +152,15 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
         let timer = Instant::now_coarse();
 
         // Make ingest command.
-        let mut ingest = Request::new();
-        ingest.set_cmd_type(CmdType::IngestSST);
+        let mut ingest = Request::default();
+        ingest.set_cmd_type(CmdType::IngestSst);
         ingest.mut_ingest_sst().set_sst(req.take_sst());
         let mut context = req.take_context();
-        let mut header = RaftRequestHeader::new();
+        let mut header = RaftRequestHeader::default();
         header.set_peer(context.take_peer());
         header.set_region_id(context.get_region_id());
         header.set_region_epoch(context.take_region_epoch());
-        let mut cmd = RaftCmdRequest::new();
+        let mut cmd = RaftCmdRequest::default();
         cmd.set_header(header);
         cmd.mut_requests().push(ingest);
 
@@ -175,7 +174,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
                 .map_err(Error::from)
                 .then(|res| match res {
                     Ok(mut res) => {
-                        let mut resp = IngestResponse::new();
+                        let mut resp = IngestResponse::default();
                         let mut header = res.response.take_header();
                         if header.has_error() {
                             resp.set_error(header.take_error());
@@ -231,7 +230,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
 
             future::result(res)
                 .map_err(Error::from)
-                .map(|_| CompactResponse::new())
+                .map(|_| CompactResponse::default())
                 .then(move |res| send_rpc_response!(res, sink, label, timer))
         }))
     }

--- a/src/import/test_helpers.rs
+++ b/src/import/test_helpers.rs
@@ -23,7 +23,7 @@ pub fn check_db_range(db: &DB, range: (u8, u8)) {
     }
 }
 
-pub fn gen_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SSTMeta, Vec<u8>) {
+pub fn gen_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SstMeta, Vec<u8>) {
     let env_opt = EnvOptions::new();
     let cf_opt = ColumnFamilyOptions::new();
     let mut w = SstFileWriter::new(env_opt, cf_opt);
@@ -38,11 +38,11 @@ pub fn gen_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SSTMeta, Vec<u
     read_sst_file(path, range)
 }
 
-pub fn read_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SSTMeta, Vec<u8>) {
+pub fn read_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SstMeta, Vec<u8>) {
     let data = fs::read(path).unwrap();
     let crc32 = calc_data_crc32(&data);
 
-    let mut meta = SSTMeta::new();
+    let mut meta = SstMeta::default();
     meta.set_uuid(Uuid::new_v4().as_bytes().to_vec());
     meta.mut_range().set_start(vec![range.0]);
     meta.mut_range().set_end(vec![range.1]);

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -10,7 +10,6 @@ use futures::{future, Future, Sink, Stream};
 use grpcio::{CallOption, EnvBuilder, WriteFlags};
 use kvproto::metapb;
 use kvproto::pdpb::{self, Member};
-use protobuf::RepeatedField;
 
 use super::metrics::*;
 use super::util::{check_resp_header, sync_request, validate_endpoints, Inner, LeaderClient};
@@ -63,7 +62,7 @@ impl RpcClient {
 
     /// Creates a new request header.
     fn header(&self) -> pdpb::RequestHeader {
-        let mut header = pdpb::RequestHeader::new();
+        let mut header = pdpb::RequestHeader::default();
         header.set_cluster_id(self.cluster_id);
         header
     }
@@ -88,7 +87,7 @@ impl RpcClient {
             .with_label_values(&["get_region"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetRegionRequest::new();
+        let mut req = pdpb::GetRegionRequest::default();
         req.set_header(self.header());
         req.set_region_key(key.to_vec());
 
@@ -132,7 +131,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["bootstrap_cluster"])
             .start_coarse_timer();
 
-        let mut req = pdpb::BootstrapRequest::new();
+        let mut req = pdpb::BootstrapRequest::default();
         req.set_header(self.header());
         req.set_store(stores);
         req.set_region(region);
@@ -149,7 +148,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["is_cluster_bootstrapped"])
             .start_coarse_timer();
 
-        let mut req = pdpb::IsBootstrappedRequest::new();
+        let mut req = pdpb::IsBootstrappedRequest::default();
         req.set_header(self.header());
 
         let resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
@@ -165,7 +164,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["alloc_id"])
             .start_coarse_timer();
 
-        let mut req = pdpb::AllocIDRequest::new();
+        let mut req = pdpb::AllocIdRequest::default();
         req.set_header(self.header());
 
         let resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
@@ -181,7 +180,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["put_store"])
             .start_coarse_timer();
 
-        let mut req = pdpb::PutStoreRequest::new();
+        let mut req = pdpb::PutStoreRequest::default();
         req.set_header(self.header());
         req.set_store(store);
 
@@ -198,7 +197,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["get_store"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetStoreRequest::new();
+        let mut req = pdpb::GetStoreRequest::default();
         req.set_header(self.header());
         req.set_store_id(store_id);
 
@@ -220,7 +219,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["get_all_stores"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetAllStoresRequest::new();
+        let mut req = pdpb::GetAllStoresRequest::default();
         req.set_header(self.header());
         req.set_exclude_tombstone_stores(exclude_tombstone);
 
@@ -229,7 +228,7 @@ impl PdClient for RpcClient {
         })?;
         check_resp_header(resp.get_header())?;
 
-        Ok(resp.take_stores().into_vec())
+        Ok(resp.take_stores())
     }
 
     fn get_cluster_config(&self) -> Result<metapb::Cluster> {
@@ -237,7 +236,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["get_cluster_config"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetClusterConfigRequest::new();
+        let mut req = pdpb::GetClusterConfigRequest::default();
         req.set_header(self.header());
 
         let mut resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
@@ -260,11 +259,11 @@ impl PdClient for RpcClient {
     fn get_region_by_id(&self, region_id: u64) -> PdFuture<Option<metapb::Region>> {
         let timer = Instant::now();
 
-        let mut req = pdpb::GetRegionByIDRequest::new();
+        let mut req = pdpb::GetRegionByIdRequest::default();
         req.set_header(self.header());
         req.set_region_id(region_id);
 
-        let executor = move |client: &RwLock<Inner>, req: pdpb::GetRegionByIDRequest| {
+        let executor = move |client: &RwLock<Inner>, req: pdpb::GetRegionByIdRequest| {
             let handler = client
                 .rl()
                 .client
@@ -296,19 +295,19 @@ impl PdClient for RpcClient {
     ) -> PdFuture<()> {
         PD_HEARTBEAT_COUNTER_VEC.with_label_values(&["send"]).inc();
 
-        let mut req = pdpb::RegionHeartbeatRequest::new();
+        let mut req = pdpb::RegionHeartbeatRequest::default();
         req.set_header(self.header());
         req.set_region(region);
         req.set_leader(leader);
-        req.set_down_peers(RepeatedField::from_vec(region_stat.down_peers));
-        req.set_pending_peers(RepeatedField::from_vec(region_stat.pending_peers));
+        req.set_down_peers(region_stat.down_peers);
+        req.set_pending_peers(region_stat.pending_peers);
         req.set_bytes_written(region_stat.written_bytes);
         req.set_keys_written(region_stat.written_keys);
         req.set_bytes_read(region_stat.read_bytes);
         req.set_keys_read(region_stat.read_keys);
         req.set_approximate_size(region_stat.approximate_size);
         req.set_approximate_keys(region_stat.approximate_keys);
-        let mut interval = pdpb::TimeInterval::new();
+        let mut interval = pdpb::TimeInterval::default();
         interval.set_start_timestamp(region_stat.last_report_ts);
         interval.set_end_timestamp(time_now_sec());
         req.set_interval(interval);
@@ -364,7 +363,7 @@ impl PdClient for RpcClient {
     fn ask_split(&self, region: metapb::Region) -> PdFuture<pdpb::AskSplitResponse> {
         let timer = Instant::now();
 
-        let mut req = pdpb::AskSplitRequest::new();
+        let mut req = pdpb::AskSplitRequest::default();
         req.set_header(self.header());
         req.set_region(region);
 
@@ -395,7 +394,7 @@ impl PdClient for RpcClient {
     ) -> PdFuture<pdpb::AskBatchSplitResponse> {
         let timer = Instant::now();
 
-        let mut req = pdpb::AskBatchSplitRequest::new();
+        let mut req = pdpb::AskBatchSplitRequest::default();
         req.set_header(self.header());
         req.set_region(region);
         req.set_split_count(count as u32);
@@ -423,7 +422,7 @@ impl PdClient for RpcClient {
     fn store_heartbeat(&self, mut stats: pdpb::StoreStats) -> PdFuture<()> {
         let timer = Instant::now();
 
-        let mut req = pdpb::StoreHeartbeatRequest::new();
+        let mut req = pdpb::StoreHeartbeatRequest::default();
         req.set_header(self.header());
         stats.mut_interval().set_end_timestamp(time_now_sec());
         req.set_stats(stats);
@@ -450,9 +449,9 @@ impl PdClient for RpcClient {
     fn report_batch_split(&self, regions: Vec<metapb::Region>) -> PdFuture<()> {
         let timer = Instant::now();
 
-        let mut req = pdpb::ReportBatchSplitRequest::new();
+        let mut req = pdpb::ReportBatchSplitRequest::default();
         req.set_header(self.header());
-        req.set_regions(RepeatedField::from_vec(regions));
+        req.set_regions(regions);
 
         let executor = move |client: &RwLock<Inner>, req: pdpb::ReportBatchSplitRequest| {
             let handler = client
@@ -479,7 +478,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["scatter_region"])
             .start_coarse_timer();
 
-        let mut req = pdpb::ScatterRegionRequest::new();
+        let mut req = pdpb::ScatterRegionRequest::default();
         req.set_header(self.header());
         req.set_region_id(region.get_id());
         if let Some(leader) = region.leader.take() {
@@ -500,10 +499,10 @@ impl PdClient for RpcClient {
     fn get_gc_safe_point(&self) -> PdFuture<u64> {
         let timer = Instant::now();
 
-        let mut req = pdpb::GetGCSafePointRequest::new();
+        let mut req = pdpb::GetGcSafePointRequest::default();
         req.set_header(self.header());
 
-        let executor = move |client: &RwLock<Inner>, req: pdpb::GetGCSafePointRequest| {
+        let executor = move |client: &RwLock<Inner>, req: pdpb::GetGcSafePointRequest| {
             let option = CallOption::default().timeout(Duration::from_secs(REQUEST_TIMEOUT));
             let handler = client
                 .rl()
@@ -529,7 +528,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["get_store"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetStoreRequest::new();
+        let mut req = pdpb::GetStoreRequest::default();
         req.set_header(self.header());
         req.set_store_id(store_id);
 
@@ -551,7 +550,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["get_operator"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetOperatorRequest::new();
+        let mut req = pdpb::GetOperatorRequest::default();
         req.set_header(self.header());
         req.set_region_id(region_id);
 

--- a/src/pd/pd.rs
+++ b/src/pd/pd.rs
@@ -15,7 +15,6 @@ use kvproto::pdpb;
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, RaftCmdRequest, SplitRequest};
 use kvproto::raft_serverpb::RaftMessage;
 use prometheus::local::LocalHistogram;
-use protobuf::RepeatedField;
 use raft::eraftpb::ConfChangeType;
 
 use super::metrics::*;
@@ -283,7 +282,7 @@ impl<T: PdClient> Runner<T> {
 
                         let req = new_batch_split_region_request(
                             split_keys,
-                            resp.take_ids().into_vec(),
+                            resp.take_ids(),
                             right_derive,
                         );
                         let region_id = region.get_id();
@@ -417,7 +416,7 @@ impl<T: PdClient> Runner<T> {
         stats.set_keys_read(
             self.store_stat.engine_total_keys_read - self.store_stat.engine_last_total_keys_read,
         );
-        let mut interval = pdpb::TimeInterval::new();
+        let mut interval = pdpb::TimeInterval::default();
         interval.set_start_timestamp(self.store_stat.last_report_ts);
         stats.set_interval(interval);
         self.store_stat.engine_last_total_bytes_read = self.store_stat.engine_total_bytes_read;
@@ -741,7 +740,7 @@ impl<T: PdClient> Runnable<Task> for Runner<T> {
 }
 
 fn new_change_peer_request(change_type: ConfChangeType, peer: metapb::Peer) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::ChangePeer);
     req.mut_change_peer().set_change_type(change_type);
     req.mut_change_peer().set_peer(peer);
@@ -754,7 +753,7 @@ fn new_split_region_request(
     peer_ids: Vec<u64>,
     right_derive: bool,
 ) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::Split);
     req.mut_split().set_split_key(split_key);
     req.mut_split().set_new_region_id(new_region_id);
@@ -765,34 +764,33 @@ fn new_split_region_request(
 
 fn new_batch_split_region_request(
     split_keys: Vec<Vec<u8>>,
-    ids: Vec<pdpb::SplitID>,
+    ids: Vec<pdpb::SplitId>,
     right_derive: bool,
 ) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::BatchSplit);
     req.mut_splits().set_right_derive(right_derive);
     let mut requests = Vec::with_capacity(ids.len());
     for (mut id, key) in ids.into_iter().zip(split_keys) {
-        let mut split = SplitRequest::new();
+        let mut split = SplitRequest::default();
         split.set_split_key(key);
         split.set_new_region_id(id.get_new_region_id());
         split.set_new_peer_ids(id.take_new_peer_ids());
         requests.push(split);
     }
-    req.mut_splits()
-        .set_requests(RepeatedField::from_vec(requests));
+    req.mut_splits().set_requests(requests);
     req
 }
 
 fn new_transfer_leader_request(peer: metapb::Peer) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::TransferLeader);
     req.mut_transfer_leader().set_peer(peer);
     req
 }
 
 fn new_merge_request(merge: pdpb::Merge) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::PrepareMerge);
     req.mut_prepare_merge()
         .set_target(merge.get_target().to_owned());
@@ -809,7 +807,7 @@ fn send_admin_request(
 ) {
     let cmd_type = request.get_cmd_type();
 
-    let mut req = RaftCmdRequest::new();
+    let mut req = RaftCmdRequest::default();
     req.mut_header().set_region_id(region_id);
     req.mut_header().set_region_epoch(epoch);
     req.mut_header().set_peer(peer);
@@ -848,7 +846,7 @@ fn send_destroy_peer_message(
     peer: metapb::Peer,
     pd_region: metapb::Region,
 ) {
-    let mut message = RaftMessage::new();
+    let mut message = RaftMessage::default();
     message.set_region_id(local_region.get_id());
     message.set_from_peer(peer.clone());
     message.set_to_peer(peer.clone());

--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -16,10 +16,9 @@ use grpcio::{
     Result as GrpcResult,
 };
 use kvproto::pdpb::{
-    ErrorType, GetMembersRequest, GetMembersResponse, Member, RegionHeartbeatRequest,
+    ErrorType, GetMembersRequest, GetMembersResponse, Member, PdClient, RegionHeartbeatRequest,
     RegionHeartbeatResponse, ResponseHeader,
 };
-use kvproto::pdpb_grpc::PdClient;
 use tokio_timer::timer::Handle;
 
 use super::{Config, Error, PdFuture, Result, REQUEST_TIMEOUT};
@@ -405,7 +404,7 @@ fn connect(
     let channel = security_mgr.connect(cb, addr);
     let client = PdClient::new(channel);
     let option = CallOption::default().timeout(Duration::from_secs(REQUEST_TIMEOUT));
-    match client.get_members_opt(&GetMembersRequest::new(), option) {
+    match client.get_members_opt(&GetMembersRequest::default(), option) {
         Ok(resp) => Ok((client, resp)),
         Err(e) => Err(Error::Grpc(e)),
     }
@@ -469,12 +468,12 @@ pub fn check_resp_header(header: &ResponseHeader) -> Result<()> {
     }
     let err = header.get_error();
     match err.get_field_type() {
-        ErrorType::ALREADY_BOOTSTRAPPED => Err(Error::ClusterBootstrapped(header.get_cluster_id())),
-        ErrorType::NOT_BOOTSTRAPPED => Err(Error::ClusterNotBootstrapped(header.get_cluster_id())),
-        ErrorType::INCOMPATIBLE_VERSION => Err(Error::Incompatible),
-        ErrorType::STORE_TOMBSTONE => Err(Error::StoreTombstone(err.get_message().to_owned())),
-        ErrorType::REGION_NOT_FOUND => Err(Error::RegionNotFound(vec![])),
-        ErrorType::UNKNOWN => Err(box_err!(err.get_message())),
-        ErrorType::OK => Ok(()),
+        ErrorType::AlreadyBootstrapped => Err(Error::ClusterBootstrapped(header.get_cluster_id())),
+        ErrorType::NotBootstrapped => Err(Error::ClusterNotBootstrapped(header.get_cluster_id())),
+        ErrorType::IncompatibleVersion => Err(Error::Incompatible),
+        ErrorType::StoreTombstone => Err(Error::StoreTombstone(err.get_message().to_owned())),
+        ErrorType::RegionNotFound => Err(Error::RegionNotFound(vec![])),
+        ErrorType::Unknown => Err(box_err!(err.get_message())),
+        ErrorType::Ok => Ok(()),
     }
 }

--- a/src/raftstore/coprocessor/mod.rs
+++ b/src/raftstore/coprocessor/mod.rs
@@ -4,7 +4,6 @@ use engine::rocks::DB;
 use kvproto::metapb::Region;
 use kvproto::pdpb::CheckPolicy;
 use kvproto::raft_cmdpb::{AdminRequest, AdminResponse, Request, Response};
-use protobuf::RepeatedField;
 use raft::StateRole;
 
 pub mod config;
@@ -72,11 +71,7 @@ pub trait QueryObserver: Coprocessor {
     /// Hook to call before proposing write request.
     ///
     /// We don't propose read request, hence there is no hook for it yet.
-    fn pre_propose_query(
-        &self,
-        _: &mut ObserverContext<'_>,
-        _: &mut RepeatedField<Request>,
-    ) -> Result<()> {
+    fn pre_propose_query(&self, _: &mut ObserverContext<'_>, _: &mut Vec<Request>) -> Result<()> {
         Ok(())
     }
 
@@ -84,7 +79,7 @@ pub trait QueryObserver: Coprocessor {
     fn pre_apply_query(&self, _: &mut ObserverContext<'_>, _: &[Request]) {}
 
     /// Hook to call after applying write request.
-    fn post_apply_query(&self, _: &mut ObserverContext<'_>, _: &mut RepeatedField<Response>) {}
+    fn post_apply_query(&self, _: &mut ObserverContext<'_>, _: &mut Vec<Response>) {}
 }
 
 /// SplitChecker is invoked during a split check scan, and decides to use

--- a/src/raftstore/coprocessor/split_check/half.rs
+++ b/src/raftstore/coprocessor/split_check/half.rs
@@ -205,9 +205,9 @@ mod tests {
             .collect();
         let engine = Arc::new(new_engine_opt(path_str, db_opts, cfs_opts).unwrap());
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(1);
-        region.mut_peers().push(Peer::new());
+        region.mut_peers().push(Peer::default());
         region.mut_region_epoch().set_version(2);
         region.mut_region_epoch().set_conf_ver(5);
 
@@ -232,14 +232,14 @@ mod tests {
         runnable.run(SplitCheckTask::new(
             region.clone(),
             false,
-            CheckPolicy::SCAN,
+            CheckPolicy::Scan,
         ));
         let split_key = Key::from_raw(b"0005");
         must_split_at(&rx, &region, vec![split_key.clone().into_encoded()]);
         runnable.run(SplitCheckTask::new(
             region.clone(),
             false,
-            CheckPolicy::APPROXIMATE,
+            CheckPolicy::Approximate,
         ));
         must_split_at(&rx, &region, vec![split_key.into_encoded()]);
     }
@@ -274,8 +274,8 @@ mod tests {
             engine.flush_cf(cf_handle, true).unwrap();
         }
 
-        let mut region = Region::new();
-        region.mut_peers().push(Peer::new());
+        let mut region = Region::default();
+        region.mut_peers().push(Peer::default());
         let middle_key = get_region_approximate_middle_cf(&engine, CF_DEFAULT, &region)
             .unwrap()
             .unwrap();

--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -278,11 +278,11 @@ mod tests {
             .collect();
         let engine = Arc::new(new_engine_opt(path_str, db_opts, cfs_opts).unwrap());
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(1);
         region.set_start_key(vec![]);
         region.set_end_key(vec![]);
-        region.mut_peers().push(Peer::new());
+        region.mut_peers().push(Peer::default());
         region.mut_region_epoch().set_version(2);
         region.mut_region_epoch().set_conf_ver(5);
 
@@ -300,7 +300,7 @@ mod tests {
 
         // so split key will be z0080
         put_data(&engine, 0, 90, false);
-        runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::SCAN));
+        runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::Scan));
         // keys has not reached the max_keys 100 yet.
         match rx.try_recv() {
             Ok((region_id, CasualMessage::RegionApproximateSize { .. }))
@@ -311,7 +311,7 @@ mod tests {
         }
 
         put_data(&engine, 90, 160, true);
-        runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::SCAN));
+        runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::Scan));
         must_split_at(
             &rx,
             &region,
@@ -319,7 +319,7 @@ mod tests {
         );
 
         put_data(&engine, 160, 300, false);
-        runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::SCAN));
+        runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::Scan));
         must_split_at(
             &rx,
             &region,
@@ -331,7 +331,7 @@ mod tests {
         );
 
         put_data(&engine, 300, 500, false);
-        runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::SCAN));
+        runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::Scan));
         must_split_at(
             &rx,
             &region,
@@ -346,7 +346,7 @@ mod tests {
 
         drop(rx);
         // It should be safe even the result can't be sent back.
-        runnable.run(SplitCheckTask::new(region, true, CheckPolicy::SCAN));
+        runnable.run(SplitCheckTask::new(region, true, CheckPolicy::Scan));
     }
 
     #[test]
@@ -381,8 +381,8 @@ mod tests {
             db.flush_cf(default_cf, true).unwrap();
         }
 
-        let mut region = Region::new();
-        region.mut_peers().push(Peer::new());
+        let mut region = Region::default();
+        region.mut_peers().push(Peer::default());
         let range_keys = get_region_approximate_keys(&db, &region).unwrap();
         assert_eq!(range_keys, cases.len() as u64);
     }

--- a/src/raftstore/coprocessor/split_check/mod.rs
+++ b/src/raftstore/coprocessor/split_check/mod.rs
@@ -47,11 +47,11 @@ impl Host {
 
     pub fn policy(&self) -> CheckPolicy {
         for checker in &self.checkers {
-            if checker.policy() == CheckPolicy::APPROXIMATE {
-                return CheckPolicy::APPROXIMATE;
+            if checker.policy() == CheckPolicy::Approximate {
+                return CheckPolicy::Approximate;
             }
         }
-        CheckPolicy::SCAN
+        CheckPolicy::Scan
     }
 
     /// Hook to call for every check during split.

--- a/src/raftstore/coprocessor/split_check/table.rs
+++ b/src/raftstore/coprocessor/split_check/table.rs
@@ -258,9 +258,9 @@ mod tests {
             Arc::new(new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap());
         let write_cf = engine.cf_handle(CF_WRITE).unwrap();
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(1);
-        region.mut_peers().push(Peer::new());
+        region.mut_peers().push(Peer::default());
 
         // arbitrary padding.
         let padding = b"_r00000005";
@@ -313,9 +313,9 @@ mod tests {
             Arc::new(new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap());
         let write_cf = engine.cf_handle(CF_WRITE).unwrap();
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(1);
-        region.mut_peers().push(Peer::new());
+        region.mut_peers().push(Peer::default());
         region.mut_region_epoch().set_version(2);
         region.mut_region_epoch().set_conf_ver(5);
 
@@ -342,7 +342,7 @@ mod tests {
             for (encoded_start_key, encoded_end_key, table_id) in cases {
                 region.set_start_key(encoded_start_key.unwrap_or_else(Vec::new));
                 region.set_end_key(encoded_end_key.unwrap_or_else(Vec::new));
-                runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::SCAN));
+                runnable.run(SplitCheckTask::new(region.clone(), true, CheckPolicy::Scan));
 
                 if let Some(id) = table_id {
                     let key = Key::from_raw(&gen_table_prefix(id));

--- a/src/raftstore/coprocessor/split_observer.rs
+++ b/src/raftstore/coprocessor/split_observer.rs
@@ -7,7 +7,7 @@ use tikv_util::codec::bytes::{self, encode_bytes};
 use crate::raftstore::store::util;
 use kvproto::metapb::Region;
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, SplitRequest};
-use protobuf::RepeatedField;
+
 use std::result::Result as StdResult;
 
 /// `SplitObserver` adjusts the split key so that it won't separate
@@ -144,7 +144,7 @@ impl AdminObserver for SplitObserver {
                             .to_owned()
                     ));
                 }
-                let mut requests = req.mut_splits().take_requests().into_vec();
+                let mut requests = req.mut_splits().take_requests();
                 if let Err(e) = self.on_split(ctx, &mut requests) {
                     error!(
                         "failed to handle split req";
@@ -153,8 +153,7 @@ impl AdminObserver for SplitObserver {
                     );
                     return Err(box_err!(e));
                 }
-                req.mut_splits()
-                    .set_requests(RepeatedField::from_vec(requests));
+                req.mut_splits().set_requests(requests);
             }
             _ => return Ok(()),
         }
@@ -174,19 +173,19 @@ mod tests {
     use tikv_util::codec::bytes::encode_bytes;
 
     fn new_split_request(key: &[u8]) -> AdminRequest {
-        let mut req = AdminRequest::new();
+        let mut req = AdminRequest::default();
         req.set_cmd_type(AdminCmdType::Split);
-        let mut split_req = SplitRequest::new();
+        let mut split_req = SplitRequest::default();
         split_req.set_split_key(key.to_vec());
         req.set_split(split_req);
         req
     }
 
     fn new_batch_split_request(keys: Vec<Vec<u8>>) -> AdminRequest {
-        let mut req = AdminRequest::new();
+        let mut req = AdminRequest::default();
         req.set_cmd_type(AdminCmdType::BatchSplit);
         for key in keys {
-            let mut split_req = SplitRequest::new();
+            let mut split_req = SplitRequest::default();
             split_req.set_split_key(key);
             req.mut_splits().mut_requests().push(split_req);
         }
@@ -212,7 +211,7 @@ mod tests {
     fn test_forget_encode() {
         let region_start_key = new_row_key(256, 1, 0);
         let key = new_row_key(256, 2, 0);
-        let mut r = Region::new();
+        let mut r = Region::default();
         r.set_id(10);
         r.set_start_key(region_start_key);
 
@@ -232,11 +231,11 @@ mod tests {
 
     #[test]
     fn test_split() {
-        let mut region = Region::new();
+        let mut region = Region::default();
         let start_key = new_row_key(1, 1, 1);
         region.set_start_key(start_key.clone());
         let mut ctx = ObserverContext::new(&region);
-        let mut req = AdminRequest::new();
+        let mut req = AdminRequest::default();
 
         let observer = SplitObserver;
 

--- a/src/raftstore/store/bootstrap.rs
+++ b/src/raftstore/store/bootstrap.rs
@@ -15,7 +15,7 @@ use kvproto::metapb;
 use kvproto::raft_serverpb::{RegionLocalState, StoreIdent};
 
 pub fn initial_region(store_id: u64, region_id: u64, peer_id: u64) -> metapb::Region {
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(region_id);
     region.set_start_key(keys::EMPTY_KEY.to_vec());
     region.set_end_key(keys::EMPTY_KEY.to_vec());
@@ -38,7 +38,7 @@ fn is_range_empty(engine: &DB, cf: &str, start_key: &[u8], end_key: &[u8]) -> Re
 
 // Bootstrap the store, the DB for this store must be empty and has no data.
 pub fn bootstrap_store(engines: &Engines, cluster_id: u64, store_id: u64) -> Result<()> {
-    let mut ident = StoreIdent::new();
+    let mut ident = StoreIdent::default();
 
     if !is_range_empty(&engines.kv, CF_DEFAULT, keys::MIN_KEY, keys::MAX_KEY)? {
         return Err(box_err!("kv store is not empty and has already had data."));
@@ -62,7 +62,7 @@ pub fn bootstrap_store(engines: &Engines, cluster_id: u64, store_id: u64) -> Res
 ///
 /// Write the first region meta and prepare state.
 pub fn prepare_bootstrap_cluster(engines: &Engines, region: &metapb::Region) -> Result<()> {
-    let mut state = RegionLocalState::new();
+    let mut state = RegionLocalState::default();
     state.set_region(region.clone());
 
     let wb = WriteBatch::new();

--- a/src/raftstore/store/cmd_resp.rs
+++ b/src/raftstore/store/cmd_resp.rs
@@ -18,7 +18,7 @@ pub fn bind_error(resp: &mut RaftCmdResponse, err: Error) {
 }
 
 pub fn new_error(err: Error) -> RaftCmdResponse {
-    let mut resp = RaftCmdResponse::new();
+    let mut resp = RaftCmdResponse::default();
     bind_error(&mut resp, err);
     resp
 }

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -15,7 +15,7 @@ use engine::CF_RAFT;
 use engine::{Peekable, Snapshot as EngineSnapshot};
 use futures::Future;
 use kvproto::errorpb;
-use kvproto::import_sstpb::SSTMeta;
+use kvproto::import_sstpb::SstMeta;
 use kvproto::metapb::{self, Region, RegionEpoch};
 use kvproto::pdpb::CheckPolicy;
 use kvproto::raft_cmdpb::{
@@ -25,7 +25,7 @@ use kvproto::raft_cmdpb::{
 use kvproto::raft_serverpb::{
     MergeState, PeerState, RaftMessage, RaftSnapshotData, RaftTruncatedState, RegionLocalState,
 };
-use protobuf::{Message, RepeatedField};
+use prost::Message;
 use raft::eraftpb::{ConfChangeType, MessageType};
 use raft::{self, SnapshotStatus, INVALID_INDEX, NO_LIMIT};
 use raft::{Ready, StateRole};
@@ -107,10 +107,10 @@ impl Drop for PeerFsm {
                 _ => continue,
             };
 
-            let mut err = errorpb::Error::new();
+            let mut err = errorpb::Error::default();
             err.set_message("region is not found".to_owned());
             err.mut_region_not_found().set_region_id(self.region_id());
-            let mut resp = RaftCmdResponse::new();
+            let mut resp = RaftCmdResponse::default();
             resp.mut_header().set_error(err);
             callback.invoke_with_response(resp);
         }
@@ -178,7 +178,7 @@ impl PeerFsm {
             "peer_id" => peer.get_id(),
         );
 
-        let mut region = metapb::Region::new();
+        let mut region = metapb::Region::default();
         region.set_id(region_id);
 
         let (tx, rx) = mpsc::loose_bounded(cfg.notify_capacity);
@@ -1191,8 +1191,8 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         let region_id = msg.get_region_id();
         let snap = msg.get_message().get_snapshot();
         let key = SnapKey::from_region_snap(region_id, snap);
-        let mut snap_data = RaftSnapshotData::new();
-        snap_data.merge_from_bytes(snap.get_data())?;
+        let mut snap_data = RaftSnapshotData::default();
+        snap_data.merge(snap.get_data())?;
         let snap_region = snap_data.take_region();
         let peer_id = msg.get_to_peer().get_id();
         let snap_enc_start_key = enc_start_key(&snap_region);
@@ -1787,15 +1787,13 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             request
                 .mut_header()
                 .set_region_epoch(sibling_region.get_region_epoch().clone());
-            let mut admin = AdminRequest::new();
+            let mut admin = AdminRequest::default();
             admin.set_cmd_type(AdminCmdType::CommitMerge);
             admin
                 .mut_commit_merge()
                 .set_source(self.fsm.peer.region().clone());
             admin.mut_commit_merge().set_commit(state.get_commit());
-            admin
-                .mut_commit_merge()
-                .set_entries(RepeatedField::from_vec(entries));
+            admin.mut_commit_merge().set_entries(entries);
             request.set_admin_request(admin);
             (request, target_id)
         };
@@ -1819,7 +1817,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             request
                 .mut_header()
                 .set_region_epoch(self.fsm.peer.region().get_region_epoch().clone());
-            let mut admin = AdminRequest::new();
+            let mut admin = AdminRequest::default();
             admin.set_cmd_type(AdminCmdType::RollbackMerge);
             admin.mut_rollback_merge().set_commit(state.get_commit());
             request.set_admin_request(admin);
@@ -2332,7 +2330,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         // doesn't matter whether the peer is a leader or not. If it's not a leader, the proposing
         // command log entry can't be committed.
 
-        let mut resp = RaftCmdResponse::new();
+        let mut resp = RaftCmdResponse::default();
         let term = self.fsm.peer.term();
         bind_term(&mut resp, term);
         if self.fsm.peer.propose(self.ctx, cb, msg, resp) {
@@ -2513,7 +2511,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         {
             return;
         }
-        let task = SplitCheckTask::new(self.fsm.peer.region().clone(), true, CheckPolicy::SCAN);
+        let task = SplitCheckTask::new(self.fsm.peer.region().clone(), true, CheckPolicy::Scan);
         if let Err(e) = self.ctx.split_check_scheduler.schedule(task) {
             error!(
                 "failed to schedule split check";
@@ -2836,7 +2834,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         self.propose_raft_command(req, Callback::None);
     }
 
-    fn on_ingest_sst_result(&mut self, ssts: Vec<SSTMeta>) {
+    fn on_ingest_sst_result(&mut self, ssts: Vec<SstMeta>) {
         for sst in &ssts {
             self.fsm.peer.size_diff_hint += sst.get_length();
         }
@@ -2955,7 +2953,7 @@ pub fn maybe_destroy_source(
 }
 
 pub fn new_admin_request(region_id: u64, peer: metapb::Peer) -> RaftCmdRequest {
-    let mut request = RaftCmdRequest::new();
+    let mut request = RaftCmdRequest::default();
     request.mut_header().set_region_id(region_id);
     request.mut_header().set_peer(peer);
     request
@@ -2968,7 +2966,7 @@ fn new_verify_hash_request(
 ) -> RaftCmdRequest {
     let mut request = new_admin_request(region_id, peer);
 
-    let mut admin = AdminRequest::new();
+    let mut admin = AdminRequest::default();
     admin.set_cmd_type(AdminCmdType::VerifyHash);
     admin.mut_verify_hash().set_index(state.index);
     admin.mut_verify_hash().set_hash(state.hash.clone());
@@ -2984,7 +2982,7 @@ fn new_compact_log_request(
 ) -> RaftCmdRequest {
     let mut request = new_admin_request(region_id, peer);
 
-    let mut admin = AdminRequest::new();
+    let mut admin = AdminRequest::default();
     admin.set_cmd_type(AdminCmdType::CompactLog);
     admin.mut_compact_log().set_compact_index(compact_index);
     admin.mut_compact_log().set_compact_term(compact_term);
@@ -3007,7 +3005,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         }?;
         response.set_cmd_type(cmd_type);
 
-        let mut resp = RaftCmdResponse::new();
+        let mut resp = RaftCmdResponse::default();
         resp.set_status_response(response);
         // Bind peer current term here.
         bind_term(&mut resp, self.fsm.peer.term());
@@ -3015,7 +3013,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
     }
 
     fn execute_region_leader(&mut self) -> Result<StatusResponse> {
-        let mut resp = StatusResponse::new();
+        let mut resp = StatusResponse::default();
         if let Some(leader) = self.fsm.peer.get_peer_from_cache(self.fsm.peer.leader_id()) {
             resp.mut_region_leader().set_leader(leader);
         }
@@ -3028,7 +3026,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             let region_id = request.get_header().get_region_id();
             return Err(Error::RegionNotInitialized(region_id));
         }
-        let mut resp = StatusResponse::new();
+        let mut resp = StatusResponse::default();
         resp.mut_region_detail()
             .set_region(self.fsm.peer.region().clone());
         if let Some(leader) = self.fsm.peer.get_peer_from_cache(self.fsm.peer.leader_id()) {

--- a/src/raftstore/store/keys.rs
+++ b/src/raftstore/store/keys.rs
@@ -359,12 +359,12 @@ mod tests {
         assert!(validate_data_key(&data_key(b"abc")));
         assert!(!validate_data_key(b"abc"));
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         // uninitialised region should not be passed in `enc_start_key` and `enc_end_key`.
         assert!(::panic_hook::recover_safe(|| enc_start_key(&region)).is_err());
         assert!(::panic_hook::recover_safe(|| enc_end_key(&region)).is_err());
 
-        region.mut_peers().push(Peer::new());
+        region.mut_peers().push(Peer::default());
         assert_eq!(enc_start_key(&region), vec![DATA_PREFIX]);
         assert_eq!(enc_end_key(&region), vec![DATA_PREFIX + 1]);
 

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::time::Instant;
 
-use kvproto::import_sstpb::SSTMeta;
+use kvproto::import_sstpb::SstMeta;
 use kvproto::metapb;
 use kvproto::metapb::RegionEpoch;
 use kvproto::pdpb::CheckPolicy;
@@ -334,7 +334,7 @@ pub enum StoreMsg {
     SnapshotStats,
 
     ValidateSSTResult {
-        invalid_ssts: Vec<SSTMeta>,
+        invalid_ssts: Vec<SstMeta>,
     },
 
     // Clear region size and keys for all regions in the range, so we can force them to re-calculate

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -2,6 +2,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
+use std::convert::TryFrom;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::sync::Arc;
@@ -18,7 +19,7 @@ use kvproto::metapb::{self, Region};
 use kvproto::raft_serverpb::{
     MergeState, PeerState, RaftApplyState, RaftLocalState, RaftSnapshotData, RegionLocalState,
 };
-use protobuf::Message;
+use prost::Message;
 use raft::eraftpb::{ConfState, Entry, HardState, Snapshot};
 use raft::{self, Error as RaftError, RaftState, Ready, Storage, StorageError};
 
@@ -122,7 +123,11 @@ impl EntryCache {
             .take_while(|e| {
                 let cur_idx = end_idx as u64 + cache_low;
                 assert_eq!(e.get_index(), cur_idx);
-                let m = u64::from(e.compute_size());
+                // `try_from` will only fail if we have 128 bit usize and e is larger
+                // than u64::MAX. We currently only support 64 bits, and even if we
+                // did support 128, the chance of a protobuf message being longer than
+                // u64::MAX bytes long is small.
+                let m = u64::try_from(e.encoded_len()).unwrap();
                 fetched_size += m;
                 if fetched_size == m {
                     end_idx += 1;
@@ -345,7 +350,7 @@ pub fn recover_from_applying_state(
     let raft_state_key = keys::raft_state_key(region_id);
     let raft_state: RaftLocalState = match box_try!(engines.raft.get_msg(&raft_state_key)) {
         Some(state) => state,
-        None => RaftLocalState::new(),
+        None => RaftLocalState::default(),
     };
 
     // if we recv append log when applying snapshot, last_index in raft_local_state will
@@ -365,7 +370,7 @@ pub fn init_raft_state(engines: &Engines, region: &Region) -> Result<RaftLocalSt
     Ok(match engines.raft.get_msg(&state_key)? {
         Some(s) => s,
         None => {
-            let mut raft_state = RaftLocalState::new();
+            let mut raft_state = RaftLocalState::default();
             if !region.get_peers().is_empty() {
                 // new split region
                 raft_state.set_last_index(RAFT_INIT_LOG_INDEX);
@@ -386,7 +391,7 @@ pub fn init_apply_state(engines: &Engines, region: &Region) -> Result<RaftApplyS
         {
             Some(s) => s,
             None => {
-                let mut apply_state = RaftApplyState::new();
+                let mut apply_state = RaftApplyState::default();
                 if !region.get_peers().is_empty() {
                     apply_state.set_applied_index(RAFT_INIT_LOG_INDEX);
                     let state = apply_state.mut_truncated_state();
@@ -524,7 +529,7 @@ impl PeerStorage {
 
     pub fn initial_state(&self) -> raft::Result<RaftState> {
         let hard_state = self.raft_state.get_hard_state().clone();
-        if hard_state == HardState::new() {
+        if hard_state == HardState::default() {
             assert!(
                 !self.is_initialized(),
                 "peer for region {:?} is initialized but local state {:?} has empty hard \
@@ -701,8 +706,8 @@ impl PeerStorage {
             return false;
         }
 
-        let mut snap_data = RaftSnapshotData::new();
-        if let Err(e) = snap_data.merge_from_bytes(snap.get_data()) {
+        let mut snap_data = RaftSnapshotData::default();
+        if let Err(e) = snap_data.merge(snap.get_data()) {
             error!(
                 "failed to decode snapshot, it may be corrupted";
                 "region_id" => self.region.get_id(),
@@ -906,8 +911,8 @@ impl PeerStorage {
             "peer_id" => self.peer_id,
         );
 
-        let mut snap_data = RaftSnapshotData::new();
-        snap_data.merge_from_bytes(snap.get_data())?;
+        let mut snap_data = RaftSnapshotData::default();
+        snap_data.merge(snap.get_data())?;
 
         let region_id = self.get_region_id();
 
@@ -1245,8 +1250,8 @@ pub fn fetch_entries_to(
             match engine.get(&key) {
                 Ok(None) => return Err(RaftError::Store(StorageError::Unavailable)),
                 Ok(Some(v)) => {
-                    let mut entry = Entry::new();
-                    entry.merge_from_bytes(&v)?;
+                    let mut entry = Entry::default();
+                    entry.merge(&*v)?;
                     assert_eq!(entry.get_index(), i);
                     total_size += v.len() as u64;
                     if buf.is_empty() || total_size <= max_size {
@@ -1269,8 +1274,8 @@ pub fn fetch_entries_to(
         &end_key,
         true, // fill_cache
         |_, value| {
-            let mut entry = Entry::new();
-            entry.merge_from_bytes(value)?;
+            let mut entry = Entry::default();
+            entry.merge(value)?;
 
             // May meet gap or has been compacted.
             if entry.get_index() != next_index {
@@ -1395,7 +1400,7 @@ pub fn do_snapshot(
         )));
     }
 
-    let mut snapshot = Snapshot::new();
+    let mut snapshot = Snapshot::default();
 
     // Set snapshot metadata.
     snapshot.mut_metadata().set_index(key.idx);
@@ -1406,7 +1411,7 @@ pub fn do_snapshot(
 
     let mut s = mgr.get_snapshot_for_building(&key)?;
     // Set snapshot data.
-    let mut snap_data = RaftSnapshotData::new();
+    let mut snap_data = RaftSnapshotData::default();
     snap_data.set_region(state.get_region().clone());
     let mut stat = SnapshotStatistics::new();
     s.build(
@@ -1417,7 +1422,7 @@ pub fn do_snapshot(
         Box::new(mgr.clone()),
     )?;
     let mut v = vec![];
-    snap_data.write_to_vec(&mut v)?;
+    snap_data.encode(&mut v)?;
     snapshot.set_data(v);
 
     SNAPSHOT_KV_COUNT_HISTOGRAM.observe(stat.kv_count as f64);
@@ -1428,7 +1433,7 @@ pub fn do_snapshot(
 
 // When we bootstrap the region we must call this to initialize region local state first.
 pub fn write_initial_raft_state<T: Mutable>(raft_wb: &T, region_id: u64) -> Result<()> {
-    let mut raft_state = RaftLocalState::new();
+    let mut raft_state = RaftLocalState::default();
     raft_state.set_last_index(RAFT_INIT_LOG_INDEX);
     raft_state.mut_hard_state().set_term(RAFT_INIT_LOG_TERM);
     raft_state.mut_hard_state().set_commit(RAFT_INIT_LOG_INDEX);
@@ -1444,7 +1449,7 @@ pub fn write_initial_apply_state<T: Mutable>(
     kv_wb: &T,
     region_id: u64,
 ) -> Result<()> {
-    let mut apply_state = RaftApplyState::new();
+    let mut apply_state = RaftApplyState::default();
     apply_state.set_applied_index(RAFT_INIT_LOG_INDEX);
     apply_state
         .mut_truncated_state()
@@ -1466,7 +1471,7 @@ pub fn write_peer_state<T: Mutable>(
     merge_state: Option<MergeState>,
 ) -> Result<()> {
     let region_id = region.get_id();
-    let mut region_state = RegionLocalState::new();
+    let mut region_state = RegionLocalState::default();
     region_state.set_state(state);
     region_state.set_region(region.clone());
     if let Some(state) = merge_state {
@@ -1568,9 +1573,9 @@ pub fn maybe_upgrade_from_2_to_3(
                 let raft_state_key = keys::raft_state_key(region_id);
                 let raft_state = raft_engine
                     .get_msg(&raft_state_key)?
-                    .unwrap_or_else(RaftLocalState::new);
-                let mut snapshot_raft_state = RaftLocalState::new();
-                box_try!(snapshot_raft_state.merge_from_bytes(value));
+                    .unwrap_or_else(RaftLocalState::default);
+                let mut snapshot_raft_state = RaftLocalState::default();
+                box_try!(snapshot_raft_state.merge(value));
                 // if we recv append log when applying snapshot, last_index in
                 // raft_local_state will larger than snapshot_index. since
                 // raft_local_state is written to raft engine, and raft
@@ -1738,21 +1743,21 @@ mod tests {
         for e in exp_ents {
             let key = keys::raft_log_key(store.get_region_id(), e.get_index());
             let bytes = store.engines.raft.get(&key).unwrap().unwrap();
-            let mut entry = Entry::new();
-            entry.merge_from_bytes(&bytes).unwrap();
+            let mut entry = Entry::default();
+            entry.merge(&*bytes).unwrap();
             assert_eq!(entry, *e);
         }
     }
 
     fn new_entry(index: u64, term: u64) -> Entry {
-        let mut e = Entry::new();
+        let mut e = Entry::default();
         e.set_index(index);
         e.set_term(term);
         e
     }
 
-    fn size_of<T: protobuf::Message>(m: &T) -> u32 {
-        m.compute_size()
+    fn size_of<T: Message>(m: &T) -> usize {
+        m.encoded_len()
     }
 
     #[test]
@@ -1873,26 +1878,26 @@ mod tests {
             (
                 4,
                 7,
-                u64::from(size_of(&ents[1]) + size_of(&ents[2])),
+                (size_of(&ents[1]) + size_of(&ents[2])) as u64,
                 Ok(vec![new_entry(4, 4), new_entry(5, 5)]),
             ),
             (
                 4,
                 7,
-                u64::from(size_of(&ents[1]) + size_of(&ents[2]) + size_of(&ents[3]) / 2),
+                (size_of(&ents[1]) + size_of(&ents[2]) + size_of(&ents[3]) / 2) as u64,
                 Ok(vec![new_entry(4, 4), new_entry(5, 5)]),
             ),
             (
                 4,
                 7,
-                u64::from(size_of(&ents[1]) + size_of(&ents[2]) + size_of(&ents[3]) - 1),
+                (size_of(&ents[1]) + size_of(&ents[2]) + size_of(&ents[3]) - 1) as u64,
                 Ok(vec![new_entry(4, 4), new_entry(5, 5)]),
             ),
             // all
             (
                 4,
                 7,
-                u64::from(size_of(&ents[1]) + size_of(&ents[2]) + size_of(&ents[3])),
+                (size_of(&ents[1]) + size_of(&ents[2]) + size_of(&ents[3])) as u64,
                 Ok(vec![new_entry(4, 4), new_entry(5, 5), new_entry(6, 6)]),
             ),
         ];
@@ -1947,7 +1952,7 @@ mod tests {
     #[test]
     fn test_storage_create_snapshot() {
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
-        let mut cs = ConfState::new();
+        let mut cs = ConfState::default();
         cs.set_nodes(vec![1, 2, 3]);
 
         let td = Builder::new().prefix("tikv-store-test").tempdir().unwrap();
@@ -1975,8 +1980,7 @@ mod tests {
         assert_eq!(snap.get_metadata().get_term(), 5);
         assert!(!snap.get_data().is_empty());
 
-        let mut data = RaftSnapshotData::new();
-        protobuf::Message::merge_from_bytes(&mut data, snap.get_data()).unwrap();
+        let data: RaftSnapshotData = Message::decode(snap.get_data()).unwrap();
         assert_eq!(data.get_region().get_id(), 1);
         assert_eq!(data.get_region().get_peers().len(), 1);
 
@@ -2011,7 +2015,7 @@ mod tests {
             &mut ready_ctx,
         )
         .unwrap();
-        let mut hs = HardState::new();
+        let mut hs = HardState::default();
         hs.set_commit(7);
         hs.set_term(5);
         ctx.raft_state.set_hard_state(hs);
@@ -2150,12 +2154,15 @@ mod tests {
         // size limit should be supported correctly.
         res = store.entries(4, 8, 0).unwrap();
         assert_eq!(res, vec![new_entry(4, 4)]);
-        let mut size = ents[1..].iter().map(|e| u64::from(e.compute_size())).sum();
+        let mut size = ents[1..]
+            .iter()
+            .map(|e| u64::try_from(e.encoded_len()).unwrap())
+            .sum();
         res = store.entries(4, 8, size).unwrap();
         let mut exp_res = ents[1..].to_vec();
         assert_eq!(res, exp_res);
         for e in &entries {
-            size += u64::from(e.compute_size());
+            size += u64::try_from(e.encoded_len()).unwrap();
             exp_res.push(e.clone());
             res = store.entries(4, 8, size).unwrap();
             assert_eq!(res, exp_res);
@@ -2264,7 +2271,7 @@ mod tests {
             new_entry(5, 5),
             new_entry(6, 6),
         ];
-        let mut cs = ConfState::new();
+        let mut cs = ConfState::default();
         cs.set_nodes(vec![1, 2, 3]);
 
         let td1 = Builder::new().prefix("tikv-store-test").tempdir().unwrap();
@@ -2429,16 +2436,16 @@ mod tests {
         let mut tbl = vec![];
 
         // Do not sync empty entrise.
-        tbl.push((Entry::new(), false));
+        tbl.push((Entry::default(), false));
 
         // Sync if sync_log is set.
-        let mut e = Entry::new();
+        let mut e = Entry::default();
         e.set_sync_log(true);
         tbl.push((e, true));
 
         // Sync if context is marked sync.
         let context = ProposalContext::SYNC_LOG.to_vec();
-        let mut e = Entry::new();
+        let mut e = Entry::default();
         e.set_context(context);
         tbl.push((e.clone(), true));
 

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -394,8 +394,8 @@ mod tests {
     }
 
     fn load_default_dataset(engines: Engines) -> (PeerStorage, DataSet) {
-        let mut r = Region::new();
-        r.mut_peers().push(Peer::new());
+        let mut r = Region::default();
+        r.mut_peers().push(Peer::default());
         r.set_id(10);
         r.set_start_key(b"a2".to_vec());
         r.set_end_key(b"a7".to_vec());
@@ -416,8 +416,8 @@ mod tests {
     }
 
     fn load_multiple_levels_dataset(engines: Engines) -> (PeerStorage, DataSet) {
-        let mut r = Region::new();
-        r.mut_peers().push(Peer::new());
+        let mut r = Region::default();
+        r.mut_peers().push(Peer::default());
         r.set_id(10);
         r.set_start_key(b"a04".to_vec());
         r.set_end_key(b"a15".to_vec());
@@ -463,7 +463,7 @@ mod tests {
     fn test_peekable() {
         let path = Builder::new().prefix("test-raftstore").tempdir().unwrap();
         let engines = new_temp_engine(&path);
-        let mut r = Region::new();
+        let mut r = Region::default();
         r.set_id(10);
         r.set_start_key(b"key0".to_vec());
         r.set_end_key(b"key4".to_vec());
@@ -633,8 +633,8 @@ mod tests {
         assert_eq!(res, base_data[1..3].to_vec());
 
         // test last region
-        let mut region = Region::new();
-        region.mut_peers().push(Peer::new());
+        let mut region = Region::default();
+        region.mut_peers().push(Peer::default());
         let store = new_peer_storage(engines.clone(), &region);
         let snap = RegionSnapshot::new(&store);
         data.clear();
@@ -734,8 +734,8 @@ mod tests {
         assert_eq!(res, expect);
 
         // test last region
-        let mut region = Region::new();
-        region.mut_peers().push(Peer::new());
+        let mut region = Region::default();
+        region.mut_peers().push(Peer::default());
         let store = new_peer_storage(engines, &region);
         let snap = RegionSnapshot::new(&store);
         let it = snap.iter(IterOption::default());
@@ -815,13 +815,13 @@ mod tests {
         let cache = cfg.storage.block_cache.build_shared_cache();
         cfg.rocksdb.titan.enabled = true;
         cfg.rocksdb.titan.purge_obsolete_files_period = ReadableDuration::secs(1);
-        cfg.rocksdb.defaultcf.disable_auto_compactions = true;
+        cfg.rocksdb.new_cf.disable_auto_compactions = true;
         // Disable dynamic_level_bytes, otherwise SST files would be ingested to L0.
-        cfg.rocksdb.defaultcf.dynamic_level_bytes = false;
-        cfg.rocksdb.defaultcf.titan.min_gc_batch_size = ReadableSize(0);
-        cfg.rocksdb.defaultcf.titan.discardable_ratio = 0.4;
-        cfg.rocksdb.defaultcf.titan.sample_ratio = 1.0;
-        cfg.rocksdb.defaultcf.titan.min_blob_size = ReadableSize(0);
+        cfg.rocksdb.new_cf.dynamic_level_bytes = false;
+        cfg.rocksdb.new_cf.titan.min_gc_batch_size = ReadableSize(0);
+        cfg.rocksdb.new_cf.titan.discardable_ratio = 0.4;
+        cfg.rocksdb.new_cf.titan.sample_ratio = 1.0;
+        cfg.rocksdb.new_cf.titan.min_blob_size = ReadableSize(0);
         let kv_db_opts = cfg.rocksdb.build_opt();
         let kv_cfs_opts = cfg.rocksdb.build_cf_opts(&cache);
 
@@ -1037,8 +1037,8 @@ mod tests {
         .unwrap();
 
         // Do scan on other DB.
-        let mut r = Region::new();
-        r.mut_peers().push(Peer::new());
+        let mut r = Region::default();
+        r.mut_peers().push(Peer::default());
         r.set_start_key(b"a".to_vec());
         r.set_end_key(b"z".to_vec());
         let snapshot = RegionSnapshot::from_raw(Arc::clone(&engines1.kv), r);

--- a/src/raftstore/store/worker/cleanup_sst.rs
+++ b/src/raftstore/store/worker/cleanup_sst.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::sync::Arc;
 
-use kvproto::import_sstpb::SSTMeta;
+use kvproto::import_sstpb::SstMeta;
 
 use crate::import::SSTImporter;
 use crate::pd::PdClient;
@@ -12,8 +12,8 @@ use crate::raftstore::store::{StoreMsg, StoreRouter};
 use tikv_util::worker::Runnable;
 
 pub enum Task {
-    DeleteSST { ssts: Vec<SSTMeta> },
-    ValidateSST { ssts: Vec<SSTMeta> },
+    DeleteSST { ssts: Vec<SstMeta> },
+    ValidateSST { ssts: Vec<SstMeta> },
 }
 
 impl fmt::Display for Task {
@@ -48,14 +48,14 @@ impl<C: PdClient, S: StoreRouter> Runner<C, S> {
     }
 
     /// Deletes SST files from the importer.
-    fn handle_delete_sst(&self, ssts: Vec<SSTMeta>) {
+    fn handle_delete_sst(&self, ssts: Vec<SstMeta>) {
         for sst in &ssts {
             let _ = self.importer.delete(sst);
         }
     }
 
     /// Validates whether the SST is stale or not.
-    fn handle_validate_sst(&self, ssts: Vec<SSTMeta>) {
+    fn handle_validate_sst(&self, ssts: Vec<SstMeta>) {
         let store_id = self.store_id;
         let mut invalid_ssts = Vec::new();
         for sst in ssts {

--- a/src/raftstore/store/worker/consistency_check.rs
+++ b/src/raftstore/store/worker/consistency_check.rs
@@ -168,8 +168,8 @@ mod tests {
         .unwrap();
         let db = Arc::new(db);
 
-        let mut region = Region::new();
-        region.mut_peers().push(Peer::new());
+        let mut region = Region::default();
+        region.mut_peers().push(Peer::default());
 
         let (tx, rx) = mpsc::sync_channel(100);
         let mut runner = Runner::new(tx);

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -186,7 +186,7 @@ impl<C: ProposalRouter> LocalReader<C> {
     fn redirect(&self, mut cmd: RaftCommand) {
         debug!("localreader redirects command"; "tag" => &self.tag, "command" => ?cmd);
         let region_id = cmd.request.get_header().get_region_id();
-        let mut err = errorpb::Error::new();
+        let mut err = errorpb::Error::default();
         match self.router.send(cmd) {
             Ok(()) => return,
             Err(TrySendError::Full(c)) => {
@@ -204,7 +204,7 @@ impl<C: ProposalRouter> LocalReader<C> {
             }
         }
 
-        let mut resp = RaftCmdResponse::new();
+        let mut resp = RaftCmdResponse::default();
         resp.mut_header().set_error(err);
         let read_resp = ReadResponse {
             response: resp,
@@ -369,7 +369,7 @@ impl<C: ProposalRouter> LocalReader<C> {
                     | CmdType::Put
                     | CmdType::DeleteRange
                     | CmdType::Prewrite
-                    | CmdType::IngestSST
+                    | CmdType::IngestSst
                     | CmdType::ReadIndex
                     | CmdType::Invalid => return false,
                 }
@@ -589,7 +589,7 @@ mod tests {
         pr_ids
             .into_iter()
             .map(|id| {
-                let mut pr = metapb::Peer::new();
+                let mut pr = metapb::Peer::default();
                 pr.set_store_id(store_id);
                 pr.set_id(id);
                 pr
@@ -638,12 +638,12 @@ mod tests {
         // from "" to "",
         // epoch 1, 1,
         // term 6.
-        let mut region1 = metapb::Region::new();
+        let mut region1 = metapb::Region::default();
         region1.set_id(1);
         let prs = new_peers(store_id, vec![2, 3, 4]);
         region1.set_peers(prs.clone().into());
         let epoch13 = {
-            let mut ep = metapb::RegionEpoch::new();
+            let mut ep = metapb::RegionEpoch::default();
             ep.set_conf_ver(1);
             ep.set_version(3);
             ep
@@ -653,14 +653,14 @@ mod tests {
         let term6 = 6;
         let mut lease = Lease::new(Duration::seconds(1)); // 1s is long enough.
 
-        let mut cmd = RaftCmdRequest::new();
-        let mut header = RaftRequestHeader::new();
+        let mut cmd = RaftCmdRequest::default();
+        let mut header = RaftRequestHeader::default();
         header.set_region_id(1);
         header.set_peer(leader2.clone());
         header.set_region_epoch(epoch13.clone());
         header.set_term(term6);
         cmd.set_header(header);
-        let mut req = Request::new();
+        let mut req = Request::default();
         req.set_cmd_type(CmdType::Snap);
         cmd.set_requests(vec![req].into());
 

--- a/src/raftstore/store/worker/split_check.rs
+++ b/src/raftstore/store/worker/split_check.rs
@@ -188,7 +188,7 @@ impl<S: CasualRouter> Runner<S> {
         }
 
         let split_keys = match host.policy() {
-            CheckPolicy::SCAN => {
+            CheckPolicy::Scan => {
                 match self.scan_split_keys(&mut host, region, &start_key, &end_key) {
                     Ok(keys) => keys,
                     Err(e) => {
@@ -197,7 +197,7 @@ impl<S: CasualRouter> Runner<S> {
                     }
                 }
             }
-            CheckPolicy::APPROXIMATE => match host.approximate_split_keys(region, &self.engine) {
+            CheckPolicy::Approximate => match host.approximate_split_keys(region, &self.engine) {
                 Ok(keys) => keys
                     .into_iter()
                     .map(|k| keys::origin_key(&k).to_vec())

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -15,11 +15,11 @@ use engine::rocks::{
 };
 use engine::{self, Engines, IterOption, Iterable, Mutable, Peekable};
 use engine::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
-use kvproto::debugpb::{self, DB as DBType, *};
+use kvproto::debugpb::{self, Db as DBType, Module};
 use kvproto::kvrpcpb::{MvccInfo, MvccLock, MvccValue, MvccWrite, Op};
 use kvproto::metapb::{Peer, Region};
 use kvproto::raft_serverpb::*;
-use protobuf::{self, Message, RepeatedField};
+use prost::Message;
 use raft::eraftpb::Entry;
 use raft::{self, RawNode};
 
@@ -162,8 +162,8 @@ impl Debugger {
 
     fn get_db_from_type(&self, db: DBType) -> Result<&DB> {
         match db {
-            DBType::KV => Ok(&self.engines.kv),
-            DBType::RAFT => Ok(&self.engines.raft),
+            DBType::Kv => Ok(&self.engines.kv),
+            DBType::Raft => Ok(&self.engines.raft),
             _ => Err(box_err!("invalid DBType type")),
         }
     }
@@ -475,7 +475,7 @@ impl Debugger {
         let fake_snap_worker = Worker::new("fake-snap-worker");
 
         let check_value = |value: Vec<u8>| -> Result<()> {
-            let local_state = box_try!(protobuf::parse_from_bytes::<RegionLocalState>(&value));
+            let local_state: RegionLocalState = box_try!(::prost::Message::decode(&value));
             match local_state.get_state() {
                 PeerState::Tombstone | PeerState::Applying => return Ok(()),
                 _ => {}
@@ -563,8 +563,8 @@ impl Debugger {
                     return Ok(());
                 }
 
-                let mut region_state = RegionLocalState::new();
-                box_try!(region_state.merge_from_bytes(value));
+                let mut region_state = RegionLocalState::default();
+                box_try!(region_state.merge(value));
                 if region_state.get_state() == PeerState::Tombstone {
                     return Ok(());
                 }
@@ -581,9 +581,7 @@ impl Debugger {
                     "new_peers" => ?new_peers,
                 );
                 // We need to leave epoch untouched to avoid inconsistency.
-                region_state
-                    .mut_region()
-                    .set_peers(RepeatedField::from_vec(new_peers));
+                region_state.mut_region().set_peers(new_peers);
                 box_try!(wb.put_msg_cf(handle, key, &region_state));
                 Ok(())
             };
@@ -640,8 +638,8 @@ impl Debugger {
                     return Ok(true);
                 }
 
-                let mut region_state = RegionLocalState::new();
-                box_try!(region_state.merge_from_bytes(value));
+                let mut region_state = RegionLocalState::default();
+                box_try!(region_state.merge(value));
                 if region_state.get_state() == PeerState::Tombstone {
                     return Ok(true);
                 }
@@ -662,7 +660,7 @@ impl Debugger {
         ));
 
         // RegionLocalState.
-        let mut region_state = RegionLocalState::new();
+        let mut region_state = RegionLocalState::default();
         region_state.set_state(PeerState::Normal);
         region_state.set_region(region);
         let key = keys::region_state_key(region_id);
@@ -726,13 +724,14 @@ impl Debugger {
 
     pub fn modify_tikv_config(
         &self,
-        module: MODULE,
+        module: Module,
         config_name: &str,
         config_value: &str,
     ) -> Result<()> {
         use super::CONFIG_ROCKSDB_GAUGE;
+
         match module {
-            MODULE::STORAGE => {
+            Module::Storage => {
                 if config_name != "block_cache.capacity" {
                     return Err(Error::InvalidArgument(format!(
                         "bad argument: {}",
@@ -748,13 +747,13 @@ impl Debugger {
                 // the size through any of them. Here we change it through default CF in kvdb.
                 // A better way to do it is to hold the cache reference somewhere, and use it to
                 // change cache size.
-                self.modify_block_cache_size(DBType::KV, CF_DEFAULT, config_value)
+                self.modify_block_cache_size(DBType::Kv, CF_DEFAULT, config_value)
             }
-            MODULE::KVDB | MODULE::RAFTDB => {
-                let db = if module == MODULE::KVDB {
-                    DBType::KV
+            Module::Kvdb | Module::Raftdb => {
+                let db = if module == Module::Kvdb {
+                    DBType::Kv
                 } else {
-                    DBType::RAFT
+                    DBType::Raft
                 };
                 let rocksdb = self.get_db_from_type(db)?;
                 let vec: Vec<&str> = config_name.split('.').collect();
@@ -1207,10 +1206,10 @@ impl MvccInfoIterator {
             let lock = box_try!(Lock::parse(&value));
             let mut lock_info = MvccLock::default();
             match lock.lock_type {
-                LockType::Put => lock_info.set_field_type(Op::Put),
-                LockType::Delete => lock_info.set_field_type(Op::Del),
-                LockType::Lock => lock_info.set_field_type(Op::Lock),
-                LockType::Pessimistic => lock_info.set_field_type(Op::PessimisticLock),
+                LockType::Put => lock_info.set_field_type_(Op::Put),
+                LockType::Delete => lock_info.set_field_type_(Op::Del),
+                LockType::Lock => lock_info.set_field_type_(Op::Lock),
+                LockType::Pessimistic => lock_info.set_field_type_(Op::PessimisticLock),
             }
             lock_info.set_start_ts(lock.ts);
             lock_info.set_primary(lock.primary);
@@ -1220,7 +1219,7 @@ impl MvccInfoIterator {
         Ok(None)
     }
 
-    fn next_default(&mut self) -> Result<Option<(Vec<u8>, RepeatedField<MvccValue>)>> {
+    fn next_default(&mut self) -> Result<Option<(Vec<u8>, Vec<MvccValue>)>> {
         if let Some((prefix, vec_kv)) = Self::next_grouped(&mut self.default_iter) {
             let mut values = Vec::with_capacity(vec_kv.len());
             for (key, value) in vec_kv {
@@ -1230,22 +1229,22 @@ impl MvccInfoIterator {
                 value_info.set_value(value);
                 values.push(value_info);
             }
-            return Ok(Some((prefix, RepeatedField::from_vec(values))));
+            return Ok(Some((prefix, values)));
         }
         Ok(None)
     }
 
-    fn next_write(&mut self) -> Result<Option<(Vec<u8>, RepeatedField<MvccWrite>)>> {
+    fn next_write(&mut self) -> Result<Option<(Vec<u8>, Vec<MvccWrite>)>> {
         if let Some((prefix, vec_kv)) = Self::next_grouped(&mut self.write_iter) {
             let mut writes = Vec::with_capacity(vec_kv.len());
             for (key, value) in vec_kv {
                 let write = box_try!(Write::parse(&value));
                 let mut write_info = MvccWrite::default();
                 match write.write_type {
-                    WriteType::Put => write_info.set_field_type(Op::Put),
-                    WriteType::Delete => write_info.set_field_type(Op::Del),
-                    WriteType::Lock => write_info.set_field_type(Op::Lock),
-                    WriteType::Rollback => write_info.set_field_type(Op::Rollback),
+                    WriteType::Put => write_info.set_field_type_(Op::Put),
+                    WriteType::Delete => write_info.set_field_type_(Op::Del),
+                    WriteType::Lock => write_info.set_field_type_(Op::Lock),
+                    WriteType::Rollback => write_info.set_field_type_(Op::Rollback),
                 }
                 write_info.set_start_ts(write.start_ts);
                 let commit_ts = box_try!(Key::decode_ts_from(keys::origin_key(&key)));
@@ -1253,7 +1252,7 @@ impl MvccInfoIterator {
                 write_info.set_short_value(write.short_value.unwrap_or_default());
                 writes.push(write_info);
             }
-            return Ok(Some((prefix, RepeatedField::from_vec(writes))));
+            return Ok(Some((prefix, writes)));
         }
         Ok(None)
     }
@@ -1275,7 +1274,7 @@ impl MvccInfoIterator {
             return Ok(None);
         }
 
-        let mut mvcc_info = MvccInfo::new();
+        let mut mvcc_info = MvccInfo::default();
         let mut min_prefix = Vec::new();
 
         let (lock_ok, writes_ok) = match (self.lock_iter.valid(), self.write_iter.valid()) {
@@ -1341,11 +1340,11 @@ impl Iterator for MvccInfoIterator {
 
 fn validate_db_and_cf(db: DBType, cf: &str) -> Result<()> {
     match (db, cf) {
-        (DBType::KV, CF_DEFAULT)
-        | (DBType::KV, CF_WRITE)
-        | (DBType::KV, CF_LOCK)
-        | (DBType::KV, CF_RAFT)
-        | (DBType::RAFT, CF_DEFAULT) => Ok(()),
+        (DBType::Kv, CF_DEFAULT)
+        | (DBType::Kv, CF_WRITE)
+        | (DBType::Kv, CF_LOCK)
+        | (DBType::Kv, CF_RAFT)
+        | (DBType::Raft, CF_DEFAULT) => Ok(()),
         _ => Err(Error::InvalidArgument(format!(
             "invalid cf {:?} for db {:?}",
             cf, db
@@ -1404,8 +1403,8 @@ fn set_region_tombstone(db: &DB, store_id: u64, region: Region, wb: &WriteBatch)
 
 fn divide_db(db: &DB, parts: usize) -> crate::raftstore::Result<Vec<Vec<u8>>> {
     // Empty start and end key cover all range.
-    let mut region = Region::new();
-    region.mut_peers().push(Peer::new());
+    let mut region = Region::default();
+    region.mut_peers().push(Peer::default());
     let default_cf_size = box_try!(get_region_approximate_keys_cf(db, CF_DEFAULT, &region));
     let write_cf_size = box_try!(get_region_approximate_keys_cf(db, CF_WRITE, &region));
 
@@ -1475,7 +1474,6 @@ fn divide_db_cf(db: &DB, parts: usize, cf: &str) -> crate::raftstore::Result<Vec
 
 #[cfg(test)]
 mod tests {
-    use std::iter::FromIterator;
     use std::sync::Arc;
 
     use engine::rocks::{ColumnFamilyOptions, DBOptions, Writable};
@@ -1492,15 +1490,15 @@ mod tests {
 
     fn init_region_state(engine: &DB, region_id: u64, stores: &[u64]) -> Region {
         let cf_raft = engine.cf_handle(CF_RAFT).unwrap();
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(region_id);
         for (i, &store_id) in stores.iter().enumerate() {
-            let mut peer = Peer::new();
+            let mut peer = Peer::default();
             peer.set_id(i as u64);
             peer.set_store_id(store_id);
             region.mut_peers().push(peer);
         }
-        let mut region_state = RegionLocalState::new();
+        let mut region_state = RegionLocalState::default();
         region_state.set_state(PeerState::Normal);
         region_state.set_region(region.clone());
         let key = keys::region_state_key(region_id);
@@ -1561,22 +1559,22 @@ mod tests {
     #[test]
     fn test_validate_db_and_cf() {
         let valid_cases = vec![
-            (DBType::KV, CF_DEFAULT),
-            (DBType::KV, CF_WRITE),
-            (DBType::KV, CF_LOCK),
-            (DBType::KV, CF_RAFT),
-            (DBType::RAFT, CF_DEFAULT),
+            (DBType::Kv, CF_DEFAULT),
+            (DBType::Kv, CF_WRITE),
+            (DBType::Kv, CF_LOCK),
+            (DBType::Kv, CF_RAFT),
+            (DBType::Raft, CF_DEFAULT),
         ];
         for (db, cf) in valid_cases {
             validate_db_and_cf(db, cf).unwrap();
         }
 
         let invalid_cases = vec![
-            (DBType::RAFT, CF_WRITE),
-            (DBType::RAFT, CF_LOCK),
-            (DBType::RAFT, CF_RAFT),
-            (DBType::INVALID, CF_DEFAULT),
-            (DBType::INVALID, "BAD_CF"),
+            (DBType::Raft, CF_WRITE),
+            (DBType::Raft, CF_LOCK),
+            (DBType::Raft, CF_RAFT),
+            (DBType::Invalid, CF_DEFAULT),
+            (DBType::Invalid, "BAD_CF"),
         ];
         for (db, cf) in invalid_cases {
             validate_db_and_cf(db, cf).unwrap_err();
@@ -1607,7 +1605,7 @@ mod tests {
 
     impl Debugger {
         fn set_store_id(&self, store_id: u64) {
-            let mut ident = StoreIdent::new();
+            let mut ident = StoreIdent::default();
             ident.set_store_id(store_id);
             let db = &self.engines.kv;
             db.put_msg(keys::STORE_IDENT_KEY, &ident).unwrap();
@@ -1622,10 +1620,10 @@ mod tests {
         engine.put(k, v).unwrap();
         assert_eq!(&*engine.get(k).unwrap().unwrap(), v);
 
-        let got = debugger.get(DBType::KV, CF_DEFAULT, k).unwrap();
+        let got = debugger.get(DBType::Kv, CF_DEFAULT, k).unwrap();
         assert_eq!(&got, v);
 
-        match debugger.get(DBType::KV, CF_DEFAULT, b"foo") {
+        match debugger.get(DBType::Kv, CF_DEFAULT, b"foo") {
             Err(Error::NotFound(_)) => (),
             _ => panic!("expect Error::NotFound(_)"),
         }
@@ -1637,7 +1635,7 @@ mod tests {
         let engine = &debugger.engines.raft;
         let (region_id, log_index) = (1, 1);
         let key = keys::raft_log_key(region_id, log_index);
-        let mut entry = Entry::new();
+        let mut entry = Entry::default();
         entry.set_term(1);
         entry.set_index(1);
         entry.set_entry_type(EntryType::EntryNormal);
@@ -1661,7 +1659,7 @@ mod tests {
         let region_id = 1;
 
         let raft_state_key = keys::raft_state_key(region_id);
-        let mut raft_state = RaftLocalState::new();
+        let mut raft_state = RaftLocalState::default();
         raft_state.set_last_index(42);
         raft_engine.put_msg(&raft_state_key, &raft_state).unwrap();
         assert_eq!(
@@ -1673,7 +1671,7 @@ mod tests {
         );
 
         let apply_state_key = keys::apply_state_key(region_id);
-        let mut apply_state = RaftApplyState::new();
+        let mut apply_state = RaftApplyState::default();
         apply_state.set_applied_index(42);
         kv_engine
             .put_msg_cf(raft_cf, &apply_state_key, &apply_state)
@@ -1687,7 +1685,7 @@ mod tests {
         );
 
         let region_state_key = keys::region_state_key(region_id);
-        let mut region_state = RegionLocalState::new();
+        let mut region_state = RegionLocalState::default();
         region_state.set_state(PeerState::Tombstone);
         kv_engine
             .put_msg_cf(raft_cf, &region_state_key, &region_state)
@@ -1717,11 +1715,11 @@ mod tests {
 
         let region_id = 1;
         let region_state_key = keys::region_state_key(region_id);
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(region_id);
         region.set_start_key(b"a".to_vec());
         region.set_end_key(b"zz".to_vec());
-        let mut state = RegionLocalState::new();
+        let mut state = RegionLocalState::default();
         state.set_region(region);
         let cf_raft = engine.cf_handle(CF_RAFT).unwrap();
         engine
@@ -1931,25 +1929,29 @@ mod tests {
         {
             let mock_region_state = |region_id: u64, peers: &[u64]| {
                 let region_state_key = keys::region_state_key(region_id);
-                let mut region_state = RegionLocalState::new();
+                let mut region_state = RegionLocalState::default();
                 region_state.set_state(PeerState::Normal);
                 {
                     let region = region_state.mut_region();
                     region.set_id(region_id);
-                    let peers = peers.iter().enumerate().map(|(i, &sid)| {
-                        let mut peer = Peer::new();
-                        peer.id = i as u64;
-                        peer.store_id = sid;
-                        peer
-                    });
-                    region.set_peers(RepeatedField::from_iter(peers));
+                    let peers = peers
+                        .iter()
+                        .enumerate()
+                        .map(|(i, &sid)| {
+                            let mut peer = Peer::default();
+                            peer.id = i as u64;
+                            peer.store_id = sid;
+                            peer
+                        })
+                        .collect();
+                    region.set_peers(peers);
                 }
                 wb2.put_msg_cf(handle2, &region_state_key, &region_state)
                     .unwrap();
             };
             let mock_raft_state = |region_id: u64, last_index: u64, commit_index: u64| {
                 let raft_state_key = keys::raft_state_key(region_id);
-                let mut raft_state = RaftLocalState::new();
+                let mut raft_state = RaftLocalState::default();
                 raft_state.set_last_index(last_index);
                 raft_state.mut_hard_state().set_commit(commit_index);
                 wb1.put_msg_cf(handle1, &raft_state_key, &raft_state)
@@ -1957,7 +1959,7 @@ mod tests {
             };
             let mock_apply_state = |region_id: u64, apply_index: u64| {
                 let raft_apply_key = keys::apply_state_key(region_id);
-                let mut apply_state = RaftApplyState::new();
+                let mut apply_state = RaftApplyState::default();
                 apply_state.set_applied_index(apply_index);
                 wb2.put_msg_cf(handle2, &raft_apply_key, &apply_state)
                     .unwrap();
@@ -1998,7 +2000,7 @@ mod tests {
         let db_opts = engine.get_db_options();
         assert_eq!(db_opts.get_max_background_jobs(), 2);
         debugger
-            .modify_tikv_config(MODULE::KVDB, "max_background_jobs", "8")
+            .modify_tikv_config(Module::Kvdb, "max_background_jobs", "8")
             .unwrap();
         let db_opts = engine.get_db_options();
         assert_eq!(db_opts.get_max_background_jobs(), 8);
@@ -2007,7 +2009,7 @@ mod tests {
         let cf_opts = engine.get_options_cf(cf);
         assert_eq!(cf_opts.get_disable_auto_compactions(), false);
         debugger
-            .modify_tikv_config(MODULE::KVDB, "default.disable_auto_compactions", "true")
+            .modify_tikv_config(Module::Kvdb, "default.disable_auto_compactions", "true")
             .unwrap();
         let cf_opts = engine.get_options_cf(cf);
         assert_eq!(cf_opts.get_disable_auto_compactions(), true);
@@ -2023,12 +2025,12 @@ mod tests {
         for (region_id, (start, end)) in metadata.into_iter().enumerate() {
             let region_id = region_id as u64;
             let cf_raft = engine.cf_handle(CF_RAFT).unwrap();
-            let mut region = Region::new();
+            let mut region = Region::default();
             region.set_id(region_id);
             region.set_start_key(start.to_owned().into_bytes());
             region.set_end_key(end.to_owned().into_bytes());
 
-            let mut region_state = RegionLocalState::new();
+            let mut region_state = RegionLocalState::default();
             region_state.set_state(PeerState::Normal);
             region_state.set_region(region);
             let key = keys::region_state_key(region_id);
@@ -2041,7 +2043,7 @@ mod tests {
             engine.delete_cf(cf_raft, &key).unwrap();
         };
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(100);
 
         region.set_start_key(b"k".to_vec());

--- a/src/server/errors.rs
+++ b/src/server/errors.rs
@@ -8,7 +8,6 @@ use std::result;
 use futures::Canceled;
 use grpcio::Error as GrpcError;
 use hyper::Error as HttpError;
-use protobuf::ProtobufError;
 
 use super::snap::Task as SnapTask;
 use crate::pd::Error as PdError;
@@ -32,11 +31,6 @@ quick_error! {
             from()
             cause(err)
             display("{:?}", err)
-            description(err.description())
-        }
-        Protobuf(err: ProtobufError) {
-            from()
-            cause(err)
             description(err.description())
         }
         Grpc(err: GrpcError) {

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -24,7 +24,6 @@ use engine::Engines;
 use engine::Peekable;
 use kvproto::metapb;
 use kvproto::raft_serverpb::StoreIdent;
-use protobuf::RepeatedField;
 use tikv_util::worker::FutureWorker;
 
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
@@ -79,7 +78,7 @@ where
         store_cfg: &StoreConfig,
         pd_client: Arc<C>,
     ) -> Node<C> {
-        let mut store = metapb::Store::new();
+        let mut store = metapb::Store::default();
         store.set_id(INVALID_ID);
         if cfg.advertise_addr.is_empty() {
             store.set_address(cfg.addr.clone());
@@ -90,12 +89,12 @@ where
 
         let mut labels = Vec::new();
         for (k, v) in &cfg.labels {
-            let mut label = metapb::StoreLabel::new();
+            let mut label = metapb::StoreLabel::default();
             label.set_key(k.to_owned());
             label.set_value(v.to_owned());
             labels.push(label);
         }
-        store.set_labels(RepeatedField::from_vec(labels));
+        store.set_labels(labels);
 
         Node {
             cluster_id: cfg.cluster_id,

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -16,9 +16,7 @@ use grpcio::{
     ChannelBuilder, Environment, Error as GrpcError, RpcStatus, RpcStatusCode, WriteFlags,
 };
 use kvproto::raft_serverpb::RaftMessage;
-use kvproto::tikvpb::BatchRaftMessage;
-use kvproto::tikvpb_grpc::TikvClient;
-use protobuf::RepeatedField;
+use kvproto::tikvpb::{BatchRaftMessage, TikvClient};
 use tikv_util::collections::{HashMap, HashMapEntry};
 use tikv_util::mpsc::batch::{self, Sender as BatchSender};
 use tikv_util::security::SecurityManager;
@@ -74,8 +72,8 @@ impl Conn {
         let (batch_sink, batch_receiver) = client1.batch_raft().unwrap();
         let batch_send_or_fallback = batch_sink
             .send_all(Reusable(rx1).map(move |v| {
-                let mut batch_msgs = BatchRaftMessage::new();
-                batch_msgs.set_msgs(RepeatedField::from(v));
+                let mut batch_msgs = BatchRaftMessage::default();
+                batch_msgs.set_msgs(v);
                 (batch_msgs, WriteFlags::default().buffer_hint(false))
             }))
             .then(move |r| {

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -231,7 +231,7 @@ mod tests {
     }
 
     fn new_store(addr: &str, state: metapb::StoreState) -> metapb::Store {
-        let mut store = metapb::Store::new();
+        let mut store = metapb::Store::default();
         store.set_id(1);
         store.set_state(state);
         store.set_address(addr.into());

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -9,14 +9,14 @@ use std::time::{Duration, Instant};
 use engine::Engines;
 use futures::{Future, Stream};
 use grpcio::{ChannelBuilder, EnvBuilder, Environment, Server as GrpcServer, ServerBuilder};
-use kvproto::debugpb_grpc::create_debug;
-use kvproto::import_sstpb_grpc::create_import_sst;
-use kvproto::tikvpb_grpc::*;
+use kvproto::debugpb::create_debug;
+use kvproto::import_sstpb::create_import_sst;
+use kvproto::tikvpb::*;
 use tokio_threadpool::{Builder as ThreadPoolBuilder, ThreadPool};
 use tokio_timer::timer::Handle;
 
 use crate::storage::lock_manager::deadlock::Service as DeadlockService;
-use kvproto::deadlock_grpc::create_deadlock;
+use kvproto::deadlockpb::create_deadlock;
 
 use crate::coprocessor::Endpoint;
 use crate::import::ImportSSTService;
@@ -356,11 +356,11 @@ mod tests {
         server.start(cfg, security_mgr).unwrap();
 
         let mut trans = server.transport();
-        trans.report_unreachable(RaftMessage::new());
+        trans.report_unreachable(RaftMessage::default());
         let mut resp = significant_msg_receiver.try_recv().unwrap();
         assert!(is_unreachable_to(&resp, 0, 0), "{:?}", resp);
 
-        let mut msg = RaftMessage::new();
+        let mut msg = RaftMessage::default();
         msg.set_region_id(1);
         trans.send(msg.clone()).unwrap();
         trans.flush();

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -8,13 +8,11 @@ use futures::{future, stream, Future, Stream};
 use futures_cpupool::{Builder, CpuPool};
 use grpcio::{Error as GrpcError, WriteFlags};
 use grpcio::{RpcContext, RpcStatus, RpcStatusCode, ServerStreamingSink, UnarySink};
-use kvproto::debugpb::*;
-use kvproto::debugpb_grpc;
+use kvproto::debugpb::{self, *};
 use kvproto::raft_cmdpb::{
     AdminCmdType, AdminRequest, RaftCmdRequest, RaftRequestHeader, RegionDetailResponse,
     StatusCmdType, StatusRequest,
 };
-use protobuf::text_format::print_to_string;
 
 use crate::raftstore::store::msg::Callback;
 use crate::server::debug::{Debugger, Error};
@@ -84,7 +82,7 @@ impl<T: RaftStoreRouter> Service<T> {
     }
 }
 
-impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
+impl<T: RaftStoreRouter + 'static> debugpb::Debug for Service<T> {
     fn get(&mut self, ctx: RpcContext<'_>, mut req: GetRequest, sink: UnarySink<GetResponse>) {
         const TAG: &str = "debug_get";
 
@@ -99,7 +97,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                     .and_then(move |debugger| debugger.get(db, &cf, key.as_slice())),
             )
             .map(|value| {
-                let mut resp = GetResponse::new();
+                let mut resp = GetResponse::default();
                 resp.set_value(value);
                 resp
             });
@@ -125,7 +123,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                     .and_then(move |debugger| debugger.raft_log(region_id, log_index)),
             )
             .map(|entry| {
-                let mut resp = RaftLogResponse::new();
+                let mut resp = RaftLogResponse::default();
                 resp.set_entry(entry);
                 resp
             });
@@ -150,7 +148,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                     .and_then(move |debugger| debugger.region_info(region_id)),
             )
             .map(|region_info| {
-                let mut resp = RegionInfoResponse::new();
+                let mut resp = RegionInfoResponse::default();
                 if let Some(raft_local_state) = region_info.raft_local_state {
                     resp.set_raft_local_state(raft_local_state);
                 }
@@ -175,7 +173,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
         const TAG: &str = "debug_region_size";
 
         let region_id = req.get_region_id();
-        let cfs = req.take_cfs().into_vec();
+        let cfs = req.take_cfs();
 
         let f = self
             .pool
@@ -184,12 +182,12 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                     .and_then(move |debugger| debugger.region_size(region_id, cfs)),
             )
             .map(|entries| {
-                let mut resp = RegionSizeResponse::new();
+                let mut resp = RegionSizeResponse::default();
                 resp.set_entries(
                     entries
                         .into_iter()
                         .map(|(cf, size)| {
-                            let mut entry = RegionSizeResponse_Entry::new();
+                            let mut entry = region_size_response::Entry::default();
                             entry.set_cf(cf);
                             entry.set_size(size as u64);
                             entry
@@ -218,7 +216,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                 stream::iter_result(iter)
                     .map_err(|e| error_to_grpc_error("scan_mvcc", e))
                     .map(|(key, mvcc_info)| {
-                        let mut resp = ScanMvccResponse::new();
+                        let mut resp = ScanMvccResponse::default();
                         resp.set_key(key);
                         resp.set_info(mvcc_info);
                         (resp, WriteFlags::default())
@@ -269,7 +267,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
             if let Err(e) = fail::cfg(name, actions) {
                 return Err(box_err!("{:?}", e));
             }
-            Ok(InjectFailPointResponse::new())
+            Ok(InjectFailPointResponse::default())
         });
 
         self.handle_response(ctx, sink, f, TAG);
@@ -289,7 +287,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                 return Err(Error::InvalidArgument("Failure Type INVALID".to_owned()));
             }
             fail::remove(name);
-            Ok(RecoverFailPointResponse::new())
+            Ok(RecoverFailPointResponse::default())
         });
 
         self.handle_response(ctx, sink, f, TAG);
@@ -305,12 +303,12 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
 
         let f = self.pool.spawn_fn(move || {
             let list = fail::list().into_iter().map(|(name, actions)| {
-                let mut entry = ListFailPointsResponse_Entry::new();
+                let mut entry = list_fail_points_response::Entry::default();
                 entry.set_name(name);
                 entry.set_actions(actions);
                 entry
             });
-            let mut resp = ListFailPointsResponse::new();
+            let mut resp = ListFailPointsResponse::default();
             resp.set_entries(list.collect());
             Ok(resp)
         });
@@ -328,7 +326,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
 
         let debugger = self.debugger.clone();
         let f = self.pool.spawn_fn(move || {
-            let mut resp = GetMetricsResponse::new();
+            let mut resp = GetMetricsResponse::default();
             resp.set_store_id(debugger.get_store_id()?);
             resp.set_prometheus(metrics::dump());
             if req.get_all() {
@@ -360,7 +358,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
         let f = self
             .pool
             .spawn(consistency_check)
-            .map(|_| RegionConsistencyCheckResponse::new());
+            .map(|_| RegionConsistencyCheckResponse::default());
         self.handle_response(ctx, sink, f, "check_region_consistency");
     }
 
@@ -381,7 +379,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
             .spawn(future::ok(self.debugger.clone()).and_then(move |debugger| {
                 debugger.modify_tikv_config(module, &config_name, &config_value)
             }))
-            .map(|_| ModifyTikvConfigResponse::new());
+            .map(|_| ModifyTikvConfigResponse::default());
 
         self.handle_response(ctx, sink, f, TAG);
     }
@@ -399,9 +397,9 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
             .pool
             .spawn_fn(move || debugger.get_region_properties(req.get_region_id()))
             .map(|props| {
-                let mut resp = GetRegionPropertiesResponse::new();
+                let mut resp = GetRegionPropertiesResponse::default();
                 for (name, value) in props {
-                    let mut prop = Property::new();
+                    let mut prop = Property::default();
                     prop.set_name(name);
                     prop.set_value(value);
                     resp.mut_props().push(prop);
@@ -418,12 +416,12 @@ fn region_detail<T: RaftStoreRouter>(
     region_id: u64,
     store_id: u64,
 ) -> impl Future<Item = RegionDetailResponse, Error = Error> {
-    let mut header = RaftRequestHeader::new();
+    let mut header = RaftRequestHeader::default();
     header.set_region_id(region_id);
     header.mut_peer().set_store_id(store_id);
-    let mut status_request = StatusRequest::new();
+    let mut status_request = StatusRequest::default();
     status_request.set_cmd_type(StatusCmdType::RegionDetail);
-    let mut raft_cmd = RaftCmdRequest::new();
+    let mut raft_cmd = RaftCmdRequest::default();
     raft_cmd.set_header(header);
     raft_cmd.set_status_request(status_request);
 
@@ -437,8 +435,7 @@ fn region_detail<T: RaftStoreRouter>(
                     if r.response.get_header().has_error() {
                         let e = r.response.get_header().get_error();
                         warn!("region_detail got error"; "err" => ?e);
-                        let msg = print_to_string(e);
-                        return Err(Error::Other(msg.into()));
+                        return Err(Error::Other(e.message.clone().into()));
                     }
                     let detail = r.response.take_status_response().take_region_detail();
                     debug!("region_detail got region detail"; "detail" => ?detail);
@@ -456,12 +453,12 @@ fn consistency_check<T: RaftStoreRouter>(
     raft_router: T,
     mut detail: RegionDetailResponse,
 ) -> impl Future<Item = (), Error = Error> {
-    let mut header = RaftRequestHeader::new();
+    let mut header = RaftRequestHeader::default();
     header.set_region_id(detail.get_region().get_id());
     header.set_peer(detail.take_leader());
-    let mut admin_request = AdminRequest::new();
+    let mut admin_request = AdminRequest::default();
     admin_request.set_cmd_type(AdminCmdType::ComputeHash);
-    let mut raft_cmd = RaftCmdRequest::new();
+    let mut raft_cmd = RaftCmdRequest::default();
     raft_cmd.set_header(header);
     raft_cmd.set_admin_request(admin_request);
 
@@ -475,8 +472,7 @@ fn consistency_check<T: RaftStoreRouter>(
                     if r.response.get_header().has_error() {
                         let e = r.response.get_header().get_error();
                         warn!("consistency-check got error"; "err" => ?e);
-                        let msg = print_to_string(e);
-                        return Err(Error::Other(msg.into()));
+                        return Err(Error::Other(e.message.clone().into()));
                     }
                     Ok(())
                 })

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -13,7 +13,7 @@ use grpcio::{
 };
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::raft_serverpb::{Done, SnapshotChunk};
-use kvproto::tikvpb_grpc::TikvClient;
+use kvproto::tikvpb::TikvClient;
 
 use crate::raftstore::store::{SnapEntry, SnapKey, SnapManager, Snapshot};
 use tikv_util::security::SecurityManager;
@@ -79,7 +79,7 @@ impl Stream for SnapChunk {
         match result {
             Ok(_) => {
                 self.remain_bytes -= buf.len();
-                let mut chunk = SnapshotChunk::new();
+                let mut chunk = SnapshotChunk::default();
                 chunk.set_data(buf);
                 Ok(Async::Ready(Some((
                     chunk,
@@ -131,7 +131,7 @@ fn send_snap(
     let total_size = s.total_size()?;
 
     let chunks = {
-        let mut first_chunk = SnapshotChunk::new();
+        let mut first_chunk = SnapshotChunk::default();
         first_chunk.set_message(msg);
 
         SnapChunk {
@@ -281,7 +281,7 @@ fn recv_snap<R: RaftStoreRouter + 'static>(
         },
     );
     f.then(move |res| match res {
-        Ok(()) => sink.success(Done::new()),
+        Ok(()) => sink.success(Done::default()),
         Err(e) => {
             let status = RpcStatus::new(RpcStatusCode::Unknown, Some(format!("{:?}", e)));
             sink.fail(status)

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -355,7 +355,6 @@ mod tests {
     use crate::config::TiKvConfig;
     use crate::server::status_server::StatusServer;
     use futures::future::{lazy, Future};
-    #[cfg(not(feature = "no-fail"))]
     use futures::Stream;
     use hyper::{Body, Client, Method, Request, StatusCode, Uri};
 

--- a/src/storage/gc_worker.rs
+++ b/src/storage/gc_worker.rs
@@ -1279,7 +1279,7 @@ mod tests {
         let regions: BTreeMap<_, _> = regions
             .into_iter()
             .map(|(start_key, end_key, id)| {
-                let mut r = metapb::Region::new();
+                let mut r = metapb::Region::default();
                 r.set_id(id);
                 r.set_start_key(start_key.clone());
                 r.set_end_key(end_key);

--- a/src/storage/kv/btree_engine.rs
+++ b/src/storage/kv/btree_engine.rs
@@ -310,7 +310,7 @@ pub mod tests {
         for (k, v) in &test_data {
             must_put(&engine, k.as_slice(), v.as_slice());
         }
-        let snap = engine.snapshot(&Context::new()).unwrap();
+        let snap = engine.snapshot(&Context::default()).unwrap();
         let mut statistics = CFStatistics::default();
 
         // lower bound > upper bound, seek() returns false.

--- a/src/storage/kv/cursor_builder.rs
+++ b/src/storage/kv/cursor_builder.rs
@@ -63,7 +63,7 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
     /// Set iterator range by giving lower and upper bound.
     /// The range is left closed right open.
     ///
-    /// Both defaults to `None`.
+    /// Both default to `None`.
     #[inline]
     pub fn range(mut self, lower: Option<Key>, upper: Option<Key>) -> Self {
         self.lower_bound = lower;

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -236,7 +236,7 @@ impl CFStatistics {
     }
 
     pub fn scan_info(&self) -> ScanInfo {
-        let mut info = ScanInfo::new();
+        let mut info = ScanInfo::default();
         info.set_processed(self.processed as i64);
         info.set_total(self.total_op_count() as i64);
         info
@@ -274,7 +274,7 @@ impl Statistics {
     }
 
     pub fn scan_detail(&self) -> ScanDetail {
-        let mut detail = ScanDetail::new();
+        let mut detail = ScanDetail::default();
         detail.set_data(self.data.scan_info());
         detail.set_lock(self.lock.scan_info());
         detail.set_write(self.write.scan_info());
@@ -726,33 +726,35 @@ pub mod tests {
 
     pub fn must_put<E: Engine>(engine: &E, key: &[u8], value: &[u8]) {
         engine
-            .put(&Context::new(), Key::from_raw(key), value.to_vec())
+            .put(&Context::default(), Key::from_raw(key), value.to_vec())
             .unwrap();
     }
 
     pub fn must_put_cf<E: Engine>(engine: &E, cf: CfName, key: &[u8], value: &[u8]) {
         engine
-            .put_cf(&Context::new(), cf, Key::from_raw(key), value.to_vec())
+            .put_cf(&Context::default(), cf, Key::from_raw(key), value.to_vec())
             .unwrap();
     }
 
     pub fn must_delete<E: Engine>(engine: &E, key: &[u8]) {
-        engine.delete(&Context::new(), Key::from_raw(key)).unwrap();
+        engine
+            .delete(&Context::default(), Key::from_raw(key))
+            .unwrap();
     }
 
     pub fn must_delete_cf<E: Engine>(engine: &E, cf: CfName, key: &[u8]) {
         engine
-            .delete_cf(&Context::new(), cf, Key::from_raw(key))
+            .delete_cf(&Context::default(), cf, Key::from_raw(key))
             .unwrap();
     }
 
     pub fn assert_has<E: Engine>(engine: &E, key: &[u8], value: &[u8]) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         assert_eq!(snapshot.get(&Key::from_raw(key)).unwrap().unwrap(), value);
     }
 
     pub fn assert_has_cf<E: Engine>(engine: &E, cf: CfName, key: &[u8], value: &[u8]) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         assert_eq!(
             snapshot.get_cf(cf, &Key::from_raw(key)).unwrap().unwrap(),
             value
@@ -760,17 +762,17 @@ pub mod tests {
     }
 
     pub fn assert_none<E: Engine>(engine: &E, key: &[u8]) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         assert_eq!(snapshot.get(&Key::from_raw(key)).unwrap(), None);
     }
 
     pub fn assert_none_cf<E: Engine>(engine: &E, cf: CfName, key: &[u8]) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         assert_eq!(snapshot.get_cf(cf, &Key::from_raw(key)).unwrap(), None);
     }
 
     fn assert_seek<E: Engine>(engine: &E, key: &[u8], pair: (&[u8], &[u8])) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -781,7 +783,7 @@ pub mod tests {
     }
 
     fn assert_reverse_seek<E: Engine>(engine: &E, key: &[u8], pair: (&[u8], &[u8])) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -842,7 +844,7 @@ pub mod tests {
     fn test_batch<E: Engine>(engine: &E) {
         engine
             .write(
-                &Context::new(),
+                &Context::default(),
                 vec![
                     Modify::Put(CF_DEFAULT, Key::from_raw(b"x"), b"1".to_vec()),
                     Modify::Put(CF_DEFAULT, Key::from_raw(b"y"), b"2".to_vec()),
@@ -854,7 +856,7 @@ pub mod tests {
 
         engine
             .write(
-                &Context::new(),
+                &Context::default(),
                 vec![
                     Modify::Delete(CF_DEFAULT, Key::from_raw(b"x")),
                     Modify::Delete(CF_DEFAULT, Key::from_raw(b"y")),
@@ -875,7 +877,7 @@ pub mod tests {
         assert_seek(engine, b"x\x00", (b"z", b"2"));
         assert_reverse_seek(engine, b"y", (b"x", b"1"));
         assert_reverse_seek(engine, b"z", (b"x", b"1"));
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut iter = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -893,7 +895,7 @@ pub mod tests {
     fn test_near_seek<E: Engine>(engine: &E) {
         must_put(engine, b"x", b"1");
         must_put(engine, b"z", b"2");
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -912,7 +914,7 @@ pub mod tests {
             let key = format!("y{}", i);
             must_put(engine, key.as_bytes(), b"3");
         }
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -928,7 +930,7 @@ pub mod tests {
     }
 
     fn test_empty_seek<E: Engine>(engine: &E) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -1055,7 +1057,7 @@ pub mod tests {
             let value = format!("value_{}", i);
             must_put(engine, key.as_bytes(), value.as_bytes());
         }
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         for step in 1..SEEK_BOUND as usize * 3 {
             for start in 0..10 {
@@ -1106,7 +1108,7 @@ pub mod tests {
     }
 
     fn test_empty_write<E: Engine>(engine: &E) {
-        engine.write(&Context::new(), vec![]).unwrap_err();
+        engine.write(&Context::default(), vec![]).unwrap_err();
     }
 
     pub fn test_cfs_statistics<E: Engine>(engine: &E) {
@@ -1121,7 +1123,7 @@ pub mod tests {
         must_delete(engine, b"foo42");
         must_delete(engine, b"foo5");
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut iter = snapshot
             .iter(IterOption::default(), ScanMode::Forward)
             .unwrap();

--- a/src/storage/kv/raftkv.rs
+++ b/src/storage/kv/raftkv.rs
@@ -16,7 +16,6 @@ use kvproto::raft_cmdpb::{
     CmdType, DeleteRangeRequest, DeleteRequest, PutRequest, RaftCmdRequest, RaftCmdResponse,
     RaftRequestHeader, Request, Response,
 };
-use protobuf::RepeatedField;
 
 use super::metrics::*;
 use super::{
@@ -140,7 +139,7 @@ fn on_write_result(mut write_resp: WriteResponse, req_cnt: usize) -> (CbContext,
         return (cb_ctx, Err(e));
     }
     let resps = write_resp.response.take_responses();
-    (cb_ctx, Ok(CmdRes::Resp(resps.into_vec())))
+    (cb_ctx, Ok(CmdRes::Resp(resps)))
 }
 
 fn on_read_result(mut read_resp: ReadResponse, req_cnt: usize) -> (CbContext, Result<CmdRes>) {
@@ -152,7 +151,7 @@ fn on_read_result(mut read_resp: ReadResponse, req_cnt: usize) -> (CbContext, Re
     if resps.len() >= 1 || resps[0].get_cmd_type() == CmdType::Snap {
         (cb_ctx, Ok(CmdRes::Snap(read_resp.snapshot.unwrap())))
     } else {
-        (cb_ctx, Ok(CmdRes::Resp(resps.into_vec())))
+        (cb_ctx, Ok(CmdRes::Resp(resps)))
     }
 }
 
@@ -163,7 +162,7 @@ impl<S: RaftStoreRouter> RaftKv<S> {
     }
 
     fn new_request_header(&self, ctx: &Context) -> RaftRequestHeader {
-        let mut header = RaftRequestHeader::new();
+        let mut header = RaftRequestHeader::default();
         header.set_region_id(ctx.get_region_id());
         header.set_peer(ctx.get_peer().clone());
         header.set_region_epoch(ctx.get_region_epoch().clone());
@@ -182,9 +181,9 @@ impl<S: RaftStoreRouter> RaftKv<S> {
     ) -> Result<()> {
         let len = reqs.len();
         let header = self.new_request_header(ctx);
-        let mut cmd = RaftCmdRequest::new();
+        let mut cmd = RaftCmdRequest::default();
         cmd.set_header(header);
-        cmd.set_requests(RepeatedField::from_vec(reqs));
+        cmd.set_requests(reqs);
 
         self.router
             .send_command(
@@ -208,9 +207,9 @@ impl<S: RaftStoreRouter> RaftKv<S> {
         ));
         let len = reqs.len();
         let header = self.new_request_header(ctx);
-        let mut cmd = RaftCmdRequest::new();
+        let mut cmd = RaftCmdRequest::default();
         cmd.set_header(header);
-        cmd.set_requests(RepeatedField::from_vec(reqs));
+        cmd.set_requests(reqs);
 
         self.router
             .send_command(
@@ -259,10 +258,10 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
 
         let mut reqs = Vec::with_capacity(modifies.len());
         for m in modifies {
-            let mut req = Request::new();
+            let mut req = Request::default();
             match m {
                 Modify::Delete(cf, k) => {
-                    let mut delete = DeleteRequest::new();
+                    let mut delete = DeleteRequest::default();
                     delete.set_key(k.into_encoded());
                     if cf != CF_DEFAULT {
                         delete.set_cf(cf.to_string());
@@ -271,7 +270,7 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
                     req.set_delete(delete);
                 }
                 Modify::Put(cf, k, v) => {
-                    let mut put = PutRequest::new();
+                    let mut put = PutRequest::default();
                     put.set_key(k.into_encoded());
                     put.set_value(v);
                     if cf != CF_DEFAULT {
@@ -281,7 +280,7 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
                     req.set_put(put);
                 }
                 Modify::DeleteRange(cf, start_key, end_key, notify_only) => {
-                    let mut delete_range = DeleteRangeRequest::new();
+                    let mut delete_range = DeleteRangeRequest::default();
                     delete_range.set_cf(cf.to_string());
                     delete_range.set_start_key(start_key.into_encoded());
                     delete_range.set_end_key(end_key.into_encoded());
@@ -326,7 +325,7 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
 
     fn async_snapshot(&self, ctx: &Context, cb: Callback<Self::Snap>) -> kv::Result<()> {
         fail_point!("raftkv_async_snapshot");
-        let mut req = Request::new();
+        let mut req = Request::default();
         req.set_cmd_type(CmdType::Snap);
 
         ASYNC_REQUESTS_COUNTER_VEC.snapshot.all.inc();

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -182,7 +182,7 @@ impl TestEngineBuilder {
         let cfs_opts = cfs
             .iter()
             .map(|cf| match *cf {
-                CF_DEFAULT => CFOptions::new(CF_DEFAULT, cfg_rocksdb.defaultcf.build_opt(&cache)),
+                CF_DEFAULT => CFOptions::new(CF_DEFAULT, cfg_rocksdb.new_cf.build_opt(&cache)),
                 CF_LOCK => CFOptions::new(CF_LOCK, cfg_rocksdb.lockcf.build_opt(&cache)),
                 CF_WRITE => CFOptions::new(CF_WRITE, cfg_rocksdb.writecf.build_opt(&cache)),
                 CF_RAFT => CFOptions::new(CF_RAFT, cfg_rocksdb.raftcf.build_opt(&cache)),
@@ -258,7 +258,7 @@ impl Engine for RocksEngine {
             "snapshot failed"
         )));
         fail_point!("rockskv_async_snapshot_not_leader", |_| {
-            let mut header = ErrorHeader::new();
+            let mut header = ErrorHeader::default();
             header.mut_not_leader().set_region_id(100);
             Err(Error::Request(header))
         });
@@ -424,7 +424,7 @@ mod tests {
         must_delete(engine, b"foo42");
         must_delete(engine, b"foo5");
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut iter = snapshot
             .iter(IterOption::default(), ScanMode::Forward)
             .unwrap();

--- a/src/storage/lock_manager/client.rs
+++ b/src/storage/lock_manager/client.rs
@@ -5,8 +5,7 @@ use crate::tikv_util::security::SecurityManager;
 use futures::unsync::mpsc::{self, UnboundedSender};
 use futures::{Future, Sink, Stream};
 use grpcio::{ChannelBuilder, EnvBuilder, WriteFlags};
-use kvproto::deadlock::*;
-use kvproto::deadlock_grpc::DeadlockClient;
+use kvproto::deadlockpb::*;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/src/storage/lock_manager/waiter_manager.rs
+++ b/src/storage/lock_manager/waiter_manager.rs
@@ -11,7 +11,7 @@ use crate::storage::{Error as StorageError, StorageCb};
 use crate::tikv_util::collections::HashMap;
 use crate::tikv_util::worker::{FutureRunnable, FutureScheduler, Stopped};
 use futures::Future;
-use kvproto::deadlock::WaitForEntry;
+use kvproto::deadlockpb::WaitForEntry;
 use prometheus::HistogramTimer;
 use std::cell::RefCell;
 use std::fmt::{self, Debug, Display, Formatter};
@@ -161,7 +161,7 @@ impl WaitTable {
             .iter()
             .flat_map(|(_, waiters)| {
                 waiters.iter().map(|waiter| {
-                    let mut wait_for_entry = WaitForEntry::new();
+                    let mut wait_for_entry = WaitForEntry::default();
                     wait_for_entry.set_txn(waiter.start_ts);
                     wait_for_entry.set_wait_for_txn(waiter.lock.ts);
                     wait_for_entry.set_key_hash(waiter.lock.hash);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1956,12 +1956,12 @@ mod tests {
         let (tx, rx) = channel();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 100)
+                .async_get(Context::default(), Key::from_raw(b"x"), 100)
                 .wait(),
         );
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"x"), b"100".to_vec()))],
                 b"x".to_vec(),
                 100,
@@ -1976,12 +1976,12 @@ mod tests {
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 101)
+                .async_get(Context::default(), Key::from_raw(b"x"), 101)
                 .wait(),
         );
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"x")],
                 100,
                 101,
@@ -1991,13 +1991,13 @@ mod tests {
         rx.recv().unwrap();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 100)
+                .async_get(Context::default(), Key::from_raw(b"x"), 100)
                 .wait(),
         );
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 101)
+                .async_get(Context::default(), Key::from_raw(b"x"), 101)
                 .wait(),
         );
     }
@@ -2010,7 +2010,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"aa".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"bb".to_vec())),
@@ -2033,7 +2033,7 @@ mod tests {
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 1)
+                .async_get(Context::default(), Key::from_raw(b"x"), 1)
                 .wait(),
         );
         expect_error(
@@ -2043,7 +2043,7 @@ mod tests {
             },
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"x"),
                     None,
                     1000,
@@ -2056,7 +2056,7 @@ mod tests {
             vec![None, None],
             storage
                 .async_batch_get(
-                    Context::new(),
+                    Context::default(),
                     vec![Key::from_raw(b"c"), Key::from_raw(b"d")],
                     1,
                 )
@@ -2070,7 +2070,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"aa".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"bb".to_vec())),
@@ -2088,7 +2088,7 @@ mod tests {
             vec![None, None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     None,
                     1000,
@@ -2102,7 +2102,7 @@ mod tests {
             vec![None, None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     None,
                     1000,
@@ -2116,7 +2116,7 @@ mod tests {
             vec![None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     Some(Key::from_raw(b"c")),
                     1000,
@@ -2130,7 +2130,7 @@ mod tests {
             vec![None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     Some(Key::from_raw(b"b")),
                     1000,
@@ -2144,7 +2144,7 @@ mod tests {
             vec![None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     None,
                     2,
@@ -2158,7 +2158,7 @@ mod tests {
             vec![None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     None,
                     2,
@@ -2170,7 +2170,7 @@ mod tests {
 
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![
                     Key::from_raw(b"a"),
                     Key::from_raw(b"b"),
@@ -2191,7 +2191,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     None,
                     1000,
@@ -2209,7 +2209,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     None,
                     1000,
@@ -2226,7 +2226,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     Some(Key::from_raw(b"c")),
                     1000,
@@ -2243,7 +2243,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     Some(Key::from_raw(b"b")),
                     1000,
@@ -2261,7 +2261,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     None,
                     2,
@@ -2278,7 +2278,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     None,
                     2,
@@ -2295,7 +2295,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"aa".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"bb".to_vec())),
@@ -2312,7 +2312,7 @@ mod tests {
             vec![None],
             storage
                 .async_batch_get(
-                    Context::new(),
+                    Context::default(),
                     vec![Key::from_raw(b"c"), Key::from_raw(b"d")],
                     2,
                 )
@@ -2320,7 +2320,7 @@ mod tests {
         );
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![
                     Key::from_raw(b"a"),
                     Key::from_raw(b"b"),
@@ -2340,7 +2340,7 @@ mod tests {
             ],
             storage
                 .async_batch_get(
-                    Context::new(),
+                    Context::default(),
                     vec![
                         Key::from_raw(b"c"),
                         Key::from_raw(b"x"),
@@ -2359,7 +2359,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"x"), b"100".to_vec()))],
                 b"x".to_vec(),
                 100,
@@ -2369,7 +2369,7 @@ mod tests {
             .unwrap();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"y"), b"101".to_vec()))],
                 b"y".to_vec(),
                 101,
@@ -2381,7 +2381,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"x")],
                 100,
                 110,
@@ -2390,7 +2390,7 @@ mod tests {
             .unwrap();
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"y")],
                 101,
                 111,
@@ -2402,18 +2402,18 @@ mod tests {
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 120)
+                .async_get(Context::default(), Key::from_raw(b"x"), 120)
                 .wait(),
         );
         expect_value(
             b"101".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"y"), 120)
+                .async_get(Context::default(), Key::from_raw(b"y"), 120)
                 .wait(),
         );
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"x"), b"105".to_vec()))],
                 b"x".to_vec(),
                 105,
@@ -2435,12 +2435,12 @@ mod tests {
         let (tx, rx) = channel();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 100)
+                .async_get(Context::default(), Key::from_raw(b"x"), 100)
                 .wait(),
         );
         storage
             .async_pause(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"x")],
                 1000,
                 expect_ok_callback(tx.clone(), 1),
@@ -2448,7 +2448,7 @@ mod tests {
             .unwrap();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"y"), b"101".to_vec()))],
                 b"y".to_vec(),
                 101,
@@ -2460,7 +2460,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"z"), b"102".to_vec()))],
                 b"y".to_vec(),
                 102,
@@ -2477,7 +2477,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"x"), b"100".to_vec()))],
                 b"x".to_vec(),
                 100,
@@ -2488,7 +2488,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_cleanup(
-                Context::new(),
+                Context::default(),
                 Key::from_raw(b"x"),
                 100,
                 expect_ok_callback(tx.clone(), 1),
@@ -2497,7 +2497,7 @@ mod tests {
         rx.recv().unwrap();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 105)
+                .async_get(Context::default(), Key::from_raw(b"x"), 105)
                 .wait(),
         );
     }
@@ -2506,10 +2506,10 @@ mod tests {
     fn test_high_priority_get_put() {
         let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         expect_none(storage.async_get(ctx, Key::from_raw(b"x"), 100).wait());
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         storage
             .async_prewrite(
@@ -2522,7 +2522,7 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         storage
             .async_commit(
@@ -2534,10 +2534,10 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         expect_none(storage.async_get(ctx, Key::from_raw(b"x"), 100).wait());
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         expect_value(
             b"100".to_vec(),
@@ -2553,12 +2553,12 @@ mod tests {
         let (tx, rx) = channel();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 100)
+                .async_get(Context::default(), Key::from_raw(b"x"), 100)
                 .wait(),
         );
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"x"), b"100".to_vec()))],
                 b"x".to_vec(),
                 100,
@@ -2569,7 +2569,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"x")],
                 100,
                 101,
@@ -2580,13 +2580,13 @@ mod tests {
 
         storage
             .async_pause(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"y")],
                 1000,
                 expect_ok_callback(tx.clone(), 3),
             )
             .unwrap();
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         expect_value(
             b"100".to_vec(),
@@ -2603,7 +2603,7 @@ mod tests {
         // Write x and y.
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"x"), b"100".to_vec())),
                     Mutation::Put((Key::from_raw(b"y"), b"100".to_vec())),
@@ -2618,7 +2618,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![
                     Key::from_raw(b"x"),
                     Key::from_raw(b"y"),
@@ -2633,26 +2633,26 @@ mod tests {
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 101)
+                .async_get(Context::default(), Key::from_raw(b"x"), 101)
                 .wait(),
         );
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"y"), 101)
+                .async_get(Context::default(), Key::from_raw(b"y"), 101)
                 .wait(),
         );
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"z"), 101)
+                .async_get(Context::default(), Key::from_raw(b"z"), 101)
                 .wait(),
         );
 
         // Delete range [x, z)
         storage
             .async_delete_range(
-                Context::new(),
+                Context::default(),
                 Key::from_raw(b"x"),
                 Key::from_raw(b"z"),
                 false,
@@ -2662,24 +2662,24 @@ mod tests {
         rx.recv().unwrap();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 101)
+                .async_get(Context::default(), Key::from_raw(b"x"), 101)
                 .wait(),
         );
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"y"), 101)
+                .async_get(Context::default(), Key::from_raw(b"y"), 101)
                 .wait(),
         );
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"z"), 101)
+                .async_get(Context::default(), Key::from_raw(b"z"), 101)
                 .wait(),
         );
 
         storage
             .async_delete_range(
-                Context::new(),
+                Context::default(),
                 Key::from_raw(b""),
                 Key::from_raw(&[255]),
                 false,
@@ -2689,7 +2689,7 @@ mod tests {
         rx.recv().unwrap();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"z"), 101)
+                .async_get(Context::default(), Key::from_raw(b"z"), 101)
                 .wait(),
         );
     }
@@ -2711,7 +2711,7 @@ mod tests {
         for kv in &test_data {
             storage
                 .async_raw_put(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     kv.0.to_vec(),
                     kv.1.to_vec(),
@@ -2723,14 +2723,14 @@ mod tests {
         expect_value(
             b"004".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"d".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"d".to_vec())
                 .wait(),
         );
 
         // Delete ["d", "e")
         storage
             .async_raw_delete_range(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 b"d".to_vec(),
                 b"e".to_vec(),
@@ -2743,25 +2743,25 @@ mod tests {
         expect_value(
             b"003".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"c".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"c".to_vec())
                 .wait(),
         );
         expect_none(
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"d".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"d".to_vec())
                 .wait(),
         );
         expect_value(
             b"005".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"e".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"e".to_vec())
                 .wait(),
         );
 
         // Delete ["aa", "ab")
         storage
             .async_raw_delete_range(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 b"aa".to_vec(),
                 b"ab".to_vec(),
@@ -2774,20 +2774,20 @@ mod tests {
         expect_value(
             b"001".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"a".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"a".to_vec())
                 .wait(),
         );
         expect_value(
             b"002".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"b".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"b".to_vec())
                 .wait(),
         );
 
         // Delete all
         storage
             .async_raw_delete_range(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 b"a".to_vec(),
                 b"z".to_vec(),
@@ -2800,7 +2800,7 @@ mod tests {
         for kv in &test_data {
             expect_none(
                 storage
-                    .async_raw_get(Context::new(), "".to_string(), kv.0.to_vec())
+                    .async_raw_get(Context::default(), "".to_string(), kv.0.to_vec())
                     .wait(),
             );
         }
@@ -2824,7 +2824,7 @@ mod tests {
         // Write key-value pairs in a batch
         storage
             .async_raw_batch_put(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 test_data.clone(),
                 expect_ok_callback(tx.clone(), 0),
@@ -2837,7 +2837,7 @@ mod tests {
             expect_value(
                 val,
                 storage
-                    .async_raw_get(Context::new(), "".to_string(), key)
+                    .async_raw_get(Context::default(), "".to_string(), key)
                     .wait(),
             );
         }
@@ -2860,7 +2860,7 @@ mod tests {
         for &(ref key, ref value) in &test_data {
             storage
                 .async_raw_put(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     key.clone(),
                     value.clone(),
@@ -2876,7 +2876,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_get(Context::new(), "".to_string(), keys)
+                .async_raw_batch_get(Context::default(), "".to_string(), keys)
                 .wait(),
         );
     }
@@ -2897,7 +2897,7 @@ mod tests {
         // Write key-value pairs in batch
         storage
             .async_raw_batch_put(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 test_data.clone(),
                 expect_ok_callback(tx.clone(), 0),
@@ -2914,14 +2914,14 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_get(Context::new(), "".to_string(), keys)
+                .async_raw_batch_get(Context::default(), "".to_string(), keys)
                 .wait(),
         );
 
         // Delete ["b", "d"]
         storage
             .async_raw_batch_delete(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 vec![b"b".to_vec(), b"d".to_vec()],
                 expect_ok_callback(tx.clone(), 1),
@@ -2933,36 +2933,36 @@ mod tests {
         expect_value(
             b"aa".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"a".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"a".to_vec())
                 .wait(),
         );
         expect_none(
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"b".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"b".to_vec())
                 .wait(),
         );
         expect_value(
             b"cc".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"c".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"c".to_vec())
                 .wait(),
         );
         expect_none(
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"d".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"d".to_vec())
                 .wait(),
         );
         expect_value(
             b"ee".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"e".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"e".to_vec())
                 .wait(),
         );
 
         // Delete ["a", "c", "e"]
         storage
             .async_raw_batch_delete(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 vec![b"a".to_vec(), b"c".to_vec(), b"e".to_vec()],
                 expect_ok_callback(tx.clone(), 2),
@@ -2974,7 +2974,7 @@ mod tests {
         for (k, _) in test_data {
             expect_none(
                 storage
-                    .async_raw_get(Context::new(), "".to_string(), k)
+                    .async_raw_get(Context::default(), "".to_string(), k)
                     .wait(),
             );
         }
@@ -3011,7 +3011,7 @@ mod tests {
         // Write key-value pairs in batch
         storage
             .async_raw_batch_put(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 test_data.clone(),
                 expect_ok_callback(tx.clone(), 0),
@@ -3028,7 +3028,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     vec![],
                     None,
@@ -3043,7 +3043,7 @@ mod tests {
             results,
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"c2".to_vec(),
                     None,
@@ -3062,7 +3062,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     vec![],
                     None,
@@ -3077,7 +3077,7 @@ mod tests {
             results,
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"c2".to_vec(),
                     None,
@@ -3097,7 +3097,7 @@ mod tests {
             results,
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"z".to_vec(),
                     None,
@@ -3118,7 +3118,7 @@ mod tests {
             results,
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"z".to_vec(),
                     None,
@@ -3141,7 +3141,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"b2".to_vec(),
                     Some(b"c2".to_vec()),
@@ -3162,7 +3162,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"b2".to_vec(),
                     Some(b"b2\x00".to_vec()),
@@ -3186,7 +3186,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"c2".to_vec(),
                     Some(b"b2".to_vec()),
@@ -3207,7 +3207,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"b2\x00".to_vec(),
                     Some(b"b2".to_vec()),
@@ -3219,7 +3219,7 @@ mod tests {
         );
 
         // End key tests. Confirm that lower/upper bound works correctly.
-        let ctx = Context::new();
+        let ctx = Context::default();
         let results = vec![
             (b"c1".to_vec(), b"cc11".to_vec()),
             (b"c2".to_vec(), b"cc22".to_vec()),
@@ -3271,7 +3271,7 @@ mod tests {
             ranges
                 .into_iter()
                 .map(|(s, e)| {
-                    let mut range = KeyRange::new();
+                    let mut range = KeyRange::default();
                     range.set_start_key(s);
                     if !e.is_empty() {
                         range.set_end_key(e);
@@ -3394,7 +3394,7 @@ mod tests {
         // Write key-value pairs in batch
         storage
             .async_raw_batch_put(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 test_data.clone(),
                 expect_ok_callback(tx.clone(), 0),
@@ -3408,7 +3408,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_get(Context::new(), "".to_string(), keys)
+                .async_raw_batch_get(Context::default(), "".to_string(), keys)
                 .wait(),
         );
 
@@ -3430,7 +3430,7 @@ mod tests {
         let ranges: Vec<KeyRange> = vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]
             .into_iter()
             .map(|k| {
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 range.set_start_key(k);
                 range
             })
@@ -3439,7 +3439,7 @@ mod tests {
             results,
             storage
                 .async_raw_batch_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     ranges.clone(),
                     5,
@@ -3468,7 +3468,7 @@ mod tests {
             results,
             storage
                 .async_raw_batch_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     ranges.clone(),
                     5,
@@ -3493,7 +3493,7 @@ mod tests {
             results,
             storage
                 .async_raw_batch_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     ranges.clone(),
                     3,
@@ -3517,7 +3517,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_scan(Context::new(), "".to_string(), ranges, 3, true, false)
+                .async_raw_batch_scan(Context::default(), "".to_string(), ranges, 3, true, false)
                 .wait(),
         );
 
@@ -3539,7 +3539,7 @@ mod tests {
         ]
         .into_iter()
         .map(|(s, e)| {
-            let mut range = KeyRange::new();
+            let mut range = KeyRange::default();
             range.set_start_key(s);
             range.set_end_key(e);
             range
@@ -3548,7 +3548,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_scan(Context::new(), "".to_string(), ranges, 5, false, true)
+                .async_raw_batch_scan(Context::default(), "".to_string(), ranges, 5, false, true)
                 .wait(),
         );
 
@@ -3563,7 +3563,7 @@ mod tests {
         let ranges: Vec<KeyRange> = vec![b"c3".to_vec(), b"b3".to_vec(), b"a3".to_vec()]
             .into_iter()
             .map(|s| {
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 range.set_start_key(s);
                 range
             })
@@ -3571,7 +3571,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_scan(Context::new(), "".to_string(), ranges, 2, false, true)
+                .async_raw_batch_scan(Context::default(), "".to_string(), ranges, 2, false, true)
                 .wait(),
         );
 
@@ -3593,7 +3593,7 @@ mod tests {
         ]
         .into_iter()
         .map(|(s, e)| {
-            let mut range = KeyRange::new();
+            let mut range = KeyRange::default();
             range.set_start_key(s);
             range.set_end_key(e);
             range
@@ -3602,7 +3602,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_scan(Context::new(), "".to_string(), ranges, 5, true, true)
+                .async_raw_batch_scan(Context::default(), "".to_string(), ranges, 5, true, true)
                 .wait(),
         );
     }
@@ -3613,7 +3613,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"x"), b"foo".to_vec())),
                     Mutation::Put((Key::from_raw(b"y"), b"foo".to_vec())),
@@ -3628,7 +3628,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"foo".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"foo".to_vec())),
@@ -3643,42 +3643,42 @@ mod tests {
         rx.recv().unwrap();
         let (lock_a, lock_b, lock_c, lock_x, lock_y, lock_z) = (
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(101);
                 lock.set_key(b"a".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(101);
                 lock.set_key(b"b".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(101);
                 lock.set_key(b"c".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"x".to_vec());
                 lock.set_lock_version(100);
                 lock.set_key(b"x".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"x".to_vec());
                 lock.set_lock_version(100);
                 lock.set_key(b"y".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"x".to_vec());
                 lock.set_lock_version(100);
                 lock.set_key(b"z".to_vec());
@@ -3687,7 +3687,7 @@ mod tests {
         );
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 99,
                 vec![],
                 10,
@@ -3697,7 +3697,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 100,
                 vec![],
                 10,
@@ -3711,7 +3711,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 100,
                 b"a".to_vec(),
                 10,
@@ -3725,7 +3725,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 100,
                 b"y".to_vec(),
                 10,
@@ -3735,7 +3735,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 101,
                 vec![],
                 10,
@@ -3756,7 +3756,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 101,
                 vec![],
                 4,
@@ -3775,7 +3775,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 101,
                 b"b".to_vec(),
                 4,
@@ -3794,7 +3794,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 101,
                 b"b".to_vec(),
                 0,
@@ -3824,7 +3824,7 @@ mod tests {
         // These locks (transaction ts=99) are not going to be resolved.
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"foo".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"foo".to_vec())),
@@ -3840,21 +3840,21 @@ mod tests {
 
         let (lock_a, lock_b, lock_c) = (
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(99);
                 lock.set_key(b"a".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(99);
                 lock.set_key(b"b".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(99);
                 lock.set_key(b"c".to_vec());
@@ -3892,7 +3892,7 @@ mod tests {
 
                 storage
                     .async_prewrite(
-                        Context::new(),
+                        Context::default(),
                         mutations,
                         b"x".to_vec(),
                         ts,
@@ -3913,7 +3913,7 @@ mod tests {
                 );
                 storage
                     .async_resolve_lock(
-                        Context::new(),
+                        Context::default(),
                         txn_status,
                         expect_ok_callback(tx.clone(), 0),
                     )
@@ -3923,7 +3923,7 @@ mod tests {
                 // All locks should be resolved except for a, b and c.
                 storage
                     .async_scan_locks(
-                        Context::new(),
+                        Context::default(),
                         ts,
                         vec![],
                         0,
@@ -3948,7 +3948,7 @@ mod tests {
 
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"foo".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"foo".to_vec())),
@@ -3966,7 +3966,7 @@ mod tests {
         let resolve_keys = vec![Key::from_raw(b"b"), Key::from_raw(b"c")];
         storage
             .async_resolve_lock_lite(
-                Context::new(),
+                Context::default(),
                 99,
                 0,
                 resolve_keys,
@@ -3977,7 +3977,7 @@ mod tests {
 
         // Check lock for key 'a'.
         let lock_a = {
-            let mut lock = LockInfo::new();
+            let mut lock = LockInfo::default();
             lock.set_primary_lock(b"c".to_vec());
             lock.set_lock_version(99);
             lock.set_key(b"a".to_vec());
@@ -3985,7 +3985,7 @@ mod tests {
         };
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 99,
                 vec![],
                 0,
@@ -3997,7 +3997,7 @@ mod tests {
         // Resolve lock for key 'a'.
         storage
             .async_resolve_lock_lite(
-                Context::new(),
+                Context::default(),
                 99,
                 0,
                 vec![Key::from_raw(b"a")],
@@ -4008,7 +4008,7 @@ mod tests {
 
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"foo".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"foo".to_vec())),
@@ -4026,7 +4026,7 @@ mod tests {
         let resolve_keys = vec![Key::from_raw(b"b"), Key::from_raw(b"c")];
         storage
             .async_resolve_lock_lite(
-                Context::new(),
+                Context::default(),
                 101,
                 102,
                 resolve_keys,
@@ -4037,7 +4037,7 @@ mod tests {
 
         // Check lock for key 'a'.
         let lock_a = {
-            let mut lock = LockInfo::new();
+            let mut lock = LockInfo::default();
             lock.set_primary_lock(b"c".to_vec());
             lock.set_lock_version(101);
             lock.set_key(b"a".to_vec());
@@ -4045,7 +4045,7 @@ mod tests {
         };
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 101,
                 vec![],
                 0,

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -222,9 +222,9 @@ pub mod tests {
     }
 
     pub fn must_get<E: Engine>(engine: &E, key: &[u8], ts: u64, expect: &[u8]) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
         assert_eq!(
             reader.get(&Key::from_raw(key), ts).unwrap().unwrap(),
             expect
@@ -232,9 +232,9 @@ pub mod tests {
     }
 
     pub fn must_get_rc<E: Engine>(engine: &E, key: &[u8], ts: u64, expect: &[u8]) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::RC);
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Rc);
         assert_eq!(
             reader.get(&Key::from_raw(key), ts).unwrap().unwrap(),
             expect
@@ -242,16 +242,16 @@ pub mod tests {
     }
 
     pub fn must_get_none<E: Engine>(engine: &E, key: &[u8], ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
         assert!(reader.get(&Key::from_raw(key), ts).unwrap().is_none());
     }
 
     pub fn must_get_err<E: Engine>(engine: &E, key: &[u8], ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
         assert!(reader.get(&Key::from_raw(key), ts).is_err());
     }
 
@@ -263,7 +263,7 @@ pub mod tests {
         pk: &[u8],
         ts: u64,
     ) -> Result<()> {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         txn.prewrite(
@@ -284,7 +284,7 @@ pub mod tests {
         for_update_ts: u64,
         is_pessimistic_lock: bool,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         let mut options = Options::default();
@@ -332,7 +332,7 @@ pub mod tests {
         for_update_ts: u64,
         is_pessimistic_lock: bool,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         let mut options = Options::default();
@@ -384,7 +384,7 @@ pub mod tests {
         for_update_ts: u64,
         is_pessimistic_lock: bool,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         let mut options = Options::default();
@@ -415,7 +415,7 @@ pub mod tests {
     }
 
     pub fn must_prewrite_lock<E: Engine>(engine: &E, key: &[u8], pk: &[u8], ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         txn.prewrite(Mutation::Lock(Key::from_raw(key)), pk, &Options::default())
@@ -424,7 +424,7 @@ pub mod tests {
     }
 
     pub fn must_prewrite_lock_err<E: Engine>(engine: &E, key: &[u8], pk: &[u8], ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         assert!(txn
@@ -439,7 +439,7 @@ pub mod tests {
         start_ts: u64,
         for_update_ts: u64,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         let mut options = Options::default();
@@ -459,7 +459,7 @@ pub mod tests {
         start_ts: u64,
         for_update_ts: u64,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         let mut options = Options::default();
@@ -474,7 +474,7 @@ pub mod tests {
         start_ts: u64,
         for_update_ts: u64,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         txn.pessimistic_rollback(Key::from_raw(key), for_update_ts)
@@ -483,7 +483,7 @@ pub mod tests {
     }
 
     pub fn must_commit<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         txn.commit(Key::from_raw(key), commit_ts).unwrap();
@@ -491,14 +491,14 @@ pub mod tests {
     }
 
     pub fn must_commit_err<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         assert!(txn.commit(Key::from_raw(key), commit_ts).is_err());
     }
 
     pub fn must_rollback<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         txn.collapse_rollback(false);
@@ -507,7 +507,7 @@ pub mod tests {
     }
 
     pub fn must_rollback_collapsed<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         txn.rollback(Key::from_raw(key)).unwrap();
@@ -515,14 +515,14 @@ pub mod tests {
     }
 
     pub fn must_rollback_err<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         assert!(txn.rollback(Key::from_raw(key)).is_err());
     }
 
     pub fn must_gc<E: Engine>(engine: &E, key: &[u8], safe_point: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, 0, true).unwrap();
         txn.gc(Key::from_raw(key), safe_point).unwrap();
@@ -530,8 +530,8 @@ pub mod tests {
     }
 
     pub fn must_locked<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
         let lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
         assert_eq!(lock.ts, start_ts);
         assert_ne!(lock.lock_type, LockType::Pessimistic);
@@ -543,8 +543,8 @@ pub mod tests {
         start_ts: u64,
         for_update_ts: u64,
     ) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
         let lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
         assert_eq!(lock.ts, start_ts);
         assert_eq!(lock.for_update_ts, for_update_ts);
@@ -552,8 +552,8 @@ pub mod tests {
     }
 
     pub fn must_unlocked<E: Engine>(engine: &E, key: &[u8]) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
         assert!(reader.load_lock(&Key::from_raw(key)).unwrap().is_none());
     }
 
@@ -564,7 +564,7 @@ pub mod tests {
         commit_ts: u64,
         tp: WriteType,
     ) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let k = Key::from_raw(key).append_ts(commit_ts);
         let v = snapshot.get_cf(CF_WRITE, &k).unwrap().unwrap();
         let write = Write::parse(&v).unwrap();
@@ -573,8 +573,8 @@ pub mod tests {
     }
 
     pub fn must_seek_write_none<E: Engine>(engine: &E, key: &[u8], ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
         assert!(reader
             .seek_write(&Key::from_raw(key), ts)
             .unwrap()
@@ -589,8 +589,8 @@ pub mod tests {
         commit_ts: u64,
         write_type: WriteType,
     ) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
         let (t, write) = reader.seek_write(&Key::from_raw(key), ts).unwrap().unwrap();
         assert_eq!(t, commit_ts);
         assert_eq!(write.start_ts, start_ts);
@@ -598,8 +598,8 @@ pub mod tests {
     }
 
     pub fn must_reverse_seek_write_none<E: Engine>(engine: &E, key: &[u8], ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
         assert!(reader
             .reverse_seek_write(&Key::from_raw(key), ts)
             .unwrap()
@@ -614,8 +614,8 @@ pub mod tests {
         commit_ts: u64,
         write_type: WriteType,
     ) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
         let (t, write) = reader
             .reverse_seek_write(&Key::from_raw(key), ts)
             .unwrap()
@@ -626,8 +626,8 @@ pub mod tests {
     }
 
     pub fn must_get_commit_ts<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
         let (ts, write_type) = reader
             .get_txn_commit_info(&Key::from_raw(key), start_ts)
             .unwrap()
@@ -637,8 +637,8 @@ pub mod tests {
     }
 
     pub fn must_get_commit_ts_none<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
 
         let ret = reader.get_txn_commit_info(&Key::from_raw(key), start_ts);
         assert!(ret.is_ok());
@@ -651,8 +651,8 @@ pub mod tests {
     }
 
     pub fn must_get_rollback_ts<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
 
         let (ts, write_type) = reader
             .get_txn_commit_info(&Key::from_raw(key), start_ts)
@@ -663,8 +663,8 @@ pub mod tests {
     }
 
     pub fn must_get_rollback_ts_none<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
 
         let ret = reader
             .get_txn_commit_info(&Key::from_raw(key), start_ts)
@@ -683,14 +683,14 @@ pub mod tests {
             keys.into_iter().map(Key::from_raw).collect(),
             next_start.map(|x| Key::from_raw(x).append_ts(0)),
         );
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(
             snapshot,
             Some(ScanMode::Mixed),
             false,
             None,
             None,
-            IsolationLevel::SI,
+            IsolationLevel::Si,
         );
         assert_eq!(
             reader.scan_keys(start.map(Key::from_raw), limit).unwrap(),

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -134,7 +134,7 @@ impl<S: Snapshot> BackwardScanner<S> {
 
             if has_lock {
                 match self.cfg.isolation_level {
-                    IsolationLevel::SI => {
+                    IsolationLevel::Si => {
                         let lock = {
                             let lock_value = self.lock_cursor.value(&mut self.statistics.lock);
                             Lock::parse(lock_value)?
@@ -145,7 +145,7 @@ impl<S: Snapshot> BackwardScanner<S> {
                             CheckLockResult::Ignored(ts) => get_ts = ts,
                         }
                     }
-                    IsolationLevel::RC => {}
+                    IsolationLevel::Rc => {}
                 }
                 self.lock_cursor.prev(&mut self.statistics.lock);
             }
@@ -447,7 +447,7 @@ mod tests {
         // Assume REVERSE_SEEK_BOUND == 4, we have keys:
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND, true)
             .range(None, Some(Key::from_raw(&[11 as u8])))
             .build()
@@ -642,7 +642,7 @@ mod tests {
             REVERSE_SEEK_BOUND * 2,
         );
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND * 2, true)
             .range(None, None)
             .build()
@@ -712,7 +712,7 @@ mod tests {
             REVERSE_SEEK_BOUND * 2,
         );
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND * 2, true)
             .range(None, None)
             .build()
@@ -779,7 +779,7 @@ mod tests {
             must_commit(&engine, b"b", ts, ts);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, 1, true)
             .range(None, None)
             .build()
@@ -850,7 +850,7 @@ mod tests {
             must_commit(&engine, b"b", ts, ts);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, 1, true)
             .range(None, None)
             .build()
@@ -929,7 +929,7 @@ mod tests {
             must_commit(&engine, b"b", ts, ts);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND + 1, true)
             .range(None, None)
             .build()
@@ -1014,7 +1014,7 @@ mod tests {
             must_commit(&engine, &[i], 14, 14);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         // Test both bound specified.
         let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, true)
@@ -1119,7 +1119,7 @@ mod tests {
             must_prewrite_put(&engine, pk, b"", pk, start_ts);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let row = &[255 as u8];
         let k = Key::from_raw(row);
 

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -159,7 +159,7 @@ impl<S: Snapshot> ForwardScanner<S> {
 
             if has_lock {
                 match self.cfg.isolation_level {
-                    IsolationLevel::SI => {
+                    IsolationLevel::Si => {
                         // Only needs to check lock in SI
                         let lock = {
                             let lock_value = self.lock_cursor.value(&mut self.statistics.lock);
@@ -171,7 +171,7 @@ impl<S: Snapshot> ForwardScanner<S> {
                             CheckLockResult::Ignored(ts) => get_ts = ts,
                         }
                     }
-                    IsolationLevel::RC => {}
+                    IsolationLevel::Rc => {}
                 }
                 self.lock_cursor.next(&mut self.statistics.lock);
             }
@@ -387,7 +387,7 @@ mod tests {
             must_rollback(&engine, b"b", ts);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, 10, false)
             .range(None, None)
             .build()
@@ -441,7 +441,7 @@ mod tests {
         must_prewrite_put(&engine, b"b", b"b_value", b"a", SEEK_BOUND / 2);
         must_commit(&engine, b"b", SEEK_BOUND / 2, SEEK_BOUND / 2);
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2, false)
             .range(None, None)
             .build()
@@ -504,7 +504,7 @@ mod tests {
         must_prewrite_put(&engine, b"b", b"b_value", b"a", SEEK_BOUND);
         must_commit(&engine, b"b", SEEK_BOUND, SEEK_BOUND);
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2, false)
             .range(None, None)
             .build()
@@ -571,7 +571,7 @@ mod tests {
             must_commit(&engine, &[i], 14, 14);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         // Test both bound specified.
         let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -61,7 +61,7 @@ impl<S: Snapshot> ScannerBuilder<S> {
 
     /// Set the isolation level.
     ///
-    /// Defaults to `IsolationLevel::SI`.
+    /// Defaults to `IsolationLevel::Si`.
     #[inline]
     pub fn isolation_level(mut self, isolation_level: IsolationLevel) -> Self {
         self.isolation_level = isolation_level;
@@ -142,7 +142,7 @@ impl<S: Snapshot> ScannerConfig<S> {
             snapshot,
             fill_cache: true,
             omit_value: false,
-            isolation_level: IsolationLevel::SI,
+            isolation_level: IsolationLevel::Si,
             lower_bound: None,
             upper_bound: None,
             ts,
@@ -223,7 +223,7 @@ mod tests {
         must_acquire_pessimistic_lock(&engine, &[3], &[3], 105, 110);
         must_prewrite_put(&engine, &[4], b"a", &[4], 105);
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         let mut expected_result = vec![
             (vec![0], Some(vec![b'v', 0])),

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -51,7 +51,7 @@ impl<S: Snapshot> MvccTxn<S> {
                 fill_cache,
                 None,
                 None,
-                IsolationLevel::SI,
+                IsolationLevel::Si,
             ),
             gc_reader: MvccReader::new(
                 snapshot,
@@ -59,7 +59,7 @@ impl<S: Snapshot> MvccTxn<S> {
                 fill_cache,
                 None,
                 None,
-                IsolationLevel::SI,
+                IsolationLevel::Si,
             ),
             start_ts,
             writes: vec![],
@@ -1024,7 +1024,7 @@ mod tests {
 
     fn test_write_size_imp(k: &[u8], v: &[u8], pk: &[u8]) {
         let engine = TestEngineBuilder::new().build().unwrap();
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, 10, true).unwrap();
         let key = Key::from_raw(k);
@@ -1062,7 +1062,7 @@ mod tests {
         must_prewrite_put(&engine, key, value, key, 5);
         must_commit(&engine, key, 5, 10);
 
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, 5, true).unwrap();
         assert!(txn
@@ -1073,7 +1073,7 @@ mod tests {
             )
             .is_err());
 
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, 5, true).unwrap();
         let mut opt = Options::default();
@@ -1166,14 +1166,14 @@ mod tests {
         );
         must_commit(&engine, &[6], 3, 6);
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(
             snapshot,
             Some(ScanMode::Forward),
             true,
             None,
             None,
-            IsolationLevel::SI,
+            IsolationLevel::Si,
         );
 
         let v = reader.scan_values_in_default(&Key::from_raw(&[3])).unwrap();
@@ -1210,14 +1210,14 @@ mod tests {
         must_prewrite_put(&engine, &[6], b"xxx", &[6], 3);
         must_commit(&engine, &[6], 3, 6);
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(
             snapshot,
             Some(ScanMode::Forward),
             true,
             None,
             None,
-            IsolationLevel::SI,
+            IsolationLevel::Si,
         );
 
         assert_eq!(reader.seek_ts(3).unwrap().unwrap(), Key::from_raw(&[2]));

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -27,11 +27,6 @@ quick_error! {
             cause(err)
             description(err.description())
         }
-        ProtoBuf(err: protobuf::error::ProtobufError) {
-            from()
-            cause(err)
-            description(err.description())
-        }
         Mvcc(err: crate::storage::mvcc::Error) {
             from()
             cause(err)
@@ -92,7 +87,7 @@ impl Error {
                 lower_bound: lower_bound.clone(),
                 upper_bound: upper_bound.clone(),
             }),
-            Error::Other(_) | Error::ProtoBuf(_) | Error::Io(_) => None,
+            Error::Other(_) | Error::Io(_) => None,
         }
     }
 }

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -413,7 +413,7 @@ fn process_read_impl<E: Engine>(
             let (kv_pairs, _) = result?;
             let mut locks = Vec::with_capacity(kv_pairs.len());
             for (key, lock) in kv_pairs {
-                let mut lock_info = LockInfo::new();
+                let mut lock_info = LockInfo::default();
                 lock_info.set_primary_lock(lock.primary);
                 lock_info.set_lock_version(lock.ts);
                 lock_info.set_key(key.into_raw()?);

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -542,65 +542,65 @@ mod tests {
         temp_map.insert(10, 20);
         let readonly_cmds = vec![
             Command::ScanLock {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 max_ts: 5,
                 start_key: None,
                 limit: 0,
             },
             Command::ResolveLock {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 txn_status: temp_map.clone(),
                 scan_key: None,
                 key_locks: vec![],
             },
             Command::MvccByKey {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 key: Key::from_raw(b"k"),
             },
             Command::MvccByStartTs {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 start_ts: 25,
             },
         ];
         let write_cmds = vec![
             Command::Prewrite {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 mutations: vec![Mutation::Put((Key::from_raw(b"k"), b"v".to_vec()))],
                 primary: b"k".to_vec(),
                 start_ts: 10,
                 options: Options::default(),
             },
             Command::AcquirePessimisticLock {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 keys: vec![(Key::from_raw(b"k"), false)],
                 primary: b"k".to_vec(),
                 start_ts: 10,
                 options: Options::default(),
             },
             Command::Commit {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 keys: vec![Key::from_raw(b"k")],
                 lock_ts: 10,
                 commit_ts: 20,
             },
             Command::Cleanup {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 key: Key::from_raw(b"k"),
                 start_ts: 10,
             },
             Command::Rollback {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 keys: vec![Key::from_raw(b"k")],
                 start_ts: 10,
             },
             Command::PessimisticRollback {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 keys: vec![Key::from_raw(b"k")],
                 start_ts: 10,
                 for_update_ts: 20,
             },
             Command::ResolveLock {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 txn_status: temp_map.clone(),
                 scan_key: None,
                 key_locks: vec![(
@@ -609,7 +609,7 @@ mod tests {
                 )],
             },
             Command::ResolveLockLite {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 start_ts: 10,
                 commit_ts: 0,
                 resolve_keys: vec![Key::from_raw(b"k")],

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -320,7 +320,7 @@ mod tests {
             let keys: Vec<String> = (START_ID..START_ID + key_num)
                 .map(|i| format!("{}{}", KEY_PREFIX, i))
                 .collect();
-            let ctx = Context::new();
+            let ctx = Context::default();
             let snapshot = engine.snapshot(&ctx).unwrap();
             let mut store = TestStore {
                 keys,
@@ -372,7 +372,7 @@ mod tests {
             SnapshotStore::new(
                 self.snapshot.clone(),
                 COMMIT_TS + 1,
-                IsolationLevel::SI,
+                IsolationLevel::Si,
                 true,
             )
         }
@@ -589,7 +589,7 @@ mod tests {
     fn test_scanner_verify_bound() {
         // Store with a limited range
         let snap = MockRangeSnapshot::new(b"b".to_vec(), b"c".to_vec());
-        let store = SnapshotStore::new(snap, 0, IsolationLevel::SI, true);
+        let store = SnapshotStore::new(snap, 0, IsolationLevel::Si, true);
         let bound_a = Key::from_encoded(b"a".to_vec());
         let bound_b = Key::from_encoded(b"b".to_vec());
         let bound_c = Key::from_encoded(b"c".to_vec());
@@ -610,7 +610,7 @@ mod tests {
 
         // Store with whole range
         let snap2 = MockRangeSnapshot::new(b"".to_vec(), b"".to_vec());
-        let store2 = SnapshotStore::new(snap2, 0, IsolationLevel::SI, true);
+        let store2 = SnapshotStore::new(snap2, 0, IsolationLevel::Si, true);
         assert!(store2.scanner(false, false, None, None).is_ok());
         assert!(store2
             .scanner(false, false, Some(bound_a.clone()), None)

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use fail;
 use grpcio::*;
 use kvproto::kvrpcpb::{self, Context, Op, PrewriteRequest, RawPutRequest};
-use kvproto::tikvpb_grpc::TikvClient;
+use kvproto::tikvpb::TikvClient;
 
 use test_raftstore::{must_get_equal, must_get_none, new_server_cluster};
 use test_storage::new_raft_engine;
@@ -59,7 +59,7 @@ fn test_storage_gcworker_busy() {
     let (tx2, rx2) = channel();
     storage
         .async_gc(
-            Context::new(),
+            Context::default(),
             1,
             Box::new(move |res: storage::Result<()>| {
                 match res {
@@ -92,7 +92,7 @@ fn test_scheduler_leader_change_twice() {
         .build()
         .unwrap();
 
-    let mut ctx0 = Context::new();
+    let mut ctx0 = Context::default();
     ctx0.set_region_id(region0.get_id());
     ctx0.set_region_epoch(region0.get_region_epoch().clone());
     ctx0.set_peer(peers[0].clone());
@@ -144,15 +144,15 @@ fn test_server_catching_api_error() {
         ChannelBuilder::new(env).connect(cluster.sim.rl().get_addr(leader.get_store_id()));
     let client = TikvClient::new(channel);
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());
 
-    let mut prewrite_req = PrewriteRequest::new();
+    let mut prewrite_req = PrewriteRequest::default();
     prewrite_req.set_context(ctx.clone());
-    let mut mutation = kvrpcpb::Mutation::new();
-    mutation.op = Op::Put;
+    let mut mutation = kvrpcpb::Mutation::default();
+    mutation.set_op(Op::Put);
     mutation.key = b"k3".to_vec();
     mutation.value = b"v3".to_vec();
     prewrite_req.set_mutations(vec![mutation].into_iter().collect());
@@ -168,7 +168,7 @@ fn test_server_catching_api_error() {
     );
     must_get_none(&cluster.get_engine(1), b"k3");
 
-    let mut put_req = RawPutRequest::new();
+    let mut put_req = RawPutRequest::default();
     put_req.set_context(ctx.clone());
     put_req.key = b"k3".to_vec();
     put_req.value = b"v3".to_vec();

--- a/tests/failpoints/cases/test_upgrade.rs
+++ b/tests/failpoints/cases/test_upgrade.rs
@@ -43,7 +43,7 @@ fn write_store_ident(db: &DB, cf: &str, key: &[u8]) -> StoreIdent {
 }
 
 fn write_region(db: &DB, cf: &str, key: &[u8]) -> Region {
-    let mut region = Region::new();
+    let mut region = Region::default();
     region.set_id(REGION_ID);
     region.set_peers(vec![new_peer(STOER_ID, PEER_ID)].into());
     region.mut_region_epoch().set_conf_ver(INIT_EPOCH_CONF_VER);

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -188,7 +188,7 @@ fn test_serde_custom_tikv_config() {
         writable_file_max_buffer_size: ReadableSize::mb(12),
         use_direct_io_for_flush_and_compaction: true,
         enable_pipelined_write: false,
-        defaultcf: DefaultCfConfig {
+        new_cf: DefaultCfConfig {
             block_size: ReadableSize::kb(12),
             block_cache_size: ReadableSize::gb(12),
             disable_block_cache: false,
@@ -428,7 +428,7 @@ fn test_serde_custom_tikv_config() {
         allow_concurrent_memtable_write: true,
         bytes_per_sync: ReadableSize::mb(1),
         wal_bytes_per_sync: ReadableSize::kb(32),
-        defaultcf: RaftDefaultCfConfig {
+        new_cf: RaftDefaultCfConfig {
             block_size: ReadableSize::kb(12),
             block_cache_size: ReadableSize::gb(12),
             disable_block_cache: false,
@@ -548,9 +548,9 @@ fn test_block_cache_backward_compatible() {
     assert!(cfg.storage.block_cache.capacity.is_some());
     assert_eq!(
         cfg.storage.block_cache.capacity.unwrap().0,
-        cfg.rocksdb.defaultcf.block_cache_size.0
+        cfg.rocksdb.new_cf.block_cache_size.0
             + cfg.rocksdb.writecf.block_cache_size.0
             + cfg.rocksdb.lockcf.block_cache_size.0
-            + cfg.raftdb.defaultcf.block_cache_size.0
+            + cfg.raftdb.new_cf.block_cache_size.0
     );
 }

--- a/tests/integrations/import/sst_service.rs
+++ b/tests/integrations/import/sst_service.rs
@@ -10,9 +10,8 @@ use uuid::Uuid;
 
 use grpcio::{ChannelBuilder, Environment, Result, WriteFlags};
 use kvproto::import_sstpb::*;
-use kvproto::import_sstpb_grpc::*;
 use kvproto::kvrpcpb::*;
-use kvproto::tikvpb_grpc::*;
+use kvproto::tikvpb::*;
 
 use test_raftstore::*;
 use tikv::import::test_helpers::*;
@@ -31,7 +30,7 @@ fn new_cluster() -> (Cluster<ServerCluster>, Context) {
     let region_id = 1;
     let leader = cluster.leader_of_region(region_id).unwrap();
     let epoch = cluster.get_region_epoch(region_id);
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region_id);
     ctx.set_peer(leader.clone());
     ctx.set_region_epoch(epoch);
@@ -92,7 +91,7 @@ fn test_ingest_sst() {
     // No region id and epoch.
     send_upload_sst(&import, &meta, &data).unwrap();
 
-    let mut ingest = IngestRequest::new();
+    let mut ingest = IngestRequest::default();
     ingest.set_context(ctx.clone());
     ingest.set_sst(meta.clone());
     let resp = import.ingest(&ingest).unwrap();
@@ -111,7 +110,7 @@ fn test_ingest_sst() {
 
     // Check ingested kvs
     for i in sst_range.0..sst_range.1 {
-        let mut m = RawGetRequest::new();
+        let mut m = RawGetRequest::default();
         m.set_context(ctx.clone());
         m.set_key(vec![i]);
         let resp = tikv.raw_get(&m).unwrap();
@@ -166,8 +165,8 @@ fn test_cleanup_sst() {
     check_sst_deleted(&import, &meta, &data);
 }
 
-fn new_sst_meta(crc32: u32, length: u64) -> SSTMeta {
-    let mut m = SSTMeta::new();
+fn new_sst_meta(crc32: u32, length: u64) -> SstMeta {
+    let mut m = SstMeta::default();
     m.set_uuid(Uuid::new_v4().as_bytes().to_vec());
     m.set_crc32(crc32);
     m.set_length(length);
@@ -176,12 +175,12 @@ fn new_sst_meta(crc32: u32, length: u64) -> SSTMeta {
 
 fn send_upload_sst(
     client: &ImportSstClient,
-    meta: &SSTMeta,
+    meta: &SstMeta,
     data: &[u8],
 ) -> Result<UploadResponse> {
-    let mut r1 = UploadRequest::new();
+    let mut r1 = UploadRequest::default();
     r1.set_meta(meta.clone());
-    let mut r2 = UploadRequest::new();
+    let mut r2 = UploadRequest::default();
     r2.set_data(data.to_vec());
     let reqs: Vec<_> = vec![r1, r2]
         .into_iter()
@@ -192,7 +191,7 @@ fn send_upload_sst(
     stream.forward(tx).and_then(|_| rx).wait()
 }
 
-fn check_sst_deleted(client: &ImportSstClient, meta: &SSTMeta, data: &[u8]) {
+fn check_sst_deleted(client: &ImportSstClient, meta: &SstMeta, data: &[u8]) {
     for _ in 0..10 {
         if send_upload_sst(client, meta, data).is_ok() {
             // If we can upload the file, it means the previous file has been deleted.

--- a/tests/integrations/pd/mock/mocker/bootstrap.rs
+++ b/tests/integrations/pd/mock/mocker/bootstrap.rs
@@ -9,25 +9,25 @@ pub struct AlreadyBootstrapped;
 
 impl PdMocker for AlreadyBootstrapped {
     fn bootstrap(&self, _: &BootstrapRequest) -> Option<Result<BootstrapResponse>> {
-        let mut err = Error::new();
-        err.set_field_type(ErrorType::ALREADY_BOOTSTRAPPED);
+        let mut err = Error::default();
+        err.set_field_type_(ErrorType::AlreadyBootstrapped);
         err.set_message("cluster is already bootstrapped".to_owned());
 
-        let mut header = ResponseHeader::new();
+        let mut header = ResponseHeader::default();
         header.set_error(err);
         header.set_cluster_id(DEFAULT_CLUSTER_ID);
 
-        let mut resp = BootstrapResponse::new();
+        let mut resp = BootstrapResponse::default();
         resp.set_header(header);
 
         Some(Ok(resp))
     }
 
     fn is_bootstrapped(&self, _: &IsBootstrappedRequest) -> Option<Result<IsBootstrappedResponse>> {
-        let mut header = ResponseHeader::new();
+        let mut header = ResponseHeader::default();
         header.set_cluster_id(DEFAULT_CLUSTER_ID);
 
-        let mut resp = IsBootstrappedResponse::new();
+        let mut resp = IsBootstrappedResponse::default();
         resp.set_bootstrapped(false);
 
         Some(Ok(resp))

--- a/tests/integrations/pd/mock/mocker/incompatible.rs
+++ b/tests/integrations/pd/mock/mocker/incompatible.rs
@@ -9,13 +9,13 @@ pub struct Incompatible;
 
 impl PdMocker for Incompatible {
     fn ask_batch_split(&self, _: &AskBatchSplitRequest) -> Option<Result<AskBatchSplitResponse>> {
-        let mut err = Error::new();
-        err.set_field_type(ErrorType::INCOMPATIBLE_VERSION);
+        let mut err = Error::default();
+        err.set_field_type_(ErrorType::IncompatibleVersion);
 
-        let mut header = ResponseHeader::new();
+        let mut header = ResponseHeader::default();
         header.set_error(err);
 
-        let mut resp = AskBatchSplitResponse::new();
+        let mut resp = AskBatchSplitResponse::default();
         resp.set_header(header);
 
         Some(Ok(resp))

--- a/tests/integrations/pd/mock/mocker/leader_change.rs
+++ b/tests/integrations/pd/mock/mocker/leader_change.rs
@@ -4,7 +4,6 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use kvproto::pdpb::*;
-use protobuf::RepeatedField;
 
 use super::*;
 
@@ -66,7 +65,7 @@ impl PdMocker for LeaderChange {
         Some(Ok(inner.resps[inner.r.idx % inner.resps.len()].clone()))
     }
 
-    fn get_region_by_id(&self, _: &GetRegionByIDRequest) -> Option<Result<GetRegionResponse>> {
+    fn get_region_by_id(&self, _: &GetRegionByIdRequest) -> Option<Result<GetRegionResponse>> {
         let mut inner = self.inner.lock().unwrap();
         let now = Instant::now();
         if now.duration_since(inner.r.ts) > LeaderChange::get_leader_interval() {
@@ -84,30 +83,30 @@ impl PdMocker for LeaderChange {
     fn set_endpoints(&self, eps: Vec<String>) {
         let mut members = Vec::with_capacity(eps.len());
         for (i, ep) in (&eps).iter().enumerate() {
-            let mut m = Member::new();
+            let mut m = Member::default();
             m.set_name(format!("pd{}", i));
             m.set_member_id(100 + i as u64);
-            m.set_client_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
-            m.set_peer_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
+            m.set_client_urls(vec![ep.to_owned()]);
+            m.set_peer_urls(vec![ep.to_owned()]);
             members.push(m);
         }
 
         // A dead PD
-        let mut m = Member::new();
+        let mut m = Member::default();
         m.set_member_id(DEAD_ID);
         m.set_name(DEAD_NAME.to_owned());
-        m.set_client_urls(RepeatedField::from_vec(vec![DEAD_URL.to_owned()]));
-        m.set_peer_urls(RepeatedField::from_vec(vec![DEAD_URL.to_owned()]));
+        m.set_client_urls(vec![DEAD_URL.to_owned()]);
+        m.set_peer_urls(vec![DEAD_URL.to_owned()]);
         members.push(m);
 
-        let mut header = ResponseHeader::new();
+        let mut header = ResponseHeader::default();
         header.set_cluster_id(1);
 
         let mut resps = Vec::with_capacity(eps.len());
         for (i, _) in (&eps).iter().enumerate() {
-            let mut resp = GetMembersResponse::new();
+            let mut resp = GetMembersResponse::default();
             resp.set_header(header.clone());
-            resp.set_members(RepeatedField::from_vec(members.clone()));
+            resp.set_members(members.clone());
             resp.set_leader(members[i].clone());
             resps.push(resp);
         }

--- a/tests/integrations/pd/mock/mocker/mod.rs
+++ b/tests/integrations/pd/mock/mocker/mod.rs
@@ -39,7 +39,7 @@ pub trait PdMocker {
         None
     }
 
-    fn alloc_id(&self, _: &AllocIDRequest) -> Option<Result<AllocIDResponse>> {
+    fn alloc_id(&self, _: &AllocIdRequest) -> Option<Result<AllocIdResponse>> {
         None
     }
 
@@ -70,7 +70,7 @@ pub trait PdMocker {
         None
     }
 
-    fn get_region_by_id(&self, _: &GetRegionByIDRequest) -> Option<Result<GetRegionResponse>> {
+    fn get_region_by_id(&self, _: &GetRegionByIdRequest) -> Option<Result<GetRegionResponse>> {
         None
     }
 
@@ -111,15 +111,15 @@ pub trait PdMocker {
 
     fn update_gc_safe_point(
         &self,
-        _: &UpdateGCSafePointRequest,
-    ) -> Option<Result<UpdateGCSafePointResponse>> {
+        _: &UpdateGcSafePointRequest,
+    ) -> Option<Result<UpdateGcSafePointResponse>> {
         None
     }
 
     fn get_gc_safe_point(
         &self,
-        _: &GetGCSafePointRequest,
-    ) -> Option<Result<GetGCSafePointResponse>> {
+        _: &GetGcSafePointRequest,
+    ) -> Option<Result<GetGcSafePointResponse>> {
         None
     }
 }

--- a/tests/integrations/pd/mock/mocker/retry.rs
+++ b/tests/integrations/pd/mock/mocker/retry.rs
@@ -38,10 +38,10 @@ impl Retry {
 }
 
 impl PdMocker for Retry {
-    fn get_region_by_id(&self, _: &GetRegionByIDRequest) -> Option<Result<GetRegionResponse>> {
+    fn get_region_by_id(&self, _: &GetRegionByIdRequest) -> Option<Result<GetRegionResponse>> {
         if self.is_ok() {
             info!("[Retry] get_region_by_id returns Ok(_)");
-            Some(Ok(GetRegionResponse::new()))
+            Some(Ok(GetRegionResponse::default()))
         } else {
             info!("[Retry] get_region_by_id returns Err(_)");
             Some(Err("please retry".to_owned()))
@@ -51,7 +51,7 @@ impl PdMocker for Retry {
     fn get_store(&self, _: &GetStoreRequest) -> Option<Result<GetStoreResponse>> {
         if self.is_ok() {
             info!("[Retry] get_store returns Ok(_)");
-            Some(Ok(GetStoreResponse::new()))
+            Some(Ok(GetStoreResponse::default()))
         } else {
             info!("[Retry] get_store returns Err(_)");
             Some(Err("please retry".to_owned()))
@@ -77,35 +77,35 @@ impl NotRetry {
 }
 
 impl PdMocker for NotRetry {
-    fn get_region_by_id(&self, _: &GetRegionByIDRequest) -> Option<Result<GetRegionResponse>> {
+    fn get_region_by_id(&self, _: &GetRegionByIdRequest) -> Option<Result<GetRegionResponse>> {
         if !self.is_visited.swap(true, Ordering::Relaxed) {
             info!(
-                "[NotRetry] get_region_by_id returns Ok(_) with header has INCOMPATIBLE_VERSION error"
+                "[NotRetry] get_region_by_id returns Ok(_) with header has IncompatibleVersion error"
             );
-            let mut err = Error::new();
-            err.set_field_type(ErrorType::INCOMPATIBLE_VERSION);
-            let mut resp = GetRegionResponse::new();
+            let mut err = Error::default();
+            err.set_field_type_(ErrorType::IncompatibleVersion);
+            let mut resp = GetRegionResponse::default();
             resp.mut_header().set_error(err);
             Some(Ok(resp))
         } else {
             info!("[NotRetry] get_region_by_id returns Ok()");
-            Some(Ok(GetRegionResponse::new()))
+            Some(Ok(GetRegionResponse::default()))
         }
     }
 
     fn get_store(&self, _: &GetStoreRequest) -> Option<Result<GetStoreResponse>> {
         if !self.is_visited.swap(true, Ordering::Relaxed) {
             info!(
-                "[NotRetry] get_region_by_id returns Ok(_) with header has INCOMPATIBLE_VERSION error"
+                "[NotRetry] get_region_by_id returns Ok(_) with header has IncompatibleVersion error"
             );
-            let mut err = Error::new();
-            err.set_field_type(ErrorType::INCOMPATIBLE_VERSION);
-            let mut resp = GetStoreResponse::new();
+            let mut err = Error::default();
+            err.set_field_type_(ErrorType::IncompatibleVersion);
+            let mut resp = GetStoreResponse::default();
             resp.mut_header().set_error(err);
             Some(Ok(resp))
         } else {
             info!("[NotRetry] get_region_by_id returns Ok()");
-            Some(Ok(GetStoreResponse::new()))
+            Some(Ok(GetStoreResponse::default()))
         }
     }
 }

--- a/tests/integrations/pd/mock/mocker/service.rs
+++ b/tests/integrations/pd/mock/mocker/service.rs
@@ -7,8 +7,6 @@ use tikv_util::collections::HashMap;
 use kvproto::metapb::{Peer, Region, Store, StoreState};
 use kvproto::pdpb::*;
 
-use protobuf::RepeatedField;
-
 use super::*;
 
 #[derive(Debug)]
@@ -34,7 +32,7 @@ impl Service {
     }
 
     fn header() -> ResponseHeader {
-        let mut header = ResponseHeader::new();
+        let mut header = ResponseHeader::default();
         header.set_cluster_id(DEFAULT_CLUSTER_ID);
         header
     }
@@ -49,16 +47,16 @@ impl Service {
 fn make_members_response(eps: Vec<String>) -> GetMembersResponse {
     let mut members = Vec::with_capacity(eps.len());
     for (i, ep) in (&eps).iter().enumerate() {
-        let mut m = Member::new();
+        let mut m = Member::default();
         m.set_name(format!("pd{}", i));
         m.set_member_id(100 + i as u64);
-        m.set_client_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
-        m.set_peer_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
+        m.set_client_urls(vec![ep.to_owned()]);
+        m.set_peer_urls(vec![ep.to_owned()]);
         members.push(m);
     }
 
-    let mut members_resp = GetMembersResponse::new();
-    members_resp.set_members(RepeatedField::from_vec(members.clone()));
+    let mut members_resp = GetMembersResponse::default();
+    members_resp.set_members(members.clone());
     members_resp.set_leader(members.pop().unwrap());
     members_resp.set_header(Service::header());
 
@@ -76,12 +74,12 @@ impl PdMocker for Service {
         let store = req.get_store();
         let region = req.get_region();
 
-        let mut resp = BootstrapResponse::new();
+        let mut resp = BootstrapResponse::default();
         let mut header = Service::header();
 
         if self.is_bootstrapped.load(Ordering::SeqCst) {
-            let mut err = Error::new();
-            err.field_type = ErrorType::UNKNOWN;
+            let mut err = Error::default();
+            err.set_field_type_(ErrorType::Unknown);
             err.set_message("cluster is already bootstrapped".to_owned());
             header.set_error(err);
             resp.set_header(header);
@@ -101,15 +99,15 @@ impl PdMocker for Service {
     }
 
     fn is_bootstrapped(&self, _: &IsBootstrappedRequest) -> Option<Result<IsBootstrappedResponse>> {
-        let mut resp = IsBootstrappedResponse::new();
+        let mut resp = IsBootstrappedResponse::default();
         let header = Service::header();
         resp.set_header(header);
         resp.set_bootstrapped(self.is_bootstrapped.load(Ordering::SeqCst));
         Some(Ok(resp))
     }
 
-    fn alloc_id(&self, _: &AllocIDRequest) -> Option<Result<AllocIDResponse>> {
-        let mut resp = AllocIDResponse::new();
+    fn alloc_id(&self, _: &AllocIdRequest) -> Option<Result<AllocIdResponse>> {
+        let mut resp = AllocIdResponse::default();
         resp.set_header(Service::header());
 
         let id = self.id_allocator.fetch_add(1, Ordering::SeqCst);
@@ -119,7 +117,7 @@ impl PdMocker for Service {
 
     // TODO: not bootstrapped error.
     fn get_store(&self, req: &GetStoreRequest) -> Option<Result<GetStoreResponse>> {
-        let mut resp = GetStoreResponse::new();
+        let mut resp = GetStoreResponse::default();
         let stores = self.stores.lock().unwrap();
         match stores.get(&req.get_store_id()) {
             Some(store) => {
@@ -129,8 +127,8 @@ impl PdMocker for Service {
             }
             None => {
                 let mut header = Service::header();
-                let mut err = Error::new();
-                err.field_type = ErrorType::UNKNOWN;
+                let mut err = Error::default();
+                err.set_field_type_(ErrorType::Unknown);
                 err.set_message(format!("store not found {}", req.get_store_id()));
                 header.set_error(err);
                 resp.set_header(header);
@@ -140,7 +138,7 @@ impl PdMocker for Service {
     }
 
     fn get_all_stores(&self, req: &GetAllStoresRequest) -> Option<Result<GetAllStoresResponse>> {
-        let mut resp = GetAllStoresResponse::new();
+        let mut resp = GetAllStoresResponse::default();
         resp.set_header(Service::header());
         let exclude_tombstone = req.get_exclude_tombstone_stores();
         let stores = self.stores.lock().unwrap();
@@ -154,7 +152,7 @@ impl PdMocker for Service {
     }
 
     fn get_region(&self, req: &GetRegionRequest) -> Option<Result<GetRegionResponse>> {
-        let mut resp = GetRegionResponse::new();
+        let mut resp = GetRegionResponse::default();
         let key = req.get_region_key();
         let regions = self.regions.lock().unwrap();
         let leaders = self.leaders.lock().unwrap();
@@ -173,16 +171,16 @@ impl PdMocker for Service {
         }
 
         let mut header = Service::header();
-        let mut err = Error::new();
-        err.field_type = ErrorType::UNKNOWN;
+        let mut err = Error::default();
+        err.set_field_type_(ErrorType::Unknown);
         err.set_message(format!("region not found {:?}", key));
         header.set_error(err);
         resp.set_header(header);
         Some(Ok(resp))
     }
 
-    fn get_region_by_id(&self, req: &GetRegionByIDRequest) -> Option<Result<GetRegionResponse>> {
-        let mut resp = GetRegionResponse::new();
+    fn get_region_by_id(&self, req: &GetRegionByIdRequest) -> Option<Result<GetRegionResponse>> {
+        let mut resp = GetRegionResponse::default();
         let regions = self.regions.lock().unwrap();
         let leaders = self.leaders.lock().unwrap();
 
@@ -197,8 +195,8 @@ impl PdMocker for Service {
             }
             None => {
                 let mut header = Service::header();
-                let mut err = Error::new();
-                err.field_type = ErrorType::UNKNOWN;
+                let mut err = Error::default();
+                err.set_field_type_(ErrorType::Unknown);
                 err.set_message(format!("region not found {}", req.region_id));
                 header.set_error(err);
                 resp.set_header(header);
@@ -221,28 +219,28 @@ impl PdMocker for Service {
             .unwrap()
             .insert(region_id, req.get_leader().clone());
 
-        let mut resp = RegionHeartbeatResponse::new();
+        let mut resp = RegionHeartbeatResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))
     }
 
     fn store_heartbeat(&self, _: &StoreHeartbeatRequest) -> Option<Result<StoreHeartbeatResponse>> {
-        let mut resp = StoreHeartbeatResponse::new();
+        let mut resp = StoreHeartbeatResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))
     }
 
     fn ask_split(&self, _: &AskSplitRequest) -> Option<Result<AskSplitResponse>> {
-        let mut resp = AskSplitResponse::new();
+        let mut resp = AskSplitResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))
     }
 
     fn ask_batch_split(&self, _: &AskBatchSplitRequest) -> Option<Result<AskBatchSplitResponse>> {
-        let mut resp = AskBatchSplitResponse::new();
+        let mut resp = AskBatchSplitResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))
@@ -252,14 +250,14 @@ impl PdMocker for Service {
         &self,
         _: &ReportBatchSplitRequest,
     ) -> Option<Result<ReportBatchSplitResponse>> {
-        let mut resp = ReportBatchSplitResponse::new();
+        let mut resp = ReportBatchSplitResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))
     }
 
     fn scatter_region(&self, _: &ScatterRegionRequest) -> Option<Result<ScatterRegionResponse>> {
-        let mut resp = ScatterRegionResponse::new();
+        let mut resp = ScatterRegionResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))

--- a/tests/integrations/pd/mock/mocker/split.rs
+++ b/tests/integrations/pd/mock/mocker/split.rs
@@ -2,8 +2,6 @@
 
 use std::sync::Mutex;
 
-use protobuf::RepeatedField;
-
 use kvproto::pdpb::{GetMembersRequest, GetMembersResponse, Member, ResponseHeader};
 
 use super::*;
@@ -42,21 +40,21 @@ impl PdMocker for Split {
     fn set_endpoints(&self, eps: Vec<String>) {
         let mut members = Vec::with_capacity(eps.len());
         for (i, ep) in (&eps).iter().enumerate() {
-            let mut m = Member::new();
+            let mut m = Member::default();
             m.set_name(format!("pd{}", i));
             m.set_member_id(100 + i as u64);
-            m.set_client_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
-            m.set_peer_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
+            m.set_client_urls(vec![ep.to_owned()]);
+            m.set_peer_urls(vec![ep.to_owned()]);
             members.push(m);
         }
 
         let mut resps = Vec::with_capacity(eps.len());
         for i in 0..eps.len() {
-            let mut resp = GetMembersResponse::new();
-            let mut header = ResponseHeader::new();
+            let mut resp = GetMembersResponse::default();
+            let mut header = ResponseHeader::default();
             header.set_cluster_id(i as u64 + 1); // start from 1.
             resp.set_header(header.clone());
-            resp.set_members(RepeatedField::from_vec(members.clone()));
+            resp.set_members(members.clone());
             resp.set_leader(members[0].clone());
             resps.push(resp);
         }

--- a/tests/integrations/pd/mock/server.rs
+++ b/tests/integrations/pd/mock/server.rs
@@ -13,7 +13,6 @@ use tikv::pd::Error as PdError;
 use tikv_util::security::*;
 
 use kvproto::pdpb::*;
-use kvproto::pdpb_grpc::{self, Pd};
 
 use super::mocker::*;
 
@@ -62,7 +61,7 @@ impl<C: PdMocker + Send + Sync + 'static> Server<C> {
     }
 
     pub fn start(&mut self, mgr: &SecurityManager, eps: Vec<(String, u16)>) {
-        let service = pdpb_grpc::create_pd(self.mocker.clone());
+        let service = create_pd(self.mocker.clone());
         let env = Arc::new(
             EnvBuilder::new()
                 .cq_count(1)
@@ -192,8 +191,8 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     fn alloc_id(
         &mut self,
         ctx: RpcContext<'_>,
-        req: AllocIDRequest,
-        sink: UnarySink<AllocIDResponse>,
+        req: AllocIdRequest,
+        sink: UnarySink<AllocIdResponse>,
     ) {
         hijack_unary(self, ctx, sink, |c| c.alloc_id(&req))
     }
@@ -277,7 +276,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     fn get_region_by_id(
         &mut self,
         ctx: RpcContext<'_>,
-        req: GetRegionByIDRequest,
+        req: GetRegionByIdRequest,
         sink: UnarySink<GetRegionResponse>,
     ) {
         hijack_unary(self, ctx, sink, |c| c.get_region_by_id(&req))
@@ -353,8 +352,8 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     fn get_gc_safe_point(
         &mut self,
         ctx: RpcContext<'_>,
-        req: GetGCSafePointRequest,
-        sink: UnarySink<GetGCSafePointResponse>,
+        req: GetGcSafePointRequest,
+        sink: UnarySink<GetGcSafePointResponse>,
     ) {
         hijack_unary(self, ctx, sink, |c| c.get_gc_safe_point(&req))
     }
@@ -362,8 +361,8 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
     fn update_gc_safe_point(
         &mut self,
         ctx: RpcContext<'_>,
-        req: UpdateGCSafePointRequest,
-        sink: UnarySink<UpdateGCSafePointResponse>,
+        req: UpdateGcSafePointRequest,
+        sink: UnarySink<UpdateGcSafePointResponse>,
     ) {
         hijack_unary(self, ctx, sink, |c| c.update_gc_safe_point(&req))
     }

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -62,17 +62,17 @@ fn test_rpc_client() {
     assert_ne!(client.get_cluster_id().unwrap(), 0);
 
     let store_id = client.alloc_id().unwrap();
-    let mut store = metapb::Store::new();
+    let mut store = metapb::Store::default();
     store.set_id(store_id);
     debug!("bootstrap store {:?}", store);
 
     let peer_id = client.alloc_id().unwrap();
-    let mut peer = metapb::Peer::new();
+    let mut peer = metapb::Peer::default();
     peer.set_id(peer_id);
     peer.set_store_id(store_id);
 
     let region_id = client.alloc_id().unwrap();
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(region_id);
     region.mut_peers().push(peer.clone());
     debug!("bootstrap region {:?}", region);
@@ -127,15 +127,15 @@ fn test_rpc_client() {
     assert_eq!(region_info.leader.unwrap(), peer);
 
     client
-        .store_heartbeat(pdpb::StoreStats::new())
+        .store_heartbeat(pdpb::StoreStats::default())
         .wait()
         .unwrap();
     client
-        .ask_batch_split(metapb::Region::new(), 1)
+        .ask_batch_split(metapb::Region::default(), 1)
         .wait()
         .unwrap();
     client
-        .report_batch_split(vec![metapb::Region::new(), metapb::Region::new()])
+        .report_batch_split(vec![metapb::Region::default(), metapb::Region::default()])
         .wait()
         .unwrap();
 
@@ -152,10 +152,10 @@ fn test_get_tombstone_stores() {
 
     let mut all_stores = vec![];
     let store_id = client.alloc_id().unwrap();
-    let mut store = metapb::Store::new();
+    let mut store = metapb::Store::default();
     store.set_id(store_id);
     let region_id = client.alloc_id().unwrap();
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(region_id);
     client
         .bootstrap_cluster(store.clone(), region.clone())
@@ -167,7 +167,7 @@ fn test_get_tombstone_stores() {
     assert_eq!(s, all_stores);
 
     // Add tombstone store.
-    let mut store99 = metapb::Store::new();
+    let mut store99 = metapb::Store::default();
     store99.set_id(99);
     store99.set_state(metapb::StoreState::Tombstone);
     server.default_handler().add_store(store99.clone());
@@ -208,7 +208,7 @@ fn test_reboot() {
 
     assert!(!client.is_cluster_bootstrapped().unwrap());
 
-    match client.bootstrap_cluster(metapb::Store::new(), metapb::Region::new()) {
+    match client.bootstrap_cluster(metapb::Store::default(), metapb::Region::default()) {
         Err(PdError::ClusterBootstrapped(_)) => (),
         _ => {
             panic!("failed, should return ClusterBootstrapped");
@@ -300,7 +300,7 @@ fn test_incompatible_version() {
 
     let client = new_client(eps, None);
 
-    let resp = client.ask_batch_split(metapb::Region::new(), 2);
+    let resp = client.ask_batch_split(metapb::Region::default(), 2);
     assert_eq!(
         resp.wait().unwrap_err().to_string(),
         PdError::Incompatible.to_string()
@@ -317,16 +317,16 @@ fn restart_leader(mgr: SecurityManager) {
     let client = new_client(eps.clone(), Some(Arc::clone(&mgr)));
     // Put a region.
     let store_id = client.alloc_id().unwrap();
-    let mut store = metapb::Store::new();
+    let mut store = metapb::Store::default();
     store.set_id(store_id);
 
     let peer_id = client.alloc_id().unwrap();
-    let mut peer = metapb::Peer::new();
+    let mut peer = metapb::Peer::default();
     peer.set_id(peer_id);
     peer.set_store_id(store_id);
 
     let region_id = client.alloc_id().unwrap();
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(region_id);
     region.mut_peers().push(peer);
     client
@@ -408,8 +408,8 @@ fn test_region_heartbeat_on_leader_change() {
         tx.send(resp).unwrap();
     });
     poller.spawn(f).forget();
-    let region = metapb::Region::new();
-    let peer = metapb::Peer::new();
+    let region = metapb::Region::default();
+    let peer = metapb::Peer::default();
     let stat = RegionStat::default();
     poller
         .spawn(client.region_heartbeat(region.clone(), peer.clone(), stat.clone()))

--- a/tests/integrations/raftstore/test_clear_stale_data.rs
+++ b/tests/integrations/raftstore/test_clear_stale_data.rs
@@ -53,7 +53,7 @@ fn test_clear_stale_data<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster
         .cfg
         .rocksdb
-        .defaultcf
+        .new_cf
         .level0_file_num_compaction_trigger = 100;
     cluster
         .cfg

--- a/tests/integrations/raftstore/test_compact_log.rs
+++ b/tests/integrations/raftstore/test_compact_log.rs
@@ -8,7 +8,7 @@ use tikv::raftstore::store::*;
 use tikv_util::collections::HashMap;
 use tikv_util::config::*;
 
-fn get_raft_msg_or_default<M: protobuf::Message + Default>(engines: &Engines, key: &[u8]) -> M {
+fn get_raft_msg_or_default<M: prost::Message + Default>(engines: &Engines, key: &[u8]) -> M {
     engines
         .kv
         .get_msg_cf(CF_RAFT, key)

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -6,10 +6,10 @@ use futures::{future, Future, Stream};
 use grpcio::{ChannelBuilder, Environment, Error, RpcStatusCode};
 
 use kvproto::coprocessor::*;
-use kvproto::debugpb_grpc::DebugClient;
+use kvproto::debugpb::DebugClient;
 use kvproto::kvrpcpb::*;
 use kvproto::raft_serverpb::*;
-use kvproto::tikvpb_grpc::TikvClient;
+use kvproto::tikvpb::TikvClient;
 use kvproto::{debugpb, metapb, raft_serverpb};
 use raft::eraftpb;
 
@@ -31,7 +31,7 @@ fn must_new_cluster() -> (Cluster<ServerCluster>, metapb::Peer, Context) {
     let region_id = 1;
     let leader = cluster.leader_of_region(region_id).unwrap();
     let epoch = cluster.get_region_epoch(region_id);
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region_id);
     ctx.set_peer(leader.clone());
     ctx.set_region_epoch(epoch);
@@ -56,7 +56,7 @@ fn test_rawkv() {
     let (k, v) = (b"key".to_vec(), b"value".to_vec());
 
     // Raw put
-    let mut put_req = RawPutRequest::new();
+    let mut put_req = RawPutRequest::default();
     put_req.set_context(ctx.clone());
     put_req.key = k.clone();
     put_req.value = v.clone();
@@ -65,7 +65,7 @@ fn test_rawkv() {
     assert!(put_resp.error.is_empty());
 
     // Raw get
-    let mut get_req = RawGetRequest::new();
+    let mut get_req = RawGetRequest::default();
     get_req.set_context(ctx.clone());
     get_req.key = k.clone();
     let get_resp = client.raw_get(&get_req).unwrap();
@@ -74,7 +74,7 @@ fn test_rawkv() {
     assert_eq!(get_resp.value, v);
 
     // Raw scan
-    let mut scan_req = RawScanRequest::new();
+    let mut scan_req = RawScanRequest::default();
     scan_req.set_context(ctx.clone());
     scan_req.start_key = k.clone();
     scan_req.limit = 1;
@@ -88,7 +88,7 @@ fn test_rawkv() {
     }
 
     // Raw delete
-    let mut delete_req = RawDeleteRequest::new();
+    let mut delete_req = RawDeleteRequest::default();
     delete_req.set_context(ctx.clone());
     delete_req.key = k.clone();
     let delete_resp = client.raw_delete(&delete_req).unwrap();
@@ -97,7 +97,7 @@ fn test_rawkv() {
 }
 
 fn must_kv_prewrite(client: &TikvClient, ctx: Context, muts: Vec<Mutation>, pk: Vec<u8>, ts: u64) {
-    let mut prewrite_req = PrewriteRequest::new();
+    let mut prewrite_req = PrewriteRequest::default();
     prewrite_req.set_context(ctx);
     prewrite_req.set_mutations(muts.into_iter().collect());
     prewrite_req.primary_lock = pk;
@@ -123,7 +123,7 @@ fn must_kv_commit(
     start_ts: u64,
     commit_ts: u64,
 ) {
-    let mut commit_req = CommitRequest::new();
+    let mut commit_req = CommitRequest::default();
     commit_req.set_context(ctx);
     commit_req.start_version = start_ts;
     commit_req.set_keys(keys.into_iter().collect());
@@ -147,8 +147,8 @@ fn test_mvcc_basic() {
     // Prewrite
     ts += 1;
     let prewrite_start_version = ts;
-    let mut mutation = Mutation::new();
-    mutation.op = Op::Put;
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
     mutation.key = k.clone();
     mutation.value = v.clone();
     must_kv_prewrite(
@@ -173,7 +173,7 @@ fn test_mvcc_basic() {
     // Get
     ts += 1;
     let get_version = ts;
-    let mut get_req = GetRequest::new();
+    let mut get_req = GetRequest::default();
     get_req.set_context(ctx.clone());
     get_req.key = k.clone();
     get_req.version = get_version;
@@ -185,7 +185,7 @@ fn test_mvcc_basic() {
     // Scan
     ts += 1;
     let scan_version = ts;
-    let mut scan_req = ScanRequest::new();
+    let mut scan_req = ScanRequest::default();
     scan_req.set_context(ctx.clone());
     scan_req.start_key = k.clone();
     scan_req.limit = 1;
@@ -202,7 +202,7 @@ fn test_mvcc_basic() {
     // Batch get
     ts += 1;
     let batch_get_version = ts;
-    let mut batch_get_req = BatchGetRequest::new();
+    let mut batch_get_req = BatchGetRequest::default();
     batch_get_req.set_context(ctx.clone());
     batch_get_req.set_keys(vec![k.clone()].into_iter().collect());
     batch_get_req.version = batch_get_version;
@@ -225,8 +225,8 @@ fn test_mvcc_rollback_and_cleanup() {
     // Prewrite
     ts += 1;
     let prewrite_start_version = ts;
-    let mut mutation = Mutation::new();
-    mutation.op = Op::Put;
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
     mutation.key = k.clone();
     mutation.value = v.clone();
     must_kv_prewrite(
@@ -252,12 +252,12 @@ fn test_mvcc_rollback_and_cleanup() {
     ts += 1;
     let prewrite_start_version2 = ts;
     let (k2, v2) = (b"key2".to_vec(), b"value2".to_vec());
-    let mut mut_pri = Mutation::new();
-    mut_pri.op = Op::Put;
+    let mut mut_pri = Mutation::default();
+    mut_pri.set_op(Op::Put);
     mut_pri.key = k2.clone();
     mut_pri.value = v2.clone();
-    let mut mut_sec = Mutation::new();
-    mut_sec.op = Op::Put;
+    let mut mut_sec = Mutation::default();
+    mut_sec.set_op(Op::Put);
     mut_sec.key = k.clone();
     mut_sec.value = b"foo".to_vec();
     must_kv_prewrite(
@@ -271,7 +271,7 @@ fn test_mvcc_rollback_and_cleanup() {
     // Scan lock, expects locks
     ts += 1;
     let scan_lock_max_version = ts;
-    let mut scan_lock_req = ScanLockRequest::new();
+    let mut scan_lock_req = ScanLockRequest::default();
     scan_lock_req.set_context(ctx.clone());
     scan_lock_req.max_version = scan_lock_max_version;
     let scan_lock_resp = client.kv_scan_lock(&scan_lock_req).unwrap();
@@ -289,7 +289,7 @@ fn test_mvcc_rollback_and_cleanup() {
 
     // Rollback
     let rollback_start_version = prewrite_start_version2;
-    let mut rollback_req = BatchRollbackRequest::new();
+    let mut rollback_req = BatchRollbackRequest::default();
     rollback_req.set_context(ctx.clone());
     rollback_req.start_version = rollback_start_version;
     rollback_req.set_keys(vec![k2.clone()].into_iter().collect());
@@ -303,7 +303,7 @@ fn test_mvcc_rollback_and_cleanup() {
 
     // Cleanup
     let cleanup_start_version = prewrite_start_version2;
-    let mut cleanup_req = CleanupRequest::new();
+    let mut cleanup_req = CleanupRequest::default();
     cleanup_req.set_context(ctx.clone());
     cleanup_req.start_version = cleanup_start_version;
     cleanup_req.set_key(k2.clone());
@@ -314,7 +314,7 @@ fn test_mvcc_rollback_and_cleanup() {
     // There should be no locks
     ts += 1;
     let scan_lock_max_version2 = ts;
-    let mut scan_lock_req = ScanLockRequest::new();
+    let mut scan_lock_req = ScanLockRequest::default();
     scan_lock_req.set_context(ctx.clone());
     scan_lock_req.max_version = scan_lock_max_version2;
     let scan_lock_resp = client.kv_scan_lock(&scan_lock_req).unwrap();
@@ -325,7 +325,6 @@ fn test_mvcc_rollback_and_cleanup() {
 #[test]
 fn test_mvcc_resolve_lock_gc_and_delete() {
     use kvproto::kvrpcpb::*;
-    use protobuf;
     let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
     let (k, v) = (b"key".to_vec(), b"value".to_vec());
 
@@ -334,8 +333,8 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     // Prewrite
     ts += 1;
     let prewrite_start_version = ts;
-    let mut mutation = Mutation::new();
-    mutation.op = Op::Put;
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
     mutation.key = k.clone();
     mutation.value = v.clone();
     must_kv_prewrite(
@@ -362,12 +361,12 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     let prewrite_start_version2 = ts;
     let (k2, v2) = (b"key2".to_vec(), b"value2".to_vec());
     let new_v = b"new value".to_vec();
-    let mut mut_pri = Mutation::new();
-    mut_pri.op = Op::Put;
+    let mut mut_pri = Mutation::default();
+    mut_pri.set_op(Op::Put);
     mut_pri.key = k.clone();
     mut_pri.value = new_v.clone();
-    let mut mut_sec = Mutation::new();
-    mut_sec.op = Op::Put;
+    let mut mut_sec = Mutation::default();
+    mut_sec.set_op(Op::Put);
     mut_sec.key = k2.clone();
     mut_sec.value = v2.to_vec();
     must_kv_prewrite(
@@ -381,13 +380,13 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     // Resolve lock
     ts += 1;
     let resolve_lock_commit_version = ts;
-    let mut resolve_lock_req = ResolveLockRequest::new();
-    let mut temp_txninfo = TxnInfo::new();
+    let mut resolve_lock_req = ResolveLockRequest::default();
+    let mut temp_txninfo = TxnInfo::default();
     temp_txninfo.txn = prewrite_start_version2;
     temp_txninfo.status = resolve_lock_commit_version;
     let vec_txninfo = vec![temp_txninfo];
     resolve_lock_req.set_context(ctx.clone());
-    resolve_lock_req.set_txn_infos(protobuf::RepeatedField::from_vec(vec_txninfo));
+    resolve_lock_req.set_txn_infos(vec_txninfo);
     let resolve_lock_resp = client.kv_resolve_lock(&resolve_lock_req).unwrap();
     assert!(!resolve_lock_resp.has_region_error());
     assert!(!resolve_lock_resp.has_error());
@@ -395,7 +394,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     // Get `k` at the latest ts.
     ts += 1;
     let get_version1 = ts;
-    let mut get_req1 = GetRequest::new();
+    let mut get_req1 = GetRequest::default();
     get_req1.set_context(ctx.clone());
     get_req1.key = k.clone();
     get_req1.version = get_version1;
@@ -407,7 +406,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     // GC `k` at the latest ts.
     ts += 1;
     let gc_safe_ponit = ts;
-    let mut gc_req = GCRequest::new();
+    let mut gc_req = GcRequest::default();
     gc_req.set_context(ctx.clone());
     gc_req.safe_point = gc_safe_ponit;
     let gc_resp = client.kv_gc(&gc_req).unwrap();
@@ -416,7 +415,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
 
     // the `k` at the old ts should be none.
     let get_version2 = commit_version + 1;
-    let mut get_req2 = GetRequest::new();
+    let mut get_req2 = GetRequest::default();
     get_req2.set_context(ctx.clone());
     get_req2.key = k.clone();
     get_req2.version = get_version2;
@@ -427,7 +426,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
 
     // Transaction debugger commands
     // MvccGetByKey
-    let mut mvcc_get_by_key_req = MvccGetByKeyRequest::new();
+    let mut mvcc_get_by_key_req = MvccGetByKeyRequest::default();
     mvcc_get_by_key_req.set_context(ctx.clone());
     mvcc_get_by_key_req.key = k.clone();
     let mvcc_get_by_key_resp = client.mvcc_get_by_key(&mvcc_get_by_key_req).unwrap();
@@ -435,7 +434,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     assert!(mvcc_get_by_key_resp.error.is_empty());
     assert!(mvcc_get_by_key_resp.has_info());
     // MvccGetByStartTs
-    let mut mvcc_get_by_start_ts_req = MvccGetByStartTsRequest::new();
+    let mut mvcc_get_by_start_ts_req = MvccGetByStartTsRequest::default();
     mvcc_get_by_start_ts_req.set_context(ctx.clone());
     mvcc_get_by_start_ts_req.start_ts = prewrite_start_version2;
     let mvcc_get_by_start_ts_resp = client
@@ -447,7 +446,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     assert_eq!(mvcc_get_by_start_ts_resp.key, k);
 
     // Delete range
-    let mut del_req = DeleteRangeRequest::new();
+    let mut del_req = DeleteRangeRequest::default();
     del_req.set_context(ctx.clone());
     del_req.start_key = b"a".to_vec();
     del_req.end_key = b"z".to_vec();
@@ -462,7 +461,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
 fn test_coprocessor() {
     let (_cluster, client, _) = must_new_cluster_and_kv_client();
     // SQL push down commands
-    let mut req = Request::new();
+    let mut req = Request::default();
     req.set_tp(REQ_TYPE_DAG);
     client.coprocessor(&req).unwrap();
 }
@@ -473,7 +472,7 @@ fn test_split_region() {
 
     // Split region commands
     let key = b"b";
-    let mut req = SplitRegionRequest::new();
+    let mut req = SplitRegionRequest::default();
     req.set_context(ctx);
     req.set_split_key(key.to_vec());
     let resp = client.split_region(&req).unwrap();
@@ -496,7 +495,7 @@ fn test_read_index() {
     let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
 
     // Read index
-    let mut req = ReadIndexRequest::new();
+    let mut req = ReadIndexRequest::default();
     req.set_context(ctx.clone());
     let mut resp = client.read_index(&req).unwrap();
     let last_index = resp.get_read_index();
@@ -504,7 +503,7 @@ fn test_read_index() {
 
     // Raw put
     let (k, v) = (b"key".to_vec(), b"value".to_vec());
-    let mut put_req = RawPutRequest::new();
+    let mut put_req = RawPutRequest::default();
     put_req.set_context(ctx.clone());
     put_req.key = k.clone();
     put_req.value = v.clone();
@@ -540,9 +539,9 @@ fn test_debug_get() {
     assert_eq!(engine.get(&key).unwrap().unwrap(), v);
 
     // Debug get
-    let mut req = debugpb::GetRequest::new();
+    let mut req = debugpb::GetRequest::default();
     req.set_cf(CF_DEFAULT.to_owned());
-    req.set_db(debugpb::DB::KV);
+    req.set_db(debugpb::Db::Kv);
     req.set_key(key);
     let mut resp = debug_client.get(&req.clone()).unwrap();
     assert_eq!(resp.take_value(), v);
@@ -564,7 +563,7 @@ fn test_debug_raft_log() {
     let engine = cluster.get_raft_engine(store_id);
     let (region_id, log_index) = (200, 200);
     let key = keys::raft_log_key(region_id, log_index);
-    let mut entry = eraftpb::Entry::new();
+    let mut entry = eraftpb::Entry::default();
     entry.set_term(1);
     entry.set_index(1);
     entry.set_entry_type(eraftpb::EntryType::EntryNormal);
@@ -576,13 +575,13 @@ fn test_debug_raft_log() {
     );
 
     // Debug raft_log
-    let mut req = debugpb::RaftLogRequest::new();
+    let mut req = debugpb::RaftLogRequest::default();
     req.set_region_id(region_id);
     req.set_log_index(log_index);
     let resp = debug_client.raft_log(&req).unwrap();
-    assert_ne!(resp.get_entry(), &eraftpb::Entry::new());
+    assert_ne!(resp.get_entry(), &eraftpb::Entry::default());
 
-    let mut req = debugpb::RaftLogRequest::new();
+    let mut req = debugpb::RaftLogRequest::default();
     req.set_region_id(region_id + 1);
     req.set_log_index(region_id + 1);
     match debug_client.raft_log(&req).unwrap_err() {
@@ -603,7 +602,7 @@ fn test_debug_region_info() {
 
     let region_id = 100;
     let raft_state_key = keys::raft_state_key(region_id);
-    let mut raft_state = raft_serverpb::RaftLocalState::new();
+    let mut raft_state = raft_serverpb::RaftLocalState::default();
     raft_state.set_last_index(42);
     raft_engine.put_msg(&raft_state_key, &raft_state).unwrap();
     assert_eq!(
@@ -615,7 +614,7 @@ fn test_debug_region_info() {
     );
 
     let apply_state_key = keys::apply_state_key(region_id);
-    let mut apply_state = raft_serverpb::RaftApplyState::new();
+    let mut apply_state = raft_serverpb::RaftApplyState::default();
     apply_state.set_applied_index(42);
     kv_engine
         .put_msg_cf(raft_cf, &apply_state_key, &apply_state)
@@ -629,7 +628,7 @@ fn test_debug_region_info() {
     );
 
     let region_state_key = keys::region_state_key(region_id);
-    let mut region_state = raft_serverpb::RegionLocalState::new();
+    let mut region_state = raft_serverpb::RegionLocalState::default();
     region_state.set_state(raft_serverpb::PeerState::Tombstone);
     kv_engine
         .put_msg_cf(raft_cf, &region_state_key, &region_state)
@@ -643,7 +642,7 @@ fn test_debug_region_info() {
     );
 
     // Debug region_info
-    let mut req = debugpb::RegionInfoRequest::new();
+    let mut req = debugpb::RegionInfoRequest::default();
     req.set_region_id(region_id);
     let mut resp = debug_client.region_info(&req.clone()).unwrap();
     assert_eq!(resp.take_raft_local_state(), raft_state);
@@ -667,11 +666,11 @@ fn test_debug_region_size() {
     // Put some data.
     let region_id = 100;
     let region_state_key = keys::region_state_key(region_id);
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(region_id);
     region.set_start_key(b"a".to_vec());
     region.set_end_key(b"z".to_vec());
-    let mut state = RegionLocalState::new();
+    let mut state = RegionLocalState::default();
     state.set_region(region);
     let cf_raft = engine.cf_handle(CF_RAFT).unwrap();
     engine
@@ -686,12 +685,12 @@ fn test_debug_region_size() {
         engine.put_cf(cf_handle, k.as_slice(), v).unwrap();
     }
 
-    let mut req = debugpb::RegionSizeRequest::new();
+    let mut req = debugpb::RegionSizeRequest::default();
     req.set_region_id(region_id);
     req.set_cfs(cfs.iter().map(|s| s.to_string()).collect());
     let entries = debug_client.region_size(&req).unwrap().take_entries();
     assert_eq!(entries.len(), 3);
-    for e in entries.into_vec() {
+    for e in &entries {
         cfs.iter().find(|&&c| c == e.cf).unwrap();
         assert!(e.size > 0);
     }
@@ -712,13 +711,13 @@ fn test_debug_fail_point() {
 
     let (fp, act) = ("raft_between_save", "off");
 
-    let mut inject_req = debugpb::InjectFailPointRequest::new();
+    let mut inject_req = debugpb::InjectFailPointRequest::default();
     inject_req.set_name(fp.to_owned());
     inject_req.set_actions(act.to_owned());
     debug_client.inject_fail_point(&inject_req).unwrap();
 
     let resp = debug_client
-        .list_fail_points(&debugpb::ListFailPointsRequest::new())
+        .list_fail_points(&debugpb::ListFailPointsRequest::default())
         .unwrap();
     let entries = resp.get_entries();
     assert_eq!(entries.len(), 1);
@@ -727,12 +726,12 @@ fn test_debug_fail_point() {
         assert_eq!(e.get_actions(), act);
     }
 
-    let mut recover_req = debugpb::RecoverFailPointRequest::new();
+    let mut recover_req = debugpb::RecoverFailPointRequest::default();
     recover_req.set_name(fp.to_owned());
     debug_client.recover_fail_point(&recover_req).unwrap();
 
     let resp = debug_client
-        .list_fail_points(&debugpb::ListFailPointsRequest::new())
+        .list_fail_points(&debugpb::ListFailPointsRequest::default())
         .unwrap();
     let entries = resp.get_entries();
     assert_eq!(entries.len(), 0);
@@ -754,7 +753,7 @@ fn test_debug_scan_mvcc() {
         engine.put_cf(cf_handle, k.as_slice(), &v).unwrap();
     }
 
-    let mut req = debugpb::ScanMvccRequest::new();
+    let mut req = debugpb::ScanMvccRequest::default();
     req.set_from_key(keys::data_key(b"m"));
     req.set_to_key(keys::data_key(b"n"));
     req.set_limit(1);

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -122,7 +122,7 @@ fn test_server_split_region_twice() {
         let mut resp = write_resp.response;
         let admin_resp = resp.mut_admin_response();
         let split_resp = admin_resp.mut_splits();
-        let mut regions = split_resp.take_regions().into_vec();
+        let mut regions = split_resp.take_regions();
         let mut d = regions.drain(..);
         let (left, right) = (d.next().unwrap(), d.next().unwrap());
         assert_eq!(left.get_end_key(), key.as_slice());
@@ -830,11 +830,11 @@ fn test_split_with_epoch_not_match() {
     pd_client.must_remove_peer(1, new_peer(2, 2));
     let region = cluster.get_region(b"");
 
-    let mut admin_req = AdminRequest::new();
+    let mut admin_req = AdminRequest::default();
     admin_req.set_cmd_type(AdminCmdType::BatchSplit);
 
-    let mut batch_split_req = BatchSplitRequest::new();
-    batch_split_req.mut_requests().push(SplitRequest::new());
+    let mut batch_split_req = BatchSplitRequest::default();
+    batch_split_req.mut_requests().push(SplitRequest::default());
     batch_split_req.mut_requests()[0].set_split_key(b"s".to_vec());
     batch_split_req.mut_requests()[0].set_new_region_id(1000);
     batch_split_req.mut_requests()[0].set_new_peer_ids(vec![1001, 1002]);

--- a/tests/integrations/raftstore/test_update_region_size.rs
+++ b/tests/integrations/raftstore/test_update_region_size.rs
@@ -20,7 +20,7 @@ fn test_update_regoin_size<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster
         .cfg
         .rocksdb
-        .defaultcf
+        .new_cf
         .level0_file_num_compaction_trigger = 10;
     cluster.start().unwrap();
 

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -3,7 +3,7 @@
 use futures::{Future, Sink, Stream};
 use grpcio::*;
 use kvproto::tikvpb::BatchCommandsRequest;
-use kvproto::tikvpb_grpc::TikvClient;
+use kvproto::tikvpb::TikvClient;
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;

--- a/tests/integrations/server/mod.rs
+++ b/tests/integrations/server/mod.rs
@@ -10,8 +10,9 @@ use grpcio::*;
 use kvproto::coprocessor::*;
 use kvproto::kvrpcpb::*;
 use kvproto::raft_serverpb::{Done, RaftMessage, SnapshotChunk};
-use kvproto::tikvpb::{BatchCommandsRequest, BatchCommandsResponse, BatchRaftMessage};
-use kvproto::tikvpb_grpc::{create_tikv, Tikv};
+use kvproto::tikvpb::{
+    create_tikv, BatchCommandsRequest, BatchCommandsResponse, BatchRaftMessage, Tikv,
+};
 use tikv_util::security::{SecurityConfig, SecurityManager};
 
 macro_rules! unary_call {
@@ -110,7 +111,7 @@ trait MockKvService {
     );
     unary_call!(kv_scan_lock, ScanLockRequest, ScanLockResponse);
     unary_call!(kv_resolve_lock, ResolveLockRequest, ResolveLockResponse);
-    unary_call!(kv_gc, GCRequest, GCResponse);
+    unary_call!(kv_gc, GcRequest, GcResponse);
     unary_call!(kv_delete_range, DeleteRangeRequest, DeleteRangeResponse);
     unary_call!(raw_get, RawGetRequest, RawGetResponse);
     unary_call!(raw_batch_get, RawBatchGetRequest, RawBatchGetResponse);
@@ -175,7 +176,7 @@ impl<T: MockKvService + Clone + Send + 'static> Tikv for MockKv<T> {
     );
     unary_call_dispatch!(kv_scan_lock, ScanLockRequest, ScanLockResponse);
     unary_call_dispatch!(kv_resolve_lock, ResolveLockRequest, ResolveLockResponse);
-    unary_call_dispatch!(kv_gc, GCRequest, GCResponse);
+    unary_call_dispatch!(kv_gc, GcRequest, GcResponse);
     unary_call_dispatch!(kv_delete_range, DeleteRangeRequest, DeleteRangeResponse);
     unary_call_dispatch!(raw_get, RawGetRequest, RawGetResponse);
     unary_call_dispatch!(raw_batch_get, RawBatchGetRequest, RawBatchGetResponse);

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -74,7 +74,7 @@ fn test_batch_raft_fallback() {
 
     let addr = format!("localhost:{}", port);
     (0..100).for_each(|_| {
-        raft_client.send(1, &addr, RaftMessage::new()).unwrap();
+        raft_client.send(1, &addr, RaftMessage::default()).unwrap();
         thread::sleep(time::Duration::from_millis(10));
         raft_client.flush();
     });
@@ -119,7 +119,7 @@ fn test_raft_client_reconnect() {
     let addr = format!("localhost:{}", port);
 
     // `send` should success.
-    (0..50).for_each(|_| raft_client.send(1, &addr, RaftMessage::new()).unwrap());
+    (0..50).for_each(|_| raft_client.send(1, &addr, RaftMessage::default()).unwrap());
     raft_client.flush();
 
     check_f(300, || counter.load(Ordering::SeqCst) == 50);
@@ -128,14 +128,14 @@ fn test_raft_client_reconnect() {
     drop(mock_server);
 
     assert!((0..100)
-        .map(|_| raft_client.send(1, &addr, RaftMessage::new()))
+        .map(|_| raft_client.send(1, &addr, RaftMessage::default()))
         .collect::<Result<(), _>>()
         .is_err());
 
     // `send` should success after the mock server restarted.
     let service = MockKvForRaft(Arc::clone(&counter));
     let mock_server = create_mock_server_on(service, port);
-    (0..50).for_each(|_| raft_client.send(1, &addr, RaftMessage::new()).unwrap());
+    (0..50).for_each(|_| raft_client.send(1, &addr, RaftMessage::default()).unwrap());
     raft_client.flush();
 
     check_f(300, || counter.load(Ordering::SeqCst) == 100);

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -172,7 +172,7 @@ fn test_engine_leader_change_twice() {
         .get_header()
         .get_current_term();
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(peers[0].clone());

--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -23,7 +23,7 @@ fn test_raftkv() {
     let leader_id = cluster.leader_of_region(region.get_id()).unwrap();
     let storage = cluster.sim.rl().storages[&leader_id.get_id()].clone();
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(region.get_peers()[0].clone());
@@ -54,7 +54,7 @@ fn test_read_leader_in_lease() {
     let leader = cluster.leader_of_region(region.get_id()).unwrap();
     let storage = cluster.sim.rl().storages[&leader.get_id()].clone();
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());
@@ -86,7 +86,7 @@ fn test_read_index_on_replica() {
     let leader = cluster.leader_of_region(region.get_id()).unwrap();
     let storage = cluster.sim.rl().storages[&leader.get_id()].clone();
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());


### PR DESCRIPTION
This is not ready to merge yet because of the `path` dependencies. Once PRs to upstream crates get merged, I can change these to Git or version deps. I'm posting earlier so reviewers can get started looking at it.

## What have you changed? (mandatory)

Changed all uses of protobufs to use Prost rather than rust-protobuf for coding and decoding.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

Existing tests.

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Benchmark result if necessary (optional)

tl;dr, we see a small, but consistent improvement (1-2%) across all benchmarks in sysbench and YCSB. Peak latency seems to decrease significantly, but the actual amount is hard to quantify (0-12%, with a median around 4%, but lots of noise).

