### PR TITLE
mvcc/reader: scan versions from u64::max to start_ts in get_txn… (#5062)

### DIFF
--- a/src/storage/mvcc/reader/mod.rs
+++ b/src/storage/mvcc/reader/mod.rs
@@ -263,18 +263,15 @@ impl<S: Snapshot> MvccReader<S> {
         key: &Key,
         start_ts: u64,
     ) -> Result<Option<(u64, WriteType)>> {
-        let mut seek_ts = start_ts;
-        while let Some((commit_ts, write)) = self.reverse_seek_write(key, seek_ts)? {
+        let mut seek_ts = u64::max_value();
+        while let Some((commit_ts, write)) = self.seek_write(key, seek_ts)? {
             if write.start_ts == start_ts {
                 return Ok(Some((commit_ts, write.write_type)));
             }
 
-            // If we reach a commit version whose type is not Rollback and start ts is
-            // larger than the given start ts, stop searching.
-            if write.write_type != WriteType::Rollback && write.start_ts > start_ts {
+            if commit_ts <= start_ts {
                 break;
             }
-
             seek_ts = commit_ts + 1;
         }
         Ok(None)
@@ -777,9 +774,9 @@ mod tests {
         let snap = RegionSnapshot::from_raw(Arc::clone(&db), region.clone());
         let mut reader = MvccReader::new(snap, None, false, None, None, IsolationLevel::SI);
 
-        // Let's assume `40_35 PUT` means a commit version with start ts is 35 and commit ts
-        // is 40.
-        // Commit versions: [40_35 PUT, 30_25 PUT, 20_20 Rollback, 10_1 PUT, 5_5 Rollback].
+        // Let's assume `50_35 PUT` means a commit version with start ts is 45 and commit ts
+        // is 50.
+        // Commit versions: [50_35 PUT, 30_25 PUT, 20_20 Rollback, 10_1 PUT, 5_5 Rollback].
         let key = Key::from_raw(k);
         let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 35).unwrap().unwrap();
         assert_eq!(commit_ts, 40);
@@ -801,11 +798,12 @@ mod tests {
         assert_eq!(commit_ts, 5);
         assert_eq!(write_type, WriteType::Rollback);
 
-        let seek_for_prev_old = reader.get_statistics().write.seek_for_prev;
-        assert!(reader.get_txn_commit_info(&key, 15).unwrap().is_none());
-        let seek_for_prev_new = reader.get_statistics().write.seek_for_prev;
+        let seek_old = reader.get_statistics().write.seek;
+        assert!(reader.get_txn_commit_info(&key, 30).unwrap().is_none());
+        let seek_new = reader.get_statistics().write.seek;
 
-        // `get_txn_commit_info(&key, 15)` stopped at `30_25 PUT`.
-        assert_eq!(seek_for_prev_new - seek_for_prev_old, 2);
+        // `get_txn_commit_info(&key, 30)` stopped at `30_25 PUT`.
+        assert_eq!(seek_new - seek_old, 3);
+    }
     }
 }

--- a/src/storage/mvcc/reader/mod.rs
+++ b/src/storage/mvcc/reader/mod.rs
@@ -799,7 +799,7 @@ mod tests {
         assert_eq!(write_type, WriteType::Rollback);
 
         let seek_old = reader.get_statistics().write.seek;
-        assert!(reader.get_txn_commit_info(&key, 15).unwrap().is_none());
+        assert!(reader.get_txn_commit_info(&key, 30).unwrap().is_none());
         let seek_new = reader.get_statistics().write.seek;
 
         // `get_txn_commit_info(&key, 15)` stopped at `30_25 PUT`.

--- a/src/storage/mvcc/reader/mod.rs
+++ b/src/storage/mvcc/reader/mod.rs
@@ -272,7 +272,7 @@ impl<S: Snapshot> MvccReader<S> {
             if commit_ts <= start_ts {
                 break;
             }
-            seek_ts = commit_ts + 1;
+            seek_ts = commit_ts - 1;
         }
         Ok(None)
     }

--- a/src/storage/mvcc/reader/mod.rs
+++ b/src/storage/mvcc/reader/mod.rs
@@ -805,5 +805,4 @@ mod tests {
         // `get_txn_commit_info(&key, 30)` stopped at `30_25 PUT`.
         assert_eq!(seek_new - seek_old, 3);
     }
-    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV! Please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
cherry-pick #5062 