### PR TITLE
raftstore: hibernate by default

### DIFF
--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -192,7 +192,7 @@ impl Default for Config {
             store_max_batch_size: 1024,
             store_pool_size: 2,
             future_poll_size: 1,
-            hibernate_regions: false,
+            hibernate_regions: true,
 
             // They are preserved for compatibility check.
             region_max_size: ReadableSize(0),

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -159,7 +159,7 @@ fn test_serde_custom_tikv_config() {
         store_max_batch_size: 21,
         store_pool_size: 3,
         future_poll_size: 2,
-        hibernate_regions: true,
+        hibernate_regions: false,
     };
     value.pd = PdConfig::new(vec!["example.com:443".to_owned()]);
     value.rocksdb = DbConfig {

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -132,7 +132,7 @@ apply-pool-size = 4
 store-max-batch-size = 21
 store-pool-size = 3
 future-poll-size = 2
-hibernate-regions = true
+hibernate-regions = false
 
 [coprocessor]
 split-region-on-table = true

--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -194,6 +194,7 @@ fn test_invaild_read_index_when_no_leader() {
     let mut cluster = new_node_cluster(0, 3);
     configure_for_lease_read(&mut cluster, Some(50), Some(3));
     cluster.cfg.raft_store.raft_heartbeat_ticks = 1;
+    cluster.cfg.raft_store.hibernate_regions = false;
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
 
@@ -245,11 +246,14 @@ fn test_invaild_read_index_when_no_leader() {
         .unwrap();
 
     let resp = rx.recv_timeout(time::Duration::from_millis(500)).unwrap();
-    assert!(resp
-        .get_header()
-        .get_error()
-        .get_message()
-        .contains("can not read index due to no leader"));
+    assert!(
+        resp.get_header()
+            .get_error()
+            .get_message()
+            .contains("can not read index due to no leader"),
+        "{:?}",
+        resp.get_header()
+    );
 }
 
 fn must_put<E: Engine>(ctx: &Context, engine: &E, key: &[u8], value: &[u8]) {


### PR DESCRIPTION
###  What have you changed?

It has been tested for quite a long time, but it still needs to be
tested in a more widely environment, so enable it by default on master.

###  What is the type of the changes?

- Improvement

###  How is the PR tested?

- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.
