### PR TITLE
Cherry-pick check titandb directory when titan is disabled

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -532,7 +532,13 @@ fn check_system_config(config: &TiKvConfig) {
             config.rocksdb.titan.dirname.as_str()
         };
         if let Err(e) = tikv_util::config::check_data_dir_empty(titan_dir, ".blob") {
-            fatal!("check: titandb-data-dir-empty; err: {}", e);
+            fatal!(
+                "check: titandb-data-dir-empty; err: {}; \
+                 hint: You have disabled titan when its data directory is not empty. \
+                 To properly shutdown titan, please enter fallback blob-run-mode and \
+                 wait till titandb files are all safely ingested.",
+                e
+            );
         }
     }
     // Check raft data dir

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -526,14 +526,18 @@ fn check_system_config(config: &TiKvConfig) {
     }
     // Check blob file dir is empty when titan is disabled
     if !config.rocksdb.titan.enabled {
-        let titan_dir = if config.rocksdb.titan.dirname.is_empty() {
-            "titandb"
+        let titan_path = if config.rocksdb.titan.dirname.is_empty() {
+            let store_path = Path::new(&config.storage.data_dir);
+            let db_path = store_path.join(Path::new(DEFAULT_ROCKSDB_SUB_DIR));
+            db_path.join(Path::new("titandb"))
         } else {
-            config.rocksdb.titan.dirname.as_str()
+            Path::new(&config.rocksdb.titan.dirname).to_path_buf()
         };
-        if let Err(e) = tikv_util::config::check_data_dir_empty(titan_dir, ".blob") {
+        if let Err(e) =
+            tikv_util::config::check_data_dir_empty(titan_path.to_str().unwrap(), "blob")
+        {
             fatal!(
-                "check: titandb-data-dir-empty; err: {}; \
+                "check: titandb-data-dir-empty; err: \"{}\"; \
                  hint: You have disabled titan when its data directory is not empty. \
                  To properly shutdown titan, please enter fallback blob-run-mode and \
                  wait till titandb files are all safely ingested.",

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -531,12 +531,8 @@ fn check_system_config(config: &TiKvConfig) {
         } else {
             config.rocksdb.titan.dirname.as_str()
         };
-        if let Err(e) = tikv_util::config::check_data_dir_empty(titan_dir) {
-            warn!(
-                "check: titandb-data-dir";
-                "path" => titan_dir,
-                "err" => %e
-            );
+        if let Err(e) = tikv_util::config::check_data_dir_empty(titan_dir, "blob") {
+            fatal!("check: titandb-data-dir-empty; err: {}", e);
         }
     }
     // Check raft data dir

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -524,6 +524,21 @@ fn check_system_config(config: &TiKvConfig) {
             "err" => %e
         );
     }
+    // Check blob file dir is empty when titan is disabled
+    if !config.rocksdb.titan.enabled {
+        let titan_dir = if config.rocksdb.titan.dirname.is_empty() {
+            "titandb"
+        } else {
+            config.rocksdb.titan.dirname.as_str()
+        };
+        if let Err(e) = tikv_util::config::check_data_dir_empty(titan_dir) {
+            warn!(
+                "check: titandb-data-dir";
+                "path" => titan_dir,
+                "err" => %e
+            );
+        }
+    }
     // Check raft data dir
     if let Err(e) = tikv_util::config::check_data_dir(&config.raft_store.raftdb_path) {
         warn!(

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -531,7 +531,7 @@ fn check_system_config(config: &TiKvConfig) {
         } else {
             config.rocksdb.titan.dirname.as_str()
         };
-        if let Err(e) = tikv_util::config::check_data_dir_empty(titan_dir, "blob") {
+        if let Err(e) = tikv_util::config::check_data_dir_empty(titan_dir, ".blob") {
             fatal!("check: titandb-data-dir-empty; err: {}", e);
         }
     }

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -524,27 +524,6 @@ fn check_system_config(config: &TiKvConfig) {
             "err" => %e
         );
     }
-    // Check blob file dir is empty when titan is disabled
-    if !config.rocksdb.titan.enabled {
-        let titan_path = if config.rocksdb.titan.dirname.is_empty() {
-            let store_path = Path::new(&config.storage.data_dir);
-            let db_path = store_path.join(Path::new(DEFAULT_ROCKSDB_SUB_DIR));
-            db_path.join(Path::new("titandb"))
-        } else {
-            Path::new(&config.rocksdb.titan.dirname).to_path_buf()
-        };
-        if let Err(e) =
-            tikv_util::config::check_data_dir_empty(titan_path.to_str().unwrap(), "blob")
-        {
-            fatal!(
-                "check: titandb-data-dir-empty; err: \"{}\"; \
-                 hint: You have disabled titan when its data directory is not empty. \
-                 To properly shutdown titan, please enter fallback blob-run-mode and \
-                 wait till titandb files are all safely ingested.",
-                e
-            );
-        }
-    }
     // Check raft data dir
     if let Err(e) = tikv_util::config::check_data_dir(&config.raft_store.raftdb_path) {
         warn!(

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -127,7 +127,7 @@ impl<T: Simulator> Cluster<T> {
         self.cfg.server.cluster_id
     }
 
-    pub fn pre_start(&mut self) -> result::Result<(), Box<dyn StdError>> {
+    pub fn pre_start_check(&mut self) -> result::Result<(), Box<dyn StdError>> {
         self.cfg.validate()
     }
 
@@ -183,7 +183,7 @@ impl<T: Simulator> Cluster<T> {
     // Bootstrap the store with fixed ID (like 1, 2, .. 5) and
     // initialize first region in all stores, then start the cluster.
     pub fn run(&mut self) {
-        self.pre_start().unwrap();
+        self.pre_start_check().unwrap();
         self.create_engines();
         self.bootstrap_region().unwrap();
         self.start().unwrap();
@@ -192,7 +192,7 @@ impl<T: Simulator> Cluster<T> {
     // Bootstrap the store with fixed ID (like 1, 2, .. 5) and
     // initialize first region in store 1, then start the cluster.
     pub fn run_conf_change(&mut self) -> u64 {
-        self.pre_start().unwrap();
+        self.pre_start_check().unwrap();
         self.create_engines();
         let region_id = self.bootstrap_conf_change();
         self.start().unwrap();

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -24,6 +24,7 @@ use tikv::raftstore::store::fsm::{create_raft_batch_system, RaftBatchSystem, Raf
 use tikv::raftstore::store::*;
 use tikv::raftstore::{Error, Result};
 use tikv::server::Result as ServerResult;
+use tikv::storage::DEFAULT_ROCKSDB_SUB_DIR;
 use tikv_util::collections::{HashMap, HashSet};
 use tikv_util::HandyRwLock;
 
@@ -128,13 +129,17 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn pre_start_check(&mut self) -> result::Result<(), Box<dyn StdError>> {
-        self.cfg.validate()
+        for path in &self.paths {
+            self.cfg.storage.data_dir = path.path().to_str().unwrap().to_owned();
+            self.cfg.validate()?
+        }
+        Ok(())
     }
 
     pub fn create_engines(&mut self) {
         for _ in 0..self.count {
             let dir = TempDir::new("test_cluster").unwrap();
-            let kv_path = dir.path().join("kv");
+            let kv_path = dir.path().join(DEFAULT_ROCKSDB_SUB_DIR);
             let cache = self.cfg.storage.block_cache.build_shared_cache();
             let kv_db_opt = self.cfg.rocksdb.build_opt();
             let kv_cfs_opt = self.cfg.rocksdb.build_cf_opts(&cache);

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -183,7 +183,6 @@ impl<T: Simulator> Cluster<T> {
     // Bootstrap the store with fixed ID (like 1, 2, .. 5) and
     // initialize first region in all stores, then start the cluster.
     pub fn run(&mut self) {
-        self.pre_start_check().unwrap();
         self.create_engines();
         self.bootstrap_region().unwrap();
         self.start().unwrap();
@@ -192,7 +191,6 @@ impl<T: Simulator> Cluster<T> {
     // Bootstrap the store with fixed ID (like 1, 2, .. 5) and
     // initialize first region in store 1, then start the cluster.
     pub fn run_conf_change(&mut self) -> u64 {
-        self.pre_start_check().unwrap();
         self.create_engines();
         let region_id = self.bootstrap_conf_change();
         self.start().unwrap();

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -169,6 +169,34 @@ impl<T: Simulator> Cluster<T> {
         Ok(())
     }
 
+    // start new engines on same directory as before.
+    pub fn start_new_engines(&mut self) -> ServerResult<()> {
+        // first clear engines.
+        self.engines.clear();
+        self.dbs.clear();
+
+        // reuse data path to start new nodes.
+        let mut sim = self.sim.wl();
+        for i in 0..self.paths.len() {
+            let (router, system) = create_raft_batch_system(&self.cfg.raft_store);
+            let engines =
+                create_test_engine_on_dir(None, router.clone(), &self.cfg, &self.paths[i]);
+            self.dbs.push(engines.clone());
+            let node_id = sim.run_node(0, self.cfg.clone(), engines.clone(), router, system)?;
+            self.engines.insert(node_id, engines);
+        }
+        // fallback to start new nodes if dir is not enough.
+        for _ in 0..self.count - self.paths.len() {
+            let (router, system) = create_raft_batch_system(&self.cfg.raft_store);
+            let (engines, path) = create_test_engine(None, router.clone(), &self.cfg);
+            self.dbs.push(engines.clone());
+            self.paths.push(path.unwrap());
+            let node_id = sim.run_node(0, self.cfg.clone(), engines.clone(), router, system)?;
+            self.engines.insert(node_id, engines);
+        }
+        Ok(())
+    }
+
     pub fn compact_data(&self) {
         for engine in self.engines.values() {
             let handle = rocks::util::get_cf_handle(&engine.kv, "default").unwrap();
@@ -195,6 +223,20 @@ impl<T: Simulator> Cluster<T> {
 
     pub fn get_node_ids(&self) -> HashSet<u64> {
         self.sim.rl().get_node_ids()
+    }
+
+    pub fn get_kv_paths(&self) -> Vec<String> {
+        self.paths
+            .iter()
+            .map(|dir| dir.path().join("kv").to_str().unwrap().to_owned())
+            .collect()
+    }
+
+    pub fn get_raft_paths(&self) -> Vec<String> {
+        self.paths
+            .iter()
+            .map(|dir| dir.path().join("raft").to_str().unwrap().to_owned())
+            .collect()
     }
 
     pub fn run_node(&mut self, node_id: u64) -> ServerResult<()> {

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1,6 +1,5 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::path::Path;
 use std::sync::{self, Arc, RwLock};
 use std::time::*;
 use std::{result, thread};
@@ -138,7 +137,7 @@ impl<T: Simulator> Cluster<T> {
                 rocks::util::new_engine_opt(kv_path.to_str().unwrap(), kv_db_opt, kv_cfs_opt)
                     .unwrap(),
             );
-            let raft_path = dir.path().join(Path::new("raft"));
+            let raft_path = dir.path().join("raft");
             let raft_engine = Arc::new(
                 rocks::util::new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None)
                     .unwrap(),
@@ -223,6 +222,13 @@ impl<T: Simulator> Cluster<T> {
 
     pub fn get_node_ids(&self) -> HashSet<u64> {
         self.sim.rl().get_node_ids()
+    }
+
+    pub fn get_paths(&self) -> Vec<String> {
+        self.paths
+            .iter()
+            .map(|dir| dir.path().to_str().unwrap().to_owned())
+            .collect()
     }
 
     pub fn get_kv_paths(&self) -> Vec<String> {

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1,5 +1,6 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::error::Error as StdError;
 use std::sync::{self, Arc, RwLock};
 use std::time::*;
 use std::{result, thread};
@@ -126,6 +127,10 @@ impl<T: Simulator> Cluster<T> {
         self.cfg.server.cluster_id
     }
 
+    pub fn pre_start(&mut self) -> result::Result<(), Box<dyn StdError>> {
+        self.cfg.validate()
+    }
+
     pub fn create_engines(&mut self) {
         for _ in 0..self.count {
             let dir = TempDir::new("test_cluster").unwrap();
@@ -178,6 +183,7 @@ impl<T: Simulator> Cluster<T> {
     // Bootstrap the store with fixed ID (like 1, 2, .. 5) and
     // initialize first region in all stores, then start the cluster.
     pub fn run(&mut self) {
+        self.pre_start().unwrap();
         self.create_engines();
         self.bootstrap_region().unwrap();
         self.start().unwrap();
@@ -186,6 +192,7 @@ impl<T: Simulator> Cluster<T> {
     // Bootstrap the store with fixed ID (like 1, 2, .. 5) and
     // initialize first region in store 1, then start the cluster.
     pub fn run_conf_change(&mut self) -> u64 {
+        self.pre_start().unwrap();
         self.create_engines();
         let region_id = self.bootstrap_conf_change();
         self.start().unwrap();
@@ -194,27 +201,6 @@ impl<T: Simulator> Cluster<T> {
 
     pub fn get_node_ids(&self) -> HashSet<u64> {
         self.sim.rl().get_node_ids()
-    }
-
-    pub fn get_paths(&self) -> Vec<String> {
-        self.paths
-            .iter()
-            .map(|dir| dir.path().to_str().unwrap().to_owned())
-            .collect()
-    }
-
-    pub fn get_kv_paths(&self) -> Vec<String> {
-        self.paths
-            .iter()
-            .map(|dir| dir.path().join("kv").to_str().unwrap().to_owned())
-            .collect()
-    }
-
-    pub fn get_raft_paths(&self) -> Vec<String> {
-        self.paths
-            .iter()
-            .map(|dir| dir.path().join("raft").to_str().unwrap().to_owned())
-            .collect()
     }
 
     pub fn run_node(&mut self, node_id: u64) -> ServerResult<()> {

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -24,7 +24,7 @@ use tikv::raftstore::store::*;
 use tikv::raftstore::Result;
 use tikv::server::Config as ServerConfig;
 use tikv::storage::kv::CompactionListener;
-use tikv::storage::Config as StorageConfig;
+use tikv::storage::{Config as StorageConfig, DEFAULT_ROCKSDB_SUB_DIR};
 use tikv_util::config::*;
 use tikv_util::escape;
 
@@ -520,7 +520,7 @@ pub fn create_test_engine(
             ));
             let cache = cfg.storage.block_cache.build_shared_cache();
             let kv_cfs_opt = cfg.rocksdb.build_cf_opts(&cache);
-            let kv_path = path.as_ref().unwrap().path().join("kv");
+            let kv_path = path.as_ref().unwrap().path().join(DEFAULT_ROCKSDB_SUB_DIR);
             let engine = Arc::new(
                 rocks::util::new_engine_opt(kv_path.to_str().unwrap(), kv_db_opt, kv_cfs_opt)
                     .unwrap(),
@@ -591,6 +591,8 @@ pub fn configure_for_enable_titan<T: Simulator>(
     min_blob_size: ReadableSize,
 ) {
     cluster.cfg.rocksdb.titan.enabled = true;
+    cluster.cfg.rocksdb.titan.purge_obsolete_files_period = ReadableDuration::millis(1);
+    cluster.cfg.rocksdb.titan.max_background_gc = 10;
     cluster.cfg.rocksdb.defaultcf.titan.min_blob_size = min_blob_size;
     cluster.cfg.rocksdb.defaultcf.titan.blob_run_mode = BlobRunMode::Normal;
 }

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -1,6 +1,5 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::path::Path;
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 use std::{thread, u64};
@@ -521,15 +520,12 @@ pub fn create_test_engine(
             ));
             let cache = cfg.storage.block_cache.build_shared_cache();
             let kv_cfs_opt = cfg.rocksdb.build_cf_opts(&cache);
+            let kv_path = path.as_ref().unwrap().path().join("kv");
             let engine = Arc::new(
-                rocks::util::new_engine_opt(
-                    path.as_ref().unwrap().path().to_str().unwrap(),
-                    kv_db_opt,
-                    kv_cfs_opt,
-                )
-                .unwrap(),
+                rocks::util::new_engine_opt(kv_path.to_str().unwrap(), kv_db_opt, kv_cfs_opt)
+                    .unwrap(),
             );
-            let raft_path = path.as_ref().unwrap().path().join(Path::new("raft"));
+            let raft_path = path.as_ref().unwrap().path().join("raft");
             let raft_engine = Arc::new(
                 rocks::util::new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None)
                     .unwrap(),

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -16,6 +16,7 @@ use kvproto::raft_cmdpb::{AdminRequest, RaftCmdRequest, RaftCmdResponse, Request
 use kvproto::raft_serverpb::{PeerState, RaftLocalState, RegionLocalState};
 use raft::eraftpb::ConfChangeType;
 
+use engine::rocks::util::config::BlobRunMode;
 use engine::rocks::{CompactionJobInfo, DB};
 use engine::*;
 use tikv::config::*;
@@ -587,6 +588,19 @@ pub fn configure_for_lease_read<T: Simulator>(
     cluster.cfg.raft_store.max_leader_missing_duration = ReadableDuration(election_timeout * 5);
 
     election_timeout
+}
+
+pub fn configure_for_enable_titan<T: Simulator>(
+    cluster: &mut Cluster<T>,
+    min_blob_size: ReadableSize,
+) {
+    cluster.cfg.rocksdb.titan.enabled = true;
+    cluster.cfg.rocksdb.defaultcf.titan.min_blob_size = min_blob_size;
+    cluster.cfg.rocksdb.defaultcf.titan.blob_run_mode = BlobRunMode::Normal;
+}
+
+pub fn configure_for_disable_titan<T: Simulator>(cluster: &mut Cluster<T>) {
+    cluster.cfg.rocksdb.titan.enabled = false;
 }
 
 /// Keep putting random kvs until specified size limit is reached.

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -591,10 +591,11 @@ pub fn configure_for_enable_titan<T: Simulator>(
     min_blob_size: ReadableSize,
 ) {
     cluster.cfg.rocksdb.titan.enabled = true;
-    cluster.cfg.rocksdb.titan.purge_obsolete_files_period = ReadableDuration::millis(1);
+    cluster.cfg.rocksdb.titan.purge_obsolete_files_period = ReadableDuration::secs(1);
     cluster.cfg.rocksdb.titan.max_background_gc = 10;
     cluster.cfg.rocksdb.defaultcf.titan.min_blob_size = min_blob_size;
     cluster.cfg.rocksdb.defaultcf.titan.blob_run_mode = BlobRunMode::Normal;
+    cluster.cfg.rocksdb.defaultcf.titan.min_gc_batch_size = ReadableSize::kb(0);
 }
 
 pub fn configure_for_disable_titan<T: Simulator>(cluster: &mut Cluster<T>) {

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -819,20 +819,20 @@ mod check_data_dir_empty {
                 .tempdir()
                 .unwrap()
                 .into_path();
-            let count = get_file_count(tmp_path.to_str().unwrap(), "txt").unwrap();
+            let count = get_file_count(tmp_path.to_str().unwrap(), ".txt").unwrap();
             assert_eq!(count, 0);
             let tmp_file = format!("{}", tmp_path.join("test-get-file-count.txt").display());
             create_file(&tmp_file, b"");
-            let count = get_file_count(tmp_path.to_str().unwrap(), "txt").unwrap();
+            let count = get_file_count(tmp_path.to_str().unwrap(), ".txt").unwrap();
             assert_eq!(count, 1);
-            let count = get_file_count(tmp_path.to_str().unwrap(), "txt1").unwrap();
+            let count = get_file_count(tmp_path.to_str().unwrap(), ".txt1").unwrap();
             assert_eq!(count, 0);
         }
 
         #[test]
         fn test_check_data_dir_empty() {
             // test invalid data_path
-            let ret = check_data_dir_empty("/sys/invalid", "txt");
+            let ret = check_data_dir_empty("/sys/invalid", ".txt");
             assert!(ret.is_err());
             // test empty data_path
             let tmp_path = Builder::new()
@@ -840,14 +840,14 @@ mod check_data_dir_empty {
                 .tempdir()
                 .unwrap()
                 .into_path();
-            let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "txt");
+            let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), ".txt");
             assert!(ret.is_ok());
             // test non-empty data_path
             let tmp_file = format!("{}", tmp_path.join("test-get-file-count.txt").display());
             create_file(&tmp_file, b"");
-            let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "txt");
+            let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), ".txt");
             assert!(ret.is_err());
-            let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "txt1");
+            let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), ".txt1");
             assert!(ret.is_ok());
         }
     }

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -773,7 +773,7 @@ fn get_file_count(data_path: &str, extension: &str) -> Result<usize, ConfigError
         let path = entry.path();
         if path.is_file() {
             if let Some(ext) = path.extension() {
-                if extension == ext {
+                if extension.is_empty() || extension == ext {
                     file_count += 1;
                 }
             } else if extension.is_empty() {
@@ -784,7 +784,7 @@ fn get_file_count(data_path: &str, extension: &str) -> Result<usize, ConfigError
     Ok(file_count)
 }
 
-// check dir is empty of file with certain extension
+// check dir is empty of file with certain extension, empty string for any extension.
 pub fn check_data_dir_empty(data_path: &str, extension: &str) -> Result<(), ConfigError> {
     let op = "data-dir.empty.check";
     let dir = Path::new(data_path);

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -1109,11 +1109,7 @@ mod tests {
 
     #[test]
     fn test_get_file_count() {
-        let tmp_path = Builder::new()
-            .prefix("test-get-file-count")
-            .tempdir()
-            .unwrap()
-            .into_path();
+        let tmp_path = TempDir::new("test-get-file-count").unwrap().into_path();
         let count = get_file_count(tmp_path.to_str().unwrap(), "txt").unwrap();
         assert_eq!(count, 0);
         let tmp_file = format!("{}", tmp_path.join("test-get-file-count.txt").display());
@@ -1132,15 +1128,16 @@ mod tests {
         let ret = check_data_dir_empty("/sys/invalid", "txt");
         assert!(ret.is_ok());
         // test empty data_path
-        let tmp_path = Builder::new()
-            .prefix("test-get-file-count")
-            .tempdir()
+        let tmp_path = TempDir::new("test-check-data-dir-empty")
             .unwrap()
             .into_path();
         let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "txt");
         assert!(ret.is_ok());
         // test non-empty data_path
-        let tmp_file = format!("{}", tmp_path.join("test-get-file-count.txt").display());
+        let tmp_file = format!(
+            "{}",
+            tmp_path.join("test-check-data-dir-empty.txt").display()
+        );
         create_file(&tmp_file, b"");
         let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "");
         assert!(ret.is_err());

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -787,7 +787,7 @@ mod check_data_dir_empty {
         Ok(file_count)
     }
 
-    // check dir is empty of file with certain suffix
+    // check dir is empty of file with certain extension
     pub fn check_data_dir_empty(data_path: &str, extension: &str) -> Result<(), ConfigError> {
         let op = "data-dir.empty.check";
         let dir = Path::new(data_path);

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -754,119 +754,52 @@ pub fn check_data_dir(_data_path: &str) -> Result<(), ConfigError> {
     Ok(())
 }
 
-mod check_data_dir_empty {
-    use std::fs;
-    use std::path::Path;
-
-    use super::ConfigError;
-
-    fn get_file_count(data_path: &str, extension: &str) -> Result<usize, ConfigError> {
-        let op = "data-dir.file-count.get";
-        let dir = fs::read_dir(data_path).map_err(|e| {
+fn get_file_count(data_path: &str, extension: &str) -> Result<usize, ConfigError> {
+    let op = "data-dir.file-count.get";
+    let dir = fs::read_dir(data_path).map_err(|e| {
+        ConfigError::FileSystem(format!(
+            "{}: read file dir {:?} failed: {:?}",
+            op, data_path, e
+        ))
+    })?;
+    let mut file_count = 0;
+    for entry in dir {
+        let entry = entry.map_err(|e| {
             ConfigError::FileSystem(format!(
-                "{}: read file dir {:?} failed: {:?}",
+                "{}: read file in file dir {:?} failed: {:?}",
                 op, data_path, e
             ))
         })?;
-        let mut file_count = 0;
-        for entry in dir {
-            let entry = entry.map_err(|e| {
-                ConfigError::FileSystem(format!(
-                    "{}: read file in file dir {:?} failed: {:?}",
-                    op, data_path, e
-                ))
-            })?;
-            let path = entry.path();
-            if path.is_file() {
-                if let Some(ext) = path.extension() {
-                    if extension == ext {
-                        file_count += 1;
-                    }
-                } else if extension.is_empty() {
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                if extension == ext {
                     file_count += 1;
                 }
+            } else if extension.is_empty() {
+                file_count += 1;
             }
         }
-        Ok(file_count)
     }
-
-    // check dir is empty of file with certain extension
-    pub fn check_data_dir_empty(data_path: &str, extension: &str) -> Result<(), ConfigError> {
-        let op = "data-dir.empty.check";
-        let dir = Path::new(data_path);
-        if dir.exists() && !dir.is_file() {
-            let count = get_file_count(data_path, extension)?;
-            if count > 0 {
-                return Err(ConfigError::Limit(format!(
-                    "{}: the number of file with extension {} in directory {} is non-zero, \
-                     got {}, expect 0.",
-                    op, extension, data_path, count,
-                )));
-            }
-        }
-        Ok(())
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use std::fs::File;
-        use std::io::Write;
-        use tempfile::Builder;
-
-        use super::*;
-
-        fn create_file(fpath: &str, buf: &[u8]) {
-            let mut file = File::create(fpath).unwrap();
-            file.write_all(buf).unwrap();
-            file.flush().unwrap();
-        }
-
-        #[test]
-        fn test_get_file_count() {
-            let tmp_path = Builder::new()
-                .prefix("test-get-file-count")
-                .tempdir()
-                .unwrap()
-                .into_path();
-            let count = get_file_count(tmp_path.to_str().unwrap(), "txt").unwrap();
-            assert_eq!(count, 0);
-            let tmp_file = format!("{}", tmp_path.join("test-get-file-count.txt").display());
-            create_file(&tmp_file, b"");
-            let count = get_file_count(tmp_path.to_str().unwrap(), "").unwrap();
-            assert_eq!(count, 1);
-            let count = get_file_count(tmp_path.to_str().unwrap(), "txt").unwrap();
-            assert_eq!(count, 1);
-            let count = get_file_count(tmp_path.to_str().unwrap(), "xt").unwrap();
-            assert_eq!(count, 0);
-        }
-
-        #[test]
-        fn test_check_data_dir_empty() {
-            // test invalid data_path
-            let ret = check_data_dir_empty("/sys/invalid", "txt");
-            assert!(ret.is_ok());
-            // test empty data_path
-            let tmp_path = Builder::new()
-                .prefix("test-get-file-count")
-                .tempdir()
-                .unwrap()
-                .into_path();
-            let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "txt");
-            assert!(ret.is_ok());
-            // test non-empty data_path
-            let tmp_file = format!("{}", tmp_path.join("test-get-file-count.txt").display());
-            create_file(&tmp_file, b"");
-            let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "");
-            assert!(ret.is_err());
-            let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "txt");
-            assert!(ret.is_err());
-            let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "xt");
-            assert!(ret.is_ok());
-        }
-    }
+    Ok(file_count)
 }
 
-pub use self::check_data_dir_empty::check_data_dir_empty;
+// check dir is empty of file with certain extension
+pub fn check_data_dir_empty(data_path: &str, extension: &str) -> Result<(), ConfigError> {
+    let op = "data-dir.empty.check";
+    let dir = Path::new(data_path);
+    if dir.exists() && !dir.is_file() {
+        let count = get_file_count(data_path, extension)?;
+        if count > 0 {
+            return Err(ConfigError::Limit(format!(
+                "{}: the number of file with extension {} in directory {} is non-zero, \
+                 got {}, expect 0.",
+                op, extension, data_path, count,
+            )));
+        }
+    }
+    Ok(())
+}
 
 /// `check_addr` validates an address. Addresses are formed like "Host:Port".
 /// More details about **Host** and **Port** can be found in WHATWG URL Standard.
@@ -912,6 +845,7 @@ pub fn check_addr(addr: &str) -> Result<(), ConfigError> {
 #[cfg(test)]
 mod tests {
     use std::fs::File;
+    use std::io::Write;
     use std::path::Path;
 
     use super::*;
@@ -1165,5 +1099,54 @@ mod tests {
         for (addr, is_ok) in table {
             assert_eq!(check_addr(addr).is_ok(), is_ok);
         }
+    }
+
+    fn create_file(fpath: &str, buf: &[u8]) {
+        let mut file = File::create(fpath).unwrap();
+        file.write_all(buf).unwrap();
+        file.flush().unwrap();
+    }
+
+    #[test]
+    fn test_get_file_count() {
+        let tmp_path = Builder::new()
+            .prefix("test-get-file-count")
+            .tempdir()
+            .unwrap()
+            .into_path();
+        let count = get_file_count(tmp_path.to_str().unwrap(), "txt").unwrap();
+        assert_eq!(count, 0);
+        let tmp_file = format!("{}", tmp_path.join("test-get-file-count.txt").display());
+        create_file(&tmp_file, b"");
+        let count = get_file_count(tmp_path.to_str().unwrap(), "").unwrap();
+        assert_eq!(count, 1);
+        let count = get_file_count(tmp_path.to_str().unwrap(), "txt").unwrap();
+        assert_eq!(count, 1);
+        let count = get_file_count(tmp_path.to_str().unwrap(), "xt").unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_check_data_dir_empty() {
+        // test invalid data_path
+        let ret = check_data_dir_empty("/sys/invalid", "txt");
+        assert!(ret.is_ok());
+        // test empty data_path
+        let tmp_path = Builder::new()
+            .prefix("test-get-file-count")
+            .tempdir()
+            .unwrap()
+            .into_path();
+        let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "txt");
+        assert!(ret.is_ok());
+        // test non-empty data_path
+        let tmp_file = format!("{}", tmp_path.join("test-get-file-count.txt").display());
+        create_file(&tmp_file, b"");
+        let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "");
+        assert!(ret.is_err());
+        let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "txt");
+        assert!(ret.is_err());
+        let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "xt");
+        assert!(ret.is_ok());
     }
 }

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -807,28 +807,6 @@ mod check_data_dir_empty {
         Ok(())
     }
 
-    // check dir is non-empty of file with certain extension
-    pub fn check_data_dir_non_empty(data_path: &str, extension: &str) -> Result<(), ConfigError> {
-        let op = "data-dir.empty.check";
-        let dir = Path::new(data_path);
-        if dir.exists() && !dir.is_file() {
-            let count = get_file_count(data_path, extension)?;
-            if count == 0 {
-                return Err(ConfigError::Limit(format!(
-                    "{}: the number of file with extension {} in directory {} is too small, \
-                     got 0, expect 1 or more.",
-                    op, extension, data_path,
-                )));
-            } else {
-                return Ok(());
-            }
-        }
-        Err(ConfigError::FileSystem(format!(
-            "{}: path: {:?} doesn't exist or isn't a directory.",
-            op, data_path
-        )))
-    }
-
     #[cfg(test)]
     mod tests {
         use std::fs::File;
@@ -885,35 +863,10 @@ mod check_data_dir_empty {
             let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "xt");
             assert!(ret.is_ok());
         }
-
-        #[test]
-        fn test_check_data_dir_non_empty() {
-            // test invalid data_path
-            let ret = check_data_dir_non_empty("/sys/invalid", "txt");
-            assert!(ret.is_err());
-            // test empty data_path
-            let tmp_path = Builder::new()
-                .prefix("test-get-file-count")
-                .tempdir()
-                .unwrap()
-                .into_path();
-            let ret = check_data_dir_non_empty(tmp_path.to_str().unwrap(), "txt");
-            assert!(ret.is_err());
-            // test non-empty data_path
-            let tmp_file = format!("{}", tmp_path.join("test-get-file-count.txt").display());
-            create_file(&tmp_file, b"");
-            let ret = check_data_dir_non_empty(tmp_path.to_str().unwrap(), "");
-            assert!(ret.is_ok());
-            let ret = check_data_dir_non_empty(tmp_path.to_str().unwrap(), "txt");
-            assert!(ret.is_ok());
-            let ret = check_data_dir_non_empty(tmp_path.to_str().unwrap(), "xt");
-            assert!(ret.is_err());
-        }
     }
 }
 
 pub use self::check_data_dir_empty::check_data_dir_empty;
-pub use self::check_data_dir_empty::check_data_dir_non_empty;
 
 /// `check_addr` validates an address. Addresses are formed like "Host:Port".
 /// More details about **Host** and **Port** can be found in WHATWG URL Standard.

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -804,6 +804,23 @@ mod check_data_dir_empty {
         Ok(())
     }
 
+    // check dir is empty of file with certain extension
+    pub fn check_data_dir_non_empty(data_path: &str, extension: &str) -> Result<(), ConfigError> {
+        let op = "data-dir.empty.check";
+        let dir = Path::new(data_path);
+        if dir.exists() && !dir.is_file() {
+            let count = get_file_count(data_path, extension)?;
+            if count == 0 {
+                return Err(ConfigError::Limit(format!(
+                    "{}: the number of file with extension {} in directory {} is too small, \
+                     got 0, expect 1 or more.",
+                    op, extension, data_path,
+                )));
+            }
+        }
+        Ok(())
+    }
+
     #[cfg(test)]
     mod tests {
         use std::fs::File;
@@ -860,10 +877,35 @@ mod check_data_dir_empty {
             let ret = check_data_dir_empty(tmp_path.to_str().unwrap(), "xt");
             assert!(ret.is_ok());
         }
+
+        #[test]
+        fn test_check_data_dir_non_empty() {
+            // test invalid data_path
+            let ret = check_data_dir_non_empty("/sys/invalid", "txt");
+            assert!(ret.is_err());
+            // test empty data_path
+            let tmp_path = Builder::new()
+                .prefix("test-get-file-count")
+                .tempdir()
+                .unwrap()
+                .into_path();
+            let ret = check_data_dir_non_empty(tmp_path.to_str().unwrap(), "txt");
+            assert!(ret.is_err());
+            // test non-empty data_path
+            let tmp_file = format!("{}", tmp_path.join("test-get-file-count.txt").display());
+            create_file(&tmp_file, b"");
+            let ret = check_data_dir_non_empty(tmp_path.to_str().unwrap(), "");
+            assert!(ret.is_ok());
+            let ret = check_data_dir_non_empty(tmp_path.to_str().unwrap(), "txt");
+            assert!(ret.is_ok());
+            let ret = check_data_dir_non_empty(tmp_path.to_str().unwrap(), "xt");
+            assert!(ret.is_err());
+        }
     }
 }
 
 pub use self::check_data_dir_empty::check_data_dir_empty;
+pub use self::check_data_dir_empty::check_data_dir_non_empty;
 
 /// `check_addr` validates an address. Addresses are formed like "Host:Port".
 /// More details about **Host** and **Port** can be found in WHATWG URL Standard.

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -816,9 +816,14 @@ mod check_data_dir_empty {
                      got 0, expect 1 or more.",
                     op, extension, data_path,
                 )));
+            } else {
+                return Ok(());
             }
         }
-        Ok(())
+        Err(ConfigError::FileSystem(format!(
+            "{}: path: {:?} doesn't exist or isn't a directory.",
+            op, data_path
+        )))
     }
 
     #[cfg(test)]
@@ -858,7 +863,7 @@ mod check_data_dir_empty {
         fn test_check_data_dir_empty() {
             // test invalid data_path
             let ret = check_data_dir_empty("/sys/invalid", "txt");
-            assert!(ret.is_err());
+            assert!(ret.is_ok());
             // test empty data_path
             let tmp_path = Builder::new()
                 .prefix("test-get-file-count")

--- a/src/config.rs
+++ b/src/config.rs
@@ -775,7 +775,7 @@ impl DbConfig {
             CFOptions::new(CF_DEFAULT, self.defaultcf.build_opt(cache)),
             CFOptions::new(CF_LOCK, self.lockcf.build_opt(cache)),
             CFOptions::new(CF_WRITE, self.writecf.build_opt(cache)),
-            // TODO: rmeove CF_RAFT.
+            // TODO: remove CF_RAFT.
             CFOptions::new(CF_RAFT, self.raftcf.build_opt(cache)),
         ]
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -611,6 +611,7 @@ pub struct TitanDBConfig {
     pub dirname: String,
     pub disable_gc: bool,
     pub max_background_gc: i32,
+    // The value of this field will be truncated to seconds.
     pub purge_obsolete_files_period: ReadableDuration,
 }
 

--- a/tests/integrations/raftstore/test_bootstrap.rs
+++ b/tests/integrations/raftstore/test_bootstrap.rs
@@ -8,8 +8,6 @@ use tempdir::TempDir;
 use kvproto::metapb;
 use kvproto::raft_serverpb::RegionLocalState;
 
-use engine::rocks;
-use engine::Engines;
 use engine::*;
 use test_raftstore::*;
 use tikv::import::SSTImporter;
@@ -22,7 +20,7 @@ use tikv_util::worker::FutureWorker;
 fn test_bootstrap_idempotent<T: Simulator>(cluster: &mut Cluster<T>) {
     // assume that there is a node  bootstrap the cluster and add region in pd successfully
     cluster.add_first_region().unwrap();
-    // now  at same time start the another node, and will recive cluster is not bootstrap
+    // now at same time start the another node, and will recive cluster is not bootstrap
     // it will try to bootstrap with a new region, but will failed
     // the region number still 1
     cluster.start().unwrap();

--- a/tests/integrations/storage/mod.rs
+++ b/tests/integrations/storage/mod.rs
@@ -4,3 +4,4 @@ mod test_raft_storage;
 mod test_raftkv;
 mod test_seek_region;
 mod test_storage;
+mod test_turnoff_titan;

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -46,8 +46,7 @@ fn test_turnoff_titan() {
     cluster.compact_data();
     sleep_ms(500);
     cluster.shutdown();
-    configure_for_disable_titan(&mut cluster);
-    cluster.start_new_engines().unwrap();
+    // TODO: reopen cluster on the same directory and check data integrity.
     for path in &titan_paths {
         assert!(tikv_util::config::check_data_dir_empty(path.as_str(), "blob").is_ok());
     }

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -10,6 +10,8 @@ fn test_turnoff_titan() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.cfg.rocksdb.defaultcf.disable_auto_compactions = true;
     cluster.cfg.rocksdb.defaultcf.num_levels = 1;
+    // pd.endpoints is required for validation.
+    cluster.cfg.pd.endpoints = vec!["127.0.0.1:2333".to_owned()];
     configure_for_enable_titan(&mut cluster, ReadableSize::kb(0));
     cluster.run();
     assert_eq!(cluster.must_get(b"k1"), None);

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -27,10 +27,10 @@ fn test_turnoff_titan() {
 
     // try reopen db when titandb dir is non-empty
     configure_for_disable_titan(&mut cluster);
-    assert!(cluster.pre_start().is_err());
+    assert!(cluster.pre_start_check().is_err());
 
     configure_for_enable_titan(&mut cluster, ReadableSize::kb(0));
-    assert!(cluster.pre_start().is_ok());
+    assert!(cluster.pre_start_check().is_ok());
     cluster.start().unwrap();
     for i in cluster.get_node_ids().into_iter() {
         let db = cluster.get_engine(i);
@@ -44,6 +44,6 @@ fn test_turnoff_titan() {
     cluster.shutdown();
 
     configure_for_disable_titan(&mut cluster);
-    assert!(cluster.pre_start().is_ok());
+    assert!(cluster.pre_start_check().is_ok());
     cluster.start().unwrap();
 }

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -9,6 +9,7 @@ use tikv_util::config::ReadableSize;
 fn test_turnoff_titan() {
     let mut cluster = new_node_cluster(0, 3);
     cluster.cfg.rocksdb.defaultcf.disable_auto_compactions = true;
+    cluster.cfg.rocksdb.defaultcf.num_levels = 1;
     configure_for_enable_titan(&mut cluster, ReadableSize::kb(0));
     cluster.run();
     assert_eq!(cluster.must_get(b"k1"), None);
@@ -27,11 +28,11 @@ fn test_turnoff_titan() {
         let db = cluster.get_engine(i);
         info!("CLUSTER LOG"; "level0" => db.get_property_int(&"rocksdb.num-files-at-level0").unwrap());
         info!("CLUSTER LOG"; "level1" => db.get_property_int(&"rocksdb.num-files-at-level1").unwrap());
-        info!("CLUSTER LOG"; "level2" => db.get_property_int(&"rocksdb.num-files-at-level2").unwrap());
-        info!("CLUSTER LOG"; "level3" => db.get_property_int(&"rocksdb.num-files-at-level3").unwrap());
-        info!("CLUSTER LOG"; "level4" => db.get_property_int(&"rocksdb.num-files-at-level4").unwrap());
-        info!("CLUSTER LOG"; "level5" => db.get_property_int(&"rocksdb.num-files-at-level5").unwrap());
-        info!("CLUSTER LOG"; "level6" => db.get_property_int(&"rocksdb.num-files-at-level6").unwrap());
+        // info!("CLUSTER LOG"; "level2" => db.get_property_int(&"rocksdb.num-files-at-level2").unwrap());
+        // info!("CLUSTER LOG"; "level3" => db.get_property_int(&"rocksdb.num-files-at-level3").unwrap());
+        // info!("CLUSTER LOG"; "level4" => db.get_property_int(&"rocksdb.num-files-at-level4").unwrap());
+        // info!("CLUSTER LOG"; "level5" => db.get_property_int(&"rocksdb.num-files-at-level5").unwrap());
+        // info!("CLUSTER LOG"; "level6" => db.get_property_int(&"rocksdb.num-files-at-level6").unwrap());
     }
     cluster.shutdown();
 
@@ -63,11 +64,11 @@ fn test_turnoff_titan() {
         let db = cluster.get_engine(i);
         info!("CLUSTER LOG"; "level0" => db.get_property_int(&"rocksdb.num-files-at-level0").unwrap());
         info!("CLUSTER LOG"; "level1" => db.get_property_int(&"rocksdb.num-files-at-level1").unwrap());
-        info!("CLUSTER LOG"; "level2" => db.get_property_int(&"rocksdb.num-files-at-level2").unwrap());
-        info!("CLUSTER LOG"; "level3" => db.get_property_int(&"rocksdb.num-files-at-level3").unwrap());
-        info!("CLUSTER LOG"; "level4" => db.get_property_int(&"rocksdb.num-files-at-level4").unwrap());
-        info!("CLUSTER LOG"; "level5" => db.get_property_int(&"rocksdb.num-files-at-level5").unwrap());
-        info!("CLUSTER LOG"; "level6" => db.get_property_int(&"rocksdb.num-files-at-level6").unwrap());
+        // info!("CLUSTER LOG"; "level2" => db.get_property_int(&"rocksdb.num-files-at-level2").unwrap());
+        // info!("CLUSTER LOG"; "level3" => db.get_property_int(&"rocksdb.num-files-at-level3").unwrap());
+        // info!("CLUSTER LOG"; "level4" => db.get_property_int(&"rocksdb.num-files-at-level4").unwrap());
+        // info!("CLUSTER LOG"; "level5" => db.get_property_int(&"rocksdb.num-files-at-level5").unwrap());
+        // info!("CLUSTER LOG"; "level6" => db.get_property_int(&"rocksdb.num-files-at-level6").unwrap());
     }
     cluster.compact_data();
     cluster.must_flush_cf(CF_DEFAULT, true);
@@ -75,11 +76,11 @@ fn test_turnoff_titan() {
         let db = cluster.get_engine(i);
         info!("CLUSTER LOG"; "level0" => db.get_property_int(&"rocksdb.num-files-at-level0").unwrap());
         info!("CLUSTER LOG"; "level1" => db.get_property_int(&"rocksdb.num-files-at-level1").unwrap());
-        info!("CLUSTER LOG"; "level2" => db.get_property_int(&"rocksdb.num-files-at-level2").unwrap());
-        info!("CLUSTER LOG"; "level3" => db.get_property_int(&"rocksdb.num-files-at-level3").unwrap());
-        info!("CLUSTER LOG"; "level4" => db.get_property_int(&"rocksdb.num-files-at-level4").unwrap());
-        info!("CLUSTER LOG"; "level5" => db.get_property_int(&"rocksdb.num-files-at-level5").unwrap());
-        info!("CLUSTER LOG"; "level6" => db.get_property_int(&"rocksdb.num-files-at-level6").unwrap());
+        // info!("CLUSTER LOG"; "level2" => db.get_property_int(&"rocksdb.num-files-at-level2").unwrap());
+        // info!("CLUSTER LOG"; "level3" => db.get_property_int(&"rocksdb.num-files-at-level3").unwrap());
+        // info!("CLUSTER LOG"; "level4" => db.get_property_int(&"rocksdb.num-files-at-level4").unwrap());
+        // info!("CLUSTER LOG"; "level5" => db.get_property_int(&"rocksdb.num-files-at-level5").unwrap());
+        // info!("CLUSTER LOG"; "level6" => db.get_property_int(&"rocksdb.num-files-at-level6").unwrap());
     }
     cluster.shutdown();
     sleep_ms(2000);

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -93,8 +93,10 @@ fn test_turnoff_titan() {
         assert!(db.set_options_cf(handle, &opt).is_ok());
     }
     cluster.compact_data();
+    // make sure there is no background error.
     assert!(cluster.put(b"a", b"v",).is_ok());
-    sleep_ms(1000);
+    // wait for gc completed.
+    sleep_ms(100);
     for i in cluster.get_node_ids().into_iter() {
         let db = cluster.get_engine(i);
         assert_eq!(
@@ -116,12 +118,11 @@ fn test_turnoff_titan() {
             2
         );
     }
+    // wait till files are purged.
+    sleep_ms(2000);
     cluster.shutdown();
 
     configure_for_disable_titan(&mut cluster);
-    assert!(cluster
-        .pre_start_check()
-        .map_err(|e| error!("{}", e))
-        .is_ok());
+    assert!(cluster.pre_start_check().is_ok());
     cluster.start().unwrap();
 }

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -7,22 +7,22 @@ use tikv_util::config::ReadableSize;
 
 #[test]
 fn test_turnoff_titan() {
-    let mut cluster = new_server_cluster(0, 3);
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.rocksdb.defaultcf.disable_auto_compactions = true;
     configure_for_enable_titan(&mut cluster, ReadableSize::kb(0));
     cluster.run();
     assert_eq!(cluster.must_get(b"k1"), None);
-    let size = 100;
+    let size = 50;
     for i in 0..size {
         assert!(cluster
             .put(
-                format!("key-{}", i).as_bytes(),
-                format!("value-{}", i).as_bytes(),
+                format!("k{:02}0", i).as_bytes(),
+                format!("v{}", i).as_bytes(),
             )
             .is_ok());
     }
     // make sure data is flushed to disk.
     cluster.must_flush_cf(CF_DEFAULT, true);
-    cluster.compact_data();
     cluster.shutdown();
 
     // try reopen db when titandb dir is non-empty
@@ -32,6 +32,7 @@ fn test_turnoff_titan() {
     configure_for_enable_titan(&mut cluster, ReadableSize::kb(0));
     assert!(cluster.pre_start_check().is_ok());
     cluster.start().unwrap();
+    assert_eq!(cluster.must_get(b"k1"), None);
     for i in cluster.get_node_ids().into_iter() {
         let db = cluster.get_engine(i);
         let handle = get_cf_handle(&db, CF_DEFAULT).unwrap();
@@ -39,11 +40,24 @@ fn test_turnoff_titan() {
         opt.push(("blob_run_mode", "kFallback"));
         assert!(db.set_options_cf(handle, &opt).is_ok());
     }
+    for i in 0..size {
+        assert!(cluster
+            .put(
+                format!("k{:02}1", i).as_bytes(),
+                format!("v{}", i).as_bytes(),
+            )
+            .is_ok());
+    }
     cluster.must_flush_cf(CF_DEFAULT, true);
     cluster.compact_data();
+    cluster.must_flush_cf(CF_DEFAULT, true);
     cluster.shutdown();
+    sleep_ms(2000);
 
     configure_for_disable_titan(&mut cluster);
-    assert!(cluster.pre_start_check().is_ok());
+    assert!(cluster
+        .pre_start_check()
+        .map_err(|e| error!("{}", e))
+        .is_ok());
     cluster.start().unwrap();
 }

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -22,6 +22,8 @@ fn test_turnoff_titan() {
         .collect();
     cluster.run();
 
+    assert_eq!(cluster.must_get(b"k1"), None);
+
     let region = cluster.get_region(b"");
     let leader_id = cluster.leader_of_region(region.get_id()).unwrap();
     let storage = cluster.sim.rl().storages[&leader_id.get_id()].clone();
@@ -38,7 +40,7 @@ fn test_turnoff_titan() {
     for path in &titan_paths {
         assert!(tikv_util::config::check_data_dir_non_empty(path.as_str(), "blob").is_ok());
     }
-    for i in 0..3 {
+    for i in cluster.get_node_ids().into_iter() {
         let db = cluster.get_engine(i);
         let handle = get_cf_handle(&db, CF_DEFAULT).unwrap();
         let mut opt = Vec::new();

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -1,0 +1,75 @@
+// Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::path::Path;
+
+use engine::rocks::util::get_cf_handle;
+use engine::*;
+use kvproto::kvrpcpb::Context;
+use test_raftstore::*;
+use tikv::storage::kv::*;
+use tikv::storage::Key;
+use tikv_util::config::ReadableSize;
+use tikv_util::HandyRwLock;
+
+#[test]
+fn test_turnoff_titan() {
+    let mut cluster = new_server_cluster(0, 3);
+    configure_for_enable_titan(&mut cluster, ReadableSize::kb(0));
+    let titan_paths: Vec<String> = cluster
+        .get_kv_paths()
+        .iter()
+        .map(|kv| Path::new(kv).join("titandb").to_str().unwrap().to_owned())
+        .collect();
+    cluster.run();
+
+    let region = cluster.get_region(b"");
+    let leader_id = cluster.leader_of_region(region.get_id()).unwrap();
+    let storage = cluster.sim.rl().storages[&leader_id.get_id()].clone();
+
+    let mut ctx = Context::default();
+    ctx.set_region_id(region.get_id());
+    ctx.set_region_epoch(region.get_region_epoch().clone());
+    ctx.set_peer(region.get_peers()[0].clone());
+
+    bulk_insert(&ctx, &storage, 100);
+
+    cluster.must_flush_cf(CF_DEFAULT, true);
+    cluster.compact_data();
+    for path in &titan_paths {
+        assert!(tikv_util::config::check_data_dir_non_empty(path.as_str(), "blob").is_ok());
+    }
+    for i in 0..3 {
+        let db = cluster.get_engine(i);
+        let handle = get_cf_handle(&db, CF_DEFAULT).unwrap();
+        let mut opt = Vec::new();
+        opt.push(("blob_run_mode", "kFallback"));
+        assert!(db.set_options_cf(handle, &opt).is_ok());
+    }
+    cluster.must_flush_cf(CF_DEFAULT, true);
+    cluster.compact_data();
+    sleep_ms(500);
+    cluster.shutdown();
+    configure_for_disable_titan(&mut cluster);
+    cluster.start_new_engines().unwrap();
+    for path in &titan_paths {
+        assert!(tikv_util::config::check_data_dir_empty(path.as_str(), "blob").is_ok());
+    }
+}
+
+fn bulk_insert<E: Engine>(ctx: &Context, engine: &E, size: usize) {
+    for i in 0..size {
+        must_put_cf(
+            ctx,
+            engine,
+            CF_DEFAULT,
+            format!("key-{}", i).as_bytes(),
+            format!("value-{}", i).as_bytes(),
+        );
+    }
+}
+
+fn must_put_cf<E: Engine>(ctx: &Context, engine: &E, cf: CfName, key: &[u8], value: &[u8]) {
+    engine
+        .put_cf(ctx, cf, Key::from_raw(key), value.to_vec())
+        .unwrap();
+}

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::path::Path;
 
@@ -33,7 +33,7 @@ fn test_turnoff_titan() {
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(region.get_peers()[0].clone());
 
-    bulk_insert(&ctx, &storage, 100);
+    bulk_insert(&ctx, &storage, 10);
 
     cluster.must_flush_cf(CF_DEFAULT, true);
     cluster.compact_data();

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -1,7 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::path::Path;
-
 use engine::rocks::util::get_cf_handle;
 use engine::*;
 use test_raftstore::*;
@@ -11,15 +9,8 @@ use tikv_util::config::ReadableSize;
 fn test_turnoff_titan() {
     let mut cluster = new_server_cluster(0, 3);
     configure_for_enable_titan(&mut cluster, ReadableSize::kb(0));
-    let titan_paths: Vec<String> = cluster
-        .get_kv_paths()
-        .iter()
-        .map(|kv| Path::new(kv).join("titandb").to_str().unwrap().to_owned())
-        .collect();
     cluster.run();
-
     assert_eq!(cluster.must_get(b"k1"), None);
-
     let size = 100;
     for i in 0..size {
         assert!(cluster
@@ -29,12 +20,18 @@ fn test_turnoff_titan() {
             )
             .is_ok());
     }
-
+    // make sure data is flushed to disk.
     cluster.must_flush_cf(CF_DEFAULT, true);
     cluster.compact_data();
-    for path in &titan_paths {
-        assert!(tikv_util::config::check_data_dir_non_empty(path.as_str(), "blob").is_ok());
-    }
+    cluster.shutdown();
+
+    // try reopen db when titandb dir is non-empty
+    configure_for_disable_titan(&mut cluster);
+    assert!(cluster.pre_start().is_err());
+
+    configure_for_enable_titan(&mut cluster, ReadableSize::kb(0));
+    assert!(cluster.pre_start().is_ok());
+    cluster.start().unwrap();
     for i in cluster.get_node_ids().into_iter() {
         let db = cluster.get_engine(i);
         let handle = get_cf_handle(&db, CF_DEFAULT).unwrap();
@@ -44,10 +41,9 @@ fn test_turnoff_titan() {
     }
     cluster.must_flush_cf(CF_DEFAULT, true);
     cluster.compact_data();
-    sleep_ms(500);
     cluster.shutdown();
-    // TODO: reopen cluster on the same directory and check data integrity.
-    for path in &titan_paths {
-        assert!(tikv_util::config::check_data_dir_empty(path.as_str(), "blob").is_ok());
-    }
+
+    configure_for_disable_titan(&mut cluster);
+    assert!(cluster.pre_start().is_ok());
+    cluster.start().unwrap();
 }

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -82,8 +82,8 @@ fn test_turnoff_titan() {
         // info!("CLUSTER LOG"; "level5" => db.get_property_int(&"rocksdb.num-files-at-level5").unwrap());
         // info!("CLUSTER LOG"; "level6" => db.get_property_int(&"rocksdb.num-files-at-level6").unwrap());
     }
-    cluster.shutdown();
     sleep_ms(2000);
+    cluster.shutdown();
 
     configure_for_disable_titan(&mut cluster);
     assert!(cluster

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -118,11 +118,14 @@ fn test_turnoff_titan() {
             2
         );
     }
-    // wait till files are purged.
-    sleep_ms(2000);
     cluster.shutdown();
-
     configure_for_disable_titan(&mut cluster);
+    // wait till files are purged, timeout set to purge_obsolete_files_period.
+    for _ in 1..100 {
+        sleep_ms(10);
+        if cluster.pre_start_check().is_ok() {
+            return;
+        }
+    }
     assert!(cluster.pre_start_check().is_ok());
-    cluster.start().unwrap();
 }

--- a/tests/integrations/storage/test_turnoff_titan.rs
+++ b/tests/integrations/storage/test_turnoff_titan.rs
@@ -23,6 +23,16 @@ fn test_turnoff_titan() {
     }
     // make sure data is flushed to disk.
     cluster.must_flush_cf(CF_DEFAULT, true);
+    for i in cluster.get_node_ids().into_iter() {
+        let db = cluster.get_engine(i);
+        info!("CLUSTER LOG"; "level0" => db.get_property_int(&"rocksdb.num-files-at-level0").unwrap());
+        info!("CLUSTER LOG"; "level1" => db.get_property_int(&"rocksdb.num-files-at-level1").unwrap());
+        info!("CLUSTER LOG"; "level2" => db.get_property_int(&"rocksdb.num-files-at-level2").unwrap());
+        info!("CLUSTER LOG"; "level3" => db.get_property_int(&"rocksdb.num-files-at-level3").unwrap());
+        info!("CLUSTER LOG"; "level4" => db.get_property_int(&"rocksdb.num-files-at-level4").unwrap());
+        info!("CLUSTER LOG"; "level5" => db.get_property_int(&"rocksdb.num-files-at-level5").unwrap());
+        info!("CLUSTER LOG"; "level6" => db.get_property_int(&"rocksdb.num-files-at-level6").unwrap());
+    }
     cluster.shutdown();
 
     // try reopen db when titandb dir is non-empty
@@ -49,8 +59,28 @@ fn test_turnoff_titan() {
             .is_ok());
     }
     cluster.must_flush_cf(CF_DEFAULT, true);
+    for i in cluster.get_node_ids().into_iter() {
+        let db = cluster.get_engine(i);
+        info!("CLUSTER LOG"; "level0" => db.get_property_int(&"rocksdb.num-files-at-level0").unwrap());
+        info!("CLUSTER LOG"; "level1" => db.get_property_int(&"rocksdb.num-files-at-level1").unwrap());
+        info!("CLUSTER LOG"; "level2" => db.get_property_int(&"rocksdb.num-files-at-level2").unwrap());
+        info!("CLUSTER LOG"; "level3" => db.get_property_int(&"rocksdb.num-files-at-level3").unwrap());
+        info!("CLUSTER LOG"; "level4" => db.get_property_int(&"rocksdb.num-files-at-level4").unwrap());
+        info!("CLUSTER LOG"; "level5" => db.get_property_int(&"rocksdb.num-files-at-level5").unwrap());
+        info!("CLUSTER LOG"; "level6" => db.get_property_int(&"rocksdb.num-files-at-level6").unwrap());
+    }
     cluster.compact_data();
     cluster.must_flush_cf(CF_DEFAULT, true);
+    for i in cluster.get_node_ids().into_iter() {
+        let db = cluster.get_engine(i);
+        info!("CLUSTER LOG"; "level0" => db.get_property_int(&"rocksdb.num-files-at-level0").unwrap());
+        info!("CLUSTER LOG"; "level1" => db.get_property_int(&"rocksdb.num-files-at-level1").unwrap());
+        info!("CLUSTER LOG"; "level2" => db.get_property_int(&"rocksdb.num-files-at-level2").unwrap());
+        info!("CLUSTER LOG"; "level3" => db.get_property_int(&"rocksdb.num-files-at-level3").unwrap());
+        info!("CLUSTER LOG"; "level4" => db.get_property_int(&"rocksdb.num-files-at-level4").unwrap());
+        info!("CLUSTER LOG"; "level5" => db.get_property_int(&"rocksdb.num-files-at-level5").unwrap());
+        info!("CLUSTER LOG"; "level6" => db.get_property_int(&"rocksdb.num-files-at-level6").unwrap());
+    }
     cluster.shutdown();
     sleep_ms(2000);
 


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Check titandb directory is empty (`ls *.blob` count = 0) when titan is disabled. Fatal panic if this check fails, which indicates titan is turned off before all blob files are merged.

###  What is the type of the changes?

- Misc (other changes)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

###  Does this PR affect `tidb-ansible`?

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

