### PR TITLE
Always collect execution summary for BatchExecutor

### DIFF
--- a/components/tidb_query/src/batch/executors/table_scan_executor.rs
+++ b/components/tidb_query/src/batch/executors/table_scan_executor.rs
@@ -656,7 +656,7 @@ mod tests {
             false,
         )
         .unwrap()
-        .with_summary_collector(ExecSummaryCollectorEnabled::new(1));
+        .collect_summary(1);
 
         executor.next_batch(1);
         executor.next_batch(2);

--- a/components/tidb_query/src/batch/interface.rs
+++ b/components/tidb_query/src/batch/interface.rs
@@ -9,6 +9,7 @@ pub use super::super::execute_stats::{ExecSummaryCollector, ExecuteStats, WithSu
 use tipb::FieldType;
 
 use crate::codec::batch::LazyBatchColumnVec;
+use crate::execute_stats::ExecSummaryCollectorEnabled;
 use crate::expr::EvalWarnings;
 use crate::storage::IntervalRange;
 use crate::Result;
@@ -47,15 +48,15 @@ pub trait BatchExecutor: Send {
 
     fn take_scanned_range(&mut self) -> IntervalRange;
 
-    fn with_summary_collector<C: ExecSummaryCollector + Send>(
+    fn collect_summary(
         self,
-        summary_collector: C,
-    ) -> WithSummaryCollector<C, Self>
+        output_index: usize,
+    ) -> WithSummaryCollector<ExecSummaryCollectorEnabled, Self>
     where
         Self: Sized,
     {
         WithSummaryCollector {
-            summary_collector,
+            summary_collector: ExecSummaryCollectorEnabled::new(output_index),
             inner: self,
         }
     }

--- a/components/tidb_query/src/batch/runner.rs
+++ b/components/tidb_query/src/batch/runner.rs
@@ -308,16 +308,25 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         deadline: Deadline,
     ) -> Result<Self> {
         let executors_len = req.get_executors().len();
-        let collect_exec_summary = req.get_collect_execution_summaries();
+        let collect_exec_summary = true;
         let config = Arc::new(EvalConfig::from_request(&req)?);
         let encode_type = req.get_encode_type();
 
-        let out_most_executor = build_executors::<_, ExecSummaryCollectorEnabled>(
-            req.take_executors().into(),
-            storage,
-            ranges,
-            config.clone(),
-        )?;
+        let out_most_executor = if collect_exec_summary {
+            build_executors::<_, ExecSummaryCollectorEnabled>(
+                req.take_executors().into(),
+                storage,
+                ranges,
+                config.clone(),
+            )?
+        } else {
+            build_executors::<_, ExecSummaryCollectorDisabled>(
+                req.take_executors().into(),
+                storage,
+                ranges,
+                config.clone(),
+            )?
+        };
 
         // Check output offsets
         let output_offsets = req.take_output_offsets();

--- a/components/tidb_query/src/batch/runner.rs
+++ b/components/tidb_query/src/batch/runner.rs
@@ -312,21 +312,12 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         let config = Arc::new(EvalConfig::from_request(&req)?);
         let encode_type = req.get_encode_type();
 
-        let out_most_executor = if collect_exec_summary {
-            build_executors::<_, ExecSummaryCollectorEnabled>(
-                req.take_executors().into(),
-                storage,
-                ranges,
-                config.clone(),
-            )?
-        } else {
-            build_executors::<_, ExecSummaryCollectorDisabled>(
-                req.take_executors().into(),
-                storage,
-                ranges,
-                config.clone(),
-            )?
-        };
+        let out_most_executor = build_executors::<_, ExecSummaryCollectorEnabled>(
+            req.take_executors().into(),
+            storage,
+            ranges,
+            config.clone(),
+        )?;
 
         // Check output offsets
         let output_offsets = req.take_output_offsets();

--- a/tests/benches/coprocessor_executors/integrated/util.rs
+++ b/tests/benches/coprocessor_executors/integrated/util.rs
@@ -122,7 +122,7 @@ where
         store: &Store<RocksEngine>,
     ) {
         crate::util::bencher::BatchNextAllBencher::new(|| {
-            tidb_query::batch::runner::build_executors::<_, ExecSummaryCollectorDisabled>(
+            tidb_query::batch::runner::build_executors(
                 black_box(executors.to_vec()),
                 black_box(TiKVStorage::from(ToTxnStore::<T>::to_store(store))),
                 black_box(ranges.to_vec()),


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

BatchExecutor spends little when collecting execution summary. Thus this PR enables it in all scenarios, so that we can collect the time of each batch executor in later PRs.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

- Unit test
- Integration test