### PR TITLE
tikv_util: calculate CRC32 for byte slice

### DIFF
--- a/components/tikv_util/src/file.rs
+++ b/components/tikv_util/src/file.rs
@@ -74,6 +74,13 @@ pub fn calc_crc32<P: AsRef<Path>>(path: P) -> io::Result<u32> {
     }
 }
 
+/// Calculates the given content's CRC32 checksum.
+pub fn calc_crc32_bytes(contents: &[u8]) -> u32 {
+    let mut digest = Digest::new(crc32::IEEE);
+    digest.write(contents);
+    digest.sum32()
+}
+
 #[cfg(test)]
 mod tests {
     use rand::distributions::Alphanumeric;
@@ -169,9 +176,7 @@ mod tests {
             .take(size)
             .collect();
         fs::write(path, s.as_bytes()).unwrap();
-        let mut digest = Digest::new(crc32::IEEE);
-        digest.write(s.as_bytes());
-        digest.sum32()
+        calc_crc32_bytes(s.as_bytes())
     }
 
     #[test]


### PR DESCRIPTION

###  What have you changed?

Add a function to calculate CRC32 for byte slice.

###  What is the type of the changes?

- New feature (a change which adds functionality)

###  How is the PR tested?

Unit test.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.
