### PR TITLE
coprocessor, storage: Change error, panic, and log outputs from Debug to Display

### DIFF
--- a/src/coprocessor/codec/datum.rs
+++ b/src/coprocessor/codec/datum.rs
@@ -289,7 +289,7 @@ impl Datum {
             Datum::Dur(d) => Some(!d.is_zero()),
             Datum::Dec(d) => Some(d.as_f64()?.round() != 0f64),
             Datum::Null => None,
-            _ => return Err(invalid_type!("can't convert {:?} to bool", self)),
+            _ => return Err(invalid_type!("can't convert {} to bool", self)),
         };
         Ok(b)
     }
@@ -305,7 +305,7 @@ impl Datum {
             Datum::Dur(ref d) => format!("{}", d),
             Datum::Dec(ref d) => format!("{}", d),
             Datum::Json(ref d) => d.to_string(),
-            ref d => return Err(invalid_type!("can't convert {:?} to string", d)),
+            ref d => return Err(invalid_type!("can't convert {} to string", d)),
         };
         Ok(s)
     }
@@ -582,10 +582,10 @@ impl Datum {
                 let dec: Result<Decimal> = (l + r).into();
                 return dec.map(Datum::Dec);
             }
-            (l, r) => return Err(invalid_type!("{:?} and {:?} can't be add together.", l, r)),
+            (l, r) => return Err(invalid_type!("{} and {} can't be add together.", l, r)),
         };
         if let Datum::Null = res {
-            return Err(box_err!("{:?} + {:?} overflow", self, d));
+            return Err(box_err!("{} + {} overflow", self, d));
         }
         Ok(res)
     }
@@ -614,10 +614,10 @@ impl Datum {
                 let dec: Result<Decimal> = (l - r).into();
                 return dec.map(Datum::Dec);
             }
-            (l, r) => return Err(invalid_type!("{:?} can't minus {:?}", l, r)),
+            (l, r) => return Err(invalid_type!("{} can't minus {}", l, r)),
         };
         if let Datum::Null = res {
-            return Err(box_err!("{:?} - {:?} overflow", self, d));
+            return Err(box_err!("{} - {} overflow", self, d));
         }
         Ok(res)
     }
@@ -635,7 +635,7 @@ impl Datum {
             (&Datum::U64(l), &Datum::U64(r)) => l.checked_mul(r).into(),
             (&Datum::F64(l), &Datum::F64(r)) => return Ok(Datum::F64(l * r)),
             (&Datum::Dec(ref l), &Datum::Dec(ref r)) => return Ok(Datum::Dec((l * r).unwrap())),
-            (l, r) => return Err(invalid_type!("{:?} can't multiply {:?}", l, r)),
+            (l, r) => return Err(invalid_type!("{} can't multiply {}", l, r)),
         };
 
         if let Datum::Null = res {
@@ -670,7 +670,7 @@ impl Datum {
                     d.map(Datum::Dec)
                 }
             },
-            (l, r) => Err(invalid_type!("{:?} can't mod {:?}", l, r)),
+            (l, r) => Err(invalid_type!("{} can't mod {}", l, r)),
         }
     }
 

--- a/src/coprocessor/codec/mysql/json/binary.rs
+++ b/src/coprocessor/codec/mysql/json/binary.rs
@@ -50,7 +50,7 @@ impl Json {
             }
             Json::None => Ok(JSON_LITERAL_NIL),
             _ => Err(invalid_type!(
-                "{:?} from {} to literal",
+                "{} from {} to literal",
                 ERR_CONVERT_FAILED,
                 self.to_string()
             )),

--- a/src/coprocessor/codec/mysql/json/comparison.rs
+++ b/src/coprocessor/codec/mysql/json/comparison.rs
@@ -42,7 +42,7 @@ impl Json {
                 Ok(v.into())
             }
             _ => Err(invalid_type!(
-                "{:?} from {} to f64",
+                "{} from {} to f64",
                 ERR_CONVERT_FAILED,
                 self.to_string()
             )),

--- a/src/coprocessor/codec/mysql/time/mod.rs
+++ b/src/coprocessor/codec/mysql/time/mod.rs
@@ -501,7 +501,7 @@ impl Time {
         let t = t.unwrap();
         if t.year() < 1000 || t.year() > 9999 {
             return Err(box_err!(
-                "datetime :{:?} out of range ('1000-01-01' to '9999-12-31')",
+                "datetime :{} out of range ('1000-01-01' to '9999-12-31')",
                 t
             ));
         }

--- a/src/coprocessor/codec/mysql/time/tz.rs
+++ b/src/coprocessor/codec/mysql/time/tz.rs
@@ -52,7 +52,7 @@ impl Tz {
 impl fmt::Debug for Tz {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Tz::Offset(ref offset) => write!(f, "Tz::Offset({:?})", offset),
+            Tz::Offset(ref offset) => write!(f, "Tz::Offset({})", offset),
             Tz::Name(ref offset) => write!(f, "Tz::Name({:?})", offset),
             Tz::Local(_) => write!(f, "Tz::Local"),
         }

--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -234,7 +234,7 @@ fn unflatten(ctx: &EvalContext, datum: Datum, field_type: &dyn FieldTypeAccessor
                     FieldTypeTp::JSON
                 ]
                 .contains(&t),
-                "unknown type {} {:?}",
+                "unknown type {} {}",
                 t,
                 datum
             );

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -400,7 +400,7 @@ mod tests {
                 expr.mut_field_type().set_charset(charset);
             }
             Datum::Null => expr.set_tp(ExprType::Null),
-            d => panic!("unsupport datum: {:?}", d),
+            d => panic!("unsupport datum: {}", d),
         }
         expr
     }
@@ -467,7 +467,7 @@ mod tests {
                 expr.set_val(buf);
             }
             Datum::Null => expr.set_tp(ExprType::Null),
-            d => panic!("unsupport datum: {:?}", d),
+            d => panic!("unsupport datum: {}", d),
         };
         expr
     }

--- a/src/storage/lock_manager/deadlock.rs
+++ b/src/storage/lock_manager/deadlock.rs
@@ -159,7 +159,7 @@ impl Display for Task {
         match self {
             Task::Detect { tp, txn_ts, lock } => write!(
                 f,
-                "Detect {{ tp: {:?}, txn_ts: {:?}, lock: {:?} }}",
+                "Detect {{ tp: {:?}, txn_ts: {}, lock: {:?} }}",
                 tp, txn_ts, lock
             ),
             Task::DetectRpc { .. } => write!(f, "detect rpc"),

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -144,7 +144,7 @@ impl Lock {
                 }
                 FOR_UPDATE_TS_PREFIX => for_update_ts = number::decode_u64(&mut b)?,
                 TXN_SIZE_PREFIX => txn_size = number::decode_u64(&mut b)?,
-                flag => panic!("invalid flag [{:?}] in lock", flag),
+                flag => panic!("invalid flag [{}] in lock", flag),
             }
         }
         Ok(Lock::new(

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -106,11 +106,7 @@ impl Write {
         }
 
         let flag = b.read_u8()?;
-        assert_eq!(
-            flag, SHORT_VALUE_PREFIX,
-            "invalid flag [{:?}] in write",
-            flag
-        );
+        assert_eq!(flag, SHORT_VALUE_PREFIX, "invalid flag [{}] in write", flag);
 
         let len = b.read_u8()?;
         if len as usize != b.len() {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -85,7 +85,7 @@ impl Debug for Msg {
 impl Display for Msg {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
-            Msg::RawCmd { ref cmd, .. } => write!(f, "RawCmd {:?}", cmd),
+            Msg::RawCmd { ref cmd, .. } => write!(f, "RawCmd {}", cmd),
             Msg::ReadFinished { cid, .. } => write!(f, "ReadFinished [cid={}]", cid),
             Msg::WriteFinished { cid, .. } => write!(f, "WriteFinished [cid={}]", cid),
             Msg::FinishedWithErr { cid, .. } => write!(f, "FinishedWithErr [cid={}]", cid),
@@ -114,7 +114,7 @@ impl TaskContext {
         let lock = gen_command_lock(latches, task.cmd());
         // Write command should acquire write lock.
         if !task.cmd().readonly() && !lock.is_write_lock() {
-            panic!("write lock is expected for command {:?}", task.cmd());
+            panic!("write lock is expected for command {}", task.cmd());
         }
         let write_bytes = if lock.is_write_lock() {
             task.cmd().write_bytes()


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

for #4960 , change some error, panic, and log outputs from `Debug` to `Display` in `coprocessor` and `storage`

## What are the type of the changes? (mandatory)

- Misc (code refine)

## How has this PR been tested? (mandatory)

This pr just make some output format refine for log / error / panic output. I think it's ok to make the current test base happy.

