### PR TITLE
raftstore: attach peer tag to box errors

### DIFF
--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -1396,7 +1396,7 @@ pub fn do_snapshot(
     let state: RegionLocalState = kv_snap
         .get_msg_cf(CF_RAFT, &keys::region_state_key(key.region_id))
         .and_then(|res| match res {
-            None => Err(box_err!("could not find region info")),
+            None => Err(box_err!("region {} could not find region info", region_id)),
             Some(state) => Ok(state),
         })
         .map_err(into_other::<_, raft::Error>)?;


### PR DESCRIPTION

###  What have you changed?

Attach peer tag to box errors, it is convenient for debugging.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.

