### PR TITLE
Add `evaluate_ctx` which returns EvalContext

### DIFF
--- a/src/coprocessor/dag/rpn_expr/types/test_util.rs
+++ b/src/coprocessor/dag/rpn_expr/types/test_util.rs
@@ -73,7 +73,11 @@ impl RpnFnScalarEvaluator {
     }
 
     /// Evaluates the given function by using collected parameters.
-    pub fn evaluate<T: Evaluable>(self, sig: ScalarFuncSig) -> Result<Option<T>> {
+    /// Then return the evaluation result and the inner `EvalContext`
+    pub fn evaluate_ctx<T: Evaluable>(
+        self,
+        sig: ScalarFuncSig,
+    ) -> (EvalContext, Result<Option<T>>) {
         let return_field_type = match self.return_field_type {
             Some(ft) => ft,
             None => T::EVAL_TYPE.into_certain_field_type_tp_for_test().into(),
@@ -102,14 +106,25 @@ impl RpnFnScalarEvaluator {
             .build();
 
         let mut columns = LazyBatchColumnVec::empty();
-        let ret = expr.eval(&mut context, &[], &mut columns, &[0], 1)?;
-        match ret {
-            // Only used in tests, so clone is fine.
-            RpnStackNode::Scalar { value, .. } => Ok(T::borrow_scalar_value(value).clone()),
-            RpnStackNode::Vector { value, .. } => {
-                assert_eq!(value.as_ref().len(), 1);
-                Ok(T::borrow_vector_value(value.as_ref())[0].clone())
-            }
-        }
+        let ret = expr.eval(&mut context, &[], &mut columns, &[0], 1);
+
+        (
+            context,
+            ret.map(|ret| {
+                match ret {
+                    // Only used in tests, so clone is fine.
+                    RpnStackNode::Scalar { value, .. } => T::borrow_scalar_value(value).clone(),
+                    RpnStackNode::Vector { value, .. } => {
+                        assert_eq!(value.as_ref().len(), 1);
+                        T::borrow_vector_value(value.as_ref())[0].clone()
+                    }
+                }
+            }),
+        )
+    }
+
+    /// Evaluates the given function by using collected parameters.
+    pub fn evaluate<T: Evaluable>(self, sig: ScalarFuncSig) -> Result<Option<T>> {
+        self.evaluate_ctx(sig).1
     }
 }

--- a/src/coprocessor/dag/rpn_expr/types/test_util.rs
+++ b/src/coprocessor/dag/rpn_expr/types/test_util.rs
@@ -73,7 +73,7 @@ impl RpnFnScalarEvaluator {
     }
 
     /// Evaluates the given function by using collected parameters.
-    /// Then return the evaluation result and the inner `EvalContext`
+    /// Then return the inner `EvalContext` and the evaluation result.
     pub fn evaluate_ctx<T: Evaluable>(
         self,
         sig: ScalarFuncSig,
@@ -107,20 +107,18 @@ impl RpnFnScalarEvaluator {
 
         let mut columns = LazyBatchColumnVec::empty();
         let ret = expr.eval(&mut context, &[], &mut columns, &[0], 1);
-
-        (
-            context,
-            ret.map(|ret| {
-                match ret {
-                    // Only used in tests, so clone is fine.
-                    RpnStackNode::Scalar { value, .. } => T::borrow_scalar_value(value).clone(),
-                    RpnStackNode::Vector { value, .. } => {
-                        assert_eq!(value.as_ref().len(), 1);
-                        T::borrow_vector_value(value.as_ref())[0].clone()
-                    }
+        let result = ret.map(|ret| {
+            match ret {
+                // Only used in tests, so clone is fine.
+                RpnStackNode::Scalar { value, .. } => T::borrow_scalar_value(value).clone(),
+                RpnStackNode::Vector { value, .. } => {
+                    assert_eq!(value.as_ref().len(), 1);
+                    T::borrow_vector_value(value.as_ref())[0].clone()
                 }
-            }),
-        )
+            }
+        });
+
+        (context, result)
     }
 
     /// Evaluates the given function by using collected parameters.

--- a/src/coprocessor/dag/rpn_expr/types/test_util.rs
+++ b/src/coprocessor/dag/rpn_expr/types/test_util.rs
@@ -73,11 +73,11 @@ impl RpnFnScalarEvaluator {
     }
 
     /// Evaluates the given function by using collected parameters.
-    /// Then return the inner `EvalContext` and the evaluation result.
+    /// Then return the evaluation result and the inner `EvalContext`
     pub fn evaluate_ctx<T: Evaluable>(
         self,
         sig: ScalarFuncSig,
-    ) -> (EvalContext, Result<Option<T>>) {
+    ) -> (Result<Option<T>>, EvalContext) {
         let return_field_type = match self.return_field_type {
             Some(ft) => ft,
             None => T::EVAL_TYPE.into_certain_field_type_tp_for_test().into(),
@@ -118,11 +118,11 @@ impl RpnFnScalarEvaluator {
             }
         });
 
-        (context, result)
+        (result, context)
     }
 
     /// Evaluates the given function by using collected parameters.
     pub fn evaluate<T: Evaluable>(self, sig: ScalarFuncSig) -> Result<Option<T>> {
-        self.evaluate_ctx(sig).1
+        self.evaluate_ctx(sig).0
     }
 }

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -137,7 +137,7 @@ where
             meta.store_id = Some(store_id);
         }
         if let Some(first_region) = self.check_or_prepare_bootstrap_cluster(&engines, store_id)? {
-            debug!("try bootstrap cluster"; "store_id" => store_id, "region" => ?first_region);
+            info!("trying to bootstrap cluster"; "store_id" => store_id, "region" => ?first_region);
             // cluster is not bootstrapped, and we choose first store to bootstrap
             fail_point!("node_after_prepare_bootstrap_cluster", |_| Err(box_err!(
                 "injected error: node_after_prepare_bootstrap_cluster"


### PR DESCRIPTION
Signed-off-by: Iosmanthus Teng <myosmanthustree@gmail.com>


## What have you changed? (mandatory)
In some occasion, we need to read the `EvalContext` after we evaluate some `RPN` functions, however, the current `RPN` utils don't allow us to read `EvalContext` instead of constructing an evaluator by owning an `EvalConfig`. This PR adds a new function call `evaluate_ctx` to return an `EvalContext` which enables us to examine the value of `EvalContext`.

## What are the type of changes? (mandatory)
- Improvement (a change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
`cargo test coprocessor::dag::rpn_expr`
