### PR TITLE
storage: Fix scan_lock doesn't return lock's TTL

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3902,6 +3902,9 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
+
+        let mut options = Options::default();
+        options.lock_ttl = 123;
         storage
             .async_prewrite(
                 Context::default(),
@@ -3912,17 +3915,19 @@ mod tests {
                 ],
                 b"c".to_vec(),
                 101,
-                Options::default(),
+                options,
                 expect_ok_callback(tx.clone(), 0),
             )
             .unwrap();
         rx.recv().unwrap();
+
         let (lock_a, lock_b, lock_c, lock_x, lock_y, lock_z) = (
             {
                 let mut lock = LockInfo::default();
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(101);
                 lock.set_key(b"a".to_vec());
+                lock.set_lock_ttl(123);
                 lock
             },
             {
@@ -3930,6 +3935,7 @@ mod tests {
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(101);
                 lock.set_key(b"b".to_vec());
+                lock.set_lock_ttl(123);
                 lock
             },
             {
@@ -3937,6 +3943,7 @@ mod tests {
                 lock.set_primary_lock(b"c".to_vec());
                 lock.set_lock_version(101);
                 lock.set_key(b"c".to_vec());
+                lock.set_lock_ttl(123);
                 lock
             },
             {
@@ -3961,6 +3968,7 @@ mod tests {
                 lock
             },
         );
+
         storage
             .async_scan_locks(
                 Context::default(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3905,6 +3905,7 @@ mod tests {
 
         let mut options = Options::default();
         options.lock_ttl = 123;
+        options.txn_size = 3;
         storage
             .async_prewrite(
                 Context::default(),
@@ -3928,6 +3929,7 @@ mod tests {
                 lock.set_lock_version(101);
                 lock.set_key(b"a".to_vec());
                 lock.set_lock_ttl(123);
+                lock.set_txn_size(3);
                 lock
             },
             {
@@ -3936,6 +3938,7 @@ mod tests {
                 lock.set_lock_version(101);
                 lock.set_key(b"b".to_vec());
                 lock.set_lock_ttl(123);
+                lock.set_txn_size(3);
                 lock
             },
             {
@@ -3944,6 +3947,7 @@ mod tests {
                 lock.set_lock_version(101);
                 lock.set_key(b"c".to_vec());
                 lock.set_lock_ttl(123);
+                lock.set_txn_size(3);
                 lock
             },
             {

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -417,6 +417,7 @@ fn process_read_impl<E: Engine>(
                 lock_info.set_lock_version(lock.ts);
                 lock_info.set_key(key.into_raw()?);
                 lock_info.set_lock_ttl(lock.ttl);
+                lock_info.set_txn_size(lock.txn_size);
                 locks.push(lock_info);
             }
 

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -416,6 +416,7 @@ fn process_read_impl<E: Engine>(
                 lock_info.set_primary_lock(lock.primary);
                 lock_info.set_lock_version(lock.ts);
                 lock_info.set_key(key.into_raw()?);
+                lock_info.set_lock_ttl(lock.ttl);
                 locks.push(lock_info);
             }
 


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

TiKV's scan_lock didn't pass the locks' TTLs. So when GC meets lock, TiDB will get 0 as the TTL, and all locks will be regarded as expired and cleaned up. Unfinished transactions will be aborted.

This PR fixes this problem.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

