### PR TITLE
raftstore: don't print log for ComapctLog command

### DIFF
--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -919,7 +919,7 @@ impl ApplyDelegate {
         request: &AdminRequest,
     ) -> Result<(RaftCmdResponse, Option<ExecResult>)> {
         let cmd_type = request.get_cmd_type();
-        if cmd_type != AdminCmdType::CompactLog && cmd_type != AdminCmdType::CommitMerge {
+        if cmd_type != AdminCmdType::CompactLog {
             info!(
                 "{} execute admin command {:?} at [term: {}, index: {}]",
                 self.tag,

--- a/src/raftstore/store/worker/apply.rs
+++ b/src/raftstore/store/worker/apply.rs
@@ -919,13 +919,15 @@ impl ApplyDelegate {
         request: &AdminRequest,
     ) -> Result<(RaftCmdResponse, Option<ExecResult>)> {
         let cmd_type = request.get_cmd_type();
-        info!(
-            "{} execute admin command {:?} at [term: {}, index: {}]",
-            self.tag,
-            request,
-            ctx.exec_ctx.as_ref().unwrap().term,
-            ctx.exec_ctx.as_ref().unwrap().index
-        );
+        if cmd_type != AdminCmdType::CompactLog && cmd_type != AdminCmdType::CommitMerge {
+            info!(
+                "{} execute admin command {:?} at [term: {}, index: {}]",
+                self.tag,
+                request,
+                ctx.exec_ctx.as_ref().unwrap().term,
+                ctx.exec_ctx.as_ref().unwrap().index
+            );
+        }
 
         let (mut response, exec_result) = match cmd_type {
             AdminCmdType::ChangePeer => self.exec_change_peer(ctx, request),


### PR DESCRIPTION
There is already a same change in master branch, and it's merged. However the change is not cherry picked from master, because code framework changes too much. Here just re-implement it for release 2.1.