### PR TITLE
storage: remove Deref impls

### DIFF
--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -198,27 +198,27 @@ impl Tracker {
             cop_metrics
                 .local_copr_rocksdb_perf_counter
                 .with_label_values(&[self.req_ctx.tag, "internal_key_skipped_count"])
-                .inc_by(self.total_perf_stats.internal_key_skipped_count as i64);
+                .inc_by(self.total_perf_stats.0.internal_key_skipped_count as i64);
 
             cop_metrics
                 .local_copr_rocksdb_perf_counter
                 .with_label_values(&[self.req_ctx.tag, "internal_delete_skipped_count"])
-                .inc_by(self.total_perf_stats.internal_delete_skipped_count as i64);
+                .inc_by(self.total_perf_stats.0.internal_delete_skipped_count as i64);
 
             cop_metrics
                 .local_copr_rocksdb_perf_counter
                 .with_label_values(&[self.req_ctx.tag, "block_cache_hit_count"])
-                .inc_by(self.total_perf_stats.block_cache_hit_count as i64);
+                .inc_by(self.total_perf_stats.0.block_cache_hit_count as i64);
 
             cop_metrics
                 .local_copr_rocksdb_perf_counter
                 .with_label_values(&[self.req_ctx.tag, "block_read_count"])
-                .inc_by(self.total_perf_stats.block_read_count as i64);
+                .inc_by(self.total_perf_stats.0.block_read_count as i64);
 
             cop_metrics
                 .local_copr_rocksdb_perf_counter
                 .with_label_values(&[self.req_ctx.tag, "block_read_byte"])
-                .inc_by(self.total_perf_stats.block_read_byte as i64);
+                .inc_by(self.total_perf_stats.0.block_read_byte as i64);
         });
 
         tls_collect_scan_details(self.req_ctx.tag, &total_storage_stats);

--- a/src/storage/kv/perf_context.rs
+++ b/src/storage/kv/perf_context.rs
@@ -1,7 +1,5 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::ops::{Deref, DerefMut};
-
 use engine::rocks::PerfContext;
 
 #[derive(Default, Debug, Clone, Copy, Add, AddAssign, Sub, SubAssign, KV)]
@@ -48,20 +46,6 @@ impl PerfStatisticsInstant {
     }
 }
 
-impl Deref for PerfStatisticsInstant {
-    type Target = PerfStatisticsFields;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for PerfStatisticsInstant {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 /// Store statistics we need. Data comes from RocksDB's `PerfContext`.
 /// This this statistics store delta values between two instant statistics.
 #[derive(Default, Debug, Clone, Copy, Add, AddAssign, Sub, SubAssign)]
@@ -74,20 +58,6 @@ impl slog::KV for PerfStatisticsDelta {
         serializer: &mut dyn slog::Serializer,
     ) -> slog::Result {
         slog::KV::serialize(&self.0, record, serializer)
-    }
-}
-
-impl Deref for PerfStatisticsDelta {
-    type Target = PerfStatisticsFields;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for PerfStatisticsDelta {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 
@@ -143,8 +113,8 @@ mod tests {
             block_read_count: 4,
             block_read_byte: 5,
         });
-        assert_eq!(stats.block_cache_hit_count, 3);
-        stats.block_cache_hit_count = 6;
-        assert_eq!(stats.block_cache_hit_count, 6);
+        assert_eq!(stats.0.block_cache_hit_count, 3);
+        stats.0.block_cache_hit_count = 6;
+        assert_eq!(stats.0.block_cache_hit_count, 6);
     }
 }

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -1,7 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::borrow::Borrow;
 use std::fmt::{self, Debug, Display, Formatter};
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -323,7 +323,7 @@ impl Snapshot for RocksSnapshot {
     }
 }
 
-impl<D: Deref<Target = DB> + Send> EngineIterator for DBIterator<D> {
+impl<D: Borrow<DB> + Send> EngineIterator for DBIterator<D> {
     fn next(&mut self) -> bool {
         DBIterator::next(self)
     }
@@ -457,21 +457,21 @@ mod tests {
         let perf_statistics = PerfStatisticsInstant::new();
         iter.seek(&Key::from_raw(b"foo30"), &mut statistics)
             .unwrap();
-        assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 0);
+        assert_eq!(perf_statistics.delta().0.internal_delete_skipped_count, 0);
 
         let perf_statistics = PerfStatisticsInstant::new();
         iter.near_seek(&Key::from_raw(b"foo55"), &mut statistics)
             .unwrap();
-        assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 2);
+        assert_eq!(perf_statistics.delta().0.internal_delete_skipped_count, 2);
 
         let perf_statistics = PerfStatisticsInstant::new();
         iter.prev(&mut statistics);
-        assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 2);
+        assert_eq!(perf_statistics.delta().0.internal_delete_skipped_count, 2);
 
         iter.prev(&mut statistics);
-        assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 3);
+        assert_eq!(perf_statistics.delta().0.internal_delete_skipped_count, 3);
 
         iter.prev(&mut statistics);
-        assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 3);
+        assert_eq!(perf_statistics.delta().0.internal_delete_skipped_count, 3);
     }
 }


### PR DESCRIPTION
###  What have you changed?

Simple refactoring to remove `Defer` impls, which are bad style to use except for smart pointers, see for example [the std docs](https://doc.rust-lang.org/std/ops/trait.Deref.html).

###  What is the type of the changes?
- Engineering (engineering change which doesn't change any feature or fix any issue)

PTAL @AndreMouche  @MyonKeminta 