### PR TITLE
mvcc/reader.rs:removes the function `reverse_seek_write`

### DIFF
--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -597,34 +597,6 @@ pub mod tests {
         assert_eq!(write.write_type, write_type);
     }
 
-    pub fn must_reverse_seek_write_none<E: Engine>(engine: &E, key: &[u8], ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
-        assert!(reader
-            .reverse_seek_write(&Key::from_raw(key), ts)
-            .unwrap()
-            .is_none());
-    }
-
-    pub fn must_reverse_seek_write<E: Engine>(
-        engine: &E,
-        key: &[u8],
-        ts: u64,
-        start_ts: u64,
-        commit_ts: u64,
-        write_type: WriteType,
-    ) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
-        let (t, write) = reader
-            .reverse_seek_write(&Key::from_raw(key), ts)
-            .unwrap()
-            .unwrap();
-        assert_eq!(t, commit_ts);
-        assert_eq!(write.start_ts, start_ts);
-        assert_eq!(write.write_type, write_type);
-    }
-
     pub fn must_get_commit_ts<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -129,19 +129,6 @@ impl<S: Snapshot> MvccReader<S> {
     }
 
     pub fn seek_write(&mut self, key: &Key, ts: u64) -> Result<Option<(u64, Write)>> {
-        self.seek_write_impl(key, ts, false)
-    }
-
-    pub fn reverse_seek_write(&mut self, key: &Key, ts: u64) -> Result<Option<(u64, Write)>> {
-        self.seek_write_impl(key, ts, true)
-    }
-
-    fn seek_write_impl(
-        &mut self,
-        key: &Key,
-        ts: u64,
-        reverse: bool,
-    ) -> Result<Option<(u64, Write)>> {
         if self.scan_mode.is_some() {
             if self.write_cursor.is_none() {
                 let iter_opt = IterOption::new(None, None, self.fill_cache);
@@ -160,11 +147,7 @@ impl<S: Snapshot> MvccReader<S> {
         }
 
         let cursor = self.write_cursor.as_mut().unwrap();
-        let ok = if reverse {
-            cursor.near_seek_for_prev(&key.clone().append_ts(ts), &mut self.statistics.write)?
-        } else {
-            cursor.near_seek(&key.clone().append_ts(ts), &mut self.statistics.write)?
-        };
+        let ok = cursor.near_seek(&key.clone().append_ts(ts), &mut self.statistics.write)?;
         if !ok {
             return Ok(None);
         }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -960,7 +960,7 @@ mod tests {
         test_gc_imp(b"k2", &v1, &v2, &v3, &v4);
     }
 
-    fn test_write_imp(k: &[u8], v: &[u8], k2: &[u8], k3: &[u8]) {
+    fn test_write_imp(k: &[u8], v: &[u8], k2: &[u8]) {
         let engine = TestEngineBuilder::new().build().unwrap();
 
         must_prewrite_put(&engine, k, v, k, 5);
@@ -968,31 +968,27 @@ mod tests {
 
         must_commit(&engine, k, 5, 10);
         must_seek_write(&engine, k, u64::max_value(), 5, 10, WriteType::Put);
-        must_reverse_seek_write(&engine, k, 5, 5, 10, WriteType::Put);
         must_seek_write_none(&engine, k2, u64::max_value());
-        must_reverse_seek_write_none(&engine, k3, 5);
         must_get_commit_ts(&engine, k, 5, 10);
 
         must_prewrite_delete(&engine, k, k, 15);
         must_rollback(&engine, k, 15);
         must_seek_write(&engine, k, u64::max_value(), 15, 15, WriteType::Rollback);
-        must_reverse_seek_write(&engine, k, 15, 15, 15, WriteType::Rollback);
         must_get_commit_ts(&engine, k, 5, 10);
         must_get_commit_ts_none(&engine, k, 15);
 
         must_prewrite_lock(&engine, k, k, 25);
         must_commit(&engine, k, 25, 30);
         must_seek_write(&engine, k, u64::max_value(), 25, 30, WriteType::Lock);
-        must_reverse_seek_write(&engine, k, 25, 25, 30, WriteType::Lock);
         must_get_commit_ts(&engine, k, 25, 30);
     }
 
     #[test]
     fn test_write() {
-        test_write_imp(b"kk", b"v1", b"k", b"kkk");
+        test_write_imp(b"kk", b"v1", b"k");
 
         let v2 = "x".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
-        test_write_imp(b"kk", &v2, b"k", b"kkk");
+        test_write_imp(b"kk", &v2, b"k");
     }
 
     fn test_scan_keys_imp(keys: Vec<&[u8]>, values: Vec<&[u8]>) {


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

## What have you changed? (mandatory)

This PR removes the unused function `reverse_seek_write` and the related tests in `mvcc/reader/reader.rs`. 

## What are the type of the changes? (mandatory)
It's in order to make the project more friendly to read.

## How has this PR been tested? (mandatory)

yes, unit test

## Does this PR affect documentation (docs) or release note? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

@MyonKeminta @youjiali1995  PTAL
