### PR TITLE
update syn, proc-macro2 and quote version in match_template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,9 +1475,9 @@ dependencies = [
 name = "match_template"
 version = "0.0.1"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2 1.0.4",
+ "quote 1.0.2",
+ "syn 1.0.5",
 ]
 
 [[package]]

--- a/components/match_template/Cargo.toml
+++ b/components/match_template/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.15", features = ["full", "extra-traits", "fold"] }
-quote = "0.6"
-proc-macro2 = "0.4"
+syn = { version = "1", features = ["full", "extra-traits", "fold"] }
+quote = "1"
+proc-macro2 = "1"

--- a/components/match_template/src/lib.rs
+++ b/components/match_template/src/lib.rs
@@ -44,8 +44,8 @@ struct MatchArmIdentFolder {
 impl Fold for MatchArmIdentFolder {
     fn fold_macro(&mut self, i: Macro) -> Macro {
         let mut m = syn::fold::fold_macro(self, i);
-        m.tts = m
-            .tts
+        m.tokens = m
+            .tokens
             .into_iter()
             .map(|tt| {
                 if let TokenTree::Ident(i) = &tt {
@@ -92,14 +92,12 @@ impl Parse for MatchTemplate {
 
         let mut arm = arms.next().unwrap();
         assert!(arm.guard.is_none(), "Expect no match arm guard");
-        assert_eq!(arm.pats.len(), 1, "Expect one match arm pattern");
         arm.comma = None;
 
         let mut wildcard_arm = None;
         if let Some(arm) = arms.next() {
             assert!(arm.guard.is_none(), "Expect no match arm guard");
-            assert_eq!(arm.pats.len(), 1, "Expect one match arm pattern");
-            if let Pat::Wild(_) = arm.pats[0] {
+            if let Pat::Wild(_) = arm.pat {
                 wildcard_arm = Some(arm);
             } else {
                 panic!("Expect wildcard arm");


### PR DESCRIPTION
###  What have you changed?
Update the dependencies for `component/match_template`, making the dependency tree a little bit cleaner.

I have removed the assertion for the `pats` field in the `Arm` object as it no longer stores the `punctuated::Punctuated` sequence.

###  What is the type of the changes?
Engineering

###  How is the PR tested?
I haven't run any test due to resource constraints on my local machine. I would need to depend on the CI for the tests. Ran cargo-check.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No

###  Does this PR affect `tidb-ansible`?
No

###  Refer to a related PR or issue link (optional)
Resolves #5592