### PR TITLE
Fix error in setting boolean tikv config

### DIFF
--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -778,10 +778,20 @@ impl Debugger {
                         let mut opt = Vec::new();
                         opt.push((config_name, config_value));
                         box_try!(rocksdb.set_options_cf(handle, &opt));
-                        if let Ok(v) = config_value.parse::<f64>() {
-                            CONFIG_ROCKSDB_GAUGE
-                                .with_label_values(&[cf, config_name])
-                                .set(v);
+                        let cfg_parse_status = config_value.parse::<f64>();
+                        match cfg_parse_status{
+                            Ok(v) => {
+	                            CONFIG_ROCKSDB_GAUGE
+	                                .with_label_values(&[cf, config_name])
+	                                .set(v);
+                            }
+                            Err(_e) => {
+		                        if let Ok(vb) = config_value.parse::<bool>() {
+		                            CONFIG_ROCKSDB_GAUGE
+		                                .with_label_values(&[cf, config_name])
+		                                .set((vb as i64) as f64);
+		                        }
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Issue: The disable_auto_compactions tikv configuration could not be set in tikv-ctl. The value remained unchanged although tikv-ctl modify-tikv-config command returned success message.

Reason: disable_auto_compactions is a boolean type configuration, while the code doesn't handle this type of configuration.

Changes: Catch error in ```config_value.parse::<f64>()```. And try to ```config_value.parse::<bool>()``` if error happens.

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Tested by manually set disable_auto_compactions configuration in tikv-ctl, and check whether it could be changed.

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

```
$ ./tikv-ctl --host 192.168.1.104:20160 metrics | grep disable_auto_compactions
tikv_config_rocksdb{cf="default",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="lock",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="raft",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="write",name="disable_auto_compactions"} 0

$ ./tikv-ctl --host 192.168.1.104:20160 modify-tikv-config -m raftdb -n default.disable_auto_compactions -v true
success
$ ./tikv-ctl --host 192.168.1.104:20160 metrics | grep disable_auto_compactions
tikv_config_rocksdb{cf="default",name="disable_auto_compactions"} 1
tikv_config_rocksdb{cf="lock",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="raft",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="write",name="disable_auto_compactions"} 0

$ ./tikv-ctl --host 192.168.1.104:20160 modify-tikv-config -m raftdb -n default.disable_auto_compactions -v false
success
$ ./tikv-ctl --host 192.168.1.104:20160 metrics | grep disable_auto_compactions
tikv_config_rocksdb{cf="default",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="lock",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="raft",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="write",name="disable_auto_compactions"} 0

$ ./tikv-ctl --host 192.168.1.104:20160 modify-tikv-config -m raftdb -n default.disable_auto_compactions -v true
success
$ ./tikv-ctl --host 192.168.1.104:20160 metrics | grep disable_auto_compactions
tikv_config_rocksdb{cf="default",name="disable_auto_compactions"} 1
tikv_config_rocksdb{cf="lock",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="raft",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="write",name="disable_auto_compactions"} 0
```

