### PR TITLE
engine_rocks: Add extension method for creating RocksEngine references

### DIFF
--- a/components/engine_rocks/src/compat.rs
+++ b/components/engine_rocks/src/compat.rs
@@ -1,0 +1,21 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use crate::engine::RocksEngine;
+use engine::DB;
+use std::sync::Arc;
+
+/// A trait to enter the world of engine traits from a raw `Arc<DB>`
+/// with as little syntax as possible.
+///
+/// This will be used during the transition from RocksDB to the
+/// `KvEngine` abstraction and then discarded.
+pub trait EngineCompat {
+    fn c(&self) -> &RocksEngine;
+}
+
+impl EngineCompat for Arc<DB> {
+    #[inline]
+    fn c(&self) -> &RocksEngine {
+        RocksEngine::from_ref(self)
+    }
+}

--- a/components/engine_rocks/src/lib.rs
+++ b/components/engine_rocks/src/lib.rs
@@ -41,3 +41,6 @@ pub use crate::engine_iterator::*;
 
 mod options;
 pub mod util;
+
+mod compat;
+pub use compat::*;

--- a/components/engine_traits/src/lib.rs
+++ b/components/engine_traits/src/lib.rs
@@ -49,6 +49,9 @@
 //! - Port methods directly from the existing `engine` crate by re-implementing
 //!   it in engine_traits and engine_rocks, replacing all the callers with calls
 //!   into the traits, then delete the versions in the `engine` crate.
+//!
+//! - Use the .c() method from engine_rocks::compat::EngineCompat to get a
+//!   KvEngine reference from Arc<DB> in the fewest characters.
 
 #![recursion_limit = "200"]
 


### PR DESCRIPTION
###  What have you changed?

This adds an extension trait, `EngineCompat`, to `engine_rocks`, that contains a single method, `c`, for creating a `&RocksEngine` type from `&Arc<DB>`.

The intent here is to create a conversion from the world of the concrete RocksDB engine to the world of the abstract `KvEngine` with as little syntactic noise as possible. Presently, this conversion is written as `RocksEngine::from_ref`, and the more the work of abstraction progresses, the more syntactic noise I see it imposing on the tikv codebase. With this change, there will just be a 4-character inline expression added anywhere the conversion happens.

This is a temporary tool, and once tikv is fully converted to use engine traits it will go away.

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?

cargo check

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

no

###  Does this PR affect `tidb-ansible`?


###  Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/issues/4184

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

