### PR TITLE
lock_manager: reduce clean up requests (#5959) (#5965)

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -80,10 +80,7 @@ impl RpcClient {
     }
 
     /// Gets given key's Region and Region's leader from PD.
-    pub fn get_region_and_leader(
-        &self,
-        key: &[u8],
-    ) -> Result<(metapb::Region, Option<metapb::Peer>)> {
+    fn get_region_and_leader(&self, key: &[u8]) -> Result<(metapb::Region, Option<metapb::Peer>)> {
         let _timer = PD_REQUEST_HISTOGRAM_VEC
             .with_label_values(&["get_region"])
             .start_coarse_timer();

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -65,7 +65,9 @@ pub const INVALID_ID: u64 = 0;
 /// all the time.
 pub trait PdClient: Send + Sync {
     /// Returns the cluster ID.
-    fn get_cluster_id(&self) -> Result<u64>;
+    fn get_cluster_id(&self) -> Result<u64> {
+        unimplemented!();
+    }
 
     /// Creates the cluster with cluster ID, node, stores and first Region.
     /// If the cluster is already bootstrapped, return ClusterBootstrapped error.
@@ -75,20 +77,28 @@ pub trait PdClient: Send + Sync {
     /// It may happen that multi nodes start at same time to try to
     /// bootstrap, but only one can succeed, while others will fail
     /// and must remove their created local Region data themselves.
-    fn bootstrap_cluster(&self, stores: metapb::Store, region: metapb::Region) -> Result<()>;
+    fn bootstrap_cluster(&self, _stores: metapb::Store, _region: metapb::Region) -> Result<()> {
+        unimplemented!();
+    }
 
     /// Returns whether the cluster is bootstrapped or not.
     ///
     /// Cluster must be bootstrapped when we use it, so when the
     /// node starts, `is_cluster_bootstrapped` must be called,
     /// and panics if cluster was not bootstrapped.
-    fn is_cluster_bootstrapped(&self) -> Result<bool>;
+    fn is_cluster_bootstrapped(&self) -> Result<bool> {
+        unimplemented!();
+    }
 
     /// Allocates a unique positive id.
-    fn alloc_id(&self) -> Result<u64>;
+    fn alloc_id(&self) -> Result<u64> {
+        unimplemented!();
+    }
 
     /// Informs PD when the store starts or some store information changes.
-    fn put_store(&self, store: metapb::Store) -> Result<()>;
+    fn put_store(&self, _store: metapb::Store) -> Result<()> {
+        unimplemented!();
+    }
 
     /// We don't need to support Region and Peer put/delete,
     /// because PD knows all Region and Peers itself:
@@ -102,7 +112,9 @@ pub trait PdClient: Send + Sync {
     /// - For auto-balance, PD determines how to move the Region from one store to another.
 
     /// Gets store information if it is not a tombstone store.
-    fn get_store(&self, store_id: u64) -> Result<metapb::Store>;
+    fn get_store(&self, _store_id: u64) -> Result<metapb::Store> {
+        unimplemented!();
+    }
 
     /// Gets all stores information.
     fn get_all_stores(&self, _exlcude_tombstone: bool) -> Result<Vec<metapb::Store>> {
@@ -110,11 +122,15 @@ pub trait PdClient: Send + Sync {
     }
 
     /// Gets cluster meta information.
-    fn get_cluster_config(&self) -> Result<metapb::Cluster>;
+    fn get_cluster_config(&self) -> Result<metapb::Cluster> {
+        unimplemented!();
+    }
 
     /// For route.
     /// Gets Region which the key belongs to.
-    fn get_region(&self, key: &[u8]) -> Result<metapb::Region>;
+    fn get_region(&self, _key: &[u8]) -> Result<metapb::Region> {
+        unimplemented!();
+    }
 
     /// Gets Region info which the key belongs to.
     fn get_region_info(&self, key: &[u8]) -> Result<RegionInfo> {
@@ -123,38 +139,53 @@ pub trait PdClient: Send + Sync {
     }
 
     /// Gets Region by Region id.
-    fn get_region_by_id(&self, region_id: u64) -> PdFuture<Option<metapb::Region>>;
+    fn get_region_by_id(&self, _region_id: u64) -> PdFuture<Option<metapb::Region>> {
+        unimplemented!();
+    }
 
     /// Region's Leader uses this to heartbeat PD.
     fn region_heartbeat(
         &self,
-        region: metapb::Region,
-        leader: metapb::Peer,
-        region_stat: RegionStat,
-    ) -> PdFuture<()>;
+        _region: metapb::Region,
+        _leader: metapb::Peer,
+        _region_stat: RegionStat,
+    ) -> PdFuture<()> {
+        unimplemented!();
+    }
 
     /// Gets a stream of Region heartbeat response.
     ///
     /// Please note that this method should only be called once.
-    fn handle_region_heartbeat_response<F>(&self, store_id: u64, f: F) -> PdFuture<()>
+    fn handle_region_heartbeat_response<F>(&self, _store_id: u64, _f: F) -> PdFuture<()>
     where
-        F: Fn(pdpb::RegionHeartbeatResponse) + Send + 'static;
+        F: Fn(pdpb::RegionHeartbeatResponse) + Send + 'static,
+    {
+        unimplemented!();
+    }
 
     /// Asks PD for split. PD returns the newly split Region id.
-    fn ask_split(&self, region: metapb::Region) -> PdFuture<pdpb::AskSplitResponse>;
+    fn ask_split(&self, _region: metapb::Region) -> PdFuture<pdpb::AskSplitResponse> {
+        unimplemented!();
+    }
 
     /// Asks PD for batch split. PD returns the newly split Region ids.
     fn ask_batch_split(
         &self,
-        region: metapb::Region,
-        count: usize,
-    ) -> PdFuture<pdpb::AskBatchSplitResponse>;
+        _region: metapb::Region,
+        _count: usize,
+    ) -> PdFuture<pdpb::AskBatchSplitResponse> {
+        unimplemented!();
+    }
 
     /// Sends store statistics regularly.
-    fn store_heartbeat(&self, stats: pdpb::StoreStats) -> PdFuture<()>;
+    fn store_heartbeat(&self, _stats: pdpb::StoreStats) -> PdFuture<()> {
+        unimplemented!();
+    }
 
     /// Reports PD the split Region.
-    fn report_batch_split(&self, regions: Vec<metapb::Region>) -> PdFuture<()>;
+    fn report_batch_split(&self, _regions: Vec<metapb::Region>) -> PdFuture<()> {
+        unimplemented!();
+    }
 
     /// Scatters the Region across the cluster.
     fn scatter_region(&self, _: RegionInfo) -> Result<()> {
@@ -166,13 +197,19 @@ pub trait PdClient: Send + Sync {
     /// Please note that this method should only be called once.
     fn handle_reconnect<F: Fn() + Sync + Send + 'static>(&self, _: F) {}
 
-    fn get_gc_safe_point(&self) -> PdFuture<u64>;
+    fn get_gc_safe_point(&self) -> PdFuture<u64> {
+        unimplemented!();
+    }
 
     /// Gets store state if it is not a tombstone store.
-    fn get_store_stats(&self, store_id: u64) -> Result<pdpb::StoreStats>;
+    fn get_store_stats(&self, _store_id: u64) -> Result<pdpb::StoreStats> {
+        unimplemented!();
+    }
 
     /// Gets current operator of the region
-    fn get_operator(&self, region_id: u64) -> Result<pdpb::GetOperatorResponse>;
+    fn get_operator(&self, _region_id: u64) -> Result<pdpb::GetOperatorResponse> {
+        unimplemented!();
+    }
 }
 
 const REQUEST_TIMEOUT: u64 = 2; // 2s

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -5,7 +5,7 @@ use super::config::Config;
 use super::metrics::*;
 use super::waiter_manager::Scheduler as WaiterMgrScheduler;
 use super::{Error, Result};
-use crate::pd::{RpcClient, INVALID_ID};
+use crate::pd::{PdClient, INVALID_ID};
 use crate::raftstore::coprocessor::{Coprocessor, ObserverContext, RoleObserver};
 use crate::server::resolve::StoreAddrResolver;
 use crate::storage::lock_manager::Lock;
@@ -360,7 +360,11 @@ struct Inner {
 
 /// Detector is used to detect deadlocks between transactions. There is a leader
 /// in the cluster which collects all `wait_for_entry` from other followers.
-pub struct Detector<S: StoreAddrResolver + 'static> {
+pub struct Detector<S, P>
+where
+    S: StoreAddrResolver + 'static,
+    P: PdClient + 'static,
+{
     /// The store id of the node.
     store_id: u64,
     /// Used to create clients to the leader.
@@ -370,7 +374,7 @@ pub struct Detector<S: StoreAddrResolver + 'static> {
     /// The connection to the leader.
     leader_client: Option<Client>,
     /// Used to get the leader of leader region from PD.
-    pd_client: Arc<RpcClient>,
+    pd_client: Arc<P>,
     /// Used to resolve store address.
     resolver: S,
     /// Used to connect other nodes.
@@ -381,12 +385,21 @@ pub struct Detector<S: StoreAddrResolver + 'static> {
     inner: Rc<RefCell<Inner>>,
 }
 
-unsafe impl<S: StoreAddrResolver + 'static> Send for Detector<S> {}
+unsafe impl<S, P> Send for Detector<S, P>
+where
+    S: StoreAddrResolver + 'static,
+    P: PdClient + 'static,
+{
+}
 
-impl<S: StoreAddrResolver + 'static> Detector<S> {
+impl<S, P> Detector<S, P>
+where
+    S: StoreAddrResolver + 'static,
+    P: PdClient + 'static,
+{
     pub fn new(
         store_id: u64,
-        pd_client: Arc<RpcClient>,
+        pd_client: Arc<P>,
         resolver: S,
         security_mgr: Arc<SecurityManager>,
         waiter_mgr_scheduler: WaiterMgrScheduler,
@@ -444,7 +457,7 @@ impl<S: StoreAddrResolver + 'static> Detector<S> {
 
     /// Gets leader info from PD.
     fn get_leader_info(&self) -> Result<Option<(u64, String)>> {
-        let (_, leader) = self.pd_client.get_region_and_leader(LEADER_KEY)?;
+        let leader = self.pd_client.get_region_info(LEADER_KEY)?.leader;
         match leader {
             Some(leader) => {
                 let leader_id = leader.get_store_id();
@@ -702,7 +715,11 @@ impl<S: StoreAddrResolver + 'static> Detector<S> {
     }
 }
 
-impl<S: StoreAddrResolver + 'static> FutureRunnable<Task> for Detector<S> {
+impl<S, P> FutureRunnable<Task> for Detector<S, P>
+where
+    S: StoreAddrResolver + 'static,
+    P: PdClient + 'static,
+{
     fn run(&mut self, task: Task, handle: &Handle) {
         match task {
             Task::Detect { tp, txn_ts, lock } => {

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -12,17 +12,30 @@ pub use self::deadlock::Service as DeadlockService;
 use self::deadlock::{Detector, Scheduler as DetectorScheduler};
 use self::waiter_manager::{Scheduler as WaiterMgrScheduler, WaiterManager};
 
-use crate::pd::RpcClient;
+use crate::pd::PdClient;
 use crate::raftstore::coprocessor::CoprocessorHost;
 use crate::server::resolve::StoreAddrResolver;
 use crate::server::{Error, Result};
 use crate::storage::txn::{execute_callback, ProcessResult};
 use crate::storage::{lock_manager::Lock, LockMgr, StorageCb};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::thread::JoinHandle;
+use tikv_util::collections::HashSet;
 use tikv_util::security::SecurityManager;
 use tikv_util::worker::FutureWorker;
+
+const DETECTED_SLOTS_NUM: usize = 128;
+
+#[inline]
+fn detected_slot_idx(txn_ts: u64) -> usize {
+    let mut s = DefaultHasher::new();
+    txn_ts.hash(&mut s);
+    (s.finish() as usize) & (DETECTED_SLOTS_NUM - 1)
+}
 
 /// `LockManager` has two components working in two threads:
 ///   * One is the `WaiterManager` which manages transactions waiting for locks.
@@ -35,6 +48,9 @@ pub struct LockManager {
     detector_scheduler: DetectorScheduler,
 
     waiter_count: Arc<AtomicUsize>,
+
+    /// Record transactions which have sent requests to detect deadlock.
+    detected: Arc<Vec<Mutex<HashSet<u64>>>>,
 }
 
 impl Clone for LockManager {
@@ -45,6 +61,7 @@ impl Clone for LockManager {
             waiter_mgr_scheduler: self.waiter_mgr_scheduler.clone(),
             detector_scheduler: self.detector_scheduler.clone(),
             waiter_count: self.waiter_count.clone(),
+            detected: self.detected.clone(),
         }
     }
 }
@@ -53,6 +70,8 @@ impl LockManager {
     pub fn new() -> Self {
         let waiter_mgr_worker = FutureWorker::new("waiter-manager");
         let detector_worker = FutureWorker::new("deadlock-detector");
+        let mut detected = Vec::with_capacity(DETECTED_SLOTS_NUM);
+        detected.resize_with(DETECTED_SLOTS_NUM, || Mutex::new(HashSet::default()));
 
         Self {
             waiter_mgr_scheduler: WaiterMgrScheduler::new(waiter_mgr_worker.scheduler()),
@@ -60,18 +79,23 @@ impl LockManager {
             detector_scheduler: DetectorScheduler::new(detector_worker.scheduler()),
             detector_worker: Some(detector_worker),
             waiter_count: Arc::new(AtomicUsize::new(0)),
+            detected: Arc::new(detected),
         }
     }
 
     /// Starts `WaiterManager` and `Detector`.
-    pub fn start<S: StoreAddrResolver + 'static>(
+    pub fn start<S, P>(
         &mut self,
         store_id: u64,
-        pd_client: Arc<RpcClient>,
+        pd_client: Arc<P>,
         resolver: S,
         security_mgr: Arc<SecurityManager>,
         cfg: &Config,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        S: StoreAddrResolver + 'static,
+        P: PdClient + 'static,
+    {
         self.start_waiter_manager(cfg)?;
         self.start_deadlock_detector(store_id, pd_client, resolver, security_mgr, cfg)?;
         Ok(())
@@ -110,14 +134,18 @@ impl LockManager {
         }
     }
 
-    fn start_deadlock_detector<S: StoreAddrResolver + 'static>(
+    fn start_deadlock_detector<S, P>(
         &mut self,
         store_id: u64,
-        pd_client: Arc<RpcClient>,
+        pd_client: Arc<P>,
         resolver: S,
         security_mgr: Arc<SecurityManager>,
         cfg: &Config,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        S: StoreAddrResolver + 'static,
+        P: PdClient + 'static,
+    {
         let detector_runner = Detector::new(
             store_id,
             pd_client,
@@ -161,6 +189,16 @@ impl LockManager {
             self.detector_scheduler.clone(),
         )
     }
+
+    fn add_to_detected(&self, txn_ts: u64) {
+        let mut detected = self.detected[detected_slot_idx(txn_ts)].lock().unwrap();
+        detected.insert(txn_ts);
+    }
+
+    fn remove_from_detected(&self, txn_ts: u64) -> bool {
+        let mut detected = self.detected[detected_slot_idx(txn_ts)].lock().unwrap();
+        detected.remove(&txn_ts)
+    }
 }
 
 impl LockMgr for LockManager {
@@ -184,8 +222,9 @@ impl LockMgr for LockManager {
         self.waiter_mgr_scheduler
             .wait_for(start_ts, cb, pr, lock, timeout as u64);
 
-        // If it is the first lock the transaction waits for, it won't cause deadlock.
+        // If it is the first lock the transaction tries to lock, it won't cause deadlock.
         if !is_first_lock {
+            self.add_to_detected(start_ts);
             self.detector_scheduler.detect(start_ts, lock);
         }
     }
@@ -203,11 +242,9 @@ impl LockMgr for LockManager {
             self.waiter_mgr_scheduler
                 .wake_up(lock_ts, hashes, commit_ts);
         }
-        // If these locks belong to a pessimistic transaction, clean up its wait-for entries
-        // in the deadlock detector.
-        //
-        // TODO: only clean up if the transaction once waited for locks.
-        if is_pessimistic_txn {
+        // If a pessimistic transaction is committed or rolled back and it once sent requests to
+        // detect deadlock, clean up its wait-for entries in the deadlock detector.
+        if is_pessimistic_txn && self.remove_from_detected(lock_ts) {
             self.detector_scheduler.clean_up(lock_ts);
         }
     }
@@ -220,9 +257,163 @@ impl LockMgr for LockManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::mpsc::channel;
+    use crate::pd::{RegionInfo, Result as PdResult};
+    use crate::raftstore::coprocessor::Config as CopConfig;
+    use crate::server::resolve::Callback;
+    use crate::storage::{
+        mvcc::Error as MvccError, txn::Error as TxnError, Error as StorageError,
+        Result as StorageResult,
+    };
+    use kvproto::kvrpcpb::LockInfo;
+    use kvproto::metapb::Region;
+    use metrics::*;
+    use raft::StateRole;
+    use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;
+    use tikv_util::security::SecurityConfig;
+
+    struct MockPdClient;
+
+    impl PdClient for MockPdClient {
+        fn get_region_info(&self, _key: &[u8]) -> PdResult<RegionInfo> {
+            unimplemented!();
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockResolver;
+
+    impl StoreAddrResolver for MockResolver {
+        fn resolve(&self, _store_id: u64, _cb: Callback) -> Result<()> {
+            Err(Error::Other(box_err!("unimplemented")))
+        }
+    }
+
+    fn start_lock_manager() -> LockManager {
+        let (tx, _rx) = mpsc::sync_channel(100);
+        let mut coprocessor_host = CoprocessorHost::new(CopConfig::default(), tx);
+
+        let mut lock_mgr = LockManager::new();
+        lock_mgr.register_detector_role_change_observer(&mut coprocessor_host);
+        lock_mgr
+            .start(
+                1,
+                Arc::new(MockPdClient {}),
+                MockResolver {},
+                Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap()),
+                &Config::default(),
+            )
+            .unwrap();
+
+        // Make sure the deadlock detector is the leader.
+        let mut leader_region = Region::new();
+        leader_region.set_start_key(b"".to_vec());
+        leader_region.set_end_key(b"foo".to_vec());
+        coprocessor_host.on_role_change(&leader_region, StateRole::Leader);
+        thread::sleep(Duration::from_millis(100));
+
+        lock_mgr
+    }
+
+    #[test]
+    fn test_single_lock_manager() {
+        let lock_mgr = start_lock_manager();
+
+        let (tx, rx) = mpsc::channel();
+        let storage_callback = |tx: mpsc::Sender<_>| {
+            StorageCb::Boolean(Box::new(move |result| {
+                tx.send(result).unwrap();
+            }))
+        };
+        let recv = |rx: &mpsc::Receiver<StorageResult<()>>| {
+            rx.recv_timeout(Duration::from_millis(500))
+                .unwrap()
+                .unwrap_err();
+        };
+
+        // Normal wake up
+        assert_eq!(lock_mgr.has_waiter(), false);
+        lock_mgr.wait_for(
+            10,
+            storage_callback(tx.clone()),
+            ProcessResult::Res,
+            Lock { ts: 20, hash: 20 },
+            true,
+            0,
+        );
+        assert_eq!(lock_mgr.has_waiter(), true);
+        lock_mgr.wake_up(20, Some(vec![20]), 20, false);
+        recv(&rx);
+        assert_eq!(lock_mgr.has_waiter(), false);
+
+        // Normal deadlock
+        lock_mgr.wait_for(
+            30,
+            storage_callback(tx.clone()),
+            ProcessResult::Res,
+            Lock { ts: 40, hash: 40 },
+            false,
+            0,
+        );
+        lock_mgr.wait_for(
+            40,
+            storage_callback(tx.clone()),
+            ProcessResult::MultiRes {
+                results: vec![Err(StorageError::from(TxnError::from(
+                    MvccError::KeyIsLocked(LockInfo::default()),
+                )))],
+            },
+            Lock { ts: 30, hash: 30 },
+            false,
+            0,
+        );
+        recv(&rx);
+        lock_mgr.wake_up(40, Some(vec![40]), 40, true);
+        recv(&rx);
+        assert_eq!(lock_mgr.has_waiter(), false);
+
+        // If it's the first lock, no detect
+        lock_mgr.wait_for(
+            50,
+            storage_callback(tx.clone()),
+            ProcessResult::Res,
+            Lock { ts: 60, hash: 60 },
+            true,
+            0,
+        );
+        assert_eq!(lock_mgr.remove_from_detected(50), false);
+        lock_mgr.wake_up(60, Some(vec![60]), 60, false);
+        recv(&rx);
+
+        // If it's not the first lock, detect deadlock
+        lock_mgr.wait_for(
+            50,
+            storage_callback(tx.clone()),
+            ProcessResult::Res,
+            Lock { ts: 60, hash: 60 },
+            false,
+            0,
+        );
+        assert_eq!(lock_mgr.remove_from_detected(50), true);
+        lock_mgr.wake_up(60, Some(vec![60]), 60, false);
+        recv(&rx);
+
+        // If key_hashes is none, no wake up
+        let prev_wake_up = TASK_COUNTER_VEC.wake_up.get();
+        lock_mgr.wake_up(70, None, 70, false);
+        assert_eq!(TASK_COUNTER_VEC.wake_up.get(), prev_wake_up);
+
+        // If it's non-pessimistic-txn, no clean up
+        let prev_clean_up = TASK_COUNTER_VEC.clean_up.get();
+        lock_mgr.wake_up(80, None, 80, false);
+        assert_eq!(TASK_COUNTER_VEC.clean_up.get(), prev_clean_up);
+
+        // If the txn doesn't wait for locks, no clean up
+        let prev_clean_up = TASK_COUNTER_VEC.clean_up.get();
+        lock_mgr.wake_up(80, None, 80, true);
+        assert_eq!(TASK_COUNTER_VEC.clean_up.get(), prev_clean_up);
+    }
 
     #[test]
     fn test_has_waiter() {
@@ -259,7 +450,7 @@ mod tests {
     #[test]
     fn test_no_wait() {
         let lock_mgr = LockManager::new();
-        let (tx, rx) = channel();
+        let (tx, rx) = mpsc::channel();
         lock_mgr.wait_for(
             10,
             StorageCb::Boolean(Box::new(move |x| {

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -143,9 +143,8 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
 
-    use crate::pd::{PdClient, PdFuture, RegionStat, Result};
+    use crate::pd::{PdClient, Result};
     use kvproto::metapb;
-    use kvproto::pdpb;
     use tikv_util::collections::HashMap;
 
     const STORE_ADDRESS_REFRESH_SECONDS: u64 = 60;
@@ -156,21 +155,6 @@ mod tests {
     }
 
     impl PdClient for MockPdClient {
-        fn get_cluster_id(&self) -> Result<u64> {
-            unimplemented!();
-        }
-        fn bootstrap_cluster(&self, _: metapb::Store, _: metapb::Region) -> Result<()> {
-            unimplemented!();
-        }
-        fn is_cluster_bootstrapped(&self) -> Result<bool> {
-            unimplemented!();
-        }
-        fn alloc_id(&self) -> Result<u64> {
-            unimplemented!();
-        }
-        fn put_store(&self, _: metapb::Store) -> Result<()> {
-            unimplemented!();
-        }
         fn get_store(&self, _: u64) -> Result<metapb::Store> {
             // The store address will be changed every millisecond.
             let mut store = self.store.clone();
@@ -178,57 +162,6 @@ mod tests {
             sock.set_port(tikv_util::time::duration_to_ms(self.start.elapsed()) as u16);
             store.set_address(format!("{}:{}", sock.ip(), sock.port()));
             Ok(store)
-        }
-        fn get_cluster_config(&self) -> Result<metapb::Cluster> {
-            unimplemented!();
-        }
-        fn get_region(&self, _: &[u8]) -> Result<metapb::Region> {
-            unimplemented!();
-        }
-        fn get_region_by_id(&self, _: u64) -> PdFuture<Option<metapb::Region>> {
-            unimplemented!();
-        }
-        fn region_heartbeat(
-            &self,
-            _: metapb::Region,
-            _: metapb::Peer,
-            _: RegionStat,
-        ) -> PdFuture<()> {
-            unimplemented!();
-        }
-
-        fn handle_region_heartbeat_response<F>(&self, _: u64, _: F) -> PdFuture<()>
-        where
-            F: Fn(pdpb::RegionHeartbeatResponse) + Send + 'static,
-        {
-            unimplemented!()
-        }
-
-        fn ask_split(&self, _: metapb::Region) -> PdFuture<pdpb::AskSplitResponse> {
-            unimplemented!();
-        }
-
-        fn ask_batch_split(
-            &self,
-            _: metapb::Region,
-            _: usize,
-        ) -> PdFuture<pdpb::AskBatchSplitResponse> {
-            unimplemented!();
-        }
-        fn store_heartbeat(&self, _: pdpb::StoreStats) -> PdFuture<()> {
-            unimplemented!();
-        }
-        fn report_batch_split(&self, _: Vec<metapb::Region>) -> PdFuture<()> {
-            unimplemented!();
-        }
-        fn get_gc_safe_point(&self) -> PdFuture<u64> {
-            unimplemented!();
-        }
-        fn get_store_stats(&self, _: u64) -> Result<pdpb::StoreStats> {
-            unimplemented!()
-        }
-        fn get_operator(&self, _: u64) -> Result<pdpb::GetOperatorResponse> {
-            unimplemented!()
         }
     }
 


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
Cherry pck #5959 

Don't send clean up requests if a pessimistic transaction doesn't detect deadlocks.

###  What is the type of the changes?
- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?
- Unit test
- Manual test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No

###  Does this PR affect `tidb-ansible`?
No

###  Any examples? (optional)
![image](https://user-images.githubusercontent.com/14819777/69128374-1e484f80-0ae7-11ea-8f6b-578d61f627ab.png)

