### PR TITLE
Use a Make command for Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,9 @@ dev: format clippy
 build:
 	cargo build --no-default-features --features "${ENABLE_FEATURES}"
 
+docker:
+	bash ./scripts/gen-dockerfile.sh | docker build -t pingcap/tikv -f - .
+
 ## Release builds (optimized dev builds)
 ## ----------------------------
 

--- a/scripts/gen-dockerfile.sh
+++ b/scripts/gen-dockerfile.sh
@@ -1,12 +1,6 @@
 # TiKV root
-dir="."
-output="./Dockerfile"
 
-if [ "$#" -ge 1 ]; then
-    output=$1
-fi
-
-cat <<EOT > ${output}
+cat <<EOT
 FROM pingcap/rust as builder
 
 WORKDIR /tikv
@@ -29,18 +23,18 @@ COPY cmd/Cargo.toml ./cmd/
 EOT
 
 # Get components, remove test and profiler components
-components=$(ls -d ${dir}/components/*  | xargs -n 1 basename | grep -v "test" | grep -v "profiler")
+components=$(ls -d ./components/*  | xargs -n 1 basename | grep -v "test" | grep -v "profiler")
 
 # List components and add their Cargo files
 echo "# Add components Cargo files
-# Notice: every time we add a new component, we must regenerate the dockerfile" >> ${output}
+# Notice: every time we add a new component, we must regenerate the dockerfile"
 
 for i in ${components}; do
-    echo "COPY ${dir}/components/${i}/Cargo.toml ./components/${i}/Cargo.toml" >> ${output}
+    echo "COPY ./components/${i}/Cargo.toml ./components/${i}/Cargo.toml"
 done
 
 
-cat <<EOT >> ${output}
+cat <<EOT
 
 # Remove profiler from tidb_query
 RUN sed -i '/profiler/d' ./components/tidb_query/Cargo.toml
@@ -56,10 +50,10 @@ RUN mkdir -p ./cmd/src/bin && \\
 EOT
 
 for i in ${components}; do
-    echo "    mkdir ./components/${i}/src && echo '' > ./components/${i}/src/lib.rs && \\" >> ${output}
+    echo "    mkdir ./components/${i}/src && echo '' > ./components/${i}/src/lib.rs && \\"
 done
 
-cat <<EOT >> ${output}
+cat <<EOT
     # Remove test dependencies and profile features.
     for cargotoml in \$(find . -name "Cargo.toml"); do \\
         sed -i '/fuzz/d' \${cargotoml} && \\
@@ -70,15 +64,15 @@ cat <<EOT >> ${output}
 
 EOT
 
-echo 'RUN make build_dist_release && \' >> ${output}
+echo 'RUN make build_dist_release && \'
 
 for i in ${components}; do
-    echo "    rm -rf ./target/release/.fingerprint/${i}-* && \\" >> ${output}
+    echo "    rm -rf ./target/release/.fingerprint/${i}-* && \\"
 done
 
-echo "    rm -rf ./target/release/.fingerprint/tikv-*" >> ${output}
+echo "    rm -rf ./target/release/.fingerprint/tikv-*"
 
-cat <<EOT >> ${output}
+cat <<EOT
 
 # Build real binaries now
 COPY ${dir}/src ./src


### PR DESCRIPTION

###  What have you changed?

Add `make docker` to call our `scripts/gen-dockerfile.sh` script and pipe it right into `docker build`.

This means we no longer need to generate a new `Dockerfile` when we add a component, etc.

cc @zhouqiang-cl Can you help me verify this doesn't break our test/release process?

###  What is the type of the changes?

Pick one of the following and delete the others:

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
Please select the tests that you ran to verify your changes:

- Manual test (add detailed scripts or steps below)


###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

Release notes should mention:

> Moved the `Dockerfile` to a `make docker` command that builds the `pingcap/tikv` image.

###  Does this PR affect `tidb-ansible`?

Nope

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

