### PR TITLE
(3.0) txn: Check lock's TTL when doing cleanup (#5471)

### DIFF
--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -442,16 +442,16 @@ impl<E: Engine> AssertionStorage<E> {
         self.expect_invalid_tso_err(resp, start_ts, commit_ts);
     }
 
-    pub fn cleanup_ok(&self, key: &[u8], start_ts: u64) {
+    pub fn cleanup_ok(&self, key: &[u8], start_ts: u64, current_ts: u64) {
         self.store
-            .cleanup(self.ctx.clone(), Key::from_raw(key), start_ts)
+            .cleanup(self.ctx.clone(), Key::from_raw(key), start_ts, current_ts)
             .unwrap();
     }
 
-    pub fn cleanup_err(&self, key: &[u8], start_ts: u64) {
+    pub fn cleanup_err(&self, key: &[u8], start_ts: u64, current_ts: u64) {
         assert!(self
             .store
-            .cleanup(self.ctx.clone(), Key::from_raw(key), start_ts)
+            .cleanup(self.ctx.clone(), Key::from_raw(key), start_ts, current_ts)
             .is_err());
     }
 

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -163,8 +163,8 @@ impl<E: Engine> SyncTestStorage<E> {
         wait_op!(|cb| self.store.async_commit(ctx, keys, start_ts, commit_ts, cb)).unwrap()
     }
 
-    pub fn cleanup(&self, ctx: Context, key: Key, start_ts: u64) -> Result<()> {
-        wait_op!(|cb| self.store.async_cleanup(ctx, key, start_ts, cb)).unwrap()
+    pub fn cleanup(&self, ctx: Context, key: Key, start_ts: u64, current_ts: u64) -> Result<()> {
+        wait_op!(|cb| self.store.async_cleanup(ctx, key, start_ts, current_ts, cb)).unwrap()
     }
 
     pub fn rollback(&self, ctx: Context, keys: Vec<Key>, start_ts: u64) -> Result<()> {

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1533,6 +1533,7 @@ fn future_cleanup<E: Engine>(
         req.take_context(),
         Key::from_raw(req.get_key()),
         req.get_start_version(),
+        req.get_current_ts(),
         cb,
     );
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2595,8 +2595,8 @@ mod tests {
                 ts(110, 0),
                 ts(120, 0),
                 expect_fail_callback(tx.clone(), 0, |e| match e {
-                    Error::Txn(txn::Error::Mvcc(mvcc::Error::KeyIsLocked(info))) => {
-                        assert_eq!(info.get_lock_ttl(), 100)
+                    Error::Txn(txn::Error::Mvcc(mvcc::Error::KeyIsLocked { ttl, .. })) => {
+                        assert_eq!(ttl, 100)
                     }
                     e => panic!("unexpected error chain: {:?}", e),
                 }),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -112,6 +112,9 @@ pub enum Command {
         ctx: Context,
         key: Key,
         start_ts: u64,
+        /// The approximate current ts when cleanup request is invoked, which is used to check the
+        /// lock's TTL. 0 means do not check TTL.
+        current_ts: u64,
     },
     Rollback {
         ctx: Context,
@@ -1079,9 +1082,15 @@ impl<E: Engine> Storage<E> {
         ctx: Context,
         key: Key,
         start_ts: u64,
+        current_ts: u64,
         callback: Callback<()>,
     ) -> Result<()> {
-        let cmd = Command::Cleanup { ctx, key, start_ts };
+        let cmd = Command::Cleanup {
+            ctx,
+            key,
+            start_ts,
+            current_ts,
+        };
         self.schedule(cmd, StorageCb::Boolean(callback))?;
         KV_COMMAND_COUNTER_VEC_STATIC.cleanup.inc();
         Ok(())
@@ -2547,6 +2556,7 @@ mod tests {
                 Context::new(),
                 Key::from_raw(b"x"),
                 100,
+                0,
                 expect_ok_callback(tx.clone(), 1),
             )
             .unwrap();
@@ -2554,6 +2564,59 @@ mod tests {
         expect_none(
             storage
                 .async_get(Context::new(), Key::from_raw(b"x"), 105)
+                .wait(),
+        );
+    }
+
+    #[test]
+    fn test_cleanup_check_ttl() {
+        let storage = TestStorageBuilder::new().build().unwrap();
+        let (tx, rx) = channel();
+
+        let mut options = Options::default();
+        options.lock_ttl = 100;
+        let ts = mvcc::compose_ts;
+        storage
+            .async_prewrite(
+                Context::default(),
+                vec![Mutation::Put((Key::from_raw(b"x"), b"110".to_vec()))],
+                b"x".to_vec(),
+                ts(110, 0),
+                options,
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        storage
+            .async_cleanup(
+                Context::default(),
+                Key::from_raw(b"x"),
+                ts(110, 0),
+                ts(120, 0),
+                expect_fail_callback(tx.clone(), 0, |e| match e {
+                    Error::Txn(txn::Error::Mvcc(mvcc::Error::KeyIsLocked(info))) => {
+                        assert_eq!(info.get_lock_ttl(), 100)
+                    }
+                    e => panic!("unexpected error chain: {:?}", e),
+                }),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        storage
+            .async_cleanup(
+                Context::default(),
+                Key::from_raw(b"x"),
+                ts(110, 0),
+                ts(220, 0),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        expect_none(
+            storage
+                .async_get(Context::default(), Key::from_raw(b"x"), ts(230, 0))
                 .wait(),
         );
     }

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -16,6 +16,17 @@ use std::io;
 use tikv_util::metrics::CRITICAL_ERROR;
 use tikv_util::{panic_when_unexpected_key_or_data, set_panic_mark};
 
+pub const TSO_PHYSICAL_SHIFT_BITS: u64 = 18;
+
+// Extracts physical part of a timestamp, in milliseconds.
+pub fn extract_physical(ts: u64) -> u64 {
+    ts >> TSO_PHYSICAL_SHIFT_BITS
+}
+
+pub fn compose_ts(physical: u64, logical: u64) -> u64 {
+    (physical << TSO_PHYSICAL_SHIFT_BITS) + logical
+}
+
 quick_error! {
     #[derive(Debug)]
     pub enum Error {
@@ -549,6 +560,21 @@ pub mod tests {
         assert!(txn.rollback(Key::from_raw(key)).is_err());
     }
 
+    pub fn must_cleanup<E: Engine>(engine: &E, key: &[u8], start_ts: u64, current_ts: u64) {
+        let ctx = Context::default();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
+        txn.cleanup(Key::from_raw(key), current_ts).unwrap();
+        write(engine, &ctx, txn.into_modifies());
+    }
+
+    pub fn must_cleanup_err<E: Engine>(engine: &E, key: &[u8], start_ts: u64, current_ts: u64) {
+        let ctx = Context::default();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
+        assert!(txn.cleanup(Key::from_raw(key), current_ts).is_err());
+    }
+
     pub fn must_txn_heart_beat<E: Engine>(
         engine: &E,
         primary_key: &[u8],
@@ -754,5 +780,16 @@ pub mod tests {
             reader.scan_keys(start.map(Key::from_raw), limit).unwrap(),
             expect
         );
+    }
+
+    #[test]
+    fn test_ts() {
+        let physical = 1568700549751;
+        let logical = 108;
+        let ts = compose_ts(physical, logical);
+        assert_eq!(ts, 411225436913926252);
+
+        let extracted_physical = extract_physical(ts);
+        assert_eq!(extracted_physical, physical);
     }
 }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -505,13 +505,13 @@ impl<S: Snapshot> MvccTxn<S> {
                     // The `lock.primary` field will not be accessed again. Use mem::replace to
                     // avoid cloning.
                     let primary = ::std::mem::replace(&mut lock.primary, Default::default());
-                    let mut info = kvproto::kvrpcpb::LockInfo::default();
-                    info.set_primary_lock(primary);
-                    info.set_lock_version(lock.ts);
-                    info.set_key(key.into_raw()?);
-                    info.set_lock_ttl(lock.ttl);
-                    info.set_txn_size(lock.txn_size);
-                    return Err(Error::KeyIsLocked(info));
+                    return Err(Error::KeyIsLocked {
+                        key: key.into_raw()?,
+                        primary,
+                        ts: lock.ts,
+                        ttl: lock.ttl,
+                        txn_size: lock.txn_size,
+                    });
                 }
 
                 // If prewrite type is DEL or LOCK or PESSIMISTIC, it is no need to delete value.

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -4,7 +4,7 @@ use super::lock::{Lock, LockType};
 use super::metrics::*;
 use super::reader::MvccReader;
 use super::write::{Write, WriteType};
-use super::{Error, Result};
+use super::{extract_physical, Error, Result};
 use crate::storage::kv::{Modify, ScanMode, Snapshot};
 use crate::storage::{
     is_short_value, Key, Mutation, Options, Statistics, Value, CF_DEFAULT, CF_LOCK, CF_WRITE,
@@ -486,8 +486,34 @@ impl<S: Snapshot> MvccTxn<S> {
     }
 
     pub fn rollback(&mut self, key: Key) -> Result<bool> {
+        self.cleanup(key, 0)
+    }
+
+    /// Cleanup the lock if it's TTL has expired, comparing with `current_ts`. If `current_ts` is 0,
+    /// cleanup the lock without checking TTL.
+    ///
+    /// Returns whether the lock is a pessimistic lock. Returns error if the key has already been
+    /// committed.
+    pub fn cleanup(&mut self, key: Key, current_ts: u64) -> Result<bool> {
         let is_pessimistic_txn = match self.reader.load_lock(&key)? {
-            Some(ref lock) if lock.ts == self.start_ts => {
+            Some(ref mut lock) if lock.ts == self.start_ts => {
+                // If current_ts is not 0, check the Lock's TTL.
+                // If the lock is not expired, do not rollback it but report key is locked.
+                if current_ts > 0
+                    && extract_physical(lock.ts) + lock.ttl >= extract_physical(current_ts)
+                {
+                    // The `lock.primary` field will not be accessed again. Use mem::replace to
+                    // avoid cloning.
+                    let primary = ::std::mem::replace(&mut lock.primary, Default::default());
+                    let mut info = kvproto::kvrpcpb::LockInfo::default();
+                    info.set_primary_lock(primary);
+                    info.set_lock_version(lock.ts);
+                    info.set_key(key.into_raw()?);
+                    info.set_lock_ttl(lock.ttl);
+                    info.set_txn_size(lock.txn_size);
+                    return Err(Error::KeyIsLocked(info));
+                }
+
                 // If prewrite type is DEL or LOCK or PESSIMISTIC, it is no need to delete value.
                 if lock.short_value.is_none() && lock.lock_type == LockType::Put {
                     self.delete_value(key.clone(), lock.ts);
@@ -802,6 +828,37 @@ mod tests {
 
         // Rollback delete
         must_rollback(&engine, k, 15);
+    }
+
+    #[test]
+    fn test_cleanup() {
+        // Cleanup's logic is mostly similar to rollback, except the TTL check. Tests that not
+        // related to TTL check should be covered by other test cases.
+        let engine = TestEngineBuilder::new().build().unwrap();
+
+        // Shorthand for composing ts.
+        let ts = super::super::compose_ts;
+
+        let (k, v) = (b"k", b"v");
+
+        must_prewrite_put(&engine, k, v, k, ts(10, 0));
+        must_locked(&engine, k, ts(10, 0));
+        must_txn_heart_beat(&engine, k, ts(10, 0), 100, 100);
+        // Check the last txn_heart_beat has set the lock's TTL to 100.
+        must_txn_heart_beat(&engine, k, ts(10, 0), 90, 100);
+
+        // TTL not expired. Do nothing but returns an error.
+        must_cleanup_err(&engine, k, ts(10, 0), ts(20, 0));
+        must_locked(&engine, k, ts(10, 0));
+
+        // Try to cleanup another transaction's lock. Does nothing.
+        must_cleanup(&engine, k, ts(10, 1), ts(120, 0));
+        must_locked(&engine, k, ts(10, 0));
+
+        // TTL expired. The lock should be removed.
+        must_cleanup(&engine, k, ts(10, 0), ts(120, 0));
+        must_unlocked(&engine, k);
+        must_get_rollback_ts(&engine, k, ts(10, 0));
     }
 
     #[test]

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -612,6 +612,7 @@ mod tests {
                 ctx: Context::new(),
                 key: Key::from_raw(b"k"),
                 start_ts: 10,
+                current_ts: 20,
             },
             Command::Rollback {
                 ctx: Context::new(),

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -64,7 +64,7 @@ fn test_txn_store_cleanup_rollback() {
     );
     store.get_err(b"secondary", 10);
     store.rollback_ok(vec![b"primary"], 5);
-    store.cleanup_ok(b"primary", 5);
+    store.cleanup_ok(b"primary", 5, 0);
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn test_txn_store_cleanup_commit() {
     store.get_err(b"secondary", 8);
     store.get_err(b"secondary", 12);
     store.commit_ok(vec![b"primary"], 5, 10);
-    store.cleanup_err(b"primary", 5);
+    store.cleanup_err(b"primary", 5, 0);
     store.rollback_err(vec![b"primary"], 5);
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This PR cherry-picks #5471 , which is part of refinement of pessimistic transactions, to release-3.0 branch. For more details please view #5471 .

###  What is the type of the changes?

- New feature (a change which adds functionality)

###  How is the PR tested?

- Unit test
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

- No.

###  Does this PR affect `tidb-ansible`?

No.

###  Refer to a related PR or issue link (optional)

* Cherry-picks: #5471 
* Corresponding PR in TiDB: pingcap/tidb#12417

