### PR TITLE
Fix PointGetter performance issue when there are concurrent write

### DIFF
--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -166,6 +166,10 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
         use std::mem::{self, MaybeUninit};
         type Element = Result<Option<Value>>;
 
+        if keys.len() == 1 {
+            return Ok(vec![self.get(&keys[0], statistics)]);
+        }
+
         let mut order_and_keys: Vec<_> = keys.iter().enumerate().collect();
         order_and_keys.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

When there are concurrent write, lock CF will likely to contain deleted locks. In this scenario, it is much slower to `seek()` compared to `get_cf()` because internally `seek()` will try its best to find a visible user key and these tombstone keys will be iterated. However we actually don't care about the first key > given seek key. What we care is the key == seek key. For this reason, this PR substitutes the lock cursor with `get_cf()`, which was used in batch get.

This PR also substitutes the default cursor with `get_cf()`, which was used in batch get as well, considering that it is very **unlikely** that the keys given to batch get are very close to each other. While keys are not close to each other, a `near_seek()` in the default CF will simply fallback to a `seek()` eventually, which is slower than `get_cf()`.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

Manually. Using command:

```bash
go-ycsb load mysql -P workloads/workloade -p mysql.host=.... -p mysql.port=.... -p mysql.user=root -p recordcount=10000000 -p operationcount=30000000 -p threadcount=1000
```

Before this PR: OPS = 462.1 after 200s.
After this PR: OPS = 29271.1 after 200s.

Metrics:

![image](https://user-images.githubusercontent.com/1916485/65015716-dd9c5080-d954-11e9-9e8a-e0a7d8dbe017.png)
![image](https://user-images.githubusercontent.com/1916485/65015747-f3aa1100-d954-11e9-9c4f-e484cd2714c7.png)
