### PR TITLE
txn: protect primary locks of pessimistic transactions from being collapsed

### DIFF
--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -763,7 +763,7 @@ pub mod tests {
         protected: bool,
     ) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
 
         let (ts, write) = reader
             .seek_write(&Key::from_raw(key), start_ts)

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -756,6 +756,24 @@ pub mod tests {
         assert_eq!(ret, None);
     }
 
+    pub fn must_get_rollback_protected<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: u64,
+        protected: bool,
+    ) {
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::Si);
+
+        let (ts, write) = reader
+            .seek_write(&Key::from_raw(key), start_ts)
+            .unwrap()
+            .unwrap();
+        assert_eq!(ts, start_ts);
+        assert_eq!(write.write_type, WriteType::Rollback);
+        assert_eq!(write.is_protected(), protected);
+    }
+
     pub fn must_scan_keys<E: Engine>(
         engine: &E,
         start: Option<&[u8]>,

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -541,7 +541,7 @@ impl<S: Snapshot> MvccTxn<S> {
                 Ok(is_pessimistic_txn)
             }
             _ => {
-                return match self.reader.get_txn_commit_info(&key, self.start_ts)? {
+                match self.reader.get_txn_commit_info(&key, self.start_ts)? {
                     Some((ts, write_type)) => {
                         if write_type == WriteType::Rollback {
                             // return Ok on Rollback already exist
@@ -577,7 +577,7 @@ impl<S: Snapshot> MvccTxn<S> {
                         self.put_write(key, ts, write.to_bytes());
                         Ok(false)
                     }
-                };
+                }
             }
         }
     }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -153,16 +153,37 @@ impl<S: Snapshot> MvccTxn<S> {
         value: Option<Value>,
         options: &Options,
     ) {
-        if value.is_none() || is_short_value(value.as_ref().unwrap()) {
-            // If the value is short, embed it in Lock.
-            self.lock_key(key, lock_type, primary, value, options);
-        } else {
-            // value is long
-            let ts = self.start_ts;
-            self.put_value(key.clone(), ts, value.unwrap());
+        if let Some(value) = value {
+            if is_short_value(&value) {
+                // If the value is short, embed it in Lock.
+                self.lock_key(key, lock_type, primary, Some(value), options);
+            } else {
+                // value is long
+                let ts = self.start_ts;
+                self.put_value(key.clone(), ts, value);
 
+                self.lock_key(key, lock_type, primary, None, options);
+            }
+        } else {
             self.lock_key(key, lock_type, primary, None, options);
         }
+    }
+
+    fn rollback_lock(&mut self, key: Key, lock: &Lock, is_pessimistic_txn: bool) -> Result<()> {
+        // If prewrite type is DEL or LOCK or PESSIMISTIC, it is no need to delete value.
+        if lock.short_value.is_none() && lock.lock_type == LockType::Put {
+            self.delete_value(key.clone(), lock.ts);
+        }
+
+        // Only the primary key of a pessimistic transaction needs to be protected.
+        let protected: bool = is_pessimistic_txn && key.is_encoded_from(&lock.primary);
+        let write = Write::new_rollback(self.start_ts, protected);
+        self.put_write(key.clone(), self.start_ts, write.to_bytes());
+        self.unlock_key(key.clone());
+        if self.collapse_rollback {
+            self.collapse_prev_rollback(key)?;
+        }
+        Ok(())
     }
 
     fn check_data_constraint(
@@ -490,12 +511,13 @@ impl<S: Snapshot> MvccTxn<S> {
     }
 
     /// Cleanup the lock if it's TTL has expired, comparing with `current_ts`. If `current_ts` is 0,
-    /// cleanup the lock without checking TTL.
+    /// cleanup the lock without checking TTL. If the lock is the primary lock of a pessimistic
+    /// transaction, the rollback record is protected from being collapsed.
     ///
     /// Returns whether the lock is a pessimistic lock. Returns error if the key has already been
     /// committed.
     pub fn cleanup(&mut self, key: Key, current_ts: u64) -> Result<bool> {
-        let is_pessimistic_txn = match self.reader.load_lock(&key)? {
+        match self.reader.load_lock(&key)? {
             Some(ref mut lock) if lock.ts == self.start_ts => {
                 // If current_ts is not 0, check the Lock's TTL.
                 // If the lock is not expired, do not rollback it but report key is locked.
@@ -514,11 +536,9 @@ impl<S: Snapshot> MvccTxn<S> {
                     });
                 }
 
-                // If prewrite type is DEL or LOCK or PESSIMISTIC, it is no need to delete value.
-                if lock.short_value.is_none() && lock.lock_type == LockType::Put {
-                    self.delete_value(key.clone(), lock.ts);
-                }
-                lock.for_update_ts != 0
+                let is_pessimistic_txn = lock.for_update_ts != 0;
+                self.rollback_lock(key, lock, is_pessimistic_txn)?;
+                Ok(is_pessimistic_txn)
             }
             _ => {
                 return match self.reader.get_txn_commit_info(&key, self.start_ts)? {
@@ -546,22 +566,20 @@ impl<S: Snapshot> MvccTxn<S> {
                             self.collapse_prev_rollback(key.clone())?;
                         }
 
-                        // insert a Rollback to WriteCF when receives Rollback before Prewrite
-                        let write = Write::new(WriteType::Rollback, ts, None);
+                        // Insert a Rollback to Write CF in case that a stale prewrite command
+                        // is received after a cleanup command.
+                        // Pessimistic transactions prewrite successfully only if all its
+                        // pessimistic locks exist. So collapsing the rollback of a pessimistic
+                        // lock is safe. After a pessimistic transaction acquires all its locks,
+                        // it is impossible that neither a lock nor a write record is found.
+                        // Therefore, we don't need to protect the rollback here.
+                        let write = Write::new_rollback(ts, false);
                         self.put_write(key, ts, write.to_bytes());
                         Ok(false)
                     }
                 };
             }
-        };
-        let write = Write::new(WriteType::Rollback, self.start_ts, None);
-        let ts = self.start_ts;
-        self.put_write(key.clone(), ts, write.to_bytes());
-        self.unlock_key(key.clone());
-        if self.collapse_rollback {
-            self.collapse_prev_rollback(key)?;
         }
-        Ok(is_pessimistic_txn)
     }
 
     /// Delete any pessimistic lock with small for_update_ts belongs to this transaction.
@@ -579,7 +597,7 @@ impl<S: Snapshot> MvccTxn<S> {
 
     fn collapse_prev_rollback(&mut self, key: Key) -> Result<()> {
         if let Some((commit_ts, write)) = self.reader.seek_write(&key, self.start_ts)? {
-            if write.write_type == WriteType::Rollback {
+            if write.write_type == WriteType::Rollback && !write.is_protected() {
                 self.delete_write(key, commit_ts);
             }
         }
@@ -841,7 +859,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rollback_lock() {
+    fn test_rollback_lock_optimistic() {
         let engine = TestEngineBuilder::new().build().unwrap();
 
         let (k, v) = (b"k1", b"v1");
@@ -854,6 +872,35 @@ mod tests {
 
         // Rollback lock
         must_rollback(&engine, k, 15);
+        // Rollbacks of optimistic transactions needn't be protected
+        must_get_rollback_protected(&engine, k, 15, false);
+    }
+
+    #[test]
+    fn test_rollback_lock_pessimistic() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+
+        let (k1, k2, v) = (b"k1", b"k2", b"v1");
+
+        must_acquire_pessimistic_lock(&engine, k1, k1, 5, 5);
+        must_acquire_pessimistic_lock(&engine, k2, k1, 5, 7);
+        must_rollback(&engine, k1, 5);
+        must_rollback(&engine, k2, 5);
+        // The rollback of the primary key should be protected
+        must_get_rollback_protected(&engine, k1, 5, true);
+        // The rollback of the secondary key needn't be protected
+        must_get_rollback_protected(&engine, k2, 5, false);
+
+        must_acquire_pessimistic_lock(&engine, k1, k1, 15, 15);
+        must_acquire_pessimistic_lock(&engine, k2, k1, 15, 17);
+        must_pessimistic_prewrite_put(&engine, k1, v, k1, 15, 17, true);
+        must_pessimistic_prewrite_put(&engine, k2, v, k1, 15, 17, true);
+        must_rollback(&engine, k1, 15);
+        must_rollback(&engine, k2, 15);
+        // The rollback of the primary key should be protected
+        must_get_rollback_protected(&engine, k1, 15, true);
+        // The rollback of the secondary key needn't be protected
+        must_get_rollback_protected(&engine, k2, 15, false);
     }
 
     #[test]
@@ -895,12 +942,27 @@ mod tests {
 
         // Try to cleanup another transaction's lock. Does nothing.
         must_cleanup(&engine, k, ts(10, 1), ts(120, 0));
+        // If there is no exisiting lock when cleanup, it cannot be a pessimistic transaction,
+        // so the rollback needn't be protected.
+        must_get_rollback_protected(&engine, k, ts(10, 1), false);
         must_locked(&engine, k, ts(10, 0));
 
         // TTL expired. The lock should be removed.
         must_cleanup(&engine, k, ts(10, 0), ts(120, 0));
         must_unlocked(&engine, k);
+        // Rollbacks of optimistic transactions needn't be protected
+        must_get_rollback_protected(&engine, k, ts(10, 0), false);
         must_get_rollback_ts(&engine, k, ts(10, 0));
+
+        // Rollbacks of primary keys in pessimistic transactions should be protected
+        must_acquire_pessimistic_lock(&engine, k, k, ts(11, 1), ts(12, 1));
+        must_cleanup(&engine, k, ts(11, 1), ts(120, 0));
+        must_get_rollback_protected(&engine, k, ts(11, 1), true);
+
+        must_acquire_pessimistic_lock(&engine, k, k, ts(13, 1), ts(14, 1));
+        must_pessimistic_prewrite_put(&engine, k, v, k, ts(13, 1), ts(14, 1), true);
+        must_cleanup(&engine, k, ts(13, 1), ts(120, 0));
+        must_get_rollback_protected(&engine, k, ts(13, 1), true);
     }
 
     #[test]
@@ -1380,12 +1442,12 @@ mod tests {
         // Lock conflict
         must_prewrite_put(&engine, k, v, k, 3);
         must_acquire_pessimistic_lock_err(&engine, k, k, 4, 4);
-        must_rollback(&engine, k, 3);
+        must_cleanup(&engine, k, 3, 0);
         must_unlocked(&engine, k);
         must_acquire_pessimistic_lock(&engine, k, k, 5, 5);
         must_prewrite_lock_err(&engine, k, k, 6);
         must_acquire_pessimistic_lock_err(&engine, k, k, 6, 6);
-        must_rollback(&engine, k, 5);
+        must_cleanup(&engine, k, 5, 0);
         must_unlocked(&engine, k);
 
         // Data conflict
@@ -1402,7 +1464,7 @@ mod tests {
         // Rollback
         must_acquire_pessimistic_lock(&engine, k, k, 11, 11);
         must_pessimistic_locked(&engine, k, 11, 11);
-        must_rollback(&engine, k, 11);
+        must_cleanup(&engine, k, 11, 0);
         must_acquire_pessimistic_lock_err(&engine, k, k, 11, 11);
         must_pessimistic_prewrite_put_err(&engine, k, v, k, 11, 11, true);
         must_prewrite_lock_err(&engine, k, k, 11);
@@ -1411,7 +1473,7 @@ mod tests {
         must_acquire_pessimistic_lock(&engine, k, k, 12, 12);
         must_pessimistic_prewrite_put(&engine, k, v, k, 12, 12, true);
         must_locked(&engine, k, 12);
-        must_rollback(&engine, k, 12);
+        must_cleanup(&engine, k, 12, 0);
         must_acquire_pessimistic_lock_err(&engine, k, k, 12, 12);
         must_pessimistic_prewrite_put_err(&engine, k, v, k, 12, 12, true);
         must_prewrite_lock_err(&engine, k, k, 12);
@@ -1452,11 +1514,120 @@ mod tests {
         must_prewrite_put(&engine, k, v, k, 23);
         must_locked(&engine, k, 23);
         must_acquire_pessimistic_lock_err(&engine, k, k, 23, 23);
-        must_rollback(&engine, k, 23);
+        must_cleanup(&engine, k, 23, 0);
         must_acquire_pessimistic_lock(&engine, k, k, 24, 24);
         must_pessimistic_locked(&engine, k, 24, 24);
         must_commit_err(&engine, k, 24, 25);
         must_rollback(&engine, k, 24);
+
+        // Acquire lock on a prewritten key should fail.
+        must_acquire_pessimistic_lock(&engine, k, k, 26, 26);
+        must_pessimistic_locked(&engine, k, 26, 26);
+        must_pessimistic_prewrite_delete(&engine, k, k, 26, 26, true);
+        must_locked(&engine, k, 26);
+        must_acquire_pessimistic_lock_err(&engine, k, k, 26, 26);
+        must_locked(&engine, k, 26);
+
+        // Acquire lock on a committed key should fail.
+        must_commit(&engine, k, 26, 27);
+        must_unlocked(&engine, k);
+        must_get_none(&engine, k, 28);
+        must_acquire_pessimistic_lock_err(&engine, k, k, 26, 26);
+        must_unlocked(&engine, k);
+        must_get_none(&engine, k, 28);
+        // Pessimistic prewrite on a committed key should fail.
+        must_pessimistic_prewrite_put_err(&engine, k, v, k, 26, 26, true);
+        must_unlocked(&engine, k);
+        must_get_none(&engine, k, 28);
+        // Currently we cannot avoid this.
+        must_acquire_pessimistic_lock(&engine, k, k, 26, 29);
+        must_pessimistic_rollback(&engine, k, 26, 29);
+        must_unlocked(&engine, k);
+
+        // Non pessimistic key in pessimistic transaction.
+        must_pessimistic_prewrite_put(&engine, k, v, k, 30, 30, false);
+        must_locked(&engine, k, 30);
+        must_commit(&engine, k, 30, 31);
+        must_unlocked(&engine, k);
+        must_get_commit_ts(&engine, k, 30, 31);
+
+        // Rollback collapsed.
+        must_rollback_collapsed(&engine, k, 32);
+        must_rollback_collapsed(&engine, k, 33);
+        must_acquire_pessimistic_lock_err(&engine, k, k, 32, 32);
+        // Currently we cannot avoid this.
+        must_acquire_pessimistic_lock(&engine, k, k, 32, 34);
+        must_pessimistic_rollback(&engine, k, 32, 34);
+        must_unlocked(&engine, k);
+
+        // Acquire lock when there is lock with different for_update_ts.
+        must_acquire_pessimistic_lock(&engine, k, k, 35, 36);
+        must_pessimistic_locked(&engine, k, 35, 36);
+        must_acquire_pessimistic_lock(&engine, k, k, 35, 35);
+        must_pessimistic_locked(&engine, k, 35, 36);
+        must_acquire_pessimistic_lock(&engine, k, k, 35, 37);
+        must_pessimistic_locked(&engine, k, 35, 37);
+
+        // Cannot prewrite when there is another transaction's pessimistic lock.
+        must_pessimistic_prewrite_put_err(&engine, k, v, k, 36, 36, true);
+        must_pessimistic_prewrite_put_err(&engine, k, v, k, 36, 38, true);
+        must_pessimistic_locked(&engine, k, 35, 37);
+        // Cannot prewrite when there is another transaction's non-pessimistic lock.
+        must_pessimistic_prewrite_put(&engine, k, v, k, 35, 37, true);
+        must_locked(&engine, k, 35);
+        must_pessimistic_prewrite_put_err(&engine, k, v, k, 36, 38, true);
+        must_locked(&engine, k, 35);
+
+        // Commit pessimistic transaction's key but with smaller commit_ts than for_update_ts.
+        // Currently not checked, so in this case it will actually be successfully committed.
+        must_commit(&engine, k, 35, 36);
+        must_unlocked(&engine, k);
+        must_get_commit_ts(&engine, k, 35, 36);
+
+        // Prewrite meets pessimistic lock on a non-pessimistic key.
+        // Currently not checked, so prewrite will success.
+        must_acquire_pessimistic_lock(&engine, k, k, 40, 40);
+        must_pessimistic_locked(&engine, k, 40, 40);
+        must_pessimistic_prewrite_put(&engine, k, v, k, 40, 40, false);
+        must_locked(&engine, k, 40);
+        must_commit(&engine, k, 40, 41);
+        must_unlocked(&engine, k);
+
+        // Prewrite with different for_update_ts.
+        // Currently not checked.
+        must_acquire_pessimistic_lock(&engine, k, k, 42, 45);
+        must_pessimistic_locked(&engine, k, 42, 45);
+        must_pessimistic_prewrite_put(&engine, k, v, k, 42, 43, true);
+        must_locked(&engine, k, 42);
+        must_commit(&engine, k, 42, 45);
+        must_unlocked(&engine, k);
+
+        must_acquire_pessimistic_lock(&engine, k, k, 46, 47);
+        must_pessimistic_locked(&engine, k, 46, 47);
+        must_pessimistic_prewrite_put(&engine, k, v, k, 46, 48, true);
+        must_locked(&engine, k, 46);
+        must_commit(&engine, k, 46, 49);
+        must_unlocked(&engine, k);
+
+        // Prewrite on non-pessimistic key meets write with larger commit_ts than current
+        // for_update_ts (non-pessimistic data conflict).
+        // Normally non-pessimistic keys in pessimistic transactions are used when we are sure that
+        // there won't be conflicts. So this case is also not checked, and prewrite will succeeed.
+        must_pessimistic_prewrite_put(&engine, k, v, k, 47, 48, false);
+        must_locked(&engine, k, 47);
+        must_cleanup(&engine, k, 47, 0);
+        must_unlocked(&engine, k);
+
+        // The rollback of the primary key in a pessimistic transaction should be protected from
+        // being collapsed.
+        must_acquire_pessimistic_lock(&engine, k, k, 49, 60);
+        must_pessimistic_prewrite_put(&engine, k, v, k, 49, 60, true);
+        must_locked(&engine, k, 49);
+        must_cleanup(&engine, k, 49, 0);
+        must_get_rollback_protected(&engine, k, 49, true);
+        must_prewrite_put(&engine, k, v, k, 51);
+        must_rollback_collapsed(&engine, k, 51);
+        must_acquire_pessimistic_lock_err(&engine, k, k, 49, 60);
 
         // start_ts and commit_ts interlacing
         for start_ts in &[40, 50, 60] {

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -20,6 +20,9 @@ const FLAG_DELETE: u8 = b'D';
 const FLAG_LOCK: u8 = b'L';
 const FLAG_ROLLBACK: u8 = b'R';
 
+/// The short value for rollback records which are protected from being collapsed.
+const PROTECTED_ROLLBACK_SHORT_VALUE: &[u8] = b"p";
+
 impl WriteType {
     pub fn from_lock_type(tp: LockType) -> Option<WriteType> {
         match tp {
@@ -75,9 +78,24 @@ impl std::fmt::Debug for Write {
 }
 
 impl Write {
+    /// Creates a new `Write` record.
     pub fn new(write_type: WriteType, start_ts: u64, short_value: Option<Value>) -> Write {
         Write {
             write_type,
+            start_ts,
+            short_value,
+        }
+    }
+
+    pub fn new_rollback(start_ts: u64, protected: bool) -> Write {
+        let short_value = if protected {
+            Some(PROTECTED_ROLLBACK_SHORT_VALUE.to_vec())
+        } else {
+            None
+        };
+
+        Write {
+            write_type: WriteType::Rollback,
             start_ts,
             short_value,
         }
@@ -126,6 +144,15 @@ impl Write {
     pub fn parse_type(mut b: &[u8]) -> Result<WriteType> {
         WriteType::from_u8(b.read_u8()?).ok_or(Error::BadFormatWrite)
     }
+
+    pub fn is_protected(&self) -> bool {
+        self.write_type == WriteType::Rollback
+            && self
+                .short_value
+                .as_ref()
+                .map(|v| *v == PROTECTED_ROLLBACK_SHORT_VALUE)
+                .unwrap_or_default()
+    }
 }
 
 #[cfg(test)]
@@ -169,8 +196,10 @@ mod tests {
     fn test_write() {
         // Test `Write::to_bytes()` and `Write::parse()` works as a pair.
         let mut writes = vec![
-            Write::new(WriteType::Put, 0, None),
-            Write::new(WriteType::Delete, 0, Some(b"short_value".to_vec())),
+            Write::new(WriteType::Put, 0, Some(b"short_value".to_vec())),
+            Write::new(WriteType::Delete, 1 << 20, None),
+            Write::new_rollback(1 << 40, true),
+            Write::new(WriteType::Rollback, 1 << 41, None),
         ];
         for (i, write) in writes.drain(..).enumerate() {
             let v = write.to_bytes();
@@ -186,5 +215,17 @@ mod tests {
         let v = lock.to_bytes();
         assert!(Write::parse(&v[..1]).is_err());
         assert_eq!(Write::parse_type(&v).unwrap(), lock.write_type);
+    }
+
+    #[test]
+    fn test_is_protected() {
+        assert!(Write::new_rollback(1, true).is_protected());
+        assert!(!Write::new_rollback(2, false).is_protected());
+        assert!(!Write::new(
+            WriteType::Put,
+            3,
+            Some(PROTECTED_ROLLBACK_SHORT_VALUE.to_vec())
+        )
+        .is_protected());
     }
 }


### PR DESCRIPTION
###  What have you changed?

Cherry picks #5309, #5575 

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

Should be mentioned in release notes.

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

