### PR TITLE
Relies on the Storage trait instead of tikv::storage

### DIFF
--- a/benches/coprocessor_executors/hash_aggr/util.rs
+++ b/benches/coprocessor_executors/hash_aggr/util.rs
@@ -12,6 +12,7 @@ use tikv::coprocessor::dag::batch::executors::BatchSlowHashAggregationExecutor;
 use tikv::coprocessor::dag::batch::interface::*;
 use tikv::coprocessor::dag::executor::{Executor, HashAggExecutor};
 use tikv::coprocessor::dag::expr::EvalConfig;
+use tikv::storage::Statistics;
 
 use crate::util::bencher::Bencher;
 use crate::util::executor_descriptor::hash_aggregate;
@@ -63,7 +64,7 @@ impl HashAggrBencher for NormalBencher {
                 black_box(Box::new(src)),
             )
             .unwrap();
-            Box::new(ex) as Box<dyn Executor>
+            Box::new(ex) as Box<dyn Executor<StorageStats = Statistics>>
         })
         .bench(b);
     }
@@ -102,7 +103,7 @@ impl HashAggrBencher for BatchBencher {
                     black_box(aggr_expr.to_vec()),
                 )
                 .unwrap();
-                Box::new(ex) as Box<dyn BatchExecutor>
+                Box::new(ex) as Box<dyn BatchExecutor<StorageStats = Statistics>>
             } else {
                 let ex = BatchSlowHashAggregationExecutor::new(
                     black_box(Arc::new(EvalConfig::default())),
@@ -111,7 +112,7 @@ impl HashAggrBencher for BatchBencher {
                     black_box(aggr_expr.to_vec()),
                 )
                 .unwrap();
-                Box::new(ex) as Box<dyn BatchExecutor>
+                Box::new(ex) as Box<dyn BatchExecutor<StorageStats = Statistics>>
             }
         })
         .bench(b);

--- a/benches/coprocessor_executors/index_scan/util.rs
+++ b/benches/coprocessor_executors/index_scan/util.rs
@@ -14,8 +14,9 @@ use tikv::coprocessor::dag::batch::executors::BatchIndexScanExecutor;
 use tikv::coprocessor::dag::batch::interface::*;
 use tikv::coprocessor::dag::executor::{Executor, IndexScanExecutor};
 use tikv::coprocessor::dag::expr::EvalConfig;
+use tikv::coprocessor::dag::storage_impl::TiKVStorage;
 use tikv::coprocessor::RequestHandler;
-use tikv::storage::{RocksEngine, Store as TxnStore};
+use tikv::storage::{RocksEngine, Statistics, Store as TxnStore};
 
 use crate::util::executor_descriptor::index_scan;
 use crate::util::scan_bencher;
@@ -30,7 +31,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
     for NormalIndexScanExecutorBuilder<T>
 {
     type T = T;
-    type E = Box<dyn Executor>;
+    type E = Box<dyn Executor<StorageStats = Statistics>>;
     type P = IndexScanParam;
 
     fn build(
@@ -45,7 +46,9 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
         let mut executor = IndexScanExecutor::index_scan(
             black_box(req),
             black_box(ranges.to_vec()),
-            black_box(ToTxnStore::<Self::T>::to_store(store)),
+            // TODO: Change to use `FixtureStorage` directly instead of
+            // `TiKVStorage<FixtureStore<..>>`
+            black_box(TiKVStorage::from(ToTxnStore::<Self::T>::to_store(store))),
             black_box(unique),
             black_box(false),
         )
@@ -53,7 +56,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
         // There is a step of building scanner in the first `next()` which cost time,
         // so we next() before hand.
         executor.next().unwrap().unwrap();
-        Box::new(executor) as Box<dyn Executor>
+        Box::new(executor) as Box<dyn Executor<StorageStats = Statistics>>
     }
 }
 
@@ -63,7 +66,7 @@ pub struct BatchIndexScanExecutorBuilder<T: TxnStore + 'static> {
 
 impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder for BatchIndexScanExecutorBuilder<T> {
     type T = T;
-    type E = Box<dyn BatchExecutor>;
+    type E = Box<dyn BatchExecutor<StorageStats = Statistics>>;
     type P = IndexScanParam;
 
     fn build(
@@ -73,7 +76,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder for BatchIndexScan
         unique: bool,
     ) -> Self::E {
         let mut executor = BatchIndexScanExecutor::new(
-            black_box(ToTxnStore::<Self::T>::to_store(store)),
+            black_box(TiKVStorage::from(ToTxnStore::<Self::T>::to_store(store))),
             black_box(Arc::new(EvalConfig::default())),
             black_box(columns.to_vec()),
             black_box(ranges.to_vec()),
@@ -84,7 +87,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder for BatchIndexScan
         // There is a step of building scanner in the first `next()` which cost time,
         // so we next() before hand.
         executor.next_batch(1);
-        Box::new(executor) as Box<dyn BatchExecutor>
+        Box::new(executor) as Box<dyn BatchExecutor<StorageStats = Statistics>>
     }
 }
 

--- a/benches/coprocessor_executors/integrated/util.rs
+++ b/benches/coprocessor_executors/integrated/util.rs
@@ -11,6 +11,7 @@ use tipb::executor::Executor as PbExecutor;
 use test_coprocessor::*;
 use tikv::coprocessor::dag::execute_stats::ExecSummaryCollectorDisabled;
 use tikv::coprocessor::dag::expr::EvalConfig;
+use tikv::coprocessor::dag::storage_impl::TiKVStorage;
 use tikv::storage::{RocksEngine, Store as TxnStore};
 
 use crate::util::bencher::Bencher;
@@ -68,7 +69,7 @@ impl<T: TxnStore + 'static> IntegratedBencher for NormalBencher<T> {
                 ExecSummaryCollectorDisabled,
             >(
                 black_box(executors.to_vec()),
-                black_box(ToTxnStore::<T>::to_store(store)),
+                black_box(TiKVStorage::from(ToTxnStore::<T>::to_store(store))),
                 black_box(ranges.to_vec()),
                 black_box(Arc::new(EvalConfig::default())),
                 black_box(false),
@@ -114,7 +115,7 @@ impl<T: TxnStore + 'static> IntegratedBencher for BatchBencher<T> {
                 ExecSummaryCollectorDisabled,
             >(
                 black_box(executors.to_vec()),
-                black_box(ToTxnStore::<T>::to_store(store)),
+                black_box(TiKVStorage::from(ToTxnStore::<T>::to_store(store))),
                 black_box(ranges.to_vec()),
                 black_box(Arc::new(EvalConfig::default())),
             )

--- a/benches/coprocessor_executors/selection/util.rs
+++ b/benches/coprocessor_executors/selection/util.rs
@@ -10,6 +10,7 @@ use tikv::coprocessor::dag::batch::executors::BatchSelectionExecutor;
 use tikv::coprocessor::dag::batch::interface::BatchExecutor;
 use tikv::coprocessor::dag::executor::{Executor, SelectionExecutor};
 use tikv::coprocessor::dag::expr::EvalConfig;
+use tikv::storage::Statistics;
 
 use crate::util::bencher::Bencher;
 use crate::util::executor_descriptor::selection;
@@ -49,7 +50,7 @@ impl SelectionBencher for NormalBencher {
                     black_box(Box::new(src)),
                 )
                 .unwrap(),
-            ) as Box<dyn Executor>
+            ) as Box<dyn Executor<StorageStats = Statistics>>
         })
         .bench(b);
     }
@@ -77,7 +78,7 @@ impl SelectionBencher for BatchBencher {
                     black_box(exprs.to_vec()),
                 )
                 .unwrap(),
-            ) as Box<dyn BatchExecutor>
+            ) as Box<dyn BatchExecutor<StorageStats = Statistics>>
         })
         .bench(b);
     }

--- a/benches/coprocessor_executors/simple_aggr/util.rs
+++ b/benches/coprocessor_executors/simple_aggr/util.rs
@@ -10,6 +10,7 @@ use tikv::coprocessor::dag::batch::executors::BatchSimpleAggregationExecutor;
 use tikv::coprocessor::dag::batch::interface::BatchExecutor;
 use tikv::coprocessor::dag::executor::{Executor, StreamAggExecutor};
 use tikv::coprocessor::dag::expr::EvalConfig;
+use tikv::storage::Statistics;
 
 use crate::util::bencher::Bencher;
 use crate::util::executor_descriptor::simple_aggregate;
@@ -50,7 +51,7 @@ impl SimpleAggrBencher for NormalBencher {
                     black_box(meta),
                 )
                 .unwrap(),
-            ) as Box<dyn Executor>
+            ) as Box<dyn Executor<StorageStats = Statistics>>
         })
         .bench(b);
     }
@@ -79,7 +80,7 @@ impl SimpleAggrBencher for BatchBencher {
                     black_box(aggr_expr.to_vec()),
                 )
                 .unwrap(),
-            ) as Box<dyn BatchExecutor>
+            ) as Box<dyn BatchExecutor<StorageStats = Statistics>>
         })
         .bench(b);
     }

--- a/benches/coprocessor_executors/stream_aggr/util.rs
+++ b/benches/coprocessor_executors/stream_aggr/util.rs
@@ -10,6 +10,7 @@ use tikv::coprocessor::dag::batch::executors::BatchStreamAggregationExecutor;
 use tikv::coprocessor::dag::batch::interface::BatchExecutor;
 use tikv::coprocessor::dag::executor::{Executor, StreamAggExecutor};
 use tikv::coprocessor::dag::expr::EvalConfig;
+use tikv::storage::Statistics;
 
 use crate::util::bencher::Bencher;
 use crate::util::executor_descriptor::stream_aggregate;
@@ -62,7 +63,7 @@ impl StreamAggrBencher for NormalBencher {
                     black_box(meta),
                 )
                 .unwrap(),
-            ) as Box<dyn Executor>
+            ) as Box<dyn Executor<StorageStats = Statistics>>
         })
         .bench(b);
     }
@@ -98,7 +99,7 @@ impl StreamAggrBencher for BatchBencher {
                     black_box(aggr_expr.to_vec()),
                 )
                 .unwrap(),
-            ) as Box<dyn BatchExecutor>
+            ) as Box<dyn BatchExecutor<StorageStats = Statistics>>
         })
         .bench(b);
     }

--- a/benches/coprocessor_executors/table_scan/util.rs
+++ b/benches/coprocessor_executors/table_scan/util.rs
@@ -15,8 +15,9 @@ use tikv::coprocessor::dag::batch::interface::*;
 use tikv::coprocessor::dag::executor::Executor;
 use tikv::coprocessor::dag::executor::TableScanExecutor;
 use tikv::coprocessor::dag::expr::EvalConfig;
+use tikv::coprocessor::dag::storage_impl::TiKVStorage;
 use tikv::coprocessor::RequestHandler;
-use tikv::storage::{RocksEngine, Store as TxnStore};
+use tikv::storage::{RocksEngine, Statistics, Store as TxnStore};
 
 use crate::util::executor_descriptor::table_scan;
 use crate::util::scan_bencher;
@@ -31,7 +32,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
     for NormalTableScanExecutorBuilder<T>
 {
     type T = T;
-    type E = Box<dyn Executor>;
+    type E = Box<dyn Executor<StorageStats = Statistics>>;
     type P = TableScanParam;
 
     fn build(
@@ -46,14 +47,14 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
         let mut executor = TableScanExecutor::table_scan(
             black_box(req),
             black_box(ranges.to_vec()),
-            black_box(ToTxnStore::<Self::T>::to_store(store)),
+            black_box(TiKVStorage::from(ToTxnStore::<Self::T>::to_store(store))),
             black_box(false),
         )
         .unwrap();
         // There is a step of building scanner in the first `next()` which cost time,
         // so we next() before hand.
         executor.next().unwrap().unwrap();
-        Box::new(executor) as Box<dyn Executor>
+        Box::new(executor) as Box<dyn Executor<StorageStats = Statistics>>
     }
 }
 
@@ -63,7 +64,7 @@ pub struct BatchTableScanExecutorBuilder<T: TxnStore + 'static> {
 
 impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder for BatchTableScanExecutorBuilder<T> {
     type T = T;
-    type E = Box<dyn BatchExecutor>;
+    type E = Box<dyn BatchExecutor<StorageStats = Statistics>>;
     type P = TableScanParam;
 
     fn build(
@@ -73,7 +74,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder for BatchTableScan
         _: (),
     ) -> Self::E {
         let mut executor = BatchTableScanExecutor::new(
-            black_box(ToTxnStore::<Self::T>::to_store(store)),
+            black_box(TiKVStorage::from(ToTxnStore::<Self::T>::to_store(store))),
             black_box(Arc::new(EvalConfig::default())),
             black_box(columns.to_vec()),
             black_box(ranges.to_vec()),
@@ -83,7 +84,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder for BatchTableScan
         // There is a step of building scanner in the first `next()` which cost time,
         // so we next() before hand.
         executor.next_batch(1);
-        Box::new(executor) as Box<dyn BatchExecutor>
+        Box::new(executor) as Box<dyn BatchExecutor<StorageStats = Statistics>>
     }
 }
 

--- a/benches/coprocessor_executors/top_n/util.rs
+++ b/benches/coprocessor_executors/top_n/util.rs
@@ -9,6 +9,7 @@ use tipb::expression::Expr;
 use tikv::coprocessor::dag::batch::executors::BatchTopNExecutor;
 use tikv::coprocessor::dag::executor::{Executor, TopNExecutor};
 use tikv::coprocessor::dag::expr::EvalConfig;
+use tikv::storage::Statistics;
 
 use crate::util::bencher::Bencher;
 use crate::util::executor_descriptor::top_n;
@@ -64,7 +65,7 @@ impl TopNBencher for NormalBencher {
                     black_box(Box::new(src)),
                 )
                 .unwrap(),
-            ) as Box<dyn Executor>
+            ) as Box<dyn Executor<StorageStats = Statistics>>
         })
         .bench(b);
     }

--- a/benches/coprocessor_executors/util/fixture.rs
+++ b/benches/coprocessor_executors/util/fixture.rs
@@ -319,6 +319,8 @@ pub struct BatchFixtureExecutor {
 }
 
 impl BatchExecutor for BatchFixtureExecutor {
+    type StorageStats = Statistics;
+
     #[inline]
     fn schema(&self) -> &[FieldType] {
         &self.schema
@@ -349,12 +351,14 @@ impl BatchExecutor for BatchFixtureExecutor {
         }
     }
 
+    #[inline]
     fn collect_exec_stats(&mut self, _dest: &mut ExecuteStats) {
-        // DO NOTHING
+        // Do nothing
     }
 
-    fn collect_storage_stats(&mut self, _dest: &mut Statistics) {
-        // DO NOTHING
+    #[inline]
+    fn collect_storage_stats(&mut self, _dest: &mut Self::StorageStats) {
+        // Do nothing
     }
 }
 
@@ -364,6 +368,8 @@ pub struct NormalFixtureExecutor {
 }
 
 impl Executor for NormalFixtureExecutor {
+    type StorageStats = Statistics;
+
     #[inline]
     fn next(&mut self) -> tikv::coprocessor::Result<Option<Row>> {
         Ok(self.rows.next())
@@ -371,12 +377,12 @@ impl Executor for NormalFixtureExecutor {
 
     #[inline]
     fn collect_exec_stats(&mut self, _dest: &mut ExecuteStats) {
-        // DO NOTHING
+        // Do nothing
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, _dest: &mut Statistics) {
-        // DO NOTHING
+    fn collect_storage_stats(&mut self, _dest: &mut Self::StorageStats) {
+        // Do nothing
     }
 
     #[inline]
@@ -386,6 +392,7 @@ impl Executor for NormalFixtureExecutor {
 
     #[inline]
     fn take_eval_warnings(&mut self) -> Option<EvalWarnings> {
+        // Do nothing
         None
     }
 

--- a/benches/coprocessor_executors/util/mod.rs
+++ b/benches/coprocessor_executors/util/mod.rs
@@ -14,6 +14,7 @@ use kvproto::coprocessor::KeyRange;
 use tipb::executor::Executor as PbExecutor;
 
 use test_coprocessor::*;
+use tikv::coprocessor::dag::storage_impl::TiKVStorage;
 use tikv::coprocessor::RequestHandler;
 use tikv::storage::{RocksEngine, Store as TxnStore};
 
@@ -44,7 +45,9 @@ pub fn build_dag_handler<TargetTxnStore: TxnStore + 'static>(
     DAGBuilder::build(
         black_box(dag),
         black_box(ranges.to_vec()),
-        black_box(ToTxnStore::<TargetTxnStore>::to_store(store)),
+        black_box(TiKVStorage::from(ToTxnStore::<TargetTxnStore>::to_store(
+            store,
+        ))),
         Deadline::from_now("", std::time::Duration::from_secs(10)),
         64,
         false,

--- a/src/coprocessor/dag/batch/executors/index_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/index_scan_executor.rs
@@ -8,27 +8,24 @@ use tipb::executor::IndexScan;
 use tipb::expression::FieldType;
 use tipb::schema::ColumnInfo;
 
-use crate::storage::{FixtureStore, Statistics, Store};
-
 use super::util::scan_executor::*;
 use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::coprocessor::dag::batch::interface::*;
 use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
+use crate::coprocessor::dag::storage::Storage;
 use crate::coprocessor::{Error, Result};
 
-pub struct BatchIndexScanExecutor<S: Store>(ScanExecutor<S, IndexScanExecutorImpl>);
+pub struct BatchIndexScanExecutor<S: Storage>(ScanExecutor<S, IndexScanExecutorImpl>);
 
-impl BatchIndexScanExecutor<FixtureStore> {
+impl<S: Storage> BatchIndexScanExecutor<S> {
     /// Checks whether this executor can be used.
     #[inline]
     pub fn check_supported(descriptor: &IndexScan) -> Result<()> {
         check_columns_info_supported(descriptor.get_columns())
     }
-}
 
-impl<S: Store> BatchIndexScanExecutor<S> {
     pub fn new(
-        store: S,
+        storage: S,
         config: Arc<EvalConfig>,
         columns_info: Vec<ColumnInfo>,
         key_ranges: Vec<KeyRange>,
@@ -67,7 +64,7 @@ impl<S: Store> BatchIndexScanExecutor<S> {
         };
         let wrapper = ScanExecutor::new(ScanExecutorOptions {
             imp,
-            store,
+            storage,
             key_ranges,
             is_backward,
             is_key_only: false,
@@ -77,7 +74,9 @@ impl<S: Store> BatchIndexScanExecutor<S> {
     }
 }
 
-impl<S: Store> BatchExecutor for BatchIndexScanExecutor<S> {
+impl<S: Storage> BatchExecutor for BatchIndexScanExecutor<S> {
+    type StorageStats = S::Statistics;
+
     #[inline]
     fn schema(&self) -> &[FieldType] {
         self.0.schema()
@@ -94,7 +93,7 @@ impl<S: Store> BatchExecutor for BatchIndexScanExecutor<S> {
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
     }
 }
@@ -228,8 +227,8 @@ mod tests {
     use crate::coprocessor::codec::mysql::Tz;
     use crate::coprocessor::codec::{datum, table, Datum};
     use crate::coprocessor::dag::expr::EvalConfig;
+    use crate::coprocessor::dag::storage::fixture::FixtureStorage;
     use crate::coprocessor::util::convert_to_prefix_next;
-    use crate::storage::{FixtureStore, Key};
 
     #[test]
     fn test_basic() {
@@ -278,17 +277,16 @@ mod tests {
         // in the value. So let's build corresponding KV data.
 
         let store = {
-            let kv = data
+            let kv: Vec<_> = data
                 .iter()
                 .map(|datums| {
                     let index_data = datum::encode_key(datums).unwrap();
                     let key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &index_data);
-                    let key = Key::from_raw(key.as_slice());
                     let value = vec![];
-                    (key, Ok(value))
+                    (key, value)
                 })
                 .collect();
-            FixtureStore::new(kv)
+            FixtureStorage::from(kv)
         };
 
         {
@@ -401,21 +399,20 @@ mod tests {
         // For a unique index, the PK handle is stored in the value.
 
         let store = {
-            let kv = data
+            let kv: Vec<_> = data
                 .iter()
                 .map(|datums| {
                     let index_data = datum::encode_key(&datums[0..2]).unwrap();
                     let key = table::encode_index_seek_key(TABLE_ID, INDEX_ID, &index_data);
-                    let key = Key::from_raw(key.as_slice());
                     // PK handle in the value
                     let mut value = vec![];
                     value
                         .write_i64::<BigEndian>(datums[2].as_int().unwrap().unwrap())
                         .unwrap();
-                    (key, Ok(value))
+                    (key, value)
                 })
                 .collect();
-            FixtureStore::new(kv)
+            FixtureStorage::from(kv)
         };
 
         {

--- a/src/coprocessor/dag/batch/executors/limit_executor.rs
+++ b/src/coprocessor/dag/batch/executors/limit_executor.rs
@@ -4,7 +4,6 @@ use tipb::expression::FieldType;
 
 use crate::coprocessor::dag::batch::interface::*;
 use crate::coprocessor::Result;
-use crate::storage::Statistics;
 
 /// Executor that retrieves rows from the source executor
 /// and only produces part of the rows.
@@ -23,6 +22,8 @@ impl<Src: BatchExecutor> BatchLimitExecutor<Src> {
 }
 
 impl<Src: BatchExecutor> BatchExecutor for BatchLimitExecutor<Src> {
+    type StorageStats = Src::StorageStats;
+
     #[inline]
     fn schema(&self) -> &[FieldType] {
         self.src.schema()
@@ -49,7 +50,7 @@ impl<Src: BatchExecutor> BatchExecutor for BatchLimitExecutor<Src> {
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
     }
 }

--- a/src/coprocessor/dag/batch/executors/selection_executor.rs
+++ b/src/coprocessor/dag/batch/executors/selection_executor.rs
@@ -12,7 +12,6 @@ use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
 use crate::coprocessor::dag::rpn_expr::RpnStackNode;
 use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
 use crate::coprocessor::Result;
-use crate::storage::Statistics;
 
 pub struct BatchSelectionExecutor<Src: BatchExecutor> {
     context: EvalContext,
@@ -21,7 +20,7 @@ pub struct BatchSelectionExecutor<Src: BatchExecutor> {
     conditions: Vec<RpnExpression>,
 }
 
-impl BatchSelectionExecutor<Box<dyn BatchExecutor>> {
+impl BatchSelectionExecutor<Box<dyn BatchExecutor<StorageStats = ()>>> {
     /// Checks whether this executor can be used.
     #[inline]
     pub fn check_supported(descriptor: &Selection) -> Result<()> {
@@ -157,6 +156,8 @@ fn update_logical_rows_by_vector_value<T: AsMySQLBool>(
 }
 
 impl<Src: BatchExecutor> BatchExecutor for BatchSelectionExecutor<Src> {
+    type StorageStats = Src::StorageStats;
+
     #[inline]
     fn schema(&self) -> &[FieldType] {
         // The selection executor's schema comes from its child.
@@ -186,7 +187,7 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSelectionExecutor<Src> {
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
     }
 }

--- a/src/coprocessor/dag/batch/executors/stream_aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/stream_aggr_executor.rs
@@ -17,13 +17,14 @@ use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
 use crate::coprocessor::dag::rpn_expr::RpnStackNode;
 use crate::coprocessor::dag::rpn_expr::{RpnExpression, RpnExpressionBuilder};
 use crate::coprocessor::Result;
-use crate::storage::Statistics;
 
 pub struct BatchStreamAggregationExecutor<Src: BatchExecutor>(
     AggregationExecutor<Src, BatchStreamAggregationImpl>,
 );
 
 impl<Src: BatchExecutor> BatchExecutor for BatchStreamAggregationExecutor<Src> {
+    type StorageStats = Src::StorageStats;
+
     #[inline]
     fn schema(&self) -> &[FieldType] {
         self.0.schema()
@@ -40,31 +41,12 @@ impl<Src: BatchExecutor> BatchExecutor for BatchStreamAggregationExecutor<Src> {
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
     }
 }
 
-impl<Src: BatchExecutor> BatchStreamAggregationExecutor<Src> {
-    #[cfg(test)]
-    pub fn new_for_test(
-        src: Src,
-        group_by_exps: Vec<RpnExpression>,
-        aggr_defs: Vec<Expr>,
-        aggr_def_parser: impl AggrDefinitionParser,
-    ) -> Self {
-        Self::new_impl(
-            Arc::new(EvalConfig::default()),
-            src,
-            group_by_exps,
-            aggr_defs,
-            aggr_def_parser,
-        )
-        .unwrap()
-    }
-}
-
-impl BatchStreamAggregationExecutor<Box<dyn BatchExecutor>> {
+impl BatchStreamAggregationExecutor<Box<dyn BatchExecutor<StorageStats = ()>>> {
     /// Checks whether this executor can be used.
     #[inline]
     pub fn check_supported(descriptor: &Aggregation) -> Result<()> {
@@ -109,6 +91,23 @@ pub struct BatchStreamAggregationImpl {
 }
 
 impl<Src: BatchExecutor> BatchStreamAggregationExecutor<Src> {
+    #[cfg(test)]
+    pub fn new_for_test(
+        src: Src,
+        group_by_exps: Vec<RpnExpression>,
+        aggr_defs: Vec<Expr>,
+        aggr_def_parser: impl AggrDefinitionParser,
+    ) -> Self {
+        Self::new_impl(
+            Arc::new(EvalConfig::default()),
+            src,
+            group_by_exps,
+            aggr_defs,
+            aggr_def_parser,
+        )
+        .unwrap()
+    }
+
     pub fn new(
         config: Arc<EvalConfig>,
         src: Src,

--- a/src/coprocessor/dag/batch/executors/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/table_scan_executor.rs
@@ -8,28 +8,26 @@ use tipb::executor::TableScan;
 use tipb::expression::FieldType;
 use tipb::schema::ColumnInfo;
 
-use crate::storage::{FixtureStore, Statistics, Store};
 use tikv_util::collections::HashMap;
 
 use super::util::scan_executor::*;
 use crate::coprocessor::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::coprocessor::dag::batch::interface::*;
 use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
+use crate::coprocessor::dag::storage::Storage;
 use crate::coprocessor::Result;
 
-pub struct BatchTableScanExecutor<S: Store>(ScanExecutor<S, TableScanExecutorImpl>);
+pub struct BatchTableScanExecutor<S: Storage>(ScanExecutor<S, TableScanExecutorImpl>);
 
-impl BatchTableScanExecutor<FixtureStore> {
+impl<S: Storage> BatchTableScanExecutor<S> {
     /// Checks whether this executor can be used.
     #[inline]
     pub fn check_supported(descriptor: &TableScan) -> Result<()> {
         check_columns_info_supported(descriptor.get_columns())
     }
-}
 
-impl<S: Store> BatchTableScanExecutor<S> {
     pub fn new(
-        store: S,
+        storage: S,
         config: Arc<EvalConfig>,
         columns_info: Vec<ColumnInfo>,
         key_ranges: Vec<KeyRange>,
@@ -73,7 +71,7 @@ impl<S: Store> BatchTableScanExecutor<S> {
         };
         let wrapper = ScanExecutor::new(ScanExecutorOptions {
             imp,
-            store,
+            storage,
             key_ranges,
             is_backward,
             is_key_only,
@@ -83,7 +81,9 @@ impl<S: Store> BatchTableScanExecutor<S> {
     }
 }
 
-impl<S: Store> BatchExecutor for BatchTableScanExecutor<S> {
+impl<S: Storage> BatchExecutor for BatchTableScanExecutor<S> {
+    type StorageStats = S::Statistics;
+
     #[inline]
     fn schema(&self) -> &[FieldType] {
         self.0.schema()
@@ -100,7 +100,7 @@ impl<S: Store> BatchExecutor for BatchTableScanExecutor<S> {
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
     }
 }
@@ -291,8 +291,8 @@ mod tests {
     use crate::coprocessor::codec::{datum, table, Datum};
     use crate::coprocessor::dag::execute_stats::*;
     use crate::coprocessor::dag::expr::EvalConfig;
+    use crate::coprocessor::dag::storage::fixture::FixtureStorage;
     use crate::coprocessor::util::convert_to_prefix_next;
-    use crate::storage::{FixtureStore, Key};
 
     /// Test Helper for normal test with fixed schema and data.
     /// Table Schema:  ID (INT, PK),   Foo (INT),     Bar (FLOAT, Default 4.5)
@@ -309,7 +309,7 @@ mod tests {
         pub table_id: i64,
         pub columns_info: Vec<ColumnInfo>,
         pub field_types: Vec<FieldType>,
-        pub store: FixtureStore,
+        pub store: FixtureStorage,
     }
 
     impl TableScanTestHelper {
@@ -397,19 +397,19 @@ mod tests {
             ];
 
             let store = {
-                let kv = data
+                let kv: Vec<_> = data
                     .iter()
                     .map(|(row_id, columns)| {
-                        let key = Key::from_raw(&table::encode_row_key(TABLE_ID, *row_id));
+                        let key = table::encode_row_key(TABLE_ID, *row_id);
                         let value = {
                             let row = columns.iter().map(|(_, datum)| datum.clone()).collect();
                             let col_ids: Vec<_> = columns.iter().map(|(id, _)| *id).collect();
                             table::encode_row(row, &col_ids).unwrap()
                         };
-                        (key, Ok(value))
+                        (key, value)
                     })
                     .collect();
-                FixtureStore::new(kv)
+                FixtureStorage::from(kv)
             };
 
             TableScanTestHelper {
@@ -450,7 +450,7 @@ mod tests {
             ]
         }
 
-        fn store(&self) -> FixtureStore {
+        fn store(&self) -> FixtureStorage {
             self.store.clone()
         }
 
@@ -699,36 +699,36 @@ mod tests {
         let mut kv = vec![];
         {
             // row 0, which is not corrupted
-            let key = Key::from_raw(&table::encode_row_key(TABLE_ID, 0));
+            let key = table::encode_row_key(TABLE_ID, 0);
             let value = table::encode_row(vec![Datum::I64(5), Datum::I64(7)], &[2, 3]).unwrap();
-            kv.push((key, Ok(value)));
+            kv.push((key, value));
         }
         {
             // row 1, which is not corrupted
-            let key = Key::from_raw(&table::encode_row_key(TABLE_ID, 1));
+            let key = table::encode_row_key(TABLE_ID, 1);
             let value = vec![];
-            kv.push((key, Ok(value)));
+            kv.push((key, value));
         }
         {
             // row 2, which is partially corrupted
-            let key = Key::from_raw(&table::encode_row_key(TABLE_ID, 2));
+            let key = table::encode_row_key(TABLE_ID, 2);
             let mut value = table::encode_row(vec![Datum::I64(5), Datum::I64(7)], &[2, 3]).unwrap();
             // resize the value to make it partially corrupted
             value.truncate(value.len() - 3);
-            kv.push((key, Ok(value)));
+            kv.push((key, value));
         }
         {
             // row 3, which is totally corrupted due to invalid datum flag for column id
-            let key = Key::from_raw(&table::encode_row_key(TABLE_ID, 3));
+            let key = table::encode_row_key(TABLE_ID, 3);
             // this datum flag does not exist
             let value = vec![255];
-            kv.push((key, Ok(value)));
+            kv.push((key, value));
         }
         {
             // row 4, which is totally corrupted due to missing datum for column value
-            let key = Key::from_raw(&table::encode_row_key(TABLE_ID, 4));
+            let key = table::encode_row_key(TABLE_ID, 4);
             let value = datum::encode_value(&[Datum::I64(2)]).unwrap(); // col_id = 2
-            kv.push((key, Ok(value)));
+            kv.push((key, value));
         }
 
         let key_range_point: Vec<_> = kv
@@ -743,7 +743,7 @@ mod tests {
             })
             .collect();
 
-        let store = FixtureStore::new(kv.into_iter().collect());
+        let store = FixtureStorage::from(kv);
 
         // For row 0 + row 1 + (row 2 ~ row 4), we should only get row 0, row 1 and an error.
         for corrupted_row_index in 2..=4 {
@@ -812,27 +812,33 @@ mod tests {
         let mut kv = vec![];
         {
             // row 0: not locked
-            let key = Key::from_raw(&table::encode_row_key(TABLE_ID, 0));
+            let key = table::encode_row_key(TABLE_ID, 0);
             let value = table::encode_row(vec![Datum::I64(7)], &[2]).unwrap();
             kv.push((key, Ok(value)));
         }
         {
             // row 1: locked
-            let key = Key::from_raw(&table::encode_row_key(TABLE_ID, 1));
-            let value =
-                crate::storage::txn::Error::Mvcc(crate::storage::mvcc::Error::KeyIsLocked {
-                    // We won't check error detail in tests, so we can just fill fields casually.
-                    key: vec![],
-                    primary: vec![],
-                    ts: 1,
-                    ttl: 2,
-                    txn_size: 0,
-                });
-            kv.push((key, Err(value)));
+            let key = table::encode_row_key(TABLE_ID, 1);
+            let value: std::result::Result<
+                _,
+                Box<dyn Send + Sync + Fn() -> crate::coprocessor::Error>,
+            > = Err(Box::new(|| {
+                crate::coprocessor::Error::from(crate::storage::txn::Error::Mvcc(
+                    crate::storage::mvcc::Error::KeyIsLocked {
+                        // We won't check error detail in tests, so we can just fill fields casually.
+                        key: vec![],
+                        primary: vec![],
+                        ts: 1,
+                        ttl: 2,
+                        txn_size: 0,
+                    },
+                ))
+            }));
+            kv.push((key, value));
         }
         {
             // row 2: not locked
-            let key = Key::from_raw(&table::encode_row_key(TABLE_ID, 2));
+            let key = table::encode_row_key(TABLE_ID, 2);
             let value = table::encode_row(vec![Datum::I64(5)], &[2]).unwrap();
             kv.push((key, Ok(value)));
         }
@@ -849,7 +855,7 @@ mod tests {
             })
             .collect();
 
-        let store = FixtureStore::new(kv.into_iter().collect());
+        let store = FixtureStorage::new(kv.into_iter().collect());
 
         // Case 1: row 0 + row 1 + row 2
         // We should get row 0 and error because no further rows should be scanned when there is

--- a/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
+++ b/src/coprocessor/dag/batch/executors/util/aggr_executor.rs
@@ -39,7 +39,6 @@ use crate::coprocessor::dag::batch::interface::*;
 use crate::coprocessor::dag::expr::{EvalConfig, EvalContext};
 use crate::coprocessor::dag::rpn_expr::RpnExpression;
 use crate::coprocessor::Result;
-use crate::storage::Statistics;
 
 pub trait AggregationExecutorImpl<Src: BatchExecutor>: Send {
     /// Accepts entities without any group by columns and modifies them optionally.
@@ -270,6 +269,8 @@ impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> AggregationExecutor<Sr
 impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> BatchExecutor
     for AggregationExecutor<Src, I>
 {
+    type StorageStats = Src::StorageStats;
+
     #[inline]
     fn schema(&self) -> &[FieldType] {
         self.entities.schema.as_slice()
@@ -312,7 +313,7 @@ impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> BatchExecutor
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.entities.src.collect_storage_stats(dest);
     }
 }

--- a/src/coprocessor/dag/batch/executors/util/mock_executor.rs
+++ b/src/coprocessor/dag/batch/executors/util/mock_executor.rs
@@ -3,7 +3,6 @@
 use tipb::expression::FieldType;
 
 use crate::coprocessor::dag::batch::interface::*;
-use crate::storage::Statistics;
 
 /// A simple mock executor that will return batch data according to a fixture without any
 /// modification.
@@ -25,6 +24,8 @@ impl MockExecutor {
 }
 
 impl BatchExecutor for MockExecutor {
+    type StorageStats = ();
+
     fn schema(&self) -> &[FieldType] {
         &self.schema
     }
@@ -37,7 +38,7 @@ impl BatchExecutor for MockExecutor {
         // Do nothing
     }
 
-    fn collect_storage_stats(&mut self, _dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, _dest: &mut Self::StorageStats) {
         // Do nothing
     }
 }

--- a/src/coprocessor/dag/batch_handler.rs
+++ b/src/coprocessor/dag/batch_handler.rs
@@ -8,11 +8,9 @@ use kvproto::coprocessor::Response;
 use tipb::executor::ExecutorExecutionSummary;
 use tipb::select::{Chunk, SelectResponse};
 
-use super::batch::interface::BatchExecutor;
-use crate::coprocessor::dag::execute_stats::ExecuteStats;
+use super::batch::interface::{BatchExecutor, ExecuteStats};
 use crate::coprocessor::dag::expr::EvalConfig;
 use crate::coprocessor::*;
-use crate::storage::Statistics;
 
 // TODO: The value is chosen according to some very subjective experience, which is not tuned
 // carefully. We need to benchmark to find a best value. Also we may consider accepting this value
@@ -25,14 +23,13 @@ pub const BATCH_MAX_SIZE: usize = 1024;
 // TODO: Maybe there can be some better strategy. Needs benchmarks and tunes.
 const BATCH_GROW_FACTOR: usize = 2;
 
-/// Must be built from DAGRequestHandler.
-pub struct BatchDAGHandler {
+pub struct BatchDAGHandler<SS> {
     /// The deadline of this handler. For each check point (e.g. each iteration) we need to check
     /// whether or not the deadline is exceeded and break the process if so.
     // TODO: Deprecate it using a better deadline mechanism.
     deadline: Deadline,
 
-    out_most_executor: Box<dyn BatchExecutor>,
+    out_most_executor: Box<dyn BatchExecutor<StorageStats = SS>>,
 
     /// The offset of the columns need to be outputted. For example, TiDB may only needs a subset
     /// of the columns in the result so that unrelated columns don't need to be encoded and
@@ -47,10 +44,10 @@ pub struct BatchDAGHandler {
     exec_stats: ExecuteStats,
 }
 
-impl BatchDAGHandler {
+impl<SS> BatchDAGHandler<SS> {
     pub fn new(
         deadline: Deadline,
-        out_most_executor: Box<dyn BatchExecutor>,
+        out_most_executor: Box<dyn BatchExecutor<StorageStats = SS>>,
         output_offsets: Vec<u32>,
         config: Arc<EvalConfig>,
         collect_exec_summary: bool,
@@ -65,10 +62,8 @@ impl BatchDAGHandler {
             exec_stats,
         }
     }
-}
 
-impl RequestHandler for BatchDAGHandler {
-    fn handle_request(&mut self) -> Result<Response> {
+    pub fn handle_request(&mut self) -> Result<Response> {
         let mut chunks = vec![];
         let mut batch_size = BATCH_INITIAL_SIZE;
         let mut warnings = self.config.new_eval_warnings();
@@ -179,7 +174,20 @@ impl RequestHandler for BatchDAGHandler {
         }
     }
 
-    fn collect_scan_statistics(&mut self, dest: &mut Statistics) {
+    pub fn collect_storage_stats(&mut self, dest: &mut SS) {
         self.out_most_executor.collect_storage_stats(dest);
+    }
+}
+
+// TODO: This should stay in Coprocessor instead of DAG
+use crate::storage::Statistics;
+
+impl RequestHandler for BatchDAGHandler<Statistics> {
+    fn handle_request(&mut self) -> Result<Response> {
+        BatchDAGHandler::handle_request(self)
+    }
+
+    fn collect_scan_statistics(&mut self, dest: &mut Statistics) {
+        BatchDAGHandler::collect_storage_stats(self, dest);
     }
 }

--- a/src/coprocessor/dag/builder.rs
+++ b/src/coprocessor/dag/builder.rs
@@ -6,8 +6,6 @@ use kvproto::coprocessor::KeyRange;
 use tipb::executor::{self, ExecType};
 use tipb::select::DAGRequest;
 
-use crate::storage::Store;
-
 use super::batch::executors::*;
 use super::batch::interface::*;
 use super::executor::{
@@ -16,8 +14,12 @@ use super::executor::{
 };
 use crate::coprocessor::dag::execute_stats::*;
 use crate::coprocessor::dag::expr::{EvalConfig, Flag, SqlMode};
+use crate::coprocessor::dag::storage::Storage;
 use crate::coprocessor::metrics::*;
 use crate::coprocessor::*;
+
+// TODO: This builder should stay in Coprocessor instead of in DAG, because it references some
+// statistics. Or we can move some statistics into DAG.
 
 /// Utilities to build an executor DAG.
 ///
@@ -31,17 +33,17 @@ pub struct DAGBuilder;
 impl DAGBuilder {
     /// Given a list of executor descriptors and checks whether all executor descriptors can
     /// be used to build batch executors.
-    pub fn check_build_batch(exec_descriptors: &[executor::Executor]) -> Result<()> {
+    pub fn check_build_batch<S: Storage>(exec_descriptors: &[executor::Executor]) -> Result<()> {
         for ed in exec_descriptors {
             match ed.get_tp() {
                 ExecType::TypeTableScan => {
                     let descriptor = ed.get_tbl_scan();
-                    BatchTableScanExecutor::check_supported(&descriptor)
+                    BatchTableScanExecutor::<S>::check_supported(&descriptor)
                         .map_err(|e| Error::Other(box_err!("BatchTableScanExecutor: {}", e)))?;
                 }
                 ExecType::TypeIndexScan => {
                     let descriptor = ed.get_idx_scan();
-                    BatchIndexScanExecutor::check_supported(&descriptor)
+                    BatchIndexScanExecutor::<S>::check_supported(&descriptor)
                         .map_err(|e| Error::Other(box_err!("BatchIndexScanExecutor: {}", e)))?;
                 }
                 ExecType::TypeSelection => {
@@ -86,18 +88,18 @@ impl DAGBuilder {
     }
 
     // Note: `S` is `'static` because we have trait objects `Executor`.
-    pub fn build_batch<S: Store + 'static, C: ExecSummaryCollector + 'static>(
+    pub fn build_batch<S: Storage + 'static, C: ExecSummaryCollector + 'static>(
         executor_descriptors: Vec<executor::Executor>,
-        store: S,
+        storage: S,
         ranges: Vec<KeyRange>,
         config: Arc<EvalConfig>,
-    ) -> Result<Box<dyn BatchExecutor>> {
+    ) -> Result<Box<dyn BatchExecutor<StorageStats = S::Statistics>>> {
         let mut executor_descriptors = executor_descriptors.into_iter();
         let mut first_ed = executor_descriptors
             .next()
             .ok_or_else(|| Error::Other(box_err!("No executors")))?;
 
-        let mut executor: Box<dyn BatchExecutor>;
+        let mut executor: Box<dyn BatchExecutor<StorageStats = S::Statistics>>;
         let mut summary_slot_index = 0;
 
         match first_ed.get_tp() {
@@ -111,7 +113,7 @@ impl DAGBuilder {
                 let columns_info = descriptor.take_columns().into_vec();
                 executor = Box::new(
                     BatchTableScanExecutor::new(
-                        store,
+                        storage,
                         config.clone(),
                         columns_info,
                         ranges,
@@ -129,7 +131,7 @@ impl DAGBuilder {
                 let columns_info = descriptor.take_columns().into_vec();
                 executor = Box::new(
                     BatchIndexScanExecutor::new(
-                        store,
+                        storage,
                         config.clone(),
                         columns_info,
                         ranges,
@@ -150,61 +152,78 @@ impl DAGBuilder {
         for mut ed in executor_descriptors {
             summary_slot_index += 1;
 
-            let new_executor: Box<dyn BatchExecutor> = match ed.get_tp() {
-                ExecType::TypeSelection => {
-                    COPR_EXECUTOR_COUNT
-                        .with_label_values(&["batch_selection"])
-                        .inc();
+            let new_executor: Box<dyn BatchExecutor<StorageStats = S::Statistics>> =
+                match ed.get_tp() {
+                    ExecType::TypeSelection => {
+                        COPR_EXECUTOR_COUNT
+                            .with_label_values(&["batch_selection"])
+                            .inc();
 
-                    Box::new(
-                        BatchSelectionExecutor::new(
-                            config.clone(),
-                            executor,
-                            ed.take_selection().take_conditions().into_vec(),
-                        )?
-                        .with_summary_collector(C::new(summary_slot_index)),
-                    )
-                }
-                ExecType::TypeAggregation | ExecType::TypeStreamAgg
-                    if ed.get_aggregation().get_group_by().is_empty() =>
-                {
-                    COPR_EXECUTOR_COUNT
-                        .with_label_values(&["batch_simple_aggr"])
-                        .inc();
-
-                    Box::new(
-                        BatchSimpleAggregationExecutor::new(
-                            config.clone(),
-                            executor,
-                            ed.mut_aggregation().take_agg_func().into_vec(),
-                        )?
-                        .with_summary_collector(C::new(summary_slot_index)),
-                    )
-                }
-                ExecType::TypeAggregation => {
-                    if BatchFastHashAggregationExecutor::check_supported(&ed.get_aggregation())
-                        .is_ok()
+                        Box::new(
+                            BatchSelectionExecutor::new(
+                                config.clone(),
+                                executor,
+                                ed.take_selection().take_conditions().into_vec(),
+                            )?
+                            .with_summary_collector(C::new(summary_slot_index)),
+                        )
+                    }
+                    ExecType::TypeAggregation | ExecType::TypeStreamAgg
+                        if ed.get_aggregation().get_group_by().is_empty() =>
                     {
                         COPR_EXECUTOR_COUNT
-                            .with_label_values(&["batch_fast_hash_aggr"])
+                            .with_label_values(&["batch_simple_aggr"])
                             .inc();
 
                         Box::new(
-                            BatchFastHashAggregationExecutor::new(
+                            BatchSimpleAggregationExecutor::new(
                                 config.clone(),
                                 executor,
-                                ed.mut_aggregation().take_group_by().into_vec(),
                                 ed.mut_aggregation().take_agg_func().into_vec(),
                             )?
                             .with_summary_collector(C::new(summary_slot_index)),
                         )
-                    } else {
+                    }
+                    ExecType::TypeAggregation => {
+                        if BatchFastHashAggregationExecutor::check_supported(&ed.get_aggregation())
+                            .is_ok()
+                        {
+                            COPR_EXECUTOR_COUNT
+                                .with_label_values(&["batch_fast_hash_aggr"])
+                                .inc();
+
+                            Box::new(
+                                BatchFastHashAggregationExecutor::new(
+                                    config.clone(),
+                                    executor,
+                                    ed.mut_aggregation().take_group_by().into_vec(),
+                                    ed.mut_aggregation().take_agg_func().into_vec(),
+                                )?
+                                .with_summary_collector(C::new(summary_slot_index)),
+                            )
+                        } else {
+                            COPR_EXECUTOR_COUNT
+                                .with_label_values(&["batch_slow_hash_aggr"])
+                                .inc();
+
+                            Box::new(
+                                BatchSlowHashAggregationExecutor::new(
+                                    config.clone(),
+                                    executor,
+                                    ed.mut_aggregation().take_group_by().into_vec(),
+                                    ed.mut_aggregation().take_agg_func().into_vec(),
+                                )?
+                                .with_summary_collector(C::new(summary_slot_index)),
+                            )
+                        }
+                    }
+                    ExecType::TypeStreamAgg => {
                         COPR_EXECUTOR_COUNT
-                            .with_label_values(&["batch_slow_hash_aggr"])
+                            .with_label_values(&["batch_stream_aggr"])
                             .inc();
 
                         Box::new(
-                            BatchSlowHashAggregationExecutor::new(
+                            BatchStreamAggregationExecutor::new(
                                 config.clone(),
                                 executor,
                                 ed.mut_aggregation().take_group_by().into_vec(),
@@ -213,64 +232,48 @@ impl DAGBuilder {
                             .with_summary_collector(C::new(summary_slot_index)),
                         )
                     }
-                }
-                ExecType::TypeStreamAgg => {
-                    COPR_EXECUTOR_COUNT
-                        .with_label_values(&["batch_stream_aggr"])
-                        .inc();
+                    ExecType::TypeLimit => {
+                        COPR_EXECUTOR_COUNT
+                            .with_label_values(&["batch_limit"])
+                            .inc();
 
-                    Box::new(
-                        BatchStreamAggregationExecutor::new(
-                            config.clone(),
-                            executor,
-                            ed.mut_aggregation().take_group_by().into_vec(),
-                            ed.mut_aggregation().take_agg_func().into_vec(),
-                        )?
-                        .with_summary_collector(C::new(summary_slot_index)),
-                    )
-                }
-                ExecType::TypeLimit => {
-                    COPR_EXECUTOR_COUNT
-                        .with_label_values(&["batch_limit"])
-                        .inc();
-
-                    Box::new(
-                        BatchLimitExecutor::new(executor, ed.get_limit().get_limit() as usize)?
-                            .with_summary_collector(C::new(summary_slot_index)),
-                    )
-                }
-                ExecType::TypeTopN => {
-                    COPR_EXECUTOR_COUNT
-                        .with_label_values(&["batch_top_n"])
-                        .inc();
-
-                    let mut d = ed.take_topN();
-                    let order_bys = d.get_order_by().len();
-                    let mut order_exprs_def = Vec::with_capacity(order_bys);
-                    let mut order_is_desc = Vec::with_capacity(order_bys);
-                    for mut item in d.take_order_by().into_iter() {
-                        order_exprs_def.push(item.take_expr());
-                        order_is_desc.push(item.get_desc());
+                        Box::new(
+                            BatchLimitExecutor::new(executor, ed.get_limit().get_limit() as usize)?
+                                .with_summary_collector(C::new(summary_slot_index)),
+                        )
                     }
+                    ExecType::TypeTopN => {
+                        COPR_EXECUTOR_COUNT
+                            .with_label_values(&["batch_top_n"])
+                            .inc();
 
-                    Box::new(
-                        BatchTopNExecutor::new(
-                            config.clone(),
-                            executor,
-                            order_exprs_def,
-                            order_is_desc,
-                            d.get_limit() as usize,
-                        )?
-                        .with_summary_collector(C::new(summary_slot_index)),
-                    )
-                }
-                _ => {
-                    return Err(Error::Other(box_err!(
-                        "Unexpected non-first executor {:?}",
-                        first_ed.get_tp()
-                    )));
-                }
-            };
+                        let mut d = ed.take_topN();
+                        let order_bys = d.get_order_by().len();
+                        let mut order_exprs_def = Vec::with_capacity(order_bys);
+                        let mut order_is_desc = Vec::with_capacity(order_bys);
+                        for mut item in d.take_order_by().into_iter() {
+                            order_exprs_def.push(item.take_expr());
+                            order_is_desc.push(item.get_desc());
+                        }
+
+                        Box::new(
+                            BatchTopNExecutor::new(
+                                config.clone(),
+                                executor,
+                                order_exprs_def,
+                                order_is_desc,
+                                d.get_limit() as usize,
+                            )?
+                            .with_summary_collector(C::new(summary_slot_index)),
+                        )
+                    }
+                    _ => {
+                        return Err(Error::Other(box_err!(
+                            "Unexpected non-first executor {:?}",
+                            first_ed.get_tp()
+                        )));
+                    }
+                };
             executor = new_executor;
         }
 
@@ -280,26 +283,26 @@ impl DAGBuilder {
     /// Builds a normal executor pipeline.
     ///
     /// Normal executors iterate rows one by one.
-    pub fn build_normal<S: Store + 'static, C: ExecSummaryCollector + 'static>(
+    pub fn build_normal<S: Storage + 'static, C: ExecSummaryCollector + 'static>(
         exec_descriptors: Vec<executor::Executor>,
-        store: S,
+        storage: S,
         ranges: Vec<KeyRange>,
         ctx: Arc<EvalConfig>,
         is_streaming: bool,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<Box<dyn Executor<StorageStats = S::Statistics> + Send>> {
         let mut exec_descriptors = exec_descriptors.into_iter();
         let first = exec_descriptors
             .next()
             .ok_or_else(|| Error::Other(box_err!("has no executor")))?;
 
         let mut src =
-            Self::build_normal_first_executor::<_, C>(first, store, ranges, is_streaming)?;
+            Self::build_normal_first_executor::<_, C>(first, storage, ranges, is_streaming)?;
         let mut summary_slot_index = 0;
 
         for mut exec in exec_descriptors {
             summary_slot_index += 1;
 
-            let curr: Box<dyn Executor> = match exec.get_tp() {
+            let curr: Box<dyn Executor<StorageStats = S::Statistics> + Send> = match exec.get_tp() {
                 ExecType::TypeTableScan | ExecType::TypeIndexScan => {
                     return Err(box_err!(
                         "Unexpected non-first executor: {:?}",
@@ -358,18 +361,18 @@ impl DAGBuilder {
     /// other executors and never receive rows from other executors.
     ///
     /// The inner-most executor must be a table scan executor or an index scan executor.
-    fn build_normal_first_executor<S: Store + 'static, C: ExecSummaryCollector + 'static>(
+    fn build_normal_first_executor<S: Storage + 'static, C: ExecSummaryCollector + 'static>(
         mut first: executor::Executor,
-        store: S,
+        storage: S,
         ranges: Vec<KeyRange>,
         is_streaming: bool,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<Box<dyn Executor<StorageStats = S::Statistics> + Send>> {
         match first.get_tp() {
             ExecType::TypeTableScan => {
                 COPR_EXECUTOR_COUNT.with_label_values(&["table_scan"]).inc();
 
                 let ex = Box::new(
-                    ScanExecutor::table_scan(first.take_tbl_scan(), ranges, store, is_streaming)?
+                    ScanExecutor::table_scan(first.take_tbl_scan(), ranges, storage, is_streaming)?
                         .with_summary_collector(C::new(0)),
                 );
                 Ok(ex)
@@ -382,7 +385,7 @@ impl DAGBuilder {
                     ScanExecutor::index_scan(
                         first.take_idx_scan(),
                         ranges,
-                        store,
+                        storage,
                         unique,
                         is_streaming,
                     )?
@@ -390,29 +393,26 @@ impl DAGBuilder {
                 );
                 Ok(ex)
             }
-            _ => Err(box_err!(
-                "first exec type should be *Scan, but get {:?}",
-                first.get_tp()
-            )),
+            _ => Err(box_err!("Unexpected first scanner: {:?}", first.get_tp())),
         }
     }
 
-    fn build_dag<S: Store + 'static>(
+    pub fn build_dag<SS: Default + Send + 'static, S: Storage<Statistics = SS> + 'static>(
         eval_cfg: EvalConfig,
         mut req: DAGRequest,
         ranges: Vec<KeyRange>,
-        store: S,
+        storage: S,
         deadline: Deadline,
         batch_row_limit: usize,
         is_streaming: bool,
-    ) -> Result<super::DAGRequestHandler> {
+    ) -> Result<super::DAGHandler<SS>> {
         let executors_len = req.get_executors().len();
         let collect_exec_summary = req.get_collect_execution_summaries();
 
         let executor = if !(req.get_collect_execution_summaries()) {
             Self::build_normal::<_, ExecSummaryCollectorDisabled>(
                 req.take_executors().into_vec(),
-                store,
+                storage,
                 ranges,
                 Arc::new(eval_cfg),
                 is_streaming,
@@ -420,13 +420,14 @@ impl DAGBuilder {
         } else {
             Self::build_normal::<_, ExecSummaryCollectorEnabled>(
                 req.take_executors().into_vec(),
-                store,
+                storage,
                 ranges,
                 Arc::new(eval_cfg),
                 is_streaming,
             )?
         };
-        Ok(super::DAGRequestHandler::new(
+
+        Ok(super::DAGHandler::new(
             deadline,
             executor,
             req.take_output_offsets(),
@@ -440,28 +441,28 @@ impl DAGBuilder {
         ))
     }
 
-    fn build_batch_dag<S: Store + 'static>(
+    pub fn build_batch_dag<SS: Default + Send + 'static, S: Storage<Statistics = SS> + 'static>(
         deadline: Deadline,
         config: EvalConfig,
         mut req: DAGRequest,
         ranges: Vec<KeyRange>,
-        store: S,
-    ) -> Result<super::batch_handler::BatchDAGHandler> {
+        storage: S,
+    ) -> Result<super::batch_handler::BatchDAGHandler<SS>> {
         let executors_len = req.get_executors().len();
         let collect_exec_summary = req.get_collect_execution_summaries();
 
         let config = Arc::new(config);
         let out_most_executor = if collect_exec_summary {
-            super::builder::DAGBuilder::build_batch::<_, ExecSummaryCollectorEnabled>(
+            Self::build_batch::<_, ExecSummaryCollectorEnabled>(
                 req.take_executors().into_vec(),
-                store,
+                storage,
                 ranges,
                 config.clone(),
             )?
         } else {
-            super::builder::DAGBuilder::build_batch::<_, ExecSummaryCollectorDisabled>(
+            Self::build_batch::<_, ExecSummaryCollectorDisabled>(
                 req.take_executors().into_vec(),
-                store,
+                storage,
                 ranges,
                 config.clone(),
             )?
@@ -494,10 +495,11 @@ impl DAGBuilder {
         ))
     }
 
-    pub fn build<S: Store + 'static>(
+    // TODO: This should stay in Coprocessor instead of DAG.
+    pub fn build<S: Storage<Statistics = crate::storage::Statistics> + 'static>(
         req: DAGRequest,
         ranges: Vec<KeyRange>,
-        store: S,
+        storage: S,
         deadline: Deadline,
         batch_row_limit: usize,
         is_streaming: bool,
@@ -523,7 +525,7 @@ impl DAGBuilder {
         let mut is_batch = false;
         if enable_batch_if_possible && !is_streaming {
             let build_batch_result =
-                super::builder::DAGBuilder::check_build_batch(req.get_executors());
+                super::builder::DAGBuilder::check_build_batch::<S>(req.get_executors());
             if let Err(e) = build_batch_result {
                 debug!("Successfully use normal Coprocessor query engine"; "start_ts" => req.get_start_ts(), "reason" => %e);
             } else {
@@ -533,14 +535,14 @@ impl DAGBuilder {
 
         if is_batch {
             COPR_DAG_REQ_COUNT.with_label_values(&["batch"]).inc();
-            Ok(Self::build_batch_dag(deadline, eval_cfg, req, ranges, store)?.into_boxed())
+            Ok(Self::build_batch_dag(deadline, eval_cfg, req, ranges, storage)?.into_boxed())
         } else {
             COPR_DAG_REQ_COUNT.with_label_values(&["normal"]).inc();
             Ok(Self::build_dag(
                 eval_cfg,
                 req,
                 ranges,
-                store,
+                storage,
                 deadline,
                 batch_row_limit,
                 is_streaming,

--- a/src/coprocessor/dag/executor/index_scan.rs
+++ b/src/coprocessor/dag/executor/index_scan.rs
@@ -226,7 +226,7 @@ pub mod tests {
 
         pub fn new(unique: bool, test_data: TableData) -> IndexTestWrapper {
             let store = FixtureStorage::from(test_data.kv_data.clone());
-            let mut scan = IndexScan::new();
+            let mut scan = IndexScan::default();
             // prepare cols
             let cols = test_data.cols.clone();
             let col_req = cols.clone().into();

--- a/src/coprocessor/dag/executor/limit.rs
+++ b/src/coprocessor/dag/executor/limit.rs
@@ -7,7 +7,6 @@ use crate::coprocessor::dag::executor::{Executor, Row};
 use crate::coprocessor::dag::expr::EvalWarnings;
 use crate::coprocessor::dag::storage::IntervalRange;
 use crate::coprocessor::Result;
-use crate::storage::Statistics;
 
 /// Retrieves rows from the source executor and only produces part of the rows.
 pub struct LimitExecutor<Src: Executor> {
@@ -27,6 +26,8 @@ impl<Src: Executor> LimitExecutor<Src> {
 }
 
 impl<Src: Executor> Executor for LimitExecutor<Src> {
+    type StorageStats = Src::StorageStats;
+
     fn next(&mut self) -> Result<Option<Row>> {
         if self.cursor >= self.limit {
             return Ok(None);
@@ -45,7 +46,7 @@ impl<Src: Executor> Executor for LimitExecutor<Src> {
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
     }
 

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -36,7 +36,6 @@ use crate::coprocessor::dag::expr::{EvalContext, EvalWarnings};
 use crate::coprocessor::dag::storage::IntervalRange;
 use crate::coprocessor::util;
 use crate::coprocessor::*;
-use crate::storage::Statistics;
 
 /// An expression tree visitor that extracts all column offsets in the tree.
 pub struct ExprColumnRefVisitor {
@@ -235,11 +234,13 @@ impl OriginCols {
 }
 
 pub trait Executor: Send {
+    type StorageStats;
+
     fn next(&mut self) -> Result<Option<Row>>;
 
     fn collect_exec_stats(&mut self, dest: &mut ExecuteStats);
 
-    fn collect_storage_stats(&mut self, dest: &mut Statistics);
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats);
 
     fn get_len_of_columns(&self) -> usize;
 
@@ -261,7 +262,9 @@ pub trait Executor: Send {
     }
 }
 
-impl<C: ExecSummaryCollector, T: Executor> Executor for WithSummaryCollector<C, T> {
+impl<C: ExecSummaryCollector + Send, T: Executor> Executor for WithSummaryCollector<C, T> {
+    type StorageStats = T::StorageStats;
+
     fn next(&mut self) -> Result<Option<Row>> {
         let timer = self.summary_collector.on_start_iterate();
         let ret = self.inner.next();
@@ -273,13 +276,14 @@ impl<C: ExecSummaryCollector, T: Executor> Executor for WithSummaryCollector<C, 
         ret
     }
 
-    #[inline]
     fn collect_exec_stats(&mut self, dest: &mut ExecuteStats) {
+        self.summary_collector
+            .collect(&mut dest.summary_per_executor);
         self.inner.collect_exec_stats(dest);
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.inner.collect_storage_stats(dest);
     }
 
@@ -300,6 +304,8 @@ impl<C: ExecSummaryCollector, T: Executor> Executor for WithSummaryCollector<C, 
 }
 
 impl<T: Executor + ?Sized> Executor for Box<T> {
+    type StorageStats = T::StorageStats;
+
     #[inline]
     fn next(&mut self) -> Result<Option<Row>> {
         (**self).next()
@@ -311,7 +317,7 @@ impl<T: Executor + ?Sized> Executor for Box<T> {
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         (**self).collect_storage_stats(dest);
     }
 
@@ -335,22 +341,14 @@ impl<T: Executor + ?Sized> Executor for Box<T> {
 pub mod tests {
     use super::{Executor, TableScanExecutor};
     use crate::coprocessor::codec::{datum, table, Datum};
-    use crate::storage::kv::{Engine, Modify, RocksEngine, RocksSnapshot, TestEngineBuilder};
-    use crate::storage::mvcc::MvccTxn;
-    use crate::storage::SnapshotStore;
-    use crate::storage::{Key, Mutation, Options};
+    use crate::coprocessor::dag::storage::fixture::FixtureStorage;
     use cop_datatype::{FieldTypeAccessor, FieldTypeTp};
-    use kvproto::{
-        coprocessor::KeyRange,
-        kvrpcpb::{Context, IsolationLevel},
-    };
+    use kvproto::coprocessor::KeyRange;
+    use std::collections::HashMap;
     use tikv_util::codec::number::NumberEncoder;
-    use tikv_util::collections::HashMap;
-    use tipb::{
-        executor::TableScan,
-        expression::{Expr, ExprType},
-        schema::ColumnInfo,
-    };
+    use tipb::executor::TableScan;
+    use tipb::expression::{Expr, ExprType};
+    use tipb::schema::ColumnInfo;
 
     pub fn build_expr(tp: ExprType, id: Option<i64>, child: Option<Expr>) -> Expr {
         let mut expr = Expr::default();
@@ -387,110 +385,22 @@ pub mod tests {
         kv_data
     }
 
-    const START_TS: u64 = 10;
-    const COMMIT_TS: u64 = 20;
-
-    pub struct TestStore {
-        snapshot: RocksSnapshot,
-        ctx: Context,
-        engine: RocksEngine,
-    }
-
-    impl TestStore {
-        pub fn new(kv_data: &[(Vec<u8>, Vec<u8>)]) -> TestStore {
-            let engine = TestEngineBuilder::new().build().unwrap();
-            let ctx = Context::default();
-            let snapshot = engine.snapshot(&ctx).unwrap();
-            let mut store = TestStore {
-                snapshot,
-                ctx,
-                engine,
-            };
-            store.init_data(kv_data);
-            store
-        }
-
-        fn init_data(&mut self, kv_data: &[(Vec<u8>, Vec<u8>)]) {
-            if kv_data.is_empty() {
-                return;
-            }
-
-            // do prewrite.
-            let txn_motifies = {
-                let mut txn = MvccTxn::new(self.snapshot.clone(), START_TS, true).unwrap();
-                let mut pk = vec![];
-                for &(ref key, ref value) in kv_data {
-                    if pk.is_empty() {
-                        pk = key.clone();
-                    }
-                    txn.prewrite(
-                        Mutation::Put((Key::from_raw(key), value.to_vec())),
-                        &pk,
-                        &Options::default(),
-                    )
-                    .unwrap();
-                }
-                txn.into_modifies()
-            };
-            self.write_modifies(txn_motifies);
-
-            // do commit
-            let txn_modifies = {
-                let mut txn = MvccTxn::new(self.snapshot.clone(), START_TS, true).unwrap();
-                for &(ref key, _) in kv_data {
-                    txn.commit(Key::from_raw(key), COMMIT_TS).unwrap();
-                }
-                txn.into_modifies()
-            };
-            self.write_modifies(txn_modifies);
-        }
-
-        #[inline]
-        fn write_modifies(&mut self, txn: Vec<Modify>) {
-            self.engine.write(&self.ctx, txn).unwrap();
-            self.snapshot = self.engine.snapshot(&self.ctx).unwrap()
-        }
-
-        pub fn get_snapshot(&mut self) -> (RocksSnapshot, u64) {
-            (self.snapshot.clone(), COMMIT_TS + 1)
-        }
-    }
-
-    pub fn get_range(table_id: i64, start: i64, end: i64) -> KeyRange {
-        let mut key_range = KeyRange::default();
-        key_range.set_start(table::encode_row_key(table_id, start));
-        key_range.set_end(table::encode_row_key(table_id, end));
-        key_range
-    }
-
     pub fn get_point_range(table_id: i64, handle: i64) -> KeyRange {
         let start_key = table::encode_row_key(table_id, handle);
         let mut end = start_key.clone();
         crate::coprocessor::util::convert_to_prefix_next(&mut end);
-        let mut key_range = KeyRange::default();
+        let mut key_range = KeyRange::new();
         key_range.set_start(start_key);
         key_range.set_end(end);
         key_range
     }
 
-    pub fn gen_table_scan_executor(
-        tid: i64,
-        cis: Vec<ColumnInfo>,
-        raw_data: &[Vec<Datum>],
-        key_ranges: Option<Vec<KeyRange>>,
-    ) -> Box<dyn Executor> {
-        let table_data = gen_table_data(tid, &cis, raw_data);
-        let mut test_store = TestStore::new(&table_data);
-
-        let mut table_scan = TableScan::default();
-        table_scan.set_table_id(tid);
-        table_scan.set_columns(cis.clone().into());
-
-        let key_ranges = key_ranges.unwrap_or_else(|| vec![get_range(tid, 0, i64::max_value())]);
-
-        let (snapshot, start_ts) = test_store.get_snapshot();
-        let store = SnapshotStore::new(snapshot, start_ts, IsolationLevel::SI, true);
-        Box::new(TableScanExecutor::table_scan(table_scan, key_ranges, store, false).unwrap())
+    #[inline]
+    pub fn get_range(table_id: i64, start: i64, end: i64) -> KeyRange {
+        let mut key_range = KeyRange::default();
+        key_range.set_start(table::encode_row_key(table_id, start));
+        key_range.set_end(table::encode_row_key(table_id, end));
+        key_range
     }
 
     pub struct TableData {
@@ -501,6 +411,46 @@ pub mod tests {
     }
 
     impl TableData {
+        pub fn prepare(key_number: usize, table_id: i64) -> TableData {
+            let cols = vec![
+                new_col_info(1, FieldTypeTp::LongLong),
+                new_col_info(2, FieldTypeTp::VarChar),
+                new_col_info(3, FieldTypeTp::NewDecimal),
+            ];
+
+            let mut kv_data = Vec::new();
+            let mut expect_rows = Vec::new();
+
+            for handle in 0..key_number {
+                let row = map![
+                    1 => Datum::I64(handle as i64),
+                    2 => Datum::Bytes(b"abc".to_vec()),
+                    3 => Datum::Dec(10.into())
+                ];
+                let mut expect_row = HashMap::default();
+                let col_ids: Vec<_> = row.iter().map(|(&id, _)| id).collect();
+                let col_values: Vec<_> = row
+                    .iter()
+                    .map(|(cid, v)| {
+                        let f = table::flatten(v.clone()).unwrap();
+                        let value = datum::encode_value(&[f]).unwrap();
+                        expect_row.insert(*cid, value);
+                        v.clone()
+                    })
+                    .collect();
+
+                let value = table::encode_row(col_values, &col_ids).unwrap();
+                let key = table::encode_row_key(table_id, handle as i64);
+                expect_rows.push(expect_row);
+                kv_data.push((key, value));
+            }
+            Self {
+                kv_data,
+                expect_rows,
+                cols,
+            }
+        }
+
         pub fn get_prev_2_cols(&self) -> Vec<ColumnInfo> {
             let col1 = self.cols[0].clone();
             let col2 = self.cols[1].clone();
@@ -514,43 +464,20 @@ pub mod tests {
         }
     }
 
-    pub fn prepare_table_data(key_number: usize, table_id: i64) -> TableData {
-        let cols = vec![
-            new_col_info(1, FieldTypeTp::LongLong),
-            new_col_info(2, FieldTypeTp::VarChar),
-            new_col_info(3, FieldTypeTp::NewDecimal),
-        ];
+    pub fn gen_table_scan_executor(
+        tid: i64,
+        cis: Vec<ColumnInfo>,
+        raw_data: &[Vec<Datum>],
+        key_ranges: Option<Vec<KeyRange>>,
+    ) -> Box<dyn Executor<StorageStats = ()> + Send> {
+        let table_data = gen_table_data(tid, &cis, raw_data);
+        let storage = FixtureStorage::from(table_data);
 
-        let mut kv_data = Vec::new();
-        let mut expect_rows = Vec::new();
+        let mut table_scan = TableScan::default();
+        table_scan.set_table_id(tid);
+        table_scan.set_columns(cis.clone().into());
 
-        for handle in 0..key_number {
-            let row = map![
-                1 => Datum::I64(handle as i64),
-                2 => Datum::Bytes(b"abc".to_vec()),
-                3 => Datum::Dec(10.into())
-            ];
-            let mut expect_row = HashMap::default();
-            let col_ids: Vec<_> = row.iter().map(|(&id, _)| id).collect();
-            let col_values: Vec<_> = row
-                .iter()
-                .map(|(cid, v)| {
-                    let f = table::flatten(v.clone()).unwrap();
-                    let value = datum::encode_value(&[f]).unwrap();
-                    expect_row.insert(*cid, value);
-                    v.clone()
-                })
-                .collect();
-
-            let value = table::encode_row(col_values, &col_ids).unwrap();
-            let key = table::encode_row_key(table_id, handle as i64);
-            expect_rows.push(expect_row);
-            kv_data.push((key, value));
-        }
-        TableData {
-            kv_data,
-            expect_rows,
-            cols,
-        }
+        let key_ranges = key_ranges.unwrap_or_else(|| vec![get_range(tid, 0, i64::max_value())]);
+        Box::new(TableScanExecutor::table_scan(table_scan, key_ranges, storage, false).unwrap())
     }
 }

--- a/src/coprocessor/dag/executor/mod.rs
+++ b/src/coprocessor/dag/executor/mod.rs
@@ -389,7 +389,7 @@ pub mod tests {
         let start_key = table::encode_row_key(table_id, handle);
         let mut end = start_key.clone();
         crate::coprocessor::util::convert_to_prefix_next(&mut end);
-        let mut key_range = KeyRange::new();
+        let mut key_range = KeyRange::default();
         key_range.set_start(start_key);
         key_range.set_end(end);
         key_range

--- a/src/coprocessor/dag/executor/selection.rs
+++ b/src/coprocessor/dag/executor/selection.rs
@@ -4,13 +4,11 @@ use std::sync::Arc;
 
 use tipb::executor::Selection;
 
-use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
-use crate::coprocessor::Result;
-
 use super::{Executor, ExprColumnRefVisitor, Row};
 use crate::coprocessor::dag::execute_stats::ExecuteStats;
+use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
 use crate::coprocessor::dag::storage::IntervalRange;
-use crate::storage::Statistics;
+use crate::coprocessor::Result;
 
 /// Retrieves rows from the source executor and filter rows by expressions.
 pub struct SelectionExecutor<Src: Executor> {
@@ -36,6 +34,8 @@ impl<Src: Executor> SelectionExecutor<Src> {
 }
 
 impl<Src: Executor> Executor for SelectionExecutor<Src> {
+    type StorageStats = Src::StorageStats;
+
     fn next(&mut self) -> Result<Option<Row>> {
         'next: while let Some(row) = self.src.next()? {
             let row = row.take_origin()?;
@@ -57,7 +57,7 @@ impl<Src: Executor> Executor for SelectionExecutor<Src> {
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
     }
 

--- a/src/coprocessor/dag/executor/topn.rs
+++ b/src/coprocessor/dag/executor/topn.rs
@@ -15,7 +15,6 @@ use crate::coprocessor::dag::execute_stats::ExecuteStats;
 use crate::coprocessor::dag::expr::{EvalConfig, EvalContext, EvalWarnings, Expression};
 use crate::coprocessor::dag::storage::IntervalRange;
 use crate::coprocessor::Result;
-use crate::storage::Statistics;
 
 struct OrderBy {
     items: Arc<Vec<ByItem>>,
@@ -106,6 +105,8 @@ impl<Src: Executor> TopNExecutor<Src> {
 }
 
 impl<Src: Executor> Executor for TopNExecutor<Src> {
+    type StorageStats = Src::StorageStats;
+
     fn next(&mut self) -> Result<Option<Row>> {
         if self.iter.is_none() {
             self.fetch_all()?;
@@ -120,7 +121,7 @@ impl<Src: Executor> Executor for TopNExecutor<Src> {
     }
 
     #[inline]
-    fn collect_storage_stats(&mut self, dest: &mut Statistics) {
+    fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
     }
 

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -33,8 +33,9 @@ pub mod expr_util;
 pub mod handler;
 pub mod rpn_expr;
 pub mod storage;
+// TODO: This should stay in Coprocessor instead of DAG
 pub mod storage_impl;
 
 pub use self::batch_handler::BatchDAGHandler;
 pub use self::builder::DAGBuilder;
-pub use self::handler::DAGRequestHandler;
+pub use self::handler::DAGHandler;

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -19,6 +19,7 @@ use crate::storage::kv::with_tls_engine;
 use crate::storage::{self, Engine, SnapshotStore};
 use tikv_util::Either;
 
+use crate::coprocessor::dag::storage_impl::TiKVStorage;
 use crate::coprocessor::metrics::*;
 use crate::coprocessor::tracker::Tracker;
 use crate::coprocessor::*;
@@ -127,10 +128,11 @@ impl<E: Engine> Endpoint<E> {
                         req_ctx.context.get_isolation_level(),
                         !req_ctx.context.get_not_fill_cache(),
                     );
+                    let storage = TiKVStorage::from(store);
                     dag::DAGBuilder::build(
                         dag,
                         ranges,
-                        store,
+                        storage,
                         req_ctx.deadline,
                         batch_row_limit,
                         is_streaming,
@@ -240,6 +242,7 @@ impl<E: Engine> Endpoint<E> {
                 // There might be errors when handling requests. In this case, we still need its
                 // execution metrics.
                 let result = handler.handle_request();
+
                 let mut storage_stats = Statistics::default();
                 handler.collect_scan_statistics(&mut storage_stats);
 

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -62,7 +62,7 @@ pub trait RequestHandler: Send {
         panic!("streaming request is not supported for this handler");
     }
 
-    /// Collects metrics generated in this request handler so far.
+    /// Collects scan statistics generated in this request handler so far.
     fn collect_scan_statistics(&mut self, _dest: &mut Statistics) {
         // Do nothing by default
     }

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -20,12 +20,13 @@ use crate::coprocessor::*;
 use super::cmsketch::CMSketch;
 use super::fmsketch::FMSketch;
 use super::histogram::Histogram;
+use crate::coprocessor::dag::storage_impl::TiKVStorage;
 
 // `AnalyzeContext` is used to handle `AnalyzeReq`
 pub struct AnalyzeContext<S: Snapshot> {
     req: AnalyzeReq,
+    storage: Option<TiKVStorage<SnapshotStore<S>>>,
     ranges: Vec<KeyRange>,
-    store: Option<SnapshotStore<S>>,
     storage_stats: Statistics,
 }
 
@@ -44,8 +45,8 @@ impl<S: Snapshot> AnalyzeContext<S> {
         );
         Ok(Self {
             req,
+            storage: Some(store.into()),
             ranges,
-            store: Some(store),
             storage_stats: Statistics::default(),
         })
     }
@@ -73,7 +74,7 @@ impl<S: Snapshot> AnalyzeContext<S> {
     // it would build a histogram and count-min sketch of index values.
     fn handle_index(
         req: AnalyzeIndexReq,
-        scanner: &mut IndexScanExecutor<SnapshotStore<S>>,
+        scanner: &mut IndexScanExecutor<TiKVStorage<SnapshotStore<S>>>,
     ) -> Result<Vec<u8>> {
         let mut hist = Histogram::new(req.get_bucket_size() as usize);
         let mut cms = CMSketch::new(
@@ -108,7 +109,7 @@ impl<S: Snapshot> RequestHandler for AnalyzeContext<S> {
                 let mut scanner = ScanExecutor::index_scan_with_cols_len(
                     i64::from(req.get_num_columns()),
                     mem::replace(&mut self.ranges, Vec::new()),
-                    self.store.take().unwrap(),
+                    self.storage.take().unwrap(),
                 )?;
                 let res = AnalyzeContext::handle_index(req, &mut scanner);
                 scanner.collect_storage_stats(&mut self.storage_stats);
@@ -117,9 +118,9 @@ impl<S: Snapshot> RequestHandler for AnalyzeContext<S> {
 
             AnalyzeType::TypeColumn => {
                 let col_req = self.req.take_col_req();
-                let store = self.store.take().unwrap();
+                let storage = self.storage.take().unwrap();
                 let ranges = mem::replace(&mut self.ranges, Vec::new());
-                let mut builder = SampleBuilder::new(col_req, store, ranges)?;
+                let mut builder = SampleBuilder::new(col_req, storage, ranges)?;
                 let res = AnalyzeContext::handle_column(&mut builder);
                 builder.data.collect_storage_stats(&mut self.storage_stats);
                 res
@@ -147,7 +148,7 @@ impl<S: Snapshot> RequestHandler for AnalyzeContext<S> {
 }
 
 struct SampleBuilder<S: Snapshot> {
-    data: TableScanExecutor<SnapshotStore<S>>,
+    data: TableScanExecutor<TiKVStorage<SnapshotStore<S>>>,
     // the number of columns need to be sampled. It equals to cols.len()
     // if cols[0] is not pk handle, or it should be cols.len() - 1.
     col_len: usize,
@@ -164,7 +165,7 @@ struct SampleBuilder<S: Snapshot> {
 impl<S: Snapshot> SampleBuilder<S> {
     fn new(
         mut req: AnalyzeColumnsReq,
-        store: SnapshotStore<S>,
+        storage: TiKVStorage<SnapshotStore<S>>,
         ranges: Vec<KeyRange>,
     ) -> Result<Self> {
         let cols_info = req.take_columns_info();
@@ -179,7 +180,7 @@ impl<S: Snapshot> SampleBuilder<S> {
 
         let mut meta = TableScan::default();
         meta.set_columns(cols_info);
-        let table_scanner = ScanExecutor::table_scan(meta, ranges, store, false)?;
+        let table_scanner = ScanExecutor::table_scan(meta, ranges, storage, false)?;
         Ok(Self {
             data: table_scanner,
             col_len,

--- a/tests/integrations/coprocessor/test_checksum.rs
+++ b/tests/integrations/coprocessor/test_checksum.rs
@@ -9,13 +9,12 @@ use kvproto::kvrpcpb::{Context, IsolationLevel};
 use protobuf::Message;
 use tipb::checksum::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse, ChecksumScanOn};
 
-use tikv::coprocessor::*;
-use tikv::storage::{Engine, SnapshotStore};
-
 use test_coprocessor::*;
 use tikv::coprocessor::dag::storage::scanner::{RangesScanner, RangesScannerOptions};
 use tikv::coprocessor::dag::storage::Range;
 use tikv::coprocessor::dag::storage_impl::TiKVStorage;
+use tikv::coprocessor::*;
+use tikv::storage::{Engine, SnapshotStore};
 
 fn new_checksum_request(range: KeyRange, scan_on: ChecksumScanOn) -> Request {
     let mut ctx = Context::default();


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Extracted from https://github.com/tikv/tikv/pull/5119

This PR makes Coprocessor DAG completely does not rely on tikv::storage (including MVCC scanners and Statistics).

The next step will be make Coprocessor DAG does not rely on tikv::coprocessor (especially coprocessor::Error), so that Coprocessor DAG can be a standalone workspace and anything connects to TiKV is tikv::coprocessor.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

No need.

## Refer to a related PR or issue link (optional)

See https://github.com/tikv/tikv/issues/4180 Extract Coprocessor DAG
