### PR TITLE
*: register services outside of server

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -8,6 +8,9 @@ use engine::rocks::util::metrics_flusher::{MetricsFlusher, DEFAULT_FLUSHER_INTER
 use engine::rocks::util::security::encrypted_env_from_cipher_file;
 use engine::Engines;
 use fs2::FileExt;
+use kvproto::deadlock_grpc::create_deadlock;
+use kvproto::debugpb_grpc::create_debug;
+use kvproto::import_sstpb_grpc::create_import_sst;
 use pd_client::{PdClient, RpcClient};
 use std::fs::File;
 use std::path::Path;
@@ -22,6 +25,7 @@ use tikv::raftstore::store::fsm::store::{StoreMeta, PENDING_VOTES_CAP};
 use tikv::raftstore::store::{fsm, LocalReader};
 use tikv::raftstore::store::{new_compaction_listener, SnapManagerBuilder};
 use tikv::server::resolve;
+use tikv::server::service::DebugService;
 use tikv::server::status_server::StatusServer;
 use tikv::server::transport::ServerRaftStoreRouter;
 use tikv::server::DEFAULT_CLUSTER_ID;
@@ -231,6 +235,16 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
             Some(router.clone()),
         );
 
+    let server_cfg = Arc::new(cfg.server.clone());
+
+    // Create coprocessor endpoint.
+    let cop_read_pool = coprocessor::readpool_impl::build_read_pool(
+        &cfg.readpool.coprocessor.build_config(),
+        pd_sender.clone(),
+        engine.clone(),
+    );
+    let cop = coprocessor::Endpoint::new(&server_cfg, cop_read_pool);
+
     let importer = Arc::new(SSTImporter::new(import_path).unwrap());
     let import_service = ImportSSTService::new(
         cfg.import.clone(),
@@ -239,14 +253,10 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
         Arc::clone(&importer),
     );
 
-    let server_cfg = Arc::new(cfg.server.clone());
+    // Create Debug service.
+    let debug_service = DebugService::new(engines.clone(), raft_router.clone());
+
     // Create server
-    let cop_read_pool = coprocessor::readpool_impl::build_read_pool(
-        &cfg.readpool.coprocessor.build_config(),
-        pd_sender.clone(),
-        engine.clone(),
-    );
-    let cop = coprocessor::Endpoint::new(&server_cfg, cop_read_pool);
     let mut server = Server::new(
         &server_cfg,
         &security_mgr,
@@ -255,11 +265,16 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
         raft_router,
         resolver.clone(),
         snap_mgr.clone(),
-        Some(engines.clone()),
-        Some(import_service),
-        deadlock_service,
     )
     .unwrap_or_else(|e| fatal!("failed to create server: {}", e));
+
+    // Register services.
+    server.register_service(create_import_sst(import_service));
+    server.register_service(create_debug(debug_service));
+    if let Some(deadlock_service) = deadlock_service {
+        server.register_service(create_deadlock(deadlock_service));
+    }
+
     let trans = server.transport();
 
     // Create node.
@@ -334,6 +349,9 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     }
 
     // Run server.
+    server
+        .build_and_bind()
+        .unwrap_or_else(|e| fatal!("failed to build server: {}", e));
     server
         .start(server_cfg, security_mgr)
         .unwrap_or_else(|e| fatal!("failed to start server: {}", e));

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -6,6 +6,8 @@ use std::time::Duration;
 use std::{thread, usize};
 
 use grpcio::{EnvBuilder, Error as GrpcError};
+use kvproto::debugpb_grpc::create_debug;
+use kvproto::import_sstpb_grpc::create_import_sst;
 use kvproto::raft_cmdpb::*;
 use kvproto::raft_serverpb;
 use tempfile::{Builder, TempDir};
@@ -20,6 +22,7 @@ use tikv::raftstore::store::{Callback, LocalReader, SnapManager};
 use tikv::raftstore::Result;
 use tikv::server::load_statistics::ThreadLoad;
 use tikv::server::resolve::{self, Task as ResolveTask};
+use tikv::server::service::DebugService;
 use tikv::server::transport::ServerRaftStoreRouter;
 use tikv::server::transport::{RaftStoreBlackHole, RaftStoreRouter};
 use tikv::server::Result as ServerResult;
@@ -123,7 +126,7 @@ impl Simulator for ServerCluster {
         let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_VOTES_CAP)));
         let local_reader = LocalReader::new(engines.kv.clone(), store_meta.clone(), router.clone());
         let raft_router = ServerRaftStoreRouter::new(router.clone(), local_reader);
-        let sim_router = SimulateTransport::new(raft_router);
+        let sim_router = SimulateTransport::new(raft_router.clone());
 
         let raft_engine = RaftKv::new(sim_router.clone());
 
@@ -153,6 +156,8 @@ impl Simulator for ServerCluster {
             Arc::clone(&engines.kv),
             Arc::clone(&importer),
         );
+        // Create Debug service.
+        let debug_service = DebugService::new(engines.clone(), raft_router.clone());
 
         // Create pd client, snapshot manager, server.
         let (worker, resolver) = resolve::new_resolver(Arc::clone(&self.pd_client)).unwrap();
@@ -164,7 +169,7 @@ impl Simulator for ServerCluster {
         let cop = coprocessor::Endpoint::new(&server_cfg, cop_read_pool);
         let mut server = None;
         for _ in 0..100 {
-            server = Some(Server::new(
+            let mut svr = Server::new(
                 &server_cfg,
                 &security_mgr,
                 store.clone(),
@@ -172,23 +177,25 @@ impl Simulator for ServerCluster {
                 sim_router.clone(),
                 resolver.clone(),
                 snap_mgr.clone(),
-                Some(engines.clone()),
-                Some(import_service.clone()),
-                None,
-            ));
-            match server {
-                Some(Ok(_)) => break,
-                Some(Err(Error::Grpc(GrpcError::BindFail(ref addr, ref port)))) => {
+            )
+            .unwrap();
+            svr.register_service(create_import_sst(import_service.clone()));
+            svr.register_service(create_debug(debug_service.clone()));
+            match svr.build_and_bind() {
+                Ok(_) => {
+                    server = Some(svr);
+                    break;
+                }
+                Err(Error::Grpc(GrpcError::BindFail(ref addr, ref port))) => {
                     // Servers may meet the error, when we restart them.
                     debug!("fail to create a server: bind fail {:?}", (addr, port));
                     thread::sleep(Duration::from_millis(100));
                     continue;
                 }
-                Some(Err(ref e)) => panic!("fail to create a server: {:?}", e),
-                None => unreachable!(),
+                Err(ref e) => panic!("fail to create a server: {:?}", e),
             }
         }
-        let mut server = server.unwrap().unwrap();
+        let mut server = server.unwrap();
         let addr = server.listening_addr();
         cfg.server.addr = format!("{}", addr);
         let trans = server.transport();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,7 +2,6 @@
 
 mod metrics;
 mod raft_client;
-mod service;
 
 pub mod config;
 pub mod debug;
@@ -13,6 +12,7 @@ pub mod raftkv;
 pub mod readpool;
 pub mod resolve;
 pub mod server;
+pub mod service;
 pub mod snap;
 pub mod status_server;
 pub mod transport;

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -6,20 +6,13 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
-use engine::Engines;
 use futures::{Future, Stream};
 use grpcio::{ChannelBuilder, EnvBuilder, Environment, Server as GrpcServer, ServerBuilder};
-use kvproto::debugpb_grpc::create_debug;
-use kvproto::import_sstpb_grpc::create_import_sst;
 use kvproto::tikvpb_grpc::*;
 use tokio_threadpool::{Builder as ThreadPoolBuilder, ThreadPool};
 use tokio_timer::timer::Handle;
 
-use crate::storage::lock_manager::deadlock::Service as DeadlockService;
-use kvproto::deadlock_grpc::create_deadlock;
-
 use crate::coprocessor::Endpoint;
-use crate::import::ImportSSTService;
 use crate::raftstore::store::SnapManager;
 use crate::storage::{Engine, Storage};
 use tikv_util::security::SecurityManager;
@@ -74,9 +67,6 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
         raft_router: T,
         resolver: S,
         snap_mgr: SnapManager,
-        debug_engines: Option<Engines>,
-        import_service: Option<ImportSSTService<T>>,
-        deadlock_service: Option<DeadlockService>,
     ) -> Result<Self> {
         // A helper thread (or pool) for transport layer.
         let stats_pool = ThreadPoolBuilder::new()
@@ -101,7 +91,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             Arc::clone(&thread_load),
         );
 
-        let mut addr = SocketAddr::from_str(&cfg.addr)?;
+        let addr = SocketAddr::from_str(&cfg.addr)?;
         let ip = format!("{}", addr.ip());
         let channel_args = ChannelBuilder::new(Arc::clone(&env))
             .stream_initial_window_size(cfg.grpc_stream_initial_window_size.0 as i32)
@@ -110,34 +100,13 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             .max_send_message_len(-1)
             .http2_max_ping_strikes(i32::MAX) // For pings without data from clients.
             .build_args();
-        let builder_or_server = {
+        let builder = {
             let mut sb = ServerBuilder::new(Arc::clone(&env))
                 .channel_args(channel_args)
                 .register_service(create_tikv(kv_service));
             sb = security_mgr.bind(sb, &ip, addr.port());
-            if let Some(engines) = debug_engines {
-                let debug_service = DebugService::new(engines, raft_router.clone());
-                sb = sb.register_service(create_debug(debug_service));
-            }
-            if let Some(service) = import_service {
-                sb = sb.register_service(create_import_sst(service));
-            }
-            if let Some(service) = deadlock_service {
-                sb = sb.register_service(create_deadlock(service));
-            }
-            // When port is 0, it has to be binded now to get a valid address, which
-            // is then reported to PD before the server is up. 0 is usually used in tests.
-            if addr.port() == 0 {
-                let server = sb.build()?;
-                let (ref host, port) = server.bind_addrs()[0];
-                addr = SocketAddr::new(IpAddr::from_str(host)?, port as u16);
-                Either::Right(server)
-            } else {
-                Either::Left(sb)
-            }
+            Either::Left(sb)
         };
-
-        info!("listening on addr"; "addr" => addr);
 
         let raft_client = Arc::new(RwLock::new(RaftClient::new(
             Arc::clone(&env),
@@ -157,7 +126,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
 
         let svr = Server {
             env: Arc::clone(&env),
-            builder_or_server: Some(builder_or_server),
+            builder_or_server: Some(builder),
             local_addr: addr,
             trans,
             raft_router,
@@ -175,7 +144,37 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
         self.trans.clone()
     }
 
+    /// Register a gRPC service.
+    /// Register after starting, it fails and returns the service.
+    pub fn register_service(&mut self, svc: grpcio::Service) -> Option<grpcio::Service> {
+        match self.builder_or_server.take() {
+            Some(Either::Left(mut builder)) => {
+                builder = builder.register_service(svc);
+                self.builder_or_server = Some(Either::Left(builder));
+                None
+            }
+            Some(server) => {
+                self.builder_or_server = Some(server);
+                Some(svc)
+            }
+            None => Some(svc),
+        }
+    }
+
+    /// Build gRPC server and bind to address.
+    pub fn build_and_bind(&mut self) -> Result<SocketAddr> {
+        let sb = self.builder_or_server.take().unwrap().left().unwrap();
+        let server = sb.build()?;
+        let (ref host, port) = server.bind_addrs()[0];
+        let addr = SocketAddr::new(IpAddr::from_str(host)?, port as u16);
+        info!("listening on addr"; "addr" => addr);
+        self.local_addr = addr;
+        self.builder_or_server = Some(Either::Right(server));
+        Ok(addr)
+    }
+
     /// Starts the TiKV server.
+    /// Notice: Make sure call `build_and_bind` first.
     pub fn start(&mut self, cfg: Arc<Config>, security_mgr: Arc<SecurityManager>) -> Result<()> {
         let snap_runner = SnapHandler::new(
             Arc::clone(&self.env),
@@ -185,11 +184,7 @@ impl<T: RaftStoreRouter, S: StoreAddrResolver + 'static> Server<T, S> {
             Arc::clone(&cfg),
         );
         box_try!(self.snap_worker.start(snap_runner));
-        let builder_or_server = self.builder_or_server.take().unwrap();
-        let mut grpc_server = match builder_or_server {
-            Either::Left(builder) => builder.build()?,
-            Either::Right(server) => server,
-        };
+        let mut grpc_server = self.builder_or_server.take().unwrap().right().unwrap();
         grpc_server.start();
         self.builder_or_server = Some(Either::Right(grpc_server));
 
@@ -347,12 +342,10 @@ mod tests {
                 addr: Arc::clone(&addr),
             },
             SnapManager::new("", None),
-            None,
-            None,
-            None,
         )
         .unwrap();
 
+        server.build_and_bind().unwrap();
         server.start(cfg, security_mgr).unwrap();
 
         let mut trans = server.transport();


### PR DESCRIPTION
# What have you changed? (mandatory)

Pull registering services outside of `Server::new`. Passing services to `Server::new` is no longer required, it would be easy for us to register more services in the future.

## What are the type of changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

Unit tests.

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect `tidb-ansible` update? (mandatory)

No.
