### PR TITLE
txn refactoring: some tidying up

### DIFF
--- a/src/server/gc_worker.rs
+++ b/src/server/gc_worker.rs
@@ -268,8 +268,7 @@ impl<E: Engine> GcRunner<E> {
             Some(ScanMode::Forward),
             TimeStamp::zero(),
             !ctx.get_not_fill_cache(),
-        )
-        .unwrap();
+        );
         for k in keys {
             let gc_info = txn.gc(k.clone(), safe_point)?;
 

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -56,6 +56,23 @@ pub enum Modify {
     DeleteRange(CfName, Key, Key, bool),
 }
 
+impl Modify {
+    pub fn size(&self) -> usize {
+        let cf = match self {
+            Modify::Delete(cf, _) => cf,
+            Modify::Put(cf, ..) => cf,
+            Modify::DeleteRange(..) => unreachable!(),
+        };
+        let cf_size = if cf == &CF_DEFAULT { 0 } else { cf.len() };
+
+        match self {
+            Modify::Delete(_, k) => cf_size + k.as_encoded().len(),
+            Modify::Put(_, k, v) => cf_size + k.as_encoded().len() + v.len(),
+            Modify::DeleteRange(..) => unreachable!(),
+        }
+    }
+}
+
 pub trait Engine: Send + Clone + 'static {
     type Snap: Snapshot;
 

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -401,7 +401,7 @@ pub mod tests {
     ) -> Result<()> {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true);
         txn.prewrite(
             Mutation::Insert((Key::from_raw(key), value.to_vec())),
             pk,
@@ -422,7 +422,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true);
         let mutation = Mutation::Put((Key::from_raw(key), value.to_vec()));
         if options.for_update_ts.is_zero() {
             txn.prewrite(mutation, pk, &options).unwrap();
@@ -511,7 +511,7 @@ pub mod tests {
     ) -> Error {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true);
         let mut options = Options::default();
         let for_update_ts = for_update_ts.into();
         options.for_update_ts = for_update_ts;
@@ -564,7 +564,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true);
         let mut options = Options::default();
         let for_update_ts = for_update_ts.into();
         options.for_update_ts = for_update_ts;
@@ -608,7 +608,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true);
         let mut options = Options::default();
         let for_update_ts = for_update_ts.into();
         options.for_update_ts = for_update_ts;
@@ -639,7 +639,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, ts.into(), true);
         assert!(txn
             .prewrite(Mutation::Lock(Key::from_raw(key)), pk, &Options::default())
             .is_err());
@@ -665,7 +665,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         txn.acquire_pessimistic_lock(Key::from_raw(key), pk, false, &options)
             .unwrap();
         let modifies = txn.into_modifies();
@@ -718,7 +718,7 @@ pub mod tests {
     ) -> Error {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         let mut options = Options::default();
         options.for_update_ts = for_update_ts.into();
         txn.acquire_pessimistic_lock(Key::from_raw(key), pk, false, &options)
@@ -733,7 +733,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         txn.pessimistic_rollback(Key::from_raw(key), for_update_ts.into())
             .unwrap();
         write(engine, &ctx, txn.into_modifies());
@@ -747,7 +747,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         txn.commit(Key::from_raw(key), commit_ts.into()).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
@@ -760,14 +760,14 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         assert!(txn.commit(Key::from_raw(key), commit_ts.into()).is_err());
     }
 
     pub fn must_rollback<E: Engine>(engine: &E, key: &[u8], start_ts: impl Into<TimeStamp>) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         txn.collapse_rollback(false);
         txn.rollback(Key::from_raw(key)).unwrap();
         write(engine, &ctx, txn.into_modifies());
@@ -780,7 +780,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         txn.rollback(Key::from_raw(key)).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
@@ -788,7 +788,7 @@ pub mod tests {
     pub fn must_rollback_err<E: Engine>(engine: &E, key: &[u8], start_ts: impl Into<TimeStamp>) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         assert!(txn.rollback(Key::from_raw(key)).is_err());
     }
 
@@ -800,7 +800,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         txn.cleanup(Key::from_raw(key), current_ts.into()).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
@@ -813,7 +813,7 @@ pub mod tests {
     ) -> Error {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         txn.cleanup(Key::from_raw(key), current_ts.into())
             .unwrap_err()
     }
@@ -827,7 +827,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         let ttl = txn
             .txn_heart_beat(Key::from_raw(primary_key), advise_ttl)
             .unwrap();
@@ -843,7 +843,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
         txn.txn_heart_beat(Key::from_raw(primary_key), advise_ttl)
             .unwrap_err();
     }
@@ -859,7 +859,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, lock_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, lock_ts.into(), true);
         let (txn_status, _) = txn
             .check_txn_status(
                 Key::from_raw(primary_key),
@@ -882,7 +882,7 @@ pub mod tests {
     ) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, lock_ts.into(), true).unwrap();
+        let mut txn = MvccTxn::new(snapshot, lock_ts.into(), true);
         txn.check_txn_status(
             Key::from_raw(primary_key),
             caller_start_ts.into(),
@@ -895,8 +895,7 @@ pub mod tests {
     pub fn must_gc<E: Engine>(engine: &E, key: &[u8], safe_point: impl Into<TimeStamp>) {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn =
-            MvccTxn::for_scan(snapshot, Some(ScanMode::Forward), TimeStamp::zero(), true).unwrap();
+        let mut txn = MvccTxn::for_scan(snapshot, Some(ScanMode::Forward), TimeStamp::zero(), true);
         txn.gc(Key::from_raw(key), safe_point.into()).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -450,14 +450,14 @@ mod tests {
     }
 
     impl RegionEngine {
-        pub fn new(db: Arc<DB>, region: Region) -> RegionEngine {
+        fn new(db: &Arc<DB>, region: &Region) -> RegionEngine {
             RegionEngine {
                 db: Arc::clone(&db),
-                region,
+                region: region.clone(),
             }
         }
 
-        pub fn put(
+        fn put(
             &mut self,
             pk: &[u8],
             start_ts: impl Into<TimeStamp>,
@@ -469,7 +469,7 @@ mod tests {
             self.commit(pk, start_ts, commit_ts);
         }
 
-        pub fn lock(
+        fn lock(
             &mut self,
             pk: &[u8],
             start_ts: impl Into<TimeStamp>,
@@ -481,7 +481,7 @@ mod tests {
             self.commit(pk, start_ts, commit_ts);
         }
 
-        pub fn delete(
+        fn delete(
             &mut self,
             pk: &[u8],
             start_ts: impl Into<TimeStamp>,
@@ -661,7 +661,7 @@ mod tests {
 
     fn test_without_properties(path: &str, region: &Region) {
         let db = open_db(path, false);
-        let mut engine = RegionEngine::new(Arc::clone(&db), region.clone());
+        let mut engine = RegionEngine::new(&db, &region);
 
         // Put 2 keys.
         engine.put(&[1], 1, 1);
@@ -675,7 +675,7 @@ mod tests {
 
     fn test_with_properties(path: &str, region: &Region) {
         let db = open_db(path, true);
-        let mut engine = RegionEngine::new(Arc::clone(&db), region.clone());
+        let mut engine = RegionEngine::new(&db, &region);
 
         // Put 2 keys.
         engine.put(&[2], 3, 3);
@@ -756,7 +756,7 @@ mod tests {
         let path = path.path().to_str().unwrap();
         let region = make_region(1, vec![], vec![]);
         let db = open_db(path, true);
-        let mut engine = RegionEngine::new(Arc::clone(&db), region.clone());
+        let mut engine = RegionEngine::new(&db, &region);
 
         let (k, v) = (b"k", b"v");
         let m = Mutation::Put((Key::from_raw(k), v.to_vec()));
@@ -842,7 +842,7 @@ mod tests {
         let path = path.path().to_str().unwrap();
         let region = make_region(1, vec![], vec![]);
         let db = open_db(path, true);
-        let mut engine = RegionEngine::new(Arc::clone(&db), region.clone());
+        let mut engine = RegionEngine::new(&db, &region);
 
         let (k, v) = (b"k", b"v");
         let key = Key::from_raw(k);
@@ -877,7 +877,7 @@ mod tests {
         let path = path.path().to_str().unwrap();
         let region = make_region(1, vec![], vec![]);
         let db = open_db(path, true);
-        let mut engine = RegionEngine::new(Arc::clone(&db), region.clone());
+        let mut engine = RegionEngine::new(&db, &region);
 
         let (k, v) = (b"k", b"v");
         let m = Mutation::Put((Key::from_raw(k), v.to_vec()));
@@ -985,7 +985,7 @@ mod tests {
         let path = path.path().to_str().unwrap();
         let region = make_region(1, vec![], vec![]);
         let db = open_db(path, true);
-        let mut engine = RegionEngine::new(Arc::clone(&db), region.clone());
+        let mut engine = RegionEngine::new(&db, &region);
 
         let (k, v) = (b"k", b"v");
         let m = Mutation::Put((Key::from_raw(k), v.to_vec()));
@@ -1076,7 +1076,7 @@ mod tests {
         let path = path.path().to_str().unwrap();
         let region = make_region(1, vec![], vec![]);
         let db = open_db(path, true);
-        let mut engine = RegionEngine::new(Arc::clone(&db), region.clone());
+        let mut engine = RegionEngine::new(&db, &region);
 
         let (k1, k2, k3, k4, v) = (b"k1", b"k2", b"k3", b"k4", b"v");
         engine.prewrite(Mutation::Put((Key::from_raw(k1), v.to_vec())), k1, 5);
@@ -1131,7 +1131,7 @@ mod tests {
         let path = path.path().to_str().unwrap();
         let region = make_region(1, vec![], vec![]);
         let db = open_db(path, true);
-        let mut engine = RegionEngine::new(Arc::clone(&db), region.clone());
+        let mut engine = RegionEngine::new(&db, &region);
 
         // Put some locks to the db.
         engine.prewrite(

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -495,7 +495,7 @@ mod tests {
 
         fn prewrite(&mut self, m: Mutation, pk: &[u8], start_ts: impl Into<TimeStamp>) {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts.into(), true).unwrap();
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true);
             txn.prewrite(m, pk, &Options::default()).unwrap();
             self.write(txn.into_modifies());
         }
@@ -507,7 +507,7 @@ mod tests {
             start_ts: impl Into<TimeStamp>,
         ) {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts.into(), true).unwrap();
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true);
             let options = Options::default();
             txn.pessimistic_prewrite(m, pk, true, &options).unwrap();
             self.write(txn.into_modifies());
@@ -521,7 +521,7 @@ mod tests {
             for_update_ts: impl Into<TimeStamp>,
         ) {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts.into(), true).unwrap();
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true);
             let mut options = Options::default();
             options.for_update_ts = for_update_ts.into();
             txn.acquire_pessimistic_lock(k, pk, false, &options)
@@ -536,14 +536,14 @@ mod tests {
             commit_ts: impl Into<TimeStamp>,
         ) {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts.into(), true).unwrap();
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true);
             txn.commit(Key::from_raw(pk), commit_ts.into()).unwrap();
             self.write(txn.into_modifies());
         }
 
         fn rollback(&mut self, pk: &[u8], start_ts: impl Into<TimeStamp>) {
             let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts.into(), true).unwrap();
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true);
             txn.collapse_rollback(false);
             txn.rollback(Key::from_raw(pk)).unwrap();
             self.write(txn.into_modifies());
@@ -552,7 +552,7 @@ mod tests {
         fn gc(&mut self, pk: &[u8], safe_point: impl Into<TimeStamp> + Copy) {
             loop {
                 let snap = RegionSnapshot::from_raw(Arc::clone(&self.db), self.region.clone());
-                let mut txn = MvccTxn::new(snap, safe_point.into(), true).unwrap();
+                let mut txn = MvccTxn::new(snap, safe_point.into(), true);
                 txn.gc(Key::from_raw(pk), safe_point.into()).unwrap();
                 let modifies = txn.into_modifies();
                 if modifies.is_empty() {

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -512,9 +512,9 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
             }
             let mut locks = vec![];
             let mut txn = if scan_mode.is_some() {
-                MvccTxn::for_scan(snapshot, scan_mode, start_ts, !cmd.ctx.get_not_fill_cache())?
+                MvccTxn::for_scan(snapshot, scan_mode, start_ts, !cmd.ctx.get_not_fill_cache())
             } else {
-                MvccTxn::new(snapshot, start_ts, !cmd.ctx.get_not_fill_cache())?
+                MvccTxn::new(snapshot, start_ts, !cmd.ctx.get_not_fill_cache())
             };
 
             // If `options.for_update_ts` is 0, the transaction is optimistic
@@ -564,7 +564,7 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
             options,
             ..
         } => {
-            let mut txn = MvccTxn::new(snapshot, start_ts, !cmd.ctx.get_not_fill_cache())?;
+            let mut txn = MvccTxn::new(snapshot, start_ts, !cmd.ctx.get_not_fill_cache());
             let mut locks = vec![];
             let rows = keys.len();
             for (k, should_not_exist) in keys {
@@ -607,7 +607,7 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
             // Pessimistic txn needs key_hashes to wake up waiters
             let key_hashes = gen_key_hashes_if_needed(&lock_mgr, &keys);
 
-            let mut txn = MvccTxn::new(snapshot, lock_ts, !cmd.ctx.get_not_fill_cache())?;
+            let mut txn = MvccTxn::new(snapshot, lock_ts, !cmd.ctx.get_not_fill_cache());
             let mut is_pessimistic_txn = false;
             let rows = keys.len();
             for k in keys {
@@ -636,7 +636,7 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
             let mut keys = vec![key];
             let key_hashes = gen_key_hashes_if_needed(&lock_mgr, &keys);
 
-            let mut txn = MvccTxn::new(snapshot, start_ts, !cmd.ctx.get_not_fill_cache())?;
+            let mut txn = MvccTxn::new(snapshot, start_ts, !cmd.ctx.get_not_fill_cache());
             let is_pessimistic_txn = txn.cleanup(keys.pop().unwrap(), current_ts)?;
 
             wake_up_waiters_if_needed(
@@ -652,7 +652,7 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
         CommandKind::Rollback { keys, start_ts, .. } => {
             let key_hashes = gen_key_hashes_if_needed(&lock_mgr, &keys);
 
-            let mut txn = MvccTxn::new(snapshot, start_ts, !cmd.ctx.get_not_fill_cache())?;
+            let mut txn = MvccTxn::new(snapshot, start_ts, !cmd.ctx.get_not_fill_cache());
             let mut is_pessimistic_txn = false;
             let rows = keys.len();
             for k in keys {
@@ -677,7 +677,7 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
             assert!(lock_mgr.is_some());
             let key_hashes = gen_key_hashes_if_needed(&lock_mgr, &keys);
 
-            let mut txn = MvccTxn::new(snapshot, start_ts, !cmd.ctx.get_not_fill_cache())?;
+            let mut txn = MvccTxn::new(snapshot, start_ts, !cmd.ctx.get_not_fill_cache());
             let rows = keys.len();
             for k in keys {
                 txn.pessimistic_rollback(k, for_update_ts)?;
@@ -731,7 +731,7 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
                     snapshot.clone(),
                     current_lock.ts,
                     !cmd.ctx.get_not_fill_cache(),
-                )?;
+                );
                 let status = txn_status.get(&current_lock.ts);
                 let commit_ts = match status {
                     Some(ts) => *ts,
@@ -796,7 +796,7 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
         } => {
             let key_hashes = gen_key_hashes_if_needed(&lock_mgr, &resolve_keys);
 
-            let mut txn = MvccTxn::new(snapshot.clone(), start_ts, !cmd.ctx.get_not_fill_cache())?;
+            let mut txn = MvccTxn::new(snapshot.clone(), start_ts, !cmd.ctx.get_not_fill_cache());
             let rows = resolve_keys.len();
             let mut is_pessimistic_txn = false;
             // ti-client guarantees the size of resolve_keys will not too large, so no necessary
@@ -825,7 +825,7 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
             advise_ttl,
         } => {
             // TxnHeartBeat never remove locks. No need to wake up waiters.
-            let mut txn = MvccTxn::new(snapshot.clone(), start_ts, !cmd.ctx.get_not_fill_cache())?;
+            let mut txn = MvccTxn::new(snapshot.clone(), start_ts, !cmd.ctx.get_not_fill_cache());
             let lock_ttl = txn.txn_heart_beat(primary_key, advise_ttl)?;
 
             statistics.add(&txn.take_statistics());
@@ -841,7 +841,7 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
             current_ts,
             rollback_if_not_exist,
         } => {
-            let mut txn = MvccTxn::new(snapshot.clone(), lock_ts, !cmd.ctx.get_not_fill_cache())?;
+            let mut txn = MvccTxn::new(snapshot.clone(), lock_ts, !cmd.ctx.get_not_fill_cache());
             let (txn_status, is_pessimistic_txn) = txn.check_txn_status(
                 primary_key.clone(),
                 caller_start_ts,

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -557,7 +557,7 @@ mod tests {
             let pk = primary_key.as_bytes();
             // do prewrite.
             {
-                let mut txn = MvccTxn::new(self.snapshot.clone(), START_TS, true).unwrap();
+                let mut txn = MvccTxn::new(self.snapshot.clone(), START_TS, true);
                 for key in &self.keys {
                     let key = key.as_bytes();
                     txn.prewrite(
@@ -572,7 +572,7 @@ mod tests {
             self.refresh_snapshot();
             // do commit
             {
-                let mut txn = MvccTxn::new(self.snapshot.clone(), START_TS, true).unwrap();
+                let mut txn = MvccTxn::new(self.snapshot.clone(), START_TS, true);
                 for key in &self.keys {
                     let key = key.as_bytes();
                     txn.commit(Key::from_raw(key), COMMIT_TS).unwrap();

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -21,7 +21,7 @@ where
 {
     let ctx = Context::default();
     let snapshot = engine.snapshot(&ctx).unwrap();
-    let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+    let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
 
     let kvs = KvGenerator::with_seed(
         config.key_length,

--- a/tests/benches/hierarchy/txn/mod.rs
+++ b/tests/benches/hierarchy/txn/mod.rs
@@ -23,7 +23,7 @@ where
     let option = Options::default();
 
     let snapshot = engine.snapshot(&ctx).unwrap();
-    let mut txn = MvccTxn::new(snapshot, start_ts.into(), true).unwrap();
+    let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
     let kvs = KvGenerator::new(config.key_length, config.value_length).generate(DEFAULT_ITERATIONS);
     for (k, v) in &kvs {
         txn.prewrite(


### PR DESCRIPTION
###  What have you changed?

The commits stand alone and the descriptions say what they are doing. The first three are fairly trivial tidying up. ~~The forth moves `is_pessimistic_lock` from `Options` to `Command::Prewrite`, which makes sense because that is the only command it is used with.~~

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

PTAL @MyonKeminta @youjiali1995 