### PR TITLE
set upper bound for latch size

### DIFF
--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -18,6 +18,7 @@ const DEFAULT_GC_RATIO_THRESHOLD: f64 = 1.1;
 const DEFAULT_MAX_KEY_SIZE: usize = 4 * 1024;
 const DEFAULT_SCHED_CAPACITY: usize = 10240;
 const DEFAULT_SCHED_CONCURRENCY: usize = 2048000;
+const MAX_SCHED_CONCURRENCY: usize = 40960000;
 
 // According to "Little's law", assuming you can write 100MB per
 // second, and it takes about 100ms to process the write requests
@@ -59,6 +60,13 @@ impl Config {
     pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
         if self.data_dir != DEFAULT_DATA_DIR {
             self.data_dir = config::canonicalize_path(&self.data_dir)?
+        }
+        if self.scheduler_concurrency >= MAX_SCHED_CONCURRENCY {
+            warn!(
+                "scheduler concurrency {} exceed max value {}, use {} by default",
+                self.scheduler_concurrency, MAX_SCHED_CONCURRENCY, MAX_SCHED_CONCURRENCY
+            );
+            self.scheduler_concurrency = MAX_SCHED_CONCURRENCY;
         }
         Ok(())
     }


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Set upper bound for latch size to prevent user mis-configure it by a huge size. Huge size will result in long start time and large memory usage.


###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

