### PR TITLE
Fix Fuzzing using AFL and Honggfuzz

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -14,11 +14,11 @@ Supported fuzzers:
 ### Honggfuzz
 
 ```sh
-cargo install honggfuzz --version 0.5.34
+cargo install honggfuzz --version 0.5.45
 ```
 
 Note that the version of the cargo plugin installed must be the same as the
-library linked by the `fuzzer-honggfuzz` project template, here 0.5.34.
+library linked by the `fuzzer-honggfuzz` project template, here 0.5.45.
 
 Building honggfuzz test cases with `cargo run -p fuzz -- run Honggfuzz <test>`
 requires additional development libraries that will differ from system to

--- a/fuzz/cli.rs
+++ b/fuzz/cli.rs
@@ -199,7 +199,7 @@ fn run_afl(target: &str) -> Result<(), Error> {
     let seed_dir = get_seed_dir(target);
     let corpus_dir = create_corpus_dir(fuzzer.directory(), target)?;
 
-    pre_check(Command::new("cargo").args(&["afl"]), "cargo install afl")?;
+    pre_check(Command::new("cargo").args(&["afl", "--version"]), "cargo install afl")?;
 
     // 1. cargo afl build (in fuzzer-afl directory)
     let fuzzer_build = Command::new("cargo")

--- a/fuzz/cli.rs
+++ b/fuzz/cli.rs
@@ -199,7 +199,10 @@ fn run_afl(target: &str) -> Result<(), Error> {
     let seed_dir = get_seed_dir(target);
     let corpus_dir = create_corpus_dir(fuzzer.directory(), target)?;
 
-    pre_check(Command::new("cargo").args(&["afl", "--version"]), "cargo install afl")?;
+    pre_check(
+        Command::new("cargo").args(&["afl", "--version"]),
+        "cargo install afl",
+    )?;
 
     // 1. cargo afl build (in fuzzer-afl directory)
     let fuzzer_build = Command::new("cargo")

--- a/fuzz/fuzzer-honggfuzz/Cargo.toml
+++ b/fuzz/fuzzer-honggfuzz/Cargo.toml
@@ -5,4 +5,4 @@ publish = false
 
 [dependencies]
 fuzz-targets = {path = "../targets"}
-honggfuzz = "0.5"
+honggfuzz = "0.5.45"


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Currently fuzz using AFL will not work, since `cargo afl` always returns exit code 1.

fuzz using Honggfuzz will not work according to README, since it suggests a wrong version.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Manual test