### PR TITLE
tikv-ctl: fix a modify-tikv-config usage tips error

### DIFF
--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -1520,7 +1520,7 @@ fn main() {
         .subcommand(SubCommand::with_name("bad-regions").about("Get all regions with corrupt raft"))
         .subcommand(
             SubCommand::with_name("modify-tikv-config")
-                .about("Modify tikv config, eg. ./tikv-ctl -h ip:port modify-tikv-config -m kvdb -n default.disable_auto_compactions -v true")
+                .about("Modify tikv config, eg. tikv-ctl --host ip:port modify-tikv-config -m kvdb -n default.disable_auto_compactions -v true")
                 .arg(
                     Arg::with_name("module")
                         .required(true)


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

- Fix a tikv-ctl subcommand modify-tikv-config usage tips error. When I operated tikv-ctl according to current usage tips, I got the usage help printed, this is because `-h` is the shortcut of `--help`.

![image](https://user-images.githubusercontent.com/3251373/63769012-479c7980-c904-11e9-9900-c78a388600a2.png)

###  What is the type of the changes?

- Misc (other changes)

###  How is the PR tested?

manual test

![image](https://user-images.githubusercontent.com/3251373/63768894-fab8a300-c903-11e9-8b98-5a78d9954f2e.png)


###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

