### PR TITLE
tests: fix unstatble test test_prevote_reboot_minority_followers

### DIFF
--- a/tests/integrations/raftstore/test_prevote.rs
+++ b/tests/integrations/raftstore/test_prevote.rs
@@ -45,7 +45,7 @@ fn test_prevote<T: Simulator>(
     cluster.cfg.raft_store.prevote = true;
     // To stable the test, we use a large election timeout to make
     // leader's readiness get handle within an election timeout
-    configure_for_lease_read(cluster, Some(10), Some(70));
+    configure_for_lease_read(cluster, Some(10), Some(50));
 
     let leader_id = 1;
     let detect_during_failure = detect_during_failure.into();
@@ -77,7 +77,7 @@ fn test_prevote<T: Simulator>(
 
     if let (Some(rx), Some((_, should_detect))) = (rx, detect_during_failure) {
         // Once we see a response on the wire we know a prevote round is happening.
-        let received = rx.recv_timeout(Duration::from_secs(7));
+        let received = rx.recv_timeout(Duration::from_secs(5));
         debug!("Done with failure prevote notifier, got {:?}", received);
         assert_eq!(
             received.is_ok(),
@@ -114,7 +114,7 @@ fn test_prevote<T: Simulator>(
 
     // Once we see a response on the wire we know a prevote round is happening.
     if let (Some(rx), Some((_, should_detect))) = (rx, detect_during_failure) {
-        let received = rx.recv_timeout(Duration::from_secs(7));
+        let received = rx.recv_timeout(Duration::from_secs(5));
         debug!("Done with recovery prevote notifier, got {:?}", received);
 
         assert_eq!(

--- a/tests/integrations/raftstore/test_prevote.rs
+++ b/tests/integrations/raftstore/test_prevote.rs
@@ -43,6 +43,7 @@ fn test_prevote<T: Simulator>(
     detect_during_recovery: impl Into<Option<(u64, bool)>>,
 ) {
     cluster.cfg.raft_store.prevote = true;
+    cluster.cfg.raft_store.raft_election_timeout_ticks = 60;
 
     let leader_id = 1;
     let detect_during_failure = detect_during_failure.into();


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

test `test_prevote_reboot_minority_followers` failed, because a peer unexpected send a `MsgRequestVoteResponse` response to an unexpected pre-condidate which happen because the handle interval of  leader's `Readiness` are much more longer the `election_timeout`(maybe because not enough CPU resource), thus many msgs from leader are send and handle by follower after many `election_tick`. This pr fix it by increase the raft_election_timeout_ticks.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

No

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

close #5615 