### PR TITLE
Improve performance when collecting scan details

### DIFF
--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -221,11 +221,8 @@ impl Tracker {
                 .inc_by(self.total_perf_stats.block_read_byte as i64);
         });
 
-        tls_collect_cf_stats(
-            self.req_ctx.context.get_region_id(),
-            self.req_ctx.tag,
-            &total_storage_stats,
-        );
+        tls_collect_scan_details(self.req_ctx.tag, &total_storage_stats);
+        tls_collect_read_flow(self.req_ctx.context.get_region_id(), &total_storage_stats);
 
         self.current_stage = TrackerState::Tracked;
     }

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -228,8 +228,8 @@ impl CFStatistics {
         self.get + self.next + self.prev + self.seek + self.seek_for_prev
     }
 
-    pub fn details(&self) -> Vec<(&str, usize)> {
-        vec![
+    pub fn details(&self) -> [(&'static str, usize); 8] {
+        [
             (STAT_TOTAL, self.total_op_count()),
             (STAT_PROCESSED, self.processed),
             (STAT_GET, self.get),
@@ -276,8 +276,8 @@ impl Statistics {
         self.lock.processed + self.write.processed + self.data.processed
     }
 
-    pub fn details(&self) -> Vec<(&str, Vec<(&str, usize)>)> {
-        vec![
+    pub fn details(&self) -> [(&'static str, [(&'static str, usize); 8]); 3] {
+        [
             (CF_DEFAULT, self.data.details()),
             (CF_LOCK, self.lock.details()),
             (CF_WRITE, self.write.details()),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -867,7 +867,7 @@ impl<E: Engine> Storage<E> {
                                     r
                                 });
 
-                            tls_collect_scan_count(CMD, &statistics);
+                            tls_collect_scan_details(CMD, &statistics);
                             tls_collect_read_flow(ctx.get_region_id(), &statistics);
 
                             result
@@ -927,7 +927,7 @@ impl<E: Engine> Storage<E> {
                                 .collect();
 
                             tls_collect_key_reads(CMD, kv_pairs.len());
-                            tls_collect_scan_count(CMD, &statistics);
+                            tls_collect_scan_details(CMD, &statistics);
                             tls_collect_read_flow(ctx.get_region_id(), &statistics);
 
                             Ok(kv_pairs)
@@ -996,7 +996,7 @@ impl<E: Engine> Storage<E> {
                             let res = scanner.scan(limit);
 
                             let statistics = scanner.take_statistics();
-                            tls_collect_scan_count(CMD, &statistics);
+                            tls_collect_scan_details(CMD, &statistics);
                             tls_collect_read_flow(ctx.get_region_id(), &statistics);
 
                             res.map_err(Error::from).map(|results| {
@@ -1721,7 +1721,7 @@ impl<E: Engine> Storage<E> {
                                 CMD,
                                 statistics.write.flow_stats.read_keys as usize,
                             );
-                            tls_collect_scan_count(CMD, &statistics);
+                            tls_collect_scan_details(CMD, &statistics);
                             future::result(result)
                         })
                     })
@@ -1847,7 +1847,7 @@ impl<E: Engine> Storage<E> {
                                 CMD,
                                 statistics.write.flow_stats.read_keys as usize,
                             );
-                            tls_collect_scan_count(CMD, &statistics);
+                            tls_collect_scan_details(CMD, &statistics);
                             future::ok(result)
                         })
                     })

--- a/src/storage/readpool_impl.rs
+++ b/src/storage/readpool_impl.rs
@@ -9,7 +9,7 @@ use prometheus::local::*;
 
 use crate::server::readpool::{self, Builder, Config, ReadPool};
 use crate::storage::kv::{destroy_tls_engine, set_tls_engine};
-use crate::storage::{FlowStatistics, FlowStatsReporter};
+use crate::storage::{FlowStatistics, FlowStatsReporter, Statistics};
 use tikv_util::collections::HashMap;
 
 use super::metrics::*;
@@ -21,7 +21,7 @@ pub struct StorageLocalMetrics {
     local_kv_command_keyread_histogram_vec: LocalHistogramVec,
     local_kv_command_counter_vec: LocalIntCounterVec,
     local_sched_commands_pri_counter_vec: LocalIntCounterVec,
-    local_kv_command_scan_details: LocalIntCounterVec,
+    local_scan_details: HashMap<&'static str, Statistics>,
     local_read_flow_stats: HashMap<u64, FlowStatistics>,
 }
 
@@ -33,7 +33,7 @@ thread_local! {
             local_kv_command_keyread_histogram_vec: KV_COMMAND_KEYREAD_HISTOGRAM_VEC.local(),
             local_kv_command_counter_vec: KV_COMMAND_COUNTER_VEC.local(),
             local_sched_commands_pri_counter_vec: SCHED_COMMANDS_PRI_COUNTER_VEC.local(),
-            local_kv_command_scan_details: KV_COMMAND_SCAN_DETAILS.local(),
+            local_scan_details: HashMap::default(),
             local_read_flow_stats: HashMap::default(),
         }
     );
@@ -67,36 +67,39 @@ pub fn build_read_pool_for_test<E: Engine>(engine: E) -> ReadPool {
         .build()
 }
 
-#[inline]
 fn tls_flush<R: FlowStatsReporter>(reporter: &R) {
     TLS_STORAGE_METRICS.with(|m| {
-        let mut storage_metrics = m.borrow_mut();
+        let mut m = m.borrow_mut();
         // Flush Prometheus metrics
-        storage_metrics.local_sched_histogram_vec.flush();
-        storage_metrics
-            .local_sched_processing_read_histogram_vec
-            .flush();
-        storage_metrics
-            .local_kv_command_keyread_histogram_vec
-            .flush();
-        storage_metrics.local_kv_command_counter_vec.flush();
-        storage_metrics.local_sched_commands_pri_counter_vec.flush();
-        storage_metrics.local_kv_command_scan_details.flush();
+        m.local_sched_histogram_vec.flush();
+        m.local_sched_processing_read_histogram_vec.flush();
+        m.local_kv_command_keyread_histogram_vec.flush();
+        m.local_kv_command_counter_vec.flush();
+        m.local_sched_commands_pri_counter_vec.flush();
+
+        for (cmd, stat) in m.local_scan_details.drain() {
+            for (cf, cf_details) in stat.details().iter() {
+                for (tag, count) in cf_details.iter() {
+                    KV_COMMAND_SCAN_DETAILS
+                        .with_label_values(&[cmd, *cf, *tag])
+                        .inc_by(*count as i64);
+                }
+            }
+        }
 
         // Report PD metrics
-        if storage_metrics.local_read_flow_stats.is_empty() {
+        if m.local_read_flow_stats.is_empty() {
             // Stats to report to PD is empty, ignore.
             return;
         }
 
         let mut read_stats = HashMap::default();
-        mem::swap(&mut read_stats, &mut storage_metrics.local_read_flow_stats);
+        mem::swap(&mut read_stats, &mut m.local_read_flow_stats);
 
         reporter.report_read_stats(read_stats);
     });
 }
 
-#[inline]
 pub fn tls_collect_command_count(cmd: &str, priority: readpool::Priority) {
     TLS_STORAGE_METRICS.with(|m| {
         let mut storage_metrics = m.borrow_mut();
@@ -111,7 +114,6 @@ pub fn tls_collect_command_count(cmd: &str, priority: readpool::Priority) {
     });
 }
 
-#[inline]
 pub fn tls_collect_command_duration(cmd: &str, duration: Duration) {
     TLS_STORAGE_METRICS.with(|m| {
         m.borrow_mut()
@@ -121,7 +123,6 @@ pub fn tls_collect_command_duration(cmd: &str, duration: Duration) {
     });
 }
 
-#[inline]
 pub fn tls_collect_key_reads(cmd: &str, count: usize) {
     TLS_STORAGE_METRICS.with(|m| {
         m.borrow_mut()
@@ -131,7 +132,6 @@ pub fn tls_collect_key_reads(cmd: &str, count: usize) {
     });
 }
 
-#[inline]
 pub fn tls_processing_read_observe_duration<F, R>(cmd: &str, f: F) -> R
 where
     F: FnOnce() -> R,
@@ -147,22 +147,17 @@ where
     })
 }
 
-#[inline]
-pub fn tls_collect_scan_count(cmd: &str, statistics: &crate::storage::Statistics) {
+pub fn tls_collect_scan_details(cmd: &'static str, stats: &Statistics) {
     TLS_STORAGE_METRICS.with(|m| {
-        let histogram = &mut m.borrow_mut().local_kv_command_scan_details;
-        for (cf, details) in statistics.details() {
-            for (tag, count) in details {
-                histogram
-                    .with_label_values(&[cmd, cf, tag])
-                    .inc_by(count as i64);
-            }
-        }
+        m.borrow_mut()
+            .local_scan_details
+            .entry(cmd)
+            .or_insert_with(Default::default)
+            .add(stats);
     });
 }
 
-#[inline]
-pub fn tls_collect_read_flow(region_id: u64, statistics: &crate::storage::Statistics) {
+pub fn tls_collect_read_flow(region_id: u64, statistics: &Statistics) {
     TLS_STORAGE_METRICS.with(|m| {
         let map = &mut m.borrow_mut().local_read_flow_stats;
         let flow_stats = map

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -215,7 +215,7 @@ impl<E: Engine, S: MsgScheduler> Executor<E, S> {
             } else {
                 with_tls_engine(|engine| self.process_write(engine, snapshot, task))
             };
-            tls_add_statistics(tag.get_str(), &statistics);
+            tls_collect_scan_details(tag.get_str(), &statistics);
             slow_log!(
                 timer,
                 "[region {}] scheduler handle command: {}, ts: {}",

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -11,10 +11,10 @@ use tikv_util::future_pool::FuturePool;
 
 use crate::storage::kv::{destroy_tls_engine, set_tls_engine};
 use crate::storage::metrics::*;
-use crate::storage::{Engine, Statistics, StatisticsSummary};
+use crate::storage::{Engine, Statistics};
 
 pub struct SchedLocalMetrics {
-    stats: HashMap<&'static str, StatisticsSummary>,
+    local_scan_details: HashMap<&'static str, Statistics>,
     processing_read_duration: LocalHistogramVec,
     processing_write_duration: LocalHistogramVec,
     command_keyread_histogram_vec: LocalHistogramVec,
@@ -23,7 +23,7 @@ pub struct SchedLocalMetrics {
 thread_local! {
      static TLS_SCHED_METRICS: RefCell<SchedLocalMetrics> = RefCell::new(
         SchedLocalMetrics {
-            stats: HashMap::default(),
+            local_scan_details: HashMap::default(),
             processing_read_duration: SCHED_PROCESSING_READ_HISTOGRAM_VEC.local(),
             processing_write_duration: SCHED_PROCESSING_WRITE_HISTOGRAM_VEC.local(),
             command_keyread_histogram_vec: KV_COMMAND_KEYREAD_HISTOGRAM_VEC.local(),
@@ -53,31 +53,31 @@ impl SchedPool {
     }
 }
 
-pub fn tls_add_statistics(cmd: &'static str, stat: &Statistics) {
+pub fn tls_collect_scan_details(cmd: &'static str, stats: &Statistics) {
     TLS_SCHED_METRICS.with(|m| {
         m.borrow_mut()
-            .stats
+            .local_scan_details
             .entry(cmd)
             .or_insert_with(Default::default)
-            .add_statistics(stat);
+            .add(stats);
     });
 }
 
 pub fn tls_flush() {
     TLS_SCHED_METRICS.with(|m| {
-        let mut sched_metrics = m.borrow_mut();
-        for (cmd, stat) in sched_metrics.stats.drain() {
-            for (cf, details) in stat.stat.details() {
-                for (tag, count) in details {
+        let mut m = m.borrow_mut();
+        for (cmd, stat) in m.local_scan_details.drain() {
+            for (cf, cf_details) in stat.details().iter() {
+                for (tag, count) in cf_details.iter() {
                     KV_COMMAND_SCAN_DETAILS
-                        .with_label_values(&[cmd, cf, tag])
-                        .inc_by(count as i64);
+                        .with_label_values(&[cmd, *cf, *tag])
+                        .inc_by(*count as i64);
                 }
             }
         }
-        sched_metrics.processing_read_duration.flush();
-        sched_metrics.processing_write_duration.flush();
-        sched_metrics.command_keyread_histogram_vec.flush();
+        m.processing_read_duration.flush();
+        m.processing_write_duration.flush();
+        m.command_keyread_histogram_vec.flush();
     });
 }
 


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This PR improves the performance by using backlog scan details. Metrics are only updated when it is going to be flushed. Previously we need to calculate hash of each scan detail item for each operation. Now we only need to do it during flush.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)
