### PR TITLE
tidb_query: make RpnExpressionNode not Clone

### DIFF
--- a/components/tidb_query/src/batch/executors/fast_hash_aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/fast_hash_aggr_executor.rs
@@ -382,11 +382,13 @@ mod tests {
         // And group by:
         // - col_0 + col_1
 
-        let group_by_exp = RpnExpressionBuilder::new()
-            .push_column_ref(0)
-            .push_column_ref(1)
-            .push_fn_call(arithmetic_fn_meta::<RealPlus>(), 2, FieldTypeTp::Double)
-            .build();
+        let group_by_exp = || {
+            RpnExpressionBuilder::new()
+                .push_column_ref(0)
+                .push_column_ref(1)
+                .push_fn_call(arithmetic_fn_meta::<RealPlus>(), 2, FieldTypeTp::Double)
+                .build()
+        };
 
         let aggr_definitions = vec![
             ExprDefBuilder::aggr_func(ExprType::Count, FieldTypeTp::LongLong)
@@ -407,7 +409,7 @@ mod tests {
         let exec_fast = |src_exec| {
             Box::new(BatchFastHashAggregationExecutor::new_for_test(
                 src_exec,
-                group_by_exp.clone(),
+                group_by_exp(),
                 aggr_definitions.clone(),
                 AllAggrDefinitionParser,
             )) as Box<dyn BatchExecutor<StorageStats = ()>>
@@ -416,7 +418,7 @@ mod tests {
         let exec_slow = |src_exec| {
             Box::new(BatchSlowHashAggregationExecutor::new_for_test(
                 src_exec,
-                vec![group_by_exp.clone()],
+                vec![group_by_exp()],
                 aggr_definitions.clone(),
                 AllAggrDefinitionParser,
             )) as Box<dyn BatchExecutor<StorageStats = ()>>
@@ -582,12 +584,12 @@ mod tests {
     /// E.g. SELECT 1 FROM t GROUP BY x
     #[test]
     fn test_no_aggr_fn() {
-        let group_by_exp = RpnExpressionBuilder::new().push_column_ref(0).build();
+        let group_by_exp = || RpnExpressionBuilder::new().push_column_ref(0).build();
 
         let exec_fast = |src_exec| {
             Box::new(BatchFastHashAggregationExecutor::new_for_test(
                 src_exec,
-                group_by_exp.clone(),
+                group_by_exp(),
                 vec![],
                 AllAggrDefinitionParser,
             )) as Box<dyn BatchExecutor<StorageStats = ()>>
@@ -596,7 +598,7 @@ mod tests {
         let exec_slow = |src_exec| {
             Box::new(BatchSlowHashAggregationExecutor::new_for_test(
                 src_exec,
-                vec![group_by_exp.clone()],
+                vec![group_by_exp()],
                 vec![],
                 AllAggrDefinitionParser,
             )) as Box<dyn BatchExecutor<StorageStats = ()>>

--- a/components/tidb_query/src/batch/executors/selection_executor.rs
+++ b/components/tidb_query/src/batch/executors/selection_executor.rs
@@ -513,17 +513,19 @@ mod tests {
 
         let predicate: Vec<_> = (0..=1)
             .map(|offset| {
-                RpnExpressionBuilder::new()
-                    .push_column_ref(offset)
-                    .push_fn_call(is_even_fn_meta(), 1, FieldTypeTp::LongLong)
-                    .build()
+                move || {
+                    RpnExpressionBuilder::new()
+                        .push_column_ref(offset)
+                        .push_fn_call(is_even_fn_meta(), 1, FieldTypeTp::LongLong)
+                        .build()
+                }
             })
             .collect();
 
         for predicates in vec![
             // Swap predicates should produce same results.
-            vec![predicate[0].clone(), predicate[1].clone()],
-            vec![predicate[1].clone(), predicate[0].clone()],
+            vec![predicate[0](), predicate[1]()],
+            vec![predicate[1](), predicate[0]()],
         ] {
             let src_exec = make_src_executor_using_fixture_2();
             let mut exec = BatchSelectionExecutor::new_for_test(src_exec, predicates);
@@ -546,25 +548,19 @@ mod tests {
     fn test_multiple_predicate_2() {
         let predicate: Vec<_> = (0..=2)
             .map(|offset| {
-                RpnExpressionBuilder::new()
-                    .push_column_ref(offset)
-                    .push_fn_call(is_even_fn_meta(), 1, FieldTypeTp::LongLong)
-                    .build()
+                move || {
+                    RpnExpressionBuilder::new()
+                        .push_column_ref(offset)
+                        .push_fn_call(is_even_fn_meta(), 1, FieldTypeTp::LongLong)
+                        .build()
+                }
             })
             .collect();
 
         for predicates in vec![
             // Swap predicates should produce same results.
-            vec![
-                predicate[0].clone(),
-                predicate[1].clone(),
-                predicate[2].clone(),
-            ],
-            vec![
-                predicate[1].clone(),
-                predicate[2].clone(),
-                predicate[0].clone(),
-            ],
+            vec![predicate[0](), predicate[1](), predicate[2]()],
+            vec![predicate[1](), predicate[2](), predicate[0]()],
         ] {
             let src_exec = make_src_executor_using_fixture_2();
             let mut exec = BatchSelectionExecutor::new_for_test(src_exec, predicates);

--- a/components/tidb_query/src/rpn_expr/types/expr.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr.rs
@@ -6,7 +6,7 @@ use super::super::function::RpnFnMeta;
 use crate::codec::data_type::ScalarValue;
 
 /// A type for each node in the RPN expression list.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum RpnExpressionNode {
     /// Represents a function call.
     FnCall {
@@ -59,7 +59,7 @@ impl RpnExpressionNode {
 /// An expression in Reverse Polish notation, which is simply a list of RPN expression nodes.
 ///
 /// You may want to build it using `RpnExpressionBuilder`.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RpnExpression(Vec<RpnExpressionNode>);
 
 impl std::ops::Deref for RpnExpression {

--- a/components/tidb_query/src/rpn_expr/types/expr_builder.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_builder.rs
@@ -14,7 +14,7 @@ use crate::codec::{datum, Datum};
 use crate::Result;
 
 /// Helper to build an `RpnExpression`.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RpnExpressionBuilder(Vec<RpnExpressionNode>);
 
 impl RpnExpressionBuilder {


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Extracted from https://github.com/tikv/tikv/pull/5755, don't derive `Clone` for `RpnExpressionNode`. It enables an `RpnExpressionNode` to carry non-`Clone` data in the future. It also helps @andylokandy with his bump allocator work.

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

