### PR TITLE
raftstore: make `on_apply_write_cmd` failpoint injectable

### DIFF
--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -1087,7 +1087,7 @@ impl ApplyDelegate {
     ) -> Result<(RaftCmdResponse, ApplyResult)> {
         fail_point!(
             "on_apply_write_cmd",
-            cfg!(not(test)) || self.id() == 3,
+            cfg!(release) || self.id() == 3,
             |_| {
                 unimplemented!();
             }

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -1085,9 +1085,13 @@ impl ApplyDelegate {
         ctx: &ApplyContext,
         req: &RaftCmdRequest,
     ) -> Result<(RaftCmdResponse, ApplyResult)> {
-        fail_point!("on_apply_write_cmd", self.id() == 3, |_| {
-            unimplemented!();
-        });
+        fail_point!(
+            "on_apply_write_cmd",
+            cfg!(not(test)) || self.id() == 3,
+            |_| {
+                unimplemented!();
+            }
+        );
 
         let requests = req.get_requests();
         let mut responses = Vec::with_capacity(requests.len());


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Make make `on_apply_write_cmd` failpoint injectable through http service.

Don't assume reviewers understand the original issue.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
- Manual test (add detailed scripts or steps below)

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.
