### PR TITLE
2.1.4: return region error when tikv is closing

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1087,6 +1087,13 @@ fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
             err.set_server_is_busy(server_is_busy_err);
             Some(err)
         }
+        Err(Error::Closed) => {
+            // TiKV is closing, return an RegionError to tell the client that this region is unavailable
+            // temporarily, the client should retry the request in other TiKVs.
+            let mut err = RegionError::new();
+            err.set_message("TiKV is Closing".to_string());
+            Some(err)
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Return an RegionError when TiKV is closing to tell the client that this region is unavailable temporarily, the client should retry the request in other TiKVs. And this change we have tested for 1 month, it works ok.

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Long time running test.

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

