### PR TITLE
tidb_query: Support Range in TiKV Coprocessor Streaming

### DIFF
--- a/components/tidb_query/src/storage/range.rs
+++ b/components/tidb_query/src/storage/range.rs
@@ -59,12 +59,11 @@ impl std::fmt::Debug for IntervalRange {
 }
 
 impl Into<KeyRange> for IntervalRange {
-    // TODO: make clear if we need extra checking
+    // We don't need extra checkings here.
     fn into(self) -> KeyRange {
-        let mut range = KeyRange::new();
-        // TODO: reverse it?
-        range.start = self.lower_inclusive;
-        range.end = self.upper_exclusive;
+        let mut range = KeyRange::default();
+        range.start = self.upper_exclusive;
+        range.end = self.lower_inclusive;
         range
     }
 }

--- a/components/tidb_query/src/storage/range.rs
+++ b/components/tidb_query/src/storage/range.rs
@@ -58,6 +58,17 @@ impl std::fmt::Debug for IntervalRange {
     }
 }
 
+impl Into<KeyRange> for IntervalRange {
+    // TODO: make clear if we need extra checking
+    fn into(self) -> KeyRange {
+        let mut range = KeyRange::new();
+        // TODO: reverse it?
+        range.start = self.lower_inclusive;
+        range.end = self.upper_exclusive;
+        range
+    }
+}
+
 impl From<(Vec<u8>, Vec<u8>)> for IntervalRange {
     fn from((lower, upper): (Vec<u8>, Vec<u8>)) -> Self {
         IntervalRange {

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -76,6 +76,7 @@ impl RequestHandler for DAGHandler {
 
     fn handle_streaming_request(&mut self) -> (Result<(Option<Response>, bool)>, KeyRange) {
         let (resp, range) = self.0.handle_streaming_request();
+        // TODO: make it pass by inner
         (handle_qe_stream_response(resp, range.clone()), range.into())
     }
 

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -587,7 +587,9 @@ mod tests {
 
     impl RequestHandler for StreamFixture {
         // TODO: Make this KeyRange to real KeyRange
-        fn handle_streaming_request(&mut self) -> (Result<(Option<coppb::Response>, bool)>, coppb::KeyRange) {
+        fn handle_streaming_request(
+            &mut self,
+        ) -> (Result<(Option<coppb::Response>, bool)>, coppb::KeyRange) {
             let is_finished = if self.result_len == 0 {
                 true
             } else {
@@ -602,7 +604,7 @@ mod tests {
                     let handle_duration_ms = self.handle_durations_millis.next().unwrap();
                     thread::sleep(Duration::from_millis(handle_duration_ms));
                     match val {
-                        Ok(resp) => (Ok((Some(resp), is_finished)) , coppb::KeyRange::default()),
+                        Ok(resp) => (Ok((Some(resp), is_finished)), coppb::KeyRange::default()),
                         Err(e) => (Err(e), coppb::KeyRange::default()),
                     }
                 }
@@ -633,7 +635,9 @@ mod tests {
 
     impl RequestHandler for StreamFromClosure {
         // TODO: ditto, make this KeyRange to real KeyRange
-        fn handle_streaming_request(&mut self) -> (Result<(Option<coppb::Response>, bool)>, coppb::KeyRange) {
+        fn handle_streaming_request(
+            &mut self,
+        ) -> (Result<(Option<coppb::Response>, bool)>, coppb::KeyRange) {
             let (result, _) = (self.result_generator)(self.nth);
             self.nth += 1;
             (result, coppb::KeyRange::default())
@@ -931,7 +935,7 @@ mod tests {
                 resp.set_data(vec![1, 2, 13]);
                 (Ok((Some(resp), false)), coppb::KeyRange::default())
             }
-            1 => (Ok((None, false)) , coppb::KeyRange::default()),
+            1 => (Ok((None, false)), coppb::KeyRange::default()),
             _ => {
                 counter_clone.store(1, atomic::Ordering::SeqCst);
                 (Err(box_err!("unreachable")), coppb::KeyRange::default())
@@ -957,7 +961,7 @@ mod tests {
                 resp.set_data(vec![1, 2, 23]);
                 (Ok((Some(resp), false)), coppb::KeyRange::default())
             }
-            1 => (Err(box_err!("foo")) , coppb::KeyRange::default()),
+            1 => (Err(box_err!("foo")), coppb::KeyRange::default()),
             _ => {
                 counter_clone.store(1, atomic::Ordering::SeqCst);
                 (Err(box_err!("unreachable")), coppb::KeyRange::default())

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -44,7 +44,7 @@ pub const REQ_TYPE_DAG: i64 = 103;
 pub const REQ_TYPE_ANALYZE: i64 = 104;
 pub const REQ_TYPE_CHECKSUM: i64 = 105;
 
-type HandlerStreamStepResult = Result<(Option<coppb::Response>, bool)>;
+type HandlerStreamStepResult = (Result<(Option<coppb::Response>, bool)>, coppb::KeyRange);
 
 /// An interface for all kind of Coprocessor request handlers.
 pub trait RequestHandler: Send {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

To fix the bug in https://github.com/pingcap/tidb/issues/12131, tikv need to carry a `range` in TiKV coprocessor streaming response in error case.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix (Fix https://github.com/pingcap/tidb/issues/12131)

###  How is the PR tested?
Please select the tests that you ran to verify your changes:

- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

