### PR TITLE
Improve our use of unsafe code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,6 +2983,7 @@ dependencies = [
  "toml 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "utime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3469,6 +3470,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "zeroize"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "zipf"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,5 +3831,6 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
+"checksum zeroize 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4090487fa66630f7b166fba2bbb525e247a5449f41c468cc1d98f8ae6ac03120"
 "checksum zipf 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2057772d87bedea0efd93842ee0e0f52fc0c313c556d5fa8ee787771c051a61f"
 "checksum zstd-sys 1.4.13+zstd.1.4.3 (git+https://github.com/gyscos/zstd-rs.git)" = "<none>"

--- a/components/tidb_query/src/batch/executors/util/mod.rs
+++ b/components/tidb_query/src/batch/executors/util/mod.rs
@@ -6,7 +6,7 @@ pub mod hash_aggr_helper;
 pub mod mock_executor;
 pub mod scan_executor;
 
-use tikv_util::{erase_lifetime, erase_lifetime_mut};
+use tikv_util::erase_lifetime;
 use tipb::FieldType;
 
 use crate::codec::batch::LazyBatchColumnVec;
@@ -42,7 +42,7 @@ pub unsafe fn eval_exprs_decoded_no_lifetime<'a>(
 ) -> Result<()> {
     for expr in exprs {
         output.push(erase_lifetime(expr).eval_decoded(
-            erase_lifetime_mut(ctx),
+            ctx,
             erase_lifetime(schema),
             erase_lifetime(input_physical_columns),
             erase_lifetime(input_logical_rows),

--- a/components/tidb_query/src/batch/executors/util/mod.rs
+++ b/components/tidb_query/src/batch/executors/util/mod.rs
@@ -6,7 +6,6 @@ pub mod hash_aggr_helper;
 pub mod mock_executor;
 pub mod scan_executor;
 
-use tikv_util::erase_lifetime;
 use tipb::FieldType;
 
 use crate::codec::batch::LazyBatchColumnVec;
@@ -40,6 +39,10 @@ pub unsafe fn eval_exprs_decoded_no_lifetime<'a>(
     input_logical_rows: &[usize],
     output: &mut Vec<RpnStackNode<'a>>,
 ) -> Result<()> {
+    unsafe fn erase_lifetime<'a, T: ?Sized>(v: &T) -> &'a T {
+        &*(v as *const T)
+    }
+
     for expr in exprs {
         output.push(erase_lifetime(expr).eval_decoded(
             ctx,

--- a/components/tidb_query/src/batch/interface.rs
+++ b/components/tidb_query/src/batch/interface.rs
@@ -19,11 +19,6 @@ pub trait BatchExecutor: Send {
     type StorageStats;
 
     /// Gets the schema of the output.
-    ///
-    /// Provides an `Arc` instead of a pure reference to make it possible to share this schema in
-    /// multiple executors. Actually the schema is only possible to be shared in executors, but it
-    /// requires the ability to store a reference to a field in the same structure. There are other
-    /// solutions so far but looks like `Arc` is the simplest one.
     fn schema(&self) -> &[FieldType];
 
     /// Pulls next several rows of data (stored by column).

--- a/components/tidb_query/src/codec/datum.rs
+++ b/components/tidb_query/src/codec/datum.rs
@@ -1008,9 +1008,9 @@ mod tests {
     use super::*;
     use crate::codec::mysql::{Decimal, Duration, Time, MAX_FSP};
     use crate::expr::{EvalConfig, EvalContext};
-    use tikv_util::as_slice;
 
     use std::cmp::Ordering;
+    use std::slice::from_ref;
     use std::str::FromStr;
     use std::sync::Arc;
     use std::{i16, i32, i64, i8, u16, u32, u64, u8};
@@ -1610,8 +1610,8 @@ mod tests {
             }
 
             if same_type(&lhs, &rhs) {
-                let lhs_bs = encode_key(as_slice(&lhs)).unwrap();
-                let rhs_bs = encode_key(as_slice(&rhs)).unwrap();
+                let lhs_bs = encode_key(from_ref(&lhs)).unwrap();
+                let rhs_bs = encode_key(from_ref(&rhs)).unwrap();
 
                 if ret != lhs_bs.cmp(&rhs_bs) {
                     panic!("{:?} should be {:?} to {:?} when encoded", lhs, ret, rhs);
@@ -1709,7 +1709,7 @@ mod tests {
             let mut buf = key_bs.as_slice();
             for exp in &case {
                 let (act, rem) = split_datum(buf, false).unwrap();
-                let exp_bs = encode_key(as_slice(exp)).unwrap();
+                let exp_bs = encode_key(from_ref(exp)).unwrap();
                 assert_eq!(exp_bs, act);
                 buf = rem;
             }
@@ -1719,7 +1719,7 @@ mod tests {
             let mut buf = value_bs.as_slice();
             for exp in &case {
                 let (act, rem) = split_datum(buf, false).unwrap();
-                let exp_bs = encode_value(as_slice(exp)).unwrap();
+                let exp_bs = encode_value(from_ref(exp)).unwrap();
                 assert_eq!(exp_bs, act);
                 buf = rem;
             }

--- a/components/tidb_query/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query/src/codec/mysql/time/mod.rs
@@ -98,12 +98,14 @@ fn ymd_hms_nanos<T: TimeZone>(
         })
 }
 
+// Safety: caller must ensure `bs` is valid utf8.
 #[inline]
-fn from_bytes(bs: &[u8]) -> &str {
-    unsafe { str::from_utf8_unchecked(bs) }
+unsafe fn from_bytes(bs: &[u8]) -> &str {
+    str::from_utf8_unchecked(bs)
 }
 
-fn split_ymd_hms_with_frac_as_s(
+// Safety: caller must ensure `s` and `frac` are valid ascii.
+unsafe fn split_ymd_hms_with_frac_as_s(
     mut s: &[u8],
     frac: &[u8],
 ) -> Result<(i32, u32, u32, u32, u32, u32)> {
@@ -136,7 +138,8 @@ fn split_ymd_hms_with_frac_as_s(
     Ok((year, month, day, hour, minute, secs))
 }
 
-fn split_ymd_with_frac_as_hms(
+// Safety: caller must ensure `s` and `frac` are valid ascii.
+unsafe fn split_ymd_with_frac_as_hms(
     mut s: &[u8],
     frac: &[u8],
     is_float: bool,
@@ -357,12 +360,14 @@ impl Time {
                 need_adjust = s1.len() != 14 && s1.len() != 8;
                 has_hhmmss = s1.len() == 14 || s1.len() == 12 || s1.len() == 11;
                 match s1.len() {
-                    14 | 12 | 11 | 10 | 9 => {
+                    // Safety: `s1` and `frac_str` must be ascii strings.
+                    14 | 12 | 11 | 10 | 9 => unsafe {
                         split_ymd_hms_with_frac_as_s(s1.as_bytes(), frac_str.as_bytes())?
-                    }
-                    8 | 6 | 5 => {
+                    },
+                    // Safety: `s1` and `frac_str` must be ascii strings.
+                    8 | 6 | 5 => unsafe {
                         split_ymd_with_frac_as_hms(s1.as_bytes(), frac_str.as_bytes(), is_float)?
-                    }
+                    },
                     _ => {
                         return Err(box_err!(
                             "invalid datetime: {}, s1: {}, len: {}",

--- a/components/tidb_query/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query/src/codec/mysql/time/mod.rs
@@ -104,7 +104,9 @@ unsafe fn from_bytes(bs: &[u8]) -> &str {
     str::from_utf8_unchecked(bs)
 }
 
-// Safety: caller must ensure `s` and `frac` are valid ascii.
+// Safety: caller must ensure each byte of `s` and `frac` is a valid unicode
+// character (i.e., `s` and `frac` may be sliced at any index and should give
+// a valid unicode string).
 unsafe fn split_ymd_hms_with_frac_as_s(
     mut s: &[u8],
     frac: &[u8],

--- a/components/tidb_query/src/rpn_expr/types/expr_eval.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_eval.rs
@@ -191,7 +191,7 @@ impl RpnExpression {
         Ok(())
     }
 
-    /// Evaluates the expression into a vector. The input columns must be already decoded.
+    /// Evaluates the expression into a stack node. The input columns must be already decoded.
     ///
     /// It differs from `eval` in that `eval_decoded` needn't receive a mutable reference
     /// to `LazyBatchColumnVec`. However, since `eval_decoded` doesn't decode columns,
@@ -222,10 +222,7 @@ impl RpnExpression {
         for node in self.as_ref() {
             match node {
                 RpnExpressionNode::Constant { value, field_type } => {
-                    stack.push(RpnStackNode::Scalar {
-                        value: &value,
-                        field_type,
-                    });
+                    stack.push(RpnStackNode::Scalar { value, field_type });
                 }
                 RpnExpressionNode::ColumnRef { offset } => {
                     let field_type = &schema[*offset];

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -42,6 +42,7 @@ grpcio = { version = "0.5.0-alpha.3", features = [ "secure" ] }
 crossbeam = "0.5"
 fail = "0.3"
 fxhash = "0.2.1"
+zeroize = { version = "0.10", features = [ "alloc" ] }
 
 [dependencies.prometheus]
 version = "0.4.2"

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
-use std::{env, slice, thread, u64};
+use std::{env, thread, u64};
 
 use protobuf::Message;
 use rand;
@@ -267,14 +267,6 @@ pub fn unescape(s: &str) -> Vec<u8> {
     }
     buf.shrink_to_fit();
     buf
-}
-
-/// Converts a borrow to a slice.
-pub fn as_slice<T>(t: &T) -> &[T] {
-    unsafe {
-        let ptr = t as *const T;
-        slice::from_raw_parts(ptr, 1)
-    }
 }
 
 /// A helper trait for `Entry` to accept a failable closure.

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -548,14 +548,6 @@ pub fn is_zero_duration(d: &Duration) -> bool {
     d.as_secs() == 0 && d.subsec_nanos() == 0
 }
 
-pub unsafe fn erase_lifetime_mut<'a, T: ?Sized>(v: &mut T) -> &'a mut T {
-    &mut *(v as *mut T)
-}
-
-pub unsafe fn erase_lifetime<'a, T: ?Sized>(v: &T) -> &'a T {
-    &*(v as *const T)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/components/tikv_util/src/security.rs
+++ b/components/tikv_util/src/security.rs
@@ -3,7 +3,6 @@
 use std::error::Error;
 use std::fs::File;
 use std::io::Read;
-use std::ptr;
 
 use grpcio::{
     Channel, ChannelBuilder, ChannelCredentialsBuilder, ServerBuilder, ServerCredentialsBuilder,
@@ -92,11 +91,9 @@ pub struct SecurityManager {
 
 impl Drop for SecurityManager {
     fn drop(&mut self) {
-        unsafe {
-            for b in &mut self.key {
-                ptr::write_volatile(b, 0);
-            }
-        }
+        use zeroize::Zeroize;
+
+        self.key.zeroize();
     }
 }
 

--- a/components/tikv_util/src/sys/mod.rs
+++ b/components/tikv_util/src/sys/mod.rs
@@ -8,6 +8,7 @@ pub mod thread {
     use std::io::Error;
 
     pub fn set_priority(pri: i32) -> Result<(), Error> {
+        // Unsafe due to FFI.
         unsafe {
             let tid = libc::syscall(libc::SYS_gettid);
             if libc::setpriority(libc::PRIO_PROCESS as u32, tid as u32, pri) != 0 {
@@ -19,6 +20,7 @@ pub mod thread {
     }
 
     pub fn get_priority() -> Result<i32, Error> {
+        // Unsafe due to FFI.
         unsafe {
             let tid = libc::syscall(libc::SYS_gettid);
             clear_errno();
@@ -43,6 +45,7 @@ pub mod thread {
     }
 
     fn clear_errno() {
+        // Unsafe due to FFI.
         unsafe {
             *errno_location() = 0;
         }

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -759,7 +759,8 @@ mod tests {
             Builder::from_config(config)
                 .name_prefix("coprocessor_endpoint_test_full")
                 .after_start(move || set_tls_engine(engine.lock().unwrap().clone()))
-                .before_stop(|| destroy_tls_engine::<RocksEngine>())
+                // Safety: we call `set_` and `destroy_` with the same engine type.
+                .before_stop(|| unsafe { destroy_tls_engine::<RocksEngine>() })
                 .build()
         })
         .collect();

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -66,6 +66,7 @@ mod tests {
     use super::*;
 
     use std::cmp::min;
+    use std::slice::from_ref;
 
     use rand::distributions::Distribution;
     use rand::rngs::StdRng;
@@ -74,7 +75,6 @@ mod tests {
 
     use tidb_query::codec::datum;
     use tidb_query::codec::datum::Datum;
-    use tikv_util::as_slice;
     use tikv_util::collections::HashMap;
 
     impl CmSketch {
@@ -108,14 +108,14 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(0x01020304);
         for _ in 0..total {
             let val = gen.sample(&mut rng) as u64;
-            let bytes = datum::encode_value(as_slice(&Datum::U64(val))).unwrap();
+            let bytes = datum::encode_value(from_ref(&Datum::U64(val))).unwrap();
             c.insert(&bytes);
             let counter = map.entry(val).or_insert(0);
             *counter += 1;
         }
         let mut total = 0u64;
         for (val, num) in &map {
-            let bytes = datum::encode_value(as_slice(&Datum::U64(*val))).unwrap();
+            let bytes = datum::encode_value(from_ref(&Datum::U64(*val))).unwrap();
             let estimate = c.query(&bytes);
             let err = if *num > estimate {
                 *num - estimate

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -59,11 +59,11 @@ mod tests {
     use super::*;
 
     use std::iter::repeat;
+    use std::slice::from_ref;
 
     use tidb_query::codec::datum;
     use tidb_query::codec::datum::Datum;
     use tidb_query::codec::Result;
-    use tikv_util::as_slice;
 
     struct TestData {
         samples: Vec<Datum>,
@@ -107,7 +107,7 @@ mod tests {
     pub fn build_fmsketch(values: &[Datum], max_size: usize) -> Result<FmSketch> {
         let mut s = FmSketch::new(max_size);
         for value in values {
-            let bytes = datum::encode_value(as_slice(value))?;
+            let bytes = datum::encode_value(from_ref(value))?;
             s.insert(&bytes);
         }
         Ok(s)

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -710,27 +710,44 @@ thread_local! {
 }
 
 /// Execute the closure on the thread local engine.
-pub fn with_tls_engine<E: Engine, F, R>(f: F) -> R
+///
+/// Safety: precondition: `TLS_ENGINE_ANY` is non-null.
+pub unsafe fn with_tls_engine<E: Engine, F, R>(f: F) -> R
 where
     F: FnOnce(&E) -> R,
 {
     TLS_ENGINE_ANY.with(|e| {
-        let engine = unsafe { &*(*e.get() as *const E) };
+        let engine = &*(*e.get() as *const E);
         f(engine)
     })
 }
 
 /// Set the thread local engine.
+///
+/// Postcondition: `TLS_ENGINE_ANY` is non-null.
 pub fn set_tls_engine<E: Engine>(engine: E) {
-    let engine = Box::into_raw(Box::new(engine)) as *mut ();
-    TLS_ENGINE_ANY.with(|e| unsafe { *e.get() = engine });
+    // Safety: we check that `TLS_ENGINE_ANY` is null to ensure we don't leak an existing
+    // engine; we ensure there are no other references to `engine`.
+    TLS_ENGINE_ANY.with(move |e| unsafe {
+        if !(*e.get()).is_null() {
+            let engine = Box::into_raw(Box::new(engine)) as *mut ();
+            *e.get() = engine;
+        }
+    });
 }
 
 /// Destroy the thread local engine.
+///
+/// Postcondition: `TLS_ENGINE_ANY` is null.
 pub fn destroy_tls_engine<E: Engine>() {
+    // Safety: we check that `TLS_ENGINE_ANY` is non-null, we must ensure that references
+    // to `TLS_ENGINE_ANY` can never be stored outside of `TLS_ENGINE_ANY`.
     TLS_ENGINE_ANY.with(|e| unsafe {
-        drop(Box::from_raw(*e.get() as *mut E));
-        *e.get() = ptr::null_mut();
+        let ptr = *e.get();
+        if !ptr.is_null() {
+            drop(Box::from_raw(ptr as *mut E));
+            *e.get() = ptr::null_mut();
+        }
     });
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -37,11 +37,11 @@ use self::mvcc::Lock;
 
 pub use self::config::{BlockCacheConfig, Config, DEFAULT_DATA_DIR, DEFAULT_ROCKSDB_SUB_DIR};
 pub use self::gc_worker::{AutoGCConfig, GCSafePointProvider};
+use self::kv::with_tls_engine;
 pub use self::kv::{
-    destroy_tls_engine, set_tls_engine, with_tls_engine, CFStatistics, Cursor, CursorBuilder,
-    Engine, Error as EngineError, FlowStatistics, FlowStatsReporter, Iterator, Modify,
-    RegionInfoProvider, RocksEngine, ScanMode, Snapshot, Statistics, StatisticsSummary,
-    TestEngineBuilder,
+    CFStatistics, Cursor, CursorBuilder, Engine, Error as EngineError, FlowStatistics,
+    FlowStatsReporter, Iterator, Modify, RegionInfoProvider, RocksEngine, ScanMode, Snapshot,
+    Statistics, StatisticsSummary, TestEngineBuilder,
 };
 pub use self::lock_manager::{DummyLockMgr, LockMgr};
 pub use self::mvcc::Scanner as StoreScanner;
@@ -876,6 +876,15 @@ impl<E: Engine, L: LockMgr> Storage<E, L> {
         }
     }
 
+    #[inline]
+    fn with_tls_engine<F, R>(f: F) -> R
+    where
+        F: FnOnce(&E) -> R,
+    {
+        // Safety: the read pools ensure that a TLS engine exists.
+        unsafe { with_tls_engine(f) }
+    }
+
     /// Get value of the given key from a snapshot.
     ///
     /// Only writes that are committed before `start_ts` are visible.
@@ -892,7 +901,7 @@ impl<E: Engine, L: LockMgr> Storage<E, L> {
             tls_collect_command_count(CMD, priority);
             let command_duration = tikv_util::time::Instant::now_coarse();
 
-            with_tls_engine(|engine| {
+            Self::with_tls_engine(|engine| {
                 Self::async_snapshot(engine, &ctx)
                     .and_then(move |snapshot: E::Snap| {
                         tls_processing_read_observe_duration(CMD, || {
@@ -946,7 +955,7 @@ impl<E: Engine, L: LockMgr> Storage<E, L> {
             tls_collect_command_count(CMD, priority);
             let command_duration = tikv_util::time::Instant::now_coarse();
 
-            with_tls_engine(|engine| {
+            Self::with_tls_engine(|engine| {
                 Self::async_snapshot(engine, &ctx)
                     .and_then(move |snapshot: E::Snap| {
                         tls_processing_read_observe_duration(CMD, || {
@@ -1011,7 +1020,7 @@ impl<E: Engine, L: LockMgr> Storage<E, L> {
             tls_collect_command_count(CMD, priority);
             let command_duration = tikv_util::time::Instant::now_coarse();
 
-            with_tls_engine(|engine| {
+            Self::with_tls_engine(|engine| {
                 Self::async_snapshot(engine, &ctx)
                     .and_then(move |snapshot: E::Snap| {
                         tls_processing_read_observe_duration(CMD, || {
@@ -1415,7 +1424,7 @@ impl<E: Engine, L: LockMgr> Storage<E, L> {
             tls_collect_command_count(CMD, priority);
             let command_duration = tikv_util::time::Instant::now_coarse();
 
-            with_tls_engine(|engine| {
+            Self::with_tls_engine(|engine| {
                 Self::async_snapshot(engine, &ctx)
                     .and_then(move |snapshot: E::Snap| {
                         tls_processing_read_observe_duration(CMD, || {
@@ -1469,7 +1478,7 @@ impl<E: Engine, L: LockMgr> Storage<E, L> {
             tls_collect_command_count(CMD, priority);
             let command_duration = tikv_util::time::Instant::now_coarse();
 
-            with_tls_engine(|engine| {
+            Self::with_tls_engine(|engine| {
                 Self::async_snapshot(engine, &ctx)
                     .and_then(move |snapshot: E::Snap| {
                         tls_processing_read_observe_duration(CMD, || {
@@ -1752,7 +1761,7 @@ impl<E: Engine, L: LockMgr> Storage<E, L> {
             tls_collect_command_count(CMD, priority);
             let command_duration = tikv_util::time::Instant::now_coarse();
 
-            with_tls_engine(|engine| {
+            Self::with_tls_engine(|engine| {
                 Self::async_snapshot(engine, &ctx)
                     .and_then(move |snapshot: E::Snap| {
                         tls_processing_read_observe_duration(CMD, || {
@@ -1857,7 +1866,7 @@ impl<E: Engine, L: LockMgr> Storage<E, L> {
             tls_collect_command_count(CMD, priority);
             let command_duration = tikv_util::time::Instant::now_coarse();
 
-            with_tls_engine(|engine| {
+            Self::with_tls_engine(|engine| {
                 Self::async_snapshot(engine, &ctx)
                     .and_then(move |snapshot: E::Snap| {
                         tls_processing_read_observe_duration(CMD, || {

--- a/src/storage/readpool_impl.rs
+++ b/src/storage/readpool_impl.rs
@@ -61,7 +61,10 @@ pub fn build_read_pool<E: Engine, R: FlowStatsReporter>(
                 .on_tick(move || tls_flush(&reporter))
                 .after_start(move || set_tls_engine(engine.lock().unwrap().clone()))
                 .before_stop(move || {
-                    destroy_tls_engine::<E>();
+                    // Safety: we call `set_` and `destroy_` with the same engine type.
+                    unsafe {
+                        destroy_tls_engine::<E>();
+                    }
                     tls_flush(&reporter2)
                 })
                 .build()
@@ -82,7 +85,8 @@ pub fn build_read_pool_for_test<E: Engine>(
             let engine = Arc::new(Mutex::new(engine.clone()));
             Builder::from_config(config)
                 .after_start(move || set_tls_engine(engine.lock().unwrap().clone()))
-                .before_stop(|| destroy_tls_engine::<E>())
+                // Safety: we call `set_` and `destroy_` with the same engine type.
+                .before_stop(|| unsafe { destroy_tls_engine::<E>() })
                 .build()
         })
         .collect()

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -214,7 +214,8 @@ impl<E: Engine, S: MsgScheduler, L: LockMgr> Executor<E, S, L> {
                 let statistics = if readonly {
                     self.process_read(snapshot, task)
                 } else {
-                    with_tls_engine(|engine| self.process_write(engine, snapshot, task))
+                    // Safety: `self.sched_pool` ensures a TLS engine exists.
+                    unsafe { with_tls_engine(|engine| self.process_write(engine, snapshot, task)) }
                 };
                 tls_collect_scan_details(tag.get_str(), &statistics);
                 slow_log!(

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -43,6 +43,7 @@ impl SchedPool {
             .pool_size(pool_size)
             .name_prefix(name_prefix)
             .on_tick(move || tls_flush())
+            // Safety: by setting `after_start` and `before_stop`, `FuturePool` ensures the tls_engine invariants.
             .after_start(move || set_tls_engine(engine.lock().unwrap().clone()))
             .before_stop(move || {
                 destroy_tls_engine::<E>();

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -43,10 +43,14 @@ impl SchedPool {
             .pool_size(pool_size)
             .name_prefix(name_prefix)
             .on_tick(move || tls_flush())
-            // Safety: by setting `after_start` and `before_stop`, `FuturePool` ensures the tls_engine invariants.
+            // Safety: by setting `after_start` and `before_stop`, `FuturePool` ensures
+            // the tls_engine invariants.
             .after_start(move || set_tls_engine(engine.lock().unwrap().clone()))
             .before_stop(move || {
-                destroy_tls_engine::<E>();
+                // Safety: we ensure the `set_` and `destroy_` calls use the same engine type.
+                unsafe {
+                    destroy_tls_engine::<E>();
+                }
                 tls_flush();
             })
             .build();

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -372,7 +372,8 @@ impl<E: Engine, L: LockMgr> Scheduler<E, L> {
             f(engine)
         } else {
             // The program is currently in scheduler worker threads.
-            with_tls_engine(f)
+            // Safety: `self.inner.worker_pool` should ensure that a TLS engine exists.
+            unsafe { with_tls_engine(f) }
         }
     }
 


### PR DESCRIPTION
###  What have you changed?

I've reduced our unsafe footprint by removing or restricting some uses of `unsafe`. I've documented some unsafe usage. I've changed some uses of `unsafe` in minor ways to better reflect the actual unsafeness and make it easier to check the necessary invariants. This is not a full audit of our unsafe code, just a small step.

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?

N/A

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

PTAL @breeswish @5kbpers 