### PR TITLE
Pass tests on Mac OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ endif
 # Disable portable on MacOS to sidestep the compiler bug in clang 4.9
 ifeq ($(shell uname -s),Darwin)
 ROCKSDB_SYS_PORTABLE=0
+TEST_THREADS := --test-threads=2
+else
+TEST_THREADS := ""
 endif
 
 # Build portable binary by default unless disable explicitly
@@ -176,8 +179,8 @@ test:
 	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${LOCAL_DIR}/lib" && \
 	export LOG_LEVEL=DEBUG && \
 	export RUST_BACKTRACE=1 && \
-	cargo test --no-default-features --features "${ENABLE_FEATURES}" --all ${EXTRA_CARGO_ARGS} -- --nocapture && \
-	cargo test --no-default-features --features "${ENABLE_FEATURES}" --all --bench misc ${EXTRA_CARGO_ARGS} -- --nocapture  && \
+	cargo test --no-default-features --features "${ENABLE_FEATURES}" --all ${EXTRA_CARGO_ARGS} -- --nocapture $(TEST_THREADS) && \
+	cargo test --no-default-features --features "${ENABLE_FEATURES}" --all --bench misc ${EXTRA_CARGO_ARGS} -- --nocapture  $(TEST_THREADS) && \
 	if [[ "`uname`" == "Linux" ]]; then \
 		export MALLOC_CONF=prof:true,prof_active:false && \
 		cargo test --no-default-features --features "${ENABLE_FEATURES},mem-profiling" ${EXTRA_CARGO_ARGS} --bin tikv-server -- --nocapture --ignored; \

--- a/src/raftstore/store/worker/pd.rs
+++ b/src/raftstore/store/worker/pd.rs
@@ -1049,6 +1049,7 @@ fn send_destroy_peer_message(
     }
 }
 
+#[cfg(not(target_os = "macos"))]
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;


### PR DESCRIPTION
###  What have you changed?

Currently running the test suite on Mac OS fails. For some users only the pd test fails, for others there are many integration test fails (these are intermittent, but usually 10-30 failures).

This PR fixes the issues and makes the test suite pass on Mac. It should be a productivity boost for all developers using Macs (including me :-) ). This PR skips one test based on the target OS. The number of test threads is set to two, on Mac using one thread per core causes problems due to contention slowing down tests and due to the limit in the number of file descriptors which can be created. I made this change to all platforms, since it is possible that using too many threads will cause problems elsewhere, it probably does not make the tests much slower (due to thread contention on OS/HW resources), and because that is what our CI does already and there is a benefit in local tests matching the CI as closely as possible (see https://github.com/pingcap/SRE/blob/master/roles/jenkins/files/groovy/tikv_ghpr/tikv_ghpr_test.groovy#L184). If there is too big of an impact on test times, I can make this change Mac-only.

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

PTAL @Hoverbear @BusyJay 