### PR TITLE
server: report the status_address and git_hash to PD on TiKV startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#62abb760d9b125e2cfbc15a8d50b038861854e8d"
+source = "git+https://github.com/pingcap/kvproto.git#51b332bcb20b00279d30aad1629a02a9f92bbc2b"
 dependencies = [
  "futures",
  "grpcio",

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -75,6 +75,12 @@ where
             store.set_address(cfg.advertise_addr.clone())
         }
         store.set_version(env!("CARGO_PKG_VERSION").to_string());
+        store.set_status_address(cfg.status_addr.clone());
+        store.set_git_hash(
+            option_env!("TIKV_BUILD_GIT_HASH")
+                .unwrap_or("Unknown git hash")
+                .to_string(),
+        );
 
         let mut labels = Vec::new();
         for (k, v) in &cfg.labels {


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

The TiKV uses `status_address` to provide HTTP service for external components. But the original store metadata does not contain the `status_address` and `git_hash` information, so the TiDB cannot get the `status_address` from PD via `GetAllStores` gRPC interface. Furthermore, TiDB cannot use the HTTP service provided by TiKV.

This PR adds the support that reports the status_address and git_hash to PD on TiKV startup to make subsequent work easier.

Don't assume reviewers understand the original issue.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

- Integration test

