### PR TITLE
config: shorten the error message on unknown field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ dependencies = [
  "raft 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ fail = "0.3"
 uuid = { version = "0.6", features = [ "serde", "v4" ] }
 grpcio = { version = "0.5.0-alpha.3", features = [ "openssl-vendored" ] }
 raft = "0.6.0-alpha"
+regex = "1.1"
 crossbeam = "0.5"
 derive_more = "0.11.0"
 hex = "0.3"

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -589,3 +589,12 @@ fn test_error_on_unrecognized_config() {
         assert!(result.is_err());
     }
 }
+
+#[test]
+#[should_panic(expected = "unknown field `unknown-field` for key `rocksdb.defaultcf`")]
+fn test_short_error_msg_on_unrecognized_config() {
+    use std::io::Write;
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    writeln!(file, "[rocksdb.defaultcf]\nunknown-field = 123").unwrap();
+    TiKvConfig::from_file(file.path());
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

In #5190, we make TiKV panic when the config file contains some unknown fields in order to capture typo, using serde's `deny_unknown_fields` attribute. Unfortunately, the error message contains the full list of expected fields, which 

1. makes the panic message extremely long for a large struct like the CF configs, and
2. confuses the reader, making them think those fields are unexpected (see #5286).

This PR removes the list of expected fields.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

```sh
cargo test --test integrations -- test_short_error_msg_on_unrecognized_config
```

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

Follow up on #5190

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

