### PR TITLE
backup: hash backup file name 

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -17,7 +17,6 @@ use kvproto::backup::*;
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 use kvproto::metapb::*;
 use raft::StateRole;
-use tikv::coprocessor::codec::table::decode_table_id;
 use tikv::raftstore::store::util::find_peer;
 use tikv::storage::kv::{Engine, RegionInfoProvider};
 use tikv::storage::txn::{EntryBatch, SnapshotStore, TxnEntryScanner, TxnEntryStore};
@@ -375,11 +374,13 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
                     warn!("backup task has canceled"; "range" => ?brange);
                     return Ok(());
                 }
-                let table_id = brange
+                // TODO: make file_name unique and short
+                let key = brange
                     .start_key
                     .clone()
-                    .and_then(|k| decode_table_id(&k.into_raw().unwrap()).ok());
-                let name = backup_file_name(store_id, &brange.region, table_id);
+                    .map(|k| hex::encode(k.into_raw().unwrap()));
+
+                let name = backup_file_name(store_id, &brange.region, key);
                 let mut writer = match BackupWriter::new(db.clone(), &name, storage.limiter.clone())
                 {
                     Ok(w) => w,
@@ -561,14 +562,14 @@ fn get_max_start_key(start_key: Option<&Key>, region: &Region) -> Option<Key> {
 
 /// Construct an backup file name based on the given store id and region.
 /// A name consists with three parts: store id, region_id and a epoch version.
-fn backup_file_name(store_id: u64, region: &Region, table_id: Option<i64>) -> String {
-    match table_id {
-        Some(t_id) => format!(
+fn backup_file_name(store_id: u64, region: &Region, key: Option<String>) -> String {
+    match key {
+        Some(k) => format!(
             "{}_{}_{}_{}",
             store_id,
             region.get_id(),
             region.get_region_epoch().get_version(),
-            t_id
+            k
         ),
         None => format!(
             "{}_{}_{}",

--- a/components/tikv_util/src/file.rs
+++ b/components/tikv_util/src/file.rs
@@ -81,8 +81,7 @@ pub fn calc_crc32_bytes(contents: &[u8]) -> u32 {
 
 /// Calculates the given content's SHA256 checksum.
 pub fn sha256(input: &[u8]) -> Result<Vec<u8>, openssl::error::ErrorStack> {
-    openssl::hash::hash(openssl::hash::MessageDigest::sha256(), input)
-        .map(|digest| hex::encode(digest).into_bytes())
+    openssl::hash::hash(openssl::hash::MessageDigest::sha256(), input).map(|digest| digest.to_vec())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
cherry-pick #6177 to release-3.1
Signed-off-by: luancheng <luancheng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
use start key sha256 to replace raw start key, if we use start key as file name we could meet 
"file name too long" error because some index key are longer than 255 bytes


###  What is the type of the changes?

- Bugfix (a change which fixes an issue)


###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- Unit test
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
N/A


###  Does this PR affect `tidb-ansible`?
N/A

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

