### PR TITLE
*: Update Tipb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,6 +1744,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf-build"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "protobuf-codegen"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,9 +2845,10 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#833c2ffd2fe7aad5224dd7c2b05fb24bc109e969"
+source = "git+https://github.com/pingcap/tipb.git#16909e03435eec96cc72f6ca18f85b4ef930a14e"
 dependencies = [
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-build 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3471,6 +3483,7 @@ dependencies = [
 "checksum prometheus-static-metric 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1d2b4a6a1ae793e7eb6773a5301a5a08e8929ea5517b677c93e57ce2d0973c02"
 "checksum protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "128a4f37a2df739a567a8685b17f54aa19b9c3c4a6a5b8731e97a419b3db451c"
 "checksum protobuf-build 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62f22aa4ee3b1c1eb7b02150fe7d10b38ef0898c44c401e99ba6d1ed53b3a420"
+"checksum protobuf-build 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "54f826711d2d848d4dbf8681ce3894ed893440fe263c674788525a628c18a092"
 "checksum protobuf-codegen 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3624c0feac7f512de21dbf8b574ae65c6573b1872d3878be951c0912eee4daca"
 "checksum quick-error 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ac990ab4e038dd8481a5e3fd00641067fcfc674ad663f3222752ed5284e05d4"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"

--- a/benches/coprocessor_executors/hash_aggr/mod.rs
+++ b/benches/coprocessor_executors/hash_aggr/mod.rs
@@ -3,7 +3,7 @@
 mod util;
 
 use tidb_query_datatype::FieldTypeTp;
-use tipb::expression::{ExprType, ScalarFuncSig};
+use tipb::{ExprType, ScalarFuncSig};
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::{BenchCase, FixtureBuilder};

--- a/benches/coprocessor_executors/hash_aggr/util.rs
+++ b/benches/coprocessor_executors/hash_aggr/util.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use tipb::executor::Aggregation;
-use tipb::expression::Expr;
+use tipb::Aggregation;
+use tipb::Expr;
 
 use tidb_query::batch::executors::BatchFastHashAggregationExecutor;
 use tidb_query::batch::executors::BatchSlowHashAggregationExecutor;

--- a/benches/coprocessor_executors/index_scan/util.rs
+++ b/benches/coprocessor_executors/index_scan/util.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use criterion::black_box;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::IndexScan;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::IndexScan;
 
 use test_coprocessor::*;
 use tidb_query::batch::executors::BatchIndexScanExecutor;

--- a/benches/coprocessor_executors/integrated/mod.rs
+++ b/benches/coprocessor_executors/integrated/mod.rs
@@ -4,7 +4,7 @@ mod fixture;
 mod util;
 
 use tidb_query_datatype::FieldTypeTp;
-use tipb::expression::{ExprType, ScalarFuncSig};
+use tipb::{ExprType, ScalarFuncSig};
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::executor_descriptor::*;

--- a/benches/coprocessor_executors/integrated/util.rs
+++ b/benches/coprocessor_executors/integrated/util.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use criterion::black_box;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::Executor as PbExecutor;
+use tipb::Executor as PbExecutor;
 
 use test_coprocessor::*;
 use tidb_query::execute_stats::ExecSummaryCollectorDisabled;

--- a/benches/coprocessor_executors/selection/mod.rs
+++ b/benches/coprocessor_executors/selection/mod.rs
@@ -3,7 +3,7 @@
 mod util;
 
 use tidb_query_datatype::FieldTypeTp;
-use tipb::expression::ScalarFuncSig;
+use tipb::ScalarFuncSig;
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::{BenchCase, FixtureBuilder};

--- a/benches/coprocessor_executors/selection/util.rs
+++ b/benches/coprocessor_executors/selection/util.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use tipb::expression::Expr;
+use tipb::Expr;
 
 use tidb_query::batch::executors::BatchSelectionExecutor;
 use tidb_query::batch::interface::BatchExecutor;

--- a/benches/coprocessor_executors/simple_aggr/mod.rs
+++ b/benches/coprocessor_executors/simple_aggr/mod.rs
@@ -3,7 +3,7 @@
 mod util;
 
 use tidb_query_datatype::FieldTypeTp;
-use tipb::expression::ExprType;
+use tipb::ExprType;
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::{BenchCase, FixtureBuilder};

--- a/benches/coprocessor_executors/simple_aggr/util.rs
+++ b/benches/coprocessor_executors/simple_aggr/util.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use tipb::expression::Expr;
+use tipb::Expr;
 
 use tidb_query::batch::executors::BatchSimpleAggregationExecutor;
 use tidb_query::batch::interface::BatchExecutor;

--- a/benches/coprocessor_executors/stream_aggr/mod.rs
+++ b/benches/coprocessor_executors/stream_aggr/mod.rs
@@ -3,7 +3,7 @@
 mod util;
 
 use tidb_query_datatype::FieldTypeTp;
-use tipb::expression::ExprType;
+use tipb::ExprType;
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::{BenchCase, FixtureBuilder};

--- a/benches/coprocessor_executors/stream_aggr/util.rs
+++ b/benches/coprocessor_executors/stream_aggr/util.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use tipb::expression::Expr;
+use tipb::Expr;
 
 use tidb_query::batch::executors::BatchStreamAggregationExecutor;
 use tidb_query::batch::interface::BatchExecutor;

--- a/benches/coprocessor_executors/table_scan/util.rs
+++ b/benches/coprocessor_executors/table_scan/util.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use criterion::black_box;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::TableScan;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::TableScan;
 
 use test_coprocessor::*;
 use tidb_query::batch::executors::BatchTableScanExecutor;

--- a/benches/coprocessor_executors/top_n/mod.rs
+++ b/benches/coprocessor_executors/top_n/mod.rs
@@ -3,7 +3,7 @@
 mod util;
 
 use tidb_query_datatype::FieldTypeTp;
-use tipb::expression::ScalarFuncSig;
+use tipb::ScalarFuncSig;
 use tipb_helper::ExprDefBuilder;
 
 use crate::util::{BenchCase, FixtureBuilder};

--- a/benches/coprocessor_executors/top_n/util.rs
+++ b/benches/coprocessor_executors/top_n/util.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use criterion::black_box;
 
-use tipb::expression::Expr;
+use tipb::Expr;
 
 use tidb_query::batch::executors::BatchTopNExecutor;
 use tidb_query::executor::{Executor, TopNExecutor};

--- a/benches/coprocessor_executors/util/executor_descriptor.rs
+++ b/benches/coprocessor_executors/util/executor_descriptor.rs
@@ -1,8 +1,8 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::executor::{ExecType, Executor as PbExecutor, TopN};
-use tipb::expression::{ByItem, Expr};
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::{ByItem, Expr};
+use tipb::{ExecType, Executor as PbExecutor, TopN};
 
 /// Builds a table scan executor descriptor.
 pub fn table_scan(columns_info: &[ColumnInfo]) -> PbExecutor {

--- a/benches/coprocessor_executors/util/fixture.rs
+++ b/benches/coprocessor_executors/util/fixture.rs
@@ -10,8 +10,8 @@ use rand_xorshift::XorShiftRng;
 use test_coprocessor::*;
 use tidb_query_datatype::{FieldTypeAccessor, FieldTypeTp};
 use tikv_util::collections::HashMap;
-use tipb::expression::FieldType;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::FieldType;
 
 use tidb_query::batch::interface::*;
 use tidb_query::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};

--- a/benches/coprocessor_executors/util/mod.rs
+++ b/benches/coprocessor_executors/util/mod.rs
@@ -11,7 +11,7 @@ pub use self::fixture::FixtureBuilder;
 use criterion::black_box;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::Executor as PbExecutor;
+use tipb::Executor as PbExecutor;
 
 use test_coprocessor::*;
 use tikv::coprocessor::RequestHandler;
@@ -34,7 +34,7 @@ pub fn build_dag_handler<TargetTxnStore: TxnStore + 'static>(
     store: &Store<RocksEngine>,
     enable_batch: bool,
 ) -> Box<dyn RequestHandler> {
-    use tipb::select::DAGRequest;
+    use tipb::DAGRequest;
 
     let mut dag = DAGRequest::default();
     dag.set_executors(executors.to_vec().into());

--- a/benches/coprocessor_executors/util/scan_bencher.rs
+++ b/benches/coprocessor_executors/util/scan_bencher.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
 
 use test_coprocessor::*;
 use tidb_query::batch::interface::*;

--- a/benches/misc/coprocessor/codec/chunk/arrow.rs
+++ b/benches/misc/coprocessor/codec/chunk/arrow.rs
@@ -9,7 +9,7 @@ use arrow::record_batch::RecordBatch;
 use tidb_query::codec::Datum;
 use tidb_query_datatype::prelude::*;
 use tidb_query_datatype::{FieldTypeFlag, FieldTypeTp};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 pub struct Chunk {
     pub data: RecordBatch,

--- a/benches/misc/coprocessor/codec/chunk/mod.rs
+++ b/benches/misc/coprocessor/codec/chunk/mod.rs
@@ -5,7 +5,7 @@ mod arrow;
 use test::Bencher;
 
 use tidb_query_datatype::{FieldTypeAccessor, FieldTypeTp};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use tidb_query::codec::chunk::{Chunk, ChunkEncoder};
 use tidb_query::codec::datum::Datum;

--- a/benches/misc/coprocessor/dag/expr/scalar.rs
+++ b/benches/misc/coprocessor/dag/expr/scalar.rs
@@ -1,7 +1,7 @@
 use std::usize;
 use test::{black_box, Bencher};
 use tikv_util::collections::HashMap;
-use tipb::expression::ScalarFuncSig;
+use tipb::ScalarFuncSig;
 
 fn get_scalar_args_with_match(sig: ScalarFuncSig) -> (usize, usize) {
     // Only select some functions to benchmark

--- a/components/test_coprocessor/src/column.rs
+++ b/components/test_coprocessor/src/column.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 use tidb_query::codec::{datum, Datum};
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
 
 pub const TYPE_VAR_CHAR: i32 = 1;
 pub const TYPE_LONG: i32 = 2;

--- a/components/test_coprocessor/src/dag.rs
+++ b/components/test_coprocessor/src/dag.rs
@@ -6,12 +6,10 @@ use protobuf::Message;
 
 use kvproto::coprocessor::{KeyRange, Request};
 use kvproto::kvrpcpb::Context;
-use tipb::executor::{
-    Aggregation, ExecType, Executor, IndexScan, Limit, Selection, TableScan, TopN,
-};
-use tipb::expression::{ByItem, Expr, ExprType};
-use tipb::schema::ColumnInfo;
-use tipb::select::{Chunk, DAGRequest};
+use tipb::ColumnInfo;
+use tipb::{Aggregation, ExecType, Executor, IndexScan, Limit, Selection, TableScan, TopN};
+use tipb::{ByItem, Expr, ExprType};
+use tipb::{Chunk, DAGRequest};
 
 use tidb_query::codec::{datum, Datum};
 use tikv::coprocessor::REQ_TYPE_DAG;

--- a/components/test_coprocessor/src/table.rs
+++ b/components/test_coprocessor/src/table.rs
@@ -5,7 +5,7 @@ use super::*;
 use std::collections::BTreeMap;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::schema::{self, ColumnInfo};
+use tipb::{self, ColumnInfo};
 
 use tidb_query::codec::table;
 use tikv_util::codec::number::NumberEncoder;
@@ -38,9 +38,9 @@ impl Table {
         idx.map(|idx| &self.columns[*idx].1)
     }
 
-    /// Create `schema::TableInfo` from current table.
-    pub fn table_info(&self) -> schema::TableInfo {
-        let mut info = schema::TableInfo::default();
+    /// Create `tipb::TableInfo` from current table.
+    pub fn table_info(&self) -> tipb::TableInfo {
+        let mut info = tipb::TableInfo::default();
         info.set_table_id(self.id);
         info.set_columns(self.columns_info().into());
         info
@@ -54,9 +54,9 @@ impl Table {
             .collect()
     }
 
-    /// Create `schema::IndexInfo` from current table.
-    pub fn index_info(&self, index: i64, store_handle: bool) -> schema::IndexInfo {
-        let mut idx_info = schema::IndexInfo::default();
+    /// Create `tipb::IndexInfo` from current table.
+    pub fn index_info(&self, index: i64, store_handle: bool) -> tipb::IndexInfo {
+        let mut idx_info = tipb::IndexInfo::default();
         idx_info.set_table_id(self.id);
         idx_info.set_index_id(index);
         let mut has_pk = false;

--- a/components/test_coprocessor/src/util.rs
+++ b/components/test_coprocessor/src/util.rs
@@ -6,8 +6,8 @@ use futures::{Future, Stream};
 use protobuf::Message;
 
 use kvproto::coprocessor::{Request, Response};
-use tipb::schema::ColumnInfo;
-use tipb::select::{SelectResponse, StreamResponse};
+use tipb::ColumnInfo;
+use tipb::{SelectResponse, StreamResponse};
 
 use tikv::coprocessor::Endpoint;
 use tikv::storage::Engine;

--- a/components/tidb_query/src/aggr_fn/impl_avg.rs
+++ b/components/tidb_query/src/aggr_fn/impl_avg.rs
@@ -3,7 +3,7 @@
 use tidb_query_codegen::AggrFunction;
 use tidb_query_datatype::builder::FieldTypeBuilder;
 use tidb_query_datatype::{EvalType, FieldTypeFlag, FieldTypeTp};
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use super::summable::Summable;
 use crate::codec::data_type::*;

--- a/components/tidb_query/src/aggr_fn/impl_bit_op.rs
+++ b/components/tidb_query/src/aggr_fn/impl_bit_op.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 
 use tidb_query_codegen::AggrFunction;
 use tidb_query_datatype::{EvalType, FieldTypeAccessor};
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use crate::codec::data_type::*;
 use crate::codec::mysql::Tz;

--- a/components/tidb_query/src/aggr_fn/impl_count.rs
+++ b/components/tidb_query/src/aggr_fn/impl_count.rs
@@ -3,7 +3,7 @@
 use tidb_query_codegen::AggrFunction;
 use tidb_query_datatype::builder::FieldTypeBuilder;
 use tidb_query_datatype::{FieldTypeFlag, FieldTypeTp};
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use crate::codec::data_type::*;
 use crate::codec::mysql::Tz;

--- a/components/tidb_query/src/aggr_fn/impl_first.rs
+++ b/components/tidb_query/src/aggr_fn/impl_first.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use tidb_query_codegen::AggrFunction;
 use tidb_query_datatype::EvalType;
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use crate::codec::data_type::*;
 use crate::codec::mysql::Tz;

--- a/components/tidb_query/src/aggr_fn/impl_max_min.rs
+++ b/components/tidb_query/src/aggr_fn/impl_max_min.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 
 use tidb_query_codegen::AggrFunction;
 use tidb_query_datatype::{EvalType, FieldTypeAccessor};
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use crate::codec::data_type::*;
 use crate::codec::mysql::Tz;

--- a/components/tidb_query/src/aggr_fn/impl_sum.rs
+++ b/components/tidb_query/src/aggr_fn/impl_sum.rs
@@ -2,7 +2,7 @@
 
 use tidb_query_codegen::AggrFunction;
 use tidb_query_datatype::EvalType;
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use super::summable::Summable;
 use crate::codec::data_type::*;

--- a/components/tidb_query/src/aggr_fn/parser.rs
+++ b/components/tidb_query/src/aggr_fn/parser.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use crate::aggr_fn::impl_bit_op::*;
 use crate::aggr_fn::impl_max_min::*;

--- a/components/tidb_query/src/aggr_fn/util.rs
+++ b/components/tidb_query/src/aggr_fn/util.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 
 use tidb_query_datatype::builder::FieldTypeBuilder;
 use tidb_query_datatype::{EvalType, FieldTypeAccessor, FieldTypeFlag, FieldTypeTp};
-use tipb::expression::{Expr, FieldType};
+use tipb::{Expr, FieldType};
 
 use crate::rpn_expr::impl_cast::get_cast_fn_rpn_node;
 use crate::rpn_expr::{RpnExpression, RpnExpressionBuilder};

--- a/components/tidb_query/src/batch/executors/fast_hash_aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/fast_hash_aggr_executor.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use tidb_query_datatype::{EvalType, FieldTypeAccessor};
 use tikv_util::collections::HashMap;
-use tipb::executor::Aggregation;
-use tipb::expression::{Expr, FieldType};
+use tipb::Aggregation;
+use tipb::{Expr, FieldType};
 
 use crate::aggr_fn::*;
 use crate::batch::executors::util::aggr_executor::*;
@@ -351,7 +351,7 @@ mod tests {
     use super::*;
 
     use tidb_query_datatype::FieldTypeTp;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::batch::executors::util::aggr_executor::tests::*;
     use crate::batch::executors::util::mock_executor::MockExecutor;
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn test_it_works_integration() {
-        use tipb::expression::ExprType;
+        use tipb::ExprType;
         use tipb_helper::ExprDefBuilder;
 
         // This test creates a hash aggregation executor with the following aggregate functions:

--- a/components/tidb_query/src/batch/executors/index_scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/index_scan_executor.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 
 use kvproto::coprocessor::KeyRange;
 use tidb_query_datatype::EvalType;
-use tipb::executor::IndexScan;
-use tipb::expression::FieldType;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::FieldType;
+use tipb::IndexScan;
 
 use super::util::scan_executor::*;
 use crate::batch::interface::*;
@@ -224,7 +224,7 @@ mod tests {
 
     use kvproto::coprocessor::KeyRange;
     use tidb_query_datatype::{FieldTypeAccessor, FieldTypeTp};
-    use tipb::schema::ColumnInfo;
+    use tipb::ColumnInfo;
 
     use crate::codec::data_type::*;
     use crate::codec::mysql::Tz;

--- a/components/tidb_query/src/batch/executors/limit_executor.rs
+++ b/components/tidb_query/src/batch/executors/limit_executor.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use crate::batch::interface::*;
 use crate::Result;

--- a/components/tidb_query/src/batch/executors/selection_executor.rs
+++ b/components/tidb_query/src/batch/executors/selection_executor.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 
-use tipb::executor::Selection;
-use tipb::expression::Expr;
-use tipb::expression::FieldType;
+use tipb::Expr;
+use tipb::FieldType;
+use tipb::Selection;
 
 use super::super::interface::*;
 use crate::codec::data_type::*;

--- a/components/tidb_query/src/batch/executors/simple_aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/simple_aggr_executor.rs
@@ -5,8 +5,8 @@
 
 use std::sync::Arc;
 
-use tipb::executor::Aggregation;
-use tipb::expression::{Expr, FieldType};
+use tipb::Aggregation;
+use tipb::{Expr, FieldType};
 
 use crate::aggr_fn::*;
 use crate::batch::executors::util::aggr_executor::*;
@@ -460,7 +460,7 @@ mod tests {
 
     #[test]
     fn test_it_works_integration() {
-        use tipb::expression::ExprType;
+        use tipb::ExprType;
         use tipb_helper::ExprDefBuilder;
 
         // This test creates a simple aggregation executor with the following aggregate functions:

--- a/components/tidb_query/src/batch/executors/slow_hash_aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/slow_hash_aggr_executor.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use tikv_util::collections::HashMap;
 use tikv_util::collections::HashMapEntry;
-use tipb::executor::Aggregation;
-use tipb::expression::{Expr, FieldType};
+use tipb::Aggregation;
+use tipb::{Expr, FieldType};
 
 use crate::aggr_fn::*;
 use crate::batch::executors::util::aggr_executor::*;
@@ -379,7 +379,7 @@ mod tests {
     use super::*;
 
     use tidb_query_datatype::FieldTypeTp;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::batch::executors::util::aggr_executor::tests::*;
     use crate::codec::data_type::*;
@@ -389,7 +389,7 @@ mod tests {
 
     #[test]
     fn test_it_works_integration() {
-        use tipb::expression::ExprType;
+        use tipb::ExprType;
         use tipb_helper::ExprDefBuilder;
 
         // This test creates a hash aggregation executor with the following aggregate functions:

--- a/components/tidb_query/src/batch/executors/stream_aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/stream_aggr_executor.rs
@@ -4,8 +4,8 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 use tidb_query_datatype::{EvalType, FieldTypeAccessor};
-use tipb::executor::Aggregation;
-use tipb::expression::{Expr, FieldType};
+use tipb::Aggregation;
+use tipb::{Expr, FieldType};
 
 use crate::aggr_fn::*;
 use crate::batch::executors::util::aggr_executor::*;
@@ -406,7 +406,7 @@ mod tests {
     use super::*;
 
     use tidb_query_datatype::FieldTypeTp;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::batch::executors::util::mock_executor::MockExecutor;
     use crate::expr::EvalWarnings;
@@ -415,7 +415,7 @@ mod tests {
 
     #[test]
     fn test_it_works_integration() {
-        use tipb::expression::ExprType;
+        use tipb::ExprType;
         use tipb_helper::ExprDefBuilder;
 
         // This test creates a stream aggregation executor with the following aggregate functions:

--- a/components/tidb_query/src/batch/executors/table_scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/table_scan_executor.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 use kvproto::coprocessor::KeyRange;
 use tidb_query_datatype::{EvalType, FieldTypeAccessor};
 use tikv_util::collections::HashMap;
-use tipb::executor::TableScan;
-use tipb::expression::FieldType;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::FieldType;
+use tipb::TableScan;
 
 use super::util::scan_executor::*;
 use crate::batch::interface::*;
@@ -302,8 +302,8 @@ mod tests {
 
     use kvproto::coprocessor::KeyRange;
     use tidb_query_datatype::{EvalType, FieldTypeAccessor, FieldTypeTp};
-    use tipb::expression::FieldType;
-    use tipb::schema::ColumnInfo;
+    use tipb::ColumnInfo;
+    use tipb::FieldType;
 
     use crate::codec::batch::LazyBatchColumnVec;
     use crate::codec::data_type::*;

--- a/components/tidb_query/src/batch/executors/top_n_executor.rs
+++ b/components/tidb_query/src/batch/executors/top_n_executor.rs
@@ -6,8 +6,7 @@ use std::ptr::NonNull;
 
 use servo_arc::Arc;
 
-use tipb::executor::TopN;
-use tipb::expression::{Expr, FieldType};
+use tipb::{Expr, FieldType, TopN};
 
 use crate::batch::executors::util::*;
 use crate::batch::interface::*;

--- a/components/tidb_query/src/batch/executors/util/aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/util/aggr_executor.rs
@@ -30,7 +30,7 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 use tidb_query_datatype::{EvalType, FieldTypeAccessor};
-use tipb::expression::{Expr, FieldType};
+use tipb::{Expr, FieldType};
 
 use crate::aggr_fn::*;
 use crate::batch::interface::*;

--- a/components/tidb_query/src/batch/executors/util/mock_executor.rs
+++ b/components/tidb_query/src/batch/executors/util/mock_executor.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use crate::batch::interface::*;
 

--- a/components/tidb_query/src/batch/executors/util/mod.rs
+++ b/components/tidb_query/src/batch/executors/util/mod.rs
@@ -7,7 +7,7 @@ pub mod mock_executor;
 pub mod scan_executor;
 
 use tikv_util::{erase_lifetime, erase_lifetime_mut};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use crate::codec::batch::LazyBatchColumnVec;
 use crate::codec::mysql::Tz;

--- a/components/tidb_query/src/batch/executors/util/scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/util/scan_executor.rs
@@ -1,8 +1,8 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use kvproto::coprocessor::KeyRange;
-use tipb::expression::FieldType;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::FieldType;
 
 use crate::batch::interface::*;
 use crate::codec::batch::LazyBatchColumnVec;

--- a/components/tidb_query/src/batch/interface.rs
+++ b/components/tidb_query/src/batch/interface.rs
@@ -6,7 +6,7 @@
 
 pub use super::super::execute_stats::{ExecSummaryCollector, ExecuteStats, WithSummaryCollector};
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use crate::codec::batch::LazyBatchColumnVec;
 use crate::expr::EvalWarnings;

--- a/components/tidb_query/src/batch/runner.rs
+++ b/components/tidb_query/src/batch/runner.rs
@@ -3,8 +3,8 @@
 use std::sync::Arc;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::{self, ExecType, ExecutorExecutionSummary};
-use tipb::select::{Chunk, DAGRequest, SelectResponse};
+use tipb::{self, ExecType, ExecutorExecutionSummary};
+use tipb::{Chunk, DAGRequest, SelectResponse};
 
 use tikv_util::deadline::Deadline;
 
@@ -52,7 +52,7 @@ pub struct BatchExecutorsRunner<SS> {
 impl BatchExecutorsRunner<()> {
     /// Given a list of executor descriptors and checks whether all executor descriptors can
     /// be used to build batch executors.
-    pub fn check_supported(exec_descriptors: &[executor::Executor]) -> Result<()> {
+    pub fn check_supported(exec_descriptors: &[tipb::Executor]) -> Result<()> {
         for ed in exec_descriptors {
             match ed.get_tp() {
                 ExecType::TypeTableScan => {
@@ -105,7 +105,7 @@ impl BatchExecutorsRunner<()> {
 }
 
 pub fn build_executors<S: Storage + 'static, C: ExecSummaryCollector + 'static>(
-    executor_descriptors: Vec<executor::Executor>,
+    executor_descriptors: Vec<tipb::Executor>,
     storage: S,
     ranges: Vec<KeyRange>,
     config: Arc<EvalConfig>,

--- a/components/tidb_query/src/codec/batch/lazy_column.rs
+++ b/components/tidb_query/src/codec/batch/lazy_column.rs
@@ -3,7 +3,7 @@
 use std::convert::TryFrom;
 
 use tidb_query_datatype::{EvalType, FieldTypeAccessor};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::BufferVec;
 use crate::codec::data_type::VectorValue;

--- a/components/tidb_query/src/codec/batch/lazy_column_vec.rs
+++ b/components/tidb_query/src/codec/batch/lazy_column_vec.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::LazyBatchColumn;
 use crate::codec::data_type::VectorValue;

--- a/components/tidb_query/src/codec/chunk/chunk.rs
+++ b/components/tidb_query/src/codec/chunk/chunk.rs
@@ -6,7 +6,7 @@ use crate::codec::Datum;
 use std::io::Write;
 #[cfg(test)]
 use tikv_util::codec::BytesSlice;
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 /// `Chunk` stores multiple rows of data in Apache Arrow format.
 /// See https://arrow.apache.org/docs/memory_layout.html

--- a/components/tidb_query/src/codec/chunk/column.rs
+++ b/components/tidb_query/src/codec/chunk/column.rs
@@ -388,7 +388,7 @@ mod tests {
     use crate::codec::datum::Datum;
     use crate::codec::mysql::*;
     use std::{f64, u64};
-    use tipb::expression::FieldType;
+    use tipb::FieldType;
 
     #[test]
     fn test_column_i64() {

--- a/components/tidb_query/src/codec/chunk/mod.rs
+++ b/components/tidb_query/src/codec/chunk/mod.rs
@@ -11,7 +11,7 @@ pub use self::chunk::{Chunk, ChunkEncoder};
 mod tests {
     use tidb_query_datatype::FieldTypeAccessor;
     use tidb_query_datatype::FieldTypeTp;
-    use tipb::expression::FieldType;
+    use tipb::FieldType;
 
     pub fn field_type(tp: FieldTypeTp) -> FieldType {
         let mut fp = FieldType::default();

--- a/components/tidb_query/src/codec/data_type/vector.rs
+++ b/components/tidb_query/src/codec/data_type/vector.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use tidb_query_datatype::{EvalType, FieldTypeAccessor, FieldTypeFlag};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::*;
 use crate::codec::data_type::scalar::ScalarValueRef;

--- a/components/tidb_query/src/codec/error.rs
+++ b/components/tidb_query/src/codec/error.rs
@@ -9,8 +9,7 @@ use std::num::ParseFloatError;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 use std::{error, str};
-use tipb::expression::ScalarFuncSig;
-use tipb::select;
+use tipb::{self, ScalarFuncSig};
 
 pub const ERR_UNKNOWN: i32 = 1105;
 pub const ERR_REGEXP: i32 = 1139;
@@ -135,9 +134,9 @@ impl Error {
     }
 }
 
-impl From<Error> for select::Error {
-    fn from(error: Error) -> select::Error {
-        let mut err = select::Error::default();
+impl From<Error> for tipb::Error {
+    fn from(error: Error) -> tipb::Error {
+        let mut err = tipb::Error::default();
         err.set_code(error.code());
         err.set_msg(format!("{:?}", error));
         err

--- a/components/tidb_query/src/codec/raw_datum.rs
+++ b/components/tidb_query/src/codec/raw_datum.rs
@@ -4,7 +4,7 @@
 
 use tidb_query_datatype::{FieldTypeAccessor, FieldTypeTp};
 use tikv_util::codec::{bytes, number};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::data_type::*;
 use crate::codec::datum;

--- a/components/tidb_query/src/codec/table.rs
+++ b/components/tidb_query/src/codec/table.rs
@@ -7,7 +7,7 @@ use std::{cmp, u8};
 use kvproto::coprocessor::KeyRange;
 use tidb_query_datatype::prelude::*;
 use tidb_query_datatype::FieldTypeTp;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
 
 use super::mysql::{Duration, Time};
 use super::{datum, Datum, Error, Result};
@@ -410,7 +410,7 @@ pub fn cut_idx_key(key: Vec<u8>, col_ids: &[i64]) -> Result<(RowColsDict, Option
 mod tests {
     use std::i64;
 
-    use tipb::schema::ColumnInfo;
+    use tipb::ColumnInfo;
 
     use crate::codec::datum::{self, Datum};
     use tikv_util::collections::{HashMap, HashSet};

--- a/components/tidb_query/src/executor/aggregate.rs
+++ b/components/tidb_query/src/executor/aggregate.rs
@@ -1,7 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::cmp::Ordering;
-use tipb::expression::ExprType;
+use tipb::ExprType;
 
 use crate::codec::mysql::Decimal;
 use crate::codec::Datum;

--- a/components/tidb_query/src/executor/aggregation.rs
+++ b/components/tidb_query/src/executor/aggregation.rs
@@ -4,8 +4,7 @@ use std::cmp::Ordering;
 use std::mem;
 use std::sync::Arc;
 
-use tipb::executor::Aggregation;
-use tipb::expression::{Expr, ExprType};
+use tipb::{Aggregation, Expr, ExprType};
 
 use indexmap::map::Entry as OrderMapEntry;
 use indexmap::IndexMap as OrderMap;
@@ -408,8 +407,8 @@ mod tests {
     use std::i64;
 
     use tidb_query_datatype::FieldTypeTp;
-    use tipb::expression::{Expr, ExprType};
-    use tipb::schema::ColumnInfo;
+    use tipb::ColumnInfo;
+    use tipb::{Expr, ExprType};
 
     use super::super::index_scan::tests::IndexTestWrapper;
     use super::super::index_scan::IndexScanExecutor;

--- a/components/tidb_query/src/executor/index_scan.rs
+++ b/components/tidb_query/src/executor/index_scan.rs
@@ -3,8 +3,8 @@
 use std::sync::Arc;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::executor::IndexScan;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::IndexScan;
 
 use super::{scan::InnerExecutor, Row, ScanExecutor, ScanExecutorOptions};
 use crate::codec::table;
@@ -118,7 +118,7 @@ pub mod tests {
     use std::i64;
 
     use tidb_query_datatype::FieldTypeTp;
-    use tipb::schema::ColumnInfo;
+    use tipb::ColumnInfo;
 
     use super::super::tests::*;
     use super::super::Executor;

--- a/components/tidb_query/src/executor/limit.rs
+++ b/components/tidb_query/src/executor/limit.rs
@@ -1,6 +1,6 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::executor::Limit;
+use tipb::Limit;
 
 use crate::execute_stats::ExecuteStats;
 use crate::executor::{Executor, Row};

--- a/components/tidb_query/src/executor/mod.rs
+++ b/components/tidb_query/src/executor/mod.rs
@@ -26,8 +26,8 @@ use tidb_query_datatype::prelude::*;
 use tidb_query_datatype::FieldTypeFlag;
 use tikv_util::codec::number;
 use tikv_util::collections::HashSet;
-use tipb::expression::{Expr, ExprType};
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::{Expr, ExprType};
 
 use crate::codec::datum::{self, Datum, DatumEncoder};
 use crate::codec::table::{self, RowColsDict};
@@ -358,9 +358,9 @@ pub mod tests {
     use std::collections::HashMap;
     use tidb_query_datatype::{FieldTypeAccessor, FieldTypeTp};
     use tikv_util::codec::number::NumberEncoder;
-    use tipb::executor::TableScan;
-    use tipb::expression::{Expr, ExprType};
-    use tipb::schema::ColumnInfo;
+    use tipb::ColumnInfo;
+    use tipb::TableScan;
+    use tipb::{Expr, ExprType};
 
     pub fn build_expr(tp: ExprType, id: Option<i64>, child: Option<Expr>) -> Expr {
         let mut expr = Expr::default();

--- a/components/tidb_query/src/executor/runner.rs
+++ b/components/tidb_query/src/executor/runner.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use kvproto::coprocessor::KeyRange;
 use protobuf::Message;
-use tipb::executor::{self, ExecType, ExecutorExecutionSummary};
-use tipb::select::{Chunk, DAGRequest, SelectResponse, StreamResponse};
+use tipb::{self, ExecType, ExecutorExecutionSummary};
+use tipb::{Chunk, DAGRequest, SelectResponse, StreamResponse};
 
 use tikv_util::deadline::Deadline;
 
@@ -29,7 +29,7 @@ pub struct ExecutorsRunner<SS> {
 ///
 /// Normal executors iterate rows one by one.
 pub fn build_executors<S: Storage + 'static, C: ExecSummaryCollector + 'static>(
-    exec_descriptors: Vec<executor::Executor>,
+    exec_descriptors: Vec<tipb::Executor>,
     storage: S,
     ranges: Vec<KeyRange>,
     ctx: Arc<EvalConfig>,
@@ -106,7 +106,7 @@ pub fn build_executors<S: Storage + 'static, C: ExecSummaryCollector + 'static>(
 ///
 /// The inner-most executor must be a table scan executor or an index scan executor.
 fn build_first_executor<S: Storage + 'static, C: ExecSummaryCollector + 'static>(
-    mut first: executor::Executor,
+    mut first: tipb::Executor,
     storage: S,
     ranges: Vec<KeyRange>,
     is_streaming: bool,

--- a/components/tidb_query/src/executor/scan.rs
+++ b/components/tidb_query/src/executor/scan.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use kvproto::coprocessor::KeyRange;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
 
 use super::{Executor, Row};
 use crate::codec::table;

--- a/components/tidb_query/src/executor/selection.rs
+++ b/components/tidb_query/src/executor/selection.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use tipb::executor::Selection;
+use tipb::Selection;
 
 use super::{Executor, ExprColumnRefVisitor, Row};
 use crate::execute_stats::ExecuteStats;
@@ -88,7 +88,7 @@ mod tests {
 
     use tidb_query_datatype::FieldTypeTp;
     use tikv_util::codec::number::NumberEncoder;
-    use tipb::expression::{Expr, ExprType, ScalarFuncSig};
+    use tipb::{Expr, ExprType, ScalarFuncSig};
 
     use super::super::tests::*;
     use super::*;

--- a/components/tidb_query/src/executor/table_scan.rs
+++ b/components/tidb_query/src/executor/table_scan.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use kvproto::coprocessor::KeyRange;
 use tikv_util::collections::HashSet;
-use tipb::executor::TableScan;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::TableScan;
 
 use super::{scan::InnerExecutor, Row, ScanExecutor, ScanExecutorOptions};
 use crate::codec::table;
@@ -75,7 +75,7 @@ mod tests {
     use std::i64;
 
     use kvproto::coprocessor::KeyRange;
-    use tipb::{executor::TableScan, schema::ColumnInfo};
+    use tipb::{ColumnInfo, TableScan};
 
     use super::super::tests::*;
     use super::super::Executor;

--- a/components/tidb_query/src/executor/topn.rs
+++ b/components/tidb_query/src/executor/topn.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::usize;
 use std::vec::IntoIter;
 
-use tipb::executor::TopN;
-use tipb::expression::ByItem;
+use tipb::ByItem;
+use tipb::TopN;
 
 use super::topn_heap::TopNHeap;
 use super::{Executor, ExprColumnRefVisitor, Row};
@@ -155,7 +155,7 @@ pub mod tests {
     use tidb_query_datatype::FieldTypeTp;
     use tikv_util::codec::number::NumberEncoder;
     use tikv_util::collections::HashMap;
-    use tipb::expression::{Expr, ExprType};
+    use tipb::{Expr, ExprType};
 
     use crate::codec::table::RowColsDict;
     use crate::codec::Datum;

--- a/components/tidb_query/src/executor/topn_heap.rs
+++ b/components/tidb_query/src/executor/topn_heap.rs
@@ -5,7 +5,7 @@ use std::cmp::{self, Ordering};
 use std::collections::BinaryHeap;
 use std::sync::Arc;
 use std::usize;
-use tipb::expression::ByItem;
+use tipb::ByItem;
 
 use crate::codec::datum::Datum;
 use crate::executor::OriginCols;
@@ -173,7 +173,7 @@ mod tests {
     use std::cell::RefCell;
     use std::sync::Arc;
 
-    use tipb::expression::{ByItem, Expr, ExprType};
+    use tipb::{ByItem, Expr, ExprType};
 
     use crate::codec::table::RowColsDict;
     use crate::codec::Datum;

--- a/components/tidb_query/src/expr/builtin_arithmetic.rs
+++ b/components/tidb_query/src/expr/builtin_arithmetic.rs
@@ -295,7 +295,7 @@ mod tests {
     use std::{f64, i64, u64};
 
     use tidb_query_datatype::FieldTypeFlag;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::codec::error::ERR_DIVISION_BY_ZERO;
     use crate::codec::mysql::Decimal;

--- a/components/tidb_query/src/expr/builtin_cast.rs
+++ b/components/tidb_query/src/expr/builtin_cast.rs
@@ -761,7 +761,7 @@ mod tests {
     use std::{i64, u64};
 
     use tidb_query_datatype::{self, FieldTypeAccessor, FieldTypeFlag, FieldTypeTp};
-    use tipb::expression::{Expr, FieldType, ScalarFuncSig};
+    use tipb::{Expr, FieldType, ScalarFuncSig};
 
     use chrono::Utc;
 

--- a/components/tidb_query/src/expr/builtin_compare.rs
+++ b/components/tidb_query/src/expr/builtin_compare.rs
@@ -477,7 +477,7 @@ mod tests {
     use crate::expr::{EvalContext, Expression, Flag, SqlMode};
     use std::sync::Arc;
     use std::{i64, u64};
-    use tipb::expression::{Expr, ExprType, ScalarFuncSig};
+    use tipb::{Expr, ExprType, ScalarFuncSig};
 
     #[test]
     fn test_cmp_i64_with_unsigned_flag() {

--- a/components/tidb_query/src/expr/builtin_control.rs
+++ b/components/tidb_query/src/expr/builtin_control.rs
@@ -218,7 +218,7 @@ impl ScalarFunc {
 
 #[cfg(test)]
 mod tests {
-    use tipb::expression::{Expr, ExprType, ScalarFuncSig};
+    use tipb::{Expr, ExprType, ScalarFuncSig};
 
     use crate::codec::mysql::{Duration, Json, Time};
     use crate::codec::Datum;

--- a/components/tidb_query/src/expr/builtin_encryption.rs
+++ b/components/tidb_query/src/expr/builtin_encryption.rs
@@ -172,7 +172,7 @@ mod tests {
     use crate::expr::tests::{datum_expr, eval_func, scalar_func_expr};
     use crate::expr::{EvalContext, Expression};
     use hex;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_md5() {

--- a/components/tidb_query/src/expr/builtin_json.rs
+++ b/components/tidb_query/src/expr/builtin_json.rs
@@ -192,7 +192,7 @@ mod tests {
     use crate::codec::Datum;
     use crate::expr::tests::{datum_expr, make_null_datums, scalar_func_expr};
     use crate::expr::{EvalContext, Expression};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_json_type() {

--- a/components/tidb_query/src/expr/builtin_like.rs
+++ b/components/tidb_query/src/expr/builtin_like.rs
@@ -43,7 +43,7 @@ mod tests {
     use crate::codec::Datum;
     use crate::expr::tests::{datum_expr, scalar_func_expr};
     use crate::expr::{EvalContext, Expression};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_like() {

--- a/components/tidb_query/src/expr/builtin_math.rs
+++ b/components/tidb_query/src/expr/builtin_math.rs
@@ -558,7 +558,7 @@ mod tests {
     use std::{f64, i64, u64};
 
     use tidb_query_datatype::{self, FieldTypeAccessor, FieldTypeFlag};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::codec::Datum;
     use crate::expr::tests::{check_overflow, eval_func, eval_func_with, str2dec};

--- a/components/tidb_query/src/expr/builtin_miscellaneous.rs
+++ b/components/tidb_query/src/expr/builtin_miscellaneous.rs
@@ -228,7 +228,7 @@ mod tests {
     use crate::codec::Datum;
     use crate::expr::tests::{datum_expr, scalar_func_expr};
     use crate::expr::{EvalContext, Expression};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     macro_rules! test_any_value {
         ($cases: expr, $case_type: ty, Datum::$type_of_datum: ident, $maker_for_case_ele: expr, ScalarFuncSig::$sig_of_scalar_func: ident) => {{

--- a/components/tidb_query/src/expr/builtin_op.rs
+++ b/components/tidb_query/src/expr/builtin_op.rs
@@ -189,7 +189,7 @@ mod tests {
     use crate::expr::tests::{check_overflow, datum_expr, scalar_func_expr, str2dec};
     use crate::expr::{EvalContext, Expression};
     use std::i64;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_logic_op() {
@@ -358,11 +358,11 @@ mod tests {
     #[test]
     fn test_unary_op() {
         let tests = vec![
-            (ScalarFuncSig::UnaryNot, Datum::I64(1), Some(0)),
-            (ScalarFuncSig::UnaryNot, Datum::I64(0), Some(1)),
-            (ScalarFuncSig::UnaryNot, Datum::I64(123), Some(0)),
-            (ScalarFuncSig::UnaryNot, Datum::I64(-123), Some(0)),
-            (ScalarFuncSig::UnaryNot, Datum::Null, None),
+            (ScalarFuncSig::UnaryNotInt, Datum::I64(1), Some(0)),
+            (ScalarFuncSig::UnaryNotInt, Datum::I64(0), Some(1)),
+            (ScalarFuncSig::UnaryNotInt, Datum::I64(123), Some(0)),
+            (ScalarFuncSig::UnaryNotInt, Datum::I64(-123), Some(0)),
+            (ScalarFuncSig::UnaryNotInt, Datum::Null, None),
             (ScalarFuncSig::RealIsTrue, Datum::F64(0.25), Some(1)),
             (ScalarFuncSig::RealIsTrue, Datum::F64(0.0), Some(0)),
             (ScalarFuncSig::RealIsTrue, Datum::Null, Some(0)),

--- a/components/tidb_query/src/expr/builtin_other.rs
+++ b/components/tidb_query/src/expr/builtin_other.rs
@@ -37,7 +37,7 @@ mod tests {
     use crate::expr::{EvalConfig, EvalContext, Expression};
     use std::str::FromStr;
     use std::sync::Arc;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_bit_count() {

--- a/components/tidb_query/src/expr/builtin_string.rs
+++ b/components/tidb_query/src/expr/builtin_string.rs
@@ -1063,7 +1063,7 @@ mod tests {
     use crate::codec::mysql::charset::CHARSET_BIN;
     use std::{f64, i64};
     use tidb_query_datatype::{Collation, FieldTypeFlag, FieldTypeTp, MAX_BLOB_WIDTH};
-    use tipb::expression::{Expr, ScalarFuncSig};
+    use tipb::{Expr, ScalarFuncSig};
 
     use crate::codec::Datum;
     use crate::expr::tests::{

--- a/components/tidb_query/src/expr/builtin_time.rs
+++ b/components/tidb_query/src/expr/builtin_time.rs
@@ -584,7 +584,7 @@ fn month_to_period(month: u64) -> u64 {
 mod tests {
     use std::sync::Arc;
 
-    use tipb::expression::{Expr, ScalarFuncSig};
+    use tipb::{Expr, ScalarFuncSig};
 
     use crate::codec::mysql::{Duration, Time};
     use crate::codec::Datum;

--- a/components/tidb_query/src/expr/column.rs
+++ b/components/tidb_query/src/expr/column.rs
@@ -86,7 +86,7 @@ mod tests {
     use std::{str, u64};
 
     use tidb_query_datatype::{FieldTypeAccessor, FieldTypeTp};
-    use tipb::expression::FieldType;
+    use tipb::FieldType;
 
     use crate::codec::mysql::{Decimal, Duration, Json, Time};
     use crate::codec::Datum;

--- a/components/tidb_query/src/expr/ctx.rs
+++ b/components/tidb_query/src/expr/ctx.rs
@@ -3,11 +3,10 @@
 use std::sync::Arc;
 use std::{i64, mem, u64};
 
-use tipb::select;
-use tipb::select::DAGRequest;
-
 use super::{Error, Result};
 use crate::codec::mysql::Tz;
+use tipb;
+use tipb::DAGRequest;
 
 bitflags! {
     /// Please refer to SQLMode in `mysql/const.go` in repo `pingcap/parser` for details.
@@ -170,7 +169,7 @@ pub struct EvalWarnings {
     // number of warnings
     pub warning_cnt: usize,
     // details of previous max_warning_cnt warnings
-    pub warnings: Vec<select::Error>,
+    pub warnings: Vec<tipb::Error>,
 }
 
 impl EvalWarnings {

--- a/components/tidb_query/src/expr/mod.rs
+++ b/components/tidb_query/src/expr/mod.rs
@@ -10,7 +10,7 @@ use rand_xorshift::XorShiftRng;
 use tidb_query_datatype::prelude::*;
 use tidb_query_datatype::FieldTypeFlag;
 use tikv_util::codec::number;
-use tipb::expression::{Expr, ExprType, FieldType, ScalarFuncSig};
+use tipb::{Expr, ExprType, FieldType, ScalarFuncSig};
 
 use crate::codec::mysql::charset;
 use crate::codec::mysql::{Decimal, Duration, Json, Time, MAX_FSP};
@@ -327,7 +327,7 @@ mod tests {
     use std::{i64, u64};
 
     use tidb_query_datatype::{self, Collation, FieldTypeAccessor, FieldTypeFlag, FieldTypeTp};
-    use tipb::expression::{Expr, ExprType, FieldType, ScalarFuncSig};
+    use tipb::{Expr, ExprType, FieldType, ScalarFuncSig};
 
     use super::{Error, EvalConfig, EvalContext, Expression};
     use crate::codec::error::{ERR_DATA_OUT_OF_RANGE, ERR_DIVISION_BY_ZERO};

--- a/components/tidb_query/src/expr/scalar_function.rs
+++ b/components/tidb_query/src/expr/scalar_function.rs
@@ -5,7 +5,7 @@ use std::usize;
 
 use tidb_query_datatype::prelude::*;
 use tidb_query_datatype::FieldTypeFlag;
-use tipb::expression::ScalarFuncSig;
+use tipb::ScalarFuncSig;
 
 use super::builtin_compare::CmpOp;
 use super::{Error, EvalContext, Result, ScalarFunc};
@@ -199,7 +199,9 @@ impl ScalarFunc {
             | ScalarFuncSig::WeekDay
             | ScalarFuncSig::WeekOfYear
             | ScalarFuncSig::Year
-            | ScalarFuncSig::UnaryNot
+            | ScalarFuncSig::UnaryNotInt
+            | ScalarFuncSig::UnaryNotDecimal
+            | ScalarFuncSig::UnaryNotReal
             | ScalarFuncSig::UnaryMinusInt
             | ScalarFuncSig::UnaryMinusReal
             | ScalarFuncSig::UnaryMinusDecimal
@@ -763,7 +765,11 @@ dispatch_call! {
         LogicalOr => logical_or,
         LogicalXor => logical_xor,
 
-        UnaryNot => unary_not,
+        // FIXME(@lonng)
+        UnaryNotInt => unary_not,
+        UnaryNotDecimal => unary_not,
+        UnaryNotReal => unary_not,
+
         UnaryMinusInt => unary_minus_int,
         IntIsNull => int_is_null,
         IntIsFalse => int_is_false,
@@ -1077,7 +1083,7 @@ dispatch_call! {
 mod tests {
     use crate::expr::{Error, ScalarFunc};
     use std::usize;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     #[test]
     fn test_check_args() {
@@ -1267,7 +1273,9 @@ mod tests {
                     ScalarFuncSig::WeekDay,
                     ScalarFuncSig::WeekOfYear,
                     ScalarFuncSig::Year,
-                    ScalarFuncSig::UnaryNot,
+                    ScalarFuncSig::UnaryNotInt,
+                    ScalarFuncSig::UnaryNotDecimal,
+                    ScalarFuncSig::UnaryNotReal,
                     ScalarFuncSig::UnaryMinusInt,
                     ScalarFuncSig::UnaryMinusReal,
                     ScalarFuncSig::UnaryMinusDecimal,

--- a/components/tidb_query/src/rpn_expr/impl_arithmetic.rs
+++ b/components/tidb_query/src/rpn_expr/impl_arithmetic.rs
@@ -541,7 +541,7 @@ mod tests {
 
     use tidb_query_datatype::builder::FieldTypeBuilder;
     use tidb_query_datatype::{FieldTypeFlag, FieldTypeTp};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::codec::error::ERR_DIVISION_BY_ZERO;
     use crate::expr::{EvalConfig, Flag, SqlMode};

--- a/components/tidb_query/src/rpn_expr/impl_cast.rs
+++ b/components/tidb_query/src/rpn_expr/impl_cast.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 
 use tidb_query_codegen::rpn_fn;
 use tidb_query_datatype::{EvalType, FieldTypeAccessor, FieldTypeTp};
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use crate::codec::convert::*;
 use crate::codec::data_type::*;

--- a/components/tidb_query/src/rpn_expr/impl_compare.rs
+++ b/components/tidb_query/src/rpn_expr/impl_compare.rs
@@ -239,7 +239,7 @@ mod tests {
 
     use tidb_query_datatype::builder::FieldTypeBuilder;
     use tidb_query_datatype::{FieldTypeFlag, FieldTypeTp};
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::rpn_expr::test_util::RpnFnScalarEvaluator;
 

--- a/components/tidb_query/src/rpn_expr/impl_control.rs
+++ b/components/tidb_query/src/rpn_expr/impl_control.rs
@@ -47,7 +47,7 @@ fn if_condition<T: Evaluable>(
     .clone())
 }
 
-fn case_when_validator<T: Evaluable>(expr: &tipb::expression::Expr) -> Result<()> {
+fn case_when_validator<T: Evaluable>(expr: &tipb::Expr) -> Result<()> {
     for chunk in expr.get_children().chunks(2) {
         if chunk.len() == 1 {
             super::function::validate_expr_return_type(&chunk[0], T::EVAL_TYPE)?;
@@ -63,7 +63,7 @@ fn case_when_validator<T: Evaluable>(expr: &tipb::expression::Expr) -> Result<()
 mod tests {
     use super::*;
 
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::rpn_expr::test_util::RpnFnScalarEvaluator;
 

--- a/components/tidb_query/src/rpn_expr/impl_json.rs
+++ b/components/tidb_query/src/rpn_expr/impl_json.rs
@@ -18,7 +18,7 @@ fn json_type(arg: &Option<Json>) -> Result<Option<Bytes>> {
 mod tests {
     use super::*;
 
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::rpn_expr::types::test_util::RpnFnScalarEvaluator;
 

--- a/components/tidb_query/src/rpn_expr/impl_like.rs
+++ b/components/tidb_query/src/rpn_expr/impl_like.rs
@@ -26,7 +26,7 @@ pub fn like(
 
 #[cfg(test)]
 mod tests {
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::rpn_expr::test_util::RpnFnScalarEvaluator;
 

--- a/components/tidb_query/src/rpn_expr/impl_math.rs
+++ b/components/tidb_query/src/rpn_expr/impl_math.rs
@@ -47,7 +47,7 @@ fn abs_decimal(arg: &Option<Decimal>) -> Result<Option<Decimal>> {
 mod tests {
     use super::*;
 
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::rpn_expr::types::test_util::RpnFnScalarEvaluator;
 

--- a/components/tidb_query/src/rpn_expr/impl_op.rs
+++ b/components/tidb_query/src/rpn_expr/impl_op.rs
@@ -78,7 +78,7 @@ fn decimal_is_false(arg: &Option<Decimal>) -> Result<Option<i64>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::codec::mysql::{time, Tz};
     use crate::rpn_expr::test_util::RpnFnScalarEvaluator;
@@ -135,7 +135,7 @@ mod tests {
         for (arg, expect_output) in test_cases {
             let output = RpnFnScalarEvaluator::new()
                 .push_param(arg)
-                .evaluate(ScalarFuncSig::UnaryNot)
+                .evaluate(ScalarFuncSig::UnaryNotInt)
                 .unwrap();
             assert_eq!(output, expect_output);
         }

--- a/components/tidb_query/src/rpn_expr/impl_time.rs
+++ b/components/tidb_query/src/rpn_expr/impl_time.rs
@@ -39,7 +39,7 @@ pub fn date_format(
 mod tests {
     use super::*;
 
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
 
     use crate::rpn_expr::types::test_util::RpnFnScalarEvaluator;
 

--- a/components/tidb_query/src/rpn_expr/mod.rs
+++ b/components/tidb_query/src/rpn_expr/mod.rs
@@ -15,7 +15,7 @@ pub mod impl_time;
 pub use self::types::*;
 
 use tidb_query_datatype::{FieldTypeAccessor, FieldTypeFlag};
-use tipb::expression::{Expr, ScalarFuncSig};
+use tipb::{Expr, ScalarFuncSig};
 
 use crate::codec::data_type::*;
 use crate::Result;
@@ -175,7 +175,7 @@ fn map_pb_sig_to_rpn_func(value: ScalarFuncSig, children: &[Expr]) -> Result<Rpn
         ScalarFuncSig::DecimalIsFalse => decimal_is_false_fn_meta(),
         ScalarFuncSig::LogicalAnd => logical_and_fn_meta(),
         ScalarFuncSig::LogicalOr => logical_or_fn_meta(),
-        ScalarFuncSig::UnaryNot => unary_not_fn_meta(),
+        ScalarFuncSig::UnaryNotInt | ScalarFuncSig::UnaryNotDecimal | ScalarFuncSig::UnaryNotReal => unary_not_fn_meta(),
         ScalarFuncSig::PlusInt => map_int_sig(value, children, plus_mapper)?,
         ScalarFuncSig::PlusReal => arithmetic_fn_meta::<RealPlus>(),
         ScalarFuncSig::PlusDecimal => arithmetic_fn_meta::<DecimalPlus>(),

--- a/components/tidb_query/src/rpn_expr/types/expr.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::super::function::RpnFnMeta;
 use crate::codec::data_type::ScalarValue;

--- a/components/tidb_query/src/rpn_expr/types/expr_builder.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_builder.rs
@@ -4,7 +4,7 @@ use std::convert::{TryFrom, TryInto};
 
 use tidb_query_datatype::{EvalType, FieldTypeAccessor};
 use tikv_util::codec::number;
-use tipb::expression::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType};
 
 use super::super::function::RpnFnMeta;
 use super::expr::{RpnExpression, RpnExpressionNode};
@@ -96,7 +96,7 @@ impl RpnExpressionBuilder {
         max_columns: usize,
     ) -> Result<RpnExpression>
     where
-        F: Fn(tipb::expression::ScalarFuncSig, &[Expr]) -> Result<RpnFnMeta> + Copy,
+        F: Fn(tipb::ScalarFuncSig, &[Expr]) -> Result<RpnFnMeta> + Copy,
     {
         let mut expr_nodes = Vec::new();
         append_rpn_nodes_recursively(
@@ -250,7 +250,7 @@ fn append_rpn_nodes_recursively<F>(
     // the full schema instead.
 ) -> Result<()>
 where
-    F: Fn(tipb::expression::ScalarFuncSig, &[Expr]) -> Result<RpnFnMeta> + Copy,
+    F: Fn(tipb::ScalarFuncSig, &[Expr]) -> Result<RpnFnMeta> + Copy,
 {
     match tree_node.get_tp() {
         ExprType::ScalarFunc => {
@@ -290,7 +290,7 @@ fn handle_node_fn_call<F>(
     max_columns: usize,
 ) -> Result<()>
 where
-    F: Fn(tipb::expression::ScalarFuncSig, &[Expr]) -> Result<RpnFnMeta> + Copy,
+    F: Fn(tipb::ScalarFuncSig, &[Expr]) -> Result<RpnFnMeta> + Copy,
 {
     // Map pb func to `RpnFnMeta`.
     let func_meta = fn_mapper(tree_node.get_sig(), tree_node.get_children())?;
@@ -470,7 +470,7 @@ mod tests {
 
     use tidb_query_codegen::rpn_fn;
     use tidb_query_datatype::FieldTypeTp;
-    use tipb::expression::ScalarFuncSig;
+    use tipb::ScalarFuncSig;
     use tipb_helper::ExprDefBuilder;
 
     use crate::codec::datum::{self, Datum};
@@ -859,6 +859,7 @@ mod tests {
                 .push_child(ExprDefBuilder::column_ref(2, FieldTypeTp::LongLong))
                 .push_child(ExprDefBuilder::column_ref(5, FieldTypeTp::LongLong))
                 .build();
+
         for i in 0..=5 {
             assert!(RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
                 node.clone(),

--- a/components/tidb_query/src/rpn_expr/types/expr_eval.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_eval.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use super::expr::{RpnExpression, RpnExpressionNode};
 use super::RpnFnCallExtra;
@@ -283,7 +283,7 @@ mod tests {
 
     use tidb_query_codegen::rpn_fn;
     use tidb_query_datatype::{EvalType, FieldTypeAccessor, FieldTypeTp};
-    use tipb::expression::FieldType;
+    use tipb::FieldType;
     use tipb_helper::ExprDefBuilder;
 
     use crate::codec::batch::LazyBatchColumn;
@@ -942,7 +942,7 @@ mod tests {
     /// Parse from an expression tree then evaluate.
     #[test]
     fn test_parse_and_eval() {
-        use tipb::expression::{Expr, ScalarFuncSig};
+        use tipb::{Expr, ScalarFuncSig};
 
         // We will build an expression tree from:
         //      fn_d(

--- a/components/tidb_query/src/rpn_expr/types/function.rs
+++ b/components/tidb_query/src/rpn_expr/types/function.rs
@@ -93,7 +93,7 @@
 use std::convert::TryFrom;
 
 use tidb_query_datatype::{EvalType, FieldTypeAccessor};
-use tipb::expression::{Expr, FieldType};
+use tipb::{Expr, FieldType};
 
 use super::RpnStackNode;
 use crate::codec::data_type::{Evaluable, ScalarValue, ScalarValueRef, VectorValue};

--- a/components/tidb_query/src/rpn_expr/types/test_util.rs
+++ b/components/tidb_query/src/rpn_expr/types/test_util.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::{Expr, FieldType, ScalarFuncSig};
+use tipb::{Expr, FieldType, ScalarFuncSig};
 
 use crate::codec::batch::LazyBatchColumnVec;
 use crate::codec::data_type::{Evaluable, ScalarValue};

--- a/components/tidb_query/src/util.rs
+++ b/components/tidb_query/src/util.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use kvproto::coprocessor as coppb;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
 
 use crate::codec::datum::Datum;
 

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -189,7 +189,7 @@ impl ValidatorFnGenerator {
         let inners = self.tokens;
         quote! {
             fn validate #impl_generics (
-                expr: &tipb::expression::Expr
+                expr: &tipb::Expr
             ) -> crate::Result<()> #where_clause {
                 use crate::codec::data_type::Evaluable;
                 use crate::rpn_expr::function;
@@ -892,7 +892,7 @@ mod tests_normal {
                     )
                     .eval(Null, ctx, output_rows, args, extra)
                 }
-                fn validate(expr: &tipb::expression::Expr) -> crate::Result<()> {
+                fn validate(expr: &tipb::Expr) -> crate::Result<()> {
                     use crate::codec::data_type::Evaluable;
                     use crate::rpn_expr::function;
                     function::validate_expr_return_type(expr, Decimal::EVAL_TYPE)?;
@@ -1061,7 +1061,7 @@ mod tests_normal {
                         extra
                     )
                 }
-                fn validate<A: M, B>(expr: &tipb::expression::Expr) -> crate::Result<()>
+                fn validate<A: M, B>(expr: &tipb::Expr) -> crate::Result<()>
                 where
                     B: N<M>
                 {

--- a/components/tidb_query_datatype/src/builder/field_type.rs
+++ b/components/tidb_query_datatype/src/builder/field_type.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::expression::FieldType;
+use tipb::FieldType;
 
 use crate::FieldTypeAccessor;
 

--- a/components/tidb_query_datatype/src/def/field_type.rs
+++ b/components/tidb_query_datatype/src/def/field_type.rs
@@ -2,12 +2,12 @@
 
 use std::fmt;
 
-use tipb::expression::FieldType;
-use tipb::schema::ColumnInfo;
+use tipb::ColumnInfo;
+use tipb::FieldType;
 
 use num_traits::FromPrimitive;
 
-/// Valid values of `tipb::expression::FieldType::tp` and `tipb::schema::ColumnInfo::tp`.
+/// Valid values of `tipb::FieldType::tp` and `tipb::ColumnInfo::tp`.
 ///
 /// `FieldType` is the field type of a column defined by schema.
 ///
@@ -54,8 +54,8 @@ impl fmt::Display for FieldTypeTp {
     }
 }
 
-/// Valid values of `tipb::expression::FieldType::collate` and
-/// `tipb::schema::ColumnInfo::collation`.
+/// Valid values of `tipb::FieldType::collate` and
+/// `tipb::ColumnInfo::collation`.
 ///
 /// The default value if `UTF8Bin`.
 #[derive(Primitive, PartialEq, Debug, Clone, Copy)]

--- a/components/tipb_helper/src/expr_def_builder.rs
+++ b/components/tipb_helper/src/expr_def_builder.rs
@@ -2,9 +2,9 @@
 
 use codec::prelude::NumberEncoder;
 use tidb_query_datatype::{FieldTypeAccessor, FieldTypeFlag, FieldTypeTp};
-use tipb::expression::{Expr, ExprType, FieldType, ScalarFuncSig};
+use tipb::{Expr, ExprType, FieldType, ScalarFuncSig};
 
-/// A helper utility to build `tipb::expression::Expr` (a.k.a. expression definition) easily.
+/// A helper utility to build `tipb::Expr` (a.k.a. expression definition) easily.
 pub struct ExprDefBuilder(Expr);
 
 impl ExprDefBuilder {

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -4,7 +4,7 @@ use crc::crc64::{self, Digest, Hasher64};
 
 use kvproto::coprocessor::{KeyRange, Response};
 use protobuf::Message;
-use tipb::checksum::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse};
+use tipb::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse};
 
 use tidb_query::storage::scanner::{RangesScanner, RangesScannerOptions};
 use tidb_query::storage::Range;

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -7,7 +7,7 @@ pub use self::storage_impl::TiKVStorage;
 use kvproto::coprocessor::{KeyRange, Response};
 use protobuf::Message;
 use tidb_query::storage::IntervalRange;
-use tipb::select::{DAGRequest, SelectResponse, StreamResponse};
+use tipb::{DAGRequest, SelectResponse, StreamResponse};
 
 use crate::coprocessor::metrics::*;
 use crate::coprocessor::{Deadline, RequestHandler, Result};

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -5,13 +5,12 @@ use std::time::Duration;
 
 use futures::sync::mpsc;
 use futures::{future, stream, Future, Stream};
-use protobuf::{CodedInputStream, Message};
 
 use kvproto::{coprocessor as coppb, errorpb, kvrpcpb};
-use tipb::analyze::{AnalyzeReq, AnalyzeType};
-use tipb::checksum::{ChecksumRequest, ChecksumScanOn};
-use tipb::executor::ExecType;
-use tipb::select::DAGRequest;
+use protobuf::{CodedInputStream, Message};
+use tipb::{AnalyzeReq, AnalyzeType};
+use tipb::{ChecksumRequest, ChecksumScanOn};
+use tipb::{DAGRequest, ExecType};
 
 use crate::server::readpool::{self, ReadPool};
 use crate::server::Config;
@@ -487,12 +486,13 @@ mod tests {
     use std::thread;
     use std::vec;
 
-    use tipb::executor::Executor;
-    use tipb::expression::Expr;
+    use tipb::Executor;
+    use tipb::Expr;
 
     use crate::coprocessor::readpool_impl::build_read_pool_for_test;
     use crate::storage::kv::{destroy_tls_engine, set_tls_engine, RocksEngine};
     use crate::storage::TestEngineBuilder;
+    use protobuf::Message;
 
     /// A unary `RequestHandler` that always produces a fixture.
     struct UnaryFixture {

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -9,8 +9,7 @@ use kvproto::coprocessor::{KeyRange, Response};
 use protobuf::Message;
 use tidb_query::codec::datum;
 use tidb_query::executor::{Executor, IndexScanExecutor, ScanExecutor, TableScanExecutor};
-use tipb::analyze::{self, AnalyzeColumnsReq, AnalyzeIndexReq, AnalyzeReq, AnalyzeType};
-use tipb::executor::TableScan;
+use tipb::{self, AnalyzeColumnsReq, AnalyzeIndexReq, AnalyzeReq, AnalyzeType, TableScan};
 
 use super::cmsketch::CMSketch;
 use super::fmsketch::FMSketch;
@@ -55,11 +54,11 @@ impl<S: Snapshot> AnalyzeContext<S> {
         let (collectors, pk_builder) = builder.collect_columns_stats()?;
 
         let pk_hist = pk_builder.into_proto();
-        let cols: Vec<analyze::SampleCollector> =
+        let cols: Vec<tipb::SampleCollector> =
             collectors.into_iter().map(|col| col.into_proto()).collect();
 
         let res_data = {
-            let mut res = analyze::AnalyzeColumnsResp::default();
+            let mut res = tipb::AnalyzeColumnsResp::default();
             res.set_collectors(cols.into());
             res.set_pk_hist(pk_hist);
             box_try!(res.write_to_bytes())
@@ -88,7 +87,7 @@ impl<S: Snapshot> AnalyzeContext<S> {
                 }
             }
         }
-        let mut res = analyze::AnalyzeIndexResp::default();
+        let mut res = tipb::AnalyzeIndexResp::default();
         res.set_hist(hist.into_proto());
         if let Some(c) = cms {
             res.set_cms(c.into_proto());
@@ -254,8 +253,8 @@ impl SampleCollector {
         }
     }
 
-    fn into_proto(self) -> analyze::SampleCollector {
-        let mut s = analyze::SampleCollector::default();
+    fn into_proto(self) -> tipb::SampleCollector {
+        let mut s = tipb::SampleCollector::default();
         s.set_null_count(self.null_count as i64);
         s.set_count(self.count as i64);
         s.set_fm_sketch(self.fm_sketch.into_proto());

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -2,7 +2,7 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
-use tipb::analyze;
+use tipb;
 
 /// `CMSketch` is used to estimate point queries.
 /// Refer:[Count-Min Sketch](https://en.wikipedia.org/wiki/Count-min_sketch)
@@ -50,9 +50,9 @@ impl CMSketch {
         }
     }
 
-    pub fn into_proto(self) -> analyze::CMSketch {
-        let mut proto = analyze::CMSketch::default();
-        let mut rows = vec![analyze::CMSketchRow::default(); self.depth];
+    pub fn into_proto(self) -> tipb::CMSketch {
+        let mut proto = tipb::CMSketch::default();
+        let mut rows = vec![tipb::CMSketchRow::default(); self.depth];
         for (i, row) in self.table.iter().enumerate() {
             rows[i].set_counters(row.to_vec());
         }

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -3,7 +3,7 @@
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
 use tikv_util::collections::HashSet;
-use tipb::analyze;
+use tipb;
 
 /// `FMSketch` is used to count the approximate number of distinct
 /// elements in multiset.
@@ -33,8 +33,8 @@ impl FMSketch {
         self.insert_hash_value(hash);
     }
 
-    pub fn into_proto(self) -> analyze::FMSketch {
-        let mut proto = analyze::FMSketch::default();
+    pub fn into_proto(self) -> tipb::FMSketch {
+        let mut proto = tipb::FMSketch::default();
         proto.set_mask(self.mask);
         let hash = self.hash_set.into_iter().collect();
         proto.set_hashset(hash);

--- a/src/coprocessor/statistics/histogram.rs
+++ b/src/coprocessor/statistics/histogram.rs
@@ -1,7 +1,7 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::mem;
-use tipb::analyze;
+use tipb;
 
 /// Bucket is an element of histogram.
 struct Bucket {
@@ -38,8 +38,8 @@ impl Bucket {
         self.repeats = 1;
     }
 
-    fn into_proto(self) -> analyze::Bucket {
-        let mut bucket = analyze::Bucket::default();
+    fn into_proto(self) -> tipb::Bucket {
+        let mut bucket = tipb::Bucket::default();
         bucket.set_repeats(self.repeats as i64);
         bucket.set_count(self.count as i64);
         bucket.set_lower_bound(self.lower_bound);
@@ -70,10 +70,10 @@ impl Histogram {
         }
     }
 
-    pub fn into_proto(self) -> analyze::Histogram {
-        let mut hist = analyze::Histogram::default();
+    pub fn into_proto(self) -> tipb::Histogram {
+        let mut hist = tipb::Histogram::default();
         hist.set_ndv(self.ndv as i64);
-        let buckets: Vec<analyze::Bucket> = self
+        let buckets: Vec<tipb::Bucket> = self
             .buckets
             .into_iter()
             .map(|bucket| bucket.into_proto())

--- a/tests/integrations/coprocessor/test_analyze.rs
+++ b/tests/integrations/coprocessor/test_analyze.rs
@@ -3,7 +3,7 @@
 use kvproto::coprocessor::{KeyRange, Request};
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 use protobuf::Message;
-use tipb::analyze::{
+use tipb::{
     AnalyzeColumnsReq, AnalyzeColumnsResp, AnalyzeIndexReq, AnalyzeIndexResp, AnalyzeReq,
     AnalyzeType,
 };

--- a/tests/integrations/coprocessor/test_checksum.rs
+++ b/tests/integrations/coprocessor/test_checksum.rs
@@ -7,7 +7,7 @@ use crc::crc64::{self, Digest, Hasher64};
 use kvproto::coprocessor::{KeyRange, Request};
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 use protobuf::Message;
-use tipb::checksum::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse, ChecksumScanOn};
+use tipb::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse, ChecksumScanOn};
 
 use test_coprocessor::*;
 use tidb_query::storage::scanner::{RangesScanner, RangesScannerOptions};

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -4,12 +4,10 @@ use std::cmp;
 use std::i64;
 use std::thread;
 
-use protobuf::Message;
-
 use kvproto::coprocessor::Response;
 use kvproto::kvrpcpb::Context;
-use tipb::expression::{Expr, ExprType, ScalarFuncSig};
-use tipb::select::Chunk;
+use protobuf::Message;
+use tipb::{Chunk, Expr, ExprType, ScalarFuncSig};
 
 use test_coprocessor::*;
 use test_storage::*;


### PR DESCRIPTION
## What have you changed? (mandatory)

Updates the version of TiPB. This takes includes https://github.com/pingcap/tipb/pull/132 which uses the Prost approach to modularisation so that we use the same module layout with both Prost and rust-protobuf.

Note that this also means we include https://github.com/pingcap/tipb/pull/122 and so I've hacked around the changes to `UnaryNot`. These changes are done properly in https://github.com/tikv/tikv/pull/5005 which is blocked on this PR.

PTAL @BusyJay @lonng 

## What are the type of the changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

Existing tests

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
