### PR TITLE
Makefile: a new rule for CI test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ test:
 	fi
 	bash scripts/check-bins-for-jemalloc.sh
 
-# Only use in CI
+# This is used for CI test
 ci_test:
 	cargo test --no-default-features --features "${ENABLE_FEATURES}" --all --all-targets --no-run --message-format=json
 	bash scripts/check-bins-for-jemalloc.sh

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,9 @@ test:
 	fi
 	bash scripts/check-bins-for-jemalloc.sh
 
+# Only use in CI
+ci_test:
+	cargo test --no-default-features --features "${ENABLE_FEATURES}" --all --all-targets --no-run --message-format=json
 
 ## Static analysis
 ## ---------------

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ test:
 # Only use in CI
 ci_test:
 	cargo test --no-default-features --features "${ENABLE_FEATURES}" --all --all-targets --no-run --message-format=json
+	bash scripts/check-bins-for-jemalloc.sh
 
 ## Static analysis
 ## ---------------


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Speed up CI's test through ignore other irrelevant cargo test scripts.

###  What is the type of the changes?

- Misc (other changes)

###  How is the PR tested?

- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

- No

###  Does this PR affect `tidb-ansible`?

- No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

