### PR TITLE
util: compare raw and encoded keys without explicit decoding

### DIFF
--- a/components/keys/src/types.rs
+++ b/components/keys/src/types.rs
@@ -184,10 +184,6 @@ impl Key {
     }
 
     /// Returns whether the encoded key is encoded from `raw_key`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self` is not a valid encoded key.
     pub fn is_encoded_from(&self, raw_key: &[u8]) -> bool {
         bytes::is_encoded_from(&self.0, raw_key, false)
     }

--- a/components/keys/src/types.rs
+++ b/components/keys/src/types.rs
@@ -315,7 +315,7 @@ mod tests {
             });
             assert!(res.is_err());
 
-            // Should panic if encoded has less or more chunks
+            // Should fail if encoded has less or more chunks
             let shorter_encoded = Key::from_encoded_slice(&encoded.0[..encoded_len - 9]);
             assert!(!shorter_encoded.is_encoded_from(&raw));
             let mut longer_encoded = encoded.as_encoded().clone();

--- a/components/keys/src/types.rs
+++ b/components/keys/src/types.rs
@@ -321,7 +321,7 @@ mod tests {
             assert!(!longer_encoded.is_encoded_from(&raw));
 
             // Should return false if raw is longer or shorter
-            if raw.len() > 0 {
+            if !raw.is_empty() {
                 let shorter_raw = &raw[..raw.len() - 1];
                 assert!(!encoded.is_encoded_from(shorter_raw));
             }

--- a/components/keys/src/types.rs
+++ b/components/keys/src/types.rs
@@ -286,10 +286,49 @@ mod tests {
 
     #[test]
     fn test_is_encoded_from() {
-        for raw_len in 0..=255 {
+        for raw_len in 0..=24 {
             let raw: Vec<u8> = (0..raw_len).collect();
             let encoded = Key::from_raw(&raw);
             assert!(encoded.is_encoded_from(&raw));
+
+            let encoded_len = encoded.as_encoded().len();
+
+            // Should fail if we modify one byte in raw
+            for i in 0..raw.len() {
+                let mut invalid_raw = raw.clone();
+                invalid_raw[i] = raw[i].wrapping_add(1);
+                assert!(!encoded.is_encoded_from(&invalid_raw));
+            }
+
+            // Should fail if we modify one byte in encoded
+            for i in 0..encoded_len {
+                let mut invalid_encoded = encoded.clone();
+                invalid_encoded.0[i] = encoded.0[i].wrapping_add(1);
+                assert!(!invalid_encoded.is_encoded_from(&raw));
+            }
+
+            // Should panic if encoded length is not a multiple of 9
+            let res = panic_hook::recover_safe(|| {
+                let mut invalid_encoded = encoded.clone();
+                invalid_encoded.0.pop();
+                invalid_encoded.is_encoded_from(&raw)
+            });
+            assert!(res.is_err());
+
+            // Should panic if encoded has less or more chunks
+            let shorter_encoded = Key::from_encoded_slice(&encoded.0[..encoded_len - 9]);
+            assert!(!shorter_encoded.is_encoded_from(&raw));
+            let mut longer_encoded = encoded.as_encoded().clone();
+            longer_encoded.extend(&[0, 0, 0, 0, 0, 0, 0, 0, 0xFF]);
+            let longer_encoded = Key::from_encoded(longer_encoded);
+            assert!(!longer_encoded.is_encoded_from(&raw));
+
+            // Should fail if raw is longer or shorter
+            let shorter_raw = &raw[..raw.len() - 1];
+            assert!(!encoded.is_encoded_from(shorter_raw));
+            let mut longer_raw = raw.to_vec();
+            longer_raw.push(0);
+            assert!(!encoded.is_encoded_from(&longer_raw));
         }
     }
 }

--- a/components/keys/src/types.rs
+++ b/components/keys/src/types.rs
@@ -293,29 +293,26 @@ mod tests {
 
             let encoded_len = encoded.as_encoded().len();
 
-            // Should fail if we modify one byte in raw
+            // Should return false if we modify one byte in raw
             for i in 0..raw.len() {
                 let mut invalid_raw = raw.clone();
                 invalid_raw[i] = raw[i].wrapping_add(1);
                 assert!(!encoded.is_encoded_from(&invalid_raw));
             }
 
-            // Should fail if we modify one byte in encoded
+            // Should return false if we modify one byte in encoded
             for i in 0..encoded_len {
                 let mut invalid_encoded = encoded.clone();
                 invalid_encoded.0[i] = encoded.0[i].wrapping_add(1);
                 assert!(!invalid_encoded.is_encoded_from(&raw));
             }
 
-            // Should panic if encoded length is not a multiple of 9
-            let res = panic_hook::recover_safe(|| {
-                let mut invalid_encoded = encoded.clone();
-                invalid_encoded.0.pop();
-                invalid_encoded.is_encoded_from(&raw)
-            });
-            assert!(res.is_err());
+            // Should return false if encoded length is not a multiple of 9
+            let mut invalid_encoded = encoded.clone();
+            invalid_encoded.0.pop();
+            assert!(!invalid_encoded.is_encoded_from(&raw));
 
-            // Should fail if encoded has less or more chunks
+            // Should return false if encoded has less or more chunks
             let shorter_encoded = Key::from_encoded_slice(&encoded.0[..encoded_len - 9]);
             assert!(!shorter_encoded.is_encoded_from(&raw));
             let mut longer_encoded = encoded.as_encoded().clone();
@@ -323,9 +320,11 @@ mod tests {
             let longer_encoded = Key::from_encoded(longer_encoded);
             assert!(!longer_encoded.is_encoded_from(&raw));
 
-            // Should fail if raw is longer or shorter
-            let shorter_raw = &raw[..raw.len() - 1];
-            assert!(!encoded.is_encoded_from(shorter_raw));
+            // Should return false if raw is longer or shorter
+            if raw.len() > 0 {
+                let shorter_raw = &raw[..raw.len() - 1];
+                assert!(!encoded.is_encoded_from(shorter_raw));
+            }
             let mut longer_raw = raw.to_vec();
             longer_raw.push(0);
             assert!(!encoded.is_encoded_from(&longer_raw));

--- a/components/keys/src/types.rs
+++ b/components/keys/src/types.rs
@@ -182,6 +182,15 @@ impl Key {
             ts_encoded_key[..user_key_len] == user_key[..]
         }
     }
+
+    /// Returns whether the encoded key is encoded from `raw_key`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` is not a valid encoded key.
+    pub fn is_encoded_from(&self, raw_key: &[u8]) -> bool {
+        bytes::is_encoded_from(&self.0, raw_key, false)
+    }
 }
 
 impl Clone for Key {
@@ -273,5 +282,14 @@ mod tests {
         assert_eq!(false, eq(b"abxdefghijk87654321", b"abcdefghijk"));
         assert_eq!(false, eq(b"axcdefghijk87654321", b"abcdefghijk"));
         assert_eq!(false, eq(b"abcdeffhijk87654321", b"abcdefghijk"));
+    }
+
+    #[test]
+    fn test_is_encoded_from() {
+        for raw_len in 0..=255 {
+            let raw: Vec<u8> = (0..raw_len).collect();
+            let encoded = Key::from_raw(&raw);
+            assert!(encoded.is_encoded_from(&raw));
+        }
     }
 }

--- a/components/tikv_util/src/codec/bytes.rs
+++ b/components/tikv_util/src/codec/bytes.rs
@@ -288,16 +288,16 @@ pub fn is_encoded_from(encoded: &[u8], raw: &[u8], desc: bool) -> bool {
         let len = raw.len();
         let pad = (ENC_GROUP_SIZE - len) as u8;
         if desc {
-            encoded[..len]
-                .iter()
-                .zip(raw)
-                .all(|(&enc, &raw)| enc == !raw)
+            encoded[ENC_GROUP_SIZE] == !(ENC_MARKER - pad)
+                && encoded[..len]
+                    .iter()
+                    .zip(raw)
+                    .all(|(&enc, &raw)| enc == !raw)
                 && encoded[len..encoded.len() - 1].iter().all(|&v| v == 0xff)
-                && encoded[ENC_GROUP_SIZE] == !(ENC_MARKER - pad)
         } else {
-            &encoded[..len] == raw
+            encoded[ENC_GROUP_SIZE] == (ENC_MARKER - pad)
+                && &encoded[..len] == raw
                 && encoded[len..encoded.len() - 1].iter().all(|&v| v == 0)
-                && encoded[ENC_GROUP_SIZE] == (ENC_MARKER - pad)
         }
     };
 
@@ -489,7 +489,7 @@ mod tests {
                 });
                 assert!(res.is_err());
 
-                // Should panic if encoded has less or more chunks
+                // Should fail if encoded has less or more chunks
                 let shorter_encoded = &encoded[..encoded.len() - ENC_GROUP_SIZE - 1];
                 assert!(
                     !is_encoded_from(shorter_encoded, &raw, desc),

--- a/components/tikv_util/src/codec/bytes.rs
+++ b/components/tikv_util/src/codec/bytes.rs
@@ -305,8 +305,8 @@ pub fn is_encoded_from(encoded: &[u8], raw: &[u8], desc: bool) -> bool {
     // Valid encoded bytes must has complete chunks
     assert!(rev_encoded_chunks.remainder().is_empty());
 
-    // Bytes are compared in reverse order because in TiKV, if two keys are different, the last
-    // a few bytes are more likely to be different.
+    // Bytes are compared in reverse order because in real cases like TiDB, if two keys
+    // are different, the last a few bytes are more likely to be different.
 
     let raw_chunks = raw.chunks_exact(ENC_GROUP_SIZE);
     // Check the last chunk first

--- a/components/tikv_util/src/codec/bytes.rs
+++ b/components/tikv_util/src/codec/bytes.rs
@@ -515,7 +515,7 @@ mod tests {
                 );
 
                 // Should return false if raw is longer or shorter
-                if raw.len() > 0 {
+                if !raw.is_empty() {
                     let shorter_raw = &raw[..raw.len() - 1];
                     assert!(
                         !is_encoded_from(&encoded, shorter_raw, desc),


### PR DESCRIPTION
###  What have you changed?

This PR adds a function to check if the encoded and raw format refers to the same key.

#### Motivation

The motivation is that we want to know if a lock is a primary lock. However, inside TiKV we use encoded keys while the stored primary key in the lock is in the raw format.

An alternatives are directly passing raw keys into the transaction layer. But this makes the transaction code uglier. The benchmark result below shows that for a typical key length (30 bytes), it takes just less than 10ns and in most cases, two different keys are different in their tails. So the performance impact is quite small.

###  What is the type of the changes?

- New feature (a change which adds functionality)

###  How is the PR tested?
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/pull/5575 may utilize it.

###  Benchmark result if necessary (optional)

```
test codec::bytes::tests::bench_is_encoded_from       ... bench:         949 ns/iter (+/- 67)
test codec::bytes::tests::bench_is_encoded_from_small ... bench:           5 ns/iter (+/- 0)
```

###  Any examples? (optional)

