### PR TITLE
deadlock: only observe valid region

### DIFF
--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -133,9 +133,8 @@ pub trait PdClient: Send + Sync {
     }
 
     /// Gets Region info which the key belongs to.
-    fn get_region_info(&self, key: &[u8]) -> Result<RegionInfo> {
-        self.get_region(key)
-            .map(|region| RegionInfo::new(region, None))
+    fn get_region_info(&self, _key: &[u8]) -> Result<RegionInfo> {
+        unimplemented!();
     }
 
     /// Gets Region by Region id.

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -220,7 +220,8 @@ const LEADER_KEY: &[u8] = b"";
 
 /// Returns true if the region containing the LEADER_KEY.
 fn is_leader_region(region: &'_ Region) -> bool {
-    region.get_start_key() <= LEADER_KEY
+    !region.get_peers().is_empty()
+        && region.get_start_key() <= LEADER_KEY
         && (region.get_end_key().is_empty() || LEADER_KEY < region.get_end_key())
 }
 

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -265,7 +265,7 @@ mod tests {
         Result as StorageResult,
     };
     use kvproto::kvrpcpb::LockInfo;
-    use kvproto::metapb::Region;
+    use kvproto::metapb::{Peer, Region};
     use metrics::*;
     use raft::StateRole;
     use std::sync::mpsc;
@@ -291,6 +291,8 @@ mod tests {
     }
 
     fn start_lock_manager() -> LockManager {
+        use protobuf::RepeatedField;
+
         let (tx, _rx) = mpsc::sync_channel(100);
         let mut coprocessor_host = CoprocessorHost::new(CopConfig::default(), tx);
 
@@ -310,6 +312,7 @@ mod tests {
         let mut leader_region = Region::new();
         leader_region.set_start_key(b"".to_vec());
         leader_region.set_end_key(b"foo".to_vec());
+        leader_region.set_peers(RepeatedField::from_vec(vec![Peer::new()]));
         coprocessor_host.on_role_change(&leader_region, StateRole::Leader);
         thread::sleep(Duration::from_millis(100));
 

--- a/tests/integrations/server/lock_manager.rs
+++ b/tests/integrations/server/lock_manager.rs
@@ -1,0 +1,167 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::Duration;
+
+use grpcio::{ChannelBuilder, Environment};
+use kvproto::kvrpcpb::*;
+use kvproto::metapb::{Peer, Region};
+use kvproto::tikvpb_grpc::TikvClient;
+
+use test_raftstore::*;
+use tikv_util::HandyRwLock;
+
+fn acquire_pessimistic_lock(
+    client: &TikvClient,
+    ctx: Context,
+    key: Vec<u8>,
+    ts: u64,
+) -> PessimisticLockResponse {
+    let mut req = PessimisticLockRequest::new();
+    req.set_context(ctx);
+    let mut mutation = Mutation::new();
+    mutation.op = Op::PessimisticLock;
+    mutation.key = key.clone();
+    mutation.value = key.clone();
+    req.set_mutations(vec![mutation].into_iter().collect());
+    req.primary_lock = key;
+    req.start_version = ts;
+    req.for_update_ts = ts;
+    req.lock_ttl = 20;
+    req.is_first_lock = false;
+    client.kv_pessimistic_lock(&req).unwrap()
+}
+
+fn must_acquire_pessimistic_lock(client: &TikvClient, ctx: Context, key: Vec<u8>, ts: u64) {
+    let resp = acquire_pessimistic_lock(client, ctx, key, ts);
+    assert!(!resp.has_region_error(), "{:?}", resp.get_region_error());
+    assert!(resp.errors.is_empty(), "{:?}", resp.get_errors());
+}
+
+fn must_deadlock(client: &TikvClient, ctx: Context, key1: &[u8], ts: u64) {
+    let key1 = key1.to_vec();
+    let mut key2 = key1.clone();
+    key2.push(1);
+    must_acquire_pessimistic_lock(client, ctx.clone(), key1.clone(), ts);
+    must_acquire_pessimistic_lock(client, ctx.clone(), key2.clone(), ts + 1);
+
+    let client1 = client.clone();
+    let ctx1 = ctx.clone();
+    let (tx, rx) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let _ = acquire_pessimistic_lock(&client1, ctx1, key1, ts + 1);
+        tx.send(1).unwrap();
+    });
+    // Sleep to make sure txn(ts+1) is waiting for txn(ts)
+    thread::sleep(Duration::from_millis(500));
+    let resp = acquire_pessimistic_lock(client, ctx, key2, ts);
+    assert_eq!(resp.errors.len(), 1);
+    assert!(resp.errors[0].has_deadlock());
+    rx.recv().unwrap();
+}
+
+fn build_leader_client(cluster: &mut Cluster<ServerCluster>, key: &[u8]) -> (TikvClient, Context) {
+    let region_id = cluster.get_region_id(key);
+    let leader = cluster.leader_of_region(region_id).unwrap();
+    let epoch = cluster.get_region_epoch(region_id);
+
+    let env = Arc::new(Environment::new(1));
+    let channel =
+        ChannelBuilder::new(env).connect(cluster.sim.rl().get_addr(leader.get_store_id()));
+    let client = TikvClient::new(channel);
+
+    let mut ctx = Context::new();
+    ctx.set_region_id(region_id);
+    ctx.set_peer(leader);
+    ctx.set_region_epoch(epoch);
+
+    (client, ctx)
+}
+
+fn deadlock_detector_leader_must_be(cluster: &mut Cluster<ServerCluster>, store_id: u64) {
+    let leader_region = cluster.get_region(b"");
+    assert_eq!(
+        cluster
+            .leader_of_region(leader_region.get_id())
+            .unwrap()
+            .get_store_id(),
+        store_id
+    );
+    let leader_peer = find_peer_of_store(&leader_region, store_id);
+    cluster
+        .pd_client
+        .region_leader_must_be(leader_region.get_id(), leader_peer);
+}
+
+fn must_transfer_leader(cluster: &mut Cluster<ServerCluster>, region_key: &[u8], store_id: u64) {
+    let region = cluster.get_region(region_key);
+    let target_peer = find_peer_of_store(&region, store_id);
+    cluster.must_transfer_leader(region.get_id(), target_peer.clone());
+    cluster
+        .pd_client
+        .region_leader_must_be(region.get_id(), target_peer);
+}
+
+fn find_peer_of_store(region: &Region, store_id: u64) -> Peer {
+    region
+        .get_peers()
+        .iter()
+        .find(|p| p.get_store_id() == store_id)
+        .unwrap()
+        .clone()
+}
+
+#[test]
+fn test_detect_deadlock_when_shuffle_region() {
+    let mut cluster = new_server_cluster(0, 4);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    // Disable default max peer count check.
+    pd_client.disable_default_operator();
+
+    // Region 1 has 3 peers. And peer(1, 1) is the leader of region 1.
+    let region_id = cluster.run_conf_change();
+    pd_client.must_add_peer(region_id, new_peer(2, 2));
+    pd_client.must_add_peer(region_id, new_peer(3, 3));
+
+    // The leader of deadlock detector is the leader of region 1.
+    deadlock_detector_leader_must_be(&mut cluster, 1);
+    let (client, ctx) = build_leader_client(&mut cluster, b"k1");
+    must_deadlock(&client, ctx, b"k1", 10);
+
+    // The leader of region 1 has transfered. The leader of deadlock detector should also transfer.
+    must_transfer_leader(&mut cluster, b"", 2);
+    deadlock_detector_leader_must_be(&mut cluster, 2);
+    let (client, ctx) = build_leader_client(&mut cluster, b"k2");
+    must_deadlock(&client, ctx, b"k2", 20);
+
+    // Split region and transfer the leader of new region to store(3).
+    let region = cluster.get_region(b"");
+    cluster.must_split(&region, b"k10");
+    must_transfer_leader(&mut cluster, b"k10", 3);
+    // Deadlock occurs on store(3) and the leader of deadlock detector is store(2).
+    deadlock_detector_leader_must_be(&mut cluster, 2);
+    let (client, ctx) = build_leader_client(&mut cluster, b"k10");
+    must_deadlock(&client, ctx, b"k10", 30);
+
+    // Transfer the new region from store(1, 2, 3) to store(2, 3, 4).
+    let new_region = cluster.get_region(b"k10");
+    pd_client.must_add_peer(new_region.get_id(), new_peer(4, 4));
+    must_transfer_leader(&mut cluster, b"k10", 4);
+    let peer = find_peer_of_store(&new_region, 1);
+    pd_client.must_remove_peer(region_id, peer);
+
+    // Transfer the leader of deadlock detector to store(1) and
+    // deadlock occours on store(4) again.
+    must_transfer_leader(&mut cluster, b"", 1);
+    deadlock_detector_leader_must_be(&mut cluster, 1);
+    let (client, ctx) = build_leader_client(&mut cluster, b"k11");
+    must_deadlock(&client, ctx, b"k11", 30);
+
+    // Add store(1) back again which will send a role change message with empty region key range to
+    // the deadlock detector. It misleads the leader of deadlock detector stepping down.
+    pd_client.must_add_peer(new_region.get_id(), new_peer(1, 5));
+    deadlock_detector_leader_must_be(&mut cluster, 1);
+    let (client, ctx) = build_leader_client(&mut cluster, b"k1");
+    must_deadlock(&client, ctx, b"k1", 10);
+}

--- a/tests/integrations/server/lock_manager.rs
+++ b/tests/integrations/server/lock_manager.rs
@@ -162,6 +162,6 @@ fn test_detect_deadlock_when_shuffle_region() {
     // the deadlock detector. It misleads the leader of deadlock detector stepping down.
     pd_client.must_add_peer(new_region.get_id(), new_peer(1, 5));
     deadlock_detector_leader_must_be(&mut cluster, 1);
-    let (client, ctx) = build_leader_client(&mut cluster, b"k1");
-    must_deadlock(&client, ctx, b"k1", 10);
+    let (client, ctx) = build_leader_client(&mut cluster, b"k3");
+    must_deadlock(&client, ctx, b"k3", 10);
 }

--- a/tests/integrations/server/mod.rs
+++ b/tests/integrations/server/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 mod kv_service;
+mod lock_manager;
 mod raft_client;
 
 use std::sync::Arc;


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
A new peer's region info is not complete until applying snapshot which causes the leader of the deadlock detector stepping down. Only observing valid region can fix it.

###  What is the type of the changes?
- Bugfix (a change which fixes an issue)

###  How is the PR tested?
- Unit test
- Manual test (add detailed scripts or steps below)

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
Yes

###  Does this PR affect `tidb-ansible`?
No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)
Without the fix, the new added test will panic when a new peer is added to the store with the leader of deadlock detector.
```
---- server::lock_manager::test_detect_deadlock_when_shuffle_region stdout ----
thread 'server::lock_manager::test_detect_deadlock_when_shuffle_region' panicked at 'assertion failed: resp.errors[0].has_deadlock()', tests/integrations/server/lock_manager.rs:61:5
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.29/src/backtrace/libunwind.rs:88
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.29/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:47
   3: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:36
   4: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:198
   5: std::panicking::default_hook
             at src/libstd/panicking.rs:209
   6: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:475
   7: std::panicking::begin_panic
   8: integrations::server::lock_manager::must_deadlock
             at tests/integrations/server/lock_manager.rs:61
   9: integrations::server::lock_manager::test_detect_deadlock_when_shuffle_region
             at tests/integrations/server/lock_manager.rs:169
  10: integrations::server::lock_manager::test_detect_deadlock_when_shuffle_region::{{closure}}
             at tests/integrations/server/lock_manager.rs:117
  11: core::ops::function::FnOnce::call_once
             at /rustc/0e4a56b4b04ea98bb16caada30cb2418dd06e250/src/libcore/ops/function.rs:231
  12: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/0e4a56b4b04ea98bb16caada30cb2418dd06e250/src/liballoc/boxed.rs:746
  13: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:82
  14: std::panicking::try
             at /rustc/0e4a56b4b04ea98bb16caada30cb2418dd06e250/src/libstd/panicking.rs:273
  15: std::panic::catch_unwind
             at /rustc/0e4a56b4b04ea98bb16caada30cb2418dd06e250/src/libstd/panic.rs:388
  16: test::run_test::run_test_inner::{{closure}}
             at src/libtest/lib.rs:1466
```
