### PR TITLE
txn: Cover more corner cases for optimistic txn's tests

### DIFF
--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -674,6 +674,9 @@ mod tests {
 
         must_commit(&engine, k, 5, 10);
         must_written(&engine, k, 5, 10, WriteType::Put);
+        // Delayed prewrite request after committing should do nothing.
+        must_prewrite_put_err(&engine, k, v, k, 5);
+        must_unlocked(&engine, k);
         // Write conflict.
         must_prewrite_lock_err(&engine, k, k, 6);
         must_unlocked(&engine, k);
@@ -817,21 +820,6 @@ mod tests {
         test_mvcc_txn_commit_err_imp(b"k2", &long_value);
     }
 
-    fn test_mvcc_txn_rollback_imp(k: &[u8], v: &[u8]) {
-        let engine = TestEngineBuilder::new().build().unwrap();
-
-        must_prewrite_put(&engine, k, v, k, 5);
-        must_rollback(&engine, k, 5);
-        // rollback should be idempotent
-        must_rollback(&engine, k, 5);
-        // lock should be released after rollback
-        must_unlocked(&engine, k);
-        must_prewrite_lock(&engine, k, k, 10);
-        must_rollback(&engine, k, 10);
-        // data should be dropped after rollback
-        must_get_none(&engine, k, 20);
-    }
-
     #[test]
     fn test_mvcc_txn_rollback_after_commit() {
         let engine = TestEngineBuilder::new().build().unwrap();
@@ -856,29 +844,44 @@ mod tests {
         must_get(&engine, k, t4, v);
     }
 
+    fn test_mvcc_txn_rollback_imp(k: &[u8], v: &[u8]) {
+        let engine = TestEngineBuilder::new().build().unwrap();
+
+        must_prewrite_put(&engine, k, v, k, 5);
+        must_rollback(&engine, k, 5);
+        // Rollback should be idempotent
+        must_rollback(&engine, k, 5);
+        // Lock should be released after rollback
+        must_unlocked(&engine, k);
+        must_prewrite_lock(&engine, k, k, 10);
+        must_rollback(&engine, k, 10);
+        // data should be dropped after rollback
+        must_get_none(&engine, k, 20);
+
+        // Can't rollback committed transaction.
+        must_prewrite_put(&engine, k, v, k, 25);
+        must_commit(&engine, k, 25, 30);
+        must_rollback_err(&engine, k, 25);
+        must_rollback_err(&engine, k, 25);
+
+        // Can't rollback other transaction's lock
+        must_prewrite_delete(&engine, k, k, 35);
+        must_rollback(&engine, k, 34);
+        must_rollback(&engine, k, 36);
+        must_written(&engine, k, 34, 34, WriteType::Rollback);
+        must_written(&engine, k, 36, 36, WriteType::Rollback);
+        must_locked(&engine, k, 35);
+        must_commit(&engine, k, 35, 40);
+        must_get(&engine, k, 39, v);
+        must_get_none(&engine, k, 41);
+    }
+
     #[test]
     fn test_mvcc_txn_rollback() {
         test_mvcc_txn_rollback_imp(b"k", b"v");
 
         let long_value = "v".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
         test_mvcc_txn_rollback_imp(b"k2", &long_value);
-    }
-
-    fn test_mvcc_txn_rollback_err_imp(k: &[u8], v: &[u8]) {
-        let engine = TestEngineBuilder::new().build().unwrap();
-
-        must_prewrite_put(&engine, k, v, k, 5);
-        must_commit(&engine, k, 5, 10);
-        must_rollback_err(&engine, k, 5);
-        must_rollback_err(&engine, k, 5);
-    }
-
-    #[test]
-    fn test_mvcc_txn_rollback_err() {
-        test_mvcc_txn_rollback_err_imp(b"k", b"v");
-
-        let long_value = "v".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
-        test_mvcc_txn_rollback_err_imp(b"k2", &long_value);
     }
 
     #[test]


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This PR does some minor changes for MvccTxn's tests.

* Cover the case that a delayed prewrite arrives later than committing.
* Cover the case that rollback is invoked when there is another transaction's lock.
* Merged `test_mvcc_txn_rollback` and `test_mvcc_txn_rollback_err` into one test.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

By CI

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No 

###  Does this PR affect `tidb-ansible`?

No

