### PR TITLE
benches/coprocessor_executors: update libpapi_sys to build with -fPIC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "libpapi_sys"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3f846784b520347048f40a690435de31ae27b64fd413a096834124e9de356c"
+checksum = "9c687368f5a574f3aaf97cad438fb572a87aa224051e1cd01ad926b1d592886b"
 dependencies = [
  "bindgen",
  "num_cpus",


### PR DESCRIPTION
###  What have you changed?

- Upgrade `libpapi_sys`
- Then newest version of `libpapi_sys` fix build time bugs by add `-fPIC` flag into CFLAGS env

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix

###  How is the PR tested?

- Manual test (by @breeswish )

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No
