### PR TITLE
PCP: reduce size of tikv::storage::errors::Error

### DIFF
--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -374,8 +374,9 @@ impl<E: Engine> AssertionStorage<E> {
         let locks: Vec<(&[u8], &[u8], u64)> = res
             .iter()
             .filter_map(|x| {
-                if let Err(storage::Error::Txn(box txn::Error::Mvcc(mvcc::Error::KeyIsLocked(info)))) =
-                    x
+                if let Err(storage::Error::Txn(box txn::Error::Mvcc(mvcc::Error::KeyIsLocked(
+                    info,
+                )))) = x
                 {
                     Some((
                         info.get_key(),

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -217,7 +217,7 @@ impl<E: Engine> AssertionStorage<E> {
                 ref e,
             ))))
             | storage::Error::Txn(box txn::Error::Engine(kv::Error::Request(ref e)))
-            | storage::Error::Engine(kv::Error::Request(ref e)) => {
+            | storage::Error::Engine(box kv::Error::Request(ref e)) => {
                 assert!(
                     e.has_not_leader() | e.has_stale_command(),
                     "invalid error {:?}",

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -213,10 +213,10 @@ impl<E: Engine> AssertionStorage<E> {
 
     fn expect_not_leader_or_stale_command(&self, err: storage::Error) {
         match err {
-            storage::Error::Txn(txn::Error::Mvcc(mvcc::Error::Engine(kv::Error::Request(
+            storage::Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(kv::Error::Request(
                 ref e,
             ))))
-            | storage::Error::Txn(txn::Error::Engine(kv::Error::Request(ref e)))
+            | storage::Error::Txn(box txn::Error::Engine(kv::Error::Request(ref e)))
             | storage::Error::Engine(kv::Error::Request(ref e)) => {
                 assert!(
                     e.has_not_leader() | e.has_stale_command(),
@@ -237,7 +237,7 @@ impl<E: Engine> AssertionStorage<E> {
         assert!(resp.is_err());
         let err = resp.unwrap_err();
         match err {
-            storage::Error::Txn(txn::Error::InvalidTxnTso {
+            storage::Error::Txn(box txn::Error::InvalidTxnTso {
                 start_ts,
                 commit_ts,
             }) => {
@@ -374,7 +374,7 @@ impl<E: Engine> AssertionStorage<E> {
         let locks: Vec<(&[u8], &[u8], u64)> = res
             .iter()
             .filter_map(|x| {
-                if let Err(storage::Error::Txn(txn::Error::Mvcc(mvcc::Error::KeyIsLocked(info)))) =
+                if let Err(storage::Error::Txn(box txn::Error::Mvcc(mvcc::Error::KeyIsLocked(info)))) =
                     x
                 {
                     Some((
@@ -409,7 +409,7 @@ impl<E: Engine> AssertionStorage<E> {
             .unwrap_err();
 
         match err {
-            storage::Error::Txn(txn::Error::Mvcc(mvcc::Error::WriteConflict {
+            storage::Error::Txn(box txn::Error::Mvcc(mvcc::Error::WriteConflict {
                 start_ts,
                 conflict_start_ts,
                 ref key,

--- a/components/test_storage/src/lib.rs
+++ b/components/test_storage/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
+#![feature(box_patterns)]
 
 #[macro_use]
 extern crate tikv_util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 #![feature(specialization)]
 #![feature(const_fn)]
 #![feature(mem_take)]
+#![feature(box_patterns)]
 
 #[macro_use]
 extern crate bitflags;

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -396,7 +396,7 @@ fn extract_raw_key_from_process_result(pr: &ProcessResult) -> &[u8] {
         ProcessResult::MultiRes { results } => {
             assert!(results.len() == 1);
             match &results[0] {
-                Err(StorageError::Txn(TxnError::Mvcc(MvccError::KeyIsLocked(info)))) => {
+                Err(StorageError::Txn(box TxnError::Mvcc(MvccError::KeyIsLocked(info)))) => {
                     info.get_key()
                 }
                 _ => panic!("unexpected mvcc error"),

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -2629,7 +2629,7 @@ fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
     use crate::storage::Error;
     match *res {
         // TODO: use `Error::cause` instead.
-        Err(Error::Engine(EngineError::Request(ref e)))
+        Err(Error::Engine(box EngineError::Request(ref e)))
         | Err(Error::Txn(box TxnError::Engine(EngineError::Request(ref e))))
         | Err(Error::Txn(box TxnError::Mvcc(MvccError::Engine(EngineError::Request(ref e))))) => {
             Some(e.to_owned())

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -2661,7 +2661,9 @@ fn extract_region_error<T>(res: &storage::Result<T>) -> Option<RegionError> {
 
 fn extract_committed(err: &storage::Error) -> Option<u64> {
     match *err {
-        storage::Error::Txn(box TxnError::Mvcc(MvccError::Committed { commit_ts })) => Some(commit_ts),
+        storage::Error::Txn(box TxnError::Mvcc(MvccError::Committed { commit_ts })) => {
+            Some(commit_ts)
+        }
         _ => None,
     }
 }

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -53,7 +53,7 @@ quick_error! {
             description("max key size exceeded")
             display("max key size exceeded, size: {}, limit: {}", size, limit)
         }
-        InvalidCf (cf_name: String) {
+        InvalidCf (cf_name: Box<String>) {
             description("invalid cf name")
             display("invalid cf name: {}", cf_name)
         }

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -11,8 +11,9 @@ use crate::storage::{kv::Error as EngineError, mvcc, txn};
 quick_error! {
     #[derive(Debug)]
     pub enum Error {
-        Engine(err: EngineError) {
+        Engine(err: Box<EngineError>) {
             from()
+            from(err: EngineError) -> (Box::new(err))
             cause(err)
             description(err.description())
         }

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -16,13 +16,15 @@ quick_error! {
             cause(err)
             description(err.description())
         }
-        Txn(err: txn::Error) {
+        Txn(err: Box<txn::Error>) {
             from()
+            from(err: txn::Error) -> (Box::new(err))
             cause(err)
             description(err.description())
         }
-        Mvcc(err: mvcc::Error) {
+        Mvcc(err: Box<mvcc::Error>) {
             from()
+            from(err: mvcc::Error) -> (Box::new(err))
             cause(err)
             description(err.description())
         }
@@ -34,8 +36,9 @@ quick_error! {
             cause(err.as_ref())
             description(err.description())
         }
-        Io(err: IoError) {
+        Io(err: Box<IoError>) {
             from()
+            from(err: IoError) -> (Box::new(err))
             cause(err)
             description(err.description())
         }

--- a/src/storage/lock_manager/mod.rs
+++ b/src/storage/lock_manager/mod.rs
@@ -77,7 +77,7 @@ impl LockMgr for DummyLockMgr {
 
 pub fn extract_lock_from_result(res: &Result<(), StorageError>) -> Lock {
     match res {
-        Err(StorageError::Txn(TxnError::Mvcc(MvccError::KeyIsLocked(info)))) => Lock {
+        Err(StorageError::Txn(box TxnError::Mvcc(MvccError::KeyIsLocked(info)))) => Lock {
             ts: info.get_lock_version(),
             hash: gen_key_hash(&Key::from_raw(info.get_key())),
         },

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1631,7 +1631,6 @@ mod tests {
         expect_error(
             |e| match e {
                 Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
-                    ()
                 }
                 e => panic!("unexpected error chain: {:?}", e),
             },
@@ -1642,7 +1641,6 @@ mod tests {
         expect_error(
             |e| match e {
                 Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
-                    ()
                 }
                 e => panic!("unexpected error chain: {:?}", e),
             },
@@ -1660,7 +1658,6 @@ mod tests {
         expect_error(
             |e| match e {
                 Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
-                    ()
                 }
                 e => panic!("unexpected error chain: {:?}", e),
             },

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1572,7 +1572,7 @@ mod tests {
         rx.recv().unwrap();
         expect_error(
             |e| match e {
-                Error::Txn(txn::Error::Mvcc(mvcc::Error::KeyIsLocked { .. })) => (),
+                Error::Txn(box txn::Error::Mvcc(mvcc::Error::KeyIsLocked { .. })) => (),
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage
@@ -1620,7 +1620,7 @@ mod tests {
                 1,
                 Options::default(),
                 expect_fail_callback(tx.clone(), 0, |e| match e {
-                    Error::Txn(txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
+                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
                     }
                     e => panic!("unexpected error chain: {:?}", e),
                 }),
@@ -1629,7 +1629,7 @@ mod tests {
         rx.recv().unwrap();
         expect_error(
             |e| match e {
-                Error::Txn(txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => (),
+                Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => (),
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage
@@ -1638,7 +1638,7 @@ mod tests {
         );
         expect_error(
             |e| match e {
-                Error::Txn(txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => (),
+                Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => (),
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage
@@ -1654,7 +1654,7 @@ mod tests {
         );
         expect_error(
             |e| match e {
-                Error::Txn(txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => (),
+                Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => (),
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage
@@ -1675,7 +1675,7 @@ mod tests {
         for v in x {
             expect_error(
                 |e| match e {
-                    Error::Txn(txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
+                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
                     }
                     e => panic!("unexpected error chain: {:?}", e),
                 },
@@ -2001,7 +2001,7 @@ mod tests {
             .unwrap();
         expect_error(
             |e| match e {
-                Error::Txn(txn::Error::Mvcc(mvcc::Error::KeyIsLocked(..))) => (),
+                Error::Txn(box txn::Error::Mvcc(mvcc::Error::KeyIsLocked(..))) => (),
                 e => panic!("unexpected error chain: {:?}", e),
             },
             x.remove(0),
@@ -2110,7 +2110,7 @@ mod tests {
                 105,
                 Options::default(),
                 expect_fail_callback(tx.clone(), 6, |e| match e {
-                    Error::Txn(txn::Error::Mvcc(mvcc::Error::WriteConflict { .. })) => (),
+                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::WriteConflict { .. })) => (),
                     e => panic!("unexpected error chain: {:?}", e),
                 }),
             )
@@ -2221,7 +2221,7 @@ mod tests {
                 ts(110, 0),
                 ts(120, 0),
                 expect_fail_callback(tx.clone(), 0, |e| match e {
-                    Error::Txn(txn::Error::Mvcc(mvcc::Error::KeyIsLocked(info))) => {
+                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::KeyIsLocked(info))) => {
                         assert_eq!(info.get_lock_ttl(), 100)
                     }
                     e => panic!("unexpected error chain: {:?}", e),
@@ -3873,7 +3873,7 @@ mod tests {
                 10,
                 100,
                 expect_fail_callback(tx.clone(), 0, |e| match e {
-                    Error::Txn(txn::Error::Mvcc(mvcc::Error::TxnLockNotFound { .. })) => (),
+                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::TxnLockNotFound { .. })) => (),
                     e => panic!("unexpected error chain: {:?}", e),
                 }),
             )
@@ -3927,7 +3927,7 @@ mod tests {
                 11,
                 150,
                 expect_fail_callback(tx.clone(), 0, |e| match e {
-                    Error::Txn(txn::Error::Mvcc(mvcc::Error::TxnLockNotFound { .. })) => (),
+                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::TxnLockNotFound { .. })) => (),
                     e => panic!("unexpected error chain: {:?}", e),
                 }),
             )
@@ -3958,7 +3958,7 @@ mod tests {
                 ts(9, 1),
                 false,
                 expect_fail_callback(tx.clone(), 0, |e| match e {
-                    Error::Txn(txn::Error::Mvcc(mvcc::Error::TxnNotFound { .. })) => (),
+                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::TxnNotFound { .. })) => (),
                     e => panic!("unexpected error chain: {:?}", e),
                 }),
             )
@@ -3989,7 +3989,7 @@ mod tests {
                 ts(9, 0),
                 Options::default(),
                 expect_fail_callback(tx.clone(), 0, |e| match e {
-                    Error::Txn(txn::Error::Mvcc(mvcc::Error::WriteConflict { .. })) => (),
+                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::WriteConflict { .. })) => (),
                     e => panic!("unexpected error chain: {:?}", e),
                 }),
             )
@@ -4084,7 +4084,7 @@ mod tests {
                 ts(25, 0),
                 ts(28, 0),
                 expect_fail_callback(tx.clone(), 0, |e| match e {
-                    Error::Txn(txn::Error::Mvcc(mvcc::Error::TxnLockNotFound { .. })) => (),
+                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::TxnLockNotFound { .. })) => (),
                     e => panic!("unexpected error chain: {:?}", e),
                 }),
             )

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1287,7 +1287,7 @@ impl<E: Engine, L: LockMgr> Storage<E, L> {
                 return Ok(c);
             }
         }
-        Err(Error::InvalidCf(cf.to_owned()))
+        Err(Error::InvalidCf(Box::new(cf.to_owned())))
     }
 
     /// Check if key range is valid

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1620,8 +1620,9 @@ mod tests {
                 1,
                 Options::default(),
                 expect_fail_callback(tx.clone(), 0, |e| match e {
-                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
-                    }
+                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(
+                        EngineError::Request(..),
+                    ))) => {}
                     e => panic!("unexpected error chain: {:?}", e),
                 }),
             )
@@ -1629,7 +1630,9 @@ mod tests {
         rx.recv().unwrap();
         expect_error(
             |e| match e {
-                Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => (),
+                Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
+                    ()
+                }
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage
@@ -1638,7 +1641,9 @@ mod tests {
         );
         expect_error(
             |e| match e {
-                Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => (),
+                Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
+                    ()
+                }
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage
@@ -1654,7 +1659,9 @@ mod tests {
         );
         expect_error(
             |e| match e {
-                Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => (),
+                Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
+                    ()
+                }
                 e => panic!("unexpected error chain: {:?}", e),
             },
             storage
@@ -1675,8 +1682,9 @@ mod tests {
         for v in x {
             expect_error(
                 |e| match e {
-                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(EngineError::Request(..)))) => {
-                    }
+                    Error::Txn(box txn::Error::Mvcc(mvcc::Error::Engine(
+                        EngineError::Request(..),
+                    ))) => {}
                     e => panic!("unexpected error chain: {:?}", e),
                 },
                 v,

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -54,8 +54,8 @@ fn test_scheduler_leader_change_twice() {
     fail::remove(snapshot_fp);
 
     match prewrite_rx.recv_timeout(Duration::from_secs(5)).unwrap() {
-        Err(storage::Error::Txn(txn::Error::Engine(kv::Error::Request(ref e))))
-        | Err(storage::Error::Engine(kv::Error::Request(ref e))) => {
+        Err(storage::Error::Txn(box txn::Error::Engine(kv::Error::Request(ref e))))
+        | Err(storage::Error::Engine(box kv::Error::Request(ref e))) => {
             assert!(e.has_stale_command(), "{:?}", e);
         }
         res => {

--- a/tests/failpoints/mod.rs
+++ b/tests/failpoints/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
-
+#![feature(box_patterns)]
 #![recursion_limit = "100"]
 
 #[macro_use]

--- a/tests/integrations/mod.rs
+++ b/tests/integrations/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(test)]
+#![feature(box_patterns)]
 
 extern crate test;
 

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -1,5 +1,4 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
-
 use std::thread;
 use std::time::Duration;
 
@@ -103,7 +102,7 @@ fn test_raft_storage_rollback_before_prewrite() {
     assert!(ret.is_err());
     let err = ret.unwrap_err();
     match err {
-        storage::Error::Txn(txn::Error::Mvcc(mvcc::Error::WriteConflict { .. })) => {}
+        storage::Error::Txn(box txn::Error::Mvcc(mvcc::Error::WriteConflict { .. })) => {}
         _ => {
             panic!("expect WriteConflict error, but got {:?}", err);
         }
@@ -140,7 +139,7 @@ fn test_raft_storage_store_not_match() {
     ctx.set_peer(peer);
     assert!(storage.get(ctx.clone(), &key, 20).is_err());
     let res = storage.get(ctx.clone(), &key, 20);
-    if let storage::Error::Txn(txn::Error::Engine(kv::Error::Request(ref e))) =
+    if let storage::Error::Txn(box txn::Error::Engine(kv::Error::Request(ref e))) =
         *res.as_ref().err().unwrap()
     {
         assert!(e.has_store_not_match());


### PR DESCRIPTION
Signed-off-by: Renkai <gaelookair@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This is an attempt to solve https://github.com/tikv/tikv/issues/5700 .
Since I am new to both Rust and TiKV, it might not be the final solution, I hope I can get some comment from reviewers to continue.

`std::mem::size_of::<tikv::storage::errors::Error>()` is now `24`, quite smaller than 200.

###  What is the type of the changes?
- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No 

###  Does this PR affect `tidb-ansible`?
No 
###  Refer to a related PR or issue link (optional)
https://github.com/tikv/tikv/issues/5700
###  Benchmark result if necessary (optional)

###  Any examples? (optional)

