### PR TITLE
fix cargo build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 tcmalloc = ["tikv_alloc/tcmalloc"]
 jemalloc = ["tikv_alloc/jemalloc", "engine/jemalloc", "engine_rocks/jemalloc"]
 mimalloc = ["tikv_alloc/mimalloc"]


### PR DESCRIPTION
Signed-off-by: niedhui <niedhui@gmail.com>

###  What have you changed?

Add `protobuf-codec` as a default feature, as we need either `protobuf-codec` or `prost-codec`

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Manually, build TiKV using Clion, or just `cargo build`

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

#6087 



