### PR TITLE
lock_manager: reduce clean up requests

### DIFF
--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -79,10 +79,7 @@ impl RpcClient {
     }
 
     /// Gets given key's Region and Region's leader from PD.
-    pub fn get_region_and_leader(
-        &self,
-        key: &[u8],
-    ) -> Result<(metapb::Region, Option<metapb::Peer>)> {
+    fn get_region_and_leader(&self, key: &[u8]) -> Result<(metapb::Region, Option<metapb::Peer>)> {
         let _timer = PD_REQUEST_HISTOGRAM_VEC
             .with_label_values(&["get_region"])
             .start_coarse_timer();

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -80,7 +80,9 @@ pub const INVALID_ID: u64 = 0;
 /// all the time.
 pub trait PdClient: Send + Sync {
     /// Returns the cluster ID.
-    fn get_cluster_id(&self) -> Result<u64>;
+    fn get_cluster_id(&self) -> Result<u64> {
+        unimplemented!();
+    }
 
     /// Creates the cluster with cluster ID, node, stores and first Region.
     /// If the cluster is already bootstrapped, return ClusterBootstrapped error.
@@ -90,20 +92,28 @@ pub trait PdClient: Send + Sync {
     /// It may happen that multi nodes start at same time to try to
     /// bootstrap, but only one can succeed, while others will fail
     /// and must remove their created local Region data themselves.
-    fn bootstrap_cluster(&self, stores: metapb::Store, region: metapb::Region) -> Result<()>;
+    fn bootstrap_cluster(&self, _stores: metapb::Store, _region: metapb::Region) -> Result<()> {
+        unimplemented!();
+    }
 
     /// Returns whether the cluster is bootstrapped or not.
     ///
     /// Cluster must be bootstrapped when we use it, so when the
     /// node starts, `is_cluster_bootstrapped` must be called,
     /// and panics if cluster was not bootstrapped.
-    fn is_cluster_bootstrapped(&self) -> Result<bool>;
+    fn is_cluster_bootstrapped(&self) -> Result<bool> {
+        unimplemented!();
+    }
 
     /// Allocates a unique positive id.
-    fn alloc_id(&self) -> Result<u64>;
+    fn alloc_id(&self) -> Result<u64> {
+        unimplemented!();
+    }
 
     /// Informs PD when the store starts or some store information changes.
-    fn put_store(&self, store: metapb::Store) -> Result<()>;
+    fn put_store(&self, _store: metapb::Store) -> Result<()> {
+        unimplemented!();
+    }
 
     /// We don't need to support Region and Peer put/delete,
     /// because PD knows all Region and Peers itself:
@@ -117,7 +127,9 @@ pub trait PdClient: Send + Sync {
     /// - For auto-balance, PD determines how to move the Region from one store to another.
 
     /// Gets store information if it is not a tombstone store.
-    fn get_store(&self, store_id: u64) -> Result<metapb::Store>;
+    fn get_store(&self, _store_id: u64) -> Result<metapb::Store> {
+        unimplemented!();
+    }
 
     /// Gets all stores information.
     fn get_all_stores(&self, _exclude_tombstone: bool) -> Result<Vec<metapb::Store>> {
@@ -125,11 +137,15 @@ pub trait PdClient: Send + Sync {
     }
 
     /// Gets cluster meta information.
-    fn get_cluster_config(&self) -> Result<metapb::Cluster>;
+    fn get_cluster_config(&self) -> Result<metapb::Cluster> {
+        unimplemented!();
+    }
 
     /// For route.
     /// Gets Region which the key belongs to.
-    fn get_region(&self, key: &[u8]) -> Result<metapb::Region>;
+    fn get_region(&self, _key: &[u8]) -> Result<metapb::Region> {
+        unimplemented!();
+    }
 
     /// Gets Region info which the key belongs to.
     fn get_region_info(&self, key: &[u8]) -> Result<RegionInfo> {
@@ -138,39 +154,54 @@ pub trait PdClient: Send + Sync {
     }
 
     /// Gets Region by Region id.
-    fn get_region_by_id(&self, region_id: u64) -> PdFuture<Option<metapb::Region>>;
+    fn get_region_by_id(&self, _region_id: u64) -> PdFuture<Option<metapb::Region>> {
+        unimplemented!();
+    }
 
     /// Region's Leader uses this to heartbeat PD.
     fn region_heartbeat(
         &self,
-        term: u64,
-        region: metapb::Region,
-        leader: metapb::Peer,
-        region_stat: RegionStat,
-    ) -> PdFuture<()>;
+        _term: u64,
+        _region: metapb::Region,
+        _leader: metapb::Peer,
+        _region_stat: RegionStat,
+    ) -> PdFuture<()> {
+        unimplemented!();
+    }
 
     /// Gets a stream of Region heartbeat response.
     ///
     /// Please note that this method should only be called once.
-    fn handle_region_heartbeat_response<F>(&self, store_id: u64, f: F) -> PdFuture<()>
+    fn handle_region_heartbeat_response<F>(&self, _store_id: u64, _f: F) -> PdFuture<()>
     where
-        F: Fn(pdpb::RegionHeartbeatResponse) + Send + 'static;
+        F: Fn(pdpb::RegionHeartbeatResponse) + Send + 'static,
+    {
+        unimplemented!();
+    }
 
     /// Asks PD for split. PD returns the newly split Region id.
-    fn ask_split(&self, region: metapb::Region) -> PdFuture<pdpb::AskSplitResponse>;
+    fn ask_split(&self, _region: metapb::Region) -> PdFuture<pdpb::AskSplitResponse> {
+        unimplemented!();
+    }
 
     /// Asks PD for batch split. PD returns the newly split Region ids.
     fn ask_batch_split(
         &self,
-        region: metapb::Region,
-        count: usize,
-    ) -> PdFuture<pdpb::AskBatchSplitResponse>;
+        _region: metapb::Region,
+        _count: usize,
+    ) -> PdFuture<pdpb::AskBatchSplitResponse> {
+        unimplemented!();
+    }
 
     /// Sends store statistics regularly.
-    fn store_heartbeat(&self, stats: pdpb::StoreStats) -> PdFuture<()>;
+    fn store_heartbeat(&self, _stats: pdpb::StoreStats) -> PdFuture<()> {
+        unimplemented!();
+    }
 
     /// Reports PD the split Region.
-    fn report_batch_split(&self, regions: Vec<metapb::Region>) -> PdFuture<()>;
+    fn report_batch_split(&self, _regions: Vec<metapb::Region>) -> PdFuture<()> {
+        unimplemented!();
+    }
 
     /// Scatters the Region across the cluster.
     fn scatter_region(&self, _: RegionInfo) -> Result<()> {
@@ -182,13 +213,19 @@ pub trait PdClient: Send + Sync {
     /// Please note that this method should only be called once.
     fn handle_reconnect<F: Fn() + Sync + Send + 'static>(&self, _: F) {}
 
-    fn get_gc_safe_point(&self) -> PdFuture<u64>;
+    fn get_gc_safe_point(&self) -> PdFuture<u64> {
+        unimplemented!();
+    }
 
     /// Gets store state if it is not a tombstone store.
-    fn get_store_stats(&self, store_id: u64) -> Result<pdpb::StoreStats>;
+    fn get_store_stats(&self, _store_id: u64) -> Result<pdpb::StoreStats> {
+        unimplemented!();
+    }
 
     /// Gets current operator of the region
-    fn get_operator(&self, region_id: u64) -> Result<pdpb::GetOperatorResponse>;
+    fn get_operator(&self, _region_id: u64) -> Result<pdpb::GetOperatorResponse> {
+        unimplemented!();
+    }
 }
 
 const REQUEST_TIMEOUT: u64 = 2; // 2s

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -19,6 +19,8 @@ use crate::storage::txn::{execute_callback, ProcessResult};
 use crate::storage::{lock_manager::Lock, LockManager as LockManagerTrait, StorageCb};
 use pd_client::PdClient;
 use spin::Mutex;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
@@ -30,7 +32,9 @@ const DETECTED_SLOTS_NUM: usize = 128;
 
 #[inline]
 fn detected_slot_idx(txn_ts: u64) -> usize {
-    txn_ts as usize & (DETECTED_SLOTS_NUM - 1)
+    let mut s = DefaultHasher::new();
+    txn_ts.hash(&mut s);
+    (s.finish() as usize) & (DETECTED_SLOTS_NUM - 1)
 }
 
 /// `LockManager` has two components working in two threads:

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -45,7 +45,7 @@ pub struct LockManager {
 
     waiter_count: Arc<AtomicUsize>,
 
-    // Record transactions once detected deadlock.
+    /// Record transactions which have sent requests to detect deadlock.
     detected: Arc<Vec<Mutex<HashSet<u64>>>>,
 }
 
@@ -238,8 +238,8 @@ impl LockManagerTrait for LockManager {
             self.waiter_mgr_scheduler
                 .wake_up(lock_ts, hashes, commit_ts);
         }
-        // If a pessimistic transaction is committed or rolled back and it once detected deadlock,
-        // clean up its wait-for entries in the deadlock detector.
+        // If a pessimistic transaction is committed or rolled back and it once sent requests to
+        // detect deadlock, clean up its wait-for entries in the deadlock detector.
         if is_pessimistic_txn && self.remove_from_detected(lock_ts) {
             self.detector_scheduler.clean_up(lock_ts);
         }

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -17,12 +17,21 @@ use crate::server::resolve::StoreAddrResolver;
 use crate::server::{Error, Result};
 use crate::storage::txn::{execute_callback, ProcessResult};
 use crate::storage::{lock_manager::Lock, LockManager as LockManagerTrait, StorageCb};
-use pd_client::RpcClient;
+use pd_client::PdClient;
+use spin::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
+use tikv_util::collections::HashSet;
 use tikv_util::security::SecurityManager;
 use tikv_util::worker::FutureWorker;
+
+const DETECTED_SLOTS_NUM: usize = 128;
+
+#[inline]
+fn detected_slot_idx(txn_ts: u64) -> usize {
+    txn_ts as usize & (DETECTED_SLOTS_NUM - 1)
+}
 
 /// `LockManager` has two components working in two threads:
 ///   * One is the `WaiterManager` which manages transactions waiting for locks.
@@ -35,6 +44,9 @@ pub struct LockManager {
     detector_scheduler: DetectorScheduler,
 
     waiter_count: Arc<AtomicUsize>,
+
+    // Record transactions once detected deadlock.
+    detected: Arc<Vec<Mutex<HashSet<u64>>>>,
 }
 
 impl Clone for LockManager {
@@ -45,6 +57,7 @@ impl Clone for LockManager {
             waiter_mgr_scheduler: self.waiter_mgr_scheduler.clone(),
             detector_scheduler: self.detector_scheduler.clone(),
             waiter_count: self.waiter_count.clone(),
+            detected: self.detected.clone(),
         }
     }
 }
@@ -53,6 +66,8 @@ impl LockManager {
     pub fn new() -> Self {
         let waiter_mgr_worker = FutureWorker::new("waiter-manager");
         let detector_worker = FutureWorker::new("deadlock-detector");
+        let mut detected = Vec::with_capacity(DETECTED_SLOTS_NUM);
+        detected.resize_with(DETECTED_SLOTS_NUM, || Mutex::new(HashSet::default()));
 
         Self {
             waiter_mgr_scheduler: WaiterMgrScheduler::new(waiter_mgr_worker.scheduler()),
@@ -60,18 +75,23 @@ impl LockManager {
             detector_scheduler: DetectorScheduler::new(detector_worker.scheduler()),
             detector_worker: Some(detector_worker),
             waiter_count: Arc::new(AtomicUsize::new(0)),
+            detected: Arc::new(detected),
         }
     }
 
     /// Starts `WaiterManager` and `Detector`.
-    pub fn start<S: StoreAddrResolver + 'static>(
+    pub fn start<S, P>(
         &mut self,
         store_id: u64,
-        pd_client: Arc<RpcClient>,
+        pd_client: Arc<P>,
         resolver: S,
         security_mgr: Arc<SecurityManager>,
         cfg: &Config,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        S: StoreAddrResolver + 'static,
+        P: PdClient + 'static,
+    {
         self.start_waiter_manager(cfg)?;
         self.start_deadlock_detector(store_id, pd_client, resolver, security_mgr, cfg)?;
         Ok(())
@@ -110,14 +130,18 @@ impl LockManager {
         }
     }
 
-    fn start_deadlock_detector<S: StoreAddrResolver + 'static>(
+    fn start_deadlock_detector<S, P>(
         &mut self,
         store_id: u64,
-        pd_client: Arc<RpcClient>,
+        pd_client: Arc<P>,
         resolver: S,
         security_mgr: Arc<SecurityManager>,
         cfg: &Config,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        S: StoreAddrResolver + 'static,
+        P: PdClient + 'static,
+    {
         let detector_runner = Detector::new(
             store_id,
             pd_client,
@@ -161,6 +185,16 @@ impl LockManager {
             self.detector_scheduler.clone(),
         )
     }
+
+    fn add_to_detected(&self, txn_ts: u64) {
+        let mut detected = self.detected[detected_slot_idx(txn_ts)].lock();
+        detected.insert(txn_ts);
+    }
+
+    fn remove_from_detected(&self, txn_ts: u64) -> bool {
+        let mut detected = self.detected[detected_slot_idx(txn_ts)].lock();
+        detected.remove(&txn_ts)
+    }
 }
 
 impl LockManagerTrait for LockManager {
@@ -184,8 +218,9 @@ impl LockManagerTrait for LockManager {
         self.waiter_mgr_scheduler
             .wait_for(start_ts, cb, pr, lock, timeout as u64);
 
-        // If it is the first lock the transaction waits for, it won't cause deadlock.
+        // If it is the first lock the transaction tries to lock, it won't cause deadlock.
         if !is_first_lock {
+            self.add_to_detected(start_ts);
             self.detector_scheduler.detect(start_ts, lock);
         }
     }
@@ -203,11 +238,9 @@ impl LockManagerTrait for LockManager {
             self.waiter_mgr_scheduler
                 .wake_up(lock_ts, hashes, commit_ts);
         }
-        // If these locks belong to a pessimistic transaction, clean up its wait-for entries
-        // in the deadlock detector.
-        //
-        // TODO: only clean up if the transaction once waited for locks.
-        if is_pessimistic_txn {
+        // If a pessimistic transaction is committed or rolled back and it once detected deadlock,
+        // clean up its wait-for entries in the deadlock detector.
+        if is_pessimistic_txn && self.remove_from_detected(lock_ts) {
             self.detector_scheduler.clean_up(lock_ts);
         }
     }
@@ -220,9 +253,163 @@ impl LockManagerTrait for LockManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::mpsc::channel;
+    use crate::raftstore::coprocessor::Config as CopConfig;
+    use crate::server::resolve::Callback;
+    use crate::storage::{
+        mvcc::Error as MvccError, txn::Error as TxnError, Error as StorageError,
+        Result as StorageResult,
+    };
+    use kvproto::kvrpcpb::LockInfo;
+    use kvproto::metapb::Region;
+    use metrics::*;
+    use pd_client::{RegionInfo, Result as PdResult};
+    use raft::StateRole;
+    use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;
+    use tikv_util::security::SecurityConfig;
+
+    struct MockPdClient;
+
+    impl PdClient for MockPdClient {
+        fn get_region_info(&self, _key: &[u8]) -> PdResult<RegionInfo> {
+            unimplemented!();
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockResolver;
+
+    impl StoreAddrResolver for MockResolver {
+        fn resolve(&self, _store_id: u64, _cb: Callback) -> Result<()> {
+            Err(Error::Other(box_err!("unimplemented")))
+        }
+    }
+
+    fn start_lock_manager() -> LockManager {
+        let (tx, _rx) = mpsc::sync_channel(100);
+        let mut coprocessor_host = CoprocessorHost::new(CopConfig::default(), tx);
+
+        let mut lock_mgr = LockManager::new();
+        lock_mgr.register_detector_role_change_observer(&mut coprocessor_host);
+        lock_mgr
+            .start(
+                1,
+                Arc::new(MockPdClient {}),
+                MockResolver {},
+                Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap()),
+                &Config::default(),
+            )
+            .unwrap();
+
+        // Make sure the deadlock detector is the leader.
+        let mut leader_region = Region::new();
+        leader_region.set_start_key(b"".to_vec());
+        leader_region.set_end_key(b"foo".to_vec());
+        coprocessor_host.on_role_change(&leader_region, StateRole::Leader);
+        thread::sleep(Duration::from_millis(100));
+
+        lock_mgr
+    }
+
+    #[test]
+    fn test_single_lock_manager() {
+        let lock_mgr = start_lock_manager();
+
+        let (tx, rx) = mpsc::channel();
+        let storage_callback = |tx: mpsc::Sender<_>| {
+            StorageCb::Boolean(Box::new(move |result| {
+                tx.send(result).unwrap();
+            }))
+        };
+        let recv = |rx: &mpsc::Receiver<StorageResult<()>>| {
+            rx.recv_timeout(Duration::from_millis(500))
+                .unwrap()
+                .unwrap_err();
+        };
+
+        // Normal wake up
+        assert_eq!(lock_mgr.has_waiter(), false);
+        lock_mgr.wait_for(
+            10,
+            storage_callback(tx.clone()),
+            ProcessResult::Res,
+            Lock { ts: 20, hash: 20 },
+            true,
+            0,
+        );
+        assert_eq!(lock_mgr.has_waiter(), true);
+        lock_mgr.wake_up(20, Some(vec![20]), 20, false);
+        recv(&rx);
+        assert_eq!(lock_mgr.has_waiter(), false);
+
+        // Normal deadlock
+        lock_mgr.wait_for(
+            30,
+            storage_callback(tx.clone()),
+            ProcessResult::Res,
+            Lock { ts: 40, hash: 40 },
+            false,
+            0,
+        );
+        lock_mgr.wait_for(
+            40,
+            storage_callback(tx.clone()),
+            ProcessResult::MultiRes {
+                results: vec![Err(StorageError::from(TxnError::from(
+                    MvccError::KeyIsLocked(LockInfo::default()),
+                )))],
+            },
+            Lock { ts: 30, hash: 30 },
+            false,
+            0,
+        );
+        recv(&rx);
+        lock_mgr.wake_up(40, Some(vec![40]), 40, true);
+        recv(&rx);
+        assert_eq!(lock_mgr.has_waiter(), false);
+
+        // If it's the first lock, no detect
+        lock_mgr.wait_for(
+            50,
+            storage_callback(tx.clone()),
+            ProcessResult::Res,
+            Lock { ts: 60, hash: 60 },
+            true,
+            0,
+        );
+        assert_eq!(lock_mgr.remove_from_detected(50), false);
+        lock_mgr.wake_up(60, Some(vec![60]), 60, false);
+        recv(&rx);
+
+        // If it's not the first lock, detect deadlock
+        lock_mgr.wait_for(
+            50,
+            storage_callback(tx.clone()),
+            ProcessResult::Res,
+            Lock { ts: 60, hash: 60 },
+            false,
+            0,
+        );
+        assert_eq!(lock_mgr.remove_from_detected(50), true);
+        lock_mgr.wake_up(60, Some(vec![60]), 60, false);
+        recv(&rx);
+
+        // If key_hashes is none, no wake up
+        let prev_wake_up = TASK_COUNTER_VEC.wake_up.get();
+        lock_mgr.wake_up(70, None, 70, false);
+        assert_eq!(TASK_COUNTER_VEC.wake_up.get(), prev_wake_up);
+
+        // If it's non-pessimistic-txn, no clean up
+        let prev_clean_up = TASK_COUNTER_VEC.clean_up.get();
+        lock_mgr.wake_up(80, None, 80, false);
+        assert_eq!(TASK_COUNTER_VEC.clean_up.get(), prev_clean_up);
+
+        // If the txn doesn't wait for locks, no clean up
+        let prev_clean_up = TASK_COUNTER_VEC.clean_up.get();
+        lock_mgr.wake_up(80, None, 80, true);
+        assert_eq!(TASK_COUNTER_VEC.clean_up.get(), prev_clean_up);
+    }
 
     #[test]
     fn test_has_waiter() {
@@ -259,7 +446,7 @@ mod tests {
     #[test]
     fn test_no_wait() {
         let lock_mgr = LockManager::new();
-        let (tx, rx) = channel();
+        let (tx, rx) = mpsc::channel();
         lock_mgr.wait_for(
             10,
             StorageCb::Boolean(Box::new(move |x| {

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -142,8 +142,7 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use kvproto::metapb;
-    use kvproto::pdpb;
-    use pd_client::{PdClient, PdFuture, RegionStat, Result};
+    use pd_client::{PdClient, Result};
     use tikv_util::collections::HashMap;
 
     const STORE_ADDRESS_REFRESH_SECONDS: u64 = 60;
@@ -154,21 +153,6 @@ mod tests {
     }
 
     impl PdClient for MockPdClient {
-        fn get_cluster_id(&self) -> Result<u64> {
-            unimplemented!();
-        }
-        fn bootstrap_cluster(&self, _: metapb::Store, _: metapb::Region) -> Result<()> {
-            unimplemented!();
-        }
-        fn is_cluster_bootstrapped(&self) -> Result<bool> {
-            unimplemented!();
-        }
-        fn alloc_id(&self) -> Result<u64> {
-            unimplemented!();
-        }
-        fn put_store(&self, _: metapb::Store) -> Result<()> {
-            unimplemented!();
-        }
         fn get_store(&self, _: u64) -> Result<metapb::Store> {
             // The store address will be changed every millisecond.
             let mut store = self.store.clone();
@@ -176,58 +160,6 @@ mod tests {
             sock.set_port(tikv_util::time::duration_to_ms(self.start.elapsed()) as u16);
             store.set_address(format!("{}:{}", sock.ip(), sock.port()));
             Ok(store)
-        }
-        fn get_cluster_config(&self) -> Result<metapb::Cluster> {
-            unimplemented!();
-        }
-        fn get_region(&self, _: &[u8]) -> Result<metapb::Region> {
-            unimplemented!();
-        }
-        fn get_region_by_id(&self, _: u64) -> PdFuture<Option<metapb::Region>> {
-            unimplemented!();
-        }
-        fn region_heartbeat(
-            &self,
-            _: u64,
-            _: metapb::Region,
-            _: metapb::Peer,
-            _: RegionStat,
-        ) -> PdFuture<()> {
-            unimplemented!();
-        }
-
-        fn handle_region_heartbeat_response<F>(&self, _: u64, _: F) -> PdFuture<()>
-        where
-            F: Fn(pdpb::RegionHeartbeatResponse) + Send + 'static,
-        {
-            unimplemented!()
-        }
-
-        fn ask_split(&self, _: metapb::Region) -> PdFuture<pdpb::AskSplitResponse> {
-            unimplemented!();
-        }
-
-        fn ask_batch_split(
-            &self,
-            _: metapb::Region,
-            _: usize,
-        ) -> PdFuture<pdpb::AskBatchSplitResponse> {
-            unimplemented!();
-        }
-        fn store_heartbeat(&self, _: pdpb::StoreStats) -> PdFuture<()> {
-            unimplemented!();
-        }
-        fn report_batch_split(&self, _: Vec<metapb::Region>) -> PdFuture<()> {
-            unimplemented!();
-        }
-        fn get_gc_safe_point(&self) -> PdFuture<u64> {
-            unimplemented!();
-        }
-        fn get_store_stats(&self, _: u64) -> Result<pdpb::StoreStats> {
-            unimplemented!()
-        }
-        fn get_operator(&self, _: u64) -> Result<pdpb::GetOperatorResponse> {
-            unimplemented!()
         }
     }
 


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
Don't send clean up requests if a pessimistic transaction doesn't detect deadlocks.

###  What is the type of the changes?
- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?
- Unit test
- Manual test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No

###  Does this PR affect `tidb-ansible`?
No

###  Any examples? (optional)
![image](https://user-images.githubusercontent.com/14819777/69128374-1e484f80-0ae7-11ea-8f6b-578d61f627ab.png)


