### PR TITLE
cmd: wrap up tikv config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,7 @@ dependencies = [
  "signal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
+ "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tikv 4.0.0-alpha",
  "tikv_util 0.1.0",
  "toml 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "raft 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -42,6 +42,7 @@ url = "1.7.2"
 futures = "0.1"
 serde = "1.0"
 serde_json = "1.0"
+serde_derive = "1.0"
 fail = "0.3"
 grpcio = { version = "0.5.0-alpha.3", features = [ "openssl-vendored" ] }
 raft = "0.6.0-alpha"

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -55,3 +55,6 @@ pd_client = { path = "../components/pd_client" }
 
 [target.'cfg(unix)'.dependencies]
 signal = "0.6"
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/cmd/src/bin/tikv-server.rs
+++ b/cmd/src/bin/tikv-server.rs
@@ -6,8 +6,8 @@
 use std::process;
 
 use clap::{crate_authors, crate_version, App, Arg};
+use cmd::config::Config;
 use cmd::setup::validate_and_persist_config;
-use tikv::config::TiKvConfig;
 
 fn main() {
     let matches = App::new("TiKV")
@@ -137,14 +137,14 @@ fn main() {
         .get_matches();
 
     if matches.is_present("print-sample-config") {
-        let config = TiKvConfig::default();
+        let config = Config::default();
         println!("{}", toml::to_string_pretty(&config).unwrap());
         process::exit(0);
     }
 
     let mut config = matches
         .value_of("config")
-        .map_or_else(TiKvConfig::default, |path| TiKvConfig::from_file(&path));
+        .map_or_else(Config::default, |path| Config::from_file(&path));
 
     cmd::setup::overwrite_config_with_cmd_args(&mut config, &matches);
 

--- a/cmd/src/config.rs
+++ b/cmd/src/config.rs
@@ -1,0 +1,33 @@
+// Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
+
+use tikv::config::TiKvConfig;
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[serde(default)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "kebab-case")]
+pub struct Config {
+    #[serde(flatten)]
+    pub tikv_cfg: TiKvConfig,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            tikv_cfg: TiKvConfig::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toml;
+
+    #[test]
+    fn test_flatten() {
+        let tikv_str = toml::to_string(&TiKvConfig::default()).unwrap();
+        let cfg_str = toml::to_string(&Config::default()).unwrap();
+        assert_eq!(tikv_str, cfg_str);
+    }
+}

--- a/cmd/src/config.rs
+++ b/cmd/src/config.rs
@@ -1,6 +1,13 @@
-// Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::error::Error;
+use std::fs;
+use std::io::{Error as IoError, Write};
+use std::path::Path;
 
 use tikv::config::TiKvConfig;
+
+const LAST_CONFIG_FILE: &str = "last_tikv.toml";
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
@@ -9,6 +16,7 @@ use tikv::config::TiKvConfig;
 pub struct Config {
     #[serde(flatten)]
     pub tikv_cfg: TiKvConfig,
+    // Add more config here.
 }
 
 impl Default for Config {
@@ -19,15 +27,140 @@ impl Default for Config {
     }
 }
 
+impl Config {
+    pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
+        self.tikv_cfg.validate()
+    }
+
+    pub fn compatible_adjust(&mut self) {
+        self.tikv_cfg.compatible_adjust();
+    }
+
+    pub fn check_critical_cfg_with(&self, last_cfg: &Self) -> Result<(), String> {
+        self.tikv_cfg.check_critical_cfg_with(&last_cfg.tikv_cfg)
+    }
+
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Self {
+        (|| -> Result<Self, Box<dyn Error>> {
+            let s = fs::read_to_string(&path)?;
+            Ok(::toml::from_str(&s)?)
+        })()
+        .unwrap_or_else(|e| {
+            panic!(
+                "invalid auto generated configuration file {}, err {}",
+                path.as_ref().display(),
+                e
+            );
+        })
+    }
+
+    pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), IoError> {
+        let content = ::toml::to_string(&self).unwrap();
+        let mut f = fs::File::create(&path)?;
+        f.write_all(content.as_bytes())?;
+        f.sync_all()?;
+
+        Ok(())
+    }
+}
+
+/// Prevents launching with an incompatible configuration
+///
+/// Loads the previously-loaded configuration from `last_tikv.toml`,
+/// compares key configuration items and fails if they are not
+/// identical.
+pub fn check_critical_config(config: &Config) -> Result<(), String> {
+    // Check current critical configurations with last time, if there are some
+    // changes, user must guarantee relevant works have been done.
+    let store_path = Path::new(&config.tikv_cfg.storage.data_dir);
+    let last_cfg_path = store_path.join(LAST_CONFIG_FILE);
+
+    if last_cfg_path.exists() {
+        let last_cfg = Config::from_file(&last_cfg_path);
+        config.check_critical_cfg_with(&last_cfg)?;
+    }
+
+    Ok(())
+}
+
+/// Persists critical config to `last_tikv.toml`
+pub fn persist_critical_config(config: &Config) -> Result<(), String> {
+    let store_path = Path::new(&config.tikv_cfg.storage.data_dir);
+    let last_cfg_path = store_path.join(LAST_CONFIG_FILE);
+
+    // Create parent directory if missing.
+    if let Err(e) = fs::create_dir_all(&store_path) {
+        return Err(format!(
+            "create parent directory '{}' failed: {}",
+            store_path.to_str().unwrap(),
+            e
+        ));
+    }
+
+    // Persist current critical configurations to file.
+    if let Err(e) = config.write_to_file(&last_cfg_path) {
+        return Err(format!(
+            "persist critical config to '{}' failed: {}",
+            last_cfg_path.to_str().unwrap(),
+            e
+        ));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::Builder;
     use toml;
 
     #[test]
+    fn test_persist_cfg() {
+        let dir = Builder::new().prefix("test_persist_cfg").tempdir().unwrap();
+        let path_buf = dir.path().join(LAST_CONFIG_FILE);
+        let file = path_buf.as_path().to_str().unwrap();
+        let (s1, s2) = ("/xxx/wal_dir".to_owned(), "/yyy/wal_dir".to_owned());
+
+        let mut cfg = Config::default();
+
+        cfg.tikv_cfg.rocksdb.wal_dir = s1.clone();
+        cfg.tikv_cfg.raftdb.wal_dir = s2.clone();
+        cfg.write_to_file(file).unwrap();
+        let cfg_from_file = Config::from_file(file);
+        assert_eq!(cfg_from_file.tikv_cfg.rocksdb.wal_dir, s1.clone());
+        assert_eq!(cfg_from_file.tikv_cfg.raftdb.wal_dir, s2.clone());
+
+        // write critical config when exist.
+        cfg.tikv_cfg.rocksdb.wal_dir = s2.clone();
+        cfg.tikv_cfg.raftdb.wal_dir = s1.clone();
+        cfg.write_to_file(file).unwrap();
+        let cfg_from_file = Config::from_file(file);
+        assert_eq!(cfg_from_file.tikv_cfg.rocksdb.wal_dir, s2.clone());
+        assert_eq!(cfg_from_file.tikv_cfg.raftdb.wal_dir, s1.clone());
+    }
+
+    #[test]
+    fn test_create_parent_dir_if_missing() {
+        let root_path = Builder::new()
+            .prefix("test_create_parent_dir_if_missing")
+            .tempdir()
+            .unwrap();
+        let path = root_path.path().join("not_exist_dir");
+
+        let mut cfg = Config::default();
+        cfg.tikv_cfg.storage.data_dir = path.as_path().to_str().unwrap().to_owned();
+        assert!(check_critical_config(&cfg).is_ok());
+    }
+
+    #[test]
     fn test_flatten() {
+        // With flatten feature, the output string should be the same.
         let tikv_str = toml::to_string(&TiKvConfig::default()).unwrap();
         let cfg_str = toml::to_string(&Config::default()).unwrap();
         assert_eq!(tikv_str, cfg_str);
+
+        // A serialized TiKvConfig should be able to deserialize to a Config.
+        assert_eq!(Config::default(), toml::from_str(&tikv_str).unwrap());
     }
 }

--- a/cmd/src/lib.rs
+++ b/cmd/src/lib.rs
@@ -4,8 +4,11 @@
 extern crate slog;
 #[macro_use]
 extern crate slog_global;
+#[macro_use]
+extern crate serde_derive;
 
 #[macro_use]
 pub mod setup;
+pub mod config;
 pub mod server;
 pub mod signal_handler;

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -39,14 +39,11 @@ use tikv_util::security::SecurityManager;
 use tikv_util::time::Monitor;
 use tikv_util::worker::FutureWorker;
 
-use crate::config::{check_critical_config, Config};
+use crate::config::Config;
 
 const RESERVED_OPEN_FDS: u64 = 1000;
 
 pub fn run_tikv(mut cfg: Config) {
-    if let Err(e) = check_critical_config(&cfg) {
-        fatal!("critical config check failed: {}", e);
-    }
     let config = &mut cfg.tikv_cfg;
 
     // Sets the global logger ASAP.

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -39,9 +39,16 @@ use tikv_util::security::SecurityManager;
 use tikv_util::time::Monitor;
 use tikv_util::worker::FutureWorker;
 
+use crate::config::{check_critical_config, Config};
+
 const RESERVED_OPEN_FDS: u64 = 1000;
 
-pub fn run_tikv(mut config: TiKvConfig) {
+pub fn run_tikv(mut cfg: Config) {
+    if let Err(e) = check_critical_config(&cfg) {
+        fatal!("critical config check failed: {}", e);
+    }
+    let config = &mut cfg.tikv_cfg;
+
     // Sets the global logger ASAP.
     // It is okay to use the config w/o `validate()`,
     // because `initial_logger()` handles various conditions.

--- a/cmd/src/setup.rs
+++ b/cmd/src/setup.rs
@@ -6,9 +6,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use chrono;
 use clap::ArgMatches;
 
-use tikv::config::{check_critical_config, persist_critical_config, MetricConfig, TiKvConfig};
+use tikv::config::{MetricConfig, TiKvConfig};
 use tikv_util::collections::HashMap;
 use tikv_util::{self, logger};
+
+use crate::config::{check_critical_config, persist_critical_config, Config};
 
 // A workaround for checking if log is initialized.
 pub static LOG_INITIALIZED: AtomicBool = AtomicBool::new(false);
@@ -76,7 +78,8 @@ pub fn initial_metric(cfg: &MetricConfig, node_id: Option<u64>) {
 }
 
 #[allow(dead_code)]
-pub fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatches<'_>) {
+pub fn overwrite_config_with_cmd_args(config: &mut Config, matches: &ArgMatches<'_>) {
+    let config = &mut config.tikv_cfg;
     if let Some(level) = matches.value_of("log-level") {
         config.log_level = logger::get_level_by_string(level).unwrap();
     }
@@ -137,7 +140,7 @@ pub fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatc
 }
 
 #[allow(dead_code)]
-pub fn validate_and_persist_config(config: &mut TiKvConfig, persist: bool) {
+pub fn validate_and_persist_config(config: &mut Config, persist: bool) {
     if let Err(e) = check_critical_config(config) {
         fatal!("critical config check failed: {}", e);
     }


### PR DESCRIPTION
###  What have you changed?

Add a new Config in the cmd crate, it wraps TiKvConfig, also this PR moves persist feature from the TiKvConfig to the new Config. This change allows adding further configuration from other components.

It's preparation for the upcoming backup feature.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?

Integration tests.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.
