### PR TITLE
copr: supprot scanning all locks first in RangeScanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
  "grpcio",
  "hex",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "lazy_static",
  "prometheus",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -396,7 +396,7 @@ dependencies = [
  "futures-cpupool",
  "grpcio",
  "hex",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "libc",
  "log",
  "nix 0.11.1",
@@ -730,7 +730,7 @@ version = "0.0.1"
 dependencies = [
  "engine_traits",
  "hex",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "lazy_static",
  "prometheus",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +757,7 @@ dependencies = [
  "engine",
  "engine_traits",
  "hex",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "lazy_static",
  "prometheus",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1378,7 +1378,7 @@ dependencies = [
  "failure",
  "farmhash",
  "hex",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "panic_hook",
  "slog",
  "tikv_alloc",
@@ -1388,7 +1388,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/Fullstop000/kvproto.git#34635b3ffd6a92aa01188bde0d3dab0e5dfdfb0f"
+source = "git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks#b7f9ad8ff8182841e4e1047919af0b4edf22235e"
 dependencies = [
  "bytes",
  "futures",
@@ -1396,6 +1396,18 @@ dependencies = [
  "lazy_static",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-build",
+ "raft-proto 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kvproto"
+version = "0.0.2"
+source = "git+https://github.com/pingcap/kvproto.git#4c654046831d1f4d7db8e4d44f7a6d0b35c33168"
+dependencies = [
+ "futures",
+ "grpcio",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-build",
  "raft-proto 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1523,7 +1535,7 @@ name = "log_wrappers"
 version = "0.0.1"
 dependencies = [
  "hex",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "slog",
  "slog-term",
  "tikv_alloc",
@@ -1993,7 +2005,7 @@ dependencies = [
  "grpcio",
  "hex",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "lazy_static",
  "log",
  "prometheus",
@@ -2988,7 +3000,7 @@ dependencies = [
  "grpcio",
  "hex",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "lazy_static",
  "prometheus",
  "quick-error",
@@ -3206,7 +3218,7 @@ name = "test_coprocessor"
 version = "0.0.1"
 dependencies = [
  "futures",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_storage",
@@ -3226,7 +3238,7 @@ dependencies = [
  "grpcio",
  "hex",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "pd_client",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3249,7 +3261,7 @@ dependencies = [
  "engine_rocks",
  "engine_traits",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "uuid",
 ]
 
@@ -3259,7 +3271,7 @@ version = "0.0.1"
 dependencies = [
  "futures",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "test_raftstore",
  "tikv",
  "tikv_util",
@@ -3297,7 +3309,7 @@ dependencies = [
  "grpcio",
  "hex",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "panic_hook",
  "pd_client",
  "profiler",
@@ -3360,7 +3372,7 @@ dependencies = [
  "flate2",
  "hex",
  "indexmap",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "lazy_static",
  "match_template",
  "nom 5.0.1",
@@ -3444,7 +3456,7 @@ dependencies = [
  "hex",
  "hyper",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
  "lazy_static",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
  "grpcio",
  "hex",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "lazy_static",
  "prometheus",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -396,7 +396,7 @@ dependencies = [
  "futures-cpupool",
  "grpcio",
  "hex",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "libc",
  "log",
  "nix 0.11.1",
@@ -730,7 +730,7 @@ version = "0.0.1"
 dependencies = [
  "engine_traits",
  "hex",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "lazy_static",
  "prometheus",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +757,7 @@ dependencies = [
  "engine",
  "engine_traits",
  "hex",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "lazy_static",
  "prometheus",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1378,7 +1378,7 @@ dependencies = [
  "failure",
  "farmhash",
  "hex",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "panic_hook",
  "slog",
  "tikv_alloc",
@@ -1396,18 +1396,6 @@ dependencies = [
  "lazy_static",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf-build",
- "raft-proto 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kvproto"
-version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#4c654046831d1f4d7db8e4d44f7a6d0b35c33168"
-dependencies = [
- "futures",
- "grpcio",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-build",
  "raft-proto 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1535,7 +1523,7 @@ name = "log_wrappers"
 version = "0.0.1"
 dependencies = [
  "hex",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "slog",
  "slog-term",
  "tikv_alloc",
@@ -2005,7 +1993,7 @@ dependencies = [
  "grpcio",
  "hex",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "lazy_static",
  "log",
  "prometheus",
@@ -3000,7 +2988,7 @@ dependencies = [
  "grpcio",
  "hex",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "lazy_static",
  "prometheus",
  "quick-error",
@@ -3218,7 +3206,7 @@ name = "test_coprocessor"
 version = "0.0.1"
 dependencies = [
  "futures",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_storage",
@@ -3238,7 +3226,7 @@ dependencies = [
  "grpcio",
  "hex",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "pd_client",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3261,7 +3249,7 @@ dependencies = [
  "engine_rocks",
  "engine_traits",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "uuid",
 ]
 
@@ -3271,7 +3259,7 @@ version = "0.0.1"
 dependencies = [
  "futures",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "test_raftstore",
  "tikv",
  "tikv_util",
@@ -3309,7 +3297,7 @@ dependencies = [
  "grpcio",
  "hex",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "panic_hook",
  "pd_client",
  "profiler",
@@ -3372,7 +3360,7 @@ dependencies = [
  "flate2",
  "hex",
  "indexmap",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "lazy_static",
  "match_template",
  "nom 5.0.1",
@@ -3456,7 +3444,7 @@ dependencies = [
  "hex",
  "hyper",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/Fullstop000/kvproto.git?branch=batch_resolve_locks)",
+ "kvproto",
  "lazy_static",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#4c654046831d1f4d7db8e4d44f7a6d0b35c33168"
+source = "git+https://github.com/Fullstop000/kvproto.git#34635b3ffd6a92aa01188bde0d3dab0e5dfdfb0f"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ rev_lines = "0.2.1"
 nom = "5.0.1"
 derive-new = "0.5"
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 
 tikv_alloc = { path = "components/tikv_alloc", default-features = false }
 tikv_util = { path = "components/tikv_util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ rev_lines = "0.2.1"
 nom = "5.0.1"
 derive-new = "0.5"
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 
 tikv_alloc = { path = "components/tikv_alloc", default-features = false }
 tikv_util = { path = "components/tikv_util" }

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -48,7 +48,7 @@ grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default
 raft = { version = "0.6.0-alpha" , default-features = false }
 hex = "0.3"
 vlog = "0.1.4"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 tikv_util = { path = "../components/tikv_util" }
 engine = { path = "../components/engine" }
 pd_client = { path = "../components/pd_client" }

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -48,7 +48,7 @@ grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default
 raft = { version = "0.6.0-alpha" , default-features = false }
 hex = "0.3"
 vlog = "0.1.4"
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 tikv_util = { path = "../components/tikv_util" }
 engine = { path = "../components/engine" }
 pd_client = { path = "../components/pd_client" }

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -10,8 +10,8 @@ path = "tests/integrations/mod.rs"
 
 [dependencies]
 crc64fast = "0.1"
-tikv = { path = "../../" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+tikv = { path = "../../", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -11,7 +11,7 @@ path = "tests/integrations/mod.rs"
 [dependencies]
 crc64fast = "0.1"
 tikv = { path = "../../", default-features = false }
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -10,7 +10,7 @@ path = "tests/integrations/mod.rs"
 
 [dependencies]
 crc64fast = "0.1"
-tikv = { path = "../../", default-features = false }
+tikv = { path = "../../" }
 kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/backup/tests/integrations/test_backup.rs
+++ b/components/backup/tests/integrations/test_backup.rs
@@ -210,6 +210,7 @@ impl TestSuite {
             scan_backward_in_range: false,
             is_key_only: false,
             is_scanned_range_aware: false,
+            scan_locks_first: false,
         });
         let digest = crc64fast::Digest::new();
         while let Some((k, v)) = scanner.next().unwrap() {

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -12,7 +12,7 @@ prost-codec = ["prost"]
 
 [dependencies]
 protobuf = "2.8"
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 raft = { version = "0.6.0-alpha" , default-features = false }
 prost = { version = "0.5", optional = true }
 quick-error = "1.2.2"

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -12,7 +12,7 @@ prost-codec = ["prost"]
 
 [dependencies]
 protobuf = "2.8"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha" , default-features = false }
 prost = { version = "0.5", optional = true }
 quick-error = "1.2.2"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -10,7 +10,7 @@ portable = ["rocksdb/portable"]
 sse = ["rocksdb/sse"]
 
 [dependencies]
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 protobuf = "2"
 raft = { version = "0.6.0-alpha", default-features = false }
 quick-error = "1.2.2"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -10,7 +10,7 @@ portable = ["rocksdb/portable"]
 sse = ["rocksdb/sse"]
 
 [dependencies]
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 protobuf = "2"
 raft = { version = "0.6.0-alpha", default-features = false }
 quick-error = "1.2.2"

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -10,9 +10,8 @@ derive_more = "0.15.0"
 failure = "0.1"
 farmhash = "1.1.5"
 hex = "0.3"
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 slog = "2.3"
-
 tikv_alloc = { path = "../tikv_alloc", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }
 

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -10,7 +10,7 @@ derive_more = "0.15.0"
 failure = "0.1"
 farmhash = "1.1.5"
 hex = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 slog = "2.3"
 
 tikv_alloc = { path = "../tikv_alloc", default-features = false }

--- a/components/log_wrappers/Cargo.toml
+++ b/components/log_wrappers/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 slog = "2.3"
 slog-term = "2.4"
 hex = "0.3"
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 tikv_alloc = { path = "../tikv_alloc", default-features = false }

--- a/components/log_wrappers/Cargo.toml
+++ b/components/log_wrappers/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 slog = "2.3"
 slog-term = "2.4"
 hex = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 tikv_alloc = { path = "../tikv_alloc", default-features = false }

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -23,7 +23,7 @@ serde_derive = "1.0"
 grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default-features = false }
 keys = { path = "../keys" }
 tikv_util = { path = "../tikv_util" }
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 hex = "0.3"
 
 [dependencies.prometheus]

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -23,7 +23,7 @@ serde_derive = "1.0"
 grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default-features = false }
 keys = { path = "../keys" }
 tikv_util = { path = "../tikv_util" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 hex = "0.3"
 
 [dependencies.prometheus]

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -16,7 +16,7 @@ tokio-sync = "0.1.7"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 engine_traits = { path = "../engine_traits" }
 keys = { path = "../keys" }
 tikv_alloc = { path = "../tikv_alloc", default-features = false }

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -16,7 +16,7 @@ tokio-sync = "0.1.7"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 engine_traits = { path = "../engine_traits" }
 keys = { path = "../keys" }
 tikv_alloc = { path = "../tikv_alloc", default-features = false }

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -10,7 +10,7 @@ prost-codec = ["prost"]
 [dependencies]
 tikv = { path = "../../" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 prost = { version = "0.5", optional = true }
 protobuf = "2"
 futures = "0.1"

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -10,7 +10,7 @@ prost-codec = ["prost"]
 [dependencies]
 tikv = { path = "../../" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 prost = { version = "0.5", optional = true }
 protobuf = "2"
 futures = "0.1"

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 tikv_util = { path = "../tikv_util" }
 tikv = { path = "../../" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 protobuf = "2.8"
 tempfile = "3.0"
 raft = { version = "0.6.0-alpha" , default-features = false }

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 tikv_util = { path = "../tikv_util" }
 tikv = { path = "../../" }
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 protobuf = "2.8"
 tempfile = "3.0"
 raft = { version = "0.6.0-alpha" , default-features = false }

--- a/components/test_sst_importer/Cargo.toml
+++ b/components/test_sst_importer/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 crc32fast = "1.2"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 
 engine = { path = "../engine" }
 engine_traits = { path = "../engine_traits" }

--- a/components/test_sst_importer/Cargo.toml
+++ b/components/test_sst_importer/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 crc32fast = "1.2"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 
 engine = { path = "../engine" }
 engine_traits = { path = "../engine_traits" }

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -9,5 +9,5 @@ keys = { path = "../keys" }
 tikv_util = { path = "../tikv_util" }
 tikv = { path = "../../" }
 test_raftstore = { path = "../test_raftstore" }
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 futures = "0.1"

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -9,5 +9,5 @@ keys = { path = "../keys" }
 tikv_util = { path = "../tikv_util" }
 tikv = { path = "../../" }
 test_raftstore = { path = "../test_raftstore" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 futures = "0.1"

--- a/components/tidb_query/Cargo.toml
+++ b/components/tidb_query/Cargo.toml
@@ -40,7 +40,7 @@ slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debu
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 boolinator = "2.4.0"
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
-kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 
 tipb_helper = { path = "../tipb_helper" }
 tikv_util = { path = "../tikv_util" }

--- a/components/tidb_query/Cargo.toml
+++ b/components/tidb_query/Cargo.toml
@@ -40,7 +40,7 @@ slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debu
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 boolinator = "2.4.0"
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false }
 
 tipb_helper = { path = "../tipb_helper" }
 tikv_util = { path = "../tikv_util" }

--- a/components/tidb_query/src/batch/executors/index_scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/index_scan_executor.rs
@@ -322,6 +322,7 @@ mod tests {
                 key_ranges,
                 true,
                 false,
+                false,
             )
             .unwrap();
 
@@ -374,6 +375,7 @@ mod tests {
                     columns_info[2].clone(),
                 ],
                 key_ranges,
+                false,
                 false,
                 false,
             )
@@ -451,6 +453,7 @@ mod tests {
                 key_ranges,
                 false,
                 false,
+                false,
             )
             .unwrap();
 
@@ -506,6 +509,7 @@ mod tests {
                 key_ranges,
                 false,
                 true,
+                false,
             )
             .unwrap();
 

--- a/components/tidb_query/src/batch/executors/index_scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/index_scan_executor.rs
@@ -36,6 +36,7 @@ impl<S: Storage> BatchIndexScanExecutor<S> {
         key_ranges: Vec<KeyRange>,
         is_backward: bool,
         unique: bool,
+        scan_locks_first: bool,
     ) -> Result<Self> {
         // Note 1: `unique = true` doesn't completely mean that it is a unique index scan. Instead
         // it just means that we can use point-get for this index. In the following scenarios
@@ -74,6 +75,7 @@ impl<S: Storage> BatchIndexScanExecutor<S> {
             is_backward,
             is_key_only: false,
             accept_point_range: unique,
+            scan_locks_first,
         })?;
         Ok(Self(wrapper))
     }

--- a/components/tidb_query/src/batch/executors/table_scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/table_scan_executor.rs
@@ -39,6 +39,7 @@ impl<S: Storage> BatchTableScanExecutor<S> {
         columns_info: Vec<ColumnInfo>,
         key_ranges: Vec<KeyRange>,
         is_backward: bool,
+        scan_locks_first: bool,
     ) -> Result<Self> {
         let is_column_filled = vec![false; columns_info.len()];
         let mut is_key_only = true;
@@ -83,6 +84,7 @@ impl<S: Storage> BatchTableScanExecutor<S> {
             is_backward,
             is_key_only,
             accept_point_range: true,
+            scan_locks_first,
         })?;
         Ok(Self(wrapper))
     }

--- a/components/tidb_query/src/batch/executors/table_scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/table_scan_executor.rs
@@ -575,6 +575,7 @@ mod tests {
             columns_info.clone(),
             ranges,
             false,
+            false,
         )
         .unwrap();
 
@@ -655,6 +656,7 @@ mod tests {
             Arc::new(EvalConfig::default()),
             helper.columns_info_by_idx(&[0]),
             vec![helper.whole_table_range()],
+            false,
             false,
         )
         .unwrap()
@@ -793,6 +795,7 @@ mod tests {
                     key_range_point[corrupted_row_index].clone(),
                 ],
                 false,
+                false,
             )
             .unwrap();
 
@@ -897,6 +900,7 @@ mod tests {
                     key_range_point[2].clone(),
                 ],
                 false,
+                false,
             )
             .unwrap();
 
@@ -930,6 +934,7 @@ mod tests {
                     key_range_point[1].clone(),
                     key_range_point[2].clone(),
                 ],
+                false,
                 false,
             )
             .unwrap();
@@ -967,6 +972,7 @@ mod tests {
                 columns_info.clone(),
                 vec![key_range_point[1].clone(), key_range_point[2].clone()],
                 false,
+                false,
             )
             .unwrap();
 
@@ -984,6 +990,7 @@ mod tests {
                 Arc::new(EvalConfig::default()),
                 columns_info.clone(),
                 vec![key_range_point[2].clone(), key_range_point[0].clone()],
+                false,
                 false,
             )
             .unwrap();
@@ -1015,6 +1022,7 @@ mod tests {
                 Arc::new(EvalConfig::default()),
                 columns_info.clone(),
                 vec![key_range_point[1].clone()],
+                false,
                 false,
             )
             .unwrap();
@@ -1062,6 +1070,7 @@ mod tests {
             Arc::new(EvalConfig::default()),
             columns_info,
             vec![key_range],
+            false,
             false,
         )
         .unwrap();

--- a/components/tidb_query/src/batch/executors/util/scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/util/scan_executor.rs
@@ -55,6 +55,7 @@ pub struct ScanExecutorOptions<S, I> {
     pub is_backward: bool,
     pub is_key_only: bool,
     pub accept_point_range: bool,
+    pub scan_locks_first: bool,
 }
 
 impl<S: Storage, I: ScanExecutorImpl> ScanExecutor<S, I> {
@@ -66,6 +67,7 @@ impl<S: Storage, I: ScanExecutorImpl> ScanExecutor<S, I> {
             is_backward,
             is_key_only,
             accept_point_range,
+            scan_locks_first,
         }: ScanExecutorOptions<S, I>,
     ) -> Result<Self> {
         crate::codec::table::check_table_ranges(&key_ranges)?;
@@ -83,6 +85,7 @@ impl<S: Storage, I: ScanExecutorImpl> ScanExecutor<S, I> {
                 scan_backward_in_range: is_backward,
                 is_key_only,
                 is_scanned_range_aware: false,
+                scan_locks_first,
             }),
             is_ended: false,
         })

--- a/components/tidb_query/src/batch/runner.rs
+++ b/components/tidb_query/src/batch/runner.rs
@@ -115,6 +115,7 @@ pub fn build_executors<S: Storage + 'static, C: ExecSummaryCollector + 'static>(
     storage: S,
     ranges: Vec<KeyRange>,
     config: Arc<EvalConfig>,
+    scan_locks_first: bool,
 ) -> Result<Box<dyn BatchExecutor<StorageStats = S::Statistics>>> {
     let mut executor_descriptors = executor_descriptors.into_iter();
     let mut first_ed = executor_descriptors
@@ -140,6 +141,7 @@ pub fn build_executors<S: Storage + 'static, C: ExecSummaryCollector + 'static>(
                     columns_info,
                     ranges,
                     descriptor.get_desc(),
+                    scan_locks_first,
                 )?
                 .with_summary_collector(C::new(summary_slot_index)),
             );
@@ -159,6 +161,7 @@ pub fn build_executors<S: Storage + 'static, C: ExecSummaryCollector + 'static>(
                     ranges,
                     descriptor.get_desc(),
                     descriptor.get_unique(),
+                    scan_locks_first,
                 )?
                 .with_summary_collector(C::new(summary_slot_index)),
             );
@@ -306,6 +309,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         ranges: Vec<KeyRange>,
         storage: S,
         deadline: Deadline,
+        scan_locks_first: bool,
     ) -> Result<Self> {
         let executors_len = req.get_executors().len();
         let collect_exec_summary = req.get_collect_execution_summaries();
@@ -318,6 +322,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
                 storage,
                 ranges,
                 config.clone(),
+                scan_locks_first,
             )?
         } else {
             build_executors::<_, ExecSummaryCollectorDisabled>(
@@ -325,6 +330,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
                 storage,
                 ranges,
                 config.clone(),
+                scan_locks_first,
             )?
         };
 

--- a/components/tidb_query/src/executor/aggregation.rs
+++ b/components/tidb_query/src/executor/aggregation.rs
@@ -516,6 +516,7 @@ mod tests {
             wrapper.store,
             unique,
             false,
+            false,
         )
         .unwrap();
         // init the stream aggregation executor
@@ -551,6 +552,7 @@ mod tests {
             wrapper.ranges,
             wrapper.store,
             unique,
+            false,
             false,
         )
         .unwrap();
@@ -605,6 +607,7 @@ mod tests {
             wrapper.ranges,
             wrapper.store,
             unique,
+            false,
             false,
         )
         .unwrap();

--- a/components/tidb_query/src/executor/index_scan.rs
+++ b/components/tidb_query/src/executor/index_scan.rs
@@ -277,6 +277,7 @@ pub mod tests {
             wrapper.store,
             false,
             false,
+            false,
         )
         .unwrap();
 
@@ -336,6 +337,7 @@ pub mod tests {
             wrapper.store,
             unique,
             false,
+            false,
         )
         .unwrap();
         for handle in 0..KEY_NUMBER {
@@ -392,6 +394,7 @@ pub mod tests {
             wrapper.store,
             unique,
             false,
+            false,
         )
         .unwrap();
 
@@ -419,6 +422,7 @@ pub mod tests {
             EvalContext::default(),
             wrapper.ranges,
             wrapper.store,
+            false,
             false,
             false,
         )

--- a/components/tidb_query/src/executor/index_scan.rs
+++ b/components/tidb_query/src/executor/index_scan.rs
@@ -77,6 +77,7 @@ impl<S: Storage> IndexScanExecutor<S> {
         storage: S,
         unique: bool,
         is_scanned_range_aware: bool,
+        scan_locks_first: bool,
     ) -> Result<Self> {
         let columns = meta.get_columns().to_vec();
         let inner = IndexInnerExecutor::new(&mut meta);
@@ -90,6 +91,7 @@ impl<S: Storage> IndexScanExecutor<S> {
             is_key_only: false,
             accept_point_range: unique,
             is_scanned_range_aware,
+            scan_locks_first,
         })
     }
 
@@ -114,6 +116,7 @@ impl<S: Storage> IndexScanExecutor<S> {
             is_key_only: false,
             accept_point_range: false,
             is_scanned_range_aware: false,
+            scan_locks_first: false,
         })
     }
 }

--- a/components/tidb_query/src/executor/mod.rs
+++ b/components/tidb_query/src/executor/mod.rs
@@ -528,6 +528,7 @@ pub mod tests {
                 key_ranges,
                 storage,
                 false,
+                false,
             )
             .unwrap(),
         )

--- a/components/tidb_query/src/executor/scan.rs
+++ b/components/tidb_query/src/executor/scan.rs
@@ -43,6 +43,7 @@ pub struct ScanExecutorOptions<S, T> {
     pub is_key_only: bool,
     pub accept_point_range: bool,
     pub is_scanned_range_aware: bool,
+    pub scan_locks_first: bool,
 }
 
 impl<S: Storage, T: InnerExecutor> ScanExecutor<S, T> {
@@ -57,6 +58,7 @@ impl<S: Storage, T: InnerExecutor> ScanExecutor<S, T> {
             is_key_only,
             accept_point_range,
             is_scanned_range_aware,
+            scan_locks_first,
         }: ScanExecutorOptions<S, T>,
     ) -> Result<Self> {
         box_try!(table::check_table_ranges(&key_ranges));
@@ -73,6 +75,7 @@ impl<S: Storage, T: InnerExecutor> ScanExecutor<S, T> {
             scan_backward_in_range: is_backward,
             is_key_only,
             is_scanned_range_aware,
+            scan_locks_first,
         });
 
         Ok(Self {

--- a/components/tidb_query/src/executor/table_scan.rs
+++ b/components/tidb_query/src/executor/table_scan.rs
@@ -57,6 +57,7 @@ impl<S: Storage> TableScanExecutor<S> {
         key_ranges: Vec<KeyRange>,
         storage: S,
         is_scanned_range_aware: bool,
+        scan_locks_first: bool,
     ) -> Result<Self> {
         let inner = TableInnerExecutor::new(&meta);
         let is_key_only = inner.is_key_only();
@@ -71,6 +72,7 @@ impl<S: Storage> TableScanExecutor<S> {
             is_key_only,
             accept_point_range: true,
             is_scanned_range_aware,
+            scan_locks_first,
         })
     }
 }

--- a/components/tidb_query/src/executor/table_scan.rs
+++ b/components/tidb_query/src/executor/table_scan.rs
@@ -145,6 +145,7 @@ mod tests {
             wrapper.ranges,
             wrapper.store,
             false,
+            false,
         )
         .unwrap();
 
@@ -190,6 +191,7 @@ mod tests {
             wrapper.ranges,
             wrapper.store,
             false,
+            false,
         )
         .unwrap();
 
@@ -234,6 +236,7 @@ mod tests {
             wrapper.ranges,
             wrapper.store,
             true,
+            false,
         )
         .unwrap();
 

--- a/components/tidb_query/src/storage/fixture.rs
+++ b/components/tidb_query/src/storage/fixture.rs
@@ -54,6 +54,7 @@ impl super::Storage for FixtureStorage {
         &mut self,
         is_backward_scan: bool,
         is_key_only: bool,
+        _ignore_lock: bool,
         range: IntervalRange,
     ) -> Result<()> {
         let data_view = self
@@ -103,6 +104,10 @@ impl super::Storage for FixtureStorage {
     }
 
     fn collect_statistics(&mut self, _dest: &mut Self::Statistics) {}
+
+    fn find_locks(&mut self, ranges: Vec<Range>) -> Result<()> {
+        unimplemented!();
+    }
 }
 
 #[cfg(test)]
@@ -137,7 +142,7 @@ mod tests {
 
         // Scan Backward = false, Key only = false
         storage
-            .begin_scan(false, false, IntervalRange::from(("foo", "foo_3")))
+            .begin_scan(false, false, false, IntervalRange::from(("foo", "foo_3")))
             .unwrap();
 
         assert_eq!(
@@ -163,7 +168,7 @@ mod tests {
 
         // Scan Backward = false, Key only = false
         storage
-            .begin_scan(false, false, IntervalRange::from(("bar", "bar_2")))
+            .begin_scan(false, false, false, IntervalRange::from(("bar", "bar_2")))
             .unwrap();
 
         assert_eq!(
@@ -174,7 +179,7 @@ mod tests {
 
         // Scan Backward = false, Key only = true
         storage
-            .begin_scan(false, true, IntervalRange::from(("bar", "foo_")))
+            .begin_scan(false, true, false, IntervalRange::from(("bar", "foo_")))
             .unwrap();
 
         assert_eq!(
@@ -193,7 +198,7 @@ mod tests {
 
         // Scan Backward = true, Key only = false
         storage
-            .begin_scan(true, false, IntervalRange::from(("foo", "foo_3")))
+            .begin_scan(true, false, false, IntervalRange::from(("foo", "foo_3")))
             .unwrap();
 
         assert_eq!(
@@ -209,12 +214,12 @@ mod tests {
 
         // Scan empty range
         storage
-            .begin_scan(false, false, IntervalRange::from(("faa", "fab")))
+            .begin_scan(false, false, false, IntervalRange::from(("faa", "fab")))
             .unwrap();
         assert_eq!(storage.scan_next().unwrap(), None);
 
         storage
-            .begin_scan(false, false, IntervalRange::from(("foo", "foo")))
+            .begin_scan(false, false, false, IntervalRange::from(("foo", "foo")))
             .unwrap();
         assert_eq!(storage.scan_next().unwrap(), None);
     }

--- a/components/tidb_query/src/storage/mod.rs
+++ b/components/tidb_query/src/storage/mod.rs
@@ -23,10 +23,13 @@ pub trait Storage: Send {
         &mut self,
         is_backward_scan: bool,
         is_key_only: bool,
+        ignore_lock: bool,
         range: IntervalRange,
     ) -> Result<()>;
 
     fn scan_next(&mut self) -> Result<Option<OwnedKvPair>>;
+
+    fn find_locks(&mut self, ranges: Vec<Range>) -> Result<()>;
 
     // TODO: Use const generics.
     // TODO: Use reference is better.
@@ -42,13 +45,18 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
         &mut self,
         is_backward_scan: bool,
         is_key_only: bool,
+        ignore_lock: bool,
         range: IntervalRange,
     ) -> Result<()> {
-        (**self).begin_scan(is_backward_scan, is_key_only, range)
+        (**self).begin_scan(is_backward_scan, is_key_only, ignore_lock, range)
     }
 
     fn scan_next(&mut self) -> Result<Option<OwnedKvPair>> {
         (**self).scan_next()
+    }
+
+    fn find_locks(&mut self, ranges: Vec<Range>) -> Result<()> {
+        (**self).find_locks(ranges)
     }
 
     fn get(&mut self, is_key_only: bool, range: PointRange) -> Result<Option<OwnedKvPair>> {

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -40,6 +40,7 @@ impl<S: Snapshot> ChecksumContext<S> {
             scan_backward_in_range: false,
             is_key_only: false,
             is_scanned_range_aware: false,
+            scan_locks_first: false,
         });
         Ok(Self { req, scanner })
     }

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -194,6 +194,7 @@ impl<E: Engine> Endpoint<E> {
                         batch_row_limit,
                         is_streaming,
                         enable_batch_if_possible,
+                        req.scan_all_locks,
                     )
                 });
             }
@@ -524,6 +525,10 @@ fn make_error_response(e: Error) -> coppb::Response {
         Error::Locked(info) => {
             tag = "meet_lock";
             resp.set_locked(info);
+        }
+        Error::MultiLocked(info) => {
+            tag = "meet_multiple_locks";
+            resp.set_all_locks(info.into());
         }
         Error::MaxExecuteTimeExceeded => {
             tag = "max_execute_time_exceeded";

--- a/src/coprocessor/error.rs
+++ b/src/coprocessor/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     #[fail(display = "Key is locked (will clean up) {:?}", _0)]
     Locked(kvproto::kvrpcpb::LockInfo),
 
+    #[fail(display = "Multiple keys are locked (will clean up)")]
+    MultiLocked(Vec<kvproto::kvrpcpb::LockInfo>),
+
     #[fail(display = "Coprocessor task terminated due to exceeding max time limit")]
     MaxExecuteTimeExceeded,
 

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -180,7 +180,7 @@ impl<S: Snapshot> SampleBuilder<S> {
         let mut meta = TableScan::default();
         meta.set_columns(cols_info);
         let table_scanner =
-            ScanExecutor::table_scan(meta, EvalContext::default(), ranges, storage, false)?;
+            ScanExecutor::table_scan(meta, EvalContext::default(), ranges, storage, false, false)?;
         Ok(Self {
             data: table_scanner,
             col_len,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -462,6 +462,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                                 scanner = snap_store.scanner(
                                     false,
                                     options.key_only,
+                                    false,
                                     Some(start_key),
                                     end_key,
                                 )?;
@@ -469,6 +470,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                                 scanner = snap_store.scanner(
                                     true,
                                     options.key_only,
+                                    false,
                                     end_key,
                                     Some(start_key),
                                 )?;

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -156,7 +156,7 @@ impl<S: Snapshot> BackwardScanner<S> {
                     IsolationLevel::Rc => {}
                 }
                 if let Some(lock_cursor) = self.lock_cursor.as_mut() {
-                    lock_cursor.next(&mut self.statistics.lock);
+                    lock_cursor.prev(&mut self.statistics.lock);
                 }
             }
             if has_write {

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -4,8 +4,8 @@ use kvproto::kvrpcpb::{IsolationLevel, LockInfo};
 
 use crate::storage::metrics::*;
 use crate::storage::mvcc::{
-    EntryScanner, Error as MvccError, ErrorInner as MvccErrorInner, Scanner as MvccScanner,
-    ScannerBuilder, WriteRef, PointGetter, PointGetterBuilder, TsSet, Lock,
+    EntryScanner, Error as MvccError, ErrorInner as MvccErrorInner, Lock, PointGetter,
+    PointGetterBuilder, Scanner as MvccScanner, ScannerBuilder, TsSet, WriteRef,
 };
 use crate::storage::{CursorBuilder, Key, KvPair, Snapshot, Statistics, Value};
 use engine::CF_LOCK;
@@ -310,7 +310,9 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
                                 match lock.check_ts_conflict(key, self.start_ts, &self.bypass_locks)
                                 {
                                     Ok(()) => continue,
-                                    Err(MvccError(box MvccErrorInner::KeyIsLocked(lock))) => locks.push(lock),
+                                    Err(MvccError(box MvccErrorInner::KeyIsLocked(lock))) => {
+                                        locks.push(lock)
+                                    }
                                     Err(e) => return Err(Error::from(e)),
                                 }
                             }
@@ -337,7 +339,9 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
                                         &self.bypass_locks,
                                     ) {
                                         Ok(()) => {}
-                                        Err(MvccError(box MvccErrorInner::KeyIsLocked(lock))) => locks.push(lock),
+                                        Err(MvccError(box MvccErrorInner::KeyIsLocked(lock))) => {
+                                            locks.push(lock)
+                                        }
                                         Err(e) => return Err(Error::from(e)),
                                     }
                                     lock_cursor.next(&mut statistics.lock);
@@ -1345,6 +1349,7 @@ mod benches {
                 .scanner(
                     test::black_box(true),
                     test::black_box(false),
+                    test::black_box(false),
                     test::black_box(None),
                     test::black_box(None),
                 )
@@ -1366,6 +1371,7 @@ mod benches {
             let mut scanner = store
                 .scanner(
                     test::black_box(true),
+                    test::black_box(false),
                     test::black_box(false),
                     test::black_box(None),
                     test::black_box(None),
@@ -1391,6 +1397,7 @@ mod benches {
             let mut scanner = store
                 .scanner(
                     test::black_box(true),
+                    test::black_box(false),
                     test::black_box(false),
                     test::black_box(None),
                     test::black_box(None),

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -3,22 +3,14 @@
 use kvproto::kvrpcpb::{IsolationLevel, LockInfo};
 
 use crate::storage::metrics::*;
-<<<<<<< HEAD
 use crate::storage::mvcc::{
     EntryScanner, Error as MvccError, ErrorInner as MvccErrorInner, Scanner as MvccScanner,
-    ScannerBuilder, WriteRef,
+    ScannerBuilder, WriteRef, PointGetter, PointGetterBuilder, TsSet, Lock,
 };
-use crate::storage::mvcc::{PointGetter, PointGetterBuilder, TimeStamp, TsSet};
-use crate::storage::{Key, KvPair, Snapshot, Statistics, Value};
-=======
-use crate::storage::mvcc::EntryScanner;
-use crate::storage::mvcc::Error as MvccError;
-use crate::storage::mvcc::{Lock, Scanner as MvccScanner, ScannerBuilder, Write};
-use crate::storage::mvcc::{PointGetter, PointGetterBuilder, TsSet};
 use crate::storage::{CursorBuilder, Key, KvPair, Snapshot, Statistics, Value};
 use engine::CF_LOCK;
+use keys::TimeStamp;
 use tidb_query::storage::Range;
->>>>>>> *: add batch resolve locks support
 
 use super::{Error, ErrorInner, Result};
 
@@ -318,7 +310,7 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
                                 match lock.check_ts_conflict(key, self.start_ts, &self.bypass_locks)
                                 {
                                     Ok(()) => continue,
-                                    Err(MvccError::KeyIsLocked(lock)) => locks.push(lock),
+                                    Err(MvccError(box MvccErrorInner::KeyIsLocked(lock))) => locks.push(lock),
                                     Err(e) => return Err(Error::from(e)),
                                 }
                             }
@@ -345,7 +337,7 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
                                         &self.bypass_locks,
                                     ) {
                                         Ok(()) => {}
-                                        Err(MvccError::KeyIsLocked(lock)) => locks.push(lock),
+                                        Err(MvccError(box MvccErrorInner::KeyIsLocked(lock))) => locks.push(lock),
                                         Err(e) => return Err(Error::from(e)),
                                     }
                                     lock_cursor.next(&mut statistics.lock);

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -52,7 +52,7 @@ slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debu
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 tikv_util = { path = "../components/tikv_util" }
 pd_client = { path = "../components/pd_client" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/Fullstop000/kvproto.git", default-features = false, branch = "batch_resolve_locks" }
 tikv = { path = "../" }
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }

--- a/tests/benches/coprocessor_executors/index_scan/util.rs
+++ b/tests/benches/coprocessor_executors/index_scan/util.rs
@@ -52,6 +52,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
             black_box(TiKVStorage::from(ToTxnStore::<Self::T>::to_store(store))),
             black_box(unique),
             black_box(false),
+            black_box(false),
         )
         .unwrap();
         // There is a step of building scanner in the first `next()` which cost time,
@@ -83,6 +84,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder for BatchIndexScan
             black_box(ranges.to_vec()),
             black_box(false),
             black_box(unique),
+            black_box(false),
         )
         .unwrap();
         // There is a step of building scanner in the first `next()` which cost time,

--- a/tests/benches/coprocessor_executors/integrated/util.rs
+++ b/tests/benches/coprocessor_executors/integrated/util.rs
@@ -81,6 +81,7 @@ where
                 black_box(ranges.to_vec()),
                 black_box(Arc::new(EvalConfig::default())),
                 black_box(false),
+                black_box(false),
             )
             .unwrap()
         })
@@ -127,6 +128,7 @@ where
                 black_box(TiKVStorage::from(ToTxnStore::<T>::to_store(store))),
                 black_box(ranges.to_vec()),
                 black_box(Arc::new(EvalConfig::default())),
+                black_box(false),
             )
             .unwrap()
         })

--- a/tests/benches/coprocessor_executors/table_scan/util.rs
+++ b/tests/benches/coprocessor_executors/table_scan/util.rs
@@ -50,6 +50,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder
             black_box(ranges.to_vec()),
             black_box(TiKVStorage::from(ToTxnStore::<Self::T>::to_store(store))),
             black_box(false),
+            black_box(false),
         )
         .unwrap();
         // There is a step of building scanner in the first `next()` which cost time,
@@ -79,6 +80,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder for BatchTableScan
             black_box(Arc::new(EvalConfig::default())),
             black_box(columns.to_vec()),
             black_box(ranges.to_vec()),
+            black_box(false),
             black_box(false),
         )
         .unwrap();

--- a/tests/benches/coprocessor_executors/util/mod.rs
+++ b/tests/benches/coprocessor_executors/util/mod.rs
@@ -50,6 +50,7 @@ pub fn build_dag_handler<TargetTxnStore: TxnStore + 'static>(
         64,
         false,
         enable_batch,
+        false,
     )
     .unwrap()
 }

--- a/tests/integrations/coprocessor/test_checksum.rs
+++ b/tests/integrations/coprocessor/test_checksum.rs
@@ -78,6 +78,7 @@ fn reversed_checksum_crc64_xor<E: Engine>(store: &Store<E>, range: KeyRange) -> 
         scan_backward_in_range: true,
         is_key_only: false,
         is_scanned_range_aware: false,
+        scan_locks_first: false,
     });
 
     let mut checksum = 0;


### PR DESCRIPTION
PCP https://github.com/tikv/tikv/issues/5707
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

- `ForwardScanner` and `BackwardScanner` can ignore locks when scanning.
- `RangeScanner` is able to collect all locks in the ranges first.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?
- [x] Unit test
- [ ] Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

###  Does this PR affect `tidb-ansible`?

###  Refer to a related PR or issue link (optional)
- [x] kvproto: https://github.com/pingcap/kvproto/pull/502
- [ ] TiDB:
###  Benchmark result if necessary (optional)
- [ ] TODO
###  Any examples? (optional)

