### PR TITLE
Change WriteBatch interface to mutable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#79dee6393e290f6d5338b1b06fe6424fc4b7f3dd"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=local-perf-4.0#5a615b6ecf96c5136be8b83df3a68963fb4cd2d4"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#79dee6393e290f6d5338b1b06fe6424fc4b7f3dd"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=local-perf-4.0#5a615b6ecf96c5136be8b83df3a68963fb4cd2d4"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -2641,7 +2641,7 @@ checksum = "2089e4031214d129e201f8c3c8c2fe97cd7322478a0d1cdf78e7029b0042efdb"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#79dee6393e290f6d5338b1b06fe6424fc4b7f3dd"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=local-perf-4.0#5a615b6ecf96c5136be8b83df3a68963fb4cd2d4"
 dependencies = [
  "crc",
  "libc",

--- a/benches/misc/writebatch/bench_writebatch.rs
+++ b/benches/misc/writebatch/bench_writebatch.rs
@@ -1,13 +1,13 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine::rocks::{Writable, WriteBatch, DB};
+use engine::rocks::{WriteBatch, WriteBatchBase, DB};
 use tempfile::Builder;
 use test::Bencher;
 
 fn writebatch(db: &DB, round: usize, batch_keys: usize) {
     let v = b"operators are syntactic sugar for calls to methods of built-in traits";
     for r in 0..round {
-        let batch = WriteBatch::default();
+        let mut batch = WriteBatch::default();
         for i in 0..batch_keys {
             let k = format!("key_round{}_key{}", r, i);
             batch.put(k.as_bytes(), v).unwrap();
@@ -84,7 +84,7 @@ fn bench_writebatch_1024(b: &mut Bencher) {
     bench_writebatch_impl(b, 1024);
 }
 
-fn fill_writebatch(wb: &WriteBatch, target_size: usize) {
+fn fill_writebatch(wb: &mut WriteBatch, target_size: usize) {
     let (k, v) = (b"this is the key", b"this is the value");
     loop {
         wb.put(k, v).unwrap();
@@ -98,7 +98,7 @@ fn fill_writebatch(wb: &WriteBatch, target_size: usize) {
 fn bench_writebatch_without_capacity(b: &mut Bencher) {
     b.iter(|| {
         let mut wb = WriteBatch::default();
-        fill_writebatch(&wb, 4096);
+        fill_writebatch(&mut wb, 4096);
     });
 }
 
@@ -106,6 +106,6 @@ fn bench_writebatch_without_capacity(b: &mut Bencher) {
 fn bench_writebatch_with_capacity(b: &mut Bencher) {
     b.iter(|| {
         let mut wb = WriteBatch::with_capacity(4096);
-        fill_writebatch(&wb, 4096);
+        fill_writebatch(&mut wb, 4096);
     });
 }

--- a/benches/misc/writebatch/bench_writebatch.rs
+++ b/benches/misc/writebatch/bench_writebatch.rs
@@ -97,7 +97,7 @@ fn fill_writebatch(wb: &WriteBatch, target_size: usize) {
 #[bench]
 fn bench_writebatch_without_capacity(b: &mut Bencher) {
     b.iter(|| {
-        let wb = WriteBatch::default();
+        let mut wb = WriteBatch::default();
         fill_writebatch(&wb, 4096);
     });
 }
@@ -105,7 +105,7 @@ fn bench_writebatch_without_capacity(b: &mut Bencher) {
 #[bench]
 fn bench_writebatch_with_capacity(b: &mut Bencher) {
     b.iter(|| {
-        let wb = WriteBatch::with_capacity(4096);
+        let mut wb = WriteBatch::with_capacity(4096);
         fill_writebatch(&wb, 4096);
     });
 }

--- a/benches/raftstore/mod.rs
+++ b/benches/raftstore/mod.rs
@@ -11,7 +11,7 @@ use tikv::raftstore::store::keys;
 const DEFAULT_DATA_SIZE: usize = 100_000;
 
 fn enc_write_kvs(db: &DB, kvs: &[(Vec<u8>, Vec<u8>)]) {
-    let wb = WriteBatch::default();
+    let mut wb = WriteBatch::default();
     for &(ref k, ref v) in kvs {
         wb.put(&keys::data_key(k), v).unwrap();
     }

--- a/benches/raftstore/mod.rs
+++ b/benches/raftstore/mod.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 
 use criterion::{Bencher, Criterion};
-use engine::rocks::{Writable, WriteBatch, DB};
+use engine::rocks::{WriteBatch, WriteBatchBase, DB};
 use test_raftstore::*;
 use test_util::*;
 use tikv::raftstore::store::keys;

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -33,7 +33,8 @@ rev = "b668f3911d6569de2e1e8b2672fccec1cc8298be"
 features = ["nightly", "push", "process"]
 
 [dependencies.rocksdb]
-git = "https://github.com/pingcap/rust-rocksdb.git"
+git = "https://github.com/Little-Wallace/rust-rocksdb.git"
+branch = "local-perf-4.0"
 package = "rocksdb"
 
 [dev-dependencies]

--- a/components/engine/src/lib.rs
+++ b/components/engine/src/lib.rs
@@ -21,7 +21,8 @@ pub mod util;
 
 pub mod rocks;
 pub use crate::rocks::{
-    CFHandle, DBIterator, DBVector, Range, ReadOptions, WriteBatch, WriteOptions, DB,
+    CFHandle, DBIterator, DBVector, Range, ReadOptions, WriteBatch, WriteBatchBase, WriteOptions,
+    DB,
 };
 mod errors;
 pub use crate::errors::*;

--- a/components/engine/src/mutable.rs
+++ b/components/engine/src/mutable.rs
@@ -1,9 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::rocks::{CFHandle, Writable};
+use crate::rocks::{CFHandle, Writable, WriteBatchBase};
 use crate::Result;
 
-pub trait Mutable: Writable {
+pub trait Immutable: Writable {
     fn put_msg<M: protobuf::Message>(&self, key: &[u8], m: &M) -> Result<()> {
         let value = m.write_to_bytes()?;
         self.put(key, &value)?;
@@ -18,6 +18,26 @@ pub trait Mutable: Writable {
     }
 
     fn del(&self, key: &[u8]) -> Result<()> {
+        self.delete(key)?;
+        Ok(())
+    }
+}
+
+pub trait Mutable: WriteBatchBase {
+    fn put_msg<M: protobuf::Message>(&mut self, key: &[u8], m: &M) -> Result<()> {
+        let value = m.write_to_bytes()?;
+        self.put(key, &value)?;
+        Ok(())
+    }
+
+    // TODO: change CFHandle to str.
+    fn put_msg_cf<M: protobuf::Message>(&mut self, cf: &CFHandle, key: &[u8], m: &M) -> Result<()> {
+        let value = m.write_to_bytes()?;
+        self.put_cf(cf, key, &value)?;
+        Ok(())
+    }
+
+    fn del(&mut self, key: &[u8]) -> Result<()> {
         self.delete(key)?;
         Ok(())
     }

--- a/components/engine/src/rocks/db.rs
+++ b/components/engine/src/rocks/db.rs
@@ -2,9 +2,9 @@
 
 use std::option::Option;
 
-use super::{util, DBIterator, DBVector, WriteBatch, DB};
+use super::{util, CFHandle, DBIterator, DBVector, WriteBatch, WriteBatchBase, DB};
 use crate::iterable::IterOptionsExt;
-use crate::{IterOption, Iterable, Mutable, Peekable, Result};
+use crate::{Immutable, IterOption, Iterable, Mutable, Peekable, Result};
 
 impl Peekable for DB {
     fn get_value(&self, key: &[u8]) -> Result<Option<DBVector>> {
@@ -31,5 +31,6 @@ impl Iterable for DB {
     }
 }
 
-impl Mutable for DB {}
+impl Immutable for DB {}
+
 impl Mutable for WriteBatch {}

--- a/components/engine/src/rocks/mod.rs
+++ b/components/engine/src/rocks/mod.rs
@@ -16,14 +16,14 @@ pub use rocksdb::{
     IngestExternalFileOptions, IngestionInfo, Kv, LRUCacheOptions, MapProperty, MemoryAllocator,
     PerfContext, Range, RateLimiter, ReadOptions, SeekKey, SequentialFile, SliceTransform,
     TablePropertiesCollection, TablePropertiesCollector, TablePropertiesCollectorFactory,
-    TitanBlobIndex, TitanDBOptions, UserCollectedProperties, Writable, WriteBatch, WriteOptions,
-    WriteStallCondition, WriteStallInfo, DB,
+    TitanBlobIndex, TitanDBOptions, UserCollectedProperties, Writable, WriteBatch, WriteBatchBase,
+    WriteOptions, WriteStallCondition, WriteStallInfo, DB,
 };
 
 #[cfg(test)]
 mod tests {
     use crate::rocks::{util, Writable};
-    use crate::{Iterable, Mutable, Peekable};
+    use crate::{Immutable, Iterable, Mutable, Peekable};
     use kvproto::metapb::Region;
     use std::sync::Arc;
     use tempfile::Builder;

--- a/components/engine/src/util.rs
+++ b/components/engine/src/util.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::rocks;
-use crate::rocks::{Range, TablePropertiesCollection, Writable, WriteBatch, DB};
+use crate::rocks::{Range, TablePropertiesCollection, Writable, WriteBatch, WriteBatchBase, DB};
 use crate::CF_LOCK;
 
 use super::Result;
@@ -37,7 +37,7 @@ pub fn delete_all_in_range_cf(
     use_delete_range: bool,
 ) -> Result<()> {
     let handle = rocks::util::get_cf_handle(db, cf)?;
-    let wb = WriteBatch::default();
+    let mut wb = WriteBatch::default();
     if use_delete_range && cf != CF_LOCK {
         wb.delete_range_cf(handle, start_key, end_key)?;
     } else {
@@ -138,7 +138,7 @@ mod tests {
             .collect();
         let db = new_engine_opt(path_str, DBOptions::new(), cfs_opts).unwrap();
 
-        let wb = WriteBatch::default();
+        let mut wb = WriteBatch::default();
         let ts: u8 = 12;
         let keys: Vec<_> = vec![
             b"k1".to_vec(),
@@ -245,7 +245,7 @@ mod tests {
         cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
         let cf = "default";
         let db = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
-        let wb = WriteBatch::default();
+        let mut wb = WriteBatch::default();
         let kvs: Vec<(&[u8], &[u8])> = vec![
             (b"kabcdefg1", b"v1"),
             (b"kabcdefg2", b"v2"),

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -35,7 +35,8 @@ rev = "b668f3911d6569de2e1e8b2672fccec1cc8298be"
 features = ["nightly", "push", "process"]
 
 [dependencies.rocksdb]
-git = "https://github.com/pingcap/rust-rocksdb.git"
+git = "https://github.com/Little-Wallace/rust-rocksdb.git"
+branch = "local-perf-4.0"
 package = "rocksdb"
 
 [dev-dependencies]

--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use engine_traits::{
-    Error, IterOptions, Iterable, KvEngine, Mutable, Peekable, ReadOptions, Result, WriteOptions,
+    Error, IterOptions, Iterable, KvEngine, Peekable, ReadOptions, Result, SafeMutable,
+    WriteOptions,
 };
 use rocksdb::{DBIterator, Writable, DB};
 
@@ -127,21 +128,21 @@ impl Peekable for RocksEngine {
     }
 }
 
-impl Mutable for RocksEngine {
-    fn put_opt(&mut self, _: &WriteOptions, key: &[u8], value: &[u8]) -> Result<()> {
+impl SafeMutable for RocksEngine {
+    fn put_opt(&self, _: &WriteOptions, key: &[u8], value: &[u8]) -> Result<()> {
         self.0.put(key, value).map_err(Error::Engine)
     }
 
-    fn put_cf_opt(&mut self, _: &WriteOptions, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
+    fn put_cf_opt(&self, _: &WriteOptions, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
         let handle = get_cf_handle(&self.0, cf)?;
         self.0.put_cf(handle, key, value).map_err(Error::Engine)
     }
 
-    fn delete_opt(&mut self, _: &WriteOptions, key: &[u8]) -> Result<()> {
+    fn delete_opt(&self, _: &WriteOptions, key: &[u8]) -> Result<()> {
         self.0.delete(key).map_err(Error::Engine)
     }
 
-    fn delete_cf_opt(&mut self, _: &WriteOptions, cf: &str, key: &[u8]) -> Result<()> {
+    fn delete_cf_opt(&self, _: &WriteOptions, cf: &str, key: &[u8]) -> Result<()> {
         let handle = get_cf_handle(&self.0, cf)?;
         self.0.delete_cf(handle, key).map_err(Error::Engine)
     }
@@ -150,7 +151,7 @@ impl Mutable for RocksEngine {
 #[cfg(test)]
 mod tests {
     use engine::rocks::util;
-    use engine_traits::{Iterable, KvEngine, Mutable, Peekable};
+    use engine_traits::{Iterable, KvEngine, Peekable, SafeMutable};
     use kvproto::metapb::Region;
     use std::sync::Arc;
     use tempfile::Builder;

--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -128,20 +128,20 @@ impl Peekable for RocksEngine {
 }
 
 impl Mutable for RocksEngine {
-    fn put_opt(&self, _: &WriteOptions, key: &[u8], value: &[u8]) -> Result<()> {
+    fn put_opt(&mut self, _: &WriteOptions, key: &[u8], value: &[u8]) -> Result<()> {
         self.0.put(key, value).map_err(Error::Engine)
     }
 
-    fn put_cf_opt(&self, _: &WriteOptions, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
+    fn put_cf_opt(&mut self, _: &WriteOptions, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
         let handle = get_cf_handle(&self.0, cf)?;
         self.0.put_cf(handle, key, value).map_err(Error::Engine)
     }
 
-    fn delete_opt(&self, _: &WriteOptions, key: &[u8]) -> Result<()> {
+    fn delete_opt(&mut self, _: &WriteOptions, key: &[u8]) -> Result<()> {
         self.0.delete(key).map_err(Error::Engine)
     }
 
-    fn delete_cf_opt(&self, _: &WriteOptions, cf: &str, key: &[u8]) -> Result<()> {
+    fn delete_cf_opt(&mut self, _: &WriteOptions, cf: &str, key: &[u8]) -> Result<()> {
         let handle = get_cf_handle(&self.0, cf)?;
         self.0.delete_cf(handle, key).map_err(Error::Engine)
     }

--- a/components/engine_rocks/src/write_batch.rs
+++ b/components/engine_rocks/src/write_batch.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use engine_traits::{self, Error, Mutable, Result, WriteOptions};
-use rocksdb::{Writable, WriteBatch as RawWriteBatch, DB};
+use rocksdb::{WriteBatch as RawWriteBatch, WriteBatchBase, DB};
 
 use crate::util::get_cf_handle;
 
@@ -58,7 +58,7 @@ impl engine_traits::WriteBatch for WriteBatch {
         self.wb.is_empty()
     }
 
-    fn clear(&self) {
+    fn clear(&mut self) {
         self.wb.clear();
     }
 
@@ -76,20 +76,20 @@ impl engine_traits::WriteBatch for WriteBatch {
 }
 
 impl Mutable for WriteBatch {
-    fn put_opt(&self, _: &WriteOptions, key: &[u8], value: &[u8]) -> Result<()> {
+    fn put_opt(&mut self, _: &WriteOptions, key: &[u8], value: &[u8]) -> Result<()> {
         self.wb.put(key, value).map_err(Error::Engine)
     }
 
-    fn put_cf_opt(&self, _: &WriteOptions, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
+    fn put_cf_opt(&mut self, _: &WriteOptions, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
         let handle = get_cf_handle(self.db.as_ref(), cf)?;
         self.wb.put_cf(handle, key, value).map_err(Error::Engine)
     }
 
-    fn delete_opt(&self, _: &WriteOptions, key: &[u8]) -> Result<()> {
+    fn delete_opt(&mut self, _: &WriteOptions, key: &[u8]) -> Result<()> {
         self.wb.delete(key).map_err(Error::Engine)
     }
 
-    fn delete_cf_opt(&self, _: &WriteOptions, cf: &str, key: &[u8]) -> Result<()> {
+    fn delete_cf_opt(&mut self, _: &WriteOptions, cf: &str, key: &[u8]) -> Result<()> {
         let handle = get_cf_handle(self.db.as_ref(), cf)?;
         self.wb.delete_cf(handle, key).map_err(Error::Engine)
     }

--- a/components/engine_traits/src/engine.rs
+++ b/components/engine_traits/src/engine.rs
@@ -6,7 +6,7 @@ use crate::*;
 
 pub trait KvEngine:
     Peekable
-    + Mutable
+    + SafeMutable
     + Iterable
     + DBOptionsExt
     + CFHandleExt

--- a/components/engine_traits/src/mutable.rs
+++ b/components/engine_traits/src/mutable.rs
@@ -34,3 +34,35 @@ pub trait Mutable {
         self.put_cf(cf, key, &m.write_to_bytes()?)
     }
 }
+
+pub trait SafeMutable {
+    fn put_opt(&self, opts: &WriteOptions, key: &[u8], value: &[u8]) -> Result<()>;
+    fn put_cf_opt(&self, opts: &WriteOptions, cf: &str, key: &[u8], value: &[u8]) -> Result<()>;
+
+    fn delete_opt(&self, opts: &WriteOptions, key: &[u8]) -> Result<()>;
+    fn delete_cf_opt(&self, opts: &WriteOptions, cf: &str, key: &[u8]) -> Result<()>;
+
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.put_opt(&WriteOptions::default(), key, value)
+    }
+
+    fn put_cf(&self, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
+        self.put_cf_opt(&WriteOptions::default(), cf, key, value)
+    }
+
+    fn delete(&self, key: &[u8]) -> Result<()> {
+        self.delete_opt(&WriteOptions::default(), key)
+    }
+
+    fn delete_cf(&self, cf: &str, key: &[u8]) -> Result<()> {
+        self.delete_cf_opt(&WriteOptions::default(), cf, key)
+    }
+
+    fn put_msg<M: protobuf::Message>(&self, key: &[u8], m: &M) -> Result<()> {
+        self.put(key, &m.write_to_bytes()?)
+    }
+
+    fn put_msg_cf<M: protobuf::Message>(&self, cf: &str, key: &[u8], m: &M) -> Result<()> {
+        self.put_cf(cf, key, &m.write_to_bytes()?)
+    }
+}

--- a/components/engine_traits/src/mutable.rs
+++ b/components/engine_traits/src/mutable.rs
@@ -3,33 +3,34 @@
 use crate::*;
 
 pub trait Mutable {
-    fn put_opt(&self, opts: &WriteOptions, key: &[u8], value: &[u8]) -> Result<()>;
-    fn put_cf_opt(&self, opts: &WriteOptions, cf: &str, key: &[u8], value: &[u8]) -> Result<()>;
+    fn put_opt(&mut self, opts: &WriteOptions, key: &[u8], value: &[u8]) -> Result<()>;
+    fn put_cf_opt(&mut self, opts: &WriteOptions, cf: &str, key: &[u8], value: &[u8])
+        -> Result<()>;
 
-    fn delete_opt(&self, opts: &WriteOptions, key: &[u8]) -> Result<()>;
-    fn delete_cf_opt(&self, opts: &WriteOptions, cf: &str, key: &[u8]) -> Result<()>;
+    fn delete_opt(&mut self, opts: &WriteOptions, key: &[u8]) -> Result<()>;
+    fn delete_cf_opt(&mut self, opts: &WriteOptions, cf: &str, key: &[u8]) -> Result<()>;
 
-    fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+    fn put(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
         self.put_opt(&WriteOptions::default(), key, value)
     }
 
-    fn put_cf(&self, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
+    fn put_cf(&mut self, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
         self.put_cf_opt(&WriteOptions::default(), cf, key, value)
     }
 
-    fn delete(&self, key: &[u8]) -> Result<()> {
+    fn delete(&mut self, key: &[u8]) -> Result<()> {
         self.delete_opt(&WriteOptions::default(), key)
     }
 
-    fn delete_cf(&self, cf: &str, key: &[u8]) -> Result<()> {
+    fn delete_cf(&mut self, cf: &str, key: &[u8]) -> Result<()> {
         self.delete_cf_opt(&WriteOptions::default(), cf, key)
     }
 
-    fn put_msg<M: protobuf::Message>(&self, key: &[u8], m: &M) -> Result<()> {
+    fn put_msg<M: protobuf::Message>(&mut self, key: &[u8], m: &M) -> Result<()> {
         self.put(key, &m.write_to_bytes()?)
     }
 
-    fn put_msg_cf<M: protobuf::Message>(&self, cf: &str, key: &[u8], m: &M) -> Result<()> {
+    fn put_msg_cf<M: protobuf::Message>(&mut self, cf: &str, key: &[u8], m: &M) -> Result<()> {
         self.put_cf(cf, key, &m.write_to_bytes()?)
     }
 }

--- a/components/engine_traits/src/write_batch.rs
+++ b/components/engine_traits/src/write_batch.rs
@@ -7,8 +7,8 @@ pub trait WriteBatch: Mutable + Send {
     fn data_size(&self) -> usize;
     fn count(&self) -> usize;
     fn is_empty(&self) -> bool;
-    fn clear(&self);
 
+    fn clear(&mut self);
     fn set_save_point(&mut self);
     fn pop_save_point(&mut self) -> Result<()>;
     fn rollback_to_save_point(&mut self) -> Result<()>;

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -2918,7 +2918,6 @@ mod tests {
     use crate::raftstore::store::msg::WriteResponse;
     use crate::raftstore::store::peer_storage::RAFT_INIT_LOG_INDEX;
     use crate::raftstore::store::util::{new_learner_peer, new_peer};
-    use engine::rocks::Writable;
     use engine::Peekable;
     use engine::{WriteBatch, DB};
     use engine_rocks::RocksEngine;
@@ -2976,7 +2975,7 @@ mod tests {
         let mut req = RaftCmdRequest::default();
         req.mut_admin_request()
             .set_cmd_type(AdminCmdType::ComputeHash);
-        let wb = WriteBatch::default();
+        let mut wb = WriteBatch::default();
         assert_eq!(should_write_to_engine(&req, wb.count()), true);
 
         // IngestSst command
@@ -2985,12 +2984,12 @@ mod tests {
         req.set_ingest_sst(IngestSstRequest::default());
         let mut cmd = RaftCmdRequest::default();
         cmd.mut_requests().push(req);
-        let wb = WriteBatch::default();
+        let mut wb = WriteBatch::default();
         assert_eq!(should_write_to_engine(&cmd, wb.count()), true);
 
         // Write batch keys reach WRITE_BATCH_MAX_KEYS
         let req = RaftCmdRequest::default();
-        let wb = WriteBatch::default();
+        let mut wb = WriteBatch::default();
         for i in 0..WRITE_BATCH_MAX_KEYS {
             let key = format!("key_{}", i);
             wb.put(key.as_bytes(), b"value").unwrap();
@@ -2999,7 +2998,7 @@ mod tests {
 
         // Write batch keys not reach WRITE_BATCH_MAX_KEYS
         let req = RaftCmdRequest::default();
-        let wb = WriteBatch::default();
+        let mut wb = WriteBatch::default();
         for i in 0..WRITE_BATCH_MAX_KEYS - 1 {
             let key = format!("key_{}", i);
             wb.put(key.as_bytes(), b"value").unwrap();

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -31,7 +31,7 @@ pub use self::peer::{
     Peer, PeerStat, ProposalContext, ReadExecutor, RequestInspector, RequestPolicy,
 };
 pub use self::peer_storage::{
-    clear_meta, do_snapshot, init_apply_state, init_raft_state, maybe_upgrade_from_2_to_3,
+    clear_raftdb_meta, do_snapshot, init_apply_state, init_raft_state, maybe_upgrade_from_2_to_3,
     write_initial_apply_state, write_initial_raft_state, write_peer_state, CacheQueryStats,
     PeerStorage, SnapState, INIT_EPOCH_CONF_VER, INIT_EPOCH_VER, RAFT_INIT_LOG_INDEX,
     RAFT_INIT_LOG_TERM,

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -548,12 +548,13 @@ impl Peer {
         );
 
         // Set Tombstone state explicitly
-        let kv_wb = WriteBatch::default();
-        let raft_wb = WriteBatch::default();
-        self.mut_store().clear_meta(&kv_wb, &raft_wb)?;
+        let mut kv_wb = WriteBatch::default();
+        let mut raft_wb = WriteBatch::default();
+        self.mut_store().clear_kvdb_meta(&mut kv_wb)?;
+        self.mut_store().clear_raftdb_meta(&mut raft_wb)?;
         write_peer_state(
             &ctx.engines.kv,
-            &kv_wb,
+            &mut kv_wb,
             &region,
             PeerState::Tombstone,
             self.pending_merge_state.clone(),

--- a/src/raftstore/store/snap.rs
+++ b/src/raftstore/store/snap.rs
@@ -1362,7 +1362,7 @@ pub mod tests {
     use engine::rocks;
     use engine::rocks::util::CFOptions;
     use engine::rocks::{DBOptions, Env, DB};
-    use engine::{Engines, Mutable, Peekable};
+    use engine::{Engines, Immutable, Mutable, Peekable};
     use engine::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
     use engine_rocks::RocksSnapshot;
     use engine_traits::Iterable;

--- a/src/raftstore/store/snap/io.rs
+++ b/src/raftstore/store/snap/io.rs
@@ -4,7 +4,7 @@ use std::io::{self, BufReader};
 use std::{fs, usize};
 
 use engine::rocks::util::get_cf_handle;
-use engine::rocks::{IngestExternalFileOptions, Writable, WriteBatch, WriteBatchBase, DB};
+use engine::rocks::{IngestExternalFileOptions, WriteBatch, WriteBatchBase, DB};
 use engine::CfName;
 use engine_rocks::{RocksSnapshot, RocksSstWriter, RocksSstWriterBuilder};
 use engine_traits::IOLimiter;

--- a/src/raftstore/store/snap/io.rs
+++ b/src/raftstore/store/snap/io.rs
@@ -4,7 +4,7 @@ use std::io::{self, BufReader};
 use std::{fs, usize};
 
 use engine::rocks::util::get_cf_handle;
-use engine::rocks::{IngestExternalFileOptions, Writable, WriteBatch, DB};
+use engine::rocks::{IngestExternalFileOptions, Writable, WriteBatch, WriteBatchBase, DB};
 use engine::CfName;
 use engine_rocks::{RocksSnapshot, RocksSstWriter, RocksSstWriterBuilder};
 use engine_traits::IOLimiter;
@@ -107,7 +107,7 @@ pub fn apply_plain_cf_file(
 ) -> Result<(), Error> {
     let mut decoder = BufReader::new(box_try!(File::open(path)));
     let cf_handle = box_try!(get_cf_handle(&db, cf));
-    let wb = WriteBatch::default();
+    let mut wb = WriteBatch::default();
     loop {
         if stale_detector.is_stale() {
             return Err(Error::Abort);

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -283,7 +283,7 @@ mod tests {
         let handle = get_cf_handle(&db, CF_DEFAULT).unwrap();
 
         // Generate the first SST file.
-        let wb = WriteBatch::default();
+        let mut wb = WriteBatch::default();
         for i in 0..1000 {
             let k = format!("key_{}", i);
             wb.put_cf(handle, k.as_bytes(), b"whatever content")
@@ -293,7 +293,7 @@ mod tests {
         db.flush_cf(handle, true).unwrap();
 
         // Generate another SST file has the same content with first SST file.
-        let wb = WriteBatch::default();
+        let mut wb = WriteBatch::default();
         for i in 0..1000 {
             let k = format!("key_{}", i);
             wb.put_cf(handle, k.as_bytes(), b"whatever content")

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -255,7 +255,7 @@ mod tests {
     use engine::rocks::util::{get_cf_handle, new_engine, new_engine_opt, CFOptions};
     use engine::rocks::Writable;
     use engine::rocks::{ColumnFamilyOptions, DBOptions};
-    use engine::{WriteBatch, DB};
+    use engine::{WriteBatch, WriteBatchBase, DB};
     use engine::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
     use tempfile::Builder;
 

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -11,7 +11,7 @@ use std::u64;
 
 use engine::rocks;
 use engine::CF_RAFT;
-use engine::{util as engine_util, Engines, Immutable, Mutable, Peekable};
+use engine::{util as engine_util, Engines, Mutable, Peekable};
 use engine::{WriteBatch, WriteBatchBase};
 use engine_rocks::RocksSnapshot;
 use kvproto::raft_serverpb::{PeerState, RaftApplyState, RegionLocalState};

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use engine::rocks;
 use engine::rocks::util::CFOptions;
 use engine::rocks::{
-    ColumnFamilyOptions, DBIterator, SeekKey as DBSeekKey, Writable, WriteBatch, WriteBatchBase, DB,
+    ColumnFamilyOptions, DBIterator, SeekKey as DBSeekKey, WriteBatch, WriteBatchBase, DB,
 };
 use engine::Engines;
 use engine::Error as EngineError;

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use engine::rocks;
 use engine::rocks::util::CFOptions;
 use engine::rocks::{
-    ColumnFamilyOptions, DBIterator, SeekKey as DBSeekKey, Writable, WriteBatch, DB,
+    ColumnFamilyOptions, DBIterator, SeekKey as DBSeekKey, Writable, WriteBatch, WriteBatchBase, DB,
 };
 use engine::Engines;
 use engine::Error as EngineError;
@@ -214,7 +214,7 @@ impl TestEngineBuilder {
 }
 
 fn write_modifies(engine: &Engines, modifies: Vec<Modify>) -> Result<()> {
-    let wb = WriteBatch::default();
+    let mut wb = WriteBatch::default();
     for rev in modifies {
         let res = match rev {
             Modify::Delete(cf, k) => {

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -7,7 +7,7 @@ use crate::storage::mvcc::write::{Write, WriteType};
 use crate::storage::mvcc::{default_not_found_error, WriteRef};
 use crate::storage::mvcc::{Result, TimeStamp};
 use crate::storage::{Key, Value};
-use engine::IterOption;
+use engine::{IterOption, WriteBatchBase};
 use engine::{CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::IsolationLevel;
 
@@ -440,7 +440,7 @@ mod tests {
     use crate::storage::{Key, Mutation, Options};
     use engine::rocks::util::CFOptions;
     use engine::rocks::{self, ColumnFamilyOptions, DBOptions};
-    use engine::rocks::{Writable, WriteBatch, DB};
+    use engine::rocks::{Writable, WriteBatch, WriteBatchBase, DB};
     use engine::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
     use kvproto::kvrpcpb::IsolationLevel;
     use kvproto::metapb::{Peer, Region};

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -568,7 +568,7 @@ mod tests {
 
         fn write(&mut self, modifies: Vec<Modify>) {
             let db = &self.db;
-            let wb = WriteBatch::default();
+            let mut wb = WriteBatch::default();
             for rev in modifies {
                 match rev {
                     Modify::Put(cf, k, v) => {

--- a/tests/integrations/raftstore/test_tombstone.rs
+++ b/tests/integrations/raftstore/test_tombstone.rs
@@ -10,7 +10,7 @@ use protobuf::Message;
 use engine::rocks::util::get_cf_handle;
 use engine::rocks::Writable;
 use engine::CF_RAFT;
-use engine::{Iterable, Mutable, Peekable};
+use engine::{Immutable, Iterable, Peekable};
 use test_raftstore::*;
 use tikv::raftstore::store::keys;
 


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

The `WriteBatch` of RocksDB is not a thread-safe struct. I think the interface of it such as `put` should be `mutable` instead of `immutable`. So I change it as `put(&mut self, key: &[u8], value: &[u8]);`

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?


###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link



