### PR TITLE
txn refactoring part 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "futures",
  "grpcio",
  "hex",
+ "keys",
  "kvproto",
  "lazy_static",
  "prometheus",
@@ -1365,6 +1366,7 @@ dependencies = [
  "hex",
  "kvproto",
  "panic_hook",
+ "slog",
  "tikv_alloc",
  "tikv_util",
 ]
@@ -1972,6 +1974,7 @@ dependencies = [
  "futures",
  "grpcio",
  "hex",
+ "keys",
  "kvproto",
  "lazy_static",
  "log",
@@ -3172,6 +3175,7 @@ dependencies = [
  "futures",
  "grpcio",
  "hex",
+ "keys",
  "kvproto",
  "pd_client",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3204,6 +3208,7 @@ name = "test_storage"
 version = "0.0.1"
 dependencies = [
  "futures",
+ "keys",
  "kvproto",
  "test_raftstore",
  "tikv",
@@ -3329,6 +3334,7 @@ dependencies = [
  "criterion-cpu-time",
  "criterion-papi",
  "crossbeam",
+ "derive-new",
  "derive_more",
  "engine",
  "engine_rocks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ mime = "0.3.13"
 failure = "0.1"
 prost = "0.5.0"
 regex = "1.3"
+derive-new = "0.5"
 tipb = { git = "https://github.com/pingcap/tipb.git" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 

--- a/benches/misc/storage/incremental_get.rs
+++ b/benches/misc/storage/incremental_get.rs
@@ -34,7 +34,13 @@ fn table_lookup_gen_data() -> (SnapshotStore<SyncSnapshot>, Vec<Key>) {
     db.compact_range_cf(db.cf_handle("lock").unwrap(), None, None);
 
     let snapshot = engine.snapshot(&Context::default()).unwrap();
-    let store = SnapshotStore::new(snapshot, 10, IsolationLevel::Si, true, Default::default());
+    let store = SnapshotStore::new(
+        snapshot,
+        10.into(),
+        IsolationLevel::Si,
+        true,
+        Default::default(),
+    );
 
     // Keys are given in order, and are far away from each other to simulate a normal table lookup
     // scenario.

--- a/benches/misc/storage/scan.rs
+++ b/benches/misc/storage/scan.rs
@@ -66,7 +66,7 @@ fn bench_tombstone_scan(b: &mut Bencher) {
                 None,
                 1,
                 false,
-                ts_generator.next().unwrap()
+                ts_generator.next().unwrap(),
             )
             .unwrap()
             .is_empty())

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -31,6 +31,7 @@ serde = "1.0"
 serde_derive = "1.0"
 lazy_static = "1.3"
 failure = "0.1"
+keys = { path = "../keys" }
 tikv_alloc = { path = "../tikv_alloc", default-features = false }
 tidb_query = { path = "../tidb_query", default-features = false }
 

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -13,6 +13,7 @@ use external_storage::*;
 use futures::lazy;
 use futures::prelude::Future;
 use futures::sync::mpsc::*;
+use keys::TimeStamp;
 use kvproto::backup::*;
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 use kvproto::metapb::*;
@@ -38,8 +39,8 @@ const IDLE_THREADPOOL_DURATION: u64 = 30 * 60 * 1000; // 30 mins
 pub struct Task {
     start_key: Vec<u8>,
     end_key: Vec<u8>,
-    start_ts: u64,
-    end_ts: u64,
+    start_ts: TimeStamp,
+    end_ts: TimeStamp,
     storage: LimitedStorage,
     pub(crate) resp: UnboundedSender<BackupResponse>,
     concurrency: u32,
@@ -90,8 +91,8 @@ impl Task {
             Task {
                 start_key: req.get_start_key().to_owned(),
                 end_key: req.get_end_key().to_owned(),
-                start_ts: req.get_start_version(),
-                end_ts: req.get_end_version(),
+                start_ts: req.get_start_version().into(),
+                end_ts: req.get_end_version().into(),
                 resp,
                 storage,
                 concurrency: req.get_concurrency(),
@@ -121,7 +122,7 @@ impl BackupRange {
         &self,
         writer: &mut BackupWriter,
         engine: &E,
-        backup_ts: u64,
+        backup_ts: TimeStamp,
     ) -> Result<Statistics> {
         let mut ctx = Context::new();
         ctx.set_region_id(self.region.get_id());
@@ -352,8 +353,8 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
     fn spawn_backup_worker(
         &self,
         prs: Arc<Mutex<Progress<R>>>,
-        start_ts: u64,
-        end_ts: u64,
+        start_ts: TimeStamp,
+        end_ts: TimeStamp,
         storage: LimitedStorage,
         tx: mpsc::Sender<(BackupRange, Result<BackupRes>)>,
         cancel: Arc<AtomicBool>,
@@ -463,8 +464,8 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
                     for file in files.iter_mut() {
                         file.set_start_key(start_key.clone());
                         file.set_end_key(end_key.clone());
-                        file.set_start_version(task.start_ts);
-                        file.set_end_version(task.end_ts);
+                        file.set_start_version(task.start_ts.into_inner());
+                        file.set_end_version(task.end_ts.into_inner());
                     }
                     response.set_files(files.into());
                 }
@@ -746,8 +747,8 @@ pub mod tests {
                 let task = Task {
                     start_key: start_key.to_vec(),
                     end_key: end_key.to_vec(),
-                    start_ts: 1,
-                    end_ts: 1,
+                    start_ts: 1.into(),
+                    end_ts: 1.into(),
                     resp: tx,
                     storage,
                     concurrency: 4,
@@ -814,9 +815,9 @@ pub mod tests {
             .region_info
             .set_regions(vec![(b"".to_vec(), b"5".to_vec(), 1)]);
 
-        let mut ts = 1;
+        let mut ts: TimeStamp = 1.into();
         let mut alloc_ts = || {
-            ts += 1;
+            ts = ts.incr();
             ts
         };
         let mut backup_tss = vec![];
@@ -844,8 +845,8 @@ pub mod tests {
             let mut req = BackupRequest::new();
             req.set_start_key(vec![]);
             req.set_end_key(vec![b'5']);
-            req.set_start_version(ts);
-            req.set_end_version(ts);
+            req.set_start_version(ts.into_inner());
+            req.set_end_version(ts.into_inner());
             req.set_concurrency(4);
             let (tx, rx) = unbounded();
             // Empty path should return an error.
@@ -891,9 +892,9 @@ pub mod tests {
             .region_info
             .set_regions(vec![(b"".to_vec(), b"5".to_vec(), 1)]);
 
-        let mut ts = 1;
+        let mut ts: TimeStamp = 1.into();
         let mut alloc_ts = || {
-            ts += 1;
+            ts = ts.incr();
             ts
         };
         let start = alloc_ts();
@@ -910,8 +911,8 @@ pub mod tests {
         let mut req = BackupRequest::new();
         req.set_start_key(vec![]);
         req.set_end_key(vec![b'5']);
-        req.set_start_version(now);
-        req.set_end_version(now);
+        req.set_start_version(now.into_inner());
+        req.set_end_version(now.into_inner());
         req.set_concurrency(4);
         // Set an unique path to avoid AlreadyExists error.
         req.set_path(format!(
@@ -935,8 +936,8 @@ pub mod tests {
         // Test whether it can correctly convert not leader to region error.
         engine.trigger_not_leader();
         let now = alloc_ts();
-        req.set_start_version(now);
-        req.set_end_version(now);
+        req.set_start_version(now.into_inner());
+        req.set_end_version(now.into_inner());
         // Set an unique path to avoid AlreadyExists error.
         req.set_path(format!(
             "local://{}",
@@ -965,9 +966,9 @@ pub mod tests {
             .region_info
             .set_regions(vec![(b"".to_vec(), b"5".to_vec(), 1)]);
 
-        let mut ts = 1;
+        let mut ts: TimeStamp = 1.into();
         let mut alloc_ts = || {
-            ts += 1;
+            ts = ts.incr();
             ts
         };
         let start = alloc_ts();
@@ -987,8 +988,8 @@ pub mod tests {
         let mut req = BackupRequest::new();
         req.set_start_key(vec![]);
         req.set_end_key(vec![]);
-        req.set_start_version(now);
-        req.set_end_version(now);
+        req.set_start_version(now.into_inner());
+        req.set_end_version(now.into_inner());
         req.set_concurrency(4);
         req.set_path(format!("local://{}", temp.path().display()));
 

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -815,11 +815,8 @@ pub mod tests {
             .region_info
             .set_regions(vec![(b"".to_vec(), b"5".to_vec(), 1)]);
 
-        let mut ts: TimeStamp = 1.into();
-        let mut alloc_ts = || {
-            ts = ts.incr();
-            ts
-        };
+        let mut ts = TimeStamp::new(1);
+        let mut alloc_ts = || *ts.incr();
         let mut backup_tss = vec![];
         // Multi-versions for key 0..9.
         for len in &[SHORT_VALUE_MAX_LEN - 1, SHORT_VALUE_MAX_LEN * 2] {
@@ -893,10 +890,7 @@ pub mod tests {
             .set_regions(vec![(b"".to_vec(), b"5".to_vec(), 1)]);
 
         let mut ts: TimeStamp = 1.into();
-        let mut alloc_ts = || {
-            ts = ts.incr();
-            ts
-        };
+        let mut alloc_ts = || *ts.incr();
         let start = alloc_ts();
         let key = format!("{}", start);
         must_prewrite_put(
@@ -967,10 +961,7 @@ pub mod tests {
             .set_regions(vec![(b"".to_vec(), b"5".to_vec(), 1)]);
 
         let mut ts: TimeStamp = 1.into();
-        let mut alloc_ts = || {
-            ts = ts.incr();
-            ts
-        };
+        let mut alloc_ts = || *ts.incr();
         let start = alloc_ts();
         let key = format!("{}", start);
         must_prewrite_put(

--- a/components/backup/src/service.rs
+++ b/components/backup/src/service.rs
@@ -85,6 +85,7 @@ mod tests {
 
     use super::*;
     use crate::endpoint::tests::*;
+    use keys::TimeStamp;
     use tikv::storage::mvcc::tests::*;
     use tikv_util::mpsc::Receiver;
 
@@ -114,9 +115,9 @@ mod tests {
             (b"2".to_vec(), b"5".to_vec(), 2),
         ]);
 
-        let mut ts = 1;
+        let mut ts: TimeStamp = 1.into();
         let mut alloc_ts = || {
-            ts += 1;
+            ts = ts.incr();
             ts
         };
         for i in 0..5 {
@@ -137,8 +138,8 @@ mod tests {
         let mut req = BackupRequest::new();
         req.set_start_key(vec![]);
         req.set_end_key(vec![b'5']);
-        req.set_start_version(now);
-        req.set_end_version(now);
+        req.set_start_version(now.into_inner());
+        req.set_end_version(now.into_inner());
         // Set an unique path to avoid AlreadyExists error.
         req.set_path(format!(
             "local://{}",

--- a/components/backup/src/service.rs
+++ b/components/backup/src/service.rs
@@ -116,10 +116,7 @@ mod tests {
         ]);
 
         let mut ts: TimeStamp = 1.into();
-        let mut alloc_ts = || {
-            ts = ts.incr();
-            ts
-        };
+        let mut alloc_ts = || *ts.incr();
         for i in 0..5 {
             let start = alloc_ts();
             let key = format!("{}", i);

--- a/components/backup/tests/integrations/test_backup.rs
+++ b/components/backup/tests/integrations/test_backup.rs
@@ -104,14 +104,13 @@ impl TestSuite {
             endpoints,
             tikv_cli,
             context,
-            ts: TimeStamp::min(),
+            ts: TimeStamp::zero(),
             _env: env,
         }
     }
 
     fn alloc_ts(&mut self) -> TimeStamp {
-        self.ts = self.ts.incr();
-        self.ts
+        *self.ts.incr()
     }
 
     fn stop(mut self) {
@@ -285,7 +284,7 @@ fn test_backup_and_import() {
         backup_ts,
         format!(
             "local://{}",
-            tmp.path().join(format!("{}", backup_ts.incr())).display()
+            tmp.path().join(format!("{}", backup_ts.next())).display()
         ),
     );
     let resps2 = rx.collect().wait().unwrap();
@@ -345,7 +344,7 @@ fn test_backup_and_import() {
         format!(
             "local://{}",
             tmp.path()
-                .join(format!("{}", backup_ts.incr().incr()))
+                .join(format!("{}", backup_ts.next().next()))
                 .display()
         ),
     );

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -11,6 +11,7 @@ failure = "0.1"
 farmhash = "1.1.5"
 hex = "0.3"
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+slog = "2.3"
 
 tikv_alloc = { path = "../tikv_alloc", default-features = false }
 tikv_util = { path = "../tikv_util" }

--- a/components/keys/src/lib.rs
+++ b/components/keys/src/lib.rs
@@ -15,7 +15,7 @@ use std::mem;
 pub mod rewrite;
 mod types;
 
-pub use types::{Key, KvPair, Value};
+pub use types::{Instant, Key, KvPair, TimeStamp, Value};
 
 pub const MIN_KEY: &[u8] = &[];
 pub const MAX_KEY: &[u8] = &[0xFF];

--- a/components/keys/src/lib.rs
+++ b/components/keys/src/lib.rs
@@ -13,9 +13,11 @@ use kvproto::metapb::Region;
 use std::mem;
 
 pub mod rewrite;
+mod timestamp;
 mod types;
 
-pub use types::{Instant, Key, KvPair, TimeStamp, Value};
+pub use timestamp::{TimeStamp, UnixSecs};
+pub use types::{Key, KvPair, Value};
 
 pub const MIN_KEY: &[u8] = &[];
 pub const MAX_KEY: &[u8] = &[0xFF];

--- a/components/keys/src/timestamp.rs
+++ b/components/keys/src/timestamp.rs
@@ -1,0 +1,142 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::fmt;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct TimeStamp(u64);
+
+const TSO_PHYSICAL_SHIFT_BITS: u64 = 18;
+
+impl TimeStamp {
+    /// Create a time stamp from physical and logical components.
+    pub fn compose(physical: u64, logical: u64) -> TimeStamp {
+        TimeStamp((physical << TSO_PHYSICAL_SHIFT_BITS) + logical)
+    }
+
+    pub const fn zero() -> TimeStamp {
+        TimeStamp(0)
+    }
+
+    pub const fn max() -> TimeStamp {
+        TimeStamp(std::u64::MAX)
+    }
+
+    pub const fn new(ts: u64) -> TimeStamp {
+        TimeStamp(ts)
+    }
+
+    /// Extracts physical part of a timestamp, in milliseconds.
+    pub fn physical(self) -> u64 {
+        self.0 >> TSO_PHYSICAL_SHIFT_BITS
+    }
+
+    pub fn next(self) -> TimeStamp {
+        TimeStamp(self.0 + 1)
+    }
+
+    pub fn prev(self) -> TimeStamp {
+        TimeStamp(self.0 - 1)
+    }
+
+    pub fn incr(&mut self) -> &mut TimeStamp {
+        self.0 += 1;
+        self
+    }
+
+    pub fn decr(&mut self) -> &mut TimeStamp {
+        self.0 -= 1;
+        self
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+
+    pub fn into_inner(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for TimeStamp {
+    fn from(ts: u64) -> TimeStamp {
+        TimeStamp(ts)
+    }
+}
+
+impl From<&u64> for TimeStamp {
+    fn from(ts: &u64) -> TimeStamp {
+        TimeStamp(*ts)
+    }
+}
+
+impl fmt::Display for TimeStamp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl slog::Value for TimeStamp {
+    fn serialize(
+        &self,
+        record: &slog::Record,
+        key: slog::Key,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        slog::Value::serialize(&self.0, record, key, serializer)
+    }
+}
+
+/// A time in seconds since the start of the Unix epoch.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct UnixSecs(u64);
+
+impl UnixSecs {
+    pub fn now() -> UnixSecs {
+        UnixSecs(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+    }
+
+    pub fn zero() -> UnixSecs {
+        UnixSecs(0)
+    }
+
+    pub fn into_inner(self) -> u64 {
+        self.0
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Key;
+
+    #[test]
+    fn test_ts() {
+        let physical = 1568700549751;
+        let logical = 108;
+        let ts = TimeStamp::compose(physical, logical);
+        assert_eq!(ts, 411225436913926252.into());
+
+        let extracted_physical = ts.physical();
+        assert_eq!(extracted_physical, physical);
+    }
+
+    #[test]
+    fn test_split_ts() {
+        let k = b"k";
+        let ts = TimeStamp(123);
+        assert!(Key::split_on_ts_for(k).is_err());
+        let enc = Key::from_encoded_slice(k).append_ts(ts);
+        let res = Key::split_on_ts_for(enc.as_encoded()).unwrap();
+        assert_eq!(res, (k.as_ref(), ts));
+    }
+}

--- a/components/keys/src/types.rs
+++ b/components/keys/src/types.rs
@@ -1,6 +1,7 @@
 use byteorder::{ByteOrder, NativeEndian};
 use hex::ToHex;
 use std::fmt::{self, Debug, Display, Formatter};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tikv_util::codec;
 use tikv_util::codec::bytes;
 use tikv_util::codec::bytes::BytesEncoder;
@@ -82,9 +83,9 @@ impl Key {
 
     /// Creates a new key by appending a `u64` timestamp to this key.
     #[inline]
-    pub fn append_ts(self, ts: u64) -> Key {
+    pub fn append_ts(self, ts: TimeStamp) -> Key {
         let mut encoded = self.0;
-        encoded.encode_u64_desc(ts).unwrap();
+        encoded.encode_u64_desc(ts.0).unwrap();
         Key(encoded)
     }
 
@@ -93,7 +94,7 @@ impl Key {
     /// Preconditions: the caller must ensure this is actually a timestamped
     /// key.
     #[inline]
-    pub fn decode_ts(&self) -> Result<u64, codec::Error> {
+    pub fn decode_ts(&self) -> Result<TimeStamp, codec::Error> {
         Ok(Self::decode_ts_from(&self.0)?)
     }
 
@@ -122,14 +123,14 @@ impl Key {
 
     /// Split a ts encoded key, return the user key and timestamp.
     #[inline]
-    pub fn split_on_ts_for(key: &[u8]) -> Result<(&[u8], u64), codec::Error> {
+    pub fn split_on_ts_for(key: &[u8]) -> Result<(&[u8], TimeStamp), codec::Error> {
         if key.len() < number::U64_SIZE {
             Err(codec::Error::KeyLength)
         } else {
             let pos = key.len() - number::U64_SIZE;
             let k = &key[..pos];
             let mut ts = &key[pos..];
-            Ok((k, number::decode_u64_desc(&mut ts)?))
+            Ok((k, number::decode_u64_desc(&mut ts)?.into()))
         }
     }
 
@@ -145,13 +146,13 @@ impl Key {
 
     /// Decode the timestamp from a ts encoded key.
     #[inline]
-    pub fn decode_ts_from(key: &[u8]) -> Result<u64, codec::Error> {
+    pub fn decode_ts_from(key: &[u8]) -> Result<TimeStamp, codec::Error> {
         let len = key.len();
         if len < number::U64_SIZE {
             return Err(codec::Error::KeyLength);
         }
         let mut ts = &key[len - number::U64_SIZE..];
-        number::decode_u64_desc(&mut ts)
+        Ok(TimeStamp(number::decode_u64_desc(&mut ts)?))
     }
 
     /// Whether the user key part of a ts encoded key `ts_encoded_key` equals to the encoded
@@ -216,14 +217,126 @@ impl Display for Key {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct TimeStamp(u64);
+
+const TSO_PHYSICAL_SHIFT_BITS: u64 = 18;
+
+impl TimeStamp {
+    /// Create a time stamp from physical and logical components.
+    pub fn compose(physical: u64, logical: u64) -> TimeStamp {
+        TimeStamp((physical << TSO_PHYSICAL_SHIFT_BITS) + logical)
+    }
+
+    pub const fn min() -> TimeStamp {
+        TimeStamp(0)
+    }
+
+    pub const fn max() -> TimeStamp {
+        TimeStamp(std::u64::MAX)
+    }
+
+    pub const fn new(ts: u64) -> TimeStamp {
+        TimeStamp(ts)
+    }
+
+    /// Extracts physical part of a timestamp, in milliseconds.
+    pub fn extract_physical(self) -> u64 {
+        self.0 >> TSO_PHYSICAL_SHIFT_BITS
+    }
+
+    pub fn incr(self) -> TimeStamp {
+        TimeStamp(self.0 + 1)
+    }
+
+    pub fn decr(self) -> TimeStamp {
+        TimeStamp(self.0 - 1)
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+
+    pub fn into_inner(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for TimeStamp {
+    fn from(ts: u64) -> TimeStamp {
+        TimeStamp(ts)
+    }
+}
+
+impl From<&u64> for TimeStamp {
+    fn from(ts: &u64) -> TimeStamp {
+        TimeStamp(*ts)
+    }
+}
+
+impl fmt::Display for TimeStamp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl slog::Value for TimeStamp {
+    fn serialize(
+        &self,
+        record: &slog::Record,
+        key: slog::Key,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        slog::Value::serialize(&self.0, record, key, serializer)
+    }
+}
+
+/// A time in seconds since the start of the Unix epoch.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Instant(u64);
+
+impl Instant {
+    pub fn now() -> Instant {
+        Instant(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+    }
+
+    pub fn zero() -> Instant {
+        Instant(0)
+    }
+
+    pub fn into_inner(self) -> u64 {
+        self.0
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
+    fn test_ts() {
+        let physical = 1568700549751;
+        let logical = 108;
+        let ts = TimeStamp::compose(physical, logical);
+        assert_eq!(ts, 411225436913926252.into());
+
+        let extracted_physical = ts.extract_physical();
+        assert_eq!(extracted_physical, physical);
+    }
+
+    #[test]
     fn test_split_ts() {
         let k = b"k";
-        let ts = 123;
+        let ts = TimeStamp(123);
         assert!(Key::split_on_ts_for(k).is_err());
         let enc = Key::from_encoded_slice(k).append_ts(ts);
         let res = Key::split_on_ts_for(enc.as_encoded()).unwrap();

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -21,6 +21,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 grpcio = { version = "0.5.0-alpha.3", features = [ "secure" ] }
+keys = { path = "../keys" }
 tikv_util = { path = "../tikv_util" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 hex = "0.3"

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -15,8 +15,9 @@ use super::metrics::*;
 use super::util::{check_resp_header, sync_request, validate_endpoints, Inner, LeaderClient};
 use super::{Config, PdFuture};
 use super::{Error, PdClient, RegionInfo, RegionStat, Result, REQUEST_TIMEOUT};
+use keys::Instant as PdInstant;
 use tikv_util::security::SecurityManager;
-use tikv_util::time::{duration_to_sec, time_now_sec};
+use tikv_util::time::duration_to_sec;
 use tikv_util::{Either, HandyRwLock};
 
 const CQ_COUNT: usize = 1;
@@ -307,8 +308,8 @@ impl PdClient for RpcClient {
         req.set_approximate_size(region_stat.approximate_size);
         req.set_approximate_keys(region_stat.approximate_keys);
         let mut interval = pdpb::TimeInterval::default();
-        interval.set_start_timestamp(region_stat.last_report_ts);
-        interval.set_end_timestamp(time_now_sec());
+        interval.set_start_timestamp(region_stat.last_report_ts.into_inner());
+        interval.set_end_timestamp(PdInstant::now().into_inner());
         req.set_interval(interval);
 
         let executor = |client: &RwLock<Inner>, req: pdpb::RegionHeartbeatRequest| {
@@ -423,7 +424,9 @@ impl PdClient for RpcClient {
 
         let mut req = pdpb::StoreHeartbeatRequest::default();
         req.set_header(self.header());
-        stats.mut_interval().set_end_timestamp(time_now_sec());
+        stats
+            .mut_interval()
+            .set_end_timestamp(PdInstant::now().into_inner());
         req.set_stats(stats);
         let executor = move |client: &RwLock<Inner>, req: pdpb::StoreHeartbeatRequest| {
             let handler = client

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -13,9 +13,8 @@ use kvproto::pdpb::{self, Member};
 
 use super::metrics::*;
 use super::util::{check_resp_header, sync_request, validate_endpoints, Inner, LeaderClient};
-use super::{Config, PdFuture};
+use super::{Config, PdFuture, UnixSecs};
 use super::{Error, PdClient, RegionInfo, RegionStat, Result, REQUEST_TIMEOUT};
-use keys::Instant as PdInstant;
 use tikv_util::security::SecurityManager;
 use tikv_util::time::duration_to_sec;
 use tikv_util::{Either, HandyRwLock};
@@ -309,7 +308,7 @@ impl PdClient for RpcClient {
         req.set_approximate_keys(region_stat.approximate_keys);
         let mut interval = pdpb::TimeInterval::default();
         interval.set_start_timestamp(region_stat.last_report_ts.into_inner());
-        interval.set_end_timestamp(PdInstant::now().into_inner());
+        interval.set_end_timestamp(UnixSecs::now().into_inner());
         req.set_interval(interval);
 
         let executor = |client: &RwLock<Inner>, req: pdpb::RegionHeartbeatRequest| {
@@ -426,7 +425,7 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         stats
             .mut_interval()
-            .set_end_timestamp(PdInstant::now().into_inner());
+            .set_end_timestamp(UnixSecs::now().into_inner());
         req.set_stats(stats);
         let executor = move |client: &RwLock<Inner>, req: pdpb::StoreHeartbeatRequest| {
             let handler = client

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -32,6 +32,7 @@ pub use self::util::RECONNECT_INTERVAL_SEC;
 use std::ops::Deref;
 
 use futures::Future;
+use keys::Instant;
 use kvproto::metapb;
 use kvproto::pdpb;
 
@@ -48,7 +49,7 @@ pub struct RegionStat {
     pub read_keys: u64,
     pub approximate_size: u64,
     pub approximate_keys: u64,
-    pub last_report_ts: u64,
+    pub last_report_ts: Instant,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -32,7 +32,7 @@ pub use self::util::RECONNECT_INTERVAL_SEC;
 use std::ops::Deref;
 
 use futures::Future;
-use keys::Instant;
+use keys::UnixSecs;
 use kvproto::metapb;
 use kvproto::pdpb;
 
@@ -49,7 +49,7 @@ pub struct RegionStat {
     pub read_keys: u64,
     pub approximate_size: u64,
     pub approximate_keys: u64,
-    pub last_report_ts: Instant,
+    pub last_report_ts: UnixSecs,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -118,7 +118,7 @@ impl<E: Engine> Store<E> {
         Self {
             store: SyncTestStorageBuilder::from_engine(engine).build().unwrap(),
             current_ts: 1.into(),
-            last_committed_ts: TimeStamp::min(),
+            last_committed_ts: TimeStamp::zero(),
             handles: vec![],
         }
     }

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -10,7 +10,7 @@ use test_storage::{SyncTestStorage, SyncTestStorageBuilder};
 use tidb_query::codec::{datum, table, Datum};
 use tidb_query::expr::EvalContext;
 use tikv::storage::{
-    Engine, FixtureStore, Key, Mutation, RocksEngine, SnapshotStore, TestEngineBuilder,
+    Engine, FixtureStore, Key, Mutation, RocksEngine, SnapshotStore, TestEngineBuilder, TimeStamp,
 };
 use tikv_util::collections::HashMap;
 
@@ -102,8 +102,8 @@ impl<'a, E: Engine> Delete<'a, E> {
 /// A store that operates over MVCC and support transactions.
 pub struct Store<E: Engine> {
     store: SyncTestStorage<E>,
-    current_ts: u64,
-    last_committed_ts: u64,
+    current_ts: TimeStamp,
+    last_committed_ts: TimeStamp,
     handles: Vec<Vec<u8>>,
 }
 
@@ -117,14 +117,14 @@ impl<E: Engine> Store<E> {
     pub fn from_engine(engine: E) -> Self {
         Self {
             store: SyncTestStorageBuilder::from_engine(engine).build().unwrap(),
-            current_ts: 1,
-            last_committed_ts: 0,
+            current_ts: 1.into(),
+            last_committed_ts: TimeStamp::min(),
             handles: vec![],
         }
     }
 
     pub fn begin(&mut self) {
-        self.current_ts = next_id() as u64;
+        self.current_ts = (next_id() as u64).into();
         self.handles.clear();
     }
 
@@ -159,7 +159,7 @@ impl<E: Engine> Store<E> {
     }
 
     pub fn commit_with_ctx(&mut self, ctx: Context) {
-        let commit_ts = next_id() as u64;
+        let commit_ts = (next_id() as u64).into();
         let handles: Vec<_> = self.handles.drain(..).map(|x| Key::from_raw(&x)).collect();
         if !handles.is_empty() {
             self.store

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -20,5 +20,6 @@ slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debu
 # better to not use slog-global, but pass in the logger
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 engine = { path = "../engine" }
+keys = { path = "../keys" }
 hex = "0.3"
 pd_client = { path = "../pd_client" }

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -15,7 +15,7 @@ use kvproto::metapb::{self, Region};
 use kvproto::pdpb;
 use raft::eraftpb;
 
-use keys::Instant as PdInstant;
+use keys::UnixSecs as PdInstant;
 use pd_client::{Error, Key, PdClient, PdFuture, RegionStat, Result};
 use tikv::raftstore::store::keys::{self, data_key, enc_end_key, enc_start_key};
 use tikv::raftstore::store::util::check_key_in_region;

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -15,6 +15,7 @@ use kvproto::metapb::{self, Region};
 use kvproto::pdpb;
 use raft::eraftpb;
 
+use keys::Instant as PdInstant;
 use pd_client::{Error, Key, PdClient, PdFuture, RegionStat, Result};
 use tikv::raftstore::store::keys::{self, data_key, enc_end_key, enc_start_key};
 use tikv::raftstore::store::util::check_key_in_region;
@@ -211,7 +212,7 @@ struct Cluster {
     region_id_keys: HashMap<u64, Key>,
     region_approximate_size: HashMap<u64, u64>,
     region_approximate_keys: HashMap<u64, u64>,
-    region_last_report_ts: HashMap<u64, u64>,
+    region_last_report_ts: HashMap<u64, PdInstant>,
     region_last_report_term: HashMap<u64, u64>,
     base_id: AtomicUsize,
 
@@ -323,7 +324,7 @@ impl Cluster {
         self.region_approximate_keys.get(&region_id).cloned()
     }
 
-    fn get_region_last_report_ts(&self, region_id: u64) -> Option<u64> {
+    fn get_region_last_report_ts(&self, region_id: u64) -> Option<PdInstant> {
         self.region_last_report_ts.get(&region_id).cloned()
     }
 
@@ -955,7 +956,7 @@ impl TestPdClient {
         self.cluster.rl().get_region_approximate_keys(region_id)
     }
 
-    pub fn get_region_last_report_ts(&self, region_id: u64) -> Option<u64> {
+    pub fn get_region_last_report_ts(&self, region_id: u64) -> Option<PdInstant> {
         self.cluster.rl().get_region_last_report_ts(region_id)
     }
 

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+keys = { path = "../keys" }
 tikv_util = { path = "../tikv_util" }
 tikv = { path = "../../", default-features = false }
 test_raftstore = { path = "../test_raftstore" }

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -2,6 +2,7 @@
 
 use kvproto::kvrpcpb::{Context, LockInfo};
 
+use keys::TimeStamp;
 use test_raftstore::{Cluster, ServerCluster, SimulateEngine};
 use tikv::storage::kv::{self, RocksEngine};
 use tikv::storage::mvcc::{self, MAX_TXN_WRITE_SIZE};
@@ -55,20 +56,28 @@ impl AssertionStorage<SimulateEngine> {
         &mut self,
         cluster: &mut Cluster<ServerCluster>,
         key: &[u8],
-        start_ts: u64,
-        commit_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
     ) {
         let mutations = vec![Mutation::Delete(Key::from_raw(key))];
         let commit_keys = vec![Key::from_raw(key)];
-        self.two_pc_ok_for_cluster(cluster, mutations, key, commit_keys, start_ts, commit_ts);
+        self.two_pc_ok_for_cluster(
+            cluster,
+            mutations,
+            key,
+            commit_keys,
+            start_ts.into(),
+            commit_ts.into(),
+        );
     }
 
     fn get_from_custer(
         &mut self,
         cluster: &mut Cluster<ServerCluster>,
         key: &[u8],
-        ts: u64,
+        ts: impl Into<TimeStamp>,
     ) -> Option<Value> {
+        let ts = ts.into();
         for _ in 0..3 {
             let res = self.store.get(self.ctx.clone(), &Key::from_raw(key), ts);
             if let Ok(data) = res {
@@ -84,7 +93,7 @@ impl AssertionStorage<SimulateEngine> {
         &mut self,
         cluster: &mut Cluster<ServerCluster>,
         key: &[u8],
-        ts: u64,
+        ts: impl Into<TimeStamp>,
     ) {
         assert_eq!(self.get_from_custer(cluster, key, ts), None);
     }
@@ -94,8 +103,8 @@ impl AssertionStorage<SimulateEngine> {
         cluster: &mut Cluster<ServerCluster>,
         key: &[u8],
         value: &[u8],
-        start_ts: u64,
-        commit_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
     ) {
         let mutations = vec![Mutation::Put((Key::from_raw(key), value.to_vec()))];
         let commit_keys = vec![Key::from_raw(key)];
@@ -108,11 +117,12 @@ impl AssertionStorage<SimulateEngine> {
         prewrite_mutations: Vec<Mutation>,
         key: &[u8],
         commit_keys: Vec<Key>,
-        start_ts: u64,
-        commit_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
     ) {
         let retry_time = 3;
         let mut success = false;
+        let start_ts = start_ts.into();
         for _ in 0..retry_time {
             let res = self.store.prewrite(
                 self.ctx.clone(),
@@ -130,6 +140,7 @@ impl AssertionStorage<SimulateEngine> {
         assert!(success);
 
         success = false;
+        let commit_ts = commit_ts.into();
         for _ in 0..retry_time {
             let res = self
                 .store
@@ -148,8 +159,9 @@ impl AssertionStorage<SimulateEngine> {
         &mut self,
         cluster: &mut Cluster<ServerCluster>,
         region_key: &[u8],
-        safe_point: u64,
+        safe_point: impl Into<TimeStamp>,
     ) {
+        let safe_point = safe_point.into();
         for _ in 0..3 {
             let ret = self.store.gc(self.ctx.clone(), safe_point);
             if ret.is_ok() {
@@ -180,29 +192,35 @@ impl AssertionStorage<SimulateEngine> {
 }
 
 impl<E: Engine> AssertionStorage<E> {
-    pub fn get_none(&self, key: &[u8], ts: u64) {
-        let key = Key::from_raw(key);
-        assert_eq!(self.store.get(self.ctx.clone(), &key, ts).unwrap(), None);
-    }
-
-    pub fn get_err(&self, key: &[u8], ts: u64) {
-        let key = Key::from_raw(key);
-        assert!(self.store.get(self.ctx.clone(), &key, ts).is_err());
-    }
-
-    pub fn get_ok(&self, key: &[u8], ts: u64, expect: &[u8]) {
+    pub fn get_none(&self, key: &[u8], ts: impl Into<TimeStamp>) {
         let key = Key::from_raw(key);
         assert_eq!(
-            self.store.get(self.ctx.clone(), &key, ts).unwrap().unwrap(),
+            self.store.get(self.ctx.clone(), &key, ts.into()).unwrap(),
+            None
+        );
+    }
+
+    pub fn get_err(&self, key: &[u8], ts: impl Into<TimeStamp>) {
+        let key = Key::from_raw(key);
+        assert!(self.store.get(self.ctx.clone(), &key, ts.into()).is_err());
+    }
+
+    pub fn get_ok(&self, key: &[u8], ts: impl Into<TimeStamp>, expect: &[u8]) {
+        let key = Key::from_raw(key);
+        assert_eq!(
+            self.store
+                .get(self.ctx.clone(), &key, ts.into())
+                .unwrap()
+                .unwrap(),
             expect
         );
     }
 
-    pub fn batch_get_ok(&self, keys: &[&[u8]], ts: u64, expect: Vec<&[u8]>) {
+    pub fn batch_get_ok(&self, keys: &[&[u8]], ts: impl Into<TimeStamp>, expect: Vec<&[u8]>) {
         let keys: Vec<Key> = keys.iter().map(|x| Key::from_raw(x)).collect();
         let result: Vec<Vec<u8>> = self
             .store
-            .batch_get(self.ctx.clone(), &keys, ts)
+            .batch_get(self.ctx.clone(), &keys, ts.into())
             .unwrap()
             .into_iter()
             .map(|x| x.unwrap().1)
@@ -233,7 +251,12 @@ impl<E: Engine> AssertionStorage<E> {
         }
     }
 
-    fn expect_invalid_tso_err(&self, resp: Result<(), storage::Error>, sts: u64, cmt_ts: u64) {
+    fn expect_invalid_tso_err(
+        &self,
+        resp: Result<(), storage::Error>,
+        sts: impl Into<TimeStamp>,
+        cmt_ts: impl Into<TimeStamp>,
+    ) {
         assert!(resp.is_err());
         let err = resp.unwrap_err();
         match err {
@@ -241,8 +264,8 @@ impl<E: Engine> AssertionStorage<E> {
                 start_ts,
                 commit_ts,
             }) => {
-                assert_eq!(sts, start_ts);
-                assert_eq!(cmt_ts, commit_ts);
+                assert_eq!(sts.into(), start_ts);
+                assert_eq!(cmt_ts.into(), commit_ts);
             }
             _ => {
                 panic!("expect invalid tso error, but got {:?}", err);
@@ -250,7 +273,14 @@ impl<E: Engine> AssertionStorage<E> {
         }
     }
 
-    pub fn put_ok(&self, key: &[u8], value: &[u8], start_ts: u64, commit_ts: u64) {
+    pub fn put_ok(
+        &self,
+        key: &[u8],
+        value: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
+    ) {
+        let start_ts = start_ts.into();
         self.store
             .prewrite(
                 self.ctx.clone(),
@@ -264,12 +294,18 @@ impl<E: Engine> AssertionStorage<E> {
                 self.ctx.clone(),
                 vec![Key::from_raw(key)],
                 start_ts,
-                commit_ts,
+                commit_ts.into(),
             )
             .unwrap();
     }
 
-    pub fn delete_ok(&self, key: &[u8], start_ts: u64, commit_ts: u64) {
+    pub fn delete_ok(
+        &self,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
+    ) {
+        let start_ts = start_ts.into();
         self.store
             .prewrite(
                 self.ctx.clone(),
@@ -283,7 +319,7 @@ impl<E: Engine> AssertionStorage<E> {
                 self.ctx.clone(),
                 vec![Key::from_raw(key)],
                 start_ts,
-                commit_ts,
+                commit_ts.into(),
             )
             .unwrap();
     }
@@ -292,13 +328,13 @@ impl<E: Engine> AssertionStorage<E> {
         &self,
         start_key: &[u8],
         limit: usize,
-        ts: u64,
+        ts: impl Into<TimeStamp>,
         expect: Vec<Option<(&[u8], &[u8])>>,
     ) {
         let key_address = Key::from_raw(start_key);
         let result = self
             .store
-            .scan(self.ctx.clone(), key_address, None, limit, false, ts)
+            .scan(self.ctx.clone(), key_address, None, limit, false, ts.into())
             .unwrap();
         let result: Vec<Option<KvPair>> = result.into_iter().map(Result::ok).collect();
         let expect: Vec<Option<KvPair>> = expect
@@ -312,13 +348,13 @@ impl<E: Engine> AssertionStorage<E> {
         &self,
         start_key: &[u8],
         limit: usize,
-        ts: u64,
+        ts: impl Into<TimeStamp>,
         expect: Vec<Option<(&[u8], &[u8])>>,
     ) {
         let key_address = Key::from_raw(start_key);
         let result = self
             .store
-            .reverse_scan(self.ctx.clone(), key_address, None, limit, false, ts)
+            .reverse_scan(self.ctx.clone(), key_address, None, limit, false, ts.into())
             .unwrap();
         let result: Vec<Option<KvPair>> = result.into_iter().map(Result::ok).collect();
         let expect: Vec<Option<KvPair>> = expect
@@ -332,13 +368,13 @@ impl<E: Engine> AssertionStorage<E> {
         &self,
         start_key: &[u8],
         limit: usize,
-        ts: u64,
+        ts: impl Into<TimeStamp>,
         expect: Vec<Option<&[u8]>>,
     ) {
         let key_address = Key::from_raw(start_key);
         let result = self
             .store
-            .scan(self.ctx.clone(), key_address, None, limit, true, ts)
+            .scan(self.ctx.clone(), key_address, None, limit, true, ts.into())
             .unwrap();
         let result: Vec<Option<KvPair>> = result.into_iter().map(Result::ok).collect();
         let expect: Vec<Option<KvPair>> = expect
@@ -348,15 +384,35 @@ impl<E: Engine> AssertionStorage<E> {
         assert_eq!(result, expect);
     }
 
-    pub fn prewrite_ok(&self, mutations: Vec<Mutation>, primary: &[u8], start_ts: u64) {
+    pub fn prewrite_ok(
+        &self,
+        mutations: Vec<Mutation>,
+        primary: &[u8],
+        start_ts: impl Into<TimeStamp>,
+    ) {
         self.store
-            .prewrite(self.ctx.clone(), mutations, primary.to_vec(), start_ts)
+            .prewrite(
+                self.ctx.clone(),
+                mutations,
+                primary.to_vec(),
+                start_ts.into(),
+            )
             .unwrap();
     }
 
-    pub fn prewrite_err(&self, mutations: Vec<Mutation>, primary: &[u8], start_ts: u64) {
+    pub fn prewrite_err(
+        &self,
+        mutations: Vec<Mutation>,
+        primary: &[u8],
+        start_ts: impl Into<TimeStamp>,
+    ) {
         self.store
-            .prewrite(self.ctx.clone(), mutations, primary.to_vec(), start_ts)
+            .prewrite(
+                self.ctx.clone(),
+                mutations,
+                primary.to_vec(),
+                start_ts.into(),
+            )
             .unwrap_err();
     }
 
@@ -364,14 +420,19 @@ impl<E: Engine> AssertionStorage<E> {
         &self,
         mutations: Vec<Mutation>,
         primary: &[u8],
-        start_ts: u64,
-        expect_locks: Vec<(&[u8], &[u8], u64)>,
+        start_ts: impl Into<TimeStamp>,
+        expect_locks: Vec<(&[u8], &[u8], TimeStamp)>,
     ) {
         let res = self
             .store
-            .prewrite(self.ctx.clone(), mutations, primary.to_vec(), start_ts)
+            .prewrite(
+                self.ctx.clone(),
+                mutations,
+                primary.to_vec(),
+                start_ts.into(),
+            )
             .unwrap();
-        let locks: Vec<(&[u8], &[u8], u64)> = res
+        let locks: Vec<(&[u8], &[u8], TimeStamp)> = res
             .iter()
             .filter_map(|x| {
                 if let Err(storage::Error::Txn(txn::Error::Mvcc(mvcc::Error::KeyIsLocked(info)))) =
@@ -380,7 +441,7 @@ impl<E: Engine> AssertionStorage<E> {
                     Some((
                         info.get_key(),
                         info.get_primary_lock(),
-                        info.get_lock_version(),
+                        info.get_lock_version().into(),
                     ))
                 } else {
                     None
@@ -394,10 +455,11 @@ impl<E: Engine> AssertionStorage<E> {
         &self,
         mutations: Vec<Mutation>,
         cur_primary: &[u8],
-        cur_start_ts: u64,
+        cur_start_ts: impl Into<TimeStamp>,
         confl_key: &[u8],
-        confl_ts: u64,
+        confl_ts: impl Into<TimeStamp>,
     ) {
+        let cur_start_ts = cur_start_ts.into();
         let err = self
             .store
             .prewrite(
@@ -417,7 +479,7 @@ impl<E: Engine> AssertionStorage<E> {
                 ..
             })) => {
                 assert_eq!(cur_start_ts, start_ts);
-                assert_eq!(confl_ts, conflict_start_ts);
+                assert_eq!(confl_ts.into(), conflict_start_ts);
                 assert_eq!(key.to_owned(), confl_key.to_owned());
                 assert_eq!(primary.to_owned(), cur_primary.to_owned());
             }
@@ -427,14 +489,26 @@ impl<E: Engine> AssertionStorage<E> {
         }
     }
 
-    pub fn commit_ok(&self, keys: Vec<&[u8]>, start_ts: u64, commit_ts: u64) {
+    pub fn commit_ok(
+        &self,
+        keys: Vec<&[u8]>,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
+    ) {
         let keys: Vec<Key> = keys.iter().map(|x| Key::from_raw(x)).collect();
         self.store
-            .commit(self.ctx.clone(), keys, start_ts, commit_ts)
+            .commit(self.ctx.clone(), keys, start_ts.into(), commit_ts.into())
             .unwrap();
     }
 
-    pub fn commit_with_illegal_tso(&self, keys: Vec<&[u8]>, start_ts: u64, commit_ts: u64) {
+    pub fn commit_with_illegal_tso(
+        &self,
+        keys: Vec<&[u8]>,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
+    ) {
+        let start_ts = start_ts.into();
+        let commit_ts = commit_ts.into();
         let keys: Vec<Key> = keys.iter().map(|x| Key::from_raw(x)).collect();
         let resp = self
             .store
@@ -442,79 +516,112 @@ impl<E: Engine> AssertionStorage<E> {
         self.expect_invalid_tso_err(resp, start_ts, commit_ts);
     }
 
-    pub fn cleanup_ok(&self, key: &[u8], start_ts: u64, current_ts: u64) {
+    pub fn cleanup_ok(
+        &self,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        current_ts: impl Into<TimeStamp>,
+    ) {
         self.store
-            .cleanup(self.ctx.clone(), Key::from_raw(key), start_ts, current_ts)
+            .cleanup(
+                self.ctx.clone(),
+                Key::from_raw(key),
+                start_ts.into(),
+                current_ts.into(),
+            )
             .unwrap();
     }
 
-    pub fn cleanup_err(&self, key: &[u8], start_ts: u64, current_ts: u64) {
+    pub fn cleanup_err(
+        &self,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        current_ts: impl Into<TimeStamp>,
+    ) {
         assert!(self
             .store
-            .cleanup(self.ctx.clone(), Key::from_raw(key), start_ts, current_ts)
+            .cleanup(
+                self.ctx.clone(),
+                Key::from_raw(key),
+                start_ts.into(),
+                current_ts.into()
+            )
             .is_err());
     }
 
-    pub fn rollback_ok(&self, keys: Vec<&[u8]>, start_ts: u64) {
+    pub fn rollback_ok(&self, keys: Vec<&[u8]>, start_ts: impl Into<TimeStamp>) {
         let keys: Vec<Key> = keys.iter().map(|x| Key::from_raw(x)).collect();
         self.store
-            .rollback(self.ctx.clone(), keys, start_ts)
+            .rollback(self.ctx.clone(), keys, start_ts.into())
             .unwrap();
     }
 
-    pub fn rollback_err(&self, keys: Vec<&[u8]>, start_ts: u64) {
+    pub fn rollback_err(&self, keys: Vec<&[u8]>, start_ts: impl Into<TimeStamp>) {
         let keys: Vec<Key> = keys.iter().map(|x| Key::from_raw(x)).collect();
         assert!(self
             .store
-            .rollback(self.ctx.clone(), keys, start_ts)
+            .rollback(self.ctx.clone(), keys, start_ts.into())
             .is_err());
     }
 
     pub fn scan_locks_ok(
         &self,
-        max_ts: u64,
+        max_ts: impl Into<TimeStamp>,
         start_key: Vec<u8>,
         limit: usize,
         expect: Vec<LockInfo>,
     ) {
         assert_eq!(
             self.store
-                .scan_locks(self.ctx.clone(), max_ts, start_key, limit)
+                .scan_locks(self.ctx.clone(), max_ts.into(), start_key, limit)
                 .unwrap(),
             expect
         );
     }
 
-    pub fn resolve_lock_ok(&self, start_ts: u64, commit_ts: Option<u64>) {
+    pub fn resolve_lock_ok(
+        &self,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: Option<impl Into<TimeStamp>>,
+    ) {
         self.store
-            .resolve_lock(self.ctx.clone(), start_ts, commit_ts)
+            .resolve_lock(self.ctx.clone(), start_ts.into(), commit_ts.map(Into::into))
             .unwrap();
     }
 
     pub fn resolve_lock_batch_ok(
         &self,
-        start_ts_1: u64,
-        commit_ts_1: u64,
-        start_ts_2: u64,
-        commit_ts_2: u64,
+        start_ts_1: impl Into<TimeStamp>,
+        commit_ts_1: impl Into<TimeStamp>,
+        start_ts_2: impl Into<TimeStamp>,
+        commit_ts_2: impl Into<TimeStamp>,
     ) {
         self.store
             .resolve_lock_batch(
                 self.ctx.clone(),
-                vec![(start_ts_1, commit_ts_1), (start_ts_2, commit_ts_2)],
+                vec![
+                    (start_ts_1.into(), commit_ts_1.into()),
+                    (start_ts_2.into(), commit_ts_2.into()),
+                ],
             )
             .unwrap();
     }
 
-    pub fn resolve_lock_with_illegal_tso(&self, start_ts: u64, commit_ts: Option<u64>) {
+    pub fn resolve_lock_with_illegal_tso(
+        &self,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: Option<impl Into<TimeStamp>>,
+    ) {
+        let start_ts = start_ts.into();
+        let commit_ts = commit_ts.map(Into::into);
         let resp = self
             .store
             .resolve_lock(self.ctx.clone(), start_ts, commit_ts);
         self.expect_invalid_tso_err(resp, start_ts, commit_ts.unwrap())
     }
 
-    pub fn gc_ok(&self, safe_point: u64) {
-        self.store.gc(self.ctx.clone(), safe_point).unwrap();
+    pub fn gc_ok(&self, safe_point: impl Into<TimeStamp>) {
+        self.store.gc(self.ctx.clone(), safe_point.into()).unwrap();
     }
 
     pub fn raw_get_ok(&self, cf: String, key: Vec<u8>, value: Option<Vec<u8>>) {

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -233,7 +233,7 @@ impl<E: Engine> SyncTestStorage<E> {
         let mut txn_status = HashMap::default();
         txn_status.insert(
             start_ts.into(),
-            commit_ts.map(Into::into).unwrap_or_else(TimeStamp::min),
+            commit_ts.map(Into::into).unwrap_or_else(TimeStamp::zero),
         );
         wait_op!(|cb| self.store.async_resolve_lock(ctx, txn_status, cb)).unwrap()
     }

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -2,6 +2,7 @@
 
 use futures::Future;
 
+use keys::TimeStamp;
 use kvproto::kvrpcpb::{Context, LockInfo};
 use tikv::server::gc_worker::{AutoGCConfig, GCConfig, GCSafePointProvider, GCWorker};
 use tikv::storage::config::Config;
@@ -92,8 +93,15 @@ impl<E: Engine> SyncTestStorage<E> {
         self.store.get_engine()
     }
 
-    pub fn get(&self, ctx: Context, key: &Key, start_ts: u64) -> Result<Option<Value>> {
-        self.store.async_get(ctx, key.to_owned(), start_ts).wait()
+    pub fn get(
+        &self,
+        ctx: Context,
+        key: &Key,
+        start_ts: impl Into<TimeStamp>,
+    ) -> Result<Option<Value>> {
+        self.store
+            .async_get(ctx, key.to_owned(), start_ts.into())
+            .wait()
     }
 
     #[allow(dead_code)]
@@ -101,10 +109,10 @@ impl<E: Engine> SyncTestStorage<E> {
         &self,
         ctx: Context,
         keys: &[Key],
-        start_ts: u64,
+        start_ts: impl Into<TimeStamp>,
     ) -> Result<Vec<Result<KvPair>>> {
         self.store
-            .async_batch_get(ctx, keys.to_owned(), start_ts)
+            .async_batch_get(ctx, keys.to_owned(), start_ts.into())
             .wait()
     }
 
@@ -115,7 +123,7 @@ impl<E: Engine> SyncTestStorage<E> {
         end_key: Option<Key>,
         limit: usize,
         key_only: bool,
-        start_ts: u64,
+        start_ts: impl Into<TimeStamp>,
     ) -> Result<Vec<Result<KvPair>>> {
         self.store
             .async_scan(
@@ -123,7 +131,7 @@ impl<E: Engine> SyncTestStorage<E> {
                 start_key,
                 end_key,
                 limit,
-                start_ts,
+                start_ts.into(),
                 Options::new(0, false, key_only),
             )
             .wait()
@@ -136,7 +144,7 @@ impl<E: Engine> SyncTestStorage<E> {
         end_key: Option<Key>,
         limit: usize,
         key_only: bool,
-        start_ts: u64,
+        start_ts: impl Into<TimeStamp>,
     ) -> Result<Vec<Result<KvPair>>> {
         self.store
             .async_scan(
@@ -144,7 +152,7 @@ impl<E: Engine> SyncTestStorage<E> {
                 start_key,
                 end_key,
                 limit,
-                start_ts,
+                start_ts.into(),
                 Options::new(0, false, key_only).reverse_scan(),
             )
             .wait()
@@ -155,13 +163,13 @@ impl<E: Engine> SyncTestStorage<E> {
         ctx: Context,
         mutations: Vec<Mutation>,
         primary: Vec<u8>,
-        start_ts: u64,
+        start_ts: impl Into<TimeStamp>,
     ) -> Result<Vec<Result<()>>> {
         wait_op!(|cb| self.store.async_prewrite(
             ctx,
             mutations,
             primary,
-            start_ts,
+            start_ts.into(),
             Options::default(),
             cb
         ))
@@ -172,46 +180,75 @@ impl<E: Engine> SyncTestStorage<E> {
         &self,
         ctx: Context,
         keys: Vec<Key>,
-        start_ts: u64,
-        commit_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
     ) -> Result<()> {
-        wait_op!(|cb| self.store.async_commit(ctx, keys, start_ts, commit_ts, cb)).unwrap()
+        wait_op!(|cb| self
+            .store
+            .async_commit(ctx, keys, start_ts.into(), commit_ts.into(), cb))
+        .unwrap()
     }
 
-    pub fn cleanup(&self, ctx: Context, key: Key, start_ts: u64, current_ts: u64) -> Result<()> {
-        wait_op!(|cb| self.store.async_cleanup(ctx, key, start_ts, current_ts, cb)).unwrap()
+    pub fn cleanup(
+        &self,
+        ctx: Context,
+        key: Key,
+        start_ts: impl Into<TimeStamp>,
+        current_ts: impl Into<TimeStamp>,
+    ) -> Result<()> {
+        wait_op!(|cb| self
+            .store
+            .async_cleanup(ctx, key, start_ts.into(), current_ts.into(), cb))
+        .unwrap()
     }
 
-    pub fn rollback(&self, ctx: Context, keys: Vec<Key>, start_ts: u64) -> Result<()> {
-        wait_op!(|cb| self.store.async_rollback(ctx, keys, start_ts, cb)).unwrap()
+    pub fn rollback(
+        &self,
+        ctx: Context,
+        keys: Vec<Key>,
+        start_ts: impl Into<TimeStamp>,
+    ) -> Result<()> {
+        wait_op!(|cb| self.store.async_rollback(ctx, keys, start_ts.into(), cb)).unwrap()
     }
 
     pub fn scan_locks(
         &self,
         ctx: Context,
-        max_ts: u64,
+        max_ts: impl Into<TimeStamp>,
         start_key: Vec<u8>,
         limit: usize,
     ) -> Result<Vec<LockInfo>> {
         wait_op!(|cb| self
             .store
-            .async_scan_locks(ctx, max_ts, start_key, limit, cb))
+            .async_scan_locks(ctx, max_ts.into(), start_key, limit, cb))
         .unwrap()
     }
 
-    pub fn resolve_lock(&self, ctx: Context, start_ts: u64, commit_ts: Option<u64>) -> Result<()> {
+    pub fn resolve_lock(
+        &self,
+        ctx: Context,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: Option<impl Into<TimeStamp>>,
+    ) -> Result<()> {
         let mut txn_status = HashMap::default();
-        txn_status.insert(start_ts, commit_ts.unwrap_or(0));
+        txn_status.insert(
+            start_ts.into(),
+            commit_ts.map(Into::into).unwrap_or_else(TimeStamp::min),
+        );
         wait_op!(|cb| self.store.async_resolve_lock(ctx, txn_status, cb)).unwrap()
     }
 
-    pub fn resolve_lock_batch(&self, ctx: Context, txns: Vec<(u64, u64)>) -> Result<()> {
-        let txn_status: HashMap<u64, u64> = txns.into_iter().collect();
+    pub fn resolve_lock_batch(
+        &self,
+        ctx: Context,
+        txns: Vec<(TimeStamp, TimeStamp)>,
+    ) -> Result<()> {
+        let txn_status: HashMap<TimeStamp, TimeStamp> = txns.into_iter().collect();
         wait_op!(|cb| self.store.async_resolve_lock(ctx, txn_status, cb)).unwrap()
     }
 
-    pub fn gc(&self, ctx: Context, safe_point: u64) -> Result<()> {
-        wait_op!(|cb| self.gc_worker.async_gc(ctx, safe_point, cb)).unwrap()
+    pub fn gc(&self, ctx: Context, safe_point: impl Into<TimeStamp>) -> Result<()> {
+        wait_op!(|cb| self.gc_worker.async_gc(ctx, safe_point.into(), cb)).unwrap()
     }
 
     pub fn raw_get(&self, ctx: Context, cf: String, key: Vec<u8>) -> Result<Option<Vec<u8>>> {

--- a/components/tikv_util/src/time.rs
+++ b/components/tikv_util/src/time.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 use std::sync::mpsc::{self, Sender};
 use std::thread::{self, Builder, JoinHandle};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
 use time::{Duration as TimeDuration, Timespec};
 
@@ -33,15 +33,6 @@ pub fn duration_to_nanos(d: Duration) -> u64 {
     let nanos = u64::from(d.subsec_nanos());
     // Most of case, we can't have so large Duration, so here just panic if overflow now.
     d.as_secs() * 1_000_000_000 + nanos
-}
-
-/// Gets the current timestamp in seconds.
-#[inline]
-pub fn time_now_sec() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
 }
 
 pub struct SlowTimer {

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -28,7 +28,7 @@ impl<S: Snapshot> ChecksumContext<S> {
     ) -> Result<Self> {
         let store = SnapshotStore::new(
             snap,
-            req.get_start_ts(),
+            req.get_start_ts().into(),
             req_ctx.context.get_isolation_level(),
             !req_ctx.context.get_not_fill_cache(),
             req_ctx.bypass_locks.clone(),

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -137,7 +137,7 @@ impl<E: Engine> Endpoint<E> {
                     // TODO: Remove explicit type once rust-lang#41078 is resolved
                     let store = SnapshotStore::new(
                         snap,
-                        dag.get_start_ts(),
+                        dag.get_start_ts().into(),
                         req_ctx.context.get_isolation_level(),
                         !req_ctx.context.get_not_fill_cache(),
                         req_ctx.bypass_locks.clone(),

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -117,13 +117,7 @@ impl ReqContext {
         txn_start_ts: Option<u64>,
     ) -> Self {
         let deadline = Deadline::from_now(max_handle_duration);
-        let bypass_locks = TsSet::new(
-            context
-                .take_resolved_locks()
-                .into_iter()
-                .map(Into::into)
-                .collect(),
-        );
+        let bypass_locks = TsSet::from_u64s(context.take_resolved_locks());
         Self {
             tag,
             context,

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -117,7 +117,13 @@ impl ReqContext {
         txn_start_ts: Option<u64>,
     ) -> Self {
         let deadline = Deadline::from_now(max_handle_duration);
-        let bypass_locks = TsSet::new(context.take_resolved_locks());
+        let bypass_locks = TsSet::new(
+            context
+                .take_resolved_locks()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        );
         Self {
             tag,
             context,

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -36,7 +36,7 @@ impl<S: Snapshot> AnalyzeContext<S> {
     ) -> Result<Self> {
         let store = SnapshotStore::new(
             snap,
-            req.get_start_ts(),
+            req.get_start_ts().into(),
             req_ctx.context.get_isolation_level(),
             !req_ctx.context.get_not_fill_cache(),
             req_ctx.bypass_locks.clone(),

--- a/src/raftstore/coprocessor/properties.rs
+++ b/src/raftstore/coprocessor/properties.rs
@@ -56,7 +56,7 @@ impl MvccProperties {
     pub fn new() -> MvccProperties {
         MvccProperties {
             min_ts: TimeStamp::max(),
-            max_ts: TimeStamp::min(),
+            max_ts: TimeStamp::zero(),
             num_rows: 0,
             num_puts: 0,
             num_versions: 0,

--- a/src/raftstore/coprocessor/properties.rs
+++ b/src/raftstore/coprocessor/properties.rs
@@ -7,7 +7,7 @@ use std::ops::{Deref, DerefMut};
 use std::u64;
 
 use crate::raftstore::store::keys;
-use crate::storage::mvcc::{Write, WriteType};
+use crate::storage::mvcc::{TimeStamp, Write, WriteType};
 use crate::storage::types::Key;
 use engine::rocks::{
     CFHandle, DBEntryType, Range, TablePropertiesCollector, TablePropertiesCollectorFactory,
@@ -44,8 +44,8 @@ fn get_entry_size(value: &[u8], entry_type: DBEntryType) -> std::result::Result<
 
 #[derive(Clone, Debug, Default)]
 pub struct MvccProperties {
-    pub min_ts: u64,           // The minimal timestamp.
-    pub max_ts: u64,           // The maximal timestamp.
+    pub min_ts: TimeStamp,     // The minimal timestamp.
+    pub max_ts: TimeStamp,     // The maximal timestamp.
     pub num_rows: u64,         // The number of rows.
     pub num_puts: u64,         // The number of MVCC puts of all rows.
     pub num_versions: u64,     // The number of MVCC versions of all rows.
@@ -55,8 +55,8 @@ pub struct MvccProperties {
 impl MvccProperties {
     pub fn new() -> MvccProperties {
         MvccProperties {
-            min_ts: u64::MAX,
-            max_ts: u64::MIN,
+            min_ts: TimeStamp::max(),
+            max_ts: TimeStamp::min(),
             num_rows: 0,
             num_puts: 0,
             num_versions: 0,
@@ -75,8 +75,8 @@ impl MvccProperties {
 
     pub fn encode(&self) -> UserProperties {
         let mut props = UserProperties::new();
-        props.encode_u64(PROP_MIN_TS, self.min_ts);
-        props.encode_u64(PROP_MAX_TS, self.max_ts);
+        props.encode_u64(PROP_MIN_TS, self.min_ts.into_inner());
+        props.encode_u64(PROP_MAX_TS, self.max_ts.into_inner());
         props.encode_u64(PROP_NUM_ROWS, self.num_rows);
         props.encode_u64(PROP_NUM_PUTS, self.num_puts);
         props.encode_u64(PROP_NUM_VERSIONS, self.num_versions);
@@ -86,8 +86,8 @@ impl MvccProperties {
 
     pub fn decode<T: DecodeProperties>(props: &T) -> Result<MvccProperties> {
         let mut res = MvccProperties::new();
-        res.min_ts = props.decode_u64(PROP_MIN_TS)?;
-        res.max_ts = props.decode_u64(PROP_MAX_TS)?;
+        res.min_ts = props.decode_u64(PROP_MIN_TS)?.into();
+        res.max_ts = props.decode_u64(PROP_MAX_TS)?.into();
         res.num_rows = props.decode_u64(PROP_NUM_ROWS)?;
         res.num_puts = props.decode_u64(PROP_NUM_PUTS)?;
         res.num_versions = props.decode_u64(PROP_NUM_VERSIONS)?;
@@ -701,11 +701,19 @@ mod tests {
 
         let cases = ["a", "b", "c"];
         for &key in &cases {
-            let k1 = keys::data_key(Key::from_raw(key.as_bytes()).append_ts(2).as_encoded());
+            let k1 = keys::data_key(
+                Key::from_raw(key.as_bytes())
+                    .append_ts(2.into())
+                    .as_encoded(),
+            );
             let write_cf = db.cf_handle(CF_WRITE).unwrap();
             db.put_cf(write_cf, &k1, b"v1").unwrap();
             db.delete_cf(write_cf, &k1).unwrap();
-            let key = keys::data_key(Key::from_raw(key.as_bytes()).append_ts(3).as_encoded());
+            let key = keys::data_key(
+                Key::from_raw(key.as_bytes())
+                    .append_ts(3.into())
+                    .as_encoded(),
+            );
             db.put_cf(write_cf, &key, b"v2").unwrap();
             db.flush_cf(write_cf, true).unwrap();
         }
@@ -734,6 +742,7 @@ mod tests {
         ];
         let mut collector = MvccPropertiesCollector::new();
         for &(key, ts, write_type, entry_type) in &cases {
+            let ts = ts.into();
             let k = Key::from_raw(key.as_bytes()).append_ts(ts);
             let k = keys::data_key(k.as_encoded());
             let v = Write::new(write_type, ts, None).as_ref().to_bytes();
@@ -742,8 +751,8 @@ mod tests {
         let result = UserProperties(collector.finish());
 
         let props = MvccProperties::decode(&result).unwrap();
-        assert_eq!(props.min_ts, 1);
-        assert_eq!(props.max_ts, 7);
+        assert_eq!(props.min_ts, 1.into());
+        assert_eq!(props.max_ts, 7.into());
         assert_eq!(props.num_rows, 4);
         assert_eq!(props.num_puts, 4);
         assert_eq!(props.num_versions, 7);
@@ -752,7 +761,7 @@ mod tests {
 
     #[bench]
     fn bench_mvcc_properties(b: &mut Bencher) {
-        let ts = 1;
+        let ts = 1.into();
         let num_entries = 100;
         let mut entries = Vec::new();
         for i in 0..num_entries {

--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -216,7 +216,7 @@ mod tests {
     };
     use crate::raftstore::coprocessor::{Config, CoprocessorHost};
     use crate::raftstore::store::{keys, CasualMessage, SplitCheckRunner, SplitCheckTask};
-    use crate::storage::mvcc::{Write, WriteType};
+    use crate::storage::mvcc::{TimeStamp, Write, WriteType};
     use crate::storage::Key;
     use engine::rocks;
     use engine::rocks::util::{new_engine_opt, CFOptions};
@@ -237,9 +237,13 @@ mod tests {
         let write_cf = engine.cf_handle(CF_WRITE).unwrap();
         let default_cf = engine.cf_handle(CF_DEFAULT).unwrap();
         let write_value = if fill_short_value {
-            Write::new(WriteType::Put, 0, Some(b"shortvalue".to_vec()))
+            Write::new(
+                WriteType::Put,
+                TimeStamp::min(),
+                Some(b"shortvalue".to_vec()),
+            )
         } else {
-            Write::new(WriteType::Put, 0, None)
+            Write::new(WriteType::Put, TimeStamp::min(), None)
         }
         .as_ref()
         .to_bytes();
@@ -249,7 +253,7 @@ mod tests {
             for i in start_idx..batch_idx {
                 let key = keys::data_key(
                     Key::from_raw(format!("{:04}", i).as_bytes())
-                        .append_ts(2)
+                        .append_ts(2.into())
                         .as_encoded(),
                 );
                 engine.put_cf(write_cf, &key, &write_value).unwrap();
@@ -314,7 +318,7 @@ mod tests {
         must_split_at(
             &rx,
             &region,
-            vec![Key::from_raw(b"0080").append_ts(2).into_encoded()],
+            vec![Key::from_raw(b"0080").append_ts(2.into()).into_encoded()],
         );
 
         put_data(&engine, 160, 300, false);
@@ -323,9 +327,9 @@ mod tests {
             &rx,
             &region,
             vec![
-                Key::from_raw(b"0080").append_ts(2).into_encoded(),
-                Key::from_raw(b"0160").append_ts(2).into_encoded(),
-                Key::from_raw(b"0240").append_ts(2).into_encoded(),
+                Key::from_raw(b"0080").append_ts(2.into()).into_encoded(),
+                Key::from_raw(b"0160").append_ts(2.into()).into_encoded(),
+                Key::from_raw(b"0240").append_ts(2.into()).into_encoded(),
             ],
         );
 
@@ -335,11 +339,11 @@ mod tests {
             &rx,
             &region,
             vec![
-                Key::from_raw(b"0080").append_ts(2).into_encoded(),
-                Key::from_raw(b"0160").append_ts(2).into_encoded(),
-                Key::from_raw(b"0240").append_ts(2).into_encoded(),
-                Key::from_raw(b"0320").append_ts(2).into_encoded(),
-                Key::from_raw(b"0400").append_ts(2).into_encoded(),
+                Key::from_raw(b"0080").append_ts(2.into()).into_encoded(),
+                Key::from_raw(b"0160").append_ts(2.into()).into_encoded(),
+                Key::from_raw(b"0240").append_ts(2.into()).into_encoded(),
+                Key::from_raw(b"0320").append_ts(2.into()).into_encoded(),
+                Key::from_raw(b"0400").append_ts(2.into()).into_encoded(),
             ],
         );
 
@@ -368,8 +372,14 @@ mod tests {
 
         let cases = [("a", 1024), ("b", 2048), ("c", 4096)];
         for &(key, vlen) in &cases {
-            let key = keys::data_key(Key::from_raw(key.as_bytes()).append_ts(2).as_encoded());
-            let write_v = Write::new(WriteType::Put, 0, None).as_ref().to_bytes();
+            let key = keys::data_key(
+                Key::from_raw(key.as_bytes())
+                    .append_ts(2.into())
+                    .as_encoded(),
+            );
+            let write_v = Write::new(WriteType::Put, TimeStamp::min(), None)
+                .as_ref()
+                .to_bytes();
             let write_cf = db.cf_handle(CF_WRITE).unwrap();
             db.put_cf(write_cf, &key, &write_v).unwrap();
             db.flush_cf(write_cf, true).unwrap();
@@ -412,8 +422,14 @@ mod tests {
         // 3 points will be inserted into range properties
         let cases = [("a", 4194304), ("b", 4194304), ("c", 4194304)];
         for &(key, vlen) in &cases {
-            let key = keys::data_key(Key::from_raw(key.as_bytes()).append_ts(2).as_encoded());
-            let write_v = Write::new(WriteType::Put, 0, None).as_ref().to_bytes();
+            let key = keys::data_key(
+                Key::from_raw(key.as_bytes())
+                    .append_ts(2.into())
+                    .as_encoded(),
+            );
+            let write_v = Write::new(WriteType::Put, TimeStamp::min(), None)
+                .as_ref()
+                .to_bytes();
             db.put_cf(write_cf, &key, &write_v).unwrap();
 
             let default_v = vec![0; vlen as usize];

--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -239,11 +239,11 @@ mod tests {
         let write_value = if fill_short_value {
             Write::new(
                 WriteType::Put,
-                TimeStamp::min(),
+                TimeStamp::zero(),
                 Some(b"shortvalue".to_vec()),
             )
         } else {
-            Write::new(WriteType::Put, TimeStamp::min(), None)
+            Write::new(WriteType::Put, TimeStamp::zero(), None)
         }
         .as_ref()
         .to_bytes();
@@ -377,7 +377,7 @@ mod tests {
                     .append_ts(2.into())
                     .as_encoded(),
             );
-            let write_v = Write::new(WriteType::Put, TimeStamp::min(), None)
+            let write_v = Write::new(WriteType::Put, TimeStamp::zero(), None)
                 .as_ref()
                 .to_bytes();
             let write_cf = db.cf_handle(CF_WRITE).unwrap();
@@ -427,7 +427,7 @@ mod tests {
                     .append_ts(2.into())
                     .as_encoded(),
             );
-            let write_v = Write::new(WriteType::Put, TimeStamp::min(), None)
+            let write_v = Write::new(WriteType::Put, TimeStamp::zero(), None)
                 .as_ref()
                 .to_bytes();
             db.put_cf(write_cf, &key, &write_v).unwrap();

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -895,8 +895,8 @@ mod tests {
         // Write some mvcc keys and values into db
         // default_cf : a_7, b_7
         // write_cf : a_8, b_8
-        let start_ts = 7;
-        let commit_ts = 8;
+        let start_ts = 7.into();
+        let commit_ts = 8.into();
         let write = Write::new(WriteType::Put, start_ts, None);
         let db = &engines.kv;
         let default_cf = db.cf_handle(CF_DEFAULT).unwrap();
@@ -1091,7 +1091,7 @@ mod tests {
         r.set_start_key(b"a".to_vec());
         r.set_end_key(b"z".to_vec());
         let snapshot = RegionSnapshot::from_raw(Arc::clone(&engines1.kv), r);
-        let mut scanner = ScannerBuilder::new(snapshot, 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
             .range(Some(Key::from_raw(b"a")), None)
             .build()
             .unwrap();

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -262,7 +262,7 @@ mod tests {
     use crate::raftstore::coprocessor::properties::get_range_entries_and_versions;
     use crate::raftstore::coprocessor::properties::MvccPropertiesCollectorFactory;
     use crate::raftstore::store::keys::data_key;
-    use crate::storage::mvcc::{Write, WriteType};
+    use crate::storage::mvcc::{TimeStamp, Write, WriteType};
     use crate::storage::types::Key as MvccKey;
 
     use super::*;
@@ -322,7 +322,7 @@ mod tests {
         assert!(old_sst_files_size > new_sst_files_size);
     }
 
-    fn mvcc_put(db: &DB, k: &[u8], v: &[u8], start_ts: u64, commit_ts: u64) {
+    fn mvcc_put(db: &DB, k: &[u8], v: &[u8], start_ts: TimeStamp, commit_ts: TimeStamp) {
         let cf = get_cf_handle(db, CF_WRITE).unwrap();
         let k = MvccKey::from_encoded(data_key(k)).append_ts(commit_ts);
         let w = Write::new(WriteType::Put, start_ts, Some(v.to_vec()));
@@ -330,7 +330,7 @@ mod tests {
             .unwrap();
     }
 
-    fn delete(db: &DB, k: &[u8], commit_ts: u64) {
+    fn delete(db: &DB, k: &[u8], commit_ts: TimeStamp) {
         let cf = get_cf_handle(db, CF_WRITE).unwrap();
         let k = MvccKey::from_encoded(data_key(k)).append_ts(commit_ts);
         db.delete_cf(cf, k.as_encoded()).unwrap();
@@ -360,14 +360,14 @@ mod tests {
         // mvcc_put 0..5
         for i in 0..5 {
             let (k, v) = (format!("k{}", i), format!("value{}", i));
-            mvcc_put(&engine, k.as_bytes(), v.as_bytes(), 1, 2);
+            mvcc_put(&engine, k.as_bytes(), v.as_bytes(), 1.into(), 2.into());
         }
         engine.flush_cf(cf, true).unwrap();
 
         // gc 0..5
         for i in 0..5 {
             let k = format!("k{}", i);
-            delete(&engine, k.as_bytes(), 2);
+            delete(&engine, k.as_bytes(), 2.into());
         }
         engine.flush_cf(cf, true).unwrap();
 
@@ -379,7 +379,7 @@ mod tests {
         // mvcc_put 5..10
         for i in 5..10 {
             let (k, v) = (format!("k{}", i), format!("value{}", i));
-            mvcc_put(&engine, k.as_bytes(), v.as_bytes(), 1, 2);
+            mvcc_put(&engine, k.as_bytes(), v.as_bytes(), 1.into(), 2.into());
         }
         engine.flush_cf(cf, true).unwrap();
 
@@ -403,7 +403,7 @@ mod tests {
         // gc 5..10
         for i in 5..10 {
             let k = format!("k{}", i);
-            delete(&engine, k.as_bytes(), 2);
+            delete(&engine, k.as_bytes(), 2.into());
         }
         engine.flush_cf(cf, true).unwrap();
 

--- a/src/raftstore/store/worker/pd.rs
+++ b/src/raftstore/store/worker/pd.rs
@@ -28,11 +28,11 @@ use crate::raftstore::store::Callback;
 use crate::raftstore::store::StoreInfo;
 use crate::raftstore::store::{CasualMessage, PeerMsg, RaftCommand, RaftRouter};
 use crate::storage::FlowStatistics;
+use keys::Instant;
 use pd_client::metrics::*;
 use pd_client::{Error, PdClient, RegionStat};
 use tikv_util::collections::HashMap;
 use tikv_util::metrics::ThreadInfoStatistics;
-use tikv_util::time::time_now_sec;
 use tikv_util::worker::{FutureRunnable as Runnable, FutureScheduler as Scheduler, Stopped};
 
 type RecordPairVec = Vec<pdpb::RecordPair>;
@@ -96,7 +96,7 @@ pub struct StoreStat {
     pub engine_total_keys_read: u64,
     pub engine_last_total_bytes_read: u64,
     pub engine_last_total_keys_read: u64,
-    pub last_report_ts: u64,
+    pub last_report_ts: Instant,
 
     pub region_bytes_read: LocalHistogram,
     pub region_keys_read: LocalHistogram,
@@ -116,7 +116,7 @@ impl Default for StoreStat {
             region_bytes_written: REGION_WRITTEN_BYTES_HISTOGRAM.local(),
             region_keys_written: REGION_WRITTEN_KEYS_HISTOGRAM.local(),
 
-            last_report_ts: 0,
+            last_report_ts: Instant::zero(),
             engine_total_bytes_read: 0,
             engine_total_keys_read: 0,
             engine_last_total_bytes_read: 0,
@@ -137,7 +137,7 @@ pub struct PeerStat {
     pub last_read_keys: u64,
     pub last_written_bytes: u64,
     pub last_written_keys: u64,
-    pub last_report_ts: u64,
+    pub last_report_ts: Instant,
 }
 
 impl Display for Task {
@@ -290,8 +290,8 @@ pub struct Runner<T: PdClient> {
     region_peers: HashMap<u64, PeerStat>,
     store_stat: StoreStat,
     is_hb_receiver_scheduled: bool,
-    // Records the timestamp of boot time.
-    start_ts: u64,
+    // Records the boot time.
+    start_ts: Instant,
 
     // use for Runner inner handle function to send Task to itself
     // actually it is the sender connected to Runner's Worker which
@@ -325,7 +325,7 @@ impl<T: PdClient> Runner<T> {
             is_hb_receiver_scheduled: false,
             region_peers: HashMap::default(),
             store_stat: StoreStat::default(),
-            start_ts: time_now_sec(),
+            start_ts: Instant::now(),
             scheduler,
             stats_monitor,
         }
@@ -546,11 +546,11 @@ impl<T: PdClient> Runner<T> {
         ));
 
         let mut interval = pdpb::TimeInterval::default();
-        interval.set_start_timestamp(self.store_stat.last_report_ts);
+        interval.set_start_timestamp(self.store_stat.last_report_ts.into_inner());
         stats.set_interval(interval);
         self.store_stat.engine_last_total_bytes_read = self.store_stat.engine_total_bytes_read;
         self.store_stat.engine_last_total_keys_read = self.store_stat.engine_total_keys_read;
-        self.store_stat.last_report_ts = time_now_sec();
+        self.store_stat.last_report_ts = Instant::now();
         self.store_stat.region_bytes_written.flush();
         self.store_stat.region_keys_written.flush();
         self.store_stat.region_bytes_read.flush();
@@ -843,8 +843,8 @@ impl<T: PdClient> Runnable<Task> for Runner<T> {
                     peer_stat.last_written_keys = written_keys;
                     peer_stat.last_read_bytes = peer_stat.read_bytes;
                     peer_stat.last_read_keys = peer_stat.read_keys;
-                    peer_stat.last_report_ts = time_now_sec();
-                    if last_report_ts == 0 {
+                    peer_stat.last_report_ts = Instant::now();
+                    if last_report_ts.is_zero() {
                         last_report_ts = self.start_ts;
                     }
                     (

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -1833,9 +1833,9 @@ mod tests {
                 version,
                 0,
                 None,
-                TimeStamp::min(),
+                TimeStamp::zero(),
                 0,
-                TimeStamp::min(),
+                TimeStamp::zero(),
             );
             let value = lock.to_bytes();
             engine
@@ -2239,9 +2239,9 @@ mod tests {
                 ts.into(),
                 0,
                 v,
-                TimeStamp::min(),
+                TimeStamp::zero(),
                 0,
-                TimeStamp::min(),
+                TimeStamp::zero(),
             );
             kv.push((CF_LOCK, Key::from_raw(key), lock.to_bytes(), expect));
         }

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -33,7 +33,7 @@ use crate::raftstore::store::{
 };
 use crate::raftstore::store::{keys, PeerStorage};
 use crate::server::gc_worker::GCWorker;
-use crate::storage::mvcc::{Lock, LockType, Write, WriteRef, WriteType};
+use crate::storage::mvcc::{Lock, LockType, TimeStamp, Write, WriteRef, WriteType};
 use crate::storage::types::Key;
 use crate::storage::Engine;
 use crate::storage::Iterator as EngineIterator;
@@ -868,8 +868,8 @@ impl<E: Engine> Debugger<E> {
             ("num_files", collection.len() as u64),
             ("num_entries", num_entries),
             ("num_deletes", num_entries - mvcc_properties.num_versions),
-            ("mvcc.min_ts", mvcc_properties.min_ts),
-            ("mvcc.max_ts", mvcc_properties.max_ts),
+            ("mvcc.min_ts", mvcc_properties.min_ts.into_inner()),
+            ("mvcc.max_ts", mvcc_properties.max_ts.into_inner()),
             ("mvcc.num_rows", mvcc_properties.num_rows),
             ("mvcc.num_puts", mvcc_properties.num_puts),
             ("mvcc.num_versions", mvcc_properties.num_versions),
@@ -1142,7 +1142,7 @@ impl MvccChecker {
         Ok(None)
     }
 
-    fn next_default(&mut self, key: &[u8]) -> Result<Option<u64>> {
+    fn next_default(&mut self, key: &[u8]) -> Result<Option<TimeStamp>> {
         if self.default_iter.valid()
             && box_try!(Key::truncate_ts_for(keys::origin_key(
                 self.default_iter.key()
@@ -1157,7 +1157,7 @@ impl MvccChecker {
         Ok(None)
     }
 
-    fn next_write(&mut self, key: &[u8]) -> Result<Option<(u64, Write)>> {
+    fn next_write(&mut self, key: &[u8]) -> Result<Option<(TimeStamp, Write)>> {
         if self.write_iter.valid()
             && box_try!(Key::truncate_ts_for(keys::origin_key(
                 self.write_iter.key()
@@ -1171,7 +1171,13 @@ impl MvccChecker {
         Ok(None)
     }
 
-    fn delete(&mut self, wb: &WriteBatch, cf: &str, key: &[u8], ts: Option<u64>) -> Result<()> {
+    fn delete(
+        &mut self,
+        wb: &WriteBatch,
+        cf: &str,
+        key: &[u8],
+        ts: Option<TimeStamp>,
+    ) -> Result<()> {
         let handle = box_try!(get_cf_handle(self.db.as_ref(), cf));
         match ts {
             Some(ts) => {
@@ -1240,7 +1246,7 @@ impl MvccInfoIterator {
                 LockType::Lock => lock_info.set_type(Op::Lock),
                 LockType::Pessimistic => lock_info.set_type(Op::PessimisticLock),
             }
-            lock_info.set_start_ts(lock.ts);
+            lock_info.set_start_ts(lock.ts.into_inner());
             lock_info.set_primary(lock.primary);
             lock_info.set_short_value(lock.short_value.unwrap_or_default());
             return Ok(Some((key, lock_info)));
@@ -1254,7 +1260,7 @@ impl MvccInfoIterator {
             for (key, value) in vec_kv {
                 let mut value_info = MvccValue::default();
                 let start_ts = box_try!(Key::decode_ts_from(keys::origin_key(&key)));
-                value_info.set_start_ts(start_ts);
+                value_info.set_start_ts(start_ts.into_inner());
                 value_info.set_value(value);
                 values.push(value_info);
             }
@@ -1275,9 +1281,9 @@ impl MvccInfoIterator {
                     WriteType::Lock => write_info.set_type(Op::Lock),
                     WriteType::Rollback => write_info.set_type(Op::Rollback),
                 }
-                write_info.set_start_ts(write.start_ts);
+                write_info.set_start_ts(write.start_ts.into_inner());
                 let commit_ts = box_try!(Key::decode_ts_from(keys::origin_key(&key)));
-                write_info.set_commit_ts(commit_ts);
+                write_info.set_commit_ts(commit_ts.into_inner());
                 write_info.set_short_value(write.short_value.unwrap_or_default());
                 writes.push(write_info);
             }
@@ -1801,7 +1807,11 @@ mod tests {
         let debugger = new_debugger();
         let engine = &debugger.engines.kv;
 
-        let cf_default_data = vec![(b"k1", b"v", 5), (b"k2", b"x", 10), (b"k3", b"y", 15)];
+        let cf_default_data = vec![
+            (b"k1", b"v", 5.into()),
+            (b"k2", b"x", 10.into()),
+            (b"k3", b"y", 15.into()),
+        ];
         for &(prefix, value, ts) in &cf_default_data {
             let encoded_key = Key::from_raw(prefix).append_ts(ts);
             let key = keys::data_key(encoded_key.as_encoded().as_slice());
@@ -1810,14 +1820,23 @@ mod tests {
 
         let lock_cf = engine.cf_handle(CF_LOCK).unwrap();
         let cf_lock_data = vec![
-            (b"k1", LockType::Put, b"v", 5),
-            (b"k4", LockType::Lock, b"x", 10),
-            (b"k5", LockType::Delete, b"y", 15),
+            (b"k1", LockType::Put, b"v", 5.into()),
+            (b"k4", LockType::Lock, b"x", 10.into()),
+            (b"k5", LockType::Delete, b"y", 15.into()),
         ];
         for &(prefix, tp, value, version) in &cf_lock_data {
             let encoded_key = Key::from_raw(prefix);
             let key = keys::data_key(encoded_key.as_encoded().as_slice());
-            let lock = Lock::new(tp, value.to_vec(), version, 0, None, 0, 0, 0);
+            let lock = Lock::new(
+                tp,
+                value.to_vec(),
+                version,
+                0,
+                None,
+                TimeStamp::min(),
+                0,
+                TimeStamp::min(),
+            );
             let value = lock.to_bytes();
             engine
                 .put_cf(lock_cf, key.as_slice(), value.as_slice())
@@ -1826,10 +1845,10 @@ mod tests {
 
         let write_cf = engine.cf_handle(CF_WRITE).unwrap();
         let cf_write_data = vec![
-            (b"k2", WriteType::Put, 5, 10),
-            (b"k3", WriteType::Put, 15, 20),
-            (b"k6", WriteType::Lock, 25, 30),
-            (b"k7", WriteType::Rollback, 35, 40),
+            (b"k2", WriteType::Put, 5.into(), 10.into()),
+            (b"k3", WriteType::Put, 15.into(), 20.into()),
+            (b"k6", WriteType::Lock, 25.into(), 30.into()),
+            (b"k7", WriteType::Rollback, 35.into(), 40.into()),
         ];
         for &(prefix, tp, start_ts, commit_ts) in &cf_write_data {
             let encoded_key = Key::from_raw(prefix).append_ts(commit_ts);
@@ -2203,7 +2222,7 @@ mod tests {
         for (key, ts, expect) in default {
             kv.push((
                 CF_DEFAULT,
-                Key::from_raw(key).append_ts(ts),
+                Key::from_raw(key).append_ts(ts.into()),
                 b"v".to_vec(),
                 expect,
             ));
@@ -2214,7 +2233,16 @@ mod tests {
             } else {
                 None
             };
-            let lock = Lock::new(tp, vec![], ts, 0, v, 0, 0, 0);
+            let lock = Lock::new(
+                tp,
+                vec![],
+                ts.into(),
+                0,
+                v,
+                TimeStamp::min(),
+                0,
+                TimeStamp::min(),
+            );
             kv.push((CF_LOCK, Key::from_raw(key), lock.to_bytes(), expect));
         }
         for (key, start_ts, commit_ts, tp, short_value, expect) in write {
@@ -2223,10 +2251,10 @@ mod tests {
             } else {
                 None
             };
-            let write = Write::new(tp, start_ts, v);
+            let write = Write::new(tp, start_ts.into(), v);
             kv.push((
                 CF_WRITE,
-                Key::from_raw(key).append_ts(commit_ts),
+                Key::from_raw(key).append_ts(commit_ts.into()),
                 write.as_ref().to_bytes(),
                 expect,
             ));

--- a/src/server/gc_worker.rs
+++ b/src/server/gc_worker.rs
@@ -258,7 +258,7 @@ impl<E: Engine> GCRunner<E> {
         mut next_scan_key: Option<Key>,
     ) -> Result<Option<Key>> {
         let snapshot = self.get_snapshot(ctx)?;
-        let mut txn = MvccTxn::new(snapshot, TimeStamp::min(), !ctx.get_not_fill_cache()).unwrap();
+        let mut txn = MvccTxn::new(snapshot, TimeStamp::zero(), !ctx.get_not_fill_cache()).unwrap();
         for k in keys {
             let gc_info = txn.gc(k.clone(), safe_point)?;
 
@@ -736,7 +736,7 @@ impl<S: GCSafePointProvider, R: RegionInfoProvider> GCManager<S, R> {
     ) -> GCManager<S, R> {
         GCManager {
             cfg,
-            safe_point: TimeStamp::min(),
+            safe_point: TimeStamp::zero(),
             safe_point_last_check_time: Instant::now(),
             worker_scheduler,
             gc_manager_ctx: GCManagerContext::new(),
@@ -799,7 +799,7 @@ impl<S: GCSafePointProvider, R: RegionInfoProvider> GCManager<S, R> {
     /// updated to a greater value than initial value.
     fn initialize(&mut self) {
         debug!("gc-manager is initializing");
-        self.safe_point = TimeStamp::min();
+        self.safe_point = TimeStamp::zero();
         self.try_update_safe_point();
         debug!("gc-manager started"; "safe_point" => self.safe_point);
     }
@@ -1451,7 +1451,7 @@ mod tests {
     fn test_update_safe_point() {
         let mut test_util = GCManagerTestUtil::new(BTreeMap::new());
         let mut gc_manager = test_util.gc_manager.take().unwrap();
-        assert_eq!(gc_manager.safe_point, TimeStamp::min());
+        assert_eq!(gc_manager.safe_point, TimeStamp::zero());
         test_util.add_next_safe_point(233);
         assert!(gc_manager.try_update_safe_point());
         assert_eq!(gc_manager.safe_point, 233.into());
@@ -1475,11 +1475,11 @@ mod tests {
     fn test_gc_manager_initialize() {
         let mut test_util = GCManagerTestUtil::new(BTreeMap::new());
         let mut gc_manager = test_util.gc_manager.take().unwrap();
-        assert_eq!(gc_manager.safe_point, TimeStamp::min());
+        assert_eq!(gc_manager.safe_point, TimeStamp::zero());
         test_util.add_next_safe_point(0);
         test_util.add_next_safe_point(5);
         gc_manager.initialize();
-        assert_eq!(gc_manager.safe_point, TimeStamp::min());
+        assert_eq!(gc_manager.safe_point, TimeStamp::zero());
         assert!(gc_manager.try_update_safe_point());
         assert_eq!(gc_manager.safe_point, 5.into());
     }

--- a/src/server/gc_worker.rs
+++ b/src/server/gc_worker.rs
@@ -25,7 +25,7 @@ use crate::raftstore::store::util::find_peer;
 use crate::server::transport::ServerRaftStoreRouter;
 use crate::storage::kv::{Engine, Error as EngineError, RegionInfoProvider, ScanMode, Statistics};
 use crate::storage::metrics::*;
-use crate::storage::mvcc::{MvccReader, MvccTxn};
+use crate::storage::mvcc::{MvccReader, MvccTxn, TimeStamp};
 use crate::storage::{Callback, Error, Key, Result};
 use pd_client::PdClient;
 use tikv_util::config::ReadableSize;
@@ -88,14 +88,15 @@ impl GCConfig {
 /// Provides safe point.
 /// TODO: Give it a better name?
 pub trait GCSafePointProvider: Send + 'static {
-    fn get_safe_point(&self) -> Result<u64>;
+    fn get_safe_point(&self) -> Result<TimeStamp>;
 }
 
 impl<T: PdClient + 'static> GCSafePointProvider for Arc<T> {
-    fn get_safe_point(&self) -> Result<u64> {
+    fn get_safe_point(&self) -> Result<TimeStamp> {
         let future = self.get_gc_safe_point();
         future
             .wait()
+            .map(Into::into)
             .map_err(|e| box_err!("failed to get safe point from PD: {:?}", e))
     }
 }
@@ -103,7 +104,7 @@ impl<T: PdClient + 'static> GCSafePointProvider for Arc<T> {
 enum GCTask {
     GC {
         ctx: Context,
-        safe_point: u64,
+        safe_point: TimeStamp,
         callback: Callback<()>,
     },
     UnsafeDestroyRange {
@@ -210,7 +211,7 @@ impl<E: Engine> GCRunner<E> {
     fn scan_keys(
         &mut self,
         ctx: &mut Context,
-        safe_point: u64,
+        safe_point: TimeStamp,
         from: Option<Key>,
         limit: usize,
     ) -> Result<(Vec<Key>, Option<Key>)> {
@@ -252,12 +253,12 @@ impl<E: Engine> GCRunner<E> {
     fn gc_keys(
         &mut self,
         ctx: &mut Context,
-        safe_point: u64,
+        safe_point: TimeStamp,
         keys: Vec<Key>,
         mut next_scan_key: Option<Key>,
     ) -> Result<Option<Key>> {
         let snapshot = self.get_snapshot(ctx)?;
-        let mut txn = MvccTxn::new(snapshot, 0, !ctx.get_not_fill_cache()).unwrap();
+        let mut txn = MvccTxn::new(snapshot, TimeStamp::min(), !ctx.get_not_fill_cache()).unwrap();
         for k in keys {
             let gc_info = txn.gc(k.clone(), safe_point)?;
 
@@ -298,7 +299,7 @@ impl<E: Engine> GCRunner<E> {
         Ok(next_scan_key)
     }
 
-    fn gc(&mut self, ctx: &mut Context, safe_point: u64) -> Result<()> {
+    fn gc(&mut self, ctx: &mut Context, safe_point: TimeStamp) -> Result<()> {
         debug!(
             "start doing GC";
             "region_id" => ctx.get_region_id(),
@@ -491,7 +492,7 @@ fn handle_gc_task_schedule_error(e: ScheduleError<GCTask>) -> Result<()> {
 fn schedule_gc(
     scheduler: &worker::Scheduler<GCTask>,
     ctx: Context,
-    safe_point: u64,
+    safe_point: TimeStamp,
     callback: Callback<()>,
 ) -> Result<()> {
     scheduler
@@ -504,7 +505,7 @@ fn schedule_gc(
 }
 
 /// Does GC synchronously.
-fn gc(scheduler: &worker::Scheduler<GCTask>, ctx: Context, safe_point: u64) -> Result<()> {
+fn gc(scheduler: &worker::Scheduler<GCTask>, ctx: Context, safe_point: TimeStamp) -> Result<()> {
     wait_op!(|callback| schedule_gc(scheduler, ctx, safe_point, callback)).unwrap_or_else(|| {
         error!("failed to receive result of gc");
         Err(box_err!("gc_worker: failed to receive result of gc"))
@@ -717,7 +718,7 @@ struct GCManager<S: GCSafePointProvider, R: RegionInfoProvider> {
 
     /// The current safe point. `GCManager` will try to update it periodically. When `safe_point` is
     /// updated, `GCManager` will start to do GC on all regions.
-    safe_point: u64,
+    safe_point: TimeStamp,
 
     safe_point_last_check_time: Instant,
 
@@ -735,7 +736,7 @@ impl<S: GCSafePointProvider, R: RegionInfoProvider> GCManager<S, R> {
     ) -> GCManager<S, R> {
         GCManager {
             cfg,
-            safe_point: 0,
+            safe_point: TimeStamp::min(),
             safe_point_last_check_time: Instant::now(),
             worker_scheduler,
             gc_manager_ctx: GCManagerContext::new(),
@@ -798,13 +799,13 @@ impl<S: GCSafePointProvider, R: RegionInfoProvider> GCManager<S, R> {
     /// updated to a greater value than initial value.
     fn initialize(&mut self) {
         debug!("gc-manager is initializing");
-        self.safe_point = 0;
+        self.safe_point = TimeStamp::min();
         self.try_update_safe_point();
         debug!("gc-manager started"; "safe_point" => self.safe_point);
     }
 
     /// Waits until the safe_point updates. Returns the new safe point.
-    fn wait_for_next_safe_point(&mut self) -> GCManagerResult<u64> {
+    fn wait_for_next_safe_point(&mut self) -> GCManagerResult<TimeStamp> {
         loop {
             if self.try_update_safe_point() {
                 return Ok(self.safe_point);
@@ -841,7 +842,7 @@ impl<S: GCSafePointProvider, R: RegionInfoProvider> GCManager<S, R> {
             Ordering::Greater => {
                 debug!("gc_worker: update safe point"; "safe_point" => safe_point);
                 self.safe_point = safe_point;
-                AUTO_GC_SAFE_POINT_GAUGE.set(safe_point as i64);
+                AUTO_GC_SAFE_POINT_GAUGE.set(safe_point.into_inner() as i64);
                 true
             }
         }
@@ -1215,7 +1216,12 @@ impl<E: Engine> GCWorker<E> {
         Ok(())
     }
 
-    pub fn async_gc(&self, ctx: Context, safe_point: u64, callback: Callback<()>) -> Result<()> {
+    pub fn async_gc(
+        &self,
+        ctx: Context,
+        safe_point: TimeStamp,
+        callback: Callback<()>,
+    ) -> Result<()> {
         KV_COMMAND_COUNTER_VEC_STATIC.gc.inc();
         self.worker_scheduler
             .schedule(GCTask::GC {
@@ -1277,11 +1283,11 @@ mod tests {
     use std::sync::mpsc::{channel, Receiver, Sender};
 
     struct MockSafePointProvider {
-        rx: Receiver<u64>,
+        rx: Receiver<TimeStamp>,
     }
 
     impl GCSafePointProvider for MockSafePointProvider {
-        fn get_safe_point(&self) -> Result<u64> {
+        fn get_safe_point(&self) -> Result<TimeStamp> {
             // Error will be ignored by `GCManager`, which is equivalent to that the safe_point
             // is not updated.
             self.rx.try_recv().map_err(|e| box_err!(e))
@@ -1319,7 +1325,7 @@ mod tests {
     struct GCManagerTestUtil {
         gc_manager: Option<GCManager<MockSafePointProvider, MockRegionInfoProvider>>,
         worker: Worker<GCTask>,
-        safe_point_sender: Sender<u64>,
+        safe_point_sender: Sender<TimeStamp>,
         gc_task_receiver: Receiver<GCTask>,
     }
 
@@ -1355,8 +1361,8 @@ mod tests {
             self.gc_task_receiver.try_iter().collect()
         }
 
-        pub fn add_next_safe_point(&self, safe_point: u64) {
-            self.safe_point_sender.send(safe_point).unwrap();
+        pub fn add_next_safe_point(&self, safe_point: impl Into<TimeStamp>) {
+            self.safe_point_sender.send(safe_point.into()).unwrap();
         }
 
         pub fn stop(&mut self) {
@@ -1375,8 +1381,8 @@ mod tests {
     /// Param `expected_gc_tasks` is a `Vec` of tuples which is `(region_id, safe_point)`.
     fn test_auto_gc(
         regions: Vec<(Vec<u8>, Vec<u8>, u64)>,
-        safe_points: Vec<u64>,
-        expected_gc_tasks: Vec<(u64, u64)>,
+        safe_points: Vec<impl Into<TimeStamp> + Copy>,
+        expected_gc_tasks: Vec<(u64, impl Into<TimeStamp>)>,
     ) {
         let regions: BTreeMap<_, _> = regions
             .into_iter()
@@ -1416,7 +1422,7 @@ mod tests {
         assert_eq!(gc_tasks.len(), expected_gc_tasks.len());
         let all_passed = gc_tasks.into_iter().zip(expected_gc_tasks.into_iter()).all(
             |((region, safe_point), (expect_region, expect_safe_point))| {
-                region == expect_region && safe_point == expect_safe_point
+                region == expect_region && safe_point == expect_safe_point.into()
             },
         );
         assert!(all_passed);
@@ -1445,10 +1451,10 @@ mod tests {
     fn test_update_safe_point() {
         let mut test_util = GCManagerTestUtil::new(BTreeMap::new());
         let mut gc_manager = test_util.gc_manager.take().unwrap();
-        assert_eq!(gc_manager.safe_point, 0);
+        assert_eq!(gc_manager.safe_point, TimeStamp::min());
         test_util.add_next_safe_point(233);
         assert!(gc_manager.try_update_safe_point());
-        assert_eq!(gc_manager.safe_point, 233);
+        assert_eq!(gc_manager.safe_point, 233.into());
 
         let (tx, rx) = channel();
         ThreadBuilder::new()
@@ -1460,7 +1466,7 @@ mod tests {
         test_util.add_next_safe_point(233);
         test_util.add_next_safe_point(233);
         test_util.add_next_safe_point(234);
-        assert_eq!(rx.recv().unwrap(), 234);
+        assert_eq!(rx.recv().unwrap(), 234.into());
 
         test_util.stop();
     }
@@ -1469,13 +1475,13 @@ mod tests {
     fn test_gc_manager_initialize() {
         let mut test_util = GCManagerTestUtil::new(BTreeMap::new());
         let mut gc_manager = test_util.gc_manager.take().unwrap();
-        assert_eq!(gc_manager.safe_point, 0);
+        assert_eq!(gc_manager.safe_point, TimeStamp::min());
         test_util.add_next_safe_point(0);
         test_util.add_next_safe_point(5);
         gc_manager.initialize();
-        assert_eq!(gc_manager.safe_point, 0);
+        assert_eq!(gc_manager.safe_point, TimeStamp::min());
         assert!(gc_manager.try_update_safe_point());
-        assert_eq!(gc_manager.safe_point, 5);
+        assert_eq!(gc_manager.safe_point, 5.into());
     }
 
     #[test]
@@ -1598,7 +1604,7 @@ mod tests {
                 Key::from_encoded_slice(b""),
                 None,
                 expected_data.len() + 1,
-                1,
+                1.into(),
                 Options::default(),
             )
             .wait()
@@ -1614,8 +1620,8 @@ mod tests {
 
     fn test_destroy_range_impl(
         init_keys: &[Vec<u8>],
-        start_ts: u64,
-        commit_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
         start_key: &[u8],
         end_key: &[u8],
     ) -> Result<()> {
@@ -1649,6 +1655,8 @@ mod tests {
             .collect();
         let primary = init_keys[0].clone();
 
+        let start_ts = start_ts.into();
+
         // Write these data to the storage.
         wait_op!(|cb| storage.async_prewrite(
             Context::default(),
@@ -1663,9 +1671,15 @@ mod tests {
 
         // Commit.
         let keys: Vec<_> = init_keys.iter().map(|k| Key::from_raw(k)).collect();
-        wait_op!(|cb| storage.async_commit(Context::default(), keys, start_ts, commit_ts, cb))
-            .unwrap()
-            .unwrap();
+        wait_op!(|cb| storage.async_commit(
+            Context::default(),
+            keys,
+            start_ts,
+            commit_ts.into(),
+            cb
+        ))
+        .unwrap()
+        .unwrap();
 
         // Assert these data is successfully written to the storage.
         check_data(&storage, &data);

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -15,8 +15,10 @@ use self::waiter_manager::{Scheduler as WaiterMgrScheduler, WaiterManager};
 use crate::raftstore::coprocessor::CoprocessorHost;
 use crate::server::resolve::StoreAddrResolver;
 use crate::server::{Error, Result};
-use crate::storage::txn::{execute_callback, ProcessResult};
-use crate::storage::{lock_manager::Lock, LockManager as LockManagerTrait, StorageCallback};
+use crate::storage::{
+    lock_manager::Lock, txn::ProcessResult, LockManager as LockManagerTrait, StorageCallback,
+    TimeStamp,
+};
 use pd_client::PdClient;
 use spin::Mutex;
 use std::collections::hash_map::DefaultHasher;
@@ -31,7 +33,7 @@ use tikv_util::worker::FutureWorker;
 const DETECTED_SLOTS_NUM: usize = 128;
 
 #[inline]
-fn detected_slot_idx(txn_ts: u64) -> usize {
+fn detected_slot_idx(txn_ts: TimeStamp) -> usize {
     let mut s = DefaultHasher::new();
     txn_ts.hash(&mut s);
     (s.finish() as usize) & (DETECTED_SLOTS_NUM - 1)
@@ -50,7 +52,7 @@ pub struct LockManager {
     waiter_count: Arc<AtomicUsize>,
 
     /// Record transactions which have sent requests to detect deadlock.
-    detected: Arc<Vec<Mutex<HashSet<u64>>>>,
+    detected: Arc<Vec<Mutex<HashSet<TimeStamp>>>>,
 }
 
 impl Clone for LockManager {
@@ -190,12 +192,12 @@ impl LockManager {
         )
     }
 
-    fn add_to_detected(&self, txn_ts: u64) {
+    fn add_to_detected(&self, txn_ts: TimeStamp) {
         let mut detected = self.detected[detected_slot_idx(txn_ts)].lock();
         detected.insert(txn_ts);
     }
 
-    fn remove_from_detected(&self, txn_ts: u64) -> bool {
+    fn remove_from_detected(&self, txn_ts: TimeStamp) -> bool {
         let mut detected = self.detected[detected_slot_idx(txn_ts)].lock();
         detected.remove(&txn_ts)
     }
@@ -204,7 +206,7 @@ impl LockManager {
 impl LockManagerTrait for LockManager {
     fn wait_for(
         &self,
-        start_ts: u64,
+        start_ts: TimeStamp,
         cb: StorageCallback,
         pr: ProcessResult,
         lock: Lock,
@@ -231,9 +233,9 @@ impl LockManagerTrait for LockManager {
 
     fn wake_up(
         &self,
-        lock_ts: u64,
+        lock_ts: TimeStamp,
         hashes: Option<Vec<u64>>,
-        commit_ts: u64,
+        commit_ts: TimeStamp,
         is_pessimistic_txn: bool,
     ) {
         // If `hashes` is some, there may be some waiters waiting for these locks.
@@ -322,7 +324,7 @@ mod tests {
 
         let (tx, rx) = mpsc::channel();
         let storage_callback = |tx: mpsc::Sender<_>| {
-            StorageCb::Boolean(Box::new(move |result| {
+            StorageCallback::Boolean(Box::new(move |result| {
                 tx.send(result).unwrap();
             }))
         };
@@ -335,83 +337,98 @@ mod tests {
         // Normal wake up
         assert_eq!(lock_mgr.has_waiter(), false);
         lock_mgr.wait_for(
-            10,
+            10.into(),
             storage_callback(tx.clone()),
             ProcessResult::Res,
-            Lock { ts: 20, hash: 20 },
+            Lock {
+                ts: 20.into(),
+                hash: 20,
+            },
             true,
             0,
         );
         assert_eq!(lock_mgr.has_waiter(), true);
-        lock_mgr.wake_up(20, Some(vec![20]), 20, false);
+        lock_mgr.wake_up(20.into(), Some(vec![20]), 20.into(), false);
         recv(&rx);
         assert_eq!(lock_mgr.has_waiter(), false);
 
         // Normal deadlock
         lock_mgr.wait_for(
-            30,
+            30.into(),
             storage_callback(tx.clone()),
             ProcessResult::Res,
-            Lock { ts: 40, hash: 40 },
+            Lock {
+                ts: 40.into(),
+                hash: 40,
+            },
             false,
             0,
         );
         lock_mgr.wait_for(
-            40,
+            40.into(),
             storage_callback(tx.clone()),
             ProcessResult::MultiRes {
                 results: vec![Err(StorageError::from(TxnError::from(
                     MvccError::KeyIsLocked(LockInfo::default()),
                 )))],
             },
-            Lock { ts: 30, hash: 30 },
+            Lock {
+                ts: 30.into(),
+                hash: 30,
+            },
             false,
             0,
         );
         recv(&rx);
-        lock_mgr.wake_up(40, Some(vec![40]), 40, true);
+        lock_mgr.wake_up(40.into(), Some(vec![40]), 40.into(), true);
         recv(&rx);
         assert_eq!(lock_mgr.has_waiter(), false);
 
         // If it's the first lock, no detect
         lock_mgr.wait_for(
-            50,
+            50.into(),
             storage_callback(tx.clone()),
             ProcessResult::Res,
-            Lock { ts: 60, hash: 60 },
+            Lock {
+                ts: 60.into(),
+                hash: 60,
+            },
             true,
             0,
         );
-        assert_eq!(lock_mgr.remove_from_detected(50), false);
-        lock_mgr.wake_up(60, Some(vec![60]), 60, false);
+        assert_eq!(lock_mgr.remove_from_detected(50.into()), false);
+        lock_mgr.wake_up(60.into(), Some(vec![60]), 60.into(), false);
         recv(&rx);
 
         // If it's not the first lock, detect deadlock
         lock_mgr.wait_for(
-            50,
+            50.into(),
             storage_callback(tx.clone()),
             ProcessResult::Res,
-            Lock { ts: 60, hash: 60 },
+            Lock {
+                ts: 60.into(),
+                hash: 60,
+            },
             false,
             0,
         );
-        assert_eq!(lock_mgr.remove_from_detected(50), true);
-        lock_mgr.wake_up(60, Some(vec![60]), 60, false);
+        assert_eq!(lock_mgr.remove_from_detected(50.into()), true);
+        lock_mgr.wake_up(60.into(), Some(vec![60]), 60.into(), false);
         recv(&rx);
 
         // If key_hashes is none, no wake up
         let prev_wake_up = TASK_COUNTER_VEC.wake_up.get();
-        lock_mgr.wake_up(70, None, 70, false);
+        lock_mgr.wake_up(70.into(), None, 70.into(), false);
         assert_eq!(TASK_COUNTER_VEC.wake_up.get(), prev_wake_up);
 
         // If it's non-pessimistic-txn, no clean up
         let prev_clean_up = TASK_COUNTER_VEC.clean_up.get();
-        lock_mgr.wake_up(80, None, 80, false);
+        lock_mgr.wake_up(80.into(), None, 80.into(), false);
         assert_eq!(TASK_COUNTER_VEC.clean_up.get(), prev_clean_up);
 
         // If the txn doesn't wait for locks, no clean up
         let prev_clean_up = TASK_COUNTER_VEC.clean_up.get();
-        lock_mgr.wake_up(80, None, 80, true);
+        lock_mgr.wake_up(80.into(), None, 80.into(), true);
         assert_eq!(TASK_COUNTER_VEC.clean_up.get(), prev_clean_up);
     }
 
@@ -422,9 +439,9 @@ mod tests {
             .start_waiter_manager(&Config::default())
             .expect("could not start waiter manager");
         assert!(!lock_mgr.has_waiter());
-        let (lock_ts, hash) = (10, 1);
+        let (lock_ts, hash) = (10.into(), 1);
         lock_mgr.wait_for(
-            20,
+            20.into(),
             StorageCallback::Boolean(Box::new(|_| ())),
             ProcessResult::Res,
             Lock { ts: lock_ts, hash },
@@ -433,7 +450,7 @@ mod tests {
         );
         // new waiters should be sensed immediately
         assert!(lock_mgr.has_waiter());
-        lock_mgr.wake_up(lock_ts, Some(vec![hash]), 15, false);
+        lock_mgr.wake_up(lock_ts, Some(vec![hash]), 15.into(), false);
         thread::sleep(Duration::from_secs(1));
         assert!(!lock_mgr.has_waiter());
         lock_mgr.stop_waiter_manager();
@@ -452,7 +469,7 @@ mod tests {
         let lock_mgr = LockManager::new();
         let (tx, rx) = mpsc::channel();
         lock_mgr.wait_for(
-            10,
+            10.into(),
             StorageCallback::Boolean(Box::new(move |x| {
                 tx.send(x).unwrap();
             })),

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -16,7 +16,7 @@ use crate::raftstore::coprocessor::CoprocessorHost;
 use crate::server::resolve::StoreAddrResolver;
 use crate::server::{Error, Result};
 use crate::storage::{
-    lock_manager::Lock, txn::ProcessResult, LockManager as LockManagerTrait, StorageCallback,
+    lock_manager::Lock, types::ProcessResult, LockManager as LockManagerTrait, StorageCallback,
     TimeStamp,
 };
 use pd_client::PdClient;

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -6,7 +6,7 @@ use super::metrics::*;
 use crate::storage::lock_manager::Lock;
 use crate::storage::mvcc::{Error as MvccError, TimeStamp};
 use crate::storage::txn::Error as TxnError;
-use crate::storage::txn::ProcessResult;
+use crate::storage::types::ProcessResult;
 use crate::storage::{Error as StorageError, StorageCallback};
 use futures::Future;
 use kvproto::deadlock::WaitForEntry;
@@ -434,14 +434,14 @@ mod tests {
         let mut wait_table = WaitTable::new(Arc::new(AtomicUsize::new(0)));
         for i in 0..10 {
             let n = i as u64;
-            wait_table.add_waiter(n.into(), dummy_waiter(TimeStamp::min(), n.into(), n));
+            wait_table.add_waiter(n.into(), dummy_waiter(TimeStamp::zero(), n.into(), n));
         }
         assert_eq!(10, wait_table.size());
         for i in (0..10).rev() {
             let n = i as u64;
             assert!(wait_table
                 .remove_waiter(
-                    TimeStamp::min(),
+                    TimeStamp::zero(),
                     Lock {
                         ts: n.into(),
                         hash: n
@@ -452,9 +452,9 @@ mod tests {
         assert_eq!(0, wait_table.size());
         assert!(wait_table
             .remove_waiter(
-                TimeStamp::min(),
+                TimeStamp::zero(),
                 Lock {
-                    ts: TimeStamp::min(),
+                    ts: TimeStamp::zero(),
                     hash: 0
                 }
             )
@@ -474,7 +474,7 @@ mod tests {
         assert!(wait_table.take_ready_waiters(ts, hashes.clone()).is_empty());
 
         for hash in hashes.iter() {
-            wait_table.add_waiter(ts, dummy_waiter(TimeStamp::min(), ts, *hash));
+            wait_table.add_waiter(ts, dummy_waiter(TimeStamp::zero(), ts, *hash));
         }
         hashes.sort();
 
@@ -574,11 +574,11 @@ mod tests {
             tx.send(result).unwrap();
         });
         waiter_mgr_scheduler.wait_for(
-            TimeStamp::min(),
+            TimeStamp::zero(),
             StorageCallback::Boolean(cb),
             ProcessResult::Res,
             Lock {
-                ts: TimeStamp::min(),
+                ts: TimeStamp::zero(),
                 hash: 0,
             },
             0,
@@ -597,11 +597,11 @@ mod tests {
             tx.send(result).unwrap();
         });
         waiter_mgr_scheduler.wait_for(
-            TimeStamp::min(),
+            TimeStamp::zero(),
             StorageCallback::Boolean(cb),
             ProcessResult::Res,
             Lock {
-                ts: TimeStamp::min(),
+                ts: TimeStamp::zero(),
                 hash: 0,
             },
             100,
@@ -619,16 +619,16 @@ mod tests {
             tx.send(result).unwrap();
         });
         waiter_mgr_scheduler.wait_for(
-            TimeStamp::min(),
+            TimeStamp::zero(),
             StorageCallback::Boolean(cb),
             ProcessResult::Res,
             Lock {
-                ts: TimeStamp::min(),
+                ts: TimeStamp::zero(),
                 hash: 1,
             },
             0,
         );
-        waiter_mgr_scheduler.wake_up(TimeStamp::min(), vec![3, 1, 2], 1.into());
+        waiter_mgr_scheduler.wake_up(TimeStamp::zero(), vec![3, 1, 2], 1.into());
         assert!(rx
             .recv_timeout(Duration::from_millis(500))
             .unwrap()

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -16,7 +16,9 @@ use crate::server::transport::RaftStoreRouter;
 use crate::server::Error;
 use crate::storage::kv::Error as EngineError;
 use crate::storage::lock_manager::LockManager;
-use crate::storage::mvcc::{Error as MvccError, LockType, Write as MvccWrite, WriteType};
+use crate::storage::mvcc::{
+    Error as MvccError, LockType, TimeStamp, Write as MvccWrite, WriteType,
+};
 use crate::storage::txn::Error as TxnError;
 use crate::storage::{
     self, Engine, Key, Mutation, Options, PointGetCommand, Storage, TxnStatus, Value,
@@ -54,8 +56,8 @@ const REQUEST_BATCH_LIMITER_LOW_LOAD_RATIO: f32 = 0.3;
 #[derive(Hash, PartialEq, Eq, Debug)]
 struct RegionVerId {
     region_id: u64,
-    conf_ver: u64,
-    version: u64,
+    conf_ver: TimeStamp,
+    version: TimeStamp,
     term: u64,
 }
 
@@ -64,8 +66,8 @@ impl RegionVerId {
     fn from_context(ctx: &Context) -> Self {
         RegionVerId {
             region_id: ctx.get_region_id(),
-            conf_ver: ctx.get_region_epoch().get_conf_ver(),
-            version: ctx.get_region_epoch().get_version(),
+            conf_ver: ctx.get_region_epoch().get_conf_ver().into(),
+            version: ctx.get_region_epoch().get_version().into(),
             term: ctx.get_term(),
         }
     }
@@ -1259,9 +1261,9 @@ impl<T: RaftStoreRouter + 'static, E: Engine, L: LockManager> Tikv for Service<T
             .start_coarse_timer();
 
         let (cb, f) = paired_future_callback();
-        let res = self
-            .storage
-            .async_mvcc_by_start_ts(req.take_context(), req.get_start_ts(), cb);
+        let res =
+            self.storage
+                .async_mvcc_by_start_ts(req.take_context(), req.get_start_ts().into(), cb);
 
         let future = AndThenWith::new(res, f.map_err(Error::from))
             .and_then(|v| {
@@ -1862,7 +1864,7 @@ fn future_get<E: Engine, L: LockManager>(
         .async_get(
             req.take_context(),
             Key::from_raw(req.get_key()),
-            req.get_version(),
+            req.get_version().into(),
         )
         .then(|v| {
             let mut resp = GetResponse::default();
@@ -1953,7 +1955,7 @@ fn future_scan<E: Engine, L: LockManager>(
             Key::from_raw(req.get_start_key()),
             end_key,
             req.get_limit() as usize,
-            req.get_version(),
+            req.get_version().into(),
             options,
         )
         .then(|v| {
@@ -1985,17 +1987,17 @@ fn future_prewrite<E: Engine, L: LockManager>(
     let mut options = Options::default();
     options.lock_ttl = req.get_lock_ttl();
     options.skip_constraint_check = req.get_skip_constraint_check();
-    options.for_update_ts = req.get_for_update_ts();
+    options.for_update_ts = req.get_for_update_ts().into();
     options.is_pessimistic_lock = req.take_is_pessimistic_lock();
     options.txn_size = req.get_txn_size();
-    options.min_commit_ts = req.get_min_commit_ts();
+    options.min_commit_ts = req.get_min_commit_ts().into();
 
     let (cb, f) = paired_future_callback();
     let res = storage.async_prewrite(
         req.take_context(),
         mutations,
         req.take_primary_lock(),
-        req.get_start_version(),
+        req.get_start_version().into(),
         options,
         cb,
     );
@@ -2029,7 +2031,7 @@ fn future_acquire_pessimistic_lock<E: Engine, L: LockManager>(
     let mut options = Options::default();
     options.lock_ttl = req.get_lock_ttl();
     options.is_first_lock = req.get_is_first_lock();
-    options.for_update_ts = req.get_for_update_ts();
+    options.for_update_ts = req.get_for_update_ts().into();
     options.wait_timeout = req.get_wait_timeout();
 
     let (cb, f) = paired_future_callback();
@@ -2037,7 +2039,7 @@ fn future_acquire_pessimistic_lock<E: Engine, L: LockManager>(
         req.take_context(),
         keys,
         req.take_primary_lock(),
-        req.get_start_version(),
+        req.get_start_version().into(),
         options,
         cb,
     );
@@ -2062,8 +2064,8 @@ fn future_pessimistic_rollback<E: Engine, L: LockManager>(
     let res = storage.async_pessimistic_rollback(
         req.take_context(),
         keys,
-        req.get_start_version(),
-        req.get_for_update_ts(),
+        req.get_start_version().into(),
+        req.get_for_update_ts().into(),
         cb,
     );
 
@@ -2087,8 +2089,8 @@ fn future_commit<E: Engine, L: LockManager>(
     let res = storage.async_commit(
         req.take_context(),
         keys,
-        req.get_start_version(),
-        req.get_commit_version(),
+        req.get_start_version().into(),
+        req.get_commit_version().into(),
         cb,
     );
 
@@ -2111,8 +2113,8 @@ fn future_cleanup<E: Engine, L: LockManager>(
     let res = storage.async_cleanup(
         req.take_context(),
         Key::from_raw(req.get_key()),
-        req.get_start_version(),
-        req.get_current_ts(),
+        req.get_start_version().into(),
+        req.get_current_ts().into(),
         cb,
     );
 
@@ -2122,7 +2124,7 @@ fn future_cleanup<E: Engine, L: LockManager>(
             resp.set_region_error(err);
         } else if let Err(e) = v {
             if let Some(ts) = extract_committed(&e) {
-                resp.set_commit_version(ts);
+                resp.set_commit_version(ts.into_inner());
             } else {
                 resp.set_error(extract_key_error(&e));
             }
@@ -2137,7 +2139,7 @@ fn future_batch_get<E: Engine, L: LockManager>(
 ) -> impl Future<Item = BatchGetResponse, Error = Error> {
     let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
     storage
-        .async_batch_get(req.take_context(), keys, req.get_version())
+        .async_batch_get(req.take_context(), keys, req.get_version().into())
         .then(|v| {
             let mut resp = BatchGetResponse::default();
             if let Some(err) = extract_region_error(&v) {
@@ -2156,7 +2158,7 @@ fn future_batch_rollback<E: Engine, L: LockManager>(
     let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
 
     let (cb, f) = paired_future_callback();
-    let res = storage.async_rollback(req.take_context(), keys, req.get_start_version(), cb);
+    let res = storage.async_rollback(req.take_context(), keys, req.get_start_version().into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
         let mut resp = BatchRollbackResponse::default();
@@ -2179,7 +2181,7 @@ fn future_txn_heart_beat<E: Engine, L: LockManager>(
     let res = storage.async_txn_heart_beat(
         req.take_context(),
         primary_key,
-        req.get_start_version(),
+        req.get_start_version().into(),
         req.get_advise_lock_ttl(),
         cb,
     );
@@ -2214,14 +2216,14 @@ fn future_check_txn_status<E: Engine, L: LockManager>(
     let res = storage.async_check_txn_status(
         req.take_context(),
         primary_key,
-        req.get_lock_ts(),
-        req.get_caller_start_ts(),
-        req.get_current_ts(),
+        req.get_lock_ts().into(),
+        req.get_caller_start_ts().into(),
+        req.get_current_ts().into(),
         req.get_rollback_if_not_exist(),
         cb,
     );
 
-    let caller_start_ts = req.get_caller_start_ts();
+    let caller_start_ts = req.get_caller_start_ts().into();
     AndThenWith::new(res, f.map_err(Error::from)).map(move |v| {
         let mut resp = CheckTxnStatusResponse::default();
         if let Some(err) = extract_region_error(&v) {
@@ -2232,7 +2234,9 @@ fn future_check_txn_status<E: Engine, L: LockManager>(
                     TxnStatus::Rollbacked => resp.set_action(Action::NoAction),
                     TxnStatus::TtlExpire => resp.set_action(Action::TtlExpireRollback),
                     TxnStatus::LockNotExist => resp.set_action(Action::LockNotExistRollback),
-                    TxnStatus::Committed { commit_ts } => resp.set_commit_version(commit_ts),
+                    TxnStatus::Committed { commit_ts } => {
+                        resp.set_commit_version(commit_ts.into_inner())
+                    }
                     TxnStatus::Uncommitted {
                         lock_ttl,
                         min_commit_ts,
@@ -2257,7 +2261,7 @@ fn future_scan_lock<E: Engine, L: LockManager>(
     let (cb, f) = paired_future_callback();
     let res = storage.async_scan_locks(
         req.take_context(),
-        req.get_max_version(),
+        req.get_max_version().into(),
         req.take_start_key(),
         req.get_limit() as usize,
         cb,
@@ -2288,22 +2292,22 @@ fn future_resolve_lock<E: Engine, L: LockManager>(
         .collect();
     let txn_status = if req.get_start_version() > 0 {
         HashMap::from_iter(iter::once((
-            req.get_start_version(),
-            req.get_commit_version(),
+            req.get_start_version().into(),
+            req.get_commit_version().into(),
         )))
     } else {
         HashMap::from_iter(
             req.take_txn_infos()
                 .into_iter()
-                .map(|info| (info.txn, info.status)),
+                .map(|info| (info.txn.into(), info.status.into())),
         )
     };
 
     let (cb, f) = paired_future_callback();
     let res = if !resolve_keys.is_empty() {
-        let start_ts = req.get_start_version();
-        assert!(start_ts > 0);
-        let commit_ts = req.get_commit_version();
+        let start_ts: TimeStamp = req.get_start_version().into();
+        assert!(!start_ts.is_zero());
+        let commit_ts = req.get_commit_version().into();
         storage.async_resolve_lock_lite(req.take_context(), start_ts, commit_ts, resolve_keys, cb)
     } else {
         storage.async_resolve_lock(req.take_context(), txn_status, cb)
@@ -2325,7 +2329,7 @@ fn future_gc<E: Engine>(
     mut req: GcRequest,
 ) -> impl Future<Item = GcResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
-    let res = gc_worker.async_gc(req.take_context(), req.get_safe_point(), cb);
+    let res = gc_worker.async_gc(req.take_context(), req.get_safe_point().into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
         let mut resp = GcResponse::default();
@@ -2666,7 +2670,7 @@ fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
     }
 }
 
-fn extract_committed(err: &storage::Error) -> Option<u64> {
+fn extract_committed(err: &storage::Error) -> Option<TimeStamp> {
     match *err {
         storage::Error::Txn(TxnError::Mvcc(MvccError::Committed { commit_ts })) => Some(commit_ts),
         _ => None,
@@ -2689,9 +2693,9 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
             ..
         })) => {
             let mut write_conflict = WriteConflict::default();
-            write_conflict.set_start_ts(*start_ts);
-            write_conflict.set_conflict_ts(*conflict_start_ts);
-            write_conflict.set_conflict_commit_ts(*conflict_commit_ts);
+            write_conflict.set_start_ts(start_ts.into_inner());
+            write_conflict.set_conflict_ts(conflict_start_ts.into_inner());
+            write_conflict.set_conflict_commit_ts(conflict_commit_ts.into_inner());
             write_conflict.set_key(key.to_owned());
             write_conflict.set_primary(primary.to_owned());
             key_error.set_conflict(write_conflict);
@@ -2710,7 +2714,7 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
         }
         storage::Error::Txn(TxnError::Mvcc(MvccError::TxnNotFound { start_ts, key })) => {
             let mut txn_not_found = TxnNotFound::default();
-            txn_not_found.set_start_ts(*start_ts);
+            txn_not_found.set_start_ts(start_ts.into_inner());
             txn_not_found.set_primary_key(key.to_owned());
             key_error.set_txn_not_found(txn_not_found);
         }
@@ -2722,7 +2726,7 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
         })) => {
             warn!("txn deadlocks"; "err" => ?err);
             let mut deadlock = Deadlock::default();
-            deadlock.set_lock_ts(*lock_ts);
+            deadlock.set_lock_ts(lock_ts.into_inner());
             deadlock.set_lock_key(lock_key.to_owned());
             deadlock.set_deadlock_key_hash(*deadlock_key_hash);
             key_error.set_deadlock(deadlock);
@@ -2734,10 +2738,10 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
             min_commit_ts,
         })) => {
             let mut commit_ts_expired = CommitTsExpired::default();
-            commit_ts_expired.set_start_ts(*start_ts);
-            commit_ts_expired.set_attempted_commit_ts(*commit_ts);
+            commit_ts_expired.set_start_ts(start_ts.into_inner());
+            commit_ts_expired.set_attempted_commit_ts(commit_ts.into_inner());
             commit_ts_expired.set_key(key.to_owned());
-            commit_ts_expired.set_min_commit_ts(*min_commit_ts);
+            commit_ts_expired.set_min_commit_ts(min_commit_ts.into_inner());
             key_error.set_commit_ts_expired(commit_ts_expired);
         }
         _ => {
@@ -2785,7 +2789,7 @@ fn extract_mvcc_info(mvcc: storage::MvccInfo) -> MvccInfo {
             LockType::Pessimistic => Op::PessimisticLock,
         };
         lock_info.set_type(op);
-        lock_info.set_start_ts(lock.ts);
+        lock_info.set_start_ts(lock.ts.into_inner());
         lock_info.set_primary(lock.primary);
         lock_info.set_short_value(lock.short_value.unwrap_or_default());
         mvcc_info.set_lock(lock_info);
@@ -2797,18 +2801,18 @@ fn extract_mvcc_info(mvcc: storage::MvccInfo) -> MvccInfo {
     mvcc_info
 }
 
-fn extract_2pc_values(res: Vec<(u64, Value)>) -> Vec<MvccValue> {
+fn extract_2pc_values(res: Vec<(TimeStamp, Value)>) -> Vec<MvccValue> {
     res.into_iter()
         .map(|(start_ts, value)| {
             let mut value_info = MvccValue::default();
-            value_info.set_start_ts(start_ts);
+            value_info.set_start_ts(start_ts.into_inner());
             value_info.set_value(value);
             value_info
         })
         .collect()
 }
 
-fn extract_2pc_writes(res: Vec<(u64, MvccWrite)>) -> Vec<kvrpcpb::MvccWrite> {
+fn extract_2pc_writes(res: Vec<(TimeStamp, MvccWrite)>) -> Vec<kvrpcpb::MvccWrite> {
     res.into_iter()
         .map(|(commit_ts, write)| {
             let mut write_info = kvrpcpb::MvccWrite::default();
@@ -2819,8 +2823,8 @@ fn extract_2pc_writes(res: Vec<(u64, MvccWrite)>) -> Vec<kvrpcpb::MvccWrite> {
                 WriteType::Rollback => Op::Rollback,
             };
             write_info.set_type(op);
-            write_info.set_start_ts(write.start_ts);
-            write_info.set_commit_ts(commit_ts);
+            write_info.set_start_ts(write.start_ts.into_inner());
+            write_info.set_commit_ts(commit_ts.into_inner());
             write_info.set_short_value(write.short_value.unwrap_or_default());
             write_info
         })
@@ -2869,9 +2873,9 @@ mod tests {
 
     #[test]
     fn test_extract_key_error_write_conflict() {
-        let start_ts = 110;
-        let conflict_start_ts = 108;
-        let conflict_commit_ts = 109;
+        let start_ts = 110.into();
+        let conflict_start_ts = 108.into();
+        let conflict_commit_ts = 109.into();
         let key = b"key".to_vec();
         let primary = b"primary".to_vec();
         let case = storage::Error::from(TxnError::from(MvccError::WriteConflict {
@@ -2883,9 +2887,9 @@ mod tests {
         }));
         let mut expect = KeyError::default();
         let mut write_conflict = WriteConflict::default();
-        write_conflict.set_start_ts(start_ts);
-        write_conflict.set_conflict_ts(conflict_start_ts);
-        write_conflict.set_conflict_commit_ts(conflict_commit_ts);
+        write_conflict.set_start_ts(start_ts.into_inner());
+        write_conflict.set_conflict_ts(conflict_start_ts.into_inner());
+        write_conflict.set_conflict_commit_ts(conflict_commit_ts.into_inner());
         write_conflict.set_key(key);
         write_conflict.set_primary(primary);
         expect.set_conflict(write_conflict);

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -56,8 +56,8 @@ const REQUEST_BATCH_LIMITER_LOW_LOAD_RATIO: f32 = 0.3;
 #[derive(Hash, PartialEq, Eq, Debug)]
 struct RegionVerId {
     region_id: u64,
-    conf_ver: TimeStamp,
-    version: TimeStamp,
+    conf_ver: u64,
+    version: u64,
     term: u64,
 }
 
@@ -66,8 +66,8 @@ impl RegionVerId {
     fn from_context(ctx: &Context) -> Self {
         RegionVerId {
             region_id: ctx.get_region_id(),
-            conf_ver: ctx.get_region_epoch().get_conf_ver().into(),
-            version: ctx.get_region_epoch().get_version().into(),
+            conf_ver: ctx.get_region_epoch().get_conf_ver(),
+            version: ctx.get_region_epoch().get_version(),
             term: ctx.get_term(),
         }
     }

--- a/src/storage/commands.rs
+++ b/src/storage/commands.rs
@@ -6,7 +6,7 @@ use kvproto::kvrpcpb::{CommandPri, Context, GetRequest, RawGetRequest};
 use tikv_util::collections::HashMap;
 
 use crate::storage::metrics::{self, CommandPriority};
-use crate::storage::mvcc::Lock;
+use crate::storage::mvcc::{Lock, TimeStamp};
 use crate::storage::types::{Key, Mutation};
 
 pub const CMD_TAG_GC: &str = "gc";
@@ -17,7 +17,7 @@ pub struct PointGetCommand {
     pub(super) ctx: Context,
     pub(super) key: Key,
     /// None if this is a raw get, Some if this is a transactional get.
-    pub(super) ts: Option<u64>,
+    pub(super) ts: Option<TimeStamp>,
 }
 
 impl PointGetCommand {
@@ -25,7 +25,7 @@ impl PointGetCommand {
         PointGetCommand {
             ctx: request.take_context(),
             key: Key::from_raw(request.get_key()),
-            ts: Some(request.get_version()),
+            ts: Some(request.get_version().into()),
         }
     }
 
@@ -38,7 +38,7 @@ impl PointGetCommand {
     }
 
     #[cfg(test)]
-    pub fn from_key_ts(key: Key, ts: Option<u64>) -> Self {
+    pub fn from_key_ts(key: Key, ts: Option<TimeStamp>) -> Self {
         PointGetCommand {
             ctx: Context::default(),
             key,
@@ -73,7 +73,7 @@ pub enum CommandKind {
         /// The primary lock. Secondary locks (from `mutations`) will refer to the primary lock.
         primary: Vec<u8>,
         /// The transaction timestamp.
-        start_ts: u64,
+        start_ts: TimeStamp,
         options: Options,
     },
     /// Acquire a Pessimistic lock on the keys.
@@ -85,7 +85,7 @@ pub enum CommandKind {
         /// The primary lock. Secondary locks (from `keys`) will refer to the primary lock.
         primary: Vec<u8>,
         /// The transaction timestamp.
-        start_ts: u64,
+        start_ts: TimeStamp,
         options: Options,
     },
     /// Commit the transaction that started at `lock_ts`.
@@ -95,9 +95,9 @@ pub enum CommandKind {
         /// The keys affected.
         keys: Vec<Key>,
         /// The lock timestamp.
-        lock_ts: u64,
+        lock_ts: TimeStamp,
         /// The commit timestamp.
-        commit_ts: u64,
+        commit_ts: TimeStamp,
     },
     /// Rollback mutations on a single key.
     ///
@@ -105,10 +105,10 @@ pub enum CommandKind {
     Cleanup {
         key: Key,
         /// The transaction timestamp.
-        start_ts: u64,
+        start_ts: TimeStamp,
         /// The approximate current ts when cleanup request is invoked, which is used to check the
         /// lock's TTL. 0 means do not check TTL.
-        current_ts: u64,
+        current_ts: TimeStamp,
     },
     /// Rollback from the transaction that was started at `start_ts`.
     ///
@@ -116,7 +116,7 @@ pub enum CommandKind {
     Rollback {
         keys: Vec<Key>,
         /// The transaction timestamp.
-        start_ts: u64,
+        start_ts: TimeStamp,
     },
     /// Rollback pessimistic locks identified by `start_ts` and `for_update_ts`.
     ///
@@ -125,8 +125,8 @@ pub enum CommandKind {
         /// The keys to be rolled back.
         keys: Vec<Key>,
         /// The transaction timestamp.
-        start_ts: u64,
-        for_update_ts: u64,
+        start_ts: TimeStamp,
+        for_update_ts: TimeStamp,
     },
     /// Heart beat of a transaction. It enlarges the primary lock's TTL.
     ///
@@ -137,7 +137,7 @@ pub enum CommandKind {
         /// The primary key of the transaction.
         primary_key: Key,
         /// The transaction's start_ts.
-        start_ts: u64,
+        start_ts: TimeStamp,
         /// The new TTL that will be used to update the lock's TTL. If the lock's TTL is already
         /// greater than `advise_ttl`, nothing will happen.
         advise_ttl: u64,
@@ -154,11 +154,11 @@ pub enum CommandKind {
         /// The primary key of the transaction.
         primary_key: Key,
         /// The lock's ts, namely the transaction's start_ts.
-        lock_ts: u64,
+        lock_ts: TimeStamp,
         /// The start_ts of the transaction that invokes this command.
-        caller_start_ts: u64,
+        caller_start_ts: TimeStamp,
         /// The approximate current_ts when the command is invoked.
-        current_ts: u64,
+        current_ts: TimeStamp,
         /// Specifies the behavior when neither commit/rollback record nor lock is found. If true,
         /// rollbacks that transaction; otherwise returns an error.
         rollback_if_not_exist: bool,
@@ -166,7 +166,7 @@ pub enum CommandKind {
     /// Scan locks from `start_key`, and find all locks whose timestamp is before `max_ts`.
     ScanLock {
         /// The maximum transaction timestamp to scan.
-        max_ts: u64,
+        max_ts: TimeStamp,
         /// The key to start from. (`None` means start from the very beginning.)
         start_key: Option<Key>,
         /// The result limit.
@@ -193,16 +193,16 @@ pub enum CommandKind {
         /// will be rolled back.  `"k3"` will not be affected, because its lock_ts is not contained in
         /// `txn_status`. `"k4"` will not be affected either, because it doesn't have a non-committed
         /// version.
-        txn_status: HashMap<u64, u64>,
+        txn_status: HashMap<TimeStamp, TimeStamp>,
         scan_key: Option<Key>,
         key_locks: Vec<(Key, Lock)>,
     },
     /// Resolve locks on `resolve_keys` according to `start_ts` and `commit_ts`.
     ResolveLockLite {
         /// The transaction timestamp.
-        start_ts: u64,
+        start_ts: TimeStamp,
         /// The transaction commit timestamp.
-        commit_ts: u64,
+        commit_ts: TimeStamp,
         /// The keys to resolve.
         resolve_keys: Vec<Key>,
     },
@@ -230,7 +230,7 @@ pub enum CommandKind {
     /// Retrieve MVCC information for the given key.
     MvccByKey { key: Key },
     /// Retrieve MVCC info for the first committed key which `start_ts == ts`.
-    MvccByStartTs { start_ts: u64 },
+    MvccByStartTs { start_ts: TimeStamp },
 }
 
 impl Command {
@@ -291,7 +291,7 @@ impl Command {
         }
     }
 
-    pub fn ts(&self) -> u64 {
+    pub fn ts(&self) -> TimeStamp {
         match self.kind {
             CommandKind::Prewrite { start_ts, .. }
             | CommandKind::AcquirePessimisticLock { start_ts, .. }
@@ -308,7 +308,7 @@ impl Command {
             CommandKind::ResolveLock { .. }
             | CommandKind::DeleteRange { .. }
             | CommandKind::Pause { .. }
-            | CommandKind::MvccByKey { .. } => 0,
+            | CommandKind::MvccByKey { .. } => TimeStamp::min(),
         }
     }
 
@@ -521,11 +521,11 @@ pub struct Options {
     pub key_only: bool,
     pub reverse_scan: bool,
     pub is_first_lock: bool,
-    pub for_update_ts: u64,
+    pub for_update_ts: TimeStamp,
     pub is_pessimistic_lock: Vec<bool>,
     // How many keys this transaction involved.
     pub txn_size: u64,
-    pub min_commit_ts: u64,
+    pub min_commit_ts: TimeStamp,
     // Time to wait for lock released in milliseconds when encountering locks.
     // 0 means using default timeout. Negative means no wait.
     pub wait_timeout: i64,

--- a/src/storage/commands.rs
+++ b/src/storage/commands.rs
@@ -308,7 +308,7 @@ impl Command {
             CommandKind::ResolveLock { .. }
             | CommandKind::DeleteRange { .. }
             | CommandKind::Pause { .. }
-            | CommandKind::MvccByKey { .. } => TimeStamp::min(),
+            | CommandKind::MvccByKey { .. } => TimeStamp::zero(),
         }
     }
 

--- a/src/storage/lock_manager.rs
+++ b/src/storage/lock_manager.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::storage::txn::ProcessResult;
-use crate::storage::StorageCb;
+use crate::storage::StorageCallback;
 
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 pub struct Lock {
@@ -21,7 +21,7 @@ pub trait LockManager: Clone + Send + 'static {
     fn wait_for(
         &self,
         start_ts: u64,
-        cb: StorageCb,
+        cb: StorageCallback,
         pr: ProcessResult,
         lock: Lock,
         is_first_lock: bool,
@@ -53,7 +53,7 @@ impl LockManager for DummyLockManager {
     fn wait_for(
         &self,
         _start_ts: u64,
-        _cb: StorageCb,
+        _cb: StorageCallback,
         _pr: ProcessResult,
         _lock: Lock,
         _is_first_lock: bool,

--- a/src/storage/lock_manager.rs
+++ b/src/storage/lock_manager.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::storage::{txn::ProcessResult, StorageCallback, TimeStamp};
+use crate::storage::{types::ProcessResult, StorageCallback, TimeStamp};
 
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 pub struct Lock {

--- a/src/storage/lock_manager.rs
+++ b/src/storage/lock_manager.rs
@@ -1,11 +1,10 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::storage::txn::ProcessResult;
-use crate::storage::StorageCallback;
+use crate::storage::{txn::ProcessResult, StorageCallback, TimeStamp};
 
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 pub struct Lock {
-    pub ts: u64,
+    pub ts: TimeStamp,
     pub hash: u64,
 }
 
@@ -20,7 +19,7 @@ pub trait LockManager: Clone + Send + 'static {
     /// If the lock is the first lock the transaction waits for, it won't result in deadlock.
     fn wait_for(
         &self,
-        start_ts: u64,
+        start_ts: TimeStamp,
         cb: StorageCallback,
         pr: ProcessResult,
         lock: Lock,
@@ -31,9 +30,9 @@ pub trait LockManager: Clone + Send + 'static {
     /// The locks with `lock_ts` and `hashes` are released, tries to wake up transactions.
     fn wake_up(
         &self,
-        lock_ts: u64,
+        lock_ts: TimeStamp,
         hashes: Option<Vec<u64>>,
-        commit_ts: u64,
+        commit_ts: TimeStamp,
         is_pessimistic_txn: bool,
     );
 
@@ -52,7 +51,7 @@ pub struct DummyLockManager;
 impl LockManager for DummyLockManager {
     fn wait_for(
         &self,
-        _start_ts: u64,
+        _start_ts: TimeStamp,
         _cb: StorageCallback,
         _pr: ProcessResult,
         _lock: Lock,
@@ -63,9 +62,9 @@ impl LockManager for DummyLockManager {
 
     fn wake_up(
         &self,
-        _lock_ts: u64,
+        _lock_ts: TimeStamp,
         _hashes: Option<Vec<u64>>,
-        _commit_ts: u64,
+        _commit_ts: TimeStamp,
         _is_pessimistic_txn: bool,
     ) {
     }

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -116,16 +116,16 @@ impl Lock {
                 ts,
                 ttl,
                 None,
-                TimeStamp::min(),
+                TimeStamp::zero(),
                 0,
-                TimeStamp::min(),
+                TimeStamp::zero(),
             ));
         }
 
         let mut short_value = None;
-        let mut for_update_ts = TimeStamp::min();
+        let mut for_update_ts = TimeStamp::zero();
         let mut txn_size: u64 = 0;
-        let mut min_commit_ts = TimeStamp::min();
+        let mut min_commit_ts = TimeStamp::zero();
         while !b.is_empty() {
             match b.read_u8()? {
                 SHORT_VALUE_PREFIX => {
@@ -259,9 +259,9 @@ mod tests {
                 1.into(),
                 10,
                 None,
-                TimeStamp::min(),
+                TimeStamp::zero(),
                 0,
-                TimeStamp::min(),
+                TimeStamp::zero(),
             ),
             Lock::new(
                 LockType::Delete,
@@ -269,9 +269,9 @@ mod tests {
                 1.into(),
                 10,
                 Some(b"short_value".to_vec()),
-                TimeStamp::min(),
+                TimeStamp::zero(),
                 0,
-                TimeStamp::min(),
+                TimeStamp::zero(),
             ),
             Lock::new(
                 LockType::Put,
@@ -281,7 +281,7 @@ mod tests {
                 None,
                 10.into(),
                 0,
-                TimeStamp::min(),
+                TimeStamp::zero(),
             ),
             Lock::new(
                 LockType::Delete,
@@ -291,7 +291,7 @@ mod tests {
                 Some(b"short_value".to_vec()),
                 10.into(),
                 0,
-                TimeStamp::min(),
+                TimeStamp::zero(),
             ),
             Lock::new(
                 LockType::Put,
@@ -299,9 +299,9 @@ mod tests {
                 1.into(),
                 10,
                 None,
-                TimeStamp::min(),
+                TimeStamp::zero(),
                 16,
-                TimeStamp::min(),
+                TimeStamp::zero(),
             ),
             Lock::new(
                 LockType::Delete,
@@ -309,9 +309,9 @@ mod tests {
                 1.into(),
                 10,
                 Some(b"short_value".to_vec()),
-                TimeStamp::min(),
+                TimeStamp::zero(),
                 16,
-                TimeStamp::min(),
+                TimeStamp::zero(),
             ),
             Lock::new(
                 LockType::Put,
@@ -321,7 +321,7 @@ mod tests {
                 None,
                 10.into(),
                 16,
-                TimeStamp::min(),
+                TimeStamp::zero(),
             ),
             Lock::new(
                 LockType::Delete,
@@ -331,7 +331,7 @@ mod tests {
                 Some(b"short_value".to_vec()),
                 10.into(),
                 0,
-                TimeStamp::min(),
+                TimeStamp::zero(),
             ),
             Lock::new(
                 LockType::Put,
@@ -359,9 +359,9 @@ mod tests {
             1.into(),
             10,
             Some(b"short_value".to_vec()),
-            TimeStamp::min(),
+            TimeStamp::zero(),
             0,
-            TimeStamp::min(),
+            TimeStamp::zero(),
         );
         let v = lock.to_bytes();
         assert!(Lock::parse(&v[..4]).is_err());
@@ -376,9 +376,9 @@ mod tests {
             100.into(),
             3,
             None,
-            TimeStamp::min(),
+            TimeStamp::zero(),
             1,
-            TimeStamp::min(),
+            TimeStamp::zero(),
         );
 
         let empty = Default::default();

--- a/src/storage/mvcc/lock.rs
+++ b/src/storage/mvcc/lock.rs
@@ -1,12 +1,13 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::super::types::Value;
-use super::{Error, Result, TsSet};
+use super::{Error, Result, TimeStamp, TsSet};
 use crate::storage::{
     Key, Mutation, FOR_UPDATE_TS_PREFIX, MIN_COMMIT_TS_PREFIX, SHORT_VALUE_MAX_LEN,
     SHORT_VALUE_PREFIX, TXN_SIZE_PREFIX,
 };
 use byteorder::ReadBytesExt;
+use derive_new::new;
 use kvproto::kvrpcpb::{LockInfo, Op};
 use tikv_util::codec::bytes::{self, BytesEncoder};
 use tikv_util::codec::number::{self, NumberEncoder, MAX_VAR_U64_LEN};
@@ -53,66 +54,44 @@ impl LockType {
     }
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(new, PartialEq, Clone, Debug)]
 pub struct Lock {
     pub lock_type: LockType,
     pub primary: Vec<u8>,
-    pub ts: u64,
+    pub ts: TimeStamp,
     pub ttl: u64,
     pub short_value: Option<Value>,
     // If for_update_ts != 0, this lock belongs to a pessimistic transaction
-    pub for_update_ts: u64,
+    pub for_update_ts: TimeStamp,
     pub txn_size: u64,
-    pub min_commit_ts: u64,
+    pub min_commit_ts: TimeStamp,
 }
 
 impl Lock {
-    pub fn new(
-        lock_type: LockType,
-        primary: Vec<u8>,
-        ts: u64,
-        ttl: u64,
-        short_value: Option<Value>,
-        for_update_ts: u64,
-        txn_size: u64,
-        min_commit_ts: u64,
-    ) -> Lock {
-        Lock {
-            lock_type,
-            primary,
-            ts,
-            ttl,
-            short_value,
-            for_update_ts,
-            txn_size,
-            min_commit_ts,
-        }
-    }
-
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut b = Vec::with_capacity(
             1 + MAX_VAR_U64_LEN + self.primary.len() + MAX_VAR_U64_LEN + SHORT_VALUE_MAX_LEN + 2,
         );
         b.push(self.lock_type.to_u8());
         b.encode_compact_bytes(&self.primary).unwrap();
-        b.encode_var_u64(self.ts).unwrap();
+        b.encode_var_u64(self.ts.into_inner()).unwrap();
         b.encode_var_u64(self.ttl).unwrap();
         if let Some(ref v) = self.short_value {
             b.push(SHORT_VALUE_PREFIX);
             b.push(v.len() as u8);
             b.extend_from_slice(v);
         }
-        if self.for_update_ts > 0 {
+        if !self.for_update_ts.is_zero() {
             b.push(FOR_UPDATE_TS_PREFIX);
-            b.encode_u64(self.for_update_ts).unwrap();
+            b.encode_u64(self.for_update_ts.into_inner()).unwrap();
         }
         if self.txn_size > 0 {
             b.push(TXN_SIZE_PREFIX);
             b.encode_u64(self.txn_size).unwrap();
         }
-        if self.min_commit_ts > 0 {
+        if !self.min_commit_ts.is_zero() {
             b.push(MIN_COMMIT_TS_PREFIX);
-            b.encode_u64(self.min_commit_ts).unwrap();
+            b.encode_u64(self.min_commit_ts.into_inner()).unwrap();
         }
         b
     }
@@ -123,7 +102,7 @@ impl Lock {
         }
         let lock_type = LockType::from_u8(b.read_u8()?).ok_or(Error::BadFormatLock)?;
         let primary = bytes::decode_compact_bytes(&mut b)?;
-        let ts = number::decode_var_u64(&mut b)?;
+        let ts = number::decode_var_u64(&mut b)?.into();
         let ttl = if b.is_empty() {
             0
         } else {
@@ -131,13 +110,22 @@ impl Lock {
         };
 
         if b.is_empty() {
-            return Ok(Lock::new(lock_type, primary, ts, ttl, None, 0, 0, 0));
+            return Ok(Lock::new(
+                lock_type,
+                primary,
+                ts,
+                ttl,
+                None,
+                TimeStamp::min(),
+                0,
+                TimeStamp::min(),
+            ));
         }
 
         let mut short_value = None;
-        let mut for_update_ts = 0;
+        let mut for_update_ts = TimeStamp::min();
         let mut txn_size: u64 = 0;
-        let mut min_commit_ts: u64 = 0;
+        let mut min_commit_ts = TimeStamp::min();
         while !b.is_empty() {
             match b.read_u8()? {
                 SHORT_VALUE_PREFIX => {
@@ -152,9 +140,9 @@ impl Lock {
                     short_value = Some(b[..len as usize].to_vec());
                     b = &b[len as usize..];
                 }
-                FOR_UPDATE_TS_PREFIX => for_update_ts = number::decode_u64(&mut b)?,
+                FOR_UPDATE_TS_PREFIX => for_update_ts = number::decode_u64(&mut b)?.into(),
                 TXN_SIZE_PREFIX => txn_size = number::decode_u64(&mut b)?,
-                MIN_COMMIT_TS_PREFIX => min_commit_ts = number::decode_u64(&mut b)?,
+                MIN_COMMIT_TS_PREFIX => min_commit_ts = number::decode_u64(&mut b)?.into(),
                 flag => panic!("invalid flag [{}] in lock", flag),
             }
         }
@@ -173,7 +161,7 @@ impl Lock {
     pub fn into_lock_info(self, raw_key: Vec<u8>) -> LockInfo {
         let mut info = LockInfo::default();
         info.set_primary_lock(self.primary);
-        info.set_lock_version(self.ts);
+        info.set_lock_version(self.ts.into_inner());
         info.set_key(raw_key);
         info.set_lock_ttl(self.ttl);
         info.set_txn_size(self.txn_size);
@@ -187,8 +175,8 @@ impl Lock {
         info
     }
 
-    /// Checks whether the lock conflicts with the given `ts`. If `ts == MaxU64`, the primary lock will be ignored.
-    pub fn check_ts_conflict(self, key: &Key, ts: u64, bypass_locks: &TsSet) -> Result<()> {
+    /// Checks whether the lock conflicts with the given `ts`. If `ts == TimeStamp::max()`, the primary lock will be ignored.
+    pub fn check_ts_conflict(self, key: &Key, ts: TimeStamp, bypass_locks: &TsSet) -> Result<()> {
         if self.ts > ts
             || self.lock_type == LockType::Lock
             || self.lock_type == LockType::Pessimistic
@@ -203,8 +191,8 @@ impl Lock {
 
         let raw_key = key.to_raw()?;
 
-        if ts == std::u64::MAX && raw_key == self.primary {
-            // When `ts == u64::MAX` (which means to get latest committed version for
+        if ts == TimeStamp::max() && raw_key == self.primary {
+            // When `ts == TimeStamp::max()` (which means to get latest committed version for
             // primary key), and current key is the primary key, we ignore this lock.
             return Ok(());
         }
@@ -265,59 +253,95 @@ mod tests {
     fn test_lock() {
         // Test `Lock::to_bytes()` and `Lock::parse()` works as a pair.
         let mut locks = vec![
-            Lock::new(LockType::Put, b"pk".to_vec(), 1, 10, None, 0, 0, 0),
             Lock::new(
-                LockType::Delete,
+                LockType::Put,
                 b"pk".to_vec(),
-                1,
+                1.into(),
                 10,
-                Some(b"short_value".to_vec()),
+                None,
+                TimeStamp::min(),
                 0,
-                0,
-                0,
+                TimeStamp::min(),
             ),
-            Lock::new(LockType::Put, b"pk".to_vec(), 1, 10, None, 10, 0, 0),
             Lock::new(
                 LockType::Delete,
                 b"pk".to_vec(),
-                1,
+                1.into(),
                 10,
                 Some(b"short_value".to_vec()),
-                10,
+                TimeStamp::min(),
                 0,
-                0,
+                TimeStamp::min(),
             ),
-            Lock::new(LockType::Put, b"pk".to_vec(), 1, 10, None, 0, 16, 0),
+            Lock::new(
+                LockType::Put,
+                b"pk".to_vec(),
+                1.into(),
+                10,
+                None,
+                10.into(),
+                0,
+                TimeStamp::min(),
+            ),
             Lock::new(
                 LockType::Delete,
                 b"pk".to_vec(),
-                1,
+                1.into(),
                 10,
                 Some(b"short_value".to_vec()),
+                10.into(),
                 0,
+                TimeStamp::min(),
+            ),
+            Lock::new(
+                LockType::Put,
+                b"pk".to_vec(),
+                1.into(),
+                10,
+                None,
+                TimeStamp::min(),
                 16,
-                0,
+                TimeStamp::min(),
             ),
-            Lock::new(LockType::Put, b"pk".to_vec(), 1, 10, None, 10, 16, 0),
             Lock::new(
                 LockType::Delete,
                 b"pk".to_vec(),
-                1,
+                1.into(),
                 10,
                 Some(b"short_value".to_vec()),
+                TimeStamp::min(),
+                16,
+                TimeStamp::min(),
+            ),
+            Lock::new(
+                LockType::Put,
+                b"pk".to_vec(),
+                1.into(),
                 10,
+                None,
+                10.into(),
+                16,
+                TimeStamp::min(),
+            ),
+            Lock::new(
+                LockType::Delete,
+                b"pk".to_vec(),
+                1.into(),
+                10,
+                Some(b"short_value".to_vec()),
+                10.into(),
                 0,
-                0,
+                TimeStamp::min(),
             ),
             Lock::new(
                 LockType::Put,
                 b"pkpkpk".to_vec(),
-                111,
+                111.into(),
                 222,
                 None,
-                333,
+                333.into(),
                 444,
-                555,
+                555.into(),
             ),
         ];
         for (i, lock) in locks.drain(..).enumerate() {
@@ -332,12 +356,12 @@ mod tests {
         let lock = Lock::new(
             LockType::Lock,
             b"pk".to_vec(),
-            1,
+            1.into(),
             10,
             Some(b"short_value".to_vec()),
+            TimeStamp::min(),
             0,
-            0,
-            0,
+            TimeStamp::min(),
         );
         let v = lock.to_bytes();
         assert!(Lock::parse(&v[..4]).is_err());
@@ -346,49 +370,68 @@ mod tests {
     #[test]
     fn test_check_ts_conflict() {
         let key = Key::from_raw(b"foo");
-        let mut lock = Lock::new(LockType::Put, vec![], 100, 3, None, 0, 1, 0);
+        let mut lock = Lock::new(
+            LockType::Put,
+            vec![],
+            100.into(),
+            3,
+            None,
+            TimeStamp::min(),
+            1,
+            TimeStamp::min(),
+        );
 
         let empty = Default::default();
 
         // Ignore the lock if read ts is less than the lock version
-        lock.clone().check_ts_conflict(&key, 50, &empty).unwrap();
+        lock.clone()
+            .check_ts_conflict(&key, 50.into(), &empty)
+            .unwrap();
 
         // Returns the lock if read ts >= lock version
         lock.clone()
-            .check_ts_conflict(&key, 110, &empty)
+            .check_ts_conflict(&key, 110.into(), &empty)
             .unwrap_err();
 
         // Ignore locks that occurs in the `bypass_locks` set.
         lock.clone()
-            .check_ts_conflict(&key, 110, &TsSet::new(vec![109]))
+            .check_ts_conflict(&key, 110.into(), &TsSet::from_u64s(vec![109]))
             .unwrap_err();
         lock.clone()
-            .check_ts_conflict(&key, 110, &TsSet::new(vec![110]))
+            .check_ts_conflict(&key, 110.into(), &TsSet::from_u64s(vec![110]))
             .unwrap_err();
         lock.clone()
-            .check_ts_conflict(&key, 110, &TsSet::new(vec![100]))
+            .check_ts_conflict(&key, 110.into(), &TsSet::from_u64s(vec![100]))
             .unwrap();
         lock.clone()
-            .check_ts_conflict(&key, 110, &TsSet::new(vec![99, 101, 102, 100, 80]))
+            .check_ts_conflict(
+                &key,
+                110.into(),
+                &TsSet::from_u64s(vec![99, 101, 102, 100, 80]),
+            )
             .unwrap();
 
         // Ignore the lock if it is Lock or Pessimistic.
         lock.lock_type = LockType::Lock;
-        lock.clone().check_ts_conflict(&key, 110, &empty).unwrap();
+        lock.clone()
+            .check_ts_conflict(&key, 110.into(), &empty)
+            .unwrap();
         lock.lock_type = LockType::Pessimistic;
-        lock.clone().check_ts_conflict(&key, 110, &empty).unwrap();
+        lock.clone()
+            .check_ts_conflict(&key, 110.into(), &empty)
+            .unwrap();
 
         // Ignore the primary lock when reading the latest committed version by setting u64::MAX as ts
         lock.lock_type = LockType::Put;
         lock.primary = b"foo".to_vec();
         lock.clone()
-            .check_ts_conflict(&key, std::u64::MAX, &empty)
+            .check_ts_conflict(&key, TimeStamp::max(), &empty)
             .unwrap();
 
         // Should not ignore the secondary lock even though reading the latest version
         lock.primary = b"bar".to_vec();
         lock.clone()
-            .check_ts_conflict(&key, std::u64::MAX, &empty)
+            .check_ts_conflict(&key, TimeStamp::max(), &empty)
             .unwrap_err();
     }
 }

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -12,6 +12,8 @@ pub use self::lock::{Lock, LockType};
 pub use self::reader::*;
 pub use self::txn::{MvccTxn, MAX_TXN_WRITE_SIZE};
 pub use self::write::{Write, WriteRef, WriteType};
+pub use crate::new_txn;
+pub use keys::TimeStamp;
 
 use std::error;
 use std::io;
@@ -20,18 +22,7 @@ use tikv_util::collections::HashSet;
 use tikv_util::metrics::CRITICAL_ERROR;
 use tikv_util::{panic_when_unexpected_key_or_data, set_panic_mark};
 
-pub const TSO_PHYSICAL_SHIFT_BITS: u64 = 18;
-
 const TS_SET_USE_VEC_LIMIT: usize = 8;
-
-// Extracts physical part of a timestamp, in milliseconds.
-pub fn extract_physical(ts: u64) -> u64 {
-    ts >> TSO_PHYSICAL_SHIFT_BITS
-}
-
-pub fn compose_ts(physical: u64, logical: u64) -> u64 {
-    (physical << TSO_PHYSICAL_SHIFT_BITS) + logical
-}
 
 /// A hybrid immutable set for timestamps.
 #[derive(Debug, Clone, PartialEq)]
@@ -40,9 +31,9 @@ pub enum TsSet {
     Empty,
     /// `Vec` is suitable when the set is small or the set is barely used, and it doesn't worth
     /// converting a `Vec` into a `HashSet`.
-    Vec(Arc<Vec<u64>>),
+    Vec(Arc<Vec<TimeStamp>>),
     /// `Set` is suitable when there are many timestamps **and** it will be queried multiple times.
-    Set(Arc<HashSet<u64>>),
+    Set(Arc<HashSet<TimeStamp>>),
 }
 
 impl Default for TsSet {
@@ -56,7 +47,7 @@ impl TsSet {
     /// Create a `TsSet` from the given vec of timestamps. It will select the proper internal
     /// collection type according to the size.
     #[inline]
-    pub fn new(ts: Vec<u64>) -> Self {
+    pub fn new(ts: Vec<TimeStamp>) -> Self {
         if ts.is_empty() {
             TsSet::Empty
         } else if ts.len() <= TS_SET_USE_VEC_LIMIT {
@@ -67,12 +58,17 @@ impl TsSet {
         }
     }
 
+    #[cfg(test)]
+    pub fn from_u64s(ts: Vec<u64>) -> Self {
+        Self::new(ts.into_iter().map(Into::into).collect())
+    }
+
     /// Create a `TsSet` from the given vec of timestamps, but it will be forced to use `Vec` as the
     /// internal collection type. When it's sure that the set will be queried at most once, use this
     /// is better than `TsSet::new`, since both the querying on `Vec` and the conversion from `Vec`
     /// to `HashSet` is O(N).
     #[inline]
-    pub fn vec(ts: Vec<u64>) -> Self {
+    pub fn vec(ts: Vec<TimeStamp>) -> Self {
         if ts.is_empty() {
             TsSet::Empty
         } else {
@@ -82,7 +78,7 @@ impl TsSet {
 
     /// Query whether the given timestamp is contained in the set.
     #[inline]
-    pub fn contains(&self, ts: u64) -> bool {
+    pub fn contains(&self, ts: TimeStamp) -> bool {
         match self {
             TsSet::Empty => false,
             TsSet::Vec(vec) => vec.contains(&ts),
@@ -115,32 +111,32 @@ quick_error! {
         }
         BadFormatLock { description("bad format lock data") }
         BadFormatWrite { description("bad format write data") }
-        Committed { commit_ts: u64 } {
+        Committed { commit_ts: TimeStamp } {
             description("txn already committed")
             display("txn already committed @{}", commit_ts)
         }
-        PessimisticLockRollbacked { start_ts: u64, key: Vec<u8> } {
+        PessimisticLockRollbacked { start_ts: TimeStamp, key: Vec<u8> } {
             description("pessimistic lock already rollbacked")
             display("pessimistic lock already rollbacked, start_ts:{}, key:{}", start_ts, hex::encode_upper(key))
         }
-        TxnLockNotFound { start_ts: u64, commit_ts: u64, key: Vec<u8> } {
+        TxnLockNotFound { start_ts: TimeStamp, commit_ts: TimeStamp, key: Vec<u8> } {
             description("txn lock not found")
             display("txn lock not found {}-{} key:{}", start_ts, commit_ts, hex::encode_upper(key))
         }
-        TxnNotFound { start_ts:  u64, key: Vec<u8> } {
+        TxnNotFound { start_ts:  TimeStamp, key: Vec<u8> } {
             description("txn not found")
             display("txn not found {} key: {}", start_ts, hex::encode_upper(key))
         }
-        LockTypeNotMatch { start_ts: u64, key: Vec<u8>, pessimistic: bool } {
+        LockTypeNotMatch { start_ts: TimeStamp, key: Vec<u8>, pessimistic: bool } {
             description("lock type not match")
             display("lock type not match, start_ts:{}, key:{}, pessimistic:{}", start_ts, hex::encode_upper(key), pessimistic)
         }
-        WriteConflict { start_ts: u64, conflict_start_ts: u64, conflict_commit_ts: u64, key: Vec<u8>, primary: Vec<u8> } {
+        WriteConflict { start_ts: TimeStamp, conflict_start_ts: TimeStamp, conflict_commit_ts: TimeStamp, key: Vec<u8>, primary: Vec<u8> } {
             description("write conflict")
             display("write conflict, start_ts:{}, conflict_start_ts:{}, conflict_commit_ts:{}, key:{}, primary:{}",
                     start_ts, conflict_start_ts, conflict_commit_ts, hex::encode_upper(key), hex::encode_upper(primary))
         }
-        Deadlock { start_ts: u64, lock_ts: u64, lock_key: Vec<u8>, deadlock_key_hash: u64 } {
+        Deadlock { start_ts: TimeStamp, lock_ts: TimeStamp, lock_key: Vec<u8>, deadlock_key_hash: u64 } {
             description("deadlock")
             display("deadlock occurs between txn:{} and txn:{}, lock_key:{}, deadlock_key_hash:{}",
                     start_ts, lock_ts, hex::encode_upper(lock_key), deadlock_key_hash)
@@ -153,12 +149,12 @@ quick_error! {
             description("write cf corresponding value not found in default cf")
             display("default not found: key:{}, maybe read truncated/dropped table data?", hex::encode_upper(key))
         }
-        CommitTsExpired { start_ts: u64, commit_ts: u64, key: Vec<u8>, min_commit_ts: u64 } {
+        CommitTsExpired { start_ts: TimeStamp, commit_ts: TimeStamp, key: Vec<u8>, min_commit_ts: TimeStamp } {
             description("commit_ts less than lock's min_commit_ts")
             display("try to commit key {} with commit_ts {} but min_commit_ts is {}", hex::encode_upper(key), commit_ts, min_commit_ts)
         }
         KeyVersion { description("bad format key(version)") }
-        PessimisticLockNotFound { start_ts: u64, key: Vec<u8> } {
+        PessimisticLockNotFound { start_ts: TimeStamp, key: Vec<u8> } {
             description("pessimistic lock not found when prewrite")
             display("pessimistic lock not found, start_ts:{}, key:{}", start_ts, hex::encode_upper(key))
         }
@@ -305,38 +301,41 @@ pub mod tests {
         }
     }
 
-    pub fn must_get<E: Engine>(engine: &E, key: &[u8], ts: u64, expect: &[u8]) {
+    pub fn must_get<E: Engine>(engine: &E, key: &[u8], ts: impl Into<TimeStamp>, expect: &[u8]) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
         assert_eq!(
-            reader.get(&Key::from_raw(key), ts).unwrap().unwrap(),
+            reader.get(&Key::from_raw(key), ts.into()).unwrap().unwrap(),
             expect
         );
     }
 
-    pub fn must_get_rc<E: Engine>(engine: &E, key: &[u8], ts: u64, expect: &[u8]) {
+    pub fn must_get_rc<E: Engine>(engine: &E, key: &[u8], ts: impl Into<TimeStamp>, expect: &[u8]) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Rc);
         assert_eq!(
-            reader.get(&Key::from_raw(key), ts).unwrap().unwrap(),
+            reader.get(&Key::from_raw(key), ts.into()).unwrap().unwrap(),
             expect
         );
     }
 
-    pub fn must_get_none<E: Engine>(engine: &E, key: &[u8], ts: u64) {
+    pub fn must_get_none<E: Engine>(engine: &E, key: &[u8], ts: impl Into<TimeStamp>) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
-        assert!(reader.get(&Key::from_raw(key), ts).unwrap().is_none());
+        assert!(reader
+            .get(&Key::from_raw(key), ts.into())
+            .unwrap()
+            .is_none());
     }
 
-    pub fn must_get_err<E: Engine>(engine: &E, key: &[u8], ts: u64) {
+    pub fn must_get_err<E: Engine>(engine: &E, key: &[u8], ts: impl Into<TimeStamp>) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
-        assert!(reader.get(&Key::from_raw(key), ts).is_err());
+        assert!(reader.get(&Key::from_raw(key), ts.into()).is_err());
     }
 
     // Insert has a constraint that key should not exist
@@ -345,11 +344,11 @@ pub mod tests {
         key: &[u8],
         value: &[u8],
         pk: &[u8],
-        ts: u64,
+        ts: impl Into<TimeStamp>,
     ) -> Result<()> {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
         txn.prewrite(
             Mutation::Insert((Key::from_raw(key), value.to_vec())),
             pk,
@@ -364,15 +363,15 @@ pub mod tests {
         key: &[u8],
         value: &[u8],
         pk: &[u8],
-        ts: u64,
+        ts: impl Into<TimeStamp>,
         is_pessimistic_lock: bool,
         options: Options,
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
         let mutation = Mutation::Put((Key::from_raw(key), value.to_vec()));
-        if options.for_update_ts == 0 {
+        if options.for_update_ts.is_zero() {
             txn.prewrite(mutation, pk, &options).unwrap();
         } else {
             txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options)
@@ -381,7 +380,13 @@ pub mod tests {
         write(engine, &ctx, txn.into_modifies());
     }
 
-    pub fn must_prewrite_put<E: Engine>(engine: &E, key: &[u8], value: &[u8], pk: &[u8], ts: u64) {
+    pub fn must_prewrite_put<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        value: &[u8],
+        pk: &[u8],
+        ts: impl Into<TimeStamp>,
+    ) {
         let options = Options::default();
         must_prewrite_put_impl(engine, key, value, pk, ts, false, options);
     }
@@ -391,12 +396,12 @@ pub mod tests {
         key: &[u8],
         value: &[u8],
         pk: &[u8],
-        ts: u64,
-        for_update_ts: u64,
+        ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
         is_pessimistic_lock: bool,
     ) {
         let mut options = Options::default();
-        options.for_update_ts = for_update_ts;
+        options.for_update_ts = for_update_ts.into();
         must_prewrite_put_impl(engine, key, value, pk, ts, is_pessimistic_lock, options);
     }
 
@@ -405,13 +410,13 @@ pub mod tests {
         key: &[u8],
         value: &[u8],
         pk: &[u8],
-        ts: u64,
-        for_update_ts: u64,
+        ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
         is_pessimistic_lock: bool,
         lock_ttl: u64,
     ) {
         let mut options = Options::default();
-        options.for_update_ts = for_update_ts;
+        options.for_update_ts = for_update_ts.into();
         options.lock_ttl = lock_ttl;
         must_prewrite_put_impl(engine, key, value, pk, ts, is_pessimistic_lock, options);
     }
@@ -421,15 +426,25 @@ pub mod tests {
         key: &[u8],
         value: &[u8],
         pk: &[u8],
-        ts: u64,
+        ts: impl Into<TimeStamp>,
         ttl: u64,
-        for_update_ts: u64,
+        for_update_ts: impl Into<TimeStamp>,
     ) {
         let mut options = Options::default();
         options.lock_ttl = ttl;
-        options.min_commit_ts = ts + 1;
+        let ts = ts.into();
+        options.min_commit_ts = (ts.into_inner() + 1).into();
+        let for_update_ts = for_update_ts.into();
         options.for_update_ts = for_update_ts;
-        must_prewrite_put_impl(engine, key, value, pk, ts, for_update_ts != 0, options);
+        must_prewrite_put_impl(
+            engine,
+            key,
+            value,
+            pk,
+            ts,
+            !for_update_ts.is_zero(),
+            options,
+        );
     }
 
     fn must_prewrite_put_err_impl<E: Engine>(
@@ -437,17 +452,18 @@ pub mod tests {
         key: &[u8],
         value: &[u8],
         pk: &[u8],
-        ts: u64,
-        for_update_ts: u64,
+        ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
         is_pessimistic_lock: bool,
     ) -> Error {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
         let mut options = Options::default();
+        let for_update_ts = for_update_ts.into();
         options.for_update_ts = for_update_ts;
         let mutation = Mutation::Put((Key::from_raw(key), value.to_vec()));
-        if for_update_ts == 0 {
+        if for_update_ts.is_zero() {
             txn.prewrite(mutation, pk, &options).unwrap_err()
         } else {
             txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options)
@@ -460,9 +476,9 @@ pub mod tests {
         key: &[u8],
         value: &[u8],
         pk: &[u8],
-        ts: u64,
+        ts: impl Into<TimeStamp>,
     ) -> Error {
-        must_prewrite_put_err_impl(engine, key, value, pk, ts, 0, false)
+        must_prewrite_put_err_impl(engine, key, value, pk, ts, TimeStamp::min(), false)
     }
 
     pub fn must_pessimistic_prewrite_put_err<E: Engine>(
@@ -470,8 +486,8 @@ pub mod tests {
         key: &[u8],
         value: &[u8],
         pk: &[u8],
-        ts: u64,
-        for_update_ts: u64,
+        ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
         is_pessimistic_lock: bool,
     ) -> Error {
         must_prewrite_put_err_impl(
@@ -489,17 +505,18 @@ pub mod tests {
         engine: &E,
         key: &[u8],
         pk: &[u8],
-        ts: u64,
-        for_update_ts: u64,
+        ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
         is_pessimistic_lock: bool,
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
         let mut options = Options::default();
+        let for_update_ts = for_update_ts.into();
         options.for_update_ts = for_update_ts;
         let mutation = Mutation::Delete(Key::from_raw(key));
-        if for_update_ts == 0 {
+        if for_update_ts.is_zero() {
             txn.prewrite(mutation, pk, &options).unwrap();
         } else {
             txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options)
@@ -508,16 +525,21 @@ pub mod tests {
         engine.write(&ctx, txn.into_modifies()).unwrap();
     }
 
-    pub fn must_prewrite_delete<E: Engine>(engine: &E, key: &[u8], pk: &[u8], ts: u64) {
-        must_prewrite_delete_impl(engine, key, pk, ts, 0, false);
+    pub fn must_prewrite_delete<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        pk: &[u8],
+        ts: impl Into<TimeStamp>,
+    ) {
+        must_prewrite_delete_impl(engine, key, pk, ts, TimeStamp::min(), false);
     }
 
     pub fn must_pessimistic_prewrite_delete<E: Engine>(
         engine: &E,
         key: &[u8],
         pk: &[u8],
-        ts: u64,
-        for_update_ts: u64,
+        ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
         is_pessimistic_lock: bool,
     ) {
         must_prewrite_delete_impl(engine, key, pk, ts, for_update_ts, is_pessimistic_lock);
@@ -527,17 +549,18 @@ pub mod tests {
         engine: &E,
         key: &[u8],
         pk: &[u8],
-        ts: u64,
-        for_update_ts: u64,
+        ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
         is_pessimistic_lock: bool,
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
         let mut options = Options::default();
+        let for_update_ts = for_update_ts.into();
         options.for_update_ts = for_update_ts;
         let mutation = Mutation::Lock(Key::from_raw(key));
-        if for_update_ts == 0 {
+        if for_update_ts.is_zero() {
             txn.prewrite(mutation, pk, &options).unwrap();
         } else {
             txn.pessimistic_prewrite(mutation, pk, is_pessimistic_lock, &options)
@@ -546,14 +569,24 @@ pub mod tests {
         engine.write(&ctx, txn.into_modifies()).unwrap();
     }
 
-    pub fn must_prewrite_lock<E: Engine>(engine: &E, key: &[u8], pk: &[u8], ts: u64) {
-        must_prewrite_lock_impl(engine, key, pk, ts, 0, false);
+    pub fn must_prewrite_lock<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        pk: &[u8],
+        ts: impl Into<TimeStamp>,
+    ) {
+        must_prewrite_lock_impl(engine, key, pk, ts, TimeStamp::min(), false);
     }
 
-    pub fn must_prewrite_lock_err<E: Engine>(engine: &E, key: &[u8], pk: &[u8], ts: u64) {
+    pub fn must_prewrite_lock_err<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        pk: &[u8],
+        ts: impl Into<TimeStamp>,
+    ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
         assert!(txn
             .prewrite(Mutation::Lock(Key::from_raw(key)), pk, &Options::default())
             .is_err());
@@ -563,8 +596,8 @@ pub mod tests {
         engine: &E,
         key: &[u8],
         pk: &[u8],
-        ts: u64,
-        for_update_ts: u64,
+        ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
         is_pessimistic_lock: bool,
     ) {
         must_prewrite_lock_impl(engine, key, pk, ts, for_update_ts, is_pessimistic_lock);
@@ -574,12 +607,12 @@ pub mod tests {
         engine: &E,
         key: &[u8],
         pk: &[u8],
-        start_ts: u64,
+        start_ts: impl Into<TimeStamp>,
         options: Options,
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
         txn.acquire_pessimistic_lock(Key::from_raw(key), pk, false, &options)
             .unwrap();
         let modifies = txn.into_modifies();
@@ -592,8 +625,8 @@ pub mod tests {
         engine: &E,
         key: &[u8],
         pk: &[u8],
-        start_ts: u64,
-        for_update_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
     ) {
         must_acquire_pessimistic_lock_with_ttl(engine, key, pk, start_ts, for_update_ts, 0);
     }
@@ -602,12 +635,12 @@ pub mod tests {
         engine: &E,
         key: &[u8],
         pk: &[u8],
-        start_ts: u64,
-        for_update_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
         ttl: u64,
     ) {
         let mut options = Options::default();
-        options.for_update_ts = for_update_ts;
+        options.for_update_ts = for_update_ts.into();
         options.lock_ttl = ttl;
         must_acquire_pessimistic_lock_impl(engine, key, pk, start_ts, options);
     }
@@ -616,8 +649,8 @@ pub mod tests {
         engine: &E,
         key: &[u8],
         pk: &[u8],
-        start_ts: u64,
-        for_update_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
         lock_ttl: u64,
     ) {
         must_acquire_pessimistic_lock_with_ttl(engine, key, pk, start_ts, for_update_ts, lock_ttl);
@@ -627,14 +660,14 @@ pub mod tests {
         engine: &E,
         key: &[u8],
         pk: &[u8],
-        start_ts: u64,
-        for_update_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
     ) -> Error {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
         let mut options = Options::default();
-        options.for_update_ts = for_update_ts;
+        options.for_update_ts = for_update_ts.into();
         txn.acquire_pessimistic_lock(Key::from_raw(key), pk, false, &options)
             .unwrap_err()
     }
@@ -642,86 +675,106 @@ pub mod tests {
     pub fn must_pessimistic_rollback<E: Engine>(
         engine: &E,
         key: &[u8],
-        start_ts: u64,
-        for_update_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
-        txn.pessimistic_rollback(Key::from_raw(key), for_update_ts)
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        txn.pessimistic_rollback(Key::from_raw(key), for_update_ts.into())
             .unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
 
-    pub fn must_commit<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
+    pub fn must_commit<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
+    ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
-        txn.commit(Key::from_raw(key), commit_ts).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        txn.commit(Key::from_raw(key), commit_ts.into()).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
 
-    pub fn must_commit_err<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
+    pub fn must_commit_err<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
+    ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
-        assert!(txn.commit(Key::from_raw(key), commit_ts).is_err());
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        assert!(txn.commit(Key::from_raw(key), commit_ts.into()).is_err());
     }
 
-    pub fn must_rollback<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+    pub fn must_rollback<E: Engine>(engine: &E, key: &[u8], start_ts: impl Into<TimeStamp>) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
         txn.collapse_rollback(false);
         txn.rollback(Key::from_raw(key)).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
 
-    pub fn must_rollback_collapsed<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+    pub fn must_rollback_collapsed<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+    ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
         txn.rollback(Key::from_raw(key)).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
 
-    pub fn must_rollback_err<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+    pub fn must_rollback_err<E: Engine>(engine: &E, key: &[u8], start_ts: impl Into<TimeStamp>) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
         assert!(txn.rollback(Key::from_raw(key)).is_err());
     }
 
-    pub fn must_cleanup<E: Engine>(engine: &E, key: &[u8], start_ts: u64, current_ts: u64) {
+    pub fn must_cleanup<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        current_ts: impl Into<TimeStamp>,
+    ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
-        txn.cleanup(Key::from_raw(key), current_ts).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        txn.cleanup(Key::from_raw(key), current_ts.into()).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
 
     pub fn must_cleanup_err<E: Engine>(
         engine: &E,
         key: &[u8],
-        start_ts: u64,
-        current_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        current_ts: impl Into<TimeStamp>,
     ) -> Error {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
-        txn.cleanup(Key::from_raw(key), current_ts).unwrap_err()
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        txn.cleanup(Key::from_raw(key), current_ts.into())
+            .unwrap_err()
     }
 
     pub fn must_txn_heart_beat<E: Engine>(
         engine: &E,
         primary_key: &[u8],
-        start_ts: u64,
+        start_ts: impl Into<TimeStamp>,
         advise_ttl: u64,
         expect_ttl: u64,
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
         let ttl = txn
             .txn_heart_beat(Key::from_raw(primary_key), advise_ttl)
             .unwrap();
@@ -732,12 +785,12 @@ pub mod tests {
     pub fn must_txn_heart_beat_err<E: Engine>(
         engine: &E,
         primary_key: &[u8],
-        start_ts: u64,
+        start_ts: impl Into<TimeStamp>,
         advise_ttl: u64,
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
         txn.txn_heart_beat(Key::from_raw(primary_key), advise_ttl)
             .unwrap_err();
     }
@@ -745,20 +798,20 @@ pub mod tests {
     pub fn must_check_txn_status<E: Engine>(
         engine: &E,
         primary_key: &[u8],
-        lock_ts: u64,
-        caller_start_ts: u64,
-        current_ts: u64,
+        lock_ts: impl Into<TimeStamp>,
+        caller_start_ts: impl Into<TimeStamp>,
+        current_ts: impl Into<TimeStamp>,
         rollback_if_not_exist: bool,
         expect_status: TxnStatus,
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, lock_ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, lock_ts.into(), true).unwrap();
         let (txn_status, _) = txn
             .check_txn_status(
                 Key::from_raw(primary_key),
-                caller_start_ts,
-                current_ts,
+                caller_start_ts.into(),
+                current_ts.into(),
                 rollback_if_not_exist,
             )
             .unwrap();
@@ -769,44 +822,49 @@ pub mod tests {
     pub fn must_check_txn_status_err<E: Engine>(
         engine: &E,
         primary_key: &[u8],
-        lock_ts: u64,
-        caller_start_ts: u64,
-        current_ts: u64,
+        lock_ts: impl Into<TimeStamp>,
+        caller_start_ts: impl Into<TimeStamp>,
+        current_ts: impl Into<TimeStamp>,
         rollback_if_not_exist: bool,
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, lock_ts, true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, lock_ts.into(), true).unwrap();
         txn.check_txn_status(
             Key::from_raw(primary_key),
-            caller_start_ts,
-            current_ts,
+            caller_start_ts.into(),
+            current_ts.into(),
             rollback_if_not_exist,
         )
         .unwrap_err();
     }
 
-    pub fn must_gc<E: Engine>(engine: &E, key: &[u8], safe_point: u64) {
+    pub fn must_gc<E: Engine>(engine: &E, key: &[u8], safe_point: impl Into<TimeStamp>) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, 0, true).unwrap();
-        txn.gc(Key::from_raw(key), safe_point).unwrap();
+        let mut txn = MvccTxn::new(snapshot, TimeStamp::min(), true).unwrap();
+        txn.gc(Key::from_raw(key), safe_point.into()).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
 
-    pub fn must_locked<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+    pub fn must_locked<E: Engine>(engine: &E, key: &[u8], start_ts: impl Into<TimeStamp>) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
         let lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
-        assert_eq!(lock.ts, start_ts);
+        assert_eq!(lock.ts, start_ts.into());
         assert_ne!(lock.lock_type, LockType::Pessimistic);
     }
 
-    pub fn must_locked_with_ttl<E: Engine>(engine: &E, key: &[u8], start_ts: u64, ttl: u64) {
+    pub fn must_locked_with_ttl<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        ttl: u64,
+    ) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
         let lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
-        assert_eq!(lock.ts, start_ts);
+        assert_eq!(lock.ts, start_ts.into());
         assert_ne!(lock.lock_type, LockType::Pessimistic);
         assert_eq!(lock.ttl, ttl);
     }
@@ -814,17 +872,17 @@ pub mod tests {
     pub fn must_large_txn_locked<E: Engine>(
         engine: &E,
         key: &[u8],
-        start_ts: u64,
+        start_ts: impl Into<TimeStamp>,
         ttl: u64,
-        min_commit_ts: u64,
+        min_commit_ts: impl Into<TimeStamp>,
         is_pessimistic: bool,
     ) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
         let lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
-        assert_eq!(lock.ts, start_ts);
+        assert_eq!(lock.ts, start_ts.into());
         assert_eq!(lock.ttl, ttl);
-        assert_eq!(lock.min_commit_ts, min_commit_ts);
+        assert_eq!(lock.min_commit_ts, min_commit_ts.into());
         if is_pessimistic {
             assert_eq!(lock.lock_type, LockType::Pessimistic);
         } else {
@@ -835,14 +893,14 @@ pub mod tests {
     pub fn must_pessimistic_locked<E: Engine>(
         engine: &E,
         key: &[u8],
-        start_ts: u64,
-        for_update_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
     ) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
         let lock = reader.load_lock(&Key::from_raw(key)).unwrap().unwrap();
-        assert_eq!(lock.ts, start_ts);
-        assert_eq!(lock.for_update_ts, for_update_ts);
+        assert_eq!(lock.ts, start_ts.into());
+        assert_eq!(lock.for_update_ts, for_update_ts.into());
         assert_eq!(lock.lock_type, LockType::Pessimistic);
     }
 
@@ -855,23 +913,23 @@ pub mod tests {
     pub fn must_written<E: Engine>(
         engine: &E,
         key: &[u8],
-        start_ts: u64,
-        commit_ts: u64,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
         tp: WriteType,
     ) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let k = Key::from_raw(key).append_ts(commit_ts);
+        let k = Key::from_raw(key).append_ts(commit_ts.into());
         let v = snapshot.get_cf(CF_WRITE, &k).unwrap().unwrap();
         let write = WriteRef::parse(&v).unwrap();
-        assert_eq!(write.start_ts, start_ts);
+        assert_eq!(write.start_ts, start_ts.into());
         assert_eq!(write.write_type, tp);
     }
 
-    pub fn must_seek_write_none<E: Engine>(engine: &E, key: &[u8], ts: u64) {
+    pub fn must_seek_write_none<E: Engine>(engine: &E, key: &[u8], ts: impl Into<TimeStamp>) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
         assert!(reader
-            .seek_write(&Key::from_raw(key), ts)
+            .seek_write(&Key::from_raw(key), ts.into())
             .unwrap()
             .is_none());
     }
@@ -879,35 +937,47 @@ pub mod tests {
     pub fn must_seek_write<E: Engine>(
         engine: &E,
         key: &[u8],
-        ts: u64,
-        start_ts: u64,
-        commit_ts: u64,
+        ts: impl Into<TimeStamp>,
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
         write_type: WriteType,
     ) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
-        let (t, write) = reader.seek_write(&Key::from_raw(key), ts).unwrap().unwrap();
-        assert_eq!(t, commit_ts);
-        assert_eq!(write.start_ts, start_ts);
+        let (t, write) = reader
+            .seek_write(&Key::from_raw(key), ts.into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(t, commit_ts.into());
+        assert_eq!(write.start_ts, start_ts.into());
         assert_eq!(write.write_type, write_type);
     }
 
-    pub fn must_get_commit_ts<E: Engine>(engine: &E, key: &[u8], start_ts: u64, commit_ts: u64) {
+    pub fn must_get_commit_ts<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        commit_ts: impl Into<TimeStamp>,
+    ) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
         let (ts, write_type) = reader
-            .get_txn_commit_info(&Key::from_raw(key), start_ts)
+            .get_txn_commit_info(&Key::from_raw(key), start_ts.into())
             .unwrap()
             .unwrap();
         assert_ne!(write_type, WriteType::Rollback);
-        assert_eq!(ts, commit_ts);
+        assert_eq!(ts, commit_ts.into());
     }
 
-    pub fn must_get_commit_ts_none<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+    pub fn must_get_commit_ts_none<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+    ) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
 
-        let ret = reader.get_txn_commit_info(&Key::from_raw(key), start_ts);
+        let ret = reader.get_txn_commit_info(&Key::from_raw(key), start_ts.into());
         assert!(ret.is_ok());
         match ret.unwrap() {
             None => {}
@@ -917,10 +987,11 @@ pub mod tests {
         }
     }
 
-    pub fn must_get_rollback_ts<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+    pub fn must_get_rollback_ts<E: Engine>(engine: &E, key: &[u8], start_ts: impl Into<TimeStamp>) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
 
+        let start_ts = start_ts.into();
         let (ts, write_type) = reader
             .get_txn_commit_info(&Key::from_raw(key), start_ts)
             .unwrap()
@@ -929,12 +1000,16 @@ pub mod tests {
         assert_eq!(write_type, WriteType::Rollback);
     }
 
-    pub fn must_get_rollback_ts_none<E: Engine>(engine: &E, key: &[u8], start_ts: u64) {
+    pub fn must_get_rollback_ts_none<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+    ) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
 
         let ret = reader
-            .get_txn_commit_info(&Key::from_raw(key), start_ts)
+            .get_txn_commit_info(&Key::from_raw(key), start_ts.into())
             .unwrap();
         assert_eq!(ret, None);
     }
@@ -942,12 +1017,13 @@ pub mod tests {
     pub fn must_get_rollback_protected<E: Engine>(
         engine: &E,
         key: &[u8],
-        start_ts: u64,
+        start_ts: impl Into<TimeStamp>,
         protected: bool,
     ) {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
 
+        let start_ts = start_ts.into();
         let (ts, write) = reader
             .seek_write(&Key::from_raw(key), start_ts)
             .unwrap()
@@ -966,7 +1042,7 @@ pub mod tests {
     ) {
         let expect = (
             keys.into_iter().map(Key::from_raw).collect(),
-            next_start.map(|x| Key::from_raw(x).append_ts(0)),
+            next_start.map(|x| Key::from_raw(x).append_ts(TimeStamp::min())),
         );
         let snapshot = engine.snapshot(&Context::default()).unwrap();
         let mut reader =
@@ -978,43 +1054,33 @@ pub mod tests {
     }
 
     #[test]
-    fn test_ts_calculation() {
-        let physical = 1568700549751;
-        let logical = 108;
-        let ts = compose_ts(physical, logical);
-        assert_eq!(ts, 411225436913926252);
-
-        let extracted_physical = extract_physical(ts);
-        assert_eq!(extracted_physical, physical);
-    }
-
-    #[test]
     fn test_ts_set() {
         let s = TsSet::new(vec![]);
         assert_eq!(s, TsSet::Empty);
-        assert!(!s.contains(1));
+        assert!(!s.contains(1.into()));
 
         let s = TsSet::vec(vec![]);
         assert_eq!(s, TsSet::Empty);
 
-        let s = TsSet::new(vec![1, 2]);
-        assert_eq!(s, TsSet::Vec(Arc::new(vec![1, 2])));
-        assert!(s.contains(1));
-        assert!(s.contains(2));
-        assert!(!s.contains(3));
+        let s = TsSet::from_u64s(vec![1, 2]);
+        assert_eq!(s, TsSet::Vec(Arc::new(vec![1.into(), 2.into()])));
+        assert!(s.contains(1.into()));
+        assert!(s.contains(2.into()));
+        assert!(!s.contains(3.into()));
 
-        let s2 = TsSet::vec(vec![1, 2]);
+        let s2 = TsSet::vec(vec![1.into(), 2.into()]);
         assert_eq!(s2, s);
 
-        let big_ts_list: Vec<_> = (0..=TS_SET_USE_VEC_LIMIT as u64).collect();
+        let big_ts_list: Vec<TimeStamp> =
+            (0..=TS_SET_USE_VEC_LIMIT as u64).map(Into::into).collect();
         let s = TsSet::new(big_ts_list.clone());
         assert_eq!(
             s,
             TsSet::Set(Arc::new(big_ts_list.clone().into_iter().collect()))
         );
-        assert!(s.contains(1));
-        assert!(s.contains(TS_SET_USE_VEC_LIMIT as u64));
-        assert!(!s.contains(TS_SET_USE_VEC_LIMIT as u64 + 1));
+        assert!(s.contains(1.into()));
+        assert!(s.contains((TS_SET_USE_VEC_LIMIT as u64).into()));
+        assert!(!s.contains((TS_SET_USE_VEC_LIMIT as u64 + 1).into()));
 
         let s = TsSet::vec(big_ts_list.clone());
         assert_eq!(s, TsSet::Vec(Arc::new(big_ts_list)));

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -3,7 +3,7 @@
 use kvproto::kvrpcpb::IsolationLevel;
 
 use crate::storage::mvcc::write::{WriteRef, WriteType};
-use crate::storage::mvcc::{default_not_found_error, Lock, Result, TsSet};
+use crate::storage::mvcc::{default_not_found_error, Lock, Result, TimeStamp, TsSet};
 use crate::storage::{Cursor, CursorBuilder, Key, ScanMode, Snapshot, Statistics, Value, CF_LOCK};
 use crate::storage::{CF_DEFAULT, CF_WRITE};
 
@@ -14,13 +14,13 @@ pub struct PointGetterBuilder<S: Snapshot> {
     fill_cache: bool,
     omit_value: bool,
     isolation_level: IsolationLevel,
-    ts: u64,
+    ts: TimeStamp,
     bypass_locks: TsSet,
 }
 
 impl<S: Snapshot> PointGetterBuilder<S> {
     /// Initialize a new `PointGetterBuilder`.
-    pub fn new(snapshot: S, ts: u64) -> Self {
+    pub fn new(snapshot: S, ts: TimeStamp) -> Self {
         Self {
             snapshot,
             multi: true,
@@ -119,7 +119,7 @@ pub struct PointGetter<S: Snapshot> {
     multi: bool,
     omit_value: bool,
     isolation_level: IsolationLevel,
-    ts: u64,
+    ts: TimeStamp,
     bypass_locks: TsSet,
 
     statistics: Statistics,
@@ -241,7 +241,11 @@ impl<S: Snapshot> PointGetter<S> {
     /// We assume that mostly the keys given to batch get keys are not very close to each other.
     /// `near_seek` will likely fall back to `seek` in such scenario, which takes 2x time
     /// compared to `get_cf`. Thus we use `get_cf` directly here.
-    fn load_data_from_default_cf(&mut self, write_start_ts: u64, user_key: &Key) -> Result<Value> {
+    fn load_data_from_default_cf(
+        &mut self,
+        write_start_ts: TimeStamp,
+        user_key: &Key,
+    ) -> Result<Value> {
         // TODO: Not necessary to receive a `Write`.
         self.statistics.data.get += 1;
         // TODO: We can avoid this clone.
@@ -272,7 +276,7 @@ mod tests {
     use crate::storage::SHORT_VALUE_MAX_LEN;
     use crate::storage::{CFStatistics, Engine, Key, RocksEngine, TestEngineBuilder};
 
-    fn new_multi_point_getter<E: Engine>(engine: &E, ts: u64) -> PointGetter<E::Snap> {
+    fn new_multi_point_getter<E: Engine>(engine: &E, ts: TimeStamp) -> PointGetter<E::Snap> {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
         PointGetterBuilder::new(snapshot, ts)
             .isolation_level(IsolationLevel::Si)
@@ -280,7 +284,7 @@ mod tests {
             .unwrap()
     }
 
-    fn new_single_point_getter<E: Engine>(engine: &E, ts: u64) -> PointGetter<E::Snap> {
+    fn new_single_point_getter<E: Engine>(engine: &E, ts: TimeStamp) -> PointGetter<E::Snap> {
         let snapshot = engine.snapshot(&Context::new()).unwrap();
         PointGetterBuilder::new(snapshot, ts)
             .isolation_level(IsolationLevel::Si)
@@ -431,7 +435,7 @@ mod tests {
     fn test_multi_basic_1() {
         let engine = new_sample_engine();
 
-        let mut getter = new_multi_point_getter(&engine, 200);
+        let mut getter = new_multi_point_getter(&engine, 200.into());
 
         // Get a deleted key
         must_get_none(&mut getter, b"foo1");
@@ -477,7 +481,7 @@ mod tests {
     fn test_multi_basic_2() {
         let engine = new_sample_engine();
 
-        let mut getter = new_multi_point_getter(&engine, 5);
+        let mut getter = new_multi_point_getter(&engine, 5.into());
 
         must_get_value(&mut getter, b"bar", b"barv");
         let s = getter.take_statistics();
@@ -517,7 +521,7 @@ mod tests {
     fn test_multi_basic_3() {
         let engine = new_sample_engine();
 
-        let mut getter = new_multi_point_getter(&engine, 2);
+        let mut getter = new_multi_point_getter(&engine, 2.into());
 
         must_get_none(&mut getter, b"foo1");
         let s = getter.take_statistics();
@@ -538,7 +542,7 @@ mod tests {
     fn test_multi_locked() {
         let engine = new_sample_engine_2();
 
-        let mut getter = new_multi_point_getter(&engine, 1);
+        let mut getter = new_multi_point_getter(&engine, 1.into());
         must_get_none(&mut getter, b"a");
         must_get_none(&mut getter, b"bar");
         must_get_none(&mut getter, b"foo1");
@@ -546,7 +550,7 @@ mod tests {
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 3, 0, 0);
 
-        let mut getter = new_multi_point_getter(&engine, 3);
+        let mut getter = new_multi_point_getter(&engine, 3.into());
         must_get_none(&mut getter, b"a");
         must_get_value(&mut getter, b"bar", b"barv");
         must_get_value(&mut getter, b"bar", b"barv");
@@ -557,7 +561,7 @@ mod tests {
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 6, 0, 0);
 
-        let mut getter = new_multi_point_getter(&engine, 4);
+        let mut getter = new_multi_point_getter(&engine, 4.into());
         must_get_none(&mut getter, b"a");
         must_get_err(&mut getter, b"bar");
         must_get_err(&mut getter, b"bar");
@@ -573,29 +577,29 @@ mod tests {
     fn test_single_basic() {
         let engine = new_sample_engine_2();
 
-        let mut getter = new_single_point_getter(&engine, 1);
+        let mut getter = new_single_point_getter(&engine, 1.into());
         must_get_none(&mut getter, b"foo1");
 
-        let mut getter = new_single_point_getter(&engine, 3);
+        let mut getter = new_single_point_getter(&engine, 3.into());
         must_get_value(&mut getter, b"bar", b"barv");
         must_get_none(&mut getter, b"bar");
         must_get_none(&mut getter, b"foo1");
 
-        let mut getter = new_single_point_getter(&engine, 3);
+        let mut getter = new_single_point_getter(&engine, 3.into());
         must_get_value(&mut getter, b"foo1", b"foo1v");
         must_get_none(&mut getter, b"foo2");
 
-        let mut getter = new_single_point_getter(&engine, 3);
+        let mut getter = new_single_point_getter(&engine, 3.into());
         must_get_none(&mut getter, b"foo2");
         must_get_none(&mut getter, b"foo2");
 
-        let mut getter = new_single_point_getter(&engine, 4);
+        let mut getter = new_single_point_getter(&engine, 4.into());
         must_get_err(&mut getter, b"bar");
         must_get_none(&mut getter, b"bar");
         must_get_none(&mut getter, b"a");
         must_get_none(&mut getter, b"foo1");
 
-        let mut getter = new_single_point_getter(&engine, 4);
+        let mut getter = new_single_point_getter(&engine, 4.into());
         must_get_value(&mut getter, b"foo1", b"foo1v");
         must_get_none(&mut getter, b"foo1");
     }
@@ -606,7 +610,7 @@ mod tests {
 
         let snapshot = engine.snapshot(&Context::new()).unwrap();
 
-        let mut getter = PointGetterBuilder::new(snapshot.clone(), 4)
+        let mut getter = PointGetterBuilder::new(snapshot.clone(), 4.into())
             .isolation_level(IsolationLevel::Si)
             .omit_value(true)
             .build()
@@ -618,7 +622,7 @@ mod tests {
 
         fn new_omit_value_single_point_getter(
             snapshot: SyncSnapshot,
-            ts: u64,
+            ts: TimeStamp,
         ) -> PointGetter<SyncSnapshot> {
             PointGetterBuilder::new(snapshot, ts)
                 .isolation_level(IsolationLevel::Si)
@@ -628,15 +632,15 @@ mod tests {
                 .unwrap()
         }
 
-        let mut getter = new_omit_value_single_point_getter(snapshot.clone(), 4);
+        let mut getter = new_omit_value_single_point_getter(snapshot.clone(), 4.into());
         must_get_err(&mut getter, b"bar");
         must_get_none(&mut getter, b"bar");
 
-        let mut getter = new_omit_value_single_point_getter(snapshot.clone(), 4);
+        let mut getter = new_omit_value_single_point_getter(snapshot.clone(), 4.into());
         must_get_key(&mut getter, b"foo1");
         must_get_none(&mut getter, b"foo1");
 
-        let mut getter = new_omit_value_single_point_getter(snapshot.clone(), 4);
+        let mut getter = new_omit_value_single_point_getter(snapshot.clone(), 4.into());
         must_get_none(&mut getter, b"foo3");
         must_get_none(&mut getter, b"foo3");
     }
@@ -649,18 +653,18 @@ mod tests {
         must_prewrite_put(&engine, key, val, key, 10);
         must_commit(&engine, key, 10, 20);
 
-        let mut getter = new_single_point_getter(&engine, std::u64::MAX);
+        let mut getter = new_single_point_getter(&engine, TimeStamp::max());
         must_get_value(&mut getter, key, val);
 
         // Ignore the primary lock if read with max ts.
         must_prewrite_delete(&engine, key, key, 30);
-        let mut getter = new_single_point_getter(&engine, std::u64::MAX);
+        let mut getter = new_single_point_getter(&engine, TimeStamp::max());
         must_get_value(&mut getter, key, val);
         must_rollback(&engine, key, 30);
 
         // Should not ignore the secondary lock even though reading the latest version
         must_prewrite_delete(&engine, key, b"bar", 40);
-        let mut getter = new_single_point_getter(&engine, std::u64::MAX);
+        let mut getter = new_single_point_getter(&engine, TimeStamp::max());
         must_get_err(&mut getter, key);
         must_rollback(&engine, key, 40);
 
@@ -670,7 +674,7 @@ mod tests {
         // write.start_ts(10) < primary_lock.start_ts(15) < write.commit_ts(20)
         must_acquire_pessimistic_lock(&engine, key, key, 15, 50);
         must_pessimistic_prewrite_delete(&engine, key, key, 15, 50, true);
-        let mut getter = new_single_point_getter(&engine, std::u64::MAX);
+        let mut getter = new_single_point_getter(&engine, TimeStamp::max());
         must_get_value(&mut getter, key, val);
     }
 
@@ -685,17 +689,17 @@ mod tests {
         must_prewrite_delete(&engine, key, key, 30);
 
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut getter = PointGetterBuilder::new(snapshot, 60)
+        let mut getter = PointGetterBuilder::new(snapshot, 60.into())
             .isolation_level(IsolationLevel::Si)
-            .bypass_locks(TsSet::new(vec![30, 40, 50]))
+            .bypass_locks(TsSet::from_u64s(vec![30, 40, 50]))
             .build()
             .unwrap();
         must_get_value(&mut getter, key, val);
 
         let snapshot = engine.snapshot(&Context::new()).unwrap();
-        let mut getter = PointGetterBuilder::new(snapshot, 60)
+        let mut getter = PointGetterBuilder::new(snapshot, 60.into())
             .isolation_level(IsolationLevel::Si)
-            .bypass_locks(TsSet::new(vec![31, 29]))
+            .bypass_locks(TsSet::from_u64s(vec![31, 29]))
             .build()
             .unwrap();
         must_get_err(&mut getter, key);

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -4,8 +4,8 @@ use crate::raftstore::coprocessor::properties::MvccProperties;
 use crate::storage::kv::{Cursor, ScanMode, Snapshot, Statistics};
 use crate::storage::mvcc::lock::Lock;
 use crate::storage::mvcc::write::{Write, WriteType};
-use crate::storage::mvcc::Result;
 use crate::storage::mvcc::{default_not_found_error, WriteRef};
+use crate::storage::mvcc::{Result, TimeStamp};
 use crate::storage::{Key, Value};
 use engine::IterOption;
 use engine::{CF_LOCK, CF_WRITE};
@@ -61,7 +61,7 @@ impl<S: Snapshot> MvccReader<S> {
         self.key_only = key_only;
     }
 
-    pub fn load_data(&mut self, key: &Key, ts: u64) -> Result<Option<Value>> {
+    pub fn load_data(&mut self, key: &Key, ts: TimeStamp) -> Result<Option<Value>> {
         if self.key_only {
             return Ok(Some(vec![]));
         }
@@ -121,7 +121,7 @@ impl<S: Snapshot> MvccReader<S> {
         }
     }
 
-    pub fn seek_write(&mut self, key: &Key, ts: u64) -> Result<Option<(u64, Write)>> {
+    pub fn seek_write(&mut self, key: &Key, ts: TimeStamp) -> Result<Option<(TimeStamp, Write)>> {
         if self.scan_mode.is_some() {
             if self.write_cursor.is_none() {
                 let iter_opt = IterOption::new(None, None, self.fill_cache);
@@ -156,14 +156,14 @@ impl<S: Snapshot> MvccReader<S> {
 
     /// Checks if there is a lock which blocks reading the key at the given ts.
     /// Returns the blocking lock as the `Err` variant.
-    fn check_lock(&mut self, key: &Key, ts: u64) -> Result<()> {
+    fn check_lock(&mut self, key: &Key, ts: TimeStamp) -> Result<()> {
         if let Some(lock) = self.load_lock(key)? {
             return lock.check_ts_conflict(key, ts, &Default::default());
         }
         Ok(())
     }
 
-    pub fn get(&mut self, key: &Key, ts: u64) -> Result<Option<Value>> {
+    pub fn get(&mut self, key: &Key, ts: TimeStamp) -> Result<Option<Value>> {
         // Check for locks that signal concurrent writes.
         match self.isolation_level {
             IsolationLevel::Si => self.check_lock(key, ts)?,
@@ -186,7 +186,7 @@ impl<S: Snapshot> MvccReader<S> {
         Ok(None)
     }
 
-    pub fn get_write(&mut self, key: &Key, mut ts: u64) -> Result<Option<Write>> {
+    pub fn get_write(&mut self, key: &Key, mut ts: TimeStamp) -> Result<Option<Write>> {
         loop {
             match self.seek_write(key, ts)? {
                 Some((commit_ts, write)) => match write.write_type {
@@ -196,7 +196,7 @@ impl<S: Snapshot> MvccReader<S> {
                     WriteType::Delete => {
                         return Ok(None);
                     }
-                    WriteType::Lock | WriteType::Rollback => ts = commit_ts - 1,
+                    WriteType::Lock | WriteType::Rollback => ts = commit_ts.decr(),
                 },
                 None => return Ok(None),
             }
@@ -206,14 +206,14 @@ impl<S: Snapshot> MvccReader<S> {
     pub fn get_txn_commit_info(
         &mut self,
         key: &Key,
-        start_ts: u64,
-    ) -> Result<Option<(u64, WriteType)>> {
+        start_ts: TimeStamp,
+    ) -> Result<Option<(TimeStamp, WriteType)>> {
         // It's possible a txn with a small `start_ts` has a greater `commit_ts` than a txn with
         // a greater `start_ts` in pessimistic transaction.
         // I.e., txn_1.commit_ts > txn_2.commit_ts > txn_2.start_ts > txn_1.start_ts.
         //
-        // Scan all the versions from `u64::max_value()` to `start_ts`.
-        let mut seek_ts = u64::max_value();
+        // Scan all the versions from `TimeStamp::max()` to `start_ts`.
+        let mut seek_ts = TimeStamp::max();
         while let Some((commit_ts, write)) = self.seek_write(key, seek_ts)? {
             if write.start_ts == start_ts {
                 return Ok(Some((commit_ts, write.write_type)));
@@ -221,7 +221,7 @@ impl<S: Snapshot> MvccReader<S> {
             if commit_ts <= start_ts {
                 break;
             }
-            seek_ts = commit_ts - 1;
+            seek_ts = commit_ts.decr();
         }
         Ok(None)
     }
@@ -258,7 +258,7 @@ impl<S: Snapshot> MvccReader<S> {
     }
 
     /// Return the first committed key for which `start_ts` equals to `ts`
-    pub fn seek_ts(&mut self, ts: u64) -> Result<Option<Key>> {
+    pub fn seek_ts(&mut self, ts: TimeStamp) -> Result<Option<Key>> {
         assert!(self.scan_mode.is_some());
         self.create_write_cursor()?;
 
@@ -340,13 +340,13 @@ impl<S: Snapshot> MvccReader<S> {
             }
             let key =
                 Key::from_encoded(cursor.key(&mut self.statistics.write).to_vec()).truncate_ts()?;
-            start = Some(key.clone().append_ts(0));
+            start = Some(key.clone().append_ts(TimeStamp::min()));
             keys.push(key);
         }
     }
 
     // Get all Value of the given key in CF_DEFAULT
-    pub fn scan_values_in_default(&mut self, key: &Key) -> Result<Vec<(u64, Value)>> {
+    pub fn scan_values_in_default(&mut self, key: &Key) -> Result<Vec<(TimeStamp, Value)>> {
         self.create_data_cursor()?;
         let cursor = self.data_cursor.as_mut().unwrap();
         let mut ok = cursor.seek(key, &mut self.statistics.data)?;
@@ -369,7 +369,7 @@ impl<S: Snapshot> MvccReader<S> {
 
     // Returns true if it needs gc.
     // This is for optimization purpose, does not mean to be accurate.
-    pub fn need_gc(&self, safe_point: u64, ratio_threshold: f64) -> bool {
+    pub fn need_gc(&self, safe_point: TimeStamp, ratio_threshold: f64) -> bool {
         // Always GC.
         if ratio_threshold < 1.0 {
             return true;
@@ -401,7 +401,7 @@ impl<S: Snapshot> MvccReader<S> {
         props.max_row_versions > GC_MAX_ROW_VERSIONS_THRESHOLD
     }
 
-    fn get_mvcc_properties(&self, safe_point: u64) -> Option<MvccProperties> {
+    fn get_mvcc_properties(&self, safe_point: TimeStamp) -> Option<MvccProperties> {
         let collection = match self.snapshot.get_properties_cf(CF_WRITE) {
             Ok(v) => v,
             Err(_) => return None,
@@ -436,7 +436,7 @@ mod tests {
     use crate::storage::kv::Modify;
     use crate::storage::mvcc::lock::{Lock, LockType};
     use crate::storage::mvcc::write::{Write, WriteType};
-    use crate::storage::mvcc::{MvccReader, MvccTxn};
+    use crate::storage::mvcc::{MvccReader, MvccTxn, TimeStamp};
     use crate::storage::{Key, Mutation, Options};
     use engine::rocks::util::CFOptions;
     use engine::rocks::{self, ColumnFamilyOptions, DBOptions};
@@ -461,34 +461,57 @@ mod tests {
             }
         }
 
-        pub fn put(&mut self, pk: &[u8], start_ts: u64, commit_ts: u64) {
+        pub fn put(
+            &mut self,
+            pk: &[u8],
+            start_ts: impl Into<TimeStamp>,
+            commit_ts: impl Into<TimeStamp>,
+        ) {
+            let start_ts = start_ts.into();
             let m = Mutation::Put((Key::from_raw(pk), vec![]));
             self.prewrite(m, pk, start_ts);
             self.commit(pk, start_ts, commit_ts);
         }
 
-        pub fn lock(&mut self, pk: &[u8], start_ts: u64, commit_ts: u64) {
+        pub fn lock(
+            &mut self,
+            pk: &[u8],
+            start_ts: impl Into<TimeStamp>,
+            commit_ts: impl Into<TimeStamp>,
+        ) {
+            let start_ts = start_ts.into();
             let m = Mutation::Lock(Key::from_raw(pk));
             self.prewrite(m, pk, start_ts);
             self.commit(pk, start_ts, commit_ts);
         }
 
-        pub fn delete(&mut self, pk: &[u8], start_ts: u64, commit_ts: u64) {
+        pub fn delete(
+            &mut self,
+            pk: &[u8],
+            start_ts: impl Into<TimeStamp>,
+            commit_ts: impl Into<TimeStamp>,
+        ) {
+            let start_ts = start_ts.into();
             let m = Mutation::Delete(Key::from_raw(pk));
             self.prewrite(m, pk, start_ts);
             self.commit(pk, start_ts, commit_ts);
         }
 
-        fn prewrite(&mut self, m: Mutation, pk: &[u8], start_ts: u64) {
+        fn prewrite(&mut self, m: Mutation, pk: &[u8], start_ts: impl Into<TimeStamp>) {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts, true).unwrap();
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true).unwrap();
             txn.prewrite(m, pk, &Options::default()).unwrap();
             self.write(txn.into_modifies());
         }
 
-        fn prewrite_pessimistic_lock(&mut self, m: Mutation, pk: &[u8], start_ts: u64) {
+        fn prewrite_pessimistic_lock(
+            &mut self,
+            m: Mutation,
+            pk: &[u8],
+            start_ts: impl Into<TimeStamp>,
+        ) {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts, true).unwrap();
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true).unwrap();
             let options = Options::default();
             txn.pessimistic_prewrite(m, pk, true, &options).unwrap();
             self.write(txn.into_modifies());
@@ -498,38 +521,43 @@ mod tests {
             &mut self,
             k: Key,
             pk: &[u8],
-            start_ts: u64,
-            for_update_ts: u64,
+            start_ts: impl Into<TimeStamp>,
+            for_update_ts: impl Into<TimeStamp>,
         ) {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts, true).unwrap();
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true).unwrap();
             let mut options = Options::default();
-            options.for_update_ts = for_update_ts;
+            options.for_update_ts = for_update_ts.into();
             txn.acquire_pessimistic_lock(k, pk, false, &options)
                 .unwrap();
             self.write(txn.into_modifies());
         }
 
-        fn commit(&mut self, pk: &[u8], start_ts: u64, commit_ts: u64) {
+        fn commit(
+            &mut self,
+            pk: &[u8],
+            start_ts: impl Into<TimeStamp>,
+            commit_ts: impl Into<TimeStamp>,
+        ) {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts, true).unwrap();
-            txn.commit(Key::from_raw(pk), commit_ts).unwrap();
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true).unwrap();
+            txn.commit(Key::from_raw(pk), commit_ts.into()).unwrap();
             self.write(txn.into_modifies());
         }
 
-        fn rollback(&mut self, pk: &[u8], start_ts: u64) {
+        fn rollback(&mut self, pk: &[u8], start_ts: impl Into<TimeStamp>) {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts, true).unwrap();
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true).unwrap();
             txn.collapse_rollback(false);
             txn.rollback(Key::from_raw(pk)).unwrap();
             self.write(txn.into_modifies());
         }
 
-        fn gc(&mut self, pk: &[u8], safe_point: u64) {
+        fn gc(&mut self, pk: &[u8], safe_point: impl Into<TimeStamp> + Copy) {
             loop {
                 let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-                let mut txn = MvccTxn::new(snap, safe_point, true).unwrap();
-                txn.gc(Key::from_raw(pk), safe_point).unwrap();
+                let mut txn = MvccTxn::new(snap, safe_point.into(), true).unwrap();
+                txn.gc(Key::from_raw(pk), safe_point.into()).unwrap();
                 let modifies = txn.into_modifies();
                 if modifies.is_empty() {
                     return;
@@ -613,11 +641,12 @@ mod tests {
     fn check_need_gc(
         db: Arc<DB>,
         region: Region,
-        safe_point: u64,
+        safe_point: impl Into<TimeStamp>,
         need_gc: bool,
     ) -> Option<MvccProperties> {
         let snap = RegionSnapshot::from_raw(Arc::clone(&db), region.clone());
         let reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
+        let safe_point = safe_point.into();
         assert_eq!(reader.need_gc(safe_point, 1.0), need_gc);
         reader.get_mvcc_properties(safe_point)
     }
@@ -665,8 +694,8 @@ mod tests {
         // SST file with properties. Now all SST files have properties and
         // all keys have only one version, so we don't need gc.
         let props = check_need_gc(Arc::clone(&db), region.clone(), 10, false).unwrap();
-        assert_eq!(props.min_ts, 1);
-        assert_eq!(props.max_ts, 4);
+        assert_eq!(props.min_ts, 1.into());
+        assert_eq!(props.max_ts, 4.into());
         assert_eq!(props.num_rows, 4);
         assert_eq!(props.num_puts, 4);
         assert_eq!(props.num_versions, 4);
@@ -681,16 +710,16 @@ mod tests {
         // After this flush, keys 5,6 in the new SST file have more than one
         // versions, so we need gc.
         let props = check_need_gc(Arc::clone(&db), region.clone(), 10, true).unwrap();
-        assert_eq!(props.min_ts, 1);
-        assert_eq!(props.max_ts, 8);
+        assert_eq!(props.min_ts, 1.into());
+        assert_eq!(props.max_ts, 8.into());
         assert_eq!(props.num_rows, 6);
         assert_eq!(props.num_puts, 6);
         assert_eq!(props.num_versions, 8);
         assert_eq!(props.max_row_versions, 2);
         // But if the `safe_point` is older than all versions, we don't need gc too.
         let props = check_need_gc(Arc::clone(&db), region.clone(), 0, false).unwrap();
-        assert_eq!(props.min_ts, u64::MAX);
-        assert_eq!(props.max_ts, 0);
+        assert_eq!(props.min_ts, TimeStamp::max());
+        assert_eq!(props.max_ts, TimeStamp::min());
         assert_eq!(props.num_rows, 0);
         assert_eq!(props.num_puts, 0);
         assert_eq!(props.num_versions, 0);
@@ -703,8 +732,8 @@ mod tests {
         // After this compact, all versions of keys 5,6 are deleted,
         // no keys have more than one versions, so we don't need gc.
         let props = check_need_gc(Arc::clone(&db), region.clone(), 10, false).unwrap();
-        assert_eq!(props.min_ts, 1);
-        assert_eq!(props.max_ts, 4);
+        assert_eq!(props.min_ts, 1.into());
+        assert_eq!(props.max_ts, 4.into());
         assert_eq!(props.num_rows, 4);
         assert_eq!(props.num_puts, 4);
         assert_eq!(props.num_versions, 4);
@@ -714,8 +743,8 @@ mod tests {
         engine.lock(&[7], 9, 9);
         engine.flush();
         let props = check_need_gc(Arc::clone(&db), region.clone(), 10, true).unwrap();
-        assert_eq!(props.min_ts, 1);
-        assert_eq!(props.max_ts, 9);
+        assert_eq!(props.min_ts, 1.into());
+        assert_eq!(props.max_ts, 9.into());
         assert_eq!(props.num_rows, 5);
         assert_eq!(props.num_puts, 4);
         assert_eq!(props.num_versions, 5);
@@ -761,32 +790,47 @@ mod tests {
         // is 50.
         // Commit versions: [50_45 PUT, 45_40 PUT, 40_35 PUT, 30_25 PUT, 20_20 Rollback, 10_1 PUT, 5_5 Rollback].
         let key = Key::from_raw(k);
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 45).unwrap().unwrap();
-        assert_eq!(commit_ts, 50);
+        let (commit_ts, write_type) = reader
+            .get_txn_commit_info(&key, 45.into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(commit_ts, 50.into());
         assert_eq!(write_type, WriteType::Put);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 35).unwrap().unwrap();
-        assert_eq!(commit_ts, 40);
+        let (commit_ts, write_type) = reader
+            .get_txn_commit_info(&key, 35.into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(commit_ts, 40.into());
         assert_eq!(write_type, WriteType::Put);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 25).unwrap().unwrap();
-        assert_eq!(commit_ts, 30);
+        let (commit_ts, write_type) = reader
+            .get_txn_commit_info(&key, 25.into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(commit_ts, 30.into());
         assert_eq!(write_type, WriteType::Put);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 20).unwrap().unwrap();
-        assert_eq!(commit_ts, 20);
+        let (commit_ts, write_type) = reader
+            .get_txn_commit_info(&key, 20.into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(commit_ts, 20.into());
         assert_eq!(write_type, WriteType::Rollback);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 1).unwrap().unwrap();
-        assert_eq!(commit_ts, 10);
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 1.into()).unwrap().unwrap();
+        assert_eq!(commit_ts, 10.into());
         assert_eq!(write_type, WriteType::Put);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 5).unwrap().unwrap();
-        assert_eq!(commit_ts, 5);
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 5.into()).unwrap().unwrap();
+        assert_eq!(commit_ts, 5.into());
         assert_eq!(write_type, WriteType::Rollback);
 
         let seek_old = reader.get_statistics().write.seek;
-        assert!(reader.get_txn_commit_info(&key, 30).unwrap().is_none());
+        assert!(reader
+            .get_txn_commit_info(&key, 30.into())
+            .unwrap()
+            .is_none());
         let seek_new = reader.get_statistics().write.seek;
 
         // `get_txn_commit_info(&key, 30)` stopped at `30_25 PUT`.
@@ -819,12 +863,12 @@ mod tests {
 
         let snap = RegionSnapshot::from_raw(Arc::clone(&db), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 2).unwrap().unwrap();
-        assert_eq!(commit_ts, 3);
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 2.into()).unwrap().unwrap();
+        assert_eq!(commit_ts, 3.into());
         assert_eq!(write_type, WriteType::Put);
 
-        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 1).unwrap().unwrap();
-        assert_eq!(commit_ts, 4);
+        let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 1.into()).unwrap().unwrap();
+        assert_eq!(commit_ts, 4.into());
         assert_eq!(write_type, WriteType::Put);
     }
 
@@ -865,35 +909,47 @@ mod tests {
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
         let k = Key::from_raw(k);
-        let (commit_ts, write) = reader.seek_write(&k, 30).unwrap().unwrap();
-        assert_eq!(commit_ts, 25);
-        assert_eq!(write, Write::new(WriteType::Put, 23, Some(v.to_vec())));
+        let (commit_ts, write) = reader.seek_write(&k, 30.into()).unwrap().unwrap();
+        assert_eq!(commit_ts, 25.into());
+        assert_eq!(
+            write,
+            Write::new(WriteType::Put, 23.into(), Some(v.to_vec()))
+        );
 
-        let (commit_ts, write) = reader.seek_write(&k, 25).unwrap().unwrap();
-        assert_eq!(commit_ts, 25);
-        assert_eq!(write, Write::new(WriteType::Put, 23, Some(v.to_vec())));
+        let (commit_ts, write) = reader.seek_write(&k, 25.into()).unwrap().unwrap();
+        assert_eq!(commit_ts, 25.into());
+        assert_eq!(
+            write,
+            Write::new(WriteType::Put, 23.into(), Some(v.to_vec()))
+        );
 
-        let (commit_ts, write) = reader.seek_write(&k, 20).unwrap().unwrap();
-        assert_eq!(commit_ts, 20);
-        assert_eq!(write, Write::new(WriteType::Lock, 10, None));
+        let (commit_ts, write) = reader.seek_write(&k, 20.into()).unwrap().unwrap();
+        assert_eq!(commit_ts, 20.into());
+        assert_eq!(write, Write::new(WriteType::Lock, 10.into(), None));
 
-        let (commit_ts, write) = reader.seek_write(&k, 19).unwrap().unwrap();
-        assert_eq!(commit_ts, 17);
-        assert_eq!(write, Write::new(WriteType::Put, 15, Some(v.to_vec())));
+        let (commit_ts, write) = reader.seek_write(&k, 19.into()).unwrap().unwrap();
+        assert_eq!(commit_ts, 17.into());
+        assert_eq!(
+            write,
+            Write::new(WriteType::Put, 15.into(), Some(v.to_vec()))
+        );
 
-        let (commit_ts, write) = reader.seek_write(&k, 3).unwrap().unwrap();
-        assert_eq!(commit_ts, 3);
-        assert_eq!(write, Write::new(WriteType::Rollback, 3, None));
+        let (commit_ts, write) = reader.seek_write(&k, 3.into()).unwrap().unwrap();
+        assert_eq!(commit_ts, 3.into());
+        assert_eq!(write, Write::new(WriteType::Rollback, 3.into(), None));
 
-        let (commit_ts, write) = reader.seek_write(&k, 16).unwrap().unwrap();
-        assert_eq!(commit_ts, 7);
-        assert_eq!(write, Write::new(WriteType::Rollback, 7, None));
+        let (commit_ts, write) = reader.seek_write(&k, 16.into()).unwrap().unwrap();
+        assert_eq!(commit_ts, 7.into());
+        assert_eq!(write, Write::new(WriteType::Rollback, 7.into(), None));
 
-        let (commit_ts, write) = reader.seek_write(&k, 6).unwrap().unwrap();
-        assert_eq!(commit_ts, 5);
-        assert_eq!(write, Write::new(WriteType::Put, 1, Some(v.to_vec())));
+        let (commit_ts, write) = reader.seek_write(&k, 6.into()).unwrap().unwrap();
+        assert_eq!(commit_ts, 5.into());
+        assert_eq!(
+            write,
+            Write::new(WriteType::Put, 1.into(), Some(v.to_vec()))
+        );
 
-        assert!(reader.seek_write(&k, 2).unwrap().is_none());
+        assert!(reader.seek_write(&k, 2.into()).unwrap().is_none());
 
         // Test seek_write should not see the next key.
         let (k2, v2) = (b"k2", b"v2");
@@ -904,18 +960,24 @@ mod tests {
         let snap = RegionSnapshot::from_raw(Arc::clone(&db), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
-        let (commit_ts, write) = reader.seek_write(&Key::from_raw(k2), 3).unwrap().unwrap();
-        assert_eq!(commit_ts, 2);
-        assert_eq!(write, Write::new(WriteType::Put, 1, Some(v2.to_vec())));
+        let (commit_ts, write) = reader
+            .seek_write(&Key::from_raw(k2), 3.into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(commit_ts, 2.into());
+        assert_eq!(
+            write,
+            Write::new(WriteType::Put, 1.into(), Some(v2.to_vec()))
+        );
 
-        assert!(reader.seek_write(&k, 2).unwrap().is_none());
+        assert!(reader.seek_write(&k, 2.into()).unwrap().is_none());
 
         // Test seek_write touches region's end.
         let region1 = make_region(1, vec![], Key::from_raw(b"k1").into_encoded());
         let snap = RegionSnapshot::from_raw(Arc::clone(&db), region1);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
-        assert!(reader.seek_write(&k, 2).unwrap().is_none());
+        assert!(reader.seek_write(&k, 2.into()).unwrap().is_none());
     }
 
     #[test]
@@ -971,40 +1033,40 @@ mod tests {
         //                   5_5 Rollback, 2_1 PUT].
         let key = Key::from_raw(k);
 
-        assert!(reader.get_write(&key, 1).unwrap().is_none());
+        assert!(reader.get_write(&key, 1.into()).unwrap().is_none());
 
-        let write = reader.get_write(&key, 2).unwrap().unwrap();
+        let write = reader.get_write(&key, 2.into()).unwrap().unwrap();
         assert_eq!(write.write_type, WriteType::Put);
-        assert_eq!(write.start_ts, 1);
+        assert_eq!(write.start_ts, 1.into());
 
-        let write = reader.get_write(&key, 5).unwrap().unwrap();
+        let write = reader.get_write(&key, 5.into()).unwrap().unwrap();
         assert_eq!(write.write_type, WriteType::Put);
-        assert_eq!(write.start_ts, 1);
+        assert_eq!(write.start_ts, 1.into());
 
-        let write = reader.get_write(&key, 7).unwrap().unwrap();
+        let write = reader.get_write(&key, 7.into()).unwrap().unwrap();
         assert_eq!(write.write_type, WriteType::Put);
-        assert_eq!(write.start_ts, 1);
+        assert_eq!(write.start_ts, 1.into());
 
-        assert!(reader.get_write(&key, 9).unwrap().is_none());
+        assert!(reader.get_write(&key, 9.into()).unwrap().is_none());
 
-        let write = reader.get_write(&key, 14).unwrap().unwrap();
+        let write = reader.get_write(&key, 14.into()).unwrap().unwrap();
         assert_eq!(write.write_type, WriteType::Put);
-        assert_eq!(write.start_ts, 12);
+        assert_eq!(write.start_ts, 12.into());
 
-        let write = reader.get_write(&key, 16).unwrap().unwrap();
+        let write = reader.get_write(&key, 16.into()).unwrap().unwrap();
         assert_eq!(write.write_type, WriteType::Put);
-        assert_eq!(write.start_ts, 12);
+        assert_eq!(write.start_ts, 12.into());
 
-        let write = reader.get_write(&key, 20).unwrap().unwrap();
+        let write = reader.get_write(&key, 20.into()).unwrap().unwrap();
         assert_eq!(write.write_type, WriteType::Put);
-        assert_eq!(write.start_ts, 18);
+        assert_eq!(write.start_ts, 18.into());
 
-        let write = reader.get_write(&key, 24).unwrap().unwrap();
+        let write = reader.get_write(&key, 24.into()).unwrap().unwrap();
         assert_eq!(write.write_type, WriteType::Put);
-        assert_eq!(write.start_ts, 18);
+        assert_eq!(write.start_ts, 18.into());
 
         assert!(reader
-            .get_write(&Key::from_raw(b"j"), 100)
+            .get_write(&Key::from_raw(b"j"), 100.into())
             .unwrap()
             .is_none());
     }
@@ -1028,34 +1090,40 @@ mod tests {
         let snap = RegionSnapshot::from_raw(Arc::clone(&db), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         // Ignore the lock if read ts is less than the lock version
-        assert!(reader.check_lock(&Key::from_raw(k1), 4).is_ok());
-        assert!(reader.check_lock(&Key::from_raw(k2), 4).is_ok());
+        assert!(reader.check_lock(&Key::from_raw(k1), 4.into()).is_ok());
+        assert!(reader.check_lock(&Key::from_raw(k2), 4.into()).is_ok());
         // Returns the lock if read ts >= lock version
-        assert!(reader.check_lock(&Key::from_raw(k1), 6).is_err());
-        assert!(reader.check_lock(&Key::from_raw(k2), 6).is_err());
+        assert!(reader.check_lock(&Key::from_raw(k1), 6.into()).is_err());
+        assert!(reader.check_lock(&Key::from_raw(k2), 6.into()).is_err());
         // Read locks don't block any read operation
-        assert!(reader.check_lock(&Key::from_raw(k3), 6).is_ok());
-        // Ignore the primary lock when reading the latest committed version by setting u64::MAX as ts
-        assert!(reader.check_lock(&Key::from_raw(k1), u64::MAX).is_ok());
+        assert!(reader.check_lock(&Key::from_raw(k3), 6.into()).is_ok());
+        // Ignore the primary lock when reading the latest committed version by setting TimeStamp::max() as ts
+        assert!(reader
+            .check_lock(&Key::from_raw(k1), TimeStamp::max())
+            .is_ok());
         // Should not ignore the secondary lock even though reading the latest version
-        assert!(reader.check_lock(&Key::from_raw(k2), u64::MAX).is_err());
+        assert!(reader
+            .check_lock(&Key::from_raw(k2), TimeStamp::max())
+            .is_err());
 
         // Commit the primary lock only
         engine.commit(k1, 5, 7);
         let snap = RegionSnapshot::from_raw(Arc::clone(&db), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         // Then reading the primary key should succeed
-        assert!(reader.check_lock(&Key::from_raw(k1), 6).is_ok());
+        assert!(reader.check_lock(&Key::from_raw(k1), 6.into()).is_ok());
         // Reading secondary keys should still fail
-        assert!(reader.check_lock(&Key::from_raw(k2), 6).is_err());
-        assert!(reader.check_lock(&Key::from_raw(k2), u64::MAX).is_err());
+        assert!(reader.check_lock(&Key::from_raw(k2), 6.into()).is_err());
+        assert!(reader
+            .check_lock(&Key::from_raw(k2), TimeStamp::max())
+            .is_err());
 
         // Pessimistic locks
         engine.acquire_pessimistic_lock(Key::from_raw(k4), k4, 9, 9);
         let snap = RegionSnapshot::from_raw(Arc::clone(&db), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         // Pessimistic locks don't block any read operation
-        assert!(reader.check_lock(&Key::from_raw(k4), 10).is_ok());
+        assert!(reader.check_lock(&Key::from_raw(k4), 10.into()).is_ok());
     }
 
     #[test]
@@ -1089,11 +1157,41 @@ mod tests {
         // All locks whose ts <= 10.
         let visible_locks: Vec<_> = vec![
             // key, lock_type, short_value, ts, for_update_ts
-            (b"k1".to_vec(), LockType::Put, Some(b"v1".to_vec()), 5, 0),
-            (b"k2".to_vec(), LockType::Put, Some(b"v2".to_vec()), 10, 0),
-            (b"k3".to_vec(), LockType::Delete, None, 10, 0),
-            (b"k3\x00".to_vec(), LockType::Lock, None, 10, 0),
-            (b"k5".to_vec(), LockType::Pessimistic, None, 10, 12),
+            (
+                b"k1".to_vec(),
+                LockType::Put,
+                Some(b"v1".to_vec()),
+                5.into(),
+                TimeStamp::min(),
+            ),
+            (
+                b"k2".to_vec(),
+                LockType::Put,
+                Some(b"v2".to_vec()),
+                10.into(),
+                TimeStamp::min(),
+            ),
+            (
+                b"k3".to_vec(),
+                LockType::Delete,
+                None,
+                10.into(),
+                TimeStamp::min(),
+            ),
+            (
+                b"k3\x00".to_vec(),
+                LockType::Lock,
+                None,
+                10.into(),
+                TimeStamp::min(),
+            ),
+            (
+                b"k5".to_vec(),
+                LockType::Pessimistic,
+                None,
+                10.into(),
+                12.into(),
+            ),
         ]
         .into_iter()
         .map(|(k, lock_type, short_value, ts, for_update_ts)| {
@@ -1107,7 +1205,7 @@ mod tests {
                     short_value,
                     for_update_ts,
                     0,
-                    0,
+                    TimeStamp::min(),
                 ),
             )
         })
@@ -1119,7 +1217,7 @@ mod tests {
                 let snap = RegionSnapshot::from_raw(Arc::clone(&db), region.clone());
                 let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
                 let res = reader
-                    .scan_locks(start_key.as_ref(), |l| l.ts <= 10, limit)
+                    .scan_locks(start_key.as_ref(), |l| l.ts <= 10.into(), limit)
                     .unwrap();
                 assert_eq!(res.0, expect_res);
                 assert_eq!(res.1, expect_is_remain);

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -7,7 +7,7 @@ use kvproto::kvrpcpb::IsolationLevel;
 
 use crate::storage::kv::SEEK_BOUND;
 use crate::storage::mvcc::write::{Write, WriteType};
-use crate::storage::mvcc::{Result, WriteRef};
+use crate::storage::mvcc::{Result, TimeStamp, WriteRef};
 use crate::storage::{Cursor, Key, Lock, Snapshot, Statistics, Value};
 
 use super::ScannerConfig;
@@ -169,7 +169,7 @@ impl<S: Snapshot> BackwardScanner<S> {
     fn reverse_get(
         &mut self,
         user_key: &Key,
-        ts: u64,
+        ts: TimeStamp,
         met_prev_user_key: &mut bool,
     ) -> Result<Option<Value>> {
         assert!(self.write_cursor.valid()?);
@@ -179,7 +179,7 @@ impl<S: Snapshot> BackwardScanner<S> {
         // We need to save last desired version, because when we may move to an unwanted version
         // at any time.
         let mut last_version = None;
-        let mut last_checked_commit_ts = 0;
+        let mut last_checked_commit_ts = TimeStamp::min();
 
         for i in 0..REVERSE_SEEK_BOUND {
             if i > 0 {
@@ -446,7 +446,7 @@ mod tests {
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND, true)
+        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND.into(), true)
             .range(None, Some(Key::from_raw(&[11 as u8])))
             .build()
             .unwrap();
@@ -641,7 +641,7 @@ mod tests {
         );
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND * 2, true)
+        let mut scanner = ScannerBuilder::new(snapshot, (REVERSE_SEEK_BOUND * 2).into(), true)
             .range(None, None)
             .build()
             .unwrap();
@@ -711,7 +711,7 @@ mod tests {
         );
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND * 2, true)
+        let mut scanner = ScannerBuilder::new(snapshot, (REVERSE_SEEK_BOUND * 2).into(), true)
             .range(None, None)
             .build()
             .unwrap();
@@ -778,7 +778,7 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 1, true)
+        let mut scanner = ScannerBuilder::new(snapshot, 1.into(), true)
             .range(None, None)
             .build()
             .unwrap();
@@ -849,7 +849,7 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 1, true)
+        let mut scanner = ScannerBuilder::new(snapshot, 1.into(), true)
             .range(None, None)
             .build()
             .unwrap();
@@ -928,7 +928,7 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND + 1, true)
+        let mut scanner = ScannerBuilder::new(snapshot, (REVERSE_SEEK_BOUND + 1).into(), true)
             .range(None, None)
             .build()
             .unwrap();
@@ -1015,7 +1015,7 @@ mod tests {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         // Test both bound specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), true)
             .range(Some(Key::from_raw(&[3u8])), Some(Key::from_raw(&[5u8])))
             .build()
             .unwrap();
@@ -1030,7 +1030,7 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test left bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), true)
             .range(None, Some(Key::from_raw(&[3u8])))
             .build()
             .unwrap();
@@ -1045,7 +1045,7 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test right bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), true)
             .range(Some(Key::from_raw(&[5u8])), None)
             .build()
             .unwrap();
@@ -1060,7 +1060,7 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test both bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), true)
             .range(None, None)
             .build()
             .unwrap();
@@ -1122,7 +1122,7 @@ mod tests {
         let k = Key::from_raw(row);
 
         // Call reverse scan
-        let ts = 2;
+        let ts = 2.into();
         let mut scanner = ScannerBuilder::new(snapshot, ts, true)
             .range(None, Some(k))
             .build()

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -179,7 +179,7 @@ impl<S: Snapshot> BackwardScanner<S> {
         // We need to save last desired version, because when we may move to an unwanted version
         // at any time.
         let mut last_version = None;
-        let mut last_checked_commit_ts = TimeStamp::min();
+        let mut last_checked_commit_ts = TimeStamp::zero();
 
         for i in 0..REVERSE_SEEK_BOUND {
             if i > 0 {

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -7,7 +7,7 @@ use kvproto::kvrpcpb::IsolationLevel;
 
 use crate::storage::kv::SEEK_BOUND;
 use crate::storage::mvcc::write::{WriteRef, WriteType};
-use crate::storage::mvcc::Result;
+use crate::storage::mvcc::{Result, TimeStamp};
 use crate::storage::{Cursor, Key, Lock, Snapshot, Statistics, Value};
 
 use super::ScannerConfig;
@@ -200,7 +200,7 @@ impl<S: Snapshot> ForwardScanner<S> {
     fn get(
         &mut self,
         user_key: &Key,
-        ts: u64,
+        ts: TimeStamp,
         met_next_user_key: &mut bool,
     ) -> Result<Option<Value>> {
         assert!(self.write_cursor.valid()?);
@@ -335,7 +335,7 @@ impl<S: Snapshot> ForwardScanner<S> {
         // `current_user_key` must have reserved space here, so its clone has reserved space too.
         // So no reallocation happens in `append_ts`.
         self.write_cursor.internal_seek(
-            &current_user_key.clone().append_ts(0),
+            &current_user_key.clone().append_ts(TimeStamp::min()),
             &mut self.statistics.write,
         )?;
 
@@ -378,7 +378,7 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
             .range(None, None)
             .build()
             .unwrap();
@@ -432,7 +432,7 @@ mod tests {
         must_commit(&engine, b"b", SEEK_BOUND / 2, SEEK_BOUND / 2);
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2, false)
+        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into(), false)
             .range(None, None)
             .build()
             .unwrap();
@@ -495,7 +495,7 @@ mod tests {
         must_commit(&engine, b"b", SEEK_BOUND, SEEK_BOUND);
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, SEEK_BOUND * 2, false)
+        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into(), false)
             .range(None, None)
             .build()
             .unwrap();
@@ -564,7 +564,7 @@ mod tests {
         let snapshot = engine.snapshot(&Context::default()).unwrap();
 
         // Test both bound specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
             .range(Some(Key::from_raw(&[3u8])), Some(Key::from_raw(&[5u8])))
             .build()
             .unwrap();
@@ -579,7 +579,7 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test left bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
             .range(None, Some(Key::from_raw(&[3u8])))
             .build()
             .unwrap();
@@ -594,7 +594,7 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test right bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
             .range(Some(Key::from_raw(&[5u8])), None)
             .build()
             .unwrap();
@@ -609,7 +609,7 @@ mod tests {
         assert_eq!(scanner.next().unwrap(), None);
 
         // Test both bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10, false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
             .range(None, None)
             .build()
             .unwrap();

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -335,7 +335,7 @@ impl<S: Snapshot> ForwardScanner<S> {
         // `current_user_key` must have reserved space here, so its clone has reserved space too.
         // So no reallocation happens in `append_ts`.
         self.write_cursor.internal_seek(
-            &current_user_key.clone().append_ts(TimeStamp::min()),
+            &current_user_key.clone().append_ts(TimeStamp::zero()),
             &mut self.statistics.write,
         )?;
 

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -9,7 +9,7 @@ use kvproto::kvrpcpb::IsolationLevel;
 
 use self::backward::BackwardScanner;
 use self::forward::ForwardScanner;
-use crate::storage::mvcc::{default_not_found_error, Result, TsSet};
+use crate::storage::mvcc::{default_not_found_error, Result, TimeStamp, TsSet};
 use crate::storage::txn::Result as TxnResult;
 use crate::storage::{
     Cursor, CursorBuilder, Iterator, Key, ScanMode, Scanner as StoreScanner, Snapshot, Statistics,
@@ -22,7 +22,7 @@ pub struct ScannerBuilder<S: Snapshot>(ScannerConfig<S>);
 
 impl<S: Snapshot> ScannerBuilder<S> {
     /// Initialize a new `ScannerBuilder`
-    pub fn new(snapshot: S, ts: u64, desc: bool) -> Self {
+    pub fn new(snapshot: S, ts: TimeStamp, desc: bool) -> Self {
         Self(ScannerConfig::new(snapshot, ts, desc))
     }
 
@@ -146,14 +146,14 @@ pub struct ScannerConfig<S: Snapshot> {
     lower_bound: Option<Key>,
     upper_bound: Option<Key>,
 
-    ts: u64,
+    ts: TimeStamp,
     desc: bool,
 
     bypass_locks: TsSet,
 }
 
 impl<S: Snapshot> ScannerConfig<S> {
-    fn new(snapshot: S, ts: u64, desc: bool) -> Self {
+    fn new(snapshot: S, ts: TimeStamp, desc: bool) -> Self {
         Self {
             snapshot,
             fill_cache: true,
@@ -209,7 +209,7 @@ impl<S: Snapshot> ScannerConfig<S> {
 fn near_load_data_by_write<I>(
     default_cursor: &mut Cursor<I>, // TODO: make it `ForwardCursor`.
     user_key: &Key,
-    write_start_ts: u64,
+    write_start_ts: TimeStamp,
     statistics: &mut Statistics,
 ) -> Result<Value>
 where
@@ -234,7 +234,7 @@ where
 fn near_reverse_load_data_by_write<I>(
     default_cursor: &mut Cursor<I>, // TODO: make it `BackwardCursor`.
     user_key: &Key,
-    write_start_ts: u64,
+    write_start_ts: TimeStamp,
     statistics: &mut Statistics,
 ) -> Result<Value>
 where
@@ -288,9 +288,9 @@ mod tests {
     }
 
     fn test_scan_with_lock_and_write_impl(desc: bool) {
-        const SCAN_TS: u64 = 10;
-        const PREV_TS: u64 = 4;
-        const POST_TS: u64 = 5;
+        const SCAN_TS: TimeStamp = TimeStamp::new(10);
+        const PREV_TS: TimeStamp = TimeStamp::new(4);
+        const POST_TS: TimeStamp = TimeStamp::new(5);
 
         let new_engine = || TestEngineBuilder::new().build().unwrap();
         let add_write_at_ts = |commit_ts, engine, key, value| {
@@ -399,17 +399,17 @@ mod tests {
             expected_result = expected_result.into_iter().rev().collect();
         }
 
-        let scanner = ScannerBuilder::new(snapshot.clone(), 30, desc)
+        let scanner = ScannerBuilder::new(snapshot.clone(), 30.into(), desc)
             .build()
             .unwrap();
         check_scan_result(scanner, &expected_result);
 
-        let scanner = ScannerBuilder::new(snapshot.clone(), 70, desc)
+        let scanner = ScannerBuilder::new(snapshot.clone(), 70.into(), desc)
             .build()
             .unwrap();
         check_scan_result(scanner, &expected_result);
 
-        let scanner = ScannerBuilder::new(snapshot.clone(), 103, desc)
+        let scanner = ScannerBuilder::new(snapshot.clone(), 103.into(), desc)
             .build()
             .unwrap();
         check_scan_result(scanner, &expected_result);
@@ -420,7 +420,9 @@ mod tests {
         } else {
             expected_result[4].1 = None;
         }
-        let scanner = ScannerBuilder::new(snapshot, 106, desc).build().unwrap();
+        let scanner = ScannerBuilder::new(snapshot, 106.into(), desc)
+            .build()
+            .unwrap();
         check_scan_result(scanner, &expected_result);
     }
 
@@ -449,7 +451,7 @@ mod tests {
             must_prewrite_put(&engine, &[i], &[b'v', i], &[i], 30 + u64::from(i) * 10);
         }
 
-        let bypass_locks = TsSet::new(vec![30, 41, 50]);
+        let bypass_locks = TsSet::from_u64s(vec![30, 41, 50]);
 
         // Scan at ts 65 will meet locks at 40 and 60.
         let mut expected_result = vec![
@@ -465,7 +467,7 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(&Context::default()).unwrap();
-        let scanner = ScannerBuilder::new(snapshot.clone(), 65, desc)
+        let scanner = ScannerBuilder::new(snapshot.clone(), 65.into(), desc)
             .bypass_locks(bypass_locks)
             .build()
             .unwrap();

--- a/src/storage/mvcc/reader/scanner/txn_entry.rs
+++ b/src/storage/mvcc/reader/scanner/txn_entry.rs
@@ -352,7 +352,7 @@ impl<S: Snapshot> Scanner<S> {
         // `current_user_key` must have reserved space here, so its clone has reserved space too.
         // So no reallocation happens in `append_ts`.
         self.write_cursor.internal_seek(
-            &current_user_key.clone().append_ts(TimeStamp::min()),
+            &current_user_key.clone().append_ts(TimeStamp::zero()),
             &mut self.statistics.write,
         )?;
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -4,7 +4,7 @@ use super::lock::{Lock, LockType};
 use super::metrics::*;
 use super::reader::MvccReader;
 use super::write::{Write, WriteType};
-use super::{extract_physical, Error, Result};
+use super::{Error, Result, TimeStamp};
 use crate::storage::kv::{Modify, ScanMode, Snapshot};
 use crate::storage::{
     is_short_value, Key, Mutation, Options, Statistics, TxnStatus, Value, CF_DEFAULT, CF_LOCK,
@@ -24,7 +24,7 @@ pub struct GcInfo {
 pub struct MvccTxn<S: Snapshot> {
     reader: MvccReader<S>,
     gc_reader: MvccReader<S>,
-    start_ts: u64,
+    start_ts: TimeStamp,
     writes: Vec<Modify>,
     write_size: usize,
     // collapse continuous rollbacks.
@@ -38,13 +38,14 @@ impl<S: Snapshot> fmt::Debug for MvccTxn<S> {
 }
 
 impl<S: Snapshot> MvccTxn<S> {
-    pub fn new(snapshot: S, start_ts: u64, fill_cache: bool) -> Result<Self> {
+    pub fn new(snapshot: S, start_ts: TimeStamp, fill_cache: bool) -> Result<Self> {
         Ok(Self {
-            // Todo: use session variable to indicate fill cache or not
+            // FIXME: use session variable to indicate fill cache or not.
+
             // ScanMode is `None`, since in prewrite and other operations, keys are not given in
             // order and we use prefix seek for each key. An exception is GC, which uses forward
             // scan only.
-            // IsolationLevel is `SI`, actually the method we use in MvccTxn does not rely on
+            // IsolationLevel is `Si`, actually the method we use in MvccTxn does not rely on
             // isolation level, so it can be any value.
             reader: MvccReader::new(snapshot.clone(), None, fill_cache, IsolationLevel::Si),
             gc_reader: MvccReader::new(
@@ -111,31 +112,31 @@ impl<S: Snapshot> MvccTxn<S> {
         self.writes.push(Modify::Delete(CF_LOCK, key));
     }
 
-    fn put_value(&mut self, key: Key, ts: u64, value: Value) {
+    fn put_value(&mut self, key: Key, ts: TimeStamp, value: Value) {
         let key = key.append_ts(ts);
         self.write_size += key.as_encoded().len() + value.len();
         self.writes.push(Modify::Put(CF_DEFAULT, key, value));
     }
 
-    fn delete_value(&mut self, key: Key, ts: u64) {
+    fn delete_value(&mut self, key: Key, ts: TimeStamp) {
         let key = key.append_ts(ts);
         self.write_size += key.as_encoded().len();
         self.writes.push(Modify::Delete(CF_DEFAULT, key));
     }
 
-    fn put_write(&mut self, key: Key, ts: u64, value: Value) {
+    fn put_write(&mut self, key: Key, ts: TimeStamp, value: Value) {
         let key = key.append_ts(ts);
         self.write_size += CF_WRITE.len() + key.as_encoded().len() + value.len();
         self.writes.push(Modify::Put(CF_WRITE, key, value));
     }
 
-    fn delete_write(&mut self, key: Key, ts: u64) {
+    fn delete_write(&mut self, key: Key, ts: TimeStamp) {
         let key = key.append_ts(ts);
         self.write_size += CF_WRITE.len() + key.as_encoded().len();
         self.writes.push(Modify::Delete(CF_WRITE, key));
     }
 
-    fn key_exist(&mut self, key: &Key, ts: u64) -> Result<bool> {
+    fn key_exist(&mut self, key: &Key, ts: TimeStamp) -> Result<bool> {
         Ok(self.reader.get_write(&key, ts)?.is_some())
     }
 
@@ -187,7 +188,7 @@ impl<S: Snapshot> MvccTxn<S> {
         &mut self,
         should_not_exist: bool,
         write: &Write,
-        write_commit_ts: u64,
+        write_commit_ts: TimeStamp,
         key: &Key,
     ) -> Result<()> {
         if !should_not_exist || write.write_type == WriteType::Delete {
@@ -197,7 +198,7 @@ impl<S: Snapshot> MvccTxn<S> {
         // The current key exists under any of the following conditions:
         // 1.The current write type is `PUT`
         // 2.The current write type is `Rollback` or `Lock`, and the key have an older version.
-        if write.write_type == WriteType::Put || self.key_exist(&key, write_commit_ts - 1)? {
+        if write.write_type == WriteType::Put || self.key_exist(&key, write_commit_ts.decr())? {
             return Err(Error::AlreadyExist { key: key.to_raw()? });
         }
 
@@ -212,7 +213,7 @@ impl<S: Snapshot> MvccTxn<S> {
     fn handle_non_pessimistic_lock_conflict(
         &self,
         key: Key,
-        for_update_ts: u64,
+        for_update_ts: TimeStamp,
         lock: Lock,
     ) -> Result<()> {
         // The previous pessimistic transaction has been committed or aborted.
@@ -268,7 +269,7 @@ impl<S: Snapshot> MvccTxn<S> {
             return Ok(());
         }
 
-        if let Some((commit_ts, write)) = self.reader.seek_write(&key, u64::max_value())? {
+        if let Some((commit_ts, write)) = self.reader.seek_write(&key, TimeStamp::max())? {
             // The isolation level of pessimistic transactions is RC. `for_update_ts` is
             // the commit_ts of the data this transaction read. If exists a commit version
             // whose commit timestamp is larger than current `for_update_ts`, the
@@ -401,7 +402,7 @@ impl<S: Snapshot> MvccTxn<S> {
         let (key, value) = mutation.into_key_value();
         // Check whether there is a newer version.
         if !options.skip_constraint_check {
-            if let Some((commit_ts, write)) = self.reader.seek_write(&key, u64::max_value())? {
+            if let Some((commit_ts, write)) = self.reader.seek_write(&key, TimeStamp::max())? {
                 // Abort on writes after our start timestamp ...
                 // If exists a commit version whose commit timestamp is larger than or equal to
                 // current start timestamp, we should abort current prewrite, even if the commit
@@ -449,7 +450,7 @@ impl<S: Snapshot> MvccTxn<S> {
         Ok(())
     }
 
-    pub fn commit(&mut self, key: Key, commit_ts: u64) -> Result<bool> {
+    pub fn commit(&mut self, key: Key, commit_ts: TimeStamp) -> Result<bool> {
         let (lock_type, short_value, is_pessimistic_txn) = match self.reader.load_lock(&key)? {
             Some(ref mut lock) if lock.ts == self.start_ts => {
                 // A pessimistic lock cannot be committed.
@@ -485,7 +486,7 @@ impl<S: Snapshot> MvccTxn<S> {
                 (
                     lock.lock_type,
                     lock.short_value.take(),
-                    lock.for_update_ts != 0,
+                    lock.for_update_ts != TimeStamp::min(),
                 )
             }
             _ => {
@@ -527,7 +528,7 @@ impl<S: Snapshot> MvccTxn<S> {
     }
 
     pub fn rollback(&mut self, key: Key) -> Result<bool> {
-        self.cleanup(key, 0)
+        self.cleanup(key, TimeStamp::min())
     }
 
     fn check_txn_status_missing_lock(
@@ -584,20 +585,20 @@ impl<S: Snapshot> MvccTxn<S> {
     ///
     /// Returns whether the lock is a pessimistic lock. Returns error if the key has already been
     /// committed.
-    pub fn cleanup(&mut self, key: Key, current_ts: u64) -> Result<bool> {
+    pub fn cleanup(&mut self, key: Key, current_ts: TimeStamp) -> Result<bool> {
         match self.reader.load_lock(&key)? {
             Some(ref lock) if lock.ts == self.start_ts => {
                 // If current_ts is not 0, check the Lock's TTL.
                 // If the lock is not expired, do not rollback it but report key is locked.
-                if current_ts > 0
-                    && extract_physical(lock.ts) + lock.ttl >= extract_physical(current_ts)
+                if !current_ts.is_zero()
+                    && lock.ts.extract_physical() + lock.ttl >= current_ts.extract_physical()
                 {
                     return Err(Error::KeyIsLocked(
                         lock.clone().into_lock_info(key.into_raw()?),
                     ));
                 }
 
-                let is_pessimistic_txn = lock.for_update_ts != 0;
+                let is_pessimistic_txn = lock.for_update_ts != TimeStamp::min();
                 self.rollback_lock(key, lock, is_pessimistic_txn)?;
                 Ok(is_pessimistic_txn)
             }
@@ -618,7 +619,7 @@ impl<S: Snapshot> MvccTxn<S> {
     }
 
     /// Delete any pessimistic lock with small for_update_ts belongs to this transaction.
-    pub fn pessimistic_rollback(&mut self, key: Key, for_update_ts: u64) -> Result<()> {
+    pub fn pessimistic_rollback(&mut self, key: Key, for_update_ts: TimeStamp) -> Result<()> {
         if let Some(lock) = self.reader.load_lock(&key)? {
             if lock.lock_type == LockType::Pessimistic
                 && lock.ts == self.start_ts
@@ -669,7 +670,7 @@ impl<S: Snapshot> MvccTxn<S> {
         );
         Err(Error::TxnLockNotFound {
             start_ts: self.start_ts,
-            commit_ts: 0,
+            commit_ts: TimeStamp::min(),
             key: primary_key.into_raw()?,
         })
     }
@@ -692,15 +693,15 @@ impl<S: Snapshot> MvccTxn<S> {
     pub fn check_txn_status(
         &mut self,
         primary_key: Key,
-        caller_start_ts: u64,
-        current_ts: u64,
+        caller_start_ts: TimeStamp,
+        current_ts: TimeStamp,
         rollback_if_not_exist: bool,
     ) -> Result<(TxnStatus, bool)> {
         match self.reader.load_lock(&primary_key)? {
             Some(ref mut lock) if lock.ts == self.start_ts => {
-                let is_pessimistic_txn = lock.for_update_ts != 0;
+                let is_pessimistic_txn = !lock.for_update_ts.is_zero();
 
-                if extract_physical(lock.ts) + lock.ttl < extract_physical(current_ts) {
+                if lock.ts.extract_physical() + lock.ttl < current_ts.extract_physical() {
                     // If the lock is expired, clean it up.
                     self.rollback_lock(primary_key, lock, is_pessimistic_txn)?;
                     MVCC_CHECK_TXN_STATUS_COUNTER_VEC.rollback.inc();
@@ -709,8 +710,8 @@ impl<S: Snapshot> MvccTxn<S> {
 
                 // If this is a large transaction and the lock is active, push forward the minCommitTS.
                 // lock.minCommitTS == 0 may be a secondary lock, or not a large transaction.
-                if lock.min_commit_ts > 0 && caller_start_ts >= lock.min_commit_ts {
-                    lock.min_commit_ts = caller_start_ts + 1;
+                if !lock.min_commit_ts.is_zero() && caller_start_ts >= lock.min_commit_ts {
+                    lock.min_commit_ts = caller_start_ts.incr();
 
                     if lock.min_commit_ts < current_ts {
                         lock.min_commit_ts = current_ts;
@@ -731,15 +732,15 @@ impl<S: Snapshot> MvccTxn<S> {
         }
     }
 
-    pub fn gc(&mut self, key: Key, safe_point: u64) -> Result<GcInfo> {
+    pub fn gc(&mut self, key: Key, safe_point: TimeStamp) -> Result<GcInfo> {
         let mut remove_older = false;
-        let mut ts: u64 = u64::max_value();
+        let mut ts = TimeStamp::max();
         let mut found_versions = 0;
         let mut deleted_versions = 0;
         let mut latest_delete = None;
         let mut is_completed = true;
         while let Some((commit, write)) = self.gc_reader.seek_write(&key, ts)? {
-            ts = commit - 1;
+            ts = commit.decr();
             found_versions += 1;
 
             if self.write_size >= MAX_TXN_WRITE_SIZE {
@@ -799,6 +800,16 @@ impl<S: Snapshot> MvccTxn<S> {
     }
 }
 
+/// Create a new MvccTxn using a u64 literal for the timestamp.
+///
+/// Intended to only be used in test code.
+#[macro_export]
+macro_rules! new_txn {
+    ($ss: expr, $ts: literal, $fill_cache: expr) => {
+        $crate::storage::mvcc::MvccTxn::new($ss, $ts.into(), $fill_cache).unwrap()
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use kvproto::kvrpcpb::{Context, IsolationLevel};
@@ -806,7 +817,7 @@ mod tests {
     use crate::storage::kv::Engine;
     use crate::storage::mvcc::tests::*;
     use crate::storage::mvcc::WriteType;
-    use crate::storage::mvcc::{Error, MvccReader, MvccTxn};
+    use crate::storage::mvcc::{Error, MvccReader, TimeStamp};
     use crate::storage::{
         Key, Mutation, Options, ScanMode, TestEngineBuilder, SHORT_VALUE_MAX_LEN,
     };
@@ -1022,7 +1033,7 @@ mod tests {
         let engine = TestEngineBuilder::new().build().unwrap();
 
         // Shorthand for composing ts.
-        let ts = super::super::compose_ts;
+        let ts = TimeStamp::compose;
 
         let (k, v) = (b"k", b"v");
 
@@ -1125,7 +1136,7 @@ mod tests {
         let (k, v) = (b"k", b"v");
 
         // Shortcuts
-        let ts = super::super::compose_ts;
+        let ts = TimeStamp::compose;
         use super::TxnStatus;
         let uncommitted = TxnStatus::uncommitted;
 
@@ -1303,19 +1314,19 @@ mod tests {
         must_seek_write_none(&engine, k, 5);
 
         must_commit(&engine, k, 5, 10);
-        must_seek_write(&engine, k, u64::max_value(), 5, 10, WriteType::Put);
-        must_seek_write_none(&engine, k2, u64::max_value());
+        must_seek_write(&engine, k, TimeStamp::max(), 5, 10, WriteType::Put);
+        must_seek_write_none(&engine, k2, TimeStamp::max());
         must_get_commit_ts(&engine, k, 5, 10);
 
         must_prewrite_delete(&engine, k, k, 15);
         must_rollback(&engine, k, 15);
-        must_seek_write(&engine, k, u64::max_value(), 15, 15, WriteType::Rollback);
+        must_seek_write(&engine, k, TimeStamp::max(), 15, 15, WriteType::Rollback);
         must_get_commit_ts(&engine, k, 5, 10);
         must_get_commit_ts_none(&engine, k, 15);
 
         must_prewrite_lock(&engine, k, k, 25);
         must_commit(&engine, k, 25, 30);
-        must_seek_write(&engine, k, u64::max_value(), 25, 30, WriteType::Lock);
+        must_seek_write(&engine, k, TimeStamp::max(), 25, 30, WriteType::Lock);
         must_get_commit_ts(&engine, k, 25, 30);
     }
 
@@ -1358,7 +1369,7 @@ mod tests {
         let engine = TestEngineBuilder::new().build().unwrap();
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, 10, true).unwrap();
+        let mut txn = new_txn!(snapshot, 10, true);
         let key = Key::from_raw(k);
         assert_eq!(txn.write_size, 0);
 
@@ -1372,8 +1383,8 @@ mod tests {
         engine.write(&ctx, txn.into_modifies()).unwrap();
 
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, 10, true).unwrap();
-        txn.commit(key, 15).unwrap();
+        let mut txn = new_txn!(snapshot, 10, true);
+        txn.commit(key, 15.into()).unwrap();
         assert!(txn.write_size() > 0);
         engine.write(&ctx, txn.into_modifies()).unwrap();
     }
@@ -1396,7 +1407,7 @@ mod tests {
 
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, 5, true).unwrap();
+        let mut txn = new_txn!(snapshot, 5, true);
         assert!(txn
             .prewrite(
                 Mutation::Put((Key::from_raw(key), value.to_vec())),
@@ -1407,7 +1418,7 @@ mod tests {
 
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, 5, true).unwrap();
+        let mut txn = new_txn!(snapshot, 5, true);
         let mut opt = Options::default();
         opt.skip_constraint_check = true;
         assert!(txn
@@ -1504,8 +1515,14 @@ mod tests {
 
         let v = reader.scan_values_in_default(&Key::from_raw(&[3])).unwrap();
         assert_eq!(v.len(), 2);
-        assert_eq!(v[1], (3, "a".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes()));
-        assert_eq!(v[0], (5, "b".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes()));
+        assert_eq!(
+            v[1],
+            (3.into(), "a".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes())
+        );
+        assert_eq!(
+            v[0],
+            (5.into(), "b".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes())
+        );
     }
 
     #[test]
@@ -1540,7 +1557,10 @@ mod tests {
         let mut reader =
             MvccReader::new(snapshot, Some(ScanMode::Forward), true, IsolationLevel::Si);
 
-        assert_eq!(reader.seek_ts(3).unwrap().unwrap(), Key::from_raw(&[2]));
+        assert_eq!(
+            reader.seek_ts(3.into()).unwrap().unwrap(),
+            Key::from_raw(&[2])
+        );
     }
 
     #[test]
@@ -1939,7 +1959,7 @@ mod tests {
 
         let (k, v) = (b"k1", b"v1");
 
-        let ts = super::super::compose_ts;
+        let ts = TimeStamp::compose;
 
         // Shortcuts
         use super::TxnStatus::{self, *};
@@ -1954,7 +1974,7 @@ mod tests {
             must_seek_write(
                 &engine,
                 k,
-                u64::max_value(),
+                TimeStamp::max(),
                 ts(3, 0),
                 ts(3, 0),
                 WriteType::Rollback,
@@ -2106,7 +2126,7 @@ mod tests {
         must_seek_write(
             &engine,
             k,
-            u64::max_value(),
+            TimeStamp::max(),
             ts(20, 0),
             ts(20, 0),
             WriteType::Rollback,
@@ -2123,7 +2143,7 @@ mod tests {
             ts(10, 0),
             ts(10, 0),
             r,
-            uncommitted(100, 0),
+            uncommitted(100, TimeStamp::min()),
         );
         must_large_txn_locked(&engine, k, ts(4, 0), 100, 0, true);
 
@@ -2166,7 +2186,7 @@ mod tests {
             ts(160, 0),
             ts(160, 0),
             r,
-            uncommitted(100, 0),
+            uncommitted(100, TimeStamp::min()),
         );
         must_large_txn_locked(&engine, k, ts(150, 0), 100, 0, true);
         must_check_txn_status(&engine, k, ts(150, 0), ts(160, 0), ts(260, 0), r, TtlExpire);
@@ -2175,7 +2195,7 @@ mod tests {
         must_seek_write(
             &engine,
             k,
-            u64::max_value(),
+            TimeStamp::max(),
             ts(150, 0),
             ts(150, 0),
             WriteType::Rollback,
@@ -2189,7 +2209,7 @@ mod tests {
             k,
             ts(270, 0),
             ts(271, 0),
-            u64::max_value(),
+            TimeStamp::max(),
             r,
             TtlExpire,
         );
@@ -2197,7 +2217,7 @@ mod tests {
         must_seek_write(
             &engine,
             k,
-            u64::max_value(),
+            TimeStamp::max(),
             ts(270, 0),
             ts(270, 0),
             WriteType::Rollback,
@@ -2210,7 +2230,7 @@ mod tests {
             k,
             ts(280, 0),
             ts(281, 0),
-            u64::max_value(),
+            TimeStamp::max(),
             r,
             TtlExpire,
         );
@@ -2218,7 +2238,7 @@ mod tests {
         must_seek_write(
             &engine,
             k,
-            u64::max_value(),
+            TimeStamp::max(),
             ts(280, 0),
             ts(280, 0),
             WriteType::Rollback,
@@ -2302,7 +2322,7 @@ mod tests {
 
         // Write a pessimistic lock.
         must_rollback(&engine, k, 10);
-        options.for_update_ts = 50;
+        options.for_update_ts = 50.into();
         must_acquire_pessimistic_lock_impl(&engine, k, k, 50, options.clone());
 
         expected_lock_info.set_lock_version(50);

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -11,6 +11,8 @@ mod store;
 use std::error;
 use std::io::Error as IoError;
 
+use crate::storage::mvcc::TimeStamp;
+
 pub use self::process::{ProcessResult, RESOLVE_LOCK_BATCH_SIZE};
 pub use self::scheduler::{Msg, Scheduler};
 pub use self::store::{EntryBatch, TxnEntry, TxnEntryScanner, TxnEntryStore};
@@ -51,7 +53,7 @@ quick_error! {
             cause(err)
             description(err.description())
         }
-        InvalidTxnTso {start_ts: u64, commit_ts: u64} {
+        InvalidTxnTso {start_ts: TimeStamp, commit_ts: TimeStamp} {
             description("Invalid transaction tso")
             display("Invalid transaction tso with start_ts:{},commit_ts:{}",
                         start_ts,

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -13,7 +13,7 @@ use std::io::Error as IoError;
 
 use crate::storage::mvcc::TimeStamp;
 
-pub use self::process::{ProcessResult, RESOLVE_LOCK_BATCH_SIZE};
+pub use self::process::RESOLVE_LOCK_BATCH_SIZE;
 pub use self::scheduler::{Msg, Scheduler};
 pub use self::store::{EntryBatch, TxnEntry, TxnEntryScanner, TxnEntryStore};
 pub use self::store::{FixtureStore, FixtureStoreScanner};

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -11,7 +11,7 @@ mod store;
 use std::error;
 use std::io::Error as IoError;
 
-pub use self::process::{execute_callback, ProcessResult, RESOLVE_LOCK_BATCH_SIZE};
+pub use self::process::{ProcessResult, RESOLVE_LOCK_BATCH_SIZE};
 pub use self::scheduler::{Msg, Scheduler};
 pub use self::store::{EntryBatch, TxnEntry, TxnEntryScanner, TxnEntryStore};
 pub use self::store::{FixtureStore, FixtureStoreScanner};

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -33,7 +33,7 @@ use tikv_util::{collections::HashMap, time::SlowTimer};
 use crate::storage::kv::{with_tls_engine, Result as EngineResult};
 use crate::storage::lock_manager::{self, LockManager};
 use crate::storage::txn::latch::{Latches, Lock};
-use crate::storage::txn::process::{Executor, MsgScheduler, ProcessResult, Task};
+use crate::storage::txn::process::{Executor, MsgScheduler, Task};
 use crate::storage::txn::sched_pool::SchedPool;
 use crate::storage::txn::Error;
 use crate::storage::{
@@ -42,6 +42,7 @@ use crate::storage::{
         SCHED_HISTOGRAM_VEC_STATIC, SCHED_LATCH_HISTOGRAM_VEC, SCHED_STAGE_COUNTER_VEC,
         SCHED_TOO_BUSY_COUNTER_VEC, SCHED_WRITING_BYTES_GAUGE,
     },
+    types::ProcessResult,
     Key,
 };
 use crate::storage::{
@@ -638,9 +639,9 @@ mod tests {
                             10.into(),
                             20,
                             None,
-                            TimeStamp::min(),
+                            TimeStamp::zero(),
                             0,
-                            TimeStamp::min(),
+                            TimeStamp::zero(),
                         ),
                     )],
                 },
@@ -649,7 +650,7 @@ mod tests {
                 ctx: Context::default(),
                 kind: CommandKind::ResolveLockLite {
                     start_ts: 10.into(),
-                    commit_ts: TimeStamp::min(),
+                    commit_ts: TimeStamp::zero(),
                     resolve_keys: vec![Key::from_raw(b"k")],
                 },
             },

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -3,10 +3,9 @@
 use kvproto::kvrpcpb::IsolationLevel;
 
 use crate::storage::metrics::*;
-use crate::storage::mvcc::EntryScanner;
 use crate::storage::mvcc::Error as MvccError;
-use crate::storage::mvcc::{PointGetter, PointGetterBuilder, TsSet};
-use crate::storage::mvcc::{Scanner as MvccScanner, ScannerBuilder, WriteRef};
+use crate::storage::mvcc::{EntryScanner, Scanner as MvccScanner, ScannerBuilder, WriteRef};
+use crate::storage::mvcc::{PointGetter, PointGetterBuilder, TimeStamp, TsSet};
 use crate::storage::{Key, KvPair, Snapshot, Statistics, Value};
 
 use super::{Error, Result};
@@ -170,7 +169,7 @@ impl EntryBatch {
 
 pub struct SnapshotStore<S: Snapshot> {
     snapshot: S,
-    start_ts: u64,
+    start_ts: TimeStamp,
     isolation_level: IsolationLevel,
     fill_cache: bool,
     bypass_locks: TsSet,
@@ -301,7 +300,7 @@ impl<S: Snapshot> TxnEntryStore for SnapshotStore<S> {
 impl<S: Snapshot> SnapshotStore<S> {
     pub fn new(
         snapshot: S,
-        start_ts: u64,
+        start_ts: TimeStamp,
         isolation_level: IsolationLevel,
         fill_cache: bool,
         bypass_locks: TsSet,
@@ -318,7 +317,7 @@ impl<S: Snapshot> SnapshotStore<S> {
     }
 
     #[inline]
-    pub fn set_start_ts(&mut self, start_ts: u64) {
+    pub fn set_start_ts(&mut self, start_ts: TimeStamp) {
         self.start_ts = start_ts;
     }
 
@@ -506,9 +505,7 @@ impl Scanner for FixtureStoreScanner {
 
 #[cfg(test)]
 mod tests {
-    use super::Error;
-    use super::{FixtureStore, Scanner, SnapshotStore, Store};
-
+    use super::*;
     use crate::storage::kv::{
         Engine, Result as EngineResult, RocksEngine, RocksSnapshot, ScanMode,
     };
@@ -522,8 +519,8 @@ mod tests {
     use kvproto::kvrpcpb::{Context, IsolationLevel};
 
     const KEY_PREFIX: &str = "key_prefix";
-    const START_TS: u64 = 10;
-    const COMMIT_TS: u64 = 20;
+    const START_TS: TimeStamp = TimeStamp::new(10);
+    const COMMIT_TS: TimeStamp = TimeStamp::new(20);
     const START_ID: u64 = 1000;
 
     struct TestStore {
@@ -590,7 +587,7 @@ mod tests {
         fn store(&self) -> SnapshotStore<RocksSnapshot> {
             SnapshotStore::new(
                 self.snapshot.clone(),
-                COMMIT_TS + 1,
+                COMMIT_TS.incr(),
                 IsolationLevel::Si,
                 true,
                 Default::default(),
@@ -811,7 +808,13 @@ mod tests {
     fn test_scanner_verify_bound() {
         // Store with a limited range
         let snap = MockRangeSnapshot::new(b"b".to_vec(), b"c".to_vec());
-        let store = SnapshotStore::new(snap, 0, IsolationLevel::Si, true, Default::default());
+        let store = SnapshotStore::new(
+            snap,
+            TimeStamp::min(),
+            IsolationLevel::Si,
+            true,
+            Default::default(),
+        );
         let bound_a = Key::from_encoded(b"a".to_vec());
         let bound_b = Key::from_encoded(b"b".to_vec());
         let bound_c = Key::from_encoded(b"c".to_vec());
@@ -832,7 +835,13 @@ mod tests {
 
         // Store with whole range
         let snap2 = MockRangeSnapshot::new(b"".to_vec(), b"".to_vec());
-        let store2 = SnapshotStore::new(snap2, 0, IsolationLevel::Si, true, Default::default());
+        let store2 = SnapshotStore::new(
+            snap2,
+            TimeStamp::min(),
+            IsolationLevel::Si,
+            true,
+            Default::default(),
+        );
         assert!(store2.scanner(false, false, None, None).is_ok());
         assert!(store2
             .scanner(false, false, Some(bound_a.clone()), None)

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -587,7 +587,7 @@ mod tests {
         fn store(&self) -> SnapshotStore<RocksSnapshot> {
             SnapshotStore::new(
                 self.snapshot.clone(),
-                COMMIT_TS.incr(),
+                COMMIT_TS.next(),
                 IsolationLevel::Si,
                 true,
                 Default::default(),
@@ -810,7 +810,7 @@ mod tests {
         let snap = MockRangeSnapshot::new(b"b".to_vec(), b"c".to_vec());
         let store = SnapshotStore::new(
             snap,
-            TimeStamp::min(),
+            TimeStamp::zero(),
             IsolationLevel::Si,
             true,
             Default::default(),
@@ -837,7 +837,7 @@ mod tests {
         let snap2 = MockRangeSnapshot::new(b"".to_vec(), b"".to_vec());
         let store2 = SnapshotStore::new(
             snap2,
-            TimeStamp::min(),
+            TimeStamp::zero(),
             IsolationLevel::Si,
             true,
             Default::default(),

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use kvproto::kvrpcpb::LockInfo;
 
 use crate::storage::{
-    mvcc::{Lock, Write},
+    mvcc::{Lock, TimeStamp, Write},
     Callback, Result,
 };
 
@@ -19,9 +19,9 @@ pub use keys::{Key, KvPair, Value};
 pub struct MvccInfo {
     pub lock: Option<Lock>,
     /// commit_ts and write
-    pub writes: Vec<(u64, Write)>,
+    pub writes: Vec<(TimeStamp, Write)>,
     /// start_ts and value
-    pub values: Vec<(u64, Value)>,
+    pub values: Vec<(TimeStamp, Value)>,
 }
 
 /// A row mutation.
@@ -76,20 +76,23 @@ pub enum TxnStatus {
     /// The txn is just rolled back due to lock not exist.
     LockNotExist,
     /// The txn haven't yet been committed.
-    Uncommitted { lock_ttl: u64, min_commit_ts: u64 },
+    Uncommitted {
+        lock_ttl: u64,
+        min_commit_ts: TimeStamp,
+    },
     /// The txn was committed.
-    Committed { commit_ts: u64 },
+    Committed { commit_ts: TimeStamp },
 }
 
 impl TxnStatus {
-    pub fn uncommitted(lock_ttl: u64, min_commit_ts: u64) -> Self {
+    pub fn uncommitted(lock_ttl: u64, min_commit_ts: TimeStamp) -> Self {
         Self::Uncommitted {
             lock_ttl,
             min_commit_ts,
         }
     }
 
-    pub fn committed(commit_ts: u64) -> Self {
+    pub fn committed(commit_ts: TimeStamp) -> Self {
         Self::Committed { commit_ts }
     }
 }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -94,7 +94,7 @@ impl TxnStatus {
     }
 }
 
-pub enum StorageCb {
+pub enum StorageCallback {
     Boolean(Callback<()>),
     Booleans(Callback<Vec<Result<()>>>),
     MvccInfoByKey(Callback<MvccInfo>),

--- a/tests/failpoints/cases/test_gc_worker.rs
+++ b/tests/failpoints/cases/test_gc_worker.rs
@@ -23,7 +23,7 @@ fn test_gcworker_busy() {
         gc_worker
             .async_gc(
                 ctx.clone(),
-                1,
+                1.into(),
                 Box::new(move |res: storage::Result<()>| {
                     assert!(res.is_ok());
                     tx1.send(1).unwrap();
@@ -38,7 +38,7 @@ fn test_gcworker_busy() {
     gc_worker
         .async_gc(
             ctx.clone(),
-            1,
+            1.into(),
             Box::new(move |res: storage::Result<()>| {
                 assert!(res.is_ok());
                 tx1.send(1).unwrap();
@@ -51,7 +51,7 @@ fn test_gcworker_busy() {
     gc_worker
         .async_gc(
             Context::default(),
-            1,
+            1.into(),
             Box::new(move |res: storage::Result<()>| {
                 match res {
                     Err(storage::Error::GCWorkerTooBusy) => {}

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -39,7 +39,7 @@ fn test_scheduler_leader_change_twice() {
             ctx0,
             vec![Mutation::Put((Key::from_raw(b"k"), b"v".to_vec()))],
             b"k".to_vec(),
-            10,
+            10.into(),
             Options::default(),
             Box::new(move |res: storage::Result<_>| {
                 prewrite_tx.send(res).unwrap();

--- a/tests/integrations/coprocessor/test_checksum.rs
+++ b/tests/integrations/coprocessor/test_checksum.rs
@@ -14,7 +14,7 @@ use tidb_query::storage::scanner::{RangesScanner, RangesScannerOptions};
 use tidb_query::storage::Range;
 use tikv::coprocessor::dag::TiKVStorage;
 use tikv::coprocessor::*;
-use tikv::storage::{Engine, SnapshotStore};
+use tikv::storage::{Engine, SnapshotStore, TimeStamp};
 
 fn new_checksum_request(range: KeyRange, scan_on: ChecksumScanOn) -> Request {
     let mut ctx = Context::default();
@@ -69,7 +69,7 @@ fn reversed_checksum_crc64_xor<E: Engine>(store: &Store<E>, range: KeyRange) -> 
     let ctx = Context::default();
     let store = SnapshotStore::new(
         store.get_engine().snapshot(&ctx).unwrap(),
-        u64::MAX,
+        TimeStamp::max(),
         IsolationLevel::Si,
         true,
         Default::default(),

--- a/tests/integrations/raftstore/test_compact_after_delete.rs
+++ b/tests/integrations/raftstore/test_compact_after_delete.rs
@@ -5,18 +5,23 @@ use engine::rocks::Range;
 use engine::CF_WRITE;
 use test_raftstore::*;
 use tikv::raftstore::store::keys::{data_key, DATA_MAX_KEY};
-use tikv::storage::mvcc::{Write, WriteType};
+use tikv::storage::mvcc::{TimeStamp, Write, WriteType};
 use tikv::storage::types::Key as MvccKey;
 use tikv_util::config::*;
 
-fn gen_mvcc_put_kv(k: &[u8], v: &[u8], start_ts: u64, commit_ts: u64) -> (Vec<u8>, Vec<u8>) {
+fn gen_mvcc_put_kv(
+    k: &[u8],
+    v: &[u8],
+    start_ts: TimeStamp,
+    commit_ts: TimeStamp,
+) -> (Vec<u8>, Vec<u8>) {
     let k = MvccKey::from_encoded(data_key(k));
     let k = k.append_ts(commit_ts);
     let w = Write::new(WriteType::Put, start_ts, Some(v.to_vec()));
     (k.as_encoded().clone(), w.as_ref().to_bytes())
 }
 
-fn gen_delete_k(k: &[u8], commit_ts: u64) -> Vec<u8> {
+fn gen_delete_k(k: &[u8], commit_ts: TimeStamp) -> Vec<u8> {
     let k = MvccKey::from_encoded(data_key(k));
     let k = k.append_ts(commit_ts);
     k.as_encoded().clone()
@@ -31,7 +36,7 @@ fn test_compact_after_delete<T: Simulator>(cluster: &mut Cluster<T>) {
 
     for i in 0..1000 {
         let (k, v) = (format!("k{}", i), format!("value{}", i));
-        let (k, v) = gen_mvcc_put_kv(k.as_bytes(), v.as_bytes(), 1, 2);
+        let (k, v) = gen_mvcc_put_kv(k.as_bytes(), v.as_bytes(), 1.into(), 2.into());
         cluster.must_put_cf(CF_WRITE, &k, &v);
     }
     for engines in cluster.engines.values() {
@@ -41,7 +46,7 @@ fn test_compact_after_delete<T: Simulator>(cluster: &mut Cluster<T>) {
 
     for i in 0..1000 {
         let k = format!("k{}", i);
-        let k = gen_delete_k(k.as_bytes(), 2);
+        let k = gen_delete_k(k.as_bytes(), 2.into());
         cluster.must_delete_cf(CF_WRITE, &k);
     }
     for engines in cluster.engines.values() {

--- a/tests/integrations/raftstore/test_region_heartbeat.rs
+++ b/tests/integrations/raftstore/test_region_heartbeat.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
+use keys::Instant as PdInstant;
 use test_raftstore::*;
 use tikv_util::config::*;
 use tikv_util::HandyRwLock;
@@ -163,7 +164,7 @@ fn test_region_heartbeat_timestamp() {
     // transfer leader to (2, 2) first to make address resolve happen early.
     cluster.must_transfer_leader(1, new_peer(2, 2));
     let reported_ts = cluster.pd_client.get_region_last_report_ts(1).unwrap();
-    assert_ne!(reported_ts, 0);
+    assert_ne!(reported_ts, PdInstant::zero());
 
     sleep(Duration::from_millis(1000));
     cluster.must_transfer_leader(1, new_peer(1, 1));

--- a/tests/integrations/raftstore/test_region_heartbeat.rs
+++ b/tests/integrations/raftstore/test_region_heartbeat.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
-use keys::Instant as PdInstant;
+use keys::UnixSecs as PdInstant;
 use test_raftstore::*;
 use tikv_util::config::*;
 use tikv_util::HandyRwLock;

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -25,7 +25,7 @@ use tikv::raftstore::coprocessor::CoprocessorHost;
 use tikv::raftstore::store::fsm::store::StoreMeta;
 use tikv::raftstore::store::keys;
 use tikv::raftstore::store::SnapManager;
-use tikv::storage::mvcc::{Lock, LockType};
+use tikv::storage::mvcc::{Lock, LockType, TimeStamp};
 use tikv::storage::Key;
 use tikv_util::worker::FutureWorker;
 use tikv_util::HandyRwLock;
@@ -785,7 +785,17 @@ fn test_debug_scan_mvcc() {
         keys::data_key(b"meta_lock_2"),
     ];
     for k in &keys {
-        let v = Lock::new(LockType::Put, b"pk".to_vec(), 1, 10, None, 0, 0, 0).to_bytes();
+        let v = Lock::new(
+            LockType::Put,
+            b"pk".to_vec(),
+            1.into(),
+            10,
+            None,
+            TimeStamp::min(),
+            0,
+            TimeStamp::min(),
+        )
+        .to_bytes();
         let cf_handle = engine.cf_handle(CF_LOCK).unwrap();
         engine.put_cf(cf_handle, k.as_slice(), &v).unwrap();
     }

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -791,9 +791,9 @@ fn test_debug_scan_mvcc() {
             1.into(),
             10,
             None,
-            TimeStamp::min(),
+            TimeStamp::zero(),
             0,
-            TimeStamp::min(),
+            TimeStamp::zero(),
         )
         .to_bytes();
         let cf_handle = engine.cf_handle(CF_LOCK).unwrap();

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -211,9 +211,9 @@ fn write_test_data<E: Engine>(
             .into_iter()
             .for_each(|res| res.unwrap());
         storage
-            .commit(ctx.clone(), vec![Key::from_raw(k)], ts, ts.incr())
+            .commit(ctx.clone(), vec![Key::from_raw(k)], ts, ts.next())
             .unwrap();
-        ts = ts.incr().incr();
+        ts.incr().incr();
     }
 }
 

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -15,7 +15,7 @@ use test_storage::*;
 use tikv::server::gc_worker::DEFAULT_GC_BATCH_KEYS;
 use tikv::storage::mvcc::MAX_TXN_WRITE_SIZE;
 use tikv::storage::txn::RESOLVE_LOCK_BATCH_SIZE;
-use tikv::storage::{Engine, Key, Mutation};
+use tikv::storage::{Engine, Key, Mutation, TimeStamp};
 
 #[test]
 fn test_txn_store_get() {
@@ -103,12 +103,12 @@ fn test_txn_store_for_point_get_with_pk() {
         5,
     );
     store.get_ok(b"primary", 4, b"v1");
-    store.get_ok(b"primary", u64::MAX, b"v1");
+    store.get_ok(b"primary", TimeStamp::max(), b"v1");
     store.get_err(b"primary", 6);
 
     store.get_ok(b"secondary", 4, b"v3");
     store.get_err(b"secondary", 6);
-    store.get_err(b"secondary", u64::MAX);
+    store.get_err(b"secondary", TimeStamp::max());
 
     store.get_err(b"new_key", 6);
     store.get_ok(b"b", 6, b"v2");
@@ -518,7 +518,7 @@ fn test_txn_store_resolve_lock() {
         b"p2",
         10,
     );
-    store.resolve_lock_ok(5, None);
+    store.resolve_lock_ok(5, None::<TimeStamp>);
     store.resolve_lock_ok(10, Some(20));
     store.get_none(b"p1", 20);
     store.get_none(b"s1", 30);
@@ -795,11 +795,11 @@ fn test_txn_store_lock_primary() {
         ],
         b"p",
         2,
-        vec![(b"p", b"p", 1)],
+        vec![(b"p", b"p", 1.into())],
     );
     // txn2 cleanups txn1's lock.
     store.rollback_ok(vec![b"p"], 1);
-    store.resolve_lock_ok(1, None);
+    store.resolve_lock_ok(1, None::<TimeStamp>);
 
     // txn3 wants to write "p", "s", neither of them should be locked.
     store.prewrite_ok(
@@ -841,8 +841,8 @@ impl Oracle {
         }
     }
 
-    fn get_ts(&self) -> u64 {
-        self.ts.fetch_add(1, Ordering::Relaxed) as u64
+    fn get_ts(&self) -> TimeStamp {
+        (self.ts.fetch_add(1, Ordering::Relaxed) as u64).into()
     }
 }
 


### PR DESCRIPTION
###  What have you changed?

The first commit is mostly a simple renaming, plus some minor code motion. The second commit moves from using `u64` to represent time stamps to using a `TimeStamp` newtype. This improves type safety and readability.


###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

PTAL @AndreMouche @breeswish 