### PR TITLE
tidb_query: avoid unnecessary generic monopolization in rpn_fn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+checksum = "3fe629a532efad5526454efb0700f86d5ad7ff001acb37e431c8bf017a432a8e"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -606,27 +606,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+checksum = "ee54512bec54b41cf2337a22ddfadb53c7d4c738494dc2a186d7b037ad683b85"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "strsim 0.7.0",
- "syn 0.15.44",
+ "proc-macro2 1.0.4",
+ "quote 1.0.2",
+ "strsim 0.9.2",
+ "syn 1.0.5",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
+checksum = "0cd3e432e52c0810b72898296a69d66b1d78d1517dff6cde7a130557a55a62c1"
 dependencies = [
  "darling_core",
- "quote 0.6.13",
- "syn 0.15.44",
+ "quote 1.0.2",
+ "syn 1.0.5",
 ]
 
 [[package]]
@@ -2667,15 +2667,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-
-[[package]]
-name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 
 [[package]]
 name = "structopt"
@@ -2921,9 +2921,9 @@ version = "0.0.1"
 dependencies = [
  "darling",
  "heck",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2 1.0.4",
+ "quote 1.0.2",
+ "syn 1.0.5",
 ]
 
 [[package]]

--- a/components/tidb_query/src/codec/data_type/mod.rs
+++ b/components/tidb_query/src/codec/data_type/mod.rs
@@ -81,12 +81,6 @@ pub trait Evaluable: Clone + std::fmt::Debug + Send + Sync + 'static {
     /// Converts a vector of this concrete type into a `VectorValue` in the same type;
     /// panics if the varient mismatches.
     fn into_vector_value(vec: Vec<Option<Self>>) -> VectorValue;
-
-    /// Try to borrow this concrete type from a `ScalarValue`.
-    fn try_borrow_scalar_value(v: &ScalarValue) -> Option<&Option<Self>>;
-
-    /// Try to borrow a slice of this concrete type from a `VectorValue`.
-    fn try_borrow_vector_value(v: &VectorValue) -> Option<&[Option<Self>]>;
 }
 
 macro_rules! impl_evaluable_type {
@@ -112,22 +106,6 @@ macro_rules! impl_evaluable_type {
             #[inline]
             fn into_vector_value(vec: Vec<Option<Self>>) -> VectorValue {
                 VectorValue::from(vec)
-            }
-
-            #[inline]
-            fn try_borrow_scalar_value(v: &ScalarValue) -> Option<&Option<Self>> {
-                match v {
-                    ScalarValue::$ty(value) => Some(value),
-                    _ => None,
-                }
-            }
-
-            #[inline]
-            fn try_borrow_vector_value(v: &VectorValue) -> Option<&[Option<Self>]> {
-                match v {
-                    VectorValue::$ty(value) => Some(value),
-                    _ => None,
-                }
             }
         }
     };

--- a/components/tidb_query/src/codec/data_type/mod.rs
+++ b/components/tidb_query/src/codec/data_type/mod.rs
@@ -115,7 +115,7 @@ macro_rules! impl_evaluable_type {
             }
 
             #[inline]
-            default fn try_borrow_scalar_value(v: &ScalarValue) -> Option<&Option<Self>> {
+            fn try_borrow_scalar_value(v: &ScalarValue) -> Option<&Option<Self>> {
                 match v {
                     ScalarValue::$ty(value) => Some(value),
                     _ => None,
@@ -123,7 +123,7 @@ macro_rules! impl_evaluable_type {
             }
 
             #[inline]
-            default fn try_borrow_vector_value(v: &VectorValue) -> Option<&[Option<Self>]> {
+            fn try_borrow_vector_value(v: &VectorValue) -> Option<&[Option<Self>]> {
                 match v {
                     VectorValue::$ty(value) => Some(value),
                     _ => None,

--- a/components/tidb_query/src/codec/data_type/mod.rs
+++ b/components/tidb_query/src/codec/data_type/mod.rs
@@ -66,17 +66,27 @@ where
 pub trait Evaluable: Clone + std::fmt::Debug + Send + Sync + 'static {
     const EVAL_TYPE: EvalType;
 
-    /// Borrows this concrete type from a `ScalarValue` in the same type.
+    /// Borrows this concrete type from a `ScalarValue` in the same type;
+    /// panics if the varient mismatches.
     fn borrow_scalar_value(v: &ScalarValue) -> &Option<Self>;
 
-    /// Borrows this concrete type from a `ScalarValueRef` in the same type.
+    /// Borrows this concrete type from a `ScalarValueRef` in the same type;
+    /// panics if the varient mismatches.
     fn borrow_scalar_value_ref<'a>(v: &'a ScalarValueRef<'a>) -> &'a Option<Self>;
 
-    /// Borrows a slice of this concrete type from a `VectorValue` in the same type.
+    /// Borrows a slice of this concrete type from a `VectorValue` in the same type;
+    /// panics if the varient mismatches.
     fn borrow_vector_value(v: &VectorValue) -> &[Option<Self>];
 
-    /// Converts a vector of this concrete type into a `VectorValue` in the same type.
+    /// Converts a vector of this concrete type into a `VectorValue` in the same type;
+    /// panics if the varient mismatches.
     fn into_vector_value(vec: Vec<Option<Self>>) -> VectorValue;
+
+    /// Try to borrow this concrete type from a `ScalarValue`.
+    fn try_borrow_scalar_value(v: &ScalarValue) -> Option<&Option<Self>>;
+
+    /// Try to borrow a slice of this concrete type from a `VectorValue`.
+    fn try_borrow_vector_value(v: &VectorValue) -> Option<&[Option<Self>]>;
 }
 
 macro_rules! impl_evaluable_type {
@@ -102,6 +112,22 @@ macro_rules! impl_evaluable_type {
             #[inline]
             fn into_vector_value(vec: Vec<Option<Self>>) -> VectorValue {
                 VectorValue::from(vec)
+            }
+
+            #[inline]
+            default fn try_borrow_scalar_value(v: &ScalarValue) -> Option<&Option<Self>> {
+                match v {
+                    ScalarValue::$ty(value) => Some(value),
+                    _ => None,
+                }
+            }
+
+            #[inline]
+            default fn try_borrow_vector_value(v: &VectorValue) -> Option<&[Option<Self>]> {
+                match v {
+                    VectorValue::$ty(value) => Some(value),
+                    _ => None,
+                }
             }
         }
     };

--- a/components/tidb_query/src/rpn_expr/types/function.rs
+++ b/components/tidb_query/src/rpn_expr/types/function.rs
@@ -21,6 +21,7 @@
 //! `components/tidb_query_codegen/src/rpn_function`.
 
 use std::convert::TryFrom;
+use std::marker::PhantomData;
 
 use tidb_query_datatype::{EvalType, FieldTypeAccessor};
 use tipb::{Expr, FieldType};
@@ -163,19 +164,24 @@ pub trait Evaluator {
     ) -> Result<VectorValue>;
 }
 
-pub struct ArgConstructor<E: Evaluator> {
+pub struct ArgConstructor<A: Evaluable, E: Evaluator> {
     arg_index: usize,
     inner: E,
+    marker: PhantomData<A>,
 }
 
-impl<E: Evaluator> ArgConstructor<E> {
+impl<A: Evaluable, E: Evaluator> ArgConstructor<A, E> {
     #[inline]
     pub fn new(arg_index: usize, inner: E) -> Self {
-        ArgConstructor { arg_index, inner }
+        ArgConstructor {
+            arg_index,
+            inner,
+            marker: PhantomData,
+        }
     }
 }
 
-impl<E: Evaluator> Evaluator for ArgConstructor<E> {
+impl<A: Evaluable, E: Evaluator> Evaluator for ArgConstructor<A, E> {
     fn eval(
         self,
         def: impl ArgDef,
@@ -186,33 +192,37 @@ impl<E: Evaluator> Evaluator for ArgConstructor<E> {
     ) -> Result<VectorValue> {
         match &args[self.arg_index] {
             RpnStackNode::Scalar { value, .. } => {
-                match_template_evaluable! {
-                    TT, match value {
-                        ScalarValue::TT(v) => {
-                            let new_def = Arg {
-                                arg: ScalarArg(v),
-                                rem: def,
-                            };
-                            self.inner.eval(new_def, ctx, output_rows, args, extra)
-                        }
-                    }
+                if let Some(v) = A::try_borrow_scalar_value(value) {
+                    let new_def = Arg {
+                        arg: ScalarArg(v),
+                        rem: def,
+                    };
+                    self.inner.eval(new_def, ctx, output_rows, args, extra)
+                } else {
+                    // TODO: Should print fn name
+                    panic!(
+                        "Cannot apply {:?} at {} argument postion",
+                        value, self.arg_index
+                    );
                 }
             }
             RpnStackNode::Vector { value, .. } => {
                 let logical_rows = value.logical_rows();
-                match_template_evaluable! {
-                    TT, match value.as_ref() {
-                        VectorValue::TT(ref v) => {
-                            let new_def = Arg {
-                                arg: VectorArg {
-                                    physical_col: v,
-                                    logical_rows,
-                                },
-                                rem: def,
-                            };
-                            self.inner.eval(new_def, ctx, output_rows, args, extra)
-                        }
-                    }
+                if let Some(v) = A::try_borrow_vector_value(value.as_ref()) {
+                    let new_def = Arg {
+                        arg: VectorArg {
+                            physical_col: v,
+                            logical_rows,
+                        },
+                        rem: def,
+                    };
+                    self.inner.eval(new_def, ctx, output_rows, args, extra)
+                } else {
+                    // TODO: Should print fn name
+                    panic!(
+                        "Cannot apply {:?} at {} argument postion",
+                        value, self.arg_index
+                    );
                 }
             }
         }

--- a/components/tidb_query/src/rpn_expr/types/function.rs
+++ b/components/tidb_query/src/rpn_expr/types/function.rs
@@ -199,9 +199,9 @@ impl<A: Evaluable, E: Evaluator> Evaluator for ArgConstructor<A, E> {
                     };
                     self.inner.eval(new_def, ctx, output_rows, args, extra)
                 } else {
-                    // TODO: Should print fn name
+                    // TODO: Should print fn name as well
                     panic!(
-                        "Cannot apply {:?} at {} argument postion",
+                        "Cannot apply {:?} at argument postion {}",
                         value, self.arg_index
                     );
                 }
@@ -218,9 +218,9 @@ impl<A: Evaluable, E: Evaluator> Evaluator for ArgConstructor<A, E> {
                     };
                     self.inner.eval(new_def, ctx, output_rows, args, extra)
                 } else {
-                    // TODO: Should print fn name
+                    // TODO: Should print fn name as well
                     panic!(
-                        "Cannot apply {:?} at {} argument postion",
+                        "Cannot apply {:?} at argument postion {}",
                         value, self.arg_index
                     );
                 }

--- a/components/tidb_query_codegen/Cargo.toml
+++ b/components/tidb_query_codegen/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 proc-macro = true
 
 [dependencies]
-darling = "0.9"
-syn = "0.15"
-quote = "0.6"
-proc-macro2 = "0.4"
+darling = "0.10"
+syn = { version = "1", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"
 heck = "0.3"


### PR DESCRIPTION
###  What have you changed?

Made use of compile-time type information given by #[rpn_fn] macro to avoid unnecessary monopolization on rpn_fn functions so as to cut down compilation time consumption.

###  What is the type of changes?

- Engineering

###  How is the PR tested?

Unit tests

###  Benchmark result if necessary (optional)

Reduced compilation time spend on tidb_query submodule from `4m51s` to `1m08s` in release mode on IDC.