### PR TITLE
copr: Add vectorized BitNegSig

### DIFF
--- a/components/tidb_query/src/rpn_expr/impl_op.rs
+++ b/components/tidb_query/src/rpn_expr/impl_op.rs
@@ -63,6 +63,12 @@ pub fn is_null<T: Evaluable>(arg: &Option<T>) -> Result<Option<i64>> {
 
 #[rpn_fn]
 #[inline]
+pub fn bit_neg(arg: &Option<Int>) -> Result<Option<Int>> {
+    Ok(arg.map(|arg| !arg))
+}
+
+#[rpn_fn]
+#[inline]
 pub fn int_is_true(arg: &Option<Int>) -> Result<Option<i64>> {
     Ok(Some(arg.map_or(0, |v| (v != 0) as i64)))
 }
@@ -273,6 +279,23 @@ mod tests {
                 .evaluate(sig)
                 .unwrap();
             assert_eq!(output, expect_output, "{:?}, {:?}", arg, sig);
+        }
+    }
+
+    #[test]
+    fn test_bit_neg() {
+        let cases = vec![
+            (Some(123), Some(-124)),
+            (Some(-123), Some(122)),
+            (Some(0), Some(-1)),
+            (None, None),
+        ];
+        for (arg, expected) in cases {
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(arg)
+                .evaluate(ScalarFuncSig::BitNegSig)
+                .unwrap();
+            assert_eq!(output, expected);
         }
     }
 

--- a/components/tidb_query/src/rpn_expr/mod.rs
+++ b/components/tidb_query/src/rpn_expr/mod.rs
@@ -182,6 +182,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::UnaryNotInt => unary_not_int_fn_meta(),
         ScalarFuncSig::UnaryNotReal => unary_not_real_fn_meta(),
         ScalarFuncSig::UnaryNotDecimal => unary_not_decimal_fn_meta(),
+        ScalarFuncSig::BitNegSig => bit_neg_fn_meta(),
         ScalarFuncSig::PlusInt => map_int_sig(value, children, plus_mapper)?,
         ScalarFuncSig::PlusReal => arithmetic_fn_meta::<RealPlus>(),
         ScalarFuncSig::PlusDecimal => arithmetic_fn_meta::<DecimalPlus>(),


### PR DESCRIPTION
PCP #5751

### What have you changed?

Add vectorized BitNegSig

### What is the type of the changes?

Improvement. Non-vectorized BitNegSig already exists. Just add a vectorized version for better performance.

### How is the PR tested?

Unit tested. Will run copr test later.

### Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No. It should not change the behavior.

### Does this PR affect tidb-ansible?

No.
