### PR TITLE
pessimistic-txn: eliminate `CleanUpWaitFor` when waiter timeouts

### DIFF
--- a/src/binutil/server.rs
+++ b/src/binutil/server.rs
@@ -322,6 +322,7 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
             pd_client,
             resolver,
             cfg.pessimistic_txn.monitor_membership_interval,
+            cfg.pessimistic_txn.wait_for_lock_timeout,
         );
         waiter_mgr_worker
             .as_mut()

--- a/src/storage/lock_manager/deadlock.rs
+++ b/src/storage/lock_manager/deadlock.rs
@@ -310,13 +310,15 @@ impl Inner {
         store_id: u64,
         waiter_mgr_scheduler: WaiterMgrScheduler,
         security_mgr: Arc<SecurityManager>,
+        ttl: u64,
     ) -> Self {
         Self {
             store_id,
             leader_info: None,
             leader_client: None,
-            // TODO: make it configurable.
-            detect_table: Rc::new(RefCell::new(DetectTable::new(time::Duration::from_secs(3)))),
+            detect_table: Rc::new(RefCell::new(DetectTable::new(time::Duration::from_millis(
+                ttl,
+            )))),
             waiter_mgr_scheduler,
             security_mgr,
             max_ts: 0,
@@ -413,6 +415,7 @@ impl<S: StoreAddrResolver + 'static> Detector<S> {
         pd_client: Arc<RpcClient>,
         resolver: S,
         monitor_membership_interval: u64,
+        ttl: u64,
     ) -> Self {
         assert!(store_id != INVALID_ID);
         Self {
@@ -422,6 +425,7 @@ impl<S: StoreAddrResolver + 'static> Detector<S> {
                 store_id,
                 waiter_mgr_scheduler,
                 security_mgr,
+                ttl,
             ))),
             monitor_membership_interval,
             is_initialized: false,

--- a/src/storage/lock_manager/waiter_manager.rs
+++ b/src/storage/lock_manager/waiter_manager.rs
@@ -263,7 +263,6 @@ impl WaiterManager {
         }
         if self.wait_table.borrow_mut().add_waiter(lock.ts, waiter) {
             let wait_table = Rc::clone(&self.wait_table);
-            let detector_scheduler = self.detector_scheduler.clone();
             let when = Instant::now() + Duration::from_millis(self.wait_for_lock_timeout);
             // TODO: cancel timer when wake up.
             let timer = Delay::new(when)
@@ -273,8 +272,8 @@ impl WaiterManager {
                         .borrow_mut()
                         .remove_waiter(start_ts, lock.clone())
                         .and_then(|waiter| {
-                            // TODO: remove it
-                            detector_scheduler.clean_up_wait_for(start_ts, lock);
+                            // The corresponding `WaitForEntry` in deadlock detector
+                            // will be removed by expiration.
                             execute_callback(waiter.cb, waiter.pr);
                             Some(())
                         });


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
Use `wait-for-lock-timeout` as the TTL of the detect table. So when waiter timeouts, there is no need to send 'CleanUpWaitFor` request to the deadlock detector.

## What are the type of the changes? (mandatory)
- Improvement (change which is an improvement to an existing feature)
