### PR TITLE
lib: output build profile and enabled features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ protobuf-codec = [
   "grpcio/protobuf-codec",
   "raft/protobuf-codec",
 ]
+# Please update tikv#detect_enabled_features when introducing new features.
 
 [lib]
 name = "tikv"
@@ -179,11 +180,11 @@ default-members = ["cmd"]
 [profile.dev]
 opt-level = 0
 debug = 1 # required for line numbers in tests, see tikv #5049
-codegen-units = 4
+codegen-units = 16
 lto = false
 incremental = true
 panic = 'abort'
-debug-assertions = false
+debug-assertions = true # enable debug-assertions to make tikv#detect_build_profile work.
 overflow-checks = false
 rpath = false
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,46 @@ pub mod raftstore;
 pub mod server;
 pub mod storage;
 
+// Detect tikv enabled features.
+fn detect_enabled_features() -> String {
+    macro_rules! detect {
+        ($f:expr, $feat:tt) => {
+            if cfg!(feature = $feat) {
+                $f.push_str($feat);
+                $f.push(' ');
+            }
+        };
+    }
+
+    let mut flags = String::new();
+    detect!(flags, "tcmalloc");
+    detect!(flags, "jemalloc");
+    detect!(flags, "mimalloc");
+    detect!(flags, "portable");
+    detect!(flags, "sse");
+    detect!(flags, "mem-profiling");
+    detect!(flags, "failpoints");
+    detect!(flags, "prost-codec");
+    detect!(flags, "protobuf-codec");
+    flags.pop(); // Try to trim the last ' '.
+    flags
+}
+
+// Detect tikv build profile.
+fn detect_build_profile() -> &'static str {
+    // Detect build profile by debug_assertions see more:
+    // https://users.rust-lang.org/t/conditional-compilation-for-debug-release/1098
+    // TODO: Find a better way to detect, since debug_assertions can be enabled
+    //       in a custom profile.
+    if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    }
+}
+
 /// Returns the tikv version information.
+// TODO: Should we remove `UTC Build Time`? It breaks reproducible builds.
 pub fn tikv_version_info() -> String {
     let fallback = "Unknown (env var does not exist when building)";
     format!(
@@ -72,12 +111,16 @@ pub fn tikv_version_info() -> String {
          \nGit Commit Hash:   {}\
          \nGit Commit Branch: {}\
          \nUTC Build Time:    {}\
-         \nRust Version:      {}",
+         \nRust Version:      {}\
+         \nFeatures:          {}\
+         \nBuild Profile:     {}",
         env!("CARGO_PKG_VERSION"),
         option_env!("TIKV_BUILD_GIT_HASH").unwrap_or(fallback),
         option_env!("TIKV_BUILD_GIT_BRANCH").unwrap_or(fallback),
         option_env!("TIKV_BUILD_TIME").unwrap_or(fallback),
         option_env!("TIKV_BUILD_RUSTC_VERSION").unwrap_or(fallback),
+        detect_enabled_features(),
+        detect_build_profile(),
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@ pub mod raftstore;
 pub mod server;
 pub mod storage;
 
-// Detect tikv enabled features.
 fn detect_enabled_features() -> String {
     macro_rules! detect {
         ($f:expr, $feat:tt) => {
@@ -89,7 +88,6 @@ fn detect_enabled_features() -> String {
     flags
 }
 
-// Detect tikv build profile.
 fn detect_build_profile() -> &'static str {
     // Detect build profile by debug_assertions see more:
     // https://users.rust-lang.org/t/conditional-compilation-for-debug-release/1098


### PR DESCRIPTION
###  What have you changed?

Add build profile and enabled features to version output, so we know how a tikv binary be built.

Also, this PR speeds up debug build.

```
origin 2641.93s user 297.26s system 1072% cpu 4:33.96 total
this   2720.46s user 302.55s system 1132% cpu 4:26.85 total
```
<!--
```
origin@4         2641.93s user 297.26s system 1072% cpu 4:33.96 total
debug-asserts@4  2705.38s user 299.33s system 1067% cpu 4:41.48 total
debug-asserts@16 2720.46s user 302.55s system 1132% cpu 4:26.85 total
```
-->

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

- Manual test (add detailed scripts or steps below)

```bash
# check its output.
$ tikv-server -V
TiKV 
Release Version:   4.0.0-alpha
Git Commit Hash:   Unknown (env var does not exist when building)
Git Commit Branch: Unknown (env var does not exist when building)
UTC Build Time:    Unknown (env var does not exist when building)
Rust Version:      Unknown (env var does not exist when building)
Features:          jemalloc portable sse protobuf-codec
Build Profile:     debug
```

