### PR TITLE
fix criterion-papi build failure on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "libpapi_sys"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23d4b1923176ed3ea37d3ce083df98861519be9b5c5f5c96d37ea2b9b7adf94"
+checksum = "5941a57eb66cca3599174981c3cc970dc84bbf5d13f37d247f660a4a6517c8d9"
 dependencies = [
  "bindgen",
  "num_cpus",


### PR DESCRIPTION
###  What have you changed?

criterion-papi previously has a mistake in its build script thus it makes TiKV fail to build on macOS. Now I fix the issue in https://github.com/YangKeao/rust-papi/pull/1. Upgrading to libpapi_sys 0.1.3 fixes it.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Manual test (add detailed scripts or steps below)

It now compiles on my laptop running macOS.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

