### PR TITLE
gc: config gc io limit dynamically (#5769) (#5957)

### DIFF
--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -39,6 +39,8 @@ use tikv::config::TiKvConfig;
 use tikv::pd::{Config as PdConfig, PdClient, RpcClient};
 use tikv::raftstore::store::{keys, INIT_EPOCH_CONF_VER};
 use tikv::server::debug::{BottommostLevelCompaction, Debugger, RegionInfo};
+use tikv::server::ServerRaftStoreRouter;
+use tikv::storage::kv::{raftkv::RaftKv, Engine};
 use tikv::storage::Key;
 use tikv_util::security::{SecurityConfig, SecurityManager};
 use tikv_util::{escape, unescape};
@@ -87,11 +89,10 @@ fn new_debug_executor(
             let raft_db =
                 rocks::util::new_engine_opt(&raft_path, raft_db_opts, raft_db_cf_opts).unwrap();
 
-            Box::new(Debugger::new(Engines::new(
-                Arc::new(kv_db),
-                Arc::new(raft_db),
-                cache.is_some(),
-            ))) as Box<dyn DebugExecutor>
+            Box::new(Debugger::<RaftKv<ServerRaftStoreRouter>>::new(
+                Engines::new(Arc::new(kv_db), Arc::new(raft_db), cache.is_some()),
+                None,
+            )) as Box<dyn DebugExecutor>
         }
         (Some(remote), None) => Box::new(new_debug_client(remote, mgr)) as Box<dyn DebugExecutor>,
         _ => unreachable!(),
@@ -745,7 +746,7 @@ impl DebugExecutor for DebugClient {
     }
 }
 
-impl DebugExecutor for Debugger {
+impl<E: Engine> DebugExecutor for Debugger<E> {
     fn check_local_mode(&self) {}
 
     fn get_all_meta_regions(&self) -> Vec<u64> {

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -229,7 +229,11 @@ fn run_raft_server(pd_client: RpcClient, cfg: &TiKvConfig, security_mgr: Arc<Sec
     );
 
     // Create Debug service.
-    let debug_service = DebugService::new(engines.clone(), raft_router.clone());
+    let debug_service = DebugService::new(
+        engines.clone(),
+        raft_router.clone(),
+        storage.gc_worker.clone(),
+    );
 
     // Create Backup service.
     let mut backup_worker = tikv_util::worker::Worker::new("backup-endpoint");

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -159,7 +159,11 @@ impl Simulator for ServerCluster {
             Arc::clone(&importer),
         );
         // Create Debug service.
-        let debug_service = DebugService::new(engines.clone(), raft_router.clone());
+        let debug_service = DebugService::new(
+            engines.clone(),
+            raft_router.clone(),
+            store.gc_worker.clone(),
+        );
 
         // Create pd client, snapshot manager, server.
         let (worker, resolver) = resolve::new_resolver(Arc::clone(&self.pd_client)).unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -631,7 +631,7 @@ pub struct Storage<E: Engine, L: LockMgr> {
     read_pool: ReadPool,
 
     /// Used to handle requests related to GC.
-    gc_worker: GCWorker<E>,
+    pub gc_worker: GCWorker<E>,
 
     /// How many strong references. Thread pool and workers will be stopped
     /// once there are no more references.


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
Cherry pick #5769 

`tikv-ctl` can change gc io limit dynamically now. Usage:
```
tikv-ctl --host=host modify-tikv-config -m server -n gc.max_write_bytes_per_sec -v 10MB
```

It's used to limit the write flow when gc influences normal requests, and remove the limit when there is no influence.

###  What is the type of the changes?
- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?
- Unit test
- Manual test (add detailed scripts or steps below)
![image](https://user-images.githubusercontent.com/14819777/67920630-e46ae400-fbdf-11e9-9584-9492e7778643.png)
