### PR TITLE
copr: add non-vectorized json depth

### DIFF
--- a/components/tidb_query/src/expr/builtin_json.rs
+++ b/components/tidb_query/src/expr/builtin_json.rs
@@ -9,6 +9,16 @@ use std::collections::BTreeMap;
 
 impl ScalarFunc {
     #[inline]
+    pub fn json_depth<'a, 'b: 'a>(
+        &'b self,
+        ctx: &mut EvalContext,
+        row: &'a [Datum],
+    ) -> Result<Option<Cow<'a, i64>>> {
+        let j = try_opt!(self.children[0].eval_json(ctx, row));
+        Ok(Some(Cow::Borrowed(&j.depth())))
+    }
+
+    #[inline]
     pub fn json_type<'a, 'b: 'a>(
         &'b self,
         ctx: &mut EvalContext,
@@ -193,6 +203,53 @@ mod tests {
     use crate::expr::tests::{datum_expr, make_null_datums, scalar_func_expr};
     use crate::expr::{EvalContext, Expression};
     use tipb::ScalarFuncSig;
+
+    #[test]
+    fn test_json_depth() {
+        let cases = vec![
+            (None, None),
+            (Some("null"), Some(1)),
+            (Some("[true, 2017]"), Some(2)),
+            (Some(r#"{"a": {"a1": [3]}, "b": {"b1": {"c": {"d": [5]}}}}"#), Some(6)),
+            (Some("{}"), Some(1)),
+            (Some("[]"), Some(1)),
+            (Some("true"), Some(1)),
+            (Some("1"), Some(1)),
+            (Some("-1"), Some(1)),
+            (Some(r#""a""#), Some(1)),
+            (Some(r#"[10, 20]"#), Some(2)),
+            (Some(r#"[[], {}]"#),Some(2) ),
+            (Some(r#"[10, {"a": 20}]"#), Some(3)),
+            (Some(r#"[[2], 3, [[[4]]]]"#), Some(5)),
+            (Some(r#"{"Name": "Homer"}"#), Some(2)),
+            (Some(r#"[10, {"a": 20}]"#), Some(3)),
+            (Some(r#"{"Person": {"Name": "Homer", "Age": 39, "Hobbies": ["Eating", "Sleeping"]} }"#), Some(4)),
+            (Some(r#"{"a":1}"#), Some(2)),
+            (Some(r#"{"a":[1]}"#), Some(3)),
+            (Some(r#"{"b":2, "c":3}"#), Some(2)),
+            (Some(r#"[1]"#), Some(2)),
+            (Some(r#"[1,2]"#), Some(2)),
+            (Some(r#"[1,2,[1,3]]"#), Some(3)),
+            (Some(r#"[1,2,[1,[5,[3]]]]"#), Some(5)),
+            (Some(r#"[1,2,[1,[5,{"a":[2,3]}]]]"#), Some(6)),
+            (Some(r#"[{"a":1}]"#), Some(3)),
+            (Some(r#"[{"a":1,"b":2}]"#), Some(3)),
+            (Some(r#"[{"a":{"a":1},"b":2}]"#), Some(4)),
+        ];
+        let mut ctx = EvalContext::default();
+        for (input, exp) in cases {
+            let input = match input {
+                None => Datum::Null,
+                Some(s) => Datum::Json(s.parse().unwrap()),
+            };
+
+            let arg = datum_expr(input);
+            let op = scalar_func_expr(ScalarFuncSig::JsonDepthSig, &[arg]);
+            let op = Expression::build(&mut ctx, op).unwrap();
+            let got = op.eval(&mut ctx, &[]).unwrap();
+            assert_eq!(got, exp);
+        }
+    }
 
     #[test]
     fn test_json_type() {

--- a/components/tidb_query/src/expr/scalar_function.rs
+++ b/components/tidb_query/src/expr/scalar_function.rs
@@ -528,7 +528,6 @@ impl ScalarFunc {
             | ScalarFuncSig::JsonQuoteSig
             | ScalarFuncSig::JsonSearchSig
             | ScalarFuncSig::JsonStorageSizeSig
-            | ScalarFuncSig::JsonDepthSig
             | ScalarFuncSig::JsonKeysSig
             | ScalarFuncSig::JsonLengthSig
             | ScalarFuncSig::JsonValidJsonSig
@@ -1389,6 +1388,7 @@ mod tests {
                     ScalarFuncSig::UncompressedLength,
                     ScalarFuncSig::Quote,
                     ScalarFuncSig::OctInt,
+                    ScalarFuncSig::JsonDepthSig,
                 ],
                 1,
                 1,


### PR DESCRIPTION
Signed-off-by: Wangweizhen <hawking.rei@gmail.com>

PCP #5751


###  What have you changed?

Add non-vectorized json-depth

###  What is the type of the changes?

- New feature

###  How is the PR tested?

Unit tested. Will run copr test later.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No. It should not change the behavior.

###  Does this PR affect `tidb-ansible`?

No.