### PR TITLE
Fix a failing test due to recursion limit

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -742,11 +742,13 @@ mod tests {
     fn test_stack_guard() {
         let engine = TestEngineBuilder::new().build().unwrap();
         let read_pool = build_read_pool_for_test(&CoprReadPoolConfig::default_for_test(), engine);
-        let cop = Endpoint::<RocksEngine>::new(&Config::default(), read_pool);
+        let mut cop = Endpoint::<RocksEngine>::new(&Config::default(), read_pool);
+        cop.recursion_limit = 100;
 
         let req = {
             let mut expr = Expr::default();
-            // The recursion limit in Prost and rust-protobuf (by default) is 100.
+            // The recursion limit in Prost and rust-protobuf (by default) is 100 (for rust-protobuf,
+            // that limit is set to 1000 as a configuration default).
             for _ in 0..101 {
                 let mut e = Expr::default();
                 e.mut_children().push(expr);


### PR DESCRIPTION
###  What have you changed?

A test was failing due to recursion limit being set in configuration which I didn't notice in the Prost PR.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

Tests pass

PTAL @Hoverbear @yiwu-arbug 
