### PR TITLE
pd_client: rename kvproto::pdpb::PdClient to PdClientStub in pd_client/src/util.rs

### DIFF
--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -266,7 +266,7 @@ impl PdClient for RpcClient {
         let executor = move |client: &RwLock<Inner>, req: pdpb::GetRegionByIdRequest| {
             let handler = client
                 .rl()
-                .client
+                .client_stub
                 .get_region_by_id_async_opt(&req, Self::call_option())
                 .unwrap();
             Box::new(handler.map_err(Error::Grpc).and_then(move |mut resp| {
@@ -372,7 +372,7 @@ impl PdClient for RpcClient {
         let executor = move |client: &RwLock<Inner>, req: pdpb::AskSplitRequest| {
             let handler = client
                 .rl()
-                .client
+                .client_stub
                 .ask_split_async_opt(&req, Self::call_option())
                 .unwrap();
             Box::new(handler.map_err(Error::Grpc).and_then(move |resp| {
@@ -404,7 +404,7 @@ impl PdClient for RpcClient {
         let executor = move |client: &RwLock<Inner>, req: pdpb::AskBatchSplitRequest| {
             let handler = client
                 .rl()
-                .client
+                .client_stub
                 .ask_batch_split_async_opt(&req, Self::call_option())
                 .unwrap();
             Box::new(handler.map_err(Error::Grpc).and_then(move |resp| {
@@ -431,7 +431,7 @@ impl PdClient for RpcClient {
         let executor = move |client: &RwLock<Inner>, req: pdpb::StoreHeartbeatRequest| {
             let handler = client
                 .rl()
-                .client
+                .client_stub
                 .store_heartbeat_async_opt(&req, Self::call_option())
                 .unwrap();
             Box::new(handler.map_err(Error::Grpc).and_then(move |resp| {
@@ -458,7 +458,7 @@ impl PdClient for RpcClient {
         let executor = move |client: &RwLock<Inner>, req: pdpb::ReportBatchSplitRequest| {
             let handler = client
                 .rl()
-                .client
+                .client_stub
                 .report_batch_split_async_opt(&req, Self::call_option())
                 .unwrap();
             Box::new(handler.map_err(Error::Grpc).and_then(move |resp| {
@@ -508,7 +508,7 @@ impl PdClient for RpcClient {
             let option = CallOption::default().timeout(Duration::from_secs(REQUEST_TIMEOUT));
             let handler = client
                 .rl()
-                .client
+                .client_stub
                 .get_gc_safe_point_async_opt(&req, option)
                 .unwrap();
             Box::new(handler.map_err(Error::Grpc).and_then(move |resp| {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

`pd_client/lib.rs` has a `PdClient` trait, and `pd_client/util.rs` use `kvproto::pdpb::PdClient`.

This PR rename `kvproto::pdpb:PdClient` to `PdClientStub` in `pd_client/src/util.rs`



###  What is the type of the changes?

Pick one of the following and delete the others:

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

NO

###  Does this PR affect `tidb-ansible`?

NO

###  Refer to a related PR or issue link (optional)

N/A

###  Benchmark result if necessary (optional)
N/A

###  Any examples? (optional)
N/A
