### PR TITLE
check keys number changing of region before trigger region split check

### DIFF
--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -128,6 +128,7 @@ pub fn new_store_cfg() -> Config {
         peer_stale_state_check_interval: ReadableDuration::secs(1),
         pd_heartbeat_tick_interval: ReadableDuration::millis(20),
         region_split_check_diff: ReadableSize(10000),
+        region_split_check_keys_diff: 1000,
         report_region_flow_interval: ReadableDuration::millis(100),
         raft_store_max_leader_lease: ReadableDuration::millis(250),
         raft_reject_transfer_leader_duration: ReadableDuration::secs(0),
@@ -593,6 +594,38 @@ pub fn configure_for_lease_read<T: Simulator>(
     cluster.cfg.raft_store.max_leader_missing_duration = ReadableDuration(election_timeout * 5);
 
     election_timeout
+}
+
+/// Putting num random kvs
+pub fn put_kvs<T: Simulator>(
+    cluster: &mut Cluster<T>,
+    num: u64,
+    range: &mut dyn Iterator<Item = u64>,
+) -> Vec<u8> {
+    put_cf_kvs(cluster, CF_DEFAULT, num, range)
+}
+
+pub fn put_cf_kvs<T: Simulator>(
+    cluster: &mut Cluster<T>,
+    cf: &'static str,
+    num: u64,
+    range: &mut dyn Iterator<Item = u64>,
+) -> Vec<u8> {
+    assert!(num > 0);
+    let mut rng = rand::thread_rng();
+    let mut key = vec![];
+    let mut n = 0;
+    while n < num {
+        let key_id = range.next().unwrap();
+        let key_str = format!("{:09}", key_id);
+        key = key_str.into_bytes();
+        let mut value = vec![0; 8];
+        rng.fill_bytes(&mut value);
+        cluster.must_put_cf(cf, &key, &value);
+        n += 1;
+    }
+    cluster.must_flush_cf(cf, true);
+    key
 }
 
 /// Keep putting random kvs until specified size limit is reached.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -216,6 +216,11 @@
 ## 32MB during checking and set it back to the default value in normal operations.
 # region-split-check-diff = "6MB"
 
+## The threshold of triggering Region split check.
+## When Region keys number change exceeds this config, TiKV will check whether the Region should be split
+## or not.
+# region-split-check-keys-diff = "60000"
+
 ## The interval of triggering Region split check.
 # split-region-check-tick-interval = "10s"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1278,6 +1278,7 @@ impl TiKvConfig {
         self.storage.validate()?;
 
         self.raft_store.region_split_check_diff = self.coprocessor.region_split_size / 16;
+        self.raft_store.region_split_check_keys_diff = self.coprocessor.region_split_keys / 16;
         self.raft_store.raftdb_path = if self.raft_store.raftdb_path.is_empty() {
             config::canonicalize_sub_path(&self.storage.data_dir, "raft")?
         } else {

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -51,6 +51,9 @@ pub struct Config {
     /// When size change of region exceed the diff since last check, it
     /// will be checked again whether it should be split.
     pub region_split_check_diff: ReadableSize,
+    /// When keys number change of region exceed the diff since last check, it
+    /// will be checked again whether it should be split.
+    pub region_split_check_keys_diff: u64,
     /// Interval (ms) to check whether start compaction for a region.
     pub region_compact_check_interval: ReadableDuration,
     // delay time before deleting a stale peer
@@ -135,6 +138,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         let split_size = ReadableSize::mb(coprocessor::config::SPLIT_SIZE_MB);
+        let split_keys = coprocessor::config::SPLIT_KEYS;
         Config {
             sync_log: true,
             prevote: true,
@@ -157,6 +161,7 @@ impl Default for Config {
             raft_reject_transfer_leader_duration: ReadableDuration::secs(3),
             split_region_check_tick_interval: ReadableDuration::secs(10),
             region_split_check_diff: split_size / 16,
+            region_split_check_keys_diff: split_keys / 16,
             clean_stale_peer_delay: ReadableDuration::minutes(10),
             region_compact_check_interval: ReadableDuration::minutes(5),
             region_compact_check_step: 100,
@@ -417,6 +422,9 @@ impl Config {
         metrics
             .with_label_values(&["region_split_check_diff"])
             .set(self.region_split_check_diff.0 as f64);
+        metrics
+            .with_label_values(&["region_split_check_keys_diff"])
+            .set(self.region_split_check_keys_diff as f64);
         metrics
             .with_label_values(&["region_compact_check_interval"])
             .set(self.region_compact_check_interval.as_secs() as f64);

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -1657,6 +1657,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 // To prevent from big region, the right region needs run split
                 // check again after split.
                 new_peer.peer.size_diff_hint = self.ctx.cfg.region_split_check_diff.0;
+                new_peer.peer.keys_diff_hint = self.ctx.cfg.region_split_check_keys_diff;
             }
             let mailbox = BasicMailbox::new(sender, new_peer);
             self.ctx.router.register(new_region_id, mailbox);
@@ -1995,6 +1996,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         // the reason why follower need to update is that there is a issue that after merge
         // and then transfer leader, the new leader may have stale size and keys.
         self.fsm.peer.size_diff_hint = self.ctx.cfg.region_split_check_diff.0;
+        self.fsm.peer.keys_diff_hint = self.ctx.cfg.region_split_check_keys_diff;
         if self.fsm.peer.is_leader() {
             info!(
                 "notify pd with merge";
@@ -2568,6 +2570,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         if self.fsm.peer.approximate_size.is_some()
             && self.fsm.peer.compaction_declined_bytes < self.ctx.cfg.region_split_check_diff.0
             && self.fsm.peer.size_diff_hint < self.ctx.cfg.region_split_check_diff.0
+            && self.fsm.peer.keys_diff_hint < self.ctx.cfg.region_split_check_keys_diff
         {
             return;
         }
@@ -2581,6 +2584,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             );
         }
         self.fsm.peer.size_diff_hint = 0;
+        self.fsm.peer.keys_diff_hint = 0;
         self.fsm.peer.compaction_declined_bytes = 0;
         self.register_split_region_check_tick();
     }
@@ -2896,6 +2900,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
 
     fn on_ingest_sst_result(&mut self, ssts: Vec<SstMeta>) {
         for sst in &ssts {
+            // since keys_diff_hint is not accurate, so we just skip calculate it here for now.
             self.fsm.peer.size_diff_hint += sst.get_length();
         }
         self.register_split_region_check_tick();

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -123,6 +123,7 @@ fn test_serde_custom_tikv_config() {
         raft_reject_transfer_leader_duration: ReadableDuration::secs(3),
         split_region_check_tick_interval: ReadableDuration::secs(12),
         region_split_check_diff: ReadableSize::mb(6),
+        region_split_check_keys_diff: 60000,
         region_compact_check_interval: ReadableDuration::secs(12),
         clean_stale_peer_delay: ReadableDuration::secs(13),
         region_compact_check_step: 1_234,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -98,6 +98,7 @@ raft-entry-cache-life-time = "12s"
 raft-reject-transfer-leader-duration = "3s"
 split-region-check-tick-interval = "12s"
 region-split-check-diff = "6MB"
+region-split-check-keys-diff = 60000
 region-compact-check-interval = "12s"
 clean-stale-peer-delay = "13s"
 region-compact-check-step = 1234


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Current code only trigger region split check according to region size difference, this patch adds a keys_diff_hint to Peer struct to indicate difference in region keys number since last reset, and use this hint to decide whether split check is needed too.

###  What is the type of the changes?

Pick one of the following and delete the others:

Bugfix

###  How is the PR tested?

unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

no

###  Does this PR affect `tidb-ansible`?

yes

