### PR TITLE
Report better error message when PbCode is unspecified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#bd4b782c8393dc251f6dc15dcce8eec2c7acf315"
+source = "git+https://github.com/pingcap/tipb.git#a594830fb004783d4fb7ec4fbdf184d05fd7ab13"
 dependencies = [
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-build",

--- a/components/tidb_query/src/expr/scalar_function.rs
+++ b/components/tidb_query/src/expr/scalar_function.rs
@@ -379,8 +379,7 @@ impl ScalarFunc {
             | ScalarFuncSig::Pi => (0, 0),
 
             // unimplemented signature
-            ScalarFuncSig::Unspecified
-            | ScalarFuncSig::AddDateAndDuration
+            ScalarFuncSig::AddDateAndDuration
             | ScalarFuncSig::AddDateAndString
             | ScalarFuncSig::AddDateDatetimeInt
             | ScalarFuncSig::AddDateDatetimeString
@@ -513,6 +512,11 @@ impl ScalarFunc {
             | ScalarFuncSig::JsonKeys2ArgsSig
             | ScalarFuncSig::JsonValidStringSig
             | ScalarFuncSig::JsonValidOthersSig => return Err(Error::UnknownSignature(sig)),
+
+            // PbCode is unspecified
+            ScalarFuncSig::Unspecified => {
+                return Err(box_err!("TiDB internal error (unspecified PbCode)"))
+            }
         };
         if args < min_args || args > max_args {
             return Err(box_err!(
@@ -552,7 +556,6 @@ macro_rules! dispatch_call {
         impl ScalarFunc {
             pub fn eval_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
                 match self.sig {
-                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$i_sig => self.$i_func(ctx, row, $($i_arg),*)),*,
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -560,7 +563,6 @@ macro_rules! dispatch_call {
 
             pub fn eval_real(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<f64>> {
                 match self.sig {
-                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$r_sig => self.$r_func(ctx, row, $($r_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -571,7 +573,6 @@ macro_rules! dispatch_call {
                 row: &'a [Datum]
             ) -> Result<Option<Cow<'a, Decimal>>> {
                 match self.sig {
-                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$d_sig => self.$d_func(ctx, row, $($d_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -583,7 +584,6 @@ macro_rules! dispatch_call {
                 row: &'a [Datum]
             ) -> Result<Option<Cow<'a, [u8]>>> {
                 match self.sig {
-                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$b_sig => self.$b_func(ctx, row, $($b_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -595,7 +595,6 @@ macro_rules! dispatch_call {
                 row: &'a [Datum]
             ) -> Result<Option<Cow<'a, Time>>> {
                 match self.sig {
-                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$t_sig => self.$t_func(ctx, row, $($t_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -607,7 +606,6 @@ macro_rules! dispatch_call {
                 row: &'a [Datum]
             ) -> Result<Option<Duration>> {
                 match self.sig {
-                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$u_sig => self.$u_func(ctx, row, $($u_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -619,7 +617,6 @@ macro_rules! dispatch_call {
                 row: &'a [Datum]
             ) -> Result<Option<Cow<'a, Json>>> {
                 match self.sig {
-                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$j_sig => self.$j_func(ctx, row, $($j_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -627,7 +624,6 @@ macro_rules! dispatch_call {
 
             pub fn eval(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Datum> {
                 match self.sig {
-                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$i_sig => {
                         match self.$i_func(ctx, row, $($i_arg)*) {
                             Ok(Some(i)) => {

--- a/components/tidb_query/src/expr/scalar_function.rs
+++ b/components/tidb_query/src/expr/scalar_function.rs
@@ -379,7 +379,8 @@ impl ScalarFunc {
             | ScalarFuncSig::Pi => (0, 0),
 
             // unimplemented signature
-            ScalarFuncSig::AddDateAndDuration
+            ScalarFuncSig::Unspecified
+            | ScalarFuncSig::AddDateAndDuration
             | ScalarFuncSig::AddDateAndString
             | ScalarFuncSig::AddDateDatetimeInt
             | ScalarFuncSig::AddDateDatetimeString
@@ -551,6 +552,7 @@ macro_rules! dispatch_call {
         impl ScalarFunc {
             pub fn eval_int(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<i64>> {
                 match self.sig {
+                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$i_sig => self.$i_func(ctx, row, $($i_arg),*)),*,
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -558,6 +560,7 @@ macro_rules! dispatch_call {
 
             pub fn eval_real(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Option<f64>> {
                 match self.sig {
+                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$r_sig => self.$r_func(ctx, row, $($r_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -568,6 +571,7 @@ macro_rules! dispatch_call {
                 row: &'a [Datum]
             ) -> Result<Option<Cow<'a, Decimal>>> {
                 match self.sig {
+                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$d_sig => self.$d_func(ctx, row, $($d_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -579,6 +583,7 @@ macro_rules! dispatch_call {
                 row: &'a [Datum]
             ) -> Result<Option<Cow<'a, [u8]>>> {
                 match self.sig {
+                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$b_sig => self.$b_func(ctx, row, $($b_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -590,6 +595,7 @@ macro_rules! dispatch_call {
                 row: &'a [Datum]
             ) -> Result<Option<Cow<'a, Time>>> {
                 match self.sig {
+                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$t_sig => self.$t_func(ctx, row, $($t_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -601,6 +607,7 @@ macro_rules! dispatch_call {
                 row: &'a [Datum]
             ) -> Result<Option<Duration>> {
                 match self.sig {
+                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$u_sig => self.$u_func(ctx, row, $($u_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -612,6 +619,7 @@ macro_rules! dispatch_call {
                 row: &'a [Datum]
             ) -> Result<Option<Cow<'a, Json>>> {
                 match self.sig {
+                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$j_sig => self.$j_func(ctx, row, $($j_arg),*),)*
                     _ => Err(Error::UnknownSignature(self.sig))
                 }
@@ -619,6 +627,7 @@ macro_rules! dispatch_call {
 
             pub fn eval(&self, ctx: &mut EvalContext, row: &[Datum]) -> Result<Datum> {
                 match self.sig {
+                    ScalarFuncSig::Unspecified => Err(box_err!("Internal error, unspecified PbCode")),
                     $(ScalarFuncSig::$i_sig => {
                         match self.$i_func(ctx, row, $($i_arg)*) {
                             Ok(Some(i)) => {


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Improves the error message when TiDB forgets specifying PbCode in some expressions.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)
