### PR TITLE
Use `into` rather than explicitly using `RepeatedField`

### DIFF
--- a/benches/coprocessor_executors/index_scan/util.rs
+++ b/benches/coprocessor_executors/index_scan/util.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use protobuf::RepeatedField;
-
 use kvproto::coprocessor::KeyRange;
 use tipb::executor::IndexScan;
 use tipb::schema::ColumnInfo;
@@ -42,7 +40,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
         unique: bool,
     ) -> Self::E {
         let mut req = IndexScan::new();
-        req.set_columns(RepeatedField::from_slice(columns));
+        req.set_columns(columns.into());
 
         let mut executor = IndexScanExecutor::index_scan(
             black_box(req),

--- a/benches/coprocessor_executors/table_scan/util.rs
+++ b/benches/coprocessor_executors/table_scan/util.rs
@@ -5,8 +5,6 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use protobuf::RepeatedField;
-
 use kvproto::coprocessor::KeyRange;
 use tipb::executor::TableScan;
 use tipb::schema::ColumnInfo;
@@ -43,7 +41,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
         _: (),
     ) -> Self::E {
         let mut req = TableScan::new();
-        req.set_columns(RepeatedField::from_slice(columns));
+        req.set_columns(columns.into());
 
         let mut executor = TableScanExecutor::table_scan(
             black_box(req),

--- a/benches/coprocessor_executors/util/mod.rs
+++ b/benches/coprocessor_executors/util/mod.rs
@@ -10,8 +10,6 @@ pub use self::fixture::FixtureBuilder;
 
 use criterion::black_box;
 
-use protobuf::RepeatedField;
-
 use kvproto::coprocessor::KeyRange;
 use tipb::executor::Executor as PbExecutor;
 
@@ -41,7 +39,7 @@ pub fn build_dag_handler<TargetTxnStore: TxnStore + 'static>(
     use tipb::select::DAGRequest;
 
     let mut dag = DAGRequest::default();
-    dag.set_executors(RepeatedField::from_vec(executors.to_vec()));
+    dag.set_executors(executors.to_vec().into());
 
     DAGBuilder::build(
         black_box(dag),

--- a/benches/misc/serialization/bench_serialization.rs
+++ b/benches/misc/serialization/bench_serialization.rs
@@ -34,7 +34,7 @@ fn encode(map: &HashMap<&[u8], &[u8]>) -> Vec<u8> {
     let mut e = Entry::default();
     let mut cmd = RaftCmdRequest::default();
     let reqs = generate_requests(map);
-    cmd.set_requests(protobuf::RepeatedField::from_vec(reqs));
+    cmd.set_requests(reqs.into());
     let cmd_msg = cmd.write_to_bytes().unwrap();
     e.set_data(cmd_msg);
     e.write_to_bytes().unwrap()

--- a/components/test_coprocessor/src/dag.rs
+++ b/components/test_coprocessor/src/dag.rs
@@ -3,7 +3,6 @@
 use super::*;
 
 use protobuf::Message;
-use protobuf::RepeatedField;
 
 use kvproto::coprocessor::{KeyRange, Request};
 use kvproto::kvrpcpb::Context;
@@ -182,11 +181,11 @@ impl DAGSelect {
             exec.set_tp(ExecType::TypeAggregation);
             let mut aggr = Aggregation::new();
             if !self.aggregate.is_empty() {
-                aggr.set_agg_func(RepeatedField::from_vec(self.aggregate));
+                aggr.set_agg_func(self.aggregate.into());
             }
 
             if !self.group_by.is_empty() {
-                aggr.set_group_by(RepeatedField::from_vec(self.group_by));
+                aggr.set_group_by(self.group_by.into());
             }
             exec.set_aggregation(aggr);
             self.execs.push(exec);
@@ -196,7 +195,7 @@ impl DAGSelect {
             let mut exec = Executor::new();
             exec.set_tp(ExecType::TypeTopN);
             let mut topn = TopN::new();
-            topn.set_order_by(RepeatedField::from_vec(self.order_by));
+            topn.set_order_by(self.order_by.into());
             if let Some(limit) = self.limit.take() {
                 topn.set_limit(limit);
             }
@@ -214,7 +213,7 @@ impl DAGSelect {
         }
 
         let mut dag = DAGRequest::default();
-        dag.set_executors(RepeatedField::from_vec(self.execs));
+        dag.set_executors(self.execs.into());
         dag.set_start_ts(next_id() as u64);
         dag.set_flags(flags.iter().fold(0, |acc, f| acc | *f));
         dag.set_collect_range_counts(true);
@@ -229,7 +228,7 @@ impl DAGSelect {
         let mut req = Request::default();
         req.set_tp(REQ_TYPE_DAG);
         req.set_data(dag.write_to_bytes().unwrap());
-        req.set_ranges(RepeatedField::from_vec(vec![self.key_range]));
+        req.set_ranges(vec![self.key_range].into());
         req.set_context(ctx);
         req
     }

--- a/components/test_coprocessor/src/table.rs
+++ b/components/test_coprocessor/src/table.rs
@@ -7,8 +7,6 @@ use std::collections::BTreeMap;
 use kvproto::coprocessor::KeyRange;
 use tipb::schema::{self, ColumnInfo};
 
-use protobuf::RepeatedField;
-
 use tikv::coprocessor;
 use tikv::coprocessor::codec::table;
 use tikv_util::codec::number::NumberEncoder;
@@ -45,7 +43,7 @@ impl Table {
     pub fn table_info(&self) -> schema::TableInfo {
         let mut info = schema::TableInfo::new();
         info.set_table_id(self.id);
-        info.set_columns(RepeatedField::from_vec(self.columns_info()));
+        info.set_columns(self.columns_info().into());
         info
     }
 

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -5,7 +5,6 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 use std::{thread, u64};
 
-use protobuf;
 use rand::RngCore;
 use tempfile::{Builder, TempDir};
 
@@ -198,7 +197,7 @@ pub fn new_request(
     read_quorum: bool,
 ) -> RaftCmdRequest {
     let mut req = new_base_request(region_id, epoch, read_quorum);
-    req.set_requests(protobuf::RepeatedField::from_vec(requests));
+    req.set_requests(requests.into());
     req
 }
 

--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -21,7 +21,6 @@ use clap::{crate_authors, crate_version, App, AppSettings, Arg, ArgMatches, SubC
 use futures::{future, stream, Future, Stream};
 use grpcio::{CallOption, ChannelBuilder, Environment};
 use protobuf::Message;
-use protobuf::RepeatedField;
 
 use engine::rocks;
 use engine::rocks::util::security::encrypted_env_from_cipher_file;
@@ -584,9 +583,9 @@ impl DebugExecutor for DebugClient {
     }
 
     fn get_region_size(&self, region: u64, cfs: Vec<&str>) -> Vec<(String, usize)> {
-        let cfs = cfs.into_iter().map(ToOwned::to_owned).collect();
+        let cfs = cfs.into_iter().map(ToOwned::to_owned).collect::<Vec<_>>();
         let mut req = RegionSizeRequest::default();
-        req.set_cfs(RepeatedField::from_vec(cfs));
+        req.set_cfs(cfs.into());
         req.set_region_id(region);
         self.region_size(&req)
             .unwrap_or_else(|e| perror_and_exit("DebugClient::region_size", e))

--- a/src/coprocessor/dag/batch_handler.rs
+++ b/src/coprocessor/dag/batch_handler.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use protobuf::{Message, RepeatedField};
+use protobuf::Message;
 
 use kvproto::coprocessor::Response;
 use tipb::executor::ExecutorExecutionSummary;
@@ -163,8 +163,8 @@ impl RequestHandler for BatchDAGHandler {
                             ret.set_time_processed_ns(summary.time_processed_ns as u64);
                             ret
                         })
-                        .collect();
-                    sel_resp.set_execution_summaries(RepeatedField::from_vec(summaries));
+                        .collect::<Vec<_>>();
+                    sel_resp.set_execution_summaries(summaries.into());
                 }
 
                 sel_resp.set_warnings(warnings.warnings.into());

--- a/src/coprocessor/dag/executor/aggregation.rs
+++ b/src/coprocessor/dag/executor/aggregation.rs
@@ -402,7 +402,6 @@ mod tests {
 
     use cop_datatype::FieldTypeTp;
     use kvproto::kvrpcpb::IsolationLevel;
-    use protobuf::RepeatedField;
     use tipb::expression::{Expr, ExprType};
     use tipb::schema::ColumnInfo;
 
@@ -493,10 +492,10 @@ mod tests {
         let mut aggregation = Aggregation::default();
         let group_by_cols = vec![0, 1];
         let group_by = build_group_by(&group_by_cols);
-        aggregation.set_group_by(RepeatedField::from_vec(group_by));
+        aggregation.set_group_by(group_by.into());
         let funcs = vec![(ExprType::Count, 0), (ExprType::Sum, 1), (ExprType::Avg, 1)];
         let agg_funcs = build_aggr_func(&funcs);
-        aggregation.set_agg_func(RepeatedField::from_vec(agg_funcs));
+        aggregation.set_agg_func(agg_funcs.into());
 
         // test no row
         let idx_vals = vec![];
@@ -723,7 +722,7 @@ mod tests {
         let mut aggregation = Aggregation::default();
         let group_by_cols = vec![1, 2];
         let group_by = build_group_by(&group_by_cols);
-        aggregation.set_group_by(RepeatedField::from_vec(group_by));
+        aggregation.set_group_by(group_by.into());
         let aggr_funcs = vec![
             (ExprType::Avg, 0),
             (ExprType::Count, 2),
@@ -731,7 +730,7 @@ mod tests {
             (ExprType::Avg, 4),
         ];
         let aggr_funcs = build_aggr_func(&aggr_funcs);
-        aggregation.set_agg_func(RepeatedField::from_vec(aggr_funcs));
+        aggregation.set_agg_func(aggr_funcs.into());
         // init the hash aggregation executor
         let mut aggr_ect =
             HashAggExecutor::new(aggregation, Arc::new(EvalConfig::default()), ts_ect).unwrap();

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -119,7 +119,6 @@ pub mod tests {
 
     use cop_datatype::FieldTypeTp;
     use kvproto::kvrpcpb::IsolationLevel;
-    use protobuf::RepeatedField;
     use tipb::schema::ColumnInfo;
 
     use crate::coprocessor::codec::datum::{self, Datum};
@@ -227,9 +226,7 @@ pub mod tests {
             let mut wrapper = IndexTestWrapper::new(unique, test_data);
             let mut cols = wrapper.data.cols.clone();
             cols.push(wrapper.data.get_col_pk());
-            wrapper
-                .scan
-                .set_columns(RepeatedField::from_vec(cols.clone()));
+            wrapper.scan.set_columns(cols.clone().into());
             wrapper.cols = cols;
             wrapper
         }
@@ -239,7 +236,7 @@ pub mod tests {
             let mut scan = IndexScan::new();
             // prepare cols
             let cols = test_data.cols.clone();
-            let col_req = RepeatedField::from_vec(cols.clone());
+            let col_req = cols.clone().into();
             scan.set_columns(col_req);
             // prepare range
             let val_start = Datum::Bytes(b"a".to_vec());

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -371,7 +371,6 @@ pub mod tests {
         coprocessor::KeyRange,
         kvrpcpb::{Context, IsolationLevel},
     };
-    use protobuf::RepeatedField;
     use tikv_util::codec::number::NumberEncoder;
     use tipb::{
         executor::TableScan,
@@ -502,7 +501,7 @@ pub mod tests {
 
         let mut table_scan = TableScan::new();
         table_scan.set_table_id(tid);
-        table_scan.set_columns(RepeatedField::from_vec(cis.clone()));
+        table_scan.set_columns(cis.clone().into());
 
         let key_ranges = key_ranges.unwrap_or_else(|| vec![get_range(tid, 0, i64::max_value())]);
 

--- a/src/coprocessor/dag/executor/table_scan.rs
+++ b/src/coprocessor/dag/executor/table_scan.rs
@@ -81,7 +81,6 @@ mod tests {
     use std::i64;
 
     use kvproto::{coprocessor::KeyRange, kvrpcpb::IsolationLevel};
-    use protobuf::RepeatedField;
     use tipb::{executor::TableScan, schema::ColumnInfo};
 
     use crate::storage::SnapshotStore;
@@ -116,7 +115,7 @@ mod tests {
             let mut table_scan = TableScan::new();
             // prepare cols
             let cols = test_data.get_prev_2_cols();
-            let col_req = RepeatedField::from_vec(cols.clone());
+            let col_req = cols.clone().into();
             table_scan.set_columns(col_req);
             // prepare range
             let range = get_range(TABLE_ID, i64::MIN, i64::MAX);

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -156,7 +156,6 @@ pub mod tests {
     use std::sync::Arc;
 
     use cop_datatype::FieldTypeTp;
-    use protobuf::RepeatedField;
     use tipb::expression::{Expr, ExprType};
 
     use crate::coprocessor::codec::table::RowColsDict;
@@ -392,7 +391,7 @@ pub mod tests {
         ob_vec.push(new_order_by(1, false));
         ob_vec.push(new_order_by(2, true));
         let mut topn = TopN::default();
-        topn.set_order_by(RepeatedField::from_vec(ob_vec));
+        topn.set_order_by(ob_vec.into());
         let limit = 4;
         topn.set_limit(limit);
         // init topn executor
@@ -438,7 +437,7 @@ pub mod tests {
         ob_vec.push(new_order_by(1, false));
         ob_vec.push(new_order_by(2, true));
         let mut topn = TopN::default();
-        topn.set_order_by(RepeatedField::from_vec(ob_vec));
+        topn.set_order_by(ob_vec.into());
         // test with limit=0
         topn.set_limit(0);
         let mut topn_ect =

--- a/src/coprocessor/dag/expr/builtin_compare.rs
+++ b/src/coprocessor/dag/expr/builtin_compare.rs
@@ -475,7 +475,6 @@ mod tests {
     use crate::coprocessor::codec::Datum;
     use crate::coprocessor::dag::expr::tests::{col_expr, datum_expr, str2dec};
     use crate::coprocessor::dag::expr::{EvalContext, Expression, Flag, SqlMode};
-    use protobuf::RepeatedField;
     use std::sync::Arc;
     use std::{i64, u64};
     use tipb::expression::{Expr, ExprType, ScalarFuncSig};
@@ -575,7 +574,7 @@ mod tests {
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(sig);
 
-            expr.set_children(RepeatedField::from_vec(children));
+            expr.set_children(children.into());
             let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &row).unwrap();
             assert_eq!(res, exp);
@@ -706,7 +705,7 @@ mod tests {
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(sig);
 
-            expr.set_children(RepeatedField::from_vec(children));
+            expr.set_children(children.into());
             let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &row).unwrap();
             assert_eq!(res, exp);
@@ -893,7 +892,7 @@ mod tests {
                     let mut expr = Expr::new();
                     expr.set_tp(ExprType::ScalarFunc);
                     expr.set_sig(greatest_sig);
-                    expr.set_children(RepeatedField::from_vec(children));
+                    expr.set_children(children.into());
                     let e = Expression::build(&ctx, expr).unwrap();
                     let res = e.eval(&mut ctx, &[]).unwrap();
                     assert_eq!(res, greatest_exp);
@@ -904,7 +903,7 @@ mod tests {
                     let mut expr = Expr::new();
                     expr.set_tp(ExprType::ScalarFunc);
                     expr.set_sig(least_sig);
-                    expr.set_children(RepeatedField::from_vec(children));
+                    expr.set_children(children.into());
                     let e = Expression::build(&ctx, expr).unwrap();
                     let res = e.eval(&mut ctx, &[]).unwrap();
                     assert_eq!(res, least_exp);
@@ -954,7 +953,7 @@ mod tests {
             let mut expr = Expr::new();
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(ScalarFuncSig::GreatestTime);
-            expr.set_children(RepeatedField::from_vec(children));
+            expr.set_children(children.into());
             let e = Expression::build(&ctx, expr).unwrap();
             let err = e.eval(&mut ctx, &[]).unwrap_err();
             assert_eq!(err.code(), ERR_TRUNCATE_WRONG_VALUE);

--- a/src/coprocessor/dag/expr/builtin_control.rs
+++ b/src/coprocessor/dag/expr/builtin_control.rs
@@ -218,7 +218,6 @@ impl ScalarFunc {
 
 #[cfg(test)]
 mod tests {
-    use protobuf::RepeatedField;
     use tipb::expression::{Expr, ExprType, ScalarFuncSig};
 
     use crate::coprocessor::codec::mysql::{Duration, Json, Time};
@@ -526,7 +525,7 @@ mod tests {
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(sig);
 
-            expr.set_children(RepeatedField::from_vec(children));
+            expr.set_children(children.into());
             let e = Expression::build(&ctx, expr).unwrap();
             let res = e.eval(&mut ctx, &row).unwrap();
             assert_eq!(res, exp);

--- a/src/coprocessor/dag/handler.rs
+++ b/src/coprocessor/dag/handler.rs
@@ -1,7 +1,7 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use kvproto::coprocessor::{KeyRange, Response};
-use protobuf::{Message, RepeatedField};
+use protobuf::Message;
 use tipb::executor::ExecutorExecutionSummary;
 use tipb::select::{Chunk, SelectResponse, StreamResponse};
 
@@ -44,7 +44,7 @@ impl DAGRequestHandler {
         let mut s_resp = StreamResponse::default();
         s_resp.set_data(box_try!(chunk.write_to_bytes()));
         if let Some(eval_warnings) = self.executor.take_eval_warnings() {
-            s_resp.set_warnings(RepeatedField::from_vec(eval_warnings.warnings));
+            s_resp.set_warnings(eval_warnings.warnings.into());
             s_resp.set_warning_count(eval_warnings.warning_cnt as i64);
         }
         self.executor
@@ -81,9 +81,9 @@ impl RequestHandler for DAGRequestHandler {
                 Ok(None) => {
                     let mut resp = Response::default();
                     let mut sel_resp = SelectResponse::default();
-                    sel_resp.set_chunks(RepeatedField::from_vec(chunks));
+                    sel_resp.set_chunks(chunks.into());
                     if let Some(eval_warnings) = self.executor.take_eval_warnings() {
-                        sel_resp.set_warnings(RepeatedField::from_vec(eval_warnings.warnings));
+                        sel_resp.set_warnings(eval_warnings.warnings.into());
                         sel_resp.set_warning_count(eval_warnings.warning_cnt as i64);
                     }
                     self.executor
@@ -103,8 +103,8 @@ impl RequestHandler for DAGRequestHandler {
                                 ret.set_time_processed_ns(summary.time_processed_ns as u64);
                                 ret
                             })
-                            .collect();
-                        sel_resp.set_execution_summaries(RepeatedField::from_vec(summaries));
+                            .collect::<Vec<_>>();
+                        sel_resp.set_execution_summaries(summaries.into());
                     }
 
                     let data = box_try!(sel_resp.write_to_bytes());

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -3,7 +3,7 @@
 use std::mem;
 
 use kvproto::coprocessor::{KeyRange, Response};
-use protobuf::{Message, RepeatedField};
+use protobuf::Message;
 use rand::rngs::ThreadRng;
 use rand::{thread_rng, Rng};
 use tipb::analyze::{self, AnalyzeColumnsReq, AnalyzeIndexReq, AnalyzeReq, AnalyzeType};
@@ -62,7 +62,7 @@ impl<S: Snapshot> AnalyzeContext<S> {
 
         let res_data = {
             let mut res = analyze::AnalyzeColumnsResp::new();
-            res.set_collectors(RepeatedField::from_vec(cols));
+            res.set_collectors(cols.into());
             res.set_pk_hist(pk_hist);
             box_try!(res.write_to_bytes())
         };
@@ -260,7 +260,7 @@ impl SampleCollector {
         s.set_null_count(self.null_count as i64);
         s.set_count(self.count as i64);
         s.set_fm_sketch(self.fm_sketch.into_proto());
-        s.set_samples(RepeatedField::from_vec(self.samples));
+        s.set_samples(self.samples.into());
         if let Some(c) = self.cm_sketch {
             s.set_cm_sketch(c.into_proto())
         }

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -2,7 +2,6 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
-use protobuf::RepeatedField;
 use tipb::analyze;
 
 /// `CMSketch` is used to estimate point queries.
@@ -57,7 +56,7 @@ impl CMSketch {
         for (i, row) in self.table.iter().enumerate() {
             rows[i].set_counters(row.to_vec());
         }
-        proto.set_rows(RepeatedField::from_vec(rows));
+        proto.set_rows(rows.into());
         proto
     }
 }

--- a/src/coprocessor/statistics/histogram.rs
+++ b/src/coprocessor/statistics/histogram.rs
@@ -1,6 +1,5 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use protobuf::RepeatedField;
 use std::mem;
 use tipb::analyze;
 
@@ -80,7 +79,7 @@ impl Histogram {
             .into_iter()
             .map(|bucket| bucket.into_proto())
             .collect();
-        hist.set_buckets(RepeatedField::from_vec(buckets));
+        hist.set_buckets(buckets.into());
         hist
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 #![feature(duration_float)]
 #![feature(specialization)]
 #![feature(const_fn)]
+#![feature(mem_take)]
 
 #[macro_use]
 extern crate bitflags;

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -10,7 +10,6 @@ use futures::{future, Future, Sink, Stream};
 use grpcio::{CallOption, EnvBuilder, WriteFlags};
 use kvproto::metapb;
 use kvproto::pdpb::{self, Member};
-use protobuf::RepeatedField;
 
 use super::metrics::*;
 use super::util::{check_resp_header, sync_request, validate_endpoints, Inner, LeaderClient};
@@ -300,8 +299,8 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_region(region);
         req.set_leader(leader);
-        req.set_down_peers(RepeatedField::from_vec(region_stat.down_peers));
-        req.set_pending_peers(RepeatedField::from_vec(region_stat.pending_peers));
+        req.set_down_peers(region_stat.down_peers.into());
+        req.set_pending_peers(region_stat.pending_peers.into());
         req.set_bytes_written(region_stat.written_bytes);
         req.set_keys_written(region_stat.written_keys);
         req.set_bytes_read(region_stat.read_bytes);
@@ -452,7 +451,7 @@ impl PdClient for RpcClient {
 
         let mut req = pdpb::ReportBatchSplitRequest::default();
         req.set_header(self.header());
-        req.set_regions(RepeatedField::from_vec(regions));
+        req.set_regions(regions.into());
 
         let executor = move |client: &RwLock<Inner>, req: pdpb::ReportBatchSplitRequest| {
             let handler = client

--- a/src/pd/pd.rs
+++ b/src/pd/pd.rs
@@ -15,7 +15,6 @@ use kvproto::pdpb;
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, RaftCmdRequest, SplitRequest};
 use kvproto::raft_serverpb::RaftMessage;
 use prometheus::local::LocalHistogram;
-use protobuf::RepeatedField;
 use raft::eraftpb::ConfChangeType;
 
 use super::metrics::*;
@@ -780,8 +779,7 @@ fn new_batch_split_region_request(
         split.set_new_peer_ids(id.take_new_peer_ids());
         requests.push(split);
     }
-    req.mut_splits()
-        .set_requests(RepeatedField::from_vec(requests));
+    req.mut_splits().set_requests(requests.into());
     req
 }
 

--- a/src/raftstore/coprocessor/mod.rs
+++ b/src/raftstore/coprocessor/mod.rs
@@ -4,7 +4,6 @@ use engine::rocks::DB;
 use kvproto::metapb::Region;
 use kvproto::pdpb::CheckPolicy;
 use kvproto::raft_cmdpb::{AdminRequest, AdminResponse, Request, Response};
-use protobuf::RepeatedField;
 use raft::StateRole;
 
 pub mod config;
@@ -72,11 +71,7 @@ pub trait QueryObserver: Coprocessor {
     /// Hook to call before proposing write request.
     ///
     /// We don't propose read request, hence there is no hook for it yet.
-    fn pre_propose_query(
-        &self,
-        _: &mut ObserverContext<'_>,
-        _: &mut RepeatedField<Request>,
-    ) -> Result<()> {
+    fn pre_propose_query(&self, _: &mut ObserverContext<'_>, _: &mut Vec<Request>) -> Result<()> {
         Ok(())
     }
 
@@ -84,7 +79,7 @@ pub trait QueryObserver: Coprocessor {
     fn pre_apply_query(&self, _: &mut ObserverContext<'_>, _: &[Request]) {}
 
     /// Hook to call after applying write request.
-    fn post_apply_query(&self, _: &mut ObserverContext<'_>, _: &mut RepeatedField<Response>) {}
+    fn post_apply_query(&self, _: &mut ObserverContext<'_>, _: &mut Vec<Response>) {}
 }
 
 /// SplitChecker is invoked during a split check scan, and decides to use

--- a/src/raftstore/coprocessor/split_observer.rs
+++ b/src/raftstore/coprocessor/split_observer.rs
@@ -7,7 +7,6 @@ use tikv_util::codec::bytes::{self, encode_bytes};
 use crate::raftstore::store::util;
 use kvproto::metapb::Region;
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, SplitRequest};
-use protobuf::RepeatedField;
 use std::result::Result as StdResult;
 
 /// `SplitObserver` adjusts the split key so that it won't separate
@@ -153,8 +152,7 @@ impl AdminObserver for SplitObserver {
                     );
                     return Err(box_err!(e));
                 }
-                req.mut_splits()
-                    .set_requests(RepeatedField::from_vec(requests));
+                req.mut_splits().set_requests(requests.into());
             }
             _ => return Ok(()),
         }

--- a/src/raftstore/errors.rs
+++ b/src/raftstore/errors.rs
@@ -6,7 +6,7 @@ use std::net;
 use std::result;
 
 use crossbeam::TrySendError;
-use protobuf::{ProtobufError, RepeatedField};
+use protobuf::ProtobufError;
 
 use crate::pd;
 use kvproto::{errorpb, metapb};
@@ -184,7 +184,7 @@ impl From<Error> for errorpb::Error {
             }
             Error::EpochNotMatch(_, new_regions) => {
                 let mut e = errorpb::EpochNotMatch::default();
-                e.set_current_regions(RepeatedField::from_vec(new_regions));
+                e.set_current_regions(new_regions.into());
                 errorpb.set_epoch_not_match(e);
             }
             Error::StaleCommand => {

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -26,7 +26,6 @@ use kvproto::raft_cmdpb::{
 use kvproto::raft_serverpb::{
     MergeState, PeerState, RaftApplyState, RaftTruncatedState, RegionLocalState,
 };
-use protobuf::RepeatedField;
 use raft::eraftpb::{ConfChange, ConfChangeType, Entry, EntryType, Snapshot as RaftSnapshot};
 use raft::NO_LIMIT;
 use uuid::Uuid;
@@ -1143,7 +1142,7 @@ impl ApplyDelegate {
             let uuid = req.get_header().get_uuid().to_vec();
             resp.mut_header().set_uuid(uuid);
         }
-        resp.set_responses(RepeatedField::from_vec(responses));
+        resp.set_responses(responses.into());
 
         assert!(ranges.is_empty() || ssts.is_empty());
         let exec_res = if !ranges.is_empty() {
@@ -1657,7 +1656,7 @@ impl ApplyDelegate {
             new_region.set_region_epoch(derived.get_region_epoch().to_owned());
             new_region.set_start_key(keys.pop_front().unwrap());
             new_region.set_end_key(keys.front().unwrap().to_vec());
-            new_region.set_peers(RepeatedField::from_slice(derived.get_peers()));
+            new_region.set_peers(derived.get_peers().into());
             for (peer, peer_id) in new_region
                 .mut_peers()
                 .iter_mut()
@@ -1683,8 +1682,7 @@ impl ApplyDelegate {
             panic!("{} fails to update region {:?}: {:?}", self.tag, derived, e)
         });
         let mut resp = AdminResponse::default();
-        resp.mut_splits()
-            .set_regions(RepeatedField::from_slice(&regions));
+        resp.mut_splits().set_regions(regions.clone().into());
         PEER_ADMIN_CMD_COUNTER_VEC
             .with_label_values(&["batch-split", "success"])
             .inc();
@@ -3431,7 +3429,7 @@ mod tests {
             self.pre_query_count.fetch_add(1, Ordering::SeqCst);
         }
 
-        fn post_apply_query(&self, _: &mut ObserverContext<'_>, _: &mut RepeatedField<Response>) {
+        fn post_apply_query(&self, _: &mut ObserverContext<'_>, _: &mut Vec<Response>) {
             self.post_query_count.fetch_add(1, Ordering::SeqCst);
         }
     }
@@ -3784,7 +3782,7 @@ mod tests {
         reg.region.set_end_key(b"k5".to_vec());
         reg.region.mut_region_epoch().set_version(3);
         let peers = vec![new_peer(2, 3), new_peer(4, 5), new_learner_peer(6, 7)];
-        reg.region.set_peers(RepeatedField::from_vec(peers.clone()));
+        reg.region.set_peers(peers.clone().into());
         let (tx, _rx) = mpsc::channel();
         let sender = Notifier::Sender(tx);
         let host = Arc::new(CoprocessorHost::default());

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -25,7 +25,7 @@ use kvproto::raft_cmdpb::{
 use kvproto::raft_serverpb::{
     MergeState, PeerState, RaftMessage, RaftSnapshotData, RaftTruncatedState, RegionLocalState,
 };
-use protobuf::{Message, RepeatedField};
+use protobuf::Message;
 use raft::eraftpb::{ConfChangeType, MessageType};
 use raft::{self, SnapshotStatus, INVALID_INDEX, NO_LIMIT};
 use raft::{Ready, StateRole};
@@ -1793,9 +1793,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 .mut_commit_merge()
                 .set_source(self.fsm.peer.region().clone());
             admin.mut_commit_merge().set_commit(state.get_commit());
-            admin
-                .mut_commit_merge()
-                .set_entries(RepeatedField::from_vec(entries));
+            admin.mut_commit_merge().set_entries(entries.into());
             request.set_admin_request(admin);
             (request, target_id)
         };

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -2058,7 +2058,6 @@ mod tests {
 
     use crate::raftstore::coprocessor::properties::{IndexHandle, IndexHandles, SizeProperties};
     use crate::storage::kv::CompactedEvent;
-    use protobuf::RepeatedField;
 
     use super::*;
 
@@ -2115,7 +2114,7 @@ mod tests {
             for (i, (start, end)) in meta.into_iter().enumerate() {
                 let mut region = metapb::Region::default();
                 let peer = metapb::Peer::default();
-                region.set_peers(RepeatedField::from_vec(vec![peer]));
+                region.set_peers(vec![peer].into());
                 region.set_start_key(start.to_vec());
                 region.set_end_key(end.to_vec());
 
@@ -2151,7 +2150,7 @@ mod tests {
             for (i, (start, end)) in meta.into_iter().enumerate() {
                 let mut region = metapb::Region::default();
                 let peer = metapb::Peer::default();
-                region.set_peers(RepeatedField::from_vec(vec![peer]));
+                region.set_peers(vec![peer].into());
                 region.set_start_key(start.to_vec());
                 region.set_end_key(end.to_vec());
 

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -2620,7 +2620,7 @@ impl ReadExecutor {
         }
 
         let mut response = RaftCmdResponse::default();
-        response.set_responses(protobuf::RepeatedField::from_vec(responses));
+        response.set_responses(responses.into());
         let snapshot = if need_snapshot {
             Some(RegionSnapshot::from_snapshot(
                 self.snapshot.clone().unwrap(),

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -21,7 +21,6 @@ use kvproto::metapb::Region;
 use kvproto::raft_serverpb::RaftSnapshotData;
 use kvproto::raft_serverpb::{SnapshotCFFile, SnapshotMeta};
 use protobuf::Message;
-use protobuf::RepeatedField;
 use raft::eraftpb::Snapshot as RaftSnapshot;
 
 use crate::raftstore::errors::Error as RaftStoreError;
@@ -235,7 +234,7 @@ fn gen_snapshot_meta(cf_files: &[CfFile]) -> RaftStoreResult<SnapshotMeta> {
         meta.push(cf_file_meta);
     }
     let mut snapshot_meta = SnapshotMeta::default();
-    snapshot_meta.set_cf_files(RepeatedField::from_vec(meta));
+    snapshot_meta.set_cf_files(meta.into());
     Ok(snapshot_meta)
 }
 

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -24,7 +24,6 @@ use engine::Engines;
 use engine::Peekable;
 use kvproto::metapb;
 use kvproto::raft_serverpb::StoreIdent;
-use protobuf::RepeatedField;
 use tikv_util::worker::FutureWorker;
 
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
@@ -95,7 +94,7 @@ where
             label.set_value(v.to_owned());
             labels.push(label);
         }
-        store.set_labels(RepeatedField::from_vec(labels));
+        store.set_labels(labels.into());
 
         Node {
             cluster_id: cfg.cluster_id,

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -18,7 +18,6 @@ use grpcio::{
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::tikvpb::BatchRaftMessage;
 use kvproto::tikvpb_grpc::TikvClient;
-use protobuf::RepeatedField;
 use tikv_util::collections::{HashMap, HashMapEntry};
 use tikv_util::mpsc::batch::{self, Sender as BatchSender};
 use tikv_util::security::SecurityManager;
@@ -75,7 +74,7 @@ impl Conn {
         let batch_send_or_fallback = batch_sink
             .send_all(Reusable(rx1).map(move |v| {
                 let mut batch_msgs = BatchRaftMessage::default();
-                batch_msgs.set_msgs(RepeatedField::from(v));
+                batch_msgs.set_msgs(v.into());
                 (batch_msgs, WriteFlags::default().buffer_hint(false))
             }))
             .then(move |r| {

--- a/src/storage/kv/raftkv.rs
+++ b/src/storage/kv/raftkv.rs
@@ -16,7 +16,6 @@ use kvproto::raft_cmdpb::{
     CmdType, DeleteRangeRequest, DeleteRequest, PutRequest, RaftCmdRequest, RaftCmdResponse,
     RaftRequestHeader, Request, Response,
 };
-use protobuf::RepeatedField;
 
 use super::metrics::*;
 use super::{
@@ -185,7 +184,7 @@ impl<S: RaftStoreRouter> RaftKv<S> {
         let header = self.new_request_header(ctx);
         let mut cmd = RaftCmdRequest::default();
         cmd.set_header(header);
-        cmd.set_requests(RepeatedField::from_vec(reqs));
+        cmd.set_requests(reqs.into());
 
         self.router
             .send_command(
@@ -211,7 +210,7 @@ impl<S: RaftStoreRouter> RaftKv<S> {
         let header = self.new_request_header(ctx);
         let mut cmd = RaftCmdRequest::default();
         cmd.set_header(header);
-        cmd.set_requests(RepeatedField::from_vec(reqs));
+        cmd.set_requests(reqs.into());
 
         self.router
             .send_command(

--- a/src/storage/lock_manager/deadlock.rs
+++ b/src/storage/lock_manager/deadlock.rs
@@ -17,7 +17,6 @@ use grpcio::{
 };
 use kvproto::deadlock::*;
 use kvproto::deadlock_grpc;
-use protobuf::RepeatedField;
 use std::cell::RefCell;
 use std::fmt::{self, Display, Formatter};
 use std::rc::Rc;
@@ -586,7 +585,7 @@ impl deadlock_grpc::Deadlock for Service {
                 f.map_err(Error::from)
                     .map(|v| {
                         let mut resp = WaitForEntriesResponse::default();
-                        resp.set_entries(RepeatedField::from_vec(v));
+                        resp.set_entries(v.into());
                         resp
                     })
                     .and_then(|resp| sink.success(resp).map_err(Error::Grpc))

--- a/tests/integrations/coprocessor/test_analyze.rs
+++ b/tests/integrations/coprocessor/test_analyze.rs
@@ -2,7 +2,7 @@
 
 use kvproto::coprocessor::{KeyRange, Request};
 use kvproto::kvrpcpb::{Context, IsolationLevel};
-use protobuf::{Message, RepeatedField};
+use protobuf::Message;
 use tipb::analyze::{
     AnalyzeColumnsReq, AnalyzeColumnsResp, AnalyzeIndexReq, AnalyzeIndexResp, AnalyzeReq,
     AnalyzeType,
@@ -15,7 +15,7 @@ pub const REQ_TYPE_ANALYZE: i64 = 104;
 fn new_analyze_req(data: Vec<u8>, range: KeyRange) -> Request {
     let mut req = Request::default();
     req.set_data(data);
-    req.set_ranges(RepeatedField::from_vec(vec![range]));
+    req.set_ranges(vec![range].into());
     req.set_tp(REQ_TYPE_ANALYZE);
     req
 }
@@ -29,7 +29,7 @@ fn new_analyze_column_req(
     cm_sketch_width: i32,
 ) -> Request {
     let mut col_req = AnalyzeColumnsReq::new();
-    col_req.set_columns_info(RepeatedField::from_vec(table.columns_info()));
+    col_req.set_columns_info(table.columns_info().into());
     col_req.set_bucket_size(bucket_size);
     col_req.set_sketch_size(fm_sketch_size);
     col_req.set_sample_size(sample_size);
@@ -208,7 +208,7 @@ fn test_invalid_range() {
     let mut key_range = KeyRange::default();
     key_range.set_start(b"xxx".to_vec());
     key_range.set_end(b"zzz".to_vec());
-    req.set_ranges(RepeatedField::from_vec(vec![key_range]));
+    req.set_ranges(vec![key_range].into());
     let resp = handle_request(&endpoint, req);
     assert!(!resp.get_other_error().is_empty());
 }

--- a/tests/integrations/pd/mock/mocker/leader_change.rs
+++ b/tests/integrations/pd/mock/mocker/leader_change.rs
@@ -4,7 +4,6 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use kvproto::pdpb::*;
-use protobuf::RepeatedField;
 
 use super::*;
 
@@ -87,8 +86,8 @@ impl PdMocker for LeaderChange {
             let mut m = Member::default();
             m.set_name(format!("pd{}", i));
             m.set_member_id(100 + i as u64);
-            m.set_client_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
-            m.set_peer_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
+            m.set_client_urls(vec![ep.to_owned()].into());
+            m.set_peer_urls(vec![ep.to_owned()].into());
             members.push(m);
         }
 
@@ -96,8 +95,8 @@ impl PdMocker for LeaderChange {
         let mut m = Member::default();
         m.set_member_id(DEAD_ID);
         m.set_name(DEAD_NAME.to_owned());
-        m.set_client_urls(RepeatedField::from_vec(vec![DEAD_URL.to_owned()]));
-        m.set_peer_urls(RepeatedField::from_vec(vec![DEAD_URL.to_owned()]));
+        m.set_client_urls(vec![DEAD_URL.to_owned()].into());
+        m.set_peer_urls(vec![DEAD_URL.to_owned()].into());
         members.push(m);
 
         let mut header = ResponseHeader::default();
@@ -107,7 +106,7 @@ impl PdMocker for LeaderChange {
         for (i, _) in (&eps).iter().enumerate() {
             let mut resp = GetMembersResponse::default();
             resp.set_header(header.clone());
-            resp.set_members(RepeatedField::from_vec(members.clone()));
+            resp.set_members(members.clone().into());
             resp.set_leader(members[i].clone());
             resps.push(resp);
         }

--- a/tests/integrations/pd/mock/mocker/service.rs
+++ b/tests/integrations/pd/mock/mocker/service.rs
@@ -7,8 +7,6 @@ use tikv_util::collections::HashMap;
 use kvproto::metapb::{Peer, Region, Store, StoreState};
 use kvproto::pdpb::*;
 
-use protobuf::RepeatedField;
-
 use super::*;
 
 #[derive(Debug)]
@@ -52,13 +50,13 @@ fn make_members_response(eps: Vec<String>) -> GetMembersResponse {
         let mut m = Member::default();
         m.set_name(format!("pd{}", i));
         m.set_member_id(100 + i as u64);
-        m.set_client_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
-        m.set_peer_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
+        m.set_client_urls(vec![ep.to_owned()].into());
+        m.set_peer_urls(vec![ep.to_owned()].into());
         members.push(m);
     }
 
     let mut members_resp = GetMembersResponse::default();
-    members_resp.set_members(RepeatedField::from_vec(members.clone()));
+    members_resp.set_members(members.clone().into());
     members_resp.set_leader(members.pop().unwrap());
     members_resp.set_header(Service::header());
 

--- a/tests/integrations/pd/mock/mocker/split.rs
+++ b/tests/integrations/pd/mock/mocker/split.rs
@@ -2,8 +2,6 @@
 
 use std::sync::Mutex;
 
-use protobuf::RepeatedField;
-
 use kvproto::pdpb::{GetMembersRequest, GetMembersResponse, Member, ResponseHeader};
 
 use super::*;
@@ -45,8 +43,8 @@ impl PdMocker for Split {
             let mut m = Member::default();
             m.set_name(format!("pd{}", i));
             m.set_member_id(100 + i as u64);
-            m.set_client_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
-            m.set_peer_urls(RepeatedField::from_vec(vec![ep.to_owned()]));
+            m.set_client_urls(vec![ep.to_owned()].into());
+            m.set_peer_urls(vec![ep.to_owned()].into());
             members.push(m);
         }
 
@@ -56,7 +54,7 @@ impl PdMocker for Split {
             let mut header = ResponseHeader::default();
             header.set_cluster_id(i as u64 + 1); // start from 1.
             resp.set_header(header.clone());
-            resp.set_members(RepeatedField::from_vec(members.clone()));
+            resp.set_members(members.clone().into());
             resp.set_leader(members[0].clone());
             resps.push(resp);
         }

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -332,7 +332,7 @@ fn test_mvcc_rollback_and_cleanup() {
 #[test]
 fn test_mvcc_resolve_lock_gc_and_delete() {
     use kvproto::kvrpcpb::*;
-    use protobuf;
+
     let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
     let (k, v) = (b"key".to_vec(), b"value".to_vec());
 
@@ -394,7 +394,7 @@ fn test_mvcc_resolve_lock_gc_and_delete() {
     temp_txninfo.status = resolve_lock_commit_version;
     let vec_txninfo = vec![temp_txninfo];
     resolve_lock_req.set_context(ctx.clone());
-    resolve_lock_req.set_txn_infos(protobuf::RepeatedField::from_vec(vec_txninfo));
+    resolve_lock_req.set_txn_infos(vec_txninfo.into());
     let resolve_lock_resp = client.kv_resolve_lock(&resolve_lock_req).unwrap();
     assert!(!resolve_lock_resp.has_region_error());
     assert!(!resolve_lock_resp.has_error());


### PR DESCRIPTION
## What have you changed? (mandatory)

This means we can use `Vec`s and be compatible with both rust-protobuf (which
requires a `RepeatedField`) and Prost (which requires a `Vec`).

This is another step towards making support of both Prost and rust-proto easier. Again it does not introduce anything related to Prost, it only makes the existing code more flexible.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

Passes tests

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

cc https://github.com/tikv/tikv/pull/5068

