### PR TITLE
backup: put startKey into backup_file_name to make it unique (#6071)

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -17,7 +17,6 @@ use kvproto::backup::*;
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 use kvproto::metapb::*;
 use raft::StateRole;
-use tikv::coprocessor::codec::table::decode_table_id;
 use tikv::raftstore::store::util::find_peer;
 use tikv::storage::kv::{Engine, RegionInfoProvider};
 use tikv::storage::txn::{EntryBatch, SnapshotStore, TxnEntryScanner, TxnEntryStore};
@@ -375,11 +374,13 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
                     warn!("backup task has canceled"; "range" => ?brange);
                     return Ok(());
                 }
-                let table_id = brange
+                // TODO: make file_name unique and short
+                let key = brange
                     .start_key
                     .clone()
-                    .and_then(|k| decode_table_id(&k.into_raw().unwrap()).ok());
-                let name = backup_file_name(store_id, &brange.region, table_id);
+                    .map(|k| hex::encode(k.into_raw().unwrap()));
+
+                let name = backup_file_name(store_id, &brange.region, key);
                 let mut writer = match BackupWriter::new(db.clone(), &name, storage.limiter.clone())
                 {
                     Ok(w) => w,
@@ -561,14 +562,14 @@ fn get_max_start_key(start_key: Option<&Key>, region: &Region) -> Option<Key> {
 
 /// Construct an backup file name based on the given store id and region.
 /// A name consists with three parts: store id, region_id and a epoch version.
-fn backup_file_name(store_id: u64, region: &Region, table_id: Option<i64>) -> String {
-    match table_id {
-        Some(t_id) => format!(
+fn backup_file_name(store_id: u64, region: &Region, key: Option<String>) -> String {
+    match key {
+        Some(k) => format!(
             "{}_{}_{}_{}",
             store_id,
             region.get_id(),
             region.get_region_epoch().get_version(),
-            t_id
+            k
         ),
         None => format!(
             "{}_{}_{}",


### PR DESCRIPTION
Signed-off-by: luancheng <luancheng@pingcap.com>
Cherry-pick #6071 to release-3.1
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
use range start_key to build filename during backup, to make filename unique

###  What is the type of the changes?

Pick one of the following and delete the others:
- Improvement (a change which is an improvement to an existing feature)


###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- Unit test
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
N/A

###  Does this PR affect `tidb-ansible`?
N/A


###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

