### PR TITLE
Revert "*: deny unknown fields when deserializing config TOML (#5190)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@ All notable changes to this project are documented in this file.
 See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.md) and [PD Changelog](https://github.com/pingcap/pd/blob/master/CHANGELOG.md).
 
 ## [Unreleased]
-
 - Make several `INFO` logs `DEBUG` and refined some log messages. (https://github.com/tikv/tikv/pull/4768)
-- Unrecognized configuration will now prevent TiKV from starting. (https://github.com/tikv/tikv/pull/5190)
 
 ## [3.0.0]
 
@@ -13,14 +11,14 @@ See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.
   - Introduce Titan, a key-value plugin that improves write performance for
   scenarios with value sizes greater than 1KiB, and relieves write
   amplification in certain degrees
-  - Optimize memory management to reduce memory allocation and copying for `Iterator Key Bound Option`
+  - Optimize memory management to reduce memory allocation and copying for `Iterator Key Bound Option` 
   - Support `block cache` sharing among different column families
 
 + Server
   - Support reversed `raw_scan` and `raw_batch_scan`
   - Support batch receiving and sending Raft messages, improving TPS by 7% for write intensive scenarios
   - Support getting monitoring information via HTTP
-  - Support Local Reader in RawKV to improve performance
+  - Support Local Reader in RawKV to improve performance  
   - Reduce context switch overhead from `batch commands`
 
 + Raftstore
@@ -40,15 +38,15 @@ See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.
 
 + Coprocessor
   - Refactor the computation framework to implement vector operators, computation
-  using vector expressions, and vector aggregations to improve performance
+  using vector expressions, and vector aggregations to improve performance  
   - Support providing operator execution status for the `EXPLAIN ANALYZE` statement
-  in TiDB
+  in TiDB  
   - Switch to the `work-stealing` thread pool model to reduce context switch cost
 
 + Misc
   - Develop a unified log format specification with restructured log system to
   facilitate collection and analysis by tools
-  - Add performance metrics related to configuration information and key bound crossing.
+  - Add performance metrics related to configuration information and key bound crossing. 
 
 ## [3.0.0-rc.3]
 
@@ -73,11 +71,11 @@ See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.
 + Coprocessor
     - Improve coprocessor batch executor. [4877](https://github.com/tikv/tikv/pull/4877)
 
-+ Transaction
++ Transaction 
     - Support `ResolveLockLite` to allow only resolving specified lock keys. [4882](https://github.com/tikv/tikv/pull/4882)
     - Improve pessimistic lock transaction. [4889](https://github.com/tikv/tikv/pull/4889)
 
-+ Tikv-ctl
++ Tikv-ctl 
     - Improve `bad-regions` and `tombstone` subcommands. [4862](https://github.com/tikv/tikv/pull/4862)
 
 + Misc

--- a/components/pd_client/src/config.rs
+++ b/components/pd_client/src/config.rs
@@ -9,7 +9,6 @@ use tikv_util::config::ReadableDuration;
 /// for infinity, logging only every 10th duplicate error.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     /// The PD endpoints for the client.

--- a/components/tikv_util/src/security.rs
+++ b/components/tikv_util/src/security.rs
@@ -11,7 +11,6 @@ use grpcio::{
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct SecurityConfig {
     pub ca_path: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,7 +75,6 @@ fn memory_mb_for_cf(is_raft_db: bool, cf: &str) -> usize {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct TitanCfConfig {
     pub min_blob_size: ReadableSize,
@@ -125,7 +124,6 @@ macro_rules! cf_config {
     ($name:ident) => {
         #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
         #[serde(default)]
-        #[serde(deny_unknown_fields)]
         #[serde(rename_all = "kebab-case")]
         pub struct $name {
             pub block_size: ReadableSize,
@@ -594,7 +592,6 @@ impl RaftCfConfig {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 // Note that Titan is still an experimental feature. Once enabled, it can't fall back.
 // Forced fallback may result in data loss.
@@ -635,7 +632,6 @@ impl TitanDBConfig {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct DbConfig {
     #[serde(with = "rocks_config::recovery_mode_serde")]
@@ -865,7 +861,6 @@ impl RaftDefaultCfConfig {
 // But each instance will limit their background jobs according to their own max_background_jobs
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct RaftDbConfig {
     #[serde(with = "rocks_config::recovery_mode_serde")]
@@ -982,7 +977,6 @@ impl RaftDbConfig {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct MetricConfig {
     pub interval: ReadableDuration,
@@ -1030,7 +1024,6 @@ macro_rules! readpool_config {
     ($struct_name:ident, $test_mod_name:ident, $display_name:expr) => {
         #[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Debug)]
         #[serde(default)]
-        #[serde(deny_unknown_fields)]
         #[serde(rename_all = "kebab-case")]
         pub struct $struct_name {
             pub high_concurrency: usize,
@@ -1238,7 +1231,6 @@ impl Default for CoprReadPoolConfig {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct ReadPoolConfig {
     pub storage: StorageReadPoolConfig,
@@ -1255,7 +1247,6 @@ impl ReadPoolConfig {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct TiKvConfig {
     #[serde(with = "log_level_serde")]

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -5,7 +5,6 @@ use std::result::Result;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     pub num_threads: usize,

--- a/src/raftstore/coprocessor/config.rs
+++ b/src/raftstore/coprocessor/config.rs
@@ -5,7 +5,6 @@ use tikv_util::config::ReadableSize;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     /// When it is true, it will try to split a region with table prefix if

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -9,7 +9,6 @@ use tikv_util::config::{ReadableDuration, ReadableSize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     // true for high reliability, prevent data loss when power failure.

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -43,7 +43,6 @@ pub enum GrpcCompressionType {
 /// Configuration for the `server` module.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     #[serde(skip)]

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -27,7 +27,6 @@ const DEFAULT_SCHED_PENDING_WRITE_MB: u64 = 100;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     pub data_dir: String,
@@ -67,7 +66,6 @@ impl Config {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct BlockCacheConfig {
     pub shared: bool,

--- a/src/storage/lock_manager/config.rs
+++ b/src/storage/lock_manager/config.rs
@@ -4,7 +4,6 @@ use std::error::Error;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(default)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     pub enabled: bool,

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -555,37 +555,3 @@ fn test_block_cache_backward_compatible() {
             + cfg.raftdb.defaultcf.block_cache_size.0
     );
 }
-
-#[test]
-fn test_error_on_unrecognized_config() {
-    let contents = [
-        "unknown-field = 123\n",
-        "[unknown-dict]\ncontent = 123\n",
-        "[[unknown-array]]\ncontent = 123\n",
-        "[readpool]\nunknown-field = 123\n",
-        "[readpool.coprocessor]\nunknown-field = 123\n",
-        "[readpool.storage]\nunknown-field = 123\n",
-        "[server]\nunknown-field = 123\n",
-        "[storage]\nunknown-field = 123\n",
-        "[storage.block-cache]\nunknown-field = 123\n",
-        "[pd]\nunknown-field = 123\n",
-        "[metric]\nunknown-field = 123\n",
-        "[raftstore]\nunknown-field = 123\n",
-        "[coprocessor]\nunknown-field = 123\n",
-        "[rocksdb]\nunknown-field = 123\n",
-        "[rocksdb.titan]\nunknown-field = 123\n",
-        "[rocksdb.defaultcf]\nunknown-field = 123\n",
-        "[rocksdb.defaultcf.titan]\nunknown-field = 123\n",
-        "[rocksdb.writecf]\nunknown-field = 123\n",
-        "[rocksdb.lockcf]\nunknown-field = 123\n",
-        "[raftdb]\nunknown-field = 123\n",
-        "[raftdb.defaultcf]\nunknown-field = 123\n",
-        "[security]\nunknown-field = 123\n",
-        "[import]\nunknown-field = 123\n",
-    ];
-
-    for content in &contents {
-        let result = toml::from_str::<TiKvConfig>(content);
-        assert!(result.is_err());
-    }
-}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This reverts commit 034379605e8805c2ce2016903e21e3bd0521f64e (PR #5190).

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

n/a

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

None

###  Does this PR affect `tidb-ansible`?

None

###  Refer to a related PR or issue link (optional)

#5286

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

