### PR TITLE
Rewrite ScannerBuilder and ScannerConfig

### DIFF
--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -1047,7 +1047,8 @@ mod tests {
         r.set_start_key(b"a".to_vec());
         r.set_end_key(b"z".to_vec());
         let snapshot = RegionSnapshot::from_raw(Arc::clone(&engines1.kv), r);
-        let mut scanner = ScannerBuilder::new(snapshot, 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot, 10)
+            .desc(false)
             .range(Some(Key::from_raw(b"a")), None)
             .build()
             .unwrap();

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -362,7 +362,7 @@ impl<S: Snapshot> BackwardScanner<S> {
         if self.default_cursor.is_some() {
             return Ok(());
         }
-        self.default_cursor = Some(self.cfg.create_cf_cursor(CF_DEFAULT)?);
+        self.default_cursor = Some(self.cfg.create_cf_cursor_and_take(CF_DEFAULT)?);
         Ok(())
     }
 }
@@ -449,7 +449,8 @@ mod tests {
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND, true)
+        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND)
+            .desc(true)
             .range(None, Some(Key::from_raw(&[11 as u8])))
             .build()
             .unwrap();
@@ -644,7 +645,8 @@ mod tests {
         );
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND * 2, true)
+        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND * 2)
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -714,7 +716,8 @@ mod tests {
         );
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND * 2, true)
+        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND * 2)
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -781,7 +784,8 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 1, true)
+        let mut scanner = ScannerBuilder::new(snapshot, 1)
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -852,7 +856,8 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 1, true)
+        let mut scanner = ScannerBuilder::new(snapshot, 1)
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -931,7 +936,8 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND + 1, true)
+        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND + 1)
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -1018,7 +1024,8 @@ mod tests {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         // Test both bound specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(true)
             .range(Some(Key::from_raw(&[3u8])), Some(Key::from_raw(&[5u8])))
             .build()
             .unwrap();
@@ -1033,7 +1040,8 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test left bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(true)
             .range(None, Some(Key::from_raw(&[3u8])))
             .build()
             .unwrap();
@@ -1048,7 +1056,8 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test right bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(true)
             .range(Some(Key::from_raw(&[5u8])), None)
             .build()
             .unwrap();
@@ -1063,7 +1072,8 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test both bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -1126,7 +1136,8 @@ mod tests {
 
         // Call reverse scan
         let ts = 2;
-        let mut scanner = ScannerBuilder::new(snapshot, ts, true)
+        let mut scanner = ScannerBuilder::new(snapshot, ts)
+            .desc(true)
             .range(None, Some(k))
             .build()
             .unwrap();

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -360,7 +360,7 @@ impl<S: Snapshot> ForwardScanner<S> {
         if self.default_cursor.is_some() {
             return Ok(());
         }
-        self.default_cursor = Some(self.cfg.create_cf_cursor(CF_DEFAULT)?);
+        self.default_cursor = Some(self.cfg.create_cf_cursor_and_take(CF_DEFAULT)?);
         Ok(())
     }
 }
@@ -390,7 +390,8 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot, 10)
+            .desc(false)
             .range(None, None)
             .build()
             .unwrap();
@@ -444,7 +445,8 @@ mod tests {
         must_commit(&engine, b"b", SEEK_BOUND / 2, SEEK_BOUND / 2);
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2, false)
+        let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2)
+            .desc(false)
             .range(None, None)
             .build()
             .unwrap();
@@ -507,7 +509,8 @@ mod tests {
         must_commit(&engine, b"b", SEEK_BOUND, SEEK_BOUND);
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2, false)
+        let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2)
+            .desc(false)
             .range(None, None)
             .build()
             .unwrap();
@@ -576,7 +579,8 @@ mod tests {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         // Test both bound specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(false)
             .range(Some(Key::from_raw(&[3u8])), Some(Key::from_raw(&[5u8])))
             .build()
             .unwrap();
@@ -591,7 +595,8 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test left bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(false)
             .range(None, Some(Key::from_raw(&[3u8])))
             .build()
             .unwrap();
@@ -606,7 +611,8 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test right bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(false)
             .range(Some(Key::from_raw(&[5u8])), None)
             .build()
             .unwrap();
@@ -621,7 +627,8 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test both bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(false)
             .range(None, None)
             .build()
             .unwrap();

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -70,7 +70,7 @@ impl<S: Snapshot> ScannerBuilder<S> {
     }
 
     /// Set the desc.
-    /// 
+    ///
     /// Defaults to `false`.
     #[inline]
     pub fn desc(mut self, desc: bool) -> Self {
@@ -200,7 +200,7 @@ impl<S: Snapshot> ScannerConfig<S> {
     /// Create the cursor and take bounds.
     #[inline]
     fn create_cf_cursor_and_take(&mut self, cf: CfName) -> Result<Cursor<S::Iter>> {
-        let (lower,upper) = (self.lower_bound.take(), self.upper_bound.take());
+        let (lower, upper) = (self.lower_bound.take(), self.upper_bound.take());
         let cursor = CursorBuilder::new(&self.snapshot, cf)
             .range(lower, upper)
             .fill_cache(self.fill_cache)

--- a/src/storage/mvcc/reader/scanner/txn_entry.rs
+++ b/src/storage/mvcc/reader/scanner/txn_entry.rs
@@ -435,7 +435,8 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot, 10)
+            .desc(false)
             .range(None, None)
             .build_entry_scanner()
             .unwrap();
@@ -494,7 +495,8 @@ mod tests {
         must_commit(&engine, b"b", SEEK_BOUND / 2, SEEK_BOUND / 2);
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2, false)
+        let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2)
+            .desc(false)
             .range(None, None)
             .build_entry_scanner()
             .unwrap();
@@ -563,7 +565,8 @@ mod tests {
         must_commit(&engine, b"b", SEEK_BOUND, SEEK_BOUND);
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2, false)
+        let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2)
+            .desc(false)
             .range(None, None)
             .build_entry_scanner()
             .unwrap();
@@ -638,7 +641,8 @@ mod tests {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         // Test both bound specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(false)
             .range(Some(Key::from_raw(&[3u8])), Some(Key::from_raw(&[5u8])))
             .build_entry_scanner()
             .unwrap();
@@ -657,7 +661,8 @@ mod tests {
         assert_eq!(scanner.next_entry().unwrap(), None);
 
         // Test left bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(false)
             .range(None, Some(Key::from_raw(&[3u8])))
             .build_entry_scanner()
             .unwrap();
@@ -666,7 +671,8 @@ mod tests {
         assert_eq!(scanner.next_entry().unwrap(), None);
 
         // Test right bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(false)
             .range(Some(Key::from_raw(&[5u8])), None)
             .build_entry_scanner()
             .unwrap();
@@ -675,7 +681,8 @@ mod tests {
         assert_eq!(scanner.next_entry().unwrap(), None);
 
         // Test both bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10)
+            .desc(false)
             .range(None, None)
             .build_entry_scanner()
             .unwrap();

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -206,7 +206,8 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
     ) -> Result<MvccScanner<S>> {
         // Check request bounds with physical bound
         self.verify_range(&lower_bound, &upper_bound)?;
-        let scanner = ScannerBuilder::new(self.snapshot.clone(), self.start_ts, desc)
+        let scanner = ScannerBuilder::new(self.snapshot.clone(), self.start_ts)
+            .desc(desc)
             .range(lower_bound, upper_bound)
             .omit_value(key_only)
             .fill_cache(self.fill_cache)
@@ -227,7 +228,8 @@ impl<S: Snapshot> TxnEntryStore for SnapshotStore<S> {
         // Check request bounds with physical bound
         self.verify_range(&lower_bound, &upper_bound)?;
         let scanner =
-            ScannerBuilder::new(self.snapshot.clone(), self.start_ts, false /* desc */)
+            ScannerBuilder::new(self.snapshot.clone(), self.start_ts)
+                .desc(false)
                 .range(lower_bound, upper_bound)
                 .omit_value(false)
                 .fill_cache(self.fill_cache)

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -227,14 +227,13 @@ impl<S: Snapshot> TxnEntryStore for SnapshotStore<S> {
     ) -> Result<EntryScanner<S>> {
         // Check request bounds with physical bound
         self.verify_range(&lower_bound, &upper_bound)?;
-        let scanner =
-            ScannerBuilder::new(self.snapshot.clone(), self.start_ts)
-                .desc(false)
-                .range(lower_bound, upper_bound)
-                .omit_value(false)
-                .fill_cache(self.fill_cache)
-                .isolation_level(self.isolation_level)
-                .build_entry_scanner()?;
+        let scanner = ScannerBuilder::new(self.snapshot.clone(), self.start_ts)
+            .desc(false)
+            .range(lower_bound, upper_bound)
+            .omit_value(false)
+            .fill_cache(self.fill_cache)
+            .isolation_level(self.isolation_level)
+            .build_entry_scanner()?;
 
         Ok(scanner)
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

* Add `desc` setter to make `desc` optional.
* Add `create_cf_cursor_and_take` method, to make the build progress more semantic. The bounds would be cloned in `create_cf_cursor` and be taken in `create_cf_cursor_and_take`.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

### Related issue
#5531 

