### PR TITLE
sst_importer: change download() to use closed range

### DIFF
--- a/components/keys/src/rewrite.rs
+++ b/components/keys/src/rewrite.rs
@@ -2,6 +2,8 @@
 
 //! Key rewriting
 
+use std::ops::Bound::{self, *};
+
 /// An error indicating the key cannot be rewritten because it does not start
 /// with the given prefix.
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -42,6 +44,50 @@ pub fn rewrite_prefix_of_end_key(
     }
 
     Ok(super::next_key(new_prefix))
+}
+
+pub fn rewrite_prefix_of_start_bound(
+    old_prefix: &[u8],
+    new_prefix: &[u8],
+    start: Bound<&[u8]>,
+) -> Result<Bound<Vec<u8>>, WrongPrefix> {
+    Ok(match start {
+        Unbounded => {
+            if old_prefix.is_empty() {
+                Included(new_prefix.to_vec())
+            } else {
+                Unbounded
+            }
+        }
+        Included(s) => Included(rewrite_prefix(old_prefix, new_prefix, s)?),
+        Excluded(s) => Excluded(rewrite_prefix(old_prefix, new_prefix, s)?),
+    })
+}
+
+pub fn rewrite_prefix_of_end_bound(
+    old_prefix: &[u8],
+    new_prefix: &[u8],
+    end: Bound<&[u8]>,
+) -> Result<Bound<Vec<u8>>, WrongPrefix> {
+    fn end_key_to_bound(end_key: Vec<u8>) -> Bound<Vec<u8>> {
+        if end_key.is_empty() {
+            Bound::Unbounded
+        } else {
+            Bound::Excluded(end_key)
+        }
+    }
+
+    Ok(match end {
+        Unbounded => {
+            if old_prefix.is_empty() {
+                end_key_to_bound(super::next_key(new_prefix))
+            } else {
+                Unbounded
+            }
+        }
+        Included(e) => Included(rewrite_prefix(old_prefix, new_prefix, e)?),
+        Excluded(e) => end_key_to_bound(rewrite_prefix_of_end_key(old_prefix, new_prefix, e)?),
+    })
 }
 
 #[cfg(test)]
@@ -98,6 +144,93 @@ mod tests {
         assert_eq!(
             rewrite_prefix_of_end_key(b"\xff\xfe", b"\xff\xff", b"\xff\xff"),
             Ok(b"".to_vec()),
+        );
+    }
+
+    #[test]
+    fn test_rewrite_prefix_of_range() {
+        use std::ops::Bound::*;
+
+        let rewrite_prefix_of_range =
+            |old_prefix: &[u8], new_prefix: &[u8], start: Bound<&[u8]>, end: Bound<&[u8]>| {
+                Ok((
+                    rewrite_prefix_of_start_bound(old_prefix, new_prefix, start)?,
+                    rewrite_prefix_of_end_bound(old_prefix, new_prefix, end)?,
+                ))
+            };
+
+        assert_eq!(
+            rewrite_prefix_of_range(b"t123", b"t456", Included(b"t123456"), Included(b"t123789")),
+            Ok((Included(b"t456456".to_vec()), Included(b"t456789".to_vec()))),
+        );
+        assert_eq!(
+            rewrite_prefix_of_range(b"t123", b"t456", Included(b"t123456"), Excluded(b"t123789")),
+            Ok((Included(b"t456456".to_vec()), Excluded(b"t456789".to_vec()))),
+        );
+        assert_eq!(
+            rewrite_prefix_of_range(b"t123", b"t456", Excluded(b"t123456"), Excluded(b"t123789")),
+            Ok((Excluded(b"t456456".to_vec()), Excluded(b"t456789".to_vec()))),
+        );
+        assert_eq!(
+            rewrite_prefix_of_range(b"t123", b"t456", Excluded(b"t123456"), Included(b"t123789")),
+            Ok((Excluded(b"t456456".to_vec()), Included(b"t456789".to_vec()))),
+        );
+        assert_eq!(
+            rewrite_prefix_of_range(b"t123", b"t456", Included(b"t123789"), Unbounded),
+            Ok((Included(b"t456789".to_vec()), Unbounded)),
+        );
+        assert_eq!(
+            rewrite_prefix_of_range(b"t123", b"t456", Unbounded, Unbounded),
+            Ok((Unbounded, Unbounded)),
+        );
+
+        assert_eq!(
+            rewrite_prefix_of_range(b"", b"t654", Included(b"321"), Included(b"987")),
+            Ok((Included(b"t654321".to_vec()), Included(b"t654987".to_vec()))),
+        );
+        assert_eq!(
+            rewrite_prefix_of_range(b"", b"t654", Included(b"321"), Excluded(b"987")),
+            Ok((Included(b"t654321".to_vec()), Excluded(b"t654987".to_vec()))),
+        );
+        assert_eq!(
+            rewrite_prefix_of_range(b"", b"t654", Included(b"321"), Unbounded),
+            Ok((Included(b"t654321".to_vec()), Excluded(b"t655".to_vec()))),
+        );
+        assert_eq!(
+            rewrite_prefix_of_range(b"", b"t654", Unbounded, Included(b"987")),
+            Ok((Included(b"t654".to_vec()), Included(b"t654987".to_vec()))),
+        );
+        assert_eq!(
+            rewrite_prefix_of_range(b"", b"t654", Unbounded, Unbounded),
+            Ok((Included(b"t654".to_vec()), Excluded(b"t655".to_vec()))),
+        );
+
+        assert_eq!(
+            rewrite_prefix_of_range(
+                b"\xff\xfe",
+                b"\xff\xff",
+                Included(b"\xff\xfe"),
+                Excluded(b"\xff\xff")
+            ),
+            Ok((Included(b"\xff\xff".to_vec()), Unbounded)),
+        );
+        assert_eq!(
+            rewrite_prefix_of_range(
+                b"\xff\xfe",
+                b"\xff\xff",
+                Excluded(b"\xff\xfe"),
+                Excluded(b"\xff\xff")
+            ),
+            Ok((Excluded(b"\xff\xff".to_vec()), Unbounded)),
+        );
+        assert_eq!(
+            rewrite_prefix_of_range(
+                b"\xff\xfe",
+                b"\xff\xff",
+                Included(b"\xff\xfe"),
+                Included(b"\xff\xff")
+            ),
+            Err(WrongPrefix),
         );
     }
 }

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
+use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -73,14 +74,17 @@ impl SSTImporter {
     // This method is blocking. It performs the following transformations before
     // writing to disk:
     //
-    //  1. only KV pairs in the half-inclusive range (`[start, end)`) are used.
-    //     (set the range to `["", "")` to import everything).
+    //  1. only KV pairs in the *inclusive* range (`[start, end]`) are used.
+    //     (set the range to `["", ""]` to import everything).
     //  2. keys are rewritten according to the given rewrite rule.
     //
     // Both the range and rewrite keys are specified using origin keys. However,
     // the SST itself should be data keys (contain the `z` prefix). The range
     // should be specified using keys after rewriting, to be consistent with the
     // region info in PD.
+    //
+    // This method returns the *inclusive* key range (`[start, end]`) of SST
+    // file created, or returns None if the SST is empty.
     pub fn download(
         &self,
         meta: &SstMeta,
@@ -162,38 +166,22 @@ impl SSTImporter {
         let range_start = meta.get_range().get_start();
         let range_end = meta.get_range().get_end();
 
-        let range_start = keys::rewrite::rewrite_prefix(new_prefix, old_prefix, range_start)
-            .or_else(|_| {
-                if range_start.is_empty() {
-                    Ok(if old_prefix.is_empty() {
-                        new_prefix.to_vec()
-                    } else {
-                        Vec::new()
-                    })
-                } else {
-                    Err(Error::WrongKeyPrefix(
-                        "SST start range",
-                        range_start.to_vec(),
-                        new_prefix.to_vec(),
-                    ))
-                }
-            })?;
-        let range_end = keys::rewrite::rewrite_prefix_of_end_key(new_prefix, old_prefix, range_end)
-            .or_else(|_| {
-                if range_end.is_empty() {
-                    Ok(if old_prefix.is_empty() {
-                        keys::next_key(new_prefix)
-                    } else {
-                        Vec::new()
-                    })
-                } else {
-                    Err(Error::WrongKeyPrefix(
-                        "SST end range",
-                        range_end.to_vec(),
-                        new_prefix.to_vec(),
-                    ))
-                }
-            })?;
+        let range_start = keys::rewrite::rewrite_prefix_of_start_bound(
+            new_prefix,
+            old_prefix,
+            key_to_bound(range_start),
+        )
+        .map_err(|_| {
+            Error::WrongKeyPrefix("SST start range", range_start.to_vec(), new_prefix.to_vec())
+        })?;
+        let range_end = keys::rewrite::rewrite_prefix_of_end_bound(
+            new_prefix,
+            old_prefix,
+            key_to_bound(range_end),
+        )
+        .map_err(|_| {
+            Error::WrongKeyPrefix("SST end range", range_end.to_vec(), new_prefix.to_vec())
+        })?;
 
         // read and first and last keys from the SST, determine if we could
         // simply move the entire SST instead of iterating and generate a new one.
@@ -208,7 +196,7 @@ impl SSTImporter {
                 return Some(meta.get_range().clone());
             }
             let start_key = keys::origin_key(iter.key());
-            if *start_key < *range_start {
+            if is_before_start_bound(start_key, &range_start) {
                 // SST's start is before the range to consume, so needs to iterate to skip over
                 return None;
             }
@@ -216,8 +204,8 @@ impl SSTImporter {
 
             // seek to end and fetch the last (inclusive) key of the SST.
             iter.seek(SeekKey::End);
-            let last_key = keys::origin_end_key(iter.key());
-            if !range_end.is_empty() && *last_key >= *range_end {
+            let last_key = keys::origin_key(iter.key());
+            if is_after_end_bound(last_key, &range_end) {
                 // SST's end is after the range to consume
                 return None;
             }
@@ -225,7 +213,7 @@ impl SSTImporter {
             // range contained the entire SST, no need to iterate, just moving the file is ok
             let mut range = Range::default();
             range.set_start(start_key);
-            range.set_end(keys::next_key(last_key));
+            range.set_end(last_key.to_vec());
             Some(range)
         })();
 
@@ -241,10 +229,14 @@ impl SSTImporter {
         let new_prefix_data_key_len = key.len();
         let mut first_key = None;
 
-        iter.seek(SeekKey::Key(&keys::data_key(&range_start)));
+        match range_start {
+            Bound::Unbounded => iter.seek(SeekKey::Start),
+            Bound::Included(s) => iter.seek(SeekKey::Key(&keys::data_key(&s))),
+            Bound::Excluded(_) => unreachable!(),
+        };
         while iter.valid() {
             let old_key = keys::origin_key(iter.key());
-            if !range_end.is_empty() && *old_key >= *range_end {
+            if is_after_end_bound(old_key, &range_end) {
                 break;
             }
             if !old_key.starts_with(old_prefix) {
@@ -270,7 +262,7 @@ impl SSTImporter {
             sst_writer.finish()?;
             let mut final_range = Range::default();
             final_range.set_start(start_key);
-            final_range.set_end(keys::next_key(keys::origin_key(&key)));
+            final_range.set_end(keys::origin_key(&key).to_vec());
             Ok(Some(final_range))
         } else {
             // nothing is written: prevents finishing the SST at all.
@@ -532,6 +524,30 @@ fn path_to_sst_meta<P: AsRef<Path>>(path: P) -> Result<SstMeta> {
     Ok(meta)
 }
 
+fn key_to_bound(key: &[u8]) -> Bound<&[u8]> {
+    if key.is_empty() {
+        Bound::Unbounded
+    } else {
+        Bound::Included(key)
+    }
+}
+
+fn is_before_start_bound(value: &[u8], bound: &Bound<Vec<u8>>) -> bool {
+    match bound {
+        Bound::Unbounded => false,
+        Bound::Included(b) => *value < **b,
+        Bound::Excluded(b) => *value <= **b,
+    }
+}
+
+fn is_after_end_bound(value: &[u8], bound: &Bound<Vec<u8>>) -> bool {
+    match bound {
+        Bound::Unbounded => false,
+        Bound::Included(b) => *value > **b,
+        Bound::Excluded(b) => *value >= **b,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -724,7 +740,7 @@ mod tests {
         dbg!(&range);
 
         assert_eq!(range.get_start(), b"t123_r01");
-        assert_eq!(range.get_end(), b"t123_r14");
+        assert_eq!(range.get_end(), b"t123_r13");
 
         // verifies that the file is saved to the correct place.
         let sst_file_path = importer.dir.join(&meta).unwrap().save;
@@ -769,7 +785,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(range.get_start(), b"t567_r01");
-        assert_eq!(range.get_end(), b"t567_r14");
+        assert_eq!(range.get_end(), b"t567_r13");
 
         // verifies that the file is saved to the correct place.
         // (the file size may be changed, so not going to check the file size)
@@ -813,7 +829,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(range.get_start(), b"t9102_r01");
-        assert_eq!(range.get_end(), b"t9102_r14");
+        assert_eq!(range.get_end(), b"t9102_r13");
 
         // performs the ingest
         let ingest_dir = tempfile::tempdir().unwrap();
@@ -845,7 +861,7 @@ mod tests {
 
         // note: the range doesn't contain the DATA_PREFIX 'z'.
         meta.mut_range().set_start(b"t123_r02".to_vec());
-        meta.mut_range().set_end(b"t123_r13".to_vec());
+        meta.mut_range().set_end(b"t123_r12".to_vec());
 
         let range = importer
             .download(
@@ -859,7 +875,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(range.get_start(), b"t123_r04");
-        assert_eq!(range.get_end(), b"t123_r08");
+        assert_eq!(range.get_end(), b"t123_r07");
 
         // verifies that the file is saved to the correct place.
         // (the file size is changed, so not going to check the file size)
@@ -887,7 +903,7 @@ mod tests {
         let importer = SSTImporter::new(&importer_dir).unwrap();
 
         meta.mut_range().set_start(b"t5_r02".to_vec());
-        meta.mut_range().set_end(b"t5_r13".to_vec());
+        meta.mut_range().set_end(b"t5_r12".to_vec());
 
         let range = importer
             .download(
@@ -901,7 +917,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(range.get_start(), b"t5_r04");
-        assert_eq!(range.get_end(), b"t5_r08");
+        assert_eq!(range.get_end(), b"t5_r07");
 
         // verifies that the file is saved to the correct place.
         let sst_file_path = importer.dir.join(&meta).unwrap().save;

--- a/tests/integrations/import/sst_service.rs
+++ b/tests/integrations/import/sst_service.rs
@@ -161,7 +161,7 @@ fn test_download_sst() {
     let result = import.download(&download).unwrap();
     assert!(!result.get_is_empty());
     assert_eq!(result.get_range().get_start(), &[sst_range.0]);
-    assert_eq!(result.get_range().get_end(), &[sst_range.1]);
+    assert_eq!(result.get_range().get_end(), &[sst_range.1 - 1]);
 
     // Do an ingest and verify the result is correct.
 


### PR DESCRIPTION
###  What have you changed?

The `ingest()` function expects a closed range instead of half-open range. 

Change the `download()` function to accept and return closed ranges.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

