### PR TITLE
Batch multiple raft command into an entry

### DIFF
--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -311,6 +311,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 PeerMsg::Noop => {}
             }
         }
+        self.fsm.peer.propose_batch_request(self.ctx);
     }
 
     fn on_casual_msg(&mut self, msg: CasualMessage) {

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -68,7 +68,8 @@ use tikv_util::{is_zero_duration, sys as sys_util, Either, RingQueue};
 type Key = Vec<u8>;
 
 const KV_WB_SHRINK_SIZE: usize = 256 * 1024;
-const RAFT_WB_SHRINK_SIZE: usize = 1024 * 1024;
+const RAFT_WB_SHRINK_SIZE: usize = 16 * 1024 * 1024;
+const DEFAULT_RAFT_WB_CAPACITY: usize = 8 * 1024 * 1024;
 pub const PENDING_VOTES_CAP: usize = 20;
 const UNREACHABLE_BACKOFF: Duration = Duration::from_secs(10);
 
@@ -527,7 +528,7 @@ impl<T: Transport, C: PdClient> RaftPoller<T, C> {
                 });
             let data_size = self.poll_ctx.raft_wb.data_size();
             if data_size > RAFT_WB_SHRINK_SIZE {
-                self.poll_ctx.raft_wb = WriteBatch::with_capacity(4 * 1024);
+                self.poll_ctx.raft_wb = WriteBatch::with_capacity(DEFAULT_RAFT_WB_CAPACITY);
             } else {
                 self.poll_ctx.raft_wb.clear();
             }

--- a/src/raftstore/store/local_metrics.rs
+++ b/src/raftstore/store/local_metrics.rs
@@ -230,6 +230,7 @@ pub struct RaftProposeMetrics {
     pub read_index: u64,
     pub unsafe_read_index: u64,
     pub normal: u64,
+    pub batch: usize,
     pub transfer_leader: u64,
     pub conf_change: u64,
     pub request_wait_time: LocalHistogram,
@@ -245,6 +246,7 @@ impl Default for RaftProposeMetrics {
             normal: 0,
             transfer_leader: 0,
             conf_change: 0,
+            batch: 0,
             request_wait_time: REQUEST_WAIT_TIME_HISTOGRAM.local(),
         }
     }
@@ -295,6 +297,12 @@ impl RaftProposeMetrics {
                 .with_label_values(&["conf_change"])
                 .inc_by(self.conf_change as i64);
             self.conf_change = 0;
+        }
+        if self.batch > 0 {
+            PEER_PROPOSAL_COUNTER_VEC
+                .with_label_values(&["batch"])
+                .inc_by(self.batch as i64);
+            self.batch = 0;
         }
         self.request_wait_time.flush();
     }

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -56,6 +56,7 @@ use super::util::{self, check_region_epoch, is_initial_msg, Lease, LeaseState};
 use super::DestroyPeerJob;
 
 const SHRINK_CACHE_CAPACITY: usize = 64;
+const MAX_BATCH_KEY_NUM: usize = 128;
 
 struct ReadIndexRequest {
     id: Uuid,
@@ -261,6 +262,45 @@ pub struct WaitApplyResultState {
     pub ready_to_merge: Arc<AtomicBool>,
 }
 
+pub struct BatchRaftCmdRequest {
+    request: Option<RaftCmdRequest>,
+    batch_size: u32,
+    batch_callbacks: Vec<(Callback, usize)>,
+}
+
+impl BatchRaftCmdRequest {
+    fn new() -> BatchRaftCmdRequest {
+        BatchRaftCmdRequest {
+            request: None,
+            batch_size: 0,
+            batch_callbacks: vec![],
+        }
+    }
+
+    fn push(&mut self, mut req: RaftCmdRequest, req_size: u32, cb: Callback) {
+        let req_num = req.get_requests().len();
+        if let Some(batch_req) = self.request.as_mut() {
+            let requests: Vec<_> = req.take_requests().into();
+            for q in requests {
+                batch_req.mut_requests().push(q);
+            }
+        } else {
+            self.request = Some(req);
+        };
+        self.batch_callbacks.push((cb, req_num));
+        self.batch_size += req_size;
+    }
+
+    fn take(&mut self) -> Option<(RaftCmdRequest, Vec<(Callback, usize)>)> {
+        self.batch_size = 0;
+        if let Some(req) = self.request.take() {
+            let cbs = mem::replace(&mut self.batch_callbacks, vec![]);
+            return Some((req, cbs));
+        }
+        None
+    }
+}
+
 pub struct Peer {
     /// The ID of the Region which this Peer belongs to.
     region_id: u64,
@@ -290,6 +330,9 @@ pub struct Peer {
     pub pending_remove: bool,
     /// If a snapshot is being applied asynchronously, messages should not be sent.
     pending_messages: Vec<eraftpb::Message>,
+
+    // Batch raft command which has the same header into an entry
+    batch_raft_request: BatchRaftCmdRequest,
 
     /// Record the instants of peers being added into the configuration.
     /// Remove them after they are not pending any more.
@@ -417,6 +460,7 @@ impl Peer {
             leader_lease: Lease::new(cfg.raft_store_max_leader_lease()),
             pending_messages: vec![],
             pending_merge_apply_result: None,
+            batch_raft_request: BatchRaftCmdRequest::new(),
             peer_stat: PeerStat::default(),
             catch_up_logs: None,
         };
@@ -1694,6 +1738,94 @@ impl Peer {
         None
     }
 
+    fn batch_callback(&mut self, cbs: Vec<(Callback, usize)>, term: u64, e: Error) {
+        let mut resp = RaftCmdResponse::default();
+        cmd_resp::bind_term(&mut resp, term);
+        cmd_resp::bind_error(&mut resp, e);
+        for (cb, _) in cbs {
+            cb.invoke_with_response(resp.clone());
+        }
+    }
+
+    pub fn propose_batch_request<T, C>(&mut self, ctx: &mut PollContext<T, C>) {
+        if let Some((req, mut cbs)) = self.batch_raft_request.take() {
+            let term = req.get_header().get_term();
+            if let Err(e) = util::check_term(&req, self.term()) {
+                self.batch_callback(cbs, term, e);
+                return;
+            }
+            match self.propose_normal(ctx, req) {
+                Err(e) => {
+                    self.batch_callback(cbs, term, e);
+                }
+                Ok(idx) => {
+                    let meta = ProposalMeta {
+                        index: idx,
+                        term: self.term(),
+                        renew_lease_time: None,
+                    };
+                    if cbs.len() > 1 {
+                        ctx.raft_metrics.propose.batch += cbs.len();
+                        ctx.raft_metrics.propose.normal -= 1;
+                        self.post_propose(
+                            ctx,
+                            meta,
+                            false,
+                            Callback::Write(Box::new(move |resp| {
+                                let mut last_index = 0;
+                                let has_error = resp.response.get_header().has_error();
+                                for (cb, req_num) in cbs {
+                                    let next_index = last_index + req_num;
+                                    let mut cmd_resp = RaftCmdResponse::default();
+                                    cmd_resp.set_header(resp.response.get_header().clone());
+                                    if !has_error {
+                                        cmd_resp.set_responses(
+                                            resp.response.get_responses()[last_index..next_index]
+                                                .into(),
+                                        );
+                                    }
+                                    cb.invoke_with_response(cmd_resp);
+                                    last_index = next_index;
+                                }
+                            })),
+                        );
+                    } else {
+                        let (cb, _) = cbs.pop().unwrap();
+                        self.post_propose(ctx, meta, false, cb);
+                    }
+                }
+            }
+        }
+    }
+
+    fn should_propose_batch_request<T, C>(
+        &mut self,
+        ctx: &mut PollContext<T, C>,
+        req: &RaftCmdRequest,
+    ) -> bool {
+        if let Some(batch_req) = self.batch_raft_request.request.as_ref() {
+            let batch_term = batch_req.get_header().get_term();
+            let batch_epoch = batch_req.get_header().get_region_epoch();
+            let epoch = req.get_header().get_region_epoch();
+            let term = req.get_header().get_term();
+            if term != batch_term {
+                return true;
+            }
+            if epoch != batch_epoch {
+                return true;
+            }
+            if f64::from(self.batch_raft_request.batch_size)
+                > ctx.cfg.raft_entry_max_size.0 as f64 * 0.3
+            {
+                return true;
+            }
+            if batch_req.get_requests().len() > MAX_BATCH_KEY_NUM {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Propose a request.
     ///
     /// Return true means the request has been proposed successfully.
@@ -1720,11 +1852,32 @@ impl Peer {
                 return false;
             }
             Ok(RequestPolicy::ReadIndex) => return self.read_index(ctx, req, err_resp, cb),
-            Ok(RequestPolicy::ProposeNormal) => self.propose_normal(ctx, req),
+            Ok(RequestPolicy::ProposeNormal) => {
+                if req.has_admin_request() {
+                    self.propose_batch_request(ctx);
+                    self.propose_normal(ctx, req)
+                } else {
+                    let req_size = req.compute_size();
+                    // No batch request whose size exceed 40% of raft_entry_max_size,
+                    // so total size of request in batch_raft_request would not exceed 80% of
+                    // raft_entry_max_size
+                    let max_size = ctx.cfg.raft_entry_max_size.0 as f64 * 0.2;
+                    if self.should_propose_batch_request(ctx, &req) {
+                        self.propose_batch_request(ctx);
+                    }
+                    if f64::from(req_size) < max_size {
+                        self.batch_raft_request.push(req, req_size, cb);
+                        return true;
+                    }
+                    self.propose_normal(ctx, req)
+                }
+            }
             Ok(RequestPolicy::ProposeTransferLeader) => {
+                self.propose_batch_request(ctx);
                 return self.propose_transfer_leader(ctx, req, cb);
             }
             Ok(RequestPolicy::ProposeConfChange) => {
+                self.propose_batch_request(ctx);
                 is_conf_change = true;
                 self.propose_conf_change(ctx, &req)
             }


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Batch multiple raft command into an entry to reduce raft message between tikv-server.


###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)


###  How is the PR tested?

- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No



