### PR TITLE
Always use the optimized version of ingest_external_file_cf

### DIFF
--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -27,18 +27,6 @@ impl ImportExt for RocksEngine {
         cf: &Self::CFHandle,
         opts: &Self::IngestExternalFileOptions,
         files: &[&str],
-    ) -> Result<()> {
-        let cf = cf.as_inner();
-        self.as_inner()
-            .ingest_external_file_cf(&cf, &opts.0, files)?;
-        Ok(())
-    }
-
-    fn ingest_external_file_optimized(
-        &self,
-        cf: &Self::CFHandle,
-        opts: &Self::IngestExternalFileOptions,
-        files: &[&str],
     ) -> Result<bool> {
         let cf = cf.as_inner();
         let r = self

--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -27,12 +27,17 @@ impl ImportExt for RocksEngine {
         cf: &Self::CFHandle,
         opts: &Self::IngestExternalFileOptions,
         files: &[&str],
-    ) -> Result<bool> {
+    ) -> Result<()> {
         let cf = cf.as_inner();
-        let r = self
+        // This is calling a specially optimized version of
+        // ingest_external_file_cf. In cases where the memtable needs to be
+        // flushed it avoids blocking writers while doing the flush. The unused
+        // return value here just indicates whether the fallback path requiring
+        // the manual memtable flush was taken.
+        let _did_nonblocking_memtable_flush = self
             .as_inner()
             .ingest_external_file_optimized(&cf, &opts.0, files)?;
-        Ok(r)
+        Ok(())
     }
 
     fn validate_sst_for_ingestion<P: AsRef<Path>>(

--- a/components/engine_traits/src/import.rs
+++ b/components/engine_traits/src/import.rs
@@ -18,7 +18,7 @@ pub trait ImportExt: CFHandleExt {
         cf: &Self::CFHandle,
         opt: &Self::IngestExternalFileOptions,
         files: &[&str],
-    ) -> Result<bool>;
+    ) -> Result<()>;
 
     fn validate_sst_for_ingestion<P: AsRef<Path>>(
         &self,

--- a/components/engine_traits/src/import.rs
+++ b/components/engine_traits/src/import.rs
@@ -16,13 +16,6 @@ pub trait ImportExt: CFHandleExt {
     fn ingest_external_file_cf(
         &self,
         cf: &Self::CFHandle,
-        opts: &Self::IngestExternalFileOptions,
-        files: &[&str],
-    ) -> Result<()>;
-
-    fn ingest_external_file_optimized(
-        &self,
-        cf: &Self::CFHandle,
         opt: &Self::IngestExternalFileOptions,
         files: &[&str],
     ) -> Result<bool>;

--- a/src/raftstore/store/snap/io.rs
+++ b/src/raftstore/store/snap/io.rs
@@ -140,7 +140,7 @@ where
     let cf_handle = box_try!(db.cf_handle(cf));
     let mut ingest_opt = <E as ImportExt>::IngestExternalFileOptions::new();
     ingest_opt.move_files(true);
-    box_try!(db.ingest_external_file_optimized(cf_handle, &ingest_opt, &[path]));
+    box_try!(db.ingest_external_file_cf(cf_handle, &ingest_opt, &[path]));
     Ok(())
 }
 


### PR DESCRIPTION

###  What have you changed?

The rocks bindings contain a function called ingest_external_file_optimized, which does the same thing as ingest_external_file_cf, but has some logic to prevent blocking writers in certain cases. This patch changes engine_traits and engine_rocks to only expose ingest_external_file_cf, implemented using ingest_external_file_optimized.

Fixes https://github.com/tikv/tikv/issues/6162

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

cargo check --all

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?


###  Does this PR affect `tidb-ansible`?



###  Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/issues/6162

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

