### PR TITLE
copr: Add vectorized BitOrSig

### DIFF
--- a/components/tidb_query/src/rpn_expr/impl_op.rs
+++ b/components/tidb_query/src/rpn_expr/impl_op.rs
@@ -72,6 +72,15 @@ pub fn bit_and(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
+pub fn bit_or(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
+    Ok(match (lhs, rhs) {
+        (Some(lhs), Some(rhs)) => Some(lhs | rhs),
+        _ => None,
+    })
+}
+
+#[rpn_fn]
+#[inline]
 pub fn bit_neg(arg: &Option<Int>) -> Result<Option<Int>> {
     Ok(arg.map(|arg| !arg))
 }
@@ -305,6 +314,25 @@ mod tests {
                 .push_param(lhs)
                 .push_param(rhs)
                 .evaluate(ScalarFuncSig::BitAndSig)
+                .unwrap();
+            assert_eq!(output, expected);
+        }
+    }
+
+    #[test]
+    fn test_bit_or() {
+        let cases = vec![
+            (Some(123), Some(321), Some(379)),
+            (Some(-123), Some(321), Some(-59)),
+            (None, Some(1), None),
+            (Some(1), None, None),
+            (None, None, None),
+        ];
+        for (lhs, rhs, expected) in cases {
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(lhs)
+                .push_param(rhs)
+                .evaluate(ScalarFuncSig::BitOrSig)
                 .unwrap();
             assert_eq!(output, expected);
         }

--- a/components/tidb_query/src/rpn_expr/mod.rs
+++ b/components/tidb_query/src/rpn_expr/mod.rs
@@ -183,6 +183,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::UnaryNotReal => unary_not_real_fn_meta(),
         ScalarFuncSig::UnaryNotDecimal => unary_not_decimal_fn_meta(),
         ScalarFuncSig::BitAndSig => bit_and_fn_meta(),
+        ScalarFuncSig::BitOrSig => bit_or_fn_meta(),
         ScalarFuncSig::BitNegSig => bit_neg_fn_meta(),
         ScalarFuncSig::PlusInt => map_int_sig(value, children, plus_mapper)?,
         ScalarFuncSig::PlusReal => arithmetic_fn_meta::<RealPlus>(),


### PR DESCRIPTION
PCP #5751
### What have you changed?

Add vectorized BitOrSig
### What is the type of the changes?

Improvement. Non-vectorized BitOrSig already exists. Just add a vectorized version for better performance.
### How is the PR tested?

Unit tested. Will run copr test later.
### Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No. It should not change the behavior.
### Does this PR affect tidb-ansible?

No.
