### PR TITLE
backup: format file name with table_id

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -17,6 +17,7 @@ use kvproto::backup::*;
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 use kvproto::metapb::*;
 use raft::StateRole;
+use tikv::coprocessor::codec::table::decode_table_id;
 use tikv::raftstore::store::util::find_peer;
 use tikv::storage::kv::{Engine, RegionInfoProvider};
 use tikv::storage::txn::{EntryBatch, SnapshotStore, TxnEntryScanner, TxnEntryStore};
@@ -216,6 +217,7 @@ impl<R: RegionInfoProvider> Progress<R> {
             .next_start
             .clone()
             .map_or_else(Vec::new, |k| k.into_encoded());
+
         let start_key = self.next_start.clone();
         let end_key = self.end_key.clone();
         let res = self.region_info.seek_region(
@@ -373,7 +375,11 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
                     warn!("backup task has canceled"; "range" => ?brange);
                     return Ok(());
                 }
-                let name = backup_file_name(store_id, &brange.region);
+                let table_id = brange
+                    .start_key
+                    .clone()
+                    .and_then(|k| decode_table_id(&k.into_raw().unwrap()).ok());
+                let name = backup_file_name(store_id, &brange.region, table_id);
                 let mut writer = match BackupWriter::new(db.clone(), &name, storage.limiter.clone())
                 {
                     Ok(w) => w,
@@ -555,13 +561,22 @@ fn get_max_start_key(start_key: Option<&Key>, region: &Region) -> Option<Key> {
 
 /// Construct an backup file name based on the given store id and region.
 /// A name consists with three parts: store id, region_id and a epoch version.
-fn backup_file_name(store_id: u64, region: &Region) -> String {
-    format!(
-        "{}_{}_{}",
-        store_id,
-        region.get_id(),
-        region.get_region_epoch().get_version()
-    )
+fn backup_file_name(store_id: u64, region: &Region, table_id: Option<i64>) -> String {
+    match table_id {
+        Some(t_id) => format!(
+            "{}_{}_{}_{}",
+            store_id,
+            region.get_id(),
+            region.get_region_epoch().get_version(),
+            t_id
+        ),
+        None => format!(
+            "{}_{}_{}",
+            store_id,
+            region.get_id(),
+            region.get_region_epoch().get_version()
+        ),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
cherry-pick this [PR](https://github.com/tikv/tikv/pull/5660) to release-3.1
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
Change backup_file format from `storeID_regionID_regionVersion` to `storeID_regionID_regionVersion_tableID`,  because one region may contain several tables, when we backup tables one by one, former format could cause `FileAlreadyExists` exception.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix (a change which fixes an issue)

###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

no

###  Does this PR affect `tidb-ansible`?

no

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

