### PR TITLE
PCP: reduce size of tikv::storage::errors::Error

### DIFF
--- a/components/backup/src/errors.rs
+++ b/components/backup/src/errors.rs
@@ -58,7 +58,7 @@ impl Into<ErrorPb> for Error {
                         .inc();
                 }
 
-                err.set_region_error(e);
+                err.set_region_error(*e);
             }
             Error::Txn(TxnError::Mvcc(MvccError::KeyIsLocked(info))) => {
                 BACKUP_RANGE_ERROR_VEC

--- a/src/coprocessor/error.rs
+++ b/src/coprocessor/error.rs
@@ -62,7 +62,7 @@ impl From<tidb_query::Error> for Error {
 impl From<storage::kv::Error> for Error {
     fn from(err: storage::kv::Error) -> Self {
         match err {
-            storage::kv::Error::Request(e) => Error::Region(e),
+            storage::kv::Error::Request(e) => Error::Region(*e),
             e => Error::Other(e.to_string()),
         }
     }

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -88,7 +88,7 @@ pub type Result<T> = result::Result<T, Error>;
 impl From<Error> for kv::Error {
     fn from(e: Error) -> kv::Error {
         match e {
-            Error::RequestFailed(e) => kv::Error::Request(e),
+            Error::RequestFailed(e) => kv::Error::Request(Box::new(e)),
             Error::Server(e) => e.into(),
             e => box_err!(e),
         }
@@ -97,7 +97,7 @@ impl From<Error> for kv::Error {
 
 impl From<RaftServerError> for kv::Error {
     fn from(e: RaftServerError) -> kv::Error {
-        kv::Error::Request(e.into())
+        kv::Error::Request(Box::new(e.into()))
     }
 }
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -2628,7 +2628,7 @@ fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
         Err(Error::Engine(EngineError::Request(ref e)))
         | Err(Error::Txn(TxnError::Engine(EngineError::Request(ref e))))
         | Err(Error::Txn(TxnError::Mvcc(MvccError::Engine(EngineError::Request(ref e))))) => {
-            Some(e.to_owned())
+            Some((**e).to_owned())
         }
         Err(Error::SchedTooBusy) => {
             let mut err = RegionError::default();

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -157,7 +157,7 @@ pub enum ScanMode {
 quick_error! {
     #[derive(Debug)]
     pub enum Error {
-        Request(err: ErrorHeader) {
+        Request(err: Box<ErrorHeader>) {
             from()
             description("request to underhook engine failed")
             display("{:?}", err)
@@ -181,7 +181,7 @@ quick_error! {
 
 impl From<engine::Error> for Error {
     fn from(err: engine::Error) -> Error {
-        Error::Request(err.into())
+        Error::Request(Box::new(err.into()))
     }
 }
 

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -283,7 +283,7 @@ impl Engine for RocksEngine {
             Err(Error::Request(not_leader))
         });
         if self.not_leader.load(Ordering::SeqCst) {
-            return Err(Error::Request(_not_leader));
+            return Err(Error::Request(Box::new(_not_leader)));
         }
         box_try!(self.sched.schedule(Task::Snapshot(cb)));
         Ok(())

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -280,7 +280,7 @@ impl Engine for RocksEngine {
         };
         let _not_leader = not_leader.clone();
         fail_point!("rockskv_async_snapshot_not_leader", |_| {
-            Err(Error::Request(not_leader))
+            Err(Error::Request(Box::new(not_leader)))
         });
         if self.not_leader.load(Ordering::SeqCst) {
             return Err(Error::Request(Box::new(_not_leader)));

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -18,6 +18,18 @@ use tikv::storage::txn::RESOLVE_LOCK_BATCH_SIZE;
 use tikv::storage::{Engine, Key, Mutation};
 
 #[test]
+fn limit_enum_should_not_be_too_large() {
+    let storage_error_size = std::mem::size_of::<tikv::storage::errors::Error>();
+    let txn_error_size = std::mem::size_of::<tikv::storage::txn::Error>();
+    let mvcc_error_size = std::mem::size_of::<tikv::storage::mvcc::Error>();
+    let kv_error_size = std::mem::size_of::<tikv::storage::kv::Error>();
+    assert!(storage_error_size <= 120);
+    assert!(txn_error_size <= 112);
+    assert!(mvcc_error_size <= 104);
+    assert!(kv_error_size <= 24);
+}
+
+#[test]
 fn test_txn_store_get() {
     let store = AssertionStorage::default();
     // not exist


### PR DESCRIPTION
Signed-off-by: Renkai <gaelookair@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This is an attempt to solve https://github.com/tikv/tikv/issues/5700 .
Since I am new to both Rust and TiKV, it might not be the final solution, I hope I can get some comment from reviewers to continue.

`std::mem::size_of::<tikv::storage::errors::Error>()` is now `120`, quite smaller than 200.

###  What is the type of the changes?
- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No 

###  Does this PR affect `tidb-ansible`?
No 
###  Refer to a related PR or issue link (optional)
https://github.com/tikv/tikv/issues/5700
###  Benchmark result if necessary (optional)

###  Any examples? (optional)

