### PR TITLE
fix the issue in setting boolean tikv config

### DIFF
--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -778,10 +778,20 @@ impl Debugger {
                         let mut opt = Vec::new();
                         opt.push((config_name, config_value));
                         box_try!(rocksdb.set_options_cf(handle, &opt));
-                        if let Ok(v) = config_value.parse::<f64>() {
-                            CONFIG_ROCKSDB_GAUGE
-                                .with_label_values(&[cf, config_name])
-                                .set(v);
+                        let cfg_parse_status = config_value.parse::<f64>();
+                        match cfg_parse_status{
+                            Ok(v) => {
+	                            CONFIG_ROCKSDB_GAUGE
+	                                .with_label_values(&[cf, config_name])
+	                                .set(v);
+                            }
+                            Err(_e) => {
+		                        if let Ok(vb) = config_value.parse::<bool>() {
+		                            CONFIG_ROCKSDB_GAUGE
+		                                .with_label_values(&[cf, config_name])
+		                                .set((vb as i64) as f64);
+		                        }
+                            }
                         }
                     }
                 } else {

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -779,18 +779,18 @@ impl Debugger {
                         opt.push((config_name, config_value));
                         box_try!(rocksdb.set_options_cf(handle, &opt));
                         let cfg_parse_status = config_value.parse::<f64>();
-                        match cfg_parse_status{
+                        match cfg_parse_status {
                             Ok(v) => {
-	                            CONFIG_ROCKSDB_GAUGE
-	                                .with_label_values(&[cf, config_name])
-	                                .set(v);
+                                CONFIG_ROCKSDB_GAUGE
+                                    .with_label_values(&[cf, config_name])
+                                    .set(v);
                             }
                             Err(_e) => {
-		                        if let Ok(vb) = config_value.parse::<bool>() {
-		                            CONFIG_ROCKSDB_GAUGE
-		                                .with_label_values(&[cf, config_name])
-		                                .set((vb as i64) as f64);
-		                        }
+                                if let Ok(vb) = config_value.parse::<bool>() {
+                                    CONFIG_ROCKSDB_GAUGE
+                                        .with_label_values(&[cf, config_name])
+                                        .set((vb as i64) as f64);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Signed-off-by: pentium3 <celerond@msn.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Issue: After setting disable_auto_compactions through tikv-ctl, the config change is not reflected through metrics. This is because parse::<f64> on bool value fail.

Changes: Catch error in ```config_value.parse::<f64>()```. And try to ```config_value.parse::<bool>()``` if error happens.

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Tested by manually set disable_auto_compactions configuration in tikv-ctl, and check the metrics afterward

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

```
$ ./tikv-ctl --host 192.168.1.104:20160 metrics | grep disable_auto_compactions
tikv_config_rocksdb{cf="default",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="lock",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="raft",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="write",name="disable_auto_compactions"} 0

$ ./tikv-ctl --host 192.168.1.104:20160 modify-tikv-config -m raftdb -n default.disable_auto_compactions -v true
success
$ ./tikv-ctl --host 192.168.1.104:20160 metrics | grep disable_auto_compactions
tikv_config_rocksdb{cf="default",name="disable_auto_compactions"} 1
tikv_config_rocksdb{cf="lock",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="raft",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="write",name="disable_auto_compactions"} 0

$ ./tikv-ctl --host 192.168.1.104:20160 modify-tikv-config -m raftdb -n default.disable_auto_compactions -v false
success
$ ./tikv-ctl --host 192.168.1.104:20160 metrics | grep disable_auto_compactions
tikv_config_rocksdb{cf="default",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="lock",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="raft",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="write",name="disable_auto_compactions"} 0

$ ./tikv-ctl --host 192.168.1.104:20160 modify-tikv-config -m raftdb -n default.disable_auto_compactions -v true
success
$ ./tikv-ctl --host 192.168.1.104:20160 metrics | grep disable_auto_compactions
tikv_config_rocksdb{cf="default",name="disable_auto_compactions"} 1
tikv_config_rocksdb{cf="lock",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="raft",name="disable_auto_compactions"} 0
tikv_config_rocksdb{cf="write",name="disable_auto_compactions"} 0
```


