### PR TITLE
Move task limit from read pool to future pool

### DIFF
--- a/cmd/src/setup.rs
+++ b/cmd/src/setup.rs
@@ -28,9 +28,8 @@ macro_rules! fatal {
 
 #[allow(dead_code)]
 pub fn initial_logger(config: &TiKvConfig) {
-    let log_rotation_timespan =
-        chrono::Duration::from_std(config.log_rotation_timespan.clone().into())
-            .expect("config.log_rotation_timespan is an invalid duration.");
+    let log_rotation_timespan = chrono::Duration::from_std(config.log_rotation_timespan.into())
+        .expect("config.log_rotation_timespan is an invalid duration.");
 
     if config.log_file.is_empty() {
         let drainer = logger::term_drainer();

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -218,7 +218,7 @@ impl<'de> Deserialize<'de> for ReadableSize {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ReadableDuration(pub Duration);
 
 impl From<ReadableDuration> for Duration {

--- a/components/tikv_util/src/future_pool/builder.rs
+++ b/components/tikv_util/src/future_pool/builder.rs
@@ -10,6 +10,7 @@ pub struct Builder {
     inner_builder: TokioBuilder,
     name_prefix: Option<String>,
     on_tick: Option<Box<dyn Fn() + Send + Sync>>,
+    max_tasks: usize,
 }
 
 impl Builder {
@@ -18,6 +19,7 @@ impl Builder {
             inner_builder: TokioBuilder::new(),
             name_prefix: None,
             on_tick: None,
+            max_tasks: std::usize::MAX,
         }
     }
 
@@ -62,6 +64,11 @@ impl Builder {
         self
     }
 
+    pub fn max_tasks(&mut self, val: usize) -> &mut Self {
+        self.max_tasks = val;
+        self
+    }
+
     pub fn build(&mut self) -> super::FuturePool {
         let name = if let Some(name) = &self.name_prefix {
             name.as_str()
@@ -74,6 +81,10 @@ impl Builder {
             metrics_handled_task_count: FUTUREPOOL_HANDLED_TASK_VEC.with_label_values(&[name]),
         });
         let pool = Arc::new(self.inner_builder.build());
-        super::FuturePool { pool, env }
+        super::FuturePool {
+            pool,
+            env,
+            max_tasks: self.max_tasks,
+        }
     }
 }

--- a/components/tikv_util/src/future_pool/mod.rs
+++ b/components/tikv_util/src/future_pool/mod.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::{lazy, Future};
-use prometheus::*;
+use prometheus::{IntCounter, IntGauge};
 use tokio_threadpool::{SpawnHandle, ThreadPool};
 
 use crate::time::Instant;
@@ -34,11 +34,12 @@ struct Env {
 pub struct FuturePool {
     pool: Arc<ThreadPool>,
     env: Arc<Env>,
+    max_tasks: usize,
 }
 
 impl std::fmt::Debug for FuturePool {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        fmt.debug_struct("FuturePool").finish()
+        write!(fmt, "FuturePool")
     }
 }
 
@@ -52,6 +53,27 @@ impl FuturePool {
         // As long as different future pool has different name prefix, we can safely use the value
         // in metrics.
         self.env.metrics_running_task_count.get() as usize
+    }
+
+    fn gate_spawn(&self) -> Result<(), Full> {
+        fail_point!("future_pool_spawn_full", |_| Err(Full {
+            current_tasks: 100,
+            max_tasks: 100,
+        }));
+
+        if self.max_tasks == std::usize::MAX {
+            return Ok(());
+        }
+
+        let current_tasks = self.get_running_task_count();
+        if current_tasks >= self.max_tasks {
+            Err(Full {
+                current_tasks,
+                max_tasks: self.max_tasks,
+            })
+        } else {
+            Ok(())
+        }
     }
 
     /// Wraps a user provided future to support features of the `FuturePool`.
@@ -78,30 +100,53 @@ impl FuturePool {
     }
 
     /// Spawns a future in the pool.
-    pub fn spawn<F, R>(&self, future_fn: F)
+    pub fn spawn<F, R>(&self, future_fn: F) -> Result<(), Full>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Future + Send + 'static,
         R::Item: Send + 'static,
         R::Error: Send + 'static,
     {
+        self.gate_spawn()?;
+
         let future = self.wrap_user_future(future_fn);
         self.pool.spawn(future.then(|_| Ok(())));
+        Ok(())
     }
 
     /// Spawns a future in the pool and returns a handle to the result of the future.
     ///
     /// The future will not be executed if the handle is not polled.
     #[must_use]
-    pub fn spawn_handle<F, R>(&self, future_fn: F) -> SpawnHandle<R::Item, R::Error>
+    pub fn spawn_handle<F, R>(&self, future_fn: F) -> Result<SpawnHandle<R::Item, R::Error>, Full>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Future + Send + 'static,
         R::Item: Send + 'static,
         R::Error: Send + 'static,
     {
+        self.gate_spawn()?;
+
         let future = self.wrap_user_future(future_fn);
-        self.pool.spawn_handle(future)
+        Ok(self.pool.spawn_handle(future))
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Full {
+    pub current_tasks: usize,
+    pub max_tasks: usize,
+}
+
+impl std::fmt::Display for Full {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "future pool is full")
+    }
+}
+
+impl std::error::Error for Full {
+    fn description(&self) -> &str {
+        "future pool is full"
     }
 }
 
@@ -139,6 +184,7 @@ mod tests {
             thread::sleep(duration);
             future::ok::<_, ()>(())
         })
+        .unwrap()
         .wait()
         .unwrap();
     }
@@ -147,7 +193,8 @@ mod tests {
         pool.spawn(move || {
             thread::sleep(duration);
             future::ok::<_, ()>(())
-        });
+        })
+        .unwrap();
     }
 
     #[test]
@@ -257,13 +304,17 @@ mod tests {
             thread::sleep(Duration::from_millis(200));
             tx2.send(11).unwrap();
             future::ok::<_, ()>(())
-        });
+        })
+        .unwrap();
 
         let tx2 = tx.clone();
-        drop(pool.spawn_handle(move || {
-            tx2.send(7).unwrap();
-            future::ok::<_, ()>(())
-        }));
+        drop(
+            pool.spawn_handle(move || {
+                tx2.send(7).unwrap();
+                future::ok::<_, ()>(())
+            })
+            .unwrap(),
+        );
 
         thread::sleep(Duration::from_millis(500));
 
@@ -277,7 +328,7 @@ mod tests {
 
         let handle = pool.spawn_handle(move || future::ok::<_, ()>(42));
 
-        assert_eq!(handle.wait().unwrap(), 42);
+        assert_eq!(handle.unwrap().wait().unwrap(), 42);
     }
 
     #[test]
@@ -306,5 +357,93 @@ mod tests {
 
         thread::sleep(Duration::from_millis(2700));
         assert_eq!(pool.get_running_task_count(), 0);
+    }
+
+    fn spawn_long_time_future(
+        pool: &FuturePool,
+        id: u64,
+        future_duration_ms: u64,
+    ) -> Result<SpawnHandle<u64, ()>, Full> {
+        pool.spawn_handle(move || {
+            thread::sleep(Duration::from_millis(future_duration_ms));
+            future::ok::<u64, ()>(id)
+        })
+    }
+
+    fn wait_on_new_thread<F>(
+        sender: mpsc::Sender<std::result::Result<F::Item, F::Error>>,
+        future: F,
+    ) where
+        F: Future + Send + 'static,
+        F::Item: Send + 'static,
+        F::Error: Send + 'static,
+    {
+        thread::spawn(move || {
+            let r = future.wait();
+            sender.send(r).unwrap();
+        });
+    }
+
+    #[test]
+    fn test_full() {
+        let (tx, rx) = mpsc::channel();
+
+        let read_pool = Builder::new()
+            .name_prefix("future_pool_test_full")
+            .pool_size(2)
+            .max_tasks(4)
+            .build();
+
+        wait_on_new_thread(
+            tx.clone(),
+            spawn_long_time_future(&read_pool, 0, 5).unwrap(),
+        );
+        // not full
+        assert_eq!(rx.recv().unwrap(), Ok(0));
+
+        wait_on_new_thread(
+            tx.clone(),
+            spawn_long_time_future(&read_pool, 1, 100).unwrap(),
+        );
+        wait_on_new_thread(
+            tx.clone(),
+            spawn_long_time_future(&read_pool, 2, 200).unwrap(),
+        );
+        wait_on_new_thread(
+            tx.clone(),
+            spawn_long_time_future(&read_pool, 3, 300).unwrap(),
+        );
+        wait_on_new_thread(
+            tx.clone(),
+            spawn_long_time_future(&read_pool, 4, 400).unwrap(),
+        );
+        // no available results (running = 4)
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+
+        // full
+        assert!(spawn_long_time_future(&read_pool, 5, 100).is_err());
+
+        // full
+        assert!(spawn_long_time_future(&read_pool, 6, 100).is_err());
+
+        // wait a future completes (running = 3)
+        assert_eq!(rx.recv().unwrap(), Ok(1));
+
+        // add new (running = 4)
+        wait_on_new_thread(
+            tx.clone(),
+            spawn_long_time_future(&read_pool, 7, 5).unwrap(),
+        );
+
+        // full
+        assert!(spawn_long_time_future(&read_pool, 8, 100).is_err());
+
+        assert!(rx.recv().is_ok());
+        assert!(rx.recv().is_ok());
+        assert!(rx.recv().is_ok());
+        assert!(rx.recv().is_ok());
+
+        // no more results
+        assert!(rx.recv_timeout(Duration::from_millis(500)).is_err());
     }
 }

--- a/src/server/readpool/builder.rs
+++ b/src/server/readpool/builder.rs
@@ -4,29 +4,33 @@ use tikv_util::future_pool::Builder as FuturePoolBuilder;
 
 use super::config::Config;
 
-pub struct Builder<'a> {
-    config: &'a Config,
+pub struct Builder {
     builder_low: FuturePoolBuilder,
     builder_normal: FuturePoolBuilder,
     builder_high: FuturePoolBuilder,
 }
 
-impl<'a> Builder<'a> {
-    pub fn from_config(config: &'a Config) -> Self {
+impl Builder {
+    pub fn from_config(config: &Config) -> Self {
         let mut builder_low = FuturePoolBuilder::new();
-        builder_low.pool_size(config.low_concurrency);
-        builder_low.stack_size(config.stack_size.0 as usize);
+        builder_low
+            .pool_size(config.low_concurrency)
+            .stack_size(config.stack_size.0 as usize)
+            .max_tasks(config.max_tasks_per_worker_low * config.low_concurrency);
 
         let mut builder_normal = FuturePoolBuilder::new();
-        builder_normal.pool_size(config.normal_concurrency);
-        builder_normal.stack_size(config.stack_size.0 as usize);
+        builder_normal
+            .pool_size(config.normal_concurrency)
+            .stack_size(config.stack_size.0 as usize)
+            .max_tasks(config.max_tasks_per_worker_normal * config.normal_concurrency);
 
         let mut builder_high = FuturePoolBuilder::new();
-        builder_high.pool_size(config.high_concurrency);
-        builder_high.stack_size(config.stack_size.0 as usize);
+        builder_high
+            .pool_size(config.high_concurrency)
+            .stack_size(config.stack_size.0 as usize)
+            .max_tasks(config.max_tasks_per_worker_high * config.high_concurrency);
 
         Builder {
-            config,
             builder_low,
             builder_normal,
             builder_high,
@@ -76,10 +80,6 @@ impl<'a> Builder<'a> {
             pool_low: self.builder_low.build(),
             pool_normal: self.builder_normal.build(),
             pool_high: self.builder_high.build(),
-            max_tasks_low: self.config.max_tasks_per_worker_low * self.config.low_concurrency,
-            max_tasks_normal: self.config.max_tasks_per_worker_normal
-                * self.config.normal_concurrency,
-            max_tasks_high: self.config.max_tasks_per_worker_high * self.config.high_concurrency,
         }
     }
 

--- a/src/server/readpool/mod.rs
+++ b/src/server/readpool/mod.rs
@@ -9,10 +9,8 @@ pub use self::config::Config;
 pub use self::priority::Priority;
 
 use futures::Future;
-use tikv_util::future_pool::FuturePool;
+use tikv_util::future_pool::{Full, FuturePool};
 use tokio_threadpool::SpawnHandle;
-
-type Result<T> = std::result::Result<T, Full>;
 
 /// A priority-aware thread pool for executing futures.
 ///
@@ -23,9 +21,6 @@ pub struct ReadPool {
     pool_high: FuturePool,
     pool_normal: FuturePool,
     pool_low: FuturePool,
-    max_tasks_high: usize,
-    max_tasks_normal: usize,
-    max_tasks_low: usize,
 }
 
 impl tikv_util::AssertSend for ReadPool {}
@@ -41,47 +36,14 @@ impl ReadPool {
         }
     }
 
-    #[inline]
-    fn get_max_tasks_by_priority(&self, priority: Priority) -> usize {
-        match priority {
-            Priority::High => self.max_tasks_high,
-            Priority::Normal => self.max_tasks_normal,
-            Priority::Low => self.max_tasks_low,
-        }
-    }
-
-    #[inline]
-    fn gate_spawn<F, R>(&self, priority: Priority, f: F) -> Result<R>
-    where
-        F: FnOnce(&FuturePool) -> R,
-    {
-        fail_point!("read_pool_spawn_full", |_| Err(Full {
-            current_tasks: 100,
-            max_tasks: 100,
-        }));
-
-        let pool = self.get_pool_by_priority(priority);
-        let max_tasks = self.get_max_tasks_by_priority(priority);
-        let current_tasks = pool.get_running_task_count();
-
-        if current_tasks >= max_tasks {
-            Err(Full {
-                current_tasks,
-                max_tasks,
-            })
-        } else {
-            Ok(f(pool))
-        }
-    }
-
-    pub fn spawn<F, R>(&self, priority: Priority, future_fn: F) -> Result<()>
+    pub fn spawn<F, R>(&self, priority: Priority, future_fn: F) -> Result<(), Full>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Future + Send + 'static,
         R::Item: Send + 'static,
         R::Error: Send + 'static,
     {
-        self.gate_spawn(priority, |pool| pool.spawn(future_fn))
+        self.get_pool_by_priority(priority).spawn(future_fn)
     }
 
     #[must_use]
@@ -89,179 +51,13 @@ impl ReadPool {
         &self,
         priority: Priority,
         future_fn: F,
-    ) -> Result<SpawnHandle<R::Item, R::Error>>
+    ) -> Result<SpawnHandle<R::Item, R::Error>, Full>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Future + Send + 'static,
         R::Item: Send + 'static,
         R::Error: Send + 'static,
     {
-        self.gate_spawn(priority, |pool| pool.spawn_handle(future_fn))
-    }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct Full {
-    pub current_tasks: usize,
-    pub max_tasks: usize,
-}
-
-impl std::fmt::Display for Full {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            fmt,
-            "read pool is full, current task count = {}, max task count = {}",
-            self.current_tasks, self.max_tasks
-        )
-    }
-}
-
-impl std::error::Error for Full {
-    fn description(&self) -> &str {
-        "read pool is full"
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use futures::{future, Future};
-    use std::error;
-    use std::fmt;
-    use std::result;
-    use std::sync::mpsc::{channel, Sender};
-    use std::thread;
-    use std::time::Duration;
-
-    use super::*;
-
-    type BoxError = Box<dyn error::Error + Send + Sync>;
-
-    pub fn expect_val<T>(v: T, x: result::Result<T, BoxError>)
-    where
-        T: PartialEq + fmt::Debug + 'static,
-    {
-        assert!(x.is_ok());
-        assert_eq!(x.unwrap(), v);
-    }
-
-    pub fn expect_err<T>(desc: &str, x: result::Result<T, BoxError>) {
-        assert!(x.is_err());
-        match x {
-            Err(e) => assert!(e.description().contains(desc), "{:?}", e),
-            _ => unreachable!(),
-        }
-    }
-
-    #[test]
-    fn test_spawn_handle() {
-        let read_pool = Builder::build_for_test();
-
-        expect_val(
-            vec![1, 2, 4],
-            read_pool
-                .spawn_handle(Priority::High, || {
-                    future::ok::<Vec<u8>, BoxError>(vec![1, 2, 4])
-                })
-                .unwrap() // unwrap Full error
-                .wait(),
-        );
-
-        expect_err(
-            "foobar",
-            read_pool
-                .spawn_handle(Priority::High, || {
-                    future::err::<(), BoxError>(box_err!("foobar"))
-                })
-                .unwrap() // unwrap Full error
-                .wait(),
-        );
-    }
-
-    fn spawn_long_time_future(
-        pool: &ReadPool,
-        id: u64,
-        future_duration_ms: u64,
-    ) -> Result<SpawnHandle<u64, ()>> {
-        pool.spawn_handle(Priority::High, move || {
-            thread::sleep(Duration::from_millis(future_duration_ms));
-            future::ok::<u64, ()>(id)
-        })
-    }
-
-    fn wait_on_new_thread<F>(sender: Sender<std::result::Result<F::Item, F::Error>>, future: F)
-    where
-        F: Future + Send + 'static,
-        F::Item: Send + 'static,
-        F::Error: Send + 'static,
-    {
-        thread::spawn(move || {
-            let r = future.wait();
-            sender.send(r).unwrap();
-        });
-    }
-
-    #[test]
-    fn test_full() {
-        let (tx, rx) = channel();
-
-        let read_pool = builder::Builder::from_config(&Config {
-            high_concurrency: 2,
-            max_tasks_per_worker_high: 2,
-            ..Config::default_for_test()
-        })
-        .name_prefix("read-test-full")
-        .build();
-
-        wait_on_new_thread(
-            tx.clone(),
-            spawn_long_time_future(&read_pool, 0, 5).unwrap(),
-        );
-        // not full
-        assert_eq!(rx.recv().unwrap(), Ok(0));
-
-        wait_on_new_thread(
-            tx.clone(),
-            spawn_long_time_future(&read_pool, 1, 100).unwrap(),
-        );
-        wait_on_new_thread(
-            tx.clone(),
-            spawn_long_time_future(&read_pool, 2, 200).unwrap(),
-        );
-        wait_on_new_thread(
-            tx.clone(),
-            spawn_long_time_future(&read_pool, 3, 300).unwrap(),
-        );
-        wait_on_new_thread(
-            tx.clone(),
-            spawn_long_time_future(&read_pool, 4, 400).unwrap(),
-        );
-        // no available results (running = 4)
-        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
-
-        // full
-        assert!(spawn_long_time_future(&read_pool, 5, 100).is_err());
-
-        // full
-        assert!(spawn_long_time_future(&read_pool, 6, 100).is_err());
-
-        // wait a future completes (running = 3)
-        assert_eq!(rx.recv().unwrap(), Ok(1));
-
-        // add new (running = 4)
-        wait_on_new_thread(
-            tx.clone(),
-            spawn_long_time_future(&read_pool, 7, 5).unwrap(),
-        );
-
-        // full
-        assert!(spawn_long_time_future(&read_pool, 8, 100).is_err());
-
-        assert!(rx.recv().is_ok());
-        assert!(rx.recv().is_ok());
-        assert!(rx.recv().is_ok());
-        assert!(rx.recv().is_ok());
-
-        // no more results
-        assert!(rx.recv_timeout(Duration::from_millis(500)).is_err());
+        self.get_pool_by_priority(priority).spawn_handle(future_fn)
     }
 }

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -173,17 +173,20 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
                 SCHED_STAGE_COUNTER_VEC.get(task.tag).snapshot_err.inc();
 
                 info!("get snapshot failed"; "cid" => task.cid, "err" => ?err);
-                self.take_pool().pool.spawn(move || {
-                    notify_scheduler(
-                        self.take_scheduler(),
-                        Msg::FinishedWithErr {
-                            cid: task.cid,
-                            err: Error::from(err),
-                            tag: task.tag,
-                        },
-                    );
-                    future::ok::<_, ()>(())
-                });
+                self.take_pool()
+                    .pool
+                    .spawn(move || {
+                        notify_scheduler(
+                            self.take_scheduler(),
+                            Msg::FinishedWithErr {
+                                cid: task.cid,
+                                err: Error::from(err),
+                                tag: task.tag,
+                            },
+                        );
+                        future::ok::<_, ()>(())
+                    })
+                    .unwrap();
             }
         }
     }
@@ -201,32 +204,35 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
         }
         let sched_pool = self.clone_pool();
         let readonly = task.cmd.readonly();
-        sched_pool.pool.spawn(move || {
-            fail_point!("scheduler_async_snapshot_finish");
+        sched_pool
+            .pool
+            .spawn(move || {
+                fail_point!("scheduler_async_snapshot_finish");
 
-            let read_duration = Instant::now_coarse();
+                let read_duration = Instant::now_coarse();
 
-            let region_id = task.region_id;
-            let ts = task.ts;
-            let timer = SlowTimer::new();
+                let region_id = task.region_id;
+                let ts = task.ts;
+                let timer = SlowTimer::new();
 
-            let statistics = if readonly {
-                self.process_read(snapshot, task)
-            } else {
-                with_tls_engine(|engine| self.process_write(engine, snapshot, task))
-            };
-            tls_add_statistics(tag.get_str(), &statistics);
-            slow_log!(
-                timer,
-                "[region {}] scheduler handle command: {}, ts: {}",
-                region_id,
-                tag,
-                ts
-            );
+                let statistics = if readonly {
+                    self.process_read(snapshot, task)
+                } else {
+                    with_tls_engine(|engine| self.process_write(engine, snapshot, task))
+                };
+                tls_add_statistics(tag.get_str(), &statistics);
+                slow_log!(
+                    timer,
+                    "[region {}] scheduler handle command: {}, ts: {}",
+                    region_id,
+                    tag,
+                    ts
+                );
 
-            tls_collect_read_duration(tag.get_str(), read_duration.elapsed());
-            future::ok::<_, ()>(())
-        });
+                tls_collect_read_duration(tag.get_str(), read_duration.elapsed());
+                future::ok::<_, ()>(())
+            })
+            .unwrap();
     }
 
     /// Processes a read command within a worker thread, then posts `ReadFinished` message back to the
@@ -295,21 +301,24 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
                     let sched_pool = self.take_pool();
                     // The callback to receive async results of write prepare from the storage engine.
                     let engine_cb = Box::new(move |(_, result)| {
-                        sched_pool.pool.spawn(move || {
-                            notify_scheduler(
-                                sched,
-                                Msg::WriteFinished {
-                                    cid,
-                                    pr,
-                                    result,
-                                    tag,
-                                },
-                            );
-                            KV_COMMAND_KEYWRITE_HISTOGRAM_VEC
-                                .get(tag)
-                                .observe(rows as f64);
-                            future::ok::<_, ()>(())
-                        })
+                        sched_pool
+                            .pool
+                            .spawn(move || {
+                                notify_scheduler(
+                                    sched,
+                                    Msg::WriteFinished {
+                                        cid,
+                                        pr,
+                                        result,
+                                        tag,
+                                    },
+                                );
+                                KV_COMMAND_KEYWRITE_HISTOGRAM_VEC
+                                    .get(tag)
+                                    .observe(rows as f64);
+                                future::ok::<_, ()>(())
+                            })
+                            .unwrap()
                     });
 
                     if let Err(e) = engine.async_write(&ctx, to_be_write, engine_cb) {

--- a/tests/failpoints/cases/test_coprocessor.rs
+++ b/tests/failpoints/cases/test_coprocessor.rs
@@ -114,7 +114,7 @@ fn test_readpool_full() {
     let (_, endpoint) = init_with_data(&product, &[]);
     let req = DAGSelect::from(&product).build();
 
-    fail::cfg("read_pool_spawn_full", "return()").unwrap();
+    fail::cfg("future_pool_spawn_full", "return()").unwrap();
     let resp = handle_request(&endpoint, req);
 
     assert!(resp.get_region_error().has_server_is_busy());


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This PR moves the task limit functionality from read pool to future pool.

Extracted from https://github.com/tikv/tikv/pull/5220

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)
