### PR TITLE
txn: Fix wrong constraint check when txn is overlapping

### DIFF
--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -167,6 +167,7 @@ impl<S: Snapshot> MvccTxn<S> {
         &mut self,
         should_not_exist: bool,
         write: &Write,
+        write_commit_ts: u64,
         key: &Key,
     ) -> Result<()> {
         if !should_not_exist || write.write_type == WriteType::Delete {
@@ -176,7 +177,7 @@ impl<S: Snapshot> MvccTxn<S> {
         // The current key exists under any of the following conditions:
         // 1.The current write type is `PUT`
         // 2.The current write type is `Rollback` or `Lock`, and the key have an older version.
-        if write.write_type == WriteType::Put || self.key_exist(&key, write.start_ts - 1)? {
+        if write.write_type == WriteType::Put || self.key_exist(&key, write_commit_ts)? {
             return Err(Error::AlreadyExist { key: key.to_raw()? });
         }
 
@@ -294,7 +295,7 @@ impl<S: Snapshot> MvccTxn<S> {
             }
 
             // Check data constraint when acquiring pessimistic lock.
-            self.check_data_constraint(should_not_exist, &write, &key)?;
+            self.check_data_constraint(should_not_exist, &write, commit_ts, &key)?;
         }
 
         self.lock_key(key, LockType::Pessimistic, primary.to_vec(), None, options);
@@ -382,7 +383,7 @@ impl<S: Snapshot> MvccTxn<S> {
                         primary: primary.to_vec(),
                     });
                 }
-                self.check_data_constraint(should_not_exist, &write, &key)?;
+                self.check_data_constraint(should_not_exist, &write, commit_ts, &key)?;
             }
         }
 
@@ -1388,5 +1389,26 @@ mod tests {
         must_pessimistic_locked(&engine, k, 1, 2);
         must_acquire_pessimistic_lock(&engine, k, k, 1, 3);
         must_pessimistic_locked(&engine, k, 1, 3);
+    }
+
+    #[test]
+    fn test_constraint_check_with_overlapping_txn() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+
+        let k = b"k1";
+        let v = b"v1";
+
+        must_prewrite_put(&engine, k, v, k, 10);
+        must_commit(&engine, k, 10, 11);
+        must_acquire_pessimistic_lock(&engine, k, k, 5, 12);
+        must_pessimistic_prewrite_lock(&engine, k, k, 5, 12, true);
+        must_commit(&engine, k, 5, 15);
+
+        // Now in write cf:
+        // start_ts = 10, commit_ts = 11, Put("v1")
+        // start_ts = 5,  commit_ts = 15, Lock
+
+        must_get(&engine, k, 19, v);
+        assert!(try_prewrite_insert(&engine, k, v, k, 20).is_err());
     }
 }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -177,7 +177,7 @@ impl<S: Snapshot> MvccTxn<S> {
         // The current key exists under any of the following conditions:
         // 1.The current write type is `PUT`
         // 2.The current write type is `Rollback` or `Lock`, and the key have an older version.
-        if write.write_type == WriteType::Put || self.key_exist(&key, write_commit_ts)? {
+        if write.write_type == WriteType::Put || self.key_exist(&key, write_commit_ts - 1)? {
             return Err(Error::AlreadyExist { key: key.to_raw()? });
         }
 


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

When pessimistic transaction is enabled, transactions' time ranges `[start_ts, commit_ts]` may overlap with each other. In `MvccTxn`'s constraint check, if the first write record it found (`w`) is not `Put` or `Delete`, it will use `w.start_ts` to find further write records. If another transaction is committed between `[w.start_ts, w.commit_ts]`, it will be missed.

This PR fixes this issue and adds a simple test for it.

Please **NOTE** that:
- Do not assume reviewers understand the original issue

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

By unit tests.

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.