### PR TITLE
Copr: Implements `take_scanned_range` for `BatchExecutorRunner`

### DIFF
--- a/benches/coprocessor_executors/util/fixture.rs
+++ b/benches/coprocessor_executors/util/fixture.rs
@@ -364,8 +364,7 @@ impl BatchExecutor for BatchFixtureExecutor {
 
     #[inline]
     fn take_scanned_range(&mut self) -> IntervalRange {
-        // TODO: pass values
-        ("0", "1").into()
+        unreachable!()
     }
 }
 

--- a/benches/coprocessor_executors/util/fixture.rs
+++ b/benches/coprocessor_executors/util/fixture.rs
@@ -361,6 +361,12 @@ impl BatchExecutor for BatchFixtureExecutor {
     fn collect_storage_stats(&mut self, _dest: &mut Self::StorageStats) {
         // Do nothing
     }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        // TODO: pass values
+        ("0", "1").into()
+    }
 }
 
 pub struct NormalFixtureExecutor {

--- a/components/tidb_query/src/batch/executors/fast_hash_aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/fast_hash_aggr_executor.rs
@@ -16,6 +16,7 @@ use crate::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::codec::data_type::*;
 use crate::expr::EvalConfig;
 use crate::rpn_expr::{RpnExpression, RpnExpressionBuilder};
+use crate::storage::IntervalRange;
 use crate::Result;
 
 macro_rules! match_template_hashable {
@@ -54,6 +55,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchFastHashAggregationExecutor<Src>
     #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
+    }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        self.0.take_scanned_range()
     }
 }
 

--- a/components/tidb_query/src/batch/executors/index_scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/index_scan_executor.rs
@@ -12,7 +12,7 @@ use super::util::scan_executor::*;
 use crate::batch::interface::*;
 use crate::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::expr::{EvalConfig, EvalContext};
-use crate::storage::Storage;
+use crate::storage::{IntervalRange, Storage};
 use crate::Result;
 
 pub struct BatchIndexScanExecutor<S: Storage>(ScanExecutor<S, IndexScanExecutorImpl>);
@@ -99,6 +99,11 @@ impl<S: Storage> BatchExecutor for BatchIndexScanExecutor<S> {
     #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
+    }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        self.0.take_scanned_range()
     }
 }
 

--- a/components/tidb_query/src/batch/executors/limit_executor.rs
+++ b/components/tidb_query/src/batch/executors/limit_executor.rs
@@ -3,6 +3,7 @@
 use tipb::FieldType;
 
 use crate::batch::interface::*;
+use crate::storage::IntervalRange;
 use crate::Result;
 
 /// Executor that retrieves rows from the source executor
@@ -52,6 +53,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchLimitExecutor<Src> {
     #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
+    }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        self.src.take_scanned_range()
     }
 }
 

--- a/components/tidb_query/src/batch/executors/selection_executor.rs
+++ b/components/tidb_query/src/batch/executors/selection_executor.rs
@@ -11,6 +11,7 @@ use crate::codec::data_type::*;
 use crate::expr::{EvalConfig, EvalContext};
 use crate::rpn_expr::RpnStackNode;
 use crate::rpn_expr::{RpnExpression, RpnExpressionBuilder};
+use crate::storage::IntervalRange;
 use crate::Result;
 
 pub struct BatchSelectionExecutor<Src: BatchExecutor> {
@@ -191,6 +192,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSelectionExecutor<Src> {
     #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
+    }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        self.src.take_scanned_range()
     }
 }
 

--- a/components/tidb_query/src/batch/executors/simple_aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/simple_aggr_executor.rs
@@ -15,6 +15,7 @@ use crate::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::codec::data_type::*;
 use crate::expr::EvalConfig;
 use crate::rpn_expr::RpnStackNode;
+use crate::storage::IntervalRange;
 use crate::Result;
 
 pub struct BatchSimpleAggregationExecutor<Src: BatchExecutor>(
@@ -42,6 +43,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSimpleAggregationExecutor<Src> {
     #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
+    }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        self.0.take_scanned_range()
     }
 }
 

--- a/components/tidb_query/src/batch/executors/slow_hash_aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/slow_hash_aggr_executor.rs
@@ -18,6 +18,7 @@ use crate::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::expr::EvalConfig;
 use crate::rpn_expr::RpnStackNode;
 use crate::rpn_expr::{RpnExpression, RpnExpressionBuilder};
+use crate::storage::IntervalRange;
 use crate::Result;
 
 /// Slow Hash Aggregation Executor supports multiple groups but uses less efficient ways to
@@ -50,6 +51,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchSlowHashAggregationExecutor<Src>
     #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
+    }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        self.0.take_scanned_range()
     }
 }
 

--- a/components/tidb_query/src/batch/executors/stream_aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/stream_aggr_executor.rs
@@ -16,6 +16,7 @@ use crate::codec::data_type::*;
 use crate::expr::{EvalConfig, EvalContext};
 use crate::rpn_expr::RpnStackNode;
 use crate::rpn_expr::{RpnExpression, RpnExpressionBuilder};
+use crate::storage::IntervalRange;
 use crate::Result;
 
 pub struct BatchStreamAggregationExecutor<Src: BatchExecutor>(
@@ -43,6 +44,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchStreamAggregationExecutor<Src> {
     #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
+    }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        self.0.take_scanned_range()
     }
 }
 

--- a/components/tidb_query/src/batch/executors/table_scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/table_scan_executor.rs
@@ -14,7 +14,7 @@ use super::util::scan_executor::*;
 use crate::batch::interface::*;
 use crate::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::expr::{EvalConfig, EvalContext};
-use crate::storage::Storage;
+use crate::storage::{IntervalRange, Storage};
 use crate::Result;
 
 pub struct BatchTableScanExecutor<S: Storage>(ScanExecutor<S, TableScanExecutorImpl>);
@@ -108,6 +108,11 @@ impl<S: Storage> BatchExecutor for BatchTableScanExecutor<S> {
     #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.0.collect_storage_stats(dest);
+    }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        self.0.take_scanned_range()
     }
 }
 

--- a/components/tidb_query/src/batch/executors/top_n_executor.rs
+++ b/components/tidb_query/src/batch/executors/top_n_executor.rs
@@ -16,6 +16,7 @@ use crate::expr::EvalWarnings;
 use crate::expr::{EvalConfig, EvalContext};
 use crate::rpn_expr::RpnStackNode;
 use crate::rpn_expr::{RpnExpression, RpnExpressionBuilder};
+use crate::storage::IntervalRange;
 use crate::Result;
 
 pub struct BatchTopNExecutor<Src: BatchExecutor> {
@@ -319,6 +320,11 @@ impl<Src: BatchExecutor> BatchExecutor for BatchTopNExecutor<Src> {
     #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.src.collect_storage_stats(dest);
+    }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        self.src.take_scanned_range()
     }
 }
 

--- a/components/tidb_query/src/batch/executors/util/aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/util/aggr_executor.rs
@@ -38,6 +38,7 @@ use crate::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use crate::codec::data_type::*;
 use crate::expr::{EvalConfig, EvalContext};
 use crate::rpn_expr::RpnExpression;
+use crate::storage::IntervalRange;
 use crate::Result;
 
 pub trait AggregationExecutorImpl<Src: BatchExecutor>: Send {
@@ -315,6 +316,11 @@ impl<Src: BatchExecutor, I: AggregationExecutorImpl<Src>> BatchExecutor
     #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.entities.src.collect_storage_stats(dest);
+    }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        self.entities.src.take_scanned_range()
     }
 }
 

--- a/components/tidb_query/src/batch/executors/util/mock_executor.rs
+++ b/components/tidb_query/src/batch/executors/util/mock_executor.rs
@@ -43,9 +43,8 @@ impl BatchExecutor for MockExecutor {
         // Do nothing
     }
 
-    // TODO: make it fit next_batch
     fn take_scanned_range(&mut self) -> IntervalRange {
         // Do nothing
-        ("0", "1").into()
+        unreachable!()
     }
 }

--- a/components/tidb_query/src/batch/executors/util/mock_executor.rs
+++ b/components/tidb_query/src/batch/executors/util/mock_executor.rs
@@ -3,6 +3,7 @@
 use tipb::FieldType;
 
 use crate::batch::interface::*;
+use crate::storage::IntervalRange;
 
 /// A simple mock executor that will return batch data according to a fixture without any
 /// modification.
@@ -40,5 +41,10 @@ impl BatchExecutor for MockExecutor {
 
     fn collect_storage_stats(&mut self, _dest: &mut Self::StorageStats) {
         // Do nothing
+    }
+
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        // Do nothing
+        ("0", "1").into()
     }
 }

--- a/components/tidb_query/src/batch/executors/util/mock_executor.rs
+++ b/components/tidb_query/src/batch/executors/util/mock_executor.rs
@@ -43,6 +43,7 @@ impl BatchExecutor for MockExecutor {
         // Do nothing
     }
 
+    // TODO: make it fit next_batch
     fn take_scanned_range(&mut self) -> IntervalRange {
         // Do nothing
         ("0", "1").into()

--- a/components/tidb_query/src/batch/executors/util/scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/util/scan_executor.rs
@@ -122,10 +122,6 @@ impl<S: Storage, I: ScanExecutorImpl> ScanExecutor<S, I> {
         // Not drained
         Ok(false)
     }
-
-    pub(crate) fn take_scanned_range(&mut self) -> IntervalRange {
-        self.scanner.take_scanned_range()
-    }
 }
 
 /// Extracts `FieldType` from `ColumnInfo`.

--- a/components/tidb_query/src/batch/executors/util/scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/util/scan_executor.rs
@@ -8,7 +8,7 @@ use crate::batch::interface::*;
 use crate::codec::batch::LazyBatchColumnVec;
 use crate::expr::EvalContext;
 use crate::storage::scanner::{RangesScanner, RangesScannerOptions};
-use crate::storage::{Range, Storage};
+use crate::storage::{IntervalRange, Range, Storage};
 use crate::Result;
 
 /// Common interfaces for table scan and index scan implementations.
@@ -122,6 +122,10 @@ impl<S: Storage, I: ScanExecutorImpl> ScanExecutor<S, I> {
         // Not drained
         Ok(false)
     }
+
+    pub(crate) fn take_scanned_range(&mut self) -> IntervalRange {
+        self.scanner.take_scanned_range()
+    }
 }
 
 /// Extracts `FieldType` from `ColumnInfo`.
@@ -198,5 +202,11 @@ impl<S: Storage, I: ScanExecutorImpl> BatchExecutor for ScanExecutor<S, I> {
     #[inline]
     fn collect_storage_stats(&mut self, dest: &mut Self::StorageStats) {
         self.scanner.collect_storage_stats(dest);
+    }
+
+    #[inline]
+    fn take_scanned_range(&mut self) -> IntervalRange {
+        // TODO: check if there is a better way to reuse this method impl.
+        self.scanner.take_scanned_range()
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This is a sub pr for #5361 . This pr:
- [x] Implements take_scanned_range for BatchExecutorRunner 

###  What is the type of the changes?

Pick one of the following and delete the others:

Implements take_scanned_range for BatchExecutorRunner .

###  How is the PR tested?

Updated integration test in #5361 .

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.

###  Refer to a related PR or issue link (optional)

#5361 

