### PR TITLE
backup: support incremental backup

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -145,7 +145,9 @@ impl BackupRange {
         );
         let start_key = self.start_key.clone();
         let end_key = self.end_key.clone();
-        let mut scanner = snap_store.entry_scanner(start_key, end_key).unwrap();
+        let mut scanner = snap_store
+            .entry_scanner(start_key, end_key, 0.into())
+            .unwrap();
 
         let start = Instant::now();
         let mut batch = EntryBatch::with_capacity(1024);

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -505,16 +505,13 @@ impl<E: Engine, R: RegionInfoProvider> Runnable<Task> for Endpoint<E, R> {
             return;
         }
         info!("run backup task"; "task" => %task);
-        if task.start_ts == task.end_ts {
-            self.handle_backup_task(task);
-            self.pool.borrow_mut().heartbeat();
-        } else {
-            // TODO: support incremental backup
+        if !task.start_ts.is_zero() {
             BACKUP_RANGE_ERROR_VEC
                 .with_label_values(&["incremental"])
                 .inc();
-            error!("incremental backup is not supported yet");
         }
+        self.handle_backup_task(task);
+        self.pool.borrow_mut().heartbeat();
     }
 }
 

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -847,7 +847,7 @@ pub mod tests {
             let mut req = BackupRequest::default();
             req.set_start_key(vec![]);
             req.set_end_key(vec![b'5']);
-            req.set_start_version(ts.into_inner());
+            req.set_start_version(0);
             req.set_end_version(ts.into_inner());
             req.set_concurrency(4);
             let (tx, rx) = unbounded();

--- a/components/backup/tests/integrations/test_backup.rs
+++ b/components/backup/tests/integrations/test_backup.rs
@@ -175,13 +175,14 @@ impl TestSuite {
         &self,
         start_key: Vec<u8>,
         end_key: Vec<u8>,
+        begin_ts: TimeStamp,
         backup_ts: TimeStamp,
         path: &Path,
     ) -> future_mpsc::UnboundedReceiver<BackupResponse> {
         let mut req = BackupRequest::default();
         req.set_start_key(start_key);
         req.set_end_key(end_key);
-        req.start_version = backup_ts.into_inner();
+        req.start_version = begin_ts.into_inner();
         req.end_version = backup_ts.into_inner();
         req.set_storage_backend(make_local_backend(path));
         let (tx, rx) = future_mpsc::unbounded();
@@ -261,8 +262,9 @@ fn test_backup_and_import() {
     let backup_ts = suite.alloc_ts();
     let storage_path = tmp.path().join(format!("{}", backup_ts));
     let rx = suite.backup(
-        vec![], // start
-        vec![], // end
+        vec![],   // start
+        vec![],   // end
+        0.into(), // begin_ts
         backup_ts,
         &storage_path,
     );
@@ -279,8 +281,9 @@ fn test_backup_and_import() {
     // Backup file should have same contents.
     // backup ts + 1 avoid file already exist.
     let rx = suite.backup(
-        vec![], // start
-        vec![], // end
+        vec![],   // start
+        vec![],   // end
+        0.into(), // begin_ts
         backup_ts,
         &tmp.path().join(format!("{}", backup_ts.next())),
     );
@@ -336,8 +339,9 @@ fn test_backup_and_import() {
     // Backup file should have same contents.
     // backup ts + 2 avoid file already exist.
     let rx = suite.backup(
-        vec![], // start
-        vec![], // end
+        vec![],   // start
+        vec![],   // end
+        0.into(), // begin_ts
         backup_ts,
         &tmp.path().join(format!("{}", backup_ts.next().next())),
     );
@@ -377,8 +381,9 @@ fn test_backup_meta() {
     let tmp = Builder::new().tempdir().unwrap();
     let storage_path = tmp.path().join(format!("{}", backup_ts));
     let rx = suite.backup(
-        vec![], // start
-        vec![], // end
+        vec![],   // start
+        vec![],   // end
+        0.into(), // begin_ts
         backup_ts,
         &storage_path,
     );

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -97,7 +97,7 @@ impl<S: Snapshot> ScannerBuilder<S> {
         }
     }
 
-    pub fn build_entry_scanner(mut self) -> Result<EntryScanner<S>> {
+    pub fn build_entry_scanner(mut self, after: TimeStamp) -> Result<EntryScanner<S>> {
         let lower_bound = self.0.lower_bound.clone();
         let lock_cursor = self.0.create_cf_cursor(CF_LOCK)?;
         let write_cursor = self.0.create_cf_cursor(CF_WRITE)?;
@@ -110,6 +110,7 @@ impl<S: Snapshot> ScannerBuilder<S> {
             write_cursor,
             default_cursor,
             lower_bound,
+            after,
         )?)
     }
 }


### PR DESCRIPTION
###  What have you changed?

This PR modifies TxnEntryScanner to support scanning records after given ts. Then, we pass `begin_ts` in, so we can support incremental backup.

###  What is the type of the changes?

- New feature (a change which adds functionality)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?


###  Does this PR affect `tidb-ansible`?


###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

