### PR TITLE
tidb_query: fix analyze column inconsistent behavior betwen TiDB and TiKV

### DIFF
--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -287,7 +287,9 @@ impl SampleCollector {
         }
         if self.rng.gen_range(0, self.count) < self.max_sample_size as u64 {
             let idx = self.rng.gen_range(0, self.max_sample_size);
-            self.samples[idx] = data;
+            // https://github.com/pingcap/tidb/blob/master/statistics/sample.go#L173
+            self.samples.remove(idx);
+            self.samples.push(data);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

The TiKV has inconsistent behavior with TiDB about analyzing column. see: 
https://github.com/pingcap/tidb/blob/eae41adc0cd4a617d792a8bb426033c433a70527/statistics/sample.go#L173

The TiDB assumes samples will keep order with the original data order if the samples count greater than the `max_sample_count`. But TiKV replaces the original data if the index conflict, which breaks the assumption.

According to the TiDB logic, we should remove the item which index conflected, and append the new item to the samples.

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix (a change which fixes an issue)

###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- Unit test

