### PR TITLE
txn: check_txn_status Support setting write rollback or not when txn not exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#76b56d6eb46688c889ad5f131b26718e30a359e8"
+source = "git+https://github.com/pingcap/kvproto.git#40f562012fb1121bf35bebf7f158d730ee791290"
 dependencies = [
  "futures",
  "grpcio",

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -65,6 +65,10 @@ quick_error! {
             description("txn lock not found")
             display("txn lock not found {}-{} key:{}", start_ts, commit_ts, hex::encode_upper(key))
         }
+        TxnNotFound { start_ts:  u64, key: Vec<u8> } {
+            description("txn not found")
+            display("txn not found {} key: {}", start_ts, hex::encode_upper(key))
+        }
         LockTypeNotMatch { start_ts: u64, key: Vec<u8>, pessimistic: bool } {
             description("lock type not match")
             display("lock type not match, start_ts:{}, key:{}, pessimistic:{}", start_ts, hex::encode_upper(key), pessimistic)
@@ -120,6 +124,10 @@ impl Error {
             } => Some(Error::TxnLockNotFound {
                 start_ts: *start_ts,
                 commit_ts: *commit_ts,
+                key: key.to_owned(),
+            }),
+            Error::TxnNotFound { start_ts, key } => Some(Error::TxnNotFound {
+                start_ts: *start_ts,
                 key: key.to_owned(),
             }),
             Error::LockTypeNotMatch {
@@ -675,16 +683,42 @@ pub mod tests {
         lock_ts: u64,
         caller_start_ts: u64,
         current_ts: u64,
+        rollback_if_not_exist: bool,
         expect_status: TxnStatus,
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, lock_ts, true).unwrap();
         let (txn_status, _) = txn
-            .check_txn_status(Key::from_raw(primary_key), caller_start_ts, current_ts)
+            .check_txn_status(
+                Key::from_raw(primary_key),
+                caller_start_ts,
+                current_ts,
+                rollback_if_not_exist,
+            )
             .unwrap();
         assert_eq!(txn_status, expect_status);
         write(engine, &ctx, txn.into_modifies());
+    }
+
+    pub fn must_check_txn_status_err<E: Engine>(
+        engine: &E,
+        primary_key: &[u8],
+        lock_ts: u64,
+        caller_start_ts: u64,
+        current_ts: u64,
+        rollback_if_not_exist: bool,
+    ) {
+        let ctx = Context::default();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, lock_ts, true).unwrap();
+        txn.check_txn_status(
+            Key::from_raw(primary_key),
+            caller_start_ts,
+            current_ts,
+            rollback_if_not_exist,
+        )
+        .unwrap_err();
     }
 
     pub fn must_gc<E: Engine>(engine: &E, key: &[u8], safe_point: u64) {

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -828,10 +828,15 @@ fn process_write_impl<S: Snapshot, L: LockMgr>(
             lock_ts,
             caller_start_ts,
             current_ts,
+            rollback_if_not_exist,
         } => {
             let mut txn = MvccTxn::new(snapshot.clone(), lock_ts, !ctx.get_not_fill_cache())?;
-            let (txn_status, is_pessimistic_txn) =
-                txn.check_txn_status(primary_key.clone(), caller_start_ts, current_ts)?;
+            let (txn_status, is_pessimistic_txn) = txn.check_txn_status(
+                primary_key.clone(),
+                caller_start_ts,
+                current_ts,
+                rollback_if_not_exist,
+            )?;
 
             // The lock is possibly resolved here only when the `check_txn_status` cleaned up the
             // lock, and this may happen only when it returns `Rollbacked`.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This PR makes `check_txn_status` supports specifying the behavior when neither commit/rollback record nor lock of a transaction's primary key is found. A new parameter `rollback_if_not_exist` was added. If it's `true`, it will write a rollback record in this case; otherwise, it returns a new error TxnNotFound.

This is part of supporting large transactions.

###  What is the type of the changes?

- New feature (a change which adds functionality)

###  How is the PR tested?

- Unit test
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No
