### PR TITLE
fix(copr): Handle trailing NULL correctly for `concat_ws`.

### DIFF
--- a/components/tidb_query/src/expr/builtin_string.rs
+++ b/components/tidb_query/src/expr/builtin_string.rs
@@ -1889,8 +1889,33 @@ mod tests {
                 Datum::Bytes("abc,CAFÉ,数据库".as_bytes().to_vec()),
             ),
             (
+                vec![
+                    Datum::Bytes(b",".to_vec()),
+                    Datum::Bytes(b"abc".to_vec()),
+                    Datum::Null,
+                    Datum::Bytes(b"defg".to_vec()),
+                ],
+                Datum::Bytes(b"abc,defg".to_vec()),
+            ),
+            (
                 vec![Datum::Null, Datum::Bytes(b"abc".to_vec())],
                 Datum::Null,
+            ),
+            (
+                vec![
+                    Datum::Bytes(b",".to_vec()),
+                    Datum::Null,
+                    Datum::Bytes(b"abc".to_vec()),
+                ],
+                Datum::Bytes(b"abc".to_vec()),
+            ),
+            (
+                vec![
+                    Datum::Bytes(b",".to_vec()),
+                    Datum::Bytes(b"abc".to_vec()),
+                    Datum::Null,
+                ],
+                Datum::Bytes(b"abc".to_vec()),
             ),
             (
                 vec![
@@ -1907,11 +1932,10 @@ mod tests {
                     Datum::Bytes(b"abc".to_vec()),
                     Datum::Null,
                     Datum::Null,
-                    Datum::Bytes(b"".to_vec()),
                     Datum::Bytes(b"defg".to_vec()),
                     Datum::Null,
                 ],
-                Datum::Bytes(b"abc,,defg".to_vec()),
+                Datum::Bytes(b"abc,defg".to_vec()),
             ),
             (
                 vec![

--- a/components/tidb_query/src/expr/builtin_string.rs
+++ b/components/tidb_query/src/expr/builtin_string.rs
@@ -173,19 +173,32 @@ impl ScalarFunc {
         ctx: &mut EvalContext,
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, [u8]>>> {
-        let sep = try_opt!(self.children[0].eval_string(ctx, row));
-        let mut output = Vec::new();
-        let rest = &self.children[1..];
-        let last_idx = rest.len() - 1;
-        for (idx, x) in rest.iter().enumerate() {
-            let s = x.eval_string(ctx, row)?;
-            if let Some(s) = s {
-                output.extend_from_slice(s.as_ref());
-                if idx != last_idx {
-                    output.extend_from_slice(sep.as_ref());
+        use crate::expr::Expression;
+        fn collect_valid_strs<'a, 'b: 'a>(
+            exps: &'b [Expression],
+            ctx: &mut EvalContext,
+            row: &'a [Datum],
+        ) -> Result<Vec<Cow<'a, [u8]>>> {
+            let mut result = Vec::new();
+            for exp in exps {
+                let x = exp.eval_string(ctx, row)?;
+                if let Some(s) = x {
+                    result.push(s);
                 }
             }
+            Ok(result)
         }
+
+        let sep = try_opt!(self.children[0].eval_string(ctx, row));
+        let mut output = Vec::new();
+        let strs = collect_valid_strs(&self.children[1..], ctx, row)?;
+        for (idx, s) in strs.iter().enumerate() {
+            if idx != 0 {
+                output.extend_from_slice(sep.as_ref());
+            }
+            output.extend_from_slice(s.as_ref());
+        }
+
         Ok(Some(Cow::Owned(output)))
     }
 
@@ -1906,10 +1919,30 @@ mod tests {
             (
                 vec![
                     Datum::Bytes(b",".to_vec()),
+                    Datum::Bytes(b"abc".to_vec()),
+                    Datum::Null,
+                ],
+                Datum::Bytes(b"abc".to_vec()),
+            ),
+            (
+                vec![
+                    Datum::Bytes(b",".to_vec()),
                     Datum::Bytes(b"".to_vec()),
                     Datum::Bytes(b"abc".to_vec()),
                 ],
                 Datum::Bytes(b",abc".to_vec()),
+            ),
+            (
+                vec![
+                    Datum::Bytes(b",".to_vec()),
+                    Datum::Null,
+                    Datum::Bytes(b"abc".to_vec()),
+                    Datum::Null,
+                    Datum::Null,
+                    Datum::Bytes(b"defg".to_vec()),
+                    Datum::Null,
+                ],
+                Datum::Bytes(b"abc,defg".to_vec()),
             ),
             (
                 vec![

--- a/components/tidb_query/src/expr/builtin_string.rs
+++ b/components/tidb_query/src/expr/builtin_string.rs
@@ -1896,33 +1896,8 @@ mod tests {
                 Datum::Bytes("abc,CAFÉ,数据库".as_bytes().to_vec()),
             ),
             (
-                vec![
-                    Datum::Bytes(b",".to_vec()),
-                    Datum::Bytes(b"abc".to_vec()),
-                    Datum::Null,
-                    Datum::Bytes(b"defg".to_vec()),
-                ],
-                Datum::Bytes(b"abc,defg".to_vec()),
-            ),
-            (
                 vec![Datum::Null, Datum::Bytes(b"abc".to_vec())],
                 Datum::Null,
-            ),
-            (
-                vec![
-                    Datum::Bytes(b",".to_vec()),
-                    Datum::Null,
-                    Datum::Bytes(b"abc".to_vec()),
-                ],
-                Datum::Bytes(b"abc".to_vec()),
-            ),
-            (
-                vec![
-                    Datum::Bytes(b",".to_vec()),
-                    Datum::Bytes(b"abc".to_vec()),
-                    Datum::Null,
-                ],
-                Datum::Bytes(b"abc".to_vec()),
             ),
             (
                 vec![
@@ -1939,10 +1914,11 @@ mod tests {
                     Datum::Bytes(b"abc".to_vec()),
                     Datum::Null,
                     Datum::Null,
+                    Datum::Bytes(b"".to_vec()),
                     Datum::Bytes(b"defg".to_vec()),
                     Datum::Null,
                 ],
-                Datum::Bytes(b"abc,defg".to_vec()),
+                Datum::Bytes(b"abc,,defg".to_vec()),
             ),
             (
                 vec![

--- a/components/tidb_query/src/expr/builtin_string.rs
+++ b/components/tidb_query/src/expr/builtin_string.rs
@@ -190,15 +190,8 @@ impl ScalarFunc {
         }
 
         let sep = try_opt!(self.children[0].eval_string(ctx, row));
-        let mut output = Vec::new();
         let strs = collect_valid_strs(&self.children[1..], ctx, row)?;
-        for (idx, s) in strs.iter().enumerate() {
-            if idx != 0 {
-                output.extend_from_slice(sep.as_ref());
-            }
-            output.extend_from_slice(s.as_ref());
-        }
-
+        let output = strs.as_slice().join(sep.as_ref());
         Ok(Some(Cow::Owned(output)))
     }
 


### PR DESCRIPTION
Signed-off-by: Zhu Zihao <all_but_last@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Please explain in detail what the changes are in this PR and why they are needed:

Fix the bug introduced by #5999, described in https://github.com/tikv/tikv/pull/5978.

For given SQL statement

```sql
select concat_ws(',', 'abc', NULL);
```

TiKV will return `abc,` but expected `abc`.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)


###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?
No


