### PR TITLE
build: Support building TiKV with specified Titan 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#123e9edf2a447425dcc0942a83bbe4ae411963b3"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#4a8748c5f8dee2192236d21d2ad6394034b9b44d"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -1409,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#123e9edf2a447425dcc0942a83bbe4ae411963b3"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#4a8748c5f8dee2192236d21d2ad6394034b9b44d"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -2395,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#123e9edf2a447425dcc0942a83bbe4ae411963b3"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#4a8748c5f8dee2192236d21d2ad6394034b9b44d"
 dependencies = [
  "crc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sse = ["engine/sse"]
 mem-profiling = ["tikv_alloc/mem-profiling"]
 profiling = ["profiler/profiling"]
 failpoints = ["fail/failpoints"]
-update_titan = ["engine/update_titan"]
+update_titan = ["engine/update_titan", "engine_rocks/update_titan"]
 
 [lib]
 name = "tikv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ sse = ["engine/sse"]
 mem-profiling = ["tikv_alloc/mem-profiling"]
 profiling = ["profiler/profiling"]
 failpoints = ["fail/failpoints"]
+update_titan = ["engine/update_titan"]
 
 [lib]
 name = "tikv"

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ ifneq ($(ROCKSDB_SYS_SSE),0)
 ENABLE_FEATURES += sse
 endif
 
+# Update Titan to latest master before build
+ifneq ($(UPDATE_TITAN), 0)
+ENABLE_FEATURES += update_titan
+endif
+
 ifeq ($(FAIL_POINT),1)
 ENABLE_FEATURES += failpoints
 endif
@@ -135,6 +140,9 @@ prof_release:
 fail_release:
 	FAIL_POINT=1 make release
 
+# Build with latest Titan. Mainly used for test bot.
+titan_release:
+	UPDATE_TITAN=1 make release
 
 ## Distribution builds (true release builds)
 ## -------------------

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,6 @@ fail_release:
 # You can use environment variables `TITAN_REPO` and `TITAN_BRANCH` to update to specify Titan codeabse
 # -- https://github.com/{TITAN_REPO}/titan/tree/{TITAN_BRANCH}.
 # Default: TITAN_REPO=pingcap, TITAN_BRANCH=master
-
 titan_release:
 	UPDATE_TITAN=1 make release
 

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ fail_release:
 	FAIL_POINT=1 make release
 
 # Build with latest Titan. Mainly used for test bot.
-# You can use environment variables `TITAN_REPO` and `TITAN_BRANCH` to update to specify Titan codeabse
+# You can use environment variables `TITAN_REPO` and `TITAN_BRANCH` to update to specified Titan codeabse
 # -- https://github.com/{TITAN_REPO}/titan/tree/{TITAN_BRANCH}.
 # Default: TITAN_REPO=pingcap, TITAN_BRANCH=master
 titan_release:

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,10 @@ fail_release:
 	FAIL_POINT=1 make release
 
 # Build with latest Titan. Mainly used for test bot.
+# You can use environment variables `TITAN_REPO` and `TITAN_BRANCH` to update to specify Titan codeabse
+# -- https://github.com/{TITAN_REPO}/titan/tree/{TITAN_BRANCH}.
+# Default: TITAN_REPO=pingcap, TITAN_BRANCH=master
+
 titan_release:
 	UPDATE_TITAN=1 make release
 

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 jemalloc = ["rocksdb/jemalloc"]
 portable = ["rocksdb/portable"]
 sse = ["rocksdb/sse"]
+update_titan = ["rocksdb/update_titan"]
 
 [dependencies]
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 jemalloc = ["rocksdb/jemalloc"]
 portable = ["rocksdb/portable"]
 sse = ["rocksdb/sse"]
+update_titan = ["rocksdb/update_titan"]
 
 [dependencies]
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }


### PR DESCRIPTION
###  What have you changed?
Add `make titan_release` to support building TiKV with specified Titan.
environment variable `TITAN_REPO` and `TITAN_BRANCH` specify the codebase --`https://github.com/{TITAN_REPO}/titan/tree/{TITAN_BRANCH}` to build Titan.

Should merge https://github.com/pingcap/rust-rocksdb/pull/359 first
###  What is the type of the changes?
- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
- Manual test (add detailed scripts or steps below)
run `TITAN_REPO=Connor1996 TITAN_BRANCH=delete-files make titan_release` with very verbose output
, and it shows the enviorment variables are correctly passed to `rust-rocksdb` build progress
```
[libtitan_sys 0.0.1] if [ -n "Connor1996" ]; then \
[libtitan_sys 0.0.1]    git config --file=.gitmodules submodule.titan.url https://github.com/Connor1996/titan.git; \
[libtitan_sys 0.0.1] fi
[libtitan_sys 0.0.1] if [ -n "delete-files" ]; then \
[libtitan_sys 0.0.1]    git config --file=.gitmodules submodule.titan.branch delete-files; \
[libtitan_sys 0.0.1] fi
[libtitan_sys 0.0.1] Synchronizing submodule url for 'librocksdb_sys/libtitan_sys/titan'
[libtitan_sys 0.0.1] Synchronizing submodule url for 'librocksdb_sys/rocksdb'
```

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No

###  Does this PR affect `tidb-ansible`?
No

