### PR TITLE
Build: fix build on Mac OS by cfg'ing away pprof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3be2946c3916a4c6be1392eebb6c1e195726b0d2633dd7b8ecf234ffd50f3a"
+checksum = "880c9746895893d66a6b0ecf49d46271e3a0f6763ebbb910cb0dd7c2097a61f3"
 dependencies = [
  "chashmap",
  "crossbeam",
@@ -1274,7 +1274,7 @@ dependencies = [
  "quick-xml",
  "rgb",
  "str_stack",
- "structopt 0.3.3",
+ "structopt 0.3.4",
 ]
 
 [[package]]
@@ -1401,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.62"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
+checksum = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3018,12 +3018,12 @@ dependencies = [
 
 [[package]]
 name = "structopt"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d4f66a4c0ddf7aee4677995697366de0749b0139057342eccbb609b12d0affc"
+checksum = "c167b61c7d4c126927f5346a4327ce20abf8a186b8041bbeb1ce49e5db49587b"
 dependencies = [
  "clap",
- "structopt-derive 0.3.3",
+ "structopt-derive 0.3.4",
 ]
 
 [[package]]
@@ -3040,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe0c13e476b4e21ff7f5c4ace3818b6d7bdc16897c31c73862471bc1663acae"
+checksum = "519621841414165d2ad0d4c92be8f41844203f2b67e245f9345a5a12d40c69d7"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,6 @@ vlog = "0.1.4"
 mime = "0.3.13"
 farmhash = "1.1.5"
 failure = "0.1"
-pprof = { version = "0.3", features = ["flamegraph", "protobuf"] }
 prost = "0.5.0"
 regex = "1.3"
 tipb = { git = "https://github.com/pingcap/tipb.git" }
@@ -172,6 +171,7 @@ signal = "0.6"
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs" }
 criterion-papi = "0.1"
+pprof = { version = "0.3", features = ["flamegraph", "protobuf"] }
 
 [workspace]
 members = [


### PR DESCRIPTION
Closes #5932

###  What have you changed?

It seems that the build is broken because pprof is a Linux-only crate (because it depends on a function in libc which is not portable). In this PR I make pprof a Linux-only dep and cfg away any usage.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

it builds

PTAL @siddontang @BusyJay 