### PR TITLE
tidb_query: map CAST signatures to RPN function

### DIFF
--- a/components/tidb_query/src/rpn_expr/impl_cast.rs
+++ b/components/tidb_query/src/rpn_expr/impl_cast.rs
@@ -157,7 +157,8 @@ pub fn get_cast_fn_rpn_node(
 }
 
 /// Gets the RPN function meta
-pub fn map_cast_func(expr: &Expr, children: &[Expr]) -> Result<RpnFnMeta> {
+pub fn map_cast_func(expr: &Expr) -> Result<RpnFnMeta> {
+    let children = expr.get_children();
     if children.len() != 1 {
         return Err(other_err!(
             "Unexpected arguments: sig {:?} with {} args",

--- a/components/tidb_query/src/rpn_expr/impl_cast.rs
+++ b/components/tidb_query/src/rpn_expr/impl_cast.rs
@@ -5,23 +5,19 @@ use std::convert::TryFrom;
 
 use tidb_query_codegen::rpn_fn;
 use tidb_query_datatype::*;
-use tipb::FieldType;
+use tipb::{Expr, FieldType};
 
 use crate::codec::convert::*;
 use crate::codec::data_type::*;
 use crate::codec::error::{ERR_DATA_OUT_OF_RANGE, WARN_DATA_TRUNCATED};
 use crate::expr::EvalContext;
-use crate::rpn_expr::{RpnExpressionNode, RpnFnCallExtra};
+use crate::rpn_expr::{RpnExpressionNode, RpnFnCallExtra, RpnFnMeta};
 use crate::Result;
 
-/// Gets the cast function between specified data types.
-///
-/// TODO: This function supports some internal casts performed by TiKV. However it would be better
-/// to be done in TiDB.
-pub fn get_cast_fn_rpn_node(
+fn get_cast_fn_rpn_meta(
     from_field_type: &FieldType,
-    to_field_type: FieldType,
-) -> Result<RpnExpressionNode> {
+    to_field_type: &FieldType,
+) -> Result<RpnFnMeta> {
     let from = box_try!(EvalType::try_from(from_field_type.as_accessor().tp()));
     let to = box_try!(EvalType::try_from(to_field_type.as_accessor().tp()));
     let func_meta = match (from, to) {
@@ -136,6 +132,18 @@ pub fn get_cast_fn_rpn_node(
         (EvalType::Json, EvalType::Duration) => cast_json_as_duration_fn_meta(),
         _ => return Err(other_err!("Unsupported cast from {} to {}", from, to)),
     };
+    Ok(func_meta)
+}
+
+/// Gets the cast function between specified data types.
+///
+/// TODO: This function supports some internal casts performed by TiKV. However it would be better
+/// to be done in TiDB.
+pub fn get_cast_fn_rpn_node(
+    from_field_type: &FieldType,
+    to_field_type: FieldType,
+) -> Result<RpnExpressionNode> {
+    let func_meta = get_cast_fn_rpn_meta(from_field_type, &to_field_type)?;
     // This cast function is inserted by `Coprocessor` automatically,
     // the `inUnion` flag always false in this situation. Ideally,
     // the cast function should be inserted by TiDB and pushed down
@@ -146,6 +154,18 @@ pub fn get_cast_fn_rpn_node(
         field_type: to_field_type,
         implicit_args: Vec::new(),
     })
+}
+
+/// Gets the RPN function meta
+pub fn map_cast_func(expr: &Expr, children: &[Expr]) -> Result<RpnFnMeta> {
+    if children.len() != 1 {
+        return Err(other_err!(
+            "Unexpected arguments: sig {:?} with {} args",
+            expr.get_sig(),
+            children.len()
+        ));
+    }
+    get_cast_fn_rpn_meta(children[0].get_field_type(), expr.get_field_type())
 }
 
 /// Indicates whether the current expression is evaluated in union statement

--- a/components/tidb_query/src/rpn_expr/mod.rs
+++ b/components/tidb_query/src/rpn_expr/mod.rs
@@ -21,6 +21,7 @@ use crate::codec::data_type::*;
 use crate::Result;
 
 use self::impl_arithmetic::*;
+use self::impl_cast::*;
 use self::impl_compare::*;
 use self::impl_control::*;
 use self::impl_json::*;
@@ -109,7 +110,8 @@ fn divide_mapper(lhs_is_unsigned: bool, rhs_is_unsigned: bool) -> RpnFnMeta {
 }
 
 #[rustfmt::skip]
-fn map_pb_sig_to_rpn_func(value: ScalarFuncSig, children: &[Expr]) -> Result<RpnFnMeta> {
+fn map_pb_fn_to_rpn_func(expr: &Expr, children: &[Expr]) -> Result<RpnFnMeta> {
+    let value = expr.get_sig();
     Ok(match value {
         ScalarFuncSig::LtInt => map_int_sig(value, children, compare_mapper::<CmpOpLT>)?,
         ScalarFuncSig::LtReal => compare_fn_meta::<BasicComparer<Real, CmpOpLT>>(),
@@ -238,6 +240,55 @@ fn map_pb_sig_to_rpn_func(value: ScalarFuncSig, children: &[Expr]) -> Result<Rpn
         ScalarFuncSig::IfDecimal => if_condition_fn_meta::<Decimal>(),
         ScalarFuncSig::JsonTypeSig => json_type_fn_meta(),
         ScalarFuncSig::JsonUnquoteSig => json_unquote_fn_meta(),
+        ScalarFuncSig::CastIntAsInt |
+        ScalarFuncSig::CastIntAsReal |
+        ScalarFuncSig::CastIntAsString |
+        ScalarFuncSig::CastIntAsDecimal |
+        ScalarFuncSig::CastIntAsTime |
+        ScalarFuncSig::CastIntAsDuration |
+        ScalarFuncSig::CastIntAsJson |
+        ScalarFuncSig::CastRealAsInt |
+        ScalarFuncSig::CastRealAsReal |
+        ScalarFuncSig::CastRealAsString |
+        ScalarFuncSig::CastRealAsDecimal |
+        ScalarFuncSig::CastRealAsTime |
+        ScalarFuncSig::CastRealAsDuration |
+        ScalarFuncSig::CastRealAsJson |
+        ScalarFuncSig::CastDecimalAsInt |
+        ScalarFuncSig::CastDecimalAsReal |
+        ScalarFuncSig::CastDecimalAsString |
+        ScalarFuncSig::CastDecimalAsDecimal |
+        ScalarFuncSig::CastDecimalAsTime |
+        ScalarFuncSig::CastDecimalAsDuration |
+        ScalarFuncSig::CastDecimalAsJson |
+        ScalarFuncSig::CastStringAsInt |
+        ScalarFuncSig::CastStringAsReal |
+        ScalarFuncSig::CastStringAsString |
+        ScalarFuncSig::CastStringAsDecimal |
+        ScalarFuncSig::CastStringAsTime |
+        ScalarFuncSig::CastStringAsDuration |
+        ScalarFuncSig::CastStringAsJson |
+        ScalarFuncSig::CastTimeAsInt |
+        ScalarFuncSig::CastTimeAsReal |
+        ScalarFuncSig::CastTimeAsString |
+        ScalarFuncSig::CastTimeAsDecimal |
+        ScalarFuncSig::CastTimeAsTime |
+        ScalarFuncSig::CastTimeAsDuration |
+        ScalarFuncSig::CastTimeAsJson |
+        ScalarFuncSig::CastDurationAsInt |
+        ScalarFuncSig::CastDurationAsReal |
+        ScalarFuncSig::CastDurationAsString |
+        ScalarFuncSig::CastDurationAsDecimal |
+        ScalarFuncSig::CastDurationAsTime |
+        ScalarFuncSig::CastDurationAsDuration |
+        ScalarFuncSig::CastDurationAsJson |
+        ScalarFuncSig::CastJsonAsInt |
+        ScalarFuncSig::CastJsonAsReal |
+        ScalarFuncSig::CastJsonAsString |
+        ScalarFuncSig::CastJsonAsDecimal |
+        ScalarFuncSig::CastJsonAsTime |
+        ScalarFuncSig::CastJsonAsDuration |
+        ScalarFuncSig::CastJsonAsJson => map_cast_func(expr, children)?,
         _ => return Err(other_err!(
             "ScalarFunction {:?} is not supported in batch mode",
             value

--- a/components/tidb_query/src/rpn_expr/mod.rs
+++ b/components/tidb_query/src/rpn_expr/mod.rs
@@ -110,7 +110,7 @@ fn divide_mapper(lhs_is_unsigned: bool, rhs_is_unsigned: bool) -> RpnFnMeta {
 }
 
 #[rustfmt::skip]
-fn map_pb_fn_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
+fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
     let value = expr.get_sig();
     let children = expr.get_children();
     Ok(match value {

--- a/components/tidb_query/src/rpn_expr/mod.rs
+++ b/components/tidb_query/src/rpn_expr/mod.rs
@@ -110,8 +110,9 @@ fn divide_mapper(lhs_is_unsigned: bool, rhs_is_unsigned: bool) -> RpnFnMeta {
 }
 
 #[rustfmt::skip]
-fn map_pb_fn_to_rpn_func(expr: &Expr, children: &[Expr]) -> Result<RpnFnMeta> {
+fn map_pb_fn_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
     let value = expr.get_sig();
+    let children = expr.get_children();
     Ok(match value {
         ScalarFuncSig::LtInt => map_int_sig(value, children, compare_mapper::<CmpOpLT>)?,
         ScalarFuncSig::LtReal => compare_fn_meta::<BasicComparer<Real, CmpOpLT>>(),
@@ -288,7 +289,7 @@ fn map_pb_fn_to_rpn_func(expr: &Expr, children: &[Expr]) -> Result<RpnFnMeta> {
         ScalarFuncSig::CastJsonAsDecimal |
         ScalarFuncSig::CastJsonAsTime |
         ScalarFuncSig::CastJsonAsDuration |
-        ScalarFuncSig::CastJsonAsJson => map_cast_func(expr, children)?,
+        ScalarFuncSig::CastJsonAsJson => map_cast_func(expr)?,
         _ => return Err(other_err!(
             "ScalarFunction {:?} is not supported in batch mode",
             value

--- a/components/tidb_query/src/rpn_expr/types/expr_builder.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_builder.rs
@@ -28,7 +28,7 @@ impl RpnExpressionBuilder {
 
         match c.get_tp() {
             ExprType::ScalarFunc => {
-                super::super::map_pb_fn_to_rpn_func(c, c.get_children())?;
+                super::super::map_pb_fn_to_rpn_func(c)?;
                 for n in c.get_children() {
                     RpnExpressionBuilder::check_expr_tree_supported(n)?;
                 }
@@ -95,7 +95,7 @@ impl RpnExpressionBuilder {
         max_columns: usize,
     ) -> Result<RpnExpression>
     where
-        F: Fn(&Expr, &[Expr]) -> Result<RpnFnMeta> + Copy,
+        F: Fn(&Expr) -> Result<RpnFnMeta> + Copy,
     {
         let mut expr_nodes = Vec::new();
         append_rpn_nodes_recursively(
@@ -249,7 +249,7 @@ fn append_rpn_nodes_recursively<F>(
     // the full schema instead.
 ) -> Result<()>
 where
-    F: Fn(&Expr, &[Expr]) -> Result<RpnFnMeta> + Copy,
+    F: Fn(&Expr) -> Result<RpnFnMeta> + Copy,
 {
     match tree_node.get_tp() {
         ExprType::ScalarFunc => {
@@ -289,10 +289,10 @@ fn handle_node_fn_call<F>(
     max_columns: usize,
 ) -> Result<()>
 where
-    F: Fn(&Expr, &[Expr]) -> Result<RpnFnMeta> + Copy,
+    F: Fn(&Expr) -> Result<RpnFnMeta> + Copy,
 {
     // Map pb func to `RpnFnMeta`.
-    let func_meta = fn_mapper(&tree_node, tree_node.get_children())?;
+    let func_meta = fn_mapper(&tree_node)?;
 
     // Validate the input expression.
     (func_meta.validator_ptr)(&tree_node).map_err(|e| {
@@ -529,7 +529,7 @@ mod tests {
     /// For testing `append_rpn_nodes_recursively`. It accepts protobuf function sig enum, which
     /// cannot be modified by us in tests to support fn_a ~ fn_d. So let's just hard code some
     /// substitute.
-    fn fn_mapper(expr: &Expr, _children: &[Expr]) -> Result<RpnFnMeta> {
+    fn fn_mapper(expr: &Expr) -> Result<RpnFnMeta> {
         // fn_a: CastIntAsInt
         // fn_b: CastIntAsReal
         // fn_c: CastIntAsString

--- a/components/tidb_query/src/rpn_expr/types/expr_builder.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_builder.rs
@@ -28,8 +28,7 @@ impl RpnExpressionBuilder {
 
         match c.get_tp() {
             ExprType::ScalarFunc => {
-                let sig = c.get_sig();
-                super::super::map_pb_sig_to_rpn_func(sig, c.get_children())?;
+                super::super::map_pb_fn_to_rpn_func(c, c.get_children())?;
                 for n in c.get_children() {
                     RpnExpressionBuilder::check_expr_tree_supported(n)?;
                 }
@@ -82,7 +81,7 @@ impl RpnExpressionBuilder {
             tree_node,
             &mut expr_nodes,
             time_zone,
-            super::super::map_pb_sig_to_rpn_func,
+            super::super::map_pb_fn_to_rpn_func,
             max_columns,
         )?;
         Ok(RpnExpression::from(expr_nodes))
@@ -96,7 +95,7 @@ impl RpnExpressionBuilder {
         max_columns: usize,
     ) -> Result<RpnExpression>
     where
-        F: Fn(tipb::ScalarFuncSig, &[Expr]) -> Result<RpnFnMeta> + Copy,
+        F: Fn(&Expr, &[Expr]) -> Result<RpnFnMeta> + Copy,
     {
         let mut expr_nodes = Vec::new();
         append_rpn_nodes_recursively(
@@ -250,7 +249,7 @@ fn append_rpn_nodes_recursively<F>(
     // the full schema instead.
 ) -> Result<()>
 where
-    F: Fn(tipb::ScalarFuncSig, &[Expr]) -> Result<RpnFnMeta> + Copy,
+    F: Fn(&Expr, &[Expr]) -> Result<RpnFnMeta> + Copy,
 {
     match tree_node.get_tp() {
         ExprType::ScalarFunc => {
@@ -290,10 +289,10 @@ fn handle_node_fn_call<F>(
     max_columns: usize,
 ) -> Result<()>
 where
-    F: Fn(tipb::ScalarFuncSig, &[Expr]) -> Result<RpnFnMeta> + Copy,
+    F: Fn(&Expr, &[Expr]) -> Result<RpnFnMeta> + Copy,
 {
     // Map pb func to `RpnFnMeta`.
-    let func_meta = fn_mapper(tree_node.get_sig(), tree_node.get_children())?;
+    let func_meta = fn_mapper(&tree_node, tree_node.get_children())?;
 
     // Validate the input expression.
     (func_meta.validator_ptr)(&tree_node).map_err(|e| {
@@ -530,7 +529,7 @@ mod tests {
     /// For testing `append_rpn_nodes_recursively`. It accepts protobuf function sig enum, which
     /// cannot be modified by us in tests to support fn_a ~ fn_d. So let's just hard code some
     /// substitute.
-    fn fn_mapper(value: ScalarFuncSig, _children: &[Expr]) -> Result<RpnFnMeta> {
+    fn fn_mapper(expr: &Expr, _children: &[Expr]) -> Result<RpnFnMeta> {
         // fn_a: CastIntAsInt
         // fn_b: CastIntAsReal
         // fn_c: CastIntAsString
@@ -539,7 +538,7 @@ mod tests {
         // fn_f: CastIntAsDuration
         // fn_g: CastIntAsJson
         // fn_h: CastRealAsInt
-        Ok(match value {
+        Ok(match expr.get_sig() {
             ScalarFuncSig::CastIntAsInt => fn_a_fn_meta(),
             ScalarFuncSig::CastIntAsReal => fn_b_fn_meta(),
             ScalarFuncSig::CastIntAsString => fn_c_fn_meta(),

--- a/components/tidb_query/src/rpn_expr/types/expr_builder.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_builder.rs
@@ -28,7 +28,7 @@ impl RpnExpressionBuilder {
 
         match c.get_tp() {
             ExprType::ScalarFunc => {
-                super::super::map_pb_fn_to_rpn_func(c)?;
+                super::super::map_expr_node_to_rpn_func(c)?;
                 for n in c.get_children() {
                     RpnExpressionBuilder::check_expr_tree_supported(n)?;
                 }
@@ -81,7 +81,7 @@ impl RpnExpressionBuilder {
             tree_node,
             &mut expr_nodes,
             time_zone,
-            super::super::map_pb_fn_to_rpn_func,
+            super::super::map_expr_node_to_rpn_func,
             max_columns,
         )?;
         Ok(RpnExpression::from(expr_nodes))

--- a/components/tidb_query/src/rpn_expr/types/expr_eval.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_eval.rs
@@ -977,7 +977,7 @@ mod tests {
             Ok(Some(a.unwrap().into_inner() as i64))
         }
 
-        fn fn_mapper(expr: &Expr, _children: &[Expr]) -> Result<RpnFnMeta> {
+        fn fn_mapper(expr: &Expr) -> Result<RpnFnMeta> {
             // fn_a: CastIntAsInt
             // fn_b: CastIntAsReal
             // fn_c: CastIntAsString

--- a/components/tidb_query/src/rpn_expr/types/expr_eval.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_eval.rs
@@ -977,12 +977,12 @@ mod tests {
             Ok(Some(a.unwrap().into_inner() as i64))
         }
 
-        fn fn_mapper(value: ScalarFuncSig, _children: &[Expr]) -> Result<RpnFnMeta> {
+        fn fn_mapper(expr: &Expr, _children: &[Expr]) -> Result<RpnFnMeta> {
             // fn_a: CastIntAsInt
             // fn_b: CastIntAsReal
             // fn_c: CastIntAsString
             // fn_d: CastIntAsDecimal
-            Ok(match value {
+            Ok(match expr.get_sig() {
                 ScalarFuncSig::CastIntAsInt => fn_a_fn_meta(),
                 ScalarFuncSig::CastIntAsReal => fn_b_fn_meta(),
                 ScalarFuncSig::CastIntAsString => fn_c_fn_meta(),

--- a/components/tidb_query/src/rpn_expr/types/test_util.rs
+++ b/components/tidb_query/src/rpn_expr/types/test_util.rs
@@ -107,8 +107,7 @@ impl RpnFnScalarEvaluator {
         fun_sig_expr.set_field_type(ret_field_type.clone());
 
         // use validator_ptr to testing the test arguments.
-        let func: RpnFnMeta =
-            super::super::map_pb_fn_to_rpn_func(&fun_sig_expr, &children_ed).unwrap();
+        let func: RpnFnMeta = super::super::map_pb_fn_to_rpn_func(&fun_sig_expr).unwrap();
 
         if let Err(e) = (func.validator_ptr)(&fun_sig_expr) {
             return (Err(e), context);

--- a/components/tidb_query/src/rpn_expr/types/test_util.rs
+++ b/components/tidb_query/src/rpn_expr/types/test_util.rs
@@ -100,14 +100,15 @@ impl RpnFnScalarEvaluator {
             })
             .collect();
 
-        // use validator_ptr to testing the test arguments.
-        let func: RpnFnMeta = super::super::map_pb_sig_to_rpn_func(sig, &children_ed).unwrap();
         let ret_field_type = ret_field_type.into();
-
         let mut fun_sig_expr = Expr::default();
         fun_sig_expr.set_sig(sig);
         fun_sig_expr.set_children(children_ed.clone().into());
         fun_sig_expr.set_field_type(ret_field_type.clone());
+
+        // use validator_ptr to testing the test arguments.
+        let func: RpnFnMeta =
+            super::super::map_pb_fn_to_rpn_func(&fun_sig_expr, &children_ed).unwrap();
 
         if let Err(e) = (func.validator_ptr)(&fun_sig_expr) {
             return (Err(e), context);

--- a/components/tidb_query/src/rpn_expr/types/test_util.rs
+++ b/components/tidb_query/src/rpn_expr/types/test_util.rs
@@ -107,7 +107,7 @@ impl RpnFnScalarEvaluator {
         fun_sig_expr.set_field_type(ret_field_type.clone());
 
         // use validator_ptr to testing the test arguments.
-        let func: RpnFnMeta = super::super::map_pb_fn_to_rpn_func(&fun_sig_expr).unwrap();
+        let func: RpnFnMeta = super::super::map_expr_node_to_rpn_func(&fun_sig_expr).unwrap();
 
         if let Err(e) = (func.validator_ptr)(&fun_sig_expr) {
             return (Err(e), context);


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Map all CAST signatures to RPN function for the batch executor framework

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

Integration tests.

