### PR TITLE
raftstore: separate RaftlogGc to an individual thread

### DIFF
--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -1528,11 +1528,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         };
         self.fsm.peer.last_compacted_idx = task.end_idx;
         self.fsm.peer.mut_store().compact_to(task.end_idx);
-        if let Err(e) = self
-            .ctx
-            .cleanup_scheduler
-            .schedule(CleanupTask::RaftlogGc(task))
-        {
+        if let Err(e) = self.ctx.raftlog_gc_scheduler.schedule(task) {
             error!(
                 "failed to schedule compact task";
                 "region_id" => self.fsm.region_id(),


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Previous PR https://github.com/tikv/tikv/pull/5297 merged Compact, RaftlogGc, CleapSST into one thread. But we found that would cause a long-running compaction job blocks raftlog GC, then increase compaction frequency of RaftDB, take up more disk I/O bandwidth.
This PR separates RaftlogGc to an individual thread to fix this problem.


###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

CI

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.

