### PR TITLE
1 apply thread and 1 raftstore thread is better in 8c machine

### DIFF
--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 use std::u64;
 use time::Duration as TimeDuration;
 
+use sys_info;
+
 use crate::raftstore::{coprocessor, Result};
 use tikv_util::config::{ReadableDuration, ReadableSize};
 
@@ -133,6 +135,8 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Config {
+        let cpu_num = sys_info::cpu_num().unwrap();
+        let (apply_pool_size, store_pool_size) = if cpu_num <= 8 { (1, 1) } else { (2, 2) };
         let split_size = ReadableSize::mb(coprocessor::config::SPLIT_SIZE_MB);
         Config {
             sync_log: true,
@@ -188,9 +192,9 @@ impl Default for Config {
             cleanup_import_sst_interval: ReadableDuration::minutes(10),
             local_read_batch_size: 1024,
             apply_max_batch_size: 1024,
-            apply_pool_size: 2,
+            apply_pool_size,
             store_max_batch_size: 1024,
-            store_pool_size: 2,
+            store_pool_size,
             future_poll_size: 1,
             hibernate_regions: true,
 


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Tune apply/rafstore threads in 8C machine.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

