### PR TITLE
copr: vectorize LocateBinary2Args

### DIFF
--- a/components/tidb_query/src/rpn_expr/impl_string.rs
+++ b/components/tidb_query/src/rpn_expr/impl_string.rs
@@ -418,7 +418,7 @@ mod tests {
         ];
 
         for (substr, s, expect_output) in null_cases {
-            let output = RpnFnScalarEvaluator::new()
+            let output: Option<i64> = RpnFnScalarEvaluator::new()
                 .push_param(substr)
                 .push_param(s)
                 .evaluate(ScalarFuncSig::LocateBinary2Args)

--- a/components/tidb_query/src/rpn_expr/mod.rs
+++ b/components/tidb_query/src/rpn_expr/mod.rs
@@ -342,6 +342,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::HexIntArg => hex_int_arg_fn_meta(),
         ScalarFuncSig::LTrim => ltrim_fn_meta(),
         ScalarFuncSig::RTrim => rtrim_fn_meta(),
+        ScalarFuncSig::LocateBinary2Args => locate_binary_2_args_fn_meta(),
         _ => return Err(other_err!(
             "ScalarFunction {:?} is not supported in batch mode",
             value


### PR DESCRIPTION
Signed-off-by: mak <610546069@qq.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->
PCP #5751 
###  What have you changed?

Add vectorized LocateBinary2Args

###  What is the type of the changes?

Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No. It should not change the behavior.


###  Does this PR affect `tidb-ansible`?

No

