### PR TITLE
mvcc: reuse created write CF iterator

### DIFF
--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -810,11 +810,14 @@ mod tests {
         assert_eq!(write_type, WriteType::Rollback);
 
         let seek_old = reader.get_statistics().write.seek;
+        let next_old = reader.get_statistics().write.next;
         assert!(reader.get_txn_commit_info(&key, 30).unwrap().is_none());
         let seek_new = reader.get_statistics().write.seek;
+        let next_new = reader.get_statistics().write.next;
 
         // `get_txn_commit_info(&key, 30)` stopped at `30_25 PUT`.
-        assert_eq!(seek_new - seek_old, 3);
+        assert_eq!(seek_new - seek_old, 1);
+        assert_eq!(next_new - next_old, 2);
     }
 
     #[test]


### PR DESCRIPTION
###  What have you changed?

In `seek_write`, when `scan_mode` is `None`, a new iterator is always created. This PR changes it to reuse previously created iterator.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

Not tested yet.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

