### PR TITLE
support rpn_fn metadata in RpnFnScalarEvaluator

### DIFF
--- a/components/tidb_query/src/rpn_expr/types/expr_builder.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_builder.rs
@@ -1,5 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::any::Any;
 use std::convert::{TryFrom, TryInto};
 
 use codec::prelude::NumberDecoder;

--- a/components/tidb_query/src/rpn_expr/types/expr_builder.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_builder.rs
@@ -1,6 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::any::Any;
 use std::convert::{TryFrom, TryInto};
 
 use codec::prelude::NumberDecoder;
@@ -142,7 +141,7 @@ impl RpnExpressionBuilder {
         func_meta: RpnFnMeta,
         args_len: usize,
         return_field_type: impl Into<FieldType>,
-        metadata: Box<dyn Any + Send>,
+        metadata: Box<dyn std::any::Any + Send>,
     ) -> Self {
         let node = RpnExpressionNode::FnCall {
             func_meta,

--- a/components/tidb_query/src/rpn_expr/types/expr_builder.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_builder.rs
@@ -136,6 +136,25 @@ impl RpnExpressionBuilder {
     }
 
     #[cfg(test)]
+    pub fn push_fn_call_with_metadata(
+        mut self,
+        func_meta: RpnFnMeta,
+        args_len: usize,
+        return_field_type: impl Into<FieldType>,
+        metadata: Box<dyn Any + Send>,
+    ) -> Self {
+        let node = RpnExpressionNode::FnCall {
+            func_meta,
+            args_len,
+            field_type: return_field_type.into(),
+            implicit_args: vec![],
+            metadata,
+        };
+        self.0.push(node);
+        self
+    }
+
+    #[cfg(test)]
     pub fn push_fn_call_with_implicit_args(
         mut self,
         func_meta: RpnFnMeta,

--- a/components/tidb_query/src/rpn_expr/types/test_util.rs
+++ b/components/tidb_query/src/rpn_expr/types/test_util.rs
@@ -113,9 +113,10 @@ impl RpnFnScalarEvaluator {
             return (Err(e), context);
         }
 
+        let metadata = (func.metadata_ctor_ptr)(&mut fun_sig_expr);
         let expr = self
             .rpn_expr_builder
-            .push_fn_call(func, children_ed.len(), ret_field_type)
+            .push_fn_call_with_metadata(func, children_ed.len(), ret_field_type, metadata)
             .build();
 
         let mut columns = LazyBatchColumnVec::empty();


### PR DESCRIPTION
###  What have you changed?

Many unit tests in tidb_query use `RpnFnScalarEvaluator` to test rpn functions. Previously, we forgot to generate metadata in `RpnFnScalarEvaluator`, making tests for rpn functions with metadata fail.

This PR makes `RpnFnScalarEvaluator` support metadata.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Manual test (add detailed scripts or steps below)

`RpnFnScalarEvaluator` is tightly coupled with real signatures so it'll be a big change to do unit tests for it. Luckily, this fix should be easily validated by testing rpn functions with metadata later. A manual test with code below can pass:

```rust
fn compare_in_hash_data<T: Evaluable + Hash + Eq>(_expr: &mut tipb::Expr) -> HashSet<T> {
    HashSet::default()
}

#[rpn_fn(varg, min_args = 1, capture = [metadata], metadata_ctor = compare_in_hash_data::<T>)]
pub fn compare_in_hash<T: Evaluable + Hash + Eq>(metadata: &HashSet<T>, args: &[&Option<T>])  -> Result<Option<Int>> {
    println!("HashSet length = {}", metadata.len());
    Ok(Some(0))
}
```

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

