### PR TITLE
*: use kvproto::backup::StorageBackend in create_storage (#6186)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,6 +778,7 @@ dependencies = [
 name = "external_storage"
 version = "0.0.1"
 dependencies = [
+ "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.1)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
@@ -1306,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.1#4f292e1801d8d24b40f63acc9f9367a453de6b0f"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.1#c23886becb540cf68d6615455f3717427044bd20"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -81,7 +81,7 @@ impl Task {
             None
         };
         let storage = LimitedStorage {
-            storage: create_storage(req.get_path())?,
+            storage: create_storage(req.get_storage_backend())?,
             limiter,
         };
 
@@ -583,7 +583,7 @@ fn backup_file_name(store_id: u64, region: &Region, key: Option<String>) -> Stri
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use external_storage::LocalStorage;
+    use external_storage::{make_local_backend, make_noop_backend, LocalStorage};
     use futures::{self, Future, Stream};
     use kvproto::metapb;
     use rand;
@@ -850,10 +850,7 @@ pub mod tests {
             Task::new(req.clone(), tx.clone()).unwrap_err();
 
             // Set an unique path to avoid AlreadyExists error.
-            req.set_path(format!(
-                "local://{}",
-                tmp.path().join(format!("{}", ts)).display()
-            ));
+            req.set_storage_backend(make_local_backend(&tmp.path().join(ts.to_string())));
             if len % 2 == 0 {
                 req.set_rate_limit(10 * 1024 * 1024);
             }
@@ -912,10 +909,7 @@ pub mod tests {
         req.set_end_version(now);
         req.set_concurrency(4);
         // Set an unique path to avoid AlreadyExists error.
-        req.set_path(format!(
-            "local://{}",
-            tmp.path().join(format!("{}", now)).display()
-        ));
+        req.set_storage_backend(make_local_backend(&tmp.path().join(now.to_string())));
         let (tx, rx) = unbounded();
         let (task, _) = Task::new(req.clone(), tx).unwrap();
         endpoint.handle_backup_task(task);
@@ -936,10 +930,7 @@ pub mod tests {
         req.set_start_version(now);
         req.set_end_version(now);
         // Set an unique path to avoid AlreadyExists error.
-        req.set_path(format!(
-            "local://{}",
-            tmp.path().join(format!("{}", now)).display()
-        ));
+        req.set_storage_backend(make_local_backend(&tmp.path().join(now.to_string())));
         let (tx, rx) = unbounded();
         let (task, _) = Task::new(req.clone(), tx).unwrap();
         endpoint.handle_backup_task(task);
@@ -988,7 +979,7 @@ pub mod tests {
         req.set_start_version(now);
         req.set_end_version(now);
         req.set_concurrency(4);
-        req.set_path(format!("local://{}", temp.path().display()));
+        req.set_storage_backend(make_local_backend(temp.path()));
 
         // Cancel the task before starting the task.
         let (tx, rx) = unbounded();
@@ -1025,7 +1016,7 @@ pub mod tests {
         req.set_start_version(1);
         req.set_end_version(1);
         req.set_concurrency(4);
-        req.set_path("noop://foo".to_owned());
+        req.set_storage_backend(make_noop_backend());
 
         let (tx, rx) = unbounded();
         let (task, _) = Task::new(req.clone(), tx).unwrap();
@@ -1056,7 +1047,7 @@ pub mod tests {
         req.set_end_key(vec![]);
         req.set_start_version(1);
         req.set_end_version(1);
-        req.set_path("noop://foo".to_owned());
+        req.set_storage_backend(make_noop_backend());
 
         let (tx, _) = unbounded();
 
@@ -1117,7 +1108,7 @@ pub mod tests {
         req.set_start_version(1);
         req.set_end_version(1);
         req.set_concurrency(10);
-        req.set_path("noop://foo".to_owned());
+        req.set_storage_backend(make_noop_backend());
 
         let (tx, _) = futures::sync::mpsc::unbounded();
         let (task, _) = Task::new(req, tx).unwrap();

--- a/components/backup/src/service.rs
+++ b/components/backup/src/service.rs
@@ -85,6 +85,7 @@ mod tests {
 
     use super::*;
     use crate::endpoint::tests::*;
+    use external_storage::make_local_backend;
     use tikv::storage::mvcc::tests::*;
     use tikv_util::mpsc::Receiver;
 
@@ -140,10 +141,7 @@ mod tests {
         req.set_start_version(now);
         req.set_end_version(now);
         // Set an unique path to avoid AlreadyExists error.
-        req.set_path(format!(
-            "local://{}",
-            tmp.path().join(format!("{}", now)).display()
-        ));
+        req.set_storage_backend(make_local_backend(&tmp.path().join(now.to_string())));
 
         let stream = client.backup(&req).unwrap();
         let task = rx.recv_timeout(Duration::from_secs(5)).unwrap();
@@ -153,10 +151,7 @@ mod tests {
         endpoint.handle_backup_task(task.unwrap());
 
         // Set an unique path to avoid AlreadyExists error.
-        req.set_path(format!(
-            "local://{}",
-            tmp.path().join(format!("{}", alloc_ts())).display()
-        ));
+        req.set_storage_backend(make_local_backend(&tmp.path().join(alloc_ts().to_string())));
         let stream = client.backup(&req).unwrap();
         // Drop steam once it received something.
         client.spawn(stream.into_future().then(|_res| Ok(())));
@@ -165,10 +160,7 @@ mod tests {
         endpoint.handle_backup_task(task.unwrap());
 
         // Set an unique path to avoid AlreadyExists error.
-        req.set_path(format!(
-            "local://{}",
-            tmp.path().join(format!("{}", alloc_ts())).display()
-        ));
+        req.set_storage_backend(make_local_backend(&tmp.path().join(alloc_ts().to_string())));
         let stream = client.backup(&req).unwrap();
         let task = rx.recv_timeout(Duration::from_secs(5)).unwrap().unwrap();
         // Drop stream without start receiving will cause cancel error.

--- a/components/backup/src/writer.rs
+++ b/components/backup/src/writer.rs
@@ -240,9 +240,8 @@ mod tests {
             .build()
             .unwrap();
         let db = rocks.get_rocksdb();
-        let storage =
-            external_storage::create_storage(&format!("local://{}", temp.path().display()))
-                .unwrap();
+        let backend = external_storage::make_local_backend(temp.path());
+        let storage = external_storage::create_storage(&backend).unwrap();
 
         // Test empty file.
         let mut writer = BackupWriter::new(db.clone(), "foo", None).unwrap();

--- a/components/backup/tests/integrations/test_backup.rs
+++ b/components/backup/tests/integrations/test_backup.rs
@@ -1,5 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::path::Path;
 use std::sync::*;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -173,14 +174,14 @@ impl TestSuite {
         start_key: Vec<u8>,
         end_key: Vec<u8>,
         backup_ts: u64,
-        path: String,
+        path: &Path,
     ) -> future_mpsc::UnboundedReceiver<BackupResponse> {
         let mut req = BackupRequest::new();
         req.set_start_key(start_key);
         req.set_end_key(end_key);
         req.start_version = backup_ts;
         req.end_version = backup_ts;
-        req.set_path(path);
+        req.set_storage_backend(make_local_backend(path));
         let (tx, rx) = future_mpsc::unbounded();
         for end in self.endpoints.values() {
             let (task, _) = Task::new(req.clone(), tx.clone()).unwrap();
@@ -247,15 +248,12 @@ fn test_backup_and_import() {
     // Push down backup request.
     let tmp = Builder::new().tempdir().unwrap();
     let backup_ts = suite.alloc_ts();
-    let storage_path = format!(
-        "local://{}",
-        tmp.path().join(format!("{}", backup_ts)).display()
-    );
+    let storage_path = tmp.path().join(format!("{}", backup_ts));
     let rx = suite.backup(
         vec![], // start
         vec![], // end
         backup_ts,
-        storage_path.clone(),
+        &storage_path,
     );
     let resps1 = rx.collect().wait().unwrap();
     // Only leader can handle backup.
@@ -273,16 +271,14 @@ fn test_backup_and_import() {
         vec![], // start
         vec![], // end
         backup_ts,
-        format!(
-            "local://{}",
-            tmp.path().join(format!("{}", backup_ts + 1)).display()
-        ),
+        &tmp.path().join(format!("{}", backup_ts + 1)),
     );
     let resps2 = rx.collect().wait().unwrap();
     assert!(resps2[0].get_files().is_empty(), "{:?}", resps2);
 
     // Use importer to restore backup files.
-    let storage = create_storage(&storage_path).unwrap();
+    let backend = make_local_backend(&storage_path);
+    let storage = create_storage(&backend).unwrap();
     let region = suite.cluster.get_region(b"");
     let mut sst_meta = SSTMeta::new();
     sst_meta.region_id = region.get_id();
@@ -332,10 +328,7 @@ fn test_backup_and_import() {
         vec![], // start
         vec![], // end
         backup_ts,
-        format!(
-            "local://{}",
-            tmp.path().join(format!("{}", backup_ts + 2)).display()
-        ),
+        &tmp.path().join(format!("{}", backup_ts + 2)),
     );
     let resps3 = rx.collect().wait().unwrap();
     assert_eq!(files1, resps3[0].files);
@@ -371,15 +364,12 @@ fn test_backup_meta() {
 
     // Push down backup request.
     let tmp = Builder::new().tempdir().unwrap();
-    let storage_path = format!(
-        "local://{}",
-        tmp.path().join(format!("{}", backup_ts)).display()
-    );
+    let storage_path = tmp.path().join(format!("{}", backup_ts));
     let rx = suite.backup(
         vec![], // start
         vec![], // end
         backup_ts,
-        storage_path.clone(),
+        &storage_path,
     );
     let resps1 = rx.collect().wait().unwrap();
     // Only leader can handle backup.

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -12,3 +12,4 @@ tempfile = "3.0"
 rand = "0.6.5"
 url = "2.0"
 tikv_alloc = { path = "../tikv_alloc", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-3.1", default-features = false }

--- a/components/external_storage/src/lib.rs
+++ b/components/external_storage/src/lib.rs
@@ -9,6 +9,7 @@
     slog_error,
     slog_info,
     slog_debug,
+    slog_warn,
     slog_log,
     slog_record,
     slog_b,
@@ -25,36 +26,70 @@ use std::io::{self, Read};
 use std::path::Path;
 use std::sync::Arc;
 
-use url::Url;
+use kvproto::backup::StorageBackend_oneof_backend as Backend;
+use kvproto::backup::{Noop, StorageBackend};
 
 mod local;
 pub use local::LocalStorage;
 mod noop;
 pub use noop::NoopStorage;
 
-/// Create a new storage from the given url.
-pub fn create_storage(url: &str) -> io::Result<Arc<dyn ExternalStorage>> {
-    let url = Url::parse(url).map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("failed to create storage {} {}", e, url),
-        )
-    })?;
-
-    match url.scheme() {
-        LocalStorage::SCHEME => {
-            let p = Path::new(url.path());
+/// Create a new storage from the given storage backend description.
+pub fn create_storage(backend: &StorageBackend) -> io::Result<Arc<dyn ExternalStorage>> {
+    match &backend.backend {
+        Some(Backend::local(local)) => {
+            let p = Path::new(&local.path);
             LocalStorage::new(p).map(|s| Arc::new(s) as _)
         }
-        NoopStorage::SCHEME => Ok(Arc::new(NoopStorage::new()) as _),
-        other => {
-            error!("unknown storage"; "scheme" => other);
+        Some(Backend::noop(_)) => Ok(Arc::new(NoopStorage::new()) as _),
+        _ => {
+            let u = url_of_backend(backend);
+            error!("unknown storage"; "scheme" => u.scheme());
             Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!("unknown storage {}", url),
+                format!("unknown storage {}", u),
             ))
         }
     }
+}
+
+/// Formats the storage backend as a URL.
+pub fn url_of_backend(backend: &StorageBackend) -> url::Url {
+    let mut u = url::Url::parse("unknown:///").unwrap();
+    match &backend.backend {
+        Some(Backend::local(local)) => {
+            u.set_scheme("local").unwrap();
+            u.set_path(&local.path);
+        }
+        Some(Backend::noop(_)) => {
+            u.set_scheme("noop").unwrap();
+        }
+        Some(Backend::s3(s3)) => {
+            u.set_scheme("s3").unwrap();
+            if let Err(e) = u.set_host(Some(&s3.bucket)) {
+                warn!("ignoring invalid S3 bucket name"; "bucket" => &s3.bucket, "error" => %e);
+            }
+            u.set_path(s3.get_prefix());
+        }
+        None => {}
+    }
+    u
+}
+
+/// Creates a local `StorageBackend` to the given path.
+pub fn make_local_backend(path: &Path) -> StorageBackend {
+    let path = path.display().to_string();
+    let mut backend = StorageBackend::default();
+    backend.mut_local().set_path(path);
+    backend
+}
+
+/// Creates a noop `StorageBackend`.
+pub fn make_noop_backend() -> StorageBackend {
+    let noop = Noop::default();
+    let mut backend = StorageBackend::default();
+    backend.set_noop(noop);
+    backend
 }
 
 /// An abstraction of an external storage.
@@ -81,8 +116,33 @@ mod tests {
 
     #[test]
     fn test_create_storage() {
-        create_storage("local:///tmp/a").unwrap();
-        create_storage("noop:///foo").unwrap();
-        assert!(create_storage("invalid").is_err());
+        let backend = make_local_backend(Path::new("/tmp/a"));
+        create_storage(&backend).unwrap();
+
+        let backend = make_noop_backend();
+        create_storage(&backend).unwrap();
+
+        let backend = StorageBackend::default();
+        assert!(create_storage(&backend).is_err());
+    }
+
+    #[test]
+    fn test_url_of_backend() {
+        let backend = make_local_backend(Path::new("/tmp/a"));
+        assert_eq!(url_of_backend(&backend).to_string(), "local:///tmp/a");
+
+        let backend = make_noop_backend();
+        assert_eq!(url_of_backend(&backend).to_string(), "noop:///");
+
+        let mut backend = StorageBackend::default();
+        let s3 = backend.mut_s3();
+        s3.set_bucket("bucket".to_owned());
+        s3.set_prefix("/backup 01/prefix/".to_owned());
+        s3.set_endpoint("http://endpoint.com".to_owned());
+        // ^ only 'bucket' and 'prefix' should be visible in url_of_backend()
+        assert_eq!(
+            url_of_backend(&backend).to_string(),
+            "s3://bucket/backup%2001/prefix/"
+        );
     }
 }

--- a/components/external_storage/src/local.rs
+++ b/components/external_storage/src/local.rs
@@ -30,9 +30,6 @@ pub struct LocalStorage {
 }
 
 impl LocalStorage {
-    /// The url scheme of the `LocalStorage`.
-    pub const SCHEME: &'static str = "local";
-
     /// Create a new local storage in the given path.
     pub fn new(base: &Path) -> io::Result<LocalStorage> {
         info!("create local storage"; "base" => base.display());

--- a/components/external_storage/src/noop.rs
+++ b/components/external_storage/src/noop.rs
@@ -10,9 +10,6 @@ use super::ExternalStorage;
 pub struct NoopStorage {}
 
 impl NoopStorage {
-    /// The url scheme of the `NoopStorage`.
-    pub const SCHEME: &'static str = "noop";
-
     /// Create a new noop storage in the given path.
     pub fn new() -> NoopStorage {
         info!("create noop storage");

--- a/src/import/sst_importer.rs
+++ b/src/import/sst_importer.rs
@@ -96,7 +96,7 @@ impl SSTImporter {
     ) -> Result<Option<Range>> {
         debug!("download start";
             "meta" => ?meta,
-            "url" => ?backend,
+            "url" => %(url_of_backend(backend)),
             "name" => name,
             "rewrite_rule" => ?rewrite_rule,
             "speed_limit" => speed_limiter.as_ref().map_or(0, |l| l.get_bytes_per_second()),

--- a/src/import/sst_importer.rs
+++ b/src/import/sst_importer.rs
@@ -7,13 +7,14 @@ use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use kvproto::backup::StorageBackend;
 use kvproto::import_sstpb::*;
 use uuid::Uuid;
 
 use engine::rocks::util::io_limiter::{IOLimiter, LimitReader};
 use engine::rocks::util::{get_cf_handle, prepare_sst_for_ingestion, validate_sst_for_ingestion};
 use engine::rocks::{IngestExternalFileOptions, SeekKey, SstReader, SstWriterBuilder, DB};
-use external_storage::create_storage;
+use external_storage::{create_storage, url_of_backend};
 
 use super::{Error, Result};
 use crate::raftstore::store::keys;
@@ -88,19 +89,19 @@ impl SSTImporter {
     pub fn download(
         &self,
         meta: &SSTMeta,
-        url: &str,
+        backend: &StorageBackend,
         name: &str,
         rewrite_rule: &RewriteRule,
         speed_limiter: Option<Arc<IOLimiter>>,
     ) -> Result<Option<Range>> {
         debug!("download start";
             "meta" => ?meta,
-            "url" => url,
+            "url" => ?backend,
             "name" => name,
             "rewrite_rule" => ?rewrite_rule,
             "speed_limit" => speed_limiter.as_ref().map_or(0, |l| l.get_bytes_per_second()),
         );
-        match self.do_download(meta, url, name, rewrite_rule, speed_limiter) {
+        match self.do_download(meta, backend, name, rewrite_rule, speed_limiter) {
             Ok(r) => {
                 info!("download"; "meta" => ?meta, "range" => ?r);
                 Ok(r)
@@ -115,18 +116,19 @@ impl SSTImporter {
     fn do_download(
         &self,
         meta: &SSTMeta,
-        url: &str,
+        backend: &StorageBackend,
         name: &str,
         rewrite_rule: &RewriteRule,
         speed_limiter: Option<Arc<IOLimiter>>,
     ) -> Result<Option<Range>> {
         let path = self.dir.join(meta)?;
+        let url = url_of_backend(backend);
 
         // prepare to download the file from the external_storage
-        let ext_storage = create_storage(url)?;
+        let ext_storage = create_storage(backend)?;
         let mut ext_reader = ext_storage
             .read(name)
-            .map_err(|e| Error::CannotReadExternalStorage(url.to_owned(), name.to_owned(), e))?;
+            .map_err(|e| Error::CannotReadExternalStorage(url.to_string(), name.to_owned(), e))?;
         let mut ext_reader = LimitReader::new(speed_limiter, &mut ext_reader);
 
         // do the I/O copy from external_storage to the local file.
@@ -147,7 +149,7 @@ impl SSTImporter {
 
         debug!("downloaded file and verified";
             "meta" => ?meta,
-            "url" => url,
+            "url" => %url,
             "name" => name,
             "path" => path_str,
         );
@@ -681,7 +683,7 @@ mod tests {
         assert_eq!(meta, new_meta);
     }
 
-    fn create_sample_external_sst_file() -> Result<(TempDir, SSTMeta)> {
+    fn create_sample_external_sst_file() -> Result<(TempDir, StorageBackend, SSTMeta)> {
         let ext_sst_dir = TempDir::new("external_storage")?;
         let mut sst_writer = SstWriterBuilder::new()
             .build(ext_sst_dir.path().join("sample.sst").to_str().unwrap())?;
@@ -702,7 +704,8 @@ mod tests {
         meta.mut_region_epoch().set_conf_ver(5);
         meta.mut_region_epoch().set_version(6);
 
-        Ok((ext_sst_dir, meta))
+        let backend = external_storage::make_local_backend(ext_sst_dir.path());
+        Ok((ext_sst_dir, backend, meta))
     }
 
     fn new_rewrite_rule(old_key_prefix: &[u8], new_key_prefix: &[u8]) -> RewriteRule {
@@ -715,20 +718,14 @@ mod tests {
     #[test]
     fn test_download_sst_no_key_rewrite() {
         // creates a sample SST file.
-        let (ext_sst_dir, meta) = create_sample_external_sst_file().unwrap();
+        let (_ext_sst_dir, backend, meta) = create_sample_external_sst_file().unwrap();
 
         // performs the download.
         let importer_dir = TempDir::new("importer_dir").unwrap();
         let importer = SSTImporter::new(importer_dir.path()).unwrap();
 
         let range = importer
-            .download(
-                &meta,
-                &format!("local://{}", ext_sst_dir.path().display()),
-                "sample.sst",
-                &RewriteRule::default(),
-                None,
-            )
+            .download(&meta, &backend, "sample.sst", &RewriteRule::default(), None)
             .unwrap()
             .unwrap();
 
@@ -762,7 +759,7 @@ mod tests {
     #[test]
     fn test_download_sst_with_key_rewrite() {
         // creates a sample SST file.
-        let (ext_sst_dir, meta) = create_sample_external_sst_file().unwrap();
+        let (_ext_sst_dir, backend, meta) = create_sample_external_sst_file().unwrap();
 
         // performs the download.
         let importer_dir = TempDir::new("importer_dir").unwrap();
@@ -771,7 +768,7 @@ mod tests {
         let range = importer
             .download(
                 &meta,
-                &format!("local://{}", ext_sst_dir.path().display()),
+                &backend,
                 "sample.sst",
                 &new_rewrite_rule(b"t123", b"t567"),
                 None,
@@ -806,7 +803,7 @@ mod tests {
     #[test]
     fn test_download_sst_then_ingest() {
         // creates a sample SST file.
-        let (ext_sst_dir, mut meta) = create_sample_external_sst_file().unwrap();
+        let (_ext_sst_dir, backend, mut meta) = create_sample_external_sst_file().unwrap();
 
         // performs the download.
         let importer_dir = TempDir::new("importer_dir").unwrap();
@@ -815,7 +812,7 @@ mod tests {
         let range = importer
             .download(
                 &meta,
-                &format!("local://{}", ext_sst_dir.path().display()),
+                &backend,
                 "sample.sst",
                 &new_rewrite_rule(b"t123", b"t9102"),
                 None,
@@ -856,7 +853,7 @@ mod tests {
 
     #[test]
     fn test_download_sst_partial_range() {
-        let (ext_sst_dir, mut meta) = create_sample_external_sst_file().unwrap();
+        let (_ext_sst_dir, backend, mut meta) = create_sample_external_sst_file().unwrap();
         let importer_dir = TempDir::new("importer_dir").unwrap();
         let importer = SSTImporter::new(importer_dir.path()).unwrap();
 
@@ -865,13 +862,7 @@ mod tests {
         meta.mut_range().set_end(b"t123_r12".to_vec());
 
         let range = importer
-            .download(
-                &meta,
-                &format!("local://{}", ext_sst_dir.path().display()),
-                "sample.sst",
-                &RewriteRule::default(),
-                None,
-            )
+            .download(&meta, &backend, "sample.sst", &RewriteRule::default(), None)
             .unwrap()
             .unwrap();
 
@@ -899,7 +890,7 @@ mod tests {
 
     #[test]
     fn test_download_sst_partial_range_with_key_rewrite() {
-        let (ext_sst_dir, mut meta) = create_sample_external_sst_file().unwrap();
+        let (_ext_sst_dir, backend, mut meta) = create_sample_external_sst_file().unwrap();
         let importer_dir = TempDir::new("importer_dir").unwrap();
         let importer = SSTImporter::new(importer_dir.path()).unwrap();
 
@@ -909,7 +900,7 @@ mod tests {
         let range = importer
             .download(
                 &meta,
-                &format!("local://{}", ext_sst_dir.path().display()),
+                &backend,
                 "sample.sst",
                 &new_rewrite_rule(b"t123", b"t5"),
                 None,
@@ -946,16 +937,12 @@ mod tests {
         let importer_dir = TempDir::new("importer_dir").unwrap();
         let importer = SSTImporter::new(importer_dir.path()).unwrap();
 
+        let backend = external_storage::make_local_backend(ext_sst_dir.path());
         let mut meta = SSTMeta::new();
         meta.set_uuid(vec![0u8; 16]);
 
-        let result = importer.download(
-            &meta,
-            &format!("local://{}", ext_sst_dir.path().display()),
-            "sample.sst",
-            &RewriteRule::default(),
-            None,
-        );
+        let result =
+            importer.download(&meta, &backend, "sample.sst", &RewriteRule::default(), None);
         match &result {
             Err(Error::RocksDB(msg)) if msg.starts_with("Corruption:") => {}
             _ => panic!("unexpected download result: {:?}", result),
@@ -964,20 +951,15 @@ mod tests {
 
     #[test]
     fn test_download_sst_empty() {
-        let (ext_sst_dir, mut meta) = create_sample_external_sst_file().unwrap();
+        let (_ext_sst_dir, backend, mut meta) = create_sample_external_sst_file().unwrap();
         let importer_dir = TempDir::new("importer_dir").unwrap();
         let importer = SSTImporter::new(importer_dir.path()).unwrap();
 
         meta.mut_range().set_start(vec![b'x']);
         meta.mut_range().set_end(vec![b'y']);
 
-        let result = importer.download(
-            &meta,
-            &format!("local://{}", ext_sst_dir.path().display()),
-            "sample.sst",
-            &RewriteRule::default(),
-            None,
-        );
+        let result =
+            importer.download(&meta, &backend, "sample.sst", &RewriteRule::default(), None);
 
         match result {
             Ok(None) => {}
@@ -987,13 +969,13 @@ mod tests {
 
     #[test]
     fn test_download_sst_wrong_key_prefix() {
-        let (ext_sst_dir, meta) = create_sample_external_sst_file().unwrap();
+        let (_ext_sst_dir, backend, meta) = create_sample_external_sst_file().unwrap();
         let importer_dir = TempDir::new("importer_dir").unwrap();
         let importer = SSTImporter::new(importer_dir.path()).unwrap();
 
         let result = importer.download(
             &meta,
-            &format!("local://{}", ext_sst_dir.path().display()),
+            &backend,
             "sample.sst",
             &new_rewrite_rule(b"xxx", b"yyy"),
             None,

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -155,7 +155,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
         ctx.spawn(self.threads.spawn_fn(move || {
             let res = importer.download(
                 req.get_sst(),
-                req.get_url(),
+                req.get_storage_backend(),
                 req.get_name(),
                 req.get_rewrite_rule(),
                 limiter,

--- a/tests/integrations/import/sst_service.rs
+++ b/tests/integrations/import/sst_service.rs
@@ -132,7 +132,7 @@ fn test_download_sst() {
     // Checks that downloading a non-existing storage returns error.
     let mut download = DownloadRequest::default();
     download.set_sst(meta.clone());
-    download.set_url(format!("local://{}", temp_dir.path().display()));
+    download.set_storage_backend(external_storage::make_local_backend(temp_dir.path()));
     download.set_name("missing.sst".to_owned());
 
     let result = import.download(&download);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Please explain in detail what the changes are in this PR and why they are needed:

- Cherry-picks #6186 and pingcap/kvproto#510 to release-3.1


###  What is the type of the changes?

Pick one of the following and delete the others:

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- Unit test


###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

pingcap/br#88

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

