### PR TITLE
Make build_dist_release support Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ dist_release:
 # additional sanity checks and file movement.
 build_dist_release:
 	make x-build-dist
+ifeq ($(shell uname),Linux) # Macs don't have objcopy
 	# Reduce binary size by compressing binaries.
 	# FIXME: Currently errors with `Couldn't find DIE referenced by DW_AT_abstract_origin`
 	# dwz ${CARGO_TARGET_DIR}/release/tikv-server
@@ -164,6 +165,7 @@ build_dist_release:
 	# dwz ${CARGO_TARGET_DIR}/release/tikv-ctl
 	objcopy --compress-debug-sections=zlib-gnu ${CARGO_TARGET_DIR}/release/tikv-server
 	objcopy --compress-debug-sections=zlib-gnu ${CARGO_TARGET_DIR}/release/tikv-ctl
+endif
 
 # Distributable bins with SSE4.2 optimizations
 dist_unportable_release:


### PR DESCRIPTION


###  What have you changed?

Fixes #6022, allowing `make dist_release` and `make dist_unportable_release` to build on Mac.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Manual test (add detailed scripts or steps below)

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

Nope

###  Does this PR affect `tidb-ansible`?

Nope

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

