### PR TITLE
cop: Fix float_str_to_int_str bugs and refactor it as same as TiDB

### DIFF
--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -583,6 +583,9 @@ fn float_str_to_int_string<'a>(
     }
 
     if e_idx.is_none() {
+        // 1. If there is digit after dot, round.
+        // 2. Only when the final result <0, add '-' in the front of it.
+        // 3. The result has no '+'.
         let dot_idx = dot_idx.unwrap();
         // NOTE: to make compatible with TiDB, +0.5 -> 1, -0.5 -> -1
         let int_str = if int_cnt == 0 && valid_float.starts_with('-') {

--- a/src/coprocessor/codec/convert.rs
+++ b/src/coprocessor/codec/convert.rs
@@ -526,7 +526,7 @@ fn round_int_str(num_next_dot: char, s: &str) -> Cow<'_, str> {
     match s.rfind(|c| c != '9' && c != '+' && c != '-') {
         Some(idx) => {
             int_str.push_str(&s[..idx]);
-            let next_char = char::from_u32(s.chars().nth(idx).unwrap() as u32 + 1).unwrap();
+            let next_char = (s.as_bytes()[idx] + 1) as char;
             int_str.push(next_char);
             let zero_count = s.len() - (idx + 1);
             if zero_count > 0 {
@@ -552,119 +552,164 @@ fn round_int_str(num_next_dot: char, s: &str) -> Cow<'_, str> {
 /// because precision will be lost.
 ///
 /// When the float string indicating a value that is overflowing the i64,
-/// the original float string is returned and an overflow warning is attached
+/// the original float string is returned and an overflow warning is attached.
+///
+/// This func will find serious overflow such as the len of result > 20 (without prefix `+/-`)
+/// however, it will not check whether the result overflow BIGINT.
 fn float_str_to_int_string<'a>(
     ctx: &mut EvalContext,
     valid_float: &'a str,
 ) -> Result<Cow<'a, str>> {
+    // this func is complex, to make it same as TiDB's version,
+    // we impl it like TiDB's version(https://github.com/pingcap/tidb/blob/9b521342bf/types/convert.go#L400)
     let mut dot_idx = None;
     let mut e_idx = None;
-    let mut int_cnt: i64 = 0;
-    let mut digits_cnt: i64 = 0;
 
     for (i, c) in valid_float.chars().enumerate() {
         match c {
             '.' => dot_idx = Some(i),
             'e' | 'E' => e_idx = Some(i),
-            '0'..='9' => {
-                if e_idx.is_none() {
-                    if dot_idx.is_none() {
-                        int_cnt += 1;
-                    }
-                    digits_cnt += 1;
-                }
-            }
             _ => (),
         }
     }
 
     if dot_idx.is_none() && e_idx.is_none() {
         return Ok(Cow::Borrowed(valid_float));
-    }
-
-    if e_idx.is_none() {
-        // 1. If there is digit after dot, round.
-        // 2. Only when the final result <0, add '-' in the front of it.
-        // 3. The result has no '+'.
-        let dot_idx = dot_idx.unwrap();
-        // NOTE: to make compatible with TiDB, +0.5 -> 1, -0.5 -> -1
-        let int_str = if int_cnt == 0 && valid_float.starts_with('-') {
-            &"-0"
-        } else if int_cnt == 0 {
-            &"0"
-        } else {
-            &valid_float[..dot_idx]
-        };
-        if digits_cnt - int_cnt > 0 {
-            // It's OK to unwrap here because the `dot_idx + 1` will less than the length of `valid_float`
-            let digit_char = valid_float.chars().nth(dot_idx + 1).unwrap();
-            return Ok(round_int_str(digit_char, int_str));
-        }
-        return Ok(Cow::Borrowed(int_str));
-    }
-
-    let e_idx = e_idx.unwrap();
-    let exp = box_try!((&valid_float[e_idx + 1..]).parse::<i64>());
-    if exp > 0 && int_cnt > (i64::MAX - exp) {
-        // (exp + int_cnt) overflows MaxInt64. Add warning and return original float string
-        ctx.warnings
-            .append_warning(Error::overflow("BIGINT", &valid_float));
-        return Ok(Cow::Owned(valid_float.to_owned()));
-    }
-    if int_cnt + exp <= 0 {
-        if int_cnt == 0 && digits_cnt > 0 {
-            // NOTE: to make compatible with TiDB (different with +0.5 -> 1), +0.5e0 -> +1, -0.5e0 -> -1
-            let int_str = if valid_float.starts_with('+') {
-                &"+0"
-            } else if valid_float.starts_with('-') {
-                &"-0"
-            } else {
-                &"0"
-            };
-            let digit_char = valid_float.chars().nth(dot_idx.unwrap() + 1).unwrap();
-            return Ok(round_int_str(digit_char, int_str));
-        }
-        return Ok(Cow::Borrowed("0"));
-    }
-
-    let mut valid_int = String::from(&valid_float[..e_idx]);
-    if let Some(idx) = dot_idx {
-        valid_int.remove(idx);
-    }
-
-    let extra_zero_count = exp + int_cnt - digits_cnt;
-    if extra_zero_count > MAX_ZERO_COUNT {
-        // Overflows MaxInt64. Add warning and return original float string
-        ctx.warnings
-            .append_warning(Error::overflow("BIGINT", &valid_float));
-        return Ok(Cow::Owned(valid_float.to_owned()));
-    }
-
-    if extra_zero_count >= 0 {
-        valid_int.extend((0..extra_zero_count).map(|_| '0'));
+    } else if e_idx.is_none() {
+        no_exp_float_str_to_int_str(valid_float, dot_idx.unwrap())
     } else {
-        let len = valid_int.len();
-        if extra_zero_count >= len as i64 {
-            return Ok(Cow::Borrowed("0"));
-        }
-        let require = if valid_float.starts_with('-') || valid_float.starts_with('+') {
-            (int_cnt + exp) as usize + 1
-        } else {
-            (int_cnt + exp) as usize
-        };
-        if require < valid_int.len() {
-            let digit_char = valid_float.chars().nth(require + 1).unwrap();
-            if digit_char >= '5' {
-                valid_int = round_int_str(digit_char, &valid_int[..require]).into_owned();
-            }
-        }
-        valid_int.truncate((exp + int_cnt) as usize);
+        exp_float_str_to_int_str(ctx, valid_float, e_idx.unwrap(), dot_idx)
     }
-
-    Ok(Cow::Owned(valid_int))
 }
 
-const MAX_ZERO_COUNT: i64 = 20;
+fn exp_float_str_to_int_str<'a>(
+    ctx: &mut EvalContext,
+    valid_float: &'a str,
+    e_idx: usize,
+    dot_idx: Option<usize>,
+) -> Result<Cow<'a, str>> {
+    // intCnt and digits contain the prefix `+/-` if validFloat[0] is `+/-`
+    let mut digits: Vec<u8> = Vec::with_capacity(valid_float.len());
+    let int_cnt: i64;
+    match dot_idx {
+        None => {
+            digits.extend_from_slice((&valid_float[..e_idx]).as_bytes());
+            // if digits.len() > i64::MAX,
+            // then the input str has at least 9223372036854775808 chars,
+            // which make the str >= 8388608.0 TB,
+            // so cast it to i64 is safe.
+            int_cnt = digits.len() as i64;
+        }
+        Some(dog_idx) => {
+            digits.extend_from_slice(&valid_float[..dog_idx].as_bytes());
+            int_cnt = digits.len() as i64;
+            digits.extend_from_slice(&valid_float[((dog_idx + 1)..e_idx)].as_bytes());
+        }
+    }
+    // make `digits` immutable
+    let digits = digits;
+    let exp = box_try!((&valid_float[(e_idx + 1)..]).parse::<i64>());
+    let (int_cnt, is_overflow): (i64, bool) = int_cnt.overflowing_add(exp);
+    if int_cnt > 21 || is_overflow {
+        // MaxInt64 has 19 decimal digits.
+        // MaxUint64 has 20 decimal digits.
+        // And the intCnt may contain the len of `+/-`,
+        // so I use 21 here as the early detection.
+        ctx.warnings
+            .append_warning(Error::overflow("BIGINT", &valid_float));
+        return Ok(Cow::Borrowed(&valid_float[..e_idx]));
+    }
+    if int_cnt <= 0 {
+        let int_str = "0";
+        if int_cnt == 0 && digits.len() > 0 && digits[0].is_ascii_digit() {
+            return Ok(round_int_str(digits[0] as char, int_str));
+        } else {
+            return Ok(Cow::Borrowed(int_str));
+        }
+    }
+    if int_cnt == 1 && (digits[0] == b'-' || digits[0] == b'+') {
+        let int_str = if digits[0] == b'+' {
+            "+0"
+        } else if digits[0] == b'-' {
+            "-0"
+        } else {
+            "0"
+        };
+        let res = if digits.len() > 1 {
+            round_int_str(digits[1] as char, int_str)
+        } else {
+            Cow::Borrowed(int_str)
+        };
+        if (res.starts_with('+') || res.starts_with('-')) && (res.as_bytes()[1] == b'0') {
+            return Ok(Cow::Owned((&res[1..]).to_owned()));
+        } else {
+            return Ok(res);
+        }
+    }
+    let int_cnt = int_cnt as usize;
+    if int_cnt <= digits.len() {
+        let int_str = String::from_utf8_lossy(&digits[..int_cnt]);
+        if int_cnt < digits.len() {
+            return Ok(Cow::Owned(
+                round_int_str(digits[int_cnt] as char, &int_str).into_owned(),
+            ));
+        } else {
+            return Ok(Cow::Owned((*int_str).to_owned()));
+        }
+    } else {
+        let mut res = String::with_capacity(int_cnt);
+        for d in digits.iter() {
+            res.push(*d as char);
+        }
+        for _ in digits.len()..(int_cnt) {
+            res.push('0');
+        }
+        return Ok(Cow::Owned(res));
+    }
+}
+
+fn no_exp_float_str_to_int_str(valid_float: &str, mut dot_idx: usize) -> Result<Cow<str>> {
+    // According to TiDB's impl
+    // 1. If there is digit after dot, round.
+    // 2. Only when the final result <0, add '-' in the front of it.
+    // 3. The result has no '+'.
+
+    let digits = if valid_float.starts_with('+') || valid_float.starts_with('-') {
+        dot_idx -= 1;
+        &valid_float[1..]
+    } else {
+        valid_float
+    };
+    let int_str = if valid_float.starts_with('-') {
+        if dot_idx == 0 {
+            "-0"
+        } else {
+            // the valid_float[0] is '-', so there is `dot_idx-=1` above
+            &valid_float[..(dot_idx + 1)]
+        }
+    } else {
+        if dot_idx == 0 {
+            "0"
+        } else {
+            &digits[..dot_idx]
+        }
+    };
+
+    let res = if digits.len() > dot_idx + 1 {
+        round_int_str(digits.as_bytes()[dot_idx + 1] as char, int_str)
+    } else {
+        Cow::Owned(String::from(int_str))
+    };
+    // in the TiDB version, after round, except '0',
+    // others(even if `00`) will be prefix with `-` if valid_float[0]=='-'.
+    // so we need to remove `-` of `-0`.
+    let res_bytes = res.as_bytes();
+    if res_bytes.len() == 2 && res_bytes[0] == b'-' && res_bytes[1] == b'0' {
+        return Ok(Cow::Owned(String::from(&res[1..])));
+    } else {
+        return Ok(res);
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -1411,6 +1456,10 @@ mod tests {
     fn test_valid_get_valid_int_prefix() {
         let mut ctx = EvalContext::new(Arc::new(EvalConfig::default_for_test()));
         let cases = vec![
+            ("+0.0", "0"),
+            ("+000.0", "000"),
+            ("-0.0", "0"),
+            ("-000.0", "-000"),
             (".1", "0"),
             (".0", "0"),
             (".5", "1"),
@@ -1434,7 +1483,7 @@ mod tests {
             ("-123.45678e5", "-12345678"),
             ("+123.45678e5", "+12345678"),
             ("9e20", "900000000000000000000"), // TODO: check code validity again on function float_str_to_int_string(),
-                                               // as "900000000000000000000" is already larger than i64::MAX
+            // as "900000000000000000000" is already larger than i64::MAX
         ];
 
         for (i, e) in cases {

--- a/src/coprocessor/dag/batch/executors/index_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/index_scan_executor.rs
@@ -410,6 +410,7 @@ mod tests {
 
         // For a unique index, the PK handle is stored in the value.
 
+        let mut ctx = EvalContext::default();
         let store = {
             let kv = data
                 .iter()
@@ -420,7 +421,7 @@ mod tests {
                     // PK handle in the value
                     let mut value = vec![];
                     value
-                        .write_i64::<BigEndian>(datums[2].as_int().unwrap().unwrap())
+                        .write_i64::<BigEndian>(datums[2].as_int(&mut ctx).unwrap().unwrap())
                         .unwrap();
                     (key, Ok(value))
                 })

--- a/src/coprocessor/dag/expr/builtin_arithmetic.rs
+++ b/src/coprocessor/dag/expr/builtin_arithmetic.rs
@@ -1002,7 +1002,7 @@ mod tests {
                 &ctx,
                 scalar_func_expr(ScalarFuncSig::MultiplyIntUnsigned, &[lhs, rhs]),
             )
-                .unwrap();
+            .unwrap();
             op.mut_field_type()
                 .as_mut_accessor()
                 .set_flag(FieldTypeFlag::UNSIGNED);
@@ -1026,7 +1026,7 @@ mod tests {
                 &ctx,
                 scalar_func_expr(ScalarFuncSig::MultiplyIntUnsigned, &[lhs, rhs]),
             )
-                .unwrap();
+            .unwrap();
             op.mut_field_type()
                 .as_mut_accessor()
                 .set_flag(FieldTypeFlag::UNSIGNED);

--- a/src/coprocessor/dag/expr/builtin_arithmetic.rs
+++ b/src/coprocessor/dag/expr/builtin_arithmetic.rs
@@ -532,7 +532,10 @@ mod tests {
             ),
         ];
         let mut ctx = EvalContext::default();
+        let mut ind = 0;
         for tt in tests {
+            println!("{}", ind);
+            ind += 1;
             let lhs = datum_expr(tt.1);
             let rhs = datum_expr(tt.2);
 
@@ -999,7 +1002,7 @@ mod tests {
                 &ctx,
                 scalar_func_expr(ScalarFuncSig::MultiplyIntUnsigned, &[lhs, rhs]),
             )
-            .unwrap();
+                .unwrap();
             op.mut_field_type()
                 .as_mut_accessor()
                 .set_flag(FieldTypeFlag::UNSIGNED);
@@ -1023,7 +1026,7 @@ mod tests {
                 &ctx,
                 scalar_func_expr(ScalarFuncSig::MultiplyIntUnsigned, &[lhs, rhs]),
             )
-            .unwrap();
+                .unwrap();
             op.mut_field_type()
                 .as_mut_accessor()
                 .set_flag(FieldTypeFlag::UNSIGNED);

--- a/src/coprocessor/dag/expr/column.rs
+++ b/src/coprocessor/dag/expr/column.rs
@@ -17,7 +17,7 @@ impl Column {
     }
 
     #[inline]
-    pub fn eval_int(&self, row: &[Datum], ctx: &mut EvalContext) -> Result<Option<i64>> {
+    pub fn eval_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         row[self.offset].as_int(ctx)
     }
 

--- a/src/coprocessor/dag/expr/column.rs
+++ b/src/coprocessor/dag/expr/column.rs
@@ -151,10 +151,10 @@ mod tests {
             EvalResults(None, None, None, None, None, None, None),
             EvalResults(Some(-30), None, None, None, None, None, None),
             EvalResults(Some(-1), None, None, None, None, None, None),
-            EvalResults(None, Some(124.32), None, None, None, None, None),
-            EvalResults(None, None, Some(dec.clone()), None, None, None, None),
+            EvalResults(Some(124), Some(124.32), None, None, None, None, None),
+            EvalResults(Some(1), None, Some(dec.clone()), None, None, None, None),
             EvalResults(None, None, None, Some(s.clone()), None, None, None),
-            EvalResults(None, None, None, None, None, Some(dur), None),
+            EvalResults(Some(10000), None, None, None, None, Some(dur), None),
         ];
 
         let mut ctx = EvalContext::default();

--- a/src/coprocessor/dag/expr/column.rs
+++ b/src/coprocessor/dag/expr/column.rs
@@ -17,8 +17,8 @@ impl Column {
     }
 
     #[inline]
-    pub fn eval_int(&self, row: &[Datum]) -> Result<Option<i64>> {
-        row[self.offset].as_int()
+    pub fn eval_int(&self, row: &[Datum], ctx: &mut EvalContext) -> Result<Option<i64>> {
+        row[self.offset].as_int(ctx)
     }
 
     #[inline]

--- a/src/coprocessor/dag/expr/constant.rs
+++ b/src/coprocessor/dag/expr/constant.rs
@@ -198,13 +198,34 @@ mod tests {
         let dur = Duration::parse(b"01:00:00", 0).unwrap();
 
         let tests = vec![
-            (datum_expr(Datum::Null), EvalResults(None, None, None, None, None, None, None)),
-            (datum_expr(Datum::I64(-30)), EvalResults(Some(-30), None, None, None, None, None, None)),
-            (datum_expr(Datum::U64(u64::MAX)), EvalResults(Some(-1), None, None, None, None, None, None)),
-            (datum_expr(Datum::F64(124.32)), EvalResults(Some(124), Some(124.32), None, None, None, None, None)),
-            (datum_expr(Datum::Dec(dec.clone())), EvalResults(Some(1), None, Some(dec.clone()), None, None, None, None)),
-            (datum_expr(Datum::Bytes(s.clone())), EvalResults(None, None, None, Some(s.clone()), None, None, None)),
-            (datum_expr(Datum::Dur(dur)), EvalResults(Some(10000), None, None, None, None, Some(dur), None)),
+            (
+                datum_expr(Datum::Null),
+                EvalResults(None, None, None, None, None, None, None),
+            ),
+            (
+                datum_expr(Datum::I64(-30)),
+                EvalResults(Some(-30), None, None, None, None, None, None),
+            ),
+            (
+                datum_expr(Datum::U64(u64::MAX)),
+                EvalResults(Some(-1), None, None, None, None, None, None),
+            ),
+            (
+                datum_expr(Datum::F64(124.32)),
+                EvalResults(Some(124), Some(124.32), None, None, None, None, None),
+            ),
+            (
+                datum_expr(Datum::Dec(dec.clone())),
+                EvalResults(Some(1), None, Some(dec.clone()), None, None, None, None),
+            ),
+            (
+                datum_expr(Datum::Bytes(s.clone())),
+                EvalResults(None, None, None, Some(s.clone()), None, None, None),
+            ),
+            (
+                datum_expr(Datum::Dur(dur)),
+                EvalResults(Some(10000), None, None, None, None, Some(dur), None),
+            ),
         ];
 
         let mut ctx = EvalContext::default();

--- a/src/coprocessor/dag/expr/constant.rs
+++ b/src/coprocessor/dag/expr/constant.rs
@@ -255,7 +255,7 @@ mod tests {
     #[test]
     fn test_datum_as_bool() {
         let dec = "1.1".parse::<Decimal>().unwrap();
-        let s = "10".as_bytes().to_owned();
+        let s = b"10".to_vec();
         let dur = Duration::parse(b"01:00:00", 0).unwrap();
         let json = Json::String(String::from("test_json"));
 

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -109,8 +109,8 @@ impl Expression {
 
     fn eval_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         match *self {
-            Expression::Constant(ref constant) => constant.eval_int(),
-            Expression::ColumnRef(ref column) => column.eval_int(row),
+            Expression::Constant(ref constant) => constant.eval_int(ctx),
+            Expression::ColumnRef(ref column) => column.eval_int(row, ctx),
             Expression::ScalarFn(ref f) => f.eval_int(ctx, row),
         }
     }

--- a/src/coprocessor/dag/expr/mod.rs
+++ b/src/coprocessor/dag/expr/mod.rs
@@ -110,7 +110,7 @@ impl Expression {
     fn eval_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
         match *self {
             Expression::Constant(ref constant) => constant.eval_int(ctx),
-            Expression::ColumnRef(ref column) => column.eval_int(row, ctx),
+            Expression::ColumnRef(ref column) => column.eval_int(ctx, row),
             Expression::ScalarFn(ref f) => f.eval_int(ctx, row),
         }
     }


### PR DESCRIPTION
## What have you changed? (mandatory)

Fix some bugs

-  `6.01e-1` -> `0`
- `-0.0` -> `-0` (TiDB version is `0`)  
- etc.

Refactor the impl to make it the same as TiDB version(https://github.com/pingcap/tidb/pull/11376) . 
The origin impl is very different from TiDB version, so it is hard for the maintainer to find the difference between them, and it is hard to verify whether they as the same after TiDB change some code of it.

## What are the type of the changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- Bug fix (change which fixes an issue)
- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

- uint test

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
