### PR TITLE
expression: add missing scalar function signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3590,7 +3590,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#a594830fb004783d4fb7ec4fbdf184d05fd7ab13"
+source = "git+https://github.com/pingcap/tipb.git#0820b784842f3ef6cecc8f520e8834d326a0dbeb"
 dependencies = [
  "bytes",
  "lazy_static",

--- a/components/tidb_query/src/expr/scalar_function.rs
+++ b/components/tidb_query/src/expr/scalar_function.rs
@@ -381,7 +381,31 @@ impl ScalarFunc {
             | ScalarFuncSig::Pi => (0, 0),
 
             // unimplemented signature
-            ScalarFuncSig::AddDateAndDuration
+            ScalarFuncSig::TruncateUint
+            | ScalarFuncSig::AesDecryptIv
+            | ScalarFuncSig::AesEncryptIv
+            | ScalarFuncSig::Encode
+            | ScalarFuncSig::Decode
+            | ScalarFuncSig::SubDateStringReal
+            | ScalarFuncSig::SubDateIntReal
+            | ScalarFuncSig::SubDateIntDecimal
+            | ScalarFuncSig::SubDateDatetimeReal
+            | ScalarFuncSig::SubDateDatetimeDecimal
+            | ScalarFuncSig::SubDateDurationString
+            | ScalarFuncSig::SubDateDurationInt
+            | ScalarFuncSig::SubDateDurationReal
+            | ScalarFuncSig::SubDateDurationDecimal
+            | ScalarFuncSig::AddDateStringReal
+            | ScalarFuncSig::AddDateIntReal
+            | ScalarFuncSig::AddDateIntDecimal
+            | ScalarFuncSig::AddDateDatetimeReal
+            | ScalarFuncSig::AddDateDatetimeDecimal
+            | ScalarFuncSig::AddDateDurationString
+            | ScalarFuncSig::AddDateDurationInt
+            | ScalarFuncSig::AddDateDurationReal
+            | ScalarFuncSig::AddDateDurationDecimal
+            | ScalarFuncSig::CharLengthBinary
+            | ScalarFuncSig::AddDateAndDuration
             | ScalarFuncSig::AddDateAndString
             | ScalarFuncSig::AddDateDatetimeInt
             | ScalarFuncSig::AddDateDatetimeString
@@ -1502,6 +1526,30 @@ mod tests {
 
         // unimplemented signature
         let cases = vec![
+            ScalarFuncSig::TruncateUint,
+            ScalarFuncSig::AesDecryptIv,
+            ScalarFuncSig::AesEncryptIv,
+            ScalarFuncSig::Encode,
+            ScalarFuncSig::Decode,
+            ScalarFuncSig::SubDateStringReal,
+            ScalarFuncSig::SubDateIntReal,
+            ScalarFuncSig::SubDateIntDecimal,
+            ScalarFuncSig::SubDateDatetimeReal,
+            ScalarFuncSig::SubDateDatetimeDecimal,
+            ScalarFuncSig::SubDateDurationString,
+            ScalarFuncSig::SubDateDurationInt,
+            ScalarFuncSig::SubDateDurationReal,
+            ScalarFuncSig::SubDateDurationDecimal,
+            ScalarFuncSig::AddDateStringReal,
+            ScalarFuncSig::AddDateIntReal,
+            ScalarFuncSig::AddDateIntDecimal,
+            ScalarFuncSig::AddDateDatetimeReal,
+            ScalarFuncSig::AddDateDatetimeDecimal,
+            ScalarFuncSig::AddDateDurationString,
+            ScalarFuncSig::AddDateDurationInt,
+            ScalarFuncSig::AddDateDurationReal,
+            ScalarFuncSig::AddDateDurationDecimal,
+            ScalarFuncSig::CharLengthBinary,
             ScalarFuncSig::AddDateAndDuration,
             ScalarFuncSig::AddDateAndString,
             ScalarFuncSig::AddDateDatetimeInt,


### PR DESCRIPTION
Signed-off-by: wshwsh12 <793703860@qq.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

When I update tipb and it will compile error.
```
error[E0004]: non-exhaustive patterns: `TruncateUint`, `AesDecryptIv`, `AesEncryptIv` and 21 more not covered
  --> components/tidb_query/src/expr/scalar_function.rs:17:42
   |
17 |         let (min_args, max_args) = match sig {
   |                                          ^^^ patterns `TruncateUint`, `AesDecryptIv`, `AesEncryptIv` and 21 more not covered
   |
   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms

error: aborting due to previous error
```
We should add missing scalar function signature.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?
- Unit test
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

###  Does this PR affect `tidb-ansible`?

###  Refer to a related PR or issue link (optional)

https://github.com/pingcap/tipb/pull/155

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

