### PR TITLE
raftstore: merge Compact, RaftlogGc, CleanupSST worker into one thread

### DIFF
--- a/components/tidb_query/src/codec/mysql/duration.rs
+++ b/components/tidb_query/src/codec/mysql/duration.rs
@@ -243,7 +243,6 @@ mod parser {
                 >> (neg, [day, hhmmss[0], hhmmss[1], hhmmss[2], fraction])
         )
     }
-
 } /* parser */
 
 bitfield! {

--- a/components/tidb_query/src/expr/builtin_control.rs
+++ b/components/tidb_query/src/expr/builtin_control.rs
@@ -531,5 +531,4 @@ mod tests {
             assert_eq!(res, exp);
         }
     }
-
 }

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -140,5 +140,4 @@ mod tests {
         sketch.insert_hash_value(4);
         assert_eq!(sketch.hash_set.len(), max_size);
     }
-
 }

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -193,6 +193,7 @@ pub struct PollContext<T, C: 'static> {
     pub pd_scheduler: FutureScheduler<PdTask>,
     pub consistency_check_scheduler: Scheduler<ConsistencyCheckTask>,
     pub split_check_scheduler: Scheduler<SplitCheckTask>,
+    // handle Compact, RaftlogGc, CleanupSST task
     pub cleanup_scheduler: Scheduler<CleanupTask>,
     pub region_scheduler: Scheduler<RegionTask>,
     pub apply_router: ApplyRouter,
@@ -918,6 +919,7 @@ struct Workers {
     pd_worker: FutureWorker<PdTask>,
     consistency_check_worker: Worker<ConsistencyCheckTask>,
     split_check_worker: Worker<SplitCheckTask>,
+    // handle Compact, RaftlogGc, CleanupSST task
     cleanup_worker: Worker<CleanupTask>,
     region_worker: Worker<RegionTask>,
     coprocessor_host: Arc<CoprocessorHost>,

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -43,9 +43,9 @@ use crate::raftstore::store::peer_storage::{self, HandleRaftReadyContext, Invoke
 use crate::raftstore::store::transport::Transport;
 use crate::raftstore::store::util::is_initial_msg;
 use crate::raftstore::store::worker::{
-    CleanupSSTRunner, CleanupSSTTask, CompactRunner, CompactTask, ConsistencyCheckRunner,
-    ConsistencyCheckTask, PdRunner, RaftlogGcRunner, RaftlogGcTask, ReadDelegate, RegionRunner,
-    RegionTask, SplitCheckRunner, SplitCheckTask,
+    CleanupRunner, CleanupSSTRunner, CleanupSSTTask, CleanupTask, CompactRunner, CompactTask,
+    ConsistencyCheckRunner, ConsistencyCheckTask, PdRunner, RaftlogGcRunner, ReadDelegate,
+    RegionRunner, RegionTask, SplitCheckRunner, SplitCheckTask,
 };
 use crate::raftstore::store::PdTask;
 use crate::raftstore::store::{
@@ -191,14 +191,12 @@ pub struct PollContext<T, C: 'static> {
     pub cfg: Arc<Config>,
     pub store: metapb::Store,
     pub pd_scheduler: FutureScheduler<PdTask>,
-    pub raftlog_gc_scheduler: Scheduler<RaftlogGcTask>,
     pub consistency_check_scheduler: Scheduler<ConsistencyCheckTask>,
     pub split_check_scheduler: Scheduler<SplitCheckTask>,
-    pub cleanup_sst_scheduler: Scheduler<CleanupSSTTask>,
+    pub cleanup_scheduler: Scheduler<CleanupTask>,
     pub region_scheduler: Scheduler<RegionTask>,
     pub apply_router: ApplyRouter,
     pub router: RaftRouter,
-    pub compact_scheduler: Scheduler<CompactTask>,
     pub importer: Arc<SSTImporter>,
     pub store_meta: Arc<Mutex<StoreMeta>>,
     pub future_poller: ThreadPoolSender,
@@ -680,14 +678,12 @@ pub struct RaftPollerBuilder<T, C> {
     pub cfg: Arc<Config>,
     pub store: metapb::Store,
     pd_scheduler: FutureScheduler<PdTask>,
-    raftlog_gc_scheduler: Scheduler<RaftlogGcTask>,
     consistency_check_scheduler: Scheduler<ConsistencyCheckTask>,
     split_check_scheduler: Scheduler<SplitCheckTask>,
-    cleanup_sst_scheduler: Scheduler<CleanupSSTTask>,
+    cleanup_scheduler: Scheduler<CleanupTask>,
     pub region_scheduler: Scheduler<RegionTask>,
     apply_router: ApplyRouter,
     pub router: RaftRouter,
-    compact_scheduler: Scheduler<CompactTask>,
     pub importer: Arc<SSTImporter>,
     store_meta: Arc<Mutex<StoreMeta>>,
     future_poller: ThreadPoolSender,
@@ -876,14 +872,12 @@ where
             cfg: self.cfg.clone(),
             store: self.store.clone(),
             pd_scheduler: self.pd_scheduler.clone(),
-            raftlog_gc_scheduler: self.raftlog_gc_scheduler.clone(),
             consistency_check_scheduler: self.consistency_check_scheduler.clone(),
             split_check_scheduler: self.split_check_scheduler.clone(),
-            cleanup_sst_scheduler: self.cleanup_sst_scheduler.clone(),
             region_scheduler: self.region_scheduler.clone(),
             apply_router: self.apply_router.clone(),
             router: self.router.clone(),
-            compact_scheduler: self.compact_scheduler.clone(),
+            cleanup_scheduler: self.cleanup_scheduler.clone(),
             importer: self.importer.clone(),
             store_meta: self.store_meta.clone(),
             future_poller: self.future_poller.clone(),
@@ -922,12 +916,10 @@ where
 
 struct Workers {
     pd_worker: FutureWorker<PdTask>,
-    raftlog_gc_worker: Worker<RaftlogGcTask>,
     consistency_check_worker: Worker<ConsistencyCheckTask>,
     split_check_worker: Worker<SplitCheckTask>,
-    cleanup_sst_worker: Worker<CleanupSSTTask>,
+    cleanup_worker: Worker<CleanupTask>,
     region_worker: Worker<RegionTask>,
-    compact_worker: Worker<CompactTask>,
     coprocessor_host: Arc<CoprocessorHost>,
     future_poller: ThreadPool,
 }
@@ -970,11 +962,9 @@ impl RaftBatchSystem {
         let workers = Workers {
             split_check_worker: Worker::new("split-check"),
             region_worker: Worker::new("snapshot-worker"),
-            raftlog_gc_worker: Worker::new("raft-gc-worker"),
-            compact_worker: Worker::new("compact-worker"),
             pd_worker,
             consistency_check_worker: Worker::new("consistency-check"),
-            cleanup_sst_worker: Worker::new("cleanup-sst"),
+            cleanup_worker: Worker::new("cleanup"),
             coprocessor_host: Arc::new(coprocessor_host),
             future_poller: tokio_threadpool::Builder::new()
                 .name_prefix("future-poller")
@@ -988,11 +978,9 @@ impl RaftBatchSystem {
             router: self.router.clone(),
             split_check_scheduler: workers.split_check_worker.scheduler(),
             region_scheduler: workers.region_worker.scheduler(),
-            raftlog_gc_scheduler: workers.raftlog_gc_worker.scheduler(),
-            compact_scheduler: workers.compact_worker.scheduler(),
             pd_scheduler: workers.pd_worker.scheduler(),
             consistency_check_scheduler: workers.consistency_check_worker.scheduler(),
-            cleanup_sst_scheduler: workers.cleanup_sst_worker.scheduler(),
+            cleanup_scheduler: workers.cleanup_worker.scheduler(),
             apply_router: self.apply_router.clone(),
             trans,
             pd_client,
@@ -1089,11 +1077,17 @@ impl RaftBatchSystem {
         let timer = RegionRunner::new_timer();
         box_try!(workers.region_worker.start_with_timer(region_runner, timer));
 
-        let raftlog_gc_runner = RaftlogGcRunner::new(None);
-        box_try!(workers.raftlog_gc_worker.start(raftlog_gc_runner));
-
         let compact_runner = CompactRunner::new(Arc::clone(&engines.kv));
-        box_try!(workers.compact_worker.start(compact_runner));
+        let raftlog_gc_runner = RaftlogGcRunner::new(None);
+        let cleanup_sst_runner = CleanupSSTRunner::new(
+            store.get_id(),
+            self.router.clone(),
+            Arc::clone(&importer),
+            Arc::clone(&pd_client),
+        );
+        let cleanup_runner =
+            CleanupRunner::new(compact_runner, raftlog_gc_runner, cleanup_sst_runner);
+        box_try!(workers.cleanup_worker.start(cleanup_runner));
 
         let pd_runner = PdRunner::new(
             store.get_id(),
@@ -1108,14 +1102,6 @@ impl RaftBatchSystem {
         box_try!(workers
             .consistency_check_worker
             .start(consistency_check_runner));
-
-        let cleanup_sst_runner = CleanupSSTRunner::new(
-            store.get_id(),
-            self.router.clone(),
-            Arc::clone(&importer),
-            Arc::clone(&pd_client),
-        );
-        box_try!(workers.cleanup_sst_worker.start(cleanup_sst_runner));
 
         if let Err(e) = sys_util::thread::set_priority(sys_util::HIGH_PRI) {
             warn!("set thread priority for raftstore failed"; "error" => ?e);
@@ -1133,11 +1119,8 @@ impl RaftBatchSystem {
         let mut handles: Vec<Option<thread::JoinHandle<()>>> = vec![];
         handles.push(workers.split_check_worker.stop());
         handles.push(workers.region_worker.stop());
-        handles.push(workers.raftlog_gc_worker.stop());
-        handles.push(workers.compact_worker.stop());
         handles.push(workers.pd_worker.stop());
         handles.push(workers.consistency_check_worker.stop());
-        handles.push(workers.cleanup_sst_worker.stop());
         self.apply_system.shutdown();
         self.system.shutdown();
         for h in handles {
@@ -1480,7 +1463,7 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
 
     fn on_compact_check_tick(&mut self) {
         self.register_compact_check_tick();
-        if self.ctx.compact_scheduler.is_busy() {
+        if self.ctx.cleanup_scheduler.is_busy() {
             debug!(
                 "compact worker is busy, check space redundancy next time";
                 "store_id" => self.fsm.store.id,
@@ -1540,16 +1523,14 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
 
         // Schedule the task.
         let cf_names = vec![CF_DEFAULT.to_owned(), CF_WRITE.to_owned()];
-        if let Err(e) = self
-            .ctx
-            .compact_scheduler
-            .schedule(CompactTask::CheckAndCompact {
+        if let Err(e) = self.ctx.cleanup_scheduler.schedule(CleanupTask::Compact(
+            CompactTask::CheckAndCompact {
                 cf_names,
                 ranges: ranges_need_check,
                 tombstones_num_threshold: self.ctx.cfg.region_compact_min_tombstones,
                 tombstones_percent_threshold: self.ctx.cfg.region_compact_tombstones_percent,
-            })
-        {
+            },
+        )) {
             error!(
                 "schedule space check task failed";
                 "store_id" => self.fsm.store.id,
@@ -1723,7 +1704,11 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
                 start_key: None,
                 end_key: None,
             };
-            if let Err(e) = self.ctx.compact_scheduler.schedule(task) {
+            if let Err(e) = self
+                .ctx
+                .cleanup_scheduler
+                .schedule(CleanupTask::Compact(task))
+            {
                 error!(
                     "schedule compact lock cf task failed";
                     "store_id" => self.fsm.store.id,
@@ -1776,7 +1761,11 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
         }
 
         let task = CleanupSSTTask::DeleteSST { ssts: delete_ssts };
-        if let Err(e) = self.ctx.cleanup_sst_scheduler.schedule(task) {
+        if let Err(e) = self
+            .ctx
+            .cleanup_scheduler
+            .schedule(CleanupTask::CleanupSST(task))
+        {
             error!(
                 "schedule to delete ssts failed";
                 "store_id" => self.fsm.store.id,
@@ -1811,7 +1800,11 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
 
         if !delete_ssts.is_empty() {
             let task = CleanupSSTTask::DeleteSST { ssts: delete_ssts };
-            if let Err(e) = self.ctx.cleanup_sst_scheduler.schedule(task) {
+            if let Err(e) = self
+                .ctx
+                .cleanup_scheduler
+                .schedule(CleanupTask::CleanupSST(task))
+            {
                 error!(
                     "schedule to delete ssts failed";
                     "store_id" => self.fsm.store.id,
@@ -1824,7 +1817,11 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
             let task = CleanupSSTTask::ValidateSST {
                 ssts: validate_ssts,
             };
-            if let Err(e) = self.ctx.cleanup_sst_scheduler.schedule(task) {
+            if let Err(e) = self
+                .ctx
+                .cleanup_scheduler
+                .schedule(CleanupTask::CleanupSST(task))
+            {
                 error!(
                    "schedule to validate ssts failed";
                    "store_id" => self.fsm.store.id,

--- a/src/raftstore/store/worker/cleanup.rs
+++ b/src/raftstore/store/worker/cleanup.rs
@@ -1,0 +1,57 @@
+// Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::fmt::{self, Display, Formatter};
+
+use super::cleanup_sst::{Runner as CleanupSSTRunner, Task as CleanupSSTTask};
+use super::compact::{Runner as CompactRunner, Task as CompactTask};
+use super::raftlog_gc::{Runner as RaftlogGcRunner, Task as RaftlogGcTask};
+
+use crate::raftstore::store::StoreRouter;
+use pd_client::PdClient;
+use tikv_util::worker::Runnable;
+
+pub enum Task {
+    Compact(CompactTask),
+    RaftlogGc(RaftlogGcTask),
+    CleanupSST(CleanupSSTTask),
+}
+
+impl Display for Task {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Task::Compact(ref t) => t.fmt(f),
+            Task::RaftlogGc(ref t) => t.fmt(f),
+            Task::CleanupSST(ref t) => t.fmt(f),
+        }
+    }
+}
+
+pub struct Runner<C, S> {
+    compact: CompactRunner,
+    raftlog_gc: RaftlogGcRunner,
+    cleanup_sst: CleanupSSTRunner<C, S>,
+}
+
+impl<C: PdClient, S: StoreRouter> Runner<C, S> {
+    pub fn new(
+        compact: CompactRunner,
+        raftlog_gc: RaftlogGcRunner,
+        cleanup_sst: CleanupSSTRunner<C, S>,
+    ) -> Runner<C, S> {
+        Runner {
+            compact,
+            raftlog_gc,
+            cleanup_sst,
+        }
+    }
+}
+
+impl<C: PdClient, S: StoreRouter> Runnable<Task> for Runner<C, S> {
+    fn run(&mut self, task: Task) {
+        match task {
+            Task::Compact(t) => self.compact.run(t),
+            Task::RaftlogGc(t) => self.raftlog_gc.run(t),
+            Task::CleanupSST(t) => self.cleanup_sst.run(t),
+        }
+    }
+}

--- a/src/raftstore/store/worker/cleanup.rs
+++ b/src/raftstore/store/worker/cleanup.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::fmt::{self, Display, Formatter};
 

--- a/src/raftstore/store/worker/mod.rs
+++ b/src/raftstore/store/worker/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
+mod cleanup;
 mod cleanup_sst;
 mod compact;
 mod consistency_check;
@@ -10,6 +11,7 @@ mod read;
 mod region;
 mod split_check;
 
+pub use self::cleanup::{Runner as CleanupRunner, Task as CleanupTask};
 pub use self::cleanup_sst::{Runner as CleanupSSTRunner, Task as CleanupSSTTask};
 pub use self::compact::{Runner as CompactRunner, Task as CompactTask};
 pub use self::consistency_check::{Runner as ConsistencyCheckRunner, Task as ConsistencyCheckTask};

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -454,5 +454,4 @@ mod tests {
         iter.prev(&mut statistics);
         assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 3);
     }
-
 }

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -1134,5 +1134,4 @@ mod tests {
         assert_eq!(statistics.lock.prev, 15);
         assert_eq!(statistics.write.prev, 1);
     }
-
 }


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

For reducing the number of threads in tikv, this PR merges Compact, RaftlogGc, CleanupSST worker into one thread.

## What are the type of changes? (mandatory)

- Improvement (a change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

CI

## Does this PR affect documentation (docs) or release note? (mandatory)

No.

## Does this PR affect `tidb-ansible` update? (mandatory)

No.

