### PR TITLE
service/kv: fix wrong metrics of txn_heart_beat

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1171,7 +1171,7 @@ fn handle_batch_commands_request<E: Engine, L: LockMgr>(
         }
         Some(batch_commands_request::request::Cmd::TxnHeartBeat(req)) => {
             let timer = GRPC_MSG_HISTOGRAM_VEC
-                .kv_check_txn_status
+                .kv_txn_heart_beat
                 .start_coarse_timer();
             let resp = future_txn_heart_beat(&storage, req)
                 .map(oneof!(batch_commands_response::response::Cmd::TxnHeartBeat))


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

The txn_heart_beat API, which is part of large transaction, updates wrong metrics in code. Fix it.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

None.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.