### PR TITLE
Fix output on short version flag (#5348)

### DIFF
--- a/src/bin/tikv-ctl.rs
+++ b/src/bin/tikv-ctl.rs
@@ -17,7 +17,7 @@ use std::thread;
 use std::time::Duration;
 use std::{process, str, u64};
 
-use clap::{crate_authors, crate_version, App, AppSettings, Arg, ArgMatches, SubCommand};
+use clap::{crate_authors, App, AppSettings, Arg, ArgMatches, SubCommand};
 use futures::{future, stream, Future, Stream};
 use grpcio::{CallOption, ChannelBuilder, Environment};
 use protobuf::Message;
@@ -955,7 +955,7 @@ fn main() {
     let mut app = App::new("TiKV Control (tikv-ctl)")
         .about("A tool for interacting with TiKV deployments.")
         .author(crate_authors!())
-        .version(crate_version!())
+        .version(version_info.as_ref())
         .long_version(version_info.as_ref())
         .setting(AppSettings::AllowExternalSubcommands)
         .arg(

--- a/src/bin/tikv-server.rs
+++ b/src/bin/tikv-server.rs
@@ -5,7 +5,7 @@
 
 use std::process;
 
-use clap::{crate_authors, crate_version, App, Arg};
+use clap::{crate_authors, App, Arg};
 use tikv::binutil::{self, server, setup};
 use tikv::config::TiKvConfig;
 
@@ -13,7 +13,7 @@ fn main() {
     let matches = App::new("TiKV")
         .about("A distributed transactional key-value database powered by Rust and Raft")
         .author(crate_authors!())
-        .version(crate_version!())
+        .version(binutil::tikv_version_info().as_ref())
         .long_version(binutil::tikv_version_info().as_ref())
         .arg(
             Arg::with_name("config")


### PR DESCRIPTION
Keep -V behavior same with v2.x

Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

The -V output format of tikv-server and tikv-ctl.
The output of -V in v2.x is something like:
```
TiKV
Release Version: 2.1.14
Git Commit Hash: 32ca82bc067f7529dc07bf8ddb594b8c060b7f49
Git Commit Branch: HEAD
UTC Build Time: 2019-07-04 10:32:40
Rust Version: rustc 1.29.0-nightly (4f3c7a472 2018-07-17)
```
However, in v3.x, it's something like:
```
TiKV 3.0.2
```
And in the newest master, it's:
```
TiKV 0.0.1
```

We should keep the output format same with v2.x, because the tidb and pd's output format is that. I think they should have a unified behavior.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

manual test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

