### PR TITLE
tikv-ctl.rs: fix command help message

### DIFF
--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -1639,7 +1639,7 @@ fn main() {
                         .short("k")
                         .required(true)
                         .takes_value(true)
-                        .help("The key to split it, in unecoded escaped format")
+                        .help("The key to split it, in unencoded escaped format")
                 ),
         )
         .subcommand(


### PR DESCRIPTION
the misspelled words maybe confusing, it `encoded` or `unencoded` ?

Signed-off-by: Guangming Wang <guangming.wang@daocloud.io>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

fix typos words in help message

Please **NOTE** that:
- Do not assume reviewers understand the original issue

## What are the type of changes? (mandatory)

- Misc (other changes)

## How has this PR been tested? (mandatory)
local test.

## Does this PR affect documentation (docs) or release note? (mandatory)

NO

## Does this PR affect `tidb-ansible` update? (mandatory)

NO

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

