### PR TITLE
*: make pd module more independent

### DIFF
--- a/src/binutil/server.rs
+++ b/src/binutil/server.rs
@@ -10,6 +10,7 @@ use crate::import::{ImportSSTService, SSTImporter};
 use crate::pd::{PdClient, RpcClient};
 use crate::raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor};
 use crate::raftstore::store::fsm::store::{StoreMeta, PENDING_VOTES_CAP};
+use crate::raftstore::store::PdTask;
 use crate::raftstore::store::{fsm, LocalReader};
 use crate::raftstore::store::{new_compaction_listener, SnapManagerBuilder};
 use crate::server::resolve;
@@ -21,6 +22,7 @@ use crate::storage::lock_manager::{
     Detector, DetectorScheduler, Service as DeadlockService, WaiterManager, WaiterMgrScheduler,
 };
 use crate::storage::{self, AutoGCConfig, DEFAULT_ROCKSDB_SUB_DIR};
+use crate::storage::{FlowStatistics, FlowStatsReporter};
 use engine::rocks;
 use engine::rocks::util::metrics_flusher::{MetricsFlusher, DEFAULT_FLUSHER_INTERVAL};
 use engine::rocks::util::security::encrypted_env_from_cipher_file;
@@ -32,9 +34,10 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::Duration;
 use tikv_util::check_environment_variables;
+use tikv_util::collections::HashMap;
 use tikv_util::security::SecurityManager;
 use tikv_util::time::Monitor;
-use tikv_util::worker::FutureWorker;
+use tikv_util::worker::{FutureScheduler, FutureWorker};
 
 const RESERVED_OPEN_FDS: u64 = 1000;
 
@@ -85,6 +88,14 @@ pub fn run_tikv(mut config: TiKvConfig) {
 
     let _m = Monitor::default();
     run_raft_server(pd_client, &config, security_mgr);
+}
+
+impl FlowStatsReporter for FutureScheduler<PdTask> {
+    fn report_read_stats(&self, read_stats: HashMap<u64, FlowStatistics>) {
+        if let Err(e) = self.schedule(PdTask::ReadStats { read_stats }) {
+            error!("Failed to send read flow statistics"; "err" => ?e);
+        }
+    }
 }
 
 fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<SecurityManager>) {

--- a/src/coprocessor/readpool_impl.rs
+++ b/src/coprocessor/readpool_impl.rs
@@ -96,10 +96,6 @@ fn tls_flush<R: FlowStatsReporter>(reporter: &R) {
         mem::swap(&mut read_stats, &mut cop_metrics.local_cop_flow_stats);
 
         reporter.report_read_stats(read_stats);
-        // let result = pd_sender.schedule(PdTask::ReadStats { read_stats });
-        // if let Err(e) = result {
-        //     error!("Failed to send cop pool read flow statistics"; "err" => ?e);
-        // }
     });
 }
 

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -1,16 +1,14 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 mod client;
-mod metrics;
+pub mod metrics;
 mod util;
 
 mod config;
 pub mod errors;
-pub mod pd;
 pub use self::client::RpcClient;
 pub use self::config::Config;
 pub use self::errors::{Error, Result};
-pub use self::pd::{Runner as PdRunner, Task as PdTask};
 pub use self::util::validate_endpoints;
 pub use self::util::RECONNECT_INTERVAL_SEC;
 

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{cmp, u64};
 
-use crate::pd::{PdClient, PdTask};
+use crate::pd::PdClient;
 use crate::raftstore::{Error, Result};
 use engine::Engines;
 use engine::CF_RAFT;
@@ -51,6 +51,7 @@ use crate::raftstore::store::util::KeysInfoFormatter;
 use crate::raftstore::store::worker::{
     CleanupSSTTask, ConsistencyCheckTask, RaftlogGcTask, ReadDelegate, RegionTask, SplitCheckTask,
 };
+use crate::raftstore::store::PdTask;
 use crate::raftstore::store::{
     util, CasualMessage, Config, PeerMsg, PeerTicks, RaftCommand, SignificantMsg, SnapKey,
     SnapshotDeleter, StoreMsg,

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -22,7 +22,7 @@ use time::{self, Timespec};
 use tokio_threadpool::{Sender as ThreadPoolSender, ThreadPool};
 
 use crate::import::SSTImporter;
-use crate::pd::{PdClient, PdRunner, PdTask};
+use crate::pd::PdClient;
 use crate::raftstore::coprocessor::split_observer::SplitObserver;
 use crate::raftstore::coprocessor::{CoprocessorHost, RegionChangeEvent};
 use crate::raftstore::store::config::Config;
@@ -45,9 +45,10 @@ use crate::raftstore::store::transport::Transport;
 use crate::raftstore::store::util::is_initial_msg;
 use crate::raftstore::store::worker::{
     CleanupSSTRunner, CleanupSSTTask, CompactRunner, CompactTask, ConsistencyCheckRunner,
-    ConsistencyCheckTask, RaftlogGcRunner, RaftlogGcTask, ReadDelegate, RegionRunner, RegionTask,
-    SplitCheckRunner, SplitCheckTask,
+    ConsistencyCheckTask, PdRunner, RaftlogGcRunner, RaftlogGcTask, ReadDelegate, RegionRunner,
+    RegionTask, SplitCheckRunner, SplitCheckTask,
 };
+use crate::raftstore::store::PdTask;
 use crate::raftstore::store::{
     util, Callback, CasualMessage, PeerMsg, RaftCommand, SignificantMsg, SnapManager,
     SnapshotDeleter, StoreMsg, StoreTick,

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -42,8 +42,8 @@ pub use self::snap::{
     SnapManagerBuilder, Snapshot, SnapshotDeleter, SnapshotStatistics,
 };
 pub use self::transport::{CasualRouter, ProposalRouter, StoreRouter, Transport};
+pub use self::worker::PdTask;
 pub use self::worker::{KeyEntry, LocalReader, RegionTask};
-
 // Only used in tests
 #[cfg(test)]
 pub use self::worker::{SplitCheckRunner, SplitCheckTask};

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -28,7 +28,7 @@ use raft::{
 };
 use time::Timespec;
 
-use crate::pd::{PdTask, INVALID_ID};
+use crate::pd::INVALID_ID;
 use crate::raftstore::coprocessor::{CoprocessorHost, RegionChangeEvent};
 use crate::raftstore::store::fsm::store::PollContext;
 use crate::raftstore::store::fsm::{
@@ -36,6 +36,7 @@ use crate::raftstore::store::fsm::{
 };
 use crate::raftstore::store::keys::{enc_end_key, enc_start_key};
 use crate::raftstore::store::worker::{ReadDelegate, ReadProgress, RegionTask};
+use crate::raftstore::store::PdTask;
 use crate::raftstore::store::{keys, Callback, Config, ReadResponse, RegionSnapshot};
 use crate::raftstore::{Error, Result};
 use tikv_util::collections::HashMap;

--- a/src/raftstore/store/worker/mod.rs
+++ b/src/raftstore/store/worker/mod.rs
@@ -4,6 +4,7 @@ mod cleanup_sst;
 mod compact;
 mod consistency_check;
 mod metrics;
+mod pd;
 mod raftlog_gc;
 mod read;
 mod region;
@@ -12,6 +13,7 @@ mod split_check;
 pub use self::cleanup_sst::{Runner as CleanupSSTRunner, Task as CleanupSSTTask};
 pub use self::compact::{Runner as CompactRunner, Task as CompactTask};
 pub use self::consistency_check::{Runner as ConsistencyCheckRunner, Task as ConsistencyCheckTask};
+pub use self::pd::{Runner as PdRunner, Task as PdTask};
 pub use self::raftlog_gc::{Runner as RaftlogGcRunner, Task as RaftlogGcTask};
 pub use self::read::{LocalReader, Progress as ReadProgress, ReadDelegate};
 pub use self::region::{

--- a/src/raftstore/store/worker/pd.rs
+++ b/src/raftstore/store/worker/pd.rs
@@ -17,7 +17,7 @@ use kvproto::raft_serverpb::RaftMessage;
 use prometheus::local::LocalHistogram;
 use raft::eraftpb::ConfChangeType;
 
-use super::metrics::*;
+use crate::pd::metrics::*;
 use crate::pd::{Error, PdClient, RegionStat};
 use crate::raftstore::coprocessor::{get_region_approximate_keys, get_region_approximate_size};
 use crate::raftstore::store::cmd_resp::new_error;

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -8,10 +8,11 @@ use super::transport::RaftStoreRouter;
 use super::RaftKv;
 use super::Result;
 use crate::import::SSTImporter;
-use crate::pd::{Error as PdError, PdClient, PdTask, INVALID_ID};
+use crate::pd::{Error as PdError, PdClient, INVALID_ID};
 use crate::raftstore::coprocessor::dispatcher::CoprocessorHost;
 use crate::raftstore::store::fsm::store::StoreMeta;
 use crate::raftstore::store::fsm::{RaftBatchSystem, RaftRouter};
+use crate::raftstore::store::PdTask;
 use crate::raftstore::store::{
     self, initial_region, keys, Config as StoreConfig, SnapManager, Transport,
 };

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -10,6 +10,7 @@ use crate::storage::{Key, Value};
 use engine::rocks::TablePropertiesCollection;
 use engine::IterOption;
 use engine::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
+use tikv_util::collections::HashMap;
 use tikv_util::metrics::CRITICAL_ERROR;
 use tikv_util::{panic_when_unexpected_key_or_data, set_panic_mark};
 
@@ -194,6 +195,13 @@ pub struct CFStatistics {
 pub struct FlowStatistics {
     pub read_keys: usize,
     pub read_bytes: usize,
+}
+
+// Reports flow statistics to outside.
+pub trait FlowStatsReporter: Send + Clone + Sync + 'static {
+    // Reports read flow statistics, the argument `read_stats` is a hash map
+    // saves the flow statistics of different region.
+    fn report_read_stats(&self, read_stats: HashMap<u64, FlowStatistics>);
 }
 
 impl FlowStatistics {

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -201,6 +201,7 @@ pub struct FlowStatistics {
 pub trait FlowStatsReporter: Send + Clone + Sync + 'static {
     // Reports read flow statistics, the argument `read_stats` is a hash map
     // saves the flow statistics of different region.
+    // TODO: maybe we need to return a Result later?
     fn report_read_stats(&self, read_stats: HashMap<u64, FlowStatistics>);
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -40,8 +40,9 @@ pub use self::config::{BlockCacheConfig, Config, DEFAULT_DATA_DIR, DEFAULT_ROCKS
 pub use self::gc_worker::{AutoGCConfig, GCSafePointProvider};
 pub use self::kv::{
     destroy_tls_engine, set_tls_engine, with_tls_engine, CFStatistics, Cursor, CursorBuilder,
-    Engine, Error as EngineError, FlowStatistics, Iterator, Modify, RegionInfoProvider,
-    RocksEngine, ScanMode, Snapshot, Statistics, StatisticsSummary, TestEngineBuilder,
+    Engine, Error as EngineError, FlowStatistics, FlowStatsReporter, Iterator, Modify,
+    RegionInfoProvider, RocksEngine, ScanMode, Snapshot, Statistics, StatisticsSummary,
+    TestEngineBuilder,
 };
 use self::lock_manager::{DetectorScheduler, WaiterMgrScheduler};
 pub use self::mvcc::Scanner as StoreScanner;

--- a/src/storage/readpool_impl.rs
+++ b/src/storage/readpool_impl.rs
@@ -93,10 +93,6 @@ fn tls_flush<R: FlowStatsReporter>(reporter: &R) {
         mem::swap(&mut read_stats, &mut storage_metrics.local_read_flow_stats);
 
         reporter.report_read_stats(read_stats);
-        // let result = pd_sender.schedule(PdTask::ReadStats { read_stats });
-        // if let Err(e) = result {
-        //     error!("Failed to send read pool read flow statistics"; "err" => ?e);
-        // }
     });
 }
 

--- a/src/storage/readpool_impl.rs
+++ b/src/storage/readpool_impl.rs
@@ -7,12 +7,10 @@ use std::time::Duration;
 
 use prometheus::local::*;
 
-use crate::pd::PdTask;
 use crate::server::readpool::{self, Builder, Config, ReadPool};
 use crate::storage::kv::{destroy_tls_engine, set_tls_engine};
-use crate::storage::FlowStatistics;
+use crate::storage::{FlowStatistics, FlowStatsReporter};
 use tikv_util::collections::HashMap;
-use tikv_util::worker::FutureScheduler;
 
 use super::metrics::*;
 use super::Engine;
@@ -41,21 +39,21 @@ thread_local! {
     );
 }
 
-pub fn build_read_pool<E: Engine>(
+pub fn build_read_pool<E: Engine, R: FlowStatsReporter>(
     config: &readpool::Config,
-    pd_sender: FutureScheduler<PdTask>,
+    flow_reporter: R,
     engine: E,
 ) -> ReadPool {
-    let pd_sender2 = pd_sender.clone();
+    let flow_reporter2 = flow_reporter.clone();
     let engine = Arc::new(Mutex::new(engine));
 
     Builder::from_config(config)
         .name_prefix("store-read")
-        .on_tick(move || tls_flush(&pd_sender))
+        .on_tick(move || tls_flush(&flow_reporter))
         .after_start(move || set_tls_engine(engine.lock().unwrap().clone()))
         .before_stop(move || {
             destroy_tls_engine::<E>();
-            tls_flush(&pd_sender2)
+            tls_flush(&flow_reporter2)
         })
         .build()
 }
@@ -70,7 +68,7 @@ pub fn build_read_pool_for_test<E: Engine>(engine: E) -> ReadPool {
 }
 
 #[inline]
-fn tls_flush(pd_sender: &FutureScheduler<PdTask>) {
+fn tls_flush<R: FlowStatsReporter>(reporter: &R) {
     TLS_STORAGE_METRICS.with(|m| {
         let mut storage_metrics = m.borrow_mut();
         // Flush Prometheus metrics
@@ -94,10 +92,11 @@ fn tls_flush(pd_sender: &FutureScheduler<PdTask>) {
         let mut read_stats = HashMap::default();
         mem::swap(&mut read_stats, &mut storage_metrics.local_read_flow_stats);
 
-        let result = pd_sender.schedule(PdTask::ReadStats { read_stats });
-        if let Err(e) = result {
-            error!("Failed to send read pool read flow statistics"; "err" => ?e);
-        }
+        reporter.report_read_stats(read_stats);
+        // let result = pd_sender.schedule(PdTask::ReadStats { read_stats });
+        // if let Err(e) = result {
+        //     error!("Failed to send read pool read flow statistics"; "err" => ?e);
+        // }
     });
 }
 


### PR DESCRIPTION
Signed-off-by: siddontang <siddontang@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This PR tries to refactor PD module so we can move it to the independent crate later. Now, we do the following changes:

1. Let Coprocessor and Storage modules don't depend on PD module (IMO, they should not know PD), the two modules only send read flow statistics to PD, so we can extract this to a trait to decouple PD dependency. 
2. Let PD module not depend on raftstore module, the PD module is a base module that the raftstore should depend on it, not reverse. So we move PD task and runner to raftstore worker directly because only raftstore needs these. 

**Doing this can reduce the compiling time, in my local test with `make unportable_release`, the partial compiling time reduced from 10m12s to 9m27s.**

TODO:

1. Move PD module to the independent crate in `components`. 

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

Passing CI is fine.

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No