### PR TITLE
[release-2.1] Unified Log Format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,9 +84,12 @@ extern crate serde_json;
 #[cfg_attr(
     test,
     macro_use(
+        kv,
         slog_o,
         slog_kv,
-        slog_crit,
+        slog_info,
+        slog_debug,
+        slog_warn,
         slog_log,
         slog_record,
         slog_b,

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use std::fmt;
-use std::io::{self, Write};
+use std::io;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::path::Path;
 
@@ -20,6 +20,7 @@ use chrono;
 use grpc;
 use log;
 use log::SetLoggerError;
+use serde_json;
 use slog::{self, Drain, Key, OwnedKVList, Record, KV};
 use slog_scope::{self, GlobalLoggerGuard};
 use slog_stdlog;
@@ -27,7 +28,7 @@ use slog_term::{Decorator, RecordDecorator};
 
 pub use slog::Level;
 
-const TIMESTAMP_FORMAT: &str = "%Y/%m/%d %H:%M:%S%.3f";
+const TIMESTAMP_FORMAT: &str = "%Y/%m/%d %H:%M:%S%.3f %:z";
 const ENABLED_TARGETS: &[&str] = &[
     "tikv::",
     "tests::",
@@ -95,6 +96,18 @@ pub fn get_string_by_level(lv: Level) -> &'static str {
     }
 }
 
+// Converts `slog::Level` to unified log level format.
+fn get_unified_log_level(lv: Level) -> &'static str {
+    match lv {
+        Level::Critical => "FATAL",
+        Level::Error => "ERROR",
+        Level::Warning => "WARN",
+        Level::Info => "INFO",
+        Level::Debug => "DEBUG",
+        Level::Trace => "TRACE",
+    }
+}
+
 pub fn convert_slog_level_to_log_level(lv: Level) -> log::LogLevel {
     match lv {
         Level::Critical | Level::Error => log::LogLevel::Error,
@@ -103,20 +116,6 @@ pub fn convert_slog_level_to_log_level(lv: Level) -> log::LogLevel {
         Level::Trace => log::LogLevel::Trace,
         Level::Info => log::LogLevel::Info,
     }
-}
-
-#[test]
-fn test_get_level_by_string() {
-    // Ensure UPPER, Capitalized, and lower case all map over.
-    assert_eq!(Some(Level::Trace), get_level_by_string("TRACE"));
-    assert_eq!(Some(Level::Trace), get_level_by_string("Trace"));
-    assert_eq!(Some(Level::Trace), get_level_by_string("trace"));
-    // Due to legacy we need to ensure that `warn` maps to `Warning`.
-    assert_eq!(Some(Level::Warning), get_level_by_string("warn"));
-    assert_eq!(Some(Level::Warning), get_level_by_string("warning"));
-    // Ensure that all non-defined values map to `Info`.
-    assert_eq!(None, get_level_by_string("Off"));
-    assert_eq!(None, get_level_by_string("definitely not an option"));
 }
 
 pub struct TikvFormat<D>
@@ -142,18 +141,11 @@ where
     type Ok = ();
     type Err = io::Error;
 
-    fn log(&self, record: &Record, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+    fn log(&self, record: &Record<'_>, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
         self.decorator.with_record(record, values, |decorator| {
-            let comma_needed = print_msg_header(decorator, record)?;
-            {
-                let mut serializer = Serializer::new(decorator, comma_needed);
-
-                record.kv().serialize(record, &mut serializer)?;
-
-                values.serialize(record, &mut serializer)?;
-
-                serializer.finish()?;
-            }
+            write_log_header(decorator, record)?;
+            write_log_msg(decorator, record)?;
+            write_log_fields(decorator, record, values)?;
 
             decorator.start_whitespace()?;
             writeln!(decorator)?;
@@ -165,97 +157,83 @@ where
     }
 }
 
-/// Returns `true` if message was not empty
-fn print_msg_header(mut rd: &mut RecordDecorator, record: &Record) -> io::Result<bool> {
-    rd.start_timestamp()?;
-    write!(rd, "{}", chrono::Local::now().format(TIMESTAMP_FORMAT))?;
-
-    rd.start_whitespace()?;
-    write!(rd, " ")?;
-
-    rd.start_level()?;
-    write!(rd, "{}", record.level().as_short_str())?;
-
-    rd.start_whitespace()?;
-    write!(rd, " ")?;
-
-    rd.start_msg()?; // There is no `start_line`.
+/// Writes log header to decorator. See [log-header](https://github.com/tikv/rfcs/blob/master/text/2018-12-19-unified-log-format.md#log-header-section)
+fn write_log_header(decorator: &mut dyn RecordDecorator, record: &Record<'_>) -> io::Result<()> {
+    decorator.start_timestamp()?;
     write!(
-        rd,
-        "{}:{}",
-        Path::new(record.file())
-            .file_name()
-            .and_then(|path| path.to_str())
-            .unwrap_or("<error>"),
-        record.line()
+        decorator,
+        "[{}]",
+        chrono::Local::now().format(TIMESTAMP_FORMAT)
     )?;
 
-    rd.start_separator()?;
-    write!(rd, ":")?;
+    decorator.start_whitespace()?;
+    write!(decorator, " ")?;
 
-    rd.start_whitespace()?;
-    write!(rd, " ")?;
+    decorator.start_level()?;
+    write!(decorator, "[{}]", get_unified_log_level(record.level()))?;
 
-    rd.start_msg()?;
-    let mut count_rd = CountingWriter::new(&mut rd);
-    write!(count_rd, "{}", record.msg())?;
-    Ok(count_rd.count() != 0)
+    decorator.start_whitespace()?;
+    write!(decorator, " ")?;
+
+    // Writes source file info.
+    decorator.start_msg()?; // There is no `start_file()` or `start_line()`.
+    if let Some(path) = Path::new(record.file())
+        .file_name()
+        .and_then(|path| path.to_str())
+    {
+        write!(decorator, "[")?;
+        write_file_name(decorator, path)?;
+        write!(decorator, ":{}]", record.line())?
+    } else {
+        write!(decorator, "[<unknown>]")?
+    }
+
+    Ok(())
 }
 
-struct CountingWriter<'a> {
-    wrapped: &'a mut io::Write,
-    count: usize,
+/// Writes log message to decorator. See [log-message](https://github.com/tikv/rfcs/blob/master/text/2018-12-19-unified-log-format.md#log-message-section)
+fn write_log_msg(decorator: &mut dyn RecordDecorator, record: &Record<'_>) -> io::Result<()> {
+    decorator.start_whitespace()?;
+    write!(decorator, " ")?;
+
+    decorator.start_msg()?;
+    write!(decorator, "[")?;
+    let msg = format!("{}", record.msg());
+    write_escaped_str(decorator, &msg)?;
+    write!(decorator, "]")?;
+
+    Ok(())
 }
 
-impl<'a> CountingWriter<'a> {
-    fn new(wrapped: &'a mut io::Write) -> CountingWriter {
-        CountingWriter { wrapped, count: 0 }
-    }
+/// Writes log fields to decorator. See [log-fields](https://github.com/tikv/rfcs/blob/master/text/2018-12-19-unified-log-format.md#log-fields-section)
+fn write_log_fields(
+    decorator: &mut dyn RecordDecorator,
+    record: &Record<'_>,
+    values: &OwnedKVList,
+) -> io::Result<()> {
+    let mut serializer = Serializer::new(decorator);
 
-    fn count(&self) -> usize {
-        self.count
-    }
-}
+    record.kv().serialize(record, &mut serializer)?;
 
-impl<'a> io::Write for CountingWriter<'a> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.wrapped.write(buf).map(|n| {
-            self.count += n;
-            n
-        })
-    }
+    values.serialize(record, &mut serializer)?;
 
-    fn flush(&mut self) -> io::Result<()> {
-        self.wrapped.flush()
-    }
+    serializer.finish()?;
 
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        self.wrapped.write_all(buf).map(|_| {
-            self.count += buf.len();
-            ()
-        })
-    }
+    Ok(())
 }
 
 struct Serializer<'a> {
-    comma_needed: bool,
-    decorator: &'a mut RecordDecorator,
+    decorator: &'a mut dyn RecordDecorator,
 }
 
 impl<'a> Serializer<'a> {
-    fn new(decorator: &'a mut RecordDecorator, comma_needed: bool) -> Self {
-        Serializer {
-            comma_needed,
-            decorator,
-        }
+    fn new(decorator: &'a mut dyn RecordDecorator) -> Self {
+        Serializer { decorator }
     }
 
-    fn maybe_print_comma(&mut self) -> io::Result<()> {
-        if self.comma_needed {
-            self.decorator.start_comma()?;
-            write!(self.decorator, ", ")?;
-        }
-        self.comma_needed |= true;
+    fn write_whitespace(&mut self) -> io::Result<()> {
+        self.decorator.start_whitespace()?;
+        write!(self.decorator, " ")?;
         Ok(())
     }
 
@@ -268,106 +246,109 @@ impl<'a> Drop for Serializer<'a> {
     fn drop(&mut self) {}
 }
 
-macro_rules! s(
-    ($s:expr, $k:expr, $v:expr) => {
-        $s.maybe_print_comma()?;
-        $s.decorator.start_key()?;
-        write!($s.decorator, "{}", $k)?;
-        $s.decorator.start_separator()?;
-        write!($s.decorator, ":")?;
-        $s.decorator.start_whitespace()?;
-        write!($s.decorator, " ")?;
-        $s.decorator.start_value()?;
-        write!($s.decorator, "{}", $v)?;
-    };
-);
-
-#[cfg_attr(feature = "cargo-clippy", allow(write_literal))]
 impl<'a> slog::ser::Serializer for Serializer<'a> {
     fn emit_none(&mut self, key: Key) -> slog::Result {
-        s!(self, key, "None");
-        Ok(())
-    }
-    fn emit_unit(&mut self, key: Key) -> slog::Result {
-        s!(self, key, "()");
-        Ok(())
+        self.emit_arguments(key, &format_args!("None"))
     }
 
-    fn emit_bool(&mut self, key: Key, val: bool) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
+    fn emit_arguments(&mut self, key: Key, val: &fmt::Arguments<'_>) -> slog::Result {
+        self.write_whitespace()?;
 
-    fn emit_char(&mut self, key: Key, val: char) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
+        // Write key
+        write!(self.decorator, "[")?;
+        self.decorator.start_key()?;
+        write_escaped_str(&mut self.decorator, key as &str)?;
 
-    fn emit_usize(&mut self, key: Key, val: usize) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_isize(&mut self, key: Key, val: isize) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
+        // Write separator
+        self.decorator.start_separator()?;
+        write!(self.decorator, "=")?;
 
-    fn emit_u8(&mut self, key: Key, val: u8) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_i8(&mut self, key: Key, val: i8) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_u16(&mut self, key: Key, val: u16) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_i16(&mut self, key: Key, val: i16) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_u32(&mut self, key: Key, val: u32) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_i32(&mut self, key: Key, val: i32) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_f32(&mut self, key: Key, val: f32) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_u64(&mut self, key: Key, val: u64) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_i64(&mut self, key: Key, val: i64) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_f64(&mut self, key: Key, val: f64) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_str(&mut self, key: Key, val: &str) -> slog::Result {
-        s!(self, key, val);
-        Ok(())
-    }
-    fn emit_arguments(&mut self, key: Key, val: &fmt::Arguments) -> slog::Result {
-        s!(self, key, val);
+        // Write value
+        let value = format!("{}", val);
+        self.decorator.start_value()?;
+        write_escaped_str(self.decorator, &value)?;
+        self.decorator.reset()?;
+        write!(self.decorator, "]")?;
         Ok(())
     }
 }
 
-#[test]
-fn test_log_format() {
-    use chrono::{TimeZone, Utc};
-    use slog::Logger;
+/// Writes file name into the writer, removes the character which not match `[a-zA-Z0-9\.-_]`
+fn write_file_name<W>(writer: &mut W, file_name: &str) -> io::Result<()>
+where
+    W: io::Write + ?Sized,
+{
+    let mut start = 0;
+    let bytes = file_name.as_bytes();
+    for (index, &b) in bytes.iter().enumerate() {
+        if (b >= b'A' && b <= b'Z')
+            || (b >= b'a' && b <= b'z')
+            || (b >= b'0' && b <= b'9')
+            || b == b'.'
+            || b == b'-'
+            || b == b'_'
+        {
+            continue;
+        }
+        if start < index {
+            writer.write_all((&file_name[start..index]).as_bytes())?;
+        }
+        start = index + 1;
+    }
+    if start < bytes.len() {
+        writer.write_all((&file_name[start..]).as_bytes())?;
+    }
+    Ok(())
+}
+
+/// According to [RFC: Unified Log Format], it returns `true` when this byte stream contains
+/// the following characters, which means this input stream needs to be JSON encoded.
+/// Otherwise, it returns `false`.
+///
+/// - U+0000 (NULL) ~ U+0020 (SPACE)
+/// - U+0022 (QUOTATION MARK)
+/// - U+003D (EQUALS SIGN)
+/// - U+005B (LEFT SQUARE BRACKET)
+/// - U+005D (RIGHT SQUARE BRACKET)
+///
+/// [RFC: Unified Log Format]: (https://github.com/tikv/rfcs/blob/master/text/2018-12-19-unified-log-format.md)
+///
+#[inline]
+fn need_json_encode(bytes: &[u8]) -> bool {
+    for &byte in bytes {
+        if byte <= 0x20 || byte == 0x22 || byte == 0x3D || byte == 0x5B || byte == 0x5D {
+            return true;
+        }
+    }
+    false
+}
+
+/// According to [RFC: Unified Log Format], escapes the given data and writes it into a writer.
+/// If there is no character [`need json encode`], it writes the data into the writer directly.
+/// Else, it serializes the given data structure as JSON into a writer.
+///
+/// [RFC: Unified Log Format]: (https://github.com/tikv/rfcs/blob/master/text/2018-12-19-unified-log-format.md)
+/// [`need json encode`]: #method.need_json_encode
+///
+fn write_escaped_str<W>(writer: &mut W, value: &str) -> io::Result<()>
+where
+    W: io::Write + ?Sized,
+{
+    if !need_json_encode(value.as_bytes()) {
+        writer.write_all(value.as_bytes())?;
+    } else {
+        serde_json::to_writer(writer, value)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::DateTime;
     use slog_term::PlainSyncDecorator;
     use std::cell::RefCell;
+    use std::io;
     use std::io::Write;
     use std::str::from_utf8;
 
@@ -387,32 +368,166 @@ fn test_log_format() {
         }
     }
 
-    // Make the log
-    let decorator = PlainSyncDecorator::new(TestWriter);
-    let drain = TikvFormat::new(decorator).fuse();
-    let logger = Logger::root_typed(drain, slog_o!());
-    slog_crit!(logger, "test");
+    #[test]
+    fn test_log_format() {
+        use regex::Regex;
+        use std::time::Duration;
+        let decorator = PlainSyncDecorator::new(TestWriter);
+        let drain = TikvFormat::new(decorator).fuse();
+        let logger = slog::Logger::root_typed(drain, slog_o!());
 
-    // Check the logged value.
-    BUFFER.with(|buffer| {
-        let buffer = buffer.borrow_mut();
-        let output = from_utf8(&*buffer).unwrap();
+        // Empty message is not recommend, just for test purpose here.
+        slog_info!(logger, "");
+        slog_info!(logger, "Welcome");
+        slog_info!(logger, "Welcome TiKV");
+        slog_info!(logger, "欢迎");
+        slog_info!(logger, "欢迎 TiKV");
 
-        // This functions roughly as an assert to make sure that the log level and file name is logged.
-        let mut split_iter = output.split(" CRIT logger.rs:");
-        // The pre-split portion will contain a timestamp which we can check by parsing and ensuring it is valid.
-        let datetime = split_iter.next().unwrap();
-        assert!(Utc.datetime_from_str(datetime, TIMESTAMP_FORMAT).is_ok());
-        // The post-split portion will contain the line number of the file (which we validate is a number), and then the log message.
-        let line_and_message = split_iter.next().unwrap();
-        let mut split_iter = line_and_message.split(": ");
-        // Since the file will change, asserting the number exactly is unmaintainable.
-        split_iter
-            .next()
-            .and_then(|val| val.parse::<usize>().ok())
-            .unwrap();
-        // We do know the message though!
-        let message = split_iter.next().unwrap();
-        assert_eq!(message, "test\n");
-    });
+        slog_info!(logger, "failed to fetch URL";
+                    "url" => "http://example.com",
+                    "attempt" => 3,
+                    "backoff" => ?Duration::new(3, 0),
+        );
+
+        slog_info!(
+            logger,
+            "failed to \"fetch\" [URL]: {}",
+            "http://example.com"
+        );
+
+        slog_debug!(logger, "Slow query";
+            "sql" => "SELECT * FROM TABLE WHERE ID=\"abc\"",
+            "duration" => ?Duration::new(0, 123),
+            "process keys" => 1500,
+        );
+
+        slog_warn!(logger, "Type";
+            "Counter" => ::std::f64::NAN,
+            "Score" => ::std::f64::INFINITY,
+            "Other" => ::std::f64::NEG_INFINITY
+        );
+
+        let none: Option<u8> = None;
+        slog_info!(logger, "more type tests";
+            "field1" => "no_quote",
+            "field2" => "in quote",
+            "urls" => ?["http://xxx.com:2347", "http://xxx.com:2432"],
+            "url-peers" => ?["peer1", "peer 2"],
+            "store ids" => ?[1, 2, 3],
+            "is_true" => true,
+            "is_false" => false,
+            "is_None" => none,
+            "u8" => 34 as u8,
+            "str_array" => ?["💖",
+                "�",
+                "☺☻☹",
+                "日a本b語ç日ð本Ê語þ日¥本¼語i日©",
+                "日a本b語ç日ð本Ê語þ日¥本¼語i日©日a本b語ç日ð本Ê語þ日¥本¼語i日©日a本b語ç日ð本Ê語þ日¥本¼語i日©",
+                "\\x80\\x80\\x80\\x80",
+                "<car><mirror>XML</mirror></car>"]
+        );
+
+        let expect = r#"[2019/01/15 13:40:39.619 +08:00] [INFO] [logger.rs:469] []
+[2019/01/15 13:40:39.619 +08:00] [INFO] [logger.rs:469] [Welcome]
+[2019/01/15 13:40:39.619 +08:00] [INFO] [logger.rs:470] ["Welcome TiKV"]
+[2019/01/15 13:40:39.619 +08:00] [INFO] [logger.rs:471] [欢迎]
+[2019/01/15 13:40:39.619 +08:00] [INFO] [logger.rs:472] ["欢迎 TiKV"]
+[2019/01/15 13:40:39.615 +08:00] [INFO] [logger.rs:455] ["failed to fetch URL"] [backoff=3s] [attempt=3] [url=http://example.com]
+[2019/01/15 13:40:39.619 +08:00] [INFO] [logger.rs:460] ["failed to \"fetch\" [URL]: http://example.com"]
+[2019/01/15 13:40:39.619 +08:00] [DEBUG] [logger.rs:463] ["Slow query"] ["process keys"=1500] [duration=123ns] [sql="SELECT * FROM TABLE WHERE ID=\"abc\""]
+[2019/01/15 13:40:39.619 +08:00] [WARN] [logger.rs:473] [Type] [Other=-inf] [Score=inf] [Counter=NaN]
+[2019/01/16 16:56:04.854 +08:00] [INFO] [logger.rs:391] ["more type tests"] [str_array="[\"💖\", \"�\", \"☺☻☹\", \"日a本b語ç日ð本Ê語þ日¥本¼語i日©\", \"日a本b語ç日ð本Ê語þ日¥本¼語i日©日a本b語ç日ð本Ê語þ日¥本¼語i日©日a本b語ç日ð本Ê語þ日¥本¼語i日©\", \"\\\\x80\\\\x80\\\\x80\\\\x80\", \"<car><mirror>XML</mirror></car>\"]"] [u8=34] [is_None=None] [is_false=false] [is_true=true] ["store ids"="[1, 2, 3]"] [url-peers="[\"peer1\", \"peer 2\"]"] [urls="[\"http://xxx.com:2347\", \"http://xxx.com:2432\"]"] [field2="in quote"] [field1=no_quote]
+"#;
+
+        BUFFER.with(|buffer| {
+            let buffer = buffer.borrow_mut();
+            let output = from_utf8(&*buffer).unwrap();
+            assert_eq!(output.lines().count(), expect.lines().count());
+
+            let re = Regex::new(r"(?P<datetime>\[.*?\])\s(?P<level>\[.*?\])\s(?P<source_file>\[.*?\])\s(?P<msg>\[.*?\])\s?(?P<kvs>\[.*\])?").unwrap();
+
+            for (output_line, expect_line) in output.lines().zip(expect.lines()) {
+                let expect_segments = re.captures(expect_line).unwrap();
+                let output_segments = re.captures(output_line).unwrap();
+
+                validate_log_datetime(peel(&expect_segments["datetime"]));
+
+                assert!(validate_log_source_file(
+                    peel(&expect_segments["source_file"]),
+                    peel(&output_segments["source_file"])
+                ));
+                assert_eq!(expect_segments["level"], output_segments["level"]);
+                assert_eq!(expect_segments["msg"], output_segments["msg"]);
+                assert_eq!(
+                    expect_segments.name("kvs").map(|s| s.as_str()),
+                    output_segments.name("kvs").map(|s| s.as_str())
+                );
+            }
+        });
+    }
+
+    /// Removes the wrapping signs, peels `"[hello]"` to `"hello"`, or peels `"(hello)"` to `"hello"`,
+    fn peel(output: &str) -> &str {
+        assert!(output.len() >= 2);
+        &(output[1..output.len() - 1])
+    }
+
+    /// Validates source file info.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// assert_eq!(true, validate_log_source_file("<unknown>", "<unknown>"));
+    /// assert_eq!(true, validate_log_source_file("mod.rs:1", "mod.rs:1"));
+    /// assert_eq!(true, validate_log_source_file("mod.rs:1", "mod.rs:100"));
+    /// assert_eq!(false, validate_log_source_file("mod.rs:1", "<unknown>"));
+    /// assert_eq!(false, validate_log_source_file("mod.rs:1", "mod.rs:NAN"));
+    /// ```
+    fn validate_log_source_file(output: &str, expect: &str) -> bool {
+        if expect.eq(output) {
+            return true;
+        }
+        if expect.eq("<unknown>") || output.eq("<unknown>") {
+            return false;
+        }
+
+        let mut iter = expect.split(':').zip(output.split(':'));
+        let (expect_file_name, output_file_name) = iter.next().unwrap();
+        assert_eq!(expect_file_name, output_file_name);
+
+        let (_expect_line_number, output_line_number) = iter.next().unwrap();
+        output_line_number.parse::<usize>().is_ok()
+    }
+
+    fn validate_log_datetime(datetime: &str) {
+        assert!(
+            DateTime::parse_from_str(datetime, TIMESTAMP_FORMAT).is_ok(),
+            "{:?}",
+            datetime,
+        );
+    }
+
+    #[test]
+    fn test_get_level_by_string() {
+        // Ensure UPPER, Capitalized, and lower case all map over.
+        assert_eq!(Some(Level::Trace), get_level_by_string("TRACE"));
+        assert_eq!(Some(Level::Trace), get_level_by_string("Trace"));
+        assert_eq!(Some(Level::Trace), get_level_by_string("trace"));
+        // Due to legacy we need to ensure that `warn` maps to `Warning`.
+        assert_eq!(Some(Level::Warning), get_level_by_string("warn"));
+        assert_eq!(Some(Level::Warning), get_level_by_string("warning"));
+        // Ensure that all non-defined values map to `Info`.
+        assert_eq!(None, get_level_by_string("Off"));
+        assert_eq!(None, get_level_by_string("definitely not an option"));
+    }
+
+    #[test]
+    fn test_get_unified_log_level() {
+        assert_eq!("FATAL", get_unified_log_level(Level::Critical));
+        assert_eq!("ERROR", get_unified_log_level(Level::Error));
+        assert_eq!("WARN", get_unified_log_level(Level::Warning));
+        assert_eq!("INFO", get_unified_log_level(Level::Info));
+        assert_eq!("DEBUG", get_unified_log_level(Level::Debug));
+        assert_eq!("TRACE", get_unified_log_level(Level::Trace));
+    }
 }


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR cherry picks the unified log format formatter from 3.0 to 2.1.

Note: This PR does not introduce fields for log items.

## What are the type of the changes? (mandatory)

- New feature (change which adds functionality)

## How has this PR been tested? (mandatory)

Manually and unit tests:

```
$ target/debug/tikv-server
[2019/07/13 11:44:14.561 +08:00] [INFO] [mod.rs:26] ["Welcome to TiKV. \nRelease Version:   2.1.14\nGit Commit Hash:   Unknown (env var does not exist when building)\nGit Commit Branch: Unknown (env var does not exist when building)\nUTC Build Time:    Unknown (env var does not exist when building)\nRust Version:      Unknown (env var does not exist when building)"]
[2019/07/13 11:44:14.563 +08:00] [INFO] [config.rs:152] ["no advertise-addr is specified, fall back to addr."]
[2019/07/13 11:44:14.564 +08:00] [ERROR] [tikv-server.rs:441] ["invalid configuration: StringError(\"please specify pd.endpoints.\")"]
```
