### PR TITLE
raftstore: reduce message flush (#5475)

### DIFF
--- a/components/tikv_util/src/mpsc/batch.rs
+++ b/components/tikv_util/src/mpsc/batch.rs
@@ -114,6 +114,12 @@ pub struct Receiver<T> {
 }
 
 impl<T> Sender<T> {
+    pub fn is_empty(&self) -> bool {
+        // When there is no sender references, it can't be known whether
+        // it's empty or not.
+        self.sender.as_ref().map_or(false, |s| s.is_empty())
+    }
+
     #[inline]
     pub fn send(&self, t: T) -> Result<(), SendError<T>> {
         self.sender.as_ref().unwrap().send(t)?;

--- a/src/raftstore/store/fsm/batch.rs
+++ b/src/raftstore/store/fsm/batch.rs
@@ -268,6 +268,9 @@ pub trait PollHandler<N, C> {
 
     /// This function is called at the end of every round.
     fn end(&mut self, batch: &mut [Box<N>]);
+
+    /// This function is called when batch system is going to sleep.
+    fn pause(&mut self) {}
 }
 
 /// Internal poller that fetches batch and call handler hooks for readiness.
@@ -279,7 +282,7 @@ struct Poller<N: Fsm, C: Fsm, Handler> {
 }
 
 impl<N: Fsm, C: Fsm, Handler: PollHandler<N, C>> Poller<N, C, Handler> {
-    fn fetch_batch(&self, batch: &mut Batch<N, C>, max_size: usize) {
+    fn fetch_batch(&mut self, batch: &mut Batch<N, C>, max_size: usize) {
         let curr_batch_len = batch.len();
         if batch.control.is_some() || curr_batch_len >= max_size {
             // Do nothing if there's a pending control fsm or the batch is already full.
@@ -287,8 +290,11 @@ impl<N: Fsm, C: Fsm, Handler: PollHandler<N, C>> Poller<N, C, Handler> {
         }
 
         let mut pushed = if curr_batch_len == 0 {
-            // Block if the batch is empty.
-            match self.fsm_receiver.recv() {
+            match self.fsm_receiver.try_recv().or_else(|_| {
+                self.handler.pause();
+                // Block if the batch is empty.
+                self.fsm_receiver.recv()
+            }) {
                 Ok(fsm) => batch.push(fsm),
                 Err(_) => return,
             }

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -221,6 +221,9 @@ impl<T: RaftStoreRouter> RaftClient<T> {
     pub fn flush(&mut self) {
         let (mut counter, mut delay_counter) = (0, 0);
         for conn in self.conns.values_mut() {
+            if conn.stream.is_empty() {
+                continue;
+            }
             if let Some(notifier) = conn.stream.get_notifier() {
                 if !self.grpc_thread_load.in_heavy_load() {
                     notifier.notify();


### PR DESCRIPTION
cherry-pick #5475 to release-3.1

###  What have you changed?

Technically, a thread only needs to flush messages when it's going to
block. This PR add hooks to every block point instead of flushing at
the end of every ready.

###  What is the type of the changes?

- Improvement

###  How is the PR tested?

integration tests

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.

###  Benchmark result if necessary (optional)

Benchmark shows that when there are about 25k idle regions, raftstore CPU is reduced from 55% to 40%, and grpc is reduced from 60% to 40%。