### PR TITLE
tikv-ctl: Fix region size command

### DIFF
--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -240,8 +240,8 @@ impl Debugger {
                         start_key,
                         end_key,
                         false,
-                        |_, v| {
-                            size += v.len();
+                        |k, v| {
+                            size += k.len() + v.len();
                             Ok(true)
                         }
                     ));
@@ -1735,7 +1735,7 @@ mod tests {
         assert_eq!(sizes.len(), 4);
         for (cf, size) in sizes {
             cfs.iter().find(|&&c| c == cf).unwrap();
-            assert!(size > 0);
+            assert_eq!(size, k.len() + v.len());
         }
     }
 


### PR DESCRIPTION
## What have you changed? (mandatory)
`region size` command doesn't consider the key's size.

## What are the type of the changes? (mandatory)
- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)
unit-test

## Does this PR affect documentation (docs) or release note? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No
