### PR TITLE
*: turn on line numbers for dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ members = [
 
 [profile.dev]
 opt-level = 0
-debug = false
+debug = 1 # required for line numbers in tests, see tikv #5049
 codegen-units = 4
 lto = false
 incremental = true

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ cargo test $TESTNAME
 
 Our CI systems automatically test all the pull requests, so making sure the full suite passes the test before creating your PR is not strictly required. **All merged PRs must have passed CI test.**
 
-Note that, to reduce compilation time, TiKV builds do not include debugging information by default. The easiest way to enable debuginfo is to precede build commands with `RUSTFLAGS=-Cdebuginfo=1` (for line numbers), or `RUSTFLAGS=-Cdebuginfo=2` (for full debuginfo).
+Note that, to reduce compilation time, TiKV builds do not include full debugging information by default &mdash; `release` and `bench` builds include no debuginfo; `dev` and `test` builds include line numbers only. The easiest way to enable debuginfo is to precede build commands with `RUSTFLAGS=-Cdebuginfo=1` (for line numbers), or `RUSTFLAGS=-Cdebuginfo=2` (for full debuginfo).
 
 ```bash
 RUSTFLAGS=-Cdebuginfo=2 make


### PR DESCRIPTION
## What have you changed? (mandatory)

This should make line numbers appear on unit test failures. The "test" profile crates in cargo seem to be a superset of the "dev" profile crates, so unit test crates ("test" profile) link to the tikv dev crate. So to see line numbers in tikv itself, they have to be turned on for the dev profile.

Fixes #5049

cc @Connor1996 

## What are the type of the changes? (mandatory)

- Bug fix (change which fixes an issue)

## How has this PR been tested? (mandatory)

Manual verification (in progress).

## Does this PR affect documentation (docs) or release note? (mandatory)

Only README.md, updated.

## Does this PR affect tidb-ansible update? (mandatory)

No

## Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/issues/5049

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

