### PR TITLE
Replace uses of `new` with `default` for protobuf messages

### DIFF
--- a/benches/coprocessor_executors/util/mod.rs
+++ b/benches/coprocessor_executors/util/mod.rs
@@ -40,7 +40,7 @@ pub fn build_dag_handler<TargetTxnStore: TxnStore + 'static>(
     use tikv::coprocessor::Deadline;
     use tipb::select::DAGRequest;
 
-    let mut dag = DAGRequest::new();
+    let mut dag = DAGRequest::default();
     dag.set_executors(RepeatedField::from_vec(executors.to_vec()));
 
     DAGBuilder::build(

--- a/benches/hierarchy/engine/mod.rs
+++ b/benches/hierarchy/engine/mod.rs
@@ -13,7 +13,7 @@ fn bench_engine_put<E: Engine, F: EngineFactory<E>>(
     config: &BenchConfig<F>,
 ) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     bencher.iter_batched(
         || {
             let test_kvs: Vec<(Key, Value)> = KvGenerator::with_seed(
@@ -41,7 +41,7 @@ fn bench_engine_snapshot<E: Engine, F: EngineFactory<E>>(
     config: &BenchConfig<F>,
 ) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     bencher.iter(|| black_box(&engine).snapshot(black_box(&ctx)).unwrap());
 }
 
@@ -51,7 +51,7 @@ fn bench_engine_get<E: Engine, F: EngineFactory<E>>(
     config: &BenchConfig<F>,
 ) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     let test_kvs: Vec<Key> = KvGenerator::with_seed(
         config.key_length,
         config.value_length,

--- a/benches/hierarchy/mvcc/mod.rs
+++ b/benches/hierarchy/mvcc/mod.rs
@@ -14,7 +14,7 @@ where
     E: Engine,
     F: EngineFactory<E>,
 {
-    let ctx = Context::new();
+    let ctx = Context::default();
     let snapshot = engine.snapshot(&ctx).unwrap();
     let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
 
@@ -41,7 +41,7 @@ where
 
 fn mvcc_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     let option = Options::default();
     b.iter_batched(
         || {
@@ -120,7 +120,7 @@ fn mvcc_rollback_non_prewrote<E: Engine, F: EngineFactory<E>>(
     config: &BenchConfig<F>,
 ) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     b.iter_batched(
         || {
             let kvs = KvGenerator::with_seed(

--- a/benches/hierarchy/storage/mod.rs
+++ b/benches/hierarchy/storage/mod.rs
@@ -19,7 +19,7 @@ fn storage_raw_get<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Ben
                 .generate(DEFAULT_ITERATIONS);
             let data: Vec<(Context, Vec<u8>)> = kvs
                 .iter()
-                .map(|(k, _)| (Context::new(), k.clone()))
+                .map(|(k, _)| (Context::default(), k.clone()))
                 .collect();
             (data, &store)
         },
@@ -44,7 +44,7 @@ fn storage_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Be
                 .iter()
                 .map(|(k, v)| {
                     (
-                        Context::new(),
+                        Context::default(),
                         vec![Mutation::Put((Key::from_raw(&k), v.clone()))],
                         k.clone(),
                     )
@@ -72,7 +72,7 @@ fn storage_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Benc
             for (k, v) in &kvs {
                 store
                     .prewrite(
-                        Context::new(),
+                        Context::default(),
                         vec![Mutation::Put((Key::from_raw(&k), v.clone()))],
                         k.clone(),
                         1,
@@ -84,7 +84,7 @@ fn storage_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Benc
         },
         |(kvs, store)| {
             for (k, _) in &kvs {
-                black_box(store.commit(Context::new(), vec![Key::from_raw(k)], 1, 2)).unwrap();
+                black_box(store.commit(Context::default(), vec![Key::from_raw(k)], 1, 2)).unwrap();
             }
         },
         BatchSize::SmallInput,

--- a/benches/hierarchy/txn/mod.rs
+++ b/benches/hierarchy/txn/mod.rs
@@ -14,7 +14,7 @@ where
     E: Engine,
     F: EngineFactory<E>,
 {
-    let ctx = Context::new();
+    let ctx = Context::default();
     let option = Options::default();
 
     let snapshot = engine.snapshot(&ctx).unwrap();
@@ -36,7 +36,7 @@ where
 
 fn txn_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     let option = Options::default();
     b.iter_batched(
         || {
@@ -63,7 +63,7 @@ fn txn_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchC
 
 fn txn_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     b.iter_batched(
         || setup_prewrite(&engine, &config, 1),
         |keys| {
@@ -81,7 +81,7 @@ fn txn_commit<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchCon
 
 fn txn_rollback_prewrote<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     b.iter_batched(
         || setup_prewrite(&engine, &config, 1),
         |keys| {
@@ -99,7 +99,7 @@ fn txn_rollback_prewrote<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config
 
 fn txn_rollback_conflict<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchConfig<F>) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     b.iter_batched(
         || setup_prewrite(&engine, &config, 2),
         |keys| {
@@ -120,7 +120,7 @@ fn txn_rollback_non_prewrote<E: Engine, F: EngineFactory<E>>(
     config: &BenchConfig<F>,
 ) {
     let engine = config.engine_factory.build();
-    let ctx = Context::new();
+    let ctx = Context::default();
     b.iter_batched(
         || {
             let kvs = KvGenerator::new(config.key_length, config.value_length)

--- a/benches/misc/raftkv/mod.rs
+++ b/benches/misc/raftkv/mod.rs
@@ -39,7 +39,7 @@ impl SyncBenchRouter {
 
 impl SyncBenchRouter {
     fn invoke(&self, cmd: RaftCommand) {
-        let mut response = RaftCmdResponse::new();
+        let mut response = RaftCmdResponse::default();
         cmd_resp::bind_term(&mut response, 1);
         match cmd.callback {
             Callback::Read(cb) => {
@@ -51,7 +51,7 @@ impl SyncBenchRouter {
                 })
             }
             Callback::Write(cb) => {
-                let mut resp = Response::new();
+                let mut resp = Response::default();
                 let cmd_type = cmd.request.get_requests()[0].get_cmd_type();
                 resp.set_cmd_type(cmd_type);
                 response.mut_responses().push(resp);
@@ -96,10 +96,10 @@ fn bench_async_snapshots_noop(b: &mut test::Bencher) {
     let (_dir, db) = new_engine();
     let snapshot = engine::Snapshot::new(Arc::clone(&db));
     let resp = ReadResponse {
-        response: RaftCmdResponse::new(),
+        response: RaftCmdResponse::default(),
         snapshot: Some(RegionSnapshot::from_snapshot(
             snapshot.into_sync(),
-            Region::new(),
+            Region::default(),
         )),
     };
 
@@ -125,7 +125,7 @@ fn bench_async_snapshots_noop(b: &mut test::Bencher) {
 #[bench]
 fn bench_async_snapshot(b: &mut test::Bencher) {
     let leader = util::new_peer(2, 3);
-    let mut region = Region::new();
+    let mut region = Region::default();
     region.set_id(1);
     region.set_start_key(vec![]);
     region.set_end_key(vec![]);
@@ -135,7 +135,7 @@ fn bench_async_snapshot(b: &mut test::Bencher) {
     let (_tmp, db) = new_engine();
     let kv = RaftKv::new(SyncBenchRouter::new(region.clone(), db));
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());
@@ -150,7 +150,7 @@ fn bench_async_snapshot(b: &mut test::Bencher) {
 #[bench]
 fn bench_async_write(b: &mut test::Bencher) {
     let leader = util::new_peer(2, 3);
-    let mut region = Region::new();
+    let mut region = Region::default();
     region.set_id(1);
     region.set_start_key(vec![]);
     region.set_end_key(vec![]);
@@ -160,7 +160,7 @@ fn bench_async_write(b: &mut test::Bencher) {
     let (_tmp, db) = new_engine();
     let kv = RaftKv::new(SyncBenchRouter::new(region.clone(), db));
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());

--- a/benches/misc/serialization/bench_serialization.rs
+++ b/benches/misc/serialization/bench_serialization.rs
@@ -20,7 +20,7 @@ fn gen_rand_str(len: usize) -> Vec<u8> {
 fn generate_requests(map: &HashMap<&[u8], &[u8]>) -> Vec<Request> {
     let mut reqs = vec![];
     for (key, value) in map {
-        let mut r = Request::new();
+        let mut r = Request::default();
         r.set_cmd_type(CmdType::Put);
         r.mut_put().set_cf("tikv".to_owned());
         r.mut_put().set_key(key.to_vec());
@@ -31,8 +31,8 @@ fn generate_requests(map: &HashMap<&[u8], &[u8]>) -> Vec<Request> {
 }
 
 fn encode(map: &HashMap<&[u8], &[u8]>) -> Vec<u8> {
-    let mut e = Entry::new();
-    let mut cmd = RaftCmdRequest::new();
+    let mut e = Entry::default();
+    let mut cmd = RaftCmdRequest::default();
     let reqs = generate_requests(map);
     cmd.set_requests(protobuf::RepeatedField::from_vec(reqs));
     let cmd_msg = cmd.write_to_bytes().unwrap();
@@ -41,9 +41,9 @@ fn encode(map: &HashMap<&[u8], &[u8]>) -> Vec<u8> {
 }
 
 fn decode(data: &[u8]) {
-    let mut entry = Entry::new();
+    let mut entry = Entry::default();
     entry.merge_from_bytes(data).unwrap();
-    let mut cmd = RaftCmdRequest::new();
+    let mut cmd = RaftCmdRequest::default();
     cmd.merge_from_bytes(entry.get_data()).unwrap();
 }
 

--- a/benches/misc/storage/scan.rs
+++ b/benches/misc/storage/scan.rs
@@ -22,7 +22,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
         let mut ts = ts_generator.next().unwrap();
         store
             .prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(&k), v))],
                 k.clone(),
                 ts,
@@ -30,7 +30,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
             .expect("");
         store
             .commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(&k)],
                 ts,
                 ts_generator.next().unwrap(),
@@ -40,7 +40,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
         ts = ts_generator.next().unwrap();
         store
             .prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Delete(Key::from_raw(&k))],
                 k.clone(),
                 ts,
@@ -48,7 +48,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
             .expect("");
         store
             .commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(&k)],
                 ts,
                 ts_generator.next().unwrap(),
@@ -61,7 +61,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
         let (k, _) = kvs.next().unwrap();
         assert!(store
             .scan(
-                Context::new(),
+                Context::default(),
                 Key::from_raw(&k),
                 None,
                 1,

--- a/benches/misc/writebatch/bench_writebatch.rs
+++ b/benches/misc/writebatch/bench_writebatch.rs
@@ -7,7 +7,7 @@ use test::Bencher;
 fn writebatch(db: &DB, round: usize, batch_keys: usize) {
     let v = b"operators are syntactic sugar for calls to methods of built-in traits";
     for r in 0..round {
-        let batch = WriteBatch::new();
+        let batch = WriteBatch::default();
         for i in 0..batch_keys {
             let k = format!("key_round{}_key{}", r, i);
             batch.put(k.as_bytes(), v).unwrap();
@@ -97,7 +97,7 @@ fn fill_writebatch(wb: &WriteBatch, target_size: usize) {
 #[bench]
 fn bench_writebatch_without_capacity(b: &mut Bencher) {
     b.iter(|| {
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         fill_writebatch(&wb, 4096);
     });
 }

--- a/benches/raftstore/mod.rs
+++ b/benches/raftstore/mod.rs
@@ -11,7 +11,7 @@ use tikv::raftstore::store::keys;
 const DEFAULT_DATA_SIZE: usize = 100_000;
 
 fn enc_write_kvs(db: &DB, kvs: &[(Vec<u8>, Vec<u8>)]) {
-    let wb = WriteBatch::new();
+    let wb = WriteBatch::default();
     for &(ref k, ref v) in kvs {
         wb.put(&keys::data_key(k), v).unwrap();
     }

--- a/components/engine/src/errors.rs
+++ b/components/engine/src/errors.rs
@@ -51,7 +51,7 @@ impl From<Error> for raft::Error {
 
 impl From<Error> for kvproto::errorpb::Error {
     fn from(err: Error) -> kvproto::errorpb::Error {
-        let mut errorpb = kvproto::errorpb::Error::new();
+        let mut errorpb = kvproto::errorpb::Error::default();
         errorpb.set_message(format!("{}", err));
 
         if let Error::NotInRange(key, region_id, start_key, end_key) = err {

--- a/components/engine/src/rocks/mod.rs
+++ b/components/engine/src/rocks/mod.rs
@@ -38,7 +38,7 @@ mod tests {
         let engine =
             Arc::new(util::new_engine(path.path().to_str().unwrap(), None, &[cf], None).unwrap());
 
-        let mut r = Region::new();
+        let mut r = Region::default();
         r.set_id(10);
 
         let key = b"key";

--- a/components/engine/src/util.rs
+++ b/components/engine/src/util.rs
@@ -58,7 +58,7 @@ pub fn delete_all_in_range_cf(
     use_delete_range: bool,
 ) -> Result<()> {
     let handle = rocks::util::get_cf_handle(db, cf)?;
-    let wb = WriteBatch::new();
+    let wb = WriteBatch::default();
     if use_delete_range && cf != CF_LOCK {
         wb.delete_range_cf(handle, start_key, end_key)?;
     } else {
@@ -159,7 +159,7 @@ mod tests {
             .collect();
         let db = new_engine_opt(path_str, DBOptions::new(), cfs_opts).unwrap();
 
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         let ts: u8 = 12;
         let keys: Vec<_> = vec![
             b"k1".to_vec(),
@@ -266,7 +266,7 @@ mod tests {
         cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
         let cf = "default";
         let db = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         let kvs: Vec<(&[u8], &[u8])> = vec![
             (b"kabcdefg1", b"v1"),
             (b"kabcdefg2", b"v2"),

--- a/components/test_coprocessor/src/dag.rs
+++ b/components/test_coprocessor/src/dag.rs
@@ -173,7 +173,7 @@ impl DAGSelect {
     }
 
     pub fn build(self) -> Request {
-        self.build_with(Context::new(), &[0])
+        self.build_with(Context::default(), &[0])
     }
 
     pub fn build_with(mut self, ctx: Context, flags: &[u64]) -> Request {
@@ -213,7 +213,7 @@ impl DAGSelect {
             self.execs.push(exec);
         }
 
-        let mut dag = DAGRequest::new();
+        let mut dag = DAGRequest::default();
         dag.set_executors(RepeatedField::from_vec(self.execs));
         dag.set_start_ts(next_id() as u64);
         dag.set_flags(flags.iter().fold(0, |acc, f| acc | *f));
@@ -226,7 +226,7 @@ impl DAGSelect {
         };
         dag.set_output_offsets(output_offsets);
 
-        let mut req = Request::new();
+        let mut req = Request::default();
         req.set_tp(REQ_TYPE_DAG);
         req.set_data(dag.write_to_bytes().unwrap());
         req.set_ranges(RepeatedField::from_vec(vec![self.key_range]));

--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -89,7 +89,7 @@ pub fn init_data_with_commit(
     commit: bool,
 ) -> (Store<RocksEngine>, Endpoint<RocksEngine>) {
     let engine = TestEngineBuilder::new().build().unwrap();
-    init_data_with_engine_and_commit(Context::new(), engine, tbl, vals, commit)
+    init_data_with_engine_and_commit(Context::default(), engine, tbl, vals, commit)
 }
 
 // This function will create a Product table and initialize with the specified data.

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -35,7 +35,7 @@ impl<'a, E: Engine> Insert<'a, E> {
     }
 
     pub fn execute(self) -> i64 {
-        self.execute_with_ctx(Context::new())
+        self.execute_with_ctx(Context::default())
     }
 
     pub fn execute_with_ctx(self, ctx: Context) -> i64 {
@@ -73,7 +73,7 @@ impl<'a, E: Engine> Delete<'a, E> {
     }
 
     pub fn execute(self, id: i64, row: Vec<Datum>) {
-        self.execute_with_ctx(Context::new(), id, row)
+        self.execute_with_ctx(Context::default(), id, row)
     }
 
     pub fn execute_with_ctx(self, ctx: Context, id: i64, row: Vec<Datum>) {
@@ -169,7 +169,7 @@ impl<E: Engine> Store<E> {
     }
 
     pub fn commit(&mut self) {
-        self.commit_with_ctx(Context::new());
+        self.commit_with_ctx(Context::default());
     }
 
     pub fn get_engine(&self) -> E {
@@ -183,7 +183,7 @@ impl<E: Engine> Store<E> {
     pub fn export(&self) -> Vec<(Vec<u8>, Vec<u8>)> {
         self.store
             .scan(
-                Context::new(),
+                Context::default(),
                 Key::from_encoded(vec![]),
                 None,
                 100_000,
@@ -199,7 +199,7 @@ impl<E: Engine> Store<E> {
 
     /// Directly creates a `SnapshotStore` over current committed data.
     pub fn to_snapshot_store(&self) -> SnapshotStore<E::Snap> {
-        let snapshot = self.get_engine().snapshot(&Context::new()).unwrap();
+        let snapshot = self.get_engine().snapshot(&Context::default()).unwrap();
         SnapshotStore::new(snapshot, self.last_committed_ts, IsolationLevel::SI, true)
     }
 
@@ -246,9 +246,15 @@ mod tests {
     fn test_export() {
         let mut store = Store::new();
         store.begin();
-        store.put(Context::new(), vec![(b"key1".to_vec(), b"value1".to_vec())]);
-        store.put(Context::new(), vec![(b"key2".to_vec(), b"foo".to_vec())]);
-        store.delete(Context::new(), vec![b"key0".to_vec()]);
+        store.put(
+            Context::default(),
+            vec![(b"key1".to_vec(), b"value1".to_vec())],
+        );
+        store.put(
+            Context::default(),
+            vec![(b"key2".to_vec(), b"foo".to_vec())],
+        );
+        store.delete(Context::default(), vec![b"key0".to_vec()]);
         store.commit();
 
         assert_eq!(
@@ -260,9 +266,15 @@ mod tests {
         );
 
         store.begin();
-        store.put(Context::new(), vec![(b"key1".to_vec(), b"value2".to_vec())]);
-        store.put(Context::new(), vec![(b"key2".to_vec(), b"foo".to_vec())]);
-        store.delete(Context::new(), vec![b"key0".to_vec()]);
+        store.put(
+            Context::default(),
+            vec![(b"key1".to_vec(), b"value2".to_vec())],
+        );
+        store.put(
+            Context::default(),
+            vec![(b"key2".to_vec(), b"foo".to_vec())],
+        );
+        store.delete(Context::default(), vec![b"key0".to_vec()]);
         store.commit();
 
         assert_eq!(
@@ -274,21 +286,27 @@ mod tests {
         );
 
         store.begin();
-        store.delete(Context::new(), vec![b"key0".to_vec(), b"key2".to_vec()]);
+        store.delete(Context::default(), vec![b"key0".to_vec(), b"key2".to_vec()]);
         store.commit();
 
         assert_eq!(store.export(), vec![(b"key1".to_vec(), b"value2".to_vec())]);
 
         store.begin();
-        store.delete(Context::new(), vec![b"key1".to_vec()]);
+        store.delete(Context::default(), vec![b"key1".to_vec()]);
         store.commit();
 
         assert_eq!(store.export(), vec![]);
 
         store.begin();
-        store.put(Context::new(), vec![(b"key2".to_vec(), b"bar".to_vec())]);
-        store.put(Context::new(), vec![(b"key1".to_vec(), b"foo".to_vec())]);
-        store.put(Context::new(), vec![(b"k".to_vec(), b"box".to_vec())]);
+        store.put(
+            Context::default(),
+            vec![(b"key2".to_vec(), b"bar".to_vec())],
+        );
+        store.put(
+            Context::default(),
+            vec![(b"key1".to_vec(), b"foo".to_vec())],
+        );
+        store.put(Context::default(), vec![(b"k".to_vec(), b"box".to_vec())]);
         store.commit();
 
         assert_eq!(
@@ -301,7 +319,7 @@ mod tests {
         );
 
         store.begin();
-        store.delete(Context::new(), vec![b"key1".to_vec(), b"key1".to_vec()]);
+        store.delete(Context::default(), vec![b"key1".to_vec(), b"key1".to_vec()]);
         store.commit();
 
         assert_eq!(
@@ -313,7 +331,7 @@ mod tests {
         );
 
         store.begin();
-        store.delete(Context::new(), vec![b"key2".to_vec()]);
+        store.delete(Context::default(), vec![b"key2".to_vec()]);
 
         assert_eq!(
             store.export(),
@@ -328,8 +346,8 @@ mod tests {
         assert_eq!(store.export(), vec![(b"k".to_vec(), b"box".to_vec())]);
 
         store.begin();
-        store.put(Context::new(), vec![(b"key1".to_vec(), b"v1".to_vec())]);
-        store.put(Context::new(), vec![(b"key2".to_vec(), b"v2".to_vec())]);
+        store.put(Context::default(), vec![(b"key1".to_vec(), b"v1".to_vec())]);
+        store.put(Context::default(), vec![(b"key2".to_vec(), b"v2".to_vec())]);
 
         assert_eq!(store.export(), vec![(b"k".to_vec(), b"box".to_vec())]);
 

--- a/components/test_coprocessor/src/table.rs
+++ b/components/test_coprocessor/src/table.rs
@@ -86,7 +86,7 @@ impl Table {
 
     /// Create a `KeyRange` which select all records in current table.
     pub fn get_record_range_all(&self) -> KeyRange {
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         range.set_start(table::encode_row_key(self.id, std::i64::MIN));
         range.set_end(table::encode_row_key(self.id, std::i64::MAX));
         range
@@ -97,7 +97,7 @@ impl Table {
         let start_key = table::encode_row_key(self.id, handle_id);
         let mut end_key = start_key.clone();
         coprocessor::util::convert_to_prefix_next(&mut end_key);
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         range.set_start(start_key);
         range.set_end(end_key);
         range
@@ -105,7 +105,7 @@ impl Table {
 
     /// Create a `KeyRange` which select all index records of a specified index in current table.
     pub fn get_index_range_all(&self, idx: i64) -> KeyRange {
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         let mut buf = Vec::with_capacity(8);
         buf.encode_i64(::std::i64::MIN).unwrap();
         range.set_start(table::encode_index_seek_key(self.id, idx, &buf));

--- a/components/test_coprocessor/src/util.rs
+++ b/components/test_coprocessor/src/util.rs
@@ -33,7 +33,7 @@ where
 {
     let resp = handle_request(cop, req);
     assert!(!resp.get_data().is_empty(), "{:?}", resp);
-    let mut sel_resp = SelectResponse::new();
+    let mut sel_resp = SelectResponse::default();
     sel_resp.merge_from_bytes(resp.get_data()).unwrap();
     sel_resp
 }
@@ -53,7 +53,7 @@ where
             let resp = resp.unwrap();
             check_range(&resp);
             assert!(!resp.get_data().is_empty());
-            let mut stream_resp = StreamResponse::new();
+            let mut stream_resp = StreamResponse::default();
             stream_resp.merge_from_bytes(resp.get_data()).unwrap();
             stream_resp
         })

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -79,7 +79,7 @@ pub trait Simulator {
         match self.async_command_on_node(node_id, request, cb) {
             Ok(()) => {}
             Err(e) => {
-                let mut resp = RaftCmdResponse::new();
+                let mut resp = RaftCmdResponse::default();
                 resp.mut_header().set_error(e.into());
                 return Ok(resp);
             }
@@ -400,7 +400,7 @@ impl<T: Simulator> Cluster<T> {
     // But another node may request bootstrap at same time and get is_bootstrap false
     // Add Region but not set bootstrap to true
     pub fn add_first_region(&self) -> Result<()> {
-        let mut region = metapb::Region::new();
+        let mut region = metapb::Region::default();
         let region_id = self.pd_client.alloc_id().unwrap();
         let peer_id = self.pd_client.alloc_id().unwrap();
         region.set_id(region_id);
@@ -423,7 +423,7 @@ impl<T: Simulator> Cluster<T> {
             self.engines.insert(id, engines.clone());
         }
 
-        let mut region = metapb::Region::new();
+        let mut region = metapb::Region::default();
         region.set_id(1);
         region.set_start_key(keys::EMPTY_KEY.to_vec());
         region.set_end_key(keys::EMPTY_KEY.to_vec());

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -113,7 +113,7 @@ impl Operator {
                     };
                     new_pd_change_peer(conf_change_type, peer.clone())
                 } else {
-                    pdpb::RegionHeartbeatResponse::new()
+                    pdpb::RegionHeartbeatResponse::default()
                 }
             }
             Operator::RemovePeer { ref peer, .. } => {
@@ -124,7 +124,7 @@ impl Operator {
                 target_region_id, ..
             } => {
                 if target_region_id == region_id {
-                    pdpb::RegionHeartbeatResponse::new()
+                    pdpb::RegionHeartbeatResponse::default()
                 } else {
                     let region = cluster
                         .get_region_by_id(target_region_id)
@@ -227,7 +227,7 @@ struct Cluster {
 
 impl Cluster {
     fn new(cluster_id: u64) -> Cluster {
-        let mut meta = metapb::Cluster::new();
+        let mut meta = metapb::Cluster::default();
         meta.set_id(cluster_id);
         meta.set_max_peer_count(5);
 
@@ -460,7 +460,7 @@ impl Cluster {
         let resp = self
             .poll_heartbeat_responses(region.clone(), leader.clone())
             .unwrap_or_else(|| {
-                let mut resp = pdpb::RegionHeartbeatResponse::new();
+                let mut resp = pdpb::RegionHeartbeatResponse::default();
                 resp.set_region_id(region.get_id());
                 resp.set_region_epoch(region.take_region_epoch());
                 resp.set_target_peer(leader);
@@ -631,7 +631,7 @@ fn setdiff_peers(left: &metapb::Region, right: &metapb::Region) -> Vec<metapb::P
 
 // For test when a node is already bootstraped the cluster with the first region
 pub fn bootstrap_with_first_region(pd_client: Arc<TestPdClient>) -> Result<()> {
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(1);
     region.set_start_key(keys::EMPTY_KEY.to_vec());
     region.set_end_key(keys::EMPTY_KEY.to_vec());
@@ -1068,7 +1068,7 @@ impl PdClient for TestPdClient {
             return Box::new(err(e));
         }
 
-        let mut resp = pdpb::AskSplitResponse::new();
+        let mut resp = pdpb::AskSplitResponse::default();
         resp.set_new_region_id(self.alloc_id().unwrap());
         let mut peer_ids = vec![];
         for _ in region.get_peers() {
@@ -1103,7 +1103,7 @@ impl PdClient for TestPdClient {
             return Box::new(err(e));
         }
 
-        let mut resp = pdpb::AskBatchSplitResponse::new();
+        let mut resp = pdpb::AskBatchSplitResponse::default();
         for _ in 0..count {
             let mut id = pdpb::SplitID::new();
             id.set_new_region_id(self.alloc_id().unwrap());
@@ -1156,9 +1156,9 @@ impl PdClient for TestPdClient {
     }
 
     fn get_operator(&self, region_id: u64) -> Result<pdpb::GetOperatorResponse> {
-        let mut header = pdpb::ResponseHeader::new();
+        let mut header = pdpb::ResponseHeader::default();
         header.set_cluster_id(self.cluster_id);
-        let mut resp = pdpb::GetOperatorResponse::new();
+        let mut resp = pdpb::GetOperatorResponse::default();
         resp.set_header(header);
         resp.set_region_id(region_id);
         Ok(resp)

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -184,7 +184,7 @@ pub fn new_tikv_config(cluster_id: u64) -> TiKvConfig {
 
 // Create a base request.
 pub fn new_base_request(region_id: u64, epoch: RegionEpoch, read_quorum: bool) -> RaftCmdRequest {
-    let mut req = RaftCmdRequest::new();
+    let mut req = RaftCmdRequest::default();
     req.mut_header().set_region_id(region_id);
     req.mut_header().set_region_epoch(epoch);
     req.mut_header().set_read_quorum(read_quorum);
@@ -203,7 +203,7 @@ pub fn new_request(
 }
 
 pub fn new_put_cmd(key: &[u8], value: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::Put);
     cmd.mut_put().set_key(key.to_vec());
     cmd.mut_put().set_value(value.to_vec());
@@ -211,7 +211,7 @@ pub fn new_put_cmd(key: &[u8], value: &[u8]) -> Request {
 }
 
 pub fn new_put_cf_cmd(cf: &str, key: &[u8], value: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::Put);
     cmd.mut_put().set_key(key.to_vec());
     cmd.mut_put().set_value(value.to_vec());
@@ -220,20 +220,20 @@ pub fn new_put_cf_cmd(cf: &str, key: &[u8], value: &[u8]) -> Request {
 }
 
 pub fn new_get_cmd(key: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::Get);
     cmd.mut_get().set_key(key.to_vec());
     cmd
 }
 
 pub fn new_read_index_cmd() -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::ReadIndex);
     cmd
 }
 
 pub fn new_get_cf_cmd(cf: &str, key: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::Get);
     cmd.mut_get().set_key(key.to_vec());
     cmd.mut_get().set_cf(cf.to_string());
@@ -241,7 +241,7 @@ pub fn new_get_cf_cmd(cf: &str, key: &[u8]) -> Request {
 }
 
 pub fn new_delete_cmd(cf: &str, key: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::Delete);
     cmd.mut_delete().set_key(key.to_vec());
     cmd.mut_delete().set_cf(cf.to_string());
@@ -249,7 +249,7 @@ pub fn new_delete_cmd(cf: &str, key: &[u8]) -> Request {
 }
 
 pub fn new_delete_range_cmd(cf: &str, start: &[u8], end: &[u8]) -> Request {
-    let mut cmd = Request::new();
+    let mut cmd = Request::default();
     cmd.set_cmd_type(CmdType::DeleteRange);
     cmd.mut_delete_range().set_start_key(start.to_vec());
     cmd.mut_delete_range().set_end_key(end.to_vec());
@@ -262,20 +262,20 @@ pub fn new_status_request(
     peer: metapb::Peer,
     request: StatusRequest,
 ) -> RaftCmdRequest {
-    let mut req = new_base_request(region_id, RegionEpoch::new(), false);
+    let mut req = new_base_request(region_id, RegionEpoch::default(), false);
     req.mut_header().set_peer(peer);
     req.set_status_request(request);
     req
 }
 
 pub fn new_region_detail_cmd() -> StatusRequest {
-    let mut cmd = StatusRequest::new();
+    let mut cmd = StatusRequest::default();
     cmd.set_cmd_type(StatusCmdType::RegionDetail);
     cmd
 }
 
 pub fn new_region_leader_cmd() -> StatusRequest {
-    let mut cmd = StatusRequest::new();
+    let mut cmd = StatusRequest::default();
     cmd.set_cmd_type(StatusCmdType::RegionLeader);
     cmd
 }
@@ -291,7 +291,7 @@ pub fn new_admin_request(
 }
 
 pub fn new_change_peer_request(change_type: ConfChangeType, peer: metapb::Peer) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::ChangePeer);
     req.mut_change_peer().set_change_type(change_type);
     req.mut_change_peer().set_peer(peer);
@@ -299,7 +299,7 @@ pub fn new_change_peer_request(change_type: ConfChangeType, peer: metapb::Peer) 
 }
 
 pub fn new_compact_log_request(index: u64, term: u64) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::CompactLog);
     req.mut_compact_log().set_compact_index(index);
     req.mut_compact_log().set_compact_term(term);
@@ -307,7 +307,7 @@ pub fn new_compact_log_request(index: u64, term: u64) -> AdminRequest {
 }
 
 pub fn new_transfer_leader_cmd(peer: metapb::Peer) -> AdminRequest {
-    let mut cmd = AdminRequest::new();
+    let mut cmd = AdminRequest::default();
     cmd.set_cmd_type(AdminCmdType::TransferLeader);
     cmd.mut_transfer_leader().set_peer(peer);
     cmd
@@ -315,14 +315,14 @@ pub fn new_transfer_leader_cmd(peer: metapb::Peer) -> AdminRequest {
 
 #[allow(dead_code)]
 pub fn new_prepare_merge(target_region: metapb::Region) -> AdminRequest {
-    let mut cmd = AdminRequest::new();
+    let mut cmd = AdminRequest::default();
     cmd.set_cmd_type(AdminCmdType::PrepareMerge);
     cmd.mut_prepare_merge().set_target(target_region);
     cmd
 }
 
 pub fn new_store(store_id: u64, addr: String) -> metapb::Store {
-    let mut store = metapb::Store::new();
+    let mut store = metapb::Store::default();
     store.set_id(store_id);
     store.set_address(addr);
 
@@ -341,36 +341,36 @@ pub fn new_pd_change_peer(
     change_type: ConfChangeType,
     peer: metapb::Peer,
 ) -> RegionHeartbeatResponse {
-    let mut change_peer = ChangePeer::new();
+    let mut change_peer = ChangePeer::default();
     change_peer.set_change_type(change_type);
     change_peer.set_peer(peer);
 
-    let mut resp = RegionHeartbeatResponse::new();
+    let mut resp = RegionHeartbeatResponse::default();
     resp.set_change_peer(change_peer);
     resp
 }
 
 pub fn new_half_split_region() -> RegionHeartbeatResponse {
-    let split_region = SplitRegion::new();
-    let mut resp = RegionHeartbeatResponse::new();
+    let split_region = SplitRegion::default();
+    let mut resp = RegionHeartbeatResponse::default();
     resp.set_split_region(split_region);
     resp
 }
 
 pub fn new_pd_transfer_leader(peer: metapb::Peer) -> RegionHeartbeatResponse {
-    let mut transfer_leader = TransferLeader::new();
+    let mut transfer_leader = TransferLeader::default();
     transfer_leader.set_peer(peer);
 
-    let mut resp = RegionHeartbeatResponse::new();
+    let mut resp = RegionHeartbeatResponse::default();
     resp.set_transfer_leader(transfer_leader);
     resp
 }
 
 pub fn new_pd_merge_region(target_region: metapb::Region) -> RegionHeartbeatResponse {
-    let mut merge = Merge::new();
+    let mut merge = Merge::default();
     merge.set_target(target_region);
 
-    let mut resp = RegionHeartbeatResponse::new();
+    let mut resp = RegionHeartbeatResponse::default();
     resp.set_merge(merge);
     resp
 }

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -20,7 +20,7 @@ pub struct AssertionStorage<E: Engine> {
 impl Default for AssertionStorage<RocksEngine> {
     fn default() -> Self {
         AssertionStorage {
-            ctx: Context::new(),
+            ctx: Context::default(),
             store: SyncTestStorageBuilder::new().build().unwrap(),
         }
     }

--- a/components/test_storage/src/util.rs
+++ b/components/test_storage/src/util.rs
@@ -18,7 +18,7 @@ pub fn new_raft_engine(
     let region = cluster.get_region(key.as_bytes());
     let leader = cluster.leader_of_region(region.get_id()).unwrap();
     let engine = cluster.sim.rl().storages[&leader.get_id()].clone();
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -663,7 +663,7 @@ mod tests {
 
     #[test]
     fn test_limit_size() {
-        let mut e = Entry::new();
+        let mut e = Entry::default();
         e.set_data(b"0123456789".to_vec());
         let size = u64::from(e.compute_size());
 

--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -182,7 +182,7 @@ trait DebugExecutor {
 
         match entry.get_entry_type() {
             EntryType::EntryNormal => {
-                let mut msg = RaftCmdRequest::new();
+                let mut msg = RaftCmdRequest::default();
                 msg.merge_from_bytes(&data).unwrap();
                 v1!("Normal: {:#?}", msg);
             }
@@ -191,7 +191,7 @@ trait DebugExecutor {
                 msg.merge_from_bytes(&data).unwrap();
                 let ctx = msg.take_context();
                 v1!("ConfChange: {:?}", msg);
-                let mut cmd = RaftCmdRequest::new();
+                let mut cmd = RaftCmdRequest::default();
                 cmd.merge_from_bytes(&ctx).unwrap();
                 v1!("ConfChange.RaftCmdRequest: {:#?}", cmd);
             }
@@ -574,7 +574,7 @@ impl DebugExecutor for DebugClient {
     }
 
     fn get_value_by_key(&self, cf: &str, key: Vec<u8>) -> Vec<u8> {
-        let mut req = GetRequest::new();
+        let mut req = GetRequest::default();
         req.set_db(DBType::KV);
         req.set_cf(cf.to_owned());
         req.set_key(key);
@@ -585,7 +585,7 @@ impl DebugExecutor for DebugClient {
 
     fn get_region_size(&self, region: u64, cfs: Vec<&str>) -> Vec<(String, usize)> {
         let cfs = cfs.into_iter().map(ToOwned::to_owned).collect();
-        let mut req = RegionSizeRequest::new();
+        let mut req = RegionSizeRequest::default();
         req.set_cfs(RepeatedField::from_vec(cfs));
         req.set_region_id(region);
         self.region_size(&req)
@@ -597,7 +597,7 @@ impl DebugExecutor for DebugClient {
     }
 
     fn get_region_info(&self, region: u64) -> RegionInfo {
-        let mut req = RegionInfoRequest::new();
+        let mut req = RegionInfoRequest::default();
         req.set_region_id(region);
         let mut resp = self
             .region_info(&req)
@@ -617,7 +617,7 @@ impl DebugExecutor for DebugClient {
     }
 
     fn get_raft_log(&self, region: u64, index: u64) -> Entry {
-        let mut req = RaftLogRequest::new();
+        let mut req = RaftLogRequest::default();
         req.set_region_id(region);
         req.set_log_index(index);
         self.raft_log(&req)
@@ -631,7 +631,7 @@ impl DebugExecutor for DebugClient {
         to: Vec<u8>,
         limit: u64,
     ) -> Box<dyn Stream<Item = (Vec<u8>, MvccInfo), Error = String>> {
-        let mut req = ScanMvccRequest::new();
+        let mut req = ScanMvccRequest::default();
         req.set_from_key(from);
         req.set_to_key(to);
         req.set_limit(limit);
@@ -656,7 +656,7 @@ impl DebugExecutor for DebugClient {
         threads: u32,
         bottommost: BottommostLevelCompaction,
     ) {
-        let mut req = CompactRequest::new();
+        let mut req = CompactRequest::default();
         req.set_db(db);
         req.set_cf(cf.to_owned());
         req.set_from_key(from.to_owned());
@@ -668,7 +668,7 @@ impl DebugExecutor for DebugClient {
     }
 
     fn dump_metrics(&self, tags: Vec<&str>) {
-        let mut req = GetMetricsRequest::new();
+        let mut req = GetMetricsRequest::default();
         req.set_all(true);
         if tags.len() == 1 && tags[0] == METRICS_PROMETHEUS {
             req.set_all(false);
@@ -720,7 +720,7 @@ impl DebugExecutor for DebugClient {
     }
 
     fn check_region_consistency(&self, region_id: u64) {
-        let mut req = RegionConsistencyCheckRequest::new();
+        let mut req = RegionConsistencyCheckRequest::default();
         req.set_region_id(region_id);
         self.check_region_consistency(&req)
             .unwrap_or_else(|e| perror_and_exit("DebugClient::check_region_consistency", e));
@@ -728,7 +728,7 @@ impl DebugExecutor for DebugClient {
     }
 
     fn modify_tikv_config(&self, module: MODULE, config_name: &str, config_value: &str) {
-        let mut req = ModifyTikvConfigRequest::new();
+        let mut req = ModifyTikvConfigRequest::default();
         req.set_module(module);
         req.set_config_name(config_name.to_owned());
         req.set_config_value(config_value.to_owned());
@@ -738,7 +738,7 @@ impl DebugExecutor for DebugClient {
     }
 
     fn dump_region_properties(&self, region_id: u64) {
-        let mut req = GetRegionPropertiesRequest::new();
+        let mut req = GetRegionPropertiesRequest::default();
         req.set_region_id(region_id);
         let resp = self
             .get_region_properties(&req)
@@ -910,7 +910,7 @@ impl DebugExecutor for Debugger {
         region.mut_region_epoch().set_conf_ver(INIT_EPOCH_CONF_VER);
 
         region.peers.clear();
-        let mut peer = Peer::new();
+        let mut peer = Peer::default();
         peer.set_id(new_peer_id);
         peer.set_store_id(store_id);
         region.mut_peers().push(peer);
@@ -1990,7 +1990,7 @@ fn main() {
                     v1!("No action for fail point {}", name);
                     continue;
                 }
-                let mut inject_req = InjectFailPointRequest::new();
+                let mut inject_req = InjectFailPointRequest::default();
                 inject_req.set_name(name);
                 inject_req.set_actions(actions);
 
@@ -2007,13 +2007,13 @@ fn main() {
                 }
             }
             for (name, _) in list {
-                let mut recover_req = RecoverFailPointRequest::new();
+                let mut recover_req = RecoverFailPointRequest::default();
                 recover_req.set_name(name);
                 let option = CallOption::default().timeout(Duration::from_secs(10));
                 client.recover_fail_point_opt(&recover_req, option).unwrap();
             }
         } else if matches.is_present("list") {
-            let list_req = ListFailPointsRequest::new();
+            let list_req = ListFailPointsRequest::default();
             let option = CallOption::default().timeout(Duration::from_secs(10));
             let resp = client.list_fail_points_opt(&list_req, option).unwrap();
             v1!("{:?}", resp.get_entries());
@@ -2101,7 +2101,7 @@ fn dump_snap_meta_file(path: &str) {
     let content =
         fs::read(path).unwrap_or_else(|e| panic!("read meta file {} failed, error {:?}", path, e));
 
-    let mut meta = SnapshotMeta::new();
+    let mut meta = SnapshotMeta::default();
     meta.merge_from_bytes(&content)
         .unwrap_or_else(|e| panic!("parse from bytes error {:?}", e));
     for cf_file in meta.get_cf_files() {
@@ -2144,7 +2144,7 @@ fn split_region(pd_client: &RpcClient, mgr: Arc<SecurityManager>, region_id: u64
         TikvClient::new(channel)
     };
 
-    let mut req = SplitRegionRequest::new();
+    let mut req = SplitRegionRequest::default();
     req.mut_context().set_region_id(region_id);
     req.mut_context()
         .set_region_epoch(region.get_region_epoch().clone());

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -90,13 +90,13 @@ impl<S: Snapshot> RequestHandler for ChecksumContext<S> {
             total_bytes += k.len() + v.len();
         }
 
-        let mut resp = ChecksumResponse::new();
+        let mut resp = ChecksumResponse::default();
         resp.set_checksum(checksum);
         resp.set_total_kvs(total_kvs);
         resp.set_total_bytes(total_bytes as u64);
         let data = box_try!(resp.write_to_bytes());
 
-        let mut resp = Response::new();
+        let mut resp = Response::default();
         resp.set_data(data);
         Ok(resp)
     }

--- a/src/coprocessor/codec/error.rs
+++ b/src/coprocessor/codec/error.rs
@@ -134,7 +134,7 @@ impl Error {
 
 impl From<Error> for select::Error {
     fn from(error: Error) -> select::Error {
-        let mut err = select::Error::new();
+        let mut err = select::Error::default();
         err.set_code(error.code());
         err.set_msg(format!("{:?}", error));
         err

--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -620,18 +620,18 @@ mod tests {
     fn test_check_table_range() {
         let small_key = b"t\x80\x00\x00\x00\x00\x00\x00\x01a".to_vec();
         let large_key = b"t\x80\x00\x00\x00\x00\x00\x00\x01b".to_vec();
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         range.set_start(small_key.clone());
         range.set_end(large_key.clone());
         assert!(check_table_ranges(&[range]).is_ok());
         //test range.start > range.end
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         range.set_end(small_key.clone());
         range.set_start(large_key);
         assert!(check_table_ranges(&[range]).is_err());
 
         // test invalid end
-        let mut range = KeyRange::new();
+        let mut range = KeyRange::default();
         range.set_start(small_key);
         range.set_end(b"xx".to_vec());
         assert!(check_table_ranges(&[range]).is_err());

--- a/src/coprocessor/dag/batch/executors/index_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/index_scan_executor.rs
@@ -305,7 +305,7 @@ mod tests {
             // Case 1.1. Normal index, without PK, scan total index in reverse order.
 
             let key_ranges = vec![{
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 let start_data = datum::encode_key(&[Datum::Min]).unwrap();
                 let start_key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &start_data);
                 range.set_start(start_key);
@@ -355,7 +355,7 @@ mod tests {
             // Case 1.2. Normal index, with PK, scan index prefix.
 
             let key_ranges = vec![{
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 let start_data = datum::encode_key(&[Datum::I64(2)]).unwrap();
                 let start_key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &start_data);
                 range.set_start(start_key);
@@ -432,7 +432,7 @@ mod tests {
             // Case 2.1. Unique index, prefix range scan.
 
             let key_ranges = vec![{
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 let start_data = datum::encode_key(&[Datum::I64(5)]).unwrap();
                 let start_key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &start_data);
                 range.set_start(start_key);
@@ -486,7 +486,7 @@ mod tests {
             // Case 2.2. Unique index, point scan.
 
             let key_ranges = vec![{
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 let start_data = datum::encode_key(&[Datum::I64(5), Datum::F64(5.1)]).unwrap();
                 let start_key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &start_data);
                 range.set_start(start_key);

--- a/src/coprocessor/dag/batch/executors/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/table_scan_executor.rs
@@ -442,7 +442,7 @@ mod tests {
             self.data
                 .iter()
                 .map(|(row_id, _, _)| {
-                    let mut r = KeyRange::new();
+                    let mut r = KeyRange::default();
                     r.set_start(table::encode_row_key(self.table_id, *row_id));
                     r.set_end(r.get_start().to_vec());
                     convert_to_prefix_next(r.mut_end());
@@ -456,7 +456,7 @@ mod tests {
             vec![
                 self.table_range(std::i64::MIN, 3),
                 {
-                    let mut r = KeyRange::new();
+                    let mut r = KeyRange::default();
                     r.set_start(table::encode_row_key(self.table_id, 3));
                     r.set_end(r.get_start().to_vec());
                     convert_to_prefix_next(r.mut_end());
@@ -489,7 +489,7 @@ mod tests {
 
         /// Returns the range for handle in [start_id,end_id)
         fn table_range(&self, start_id: i64, end_id: i64) -> KeyRange {
-            let mut range = KeyRange::new();
+            let mut range = KeyRange::default();
             range.set_start(table::encode_row_key(self.table_id, start_id));
             range.set_end(table::encode_row_key(self.table_id, end_id));
             range
@@ -747,7 +747,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(index, _)| {
-                let mut r = KeyRange::new();
+                let mut r = KeyRange::default();
                 r.set_start(table::encode_row_key(TABLE_ID, index as i64));
                 r.set_end(r.get_start().to_vec());
                 convert_to_prefix_next(r.mut_end());
@@ -853,7 +853,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(index, _)| {
-                let mut r = KeyRange::new();
+                let mut r = KeyRange::default();
                 r.set_start(table::encode_row_key(TABLE_ID, index as i64));
                 r.set_end(r.get_start().to_vec());
                 convert_to_prefix_next(r.mut_end());

--- a/src/coprocessor/dag/batch/executors/util/ranges_iter.rs
+++ b/src/coprocessor/dag/batch/executors/util/ranges_iter.rs
@@ -129,7 +129,7 @@ mod tests {
         use byteorder::{BigEndian, WriteBytesExt};
 
         let v = RANGE_INDEX.fetch_add(1, atomic::Ordering::SeqCst);
-        let mut r = KeyRange::new();
+        let mut r = KeyRange::default();
         r.mut_start().write_u64::<BigEndian>(v).unwrap();
         // Enough to pass `util::is_point`.
         r.mut_end().write_u64::<BigEndian>(v + 1).unwrap();
@@ -140,7 +140,7 @@ mod tests {
         use byteorder::{BigEndian, WriteBytesExt};
 
         let v = RANGE_INDEX.fetch_add(2, atomic::Ordering::SeqCst);
-        let mut r = KeyRange::new();
+        let mut r = KeyRange::default();
         r.mut_start().write_u64::<BigEndian>(v).unwrap();
         // Enough to not pass `util::is_point`.
         r.mut_end().write_u64::<BigEndian>(v + 2).unwrap();

--- a/src/coprocessor/dag/batch_handler.rs
+++ b/src/coprocessor/dag/batch_handler.rs
@@ -92,8 +92,8 @@ impl RequestHandler for BatchDAGHandler {
             // Check error first, because it means that we should directly respond error.
             match result.is_drained {
                 Err(Error::Eval(err)) => {
-                    let mut resp = Response::new();
-                    let mut sel_resp = SelectResponse::new();
+                    let mut resp = Response::default();
+                    let mut sel_resp = SelectResponse::default();
                     sel_resp.set_error(err);
                     let data = box_try!(sel_resp.write_to_bytes());
                     resp.set_data(data);
@@ -139,8 +139,8 @@ impl RequestHandler for BatchDAGHandler {
                     .collect_statistics(&mut self.statistics);
                 self.metrics.cf_stats.add(&self.statistics.cf_stats);
 
-                let mut resp = Response::new();
-                let mut sel_resp = SelectResponse::new();
+                let mut resp = Response::default();
+                let mut sel_resp = SelectResponse::default();
                 sel_resp.set_chunks(chunks.into());
                 // TODO: output_counts should not be i64. Let's fix it in Coprocessor DAG V2.
                 sel_resp.set_output_counts(

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -147,7 +147,7 @@ pub mod tests {
     ) -> KeyRange {
         let (_, start_key) = generate_index_data(table_id, idx_id, start, val_start, unique);
         let (_, end_key) = generate_index_data(table_id, idx_id, end, val_end, unique);
-        let mut key_range = KeyRange::new();
+        let mut key_range = KeyRange::default();
         key_range.set_start(start_key);
         key_range.set_end(end_key);
         key_range

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -426,7 +426,7 @@ pub mod tests {
     impl TestStore {
         pub fn new(kv_data: &[(Vec<u8>, Vec<u8>)]) -> TestStore {
             let engine = TestEngineBuilder::new().build().unwrap();
-            let ctx = Context::new();
+            let ctx = Context::default();
             let snapshot = engine.snapshot(&ctx).unwrap();
             let mut store = TestStore {
                 snapshot,
@@ -485,7 +485,7 @@ pub mod tests {
 
     #[inline]
     pub fn get_range(table_id: i64, start: i64, end: i64) -> KeyRange {
-        let mut key_range = KeyRange::new();
+        let mut key_range = KeyRange::default();
         key_range.set_start(table::encode_row_key(table_id, start));
         key_range.set_end(table::encode_row_key(table_id, end));
         key_range

--- a/src/coprocessor/dag/handler.rs
+++ b/src/coprocessor/dag/handler.rs
@@ -41,7 +41,7 @@ impl DAGRequestHandler {
     }
 
     fn make_stream_response(&mut self, chunk: Chunk, range: Option<KeyRange>) -> Result<Response> {
-        let mut s_resp = StreamResponse::new();
+        let mut s_resp = StreamResponse::default();
         s_resp.set_data(box_try!(chunk.write_to_bytes()));
         if let Some(eval_warnings) = self.executor.take_eval_warnings() {
             s_resp.set_warnings(RepeatedField::from_vec(eval_warnings.warnings));
@@ -50,7 +50,7 @@ impl DAGRequestHandler {
         self.executor
             .collect_output_counts(s_resp.mut_output_counts());
 
-        let mut resp = Response::new();
+        let mut resp = Response::default();
         resp.set_data(box_try!(s_resp.write_to_bytes()));
         if let Some(range) = range {
             resp.set_range(range);
@@ -79,8 +79,8 @@ impl RequestHandler for DAGRequestHandler {
                     chunk.mut_rows_data().extend_from_slice(&value);
                 }
                 Ok(None) => {
-                    let mut resp = Response::new();
-                    let mut sel_resp = SelectResponse::new();
+                    let mut resp = Response::default();
+                    let mut sel_resp = SelectResponse::default();
                     sel_resp.set_chunks(RepeatedField::from_vec(chunks));
                     if let Some(eval_warnings) = self.executor.take_eval_warnings() {
                         sel_resp.set_warnings(RepeatedField::from_vec(eval_warnings.warnings));
@@ -112,8 +112,8 @@ impl RequestHandler for DAGRequestHandler {
                     return Ok(resp);
                 }
                 Err(Error::Eval(err)) => {
-                    let mut resp = Response::new();
-                    let mut sel_resp = SelectResponse::new();
+                    let mut resp = Response::default();
+                    let mut sel_resp = SelectResponse::default();
                     sel_resp.set_error(err);
                     let data = box_try!(sel_resp.write_to_bytes());
                     resp.set_data(data);
@@ -141,8 +141,8 @@ impl RequestHandler for DAGRequestHandler {
                     break;
                 }
                 Err(Error::Eval(err)) => {
-                    let mut resp = Response::new();
-                    let mut sel_resp = StreamResponse::new();
+                    let mut resp = Response::default();
+                    let mut sel_resp = StreamResponse::default();
                     sel_resp.set_error(err);
                     let data = box_try!(sel_resp.write_to_bytes());
                     resp.set_data(data);

--- a/src/coprocessor/dag/scanner.rs
+++ b/src/coprocessor/dag/scanner.rs
@@ -221,7 +221,7 @@ pub mod tests {
         let start_key = table::encode_row_key(table_id, handle);
         let mut end = start_key.clone();
         util::convert_to_prefix_next(&mut end);
-        let mut key_range = KeyRange::new();
+        let mut key_range = KeyRange::default();
         key_range.set_start(start_key);
         key_range.set_end(end);
         key_range
@@ -307,7 +307,7 @@ pub mod tests {
         // beginning, `stop_scan` in the end, producing a range. the range will be checked against
         // `expect_start_pk` and `expect_end_pk`. Pass -1 as pk means the end.
         let test_take = |scanner: &mut Scanner<_>, count, expect_start_pk, expect_end_pk| {
-            let mut range = KeyRange::new();
+            let mut range = KeyRange::default();
             scanner.start_scan(&mut range);
 
             let mut keys = Vec::new();

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -97,7 +97,7 @@ impl<E: Engine> Endpoint<E> {
 
         match req.get_tp() {
             REQ_TYPE_DAG => {
-                let mut dag = DAGRequest::new();
+                let mut dag = DAGRequest::default();
                 box_try!(dag.merge_from(&mut is));
                 let mut table_scan = false;
                 let mut is_desc_scan = false;
@@ -159,7 +159,7 @@ impl<E: Engine> Endpoint<E> {
                 });
             }
             REQ_TYPE_CHECKSUM => {
-                let mut checksum = ChecksumRequest::new();
+                let mut checksum = ChecksumRequest::default();
                 box_try!(checksum.merge_from(&mut is));
                 let table_scan = checksum.get_scan_on() == ChecksumScanOn::Table;
                 req_ctx = ReqContext::new(
@@ -455,7 +455,7 @@ fn make_error_response(e: Error) -> coppb::Response {
         "error-response";
         "err" => %e
     );
-    let mut resp = coppb::Response::new();
+    let mut resp = coppb::Response::default();
     let tag;
     match e {
         Error::Region(e) => {
@@ -475,9 +475,9 @@ fn make_error_response(e: Error) -> coppb::Response {
         }
         Error::Full => {
             tag = "full";
-            let mut errorpb = errorpb::Error::new();
+            let mut errorpb = errorpb::Error::default();
             errorpb.set_message("Coprocessor end-point is full".to_owned());
-            let mut server_is_busy_err = errorpb::ServerIsBusy::new();
+            let mut server_is_busy_err = errorpb::ServerIsBusy::default();
             server_is_busy_err.set_reason(BUSY_ERROR_MSG.to_owned());
             errorpb.set_server_is_busy(server_is_busy_err);
             resp.set_region_error(errorpb);
@@ -632,7 +632,7 @@ mod tests {
 
         // a normal request
         let handler_builder =
-            Box::new(|_, _: &_| Ok(UnaryFixture::new(Ok(coppb::Response::new())).into_boxed()));
+            Box::new(|_, _: &_| Ok(UnaryFixture::new(Ok(coppb::Response::default())).into_boxed()));
         let resp = cop
             .handle_unary_request(ReqContext::default_for_test(), handler_builder)
             .unwrap()
@@ -642,10 +642,10 @@ mod tests {
 
         // an outdated request
         let handler_builder =
-            Box::new(|_, _: &_| Ok(UnaryFixture::new(Ok(coppb::Response::new())).into_boxed()));
+            Box::new(|_, _: &_| Ok(UnaryFixture::new(Ok(coppb::Response::default())).into_boxed()));
         let outdated_req_ctx = ReqContext::new(
             "test",
-            kvrpcpb::Context::new(),
+            kvrpcpb::Context::default(),
             &[],
             Duration::from_secs(0),
             None,
@@ -680,9 +680,9 @@ mod tests {
             }
             let mut e = Executor::new();
             e.mut_selection().mut_conditions().push(expr);
-            let mut dag = DAGRequest::new();
+            let mut dag = DAGRequest::default();
             dag.mut_executors().push(e);
-            let mut req = coppb::Request::new();
+            let mut req = coppb::Request::default();
             req.set_tp(REQ_TYPE_DAG);
             req.set_data(dag.write_to_bytes().unwrap());
             req
@@ -701,7 +701,7 @@ mod tests {
         let read_pool = build_read_pool_for_test(engine.clone());
         let cop = Endpoint::<RocksEngine>::new(&Config::default(), read_pool);
 
-        let mut req = coppb::Request::new();
+        let mut req = coppb::Request::default();
         req.set_tp(9999);
 
         let resp: coppb::Response = cop
@@ -717,7 +717,7 @@ mod tests {
         let read_pool = build_read_pool_for_test(engine.clone());
         let cop = Endpoint::<RocksEngine>::new(&Config::default(), read_pool);
 
-        let mut req = coppb::Request::new();
+        let mut req = coppb::Request::default();
         req.set_tp(REQ_TYPE_DAG);
         req.set_data(vec![1, 2, 3]);
 
@@ -749,10 +749,10 @@ mod tests {
 
         // first 2 requests are processed as normal and laters are returned as errors
         for i in 0..5 {
-            let mut response = coppb::Response::new();
+            let mut response = coppb::Response::default();
             response.set_data(vec![1, 2, i]);
 
-            let mut context = kvrpcpb::Context::new();
+            let mut context = kvrpcpb::Context::default();
             context.set_priority(kvrpcpb::CommandPri::Normal);
 
             let handler_builder = Box::new(|_, _: &_| {
@@ -826,7 +826,7 @@ mod tests {
         // Fail after some success responses
         let mut responses = Vec::new();
         for i in 0..5 {
-            let mut resp = coppb::Response::new();
+            let mut resp = coppb::Response::default();
             resp.set_data(vec![1, 2, i]);
             responses.push(Ok(resp));
         }
@@ -876,7 +876,7 @@ mod tests {
         let counter_clone = Arc::clone(&counter);
         let handler = StreamFromClosure::new(move |nth| match nth {
             0 => {
-                let mut resp = coppb::Response::new();
+                let mut resp = coppb::Response::default();
                 resp.set_data(vec![1, 2, 7]);
                 Ok((Some(resp), true))
             }
@@ -902,7 +902,7 @@ mod tests {
         let counter_clone = Arc::clone(&counter);
         let handler = StreamFromClosure::new(move |nth| match nth {
             0 => {
-                let mut resp = coppb::Response::new();
+                let mut resp = coppb::Response::default();
                 resp.set_data(vec![1, 2, 13]);
                 Ok((Some(resp), false))
             }
@@ -928,7 +928,7 @@ mod tests {
         let counter_clone = Arc::clone(&counter);
         let handler = StreamFromClosure::new(move |nth| match nth {
             0 => {
-                let mut resp = coppb::Response::new();
+                let mut resp = coppb::Response::default();
                 resp.set_data(vec![1, 2, 23]);
                 Ok((Some(resp), false))
             }
@@ -967,7 +967,7 @@ mod tests {
         let counter_clone = Arc::clone(&counter);
         let handler = StreamFromClosure::new(move |nth| {
             // produce an infinite stream
-            let mut resp = coppb::Response::new();
+            let mut resp = coppb::Response::default();
             resp.set_data(vec![1, 2, nth as u8]);
             counter_clone.fetch_add(1, atomic::Ordering::SeqCst);
             Ok((Some(resp), false))
@@ -1031,7 +1031,7 @@ mod tests {
             // Request 1: Unary, success response.
             let handler_builder = Box::new(|_, _: &_| {
                 Ok(UnaryFixture::new_with_duration(
-                    Ok(coppb::Response::new()),
+                    Ok(coppb::Response::default()),
                     PAYLOAD_SMALL as u64,
                 )
                 .into_boxed())
@@ -1106,7 +1106,7 @@ mod tests {
             // Request 1: Unary, success response.
             let handler_builder = Box::new(|_, _: &_| {
                 Ok(UnaryFixture::new_with_duration(
-                    Ok(coppb::Response::new()),
+                    Ok(coppb::Response::default()),
                     PAYLOAD_LARGE as u64,
                 )
                 .into_boxed())
@@ -1123,9 +1123,9 @@ mod tests {
             let handler_builder = Box::new(|_, _: &_| {
                 Ok(StreamFixture::new_with_duration(
                     vec![
-                        Ok(coppb::Response::new()),
+                        Ok(coppb::Response::default()),
                         Err(box_err!("foo")),
-                        Ok(coppb::Response::new()),
+                        Ok(coppb::Response::default()),
                     ],
                     vec![
                         PAYLOAD_SMALL as u64,

--- a/src/coprocessor/error.rs
+++ b/src/coprocessor/error.rs
@@ -68,7 +68,7 @@ impl From<storage::txn::Error> for Error {
                 ttl,
                 txn_size,
             }) => {
-                let mut info = kvrpcpb::LockInfo::new();
+                let mut info = kvrpcpb::LockInfo::default();
                 info.set_primary_lock(primary);
                 info.set_lock_version(ts);
                 info.set_key(key);

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -172,7 +172,7 @@ impl ReqContext {
     pub fn default_for_test() -> Self {
         Self::new(
             "test",
-            kvrpcpb::Context::new(),
+            kvrpcpb::Context::default(),
             &[],
             Duration::from_secs(100),
             None,

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -127,12 +127,12 @@ impl<S: Snapshot> RequestHandler for AnalyzeContext<S> {
         };
         match ret {
             Ok(data) => {
-                let mut resp = Response::new();
+                let mut resp = Response::default();
                 resp.set_data(data);
                 Ok(resp)
             }
             Err(Error::Other(e)) => {
-                let mut resp = Response::new();
+                let mut resp = Response::default();
                 resp.set_other_error(format!("{}", e));
                 Ok(resp)
             }

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -112,9 +112,9 @@ impl Tracker {
     pub fn get_item_exec_details(&self) -> kvrpcpb::ExecDetails {
         assert_eq!(self.current_stage, TrackerState::ItemFinished);
         let is_slow_query = time::duration_to_sec(self.item_process_time) > SLOW_QUERY_LOWER_BOUND;
-        let mut exec_details = kvrpcpb::ExecDetails::new();
+        let mut exec_details = kvrpcpb::ExecDetails::default();
         if self.req_ctx.context.get_handle_time() || is_slow_query {
-            let mut handle = kvrpcpb::HandleTime::new();
+            let mut handle = kvrpcpb::HandleTime::default();
             handle.set_process_ms((time::duration_to_sec(self.item_process_time) * 1000.0) as i64);
             handle.set_wait_ms((time::duration_to_sec(self.wait_time) * 1000.0) as i64);
             exec_details.set_handle_time(handle);

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -82,7 +82,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
 
         ctx.spawn(
             future::result(res)
-                .map(|_| SwitchModeResponse::new())
+                .map(|_| SwitchModeResponse::default())
                 .then(move |res| send_rpc_response!(res, sink, label, timer)),
         )
     }
@@ -132,7 +132,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
                             })
                             .and_then(|mut file| file.finish())
                     })
-                    .map(|_| UploadResponse::new())
+                    .map(|_| UploadResponse::default())
                     .then(move |res| send_rpc_response!(res, sink, label, timer)),
             ),
         )
@@ -153,15 +153,15 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
         let timer = Instant::now_coarse();
 
         // Make ingest command.
-        let mut ingest = Request::new();
+        let mut ingest = Request::default();
         ingest.set_cmd_type(CmdType::IngestSST);
         ingest.mut_ingest_sst().set_sst(req.take_sst());
         let mut context = req.take_context();
-        let mut header = RaftRequestHeader::new();
+        let mut header = RaftRequestHeader::default();
         header.set_peer(context.take_peer());
         header.set_region_id(context.get_region_id());
         header.set_region_epoch(context.take_region_epoch());
-        let mut cmd = RaftCmdRequest::new();
+        let mut cmd = RaftCmdRequest::default();
         cmd.set_header(header);
         cmd.mut_requests().push(ingest);
 
@@ -175,7 +175,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
                 .map_err(Error::from)
                 .then(|res| match res {
                     Ok(mut res) => {
-                        let mut resp = IngestResponse::new();
+                        let mut resp = IngestResponse::default();
                         let mut header = res.response.take_header();
                         if header.has_error() {
                             resp.set_error(header.take_error());
@@ -231,7 +231,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
 
             future::result(res)
                 .map_err(Error::from)
-                .map(|_| CompactResponse::new())
+                .map(|_| CompactResponse::default())
                 .then(move |res| send_rpc_response!(res, sink, label, timer))
         }))
     }

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -63,7 +63,7 @@ impl RpcClient {
 
     /// Creates a new request header.
     fn header(&self) -> pdpb::RequestHeader {
-        let mut header = pdpb::RequestHeader::new();
+        let mut header = pdpb::RequestHeader::default();
         header.set_cluster_id(self.cluster_id);
         header
     }
@@ -88,7 +88,7 @@ impl RpcClient {
             .with_label_values(&["get_region"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetRegionRequest::new();
+        let mut req = pdpb::GetRegionRequest::default();
         req.set_header(self.header());
         req.set_region_key(key.to_vec());
 
@@ -132,7 +132,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["bootstrap_cluster"])
             .start_coarse_timer();
 
-        let mut req = pdpb::BootstrapRequest::new();
+        let mut req = pdpb::BootstrapRequest::default();
         req.set_header(self.header());
         req.set_store(stores);
         req.set_region(region);
@@ -149,7 +149,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["is_cluster_bootstrapped"])
             .start_coarse_timer();
 
-        let mut req = pdpb::IsBootstrappedRequest::new();
+        let mut req = pdpb::IsBootstrappedRequest::default();
         req.set_header(self.header());
 
         let resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
@@ -165,7 +165,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["alloc_id"])
             .start_coarse_timer();
 
-        let mut req = pdpb::AllocIDRequest::new();
+        let mut req = pdpb::AllocIDRequest::default();
         req.set_header(self.header());
 
         let resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
@@ -181,7 +181,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["put_store"])
             .start_coarse_timer();
 
-        let mut req = pdpb::PutStoreRequest::new();
+        let mut req = pdpb::PutStoreRequest::default();
         req.set_header(self.header());
         req.set_store(store);
 
@@ -198,7 +198,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["get_store"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetStoreRequest::new();
+        let mut req = pdpb::GetStoreRequest::default();
         req.set_header(self.header());
         req.set_store_id(store_id);
 
@@ -220,7 +220,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["get_all_stores"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetAllStoresRequest::new();
+        let mut req = pdpb::GetAllStoresRequest::default();
         req.set_header(self.header());
         req.set_exclude_tombstone_stores(exclude_tombstone);
 
@@ -237,7 +237,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["get_cluster_config"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetClusterConfigRequest::new();
+        let mut req = pdpb::GetClusterConfigRequest::default();
         req.set_header(self.header());
 
         let mut resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
@@ -260,7 +260,7 @@ impl PdClient for RpcClient {
     fn get_region_by_id(&self, region_id: u64) -> PdFuture<Option<metapb::Region>> {
         let timer = Instant::now();
 
-        let mut req = pdpb::GetRegionByIDRequest::new();
+        let mut req = pdpb::GetRegionByIDRequest::default();
         req.set_header(self.header());
         req.set_region_id(region_id);
 
@@ -296,7 +296,7 @@ impl PdClient for RpcClient {
     ) -> PdFuture<()> {
         PD_HEARTBEAT_COUNTER_VEC.with_label_values(&["send"]).inc();
 
-        let mut req = pdpb::RegionHeartbeatRequest::new();
+        let mut req = pdpb::RegionHeartbeatRequest::default();
         req.set_header(self.header());
         req.set_region(region);
         req.set_leader(leader);
@@ -308,7 +308,7 @@ impl PdClient for RpcClient {
         req.set_keys_read(region_stat.read_keys);
         req.set_approximate_size(region_stat.approximate_size);
         req.set_approximate_keys(region_stat.approximate_keys);
-        let mut interval = pdpb::TimeInterval::new();
+        let mut interval = pdpb::TimeInterval::default();
         interval.set_start_timestamp(region_stat.last_report_ts);
         interval.set_end_timestamp(time_now_sec());
         req.set_interval(interval);
@@ -364,7 +364,7 @@ impl PdClient for RpcClient {
     fn ask_split(&self, region: metapb::Region) -> PdFuture<pdpb::AskSplitResponse> {
         let timer = Instant::now();
 
-        let mut req = pdpb::AskSplitRequest::new();
+        let mut req = pdpb::AskSplitRequest::default();
         req.set_header(self.header());
         req.set_region(region);
 
@@ -395,7 +395,7 @@ impl PdClient for RpcClient {
     ) -> PdFuture<pdpb::AskBatchSplitResponse> {
         let timer = Instant::now();
 
-        let mut req = pdpb::AskBatchSplitRequest::new();
+        let mut req = pdpb::AskBatchSplitRequest::default();
         req.set_header(self.header());
         req.set_region(region);
         req.set_split_count(count as u32);
@@ -423,7 +423,7 @@ impl PdClient for RpcClient {
     fn store_heartbeat(&self, mut stats: pdpb::StoreStats) -> PdFuture<()> {
         let timer = Instant::now();
 
-        let mut req = pdpb::StoreHeartbeatRequest::new();
+        let mut req = pdpb::StoreHeartbeatRequest::default();
         req.set_header(self.header());
         stats.mut_interval().set_end_timestamp(time_now_sec());
         req.set_stats(stats);
@@ -450,7 +450,7 @@ impl PdClient for RpcClient {
     fn report_batch_split(&self, regions: Vec<metapb::Region>) -> PdFuture<()> {
         let timer = Instant::now();
 
-        let mut req = pdpb::ReportBatchSplitRequest::new();
+        let mut req = pdpb::ReportBatchSplitRequest::default();
         req.set_header(self.header());
         req.set_regions(RepeatedField::from_vec(regions));
 
@@ -479,7 +479,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["scatter_region"])
             .start_coarse_timer();
 
-        let mut req = pdpb::ScatterRegionRequest::new();
+        let mut req = pdpb::ScatterRegionRequest::default();
         req.set_header(self.header());
         req.set_region_id(region.get_id());
         if let Some(leader) = region.leader.take() {
@@ -500,7 +500,7 @@ impl PdClient for RpcClient {
     fn get_gc_safe_point(&self) -> PdFuture<u64> {
         let timer = Instant::now();
 
-        let mut req = pdpb::GetGCSafePointRequest::new();
+        let mut req = pdpb::GetGCSafePointRequest::default();
         req.set_header(self.header());
 
         let executor = move |client: &RwLock<Inner>, req: pdpb::GetGCSafePointRequest| {
@@ -529,7 +529,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["get_store"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetStoreRequest::new();
+        let mut req = pdpb::GetStoreRequest::default();
         req.set_header(self.header());
         req.set_store_id(store_id);
 
@@ -551,7 +551,7 @@ impl PdClient for RpcClient {
             .with_label_values(&["get_operator"])
             .start_coarse_timer();
 
-        let mut req = pdpb::GetOperatorRequest::new();
+        let mut req = pdpb::GetOperatorRequest::default();
         req.set_header(self.header());
         req.set_region_id(region_id);
 

--- a/src/pd/pd.rs
+++ b/src/pd/pd.rs
@@ -418,7 +418,7 @@ impl<T: PdClient> Runner<T> {
         stats.set_keys_read(
             self.store_stat.engine_total_keys_read - self.store_stat.engine_last_total_keys_read,
         );
-        let mut interval = pdpb::TimeInterval::new();
+        let mut interval = pdpb::TimeInterval::default();
         interval.set_start_timestamp(self.store_stat.last_report_ts);
         stats.set_interval(interval);
         self.store_stat.engine_last_total_bytes_read = self.store_stat.engine_total_bytes_read;
@@ -742,7 +742,7 @@ impl<T: PdClient> Runnable<Task> for Runner<T> {
 }
 
 fn new_change_peer_request(change_type: ConfChangeType, peer: metapb::Peer) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::ChangePeer);
     req.mut_change_peer().set_change_type(change_type);
     req.mut_change_peer().set_peer(peer);
@@ -755,7 +755,7 @@ fn new_split_region_request(
     peer_ids: Vec<u64>,
     right_derive: bool,
 ) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::Split);
     req.mut_split().set_split_key(split_key);
     req.mut_split().set_new_region_id(new_region_id);
@@ -769,12 +769,12 @@ fn new_batch_split_region_request(
     ids: Vec<pdpb::SplitID>,
     right_derive: bool,
 ) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::BatchSplit);
     req.mut_splits().set_right_derive(right_derive);
     let mut requests = Vec::with_capacity(ids.len());
     for (mut id, key) in ids.into_iter().zip(split_keys) {
-        let mut split = SplitRequest::new();
+        let mut split = SplitRequest::default();
         split.set_split_key(key);
         split.set_new_region_id(id.get_new_region_id());
         split.set_new_peer_ids(id.take_new_peer_ids());
@@ -786,14 +786,14 @@ fn new_batch_split_region_request(
 }
 
 fn new_transfer_leader_request(peer: metapb::Peer) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::TransferLeader);
     req.mut_transfer_leader().set_peer(peer);
     req
 }
 
 fn new_merge_request(merge: pdpb::Merge) -> AdminRequest {
-    let mut req = AdminRequest::new();
+    let mut req = AdminRequest::default();
     req.set_cmd_type(AdminCmdType::PrepareMerge);
     req.mut_prepare_merge()
         .set_target(merge.get_target().to_owned());
@@ -810,7 +810,7 @@ fn send_admin_request(
 ) {
     let cmd_type = request.get_cmd_type();
 
-    let mut req = RaftCmdRequest::new();
+    let mut req = RaftCmdRequest::default();
     req.mut_header().set_region_id(region_id);
     req.mut_header().set_region_epoch(epoch);
     req.mut_header().set_peer(peer);
@@ -849,7 +849,7 @@ fn send_destroy_peer_message(
     peer: metapb::Peer,
     pd_region: metapb::Region,
 ) {
-    let mut message = RaftMessage::new();
+    let mut message = RaftMessage::default();
     message.set_region_id(local_region.get_id());
     message.set_from_peer(peer.clone());
     message.set_to_peer(peer.clone());

--- a/src/pd/util.rs
+++ b/src/pd/util.rs
@@ -405,7 +405,7 @@ fn connect(
     let channel = security_mgr.connect(cb, addr);
     let client = PdClient::new(channel);
     let option = CallOption::default().timeout(Duration::from_secs(REQUEST_TIMEOUT));
-    match client.get_members_opt(&GetMembersRequest::new(), option) {
+    match client.get_members_opt(&GetMembersRequest::default(), option) {
         Ok(resp) => Ok((client, resp)),
         Err(e) => Err(Error::Grpc(e)),
     }

--- a/src/raftstore/coprocessor/dispatcher.rs
+++ b/src/raftstore/coprocessor/dispatcher.rs
@@ -373,25 +373,25 @@ mod tests {
             .register_role_observer(1, Box::new(ob.clone()));
         host.registry
             .register_region_change_observer(1, Box::new(ob.clone()));
-        let region = Region::new();
-        let mut admin_req = RaftCmdRequest::new();
-        admin_req.set_admin_request(AdminRequest::new());
+        let region = Region::default();
+        let mut admin_req = RaftCmdRequest::default();
+        admin_req.set_admin_request(AdminRequest::default());
         host.pre_propose(&region, &mut admin_req).unwrap();
         assert_all!(&[&ob.called], &[1]);
         host.pre_apply(&region, &admin_req);
         assert_all!(&[&ob.called], &[3]);
-        let mut admin_resp = RaftCmdResponse::new();
-        admin_resp.set_admin_response(AdminResponse::new());
+        let mut admin_resp = RaftCmdResponse::default();
+        admin_resp.set_admin_response(AdminResponse::default());
         host.post_apply(&region, &mut admin_resp);
         assert_all!(&[&ob.called], &[6]);
 
-        let mut query_req = RaftCmdRequest::new();
-        query_req.set_requests(RepeatedField::from_vec(vec![Request::new()]));
+        let mut query_req = RaftCmdRequest::default();
+        query_req.set_requests(RepeatedField::from_vec(vec![Request::default()]));
         host.pre_propose(&region, &mut query_req).unwrap();
         assert_all!(&[&ob.called], &[10]);
         host.pre_apply(&region, &query_req);
         assert_all!(&[&ob.called], &[15]);
-        host.post_apply(&region, &mut RaftCmdResponse::new());
+        host.post_apply(&region, &mut RaftCmdResponse::default());
         assert_all!(&[&ob.called], &[21]);
 
         host.on_role_change(&region, StateRole::Leader);
@@ -416,13 +416,13 @@ mod tests {
         host.registry
             .register_query_observer(2, Box::new(ob2.clone()));
 
-        let region = Region::new();
-        let mut admin_req = RaftCmdRequest::new();
-        admin_req.set_admin_request(AdminRequest::new());
-        let mut admin_resp = RaftCmdResponse::new();
-        admin_resp.set_admin_response(AdminResponse::new());
-        let query_req = RaftCmdRequest::new();
-        let query_resp = RaftCmdResponse::new();
+        let region = Region::default();
+        let mut admin_req = RaftCmdRequest::default();
+        admin_req.set_admin_request(AdminRequest::default());
+        let mut admin_resp = RaftCmdResponse::default();
+        admin_resp.set_admin_response(AdminResponse::default());
+        let query_req = RaftCmdRequest::default();
+        let query_resp = RaftCmdResponse::default();
 
         let cases = vec![(0, admin_req, admin_resp), (3, query_req, query_resp)];
 

--- a/src/raftstore/coprocessor/split_check/half.rs
+++ b/src/raftstore/coprocessor/split_check/half.rs
@@ -205,9 +205,9 @@ mod tests {
             .collect();
         let engine = Arc::new(new_engine_opt(path_str, db_opts, cfs_opts).unwrap());
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(1);
-        region.mut_peers().push(Peer::new());
+        region.mut_peers().push(Peer::default());
         region.mut_region_epoch().set_version(2);
         region.mut_region_epoch().set_conf_ver(5);
 
@@ -274,8 +274,8 @@ mod tests {
             engine.flush_cf(cf_handle, true).unwrap();
         }
 
-        let mut region = Region::new();
-        region.mut_peers().push(Peer::new());
+        let mut region = Region::default();
+        region.mut_peers().push(Peer::default());
         let middle_key = get_region_approximate_middle_cf(&engine, CF_DEFAULT, &region)
             .unwrap()
             .unwrap();

--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -278,11 +278,11 @@ mod tests {
             .collect();
         let engine = Arc::new(new_engine_opt(path_str, db_opts, cfs_opts).unwrap());
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(1);
         region.set_start_key(vec![]);
         region.set_end_key(vec![]);
-        region.mut_peers().push(Peer::new());
+        region.mut_peers().push(Peer::default());
         region.mut_region_epoch().set_version(2);
         region.mut_region_epoch().set_conf_ver(5);
 
@@ -381,8 +381,8 @@ mod tests {
             db.flush_cf(default_cf, true).unwrap();
         }
 
-        let mut region = Region::new();
-        region.mut_peers().push(Peer::new());
+        let mut region = Region::default();
+        region.mut_peers().push(Peer::default());
         let range_keys = get_region_approximate_keys(&db, &region).unwrap();
         assert_eq!(range_keys, cases.len() as u64);
     }

--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -408,11 +408,11 @@ pub mod tests {
             .collect();
         let engine = Arc::new(new_engine_opt(path_str, db_opts, cfs_opts).unwrap());
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(1);
         region.set_start_key(vec![]);
         region.set_end_key(vec![]);
-        region.mut_peers().push(Peer::new());
+        region.mut_peers().push(Peer::default());
         region.mut_region_epoch().set_version(2);
         region.mut_region_epoch().set_conf_ver(5);
 
@@ -520,10 +520,10 @@ pub mod tests {
     }
 
     fn make_region(id: u64, start_key: Vec<u8>, end_key: Vec<u8>) -> Region {
-        let mut peer = Peer::new();
+        let mut peer = Peer::default();
         peer.set_id(id);
         peer.set_store_id(id);
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(id);
         region.set_start_key(start_key);
         region.set_end_key(end_key);

--- a/src/raftstore/coprocessor/split_check/table.rs
+++ b/src/raftstore/coprocessor/split_check/table.rs
@@ -258,9 +258,9 @@ mod tests {
             Arc::new(new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap());
         let write_cf = engine.cf_handle(CF_WRITE).unwrap();
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(1);
-        region.mut_peers().push(Peer::new());
+        region.mut_peers().push(Peer::default());
 
         // arbitrary padding.
         let padding = b"_r00000005";
@@ -313,9 +313,9 @@ mod tests {
             Arc::new(new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap());
         let write_cf = engine.cf_handle(CF_WRITE).unwrap();
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(1);
-        region.mut_peers().push(Peer::new());
+        region.mut_peers().push(Peer::default());
         region.mut_region_epoch().set_version(2);
         region.mut_region_epoch().set_conf_ver(5);
 

--- a/src/raftstore/coprocessor/split_observer.rs
+++ b/src/raftstore/coprocessor/split_observer.rs
@@ -174,19 +174,19 @@ mod tests {
     use tikv_util::codec::bytes::encode_bytes;
 
     fn new_split_request(key: &[u8]) -> AdminRequest {
-        let mut req = AdminRequest::new();
+        let mut req = AdminRequest::default();
         req.set_cmd_type(AdminCmdType::Split);
-        let mut split_req = SplitRequest::new();
+        let mut split_req = SplitRequest::default();
         split_req.set_split_key(key.to_vec());
         req.set_split(split_req);
         req
     }
 
     fn new_batch_split_request(keys: Vec<Vec<u8>>) -> AdminRequest {
-        let mut req = AdminRequest::new();
+        let mut req = AdminRequest::default();
         req.set_cmd_type(AdminCmdType::BatchSplit);
         for key in keys {
-            let mut split_req = SplitRequest::new();
+            let mut split_req = SplitRequest::default();
             split_req.set_split_key(key);
             req.mut_splits().mut_requests().push(split_req);
         }
@@ -212,7 +212,7 @@ mod tests {
     fn test_forget_encode() {
         let region_start_key = new_row_key(256, 1, 0);
         let key = new_row_key(256, 2, 0);
-        let mut r = Region::new();
+        let mut r = Region::default();
         r.set_id(10);
         r.set_start_key(region_start_key);
 
@@ -232,11 +232,11 @@ mod tests {
 
     #[test]
     fn test_split() {
-        let mut region = Region::new();
+        let mut region = Region::default();
         let start_key = new_row_key(1, 1, 1);
         region.set_start_key(start_key.clone());
         let mut ctx = ObserverContext::new(&region);
-        let mut req = AdminRequest::new();
+        let mut req = AdminRequest::default();
 
         let observer = SplitObserver;
 

--- a/src/raftstore/errors.rs
+++ b/src/raftstore/errors.rs
@@ -143,7 +143,7 @@ pub type Result<T> = result::Result<T, Error>;
 
 impl From<Error> for errorpb::Error {
     fn from(err: Error) -> errorpb::Error {
-        let mut errorpb = errorpb::Error::new();
+        let mut errorpb = errorpb::Error::default();
         errorpb.set_message(format!("{}", err));
 
         match err {
@@ -183,15 +183,15 @@ impl From<Error> for errorpb::Error {
                     .set_end_key(region.get_end_key().to_vec());
             }
             Error::EpochNotMatch(_, new_regions) => {
-                let mut e = errorpb::EpochNotMatch::new();
+                let mut e = errorpb::EpochNotMatch::default();
                 e.set_current_regions(RepeatedField::from_vec(new_regions));
                 errorpb.set_epoch_not_match(e);
             }
             Error::StaleCommand => {
-                errorpb.set_stale_command(errorpb::StaleCommand::new());
+                errorpb.set_stale_command(errorpb::StaleCommand::default());
             }
             Error::Transport(reason) if reason == DiscardReason::Full => {
-                let mut server_is_busy_err = errorpb::ServerIsBusy::new();
+                let mut server_is_busy_err = errorpb::ServerIsBusy::default();
                 server_is_busy_err.set_reason(RAFTSTORE_IS_BUSY.to_owned());
                 errorpb.set_server_is_busy(server_is_busy_err);
             }

--- a/src/raftstore/store/bootstrap.rs
+++ b/src/raftstore/store/bootstrap.rs
@@ -15,7 +15,7 @@ use kvproto::metapb;
 use kvproto::raft_serverpb::{RegionLocalState, StoreIdent};
 
 pub fn initial_region(store_id: u64, region_id: u64, peer_id: u64) -> metapb::Region {
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(region_id);
     region.set_start_key(keys::EMPTY_KEY.to_vec());
     region.set_end_key(keys::EMPTY_KEY.to_vec());
@@ -38,7 +38,7 @@ fn is_range_empty(engine: &DB, cf: &str, start_key: &[u8], end_key: &[u8]) -> Re
 
 // Bootstrap the store, the DB for this store must be empty and has no data.
 pub fn bootstrap_store(engines: &Engines, cluster_id: u64, store_id: u64) -> Result<()> {
-    let mut ident = StoreIdent::new();
+    let mut ident = StoreIdent::default();
 
     if !is_range_empty(&engines.kv, CF_DEFAULT, keys::MIN_KEY, keys::MAX_KEY)? {
         return Err(box_err!("kv store is not empty and has already had data."));
@@ -62,10 +62,10 @@ pub fn bootstrap_store(engines: &Engines, cluster_id: u64, store_id: u64) -> Res
 ///
 /// Write the first region meta and prepare state.
 pub fn prepare_bootstrap_cluster(engines: &Engines, region: &metapb::Region) -> Result<()> {
-    let mut state = RegionLocalState::new();
+    let mut state = RegionLocalState::default();
     state.set_region(region.clone());
 
-    let wb = WriteBatch::new();
+    let wb = WriteBatch::default();
     box_try!(wb.put_msg(keys::PREPARE_BOOTSTRAP_KEY, region));
     let handle = rocks::util::get_cf_handle(&engines.kv, CF_RAFT)?;
     box_try!(wb.put_msg_cf(handle, &keys::region_state_key(region.get_id()), &state));
@@ -73,7 +73,7 @@ pub fn prepare_bootstrap_cluster(engines: &Engines, region: &metapb::Region) -> 
     engines.write_kv(&wb)?;
     engines.sync_kv()?;
 
-    let raft_wb = WriteBatch::new();
+    let raft_wb = WriteBatch::default();
     write_initial_raft_state(&raft_wb, region.get_id())?;
     engines.write_raft(&raft_wb)?;
     engines.sync_raft()?;
@@ -85,7 +85,7 @@ pub fn clear_prepare_bootstrap_cluster(engines: &Engines, region_id: u64) -> Res
     box_try!(engines.raft.delete(&keys::raft_state_key(region_id)));
     engines.sync_raft()?;
 
-    let wb = WriteBatch::new();
+    let wb = WriteBatch::default();
     box_try!(wb.delete(keys::PREPARE_BOOTSTRAP_KEY));
     // should clear raft initial state too.
     let handle = rocks::util::get_cf_handle(&engines.kv, CF_RAFT)?;

--- a/src/raftstore/store/cmd_resp.rs
+++ b/src/raftstore/store/cmd_resp.rs
@@ -18,7 +18,7 @@ pub fn bind_error(resp: &mut RaftCmdResponse, err: Error) {
 }
 
 pub fn new_error(err: Error) -> RaftCmdResponse {
-    let mut resp = RaftCmdResponse::new();
+    let mut resp = RaftCmdResponse::default();
     bind_error(&mut resp, err);
     resp
 }

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -1083,7 +1083,7 @@ impl ApplyDelegate {
         }?;
         response.set_cmd_type(cmd_type);
 
-        let mut resp = RaftCmdResponse::new();
+        let mut resp = RaftCmdResponse::default();
         if !req.get_header().get_uuid().is_empty() {
             let uuid = req.get_header().get_uuid().to_vec();
             resp.mut_header().set_uuid(uuid);
@@ -1138,7 +1138,7 @@ impl ApplyDelegate {
             responses.push(resp);
         }
 
-        let mut resp = RaftCmdResponse::new();
+        let mut resp = RaftCmdResponse::default();
         if !req.get_header().get_uuid().is_empty() {
             let uuid = req.get_header().get_uuid().to_vec();
             resp.mut_header().set_uuid(uuid);
@@ -1165,7 +1165,7 @@ impl ApplyDelegate {
         // region key range has no data prefix, so we must use origin key to check.
         util::check_key_in_region(key, &self.region)?;
 
-        let resp = Response::new();
+        let resp = Response::default();
         let key = keys::data_key(key);
         self.metrics.size_diff_hint += key.len() as i64;
         self.metrics.size_diff_hint += value.len() as i64;
@@ -1211,7 +1211,7 @@ impl ApplyDelegate {
         let key = keys::data_key(key);
         // since size_diff_hint is not accurate, so we just skip calculate the value size.
         self.metrics.size_diff_hint -= key.len() as i64;
-        let resp = Response::new();
+        let resp = Response::default();
         if !req.get_delete().get_cf().is_empty() {
             let cf = req.get_delete().get_cf();
             // TODO: check whether cf exists or not.
@@ -1272,7 +1272,7 @@ impl ApplyDelegate {
             return Err(Error::KeyNotInRegion(e_key.to_vec(), self.region.clone()));
         }
 
-        let resp = Response::new();
+        let resp = Response::default();
         let mut cf = req.get_delete_range().get_cf();
         if cf.is_empty() {
             cf = CF_DEFAULT;
@@ -1358,7 +1358,7 @@ impl ApplyDelegate {
             });
 
         ssts.push(sst.clone());
-        Ok(Response::new())
+        Ok(Response::default())
     }
 }
 
@@ -1545,7 +1545,7 @@ impl ApplyDelegate {
             panic!("{} failed to update region state: {:?}", self.tag, e);
         }
 
-        let mut resp = AdminResponse::new();
+        let mut resp = AdminResponse::default();
         resp.mut_change_peer().set_region(region.clone());
 
         Ok((
@@ -1569,7 +1569,7 @@ impl ApplyDelegate {
             "peer_id" => self.id(),
         );
         let split = req.get_split().to_owned();
-        let mut admin_req = AdminRequest::new();
+        let mut admin_req = AdminRequest::default();
         admin_req
             .mut_splits()
             .set_right_derive(split.get_right_derive());
@@ -1653,7 +1653,7 @@ impl ApplyDelegate {
         let kv = &ctx.engines.kv;
         let kv_wb_mut = ctx.kv_wb.as_mut().unwrap();
         for req in split_reqs.get_requests() {
-            let mut new_region = Region::new();
+            let mut new_region = Region::default();
             // TODO: check new region id validation.
             new_region.set_id(req.get_new_region_id());
             new_region.set_region_epoch(derived.get_region_epoch().to_owned());
@@ -1684,7 +1684,7 @@ impl ApplyDelegate {
         write_peer_state(kv, kv_wb_mut, &derived, PeerState::Normal, None).unwrap_or_else(|e| {
             panic!("{} fails to update region {:?}: {:?}", self.tag, derived, e)
         });
-        let mut resp = AdminResponse::new();
+        let mut resp = AdminResponse::default();
         resp.mut_splits()
             .set_regions(RepeatedField::from_slice(&regions));
         PEER_ADMIN_CMD_COUNTER_VEC
@@ -1730,7 +1730,7 @@ impl ApplyDelegate {
         // backward compatible.
         let conf_version = region.get_region_epoch().get_conf_ver() + 1;
         region.mut_region_epoch().set_conf_ver(conf_version);
-        let mut merging_state = MergeState::new();
+        let mut merging_state = MergeState::default();
         merging_state.set_min_index(index);
         merging_state.set_target(prepare_merge.get_target().to_owned());
         merging_state.set_commit(exec_ctx.index);
@@ -1753,7 +1753,7 @@ impl ApplyDelegate {
             .inc();
 
         Ok((
-            AdminResponse::new(),
+            AdminResponse::default(),
             ApplyResult::Res(ExecResult::PrepareMerge {
                 region,
                 state: merging_state,
@@ -1911,7 +1911,7 @@ impl ApplyDelegate {
         write_peer_state(kv, kv_wb_mut, &region, PeerState::Normal, None)
             .and_then(|_| {
                 // TODO: maybe all information needs to be filled?
-                let mut merging_state = MergeState::new();
+                let mut merging_state = MergeState::default();
                 merging_state.set_target(self.region.clone());
                 write_peer_state(
                     kv,
@@ -1932,7 +1932,7 @@ impl ApplyDelegate {
             .with_label_values(&["commit_merge", "success"])
             .inc();
 
-        let resp = AdminResponse::new();
+        let resp = AdminResponse::default();
         Ok((
             resp,
             ApplyResult::Res(ExecResult::CommitMerge {
@@ -1979,7 +1979,7 @@ impl ApplyDelegate {
         PEER_ADMIN_CMD_COUNTER_VEC
             .with_label_values(&["rollback_merge", "success"])
             .inc();
-        let resp = AdminResponse::new();
+        let resp = AdminResponse::default();
         Ok((
             resp,
             ApplyResult::Res(ExecResult::RollbackMerge {
@@ -1999,7 +1999,7 @@ impl ApplyDelegate {
             .inc();
 
         let compact_index = req.get_compact_log().get_compact_index();
-        let resp = AdminResponse::new();
+        let resp = AdminResponse::default();
         let apply_state = &mut ctx.exec_ctx.as_mut().unwrap().apply_state;
         let first_index = peer_storage::first_index(apply_state);
         if compact_index <= first_index {
@@ -2058,7 +2058,7 @@ impl ApplyDelegate {
         ctx: &ApplyContext,
         _: &AdminRequest,
     ) -> Result<(AdminResponse, ApplyResult)> {
-        let resp = AdminResponse::new();
+        let resp = AdminResponse::default();
         Ok((
             resp,
             ApplyResult::Res(ExecResult::ComputeHash {
@@ -2081,7 +2081,7 @@ impl ApplyDelegate {
         let verify_req = req.get_verify_hash();
         let index = verify_req.get_index();
         let hash = verify_req.get_hash().to_vec();
-        let resp = AdminResponse::new();
+        let resp = AdminResponse::default();
         Ok((
             resp,
             ApplyResult::Res(ExecResult::VerifyHash { index, hash }),
@@ -3002,7 +3002,7 @@ mod tests {
     }
 
     pub fn new_entry(term: u64, index: u64, req: Option<RaftCmdRequest>) -> Entry {
-        let mut e = Entry::new();
+        let mut e = Entry::default();
         e.set_index(index);
         e.set_term(term);
         if let Some(r) = req {
@@ -3014,24 +3014,24 @@ mod tests {
     #[test]
     fn test_should_write_to_engine() {
         // ComputeHash command
-        let mut req = RaftCmdRequest::new();
+        let mut req = RaftCmdRequest::default();
         req.mut_admin_request()
             .set_cmd_type(AdminCmdType::ComputeHash);
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         assert_eq!(should_write_to_engine(&req, wb.count()), true);
 
         // IngestSST command
-        let mut req = Request::new();
+        let mut req = Request::default();
         req.set_cmd_type(CmdType::IngestSST);
-        req.set_ingest_sst(IngestSSTRequest::new());
-        let mut cmd = RaftCmdRequest::new();
+        req.set_ingest_sst(IngestSSTRequest::default());
+        let mut cmd = RaftCmdRequest::default();
         cmd.mut_requests().push(req);
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         assert_eq!(should_write_to_engine(&cmd, wb.count()), true);
 
         // Write batch keys reach WRITE_BATCH_MAX_KEYS
-        let req = RaftCmdRequest::new();
-        let wb = WriteBatch::new();
+        let req = RaftCmdRequest::default();
+        let wb = WriteBatch::default();
         for i in 0..WRITE_BATCH_MAX_KEYS {
             let key = format!("key_{}", i);
             wb.put(key.as_bytes(), b"value").unwrap();
@@ -3039,8 +3039,8 @@ mod tests {
         assert_eq!(should_write_to_engine(&req, wb.count()), true);
 
         // Write batch keys not reach WRITE_BATCH_MAX_KEYS
-        let req = RaftCmdRequest::new();
-        let wb = WriteBatch::new();
+        let req = RaftCmdRequest::default();
+        let wb = WriteBatch::default();
         for i in 0..WRITE_BATCH_MAX_KEYS - 1 {
             let key = format!("key_{}", i);
             wb.put(key.as_bytes(), b"value").unwrap();
@@ -3296,8 +3296,8 @@ mod tests {
 
     impl EntryBuilder {
         fn new(index: u64, term: u64) -> EntryBuilder {
-            let req = RaftCmdRequest::new();
-            let mut entry = Entry::new();
+            let req = RaftCmdRequest::default();
+            let mut entry = Entry::default();
             entry.set_index(index);
             entry.set_term(term);
             EntryBuilder { entry, req }
@@ -3327,7 +3327,7 @@ mod tests {
         }
 
         fn epoch(mut self, conf_ver: u64, version: u64) -> EntryBuilder {
-            let mut epoch = RegionEpoch::new();
+            let mut epoch = RegionEpoch::default();
             epoch.set_version(version);
             epoch.set_conf_ver(conf_ver);
             self.req.mut_header().set_region_epoch(epoch);
@@ -3343,7 +3343,7 @@ mod tests {
         }
 
         fn add_put_req(mut self, cf: Option<&str>, key: &[u8], value: &[u8]) -> EntryBuilder {
-            let mut cmd = Request::new();
+            let mut cmd = Request::default();
             cmd.set_cmd_type(CmdType::Put);
             if let Some(cf) = cf {
                 cmd.mut_put().set_cf(cf.to_owned());
@@ -3371,7 +3371,7 @@ mod tests {
         }
 
         fn add_delete_req(mut self, cf: Option<&str>, key: &[u8]) -> EntryBuilder {
-            let mut cmd = Request::new();
+            let mut cmd = Request::default();
             cmd.set_cmd_type(CmdType::Delete);
             if let Some(cf) = cf {
                 cmd.mut_delete().set_cf(cf.to_owned());
@@ -3387,7 +3387,7 @@ mod tests {
             start_key: &[u8],
             end_key: &[u8],
         ) -> EntryBuilder {
-            let mut cmd = Request::new();
+            let mut cmd = Request::default();
             cmd.set_cmd_type(CmdType::DeleteRange);
             if let Some(cf) = cf {
                 cmd.mut_delete_range().set_cf(cf.to_owned());
@@ -3399,7 +3399,7 @@ mod tests {
         }
 
         fn ingest_sst(mut self, meta: &SSTMeta) -> EntryBuilder {
-            let mut cmd = Request::new();
+            let mut cmd = Request::default();
             cmd.set_cmd_type(CmdType::IngestSST);
             cmd.mut_ingest_sst().set_sst(meta.clone());
             self.req.mut_requests().push(cmd);
@@ -3407,7 +3407,7 @@ mod tests {
         }
 
         fn split(mut self, splits: BatchSplitRequest) -> EntryBuilder {
-            let mut req = AdminRequest::new();
+            let mut req = AdminRequest::default();
             req.set_cmd_type(AdminCmdType::BatchSplit);
             req.set_splits(splits);
             self.req.set_admin_request(req);
@@ -3606,7 +3606,7 @@ mod tests {
 
         // UploadSST
         let sst_path = import_dir.path().join("test.sst");
-        let mut sst_epoch = RegionEpoch::new();
+        let mut sst_epoch = RegionEpoch::default();
         sst_epoch.set_conf_ver(1);
         sst_epoch.set_version(3);
         let sst_range = (0, 100);
@@ -3679,7 +3679,7 @@ mod tests {
     #[test]
     fn test_check_sst_for_ingestion() {
         let mut sst = SSTMeta::new();
-        let mut region = Region::new();
+        let mut region = Region::default();
 
         // Check uuid and cf name
         assert!(check_sst_for_ingestion(&sst, &region).is_err());
@@ -3721,7 +3721,7 @@ mod tests {
     }
 
     fn new_split_req(key: &[u8], id: u64, children: Vec<u64>) -> SplitRequest {
-        let mut req = SplitRequest::new();
+        let mut req = SplitRequest::default();
         req.set_split_key(key.to_vec());
         req.set_new_region_id(id);
         req.set_new_peer_ids(children);
@@ -3825,7 +3825,7 @@ mod tests {
             capture_rx.recv_timeout(Duration::from_secs(3)).unwrap()
         };
 
-        let mut splits = BatchSplitRequest::new();
+        let mut splits = BatchSplitRequest::default();
         splits.set_right_derive(true);
         splits.mut_requests().push(new_split_req(b"k1", 8, vec![]));
         let resp = exec_split(&router, splits.clone());

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -107,10 +107,10 @@ impl Drop for PeerFsm {
                 _ => continue,
             };
 
-            let mut err = errorpb::Error::new();
+            let mut err = errorpb::Error::default();
             err.set_message("region is not found".to_owned());
             err.mut_region_not_found().set_region_id(self.region_id());
-            let mut resp = RaftCmdResponse::new();
+            let mut resp = RaftCmdResponse::default();
             resp.mut_header().set_error(err);
             callback.invoke_with_response(resp);
         }
@@ -178,7 +178,7 @@ impl PeerFsm {
             "peer_id" => peer.get_id(),
         );
 
-        let mut region = metapb::Region::new();
+        let mut region = metapb::Region::default();
         region.set_id(region_id);
 
         let (tx, rx) = mpsc::loose_bounded(cfg.notify_capacity);
@@ -1191,7 +1191,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         let region_id = msg.get_region_id();
         let snap = msg.get_message().get_snapshot();
         let key = SnapKey::from_region_snap(region_id, snap);
-        let mut snap_data = RaftSnapshotData::new();
+        let mut snap_data = RaftSnapshotData::default();
         snap_data.merge_from_bytes(snap.get_data())?;
         let snap_region = snap_data.take_region();
         let peer_id = msg.get_to_peer().get_id();
@@ -1787,7 +1787,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             request
                 .mut_header()
                 .set_region_epoch(sibling_region.get_region_epoch().clone());
-            let mut admin = AdminRequest::new();
+            let mut admin = AdminRequest::default();
             admin.set_cmd_type(AdminCmdType::CommitMerge);
             admin
                 .mut_commit_merge()
@@ -1819,7 +1819,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             request
                 .mut_header()
                 .set_region_epoch(self.fsm.peer.region().get_region_epoch().clone());
-            let mut admin = AdminRequest::new();
+            let mut admin = AdminRequest::default();
             admin.set_cmd_type(AdminCmdType::RollbackMerge);
             admin.mut_rollback_merge().set_commit(state.get_commit());
             request.set_admin_request(admin);
@@ -2340,7 +2340,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         // doesn't matter whether the peer is a leader or not. If it's not a leader, the proposing
         // command log entry can't be committed.
 
-        let mut resp = RaftCmdResponse::new();
+        let mut resp = RaftCmdResponse::default();
         let term = self.fsm.peer.term();
         bind_term(&mut resp, term);
         if self.fsm.peer.propose(self.ctx, cb, msg, resp) {
@@ -2963,7 +2963,7 @@ pub fn maybe_destroy_source(
 }
 
 pub fn new_admin_request(region_id: u64, peer: metapb::Peer) -> RaftCmdRequest {
-    let mut request = RaftCmdRequest::new();
+    let mut request = RaftCmdRequest::default();
     request.mut_header().set_region_id(region_id);
     request.mut_header().set_peer(peer);
     request
@@ -2976,7 +2976,7 @@ fn new_verify_hash_request(
 ) -> RaftCmdRequest {
     let mut request = new_admin_request(region_id, peer);
 
-    let mut admin = AdminRequest::new();
+    let mut admin = AdminRequest::default();
     admin.set_cmd_type(AdminCmdType::VerifyHash);
     admin.mut_verify_hash().set_index(state.index);
     admin.mut_verify_hash().set_hash(state.hash.clone());
@@ -2992,7 +2992,7 @@ fn new_compact_log_request(
 ) -> RaftCmdRequest {
     let mut request = new_admin_request(region_id, peer);
 
-    let mut admin = AdminRequest::new();
+    let mut admin = AdminRequest::default();
     admin.set_cmd_type(AdminCmdType::CompactLog);
     admin.mut_compact_log().set_compact_index(compact_index);
     admin.mut_compact_log().set_compact_term(compact_term);
@@ -3015,7 +3015,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         }?;
         response.set_cmd_type(cmd_type);
 
-        let mut resp = RaftCmdResponse::new();
+        let mut resp = RaftCmdResponse::default();
         resp.set_status_response(response);
         // Bind peer current term here.
         bind_term(&mut resp, self.fsm.peer.term());
@@ -3023,7 +3023,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
     }
 
     fn execute_region_leader(&mut self) -> Result<StatusResponse> {
-        let mut resp = StatusResponse::new();
+        let mut resp = StatusResponse::default();
         if let Some(leader) = self.fsm.peer.get_peer_from_cache(self.fsm.peer.leader_id()) {
             resp.mut_region_leader().set_leader(leader);
         }
@@ -3036,7 +3036,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             let region_id = request.get_header().get_region_id();
             return Err(Error::RegionNotInitialized(region_id));
         }
-        let mut resp = StatusResponse::new();
+        let mut resp = StatusResponse::default();
         resp.mut_region_detail()
             .set_region(self.fsm.peer.region().clone());
         if let Some(leader) = self.fsm.peer.get_peer_from_cache(self.fsm.peer.leader_id()) {

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -316,7 +316,7 @@ impl<T: Transport, C> PollContext<T, C> {
             "msg_type" => ?msg_type,
         );
 
-        let mut gc_msg = RaftMessage::new();
+        let mut gc_msg = RaftMessage::default();
         gc_msg.set_region_id(region_id);
         gc_msg.set_from_peer(to_peer.clone());
         gc_msg.set_to_peer(from_peer.clone());
@@ -716,8 +716,8 @@ impl<T, C> RaftPollerBuilder<T, C> {
         let mut region_peers = vec![];
 
         let t = Instant::now();
-        let mut kv_wb = WriteBatch::new();
-        let mut raft_wb = WriteBatch::new();
+        let mut kv_wb = WriteBatch::default();
+        let mut raft_wb = WriteBatch::default();
         let mut applying_regions = vec![];
         let mut merging_count = 0;
         let mut meta = self.store_meta.lock().unwrap();
@@ -897,7 +897,7 @@ where
             global_stat: self.global_stat.clone(),
             store_stat: self.global_stat.local(),
             engines: self.engines.clone(),
-            kv_wb: WriteBatch::new(),
+            kv_wb: WriteBatch::default(),
             raft_wb: WriteBatch::with_capacity(4 * 1024),
             pending_count: 0,
             sync_log: false,
@@ -1560,7 +1560,7 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
     }
 
     fn store_heartbeat_pd(&mut self) {
-        let mut stats = StoreStats::new();
+        let mut stats = StoreStats::default();
 
         let used_size = self.ctx.snap_mgr.get_total_snap_size();
         stats.set_used_size(used_size);
@@ -1884,7 +1884,7 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
             .consistency_check_time
             .insert(target_region_id, Instant::now());
         let mut request = new_admin_request(target_region_id, target_peer);
-        let mut admin = AdminRequest::new();
+        let mut admin = AdminRequest::default();
         admin.set_cmd_type(AdminCmdType::ComputeHash);
         request.set_admin_request(admin);
 
@@ -2113,8 +2113,8 @@ mod tests {
 
         {
             for (i, (start, end)) in meta.into_iter().enumerate() {
-                let mut region = metapb::Region::new();
-                let peer = metapb::Peer::new();
+                let mut region = metapb::Region::default();
+                let peer = metapb::Peer::default();
                 region.set_peers(RepeatedField::from_vec(vec![peer]));
                 region.set_start_key(start.to_vec());
                 region.set_end_key(end.to_vec());
@@ -2149,8 +2149,8 @@ mod tests {
         region_peers.clear();
         {
             for (i, (start, end)) in meta.into_iter().enumerate() {
-                let mut region = metapb::Region::new();
-                let peer = metapb::Peer::new();
+                let mut region = metapb::Region::default();
+                let peer = metapb::Peer::default();
                 region.set_peers(RepeatedField::from_vec(vec![peer]));
                 region.set_start_key(start.to_vec());
                 region.set_end_key(end.to_vec());

--- a/src/raftstore/store/keys.rs
+++ b/src/raftstore/store/keys.rs
@@ -359,12 +359,12 @@ mod tests {
         assert!(validate_data_key(&data_key(b"abc")));
         assert!(!validate_data_key(b"abc"));
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         // uninitialised region should not be passed in `enc_start_key` and `enc_end_key`.
         assert!(::panic_hook::recover_safe(|| enc_start_key(&region)).is_err());
         assert!(::panic_hook::recover_safe(|| enc_end_key(&region)).is_err());
 
-        region.mut_peers().push(Peer::new());
+        region.mut_peers().push(Peer::default());
         assert_eq!(enc_start_key(&region), vec![DATA_PREFIX]);
         assert_eq!(enc_end_key(&region), vec![DATA_PREFIX + 1]);
 

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -500,8 +500,8 @@ impl Peer {
         );
 
         // Set Tombstone state explicitly
-        let kv_wb = WriteBatch::new();
-        let raft_wb = WriteBatch::new();
+        let kv_wb = WriteBatch::default();
+        let raft_wb = WriteBatch::default();
         self.mut_store().clear_meta(&kv_wb, &raft_wb)?;
         write_peer_state(
             &ctx.engines.kv,
@@ -805,7 +805,7 @@ impl Peer {
             }
             if let Some(instant) = self.peer_heartbeats.get(&p.get_id()) {
                 if instant.elapsed() >= max_duration {
-                    let mut stats = PeerStats::new();
+                    let mut stats = PeerStats::default();
                     stats.set_peer(p.clone());
                     stats.set_down_seconds(instant.elapsed().as_secs());
                     down_peers.push(stats);
@@ -1117,7 +1117,7 @@ impl Peer {
                 return None;
             }
 
-            let mut snap_data = RaftSnapshotData::new();
+            let mut snap_data = RaftSnapshotData::default();
             snap_data
                 .merge_from_bytes(snap.get_data())
                 .unwrap_or_else(|e| {
@@ -1940,7 +1940,7 @@ impl Peer {
         // TimeoutNow has been sent out, so we need to propose explicitly to
         // update leader lease.
         if self.leader_lease.inspect(Some(renew_lease_time)) == LeaseState::Suspect {
-            let req = RaftCmdRequest::new();
+            let req = RaftCmdRequest::default();
             if let Ok(index) = self.propose_normal(poll_ctx, req) {
                 let meta = ProposalMeta {
                     index,
@@ -2295,7 +2295,7 @@ impl Peer {
     }
 
     fn send_raft_message<T: Transport>(&mut self, msg: eraftpb::Message, trans: &mut T) {
-        let mut send_msg = RaftMessage::new();
+        let mut send_msg = RaftMessage::default();
         send_msg.set_region_id(self.region_id);
         // set current epoch
         send_msg.set_region_epoch(self.region().get_region_epoch().clone());
@@ -2518,7 +2518,7 @@ impl ReadExecutor {
         // region key range has no data prefix, so we must use origin key to check.
         util::check_key_in_region(key, region)?;
 
-        let mut resp = Response::new();
+        let mut resp = Response::default();
         let snapshot = self.snapshot.as_ref().unwrap();
         let res = if !req.get_get().get_cf().is_empty() {
             let cf = req.get_get().get_cf();
@@ -2595,12 +2595,12 @@ impl ReadExecutor {
                 },
                 CmdType::Snap => {
                     need_snapshot = true;
-                    raft_cmdpb::Response::new()
+                    raft_cmdpb::Response::default()
                 }
                 CmdType::ReadIndex => {
-                    let mut resp = raft_cmdpb::Response::new();
+                    let mut resp = raft_cmdpb::Response::default();
                     if let Some(read_index) = read_index {
-                        let mut res = ReadIndexResponse::new();
+                        let mut res = ReadIndexResponse::default();
                         res.set_read_index(read_index);
                         resp.set_read_index(res);
                     } else {
@@ -2619,7 +2619,7 @@ impl ReadExecutor {
             responses.push(resp);
         }
 
-        let mut response = RaftCmdResponse::new();
+        let mut response = RaftCmdResponse::default();
         response.set_responses(protobuf::RepeatedField::from_vec(responses));
         let snapshot = if need_snapshot {
             Some(RegionSnapshot::from_snapshot(
@@ -2685,10 +2685,10 @@ fn is_request_urgent(req: &RaftCmdRequest) -> bool {
 }
 
 fn make_transfer_leader_response() -> RaftCmdResponse {
-    let mut response = AdminResponse::new();
+    let mut response = AdminResponse::default();
     response.set_cmd_type(AdminCmdType::TransferLeader);
-    response.set_transfer_leader(TransferLeaderResponse::new());
-    let mut resp = RaftCmdResponse::new();
+    response.set_transfer_leader(TransferLeaderResponse::default());
+    let mut resp = RaftCmdResponse::default();
     resp.set_admin_response(response);
     resp
 }
@@ -2709,7 +2709,7 @@ mod tests {
             AdminCmdType::VerifyHash,
         ];
         for tp in AdminCmdType::values() {
-            let mut msg = RaftCmdRequest::new();
+            let mut msg = RaftCmdRequest::default();
             msg.mut_admin_request().set_cmd_type(*tp);
             assert_eq!(
                 get_sync_log_from_request(&msg),
@@ -2733,7 +2733,7 @@ mod tests {
             AdminCmdType::RollbackMerge,
         ];
         for tp in AdminCmdType::values() {
-            let mut req = RaftCmdRequest::new();
+            let mut req = RaftCmdRequest::default();
             req.mut_admin_request().set_cmd_type(*tp);
             assert_eq!(
                 is_request_urgent(&req),
@@ -2742,7 +2742,7 @@ mod tests {
                 tp
             );
         }
-        assert!(!is_request_urgent(&RaftCmdRequest::new()));
+        assert!(!is_request_urgent(&RaftCmdRequest::default()));
     }
 
     #[test]
@@ -2789,18 +2789,18 @@ mod tests {
         let mut table = vec![];
 
         // Ok(_)
-        let mut req = RaftCmdRequest::new();
-        let mut admin_req = raft_cmdpb::AdminRequest::new();
+        let mut req = RaftCmdRequest::default();
+        let mut admin_req = raft_cmdpb::AdminRequest::default();
 
         req.set_admin_request(admin_req.clone());
         table.push((req.clone(), RequestPolicy::ProposeNormal));
 
-        admin_req.set_change_peer(raft_cmdpb::ChangePeerRequest::new());
+        admin_req.set_change_peer(raft_cmdpb::ChangePeerRequest::default());
         req.set_admin_request(admin_req.clone());
         table.push((req.clone(), RequestPolicy::ProposeConfChange));
         admin_req.clear_change_peer();
 
-        admin_req.set_transfer_leader(raft_cmdpb::TransferLeaderRequest::new());
+        admin_req.set_transfer_leader(raft_cmdpb::TransferLeaderRequest::default());
         req.set_admin_request(admin_req.clone());
         table.push((req.clone(), RequestPolicy::ProposeTransferLeader));
         admin_req.clear_transfer_leader();
@@ -2814,7 +2814,7 @@ mod tests {
             (CmdType::DeleteRange, RequestPolicy::ProposeNormal),
             (CmdType::IngestSST, RequestPolicy::ProposeNormal),
         ] {
-            let mut request = raft_cmdpb::Request::new();
+            let mut request = raft_cmdpb::Request::default();
             request.set_cmd_type(op);
             req.set_requests(vec![request].into());
             table.push((req.clone(), policy));
@@ -2840,7 +2840,7 @@ mod tests {
         }
 
         // Read quorum.
-        let mut request = raft_cmdpb::Request::new();
+        let mut request = raft_cmdpb::Request::default();
         request.set_cmd_type(CmdType::Snap);
         req.set_requests(vec![request].into());
         req.mut_header().set_read_quorum(true);
@@ -2854,14 +2854,14 @@ mod tests {
         // Err(_)
         let mut err_table = vec![];
         for op in vec![CmdType::Prewrite, CmdType::Invalid] {
-            let mut request = raft_cmdpb::Request::new();
+            let mut request = raft_cmdpb::Request::default();
             request.set_cmd_type(op);
             req.set_requests(vec![request].into());
             err_table.push(req.clone());
         }
-        let mut snap = raft_cmdpb::Request::new();
+        let mut snap = raft_cmdpb::Request::default();
         snap.set_cmd_type(CmdType::Snap);
-        let mut put = raft_cmdpb::Request::new();
+        let mut put = raft_cmdpb::Request::default();
         put.set_cmd_type(CmdType::Put);
         req.set_requests(vec![snap, put].into());
         err_table.push(req.clone());

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -345,7 +345,7 @@ pub fn recover_from_applying_state(
     let raft_state_key = keys::raft_state_key(region_id);
     let raft_state: RaftLocalState = match box_try!(engines.raft.get_msg(&raft_state_key)) {
         Some(state) => state,
-        None => RaftLocalState::new(),
+        None => RaftLocalState::default(),
     };
 
     // if we recv append log when applying snapshot, last_index in raft_local_state will
@@ -365,7 +365,7 @@ pub fn init_raft_state(engines: &Engines, region: &Region) -> Result<RaftLocalSt
     Ok(match engines.raft.get_msg(&state_key)? {
         Some(s) => s,
         None => {
-            let mut raft_state = RaftLocalState::new();
+            let mut raft_state = RaftLocalState::default();
             if !region.get_peers().is_empty() {
                 // new split region
                 raft_state.set_last_index(RAFT_INIT_LOG_INDEX);
@@ -386,7 +386,7 @@ pub fn init_apply_state(engines: &Engines, region: &Region) -> Result<RaftApplyS
         {
             Some(s) => s,
             None => {
-                let mut apply_state = RaftApplyState::new();
+                let mut apply_state = RaftApplyState::default();
                 if !region.get_peers().is_empty() {
                     apply_state.set_applied_index(RAFT_INIT_LOG_INDEX);
                     let state = apply_state.mut_truncated_state();
@@ -701,7 +701,7 @@ impl PeerStorage {
             return false;
         }
 
-        let mut snap_data = RaftSnapshotData::new();
+        let mut snap_data = RaftSnapshotData::default();
         if let Err(e) = snap_data.merge_from_bytes(snap.get_data()) {
             error!(
                 "failed to decode snapshot, it may be corrupted";
@@ -906,7 +906,7 @@ impl PeerStorage {
             "peer_id" => self.peer_id,
         );
 
-        let mut snap_data = RaftSnapshotData::new();
+        let mut snap_data = RaftSnapshotData::default();
         snap_data.merge_from_bytes(snap.get_data())?;
 
         let region_id = self.get_region_id();
@@ -1245,7 +1245,7 @@ pub fn fetch_entries_to(
             match engine.get(&key) {
                 Ok(None) => return Err(RaftError::Store(StorageError::Unavailable)),
                 Ok(Some(v)) => {
-                    let mut entry = Entry::new();
+                    let mut entry = Entry::default();
                     entry.merge_from_bytes(&v)?;
                     assert_eq!(entry.get_index(), i);
                     total_size += v.len() as u64;
@@ -1269,7 +1269,7 @@ pub fn fetch_entries_to(
         &end_key,
         true, // fill_cache
         |_, value| {
-            let mut entry = Entry::new();
+            let mut entry = Entry::default();
             entry.merge_from_bytes(value)?;
 
             // May meet gap or has been compacted.
@@ -1406,7 +1406,7 @@ pub fn do_snapshot(
 
     let mut s = mgr.get_snapshot_for_building(&key)?;
     // Set snapshot data.
-    let mut snap_data = RaftSnapshotData::new();
+    let mut snap_data = RaftSnapshotData::default();
     snap_data.set_region(state.get_region().clone());
     let mut stat = SnapshotStatistics::new();
     s.build(
@@ -1428,7 +1428,7 @@ pub fn do_snapshot(
 
 // When we bootstrap the region we must call this to initialize region local state first.
 pub fn write_initial_raft_state<T: Mutable>(raft_wb: &T, region_id: u64) -> Result<()> {
-    let mut raft_state = RaftLocalState::new();
+    let mut raft_state = RaftLocalState::default();
     raft_state.set_last_index(RAFT_INIT_LOG_INDEX);
     raft_state.mut_hard_state().set_term(RAFT_INIT_LOG_TERM);
     raft_state.mut_hard_state().set_commit(RAFT_INIT_LOG_INDEX);
@@ -1444,7 +1444,7 @@ pub fn write_initial_apply_state<T: Mutable>(
     kv_wb: &T,
     region_id: u64,
 ) -> Result<()> {
-    let mut apply_state = RaftApplyState::new();
+    let mut apply_state = RaftApplyState::default();
     apply_state.set_applied_index(RAFT_INIT_LOG_INDEX);
     apply_state
         .mut_truncated_state()
@@ -1466,7 +1466,7 @@ pub fn write_peer_state<T: Mutable>(
     merge_state: Option<MergeState>,
 ) -> Result<()> {
     let region_id = region.get_id();
-    let mut region_state = RegionLocalState::new();
+    let mut region_state = RegionLocalState::default();
     region_state.set_state(state);
     region_state.set_region(region.clone());
     if let Some(state) = merge_state {
@@ -1520,9 +1520,9 @@ pub fn maybe_upgrade_from_2_to_3(
     let mut kv_engine = rocks::util::new_engine_opt(kv_path, kv_db_opts, kv_cfs_opts)?;
 
     // Move meta data from kv engine to raft engine.
-    let upgrade_raft_wb = WriteBatch::new();
+    let upgrade_raft_wb = WriteBatch::default();
     // Cleanup meta data in kv engine.
-    let cleanup_kv_wb = WriteBatch::new();
+    let cleanup_kv_wb = WriteBatch::default();
 
     // For meta data in the default CF.
     //
@@ -1569,7 +1569,7 @@ pub fn maybe_upgrade_from_2_to_3(
                 let raft_state = raft_engine
                     .get_msg(&raft_state_key)?
                     .unwrap_or_else(RaftLocalState::new);
-                let mut snapshot_raft_state = RaftLocalState::new();
+                let mut snapshot_raft_state = RaftLocalState::default();
                 box_try!(snapshot_raft_state.merge_from_bytes(value));
                 // if we recv append log when applying snapshot, last_index in
                 // raft_local_state will larger than snapshot_index. since
@@ -1703,7 +1703,7 @@ mod tests {
         ents: &[Entry],
     ) -> PeerStorage {
         let mut store = new_storage(sched, path);
-        let mut kv_wb = WriteBatch::new();
+        let mut kv_wb = WriteBatch::default();
         let mut ctx = InvokeContext::new(&store);
         let mut ready_ctx = ReadyContext::default();
         store.append(&mut ctx, &ents[1..], &mut ready_ctx).unwrap();
@@ -1738,14 +1738,14 @@ mod tests {
         for e in exp_ents {
             let key = keys::raft_log_key(store.get_region_id(), e.get_index());
             let bytes = store.engines.raft.get(&key).unwrap().unwrap();
-            let mut entry = Entry::new();
+            let mut entry = Entry::default();
             entry.merge_from_bytes(&bytes).unwrap();
             assert_eq!(entry, *e);
         }
     }
 
     fn new_entry(index: u64, term: u64) -> Entry {
-        let mut e = Entry::new();
+        let mut e = Entry::default();
         e.set_index(index);
         e.set_term(term);
         e
@@ -1828,8 +1828,8 @@ mod tests {
 
         assert_eq!(6, get_meta_key_count(&store));
 
-        let kv_wb = WriteBatch::new();
-        let raft_wb = WriteBatch::new();
+        let kv_wb = WriteBatch::default();
+        let raft_wb = WriteBatch::default();
         store.clear_meta(&kv_wb, &raft_wb).unwrap();
         store.engines.kv.write(&kv_wb).unwrap();
         store.engines.raft.write(&raft_wb).unwrap();
@@ -1936,7 +1936,7 @@ mod tests {
                 panic!("#{}: want {:?}, got {:?}", i, werr, res);
             }
             if res.is_ok() {
-                let mut kv_wb = WriteBatch::new();
+                let mut kv_wb = WriteBatch::default();
                 ctx.save_apply_state_to(&store.engines.kv, &mut kv_wb)
                     .unwrap();
                 store.engines.kv.write(&kv_wb).unwrap();
@@ -1975,7 +1975,7 @@ mod tests {
         assert_eq!(snap.get_metadata().get_term(), 5);
         assert!(!snap.get_data().is_empty());
 
-        let mut data = RaftSnapshotData::new();
+        let mut data = RaftSnapshotData::default();
         protobuf::Message::merge_from_bytes(&mut data, snap.get_data()).unwrap();
         assert_eq!(data.get_region().get_id(), 1);
         assert_eq!(data.get_region().get_peers().len(), 1);
@@ -2003,7 +2003,7 @@ mod tests {
         let _ = s.gen_snap_task.borrow_mut().take().unwrap();
 
         let mut ctx = InvokeContext::new(&s);
-        let mut kv_wb = WriteBatch::new();
+        let mut kv_wb = WriteBatch::default();
         let mut ready_ctx = ReadyContext::default();
         s.append(
             &mut ctx,
@@ -2026,7 +2026,7 @@ mod tests {
         ctx = InvokeContext::new(&s);
         let term = s.term(7).unwrap();
         compact_raft_log(&s.tag, &mut ctx.apply_state, 7, term).unwrap();
-        kv_wb = WriteBatch::new();
+        kv_wb = WriteBatch::default();
         ctx.save_apply_state_to(&s.engines.kv, &mut kv_wb).unwrap();
         s.engines.kv.write(&kv_wb).unwrap();
         s.apply_state = ctx.apply_state;
@@ -2299,8 +2299,8 @@ mod tests {
         assert_eq!(s2.first_index(), s2.applied_index() + 1);
         let mut ctx = InvokeContext::new(&s2);
         assert_ne!(ctx.last_term, snap1.get_metadata().get_term());
-        let kv_wb = WriteBatch::new();
-        let raft_wb = WriteBatch::new();
+        let kv_wb = WriteBatch::default();
+        let raft_wb = WriteBatch::default();
         s2.apply_snapshot(&mut ctx, &snap1, &kv_wb, &raft_wb)
             .unwrap();
         assert_eq!(ctx.last_term, snap1.get_metadata().get_term());
@@ -2317,8 +2317,8 @@ mod tests {
         validate_cache(&s3, &ents[1..]);
         let mut ctx = InvokeContext::new(&s3);
         assert_ne!(ctx.last_term, snap1.get_metadata().get_term());
-        let kv_wb = WriteBatch::new();
-        let raft_wb = WriteBatch::new();
+        let kv_wb = WriteBatch::default();
+        let raft_wb = WriteBatch::default();
         s3.apply_snapshot(&mut ctx, &snap1, &kv_wb, &raft_wb)
             .unwrap();
         assert_eq!(ctx.last_term, snap1.get_metadata().get_term());
@@ -2429,16 +2429,16 @@ mod tests {
         let mut tbl = vec![];
 
         // Do not sync empty entrise.
-        tbl.push((Entry::new(), false));
+        tbl.push((Entry::default(), false));
 
         // Sync if sync_log is set.
-        let mut e = Entry::new();
+        let mut e = Entry::default();
         e.set_sync_log(true);
         tbl.push((e, true));
 
         // Sync if context is marked sync.
         let context = ProposalContext::SYNC_LOG.to_vec();
-        let mut e = Entry::new();
+        let mut e = Entry::default();
         e.set_context(context);
         tbl.push((e.clone(), true));
 

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -394,8 +394,8 @@ mod tests {
     }
 
     fn load_default_dataset(engines: Engines) -> (PeerStorage, DataSet) {
-        let mut r = Region::new();
-        r.mut_peers().push(Peer::new());
+        let mut r = Region::default();
+        r.mut_peers().push(Peer::default());
         r.set_id(10);
         r.set_start_key(b"a2".to_vec());
         r.set_end_key(b"a7".to_vec());
@@ -416,8 +416,8 @@ mod tests {
     }
 
     fn load_multiple_levels_dataset(engines: Engines) -> (PeerStorage, DataSet) {
-        let mut r = Region::new();
-        r.mut_peers().push(Peer::new());
+        let mut r = Region::default();
+        r.mut_peers().push(Peer::default());
         r.set_id(10);
         r.set_start_key(b"a04".to_vec());
         r.set_end_key(b"a15".to_vec());
@@ -463,7 +463,7 @@ mod tests {
     fn test_peekable() {
         let path = Builder::new().prefix("test-raftstore").tempdir().unwrap();
         let engines = new_temp_engine(&path);
-        let mut r = Region::new();
+        let mut r = Region::default();
         r.set_id(10);
         r.set_start_key(b"key0".to_vec());
         r.set_end_key(b"key4".to_vec());
@@ -633,8 +633,8 @@ mod tests {
         assert_eq!(res, base_data[1..3].to_vec());
 
         // test last region
-        let mut region = Region::new();
-        region.mut_peers().push(Peer::new());
+        let mut region = Region::default();
+        region.mut_peers().push(Peer::default());
         let store = new_peer_storage(engines.clone(), &region);
         let snap = RegionSnapshot::new(&store);
         data.clear();
@@ -734,8 +734,8 @@ mod tests {
         assert_eq!(res, expect);
 
         // test last region
-        let mut region = Region::new();
-        region.mut_peers().push(Peer::new());
+        let mut region = Region::default();
+        region.mut_peers().push(Peer::default());
         let store = new_peer_storage(engines, &region);
         let snap = RegionSnapshot::new(&store);
         let it = snap.iter(IterOption::default());
@@ -1037,8 +1037,8 @@ mod tests {
         .unwrap();
 
         // Do scan on other DB.
-        let mut r = Region::new();
-        r.mut_peers().push(Peer::new());
+        let mut r = Region::default();
+        r.mut_peers().push(Peer::default());
         r.set_start_key(b"a".to_vec());
         r.set_end_key(b"z".to_vec());
         let snapshot = RegionSnapshot::from_raw(Arc::clone(&engines1.kv), r);

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -120,7 +120,7 @@ impl SnapKey {
     }
 
     pub fn from_snap(snap: &RaftSnapshot) -> io::Result<SnapKey> {
-        let mut snap_data = RaftSnapshotData::new();
+        let mut snap_data = RaftSnapshotData::default();
         if let Err(e) = snap_data.merge_from_bytes(snap.get_data()) {
             return Err(io::Error::new(ErrorKind::Other, e));
         }
@@ -234,7 +234,7 @@ fn gen_snapshot_meta(cf_files: &[CfFile]) -> RaftStoreResult<SnapshotMeta> {
         cf_file_meta.set_checksum(cf_file.checksum);
         meta.push(cf_file_meta);
     }
-    let mut snapshot_meta = SnapshotMeta::new();
+    let mut snapshot_meta = SnapshotMeta::default();
     snapshot_meta.set_cf_files(RepeatedField::from_vec(meta));
     Ok(snapshot_meta)
 }
@@ -489,7 +489,7 @@ impl Snap {
 
     fn read_snapshot_meta(&mut self) -> RaftStoreResult<SnapshotMeta> {
         let buf = fs::read(&self.meta_file.path)?;
-        let mut snapshot_meta = SnapshotMeta::new();
+        let mut snapshot_meta = SnapshotMeta::default();
         snapshot_meta.merge_from_bytes(&buf)?;
         Ok(snapshot_meta)
     }
@@ -1160,7 +1160,7 @@ impl SnapManager {
         data: &[u8],
     ) -> RaftStoreResult<Box<dyn Snapshot>> {
         let core = self.core.rl();
-        let mut snapshot_data = RaftSnapshotData::new();
+        let mut snapshot_data = RaftSnapshotData::default();
         snapshot_data.merge_from_bytes(data)?;
         let f = Snap::new_for_receiving(
             &core.base,
@@ -1422,7 +1422,7 @@ pub mod tests {
         // write some data into each cf
         for (i, cf) in db.cf_names().into_iter().enumerate() {
             let handle = rocks::util::get_cf_handle(&db, cf)?;
-            let mut p = Peer::new();
+            let mut p = Peer::default();
             p.set_store_id(TEST_STORE_ID);
             p.set_id((i + 1) as u64);
             db.put_msg_cf(handle, &key[..], &p)?;
@@ -1447,7 +1447,7 @@ pub mod tests {
         )?;
         for &region_id in regions {
             // Put apply state into kv engine.
-            let mut apply_state = RaftApplyState::new();
+            let mut apply_state = RaftApplyState::default();
             apply_state.set_applied_index(10);
             apply_state.mut_truncated_state().set_index(10);
             let handle = rocks::util::get_cf_handle(&kv, CF_RAFT)?;
@@ -1455,7 +1455,7 @@ pub mod tests {
 
             // Put region info into kv engine.
             let region = gen_test_region(region_id, 1, 1);
-            let mut region_state = RegionLocalState::new();
+            let mut region_state = RegionLocalState::default();
             region_state.set_region(region);
             let handle = rocks::util::get_cf_handle(&kv, CF_RAFT)?;
             kv.put_msg_cf(handle, &keys::region_state_key(region_id), &region_state)?;
@@ -1487,10 +1487,10 @@ pub mod tests {
     }
 
     pub fn gen_test_region(region_id: u64, store_id: u64, peer_id: u64) -> Region {
-        let mut peer = Peer::new();
+        let mut peer = Peer::default();
         peer.set_store_id(store_id);
         peer.set_id(peer_id);
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(region_id);
         region.set_start_key(b"a".to_vec());
         region.set_end_key(b"z".to_vec());
@@ -1622,7 +1622,7 @@ pub mod tests {
         assert!(!s1.exists());
         assert_eq!(size_track.load(Ordering::SeqCst), 0);
 
-        let mut snap_data = RaftSnapshotData::new();
+        let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
         s1.build(
@@ -1758,7 +1758,7 @@ pub mod tests {
         .unwrap();
         assert!(!s1.exists());
 
-        let mut snap_data = RaftSnapshotData::new();
+        let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
         s1.build(
@@ -1819,7 +1819,7 @@ pub mod tests {
                     .unwrap()
                     .ends_with(META_FILE_SUFFIX)
                 {
-                    let mut snapshot_meta = SnapshotMeta::new();
+                    let mut snapshot_meta = SnapshotMeta::default();
                     let mut buf = Vec::with_capacity(TEST_META_FILE_BUFFER_SIZE);
                     {
                         let mut f = OpenOptions::new().read(true).open(e.path()).unwrap();
@@ -1947,7 +1947,7 @@ pub mod tests {
         .unwrap();
         assert!(!s1.exists());
 
-        let mut snap_data = RaftSnapshotData::new();
+        let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
         s1.build(
@@ -2072,7 +2072,7 @@ pub mod tests {
         .unwrap();
         assert!(!s1.exists());
 
-        let mut snap_data = RaftSnapshotData::new();
+        let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
         s1.build(
@@ -2186,7 +2186,7 @@ pub mod tests {
             Snap::new_for_building(&path, &key1, Arc::clone(&size_track), deleter.clone(), None)
                 .unwrap();
         let mut region = gen_test_region(1, 1, 1);
-        let mut snap_data = RaftSnapshotData::new();
+        let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
         s1.build(
@@ -2284,7 +2284,7 @@ pub mod tests {
         // Ensure the snapshot being built will not be deleted on GC.
         src_mgr.register(key.clone(), SnapEntry::Generating);
         let mut s1 = src_mgr.get_snapshot_for_building(&key).unwrap();
-        let mut snap_data = RaftSnapshotData::new();
+        let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
         s1.build(
@@ -2359,7 +2359,7 @@ pub mod tests {
         let recv_key = SnapKey::new(100, 100, 100);
         let recv_head = {
             let mut stat = SnapshotStatistics::new();
-            let mut snap_data = RaftSnapshotData::new();
+            let mut snap_data = RaftSnapshotData::default();
             let mut s = snap_mgr.get_snapshot_for_building(&recv_key).unwrap();
             s.build(
                 &snapshot,
@@ -2388,7 +2388,7 @@ pub mod tests {
             let key = SnapKey::new(region_id, 1, 1);
             let region = gen_test_region(region_id, 1, 1);
             let mut s = snap_mgr.get_snapshot_for_building(&key).unwrap();
-            let mut snap_data = RaftSnapshotData::new();
+            let mut snap_data = RaftSnapshotData::default();
             let mut stat = SnapshotStatistics::new();
             s.build(
                 &snapshot,

--- a/src/raftstore/store/snap/io.rs
+++ b/src/raftstore/store/snap/io.rs
@@ -108,7 +108,7 @@ pub fn apply_plain_cf_file(
 ) -> Result<(), Error> {
     let mut decoder = BufReader::new(box_try!(File::open(path)));
     let cf_handle = box_try!(get_cf_handle(&db, cf));
-    let wb = WriteBatch::new();
+    let wb = WriteBatch::default();
     loop {
         if stale_detector.is_stale() {
             return Err(Error::Abort);

--- a/src/raftstore/store/util.rs
+++ b/src/raftstore/store/util.rs
@@ -41,7 +41,7 @@ pub fn remove_peer(region: &mut metapb::Region, store_id: u64) -> Option<metapb:
 
 // a helper function to create peer easily.
 pub fn new_peer(store_id: u64, peer_id: u64) -> metapb::Peer {
-    let mut peer = metapb::Peer::new();
+    let mut peer = metapb::Peer::default();
     peer.set_store_id(store_id);
     peer.set_id(peer_id);
     peer
@@ -770,7 +770,7 @@ mod tests {
             ("6", "3", "6", false, true, false),
         ];
         for (key, start_key, end_key, is_in_region, inclusive, exclusive) in test_cases {
-            let mut region = metapb::Region::new();
+            let mut region = metapb::Region::default();
             region.set_start_key(start_key.as_bytes().to_vec());
             region.set_end_key(end_key.as_bytes().to_vec());
             let mut result = check_key_in_region(key.as_bytes(), &region);
@@ -784,13 +784,13 @@ mod tests {
 
     #[test]
     fn test_conf_state_from_region() {
-        let mut region = metapb::Region::new();
+        let mut region = metapb::Region::default();
 
-        let mut peer = metapb::Peer::new();
+        let mut peer = metapb::Peer::default();
         peer.set_id(1);
         region.mut_peers().push(peer);
 
-        let mut peer = metapb::Peer::new();
+        let mut peer = metapb::Peer::default();
         peer.set_id(2);
         peer.set_is_learner(true);
         region.mut_peers().push(peer);
@@ -802,7 +802,7 @@ mod tests {
 
     #[test]
     fn test_peer() {
-        let mut region = metapb::Region::new();
+        let mut region = metapb::Region::default();
         region.set_id(1);
         region.mut_peers().push(new_peer(1, 1));
         region.mut_peers().push(new_learner_peer(2, 2));
@@ -885,7 +885,7 @@ mod tests {
 
     #[test]
     fn test_epoch_stale() {
-        let mut epoch = metapb::RegionEpoch::new();
+        let mut epoch = metapb::RegionEpoch::default();
         epoch.set_version(10);
         epoch.set_conf_ver(10);
 
@@ -897,7 +897,7 @@ mod tests {
         ];
 
         for (version, conf_version, is_stale) in tbl {
-            let mut check_epoch = metapb::RegionEpoch::new();
+            let mut check_epoch = metapb::RegionEpoch::default();
             check_epoch.set_version(version);
             check_epoch.set_conf_ver(conf_version);
             assert_eq!(is_epoch_stale(&epoch, &check_epoch), is_stale);
@@ -918,7 +918,7 @@ mod tests {
         ];
 
         for (s1, s2, s3, s4, exp) in cases {
-            let mut r1 = metapb::Region::new();
+            let mut r1 = metapb::Region::default();
             for (store_id, peer_id) in s1.into_iter().zip(0..) {
                 r1.mut_peers().push(new_peer(store_id, peer_id));
             }
@@ -926,7 +926,7 @@ mod tests {
                 r1.mut_peers().push(new_learner_peer(store_id, peer_id));
             }
 
-            let mut r2 = metapb::Region::new();
+            let mut r2 = metapb::Region::default();
             for (store_id, peer_id) in s3.into_iter().zip(10..) {
                 r2.mut_peers().push(new_peer(store_id, peer_id));
             }
@@ -953,7 +953,7 @@ mod tests {
 
     #[test]
     fn test_region_sibling() {
-        let r1 = metapb::Region::new();
+        let r1 = metapb::Region::default();
         check_sibling(&r1, &r1, false);
 
         let (r1, r2) = split(r1, b"k1");
@@ -973,7 +973,7 @@ mod tests {
 
     #[test]
     fn test_check_store_id() {
-        let mut req = RaftCmdRequest::new();
+        let mut req = RaftCmdRequest::default();
         req.mut_header().mut_peer().set_store_id(1);
         check_store_id(&req, 1).unwrap();
         check_store_id(&req, 2).unwrap_err();
@@ -981,7 +981,7 @@ mod tests {
 
     #[test]
     fn test_check_peer_id() {
-        let mut req = RaftCmdRequest::new();
+        let mut req = RaftCmdRequest::default();
         req.mut_header().mut_peer().set_id(1);
         check_peer_id(&req, 1).unwrap();
         check_peer_id(&req, 2).unwrap_err();
@@ -989,7 +989,7 @@ mod tests {
 
     #[test]
     fn test_check_term() {
-        let mut req = RaftCmdRequest::new();
+        let mut req = RaftCmdRequest::default();
         req.mut_header().set_term(7);
         check_term(&req, 7).unwrap();
         check_term(&req, 8).unwrap();
@@ -1001,14 +1001,14 @@ mod tests {
 
     #[test]
     fn test_check_region_epoch() {
-        let mut epoch = RegionEpoch::new();
+        let mut epoch = RegionEpoch::default();
         epoch.set_conf_ver(2);
         epoch.set_version(2);
-        let mut region = metapb::Region::new();
+        let mut region = metapb::Region::default();
         region.set_region_epoch(epoch.clone());
 
         // Epoch is required for most requests even if it's empty.
-        check_region_epoch(&RaftCmdRequest::new(), &region, false).unwrap_err();
+        check_region_epoch(&RaftCmdRequest::default(), &region, false).unwrap_err();
 
         // These admin commands do not require epoch.
         for ty in &[
@@ -1017,9 +1017,9 @@ mod tests {
             AdminCmdType::ComputeHash,
             AdminCmdType::VerifyHash,
         ] {
-            let mut admin = AdminRequest::new();
+            let mut admin = AdminRequest::default();
             admin.set_cmd_type(*ty);
-            let mut req = RaftCmdRequest::new();
+            let mut req = RaftCmdRequest::default();
             req.set_admin_request(admin);
 
             // It is Okay if req does not have region epoch.
@@ -1039,9 +1039,9 @@ mod tests {
             AdminCmdType::RollbackMerge,
             AdminCmdType::TransferLeader,
         ] {
-            let mut admin = AdminRequest::new();
+            let mut admin = AdminRequest::default();
             admin.set_cmd_type(*ty);
-            let mut req = RaftCmdRequest::new();
+            let mut req = RaftCmdRequest::default();
             req.set_admin_request(admin);
 
             // Error if req does not have region epoch.
@@ -1049,7 +1049,7 @@ mod tests {
 
             let mut stale_version_epoch = epoch.clone();
             stale_version_epoch.set_version(1);
-            let mut stale_region = metapb::Region::new();
+            let mut stale_region = metapb::Region::default();
             stale_region.set_region_epoch(stale_version_epoch.clone());
             req.mut_header()
                 .set_region_epoch(stale_version_epoch.clone());
@@ -1074,9 +1074,9 @@ mod tests {
             AdminCmdType::RollbackMerge,
             AdminCmdType::TransferLeader,
         ] {
-            let mut admin = AdminRequest::new();
+            let mut admin = AdminRequest::default();
             admin.set_cmd_type(*ty);
-            let mut req = RaftCmdRequest::new();
+            let mut req = RaftCmdRequest::default();
             req.set_admin_request(admin);
 
             // Error if req does not have region epoch.
@@ -1084,7 +1084,7 @@ mod tests {
 
             let mut stale_conf_epoch = epoch.clone();
             stale_conf_epoch.set_conf_ver(1);
-            let mut stale_region = metapb::Region::new();
+            let mut stale_region = metapb::Region::default();
             stale_region.set_region_epoch(stale_conf_epoch.clone());
             req.mut_header().set_region_epoch(stale_conf_epoch.clone());
             check_region_epoch(&req, &stale_region, false).unwrap();

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -277,7 +277,7 @@ mod tests {
         let handle = get_cf_handle(&db, CF_DEFAULT).unwrap();
 
         // Generate the first SST file.
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         for i in 0..1000 {
             let k = format!("key_{}", i);
             wb.put_cf(handle, k.as_bytes(), b"whatever content")
@@ -287,7 +287,7 @@ mod tests {
         db.flush_cf(handle, true).unwrap();
 
         // Generate another SST file has the same content with first SST file.
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         for i in 0..1000 {
             let k = format!("key_{}", i);
             wb.put_cf(handle, k.as_bytes(), b"whatever content")

--- a/src/raftstore/store/worker/consistency_check.rs
+++ b/src/raftstore/store/worker/consistency_check.rs
@@ -168,8 +168,8 @@ mod tests {
         .unwrap();
         let db = Arc::new(db);
 
-        let mut region = Region::new();
-        region.mut_peers().push(Peer::new());
+        let mut region = Region::default();
+        region.mut_peers().push(Peer::default());
 
         let (tx, rx) = mpsc::sync_channel(100);
         let mut runner = Runner::new(tx);

--- a/src/raftstore/store/worker/raftlog_gc.rs
+++ b/src/raftstore/store/worker/raftlog_gc.rs
@@ -74,7 +74,7 @@ impl Runner {
             info!("no need to gc"; "region_id" => region_id);
             return Ok(0);
         }
-        let raft_wb = WriteBatch::new();
+        let raft_wb = WriteBatch::default();
         for idx in first_idx..end_idx {
             let key = keys::raft_log_key(region_id, idx);
             box_try!(raft_wb.delete(&key));
@@ -148,7 +148,7 @@ mod tests {
 
         // generate raft logs
         let region_id = 1;
-        let raft_wb = WriteBatch::new();
+        let raft_wb = WriteBatch::default();
         for i in 0..100 {
             let k = keys::raft_log_key(region_id, i);
             raft_wb.put(&k, b"entry").unwrap();

--- a/src/raftstore/store/worker/read.rs
+++ b/src/raftstore/store/worker/read.rs
@@ -186,7 +186,7 @@ impl<C: ProposalRouter> LocalReader<C> {
     fn redirect(&self, mut cmd: RaftCommand) {
         debug!("localreader redirects command"; "tag" => &self.tag, "command" => ?cmd);
         let region_id = cmd.request.get_header().get_region_id();
-        let mut err = errorpb::Error::new();
+        let mut err = errorpb::Error::default();
         match self.router.send(cmd) {
             Ok(()) => return,
             Err(TrySendError::Full(c)) => {
@@ -204,7 +204,7 @@ impl<C: ProposalRouter> LocalReader<C> {
             }
         }
 
-        let mut resp = RaftCmdResponse::new();
+        let mut resp = RaftCmdResponse::default();
         resp.mut_header().set_error(err);
         let read_resp = ReadResponse {
             response: resp,
@@ -589,7 +589,7 @@ mod tests {
         pr_ids
             .into_iter()
             .map(|id| {
-                let mut pr = metapb::Peer::new();
+                let mut pr = metapb::Peer::default();
                 pr.set_store_id(store_id);
                 pr.set_id(id);
                 pr
@@ -638,12 +638,12 @@ mod tests {
         // from "" to "",
         // epoch 1, 1,
         // term 6.
-        let mut region1 = metapb::Region::new();
+        let mut region1 = metapb::Region::default();
         region1.set_id(1);
         let prs = new_peers(store_id, vec![2, 3, 4]);
         region1.set_peers(prs.clone().into());
         let epoch13 = {
-            let mut ep = metapb::RegionEpoch::new();
+            let mut ep = metapb::RegionEpoch::default();
             ep.set_conf_ver(1);
             ep.set_version(3);
             ep
@@ -653,14 +653,14 @@ mod tests {
         let term6 = 6;
         let mut lease = Lease::new(Duration::seconds(1)); // 1s is long enough.
 
-        let mut cmd = RaftCmdRequest::new();
-        let mut header = RaftRequestHeader::new();
+        let mut cmd = RaftCmdRequest::default();
+        let mut header = RaftRequestHeader::default();
         header.set_region_id(1);
         header.set_peer(leader2.clone());
         header.set_region_epoch(epoch13.clone());
         header.set_term(term6);
         cmd.set_header(header);
-        let mut req = Request::new();
+        let mut req = Request::default();
         req.set_cmd_type(CmdType::Snap);
         cmd.set_requests(vec![req].into());
 

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -329,7 +329,7 @@ impl SnapContext {
         };
         s.apply(options)?;
 
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         region_state.set_state(PeerState::Normal);
         let handle = box_try!(rocks::util::get_cf_handle(&self.engines.kv, CF_RAFT));
         box_try!(wb.put_msg_cf(handle, &region_key, &region_state));
@@ -835,7 +835,7 @@ mod tests {
             s3.save().unwrap();
 
             // set applying state
-            let wb = WriteBatch::new();
+            let wb = WriteBatch::default();
             let handle = engine.kv.cf_handle(CF_RAFT).unwrap();
             let region_key = keys::region_state_key(id);
             let mut region_state = engine

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -326,7 +326,7 @@ impl Debugger {
     pub fn set_region_tombstone(&self, regions: Vec<Region>) -> Result<Vec<(u64, Error)>> {
         let store_id = self.get_store_id()?;
         let db = &self.engines.kv;
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
 
         let mut errors = Vec::with_capacity(regions.len());
         for region in regions {
@@ -346,7 +346,7 @@ impl Debugger {
 
     pub fn set_region_tombstone_by_id(&self, regions: Vec<u64>) -> Result<Vec<(u64, Error)>> {
         let db = &self.engines.kv;
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         let mut errors = Vec::with_capacity(regions.len());
         for region_id in regions {
             let key = keys::region_state_key(region_id);
@@ -552,7 +552,7 @@ impl Debugger {
             let msg = format!("Store {} in the failed list", store_id);
             return Err(Error::Other(msg.into()));
         }
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         let handle = box_try!(get_cf_handle(self.engines.kv.as_ref(), CF_RAFT));
         let store_ids = HashSet::<u64>::from_iter(store_ids);
 
@@ -563,7 +563,7 @@ impl Debugger {
                     return Ok(());
                 }
 
-                let mut region_state = RegionLocalState::new();
+                let mut region_state = RegionLocalState::default();
                 box_try!(region_state.merge_from_bytes(value));
                 if region_state.get_state() == PeerState::Tombstone {
                     return Ok(());
@@ -621,8 +621,8 @@ impl Debugger {
         let kv = self.engines.kv.as_ref();
         let raft = self.engines.raft.as_ref();
 
-        let kv_wb = WriteBatch::new();
-        let raft_wb = WriteBatch::new();
+        let kv_wb = WriteBatch::default();
+        let raft_wb = WriteBatch::default();
         let kv_handle = box_try!(get_cf_handle(kv, CF_RAFT));
 
         if region.get_start_key() >= region.get_end_key() && !region.get_end_key().is_empty() {
@@ -640,7 +640,7 @@ impl Debugger {
                     return Ok(true);
                 }
 
-                let mut region_state = RegionLocalState::new();
+                let mut region_state = RegionLocalState::default();
                 box_try!(region_state.merge_from_bytes(value));
                 if region_state.get_state() == PeerState::Tombstone {
                     return Ok(true);
@@ -662,7 +662,7 @@ impl Debugger {
         ));
 
         // RegionLocalState.
-        let mut region_state = RegionLocalState::new();
+        let mut region_state = RegionLocalState::default();
         region_state.set_state(PeerState::Normal);
         region_state.set_region(region);
         let key = keys::region_state_key(region_id);
@@ -871,7 +871,7 @@ fn recover_mvcc_for_range(
     let wb_limit: usize = 10240;
 
     loop {
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         mvcc_checker.check_mvcc(&wb, Some(wb_limit))?;
 
         let batch_size = wb.count();
@@ -1275,7 +1275,7 @@ impl MvccInfoIterator {
             return Ok(None);
         }
 
-        let mut mvcc_info = MvccInfo::new();
+        let mut mvcc_info = MvccInfo::default();
         let mut min_prefix = Vec::new();
 
         let (lock_ok, writes_ok) = match (self.lock_iter.valid(), self.write_iter.valid()) {
@@ -1404,8 +1404,8 @@ fn set_region_tombstone(db: &DB, store_id: u64, region: Region, wb: &WriteBatch)
 
 fn divide_db(db: &DB, parts: usize) -> crate::raftstore::Result<Vec<Vec<u8>>> {
     // Empty start and end key cover all range.
-    let mut region = Region::new();
-    region.mut_peers().push(Peer::new());
+    let mut region = Region::default();
+    region.mut_peers().push(Peer::default());
     let default_cf_size = box_try!(get_region_approximate_keys_cf(db, CF_DEFAULT, &region));
     let write_cf_size = box_try!(get_region_approximate_keys_cf(db, CF_WRITE, &region));
 
@@ -1492,15 +1492,15 @@ mod tests {
 
     fn init_region_state(engine: &DB, region_id: u64, stores: &[u64]) -> Region {
         let cf_raft = engine.cf_handle(CF_RAFT).unwrap();
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(region_id);
         for (i, &store_id) in stores.iter().enumerate() {
-            let mut peer = Peer::new();
+            let mut peer = Peer::default();
             peer.set_id(i as u64);
             peer.set_store_id(store_id);
             region.mut_peers().push(peer);
         }
-        let mut region_state = RegionLocalState::new();
+        let mut region_state = RegionLocalState::default();
         region_state.set_state(PeerState::Normal);
         region_state.set_region(region.clone());
         let key = keys::region_state_key(region_id);
@@ -1607,7 +1607,7 @@ mod tests {
 
     impl Debugger {
         fn set_store_id(&self, store_id: u64) {
-            let mut ident = StoreIdent::new();
+            let mut ident = StoreIdent::default();
             ident.set_store_id(store_id);
             let db = &self.engines.kv;
             db.put_msg(keys::STORE_IDENT_KEY, &ident).unwrap();
@@ -1637,7 +1637,7 @@ mod tests {
         let engine = &debugger.engines.raft;
         let (region_id, log_index) = (1, 1);
         let key = keys::raft_log_key(region_id, log_index);
-        let mut entry = Entry::new();
+        let mut entry = Entry::default();
         entry.set_term(1);
         entry.set_index(1);
         entry.set_entry_type(EntryType::EntryNormal);
@@ -1661,7 +1661,7 @@ mod tests {
         let region_id = 1;
 
         let raft_state_key = keys::raft_state_key(region_id);
-        let mut raft_state = RaftLocalState::new();
+        let mut raft_state = RaftLocalState::default();
         raft_state.set_last_index(42);
         raft_engine.put_msg(&raft_state_key, &raft_state).unwrap();
         assert_eq!(
@@ -1673,7 +1673,7 @@ mod tests {
         );
 
         let apply_state_key = keys::apply_state_key(region_id);
-        let mut apply_state = RaftApplyState::new();
+        let mut apply_state = RaftApplyState::default();
         apply_state.set_applied_index(42);
         kv_engine
             .put_msg_cf(raft_cf, &apply_state_key, &apply_state)
@@ -1687,7 +1687,7 @@ mod tests {
         );
 
         let region_state_key = keys::region_state_key(region_id);
-        let mut region_state = RegionLocalState::new();
+        let mut region_state = RegionLocalState::default();
         region_state.set_state(PeerState::Tombstone);
         kv_engine
             .put_msg_cf(raft_cf, &region_state_key, &region_state)
@@ -1717,11 +1717,11 @@ mod tests {
 
         let region_id = 1;
         let region_state_key = keys::region_state_key(region_id);
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(region_id);
         region.set_start_key(b"a".to_vec());
         region.set_end_key(b"zz".to_vec());
-        let mut state = RegionLocalState::new();
+        let mut state = RegionLocalState::default();
         state.set_region(region);
         let cf_raft = engine.cf_handle(CF_RAFT).unwrap();
         engine
@@ -1922,22 +1922,22 @@ mod tests {
         let raft_engine = debugger.engines.raft.as_ref();
         let store_id = 1; // It's a fake id.
 
-        let wb1 = WriteBatch::new();
+        let wb1 = WriteBatch::default();
         let handle1 = get_cf_handle(raft_engine, CF_DEFAULT).unwrap();
 
-        let wb2 = WriteBatch::new();
+        let wb2 = WriteBatch::default();
         let handle2 = get_cf_handle(kv_engine, CF_RAFT).unwrap();
 
         {
             let mock_region_state = |region_id: u64, peers: &[u64]| {
                 let region_state_key = keys::region_state_key(region_id);
-                let mut region_state = RegionLocalState::new();
+                let mut region_state = RegionLocalState::default();
                 region_state.set_state(PeerState::Normal);
                 {
                     let region = region_state.mut_region();
                     region.set_id(region_id);
                     let peers = peers.iter().enumerate().map(|(i, &sid)| {
-                        let mut peer = Peer::new();
+                        let mut peer = Peer::default();
                         peer.id = i as u64;
                         peer.store_id = sid;
                         peer
@@ -1949,7 +1949,7 @@ mod tests {
             };
             let mock_raft_state = |region_id: u64, last_index: u64, commit_index: u64| {
                 let raft_state_key = keys::raft_state_key(region_id);
-                let mut raft_state = RaftLocalState::new();
+                let mut raft_state = RaftLocalState::default();
                 raft_state.set_last_index(last_index);
                 raft_state.mut_hard_state().set_commit(commit_index);
                 wb1.put_msg_cf(handle1, &raft_state_key, &raft_state)
@@ -1957,7 +1957,7 @@ mod tests {
             };
             let mock_apply_state = |region_id: u64, apply_index: u64| {
                 let raft_apply_key = keys::apply_state_key(region_id);
-                let mut apply_state = RaftApplyState::new();
+                let mut apply_state = RaftApplyState::default();
                 apply_state.set_applied_index(apply_index);
                 wb2.put_msg_cf(handle2, &raft_apply_key, &apply_state)
                     .unwrap();
@@ -2023,12 +2023,12 @@ mod tests {
         for (region_id, (start, end)) in metadata.into_iter().enumerate() {
             let region_id = region_id as u64;
             let cf_raft = engine.cf_handle(CF_RAFT).unwrap();
-            let mut region = Region::new();
+            let mut region = Region::default();
             region.set_id(region_id);
             region.set_start_key(start.to_owned().into_bytes());
             region.set_end_key(end.to_owned().into_bytes());
 
-            let mut region_state = RegionLocalState::new();
+            let mut region_state = RegionLocalState::default();
             region_state.set_state(PeerState::Normal);
             region_state.set_region(region);
             let key = keys::region_state_key(region_id);
@@ -2041,7 +2041,7 @@ mod tests {
             engine.delete_cf(cf_raft, &key).unwrap();
         };
 
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(100);
 
         region.set_start_key(b"k".to_vec());
@@ -2177,7 +2177,7 @@ mod tests {
             .collect();
         let db = Arc::new(new_engine_opt(path_str, DBOptions::new(), cfs_opts).unwrap());
         // Write initial KVs.
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         for &(cf, ref k, ref v, _) in &kv {
             wb.put_cf(
                 get_cf_handle(&db, cf).unwrap(),
@@ -2189,7 +2189,7 @@ mod tests {
         db.write(&wb).unwrap();
         // Fix problems.
         let mut checker = MvccChecker::new(Arc::clone(&db), b"k", b"k8").unwrap();
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         checker.check_mvcc(&wb, None).unwrap();
         db.write(&wb).unwrap();
         // Check result.
@@ -2229,7 +2229,7 @@ mod tests {
 
         let debugger = new_debugger();
 
-        let wb = WriteBatch::new();
+        let wb = WriteBatch::default();
         for key in keys {
             let data_key = keys::data_key(key);
             let value = key.to_vec();

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -79,7 +79,7 @@ where
         store_cfg: &StoreConfig,
         pd_client: Arc<C>,
     ) -> Node<C> {
-        let mut store = metapb::Store::new();
+        let mut store = metapb::Store::default();
         store.set_id(INVALID_ID);
         if cfg.advertise_addr.is_empty() {
             store.set_address(cfg.addr.clone());
@@ -90,7 +90,7 @@ where
 
         let mut labels = Vec::new();
         for (k, v) in &cfg.labels {
-            let mut label = metapb::StoreLabel::new();
+            let mut label = metapb::StoreLabel::default();
             label.set_key(k.to_owned());
             label.set_value(v.to_owned());
             labels.push(label);

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -74,7 +74,7 @@ impl Conn {
         let (batch_sink, batch_receiver) = client1.batch_raft().unwrap();
         let batch_send_or_fallback = batch_sink
             .send_all(Reusable(rx1).map(move |v| {
-                let mut batch_msgs = BatchRaftMessage::new();
+                let mut batch_msgs = BatchRaftMessage::default();
                 batch_msgs.set_msgs(RepeatedField::from(v));
                 (batch_msgs, WriteFlags::default().buffer_hint(false))
             }))

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -231,7 +231,7 @@ mod tests {
     }
 
     fn new_store(addr: &str, state: metapb::StoreState) -> metapb::Store {
-        let mut store = metapb::Store::new();
+        let mut store = metapb::Store::default();
         store.set_id(1);
         store.set_state(state);
         store.set_address(addr.into());

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -356,11 +356,11 @@ mod tests {
         server.start(cfg, security_mgr).unwrap();
 
         let mut trans = server.transport();
-        trans.report_unreachable(RaftMessage::new());
+        trans.report_unreachable(RaftMessage::default());
         let mut resp = significant_msg_receiver.try_recv().unwrap();
         assert!(is_unreachable_to(&resp, 0, 0), "{:?}", resp);
 
-        let mut msg = RaftMessage::new();
+        let mut msg = RaftMessage::default();
         msg.set_region_id(1);
         trans.send(msg.clone()).unwrap();
         trans.flush();

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -99,7 +99,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                     .and_then(move |debugger| debugger.get(db, &cf, key.as_slice())),
             )
             .map(|value| {
-                let mut resp = GetResponse::new();
+                let mut resp = GetResponse::default();
                 resp.set_value(value);
                 resp
             });
@@ -125,7 +125,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                     .and_then(move |debugger| debugger.raft_log(region_id, log_index)),
             )
             .map(|entry| {
-                let mut resp = RaftLogResponse::new();
+                let mut resp = RaftLogResponse::default();
                 resp.set_entry(entry);
                 resp
             });
@@ -150,7 +150,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                     .and_then(move |debugger| debugger.region_info(region_id)),
             )
             .map(|region_info| {
-                let mut resp = RegionInfoResponse::new();
+                let mut resp = RegionInfoResponse::default();
                 if let Some(raft_local_state) = region_info.raft_local_state {
                     resp.set_raft_local_state(raft_local_state);
                 }
@@ -184,12 +184,12 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                     .and_then(move |debugger| debugger.region_size(region_id, cfs)),
             )
             .map(|entries| {
-                let mut resp = RegionSizeResponse::new();
+                let mut resp = RegionSizeResponse::default();
                 resp.set_entries(
                     entries
                         .into_iter()
                         .map(|(cf, size)| {
-                            let mut entry = RegionSizeResponse_Entry::new();
+                            let mut entry = RegionSizeResponse_Entry::default();
                             entry.set_cf(cf);
                             entry.set_size(size as u64);
                             entry
@@ -218,7 +218,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                 stream::iter_result(iter)
                     .map_err(|e| error_to_grpc_error("scan_mvcc", e))
                     .map(|(key, mvcc_info)| {
-                        let mut resp = ScanMvccResponse::new();
+                        let mut resp = ScanMvccResponse::default();
                         resp.set_key(key);
                         resp.set_info(mvcc_info);
                         (resp, WriteFlags::default())
@@ -269,7 +269,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
             if let Err(e) = fail::cfg(name, actions) {
                 return Err(box_err!("{:?}", e));
             }
-            Ok(InjectFailPointResponse::new())
+            Ok(InjectFailPointResponse::default())
         });
 
         self.handle_response(ctx, sink, f, TAG);
@@ -289,7 +289,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
                 return Err(Error::InvalidArgument("Failure Type INVALID".to_owned()));
             }
             fail::remove(name);
-            Ok(RecoverFailPointResponse::new())
+            Ok(RecoverFailPointResponse::default())
         });
 
         self.handle_response(ctx, sink, f, TAG);
@@ -305,12 +305,12 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
 
         let f = self.pool.spawn_fn(move || {
             let list = fail::list().into_iter().map(|(name, actions)| {
-                let mut entry = ListFailPointsResponse_Entry::new();
+                let mut entry = ListFailPointsResponse_Entry::default();
                 entry.set_name(name);
                 entry.set_actions(actions);
                 entry
             });
-            let mut resp = ListFailPointsResponse::new();
+            let mut resp = ListFailPointsResponse::default();
             resp.set_entries(list.collect());
             Ok(resp)
         });
@@ -328,7 +328,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
 
         let debugger = self.debugger.clone();
         let f = self.pool.spawn_fn(move || {
-            let mut resp = GetMetricsResponse::new();
+            let mut resp = GetMetricsResponse::default();
             resp.set_store_id(debugger.get_store_id()?);
             resp.set_prometheus(metrics::dump());
             if req.get_all() {
@@ -360,7 +360,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
         let f = self
             .pool
             .spawn(consistency_check)
-            .map(|_| RegionConsistencyCheckResponse::new());
+            .map(|_| RegionConsistencyCheckResponse::default());
         self.handle_response(ctx, sink, f, "check_region_consistency");
     }
 
@@ -381,7 +381,7 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
             .spawn(future::ok(self.debugger.clone()).and_then(move |debugger| {
                 debugger.modify_tikv_config(module, &config_name, &config_value)
             }))
-            .map(|_| ModifyTikvConfigResponse::new());
+            .map(|_| ModifyTikvConfigResponse::default());
 
         self.handle_response(ctx, sink, f, TAG);
     }
@@ -399,9 +399,9 @@ impl<T: RaftStoreRouter + 'static> debugpb_grpc::Debug for Service<T> {
             .pool
             .spawn_fn(move || debugger.get_region_properties(req.get_region_id()))
             .map(|props| {
-                let mut resp = GetRegionPropertiesResponse::new();
+                let mut resp = GetRegionPropertiesResponse::default();
                 for (name, value) in props {
-                    let mut prop = Property::new();
+                    let mut prop = Property::default();
                     prop.set_name(name);
                     prop.set_value(value);
                     resp.mut_props().push(prop);
@@ -418,12 +418,12 @@ fn region_detail<T: RaftStoreRouter>(
     region_id: u64,
     store_id: u64,
 ) -> impl Future<Item = RegionDetailResponse, Error = Error> {
-    let mut header = RaftRequestHeader::new();
+    let mut header = RaftRequestHeader::default();
     header.set_region_id(region_id);
     header.mut_peer().set_store_id(store_id);
-    let mut status_request = StatusRequest::new();
+    let mut status_request = StatusRequest::default();
     status_request.set_cmd_type(StatusCmdType::RegionDetail);
-    let mut raft_cmd = RaftCmdRequest::new();
+    let mut raft_cmd = RaftCmdRequest::default();
     raft_cmd.set_header(header);
     raft_cmd.set_status_request(status_request);
 
@@ -456,12 +456,12 @@ fn consistency_check<T: RaftStoreRouter>(
     raft_router: T,
     mut detail: RegionDetailResponse,
 ) -> impl Future<Item = (), Error = Error> {
-    let mut header = RaftRequestHeader::new();
+    let mut header = RaftRequestHeader::default();
     header.set_region_id(detail.get_region().get_id());
     header.set_peer(detail.take_leader());
-    let mut admin_request = AdminRequest::new();
+    let mut admin_request = AdminRequest::default();
     admin_request.set_cmd_type(AdminCmdType::ComputeHash);
-    let mut raft_cmd = RaftCmdRequest::new();
+    let mut raft_cmd = RaftCmdRequest::default();
     raft_cmd.set_header(header);
     raft_cmd.set_admin_request(admin_request);
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -575,7 +575,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
 
         let future = AndThenWith::new(res, f.map_err(Error::from))
             .and_then(|v| {
-                let mut resp = UnsafeDestroyRangeResponse::new();
+                let mut resp = UnsafeDestroyRangeResponse::default();
                 // Region error is impossible here.
                 if let Err(e) = v {
                     resp.set_error(format!("{}", e));
@@ -744,7 +744,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
 
         let future = AndThenWith::new(res, f.map_err(Error::from))
             .and_then(|v| {
-                let mut resp = MvccGetByKeyResponse::new();
+                let mut resp = MvccGetByKeyResponse::default();
                 if let Some(err) = extract_region_error(&v) {
                     resp.set_region_error(err);
                 } else {
@@ -786,7 +786,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
 
         let future = AndThenWith::new(res, f.map_err(Error::from))
             .and_then(|v| {
-                let mut resp = MvccGetByStartTsResponse::new();
+                let mut resp = MvccGetByStartTsResponse::default();
                 if let Some(err) = extract_region_error(&v) {
                     resp.set_region_error(err);
                 } else {
@@ -838,7 +838,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         let future = future
             .map_err(Error::from)
             .map(move |mut v| {
-                let mut resp = SplitRegionResponse::new();
+                let mut resp = SplitRegionResponse::default();
                 if v.response.get_header().has_error() {
                     resp.set_region_error(v.response.mut_header().take_error());
                 } else {
@@ -884,9 +884,9 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         let timer = GRPC_MSG_HISTOGRAM_VEC.read_index.start_coarse_timer();
 
         let region_id = req.get_context().get_region_id();
-        let mut cmd = RaftCmdRequest::new();
-        let mut header = RaftRequestHeader::new();
-        let mut inner_req = RaftRequest::new();
+        let mut cmd = RaftCmdRequest::default();
+        let mut header = RaftRequestHeader::default();
+        let mut inner_req = RaftRequest::default();
         inner_req.set_cmd_type(CmdType::ReadIndex);
         header.set_region_id(req.get_context().get_region_id());
         header.set_peer(req.get_context().get_peer().clone());
@@ -909,7 +909,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine> tikvpb_grpc::Tikv for Service<T, E
         let future = future
             .map_err(Error::from)
             .map(move |mut v| {
-                let mut resp = ReadIndexResponse::new();
+                let mut resp = ReadIndexResponse::default();
                 if v.response.get_header().has_error() {
                     resp.set_region_error(v.response.mut_header().take_error());
                 } else {
@@ -1059,7 +1059,7 @@ fn handle_batch_commands_request<E: Engine>(
     macro_rules! oneof {
         ($p:path) => {
             |resp| {
-                let mut res = BatchCommandsResponse_Response::new();
+                let mut res = BatchCommandsResponse_Response::default();
                 res.cmd = Some($p(resp));
                 res
             }
@@ -1279,7 +1279,7 @@ fn future_handle_empty(
     tikv_util::timer::GLOBAL_TIMER_HANDLE
         .delay(std::time::Instant::now() + std::time::Duration::from_millis(req.get_delay_time()))
         .map(move |_| {
-            let mut res = BatchCommandsEmptyResponse::new();
+            let mut res = BatchCommandsEmptyResponse::default();
             res.set_test_id(req.get_test_id());
             res
         })
@@ -1297,7 +1297,7 @@ fn future_get<E: Engine>(
             req.get_version(),
         )
         .then(|v| {
-            let mut resp = GetResponse::new();
+            let mut resp = GetResponse::default();
             if let Some(err) = extract_region_error(&v) {
                 resp.set_region_error(err);
             } else {
@@ -1335,7 +1335,7 @@ fn future_scan<E: Engine>(
             options,
         )
         .then(|v| {
-            let mut resp = ScanResponse::new();
+            let mut resp = ScanResponse::default();
             if let Some(err) = extract_region_error(&v) {
                 resp.set_region_error(err);
             } else {
@@ -1378,7 +1378,7 @@ fn future_prewrite<E: Engine>(
     );
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = PrewriteResponse::new();
+        let mut resp = PrewriteResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else {
@@ -1419,7 +1419,7 @@ fn future_acquire_pessimistic_lock<E: Engine>(
     );
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = PessimisticLockResponse::new();
+        let mut resp = PessimisticLockResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else {
@@ -1444,7 +1444,7 @@ fn future_pessimistic_rollback<E: Engine>(
     );
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = PessimisticRollbackResponse::new();
+        let mut resp = PessimisticRollbackResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else {
@@ -1469,7 +1469,7 @@ fn future_commit<E: Engine>(
     );
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = CommitResponse::new();
+        let mut resp = CommitResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else if let Err(e) = v {
@@ -1492,7 +1492,7 @@ fn future_cleanup<E: Engine>(
     );
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = CleanupResponse::new();
+        let mut resp = CleanupResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else if let Err(e) = v {
@@ -1514,7 +1514,7 @@ fn future_batch_get<E: Engine>(
     storage
         .async_batch_get(req.take_context(), keys, req.get_version())
         .then(|v| {
-            let mut resp = BatchGetResponse::new();
+            let mut resp = BatchGetResponse::default();
             if let Some(err) = extract_region_error(&v) {
                 resp.set_region_error(err);
             } else {
@@ -1534,7 +1534,7 @@ fn future_batch_rollback<E: Engine>(
     let res = storage.async_rollback(req.take_context(), keys, req.get_start_version(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = BatchRollbackResponse::new();
+        let mut resp = BatchRollbackResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else if let Err(e) = v {
@@ -1558,7 +1558,7 @@ fn future_scan_lock<E: Engine>(
     );
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = ScanLockResponse::new();
+        let mut resp = ScanLockResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else {
@@ -1604,7 +1604,7 @@ fn future_resolve_lock<E: Engine>(
     };
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = ResolveLockResponse::new();
+        let mut resp = ResolveLockResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else if let Err(e) = v {
@@ -1622,7 +1622,7 @@ fn future_gc<E: Engine>(
     let res = storage.async_gc(req.take_context(), req.get_safe_point(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = GCResponse::new();
+        let mut resp = GCResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else if let Err(e) = v {
@@ -1646,7 +1646,7 @@ fn future_delete_range<E: Engine>(
     );
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = DeleteRangeResponse::new();
+        let mut resp = DeleteRangeResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else if let Err(e) = v {
@@ -1663,7 +1663,7 @@ fn future_raw_get<E: Engine>(
     storage
         .async_raw_get(req.take_context(), req.take_cf(), req.take_key())
         .then(|v| {
-            let mut resp = RawGetResponse::new();
+            let mut resp = RawGetResponse::default();
             if let Some(err) = extract_region_error(&v) {
                 resp.set_region_error(err);
             } else {
@@ -1685,7 +1685,7 @@ fn future_raw_batch_get<E: Engine>(
     storage
         .async_raw_batch_get(req.take_context(), req.take_cf(), keys)
         .then(|v| {
-            let mut resp = RawBatchGetResponse::new();
+            let mut resp = RawBatchGetResponse::default();
             if let Some(err) = extract_region_error(&v) {
                 resp.set_region_error(err);
             } else {
@@ -1709,7 +1709,7 @@ fn future_raw_put<E: Engine>(
     );
 
     AndThenWith::new(res, future.map_err(Error::from)).map(|v| {
-        let mut resp = RawPutResponse::new();
+        let mut resp = RawPutResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else if let Err(e) = v {
@@ -1734,7 +1734,7 @@ fn future_raw_batch_put<E: Engine>(
     let res = storage.async_raw_batch_put(req.take_context(), cf, pairs, cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = RawBatchPutResponse::new();
+        let mut resp = RawBatchPutResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else if let Err(e) = v {
@@ -1752,7 +1752,7 @@ fn future_raw_delete<E: Engine>(
     let res = storage.async_raw_delete(req.take_context(), req.take_cf(), req.take_key(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = RawDeleteResponse::new();
+        let mut resp = RawDeleteResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else if let Err(e) = v {
@@ -1772,7 +1772,7 @@ fn future_raw_batch_delete<E: Engine>(
     let res = storage.async_raw_batch_delete(req.take_context(), cf, keys, cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = RawBatchDeleteResponse::new();
+        let mut resp = RawBatchDeleteResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else if let Err(e) = v {
@@ -1802,7 +1802,7 @@ fn future_raw_scan<E: Engine>(
             req.get_reverse(),
         )
         .then(|v| {
-            let mut resp = RawScanResponse::new();
+            let mut resp = RawScanResponse::default();
             if let Some(err) = extract_region_error(&v) {
                 resp.set_region_error(err);
             } else {
@@ -1826,7 +1826,7 @@ fn future_raw_batch_scan<E: Engine>(
             req.get_reverse(),
         )
         .then(|v| {
-            let mut resp = RawBatchScanResponse::new();
+            let mut resp = RawBatchScanResponse::default();
             if let Some(err) = extract_region_error(&v) {
                 resp.set_region_error(err);
             } else {
@@ -1850,7 +1850,7 @@ fn future_raw_delete_range<E: Engine>(
     );
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
-        let mut resp = RawDeleteRangeResponse::new();
+        let mut resp = RawDeleteRangeResponse::default();
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else if let Err(e) = v {
@@ -1879,15 +1879,15 @@ fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
             Some(e.to_owned())
         }
         Err(Error::SchedTooBusy) => {
-            let mut err = RegionError::new();
-            let mut server_is_busy_err = ServerIsBusy::new();
+            let mut err = RegionError::default();
+            let mut server_is_busy_err = ServerIsBusy::default();
             server_is_busy_err.set_reason(SCHEDULER_IS_BUSY.to_owned());
             err.set_server_is_busy(server_is_busy_err);
             Some(err)
         }
         Err(Error::GCWorkerTooBusy) => {
-            let mut err = RegionError::new();
-            let mut server_is_busy_err = ServerIsBusy::new();
+            let mut err = RegionError::default();
+            let mut server_is_busy_err = ServerIsBusy::default();
             server_is_busy_err.set_reason(GC_WORKER_IS_BUSY.to_owned());
             err.set_server_is_busy(server_is_busy_err);
             Some(err)
@@ -1904,7 +1904,7 @@ fn extract_committed(err: &storage::Error) -> Option<u64> {
 }
 
 fn extract_key_error(err: &storage::Error) -> KeyError {
-    let mut key_error = KeyError::new();
+    let mut key_error = KeyError::default();
     match *err {
         storage::Error::Txn(TxnError::Mvcc(MvccError::KeyIsLocked {
             ref key,
@@ -1913,7 +1913,7 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
             ttl,
             txn_size,
         })) => {
-            let mut lock_info = LockInfo::new();
+            let mut lock_info = LockInfo::default();
             lock_info.set_key(key.to_owned());
             lock_info.set_primary_lock(primary.to_owned());
             lock_info.set_lock_version(ts);
@@ -1930,7 +1930,7 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
             ref primary,
             ..
         })) => {
-            let mut write_conflict = WriteConflict::new();
+            let mut write_conflict = WriteConflict::default();
             write_conflict.set_start_ts(start_ts);
             write_conflict.set_conflict_ts(conflict_start_ts);
             write_conflict.set_conflict_commit_ts(conflict_commit_ts);
@@ -1941,7 +1941,7 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
             key_error.set_retryable(format!("{:?}", err));
         }
         storage::Error::Txn(TxnError::Mvcc(MvccError::AlreadyExist { ref key })) => {
-            let mut exist = AlreadyExist::new();
+            let mut exist = AlreadyExist::default();
             exist.set_key(key.clone());
             key_error.set_already_exist(exist);
         }
@@ -1957,7 +1957,7 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
             ..
         })) => {
             warn!("txn deadlocks"; "err" => ?err);
-            let mut deadlock = Deadlock::new();
+            let mut deadlock = Deadlock::default();
             deadlock.set_lock_ts(lock_ts);
             deadlock.set_lock_key(lock_key.to_owned());
             deadlock.set_deadlock_key_hash(deadlock_key_hash);
@@ -1977,20 +1977,20 @@ fn extract_kv_pairs(res: storage::Result<Vec<storage::Result<storage::KvPair>>>)
             .into_iter()
             .map(|r| match r {
                 Ok((key, value)) => {
-                    let mut pair = KvPair::new();
+                    let mut pair = KvPair::default();
                     pair.set_key(key);
                     pair.set_value(value);
                     pair
                 }
                 Err(e) => {
-                    let mut pair = KvPair::new();
+                    let mut pair = KvPair::default();
                     pair.set_error(extract_key_error(&e));
                     pair
                 }
             })
             .collect(),
         Err(e) => {
-            let mut pair = KvPair::new();
+            let mut pair = KvPair::default();
             pair.set_error(extract_key_error(&e));
             vec![pair]
         }
@@ -1998,9 +1998,9 @@ fn extract_kv_pairs(res: storage::Result<Vec<storage::Result<storage::KvPair>>>)
 }
 
 fn extract_mvcc_info(mvcc: storage::MvccInfo) -> MvccInfo {
-    let mut mvcc_info = MvccInfo::new();
+    let mut mvcc_info = MvccInfo::default();
     if let Some(lock) = mvcc.lock {
-        let mut lock_info = MvccLock::new();
+        let mut lock_info = MvccLock::default();
         let op = match lock.lock_type {
             LockType::Put => Op::Put,
             LockType::Delete => Op::Del,
@@ -2023,7 +2023,7 @@ fn extract_mvcc_info(mvcc: storage::MvccInfo) -> MvccInfo {
 fn extract_2pc_values(res: Vec<(u64, Value)>) -> Vec<MvccValue> {
     res.into_iter()
         .map(|(start_ts, value)| {
-            let mut value_info = MvccValue::new();
+            let mut value_info = MvccValue::default();
             value_info.set_start_ts(start_ts);
             value_info.set_value(value);
             value_info
@@ -2034,7 +2034,7 @@ fn extract_2pc_values(res: Vec<(u64, Value)>) -> Vec<MvccValue> {
 fn extract_2pc_writes(res: Vec<(u64, MvccWrite)>) -> Vec<kvrpcpb::MvccWrite> {
     res.into_iter()
         .map(|(commit_ts, write)| {
-            let mut write_info = kvrpcpb::MvccWrite::new();
+            let mut write_info = kvrpcpb::MvccWrite::default();
             let op = match write.write_type {
                 WriteType::Put => Op::Put,
                 WriteType::Delete => Op::Del,
@@ -2088,8 +2088,8 @@ mod tests {
             key: key.clone(),
             primary: primary.clone(),
         }));
-        let mut expect = KeyError::new();
-        let mut write_conflict = WriteConflict::new();
+        let mut expect = KeyError::default();
+        let mut write_conflict = WriteConflict::default();
         write_conflict.set_start_ts(start_ts);
         write_conflict.set_conflict_ts(conflict_start_ts);
         write_conflict.set_conflict_commit_ts(conflict_commit_ts);

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -79,7 +79,7 @@ impl Stream for SnapChunk {
         match result {
             Ok(_) => {
                 self.remain_bytes -= buf.len();
-                let mut chunk = SnapshotChunk::new();
+                let mut chunk = SnapshotChunk::default();
                 chunk.set_data(buf);
                 Ok(Async::Ready(Some((
                     chunk,
@@ -131,7 +131,7 @@ fn send_snap(
     let total_size = s.total_size()?;
 
     let chunks = {
-        let mut first_chunk = SnapshotChunk::new();
+        let mut first_chunk = SnapshotChunk::default();
         first_chunk.set_message(msg);
 
         SnapChunk {
@@ -281,7 +281,7 @@ fn recv_snap<R: RaftStoreRouter + 'static>(
         },
     );
     f.then(move |res| match res {
-        Ok(()) => sink.success(Done::new()),
+        Ok(()) => sink.success(Done::default()),
         Err(e) => {
             let status = RpcStatus::new(RpcStatusCode::Unknown, Some(format!("{:?}", e)));
             sink.fail(status)

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -355,7 +355,6 @@ mod tests {
     use crate::config::TiKvConfig;
     use crate::server::status_server::StatusServer;
     use futures::future::{lazy, Future};
-    #[cfg(not(feature = "no-fail"))]
     use futures::Stream;
     use hyper::{Body, Client, Method, Request, StatusCode, Uri};
 

--- a/src/storage/gc_worker.rs
+++ b/src/storage/gc_worker.rs
@@ -1279,7 +1279,7 @@ mod tests {
         let regions: BTreeMap<_, _> = regions
             .into_iter()
             .map(|(start_key, end_key, id)| {
-                let mut r = metapb::Region::new();
+                let mut r = metapb::Region::default();
                 r.set_id(id);
                 r.set_start_key(start_key.clone());
                 r.set_end_key(end_key);

--- a/src/storage/kv/btree_engine.rs
+++ b/src/storage/kv/btree_engine.rs
@@ -310,7 +310,7 @@ pub mod tests {
         for (k, v) in &test_data {
             must_put(&engine, k.as_slice(), v.as_slice());
         }
-        let snap = engine.snapshot(&Context::new()).unwrap();
+        let snap = engine.snapshot(&Context::default()).unwrap();
         let mut statistics = CFStatistics::default();
 
         // lower bound > upper bound, seek() returns false.

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -236,7 +236,7 @@ impl CFStatistics {
     }
 
     pub fn scan_info(&self) -> ScanInfo {
-        let mut info = ScanInfo::new();
+        let mut info = ScanInfo::default();
         info.set_processed(self.processed as i64);
         info.set_total(self.total_op_count() as i64);
         info
@@ -274,7 +274,7 @@ impl Statistics {
     }
 
     pub fn scan_detail(&self) -> ScanDetail {
-        let mut detail = ScanDetail::new();
+        let mut detail = ScanDetail::default();
         detail.set_data(self.data.scan_info());
         detail.set_lock(self.lock.scan_info());
         detail.set_write(self.write.scan_info());
@@ -726,33 +726,35 @@ pub mod tests {
 
     pub fn must_put<E: Engine>(engine: &E, key: &[u8], value: &[u8]) {
         engine
-            .put(&Context::new(), Key::from_raw(key), value.to_vec())
+            .put(&Context::default(), Key::from_raw(key), value.to_vec())
             .unwrap();
     }
 
     pub fn must_put_cf<E: Engine>(engine: &E, cf: CfName, key: &[u8], value: &[u8]) {
         engine
-            .put_cf(&Context::new(), cf, Key::from_raw(key), value.to_vec())
+            .put_cf(&Context::default(), cf, Key::from_raw(key), value.to_vec())
             .unwrap();
     }
 
     pub fn must_delete<E: Engine>(engine: &E, key: &[u8]) {
-        engine.delete(&Context::new(), Key::from_raw(key)).unwrap();
+        engine
+            .delete(&Context::default(), Key::from_raw(key))
+            .unwrap();
     }
 
     pub fn must_delete_cf<E: Engine>(engine: &E, cf: CfName, key: &[u8]) {
         engine
-            .delete_cf(&Context::new(), cf, Key::from_raw(key))
+            .delete_cf(&Context::default(), cf, Key::from_raw(key))
             .unwrap();
     }
 
     pub fn assert_has<E: Engine>(engine: &E, key: &[u8], value: &[u8]) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         assert_eq!(snapshot.get(&Key::from_raw(key)).unwrap().unwrap(), value);
     }
 
     pub fn assert_has_cf<E: Engine>(engine: &E, cf: CfName, key: &[u8], value: &[u8]) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         assert_eq!(
             snapshot.get_cf(cf, &Key::from_raw(key)).unwrap().unwrap(),
             value
@@ -760,17 +762,17 @@ pub mod tests {
     }
 
     pub fn assert_none<E: Engine>(engine: &E, key: &[u8]) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         assert_eq!(snapshot.get(&Key::from_raw(key)).unwrap(), None);
     }
 
     pub fn assert_none_cf<E: Engine>(engine: &E, cf: CfName, key: &[u8]) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         assert_eq!(snapshot.get_cf(cf, &Key::from_raw(key)).unwrap(), None);
     }
 
     fn assert_seek<E: Engine>(engine: &E, key: &[u8], pair: (&[u8], &[u8])) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -781,7 +783,7 @@ pub mod tests {
     }
 
     fn assert_reverse_seek<E: Engine>(engine: &E, key: &[u8], pair: (&[u8], &[u8])) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -842,7 +844,7 @@ pub mod tests {
     fn test_batch<E: Engine>(engine: &E) {
         engine
             .write(
-                &Context::new(),
+                &Context::default(),
                 vec![
                     Modify::Put(CF_DEFAULT, Key::from_raw(b"x"), b"1".to_vec()),
                     Modify::Put(CF_DEFAULT, Key::from_raw(b"y"), b"2".to_vec()),
@@ -854,7 +856,7 @@ pub mod tests {
 
         engine
             .write(
-                &Context::new(),
+                &Context::default(),
                 vec![
                     Modify::Delete(CF_DEFAULT, Key::from_raw(b"x")),
                     Modify::Delete(CF_DEFAULT, Key::from_raw(b"y")),
@@ -875,7 +877,7 @@ pub mod tests {
         assert_seek(engine, b"x\x00", (b"z", b"2"));
         assert_reverse_seek(engine, b"y", (b"x", b"1"));
         assert_reverse_seek(engine, b"z", (b"x", b"1"));
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut iter = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -893,7 +895,7 @@ pub mod tests {
     fn test_near_seek<E: Engine>(engine: &E) {
         must_put(engine, b"x", b"1");
         must_put(engine, b"z", b"2");
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -912,7 +914,7 @@ pub mod tests {
             let key = format!("y{}", i);
             must_put(engine, key.as_bytes(), b"3");
         }
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -928,7 +930,7 @@ pub mod tests {
     }
 
     fn test_empty_seek<E: Engine>(engine: &E) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut cursor = snapshot
             .iter(IterOption::default(), ScanMode::Mixed)
             .unwrap();
@@ -1055,7 +1057,7 @@ pub mod tests {
             let value = format!("value_{}", i);
             must_put(engine, key.as_bytes(), value.as_bytes());
         }
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         for step in 1..SEEK_BOUND as usize * 3 {
             for start in 0..10 {
@@ -1106,7 +1108,7 @@ pub mod tests {
     }
 
     fn test_empty_write<E: Engine>(engine: &E) {
-        engine.write(&Context::new(), vec![]).unwrap_err();
+        engine.write(&Context::default(), vec![]).unwrap_err();
     }
 
     pub fn test_cfs_statistics<E: Engine>(engine: &E) {
@@ -1121,7 +1123,7 @@ pub mod tests {
         must_delete(engine, b"foo42");
         must_delete(engine, b"foo5");
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut iter = snapshot
             .iter(IterOption::default(), ScanMode::Forward)
             .unwrap();

--- a/src/storage/kv/raftkv.rs
+++ b/src/storage/kv/raftkv.rs
@@ -163,7 +163,7 @@ impl<S: RaftStoreRouter> RaftKv<S> {
     }
 
     fn new_request_header(&self, ctx: &Context) -> RaftRequestHeader {
-        let mut header = RaftRequestHeader::new();
+        let mut header = RaftRequestHeader::default();
         header.set_region_id(ctx.get_region_id());
         header.set_peer(ctx.get_peer().clone());
         header.set_region_epoch(ctx.get_region_epoch().clone());
@@ -183,7 +183,7 @@ impl<S: RaftStoreRouter> RaftKv<S> {
     ) -> Result<()> {
         let len = reqs.len();
         let header = self.new_request_header(ctx);
-        let mut cmd = RaftCmdRequest::new();
+        let mut cmd = RaftCmdRequest::default();
         cmd.set_header(header);
         cmd.set_requests(RepeatedField::from_vec(reqs));
 
@@ -209,7 +209,7 @@ impl<S: RaftStoreRouter> RaftKv<S> {
         ));
         let len = reqs.len();
         let header = self.new_request_header(ctx);
-        let mut cmd = RaftCmdRequest::new();
+        let mut cmd = RaftCmdRequest::default();
         cmd.set_header(header);
         cmd.set_requests(RepeatedField::from_vec(reqs));
 
@@ -260,10 +260,10 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
 
         let mut reqs = Vec::with_capacity(modifies.len());
         for m in modifies {
-            let mut req = Request::new();
+            let mut req = Request::default();
             match m {
                 Modify::Delete(cf, k) => {
-                    let mut delete = DeleteRequest::new();
+                    let mut delete = DeleteRequest::default();
                     delete.set_key(k.into_encoded());
                     if cf != CF_DEFAULT {
                         delete.set_cf(cf.to_string());
@@ -272,7 +272,7 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
                     req.set_delete(delete);
                 }
                 Modify::Put(cf, k, v) => {
-                    let mut put = PutRequest::new();
+                    let mut put = PutRequest::default();
                     put.set_key(k.into_encoded());
                     put.set_value(v);
                     if cf != CF_DEFAULT {
@@ -282,7 +282,7 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
                     req.set_put(put);
                 }
                 Modify::DeleteRange(cf, start_key, end_key, notify_only) => {
-                    let mut delete_range = DeleteRangeRequest::new();
+                    let mut delete_range = DeleteRangeRequest::default();
                     delete_range.set_cf(cf.to_string());
                     delete_range.set_start_key(start_key.into_encoded());
                     delete_range.set_end_key(end_key.into_encoded());
@@ -327,7 +327,7 @@ impl<S: RaftStoreRouter> Engine for RaftKv<S> {
 
     fn async_snapshot(&self, ctx: &Context, cb: Callback<Self::Snap>) -> kv::Result<()> {
         fail_point!("raftkv_async_snapshot");
-        let mut req = Request::new();
+        let mut req = Request::default();
         req.set_cmd_type(CmdType::Snap);
 
         ASYNC_REQUESTS_COUNTER_VEC.snapshot.all.inc();

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -194,7 +194,7 @@ impl TestEngineBuilder {
 }
 
 fn write_modifies(engine: &Engines, modifies: Vec<Modify>) -> Result<()> {
-    let wb = WriteBatch::new();
+    let wb = WriteBatch::default();
     for rev in modifies {
         let res = match rev {
             Modify::Delete(cf, k) => {
@@ -424,7 +424,7 @@ mod tests {
         must_delete(engine, b"foo42");
         must_delete(engine, b"foo5");
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut iter = snapshot
             .iter(IterOption::default(), ScanMode::Forward)
             .unwrap();

--- a/src/storage/lock_manager/deadlock.rs
+++ b/src/storage/lock_manager/deadlock.rs
@@ -447,11 +447,11 @@ impl<S: StoreAddrResolver + 'static> Detector<S> {
                         DetectType::CleanUpWaitFor => DeadlockRequestType::CleanUpWaitFor,
                         DetectType::CleanUp => DeadlockRequestType::CleanUp,
                     };
-                    let mut entry = WaitForEntry::new();
+                    let mut entry = WaitForEntry::default();
                     entry.set_txn(txn_ts);
                     entry.set_wait_for_txn(lock.ts);
                     entry.set_key_hash(lock.hash);
-                    let mut req = DeadlockRequest::new();
+                    let mut req = DeadlockRequest::default();
                     req.set_tp(tp);
                     req.set_entry(entry);
                     if leader_client.detect(req).is_ok() {
@@ -506,7 +506,7 @@ impl<S: StoreAddrResolver + 'static> Detector<S> {
                         if let Some(deadlock_key_hash) =
                             detect_table.detect(*txn, *wait_for_txn, *key_hash)
                         {
-                            let mut resp = DeadlockResponse::new();
+                            let mut resp = DeadlockResponse::default();
                             resp.set_entry(req.take_entry());
                             resp.set_deadlock_key_hash(deadlock_key_hash);
                             Some((resp, WriteFlags::default()))
@@ -585,7 +585,7 @@ impl deadlock_grpc::Deadlock for Service {
             ctx.spawn(
                 f.map_err(Error::from)
                     .map(|v| {
-                        let mut resp = WaitForEntriesResponse::new();
+                        let mut resp = WaitForEntriesResponse::default();
                         resp.set_entries(RepeatedField::from_vec(v));
                         resp
                     })

--- a/src/storage/lock_manager/waiter_manager.rs
+++ b/src/storage/lock_manager/waiter_manager.rs
@@ -161,7 +161,7 @@ impl WaitTable {
             .iter()
             .flat_map(|(_, waiters)| {
                 waiters.iter().map(|waiter| {
-                    let mut wait_for_entry = WaitForEntry::new();
+                    let mut wait_for_entry = WaitForEntry::default();
                     wait_for_entry.set_txn(waiter.start_ts);
                     wait_for_entry.set_wait_for_txn(waiter.lock.ts);
                     wait_for_entry.set_key_hash(waiter.lock.hash);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1956,12 +1956,12 @@ mod tests {
         let (tx, rx) = channel();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 100)
+                .async_get(Context::default(), Key::from_raw(b"x"), 100)
                 .wait(),
         );
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"x"), b"100".to_vec()))],
                 b"x".to_vec(),
                 100,
@@ -1976,12 +1976,12 @@ mod tests {
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 101)
+                .async_get(Context::default(), Key::from_raw(b"x"), 101)
                 .wait(),
         );
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"x")],
                 100,
                 101,
@@ -1991,13 +1991,13 @@ mod tests {
         rx.recv().unwrap();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 100)
+                .async_get(Context::default(), Key::from_raw(b"x"), 100)
                 .wait(),
         );
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 101)
+                .async_get(Context::default(), Key::from_raw(b"x"), 101)
                 .wait(),
         );
     }
@@ -2010,7 +2010,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"aa".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"bb".to_vec())),
@@ -2033,7 +2033,7 @@ mod tests {
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 1)
+                .async_get(Context::default(), Key::from_raw(b"x"), 1)
                 .wait(),
         );
         expect_error(
@@ -2043,7 +2043,7 @@ mod tests {
             },
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"x"),
                     None,
                     1000,
@@ -2056,7 +2056,7 @@ mod tests {
             vec![None, None],
             storage
                 .async_batch_get(
-                    Context::new(),
+                    Context::default(),
                     vec![Key::from_raw(b"c"), Key::from_raw(b"d")],
                     1,
                 )
@@ -2070,7 +2070,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"aa".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"bb".to_vec())),
@@ -2088,7 +2088,7 @@ mod tests {
             vec![None, None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     None,
                     1000,
@@ -2102,7 +2102,7 @@ mod tests {
             vec![None, None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     None,
                     1000,
@@ -2116,7 +2116,7 @@ mod tests {
             vec![None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     Some(Key::from_raw(b"c")),
                     1000,
@@ -2130,7 +2130,7 @@ mod tests {
             vec![None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     Some(Key::from_raw(b"b")),
                     1000,
@@ -2144,7 +2144,7 @@ mod tests {
             vec![None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     None,
                     2,
@@ -2158,7 +2158,7 @@ mod tests {
             vec![None, None],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     None,
                     2,
@@ -2170,7 +2170,7 @@ mod tests {
 
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![
                     Key::from_raw(b"a"),
                     Key::from_raw(b"b"),
@@ -2191,7 +2191,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     None,
                     1000,
@@ -2209,7 +2209,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     None,
                     1000,
@@ -2226,7 +2226,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     Some(Key::from_raw(b"c")),
                     1000,
@@ -2243,7 +2243,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     Some(Key::from_raw(b"b")),
                     1000,
@@ -2261,7 +2261,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\x00"),
                     None,
                     2,
@@ -2278,7 +2278,7 @@ mod tests {
             ],
             storage
                 .async_scan(
-                    Context::new(),
+                    Context::default(),
                     Key::from_raw(b"\xff"),
                     None,
                     2,
@@ -2295,7 +2295,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"aa".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"bb".to_vec())),
@@ -2312,7 +2312,7 @@ mod tests {
             vec![None],
             storage
                 .async_batch_get(
-                    Context::new(),
+                    Context::default(),
                     vec![Key::from_raw(b"c"), Key::from_raw(b"d")],
                     2,
                 )
@@ -2320,7 +2320,7 @@ mod tests {
         );
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![
                     Key::from_raw(b"a"),
                     Key::from_raw(b"b"),
@@ -2340,7 +2340,7 @@ mod tests {
             ],
             storage
                 .async_batch_get(
-                    Context::new(),
+                    Context::default(),
                     vec![
                         Key::from_raw(b"c"),
                         Key::from_raw(b"x"),
@@ -2359,7 +2359,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"x"), b"100".to_vec()))],
                 b"x".to_vec(),
                 100,
@@ -2369,7 +2369,7 @@ mod tests {
             .unwrap();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"y"), b"101".to_vec()))],
                 b"y".to_vec(),
                 101,
@@ -2381,7 +2381,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"x")],
                 100,
                 110,
@@ -2390,7 +2390,7 @@ mod tests {
             .unwrap();
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"y")],
                 101,
                 111,
@@ -2402,18 +2402,18 @@ mod tests {
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 120)
+                .async_get(Context::default(), Key::from_raw(b"x"), 120)
                 .wait(),
         );
         expect_value(
             b"101".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"y"), 120)
+                .async_get(Context::default(), Key::from_raw(b"y"), 120)
                 .wait(),
         );
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"x"), b"105".to_vec()))],
                 b"x".to_vec(),
                 105,
@@ -2435,12 +2435,12 @@ mod tests {
         let (tx, rx) = channel();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 100)
+                .async_get(Context::default(), Key::from_raw(b"x"), 100)
                 .wait(),
         );
         storage
             .async_pause(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"x")],
                 1000,
                 expect_ok_callback(tx.clone(), 1),
@@ -2448,7 +2448,7 @@ mod tests {
             .unwrap();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"y"), b"101".to_vec()))],
                 b"y".to_vec(),
                 101,
@@ -2460,7 +2460,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"z"), b"102".to_vec()))],
                 b"y".to_vec(),
                 102,
@@ -2477,7 +2477,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"x"), b"100".to_vec()))],
                 b"x".to_vec(),
                 100,
@@ -2488,7 +2488,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_cleanup(
-                Context::new(),
+                Context::default(),
                 Key::from_raw(b"x"),
                 100,
                 expect_ok_callback(tx.clone(), 1),
@@ -2497,7 +2497,7 @@ mod tests {
         rx.recv().unwrap();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 105)
+                .async_get(Context::default(), Key::from_raw(b"x"), 105)
                 .wait(),
         );
     }
@@ -2506,10 +2506,10 @@ mod tests {
     fn test_high_priority_get_put() {
         let storage = TestStorageBuilder::new().build().unwrap();
         let (tx, rx) = channel();
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         expect_none(storage.async_get(ctx, Key::from_raw(b"x"), 100).wait());
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         storage
             .async_prewrite(
@@ -2522,7 +2522,7 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         storage
             .async_commit(
@@ -2534,10 +2534,10 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         expect_none(storage.async_get(ctx, Key::from_raw(b"x"), 100).wait());
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         expect_value(
             b"100".to_vec(),
@@ -2553,12 +2553,12 @@ mod tests {
         let (tx, rx) = channel();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 100)
+                .async_get(Context::default(), Key::from_raw(b"x"), 100)
                 .wait(),
         );
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![Mutation::Put((Key::from_raw(b"x"), b"100".to_vec()))],
                 b"x".to_vec(),
                 100,
@@ -2569,7 +2569,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"x")],
                 100,
                 101,
@@ -2580,13 +2580,13 @@ mod tests {
 
         storage
             .async_pause(
-                Context::new(),
+                Context::default(),
                 vec![Key::from_raw(b"y")],
                 1000,
                 expect_ok_callback(tx.clone(), 3),
             )
             .unwrap();
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_priority(CommandPri::High);
         expect_value(
             b"100".to_vec(),
@@ -2603,7 +2603,7 @@ mod tests {
         // Write x and y.
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"x"), b"100".to_vec())),
                     Mutation::Put((Key::from_raw(b"y"), b"100".to_vec())),
@@ -2618,7 +2618,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_commit(
-                Context::new(),
+                Context::default(),
                 vec![
                     Key::from_raw(b"x"),
                     Key::from_raw(b"y"),
@@ -2633,26 +2633,26 @@ mod tests {
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 101)
+                .async_get(Context::default(), Key::from_raw(b"x"), 101)
                 .wait(),
         );
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"y"), 101)
+                .async_get(Context::default(), Key::from_raw(b"y"), 101)
                 .wait(),
         );
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"z"), 101)
+                .async_get(Context::default(), Key::from_raw(b"z"), 101)
                 .wait(),
         );
 
         // Delete range [x, z)
         storage
             .async_delete_range(
-                Context::new(),
+                Context::default(),
                 Key::from_raw(b"x"),
                 Key::from_raw(b"z"),
                 false,
@@ -2662,24 +2662,24 @@ mod tests {
         rx.recv().unwrap();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"x"), 101)
+                .async_get(Context::default(), Key::from_raw(b"x"), 101)
                 .wait(),
         );
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"y"), 101)
+                .async_get(Context::default(), Key::from_raw(b"y"), 101)
                 .wait(),
         );
         expect_value(
             b"100".to_vec(),
             storage
-                .async_get(Context::new(), Key::from_raw(b"z"), 101)
+                .async_get(Context::default(), Key::from_raw(b"z"), 101)
                 .wait(),
         );
 
         storage
             .async_delete_range(
-                Context::new(),
+                Context::default(),
                 Key::from_raw(b""),
                 Key::from_raw(&[255]),
                 false,
@@ -2689,7 +2689,7 @@ mod tests {
         rx.recv().unwrap();
         expect_none(
             storage
-                .async_get(Context::new(), Key::from_raw(b"z"), 101)
+                .async_get(Context::default(), Key::from_raw(b"z"), 101)
                 .wait(),
         );
     }
@@ -2711,7 +2711,7 @@ mod tests {
         for kv in &test_data {
             storage
                 .async_raw_put(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     kv.0.to_vec(),
                     kv.1.to_vec(),
@@ -2723,14 +2723,14 @@ mod tests {
         expect_value(
             b"004".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"d".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"d".to_vec())
                 .wait(),
         );
 
         // Delete ["d", "e")
         storage
             .async_raw_delete_range(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 b"d".to_vec(),
                 b"e".to_vec(),
@@ -2743,25 +2743,25 @@ mod tests {
         expect_value(
             b"003".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"c".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"c".to_vec())
                 .wait(),
         );
         expect_none(
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"d".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"d".to_vec())
                 .wait(),
         );
         expect_value(
             b"005".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"e".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"e".to_vec())
                 .wait(),
         );
 
         // Delete ["aa", "ab")
         storage
             .async_raw_delete_range(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 b"aa".to_vec(),
                 b"ab".to_vec(),
@@ -2774,20 +2774,20 @@ mod tests {
         expect_value(
             b"001".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"a".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"a".to_vec())
                 .wait(),
         );
         expect_value(
             b"002".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"b".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"b".to_vec())
                 .wait(),
         );
 
         // Delete all
         storage
             .async_raw_delete_range(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 b"a".to_vec(),
                 b"z".to_vec(),
@@ -2800,7 +2800,7 @@ mod tests {
         for kv in &test_data {
             expect_none(
                 storage
-                    .async_raw_get(Context::new(), "".to_string(), kv.0.to_vec())
+                    .async_raw_get(Context::default(), "".to_string(), kv.0.to_vec())
                     .wait(),
             );
         }
@@ -2824,7 +2824,7 @@ mod tests {
         // Write key-value pairs in a batch
         storage
             .async_raw_batch_put(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 test_data.clone(),
                 expect_ok_callback(tx.clone(), 0),
@@ -2837,7 +2837,7 @@ mod tests {
             expect_value(
                 val,
                 storage
-                    .async_raw_get(Context::new(), "".to_string(), key)
+                    .async_raw_get(Context::default(), "".to_string(), key)
                     .wait(),
             );
         }
@@ -2860,7 +2860,7 @@ mod tests {
         for &(ref key, ref value) in &test_data {
             storage
                 .async_raw_put(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     key.clone(),
                     value.clone(),
@@ -2876,7 +2876,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_get(Context::new(), "".to_string(), keys)
+                .async_raw_batch_get(Context::default(), "".to_string(), keys)
                 .wait(),
         );
     }
@@ -2897,7 +2897,7 @@ mod tests {
         // Write key-value pairs in batch
         storage
             .async_raw_batch_put(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 test_data.clone(),
                 expect_ok_callback(tx.clone(), 0),
@@ -2914,14 +2914,14 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_get(Context::new(), "".to_string(), keys)
+                .async_raw_batch_get(Context::default(), "".to_string(), keys)
                 .wait(),
         );
 
         // Delete ["b", "d"]
         storage
             .async_raw_batch_delete(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 vec![b"b".to_vec(), b"d".to_vec()],
                 expect_ok_callback(tx.clone(), 1),
@@ -2933,36 +2933,36 @@ mod tests {
         expect_value(
             b"aa".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"a".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"a".to_vec())
                 .wait(),
         );
         expect_none(
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"b".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"b".to_vec())
                 .wait(),
         );
         expect_value(
             b"cc".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"c".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"c".to_vec())
                 .wait(),
         );
         expect_none(
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"d".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"d".to_vec())
                 .wait(),
         );
         expect_value(
             b"ee".to_vec(),
             storage
-                .async_raw_get(Context::new(), "".to_string(), b"e".to_vec())
+                .async_raw_get(Context::default(), "".to_string(), b"e".to_vec())
                 .wait(),
         );
 
         // Delete ["a", "c", "e"]
         storage
             .async_raw_batch_delete(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 vec![b"a".to_vec(), b"c".to_vec(), b"e".to_vec()],
                 expect_ok_callback(tx.clone(), 2),
@@ -2974,7 +2974,7 @@ mod tests {
         for (k, _) in test_data {
             expect_none(
                 storage
-                    .async_raw_get(Context::new(), "".to_string(), k)
+                    .async_raw_get(Context::default(), "".to_string(), k)
                     .wait(),
             );
         }
@@ -3011,7 +3011,7 @@ mod tests {
         // Write key-value pairs in batch
         storage
             .async_raw_batch_put(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 test_data.clone(),
                 expect_ok_callback(tx.clone(), 0),
@@ -3028,7 +3028,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     vec![],
                     None,
@@ -3043,7 +3043,7 @@ mod tests {
             results,
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"c2".to_vec(),
                     None,
@@ -3062,7 +3062,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     vec![],
                     None,
@@ -3077,7 +3077,7 @@ mod tests {
             results,
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"c2".to_vec(),
                     None,
@@ -3097,7 +3097,7 @@ mod tests {
             results,
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"z".to_vec(),
                     None,
@@ -3118,7 +3118,7 @@ mod tests {
             results,
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"z".to_vec(),
                     None,
@@ -3141,7 +3141,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"b2".to_vec(),
                     Some(b"c2".to_vec()),
@@ -3162,7 +3162,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"b2".to_vec(),
                     Some(b"b2\x00".to_vec()),
@@ -3186,7 +3186,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"c2".to_vec(),
                     Some(b"b2".to_vec()),
@@ -3207,7 +3207,7 @@ mod tests {
             results.clone(),
             storage
                 .async_raw_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     b"b2\x00".to_vec(),
                     Some(b"b2".to_vec()),
@@ -3219,7 +3219,7 @@ mod tests {
         );
 
         // End key tests. Confirm that lower/upper bound works correctly.
-        let ctx = Context::new();
+        let ctx = Context::default();
         let results = vec![
             (b"c1".to_vec(), b"cc11".to_vec()),
             (b"c2".to_vec(), b"cc22".to_vec()),
@@ -3271,7 +3271,7 @@ mod tests {
             ranges
                 .into_iter()
                 .map(|(s, e)| {
-                    let mut range = KeyRange::new();
+                    let mut range = KeyRange::default();
                     range.set_start_key(s);
                     if !e.is_empty() {
                         range.set_end_key(e);
@@ -3394,7 +3394,7 @@ mod tests {
         // Write key-value pairs in batch
         storage
             .async_raw_batch_put(
-                Context::new(),
+                Context::default(),
                 "".to_string(),
                 test_data.clone(),
                 expect_ok_callback(tx.clone(), 0),
@@ -3408,7 +3408,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_get(Context::new(), "".to_string(), keys)
+                .async_raw_batch_get(Context::default(), "".to_string(), keys)
                 .wait(),
         );
 
@@ -3430,7 +3430,7 @@ mod tests {
         let ranges: Vec<KeyRange> = vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]
             .into_iter()
             .map(|k| {
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 range.set_start_key(k);
                 range
             })
@@ -3439,7 +3439,7 @@ mod tests {
             results,
             storage
                 .async_raw_batch_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     ranges.clone(),
                     5,
@@ -3468,7 +3468,7 @@ mod tests {
             results,
             storage
                 .async_raw_batch_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     ranges.clone(),
                     5,
@@ -3493,7 +3493,7 @@ mod tests {
             results,
             storage
                 .async_raw_batch_scan(
-                    Context::new(),
+                    Context::default(),
                     "".to_string(),
                     ranges.clone(),
                     3,
@@ -3517,7 +3517,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_scan(Context::new(), "".to_string(), ranges, 3, true, false)
+                .async_raw_batch_scan(Context::default(), "".to_string(), ranges, 3, true, false)
                 .wait(),
         );
 
@@ -3539,7 +3539,7 @@ mod tests {
         ]
         .into_iter()
         .map(|(s, e)| {
-            let mut range = KeyRange::new();
+            let mut range = KeyRange::default();
             range.set_start_key(s);
             range.set_end_key(e);
             range
@@ -3548,7 +3548,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_scan(Context::new(), "".to_string(), ranges, 5, false, true)
+                .async_raw_batch_scan(Context::default(), "".to_string(), ranges, 5, false, true)
                 .wait(),
         );
 
@@ -3563,7 +3563,7 @@ mod tests {
         let ranges: Vec<KeyRange> = vec![b"c3".to_vec(), b"b3".to_vec(), b"a3".to_vec()]
             .into_iter()
             .map(|s| {
-                let mut range = KeyRange::new();
+                let mut range = KeyRange::default();
                 range.set_start_key(s);
                 range
             })
@@ -3571,7 +3571,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_scan(Context::new(), "".to_string(), ranges, 2, false, true)
+                .async_raw_batch_scan(Context::default(), "".to_string(), ranges, 2, false, true)
                 .wait(),
         );
 
@@ -3593,7 +3593,7 @@ mod tests {
         ]
         .into_iter()
         .map(|(s, e)| {
-            let mut range = KeyRange::new();
+            let mut range = KeyRange::default();
             range.set_start_key(s);
             range.set_end_key(e);
             range
@@ -3602,7 +3602,7 @@ mod tests {
         expect_multi_values(
             results,
             storage
-                .async_raw_batch_scan(Context::new(), "".to_string(), ranges, 5, true, true)
+                .async_raw_batch_scan(Context::default(), "".to_string(), ranges, 5, true, true)
                 .wait(),
         );
     }
@@ -3613,7 +3613,7 @@ mod tests {
         let (tx, rx) = channel();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"x"), b"foo".to_vec())),
                     Mutation::Put((Key::from_raw(b"y"), b"foo".to_vec())),
@@ -3628,7 +3628,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"foo".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"foo".to_vec())),
@@ -3643,42 +3643,42 @@ mod tests {
         rx.recv().unwrap();
         let (lock_a, lock_b, lock_c, lock_x, lock_y, lock_z) = (
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(101);
                 lock.set_key(b"a".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(101);
                 lock.set_key(b"b".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(101);
                 lock.set_key(b"c".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"x".to_vec());
                 lock.set_lock_version(100);
                 lock.set_key(b"x".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"x".to_vec());
                 lock.set_lock_version(100);
                 lock.set_key(b"y".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"x".to_vec());
                 lock.set_lock_version(100);
                 lock.set_key(b"z".to_vec());
@@ -3687,7 +3687,7 @@ mod tests {
         );
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 99,
                 vec![],
                 10,
@@ -3697,7 +3697,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 100,
                 vec![],
                 10,
@@ -3711,7 +3711,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 100,
                 b"a".to_vec(),
                 10,
@@ -3725,7 +3725,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 100,
                 b"y".to_vec(),
                 10,
@@ -3735,7 +3735,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 101,
                 vec![],
                 10,
@@ -3756,7 +3756,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 101,
                 vec![],
                 4,
@@ -3775,7 +3775,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 101,
                 b"b".to_vec(),
                 4,
@@ -3794,7 +3794,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 101,
                 b"b".to_vec(),
                 0,
@@ -3824,7 +3824,7 @@ mod tests {
         // These locks (transaction ts=99) are not going to be resolved.
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"foo".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"foo".to_vec())),
@@ -3840,21 +3840,21 @@ mod tests {
 
         let (lock_a, lock_b, lock_c) = (
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(99);
                 lock.set_key(b"a".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(99);
                 lock.set_key(b"b".to_vec());
                 lock
             },
             {
-                let mut lock = LockInfo::new();
+                let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(99);
                 lock.set_key(b"c".to_vec());
@@ -3892,7 +3892,7 @@ mod tests {
 
                 storage
                     .async_prewrite(
-                        Context::new(),
+                        Context::default(),
                         mutations,
                         b"x".to_vec(),
                         ts,
@@ -3913,7 +3913,7 @@ mod tests {
                 );
                 storage
                     .async_resolve_lock(
-                        Context::new(),
+                        Context::default(),
                         txn_status,
                         expect_ok_callback(tx.clone(), 0),
                     )
@@ -3923,7 +3923,7 @@ mod tests {
                 // All locks should be resolved except for a, b and c.
                 storage
                     .async_scan_locks(
-                        Context::new(),
+                        Context::default(),
                         ts,
                         vec![],
                         0,
@@ -3948,7 +3948,7 @@ mod tests {
 
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"foo".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"foo".to_vec())),
@@ -3966,7 +3966,7 @@ mod tests {
         let resolve_keys = vec![Key::from_raw(b"b"), Key::from_raw(b"c")];
         storage
             .async_resolve_lock_lite(
-                Context::new(),
+                Context::default(),
                 99,
                 0,
                 resolve_keys,
@@ -3977,7 +3977,7 @@ mod tests {
 
         // Check lock for key 'a'.
         let lock_a = {
-            let mut lock = LockInfo::new();
+            let mut lock = LockInfo::default();
             lock.set_primary_lock(b"c".to_vec());
             lock.set_lock_version(99);
             lock.set_key(b"a".to_vec());
@@ -3985,7 +3985,7 @@ mod tests {
         };
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 99,
                 vec![],
                 0,
@@ -3997,7 +3997,7 @@ mod tests {
         // Resolve lock for key 'a'.
         storage
             .async_resolve_lock_lite(
-                Context::new(),
+                Context::default(),
                 99,
                 0,
                 vec![Key::from_raw(b"a")],
@@ -4008,7 +4008,7 @@ mod tests {
 
         storage
             .async_prewrite(
-                Context::new(),
+                Context::default(),
                 vec![
                     Mutation::Put((Key::from_raw(b"a"), b"foo".to_vec())),
                     Mutation::Put((Key::from_raw(b"b"), b"foo".to_vec())),
@@ -4026,7 +4026,7 @@ mod tests {
         let resolve_keys = vec![Key::from_raw(b"b"), Key::from_raw(b"c")];
         storage
             .async_resolve_lock_lite(
-                Context::new(),
+                Context::default(),
                 101,
                 102,
                 resolve_keys,
@@ -4037,7 +4037,7 @@ mod tests {
 
         // Check lock for key 'a'.
         let lock_a = {
-            let mut lock = LockInfo::new();
+            let mut lock = LockInfo::default();
             lock.set_primary_lock(b"c".to_vec());
             lock.set_lock_version(101);
             lock.set_key(b"a".to_vec());
@@ -4045,7 +4045,7 @@ mod tests {
         };
         storage
             .async_scan_locks(
-                Context::new(),
+                Context::default(),
                 101,
                 vec![],
                 0,

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -222,7 +222,7 @@ pub mod tests {
     }
 
     pub fn must_get<E: Engine>(engine: &E, key: &[u8], ts: u64, expect: &[u8]) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
         assert_eq!(
@@ -232,7 +232,7 @@ pub mod tests {
     }
 
     pub fn must_get_rc<E: Engine>(engine: &E, key: &[u8], ts: u64, expect: &[u8]) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::RC);
         assert_eq!(
@@ -242,14 +242,14 @@ pub mod tests {
     }
 
     pub fn must_get_none<E: Engine>(engine: &E, key: &[u8], ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
         assert!(reader.get(&Key::from_raw(key), ts).unwrap().is_none());
     }
 
     pub fn must_get_err<E: Engine>(engine: &E, key: &[u8], ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
         assert!(reader.get(&Key::from_raw(key), ts).is_err());
@@ -263,7 +263,7 @@ pub mod tests {
         pk: &[u8],
         ts: u64,
     ) -> Result<()> {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         txn.prewrite(
@@ -284,7 +284,7 @@ pub mod tests {
         for_update_ts: u64,
         is_pessimistic_lock: bool,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         let mut options = Options::default();
@@ -332,7 +332,7 @@ pub mod tests {
         for_update_ts: u64,
         is_pessimistic_lock: bool,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         let mut options = Options::default();
@@ -384,7 +384,7 @@ pub mod tests {
         for_update_ts: u64,
         is_pessimistic_lock: bool,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         let mut options = Options::default();
@@ -415,7 +415,7 @@ pub mod tests {
     }
 
     pub fn must_prewrite_lock<E: Engine>(engine: &E, key: &[u8], pk: &[u8], ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         txn.prewrite(Mutation::Lock(Key::from_raw(key)), pk, &Options::default())
@@ -424,7 +424,7 @@ pub mod tests {
     }
 
     pub fn must_prewrite_lock_err<E: Engine>(engine: &E, key: &[u8], pk: &[u8], ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         assert!(txn
@@ -439,7 +439,7 @@ pub mod tests {
         start_ts: u64,
         for_update_ts: u64,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         let mut options = Options::default();
@@ -459,7 +459,7 @@ pub mod tests {
         start_ts: u64,
         for_update_ts: u64,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         let mut options = Options::default();
@@ -474,7 +474,7 @@ pub mod tests {
         start_ts: u64,
         for_update_ts: u64,
     ) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         txn.pessimistic_rollback(Key::from_raw(key), for_update_ts)
@@ -483,7 +483,7 @@ pub mod tests {
     }
 
     pub fn must_commit<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         txn.commit(Key::from_raw(key), commit_ts).unwrap();
@@ -491,14 +491,14 @@ pub mod tests {
     }
 
     pub fn must_commit_err<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         assert!(txn.commit(Key::from_raw(key), commit_ts).is_err());
     }
 
     pub fn must_rollback<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         txn.collapse_rollback(false);
@@ -507,7 +507,7 @@ pub mod tests {
     }
 
     pub fn must_rollback_collapsed<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         txn.rollback(Key::from_raw(key)).unwrap();
@@ -515,14 +515,14 @@ pub mod tests {
     }
 
     pub fn must_rollback_err<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
         assert!(txn.rollback(Key::from_raw(key)).is_err());
     }
 
     pub fn must_gc<E: Engine>(engine: &E, key: &[u8], safe_point: u64) {
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, 0, true).unwrap();
         txn.gc(Key::from_raw(key), safe_point).unwrap();
@@ -530,7 +530,7 @@ pub mod tests {
     }
 
     pub fn must_locked<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
         let lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
         assert_eq!(lock.ts, start_ts);
@@ -543,7 +543,7 @@ pub mod tests {
         start_ts: u64,
         for_update_ts: u64,
     ) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
         let lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
         assert_eq!(lock.ts, start_ts);
@@ -552,7 +552,7 @@ pub mod tests {
     }
 
     pub fn must_unlocked<E: Engine>(engine: &E, key: &[u8]) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
         assert!(reader.load_lock(&Key::from_raw(key)).unwrap().is_none());
     }
@@ -564,7 +564,7 @@ pub mod tests {
         commit_ts: u64,
         tp: WriteType,
     ) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let k = Key::from_raw(key).append_ts(commit_ts);
         let v = snapshot.get_cf(CF_WRITE, &k).unwrap().unwrap();
         let write = Write::parse(&v).unwrap();
@@ -573,7 +573,7 @@ pub mod tests {
     }
 
     pub fn must_seek_write_none<E: Engine>(engine: &E, key: &[u8], ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
         assert!(reader
             .seek_write(&Key::from_raw(key), ts)
@@ -589,7 +589,7 @@ pub mod tests {
         commit_ts: u64,
         write_type: WriteType,
     ) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
         let (t, write) = reader.seek_write(&Key::from_raw(key), ts).unwrap().unwrap();
         assert_eq!(t, commit_ts);
@@ -598,7 +598,7 @@ pub mod tests {
     }
 
     pub fn must_get_commit_ts<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
         let (ts, write_type) = reader
             .get_txn_commit_info(&Key::from_raw(key), start_ts)
@@ -609,7 +609,7 @@ pub mod tests {
     }
 
     pub fn must_get_commit_ts_none<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
 
         let ret = reader.get_txn_commit_info(&Key::from_raw(key), start_ts);
@@ -623,7 +623,7 @@ pub mod tests {
     }
 
     pub fn must_get_rollback_ts<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
 
         let (ts, write_type) = reader
@@ -635,7 +635,7 @@ pub mod tests {
     }
 
     pub fn must_get_rollback_ts_none<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
 
         let ret = reader
@@ -655,7 +655,7 @@ pub mod tests {
             keys.into_iter().map(Key::from_raw).collect(),
             next_start.map(|x| Key::from_raw(x).append_ts(0)),
         );
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(
             snapshot,
             Some(ScanMode::Mixed),

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -584,7 +584,7 @@ mod tests {
 
         fn write(&mut self, modifies: Vec<Modify>) {
             let db = &self.db;
-            let wb = WriteBatch::new();
+            let wb = WriteBatch::default();
             for rev in modifies {
                 match rev {
                     Modify::Put(cf, k, v) => {
@@ -643,10 +643,10 @@ mod tests {
     }
 
     fn make_region(id: u64, start_key: Vec<u8>, end_key: Vec<u8>) -> Region {
-        let mut peer = Peer::new();
+        let mut peer = Peer::default();
         peer.set_id(id);
         peer.set_store_id(id);
-        let mut region = Region::new();
+        let mut region = Region::default();
         region.set_id(id);
         region.set_start_key(start_key);
         region.set_end_key(end_key);

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -447,7 +447,7 @@ mod tests {
         // Assume REVERSE_SEEK_BOUND == 4, we have keys:
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND, true)
             .range(None, Some(Key::from_raw(&[11 as u8])))
             .build()
@@ -642,7 +642,7 @@ mod tests {
             REVERSE_SEEK_BOUND * 2,
         );
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND * 2, true)
             .range(None, None)
             .build()
@@ -712,7 +712,7 @@ mod tests {
             REVERSE_SEEK_BOUND * 2,
         );
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND * 2, true)
             .range(None, None)
             .build()
@@ -779,7 +779,7 @@ mod tests {
             must_commit(&engine, b"b", ts, ts);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, 1, true)
             .range(None, None)
             .build()
@@ -850,7 +850,7 @@ mod tests {
             must_commit(&engine, b"b", ts, ts);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, 1, true)
             .range(None, None)
             .build()
@@ -929,7 +929,7 @@ mod tests {
             must_commit(&engine, b"b", ts, ts);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND + 1, true)
             .range(None, None)
             .build()
@@ -1014,7 +1014,7 @@ mod tests {
             must_commit(&engine, &[i], 14, 14);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         // Test both bound specified.
         let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, true)
@@ -1119,7 +1119,7 @@ mod tests {
             must_prewrite_put(&engine, pk, b"", pk, start_ts);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let row = &[255 as u8];
         let k = Key::from_raw(row);
 

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -387,7 +387,7 @@ mod tests {
             must_rollback(&engine, b"b", ts);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, 10, false)
             .range(None, None)
             .build()
@@ -441,7 +441,7 @@ mod tests {
         must_prewrite_put(&engine, b"b", b"b_value", b"a", SEEK_BOUND / 2);
         must_commit(&engine, b"b", SEEK_BOUND / 2, SEEK_BOUND / 2);
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2, false)
             .range(None, None)
             .build()
@@ -504,7 +504,7 @@ mod tests {
         must_prewrite_put(&engine, b"b", b"b_value", b"a", SEEK_BOUND);
         must_commit(&engine, b"b", SEEK_BOUND, SEEK_BOUND);
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2, false)
             .range(None, None)
             .build()
@@ -571,7 +571,7 @@ mod tests {
             must_commit(&engine, &[i], 14, 14);
         }
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         // Test both bound specified.
         let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -223,7 +223,7 @@ mod tests {
         must_acquire_pessimistic_lock(&engine, &[3], &[3], 105, 110);
         must_prewrite_put(&engine, &[4], b"a", &[4], 105);
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         let mut expected_result = vec![
             (vec![0], Some(vec![b'v', 0])),

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -1020,7 +1020,7 @@ mod tests {
 
     fn test_write_size_imp(k: &[u8], v: &[u8], pk: &[u8]) {
         let engine = TestEngineBuilder::new().build().unwrap();
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, 10, true).unwrap();
         let key = Key::from_raw(k);
@@ -1058,7 +1058,7 @@ mod tests {
         must_prewrite_put(&engine, key, value, key, 5);
         must_commit(&engine, key, 5, 10);
 
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, 5, true).unwrap();
         assert!(txn
@@ -1069,7 +1069,7 @@ mod tests {
             )
             .is_err());
 
-        let ctx = Context::new();
+        let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, 5, true).unwrap();
         let mut opt = Options::default();
@@ -1162,7 +1162,7 @@ mod tests {
         );
         must_commit(&engine, &[6], 3, 6);
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(
             snapshot,
             Some(ScanMode::Forward),
@@ -1206,7 +1206,7 @@ mod tests {
         must_prewrite_put(&engine, &[6], b"xxx", &[6], 3);
         must_commit(&engine, &[6], 3, 6);
 
-        let snapshot = engine.snapshot(&Context::new()).unwrap();
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(
             snapshot,
             Some(ScanMode::Forward),

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -413,7 +413,7 @@ fn process_read_impl<E: Engine>(
             let (kv_pairs, _) = result?;
             let mut locks = Vec::with_capacity(kv_pairs.len());
             for (key, lock) in kv_pairs {
-                let mut lock_info = LockInfo::new();
+                let mut lock_info = LockInfo::default();
                 lock_info.set_primary_lock(lock.primary);
                 lock_info.set_lock_version(lock.ts);
                 lock_info.set_key(key.into_raw()?);

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -542,65 +542,65 @@ mod tests {
         temp_map.insert(10, 20);
         let readonly_cmds = vec![
             Command::ScanLock {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 max_ts: 5,
                 start_key: None,
                 limit: 0,
             },
             Command::ResolveLock {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 txn_status: temp_map.clone(),
                 scan_key: None,
                 key_locks: vec![],
             },
             Command::MvccByKey {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 key: Key::from_raw(b"k"),
             },
             Command::MvccByStartTs {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 start_ts: 25,
             },
         ];
         let write_cmds = vec![
             Command::Prewrite {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 mutations: vec![Mutation::Put((Key::from_raw(b"k"), b"v".to_vec()))],
                 primary: b"k".to_vec(),
                 start_ts: 10,
                 options: Options::default(),
             },
             Command::AcquirePessimisticLock {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 keys: vec![(Key::from_raw(b"k"), false)],
                 primary: b"k".to_vec(),
                 start_ts: 10,
                 options: Options::default(),
             },
             Command::Commit {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 keys: vec![Key::from_raw(b"k")],
                 lock_ts: 10,
                 commit_ts: 20,
             },
             Command::Cleanup {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 key: Key::from_raw(b"k"),
                 start_ts: 10,
             },
             Command::Rollback {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 keys: vec![Key::from_raw(b"k")],
                 start_ts: 10,
             },
             Command::PessimisticRollback {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 keys: vec![Key::from_raw(b"k")],
                 start_ts: 10,
                 for_update_ts: 20,
             },
             Command::ResolveLock {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 txn_status: temp_map.clone(),
                 scan_key: None,
                 key_locks: vec![(
@@ -609,7 +609,7 @@ mod tests {
                 )],
             },
             Command::ResolveLockLite {
-                ctx: Context::new(),
+                ctx: Context::default(),
                 start_ts: 10,
                 commit_ts: 0,
                 resolve_keys: vec![Key::from_raw(b"k")],

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -320,7 +320,7 @@ mod tests {
             let keys: Vec<String> = (START_ID..START_ID + key_num)
                 .map(|i| format!("{}{}", KEY_PREFIX, i))
                 .collect();
-            let ctx = Context::new();
+            let ctx = Context::default();
             let snapshot = engine.snapshot(&ctx).unwrap();
             let mut store = TestStore {
                 keys,

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -59,7 +59,7 @@ fn test_storage_gcworker_busy() {
     let (tx2, rx2) = channel();
     storage
         .async_gc(
-            Context::new(),
+            Context::default(),
             1,
             Box::new(move |res: storage::Result<()>| {
                 match res {
@@ -92,7 +92,7 @@ fn test_scheduler_leader_change_twice() {
         .build()
         .unwrap();
 
-    let mut ctx0 = Context::new();
+    let mut ctx0 = Context::default();
     ctx0.set_region_id(region0.get_id());
     ctx0.set_region_epoch(region0.get_region_epoch().clone());
     ctx0.set_peer(peers[0].clone());
@@ -144,14 +144,14 @@ fn test_server_catching_api_error() {
         ChannelBuilder::new(env).connect(cluster.sim.rl().get_addr(leader.get_store_id()));
     let client = TikvClient::new(channel);
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());
 
-    let mut prewrite_req = PrewriteRequest::new();
+    let mut prewrite_req = PrewriteRequest::default();
     prewrite_req.set_context(ctx.clone());
-    let mut mutation = kvrpcpb::Mutation::new();
+    let mut mutation = kvrpcpb::Mutation::default();
     mutation.op = Op::Put;
     mutation.key = b"k3".to_vec();
     mutation.value = b"v3".to_vec();
@@ -168,7 +168,7 @@ fn test_server_catching_api_error() {
     );
     must_get_none(&cluster.get_engine(1), b"k3");
 
-    let mut put_req = RawPutRequest::new();
+    let mut put_req = RawPutRequest::default();
     put_req.set_context(ctx.clone());
     put_req.key = b"k3".to_vec();
     put_req.value = b"v3".to_vec();

--- a/tests/failpoints/cases/test_upgrade.rs
+++ b/tests/failpoints/cases/test_upgrade.rs
@@ -32,7 +32,7 @@ const LAST_INDEX: u64 = 11;
 const STALE_LAST_INDEX: u64 = APPLIED_INDEX - 1;
 
 fn write_store_ident(db: &DB, cf: &str, key: &[u8]) -> StoreIdent {
-    let mut store_ident = StoreIdent::new();
+    let mut store_ident = StoreIdent::default();
     store_ident.set_cluster_id(CLUSTER_ID);
     store_ident.set_store_id(STOER_ID);
 
@@ -43,7 +43,7 @@ fn write_store_ident(db: &DB, cf: &str, key: &[u8]) -> StoreIdent {
 }
 
 fn write_region(db: &DB, cf: &str, key: &[u8]) -> Region {
-    let mut region = Region::new();
+    let mut region = Region::default();
     region.set_id(REGION_ID);
     region.set_peers(vec![new_peer(STOER_ID, PEER_ID)].into());
     region.mut_region_epoch().set_conf_ver(INIT_EPOCH_CONF_VER);
@@ -56,9 +56,9 @@ fn write_region(db: &DB, cf: &str, key: &[u8]) -> Region {
 }
 
 fn write_apply_state(db: &DB, cf: &str, key: &[u8]) -> RaftApplyState {
-    let mut apply_state = RaftApplyState::new();
+    let mut apply_state = RaftApplyState::default();
     apply_state.set_applied_index(APPLIED_INDEX);
-    let mut truncated_state = RaftTruncatedState::new();
+    let mut truncated_state = RaftTruncatedState::default();
     truncated_state.set_index(SNAPSHOT_INDEX);
     truncated_state.set_term(TERM);
     apply_state.set_truncated_state(truncated_state);
@@ -70,7 +70,7 @@ fn write_apply_state(db: &DB, cf: &str, key: &[u8]) -> RaftApplyState {
 }
 
 fn write_snap_raft_state(db: &DB, cf: &str, key: &[u8]) -> RaftLocalState {
-    let mut snap_raft_state = RaftLocalState::new();
+    let mut snap_raft_state = RaftLocalState::default();
     snap_raft_state.set_last_index(SNAPSHOT_INDEX);
     snap_raft_state.mut_hard_state().set_term(TERM);
     snap_raft_state.mut_hard_state().set_vote(PEER_ID);
@@ -83,7 +83,7 @@ fn write_snap_raft_state(db: &DB, cf: &str, key: &[u8]) -> RaftLocalState {
 }
 
 fn write_region_state(db: &DB, cf: &str, key: &[u8], region: Region) -> RegionLocalState {
-    let mut region_state = RegionLocalState::new();
+    let mut region_state = RegionLocalState::default();
     region_state.set_region(region);
     region_state.set_state(PeerState::Normal);
 
@@ -109,7 +109,7 @@ fn write_stale_raft_state(
 }
 
 fn write_log_entry(db: &DB, cf: &str, key: &[u8], idx: u64) -> Entry {
-    let mut entry = Entry::new();
+    let mut entry = Entry::default();
     entry.set_term(TERM);
     entry.set_index(idx);
 

--- a/tests/integrations/coprocessor/test_analyze.rs
+++ b/tests/integrations/coprocessor/test_analyze.rs
@@ -13,7 +13,7 @@ use test_coprocessor::*;
 pub const REQ_TYPE_ANALYZE: i64 = 104;
 
 fn new_analyze_req(data: Vec<u8>, range: KeyRange) -> Request {
-    let mut req = Request::new();
+    let mut req = Request::default();
     req.set_data(data);
     req.set_ranges(RepeatedField::from_vec(vec![range]));
     req.set_tp(REQ_TYPE_ANALYZE);
@@ -81,7 +81,7 @@ fn test_analyze_column_with_lock() {
         let (_, endpoint) = init_data_with_commit(&product, &data, false);
 
         let mut req = new_analyze_column_req(&product, 3, 3, 3, 4, 32);
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_isolation_level(iso_level);
         req.set_context(ctx);
 
@@ -146,7 +146,7 @@ fn test_analyze_index_with_lock() {
         let (_, endpoint) = init_data_with_commit(&product, &data, false);
 
         let mut req = new_analyze_index_req(&product, 3, product["name"].index, 4, 32);
-        let mut ctx = Context::new();
+        let mut ctx = Context::default();
         ctx.set_isolation_level(iso_level);
         req.set_context(ctx);
 
@@ -205,7 +205,7 @@ fn test_invalid_range() {
     let product = ProductTable::new();
     let (_, endpoint) = init_data_with_commit(&product, &data, true);
     let mut req = new_analyze_index_req(&product, 3, product["name"].index, 4, 32);
-    let mut key_range = KeyRange::new();
+    let mut key_range = KeyRange::default();
     key_range.set_start(b"xxx".to_vec());
     key_range.set_end(b"zzz".to_vec());
     req.set_ranges(RepeatedField::from_vec(vec![key_range]));

--- a/tests/integrations/coprocessor/test_checksum.rs
+++ b/tests/integrations/coprocessor/test_checksum.rs
@@ -16,15 +16,15 @@ use tikv::storage::{Engine, SnapshotStore};
 use test_coprocessor::*;
 
 fn new_checksum_request(range: KeyRange, scan_on: ChecksumScanOn) -> Request {
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_isolation_level(IsolationLevel::SI);
 
-    let mut checksum = ChecksumRequest::new();
+    let mut checksum = ChecksumRequest::default();
     checksum.set_start_ts(u64::MAX);
     checksum.set_scan_on(scan_on);
     checksum.set_algorithm(ChecksumAlgorithm::Crc64_Xor);
 
-    let mut req = Request::new();
+    let mut req = Request::default();
     req.set_context(ctx);
     req.set_tp(REQ_TYPE_CHECKSUM);
     req.set_data(checksum.write_to_bytes().unwrap());
@@ -57,7 +57,7 @@ fn test_checksum() {
         let expected = reversed_checksum_crc64_xor(&store, range);
 
         let response = handle_request(&endpoint, request);
-        let mut resp = ChecksumResponse::new();
+        let mut resp = ChecksumResponse::default();
         resp.merge_from_bytes(response.get_data()).unwrap();
         assert_eq!(resp.get_checksum(), expected);
         assert_eq!(resp.get_total_kvs(), data.len() as u64);
@@ -65,7 +65,7 @@ fn test_checksum() {
 }
 
 fn reversed_checksum_crc64_xor<E: Engine>(store: &Store<E>, range: KeyRange) -> u64 {
-    let ctx = Context::new();
+    let ctx = Context::default();
     let snap = SnapshotStore::new(
         store.get_engine().snapshot(&ctx).unwrap(),
         u64::MAX,

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -68,7 +68,7 @@ fn test_batch_row_limit() {
         let engine = TestEngineBuilder::new().build().unwrap();
         let mut cfg = Config::default();
         cfg.end_point_batch_row_limit = batch_row_limit;
-        init_data_with_details(Context::new(), engine, &product, &data, true, &cfg)
+        init_data_with_details(Context::default(), engine, &product, &data, true, &cfg)
     };
 
     // for dag selection
@@ -101,7 +101,7 @@ fn test_stream_batch_row_limit() {
         let engine = TestEngineBuilder::new().build().unwrap();
         let mut cfg = Config::default();
         cfg.end_point_stream_batch_row_limit = stream_row_limit;
-        init_data_with_details(Context::new(), engine, &product, &data, true, &cfg)
+        init_data_with_details(Context::default(), engine, &product, &data, true, &cfg)
     };
 
     let req = DAGSelect::from(&product).build();
@@ -186,7 +186,7 @@ fn test_scan_detail() {
         let engine = TestEngineBuilder::new().build().unwrap();
         let mut cfg = Config::default();
         cfg.end_point_batch_row_limit = 50;
-        init_data_with_details(Context::new(), engine, &product, &data, true, &cfg)
+        init_data_with_details(Context::default(), engine, &product, &data, true, &cfg)
     };
 
     let reqs = vec![
@@ -1301,7 +1301,7 @@ fn test_handle_truncate() {
         // Ignore truncate error.
         let req = DAGSelect::from(&product)
             .where_expr(cond.clone())
-            .build_with(Context::new(), &[FLAG_IGNORE_TRUNCATE]);
+            .build_with(Context::default(), &[FLAG_IGNORE_TRUNCATE]);
         let resp = handle_select(&endpoint, req);
         assert!(!resp.has_error());
         assert!(resp.get_warnings().is_empty());
@@ -1309,7 +1309,7 @@ fn test_handle_truncate() {
         // truncate as warning
         let req = DAGSelect::from(&product)
             .where_expr(cond.clone())
-            .build_with(Context::new(), &[FLAG_TRUNCATE_AS_WARNING]);
+            .build_with(Context::default(), &[FLAG_TRUNCATE_AS_WARNING]);
         let mut resp = handle_select(&endpoint, req);
         assert!(!resp.has_error());
         assert!(!resp.get_warnings().is_empty());
@@ -1474,7 +1474,7 @@ fn test_exec_details() {
     let flags = &[0];
 
     // get handle_time
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_handle_time(true);
     let req = DAGSelect::from(&product).build_with(ctx, flags);
     let resp = handle_request(&endpoint, req);
@@ -1484,7 +1484,7 @@ fn test_exec_details() {
     assert!(!exec_details.has_scan_detail());
 
     // get scan detail
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_scan_detail(true);
     let req = DAGSelect::from(&product).build_with(ctx, flags);
     let resp = handle_request(&endpoint, req);
@@ -1494,7 +1494,7 @@ fn test_exec_details() {
     assert!(exec_details.has_scan_detail());
 
     // get both
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_scan_detail(true);
     ctx.set_handle_time(true);
     let req = DAGSelect::from(&product).build_with(ctx, flags);

--- a/tests/integrations/import/sst_service.rs
+++ b/tests/integrations/import/sst_service.rs
@@ -31,7 +31,7 @@ fn new_cluster() -> (Cluster<ServerCluster>, Context) {
     let region_id = 1;
     let leader = cluster.leader_of_region(region_id).unwrap();
     let epoch = cluster.get_region_epoch(region_id);
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region_id);
     ctx.set_peer(leader.clone());
     ctx.set_region_epoch(epoch);
@@ -92,7 +92,7 @@ fn test_ingest_sst() {
     // No region id and epoch.
     send_upload_sst(&import, &meta, &data).unwrap();
 
-    let mut ingest = IngestRequest::new();
+    let mut ingest = IngestRequest::default();
     ingest.set_context(ctx.clone());
     ingest.set_sst(meta.clone());
     let resp = import.ingest(&ingest).unwrap();
@@ -111,7 +111,7 @@ fn test_ingest_sst() {
 
     // Check ingested kvs
     for i in sst_range.0..sst_range.1 {
-        let mut m = RawGetRequest::new();
+        let mut m = RawGetRequest::default();
         m.set_context(ctx.clone());
         m.set_key(vec![i]);
         let resp = tikv.raw_get(&m).unwrap();
@@ -179,9 +179,9 @@ fn send_upload_sst(
     meta: &SSTMeta,
     data: &[u8],
 ) -> Result<UploadResponse> {
-    let mut r1 = UploadRequest::new();
+    let mut r1 = UploadRequest::default();
     r1.set_meta(meta.clone());
-    let mut r2 = UploadRequest::new();
+    let mut r2 = UploadRequest::default();
     r2.set_data(data.to_vec());
     let reqs: Vec<_> = vec![r1, r2]
         .into_iter()

--- a/tests/integrations/pd/mock/mocker/bootstrap.rs
+++ b/tests/integrations/pd/mock/mocker/bootstrap.rs
@@ -9,25 +9,25 @@ pub struct AlreadyBootstrapped;
 
 impl PdMocker for AlreadyBootstrapped {
     fn bootstrap(&self, _: &BootstrapRequest) -> Option<Result<BootstrapResponse>> {
-        let mut err = Error::new();
+        let mut err = Error::default();
         err.set_field_type(ErrorType::ALREADY_BOOTSTRAPPED);
         err.set_message("cluster is already bootstrapped".to_owned());
 
-        let mut header = ResponseHeader::new();
+        let mut header = ResponseHeader::default();
         header.set_error(err);
         header.set_cluster_id(DEFAULT_CLUSTER_ID);
 
-        let mut resp = BootstrapResponse::new();
+        let mut resp = BootstrapResponse::default();
         resp.set_header(header);
 
         Some(Ok(resp))
     }
 
     fn is_bootstrapped(&self, _: &IsBootstrappedRequest) -> Option<Result<IsBootstrappedResponse>> {
-        let mut header = ResponseHeader::new();
+        let mut header = ResponseHeader::default();
         header.set_cluster_id(DEFAULT_CLUSTER_ID);
 
-        let mut resp = IsBootstrappedResponse::new();
+        let mut resp = IsBootstrappedResponse::default();
         resp.set_bootstrapped(false);
 
         Some(Ok(resp))

--- a/tests/integrations/pd/mock/mocker/incompatible.rs
+++ b/tests/integrations/pd/mock/mocker/incompatible.rs
@@ -9,13 +9,13 @@ pub struct Incompatible;
 
 impl PdMocker for Incompatible {
     fn ask_batch_split(&self, _: &AskBatchSplitRequest) -> Option<Result<AskBatchSplitResponse>> {
-        let mut err = Error::new();
+        let mut err = Error::default();
         err.set_field_type(ErrorType::INCOMPATIBLE_VERSION);
 
-        let mut header = ResponseHeader::new();
+        let mut header = ResponseHeader::default();
         header.set_error(err);
 
-        let mut resp = AskBatchSplitResponse::new();
+        let mut resp = AskBatchSplitResponse::default();
         resp.set_header(header);
 
         Some(Ok(resp))

--- a/tests/integrations/pd/mock/mocker/leader_change.rs
+++ b/tests/integrations/pd/mock/mocker/leader_change.rs
@@ -84,7 +84,7 @@ impl PdMocker for LeaderChange {
     fn set_endpoints(&self, eps: Vec<String>) {
         let mut members = Vec::with_capacity(eps.len());
         for (i, ep) in (&eps).iter().enumerate() {
-            let mut m = Member::new();
+            let mut m = Member::default();
             m.set_name(format!("pd{}", i));
             m.set_member_id(100 + i as u64);
             m.set_client_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
@@ -93,19 +93,19 @@ impl PdMocker for LeaderChange {
         }
 
         // A dead PD
-        let mut m = Member::new();
+        let mut m = Member::default();
         m.set_member_id(DEAD_ID);
         m.set_name(DEAD_NAME.to_owned());
         m.set_client_urls(RepeatedField::from_vec(vec![DEAD_URL.to_owned()]));
         m.set_peer_urls(RepeatedField::from_vec(vec![DEAD_URL.to_owned()]));
         members.push(m);
 
-        let mut header = ResponseHeader::new();
+        let mut header = ResponseHeader::default();
         header.set_cluster_id(1);
 
         let mut resps = Vec::with_capacity(eps.len());
         for (i, _) in (&eps).iter().enumerate() {
-            let mut resp = GetMembersResponse::new();
+            let mut resp = GetMembersResponse::default();
             resp.set_header(header.clone());
             resp.set_members(RepeatedField::from_vec(members.clone()));
             resp.set_leader(members[i].clone());

--- a/tests/integrations/pd/mock/mocker/retry.rs
+++ b/tests/integrations/pd/mock/mocker/retry.rs
@@ -41,7 +41,7 @@ impl PdMocker for Retry {
     fn get_region_by_id(&self, _: &GetRegionByIDRequest) -> Option<Result<GetRegionResponse>> {
         if self.is_ok() {
             info!("[Retry] get_region_by_id returns Ok(_)");
-            Some(Ok(GetRegionResponse::new()))
+            Some(Ok(GetRegionResponse::default()))
         } else {
             info!("[Retry] get_region_by_id returns Err(_)");
             Some(Err("please retry".to_owned()))
@@ -51,7 +51,7 @@ impl PdMocker for Retry {
     fn get_store(&self, _: &GetStoreRequest) -> Option<Result<GetStoreResponse>> {
         if self.is_ok() {
             info!("[Retry] get_store returns Ok(_)");
-            Some(Ok(GetStoreResponse::new()))
+            Some(Ok(GetStoreResponse::default()))
         } else {
             info!("[Retry] get_store returns Err(_)");
             Some(Err("please retry".to_owned()))
@@ -82,14 +82,14 @@ impl PdMocker for NotRetry {
             info!(
                 "[NotRetry] get_region_by_id returns Ok(_) with header has INCOMPATIBLE_VERSION error"
             );
-            let mut err = Error::new();
+            let mut err = Error::default();
             err.set_field_type(ErrorType::INCOMPATIBLE_VERSION);
-            let mut resp = GetRegionResponse::new();
+            let mut resp = GetRegionResponse::default();
             resp.mut_header().set_error(err);
             Some(Ok(resp))
         } else {
             info!("[NotRetry] get_region_by_id returns Ok()");
-            Some(Ok(GetRegionResponse::new()))
+            Some(Ok(GetRegionResponse::default()))
         }
     }
 
@@ -98,14 +98,14 @@ impl PdMocker for NotRetry {
             info!(
                 "[NotRetry] get_region_by_id returns Ok(_) with header has INCOMPATIBLE_VERSION error"
             );
-            let mut err = Error::new();
+            let mut err = Error::default();
             err.set_field_type(ErrorType::INCOMPATIBLE_VERSION);
-            let mut resp = GetStoreResponse::new();
+            let mut resp = GetStoreResponse::default();
             resp.mut_header().set_error(err);
             Some(Ok(resp))
         } else {
             info!("[NotRetry] get_region_by_id returns Ok()");
-            Some(Ok(GetStoreResponse::new()))
+            Some(Ok(GetStoreResponse::default()))
         }
     }
 }

--- a/tests/integrations/pd/mock/mocker/service.rs
+++ b/tests/integrations/pd/mock/mocker/service.rs
@@ -34,7 +34,7 @@ impl Service {
     }
 
     fn header() -> ResponseHeader {
-        let mut header = ResponseHeader::new();
+        let mut header = ResponseHeader::default();
         header.set_cluster_id(DEFAULT_CLUSTER_ID);
         header
     }
@@ -49,7 +49,7 @@ impl Service {
 fn make_members_response(eps: Vec<String>) -> GetMembersResponse {
     let mut members = Vec::with_capacity(eps.len());
     for (i, ep) in (&eps).iter().enumerate() {
-        let mut m = Member::new();
+        let mut m = Member::default();
         m.set_name(format!("pd{}", i));
         m.set_member_id(100 + i as u64);
         m.set_client_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
@@ -57,7 +57,7 @@ fn make_members_response(eps: Vec<String>) -> GetMembersResponse {
         members.push(m);
     }
 
-    let mut members_resp = GetMembersResponse::new();
+    let mut members_resp = GetMembersResponse::default();
     members_resp.set_members(RepeatedField::from_vec(members.clone()));
     members_resp.set_leader(members.pop().unwrap());
     members_resp.set_header(Service::header());
@@ -76,11 +76,11 @@ impl PdMocker for Service {
         let store = req.get_store();
         let region = req.get_region();
 
-        let mut resp = BootstrapResponse::new();
+        let mut resp = BootstrapResponse::default();
         let mut header = Service::header();
 
         if self.is_bootstrapped.load(Ordering::SeqCst) {
-            let mut err = Error::new();
+            let mut err = Error::default();
             err.field_type = ErrorType::UNKNOWN;
             err.set_message("cluster is already bootstrapped".to_owned());
             header.set_error(err);
@@ -101,7 +101,7 @@ impl PdMocker for Service {
     }
 
     fn is_bootstrapped(&self, _: &IsBootstrappedRequest) -> Option<Result<IsBootstrappedResponse>> {
-        let mut resp = IsBootstrappedResponse::new();
+        let mut resp = IsBootstrappedResponse::default();
         let header = Service::header();
         resp.set_header(header);
         resp.set_bootstrapped(self.is_bootstrapped.load(Ordering::SeqCst));
@@ -109,7 +109,7 @@ impl PdMocker for Service {
     }
 
     fn alloc_id(&self, _: &AllocIDRequest) -> Option<Result<AllocIDResponse>> {
-        let mut resp = AllocIDResponse::new();
+        let mut resp = AllocIDResponse::default();
         resp.set_header(Service::header());
 
         let id = self.id_allocator.fetch_add(1, Ordering::SeqCst);
@@ -119,7 +119,7 @@ impl PdMocker for Service {
 
     // TODO: not bootstrapped error.
     fn get_store(&self, req: &GetStoreRequest) -> Option<Result<GetStoreResponse>> {
-        let mut resp = GetStoreResponse::new();
+        let mut resp = GetStoreResponse::default();
         let stores = self.stores.lock().unwrap();
         match stores.get(&req.get_store_id()) {
             Some(store) => {
@@ -129,7 +129,7 @@ impl PdMocker for Service {
             }
             None => {
                 let mut header = Service::header();
-                let mut err = Error::new();
+                let mut err = Error::default();
                 err.field_type = ErrorType::UNKNOWN;
                 err.set_message(format!("store not found {}", req.get_store_id()));
                 header.set_error(err);
@@ -140,7 +140,7 @@ impl PdMocker for Service {
     }
 
     fn get_all_stores(&self, req: &GetAllStoresRequest) -> Option<Result<GetAllStoresResponse>> {
-        let mut resp = GetAllStoresResponse::new();
+        let mut resp = GetAllStoresResponse::default();
         resp.set_header(Service::header());
         let exclude_tombstone = req.get_exclude_tombstone_stores();
         let stores = self.stores.lock().unwrap();
@@ -154,7 +154,7 @@ impl PdMocker for Service {
     }
 
     fn get_region(&self, req: &GetRegionRequest) -> Option<Result<GetRegionResponse>> {
-        let mut resp = GetRegionResponse::new();
+        let mut resp = GetRegionResponse::default();
         let key = req.get_region_key();
         let regions = self.regions.lock().unwrap();
         let leaders = self.leaders.lock().unwrap();
@@ -173,7 +173,7 @@ impl PdMocker for Service {
         }
 
         let mut header = Service::header();
-        let mut err = Error::new();
+        let mut err = Error::default();
         err.field_type = ErrorType::UNKNOWN;
         err.set_message(format!("region not found {:?}", key));
         header.set_error(err);
@@ -182,7 +182,7 @@ impl PdMocker for Service {
     }
 
     fn get_region_by_id(&self, req: &GetRegionByIDRequest) -> Option<Result<GetRegionResponse>> {
-        let mut resp = GetRegionResponse::new();
+        let mut resp = GetRegionResponse::default();
         let regions = self.regions.lock().unwrap();
         let leaders = self.leaders.lock().unwrap();
 
@@ -197,7 +197,7 @@ impl PdMocker for Service {
             }
             None => {
                 let mut header = Service::header();
-                let mut err = Error::new();
+                let mut err = Error::default();
                 err.field_type = ErrorType::UNKNOWN;
                 err.set_message(format!("region not found {}", req.region_id));
                 header.set_error(err);
@@ -221,28 +221,28 @@ impl PdMocker for Service {
             .unwrap()
             .insert(region_id, req.get_leader().clone());
 
-        let mut resp = RegionHeartbeatResponse::new();
+        let mut resp = RegionHeartbeatResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))
     }
 
     fn store_heartbeat(&self, _: &StoreHeartbeatRequest) -> Option<Result<StoreHeartbeatResponse>> {
-        let mut resp = StoreHeartbeatResponse::new();
+        let mut resp = StoreHeartbeatResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))
     }
 
     fn ask_split(&self, _: &AskSplitRequest) -> Option<Result<AskSplitResponse>> {
-        let mut resp = AskSplitResponse::new();
+        let mut resp = AskSplitResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))
     }
 
     fn ask_batch_split(&self, _: &AskBatchSplitRequest) -> Option<Result<AskBatchSplitResponse>> {
-        let mut resp = AskBatchSplitResponse::new();
+        let mut resp = AskBatchSplitResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))
@@ -252,14 +252,14 @@ impl PdMocker for Service {
         &self,
         _: &ReportBatchSplitRequest,
     ) -> Option<Result<ReportBatchSplitResponse>> {
-        let mut resp = ReportBatchSplitResponse::new();
+        let mut resp = ReportBatchSplitResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))
     }
 
     fn scatter_region(&self, _: &ScatterRegionRequest) -> Option<Result<ScatterRegionResponse>> {
-        let mut resp = ScatterRegionResponse::new();
+        let mut resp = ScatterRegionResponse::default();
         let header = Service::header();
         resp.set_header(header);
         Some(Ok(resp))

--- a/tests/integrations/pd/mock/mocker/split.rs
+++ b/tests/integrations/pd/mock/mocker/split.rs
@@ -42,7 +42,7 @@ impl PdMocker for Split {
     fn set_endpoints(&self, eps: Vec<String>) {
         let mut members = Vec::with_capacity(eps.len());
         for (i, ep) in (&eps).iter().enumerate() {
-            let mut m = Member::new();
+            let mut m = Member::default();
             m.set_name(format!("pd{}", i));
             m.set_member_id(100 + i as u64);
             m.set_client_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
@@ -52,8 +52,8 @@ impl PdMocker for Split {
 
         let mut resps = Vec::with_capacity(eps.len());
         for i in 0..eps.len() {
-            let mut resp = GetMembersResponse::new();
-            let mut header = ResponseHeader::new();
+            let mut resp = GetMembersResponse::default();
+            let mut header = ResponseHeader::default();
             header.set_cluster_id(i as u64 + 1); // start from 1.
             resp.set_header(header.clone());
             resp.set_members(RepeatedField::from_vec(members.clone()));

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -62,17 +62,17 @@ fn test_rpc_client() {
     assert_ne!(client.get_cluster_id().unwrap(), 0);
 
     let store_id = client.alloc_id().unwrap();
-    let mut store = metapb::Store::new();
+    let mut store = metapb::Store::default();
     store.set_id(store_id);
     debug!("bootstrap store {:?}", store);
 
     let peer_id = client.alloc_id().unwrap();
-    let mut peer = metapb::Peer::new();
+    let mut peer = metapb::Peer::default();
     peer.set_id(peer_id);
     peer.set_store_id(store_id);
 
     let region_id = client.alloc_id().unwrap();
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(region_id);
     region.mut_peers().push(peer.clone());
     debug!("bootstrap region {:?}", region);
@@ -127,15 +127,15 @@ fn test_rpc_client() {
     assert_eq!(region_info.leader.unwrap(), peer);
 
     client
-        .store_heartbeat(pdpb::StoreStats::new())
+        .store_heartbeat(pdpb::StoreStats::default())
         .wait()
         .unwrap();
     client
-        .ask_batch_split(metapb::Region::new(), 1)
+        .ask_batch_split(metapb::Region::default(), 1)
         .wait()
         .unwrap();
     client
-        .report_batch_split(vec![metapb::Region::new(), metapb::Region::new()])
+        .report_batch_split(vec![metapb::Region::default(), metapb::Region::default()])
         .wait()
         .unwrap();
 
@@ -152,10 +152,10 @@ fn test_get_tombstone_stores() {
 
     let mut all_stores = vec![];
     let store_id = client.alloc_id().unwrap();
-    let mut store = metapb::Store::new();
+    let mut store = metapb::Store::default();
     store.set_id(store_id);
     let region_id = client.alloc_id().unwrap();
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(region_id);
     client
         .bootstrap_cluster(store.clone(), region.clone())
@@ -167,7 +167,7 @@ fn test_get_tombstone_stores() {
     assert_eq!(s, all_stores);
 
     // Add tombstone store.
-    let mut store99 = metapb::Store::new();
+    let mut store99 = metapb::Store::default();
     store99.set_id(99);
     store99.set_state(metapb::StoreState::Tombstone);
     server.default_handler().add_store(store99.clone());
@@ -208,7 +208,7 @@ fn test_reboot() {
 
     assert!(!client.is_cluster_bootstrapped().unwrap());
 
-    match client.bootstrap_cluster(metapb::Store::new(), metapb::Region::new()) {
+    match client.bootstrap_cluster(metapb::Store::default(), metapb::Region::default()) {
         Err(PdError::ClusterBootstrapped(_)) => (),
         _ => {
             panic!("failed, should return ClusterBootstrapped");
@@ -300,7 +300,7 @@ fn test_incompatible_version() {
 
     let client = new_client(eps, None);
 
-    let resp = client.ask_batch_split(metapb::Region::new(), 2);
+    let resp = client.ask_batch_split(metapb::Region::default(), 2);
     assert_eq!(
         resp.wait().unwrap_err().to_string(),
         PdError::Incompatible.to_string()
@@ -317,16 +317,16 @@ fn restart_leader(mgr: SecurityManager) {
     let client = new_client(eps.clone(), Some(Arc::clone(&mgr)));
     // Put a region.
     let store_id = client.alloc_id().unwrap();
-    let mut store = metapb::Store::new();
+    let mut store = metapb::Store::default();
     store.set_id(store_id);
 
     let peer_id = client.alloc_id().unwrap();
-    let mut peer = metapb::Peer::new();
+    let mut peer = metapb::Peer::default();
     peer.set_id(peer_id);
     peer.set_store_id(store_id);
 
     let region_id = client.alloc_id().unwrap();
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(region_id);
     region.mut_peers().push(peer);
     client
@@ -408,8 +408,8 @@ fn test_region_heartbeat_on_leader_change() {
         tx.send(resp).unwrap();
     });
     poller.spawn(f).forget();
-    let region = metapb::Region::new();
-    let peer = metapb::Peer::new();
+    let region = metapb::Region::default();
+    let peer = metapb::Peer::default();
     let stat = RegionStat::default();
     poller
         .spawn(client.region_heartbeat(region.clone(), peer.clone(), stat.clone()))

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -31,7 +31,7 @@ fn must_new_cluster() -> (Cluster<ServerCluster>, metapb::Peer, Context) {
     let region_id = 1;
     let leader = cluster.leader_of_region(region_id).unwrap();
     let epoch = cluster.get_region_epoch(region_id);
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region_id);
     ctx.set_peer(leader.clone());
     ctx.set_region_epoch(epoch);
@@ -56,7 +56,7 @@ fn test_rawkv() {
     let (k, v) = (b"key".to_vec(), b"value".to_vec());
 
     // Raw put
-    let mut put_req = RawPutRequest::new();
+    let mut put_req = RawPutRequest::default();
     put_req.set_context(ctx.clone());
     put_req.key = k.clone();
     put_req.value = v.clone();
@@ -65,7 +65,7 @@ fn test_rawkv() {
     assert!(put_resp.error.is_empty());
 
     // Raw get
-    let mut get_req = RawGetRequest::new();
+    let mut get_req = RawGetRequest::default();
     get_req.set_context(ctx.clone());
     get_req.key = k.clone();
     let get_resp = client.raw_get(&get_req).unwrap();
@@ -74,7 +74,7 @@ fn test_rawkv() {
     assert_eq!(get_resp.value, v);
 
     // Raw scan
-    let mut scan_req = RawScanRequest::new();
+    let mut scan_req = RawScanRequest::default();
     scan_req.set_context(ctx.clone());
     scan_req.start_key = k.clone();
     scan_req.limit = 1;
@@ -88,7 +88,7 @@ fn test_rawkv() {
     }
 
     // Raw delete
-    let mut delete_req = RawDeleteRequest::new();
+    let mut delete_req = RawDeleteRequest::default();
     delete_req.set_context(ctx.clone());
     delete_req.key = k.clone();
     let delete_resp = client.raw_delete(&delete_req).unwrap();
@@ -97,7 +97,7 @@ fn test_rawkv() {
 }
 
 fn must_kv_prewrite(client: &TikvClient, ctx: Context, muts: Vec<Mutation>, pk: Vec<u8>, ts: u64) {
-    let mut prewrite_req = PrewriteRequest::new();
+    let mut prewrite_req = PrewriteRequest::default();
     prewrite_req.set_context(ctx);
     prewrite_req.set_mutations(muts.into_iter().collect());
     prewrite_req.primary_lock = pk;
@@ -123,7 +123,7 @@ fn must_kv_commit(
     start_ts: u64,
     commit_ts: u64,
 ) {
-    let mut commit_req = CommitRequest::new();
+    let mut commit_req = CommitRequest::default();
     commit_req.set_context(ctx);
     commit_req.start_version = start_ts;
     commit_req.set_keys(keys.into_iter().collect());
@@ -147,7 +147,7 @@ fn test_mvcc_basic() {
     // Prewrite
     ts += 1;
     let prewrite_start_version = ts;
-    let mut mutation = Mutation::new();
+    let mut mutation = Mutation::default();
     mutation.op = Op::Put;
     mutation.key = k.clone();
     mutation.value = v.clone();
@@ -173,7 +173,7 @@ fn test_mvcc_basic() {
     // Get
     ts += 1;
     let get_version = ts;
-    let mut get_req = GetRequest::new();
+    let mut get_req = GetRequest::default();
     get_req.set_context(ctx.clone());
     get_req.key = k.clone();
     get_req.version = get_version;
@@ -185,7 +185,7 @@ fn test_mvcc_basic() {
     // Scan
     ts += 1;
     let scan_version = ts;
-    let mut scan_req = ScanRequest::new();
+    let mut scan_req = ScanRequest::default();
     scan_req.set_context(ctx.clone());
     scan_req.start_key = k.clone();
     scan_req.limit = 1;
@@ -202,7 +202,7 @@ fn test_mvcc_basic() {
     // Batch get
     ts += 1;
     let batch_get_version = ts;
-    let mut batch_get_req = BatchGetRequest::new();
+    let mut batch_get_req = BatchGetRequest::default();
     batch_get_req.set_context(ctx.clone());
     batch_get_req.set_keys(vec![k.clone()].into_iter().collect());
     batch_get_req.version = batch_get_version;
@@ -225,7 +225,7 @@ fn test_mvcc_rollback_and_cleanup() {
     // Prewrite
     ts += 1;
     let prewrite_start_version = ts;
-    let mut mutation = Mutation::new();
+    let mut mutation = Mutation::default();
     mutation.op = Op::Put;
     mutation.key = k.clone();
     mutation.value = v.clone();
@@ -252,11 +252,11 @@ fn test_mvcc_rollback_and_cleanup() {
     ts += 1;
     let prewrite_start_version2 = ts;
     let (k2, v2) = (b"key2".to_vec(), b"value2".to_vec());
-    let mut mut_pri = Mutation::new();
+    let mut mut_pri = Mutation::default();
     mut_pri.op = Op::Put;
     mut_pri.key = k2.clone();
     mut_pri.value = v2.clone();
-    let mut mut_sec = Mutation::new();
+    let mut mut_sec = Mutation::default();
     mut_sec.op = Op::Put;
     mut_sec.key = k.clone();
     mut_sec.value = b"foo".to_vec();
@@ -271,7 +271,7 @@ fn test_mvcc_rollback_and_cleanup() {
     // Scan lock, expects locks
     ts += 1;
     let scan_lock_max_version = ts;
-    let mut scan_lock_req = ScanLockRequest::new();
+    let mut scan_lock_req = ScanLockRequest::default();
     scan_lock_req.set_context(ctx.clone());
     scan_lock_req.max_version = scan_lock_max_version;
     let scan_lock_resp = client.kv_scan_lock(&scan_lock_req).unwrap();
@@ -289,7 +289,7 @@ fn test_mvcc_rollback_and_cleanup() {
 
     // Rollback
     let rollback_start_version = prewrite_start_version2;
-    let mut rollback_req = BatchRollbackRequest::new();
+    let mut rollback_req = BatchRollbackRequest::default();
     rollback_req.set_context(ctx.clone());
     rollback_req.start_version = rollback_start_version;
     rollback_req.set_keys(vec![k2.clone()].into_iter().collect());
@@ -303,7 +303,7 @@ fn test_mvcc_rollback_and_cleanup() {
 
     // Cleanup
     let cleanup_start_version = prewrite_start_version2;
-    let mut cleanup_req = CleanupRequest::new();
+    let mut cleanup_req = CleanupRequest::default();
     cleanup_req.set_context(ctx.clone());
     cleanup_req.start_version = cleanup_start_version;
     cleanup_req.set_key(k2.clone());
@@ -314,7 +314,7 @@ fn test_mvcc_rollback_and_cleanup() {
     // There should be no locks
     ts += 1;
     let scan_lock_max_version2 = ts;
-    let mut scan_lock_req = ScanLockRequest::new();
+    let mut scan_lock_req = ScanLockRequest::default();
     scan_lock_req.set_context(ctx.clone());
     scan_lock_req.max_version = scan_lock_max_version2;
     let scan_lock_resp = client.kv_scan_lock(&scan_lock_req).unwrap();
@@ -334,7 +334,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     // Prewrite
     ts += 1;
     let prewrite_start_version = ts;
-    let mut mutation = Mutation::new();
+    let mut mutation = Mutation::default();
     mutation.op = Op::Put;
     mutation.key = k.clone();
     mutation.value = v.clone();
@@ -362,11 +362,11 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     let prewrite_start_version2 = ts;
     let (k2, v2) = (b"key2".to_vec(), b"value2".to_vec());
     let new_v = b"new value".to_vec();
-    let mut mut_pri = Mutation::new();
+    let mut mut_pri = Mutation::default();
     mut_pri.op = Op::Put;
     mut_pri.key = k.clone();
     mut_pri.value = new_v.clone();
-    let mut mut_sec = Mutation::new();
+    let mut mut_sec = Mutation::default();
     mut_sec.op = Op::Put;
     mut_sec.key = k2.clone();
     mut_sec.value = v2.to_vec();
@@ -381,8 +381,8 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     // Resolve lock
     ts += 1;
     let resolve_lock_commit_version = ts;
-    let mut resolve_lock_req = ResolveLockRequest::new();
-    let mut temp_txninfo = TxnInfo::new();
+    let mut resolve_lock_req = ResolveLockRequest::default();
+    let mut temp_txninfo = TxnInfo::default();
     temp_txninfo.txn = prewrite_start_version2;
     temp_txninfo.status = resolve_lock_commit_version;
     let vec_txninfo = vec![temp_txninfo];
@@ -395,7 +395,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     // Get `k` at the latest ts.
     ts += 1;
     let get_version1 = ts;
-    let mut get_req1 = GetRequest::new();
+    let mut get_req1 = GetRequest::default();
     get_req1.set_context(ctx.clone());
     get_req1.key = k.clone();
     get_req1.version = get_version1;
@@ -407,7 +407,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     // GC `k` at the latest ts.
     ts += 1;
     let gc_safe_ponit = ts;
-    let mut gc_req = GCRequest::new();
+    let mut gc_req = GCRequest::default();
     gc_req.set_context(ctx.clone());
     gc_req.safe_point = gc_safe_ponit;
     let gc_resp = client.kv_gc(&gc_req).unwrap();
@@ -416,7 +416,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
 
     // the `k` at the old ts should be none.
     let get_version2 = commit_version + 1;
-    let mut get_req2 = GetRequest::new();
+    let mut get_req2 = GetRequest::default();
     get_req2.set_context(ctx.clone());
     get_req2.key = k.clone();
     get_req2.version = get_version2;
@@ -427,7 +427,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
 
     // Transaction debugger commands
     // MvccGetByKey
-    let mut mvcc_get_by_key_req = MvccGetByKeyRequest::new();
+    let mut mvcc_get_by_key_req = MvccGetByKeyRequest::default();
     mvcc_get_by_key_req.set_context(ctx.clone());
     mvcc_get_by_key_req.key = k.clone();
     let mvcc_get_by_key_resp = client.mvcc_get_by_key(&mvcc_get_by_key_req).unwrap();
@@ -435,7 +435,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     assert!(mvcc_get_by_key_resp.error.is_empty());
     assert!(mvcc_get_by_key_resp.has_info());
     // MvccGetByStartTs
-    let mut mvcc_get_by_start_ts_req = MvccGetByStartTsRequest::new();
+    let mut mvcc_get_by_start_ts_req = MvccGetByStartTsRequest::default();
     mvcc_get_by_start_ts_req.set_context(ctx.clone());
     mvcc_get_by_start_ts_req.start_ts = prewrite_start_version2;
     let mvcc_get_by_start_ts_resp = client
@@ -447,7 +447,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     assert_eq!(mvcc_get_by_start_ts_resp.key, k);
 
     // Delete range
-    let mut del_req = DeleteRangeRequest::new();
+    let mut del_req = DeleteRangeRequest::default();
     del_req.set_context(ctx.clone());
     del_req.start_key = b"a".to_vec();
     del_req.end_key = b"z".to_vec();
@@ -462,7 +462,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
 fn test_coprocessor() {
     let (_cluster, client, _) = must_new_cluster_and_kv_client();
     // SQL push down commands
-    let mut req = Request::new();
+    let mut req = Request::default();
     req.set_tp(REQ_TYPE_DAG);
     client.coprocessor(&req).unwrap();
 }
@@ -473,7 +473,7 @@ fn test_split_region() {
 
     // Split region commands
     let key = b"b";
-    let mut req = SplitRegionRequest::new();
+    let mut req = SplitRegionRequest::default();
     req.set_context(ctx);
     req.set_split_key(key.to_vec());
     let resp = client.split_region(&req).unwrap();
@@ -496,7 +496,7 @@ fn test_read_index() {
     let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
 
     // Read index
-    let mut req = ReadIndexRequest::new();
+    let mut req = ReadIndexRequest::default();
     req.set_context(ctx.clone());
     let mut resp = client.read_index(&req).unwrap();
     let last_index = resp.get_read_index();
@@ -504,7 +504,7 @@ fn test_read_index() {
 
     // Raw put
     let (k, v) = (b"key".to_vec(), b"value".to_vec());
-    let mut put_req = RawPutRequest::new();
+    let mut put_req = RawPutRequest::default();
     put_req.set_context(ctx.clone());
     put_req.key = k.clone();
     put_req.value = v.clone();
@@ -540,7 +540,7 @@ fn test_debug_get() {
     assert_eq!(engine.get(&key).unwrap().unwrap(), v);
 
     // Debug get
-    let mut req = debugpb::GetRequest::new();
+    let mut req = debugpb::GetRequest::default();
     req.set_cf(CF_DEFAULT.to_owned());
     req.set_db(debugpb::DB::KV);
     req.set_key(key);
@@ -564,7 +564,7 @@ fn test_debug_raft_log() {
     let engine = cluster.get_raft_engine(store_id);
     let (region_id, log_index) = (200, 200);
     let key = keys::raft_log_key(region_id, log_index);
-    let mut entry = eraftpb::Entry::new();
+    let mut entry = eraftpb::Entry::default();
     entry.set_term(1);
     entry.set_index(1);
     entry.set_entry_type(eraftpb::EntryType::EntryNormal);
@@ -576,13 +576,13 @@ fn test_debug_raft_log() {
     );
 
     // Debug raft_log
-    let mut req = debugpb::RaftLogRequest::new();
+    let mut req = debugpb::RaftLogRequest::default();
     req.set_region_id(region_id);
     req.set_log_index(log_index);
     let resp = debug_client.raft_log(&req).unwrap();
-    assert_ne!(resp.get_entry(), &eraftpb::Entry::new());
+    assert_ne!(resp.get_entry(), &eraftpb::Entry::default());
 
-    let mut req = debugpb::RaftLogRequest::new();
+    let mut req = debugpb::RaftLogRequest::default();
     req.set_region_id(region_id + 1);
     req.set_log_index(region_id + 1);
     match debug_client.raft_log(&req).unwrap_err() {
@@ -603,7 +603,7 @@ fn test_debug_region_info() {
 
     let region_id = 100;
     let raft_state_key = keys::raft_state_key(region_id);
-    let mut raft_state = raft_serverpb::RaftLocalState::new();
+    let mut raft_state = raft_serverpb::RaftLocalState::default();
     raft_state.set_last_index(42);
     raft_engine.put_msg(&raft_state_key, &raft_state).unwrap();
     assert_eq!(
@@ -615,7 +615,7 @@ fn test_debug_region_info() {
     );
 
     let apply_state_key = keys::apply_state_key(region_id);
-    let mut apply_state = raft_serverpb::RaftApplyState::new();
+    let mut apply_state = raft_serverpb::RaftApplyState::default();
     apply_state.set_applied_index(42);
     kv_engine
         .put_msg_cf(raft_cf, &apply_state_key, &apply_state)
@@ -629,7 +629,7 @@ fn test_debug_region_info() {
     );
 
     let region_state_key = keys::region_state_key(region_id);
-    let mut region_state = raft_serverpb::RegionLocalState::new();
+    let mut region_state = raft_serverpb::RegionLocalState::default();
     region_state.set_state(raft_serverpb::PeerState::Tombstone);
     kv_engine
         .put_msg_cf(raft_cf, &region_state_key, &region_state)
@@ -643,7 +643,7 @@ fn test_debug_region_info() {
     );
 
     // Debug region_info
-    let mut req = debugpb::RegionInfoRequest::new();
+    let mut req = debugpb::RegionInfoRequest::default();
     req.set_region_id(region_id);
     let mut resp = debug_client.region_info(&req.clone()).unwrap();
     assert_eq!(resp.take_raft_local_state(), raft_state);
@@ -667,11 +667,11 @@ fn test_debug_region_size() {
     // Put some data.
     let region_id = 100;
     let region_state_key = keys::region_state_key(region_id);
-    let mut region = metapb::Region::new();
+    let mut region = metapb::Region::default();
     region.set_id(region_id);
     region.set_start_key(b"a".to_vec());
     region.set_end_key(b"z".to_vec());
-    let mut state = RegionLocalState::new();
+    let mut state = RegionLocalState::default();
     state.set_region(region);
     let cf_raft = engine.cf_handle(CF_RAFT).unwrap();
     engine
@@ -686,7 +686,7 @@ fn test_debug_region_size() {
         engine.put_cf(cf_handle, k.as_slice(), v).unwrap();
     }
 
-    let mut req = debugpb::RegionSizeRequest::new();
+    let mut req = debugpb::RegionSizeRequest::default();
     req.set_region_id(region_id);
     req.set_cfs(cfs.iter().map(|s| s.to_string()).collect());
     let entries = debug_client.region_size(&req).unwrap().take_entries();
@@ -712,13 +712,13 @@ fn test_debug_fail_point() {
 
     let (fp, act) = ("raft_between_save", "off");
 
-    let mut inject_req = debugpb::InjectFailPointRequest::new();
+    let mut inject_req = debugpb::InjectFailPointRequest::default();
     inject_req.set_name(fp.to_owned());
     inject_req.set_actions(act.to_owned());
     debug_client.inject_fail_point(&inject_req).unwrap();
 
     let resp = debug_client
-        .list_fail_points(&debugpb::ListFailPointsRequest::new())
+        .list_fail_points(&debugpb::ListFailPointsRequest::default())
         .unwrap();
     let entries = resp.get_entries();
     assert_eq!(entries.len(), 1);
@@ -727,12 +727,12 @@ fn test_debug_fail_point() {
         assert_eq!(e.get_actions(), act);
     }
 
-    let mut recover_req = debugpb::RecoverFailPointRequest::new();
+    let mut recover_req = debugpb::RecoverFailPointRequest::default();
     recover_req.set_name(fp.to_owned());
     debug_client.recover_fail_point(&recover_req).unwrap();
 
     let resp = debug_client
-        .list_fail_points(&debugpb::ListFailPointsRequest::new())
+        .list_fail_points(&debugpb::ListFailPointsRequest::default())
         .unwrap();
     let entries = resp.get_entries();
     assert_eq!(entries.len(), 0);
@@ -754,7 +754,7 @@ fn test_debug_scan_mvcc() {
         engine.put_cf(cf_handle, k.as_slice(), &v).unwrap();
     }
 
-    let mut req = debugpb::ScanMvccRequest::new();
+    let mut req = debugpb::ScanMvccRequest::default();
     req.set_from_key(keys::data_key(b"m"));
     req.set_to_key(keys::data_key(b"n"));
     req.set_limit(1);

--- a/tests/integrations/raftstore/test_split_region.rs
+++ b/tests/integrations/raftstore/test_split_region.rs
@@ -830,11 +830,11 @@ fn test_split_with_epoch_not_match() {
     pd_client.must_remove_peer(1, new_peer(2, 2));
     let region = cluster.get_region(b"");
 
-    let mut admin_req = AdminRequest::new();
+    let mut admin_req = AdminRequest::default();
     admin_req.set_cmd_type(AdminCmdType::BatchSplit);
 
-    let mut batch_split_req = BatchSplitRequest::new();
-    batch_split_req.mut_requests().push(SplitRequest::new());
+    let mut batch_split_req = BatchSplitRequest::default();
+    batch_split_req.mut_requests().push(SplitRequest::default());
     batch_split_req.mut_requests()[0].set_split_key(b"s".to_vec());
     batch_split_req.mut_requests()[0].set_new_region_id(1000);
     batch_split_req.mut_requests()[0].set_new_peer_ids(vec![1001, 1002]);

--- a/tests/integrations/raftstore/test_tombstone.rs
+++ b/tests/integrations/raftstore/test_tombstone.rs
@@ -64,12 +64,12 @@ fn test_tombstone<T: Simulator>(cluster: &mut Cluster<T>) {
     assert_eq!(existing_kvs[0].0.as_slice(), keys::STORE_IDENT_KEY);
     assert_eq!(existing_kvs[1].0, keys::region_state_key(r1));
 
-    let mut ident = StoreIdent::new();
+    let mut ident = StoreIdent::default();
     ident.merge_from_bytes(&existing_kvs[0].1).unwrap();
     assert_eq!(ident.get_store_id(), 2);
     assert_eq!(ident.get_cluster_id(), cluster.id());
 
-    let mut state = RegionLocalState::new();
+    let mut state = RegionLocalState::default();
     state.merge_from_bytes(&existing_kvs[1].1).unwrap();
     assert_eq!(state.get_state(), PeerState::Tombstone);
 
@@ -80,7 +80,7 @@ fn test_tombstone<T: Simulator>(cluster: &mut Cluster<T>) {
     assert!(conf_ver == 4 || conf_ver == 3);
 
     // Send a stale raft message to peer (2, 2)
-    let mut raft_msg = RaftMessage::new();
+    let mut raft_msg = RaftMessage::default();
 
     raft_msg.set_region_id(r1);
     // Use an invalid from peer to ignore gc peer message.
@@ -211,7 +211,7 @@ fn test_readd_peer<T: Simulator>(cluster: &mut Cluster<T>) {
 
     // Stale gc message should be ignored.
     let epoch = pd_client.get_region_epoch(r1);
-    let mut gc_msg = RaftMessage::new();
+    let mut gc_msg = RaftMessage::default();
     gc_msg.set_region_id(r1);
     gc_msg.set_from_peer(new_peer(1, 1));
     gc_msg.set_to_peer(new_peer(2, 2));

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -74,7 +74,7 @@ fn test_batch_raft_fallback() {
 
     let addr = format!("localhost:{}", port);
     (0..100).for_each(|_| {
-        raft_client.send(1, &addr, RaftMessage::new()).unwrap();
+        raft_client.send(1, &addr, RaftMessage::default()).unwrap();
         thread::sleep(time::Duration::from_millis(10));
         raft_client.flush();
     });
@@ -119,7 +119,7 @@ fn test_raft_client_reconnect() {
     let addr = format!("localhost:{}", port);
 
     // `send` should success.
-    (0..50).for_each(|_| raft_client.send(1, &addr, RaftMessage::new()).unwrap());
+    (0..50).for_each(|_| raft_client.send(1, &addr, RaftMessage::default()).unwrap());
     raft_client.flush();
 
     check_f(300, || counter.load(Ordering::SeqCst) == 50);
@@ -129,14 +129,14 @@ fn test_raft_client_reconnect() {
 
     let send = |_| {
         thread::sleep(time::Duration::from_millis(10));
-        raft_client.send(1, &addr, RaftMessage::new())
+        raft_client.send(1, &addr, RaftMessage::default())
     };
     assert!((0..100).map(send).collect::<Result<(), _>>().is_err());
 
     // `send` should success after the mock server restarted.
     let service = MockKvForRaft(Arc::clone(&counter));
     let mock_server = create_mock_server_on(service, port);
-    (0..50).for_each(|_| raft_client.send(1, &addr, RaftMessage::new()).unwrap());
+    (0..50).for_each(|_| raft_client.send(1, &addr, RaftMessage::default()).unwrap());
     raft_client.flush();
 
     check_f(300, || counter.load(Ordering::SeqCst) == 100);

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -172,7 +172,7 @@ fn test_engine_leader_change_twice() {
         .get_header()
         .get_current_term();
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(peers[0].clone());

--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -25,7 +25,7 @@ fn test_raftkv() {
     let leader_id = cluster.leader_of_region(region.get_id()).unwrap();
     let storage = cluster.sim.rl().storages[&leader_id.get_id()].clone();
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(region.get_peers()[0].clone());
@@ -56,7 +56,7 @@ fn test_read_leader_in_lease() {
     let leader = cluster.leader_of_region(region.get_id()).unwrap();
     let storage = cluster.sim.rl().storages[&leader.get_id()].clone();
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());
@@ -88,7 +88,7 @@ fn test_read_index_on_replica() {
     let leader = cluster.leader_of_region(region.get_id()).unwrap();
     let storage = cluster.sim.rl().storages[&leader.get_id()].clone();
 
-    let mut ctx = Context::new();
+    let mut ctx = Context::default();
     ctx.set_region_id(region.get_id());
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader.clone());
@@ -143,7 +143,7 @@ fn test_read_on_replica() {
     let leader = cluster.leader_of_region(region.get_id()).unwrap();
     let leader_storage = cluster.sim.rl().storages[&leader.get_id()].clone();
 
-    let mut leader_ctx = Context::new();
+    let mut leader_ctx = Context::default();
     leader_ctx.set_region_id(region.get_id());
     leader_ctx.set_region_epoch(region.get_region_epoch().clone());
     leader_ctx.set_peer(leader.clone());
@@ -165,7 +165,7 @@ fn test_read_on_replica() {
     }
 
     assert!(follower_peer.is_some());
-    let mut follower_ctx = Context::new();
+    let mut follower_ctx = Context::default();
     follower_ctx.set_region_id(region.get_id());
     follower_ctx.set_region_epoch(region.get_region_epoch().clone());
     follower_ctx.set_peer(follower_peer.as_ref().unwrap().clone());


### PR DESCRIPTION
Use `default` rather than `new` to create protobuf messages. Both rust-protobuf and Prost support creation `default` but only rust-protobuf has `new`. This P

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Use `default` rather than `new` to create protobuf messages. Both rust-protobuf and Prost support creation `default` but only rust-protobuf has `new`. This PR gets us closer to supporting Prost in TiKV, though note this PR does not introduce any aspect of Prost.



## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

Unit tests


## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Refer to a related PR or issue link (optional)

This is a subset of https://github.com/tikv/tikv/pull/5068. This should make #5068 easier to maintain, land, and review.

PTAL @brson @breeswish (apologies for the long, boring PR)