### PR TITLE
Ignore the primary lock when read with u64::MAX

### DIFF
--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -754,8 +754,16 @@ mod tests {
         must_prewrite_put(&engine, k1, v, k1, 25);
         must_commit(&engine, k1, 25, 27);
         must_acquire_pessimistic_lock(&engine, k1, k1, 23, 29);
+        must_acquire_pessimistic_lock(&engine, k2, k1, 23, 29);
         must_get(&engine, k1, 30, v);
+
         must_pessimistic_prewrite_delete(&engine, k1, k1, 23, 29, true);
+        must_pessimistic_prewrite_delete(&engine, k2, k1, 23, 29, true);
+        // should ignore the primary lock and get none when reading the latest record
+        must_get(&engine, k1, u64::MAX, v);
+        // should read secondary locks even when reading the latest record
+        must_get_err(&engine, k2, u64::MAX);
+
         must_commit(&engine, k1, 23, 31);
         must_get(&engine, k1, 30, v);
         must_get_none(&engine, k1, 32);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Fix the same bug of the test part which https://github.com/tikv/tikv/pull/5536 fixed.

###  What is the type of the changes?

Bugfix

###  How is the PR tested?

Unit test.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

