### PR TITLE
Fix panic when profiling is enabled

### DIFF
--- a/benches/coprocessor_executors/util/bencher.rs
+++ b/benches/coprocessor_executors/util/bencher.rs
@@ -32,7 +32,7 @@ impl<E: Executor, F: FnMut() -> E> Bencher for NormalNext1Bencher<E, F> {
         b.iter_batched_ref(
             &mut self.executor_builder,
             |executor| {
-                profiler::start("NormalNext1Bencher");
+                profiler::start("./NormalNext1Bencher.profile");
                 black_box(executor.next().unwrap());
                 profiler::stop();
             },
@@ -60,7 +60,7 @@ impl<E: Executor, F: FnMut() -> E> Bencher for NormalNext1024Bencher<E, F> {
         b.iter_batched_ref(
             &mut self.executor_builder,
             |executor| {
-                profiler::start("NormalNext1024Bencher");
+                profiler::start("./NormalNext1024Bencher.profile");
                 let iter_times = black_box(1024);
                 for _ in 0..iter_times {
                     black_box(executor.next().unwrap());
@@ -91,7 +91,7 @@ impl<E: Executor, F: FnMut() -> E> Bencher for NormalNextAllBencher<E, F> {
         b.iter_batched_ref(
             &mut self.executor_builder,
             |executor| {
-                profiler::start("NormalNextAllBencher");
+                profiler::start("./NormalNextAllBencher.profile");
                 loop {
                     let r = executor.next().unwrap();
                     black_box(&r);
@@ -125,7 +125,7 @@ impl<E: BatchExecutor, F: FnMut() -> E> Bencher for BatchNext1024Bencher<E, F> {
         b.iter_batched_ref(
             &mut self.executor_builder,
             |executor| {
-                profiler::start("BatchNext1024Bencher");
+                profiler::start("./BatchNext1024Bencher.profile");
                 let iter_times = black_box(1024);
                 let r = black_box(executor.next_batch(iter_times));
                 r.is_drained.unwrap();
@@ -155,7 +155,7 @@ impl<E: BatchExecutor, F: FnMut() -> E> Bencher for BatchNextAllBencher<E, F> {
         b.iter_batched_ref(
             &mut self.executor_builder,
             |executor| {
-                profiler::start("BatchNextAllBencher");
+                profiler::start("./BatchNextAllBencher.profile");
                 loop {
                     let r = executor.next_batch(1024);
                     black_box(&r);
@@ -189,7 +189,7 @@ impl<F: FnMut() -> Box<dyn RequestHandler>> Bencher for DAGHandleBencher<F> {
         b.iter_batched_ref(
             &mut self.handler_builder,
             |handler| {
-                profiler::start("DAGHandleBencher");
+                profiler::start("./DAGHandleBencher.profile");
                 black_box(handler.handle_request().unwrap());
                 profiler::stop();
             },

--- a/components/profiler/examples/prime.rs
+++ b/components/profiler/examples/prime.rs
@@ -69,7 +69,7 @@ fn prepare_prime_numbers() -> Vec<usize> {
 fn main() {
     let prime_numbers = prepare_prime_numbers();
 
-    profiler::start("prime.profile");
+    profiler::start("./prime.profile");
 
     let mut v = 0;
     for i in 2..50000 {

--- a/components/tidb_query/src/rpn_expr/types/expr_eval.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_eval.rs
@@ -1164,7 +1164,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         let logical_rows: Vec<_> = (0..1024).collect();
 
-        profiler::start("bench_eval_plus_1024_rows.profile");
+        profiler::start("./bench_eval_plus_1024_rows.profile");
         b.iter(|| {
             let result = black_box(&exp).eval(
                 black_box(&mut ctx),
@@ -1201,7 +1201,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         let logical_rows: Vec<_> = (0..1024).collect();
 
-        profiler::start("eval_compare_1024_rows.profile");
+        profiler::start("./eval_compare_1024_rows.profile");
         b.iter(|| {
             let result = black_box(&exp).eval(
                 black_box(&mut ctx),
@@ -1238,7 +1238,7 @@ mod tests {
         let mut ctx = EvalContext::default();
         let logical_rows: Vec<_> = (0..5).collect();
 
-        profiler::start("bench_eval_compare_5_rows.profile");
+        profiler::start("./bench_eval_compare_5_rows.profile");
         b.iter(|| {
             let result = black_box(&exp).eval(
                 black_box(&mut ctx),


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Currently when enabling the profiling feature, related benchmarks will panic:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error(InvalidPath, State { next_error: None, backtrace: InternalBacktrace { backtrace: None } })', src/libcore/result.rs:1165:5
```

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Manual test (add detailed scripts or steps below)
