### PR TITLE
copr: metadata_ctor should return Result

### DIFF
--- a/components/tidb_query/src/rpn_expr/types/expr_builder.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_builder.rs
@@ -327,7 +327,7 @@ where
         )
     })?;
 
-    let metadata = (func_meta.metadata_ctor_ptr)(&mut tree_node);
+    let metadata = (func_meta.metadata_ctor_ptr)(&mut tree_node)?;
     let args: Vec<_> = tree_node.take_children().into();
     let args_len = args.len();
 

--- a/components/tidb_query/src/rpn_expr/types/expr_eval.rs
+++ b/components/tidb_query/src/rpn_expr/types/expr_eval.rs
@@ -1069,8 +1069,8 @@ mod tests {
             Ok(v.map(|v| v + *metadata))
         }
 
-        fn prepare_a<T: Evaluable>(_expr: &mut Expr) -> i64 {
-            42
+        fn prepare_a<T: Evaluable>(_expr: &mut Expr) -> Result<i64> {
+            Ok(42)
         }
 
         #[allow(clippy::trivially_copy_pass_by_ref, clippy::ptr_arg)]
@@ -1080,8 +1080,8 @@ mod tests {
             Ok(v[0].clone())
         }
 
-        fn prepare_b<T: Evaluable>(_expr: &mut Expr) -> String {
-            format!("{}", std::mem::size_of::<T>())
+        fn prepare_b<T: Evaluable>(_expr: &mut Expr) -> Result<String> {
+            Ok(format!("{}", std::mem::size_of::<T>()))
         }
 
         #[allow(clippy::trivially_copy_pass_by_ref)]
@@ -1093,8 +1093,8 @@ mod tests {
             Ok(Some(args.len() as i64))
         }
 
-        fn prepare_c<T: Evaluable>(_expr: &mut Expr) -> std::marker::PhantomData<T> {
-            std::marker::PhantomData
+        fn prepare_c<T: Evaluable>(_expr: &mut Expr) -> Result<std::marker::PhantomData<T>> {
+            Ok(std::marker::PhantomData)
         }
 
         fn fn_mapper(expr: &Expr) -> Result<RpnFnMeta> {

--- a/components/tidb_query/src/rpn_expr/types/function.rs
+++ b/components/tidb_query/src/rpn_expr/types/function.rs
@@ -42,7 +42,7 @@ pub struct RpnFnMeta {
     pub validator_ptr: fn(expr: &Expr) -> Result<()>,
 
     /// The metadata constructor of the RPN function.
-    pub metadata_ctor_ptr: fn(expr: &mut Expr) -> Box<dyn Any + Send>,
+    pub metadata_ctor_ptr: fn(expr: &mut Expr) -> Result<Box<dyn Any + Send>>,
 
     #[allow(clippy::type_complexity)]
     /// The RPN function.

--- a/components/tidb_query/src/rpn_expr/types/test_util.rs
+++ b/components/tidb_query/src/rpn_expr/types/test_util.rs
@@ -115,7 +115,12 @@ impl RpnFnScalarEvaluator {
             return (Err(e), context);
         }
 
-        let metadata = (func.metadata_ctor_ptr)(&mut fun_sig_expr);
+        let metadata = match (func.metadata_ctor_ptr)(&mut fun_sig_expr) {
+            Ok(metadata) => metadata,
+            Err(e) => {
+                return (Err(e), context);
+            }
+        };
         let expr = self
             .rpn_expr_builder
             .push_fn_call_with_metadata(func, children_ed.len(), ret_field_type, metadata)


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Please explain in detail what the changes are in this PR and why they are needed:

When use metadata in rpn framework, metadata_ctor may failed due to some expression error.

Now, metadata_ctor return the Metadata directly, It seems that return a Result<Metadata> is better.


###  What is the type of the changes?

Pick one of the following and delete the others:

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

Please select the tests that you ran to verify your changes:
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?


###  Does this PR affect `tidb-ansible`?

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

