### PR TITLE
copr: set Expr.tp in RpnFnScalarEvaluator

### DIFF
--- a/components/tidb_query/src/rpn_expr/types/expr.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr.rs
@@ -41,7 +41,10 @@ impl RpnExpressionNode {
     }
 
     #[cfg(test)]
-    pub fn expr_tp(&self) -> ExprType {
+    pub fn expr_tp(&self) -> tipb::ExprType {
+        use tidb_query_datatype::EvalType;
+        use tipb::ExprType;
+
         match self {
             RpnExpressionNode::FnCall { .. } => ExprType::ScalarFunc,
             RpnExpressionNode::Constant { value, .. } => match value.eval_type() {

--- a/components/tidb_query/src/rpn_expr/types/expr.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr.rs
@@ -40,6 +40,23 @@ impl RpnExpressionNode {
         }
     }
 
+    #[cfg(test)]
+    pub fn expr_tp(&self) -> ExprType {
+        match self {
+            RpnExpressionNode::FnCall { .. } => ExprType::ScalarFunc,
+            RpnExpressionNode::Constant { value, .. } => match value.eval_type() {
+                EvalType::Bytes => ExprType::Bytes,
+                EvalType::DateTime => ExprType::MysqlTime,
+                EvalType::Decimal => ExprType::MysqlDecimal,
+                EvalType::Duration => ExprType::MysqlDuration,
+                EvalType::Int => ExprType::Int64,
+                EvalType::Json => ExprType::MysqlJson,
+                EvalType::Real => ExprType::Float64,
+            },
+            RpnExpressionNode::ColumnRef { .. } => ExprType::ColumnRef,
+        }
+    }
+
     /// Borrows the function instance for `FnCall` variant.
     #[cfg(test)]
     pub fn fn_call_func(&self) -> RpnFnMeta {

--- a/components/tidb_query/src/rpn_expr/types/test_util.rs
+++ b/components/tidb_query/src/rpn_expr/types/test_util.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tipb::{Expr, FieldType, ScalarFuncSig};
+use tipb::{Expr, ExprType, FieldType, ScalarFuncSig};
 
 use crate::codec::batch::LazyBatchColumnVec;
 use crate::codec::data_type::{Evaluable, ScalarValue};
@@ -96,6 +96,7 @@ impl RpnFnScalarEvaluator {
             .map(|expr_node| {
                 let mut ed = Expr::default();
                 ed.set_field_type(expr_node.field_type().clone());
+                ed.set_tp(expr_node.expr_tp());
                 ed
             })
             .collect();
@@ -105,6 +106,7 @@ impl RpnFnScalarEvaluator {
         fun_sig_expr.set_sig(sig);
         fun_sig_expr.set_children(children_ed.clone().into());
         fun_sig_expr.set_field_type(ret_field_type.clone());
+        fun_sig_expr.set_tp(ExprType::ScalarFunc);
 
         // use validator_ptr to testing the test arguments.
         let func: RpnFnMeta = super::super::map_expr_node_to_rpn_func(&fun_sig_expr).unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Please explain in detail what the changes are in this PR and why they are needed:

In `RpnFnScalarEvaluator`, `evaluate_raw` will construct some `Expr` then evaluate it for test, but only `Expr.field_type` is set correctly, `Expr.tp` is left to be default value (`NULL`).

If some builtin_function try to optimize by the expression node's type, then the test will break.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

