### PR TITLE
backup: add backup service

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -1,0 +1,178 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+// TODO: remove it after all code been merged.
+#![allow(unused_variables)]
+#![allow(dead_code)]
+
+use std::cmp;
+use std::fmt;
+use std::sync::atomic::*;
+use std::sync::*;
+use std::time::*;
+
+use engine::DB;
+use external_storage::*;
+use futures::sync::mpsc::*;
+use futures::{lazy, Future};
+use kvproto::backup::*;
+use kvproto::kvrpcpb::{Context, IsolationLevel};
+use kvproto::metapb::*;
+use raft::StateRole;
+use tikv::raftstore::coprocessor::RegionInfoAccessor;
+use tikv::raftstore::store::util::find_peer;
+use tikv::server::transport::ServerRaftStoreRouter;
+use tikv::storage::kv::{
+    Engine, Error as EngineError, RegionInfoProvider, ScanMode, StatisticsSummary,
+};
+use tikv::storage::txn::{
+    EntryBatch, Error as TxnError, Msg, Scanner, SnapshotStore, Store, TxnEntryScanner,
+    TxnEntryStore,
+};
+use tikv::storage::{Key, Statistics};
+use tikv_util::worker::{Runnable, RunnableWithTimer};
+use tokio_threadpool::{Builder as ThreadPoolBuilder, ThreadPool};
+
+use crate::*;
+
+/// Backup task.
+pub struct Task {
+    pub(crate) resp: UnboundedSender<BackupResponse>,
+
+    cancel: Arc<AtomicBool>,
+}
+
+impl fmt::Display for Task {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+impl fmt::Debug for Task {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BackupTask").finish()
+    }
+}
+
+impl Task {
+    /// Create a backup task based on the given backup request.
+    pub fn new(
+        req: BackupRequest,
+        resp: UnboundedSender<BackupResponse>,
+    ) -> Result<(Task, Arc<AtomicBool>)> {
+        let cancel = Arc::new(AtomicBool::new(false));
+        Ok((
+            Task {
+                resp,
+                cancel: cancel.clone(),
+            },
+            cancel,
+        ))
+    }
+
+    /// Check whether the task is canceled.
+    pub fn has_canceled(&self) -> bool {
+        self.cancel.load(Ordering::SeqCst)
+    }
+}
+
+/// The endpoint of backup.
+///
+/// It coordinates backup tasks and dispathes them to different workers.
+pub struct Endpoint<E: Engine, R: RegionInfoProvider> {
+    db: Arc<DB>,
+    pub(crate) engine: E,
+    pub(crate) region_info: R,
+}
+
+impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
+    pub fn new(engine: E, region_info: R, db: Arc<DB>) -> Endpoint<E, R> {
+        Endpoint {
+            engine,
+            region_info,
+            db,
+        }
+    }
+
+    pub fn handle_backup_task(&self, _task: Task) {
+        // TODO: fill it.
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use external_storage::LocalStorage;
+    use futures::{Future, Stream};
+    use kvproto::metapb;
+    use std::collections::BTreeMap;
+    use std::sync::mpsc::{channel, Receiver, Sender};
+    use tempfile::TempDir;
+    use tikv::raftstore::coprocessor::RegionCollector;
+    use tikv::raftstore::coprocessor::{RegionInfo, SeekRegionCallback};
+    use tikv::raftstore::store::util::new_peer;
+    use tikv::storage::kv::Result as EngineResult;
+    use tikv::storage::mvcc::tests::*;
+    use tikv::storage::SHORT_VALUE_MAX_LEN;
+    use tikv::storage::{
+        Mutation, Options, RocksEngine, Storage, TestEngineBuilder, TestStorageBuilder,
+    };
+
+    #[derive(Clone)]
+    pub struct MockRegionInfoProvider {
+        // start_key -> (region_id, end_key)
+        regions: Arc<Mutex<RegionCollector>>,
+        cancel: Option<Arc<AtomicBool>>,
+    }
+    impl MockRegionInfoProvider {
+        pub fn new() -> Self {
+            MockRegionInfoProvider {
+                regions: Arc::new(Mutex::new(RegionCollector::new())),
+                cancel: None,
+            }
+        }
+        pub fn set_regions(&self, regions: Vec<(Vec<u8>, Vec<u8>, u64)>) {
+            let mut map = self.regions.lock().unwrap();
+            for (mut start_key, mut end_key, id) in regions {
+                if !start_key.is_empty() {
+                    start_key = Key::from_raw(&start_key).into_encoded();
+                }
+                if !end_key.is_empty() {
+                    end_key = Key::from_raw(&end_key).into_encoded();
+                }
+                let mut r = metapb::Region::default();
+                r.set_id(id);
+                r.set_start_key(start_key.clone());
+                r.set_end_key(end_key);
+                r.mut_peers().push(new_peer(1, 1));
+                map.create_region(r, StateRole::Leader);
+            }
+        }
+        fn canecl_on_seek(&mut self, cancel: Arc<AtomicBool>) {
+            self.cancel = Some(cancel);
+        }
+    }
+    impl RegionInfoProvider for MockRegionInfoProvider {
+        fn seek_region(&self, from: &[u8], callback: SeekRegionCallback) -> EngineResult<()> {
+            let from = from.to_vec();
+            let regions = self.regions.lock().unwrap();
+            if let Some(c) = self.cancel.as_ref() {
+                c.store(true, Ordering::SeqCst);
+            }
+            regions.handle_seek_region(from, callback);
+            Ok(())
+        }
+    }
+
+    pub fn new_endpoint() -> (TempDir, Endpoint<RocksEngine, MockRegionInfoProvider>) {
+        let temp = TempDir::new().unwrap();
+        let rocks = TestEngineBuilder::new()
+            .path(temp.path())
+            .cfs(&[engine::CF_DEFAULT, engine::CF_LOCK, engine::CF_WRITE])
+            .build()
+            .unwrap();
+        let db = rocks.get_rocksdb();
+        (
+            temp,
+            Endpoint::new(rocks, MockRegionInfoProvider::new(), db),
+        )
+    }
+}

--- a/components/backup/src/lib.rs
+++ b/components/backup/src/lib.rs
@@ -28,6 +28,10 @@ extern crate failure;
 #[allow(unused_extern_crates)]
 extern crate tikv_alloc;
 
+mod endpoint;
 mod errors;
+mod service;
 
+pub use endpoint::{Endpoint, Task};
 pub use errors::{Error, Result};
+pub use service::Service;

--- a/components/backup/src/service.rs
+++ b/components/backup/src/service.rs
@@ -105,7 +105,6 @@ mod tests {
 
     #[test]
     fn test_client_stop() {
-        test_util::init_log_for_test();
         let (_server, client, rx) = new_rpc_suite();
 
         let (tmp, endpoint) = new_endpoint();

--- a/components/backup/src/service.rs
+++ b/components/backup/src/service.rs
@@ -1,0 +1,189 @@
+use std::sync::atomic::*;
+
+use futures::future::*;
+use futures::prelude::*;
+use futures::sync::mpsc;
+use grpcio::*;
+use kvproto::backup::{BackupRequest, BackupResponse};
+use kvproto::backup_grpc::*;
+use tikv_util::worker::*;
+
+use super::Task;
+
+/// Service handles the RPC messages for the `Backup` service.
+#[derive(Clone)]
+pub struct Service {
+    scheduler: Scheduler<Task>,
+}
+
+impl Service {
+    /// Create a new backup service.
+    pub fn new(scheduler: Scheduler<Task>) -> Service {
+        Service { scheduler }
+    }
+}
+
+impl Backup for Service {
+    fn backup(
+        &mut self,
+        ctx: RpcContext,
+        req: BackupRequest,
+        sink: ServerStreamingSink<BackupResponse>,
+    ) {
+        let mut cancel = None;
+        // TODO: make it a bounded channel.
+        let (tx, rx) = mpsc::unbounded();
+        if let Err(status) = match Task::new(req, tx) {
+            Ok((task, c)) => {
+                cancel = Some(c);
+                self.scheduler.schedule(task).map_err(|e| {
+                    RpcStatus::new(RpcStatusCode::INVALID_ARGUMENT, Some(format!("{:?}", e)))
+                })
+            }
+            Err(e) => Err(RpcStatus::new(
+                RpcStatusCode::UNKNOWN,
+                Some(format!("{:?}", e)),
+            )),
+        } {
+            error!("backup task initiate failed"; "error" => ?status);
+            ctx.spawn(sink.fail(status).map_err(|e| {
+                error!("backup failed to send error"; "error" => ?e);
+            }));
+            return;
+        };
+
+        let send_resp = sink.send_all(rx.then(|resp| match resp {
+            Ok(resp) => Ok((resp, WriteFlags::default())),
+            Err(e) => {
+                error!("backup send failed"; "error" => ?e);
+                Err(Error::RpcFailure(RpcStatus::new(
+                    RpcStatusCode::UNKNOWN,
+                    Some(format!("{:?}", e)),
+                )))
+            }
+        }));
+        ctx.spawn(
+            send_resp
+                .map(|_s /* the sink */| {
+                    info!("backup send half closed");
+                })
+                .map_err(move |e| {
+                    if let Some(c) = cancel {
+                        // Cancel the running task.
+                        c.store(true, Ordering::SeqCst);
+                    }
+                    error!("backup canceled"; "error" => ?e);
+                }),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::endpoint::tests::*;
+    use tikv::storage::mvcc::tests::*;
+    use tikv_util::mpsc::Receiver;
+
+    fn new_rpc_suite() -> (Server, BackupClient, Receiver<Option<Task>>) {
+        let env = Arc::new(EnvBuilder::new().build());
+        let (scheduler, rx) = dummy_scheduler();
+        let backup_service = super::Service::new(scheduler);
+        let builder =
+            ServerBuilder::new(env.clone()).register_service(create_backup(backup_service));
+        let mut server = builder.bind("127.0.0.1", 0).build().unwrap();
+        server.start();
+        let (_, port) = server.bind_addrs()[0];
+        let addr = format!("127.0.0.1:{}", port);
+        let channel = ChannelBuilder::new(env.clone()).connect(&addr);
+        let client = BackupClient::new(channel);
+        (server, client, rx)
+    }
+
+    #[test]
+    fn test_client_stop() {
+        test_util::init_log_for_test();
+        let (_server, client, rx) = new_rpc_suite();
+
+        let (tmp, endpoint) = new_endpoint();
+        let engine = endpoint.engine.clone();
+        endpoint.region_info.set_regions(vec![
+            (b"".to_vec(), b"2".to_vec(), 1),
+            (b"2".to_vec(), b"5".to_vec(), 2),
+        ]);
+
+        let mut ts = 1;
+        let mut alloc_ts = || {
+            ts += 1;
+            ts
+        };
+        for i in 0..5 {
+            let start = alloc_ts();
+            let key = format!("{}", i);
+            must_prewrite_put(
+                &engine,
+                key.as_bytes(),
+                key.as_bytes(),
+                key.as_bytes(),
+                start,
+            );
+            let commit = alloc_ts();
+            must_commit(&engine, key.as_bytes(), start, commit);
+        }
+
+        let now = alloc_ts();
+        let mut req = BackupRequest::new();
+        req.set_start_key(vec![]);
+        req.set_end_key(vec![b'5']);
+        req.set_start_version(now);
+        req.set_end_version(now);
+        // Set an unique path to avoid AlreadyExists error.
+        req.set_path(format!(
+            "local://{}",
+            tmp.path().join(format!("{}", now)).display()
+        ));
+
+        let stream = client.backup(&req).unwrap();
+        let task = rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        // Drop stream without start receiving will cause cancel error.
+        drop(stream);
+        // A stopped remote must not cause panic.
+        endpoint.handle_backup_task(task.unwrap());
+
+        // Set an unique path to avoid AlreadyExists error.
+        req.set_path(format!(
+            "local://{}",
+            tmp.path().join(format!("{}", alloc_ts())).display()
+        ));
+        let stream = client.backup(&req).unwrap();
+        // Drop steam once it received something.
+        client.spawn(stream.into_future().then(|_res| Ok(())));
+        let task = rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        // A stopped remote must not cause panic.
+        endpoint.handle_backup_task(task.unwrap());
+
+        // Set an unique path to avoid AlreadyExists error.
+        req.set_path(format!(
+            "local://{}",
+            tmp.path().join(format!("{}", alloc_ts())).display()
+        ));
+        let stream = client.backup(&req).unwrap();
+        let task = rx.recv_timeout(Duration::from_secs(5)).unwrap().unwrap();
+        // Drop stream without start receiving will cause cancel error.
+        drop(stream);
+        // Wait util the task is canceled in map_err.
+        loop {
+            std::thread::sleep(Duration::from_millis(100));
+            if task.resp.unbounded_send(Default::default()).is_err() {
+                break;
+            }
+        }
+        // The task should be canceled.
+        assert!(task.has_canceled());
+        // A stopped remote must not cause panic.
+        endpoint.handle_backup_task(task);
+    }
+}

--- a/src/raftstore/coprocessor/mod.rs
+++ b/src/raftstore/coprocessor/mod.rs
@@ -18,7 +18,9 @@ pub mod split_observer;
 pub use self::config::Config;
 pub use self::dispatcher::{CoprocessorHost, Registry};
 pub use self::error::{Error, Result};
-pub use self::region_info_accessor::{RegionInfo, RegionInfoAccessor, SeekRegionCallback};
+pub use self::region_info_accessor::{
+    RegionCollector, RegionInfo, RegionInfoAccessor, SeekRegionCallback,
+};
 pub use self::split_check::{
     get_region_approximate_keys, get_region_approximate_keys_cf, get_region_approximate_middle,
     get_region_approximate_size, get_region_approximate_size_cf, HalfCheckObserver,

--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -149,7 +149,7 @@ fn register_region_event_listener(
 /// `RegionCollector` is the place where we hold all region information we collected, and the
 /// underlying runner of `RegionInfoAccessor`. It listens on events sent by the `RegionEventListener` and
 /// keeps information of all regions. Role of each region are also tracked.
-struct RegionCollector {
+pub struct RegionCollector {
     // HashMap: region_id -> (Region, State)
     regions: RegionsMap,
     // BTreeMap: data_end_key -> region_id
@@ -157,14 +157,14 @@ struct RegionCollector {
 }
 
 impl RegionCollector {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             regions: HashMap::default(),
             region_ranges: BTreeMap::default(),
         }
     }
 
-    fn create_region(&mut self, region: Region, role: StateRole) {
+    pub fn create_region(&mut self, region: Region, role: StateRole) {
         let end_key = data_end_key(region.get_end_key());
         let region_id = region.get_id();
 
@@ -340,7 +340,7 @@ impl RegionCollector {
         true
     }
 
-    fn handle_seek_region(&self, from_key: Vec<u8>, callback: SeekRegionCallback) {
+    pub fn handle_seek_region(&self, from_key: Vec<u8>, callback: SeekRegionCallback) {
         let from_key = data_key(&from_key);
         let mut iter = self
             .region_ranges

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -194,7 +194,6 @@ pub fn default_not_found_error(key: Vec<u8>, write: Write, hint: &str) -> Error 
     }
 }
 
-#[cfg(test)]
 pub mod tests {
     use kvproto::kvrpcpb::{Context, IsolationLevel};
 


### PR DESCRIPTION
###  What have you changed?

Add backup service. It accepts backup requests and forwards to a backup endpoint which does the actual backup. 

Note: The endpoint is a plain stub, and will be implemented in upcoming PRs. 

###  What is the type of the changes?

- New feature (a change which adds functionality)

###  How is the PR tested?

Unit test.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.
