### PR TITLE
Update rust-rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#4a8748c5f8dee2192236d21d2ad6394034b9b44d"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#66e0f313ef1b4147329db76991bef362960b6621"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -1409,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#4a8748c5f8dee2192236d21d2ad6394034b9b44d"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#66e0f313ef1b4147329db76991bef362960b6621"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -2395,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#4a8748c5f8dee2192236d21d2ad6394034b9b44d"
+source = "git+https://github.com/pingcap/rust-rocksdb.git#66e0f313ef1b4147329db76991bef362960b6621"
 dependencies = [
  "crc",
  "libc",


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This updates rust-rocksdb to the latest master, to pull in https://github.com/tikv/rust-rocksdb/pull/372, which adds reference-counted SST reader iterators, which is needed by https://github.com/tikv/tikv/pull/5790, which abstracts the SST reader under engine_traits.

This also pulls in a few other rust-rocksdb changes:

```
66e0f31 titan: Revert "Relax warnings as errors so we can build on Clang 11 (#90)" (#102) (#374)
2051188 titan: Revert wait for flush before GC (#103) (#373)
64bf468 Add Rc-based SstFileReader iterators (#372)
531392a titan: Implement basic range merge to maintain last level sorted run number (#92) (#371)
a0b5763 add update rocksdb script (#370)
4fa9a0c titan: Add log for blob file range (#101) (#368)
4ed8b94 git submodule when init (#366)
019e91b remove update_titan feature (#365)
9178596 fix misspelling in README.md (#358)
```

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?

cargo test --all --no-run

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

no

###  Does this PR affect `tidb-ansible`?

no

###  Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/issues/4184

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

