### PR TITLE
Assign a structure for KeyIsLocked content

### DIFF
--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -374,14 +374,14 @@ impl<E: Engine> AssertionStorage<E> {
         let locks: Vec<(&[u8], &[u8], u64)> = res
             .iter()
             .filter_map(|x| {
-                if let Err(storage::Error::Txn(txn::Error::Mvcc(mvcc::Error::KeyIsLocked {
-                    ref key,
-                    ref primary,
-                    ts,
-                    ..
-                }))) = *x
+                if let Err(storage::Error::Txn(txn::Error::Mvcc(mvcc::Error::KeyIsLocked(info)))) =
+                    x
                 {
-                    Some((key.as_ref(), primary.as_ref(), ts))
+                    Some((
+                        info.get_key(),
+                        info.get_primary_lock(),
+                        info.get_lock_version(),
+                    ))
                 } else {
                     None
                 }

--- a/src/coprocessor/dag/batch/executors/table_scan_executor.rs
+++ b/src/coprocessor/dag/batch/executors/table_scan_executor.rs
@@ -824,14 +824,7 @@ mod tests {
                 Box<dyn Send + Sync + Fn() -> crate::coprocessor::Error>,
             > = Err(Box::new(|| {
                 crate::coprocessor::Error::from(crate::storage::txn::Error::Mvcc(
-                    crate::storage::mvcc::Error::KeyIsLocked {
-                        // We won't check error detail in tests, so we can just fill fields casually.
-                        key: vec![],
-                        primary: vec![],
-                        ts: 1,
-                        ttl: 2,
-                        txn_size: 0,
-                    },
+                    crate::storage::mvcc::Error::KeyIsLocked(kvproto::kvrpcpb::LockInfo::default()),
                 ))
             }));
             kv.push((key, value));

--- a/src/coprocessor/error.rs
+++ b/src/coprocessor/error.rs
@@ -61,19 +61,7 @@ impl From<coprocessor::dag::expr::Error> for Error {
 impl From<storage::txn::Error> for Error {
     fn from(e: storage::txn::Error) -> Error {
         match e {
-            storage::txn::Error::Mvcc(storage::mvcc::Error::KeyIsLocked {
-                primary,
-                ts,
-                key,
-                ttl,
-                txn_size,
-            }) => {
-                let mut info = kvrpcpb::LockInfo::default();
-                info.set_primary_lock(primary);
-                info.set_lock_version(ts);
-                info.set_key(key);
-                info.set_lock_ttl(ttl);
-                info.set_txn_size(txn_size);
+            storage::txn::Error::Mvcc(storage::mvcc::Error::KeyIsLocked(info)) => {
                 Error::Locked(info)
             }
             _ => Error::Other(Box::new(e)),

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1905,42 +1905,30 @@ fn extract_committed(err: &storage::Error) -> Option<u64> {
 
 fn extract_key_error(err: &storage::Error) -> KeyError {
     let mut key_error = KeyError::default();
-    match *err {
-        storage::Error::Txn(TxnError::Mvcc(MvccError::KeyIsLocked {
-            ref key,
-            ref primary,
-            ts,
-            ttl,
-            txn_size,
-        })) => {
-            let mut lock_info = LockInfo::default();
-            lock_info.set_key(key.to_owned());
-            lock_info.set_primary_lock(primary.to_owned());
-            lock_info.set_lock_version(ts);
-            lock_info.set_lock_ttl(ttl);
-            lock_info.set_txn_size(txn_size);
-            key_error.set_locked(lock_info);
+    match err {
+        storage::Error::Txn(TxnError::Mvcc(MvccError::KeyIsLocked(info))) => {
+            key_error.set_locked(info.clone());
         }
         // failed in prewrite or pessimistic lock
         storage::Error::Txn(TxnError::Mvcc(MvccError::WriteConflict {
             start_ts,
             conflict_start_ts,
             conflict_commit_ts,
-            ref key,
-            ref primary,
+            key,
+            primary,
             ..
         })) => {
             let mut write_conflict = WriteConflict::default();
-            write_conflict.set_start_ts(start_ts);
-            write_conflict.set_conflict_ts(conflict_start_ts);
-            write_conflict.set_conflict_commit_ts(conflict_commit_ts);
+            write_conflict.set_start_ts(*start_ts);
+            write_conflict.set_conflict_ts(*conflict_start_ts);
+            write_conflict.set_conflict_commit_ts(*conflict_commit_ts);
             write_conflict.set_key(key.to_owned());
             write_conflict.set_primary(primary.to_owned());
             key_error.set_conflict(write_conflict);
             // for compatibility with older versions.
             key_error.set_retryable(format!("{:?}", err));
         }
-        storage::Error::Txn(TxnError::Mvcc(MvccError::AlreadyExist { ref key })) => {
+        storage::Error::Txn(TxnError::Mvcc(MvccError::AlreadyExist { key })) => {
             let mut exist = AlreadyExist::default();
             exist.set_key(key.clone());
             key_error.set_already_exist(exist);
@@ -1952,15 +1940,15 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
         }
         storage::Error::Txn(TxnError::Mvcc(MvccError::Deadlock {
             lock_ts,
-            ref lock_key,
+            lock_key,
             deadlock_key_hash,
             ..
         })) => {
             warn!("txn deadlocks"; "err" => ?err);
             let mut deadlock = Deadlock::default();
-            deadlock.set_lock_ts(lock_ts);
+            deadlock.set_lock_ts(*lock_ts);
             deadlock.set_lock_key(lock_key.to_owned());
-            deadlock.set_deadlock_key_hash(deadlock_key_hash);
+            deadlock.set_deadlock_key_hash(*deadlock_key_hash);
             key_error.set_deadlock(deadlock);
         }
         _ => {

--- a/src/storage/lock_manager/util.rs
+++ b/src/storage/lock_manager/util.rs
@@ -59,7 +59,11 @@ mod tests {
         let raw_key = b"key".to_vec();
         let key = Key::from_raw(&raw_key);
         let ts = 100;
-        let case = StorageError::from(TxnError::from(MvccError::KeyIsLocked(LockInfo::default())));
+        let mut info = LockInfo::default();
+        info.set_key(raw_key);
+        info.set_lock_version(ts);
+        info.set_lock_ttl(100);
+        let case = StorageError::from(TxnError::from(MvccError::KeyIsLocked(info)));
         let lock = extract_lock_from_result(&Err(case));
         assert_eq!(lock.ts, ts);
         assert_eq!(lock.hash, gen_key_hash(&key));

--- a/src/storage/lock_manager/util.rs
+++ b/src/storage/lock_manager/util.rs
@@ -16,9 +16,9 @@ pub fn extract_physical_timestamp(ts: u64) -> u64 {
 
 pub fn extract_lock_from_result(res: &Result<(), StorageError>) -> Lock {
     match res {
-        Err(StorageError::Txn(TxnError::Mvcc(MvccError::KeyIsLocked { key, ts, .. }))) => Lock {
-            ts: *ts,
-            hash: gen_key_hash(&Key::from_raw(&key)),
+        Err(StorageError::Txn(TxnError::Mvcc(MvccError::KeyIsLocked(info)))) => Lock {
+            ts: info.get_lock_version(),
+            hash: gen_key_hash(&Key::from_raw(info.get_key())),
         },
         _ => panic!("unexpected mvcc error"),
     }
@@ -37,10 +37,10 @@ pub fn extract_raw_key_from_process_result(pr: &ProcessResult) -> &[u8] {
     match pr {
         ProcessResult::MultiRes { results } => {
             assert!(results.len() == 1);
-            match results[0] {
-                Err(StorageError::Txn(TxnError::Mvcc(MvccError::KeyIsLocked {
-                    ref key, ..
-                }))) => key,
+            match &results[0] {
+                Err(StorageError::Txn(TxnError::Mvcc(MvccError::KeyIsLocked(info)))) => {
+                    info.get_key()
+                }
                 _ => panic!("unexpected mvcc error"),
             }
         }
@@ -52,18 +52,14 @@ pub fn extract_raw_key_from_process_result(pr: &ProcessResult) -> &[u8] {
 mod tests {
     use super::*;
 
+    use kvproto::kvrpcpb::LockInfo;
+
     #[test]
     fn test_extract_lock_from_result() {
         let raw_key = b"key".to_vec();
         let key = Key::from_raw(&raw_key);
         let ts = 100;
-        let case = StorageError::from(TxnError::from(MvccError::KeyIsLocked {
-            key: raw_key,
-            primary: vec![],
-            ts,
-            ttl: 100,
-            txn_size: 0,
-        }));
+        let case = StorageError::from(TxnError::from(MvccError::KeyIsLocked(LockInfo::default())));
         let lock = extract_lock_from_result(&Err(case));
         assert_eq!(lock.ts, ts);
         assert_eq!(lock.hash, gen_key_hash(&key));
@@ -72,15 +68,11 @@ mod tests {
     #[test]
     fn test_extract_raw_key_from_process_result() {
         let raw_key = b"foo".to_vec();
+        let mut info = LockInfo::default();
+        info.set_key(raw_key.clone());
         let pr = ProcessResult::MultiRes {
             results: vec![Err(StorageError::from(TxnError::from(
-                MvccError::KeyIsLocked {
-                    key: raw_key.clone(),
-                    primary: vec![],
-                    ts: 0,
-                    ttl: 0,
-                    txn_size: 0,
-                },
+                MvccError::KeyIsLocked(info),
             )))],
         };
         assert_eq!(raw_key, extract_raw_key_from_process_result(&pr));

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -37,14 +37,9 @@ quick_error! {
             cause(err)
             description(err.description())
         }
-        KeyIsLocked { key: Vec<u8>, primary: Vec<u8>, ts: u64, ttl: u64, txn_size: u64 } {
+        KeyIsLocked(info: kvproto::kvrpcpb::LockInfo) {
             description("key is locked (backoff or cleanup)")
-            display("key is locked (backoff or cleanup) {}-{}@{} ttl {} txn_size {}",
-                        hex::encode_upper(key),
-                        hex::encode_upper(primary),
-                        ts,
-                        ttl,
-                        txn_size)
+            display("key is locked (backoff or cleanup) {:?}", info)
         }
         BadFormatLock { description("bad format lock data") }
         BadFormatWrite { description("bad format write data") }
@@ -98,82 +93,72 @@ quick_error! {
 
 impl Error {
     pub fn maybe_clone(&self) -> Option<Error> {
-        match *self {
-            Error::Engine(ref e) => e.maybe_clone().map(Error::Engine),
-            Error::Codec(ref e) => e.maybe_clone().map(Error::Codec),
-            Error::KeyIsLocked {
-                ref key,
-                ref primary,
-                ts,
-                ttl,
-                txn_size,
-            } => Some(Error::KeyIsLocked {
-                key: key.clone(),
-                primary: primary.clone(),
-                ts,
-                ttl,
-                txn_size,
-            }),
+        match self {
+            Error::Engine(e) => e.maybe_clone().map(Error::Engine),
+            Error::Codec(e) => e.maybe_clone().map(Error::Codec),
+            Error::KeyIsLocked(info) => Some(Error::KeyIsLocked(info.clone())),
             Error::BadFormatLock => Some(Error::BadFormatLock),
             Error::BadFormatWrite => Some(Error::BadFormatWrite),
             Error::TxnLockNotFound {
                 start_ts,
                 commit_ts,
-                ref key,
+                key,
             } => Some(Error::TxnLockNotFound {
-                start_ts,
-                commit_ts,
+                start_ts: *start_ts,
+                commit_ts: *commit_ts,
                 key: key.to_owned(),
             }),
             Error::LockTypeNotMatch {
                 start_ts,
-                ref key,
+                key,
                 pessimistic,
             } => Some(Error::LockTypeNotMatch {
-                start_ts,
+                start_ts: *start_ts,
                 key: key.to_owned(),
-                pessimistic,
+                pessimistic: *pessimistic,
             }),
             Error::WriteConflict {
                 start_ts,
                 conflict_start_ts,
                 conflict_commit_ts,
-                ref key,
-                ref primary,
+                key,
+                primary,
             } => Some(Error::WriteConflict {
-                start_ts,
-                conflict_start_ts,
-                conflict_commit_ts,
+                start_ts: *start_ts,
+                conflict_start_ts: *conflict_start_ts,
+                conflict_commit_ts: *conflict_commit_ts,
                 key: key.to_owned(),
                 primary: primary.to_owned(),
             }),
             Error::Deadlock {
                 start_ts,
                 lock_ts,
-                ref lock_key,
+                lock_key,
                 deadlock_key_hash,
             } => Some(Error::Deadlock {
-                start_ts,
-                lock_ts,
+                start_ts: *start_ts,
+                lock_ts: *lock_ts,
                 lock_key: lock_key.to_owned(),
-                deadlock_key_hash,
+                deadlock_key_hash: *deadlock_key_hash,
             }),
-            Error::AlreadyExist { ref key } => Some(Error::AlreadyExist { key: key.clone() }),
-            Error::DefaultNotFound { ref key, ref write } => Some(Error::DefaultNotFound {
+            Error::AlreadyExist { key } => Some(Error::AlreadyExist { key: key.clone() }),
+            Error::DefaultNotFound { key, write } => Some(Error::DefaultNotFound {
                 key: key.to_owned(),
                 write: write.clone(),
             }),
             Error::KeyVersion => Some(Error::KeyVersion),
-            Error::Committed { commit_ts } => Some(Error::Committed { commit_ts }),
-            Error::PessimisticLockRollbacked { start_ts, ref key } => {
+            Error::Committed { commit_ts } => Some(Error::Committed {
+                commit_ts: *commit_ts,
+            }),
+            Error::PessimisticLockRollbacked { start_ts, key } => {
                 Some(Error::PessimisticLockRollbacked {
-                    start_ts,
+                    start_ts: *start_ts,
                     key: key.to_owned(),
                 })
             }
-            Error::PessimisticLockNotFound { start_ts, ref key } => {
+            Error::PessimisticLockNotFound { start_ts, key } => {
                 Some(Error::PessimisticLockNotFound {
-                    start_ts,
+                    start_ts: *start_ts,
                     key: key.to_owned(),
                 })
             }

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -185,13 +185,13 @@ impl<S: Snapshot> MvccReader<S> {
         }
 
         // There is a pending lock. Client should wait or clean it.
-        Err(Error::KeyIsLocked {
-            key: key.to_raw()?,
-            primary: lock.primary,
-            ts: lock.ts,
-            ttl: lock.ttl,
-            txn_size: lock.txn_size,
-        })
+        let mut info = kvproto::kvrpcpb::LockInfo::default();
+        info.set_primary_lock(lock.primary);
+        info.set_lock_version(lock.ts);
+        info.set_key(key.to_raw()?);
+        info.set_lock_ttl(lock.ttl);
+        info.set_txn_size(lock.txn_size);
+        Err(Error::KeyIsLocked(info))
     }
 
     pub fn get(&mut self, key: &Key, mut ts: u64) -> Result<Option<Value>> {

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -198,8 +198,8 @@ mod tests {
             match scanner.next() {
                 Ok(None) => break,
                 Ok(Some((key, value))) => scan_result.push((key.to_raw().unwrap(), Some(value))),
-                Err(TxnError::Mvcc(MvccError::KeyIsLocked { key, .. })) => {
-                    scan_result.push((key, None))
+                Err(TxnError::Mvcc(MvccError::KeyIsLocked(mut info))) => {
+                    scan_result.push((info.take_key(), None))
                 }
                 e => panic!("got error while scanning: {:?}", e),
             }

--- a/src/storage/mvcc/reader/scanner/util.rs
+++ b/src/storage/mvcc/reader/scanner/util.rs
@@ -38,13 +38,13 @@ pub fn check_lock(key: &Key, ts: u64, lock: &Lock) -> Result<CheckLockResult> {
     }
 
     // There is a pending lock. Client should wait or clean it.
-    Ok(CheckLockResult::Locked(Error::KeyIsLocked {
-        key: raw_key,
-        primary: lock.primary.clone(),
-        ts: lock.ts,
-        ttl: lock.ttl,
-        txn_size: lock.txn_size,
-    }))
+    let mut info = kvproto::kvrpcpb::LockInfo::default();
+    info.set_primary_lock(lock.primary.clone());
+    info.set_lock_version(lock.ts);
+    info.set_key(raw_key);
+    info.set_lock_ttl(lock.ttl);
+    info.set_txn_size(lock.txn_size);
+    Ok(CheckLockResult::Locked(Error::KeyIsLocked(info)))
 }
 
 /// Reads user key's value in default CF according to the given write CF value

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -202,14 +202,14 @@ impl<S: Snapshot> MvccTxn<S> {
         // abort. Resolve it immediately.
         // Optimistic lock's for_update_ts is zero.
         if for_update_ts > lock.for_update_ts {
-            Err(Error::KeyIsLocked {
-                key: key.into_raw()?,
-                primary: lock.primary,
-                ts: lock.ts,
-                // Set ttl to 0 so TiDB will resolve lock immediately.
-                ttl: 0,
-                txn_size: lock.txn_size,
-            })
+            let mut info = kvproto::kvrpcpb::LockInfo::default();
+            info.set_primary_lock(lock.primary);
+            info.set_lock_version(lock.ts);
+            info.set_key(key.into_raw()?);
+            // Set ttl to 0 so TiDB will resolve lock immediately.
+            info.set_lock_ttl(0);
+            info.set_txn_size(lock.txn_size);
+            Err(Error::KeyIsLocked(info))
         } else {
             Err(Error::Other("stale request".into()))
         }
@@ -225,13 +225,13 @@ impl<S: Snapshot> MvccTxn<S> {
         let for_update_ts = options.for_update_ts;
         if let Some(lock) = self.reader.load_lock(&key)? {
             if lock.ts != self.start_ts {
-                return Err(Error::KeyIsLocked {
-                    key: key.into_raw()?,
-                    primary: lock.primary,
-                    ts: lock.ts,
-                    ttl: lock.ttl,
-                    txn_size: options.txn_size,
-                });
+                let mut info = kvproto::kvrpcpb::LockInfo::default();
+                info.set_primary_lock(lock.primary);
+                info.set_lock_version(lock.ts);
+                info.set_key(key.into_raw()?);
+                info.set_lock_ttl(lock.ttl);
+                info.set_txn_size(options.txn_size);
+                return Err(Error::KeyIsLocked(info));
             }
             if lock.lock_type != LockType::Pessimistic {
                 return Err(Error::LockTypeNotMatch {
@@ -390,13 +390,13 @@ impl<S: Snapshot> MvccTxn<S> {
         // Check whether the current key is locked at any timestamp.
         if let Some(lock) = self.reader.load_lock(&key)? {
             if lock.ts != self.start_ts {
-                return Err(Error::KeyIsLocked {
-                    key: key.into_raw()?,
-                    primary: lock.primary,
-                    ts: lock.ts,
-                    ttl: lock.ttl,
-                    txn_size: lock.txn_size,
-                });
+                let mut info = kvproto::kvrpcpb::LockInfo::default();
+                info.set_primary_lock(lock.primary);
+                info.set_lock_version(lock.ts);
+                info.set_key(key.into_raw()?);
+                info.set_lock_ttl(lock.ttl);
+                info.set_txn_size(lock.txn_size);
+                return Err(Error::KeyIsLocked(info));
             }
             // TODO: remove it in future
             if lock.lock_type == LockType::Pessimistic {

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -644,14 +644,9 @@ mod tests {
         data.insert(Key::from_raw(b"bb"), Ok(b"alphaalpha".to_vec()));
         data.insert(
             Key::from_raw(b"bba"),
-            Err(Error::Mvcc(MvccError::KeyIsLocked {
-                // We won't check error detail in tests, so we can just fill fields casually
-                key: vec![],
-                primary: vec![],
-                ts: 1,
-                ttl: 2,
-                txn_size: 0,
-            })),
+            Err(Error::Mvcc(MvccError::KeyIsLocked(
+                kvproto::kvrpcpb::LockInfo::default(),
+            ))),
         );
         data.insert(Key::from_raw(b"z"), Ok(b"beta".to_vec()));
         data.insert(Key::from_raw(b"ca"), Ok(b"hello".to_vec()));


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR assigns a structure (i.e. `LockInfo`) for holding KeyIsLocked content, so that passing these content do not need to repeatedly write out fields.

As you can see, this change will eliminate total LOC.

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

Existing tests.