### PR TITLE
fix titan CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,7 +1458,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=perf-4.0#f9b32ab0c3c25f0931a4078883b200e51aae2fb8"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=perf-4.0#cfb77be4307d51511eb1b05077b41e25fccc88e7"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=perf-4.0#f9b32ab0c3c25f0931a4078883b200e51aae2fb8"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=perf-4.0#cfb77be4307d51511eb1b05077b41e25fccc88e7"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -2676,7 +2676,7 @@ checksum = "2089e4031214d129e201f8c3c8c2fe97cd7322478a0d1cdf78e7029b0042efdb"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=perf-4.0#f9b32ab0c3c25f0931a4078883b200e51aae2fb8"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=perf-4.0#cfb77be4307d51511eb1b05077b41e25fccc88e7"
 dependencies = [
  "crc",
  "libc",


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Update `rust-rocksdb`, to make old gcc able to compile titan.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link
https://github.com/tikv/titan/pull/123

