### PR TITLE
fix unstable test: cases::test_replica_read::test_wait_for_apply_index'

### DIFF
--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -185,7 +185,13 @@ impl Simulator for ServerCluster {
             svr.register_service(create_import_sst(import_service.clone()));
             svr.register_service(create_debug(debug_service.clone()));
             match svr.build_and_bind() {
-                Ok(_) => {
+                Ok(addr) => {
+                    let addr = format!("{}", addr);
+                    if self.addrs.values().find(|a| a == &&addr).is_some() {
+                        // This server binded to the same address as previous servers
+                        // because previous servers droped silently
+                        panic!("grpc server drop silently: addr {:?}", addr);
+                    }
                     server = Some(svr);
                     break;
                 }


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

The test was panicked at `must_add_peer` of peer 3, and not even enter the test logic! And the test panicked because peer 2 bind to the same port as peer 1 (maybe because the grpc server of peer 1 drop silently), and msg that peer 2 send to peer 1 were eventually received by itself. Which cause conf change request are alway rejected. This PR fix it by just panic if we find tow peers bind to the same port.

some log:
```
node.rs:159: [INFO] put store to PD, store: id: 1 address: "127.0.0.1:44505" version: "4.0.0-alpha"
node.rs:159: [INFO] put store to PD, store: id: 2 address: "127.0.0.1:44505" version: "4.0.0-alpha"
peer.rs:853: [DEBG] handle raft message, to_peer_id: 1, from_peer_id: 2, message_type: MsgHeartbeatResponse, peer_id: 2, region_id: 1
peer.rs:933: [WARN] store not match, ignore it, my_store_id: 2, to_store_id: 1, region_id: 1
```

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

No

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

close #5467 

