### PR TITLE
update rust-rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "bzip2-sys"
 version = "0.1.7"
-source = "git+https://github.com/alexcrichton/bzip2-rs.git#7743c8402fcf05b02ead51045ec80a00a9bec8df"
+source = "git+https://github.com/alexcrichton/bzip2-rs.git#f47e7400da86931cf1e9300e7e46452238bf08b9"
 dependencies = [
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#13c1f9452e8dc743ca1ac887992de650b5951fb7"
+source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#68467cbb5884f86d0b1161162525a4a013d6570a"
 dependencies = [
  "bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1078,13 +1078,13 @@ dependencies = [
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4-sys 1.8.0 (git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build)",
  "snappy-sys 0.1.0 (git+https://github.com/busyjay/rust-snappy.git?branch=static-link)",
- "zstd-sys 1.4.10+zstd.1.4.0 (git+https://github.com/gyscos/zstd-rs.git)",
+ "zstd-sys 1.4.12+zstd.1.4.2 (git+https://github.com/gyscos/zstd-rs.git)",
 ]
 
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#13c1f9452e8dc743ca1ac887992de650b5951fb7"
+source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#68467cbb5884f86d0b1161162525a4a013d6570a"
 dependencies = [
  "bzip2-sys 0.1.7 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1093,7 +1093,7 @@ dependencies = [
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4-sys 1.8.0 (git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build)",
  "snappy-sys 0.1.0 (git+https://github.com/busyjay/rust-snappy.git?branch=static-link)",
- "zstd-sys 1.4.10+zstd.1.4.0 (git+https://github.com/gyscos/zstd-rs.git)",
+ "zstd-sys 1.4.12+zstd.1.4.2 (git+https://github.com/gyscos/zstd-rs.git)",
 ]
 
 [[package]]
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#13c1f9452e8dc743ca1ac887992de650b5951fb7"
+source = "git+https://github.com/pingcap/rust-rocksdb.git?branch=tikv-3.0#68467cbb5884f86d0b1161162525a4a013d6570a"
 dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2905,8 +2905,8 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.10+zstd.1.4.0"
-source = "git+https://github.com/gyscos/zstd-rs.git#f5d0cddc58a1b164e7312164465d11bc701af83e"
+version = "1.4.12+zstd.1.4.2"
+source = "git+https://github.com/gyscos/zstd-rs.git#d2d3a5fea1ae370e8b3b2007df770bfa39f70342"
 dependencies = [
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3208,4 +3208,4 @@ dependencies = [
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 "checksum zipf 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2057772d87bedea0efd93842ee0e0f52fc0c313c556d5fa8ee787771c051a61f"
-"checksum zstd-sys 1.4.10+zstd.1.4.0 (git+https://github.com/gyscos/zstd-rs.git)" = "<none>"
+"checksum zstd-sys 1.4.12+zstd.1.4.2 (git+https://github.com/gyscos/zstd-rs.git)" = "<none>"


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
Update rust-rocksdb with the following cherry-picks:
```
6ead62c 2019-07-25 yiwu@pingcap.com     Avoid build require system zlib (#303)
9246b9c 2019-07-25 hi@breeswish.org     Skip jemalloc options on specific platform (#324)
7a8dd73 2019-07-22 yiwu@pingcap.com     Add jemalloc-sys dependency when jemalloc is enabled (#320)
6f2c632 2019-07-23 yiwu@pingcap.com     Not compile with gflags (#322)
09b8032 2019-07-22 yiwu@pingcap.com     Fix perf context test (#321)
d67f38e 2019-07-21 yiwu@pingcap.com     Add jemalloc feature (#319)
```

Also update rocksdb to fix compile error with gcc9:
```
7a03c83ed 2019-07-23 psergey@askmonty.org Fix MyRocks compile warnings-treated-as-errors on Fedora 30, gcc 9.1.1 (#5553)
```

## What are the type of the changes? (mandatory)
Bug fix

## How has this PR been tested? (mandatory)
CI

## Does this PR affect documentation (docs) or release note? (mandatory)
no

## Does this PR affect tidb-ansible update? (mandatory)
no

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

