### PR TITLE
adjust readpool size by the number of cpu core

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::io::Error as IoError;
 use std::io::Write;
 use std::path::Path;
 use std::usize;
+use std::cmp;
 
 use engine::rocks::{
     BlockBasedOptions, Cache, ColumnFamilyOptions, CompactionPriority, DBCompactionStyle,
@@ -1196,7 +1197,8 @@ macro_rules! readpool_config {
     };
 }
 
-const DEFAULT_STORAGE_READPOOL_CONCURRENCY: usize = 4;
+const DEFAULT_STORAGE_READPOOL_MIN_CONCURRENCY: usize = 4;
+const DEFAULT_STORAGE_READPOOL_MAX_CONCURRENCY: usize = 8;
 
 // Assume a request can be finished in 1ms, a request at position x will wait about
 // 0.001 * x secs to be actual started. A server-is-busy error will trigger 2 seconds
@@ -1210,10 +1212,14 @@ readpool_config!(StorageReadPoolConfig, storage_read_pool_test, "storage");
 
 impl Default for StorageReadPoolConfig {
     fn default() -> Self {
+        let cpu_num = sys_info::cpu_num().unwrap();
+        let mut concurrency = (f64::from(cpu_num) * 0.5) as usize;
+        concurrency = cmp::max(DEFAULT_STORAGE_READPOOL_MIN_CONCURRENCY, concurrency);
+        concurrency = cmp::min(DEFAULT_STORAGE_READPOOL_MAX_CONCURRENCY, concurrency);
         Self {
-            high_concurrency: DEFAULT_STORAGE_READPOOL_CONCURRENCY,
-            normal_concurrency: DEFAULT_STORAGE_READPOOL_CONCURRENCY,
-            low_concurrency: DEFAULT_STORAGE_READPOOL_CONCURRENCY,
+            high_concurrency: concurrency,
+            normal_concurrency: concurrency,
+            low_concurrency: concurrency,
             max_tasks_per_worker_high: DEFAULT_READPOOL_MAX_TASKS_PER_WORKER,
             max_tasks_per_worker_normal: DEFAULT_READPOOL_MAX_TASKS_PER_WORKER,
             max_tasks_per_worker_low: DEFAULT_READPOOL_MAX_TASKS_PER_WORKER,
@@ -1222,7 +1228,7 @@ impl Default for StorageReadPoolConfig {
     }
 }
 
-const DEFAULT_COPROCESSOR_READPOOL_CONCURRENCY: usize = 8;
+const DEFAULT_COPROCESSOR_READPOOL_MIN_CONCURRENCY: usize = 2;
 
 readpool_config!(
     CoprReadPoolConfig,
@@ -1233,11 +1239,8 @@ readpool_config!(
 impl Default for CoprReadPoolConfig {
     fn default() -> Self {
         let cpu_num = sys_info::cpu_num().unwrap();
-        let concurrency = if cpu_num > 8 {
-            (f64::from(cpu_num) * 0.8) as usize
-        } else {
-            DEFAULT_COPROCESSOR_READPOOL_CONCURRENCY
-        };
+        let mut concurrency = (f64::from(cpu_num) * 0.8) as usize;
+        concurrency = cmp::max(DEFAULT_COPROCESSOR_READPOOL_MIN_CONCURRENCY, concurrency);
         Self {
             high_concurrency: concurrency,
             normal_concurrency: concurrency,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@
 //! TiKV is configured through the `TiKvConfig` type, which is in turn
 //! made up of many other configuration types.
 
+use std::cmp;
 use std::error::Error;
 use std::fs;
 use std::i32;
@@ -12,7 +13,6 @@ use std::io::Error as IoError;
 use std::io::Write;
 use std::path::Path;
 use std::usize;
-use std::cmp;
 
 use engine::rocks::{
     BlockBasedOptions, Cache, ColumnFamilyOptions, CompactionPriority, DBCompactionStyle,


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Adjust readpool size by the number of cpu core, make it works better under sysbench and other benchmark cases when using default configuration value.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

- Manual test (add detailed scripts or steps below)

- [ ] benchmark

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).

###  Does this PR affect `tidb-ansible`?

No


