### PR TITLE
raftclient: warn instead of  error when send msg failed

### DIFF
--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -109,13 +109,13 @@ impl Conn {
                             drop(receiver);
                             match r {
                                 Ok(_) => info!("raft RPC finished success"),
-                                Err(ref e) => error!("raft RPC finished fail"; "err" => ?e),
+                                Err(ref e) => warn!("raft RPC finished fail"; "err" => ?e),
                             };
                             r
                         }))
                     }
                     Err(e) => {
-                        error!("batch_raft RPC finished fail"; "err" => ?e);
+                        warn!("batch_raft RPC finished fail"; "err" => ?e);
                         Box::new(future::err(e))
                     }
                 }
@@ -204,7 +204,7 @@ impl<T: RaftStoreRouter> RaftClient<T> {
             .stream
             .send(msg)
         {
-            error!("send to {} fail, the gRPC connection could be broken", addr);
+            warn!("send to {} fail, the gRPC connection could be broken", addr);
             let index = msg.region_id as usize % self.cfg.grpc_raft_conn_num;
             self.conns.remove(&(addr.to_owned(), index));
 
@@ -231,7 +231,7 @@ impl<T: RaftStoreRouter> RaftClient<T> {
                 let _ = self.stats_pool.spawn(
                     self.timer
                         .delay(Instant::now() + wait)
-                        .map_err(|_| error!("RaftClient delay flush error"))
+                        .map_err(|_| warn!("RaftClient delay flush error"))
                         .inspect(move |_| notifier.notify()),
                 );
             }

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -128,7 +128,10 @@ fn test_raft_client_reconnect() {
     drop(mock_server);
 
     assert!((0..100)
-        .map(|_| raft_client.send(1, &addr, RaftMessage::new()))
+        .map(|_| {
+            thread::sleep(time::Duration::from_millis(10));
+            raft_client.send(1, &addr, RaftMessage::new())
+        })
         .collect::<Result<(), _>>()
         .is_err());
 

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -127,13 +127,11 @@ fn test_raft_client_reconnect() {
     // `send` should fail after the mock server stopped.
     drop(mock_server);
 
-    assert!((0..100)
-        .map(|_| {
-            thread::sleep(time::Duration::from_millis(10));
-            raft_client.send(1, &addr, RaftMessage::new())
-        })
-        .collect::<Result<(), _>>()
-        .is_err());
+    let send = |_| {
+        thread::sleep(time::Duration::from_millis(10));
+        raft_client.send(1, &addr, RaftMessage::new())
+    };
+    assert!((0..100).map(send).collect::<Result<(), _>>().is_err());
 
     // `send` should success after the mock server restarted.
     let service = MockKvForRaft(Arc::clone(&counter));


### PR DESCRIPTION
Signed-off-by: zyh-hust <zhouyuanhui@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
Change error! to warn!.
When Raftclient fails to send a message, it will try again and should prompt warn instead of error.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)
 
## How has this PR been tested? (mandatory)

CI

## Does this PR affect documentation (docs) or release note? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no
