### PR TITLE
More changes to ease the tranistion to Prost

### DIFF
--- a/benches/coprocessor_executors/hash_aggr/util.rs
+++ b/benches/coprocessor_executors/hash_aggr/util.rs
@@ -91,7 +91,7 @@ impl HashAggrBencher for BatchBencher {
     ) {
         crate::util::bencher::BatchNextAllBencher::new(|| {
             let src = fb.clone().build_batch_fixture_executor();
-            let mut meta = Aggregation::new();
+            let mut meta = Aggregation::default();
             meta.set_agg_func(aggr_expr.to_vec().into());
             meta.set_group_by(group_by_expr.to_vec().into());
             if BatchFastHashAggregationExecutor::check_supported(&meta).is_ok() {

--- a/benches/coprocessor_executors/index_scan/util.rs
+++ b/benches/coprocessor_executors/index_scan/util.rs
@@ -39,7 +39,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
         store: &Store<RocksEngine>,
         unique: bool,
     ) -> Self::E {
-        let mut req = IndexScan::new();
+        let mut req = IndexScan::default();
         req.set_columns(columns.into());
 
         let mut executor = IndexScanExecutor::index_scan(

--- a/benches/coprocessor_executors/table_scan/util.rs
+++ b/benches/coprocessor_executors/table_scan/util.rs
@@ -40,7 +40,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
         store: &Store<RocksEngine>,
         _: (),
     ) -> Self::E {
-        let mut req = TableScan::new();
+        let mut req = TableScan::default();
         req.set_columns(columns.into());
 
         let mut executor = TableScanExecutor::table_scan(

--- a/benches/coprocessor_executors/util/executor_descriptor.rs
+++ b/benches/coprocessor_executors/util/executor_descriptor.rs
@@ -6,7 +6,7 @@ use tipb::schema::ColumnInfo;
 
 /// Builds a table scan executor descriptor.
 pub fn table_scan(columns_info: &[ColumnInfo]) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeTableScan);
     exec.mut_tbl_scan()
         .set_columns(columns_info.to_vec().into());
@@ -15,7 +15,7 @@ pub fn table_scan(columns_info: &[ColumnInfo]) -> PbExecutor {
 
 /// Builds a index scan executor descriptor.
 pub fn index_scan(columns_info: &[ColumnInfo], unique: bool) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeIndexScan);
     exec.mut_idx_scan()
         .set_columns(columns_info.to_vec().into());
@@ -25,7 +25,7 @@ pub fn index_scan(columns_info: &[ColumnInfo], unique: bool) -> PbExecutor {
 
 /// Builds a selection executor descriptor.
 pub fn selection(exprs: &[Expr]) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeSelection);
     exec.mut_selection().set_conditions(exprs.to_vec().into());
     exec
@@ -33,7 +33,7 @@ pub fn selection(exprs: &[Expr]) -> PbExecutor {
 
 /// Builds a simple aggregation executor descriptor.
 pub fn simple_aggregate(aggr_exprs: &[Expr]) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeStreamAgg);
     exec.mut_aggregation()
         .set_agg_func(aggr_exprs.to_vec().into());
@@ -42,7 +42,7 @@ pub fn simple_aggregate(aggr_exprs: &[Expr]) -> PbExecutor {
 
 /// Builds a hash aggregation executor descriptor.
 pub fn hash_aggregate(aggr_exprs: &[Expr], group_bys: &[Expr]) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeAggregation);
     exec.mut_aggregation()
         .set_agg_func(aggr_exprs.to_vec().into());
@@ -53,7 +53,7 @@ pub fn hash_aggregate(aggr_exprs: &[Expr], group_bys: &[Expr]) -> PbExecutor {
 
 /// Builds a stream aggregation executor descriptor.
 pub fn stream_aggregate(aggr_exprs: &[Expr], group_bys: &[Expr]) -> PbExecutor {
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeStreamAgg);
     exec.mut_aggregation()
         .set_agg_func(aggr_exprs.to_vec().into());
@@ -63,21 +63,21 @@ pub fn stream_aggregate(aggr_exprs: &[Expr], group_bys: &[Expr]) -> PbExecutor {
 }
 
 pub fn top_n(order_by_expr: &[Expr], order_is_desc: &[bool], n: usize) -> PbExecutor {
-    let mut meta = TopN::new();
+    let mut meta = TopN::default();
     meta.set_limit(n as u64);
     meta.set_order_by(
         order_by_expr
             .iter()
             .zip(order_is_desc)
             .map(|(expr, desc)| {
-                let mut item = ByItem::new();
+                let mut item = ByItem::default();
                 item.set_expr(expr.clone());
                 item.set_desc(*desc);
                 item
             })
             .collect(),
     );
-    let mut exec = PbExecutor::new();
+    let mut exec = PbExecutor::default();
     exec.set_tp(ExecType::TypeTopN);
     exec.set_topN(meta);
     exec

--- a/benches/coprocessor_executors/util/fixture.rs
+++ b/benches/coprocessor_executors/util/fixture.rs
@@ -276,7 +276,7 @@ impl FixtureBuilder {
             .into_iter()
             .enumerate()
             .map(|(index, ft)| {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.set_column_id(index as i64);
                 ci.as_mut_accessor()
                     .set_tp(ft.tp())

--- a/benches/misc/coprocessor/codec/chunk/mod.rs
+++ b/benches/misc/coprocessor/codec/chunk/mod.rs
@@ -12,7 +12,7 @@ use tikv::coprocessor::codec::datum::Datum;
 use tikv::coprocessor::codec::mysql::*;
 
 fn field_type(tp: FieldTypeTp) -> FieldType {
-    let mut fp = FieldType::new();
+    let mut fp = FieldType::default();
     fp.as_mut_accessor().set_tp(tp);
     fp
 }

--- a/components/cop_datatype/src/builder/field_type.rs
+++ b/components/cop_datatype/src/builder/field_type.rs
@@ -9,7 +9,7 @@ pub struct FieldTypeBuilder(FieldType);
 
 impl FieldTypeBuilder {
     pub fn new() -> Self {
-        Self(FieldType::new())
+        Self(FieldType::default())
     }
 
     pub fn tp(mut self, v: crate::FieldTypeTp) -> Self {

--- a/components/cop_datatype/src/def/field_type.rs
+++ b/components/cop_datatype/src/def/field_type.rs
@@ -316,7 +316,7 @@ impl FieldTypeAccessor for ColumnInfo {
 
 impl From<FieldTypeTp> for FieldType {
     fn from(fp: FieldTypeTp) -> FieldType {
-        let mut ft = FieldType::new();
+        let mut ft = FieldType::default();
         ft.as_mut_accessor().set_tp(fp);
         ft
     }
@@ -324,7 +324,7 @@ impl From<FieldTypeTp> for FieldType {
 
 impl From<FieldTypeTp> for ColumnInfo {
     fn from(fp: FieldTypeTp) -> ColumnInfo {
-        let mut ft = ColumnInfo::new();
+        let mut ft = ColumnInfo::default();
         ft.as_mut_accessor().set_tp(fp);
         ft
     }

--- a/components/test_coprocessor/src/column.rs
+++ b/components/test_coprocessor/src/column.rs
@@ -19,7 +19,7 @@ pub struct Column {
 
 impl Column {
     pub fn as_column_info(&self) -> ColumnInfo {
-        let mut c_info = ColumnInfo::new();
+        let mut c_info = ColumnInfo::default();
         c_info.set_column_id(self.id);
         c_info.set_tp(self.col_type);
         c_info.set_pk_handle(self.index == 0);

--- a/components/test_coprocessor/src/table.rs
+++ b/components/test_coprocessor/src/table.rs
@@ -41,7 +41,7 @@ impl Table {
 
     /// Create `schema::TableInfo` from current table.
     pub fn table_info(&self) -> schema::TableInfo {
-        let mut info = schema::TableInfo::new();
+        let mut info = schema::TableInfo::default();
         info.set_table_id(self.id);
         info.set_columns(self.columns_info().into());
         info
@@ -57,13 +57,13 @@ impl Table {
 
     /// Create `schema::IndexInfo` from current table.
     pub fn index_info(&self, index: i64, store_handle: bool) -> schema::IndexInfo {
-        let mut idx_info = schema::IndexInfo::new();
+        let mut idx_info = schema::IndexInfo::default();
         idx_info.set_table_id(self.id);
         idx_info.set_index_id(index);
         let mut has_pk = false;
         for col_id in &self.idxs[&index] {
             let col = self.column_by_id(*col_id).unwrap();
-            let mut c_info = ColumnInfo::new();
+            let mut c_info = ColumnInfo::default();
             c_info.set_tp(col.col_type);
             c_info.set_column_id(col.id);
             if col.id == self.handle_id {
@@ -73,7 +73,7 @@ impl Table {
             idx_info.mut_columns().push(c_info);
         }
         if !has_pk && store_handle {
-            let mut handle_info = ColumnInfo::new();
+            let mut handle_info = ColumnInfo::default();
             handle_info.set_tp(TYPE_LONG);
             handle_info.set_column_id(-1);
             handle_info.set_pk_handle(true);

--- a/components/tipb_helper/src/expr_def_builder.rs
+++ b/components/tipb_helper/src/expr_def_builder.rs
@@ -9,7 +9,7 @@ pub struct ExprDefBuilder(Expr);
 
 impl ExprDefBuilder {
     pub fn constant_int(v: i64) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::Int64);
         expr.mut_val().write_i64(v).unwrap();
         expr.mut_field_type()
@@ -19,7 +19,7 @@ impl ExprDefBuilder {
     }
 
     pub fn constant_uint(v: u64) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::Uint64);
         expr.mut_val().write_u64(v).unwrap();
         expr.mut_field_type()
@@ -30,7 +30,7 @@ impl ExprDefBuilder {
     }
 
     pub fn constant_real(v: f64) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::Float64);
         expr.mut_val().write_f64(v).unwrap();
         expr.mut_field_type()
@@ -40,7 +40,7 @@ impl ExprDefBuilder {
     }
 
     pub fn constant_bytes(v: Vec<u8>) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::String);
         expr.set_val(v);
         expr.mut_field_type()
@@ -50,14 +50,14 @@ impl ExprDefBuilder {
     }
 
     pub fn constant_null(field_type: impl Into<FieldType>) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::Null);
         expr.set_field_type(field_type.into());
         Self(expr)
     }
 
     pub fn column_ref(offset: usize, field_type: impl Into<FieldType>) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ColumnRef);
         expr.mut_val().write_i64(offset as i64).unwrap();
         expr.set_field_type(field_type.into());
@@ -65,7 +65,7 @@ impl ExprDefBuilder {
     }
 
     pub fn scalar_func(sig: ScalarFuncSig, field_type: impl Into<FieldType>) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ScalarFunc);
         expr.set_sig(sig);
         expr.set_field_type(field_type.into());
@@ -73,7 +73,7 @@ impl ExprDefBuilder {
     }
 
     pub fn aggr_func(tp: ExprType, field_type: impl Into<FieldType>) -> Self {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(tp);
         expr.set_field_type(field_type.into());
         Self(expr)

--- a/src/coprocessor/codec/chunk/mod.rs
+++ b/src/coprocessor/codec/chunk/mod.rs
@@ -14,7 +14,7 @@ mod tests {
     use tipb::expression::FieldType;
 
     pub fn field_type(tp: FieldTypeTp) -> FieldType {
-        let mut fp = FieldType::new();
+        let mut fp = FieldType::default();
         fp.as_mut_accessor().set_tp(tp);
         fp
     }

--- a/src/coprocessor/codec/table.rs
+++ b/src/coprocessor/codec/table.rs
@@ -442,7 +442,7 @@ mod tests {
     }
 
     fn new_col_info(tp: FieldTypeTp) -> ColumnInfo {
-        let mut col_info = ColumnInfo::new();
+        let mut col_info = ColumnInfo::default();
         col_info.as_mut_accessor().set_tp(tp);
         col_info
     }

--- a/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/fast_hash_aggr_executor.rs
@@ -513,7 +513,7 @@ mod tests {
             Box::new(BatchFastHashAggregationExecutor::new_for_test(
                 src_exec,
                 RpnExpressionBuilder::new().push_column_ref(0).build(),
-                vec![Expr::new()],
+                vec![Expr::default()],
                 MyParser,
             )) as Box<dyn BatchExecutor>
         };
@@ -522,7 +522,7 @@ mod tests {
             Box::new(BatchSlowHashAggregationExecutor::new_for_test(
                 src_exec,
                 vec![RpnExpressionBuilder::new().push_column_ref(0).build()],
-                vec![Expr::new()],
+                vec![Expr::default()],
                 MyParser,
             )) as Box<dyn BatchExecutor>
         };

--- a/src/coprocessor/dag/batch/executors/index_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/index_scan_executor.rs
@@ -258,17 +258,17 @@ mod tests {
         // The column info for each column in `data`. Used to build the executor.
         let columns_info = vec![
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci
             },
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::Double);
                 ci
             },
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_pk_handle(true);
                 ci

--- a/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/simple_aggr_executor.rs
@@ -330,7 +330,7 @@ mod tests {
 
         let aggr_definitions: Vec<_> = (0..6)
             .map(|index| {
-                let mut exp = Expr::new();
+                let mut exp = Expr::default();
                 exp.mut_val().push(index as u8);
                 exp
             })
@@ -607,7 +607,7 @@ mod tests {
         }
 
         let mut exec =
-            BatchSimpleAggregationExecutor::new_for_test(src_exec, vec![Expr::new()], MyParser);
+            BatchSimpleAggregationExecutor::new_for_test(src_exec, vec![Expr::default()], MyParser);
 
         let r = exec.next_batch(1);
         assert!(r.logical_rows.is_empty());

--- a/src/coprocessor/dag/batch/executors/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/table_scan_executor.rs
@@ -385,20 +385,20 @@ mod tests {
             // The column info for each column in `data`.
             let columns_info = vec![
                 {
-                    let mut ci = ColumnInfo::new();
+                    let mut ci = ColumnInfo::default();
                     ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                     ci.set_pk_handle(true);
                     ci.set_column_id(1);
                     ci
                 },
                 {
-                    let mut ci = ColumnInfo::new();
+                    let mut ci = ColumnInfo::default();
                     ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                     ci.set_column_id(2);
                     ci
                 },
                 {
-                    let mut ci = ColumnInfo::new();
+                    let mut ci = ColumnInfo::default();
                     ci.as_mut_accessor().set_tp(FieldTypeTp::Double);
                     ci.set_column_id(4);
                     ci.set_default_val(datum::encode_value(&[Datum::F64(4.5)]).unwrap());
@@ -683,20 +683,20 @@ mod tests {
 
         let columns_info = vec![
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_pk_handle(true);
                 ci.set_column_id(1);
                 ci
             },
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_column_id(2);
                 ci
             },
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_column_id(3);
                 ci
@@ -806,14 +806,14 @@ mod tests {
 
         let columns_info = vec![
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_pk_handle(true);
                 ci.set_column_id(1);
                 ci
             },
             {
-                let mut ci = ColumnInfo::new();
+                let mut ci = ColumnInfo::default();
                 ci.as_mut_accessor().set_tp(FieldTypeTp::LongLong);
                 ci.set_column_id(2);
                 ci

--- a/src/coprocessor/dag/batch/executors/util/scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/util/scan_executor.rs
@@ -176,7 +176,7 @@ impl<S: Store, I: ScanExecutorImpl, P: PointRangePolicy> ScanExecutor<S, I, P> {
 /// Extracts `FieldType` from `ColumnInfo`.
 // TODO: Embed FieldType in ColumnInfo directly in Cop DAG v2 to remove this function.
 pub fn field_type_from_column_info(ci: &ColumnInfo) -> FieldType {
-    let mut field_type = FieldType::new();
+    let mut field_type = FieldType::default();
     field_type.set_tp(ci.get_tp());
     field_type.set_flag(ci.get_flag() as u32); // FIXME: This `as u32` is really awful.
     field_type.set_flen(ci.get_columnLen());

--- a/src/coprocessor/dag/batch_handler.rs
+++ b/src/coprocessor/dag/batch_handler.rs
@@ -114,7 +114,7 @@ impl RequestHandler for BatchDAGHandler {
                     result.physical_columns.columns_len(),
                     self.out_most_executor.schema().len()
                 );
-                let mut chunk = Chunk::new();
+                let mut chunk = Chunk::default();
                 {
                     let data = chunk.mut_rows_data();
                     data.reserve(
@@ -157,7 +157,7 @@ impl RequestHandler for BatchDAGHandler {
                         .summary_per_executor
                         .iter()
                         .map(|summary| {
-                            let mut ret = ExecutorExecutionSummary::new();
+                            let mut ret = ExecutorExecutionSummary::default();
                             ret.set_num_iterations(summary.num_iterations as u64);
                             ret.set_num_produced_rows(summary.num_produced_rows as u64);
                             ret.set_time_processed_ns(summary.time_processed_ns as u64);

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -233,7 +233,7 @@ pub mod tests {
 
         pub fn new(unique: bool, test_data: Data) -> IndexTestWrapper {
             let test_store = TestStore::new(&test_data.kv_data);
-            let mut scan = IndexScan::new();
+            let mut scan = IndexScan::default();
             // prepare cols
             let cols = test_data.cols.clone();
             let col_req = cols.clone().into();

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -379,7 +379,7 @@ pub mod tests {
     };
 
     pub fn build_expr(tp: ExprType, id: Option<i64>, child: Option<Expr>) -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(tp);
         if tp == ExprType::ColumnRef {
             expr.mut_val().encode_i64(id.unwrap()).unwrap();
@@ -390,7 +390,7 @@ pub mod tests {
     }
 
     pub fn new_col_info(cid: i64, tp: FieldTypeTp) -> ColumnInfo {
-        let mut col_info = ColumnInfo::new();
+        let mut col_info = ColumnInfo::default();
         col_info.as_mut_accessor().set_tp(tp);
         col_info.set_column_id(cid);
         col_info
@@ -499,7 +499,7 @@ pub mod tests {
         let table_data = gen_table_data(tid, &cis, raw_data);
         let mut test_store = TestStore::new(&table_data);
 
-        let mut table_scan = TableScan::new();
+        let mut table_scan = TableScan::default();
         table_scan.set_table_id(tid);
         table_scan.set_columns(cis.clone().into());
 

--- a/src/coprocessor/dag/executor/selection.rs
+++ b/src/coprocessor/dag/executor/selection.rs
@@ -100,16 +100,16 @@ mod tests {
     use super::*;
 
     fn new_const_expr() -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ScalarFunc);
         expr.set_sig(ScalarFuncSig::NullEQInt);
         expr.mut_children().push({
-            let mut lhs = Expr::new();
+            let mut lhs = Expr::default();
             lhs.set_tp(ExprType::Null);
             lhs
         });
         expr.mut_children().push({
-            let mut rhs = Expr::new();
+            let mut rhs = Expr::default();
             rhs.set_tp(ExprType::Null);
             rhs
         });
@@ -117,17 +117,17 @@ mod tests {
     }
 
     fn new_col_gt_u64_expr(offset: i64, val: u64) -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ScalarFunc);
         expr.set_sig(ScalarFuncSig::GTInt);
         expr.mut_children().push({
-            let mut lhs = Expr::new();
+            let mut lhs = Expr::default();
             lhs.set_tp(ExprType::ColumnRef);
             lhs.mut_val().encode_i64(offset).unwrap();
             lhs
         });
         expr.mut_children().push({
-            let mut rhs = Expr::new();
+            let mut rhs = Expr::default();
             rhs.set_tp(ExprType::Uint64);
             rhs.mut_val().encode_u64(val).unwrap();
             rhs
@@ -183,7 +183,7 @@ mod tests {
         let inner_table_scan = gen_table_scan_executor(1, cis, &raw_data, None);
 
         // selection executor
-        let mut selection = Selection::new();
+        let mut selection = Selection::default();
         let expr = new_const_expr();
         selection.mut_conditions().push(expr);
 
@@ -222,7 +222,7 @@ mod tests {
         let inner_table_scan = gen_table_scan_executor(1, cis, &raw_data, None);
 
         // selection executor
-        let mut selection = Selection::new();
+        let mut selection = Selection::default();
         let expr = new_col_gt_u64_expr(2, 5);
         selection.mut_conditions().push(expr);
 

--- a/src/coprocessor/dag/executor/table_scan.rs
+++ b/src/coprocessor/dag/executor/table_scan.rs
@@ -112,7 +112,7 @@ mod tests {
         fn default() -> TableScanTestWrapper {
             let test_data = prepare_table_data(KEY_NUMBER, TABLE_ID);
             let test_store = TestStore::new(&test_data.kv_data);
-            let mut table_scan = TableScan::new();
+            let mut table_scan = TableScan::default();
             // prepare cols
             let cols = test_data.get_prev_2_cols();
             let col_req = cols.clone().into();

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -168,8 +168,8 @@ pub mod tests {
     use super::*;
 
     fn new_order_by(offset: i64, desc: bool) -> ByItem {
-        let mut item = ByItem::new();
-        let mut expr = Expr::new();
+        let mut item = ByItem::default();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ColumnRef);
         expr.mut_val().encode_i64(offset).unwrap();
         item.set_expr(expr);

--- a/src/coprocessor/dag/executor/topn_heap.rs
+++ b/src/coprocessor/dag/executor/topn_heap.rs
@@ -185,8 +185,8 @@ mod tests {
     use super::*;
 
     fn new_order_by(col_id: i64, desc: bool) -> ByItem {
-        let mut item = ByItem::new();
-        let mut expr = Expr::new();
+        let mut item = ByItem::default();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ColumnRef);
         expr.mut_val().encode_i64(col_id).unwrap();
         item.set_expr(expr);

--- a/src/coprocessor/dag/expr/builtin_cast.rs
+++ b/src/coprocessor/dag/expr/builtin_cast.rs
@@ -747,7 +747,7 @@ mod tests {
 
     pub fn col_expr(col_id: i64, tp: FieldTypeTp) -> Expr {
         let mut expr = base_col_expr(col_id);
-        let mut fp = FieldType::new();
+        let mut fp = FieldType::default();
         fp.as_mut_accessor().set_tp(tp);
         if tp == FieldTypeTp::String {
             fp.set_charset(charset::CHARSET_UTF8.to_owned());

--- a/src/coprocessor/dag/expr/builtin_compare.rs
+++ b/src/coprocessor/dag/expr/builtin_compare.rs
@@ -570,7 +570,7 @@ mod tests {
 
         for (sig, row, exp) in cases {
             let children: Vec<Expr> = (0..row.len()).map(|id| col_expr(id as i64)).collect();
-            let mut expr = Expr::new();
+            let mut expr = Expr::default();
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(sig);
 
@@ -701,7 +701,7 @@ mod tests {
 
         for (sig, row, exp) in cases {
             let children: Vec<Expr> = (0..row.len()).map(|id| col_expr(id as i64)).collect();
-            let mut expr = Expr::new();
+            let mut expr = Expr::default();
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(sig);
 
@@ -889,7 +889,7 @@ mod tests {
                 // Evaluate and test greatest
                 {
                     let children: Vec<Expr> = row.iter().map(|d| datum_expr(d.clone())).collect();
-                    let mut expr = Expr::new();
+                    let mut expr = Expr::default();
                     expr.set_tp(ExprType::ScalarFunc);
                     expr.set_sig(greatest_sig);
                     expr.set_children(children.into());
@@ -900,7 +900,7 @@ mod tests {
                 // Evaluate and test least
                 {
                     let children: Vec<Expr> = row.iter().map(|d| datum_expr(d.clone())).collect();
-                    let mut expr = Expr::new();
+                    let mut expr = Expr::default();
                     expr.set_tp(ExprType::ScalarFunc);
                     expr.set_sig(least_sig);
                     expr.set_children(children.into());
@@ -950,7 +950,7 @@ mod tests {
                 Datum::Bytes(t4.clone()),
             ];
             let children: Vec<Expr> = row.iter().map(|d| datum_expr(d.clone())).collect();
-            let mut expr = Expr::new();
+            let mut expr = Expr::default();
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(ScalarFuncSig::GreatestTime);
             expr.set_children(children.into());

--- a/src/coprocessor/dag/expr/builtin_control.rs
+++ b/src/coprocessor/dag/expr/builtin_control.rs
@@ -521,7 +521,7 @@ mod tests {
 
         for (sig, row, exp) in cases {
             let children: Vec<Expr> = (0..row.len()).map(|id| col_expr(id as i64)).collect();
-            let mut expr = Expr::new();
+            let mut expr = Expr::default();
             expr.set_tp(ExprType::ScalarFunc);
             expr.set_sig(sig);
 

--- a/src/coprocessor/dag/expr/column.rs
+++ b/src/coprocessor/dag/expr/column.rs
@@ -112,7 +112,7 @@ mod tests {
         let mut pad_char_ctx = EvalContext::new(Arc::new(cfg));
 
         let mut c = col_expr(0);
-        let mut field_tp = FieldType::new();
+        let mut field_tp = FieldType::default();
         let flen = 16;
         field_tp
             .as_mut_accessor()
@@ -199,7 +199,7 @@ mod tests {
         ];
         for tp in hybrid_cases {
             let mut c = col_expr(0);
-            let mut field_tp = FieldType::new();
+            let mut field_tp = FieldType::default();
             field_tp.as_mut_accessor().set_tp(tp);
             c.set_field_type(field_tp);
             let e = Expression::build(&ctx, c).unwrap();
@@ -209,7 +209,7 @@ mod tests {
 
         for tp in in_hybrid_cases {
             let mut c = col_expr(0);
-            let mut field_tp = FieldType::new();
+            let mut field_tp = FieldType::default();
             field_tp.as_mut_accessor().set_tp(tp);
             c.set_field_type(field_tp);
             let e = Expression::build(&ctx, c).unwrap();

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -359,10 +359,10 @@ mod tests {
     }
 
     pub fn scalar_func_expr(sig: ScalarFuncSig, children: &[Expr]) -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ScalarFunc);
         expr.set_sig(sig);
-        expr.set_field_type(FieldType::new());
+        expr.set_field_type(FieldType::default());
         for child in children {
             expr.mut_children().push(child.clone());
         }
@@ -370,7 +370,7 @@ mod tests {
     }
 
     pub fn col_expr(col_id: i64) -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         expr.set_tp(ExprType::ColumnRef);
         let mut buf = Vec::with_capacity(8);
         buf.encode_i64(col_id).unwrap();
@@ -386,7 +386,7 @@ mod tests {
         charset: String,
         collate: Collation,
     ) -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         match datum {
             Datum::Bytes(bs) => {
                 expr.set_tp(ExprType::Bytes);
@@ -406,7 +406,7 @@ mod tests {
     }
 
     pub fn datum_expr(datum: Datum) -> Expr {
-        let mut expr = Expr::new();
+        let mut expr = Expr::default();
         match datum {
             Datum::I64(i) => {
                 expr.set_tp(ExprType::Int64);
@@ -450,7 +450,7 @@ mod tests {
             }
             Datum::Time(t) => {
                 expr.set_tp(ExprType::MysqlTime);
-                let mut ft = FieldType::new();
+                let mut ft = FieldType::default();
                 ft.as_mut_accessor()
                     .set_tp(t.get_time_type().into())
                     .set_decimal(isize::from(t.get_fsp()));

--- a/src/coprocessor/dag/handler.rs
+++ b/src/coprocessor/dag/handler.rs
@@ -68,7 +68,7 @@ impl RequestHandler for DAGRequestHandler {
                 Ok(Some(row)) => {
                     self.deadline.check_if_exceeded()?;
                     if chunks.is_empty() || record_cnt >= self.batch_row_limit {
-                        let chunk = Chunk::new();
+                        let chunk = Chunk::default();
                         chunks.push(chunk);
                         record_cnt = 0;
                     }
@@ -97,7 +97,7 @@ impl RequestHandler for DAGRequestHandler {
                         let summaries = summary_per_executor
                             .iter()
                             .map(|summary| {
-                                let mut ret = ExecutorExecutionSummary::new();
+                                let mut ret = ExecutorExecutionSummary::default();
                                 ret.set_num_iterations(summary.num_iterations as u64);
                                 ret.set_num_produced_rows(summary.num_produced_rows as u64);
                                 ret.set_time_processed_ns(summary.time_processed_ns as u64);
@@ -126,7 +126,7 @@ impl RequestHandler for DAGRequestHandler {
 
     fn handle_streaming_request(&mut self) -> Result<(Option<Response>, bool)> {
         let (mut record_cnt, mut finished) = (0, false);
-        let mut chunk = Chunk::new();
+        let mut chunk = Chunk::default();
         self.executor.start_scan();
         while record_cnt < self.batch_row_limit {
             match self.executor.next() {

--- a/src/coprocessor/dag/rpn_expr/types/test_util.rs
+++ b/src/coprocessor/dag/rpn_expr/types/test_util.rs
@@ -89,7 +89,7 @@ impl RpnFnScalarEvaluator {
             .as_ref()
             .iter()
             .map(|expr_node| {
-                let mut ed = Expr::new();
+                let mut ed = Expr::default();
                 ed.set_field_type(expr_node.field_type().clone());
                 ed
             })

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -140,7 +140,7 @@ impl<E: Engine> Endpoint<E> {
                 });
             }
             REQ_TYPE_ANALYZE => {
-                let mut analyze = AnalyzeReq::new();
+                let mut analyze = AnalyzeReq::default();
                 box_try!(analyze.merge_from(&mut is));
                 let table_scan = analyze.get_tp() == AnalyzeType::TypeColumn;
                 req_ctx = ReqContext::new(
@@ -672,13 +672,13 @@ mod tests {
         );
 
         let req = {
-            let mut expr = Expr::new();
+            let mut expr = Expr::default();
             for _ in 0..10 {
-                let mut e = Expr::new();
+                let mut e = Expr::default();
                 e.mut_children().push(expr);
                 expr = e;
             }
-            let mut e = Executor::new();
+            let mut e = Executor::default();
             e.mut_selection().mut_conditions().push(expr);
             let mut dag = DAGRequest::default();
             dag.mut_executors().push(e);

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -61,7 +61,7 @@ impl<S: Snapshot> AnalyzeContext<S> {
             collectors.into_iter().map(|col| col.into_proto()).collect();
 
         let res_data = {
-            let mut res = analyze::AnalyzeColumnsResp::new();
+            let mut res = analyze::AnalyzeColumnsResp::default();
             res.set_collectors(cols.into());
             res.set_pk_hist(pk_hist);
             box_try!(res.write_to_bytes())
@@ -90,7 +90,7 @@ impl<S: Snapshot> AnalyzeContext<S> {
                 }
             }
         }
-        let mut res = analyze::AnalyzeIndexResp::new();
+        let mut res = analyze::AnalyzeIndexResp::default();
         res.set_hist(hist.into_proto());
         if let Some(c) = cms {
             res.set_cms(c.into_proto());
@@ -176,7 +176,7 @@ impl<S: Snapshot> SampleBuilder<S> {
             col_len -= 1;
         }
 
-        let mut meta = TableScan::new();
+        let mut meta = TableScan::default();
         meta.set_columns(cols_info);
         let table_scanner = ScanExecutor::table_scan(meta, ranges, snap, false)?;
         Ok(Self {
@@ -256,7 +256,7 @@ impl SampleCollector {
     }
 
     fn into_proto(self) -> analyze::SampleCollector {
-        let mut s = analyze::SampleCollector::new();
+        let mut s = analyze::SampleCollector::default();
         s.set_null_count(self.null_count as i64);
         s.set_count(self.count as i64);
         s.set_fm_sketch(self.fm_sketch.into_proto());

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -51,7 +51,7 @@ impl CMSketch {
     }
 
     pub fn into_proto(self) -> analyze::CMSketch {
-        let mut proto = analyze::CMSketch::new();
+        let mut proto = analyze::CMSketch::default();
         let mut rows = vec![analyze::CMSketchRow::default(); self.depth];
         for (i, row) in self.table.iter().enumerate() {
             rows[i].set_counters(row.to_vec());

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -34,7 +34,7 @@ impl FMSketch {
     }
 
     pub fn into_proto(self) -> analyze::FMSketch {
-        let mut proto = analyze::FMSketch::new();
+        let mut proto = analyze::FMSketch::default();
         proto.set_mask(self.mask);
         let hash = self.hash_set.into_iter().collect();
         proto.set_hashset(hash);

--- a/src/coprocessor/statistics/histogram.rs
+++ b/src/coprocessor/statistics/histogram.rs
@@ -40,7 +40,7 @@ impl Bucket {
     }
 
     fn into_proto(self) -> analyze::Bucket {
-        let mut bucket = analyze::Bucket::new();
+        let mut bucket = analyze::Bucket::default();
         bucket.set_repeats(self.repeats as i64);
         bucket.set_count(self.count as i64);
         bucket.set_lower_bound(self.lower_bound);
@@ -72,7 +72,7 @@ impl Histogram {
     }
 
     pub fn into_proto(self) -> analyze::Histogram {
-        let mut hist = analyze::Histogram::new();
+        let mut hist = analyze::Histogram::default();
         hist.set_ndv(self.ndv as i64);
         let buckets: Vec<analyze::Bucket> = self
             .buckets

--- a/src/import/sst_importer.rs
+++ b/src/import/sst_importer.rs
@@ -305,7 +305,7 @@ fn path_to_sst_meta<P: AsRef<Path>>(path: P) -> Result<SSTMeta> {
         return Err(Error::InvalidSSTPath(path.to_owned()));
     }
 
-    let mut meta = SSTMeta::new();
+    let mut meta = SSTMeta::default();
     let uuid = Uuid::parse_str(elems[0])?;
     meta.set_uuid(uuid.as_bytes().to_vec());
     meta.set_region_id(elems[1].parse()?);
@@ -327,7 +327,7 @@ mod tests {
         let temp_dir = Builder::new().prefix("test_import_dir").tempdir().unwrap();
         let dir = ImportDir::new(temp_dir.path()).unwrap();
 
-        let mut meta = SSTMeta::new();
+        let mut meta = SSTMeta::default();
         meta.set_uuid(Uuid::new_v4().as_bytes().to_vec());
 
         let path = dir.join(&meta).unwrap();
@@ -401,7 +401,7 @@ mod tests {
         let data = b"test_data";
         let crc32 = calc_data_crc32(data);
 
-        let mut meta = SSTMeta::new();
+        let mut meta = SSTMeta::default();
 
         {
             let mut f = ImportFile::create(meta.clone(), path.clone()).unwrap();
@@ -436,7 +436,7 @@ mod tests {
 
     #[test]
     fn test_sst_meta_to_path() {
-        let mut meta = SSTMeta::new();
+        let mut meta = SSTMeta::default();
         let uuid = Uuid::new_v4();
         meta.set_uuid(uuid.as_bytes().to_vec());
         meta.set_region_id(1);

--- a/src/import/test_helpers.rs
+++ b/src/import/test_helpers.rs
@@ -42,7 +42,7 @@ pub fn read_sst_file<P: AsRef<Path>>(path: P, range: (u8, u8)) -> (SSTMeta, Vec<
     let data = fs::read(path).unwrap();
     let crc32 = calc_data_crc32(&data);
 
-    let mut meta = SSTMeta::new();
+    let mut meta = SSTMeta::default();
     meta.set_uuid(Uuid::new_v4().as_bytes().to_vec());
     meta.mut_range().set_start(vec![range.0]);
     meta.mut_range().set_end(vec![range.1]);

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -3672,7 +3672,7 @@ mod tests {
 
     #[test]
     fn test_check_sst_for_ingestion() {
-        let mut sst = SSTMeta::new();
+        let mut sst = SSTMeta::default();
         let mut region = Region::default();
 
         // Check uuid and cf name

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -14,7 +14,6 @@ use kvproto::raft_cmdpb::{
     AdminCmdType, AdminRequest, RaftCmdRequest, RaftRequestHeader, RegionDetailResponse,
     StatusCmdType, StatusRequest,
 };
-use protobuf::text_format::print_to_string;
 
 use crate::raftstore::store::msg::Callback;
 use crate::server::debug::{Debugger, Error};
@@ -437,8 +436,7 @@ fn region_detail<T: RaftStoreRouter>(
                     if r.response.get_header().has_error() {
                         let e = r.response.get_header().get_error();
                         warn!("region_detail got error"; "err" => ?e);
-                        let msg = print_to_string(e);
-                        return Err(Error::Other(msg.into()));
+                        return Err(Error::Other(e.message.clone().into()));
                     }
                     let detail = r.response.take_status_response().take_region_detail();
                     debug!("region_detail got region detail"; "detail" => ?detail);
@@ -475,8 +473,7 @@ fn consistency_check<T: RaftStoreRouter>(
                     if r.response.get_header().has_error() {
                         let e = r.response.get_header().get_error();
                         warn!("consistency-check got error"; "err" => ?e);
-                        let msg = print_to_string(e);
-                        return Err(Error::Other(msg.into()));
+                        return Err(Error::Other(e.message.clone().into()));
                     }
                     Ok(())
                 })

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1894,7 +1894,7 @@ fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
         Err(Error::Closed) => {
             // TiKV is closing, return an RegionError to tell the client that this region is unavailable
             // temporarily, the client should retry the request in other TiKVs.
-            let mut err = RegionError::new();
+            let mut err = RegionError::default();
             err.set_message("TiKV is Closing".to_string());
             Some(err)
         }

--- a/tests/integrations/coprocessor/test_analyze.rs
+++ b/tests/integrations/coprocessor/test_analyze.rs
@@ -28,14 +28,14 @@ fn new_analyze_column_req(
     cm_sketch_depth: i32,
     cm_sketch_width: i32,
 ) -> Request {
-    let mut col_req = AnalyzeColumnsReq::new();
+    let mut col_req = AnalyzeColumnsReq::default();
     col_req.set_columns_info(table.columns_info().into());
     col_req.set_bucket_size(bucket_size);
     col_req.set_sketch_size(fm_sketch_size);
     col_req.set_sample_size(sample_size);
     col_req.set_cmsketch_depth(cm_sketch_depth);
     col_req.set_cmsketch_width(cm_sketch_width);
-    let mut analy_req = AnalyzeReq::new();
+    let mut analy_req = AnalyzeReq::default();
     analy_req.set_tp(AnalyzeType::TypeColumn);
     analy_req.set_start_ts(next_id() as u64);
     analy_req.set_col_req(col_req);
@@ -52,12 +52,12 @@ fn new_analyze_index_req(
     cm_sketch_depth: i32,
     cm_sketch_width: i32,
 ) -> Request {
-    let mut idx_req = AnalyzeIndexReq::new();
+    let mut idx_req = AnalyzeIndexReq::default();
     idx_req.set_num_columns(2);
     idx_req.set_bucket_size(bucket_size);
     idx_req.set_cmsketch_depth(cm_sketch_depth);
     idx_req.set_cmsketch_width(cm_sketch_width);
-    let mut analy_req = AnalyzeReq::new();
+    let mut analy_req = AnalyzeReq::default();
     analy_req.set_tp(AnalyzeType::TypeIndex);
     analy_req.set_start_ts(next_id() as u64);
     analy_req.set_idx_req(idx_req);
@@ -92,7 +92,7 @@ fn test_analyze_column_with_lock() {
                 assert!(resp.has_locked(), "{:?}", resp);
             }
             IsolationLevel::RC => {
-                let mut analyze_resp = AnalyzeColumnsResp::new();
+                let mut analyze_resp = AnalyzeColumnsResp::default();
                 analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
                 let hist = analyze_resp.get_pk_hist();
                 assert!(hist.get_buckets().is_empty());
@@ -117,7 +117,7 @@ fn test_analyze_column() {
     let req = new_analyze_column_req(&product, 3, 3, 3, 4, 32);
     let resp = handle_request(&endpoint, req);
     assert!(!resp.get_data().is_empty());
-    let mut analyze_resp = AnalyzeColumnsResp::new();
+    let mut analyze_resp = AnalyzeColumnsResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
     let hist = analyze_resp.get_pk_hist();
     assert_eq!(hist.get_buckets().len(), 2);
@@ -157,7 +157,7 @@ fn test_analyze_index_with_lock() {
                 assert!(resp.has_locked(), "{:?}", resp);
             }
             IsolationLevel::RC => {
-                let mut analyze_resp = AnalyzeIndexResp::new();
+                let mut analyze_resp = AnalyzeIndexResp::default();
                 analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
                 let hist = analyze_resp.get_hist();
                 assert!(hist.get_buckets().is_empty());
@@ -182,7 +182,7 @@ fn test_analyze_index() {
     let req = new_analyze_index_req(&product, 3, product["name"].index, 4, 32);
     let resp = handle_request(&endpoint, req);
     assert!(!resp.get_data().is_empty());
-    let mut analyze_resp = AnalyzeIndexResp::new();
+    let mut analyze_resp = AnalyzeIndexResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
     let hist = analyze_resp.get_hist();
     assert_eq!(hist.get_ndv(), 4);

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -120,7 +120,7 @@ fn test_stream_batch_row_limit() {
     assert_eq!(resps.len(), 3);
     let expected_output_counts = vec![vec![2 as i64], vec![2 as i64], vec![1 as i64]];
     for (i, resp) in resps.into_iter().enumerate() {
-        let mut chunk = Chunk::new();
+        let mut chunk = Chunk::default();
         chunk.merge_from_bytes(resp.get_data()).unwrap();
         assert_eq!(
             resp.get_output_counts(),
@@ -1172,7 +1172,7 @@ fn test_where() {
     let (_, endpoint) = init_with_data(&product, &data);
     let cols = product.columns_info();
     let cond = {
-        let mut col = Expr::new();
+        let mut col = Expr::default();
         col.set_tp(ExprType::ColumnRef);
         let count_offset = offset_for_column(&cols, product["count"].id);
         col.mut_val().encode_i64(count_offset).unwrap();
@@ -1180,7 +1180,7 @@ fn test_where() {
             .as_mut_accessor()
             .set_tp(FieldTypeTp::LongLong);
 
-        let mut value = Expr::new();
+        let mut value = Expr::default();
         value.set_tp(ExprType::String);
         value.set_val(String::from("2").into_bytes());
         value
@@ -1188,7 +1188,7 @@ fn test_where() {
             .as_mut_accessor()
             .set_tp(FieldTypeTp::VarString);
 
-        let mut right = Expr::new();
+        let mut right = Expr::default();
         right.set_tp(ExprType::ScalarFunc);
         right.set_sig(ScalarFuncSig::CastStringAsInt);
         right
@@ -1197,7 +1197,7 @@ fn test_where() {
             .set_tp(FieldTypeTp::LongLong);
         right.mut_children().push(value);
 
-        let mut cond = Expr::new();
+        let mut cond = Expr::default();
         cond.set_tp(ExprType::ScalarFunc);
         cond.set_sig(ScalarFuncSig::LTInt);
         cond.mut_field_type()
@@ -1235,22 +1235,22 @@ fn test_handle_truncate() {
     let cases = vec![
         {
             // count > "2x"
-            let mut col = Expr::new();
+            let mut col = Expr::default();
             col.set_tp(ExprType::ColumnRef);
             let count_offset = offset_for_column(&cols, product["count"].id);
             col.mut_val().encode_i64(count_offset).unwrap();
 
             // "2x" will be truncated.
-            let mut value = Expr::new();
+            let mut value = Expr::default();
             value.set_tp(ExprType::String);
             value.set_val(String::from("2x").into_bytes());
 
-            let mut right = Expr::new();
+            let mut right = Expr::default();
             right.set_tp(ExprType::ScalarFunc);
             right.set_sig(ScalarFuncSig::CastStringAsInt);
             right.mut_children().push(value);
 
-            let mut cond = Expr::new();
+            let mut cond = Expr::default();
             cond.set_tp(ExprType::ScalarFunc);
             cond.set_sig(ScalarFuncSig::LTInt);
             cond.mut_children().push(col);
@@ -1259,36 +1259,36 @@ fn test_handle_truncate() {
         },
         {
             // id
-            let mut col_id = Expr::new();
+            let mut col_id = Expr::default();
             col_id.set_tp(ExprType::ColumnRef);
             let id_offset = offset_for_column(&cols, product["id"].id);
             col_id.mut_val().encode_i64(id_offset).unwrap();
 
             // "3x" will be truncated.
-            let mut value = Expr::new();
+            let mut value = Expr::default();
             value.set_tp(ExprType::String);
             value.set_val(String::from("3x").into_bytes());
 
-            let mut int_3 = Expr::new();
+            let mut int_3 = Expr::default();
             int_3.set_tp(ExprType::ScalarFunc);
             int_3.set_sig(ScalarFuncSig::CastStringAsInt);
             int_3.mut_children().push(value);
 
             // count
-            let mut col_count = Expr::new();
+            let mut col_count = Expr::default();
             col_count.set_tp(ExprType::ColumnRef);
             let count_offset = offset_for_column(&cols, product["count"].id);
             col_count.mut_val().encode_i64(count_offset).unwrap();
 
             // "3x" + count
-            let mut plus = Expr::new();
+            let mut plus = Expr::default();
             plus.set_tp(ExprType::ScalarFunc);
             plus.set_sig(ScalarFuncSig::PlusInt);
             plus.mut_children().push(int_3);
             plus.mut_children().push(col_count);
 
             // id = "3x" + count
-            let mut cond = Expr::new();
+            let mut cond = Expr::default();
             cond.set_tp(ExprType::ScalarFunc);
             cond.set_sig(ScalarFuncSig::EQInt);
             cond.mut_children().push(col_id);

--- a/tests/integrations/import/sst_service.rs
+++ b/tests/integrations/import/sst_service.rs
@@ -167,7 +167,7 @@ fn test_cleanup_sst() {
 }
 
 fn new_sst_meta(crc32: u32, length: u64) -> SSTMeta {
-    let mut m = SSTMeta::new();
+    let mut m = SSTMeta::default();
     m.set_uuid(Uuid::new_v4().as_bytes().to_vec());
     m.set_crc32(crc32);
     m.set_length(length);


### PR DESCRIPTION
# What have you changed? (mandatory)

Changes more messages to use `default` rather than `new`. Removes use of `print_to_string` (which is rust-proto specific).

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

unit tests

## Does this PR affect documentation (docs) or release note? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

PTAL @breeswish @siddontang 