### PR TITLE
cmd/tikv-ctl: change all "about" prompt message first word to uppercase

### DIFF
--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -974,7 +974,7 @@ fn main() {
                 .required(false)
                 .long("skip-paranoid-checks")
                 .takes_value(false)
-                .help("skip paranoid checks when open rocksdb"),
+                .help("Skip paranoid checks when open rocksdb"),
         )
         .arg(
             Arg::with_name("config")
@@ -1097,7 +1097,7 @@ fn main() {
         )
         .subcommand(
             SubCommand::with_name("size")
-                .about("print region size")
+                .about("Print region size")
                 .arg(
                     Arg::with_name("region")
                         .short("r")
@@ -1203,7 +1203,7 @@ fn main() {
         )
         .subcommand(
             SubCommand::with_name("print")
-                .about("print the raw value")
+                .about("Print the raw value")
                 .arg(
                     Arg::with_name("cf")
                         .short("c")
@@ -1258,7 +1258,7 @@ fn main() {
         )
         .subcommand(
             SubCommand::with_name("diff")
-                .about("calculate difference of region keys from different dbs")
+                .about("Calculate difference of region keys from different dbs")
                 .arg(
                     Arg::with_name("region")
                         .required(true)


### PR DESCRIPTION
Signed-off-by: mapleFU <1506118561@qq.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

This pr changes all "about" prompt message first word to uppercase in `cmd/src/tikv_ctl.rs`

In previous `cmd/src/tikv_ctl.rs` , some prompt message begin with lowercase word. This pr changes all of them to uppercase.

## What are the type of changes? (mandatory)

The currently defined types are listed below, please pick one of the types for this PR by removing the others:

- Misc (update prompt message)

## How has this PR been tested? (mandatory)

Doesn't need to test.

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect `tidb-ansible` update? (mandatory)

No.

