### PR TITLE
backup: fix seek region panic

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -263,7 +263,7 @@ impl<R: RegionInfoProvider> Progress<R> {
             // The region's end key is empty means it is the last
             // region, we need to set the `finished` flag here in case
             // we run with `next_start` set to None
-            if b.region.get_end_key().is_empty() {
+            if b.region.get_end_key().is_empty() || b.end_key == self.end_key {
                 self.finished = true;
             }
             self.next_start = b.end_key.clone();
@@ -765,6 +765,7 @@ pub mod tests {
             (b"4", b"6", vec![]),
             (b"4", b"5", vec![]),
             (b"2", b"7", vec![(b"3", b"4")]),
+            (b"7", b"8", vec![(b"7", b"8")]),
             (b"3", b"", vec![(b"3", b"4"), (b"7", b"9"), (b"9", b"")]),
             (b"5", b"", vec![(b"7", b"9"), (b"9", b"")]),
             (b"7", b"", vec![(b"7", b"9"), (b"9", b"")]),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
Update backup task finish condition in forward
if backup_range reached task's end_key, we should set `finished` to true, otherwise next_start will be equal to end_key then cause panic

this case can cause panic
```
task: key range 1 -> 2
region1: 1 -> 3
region2: 3 -> null
```

###  What is the type of the changes?

Pick one of the following and delete the others:
- Bugfix (a change which fixes an issue)


###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- Unit test
- Manual test (add detailed scripts or steps below)

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
no

###  Does this PR affect `tidb-ansible`?
no

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

