### PR TITLE
server/service: adapt unordered split keys

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -856,7 +856,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine, L: LockMgr> Tikv for Service<T, E,
 
         let region_id = req.get_context().get_region_id();
         let (cb, future) = paired_future_callback();
-        let split_keys = if !req.get_split_key().is_empty() {
+        let mut split_keys = if !req.get_split_key().is_empty() {
             vec![Key::from_raw(req.get_split_key()).into_encoded()]
         } else {
             req.take_split_keys()
@@ -864,6 +864,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine, L: LockMgr> Tikv for Service<T, E,
                 .map(|x| Key::from_raw(&x).into_encoded())
                 .collect()
         };
+        split_keys.sort();
         let req = CasualMessage::SplitRegion {
             region_epoch: req.take_context().take_region_epoch(),
             split_keys,

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -505,8 +505,8 @@ fn test_split_region() {
     ctx.set_region_epoch(resp.get_right().get_region_epoch().to_owned());
     let mut req = SplitRegionRequest::default();
     req.set_context(ctx);
-    let mut split_keys = vec![b"c".to_vec(), b"d".to_vec(), b"e".to_vec()];
-    req.set_split_keys(split_keys.clone().into());
+    let split_keys = vec![b"e".to_vec(), b"c".to_vec(), b"d".to_vec()];
+    req.set_split_keys(split_keys.into());
     let resp = client.split_region(&req).unwrap();
     let result_split_keys: Vec<_> = resp
         .get_regions()
@@ -517,8 +517,7 @@ fn test_split_region() {
                 .unwrap()
         })
         .collect();
-    split_keys.insert(0, b"b".to_vec());
-    assert_eq!(result_split_keys, split_keys);
+    assert_eq!(result_split_keys, vec![b"b".to_vec(), b"c".to_vec(), b"d".to_vec(), b"e".to_vec()]);
 }
 
 #[test]

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -517,7 +517,10 @@ fn test_split_region() {
                 .unwrap()
         })
         .collect();
-    assert_eq!(result_split_keys, vec![b"b".to_vec(), b"c".to_vec(), b"d".to_vec(), b"e".to_vec()]);
+    assert_eq!(
+        result_split_keys,
+        vec![b"b".to_vec(), b"c".to_vec(), b"d".to_vec(), b"e".to_vec()]
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
We have supported batch split region since https://github.com/tikv/tikv/pull/5268
But the original PR neglects the fact that the keys sent from TiDB side could be unordered. It causes the problem that some keys be ignored when `raftstore` handling it.

###  What is the type of the changes?
- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- unit test
- test with tidb using following DDL statements:
```
create table t1 (a int,b int,c int,index(b),index (a),index (c,a));
split table t1 between (0) and (500000000) regions 5;
split table t1 index b  between (0) and (500000000) regions 5;
```

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?
No

###  Refer to a related PR or issue link (optional)
https://github.com/tikv/tikv/pull/5268

###  Benchmark result if necessary (optional)
None

###  Any examples? (optional)
None
