### PR TITLE
[release-3.0] raftstore: check merge entries' length to avoid slice out of range

### DIFF
--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -835,7 +835,7 @@ impl TestPdClient {
         self.must_none_peer(region_id, peer);
     }
 
-    pub fn must_merge(&self, from: u64, target: u64) {
+    pub fn merge_region(&self, from: u64, target: u64) {
         let op = Operator::MergeRegion {
             source_region_id: from,
             target_region_id: target,
@@ -843,6 +843,10 @@ impl TestPdClient {
         };
         self.schedule_operator(from, op.clone());
         self.schedule_operator(target, op);
+    }
+
+    pub fn must_merge(&self, from: u64, target: u64) {
+        self.merge_region(from, target);
 
         for _ in 1..500 {
             sleep_ms(10);
@@ -857,6 +861,10 @@ impl TestPdClient {
             return;
         }
         panic!("region {:?} is still not merged.", region.unwrap());
+    }
+
+    pub fn check_merged(&self, from: u64) -> bool {
+        self.get_region_by_id(from).wait().unwrap().is_none()
     }
 
     pub fn region_leader_must_be(&self, region_id: u64, peer: metapb::Peer) {

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -49,10 +49,7 @@ use tikv_util::Either;
 use tikv_util::MustConsumeVec;
 
 use super::metrics::*;
-use super::{
-    BasicMailbox, BatchRouter, BatchSystem, Fsm, HandlerBuilder, Mailbox, NormalScheduler,
-    PollHandler,
-};
+use super::{BasicMailbox, BatchRouter, BatchSystem, Fsm, HandlerBuilder, PollHandler};
 
 use super::super::RegionTask;
 
@@ -178,10 +175,7 @@ pub enum ExecResult {
         region: Region,
         state: MergeState,
     },
-    CatchUpLogs {
-        merge: CommitMergeRequest,
-        logs_up_to_date: Arc<AtomicU64>,
-    },
+    CatchUpLogs(CatchUpLogs),
     CommitMerge {
         region: Region,
         source: Region,
@@ -1725,7 +1719,7 @@ impl ApplyDelegate {
                 self.tag, merging_state, region, e
             )
         });
-
+        fail_point!("apply_after_prepare_merge");
         PEER_ADMIN_CMD_COUNTER_VEC
             .with_label_values(&["prepare_merge", "success"])
             .inc();
@@ -1792,26 +1786,17 @@ impl ApplyDelegate {
             );
 
             // Sends message to the source apply worker and pause `exec_commit_merge` process
-            if let Some(mailbox) = ctx.router.mailbox(self.region_id()) {
-                let logs_up_to_date = Arc::new(AtomicU64::new(0));
-                let msg = Msg::CatchUpLogs(CatchUpLogs {
-                    target_mailbox: mailbox,
-                    merge: merge.to_owned(),
-                    logs_up_to_date: logs_up_to_date.clone(),
-                });
-                ctx.router.schedule_task(source_region_id, msg);
-                return Ok((
-                    AdminResponse::default(),
-                    ApplyResult::WaitMergeSource(logs_up_to_date),
-                ));
-            } else {
-                info!(
-                    "failed to get mailbox, are we shutting down?";
-                    "region_id" => self.region_id(),
-                    "peer_id" => self.id(),
-                );
-                return Err(box_err!("failed to get mailbox"));
-            }
+            let logs_up_to_date = Arc::new(AtomicU64::new(0));
+            let msg = Msg::CatchUpLogs(CatchUpLogs {
+                target_region_id: self.region_id(),
+                merge: merge.to_owned(),
+                logs_up_to_date: logs_up_to_date.clone(),
+            });
+            ctx.router.schedule_task(source_region_id, msg);
+            return Ok((
+                AdminResponse::default(),
+                ApplyResult::WaitMergeSource(logs_up_to_date),
+            ));
         }
 
         info!(
@@ -2194,9 +2179,10 @@ pub struct Destroy {
 
 /// A message that asks the delegate to apply to the given logs and then reply to
 /// target mailbox.
+#[derive(Default, Debug)]
 pub struct CatchUpLogs {
-    /// Mailbox to notify when given logs are applied.
-    pub target_mailbox: DelegateMailbox,
+    /// The target region to be notified when given logs are applied.
+    pub target_region_id: u64,
     /// Merge request that contains logs to be applied.
     pub merge: CommitMergeRequest,
     /// A flag indicate that all source region's logs are applied.
@@ -2207,8 +2193,6 @@ pub struct CatchUpLogs {
     /// ready when polling.
     pub logs_up_to_date: Arc<AtomicU64>,
 }
-
-type DelegateMailbox = Mailbox<ApplyFsm, NormalScheduler<ApplyFsm, ControlFsm>>;
 
 pub struct GenSnapTask {
     region_id: u64,
@@ -2513,27 +2497,25 @@ impl ApplyFsm {
         }
 
         // if it is already up to date, no need to catch up anymore
-        if catch_up_logs.logs_up_to_date.load(Ordering::SeqCst) == 0 {
-            let apply_index = self.delegate.apply_state.get_applied_index();
-            if apply_index < catch_up_logs.merge.get_commit() {
-                let mut res = VecDeque::new();
-                // send logs to raftstore to append
-                res.push_back(ExecResult::CatchUpLogs {
-                    merge: catch_up_logs.merge,
-                    logs_up_to_date: catch_up_logs.logs_up_to_date,
-                });
+        let apply_index = self.delegate.apply_state.get_applied_index();
+        if apply_index < catch_up_logs.merge.get_commit() {
+            fail_point!("on_handle_catch_up_logs_for_merge");
+            let mut res = VecDeque::new();
+            // send logs to raftstore to append
+            res.push_back(ExecResult::CatchUpLogs(catch_up_logs));
 
-                // TODO: can we use `ctx.finish_for()` directly? is it safe here?
-                ctx.apply_res.push(ApplyRes {
-                    region_id: self.delegate.region_id(),
-                    apply_state: self.delegate.apply_state.clone(),
-                    exec_res: res,
-                    metrics: self.delegate.metrics.clone(),
-                    applied_index_term: self.delegate.applied_index_term,
-                });
-                return;
-            }
+            // TODO: can we use `ctx.finish_for()` directly? is it safe here?
+            ctx.apply_res.push(ApplyRes {
+                region_id: self.delegate.region_id(),
+                apply_state: self.delegate.apply_state.clone(),
+                exec_res: res,
+                metrics: self.delegate.metrics.clone(),
+                applied_index_term: self.delegate.applied_index_term,
+            });
+            return;
         }
+
+        fail_point!("after_handle_catch_up_logs_for_merge");
         fail_point!(
             "after_handle_catch_up_logs_for_merge_1000_1003",
             self.delegate.region_id() == 1000 && self.delegate.id() == 1003,
@@ -2547,12 +2529,19 @@ impl ApplyFsm {
             .store(region_id, Ordering::SeqCst);
         info!(
             "source logs are all applied now";
-            "region_id" => self.delegate.region_id(),
+            "region_id" => region_id,
             "peer_id" => self.delegate.id(),
         );
-        let _ = catch_up_logs
-            .target_mailbox
-            .force_send(Msg::LogsUpToDate(region_id));
+
+        if let Some(mailbox) = ctx.router.mailbox(catch_up_logs.target_region_id) {
+            let _ = mailbox.force_send(Msg::LogsUpToDate(region_id));
+        } else {
+            error!(
+                "failed to get mailbox, are we shutting down?";
+                "region_id" => region_id,
+                "peer_id" => self.delegate.id(),
+            );
+        }
     }
 
     fn handle_snapshot(&mut self, apply_ctx: &mut ApplyContext, snap_task: GenSnapTask) {

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::collections::Bound::{Excluded, Included, Unbounded};
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{cmp, u64};
@@ -1838,14 +1838,12 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         self.notify_prepare_merge();
 
         if let Some(logs_up_to_date) = self.fsm.peer.catch_up_logs.take() {
-            logs_up_to_date.store(region.get_id(), Ordering::SeqCst);
-            let mailbox = self.ctx.apply_router.mailbox(target).unwrap();
             // Send CatchUpLogs back to destroy source apply delegate,
             // then it will send `LogsUpToDate` to target apply delegate.
             self.ctx.apply_router.schedule_task(
                 region.get_id(),
                 ApplyTask::CatchUpLogs(CatchUpLogs {
-                    target_mailbox: mailbox,
+                    target_region_id: target,
                     merge: CommitMergeRequest::new(),
                     logs_up_to_date,
                 }),
@@ -1900,17 +1898,16 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         Some(ready_to_merge)
     }
 
-    fn on_ready_catch_up_logs(
-        &mut self,
-        merge: CommitMergeRequest,
-        logs_up_to_date: Arc<AtomicU64>,
-    ) {
+    fn on_ready_catch_up_logs(&mut self, catch_up_logs: CatchUpLogs) {
         let region_id = self.fsm.region_id();
-        assert_eq!(region_id, merge.get_source().get_id());
-        self.fsm.peer.catch_up_logs = Some(logs_up_to_date);
+        assert_eq!(region_id, catch_up_logs.merge.get_source().get_id());
 
         // directly append these logs to raft log and then commit
-        match self.fsm.peer.maybe_append_merge_entries(merge) {
+        match self
+            .fsm
+            .peer
+            .maybe_append_merge_entries(&catch_up_logs.merge)
+        {
             Some(last_index) => {
                 info!(
                     "append and commit entries to source region";
@@ -1920,12 +1917,23 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 );
                 // Now it has some committed entries, so mark it to take `Ready` in next round.
                 self.fsm.has_ready = true;
+                self.fsm.peer.catch_up_logs = Some(catch_up_logs.logs_up_to_date);
             }
             None => {
                 info!(
                     "no need to catch up logs";
                     "region_id" => region_id,
                     "peer_id" => self.fsm.peer.peer_id(),
+                );
+                // Send CatchUpLogs back to destroy source apply delegate,
+                // then it will send `LogsUpToDate` to target apply delegate.
+                self.ctx.apply_router.schedule_task(
+                    region_id,
+                    ApplyTask::CatchUpLogs(CatchUpLogs {
+                        target_region_id: catch_up_logs.target_region_id,
+                        merge: CommitMergeRequest::new(),
+                        logs_up_to_date: catch_up_logs.logs_up_to_date,
+                    }),
                 );
             }
         }
@@ -2155,11 +2163,8 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 ExecResult::PrepareMerge { region, state } => {
                     self.on_ready_prepare_merge(region, state);
                 }
-                ExecResult::CatchUpLogs {
-                    merge,
-                    logs_up_to_date,
-                } => {
-                    self.on_ready_catch_up_logs(merge, logs_up_to_date);
+                ExecResult::CatchUpLogs(catch_up_logs) => {
+                    self.on_ready_catch_up_logs(catch_up_logs);
                 }
                 ExecResult::CommitMerge { region, source } => {
                     if let Some(ready_to_merge) =

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -448,16 +448,20 @@ impl Peer {
     }
 
     #[inline]
-    pub fn maybe_append_merge_entries(&mut self, merge: CommitMergeRequest) -> Option<u64> {
+    pub fn maybe_append_merge_entries(&mut self, merge: &CommitMergeRequest) -> Option<u64> {
         let mut entries = merge.get_entries();
         if entries.is_empty() {
             return None;
         }
         let first = entries.first().unwrap();
-
         // make sure message should be with index not smaller than committed
         let mut log_idx = first.get_index() - 1;
         if log_idx < self.raft_group.raft.raft_log.committed {
+            // it indicates the logs are already committed during the process,
+            // so no need to append
+            if self.raft_group.raft.raft_log.committed - log_idx > entries.len() as u64 {
+                return None;
+            }
             entries = &entries[(self.raft_group.raft.raft_log.committed - log_idx) as usize..];
             log_idx = self.raft_group.raft.raft_log.committed;
         }

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -8,10 +8,9 @@ use std::time::*;
 use fail;
 use futures::Future;
 
+use engine::*;
 use kvproto::raft_serverpb::{PeerState, RegionLocalState};
 use raft::eraftpb::MessageType;
-
-use engine::*;
 use test_raftstore::*;
 use tikv::pd::PdClient;
 use tikv::raftstore::store::keys;
@@ -301,6 +300,77 @@ fn test_node_merge_catch_up_logs_leader_election() {
     fail::remove("before_peer_destroy_1000_1003");
 
     must_get_equal(&cluster.get_engine(3), b"k11", b"v11");
+}
+
+#[test]
+fn test_node_merge_catch_up_logs_no_need() {
+    let _guard = crate::setup();
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_merge(&mut cluster);
+    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(10);
+    cluster.cfg.raft_store.raft_election_timeout_ticks = 25;
+    cluster.cfg.raft_store.raft_log_gc_threshold = 12;
+    cluster.cfg.raft_store.raft_log_gc_count_limit = 12;
+    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(100);
+    cluster.run();
+
+    cluster.must_put(b"k1", b"v1");
+    cluster.must_put(b"k3", b"v3");
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    let region = pd_client.get_region(b"k1").unwrap();
+    let peer_on_store1 = find_peer(&region, 1).unwrap().to_owned();
+    cluster.must_transfer_leader(region.get_id(), peer_on_store1);
+    cluster.must_split(&region, b"k2");
+    let left = pd_client.get_region(b"k1").unwrap();
+    let right = pd_client.get_region(b"k2").unwrap();
+
+    // put some keys to trigger compact raft log
+    for i in 2..20 {
+        cluster.must_put(format!("k1{}", i).as_bytes(), b"v");
+        must_get_none(&cluster.get_engine(3), b"k1{}");
+    }
+
+    // let the peer of left region on store 3 falls behind.
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(left.get_id(), 3)
+            .direction(Direction::Recv)
+            .msg_type(MessageType::MsgAppend),
+    ));
+
+    // make sure the peer is isolated.
+    cluster.must_put(b"k11", b"v11");
+    must_get_none(&cluster.get_engine(3), b"k11");
+
+    // propose merge but not let apply index make progress.
+    fail::cfg("apply_after_prepare_merge", "pause").unwrap();
+    pd_client.merge_region(left.get_id(), right.get_id());
+    must_get_none(&cluster.get_engine(3), b"k11");
+
+    // wait to trigger compact raft log
+    thread::sleep(Duration::from_millis(100));
+
+    // let source region not merged
+    fail::cfg("on_handle_catch_up_logs_for_merge", "pause").unwrap();
+    fail::cfg("after_handle_catch_up_logs_for_merge", "pause").unwrap();
+    // due to `on_handle_catch_up_logs_for_merge` failpoint, we already pass `apply_index < catch_up_logs.merge.get_commit()`
+    // so now can let apply index make progress.
+    fail::remove("apply_after_prepare_merge");
+
+    // make sure all the logs are committed, including the compact command
+    cluster.clear_send_filters();
+    thread::sleep(Duration::from_millis(50));
+
+    // let merge process continue
+    fail::remove("on_handle_catch_up_logs_for_merge");
+    fail::remove("after_handle_catch_up_logs_for_merge");
+    thread::sleep(Duration::from_millis(50));
+
+    // the source region should be merged and the peer should be destroyed.
+    assert!(pd_client.check_merged(left.get_id()));
+    must_get_equal(&cluster.get_engine(3), b"k11", b"v11");
+    let router = cluster.sim.wl().get_router(3).unwrap();
+    assert!(router.mailbox(left.get_id()).is_none());
 }
 
 /// Test if merging state will be removed after accepting a snapshot.


### PR DESCRIPTION
## What have you changed? (mandatory)
In merge process, target region will send entries to fall-behind source region. It is possible to propose a `CompactLog` command after proposing `PrepareMerge`.  Note that, the `entries` involved in `CommitMerge` would not take the `CompactLog` record.


So during the merge process, if the source region catches up with the logs by raft append msgs, `self.raft_group.raft.raft_log.committed - log_idx` would be larger than `entries.len()` which leads to `entries[self.raft_group.raft.raft_log.committed - log_idx..]` out of slice range. 


So check the len before cutting up the slice.

## What are the type of changes? (mandatory)
- Bugfix (a change which fixes an issue)

## How has this PR been tested? (mandatory)
unit-test 

## Does this PR affect documentation (docs) or release note? (mandatory)
No

## Does this PR affect `tidb-ansible` update? (mandatory)
No

## Refer to a related PR or issue link (optional)
https://github.com/pingcap/tidb/issues/11744

