### PR TITLE
copr: fix read_decimal multiply overflow panic

### DIFF
--- a/components/tidb_query/src/codec/mysql/decimal.rs
+++ b/components/tidb_query/src/codec/mysql/decimal.rs
@@ -2233,10 +2233,13 @@ pub trait DecimalDecoder: NumberDecoder {
         }
         if trailing_digits > 0 {
             let x = read_word(self, DIG_2_BYTES[trailing_digits] as usize, &mut is_first)? ^ mask;
-            d.word_buf[word_idx] = x * TEN_POW[DIGITS_PER_WORD as usize - trailing_digits];
-            if d.word_buf[word_idx] > WORD_MAX {
-                return Err(box_err!("invalid trailing digits for decimal number"));
-            }
+            d.word_buf[word_idx] =
+                match x.checked_mul(TEN_POW[DIGITS_PER_WORD as usize - trailing_digits]) {
+                    Some(v) if v <= WORD_MAX => v,
+                    _ => {
+                        return Err(box_err!("invalid trailing digits for decimal number"));
+                    }
+                }
         }
         if d.int_cnt == 0 && d.frac_cnt == 0 {
             d.reset_to_zero();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Please explain in detail what the changes are in this PR and why they are needed:

use `checked_mul` to avoid overflow panic.


###  What is the type of the changes?


- Bugfix (a change which fixes an issue)

###  How is the PR tested?


###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?


###  Does this PR affect `tidb-ansible`?


###  Refer to a related PR or issue link (optional)

Resolve #6044 

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

