### PR TITLE
Remove useless clippy hints and fix some issues following clippy lints

### DIFF
--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -905,10 +905,9 @@ mod tests {
             let encoded_len = MemComparableByteCodec::encoded_len(payload_len);
             let mut payload_encoded: Vec<u8> =
                 vec![0; encoded_prefix_len + encoded_len + encoded_suffix_len];
-            #[allow(clippy::needless_range_loop)]
-            for i in 0..encoded_prefix_len {
-                payload_encoded[i] = rand::random();
-            }
+            payload_encoded[0..encoded_prefix_len]
+                .iter_mut()
+                .for_each(|byte| *byte = rand::random());
             {
                 let src = payload_raw.as_slice();
                 let dest = &mut payload_encoded.as_mut_slice()[encoded_prefix_len..];
@@ -918,10 +917,9 @@ mod tests {
                     MemComparableByteCodec::encode_all(src, dest);
                 }
             }
-            #[allow(clippy::needless_range_loop)]
-            for i in encoded_prefix_len + encoded_len..encoded_suffix_len {
-                payload_encoded[i] = rand::random();
-            }
+            payload_encoded[encoded_prefix_len + encoded_len..encoded_suffix_len]
+                .iter_mut()
+                .for_each(|byte| *byte = rand::random());
 
             let mut base_buffer: Vec<u8> =
                 Vec::with_capacity(prefix_len + encoded_len + suffix_len);

--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -510,7 +510,7 @@ impl<T: Read> CompactByteDecoder for std::io::BufReader<T> {
 
 #[cfg(test)]
 mod tests {
-    use rand;
+    use rand::prelude::*;
 
     use super::*;
     use crate::number;
@@ -905,9 +905,8 @@ mod tests {
             let encoded_len = MemComparableByteCodec::encoded_len(payload_len);
             let mut payload_encoded: Vec<u8> =
                 vec![0; encoded_prefix_len + encoded_len + encoded_suffix_len];
-            payload_encoded[0..encoded_prefix_len]
-                .iter_mut()
-                .for_each(|byte| *byte = rand::random());
+            let mut rng = thread_rng();
+            rng.fill_bytes(&mut payload_encoded[..encoded_prefix_len]);
             {
                 let src = payload_raw.as_slice();
                 let dest = &mut payload_encoded.as_mut_slice()[encoded_prefix_len..];
@@ -917,15 +916,11 @@ mod tests {
                     MemComparableByteCodec::encode_all(src, dest);
                 }
             }
-            payload_encoded[encoded_prefix_len + encoded_len..encoded_suffix_len]
-                .iter_mut()
-                .for_each(|byte| *byte = rand::random());
+            rng.fill_bytes(&mut payload_encoded[encoded_prefix_len + encoded_len..]);
 
             let mut base_buffer: Vec<u8> =
-                Vec::with_capacity(prefix_len + encoded_len + suffix_len);
-            for _ in 0..prefix_len + encoded_len + encoded_suffix_len + suffix_len {
-                base_buffer.push(rand::random());
-            }
+                vec![0; prefix_len + encoded_len + encoded_suffix_len + suffix_len];
+            rng.fill_bytes(&mut base_buffer[..]);
 
             // Test `dest` doesn't overlap `src`
             let mut output_buffer = base_buffer.clone();

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -644,9 +644,8 @@ mod tests {
             }
         }
 
-        #[allow(clippy::clone_on_copy)]
         fn foo(a: &Option<usize>) -> Option<usize> {
-            a.clone()
+            *a
         }
     }
 

--- a/components/tikv_util/src/logger/mod.rs
+++ b/components/tikv_util/src/logger/mod.rs
@@ -318,7 +318,6 @@ impl<'a> Drop for Serializer<'a> {
     fn drop(&mut self) {}
 }
 
-#[allow(clippy::write_literal)]
 impl<'a> slog::ser::Serializer for Serializer<'a> {
     fn emit_none(&mut self, key: Key) -> slog::Result {
         self.emit_arguments(key, &format_args!("None"))

--- a/src/raftstore/store/fsm/batch.rs
+++ b/src/raftstore/store/fsm/batch.rs
@@ -467,7 +467,6 @@ pub mod tests {
         }
     }
 
-    #[allow(clippy::type_complexity)]
     pub fn new_runner(cap: usize) -> (mpsc::LooseBoundedSender<Message>, Box<Runner>) {
         let (tx, rx) = mpsc::loose_bounded(cap);
         let fsm = Runner {

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -2793,7 +2793,6 @@ mod tests {
         }
     }
 
-    #[allow(clippy::useless_vec)]
     #[test]
     fn test_request_inspector() {
         struct DummyInspector {
@@ -2843,8 +2842,8 @@ mod tests {
             table.push((req.clone(), policy));
         }
 
-        for applied_to_index_term in vec![true, false] {
-            for lease_state in vec![LeaseState::Expired, LeaseState::Suspect, LeaseState::Valid] {
+        for &applied_to_index_term in &[true, false] {
+            for &lease_state in &[LeaseState::Expired, LeaseState::Suspect, LeaseState::Valid] {
                 for (req, mut policy) in table.clone() {
                     let mut inspector = DummyInspector {
                         applied_to_index_term,
@@ -2876,7 +2875,7 @@ mod tests {
 
         // Err(_)
         let mut err_table = vec![];
-        for op in vec![CmdType::Prewrite, CmdType::Invalid] {
+        for &op in &[CmdType::Prewrite, CmdType::Invalid] {
             let mut request = raft_cmdpb::Request::default();
             request.set_cmd_type(op);
             req.set_requests(vec![request].into());

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -598,7 +598,6 @@ mod tests {
         check_seek_result(&snap, Some(b"a00"), Some(b"a15"), &seek_table);
     }
 
-    #[allow(clippy::type_complexity)]
     #[test]
     fn test_iterate() {
         let path = Builder::new().prefix("test-raftstore").tempdir().unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -80,7 +80,6 @@ pub enum Mutation {
     Insert((Key, Value)),
 }
 
-#[allow(clippy::match_same_arms)]
 impl Mutation {
     pub fn key(&self) -> &Key {
         match self {


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

I notice some clippy lints are actually useless. They can be removed now.

And we'd better follow clippy if there is no special reason. I also fix some of them.

## What are the type of changes? (mandatory)

- Engineering (engineering change which doesn't change any feature or fix any issue)

## How has this PR been tested? (mandatory)

CI

## Does this PR affect documentation (docs) or release note? (mandatory)

No

## Does this PR affect `tidb-ansible` update? (mandatory)

No

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

