### PR TITLE
storage: add unit tests for interaction between scheduler and deadloc…

### DIFF
--- a/components/tikv_util/src/worker/future.rs
+++ b/components/tikv_util/src/worker/future.rs
@@ -46,7 +46,7 @@ pub struct Scheduler<T> {
 }
 
 impl<T: Display> Scheduler<T> {
-    fn new<S: Into<String>>(name: S, sender: UnboundedSender<Option<T>>) -> Scheduler<T> {
+    pub fn new<S: Into<String>>(name: S, sender: UnboundedSender<Option<T>>) -> Scheduler<T> {
         let name = name.into();
         Scheduler {
             metrics_pending_task_count: WORKER_PENDING_TASK_VEC.with_label_values(&[&name]),

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -246,7 +246,7 @@ impl From<StateRole> for Role {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum DetectType {
     Detect,
     CleanUpWaitFor,


### PR DESCRIPTION
###  What have you changed?

Add unit tests to txt::process that ensure that commands that should schedule a lock cleanup tell the deadlock detector to do so.

I am adding these because I broke this feature in https://github.com/tikv/tikv/pull/5261, but did not trigger any test failures. These are the tests that should have failed.

There should be negative tests here too but I've been working on this too long and need to shelve it. Figuring out how to write the negative tests was not as simple as I expected.

I don't understand most of the code involved here, but got the tests working by piecing together data structures until they hit all the right code paths.

I tried to structure the helper code in ways that are similar to other storage unit tests.

###  What is the type of the changes?

Pick one of the following and delete the others:

- New feature (a change which adds functionality)
- Improvement (a change which is an improvement to an existing feature)
- Bugfix (a change which fixes an issue)
- Engineering (engineering change which doesn't change any feature or fix any issue)
- Misc (other changes)

###  How is the PR tested?

Please describe the tests that you ran to verify your changes. Have you added unit or integration tests, or run manual tests? What additional tests would give you greater confidence in this change?

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

- If there is a document change, please file a PR in ([docs](https://github.com/tikv/tikv/tree/master/docs)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).

###  Does this PR affect `tidb-ansible`?

If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

