### PR TITLE
engine: Upgrade rust-rocksdb to latest master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#84451e36e69443df497c2d5ba71c0a3994384a4a"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#3cd18c44d160a3cdba586d6502d51b7cc67efc59"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -1328,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#84451e36e69443df497c2d5ba71c0a3994384a4a"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#3cd18c44d160a3cdba586d6502d51b7cc67efc59"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -2305,7 +2305,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#84451e36e69443df497c2d5ba71c0a3994384a4a"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#3cd18c44d160a3cdba586d6502d51b7cc67efc59"
 dependencies = [
  "crc",
  "libc",


### PR DESCRIPTION
Signed-off-by: Arve Knudsen <arve.knudsen@gmail.com>

###  What have you changed?

I've upgraded the rust-rocksdb dependency to latest master, in order to fix build on OS X.

###  What is the type of the changes?
- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.
