### PR TITLE
peer: initialize region's key range when a new peer is added

### DIFF
--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -171,24 +171,21 @@ impl PeerFsm {
         cfg: &Config,
         sched: Scheduler<RegionTask>,
         engines: Engines,
-        region_id: u64,
+        region: &metapb::Region,
         peer: metapb::Peer,
     ) -> Result<(LooseBoundedSender<PeerMsg>, Box<PeerFsm>)> {
         // We will remove tombstone key when apply snapshot
         info!(
             "replicate peer";
-            "region_id" => region_id,
+            "region_id" => region.get_id(),
             "peer_id" => peer.get_id(),
         );
-
-        let mut region = metapb::Region::default();
-        region.set_id(region_id);
 
         let (tx, rx) = mpsc::loose_bounded(cfg.notify_capacity);
         Ok((
             tx,
             Box::new(PeerFsm {
-                peer: Peer::new(store_id, cfg, sched, engines, &region, peer)?,
+                peer: Peer::new(store_id, cfg, sched, engines, region, peer)?,
                 tick_registry: PeerTicks::empty(),
                 missing_ticks: 0,
                 group_state: GroupState::Ordered,


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
Initialize region's key range when a new peer is added.

The leader of the first region is the leader of the deadlock detector, and it observes the role change of the first region to change its role.

However, when a new peer is added, its region info is not complete until applying snapshot. The key range of the new peer is `["", "")` which misleading the leader of the deadlock detector to step down and won't be elected until the leader of first region is changed.

###  What is the type of the changes?
- Bugfix (a change which fixes an issue)

###  How is the PR tested?
- Manual test (add detailed scripts or steps below)

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
Yes

###  Does this PR affect `tidb-ansible`?
No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

