### PR TITLE
Fix commit index is not forwarded when merge entry is empty (#5512)

### DIFF
--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -956,7 +956,7 @@ impl<T: Simulator> Cluster<T> {
 
             if try_cnt > 250 {
                 panic!(
-                    "region {} doesn't exist on store {} after {} tries: {:?}",
+                    "region {} still exists on store {} after {} tries: {:?}",
                     region_id, store_id, try_cnt, resp
                 );
             }

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -2498,6 +2498,13 @@ impl ApplyFsm {
 
         // if it is already up to date, no need to catch up anymore
         let apply_index = self.delegate.apply_state.get_applied_index();
+        debug!(
+            "check catch up logs for merge";
+            "apply_index" => apply_index,
+            "commit" => catch_up_logs.merge.get_commit(),
+            "region_id" => self.delegate.region_id(),
+            "peer_id" => self.delegate.id(),
+        );
         if apply_index < catch_up_logs.merge.get_commit() {
             fail_point!("on_handle_catch_up_logs_for_merge");
             let mut res = VecDeque::new();

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -451,11 +451,26 @@ impl Peer {
     pub fn maybe_append_merge_entries(&mut self, merge: &CommitMergeRequest) -> Option<u64> {
         let mut entries = merge.get_entries();
         if entries.is_empty() {
-            return None;
+            // Though the entries is empty, it is possible that one source peer has caught up the logs
+            // but commit index is not updated. If Other source peers are already destroyed, so the raft
+            // group will not make any progress, namely the source peer can not get the latest commit index anymore.
+            // Here update the commit index to let source apply rest uncommitted entires.
+            if merge.get_commit() > self.raft_group.raft.raft_log.committed {
+                self.raft_group.raft.raft_log.commit_to(merge.get_commit());
+                return Some(merge.get_commit());
+            } else {
+                return None;
+            }
         }
         let first = entries.first().unwrap();
         // make sure message should be with index not smaller than committed
         let mut log_idx = first.get_index() - 1;
+        debug!(
+            "append merge entries";
+            "log_index" => log_idx,
+            "merge_commit" => merge.get_commit(),
+            "commit_index" => self.raft_group.raft.raft_log.committed,
+        );
         if log_idx < self.raft_group.raft.raft_log.committed {
             // There are maybe some logs not included in CommitMergeRequest's entries, like CompactLog,
             // so the commit index may exceed the last index of the entires from CommitMergeRequest.

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -375,8 +375,7 @@ fn test_node_merge_catch_up_logs_no_need() {
     // the source region should be merged and the peer should be destroyed.
     assert!(pd_client.check_merged(left.get_id()));
     must_get_equal(&cluster.get_engine(3), b"k11", b"v11");
-    let router = cluster.sim.wl().get_router(3).unwrap();
-    assert!(router.mailbox(left.get_id()).is_none());
+    cluster.must_region_not_exist(left.get_id(), 3);
 }
 
 /// Test if merging state will be removed after accepting a snapshot.

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -701,6 +701,59 @@ fn test_node_merge_update_region() {
     assert_eq!(resp.get_responses()[0].get_get().get_value(), b"v3");
 }
 
+/// Test if merge is working properly when merge entries is empty but commit index is not updated.
+#[test]
+fn test_node_merge_catch_up_logs_empty_entries() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_merge(&mut cluster);
+    cluster.run();
+
+    cluster.must_put(b"k1", b"v1");
+    cluster.must_put(b"k3", b"v3");
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    let region = pd_client.get_region(b"k1").unwrap();
+    let peer_on_store1 = find_peer(&region, 1).unwrap().to_owned();
+    cluster.must_transfer_leader(region.get_id(), peer_on_store1);
+    cluster.must_split(&region, b"k2");
+    let left = pd_client.get_region(b"k1").unwrap();
+    let right = pd_client.get_region(b"k2").unwrap();
+
+    // make sure the peer of left region on engine 3 has caught up logs.
+    cluster.must_put(b"k0", b"v0");
+    must_get_equal(&cluster.get_engine(3), b"k0", b"v0");
+
+    // first MsgAppend will append log, second MsgAppend will set commit index,
+    // So only allowing first MsgAppend to make source peer have uncommitted entries.
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(left.get_id(), 3)
+            .direction(Direction::Recv)
+            .msg_type(MessageType::MsgAppend)
+            .allow(1),
+    ));
+    // make the source peer have no way to know the uncommitted entries can be applied from heartbeat.
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(left.get_id(), 3)
+            .msg_type(MessageType::MsgHeartbeat)
+            .direction(Direction::Recv),
+    ));
+    // make the source peer have no way to know the uncommitted entries can be applied from target region.
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(right.get_id(), 3)
+            .msg_type(MessageType::MsgAppend)
+            .direction(Direction::Recv),
+    ));
+    pd_client.must_merge(left.get_id(), right.get_id());
+    cluster.must_region_not_exist(left.get_id(), 2);
+    cluster.shutdown();
+    cluster.clear_send_filters();
+
+    // as expected, merge process will forward the commit index
+    // and the source peer will be destroyed.
+    cluster.start().unwrap();
+    cluster.must_region_not_exist(left.get_id(), 3);
+}
+
 #[test]
 fn test_merge_with_slow_promote() {
     let mut cluster = new_node_cluster(0, 3);


### PR DESCRIPTION
cherry-pick of https://github.com/tikv/tikv/pull/5512