### PR TITLE
txn: skip prewrite_key_value if former any former key has been locked

### DIFF
--- a/benches/hierarchy/mvcc/mod.rs
+++ b/benches/hierarchy/mvcc/mod.rs
@@ -29,6 +29,7 @@ where
             Mutation::Put((Key::from_raw(&k), v.clone())),
             &k.clone(),
             &Options::default(),
+            false,
         )
         .unwrap();
     }
@@ -60,7 +61,7 @@ fn mvcc_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Bench
         |(mutations, snapshot, option)| {
             for (mutation, primary) in mutations {
                 let mut txn = MvccTxn::new(snapshot.clone(), 1, true).unwrap();
-                txn.prewrite(mutation, &primary, option).unwrap();
+                txn.prewrite(mutation, &primary, option, false).unwrap();
             }
         },
         BatchSize::SmallInput,

--- a/benches/hierarchy/txn/mod.rs
+++ b/benches/hierarchy/txn/mod.rs
@@ -25,6 +25,7 @@ where
             Mutation::Put((Key::from_raw(&k), v.clone())),
             &k.clone(),
             &option,
+            false,
         )
         .unwrap();
     }
@@ -52,7 +53,7 @@ fn txn_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchC
             for (mutation, primary) in mutations {
                 let snapshot = engine.snapshot(&ctx).unwrap();
                 let mut txn = MvccTxn::new(snapshot, 1, true).unwrap();
-                txn.prewrite(mutation, &primary, option).unwrap();
+                txn.prewrite(mutation, &primary, option, false).unwrap();
                 let modifies = txn.into_modifies();
                 black_box(engine.write(&ctx, modifies)).unwrap();
             }

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -266,6 +266,7 @@ pub mod tests {
             Mutation::Insert((Key::from_raw(key), value.to_vec())),
             pk,
             &Options::default(),
+            false,
         )?;
         write(engine, &ctx, txn.into_modifies());
         Ok(())
@@ -287,9 +288,9 @@ pub mod tests {
         options.for_update_ts = for_update_ts;
         let mutation = Mutation::Put((Key::from_raw(key), value.to_vec()));
         if for_update_ts == 0 {
-            txn.prewrite(mutation, pk, &options).unwrap();
+            txn.prewrite(mutation, pk, &options, false).unwrap();
         } else {
-            txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options)
+            txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options, false)
                 .unwrap();
         }
         write(engine, &ctx, txn.into_modifies());
@@ -335,9 +336,9 @@ pub mod tests {
         options.for_update_ts = for_update_ts;
         let mutation = Mutation::Put((Key::from_raw(key), value.to_vec()));
         if for_update_ts == 0 {
-            txn.prewrite(mutation, pk, &options).unwrap_err();
+            txn.prewrite(mutation, pk, &options, false).unwrap_err();
         } else {
-            txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options)
+            txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options, false)
                 .unwrap_err();
         }
     }
@@ -387,9 +388,9 @@ pub mod tests {
         options.for_update_ts = for_update_ts;
         let mutation = Mutation::Delete(Key::from_raw(key));
         if for_update_ts == 0 {
-            txn.prewrite(mutation, pk, &options).unwrap();
+            txn.prewrite(mutation, pk, &options, false).unwrap();
         } else {
-            txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options)
+            txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options, false)
                 .unwrap();
         }
         engine.write(&ctx, txn.into_modifies()).unwrap();
@@ -425,9 +426,9 @@ pub mod tests {
         options.for_update_ts = for_update_ts;
         let mutation = Mutation::Lock(Key::from_raw(key));
         if for_update_ts == 0 {
-            txn.prewrite(mutation, pk, &options).unwrap();
+            txn.prewrite(mutation, pk, &options, false).unwrap();
         } else {
-            txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options)
+            txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options, false)
                 .unwrap();
         }
         engine.write(&ctx, txn.into_modifies()).unwrap();
@@ -442,7 +443,12 @@ pub mod tests {
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
         assert!(txn
-            .prewrite(Mutation::Lock(Key::from_raw(key)), pk, &Options::default())
+            .prewrite(
+                Mutation::Lock(Key::from_raw(key)),
+                pk,
+                &Options::default(),
+                false
+            )
             .is_err());
     }
 

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -506,7 +506,7 @@ mod tests {
         fn prewrite(&mut self, m: Mutation, pk: &[u8], start_ts: u64) {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
             let mut txn = MvccTxn::new(snap, start_ts, true).unwrap();
-            txn.prewrite(m, pk, &Options::default()).unwrap();
+            txn.prewrite(m, pk, &Options::default(), false).unwrap();
             self.write(txn.into_modifies());
         }
 
@@ -514,7 +514,8 @@ mod tests {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
             let mut txn = MvccTxn::new(snap, start_ts, true).unwrap();
             let options = Options::default();
-            txn.pessimistic_prewrite(m, pk, true, &options).unwrap();
+            txn.pessimistic_prewrite(m, pk, true, &options, false)
+                .unwrap();
             self.write(txn.into_modifies());
         }
 

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -474,6 +474,7 @@ mod tests {
                         Mutation::Put((Key::from_raw(key), key.to_vec())),
                         pk,
                         &Options::default(),
+                        false,
                     )
                     .unwrap();
                 }


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Think about the following scenario: **We will prewrite keys `[1,2,3,4,5]` and the key `1` has been locked**.

For the remaining keys, we should find the locked key as much as possible, but we don't need to call `prewrite_key_value`. To call the `prewrite_key_value`, we must allocate a `Vec` to store the primary key and clone the `Key`, which is inefficiency.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- Unit test
- Integration test
