### PR TITLE
Cherry pick #5429

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,6 @@ match_template = { path = "components/match_template" }
 cop_datatype = { path = "components/cop_datatype" }
 cop_codegen = { path = "components/cop_codegen" }
 codec = { path = "components/codec" }
-pprof = { version = "0.3", features = ["flamegraph", "protobuf"] }
 prost = "0.5.0"
 tipb_helper = { path = "components/tipb_helper" }
 tipb = { git = "https://github.com/pingcap/tipb.git" }

--- a/src/coprocessor/codec/data_type/vector.rs
+++ b/src/coprocessor/codec/data_type/vector.rs
@@ -402,8 +402,8 @@ macro_rules! impl_ext {
                 match self {
                     VectorValue::$ty(ref mut vec) => vec.push(v),
                     other => panic!(
-                        "Cannot call `{}` over to a {} column",
-                        stringify!($name),
+                        "Cannot call `{}` over a {} column",
+                        stringify!($push_name),
                         other.eval_type()
                     ),
                 };

--- a/src/coprocessor/dag/aggr_fn/impl_avg.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_avg.rs
@@ -34,14 +34,8 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserAvg {
 
         assert_eq!(aggr_def.get_tp(), ExprType::Avg);
 
-        // AVG outputs two columns.
-        out_schema.push(
-            FieldTypeBuilder::new()
-                .tp(FieldTypeTp::LongLong)
-                .flag(FieldTypeFlag::UNSIGNED)
-                .build(),
-        );
-        out_schema.push(aggr_def.take_field_type());
+        let col_sum_ft = aggr_def.take_field_type();
+        let col_sum_et = box_try!(EvalType::try_from(col_sum_ft.as_accessor().tp()));
 
         // Rewrite expression to insert CAST() if needed.
         let child = aggr_def.take_children().into_iter().next().unwrap();
@@ -49,7 +43,23 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserAvg {
             RpnExpressionBuilder::build_from_expr_tree(child, time_zone, src_schema.len())?;
         super::util::rewrite_exp_for_sum_avg(src_schema, &mut exp).unwrap();
 
-        let rewritten_eval_type = EvalType::try_from(exp.ret_field_type(src_schema).tp()).unwrap();
+        let rewritten_eval_type =
+            EvalType::try_from(exp.ret_field_type(src_schema).as_accessor().tp()).unwrap();
+        if col_sum_et != rewritten_eval_type {
+            return Err(box_err!(
+                "Unexpected return field type {}",
+                col_sum_ft.as_accessor().tp()
+            ));
+        }
+
+        // AVG outputs two columns.
+        out_schema.push(
+            FieldTypeBuilder::new()
+                .tp(FieldTypeTp::LongLong)
+                .flag(FieldTypeFlag::UNSIGNED)
+                .build(),
+        );
+        out_schema.push(col_sum_ft);
         out_exp.push(exp);
 
         Ok(match rewritten_eval_type {
@@ -257,5 +267,20 @@ mod tests {
             aggr_result[1].as_decimal_slice(),
             &[Some(Decimal::from(43u64))]
         );
+    }
+
+    #[test]
+    fn test_illegal_request() {
+        let expr = ExprDefBuilder::aggr_func(ExprType::Avg, FieldTypeTp::Double) // Expect NewDecimal but give Real
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong)) // FIXME: This type can be incorrect as well
+            .build();
+        AggrFnDefinitionParserAvg.check_supported(&expr).unwrap();
+
+        let src_schema = [FieldTypeTp::LongLong.into()];
+        let mut schema = vec![];
+        let mut exp = vec![];
+        AggrFnDefinitionParserAvg
+            .parse(expr, &Tz::utc(), &src_schema, &mut schema, &mut exp)
+            .unwrap_err();
     }
 }

--- a/src/coprocessor/dag/aggr_fn/impl_first.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_first.rs
@@ -31,13 +31,23 @@ impl super::AggrDefinitionParser for AggrFnDefinitionParserFirst {
     ) -> Result<Box<dyn super::AggrFunction>> {
         use cop_datatype::FieldTypeAccessor;
         use std::convert::TryFrom;
+
         assert_eq!(aggr_def.get_tp(), ExprType::First);
         let child = aggr_def.take_children().into_iter().next().unwrap();
         let eval_type = EvalType::try_from(child.get_field_type().tp()).unwrap();
 
-        // FIRST outputs one column with the same type as its child
-        out_schema.push(aggr_def.take_field_type());
+        let out_ft = aggr_def.take_field_type();
+        let out_et = box_try!(EvalType::try_from(out_ft.as_accessor().tp()));
 
+        if out_et != eval_type {
+            return Err(box_err!(
+                "Unexpected return field type {}",
+                out_ft.as_accessor().tp()
+            ));
+        }
+
+        // FIRST outputs one column with the same type as its child
+        out_schema.push(out_ft);
         out_exp.push(RpnExpressionBuilder::build_from_expr_tree(
             child,
             time_zone,
@@ -188,6 +198,11 @@ mod tests {
     use super::super::AggrFunction;
     use super::*;
 
+    use cop_datatype::FieldTypeTp;
+    use tipb_helper::ExprDefBuilder;
+
+    use crate::coprocessor::dag::aggr_fn::parser::AggrDefinitionParser;
+
     #[test]
     fn test_update() {
         let mut ctx = EvalContext::default();
@@ -261,5 +276,20 @@ mod tests {
             .unwrap();
         state.push_result(&mut ctx, &mut result[..]).unwrap();
         assert_eq!(result[0].as_int_slice(), &[Some(2)]);
+    }
+
+    #[test]
+    fn test_illegal_request() {
+        let expr = ExprDefBuilder::aggr_func(ExprType::First, FieldTypeTp::Double) // Expect LongLong but give Double
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+            .build();
+        AggrFnDefinitionParserFirst.check_supported(&expr).unwrap();
+
+        let src_schema = [FieldTypeTp::LongLong.into()];
+        let mut schema = vec![];
+        let mut exp = vec![];
+        AggrFnDefinitionParserFirst
+            .parse(expr, &Tz::utc(), &src_schema, &mut schema, &mut exp)
+            .unwrap_err();
     }
 }

--- a/src/coprocessor/dag/aggr_fn/impl_max_min.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_max_min.rs
@@ -60,12 +60,21 @@ impl<T: Extremum> super::AggrDefinitionParser for AggrFnDefinitionParserExtremum
         out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn super::AggrFunction>> {
         assert_eq!(aggr_def.get_tp(), T::TP);
+        let child = aggr_def.take_children().into_iter().next().unwrap();
+        let eval_type = EvalType::try_from(child.get_field_type().as_accessor().tp()).unwrap();
+
+        let out_ft = aggr_def.take_field_type();
+        let out_et = box_try!(EvalType::try_from(out_ft.as_accessor().tp()));
+
+        if out_et != eval_type {
+            return Err(box_err!(
+                "Unexpected return field type {}",
+                out_ft.as_accessor().tp()
+            ));
+        }
 
         // `MAX/MIN` outputs one column which has the same type with its child
-        out_schema.push(aggr_def.take_field_type());
-
-        let child = aggr_def.take_children().into_iter().next().unwrap();
-        let eval_type = EvalType::try_from(child.get_field_type().tp()).unwrap();
+        out_schema.push(out_ft);
         out_exp.push(RpnExpressionBuilder::build_from_expr_tree(
             child,
             time_zone,
@@ -353,5 +362,22 @@ mod tests {
         }
 
         assert_eq!(aggr_result[0].as_int_slice(), &[Some(99), Some(-1i64),]);
+    }
+
+    #[test]
+    fn test_illegal_request() {
+        let expr = ExprDefBuilder::aggr_func(ExprType::Max, FieldTypeTp::Double) // Expect LongLong but give Real
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+            .build();
+        AggrFnDefinitionParserExtremum::<Max>::new()
+            .check_supported(&expr)
+            .unwrap();
+
+        let src_schema = [FieldTypeTp::LongLong.into()];
+        let mut schema = vec![];
+        let mut exp = vec![];
+        AggrFnDefinitionParserExtremum::<Max>::new()
+            .parse(expr, &Tz::utc(), &src_schema, &mut schema, &mut exp)
+            .unwrap_err();
     }
 }

--- a/src/coprocessor/dag/aggr_fn/impl_sum.rs
+++ b/src/coprocessor/dag/aggr_fn/impl_sum.rs
@@ -33,8 +33,8 @@ impl super::parser::AggrDefinitionParser for AggrFnDefinitionParserSum {
 
         assert_eq!(aggr_def.get_tp(), ExprType::Sum);
 
-        // SUM outputs one column.
-        out_schema.push(aggr_def.take_field_type());
+        let out_ft = aggr_def.take_field_type();
+        let out_et = box_try!(EvalType::try_from(out_ft.as_accessor().tp()));
 
         // Rewrite expression, inserting CAST if necessary. See `typeInfer4Sum` in TiDB.
         let child = aggr_def.take_children().into_iter().next().unwrap();
@@ -43,7 +43,17 @@ impl super::parser::AggrDefinitionParser for AggrFnDefinitionParserSum {
         // The rewrite should always success.
         super::util::rewrite_exp_for_sum_avg(src_schema, &mut exp).unwrap();
 
-        let rewritten_eval_type = EvalType::try_from(exp.ret_field_type(src_schema).tp()).unwrap();
+        let rewritten_eval_type =
+            EvalType::try_from(exp.ret_field_type(src_schema).as_accessor().tp()).unwrap();
+        if out_et != rewritten_eval_type {
+            return Err(box_err!(
+                "Unexpected return field type {}",
+                out_ft.as_accessor().tp()
+            ));
+        }
+
+        // SUM outputs one column.
+        out_schema.push(out_ft);
         out_exp.push(exp);
 
         // Choose a type-aware SUM implementation based on the eval type after rewriting exp.
@@ -192,5 +202,20 @@ mod tests {
         state.push_result(&mut ctx, &mut aggr_result).unwrap();
 
         assert_eq!(aggr_result[0].as_real_slice(), &[Real::new(54.5).ok()]);
+    }
+
+    #[test]
+    fn test_illegal_request() {
+        let expr = ExprDefBuilder::aggr_func(ExprType::Sum, FieldTypeTp::Double) // Expect NewDecimal but give Double
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong)) // FIXME: This type can be incorrect as well
+            .build();
+        AggrFnDefinitionParserSum.check_supported(&expr).unwrap();
+
+        let src_schema = [FieldTypeTp::LongLong.into()];
+        let mut schema = vec![];
+        let mut exp = vec![];
+        AggrFnDefinitionParserSum
+            .parse(expr, &Tz::utc(), &src_schema, &mut schema, &mut exp)
+            .unwrap_err();
     }
 }

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -60,6 +60,7 @@ impl StatusServer {
             .unwrap()
     }
 
+    #[cfg(target_os = "linux")]
     fn extract_thread_name(thread_name: &str) -> String {
         lazy_static! {
             static ref THREAD_NAME_RE: Regex =


### PR DESCRIPTION
Cherry pick #5429 to avoid TiKV panic.

This PR cannot avoid related SQLs to fail. However currently in 3.0 version we do not have easy way to make it work, because of lacking cast functions, unless TiDB uses correct type for `SUM(year)`.