### PR TITLE
Check for 0.0.0.0 over 0. in advertise addr.

### DIFF
--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -159,7 +159,7 @@ impl Config {
             );
             self.advertise_addr = self.addr.clone();
         }
-        if self.advertise_addr.starts_with("0.") {
+        if self.advertise_addr.starts_with("0.0.0.0") {
             return Err(box_err!(
                 "invalid advertise-addr: {:?}",
                 self.advertise_addr


### PR DESCRIPTION
Signed-off-by: Ana Hobden <operator@hoverbear.org>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
Fix #5273 

## What are the type of changes? (mandatory)

Check for `0.0.0.0` instead of `0.` on advertise addr parameter of `tikv-server`.

## How has this PR been tested? (mandatory)

CI test.

## Does this PR affect documentation (docs) or release note? (mandatory)

It shouldn't. I actually noticed this when I was looking at https://docs.tidb.cc/Test/180406-TiDB-Domain.html which uses hostnames for advertise-addr.

## Does this PR affect `tidb-ansible` update? (mandatory)

Nope

## Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/issues/5273

## Benchmark result if necessary (optional)

Nope

## Add a few positive/negative examples (optional)

This should make `0.tikv.dev`, for example, a valid advertise addr.

