### PR TITLE
txn: protect primary locks of pessimistic transactions from being collapsed

### DIFF
--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -755,6 +755,24 @@ pub mod tests {
         assert_eq!(ret, None);
     }
 
+    pub fn must_get_rollback_protected<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: u64,
+        protected: bool,
+    ) {
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, None, None, IsolationLevel::SI);
+
+        let (ts, write) = reader
+            .seek_write(&Key::from_raw(key), start_ts)
+            .unwrap()
+            .unwrap();
+        assert_eq!(ts, start_ts);
+        assert_eq!(write.write_type, WriteType::Rollback);
+        assert_eq!(write.is_protected(), protected);
+    }
+
     pub fn must_scan_keys<E: Engine>(
         engine: &E,
         start: Option<&[u8]>,

--- a/src/storage/mvcc/write.rs
+++ b/src/storage/mvcc/write.rs
@@ -20,6 +20,9 @@ const FLAG_DELETE: u8 = b'D';
 const FLAG_LOCK: u8 = b'L';
 const FLAG_ROLLBACK: u8 = b'R';
 
+/// The short value for rollback records which are protected from being collapsed.
+const PROTECTED_ROLLBACK_SHORT_VALUE: &[u8] = b"p";
+
 impl WriteType {
     pub fn from_lock_type(tp: LockType) -> Option<WriteType> {
         match tp {
@@ -75,9 +78,24 @@ impl std::fmt::Debug for Write {
 }
 
 impl Write {
+    /// Creates a new `Write` record.
     pub fn new(write_type: WriteType, start_ts: u64, short_value: Option<Value>) -> Write {
         Write {
             write_type,
+            start_ts,
+            short_value,
+        }
+    }
+
+    pub fn new_rollback(start_ts: u64, protected: bool) -> Write {
+        let short_value = if protected {
+            Some(PROTECTED_ROLLBACK_SHORT_VALUE.to_vec())
+        } else {
+            None
+        };
+
+        Write {
+            write_type: WriteType::Rollback,
             start_ts,
             short_value,
         }
@@ -126,6 +144,15 @@ impl Write {
     pub fn parse_type(mut b: &[u8]) -> Result<WriteType> {
         WriteType::from_u8(b.read_u8()?).ok_or(Error::BadFormatWrite)
     }
+
+    pub fn is_protected(&self) -> bool {
+        self.write_type == WriteType::Rollback
+            && self
+                .short_value
+                .as_ref()
+                .map(|v| *v == PROTECTED_ROLLBACK_SHORT_VALUE)
+                .unwrap_or_default()
+    }
 }
 
 #[cfg(test)]
@@ -169,8 +196,10 @@ mod tests {
     fn test_write() {
         // Test `Write::to_bytes()` and `Write::parse()` works as a pair.
         let mut writes = vec![
-            Write::new(WriteType::Put, 0, None),
-            Write::new(WriteType::Delete, 0, Some(b"short_value".to_vec())),
+            Write::new(WriteType::Put, 0, Some(b"short_value".to_vec())),
+            Write::new(WriteType::Delete, 1 << 20, None),
+            Write::new_rollback(1 << 40, true),
+            Write::new(WriteType::Rollback, 1 << 41, None),
         ];
         for (i, write) in writes.drain(..).enumerate() {
             let v = write.to_bytes();
@@ -186,5 +215,17 @@ mod tests {
         let v = lock.to_bytes();
         assert!(Write::parse(&v[..1]).is_err());
         assert_eq!(Write::parse_type(&v).unwrap(), lock.write_type);
+    }
+
+    #[test]
+    fn test_is_protected() {
+        assert!(Write::new_rollback(1, true).is_protected());
+        assert!(!Write::new_rollback(2, false).is_protected());
+        assert!(!Write::new(
+            WriteType::Put,
+            3,
+            Some(PROTECTED_ROLLBACK_SHORT_VALUE.to_vec())
+        )
+        .is_protected());
     }
 }


### PR DESCRIPTION
###  What have you changed?

Cherry picks #5309, #5575 

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

