### PR TITLE
Extract txn types component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "tikv_alloc",
  "tikv_util",
  "tokio-threadpool",
+ "txn_types",
  "url 2.1.0",
  "uuid",
 ]
@@ -3008,7 +3009,6 @@ dependencies = [
  "test_sst_importer",
  "tikv_alloc",
  "tokio-sync",
- "txn_types",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,6 +1395,7 @@ dependencies = [
  "kvproto",
  "panic_hook",
  "slog",
+ "tikv_alloc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,13 +1388,10 @@ dependencies = [
  "byteorder",
  "derive_more",
  "failure",
- "farmhash",
  "hex",
  "kvproto",
  "panic_hook",
  "slog",
- "tikv_alloc",
- "tikv_util",
 ]
 
 [[package]]
@@ -3011,6 +3008,7 @@ dependencies = [
  "test_sst_importer",
  "tikv_alloc",
  "tokio-sync",
+ "txn_types",
  "uuid",
 ]
 
@@ -3509,6 +3507,7 @@ dependencies = [
  "tokio-threadpool",
  "tokio-timer",
  "toml",
+ "txn_types",
  "url 2.1.0",
  "utime",
  "uuid",
@@ -3869,6 +3868,24 @@ checksum = "766345ed3891b291d01af307cd3ad2992a4261cb6c0c7e665cd3e01cf379dd24"
 dependencies = [
  "memchr",
  "unchecked-index",
+]
+
+[[package]]
+name = "txn_types"
+version = "0.1.0"
+dependencies = [
+ "byteorder",
+ "codec",
+ "derive-new",
+ "derive_more",
+ "farmhash",
+ "hex",
+ "kvproto",
+ "panic_hook",
+ "quick-error",
+ "slog",
+ "tikv_alloc",
+ "tikv_util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ dependencies = [
  "tikv",
  "tikv_util",
  "toml",
+ "txn_types",
  "url 2.1.0",
  "vlog",
 ]
@@ -3224,6 +3225,7 @@ dependencies = [
  "tikv",
  "tikv_util",
  "tipb",
+ "txn_types",
 ]
 
 [[package]]
@@ -3273,6 +3275,7 @@ dependencies = [
  "test_raftstore",
  "tikv",
  "tikv_util",
+ "txn_types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,6 +3338,7 @@ dependencies = [
  "tipb_helper",
  "tokio-threadpool",
  "toml",
+ "txn_types",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default
 hex = "0.3"
 hyper = { version = "0.12", default-features = false, features = ["runtime"] }
 keys = { path = "components/keys" }
+txn_types = { path = "components/txn_types" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 libc = "0.2"
@@ -173,6 +174,7 @@ members = [
   "components/backup",
   "components/keys",
   "components/sst_importer",
+  "components/txn_types",
   "cmd",
 ]
 default-members = ["cmd"]

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -38,6 +38,7 @@ futures-cpupool = "0.1"
 grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default-features = false }
 hex = "0.3"
 keys = { path = "../components/keys" }
+txn_types = { path = "../components/txn_types" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -26,7 +26,7 @@ use engine::rocks;
 use engine::rocks::util::security::encrypted_env_from_cipher_file;
 use engine::Engines;
 use engine::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_WRITE};
-use keys::{self, Key};
+use keys;
 use kvproto::debugpb::{Db as DBType, *};
 use kvproto::kvrpcpb::{MvccInfo, SplitRegionRequest};
 use kvproto::metapb::{Peer, Region};
@@ -43,6 +43,7 @@ use tikv::server::RaftKv;
 use tikv::storage::kv::Engine;
 use tikv_util::security::{SecurityConfig, SecurityManager};
 use tikv_util::{escape, unescape};
+use txn_types::Key;
 
 const METRICS_PROMETHEUS: &str = "prometheus";
 const METRICS_ROCKSDB_KV: &str = "rocksdb_kv";

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.1"
 grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default-features = false }
 hex = "0.3"
 keys = { path = "../keys" }
+txn_types = { path = "../txn_types" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 protobuf = "2.8"

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -25,8 +25,7 @@ use tikv::storage::Statistics;
 use tikv_util::timer::Timer;
 use tikv_util::worker::{Runnable, RunnableWithTimer};
 use tokio_threadpool::{Builder as ThreadPoolBuilder, ThreadPool};
-use txn_types::Key;
-use txn_types::TimeStamp;
+use txn_types::{Key, TimeStamp};
 
 use crate::metrics::*;
 use crate::*;

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -599,9 +599,9 @@ pub mod tests {
     use tikv::raftstore::store::util::new_peer;
     use tikv::storage::kv::Result as EngineResult;
     use tikv::storage::mvcc::tests::*;
-    use tikv::storage::SHORT_VALUE_MAX_LEN;
     use tikv::storage::{RocksEngine, TestEngineBuilder};
     use tikv_util::time::Instant;
+    use txn_types::SHORT_VALUE_MAX_LEN;
 
     #[derive(Clone)]
     pub struct MockRegionInfoProvider {

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -14,8 +14,6 @@ use external_storage::*;
 use futures::lazy;
 use futures::prelude::Future;
 use futures::sync::mpsc::*;
-use keys::Key;
-use keys::TimeStamp;
 use kvproto::backup::*;
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 use kvproto::metapb::*;
@@ -27,6 +25,8 @@ use tikv::storage::Statistics;
 use tikv_util::timer::Timer;
 use tikv_util::worker::{Runnable, RunnableWithTimer};
 use tokio_threadpool::{Builder as ThreadPoolBuilder, ThreadPool};
+use txn_types::Key;
+use txn_types::TimeStamp;
 
 use crate::metrics::*;
 use crate::*;

--- a/components/backup/src/service.rs
+++ b/components/backup/src/service.rs
@@ -84,9 +84,9 @@ mod tests {
 
     use super::*;
     use crate::endpoint::tests::*;
-    use keys::TimeStamp;
     use tikv::storage::mvcc::tests::*;
     use tikv_util::mpsc::Receiver;
+    use txn_types::TimeStamp;
 
     fn new_rpc_suite() -> (Server, BackupClient, Receiver<Option<Task>>) {
         let env = Arc::new(EnvBuilder::new().build());

--- a/components/backup/tests/integrations/test_backup.rs
+++ b/components/backup/tests/integrations/test_backup.rs
@@ -13,7 +13,6 @@ use backup::Task;
 use engine::CF_DEFAULT;
 use engine::*;
 use external_storage::*;
-use keys::TimeStamp;
 use kvproto::backup::*;
 use kvproto::import_sstpb::*;
 use kvproto::kvrpcpb::*;
@@ -31,6 +30,7 @@ use tikv_util::collections::HashMap;
 use tikv_util::file::calc_crc32_bytes;
 use tikv_util::worker::Worker;
 use tikv_util::HandyRwLock;
+use txn_types::TimeStamp;
 
 struct TestSuite {
     cluster: Cluster<ServerCluster>,

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -8,13 +8,9 @@ publish = false
 byteorder = "1.2"
 derive_more = "0.15.0"
 failure = "0.1"
-farmhash = "1.1.5"
 hex = "0.3"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = "2.3"
-
-tikv_alloc = { path = "../tikv_alloc", default-features = false }
-tikv_util = { path = "../tikv_util", default-features = false }
 
 [dev-dependencies]
 panic_hook = { path = "../panic_hook" }

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -12,5 +12,7 @@ hex = "0.3"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = "2.3"
 
+tikv_alloc = { path = "../tikv_alloc", default-features = false }
+
 [dev-dependencies]
 panic_hook = { path = "../panic_hook" }

--- a/components/keys/src/lib.rs
+++ b/components/keys/src/lib.rs
@@ -13,11 +13,6 @@ use kvproto::metapb::Region;
 use std::mem;
 
 pub mod rewrite;
-mod timestamp;
-mod types;
-
-pub use timestamp::{TimeStamp, UnixSecs};
-pub use types::{Key, KvPair, Value};
 
 pub const MIN_KEY: &[u8] = &[];
 pub const MAX_KEY: &[u8] = &[0xFF];

--- a/components/keys/src/lib.rs
+++ b/components/keys/src/lib.rs
@@ -6,6 +6,8 @@
 extern crate derive_more;
 #[macro_use]
 extern crate failure;
+#[allow(unused_extern_crates)]
+extern crate tikv_alloc;
 
 use byteorder::{BigEndian, ByteOrder};
 

--- a/components/keys/src/rewrite.rs
+++ b/components/keys/src/rewrite.rs
@@ -39,7 +39,7 @@ pub fn rewrite_prefix_of_end_key(
     }
 
     if super::next_key_no_alloc(old_prefix) != src.split_last().map(|(&e, s)| (s, e)) {
-        // src is not the sucessor of old_prefix
+        // src is not the successor of old_prefix
         return Err(WrongPrefix);
     }
 

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -32,9 +32,9 @@ pub use self::util::RECONNECT_INTERVAL_SEC;
 use std::ops::Deref;
 
 use futures::Future;
-use keys::UnixSecs;
 use kvproto::metapb;
 use kvproto::pdpb;
+use tikv_util::time::UnixSecs;
 
 pub type Key = Vec<u8>;
 pub type PdFuture<T> = Box<dyn Future<Item = T, Error = Error> + Send>;

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -15,6 +15,7 @@ use engine_traits::{IOLimiter, LimitReader};
 use engine_traits::{IngestExternalFileOptions, KvEngine};
 use engine_traits::{SeekKey, SstReader, SstWriter, SstWriterBuilder};
 use external_storage::create_storage;
+use keys;
 
 use super::{Error, Result};
 

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -10,6 +10,7 @@ prost-codec = ["prost"]
 [dependencies]
 futures = "0.1"
 keys = { path = "../keys" }
+txn_types = { path = "../txn_types" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 prost = { version = "0.5", optional = true }
 protobuf = "2"

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -6,7 +6,6 @@ use std::collections::BTreeMap;
 
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 
-use keys::{Key, TimeStamp};
 use test_storage::{SyncTestStorage, SyncTestStorageBuilder};
 use tidb_query::codec::{datum, table, Datum};
 use tidb_query::expr::EvalContext;
@@ -14,6 +13,7 @@ use tikv::storage::{
     txn::FixtureStore, Engine, Mutation, RocksEngine, SnapshotStore, TestEngineBuilder,
 };
 use tikv_util::collections::HashMap;
+use txn_types::{Key, TimeStamp};
 
 pub struct Insert<'a, E: Engine> {
     store: &'a mut Store<E>,

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -10,7 +10,7 @@ use test_storage::{SyncTestStorage, SyncTestStorageBuilder};
 use tidb_query::codec::{datum, table, Datum};
 use tidb_query::expr::EvalContext;
 use tikv::storage::{
-    txn::FixtureStore, Engine, Mutation, RocksEngine, SnapshotStore, TestEngineBuilder,
+    txn::FixtureStore, Engine, RocksEngine, SnapshotStore, TestEngineBuilder,
 };
 use tikv_util::collections::HashMap;
 use txn_types::{Key, TimeStamp};

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -9,9 +9,7 @@ use kvproto::kvrpcpb::{Context, IsolationLevel};
 use test_storage::{SyncTestStorage, SyncTestStorageBuilder};
 use tidb_query::codec::{datum, table, Datum};
 use tidb_query::expr::EvalContext;
-use tikv::storage::{
-    txn::FixtureStore, Engine, RocksEngine, SnapshotStore, TestEngineBuilder,
-};
+use tikv::storage::{txn::FixtureStore, Engine, RocksEngine, SnapshotStore, TestEngineBuilder};
 use tikv_util::collections::HashMap;
 use txn_types::{Key, TimeStamp};
 

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -11,7 +11,7 @@ use tidb_query::codec::{datum, table, Datum};
 use tidb_query::expr::EvalContext;
 use tikv::storage::{txn::FixtureStore, Engine, RocksEngine, SnapshotStore, TestEngineBuilder};
 use tikv_util::collections::HashMap;
-use txn_types::{Key, TimeStamp};
+use txn_types::{Key, Mutation, TimeStamp};
 
 pub struct Insert<'a, E: Engine> {
     store: &'a mut Store<E>,

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -20,8 +20,8 @@ use pd_client::{Error, Key, PdClient, PdFuture, RegionInfo, RegionStat, Result};
 use tikv::raftstore::store::util::check_key_in_region;
 use tikv::raftstore::store::{INIT_EPOCH_CONF_VER, INIT_EPOCH_VER};
 use tikv_util::collections::{HashMap, HashMapEntry, HashSet};
-use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 use tikv_util::time::UnixSecs;
+use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 use tikv_util::{Either, HandyRwLock};
 
 use super::*;

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -15,12 +15,13 @@ use kvproto::metapb::{self, Region};
 use kvproto::pdpb;
 use raft::eraftpb;
 
-use keys::{self, data_key, enc_end_key, enc_start_key, UnixSecs};
+use keys::{self, data_key, enc_end_key, enc_start_key};
 use pd_client::{Error, Key, PdClient, PdFuture, RegionInfo, RegionStat, Result};
 use tikv::raftstore::store::util::check_key_in_region;
 use tikv::raftstore::store::{INIT_EPOCH_CONF_VER, INIT_EPOCH_VER};
 use tikv_util::collections::{HashMap, HashMapEntry, HashSet};
 use tikv_util::timer::GLOBAL_TIMER_HANDLE;
+use tikv_util::time::UnixSecs;
 use tikv_util::{Either, HandyRwLock};
 
 use super::*;

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 futures = "0.1"
 keys = { path = "../keys" }
+txn_types = { path = "../txn_types" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 test_raftstore = { path = "../test_raftstore" }
 tikv = { path = "../../", default-features = false }

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -7,10 +7,10 @@ use tikv::storage::kv::{Error as KvError, ErrorInner as KvErrorInner, RocksEngin
 use tikv::storage::mvcc::{Error as MvccError, ErrorInner as MvccErrorInner, MAX_TXN_WRITE_SIZE};
 use tikv::storage::txn::{Error as TxnError, ErrorInner as TxnErrorInner};
 use tikv::storage::{
-    self, Engine, Error as StorageError, ErrorInner as StorageErrorInner, Mutation, TxnStatus,
+    self, Engine, Error as StorageError, ErrorInner as StorageErrorInner, TxnStatus,
 };
 use tikv_util::HandyRwLock;
-use txn_types::{Key, KvPair, TimeStamp, Value};
+use txn_types::{Key, KvPair, TimeStamp, Value, Mutation};
 
 use super::*;
 

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -2,7 +2,6 @@
 
 use kvproto::kvrpcpb::{Context, LockInfo};
 
-use keys::{Key, KvPair, TimeStamp, Value};
 use test_raftstore::{Cluster, ServerCluster, SimulateEngine};
 use tikv::storage::kv::{Error as KvError, ErrorInner as KvErrorInner, RocksEngine};
 use tikv::storage::mvcc::{Error as MvccError, ErrorInner as MvccErrorInner, MAX_TXN_WRITE_SIZE};
@@ -11,6 +10,7 @@ use tikv::storage::{
     self, Engine, Error as StorageError, ErrorInner as StorageErrorInner, Mutation, TxnStatus,
 };
 use tikv_util::HandyRwLock;
+use txn_types::{Key, KvPair, TimeStamp, Value};
 
 use super::*;
 

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -10,7 +10,7 @@ use tikv::storage::{
     self, Engine, Error as StorageError, ErrorInner as StorageErrorInner, TxnStatus,
 };
 use tikv_util::HandyRwLock;
-use txn_types::{Key, KvPair, TimeStamp, Value, Mutation};
+use txn_types::{Key, KvPair, Mutation, TimeStamp, Value};
 
 use super::*;
 

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -8,11 +8,11 @@ use tikv::storage::config::Config;
 use tikv::storage::kv::RocksEngine;
 use tikv::storage::lock_manager::DummyLockManager;
 use tikv::storage::{
-    Engine, Mutation, Options, RegionInfoProvider, Result, Storage, TestEngineBuilder,
+    Engine, Options, RegionInfoProvider, Result, Storage, TestEngineBuilder,
     TestStorageBuilder, TxnStatus,
 };
 use tikv_util::collections::HashMap;
-use txn_types::{Key, KvPair, TimeStamp, Value};
+use txn_types::{Key, KvPair, TimeStamp, Value, Mutation};
 
 /// A builder to build a `SyncTestStorage`.
 ///

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -8,11 +8,11 @@ use tikv::storage::config::Config;
 use tikv::storage::kv::RocksEngine;
 use tikv::storage::lock_manager::DummyLockManager;
 use tikv::storage::{
-    Engine, Options, RegionInfoProvider, Result, Storage, TestEngineBuilder,
-    TestStorageBuilder, TxnStatus,
+    Engine, Options, RegionInfoProvider, Result, Storage, TestEngineBuilder, TestStorageBuilder,
+    TxnStatus,
 };
 use tikv_util::collections::HashMap;
-use txn_types::{Key, KvPair, TimeStamp, Value, Mutation};
+use txn_types::{Key, KvPair, Mutation, TimeStamp, Value};
 
 /// A builder to build a `SyncTestStorage`.
 ///

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -2,7 +2,6 @@
 
 use futures::Future;
 
-use keys::{Key, KvPair, TimeStamp, Value};
 use kvproto::kvrpcpb::{Context, LockInfo};
 use tikv::server::gc_worker::{AutoGcConfig, GcConfig, GcSafePointProvider, GcWorker};
 use tikv::storage::config::Config;
@@ -13,6 +12,7 @@ use tikv::storage::{
     TestStorageBuilder, TxnStatus,
 };
 use tikv_util::collections::HashMap;
+use txn_types::{Key, KvPair, TimeStamp, Value};
 
 /// A builder to build a `SyncTestStorage`.
 ///

--- a/components/tikv_util/src/time.rs
+++ b/components/tikv_util/src/time.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 use std::sync::mpsc::{self, Sender};
 use std::thread::{self, Builder, JoinHandle};
-use std::time::SystemTime;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use time::{Duration as TimeDuration, Timespec};
 
@@ -33,6 +33,33 @@ pub fn duration_to_nanos(d: Duration) -> u64 {
     let nanos = u64::from(d.subsec_nanos());
     // Most of case, we can't have so large Duration, so here just panic if overflow now.
     d.as_secs() * 1_000_000_000 + nanos
+}
+
+/// A time in seconds since the start of the Unix epoch.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct UnixSecs(u64);
+
+impl UnixSecs {
+    pub fn now() -> UnixSecs {
+        UnixSecs(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+    }
+
+    pub fn zero() -> UnixSecs {
+        UnixSecs(0)
+    }
+
+    pub fn into_inner(self) -> u64 {
+        self.0
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.0 == 0
+    }
 }
 
 pub struct SlowTimer {

--- a/components/txn_types/Cargo.toml
+++ b/components/txn_types/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "txn_types"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+byteorder = "1.2"
+farmhash = "1.1.5"
+derive_more = "0.15.0"
+hex = "0.3"
+derive-new = "0.5"
+codec = { path = "../codec" }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+slog = "2.3"
+quick-error = "1.2.2"
+
+tikv_alloc = { path = "../tikv_alloc", default-features = false }
+tikv_util = { path = "../tikv_util", default-features = false }
+
+[dev-dependencies]
+panic_hook = { path = "../panic_hook" }

--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -12,7 +12,7 @@ use std::io;
 
 pub use lock::{Lock, LockType};
 pub use timestamp::{TimeStamp, TsSet};
-pub use types::{is_short_value, Key, KvPair, Value, SHORT_VALUE_MAX_LEN};
+pub use types::{is_short_value, Key, KvPair, Value, Mutation, SHORT_VALUE_MAX_LEN};
 pub use write::{Write, WriteRef, WriteType};
 
 quick_error! {
@@ -35,6 +35,18 @@ quick_error! {
             display("key is locked (backoff or cleanup) {:?}", info)
         }
     }
+}
+
+impl Error {
+pub fn maybe_clone(&self) -> Option<Error> {
+    match self {
+        Error::Codec(e) => e.maybe_clone().map(Error::Codec),
+        Error::BadFormatLock => Some(Error::BadFormatLock),
+        Error::BadFormatWrite => Some(Error::BadFormatWrite),
+        Error::KeyIsLocked(info) => Some(Error::KeyIsLocked(info.clone())),
+        Error::Io(_) => None,
+    }
+}
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -12,7 +12,7 @@ use std::io;
 
 pub use lock::{Lock, LockType};
 pub use timestamp::{TimeStamp, TsSet};
-pub use types::{is_short_value, Key, KvPair, Value, Mutation, SHORT_VALUE_MAX_LEN};
+pub use types::{is_short_value, Key, KvPair, Mutation, Value, SHORT_VALUE_MAX_LEN};
 pub use write::{Write, WriteRef, WriteType};
 
 quick_error! {
@@ -38,15 +38,15 @@ quick_error! {
 }
 
 impl Error {
-pub fn maybe_clone(&self) -> Option<Error> {
-    match self {
-        Error::Codec(e) => e.maybe_clone().map(Error::Codec),
-        Error::BadFormatLock => Some(Error::BadFormatLock),
-        Error::BadFormatWrite => Some(Error::BadFormatWrite),
-        Error::KeyIsLocked(info) => Some(Error::KeyIsLocked(info.clone())),
-        Error::Io(_) => None,
+    pub fn maybe_clone(&self) -> Option<Error> {
+        match self {
+            Error::Codec(e) => e.maybe_clone().map(Error::Codec),
+            Error::BadFormatLock => Some(Error::BadFormatLock),
+            Error::BadFormatWrite => Some(Error::BadFormatWrite),
+            Error::KeyIsLocked(info) => Some(Error::KeyIsLocked(info.clone())),
+            Error::Io(_) => None,
+        }
     }
-}
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -1,0 +1,40 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+#[macro_use]
+extern crate quick_error;
+
+mod lock;
+mod timestamp;
+mod types;
+mod write;
+
+use std::io;
+
+pub use lock::{Lock, LockType};
+pub use timestamp::{TimeStamp, TsSet};
+pub use types::{is_short_value, Key, KvPair, Value, SHORT_VALUE_MAX_LEN};
+pub use write::{Write, WriteRef, WriteType};
+
+quick_error! {
+    #[derive(Debug)]
+    pub enum Error {
+        Io(err: io::Error) {
+            from()
+            cause(err)
+            description(err.description())
+        }
+        Codec(err: tikv_util::codec::Error) {
+            from()
+            cause(err)
+            description(err.description())
+        }
+        BadFormatLock { description("bad format lock data") }
+        BadFormatWrite { description("bad format write data") }
+        KeyIsLocked(info: kvproto::kvrpcpb::LockInfo) {
+            description("key is locked (backoff or cleanup)")
+            display("key is locked (backoff or cleanup) {:?}", info)
+        }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -2,6 +2,8 @@
 
 #[macro_use]
 extern crate quick_error;
+#[allow(unused_extern_crates)]
+extern crate tikv_alloc;
 
 mod lock;
 mod timestamp;

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -1,13 +1,10 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::storage::{
-    mvcc::{ErrorInner, Result, TimeStamp, TsSet},
-    Mutation, FOR_UPDATE_TS_PREFIX, MIN_COMMIT_TS_PREFIX, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX,
-    TXN_SIZE_PREFIX,
-};
+use super::timestamp::{TimeStamp, TsSet};
+use super::types::{Key, Mutation, Value, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
+use super::{Error, Result};
 use byteorder::ReadBytesExt;
 use derive_new::new;
-use keys::{Key, Value};
 use kvproto::kvrpcpb::{LockInfo, Op};
 use tikv_util::codec::bytes::{self, BytesEncoder};
 use tikv_util::codec::number::{self, NumberEncoder, MAX_VAR_U64_LEN};
@@ -24,6 +21,10 @@ const FLAG_PUT: u8 = b'P';
 const FLAG_DELETE: u8 = b'D';
 const FLAG_LOCK: u8 = b'L';
 const FLAG_PESSIMISTIC: u8 = b'S';
+
+const FOR_UPDATE_TS_PREFIX: u8 = b'f';
+const TXN_SIZE_PREFIX: u8 = b't';
+const MIN_COMMIT_TS_PREFIX: u8 = b'c';
 
 impl LockType {
     pub fn from_mutation(mutation: &Mutation) -> LockType {
@@ -98,9 +99,9 @@ impl Lock {
 
     pub fn parse(mut b: &[u8]) -> Result<Lock> {
         if b.is_empty() {
-            return Err(ErrorInner::BadFormatLock.into());
+            return Err(Error::BadFormatLock);
         }
-        let lock_type = LockType::from_u8(b.read_u8()?).ok_or(ErrorInner::BadFormatLock)?;
+        let lock_type = LockType::from_u8(b.read_u8()?).ok_or(Error::BadFormatLock)?;
         let primary = bytes::decode_compact_bytes(&mut b)?;
         let ts = number::decode_var_u64(&mut b)?.into();
         let ttl = if b.is_empty() {
@@ -198,7 +199,7 @@ impl Lock {
         }
 
         // There is a pending lock. Client should wait or clean it.
-        Err(ErrorInner::KeyIsLocked(self.into_lock_info(raw_key)).into())
+        Err(Error::KeyIsLocked(self.into_lock_info(raw_key)))
     }
 }
 

--- a/components/txn_types/src/timestamp.rs
+++ b/components/txn_types/src/timestamp.rs
@@ -185,4 +185,37 @@ mod tests {
         let res = Key::split_on_ts_for(enc.as_encoded()).unwrap();
         assert_eq!(res, (k.as_ref(), ts));
     }
+
+    #[test]
+    fn test_ts_set() {
+        let s = TsSet::new(vec![]);
+        assert_eq!(s, TsSet::Empty);
+        assert!(!s.contains(1.into()));
+
+        let s = TsSet::vec(vec![]);
+        assert_eq!(s, TsSet::Empty);
+
+        let s = TsSet::from_u64s(vec![1, 2]);
+        assert_eq!(s, TsSet::Vec(Arc::new(vec![1.into(), 2.into()])));
+        assert!(s.contains(1.into()));
+        assert!(s.contains(2.into()));
+        assert!(!s.contains(3.into()));
+
+        let s2 = TsSet::vec(vec![1.into(), 2.into()]);
+        assert_eq!(s2, s);
+
+        let big_ts_list: Vec<TimeStamp> =
+            (0..=TS_SET_USE_VEC_LIMIT as u64).map(Into::into).collect();
+        let s = TsSet::new(big_ts_list.clone());
+        assert_eq!(
+            s,
+            TsSet::Set(Arc::new(big_ts_list.clone().into_iter().collect()))
+        );
+        assert!(s.contains(1.into()));
+        assert!(s.contains((TS_SET_USE_VEC_LIMIT as u64).into()));
+        assert!(!s.contains((TS_SET_USE_VEC_LIMIT as u64 + 1).into()));
+
+        let s = TsSet::vec(big_ts_list.clone());
+        assert_eq!(s, TsSet::Vec(Arc::new(big_ts_list)));
+    }
 }

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -1,4 +1,4 @@
-use crate::timestamp::TimeStamp;
+use super::timestamp::TimeStamp;
 use byteorder::{ByteOrder, NativeEndian};
 use hex::ToHex;
 use std::fmt::{self, Debug, Display, Formatter};
@@ -6,6 +6,14 @@ use tikv_util::codec;
 use tikv_util::codec::bytes;
 use tikv_util::codec::bytes::BytesEncoder;
 use tikv_util::codec::number::{self, NumberEncoder};
+
+// Short value max len must <= 255.
+pub const SHORT_VALUE_MAX_LEN: usize = 255;
+pub const SHORT_VALUE_PREFIX: u8 = b'v';
+
+pub fn is_short_value(value: &[u8]) -> bool {
+    value.len() <= SHORT_VALUE_MAX_LEN
+}
 
 /// Value type which is essentially raw bytes.
 pub type Value = Vec<u8>;
@@ -214,6 +222,48 @@ impl Debug for Key {
 impl Display for Key {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.0.write_hex_upper(f)
+    }
+}
+
+/// A row mutation.
+#[derive(Debug, Clone)]
+pub enum Mutation {
+    /// Put `Value` into `Key`, overwriting any existing value.
+    Put((Key, Value)),
+    /// Delete `Key`.
+    Delete(Key),
+    /// Set a lock on `Key`.
+    Lock(Key),
+    /// Put `Value` into `Key` if `Key` does not yet exist.
+    ///
+    /// Returns [`KeyError::AlreadyExists`](kvproto::kvrpcpb::KeyError::AlreadyExists) if the key already exists.
+    Insert((Key, Value)),
+}
+
+impl Mutation {
+    pub fn key(&self) -> &Key {
+        match self {
+            Mutation::Put((ref key, _)) => key,
+            Mutation::Delete(ref key) => key,
+            Mutation::Lock(ref key) => key,
+            Mutation::Insert((ref key, _)) => key,
+        }
+    }
+
+    pub fn into_key_value(self) -> (Key, Option<Value>) {
+        match self {
+            Mutation::Put((key, value)) => (key, Some(value)),
+            Mutation::Delete(key) => (key, None),
+            Mutation::Lock(key) => (key, None),
+            Mutation::Insert((key, value)) => (key, Some(value)),
+        }
+    }
+
+    pub fn is_insert(&self) -> bool {
+        match self {
+            Mutation::Insert(_) => true,
+            _ => false,
+        }
     }
 }
 

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -1,10 +1,10 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::lock::LockType;
-use super::{Error, ErrorInner, Result, TimeStamp};
-use crate::storage::{SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
+use super::timestamp::TimeStamp;
+use super::types::{Value, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
+use super::{Error, Result};
 use codec::prelude::NumberDecoder;
-use keys::Value;
 use tikv_util::codec::number::{NumberEncoder, MAX_VAR_U64_LEN};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -107,8 +107,8 @@ impl Write {
     pub fn parse_type(mut b: &[u8]) -> Result<WriteType> {
         let write_type_bytes = b
             .read_u8()
-            .map_err(|_| Error::from(ErrorInner::BadFormatWrite))?;
-        WriteType::from_u8(write_type_bytes).ok_or_else(|| Error::from(ErrorInner::BadFormatWrite))
+            .map_err(|_| Error::from(Error::BadFormatWrite))?;
+        WriteType::from_u8(write_type_bytes).ok_or_else(|| Error::from(Error::BadFormatWrite))
     }
 
     #[inline]
@@ -132,12 +132,12 @@ impl WriteRef<'_> {
     pub fn parse(mut b: &[u8]) -> Result<WriteRef<'_>> {
         let write_type_bytes = b
             .read_u8()
-            .map_err(|_| Error::from(ErrorInner::BadFormatWrite))?;
+            .map_err(|_| Error::from(Error::BadFormatWrite))?;
         let write_type = WriteType::from_u8(write_type_bytes)
-            .ok_or_else(|| Error::from(ErrorInner::BadFormatWrite))?;
+            .ok_or_else(|| Error::from(Error::BadFormatWrite))?;
         let start_ts = b
             .read_var_u64()
-            .map_err(|_| Error::from(ErrorInner::BadFormatWrite))?
+            .map_err(|_| Error::from(Error::BadFormatWrite))?
             .into();
         if b.is_empty() {
             return Ok(WriteRef {
@@ -149,12 +149,12 @@ impl WriteRef<'_> {
 
         let flag = b
             .read_u8()
-            .map_err(|_| Error::from(ErrorInner::BadFormatWrite))?;
+            .map_err(|_| Error::from(Error::BadFormatWrite))?;
         assert_eq!(flag, SHORT_VALUE_PREFIX, "invalid flag [{}] in write", flag);
 
         let len = b
             .read_u8()
-            .map_err(|_| Error::from(ErrorInner::BadFormatWrite))?;
+            .map_err(|_| Error::from(Error::BadFormatWrite))?;
         if len as usize != b.len() {
             panic!(
                 "short value len [{}] not equal to content len [{}]",

--- a/src/coprocessor/dag/storage_impl.rs
+++ b/src/coprocessor/dag/storage_impl.rs
@@ -5,7 +5,7 @@ use tidb_query::storage::{IntervalRange, OwnedKvPair, PointRange, Result as QERe
 use crate::coprocessor::Error;
 use crate::storage::Statistics;
 use crate::storage::{Scanner, Store};
-use keys::Key;
+use txn_types::Key;
 
 /// A `Storage` implementation over TiKV's storage.
 pub struct TiKVStorage<S: Store> {

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -39,7 +39,7 @@ use kvproto::{coprocessor as coppb, kvrpcpb};
 use tikv_util::deadline::Deadline;
 use tikv_util::time::Duration;
 
-use crate::storage::mvcc::TsSet;
+use txn_types::TsSet;
 use crate::storage::Statistics;
 
 pub const REQ_TYPE_DAG: i64 = 103;

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -39,8 +39,8 @@ use kvproto::{coprocessor as coppb, kvrpcpb};
 use tikv_util::deadline::Deadline;
 use tikv_util::time::Duration;
 
-use txn_types::TsSet;
 use crate::storage::Statistics;
+use txn_types::TsSet;
 
 pub const REQ_TYPE_DAG: i64 = 103;
 pub const REQ_TYPE_ANALYZE: i64 = 104;

--- a/src/raftstore/coprocessor/properties.rs
+++ b/src/raftstore/coprocessor/properties.rs
@@ -11,9 +11,9 @@ use engine::rocks::{
     CFHandle, DBEntryType, Range, TablePropertiesCollector, TablePropertiesCollectorFactory,
     TitanBlobIndex, UserCollectedProperties, DB,
 };
-use keys::Key;
 use tikv_util::codec::number::{self, NumberEncoder};
 use tikv_util::codec::{Error, Result};
+use txn_types::Key;
 
 const PROP_NUM_ERRORS: &str = "tikv.num_errors";
 const PROP_MIN_TS: &str = "tikv.min_ts";
@@ -675,7 +675,7 @@ mod tests {
     use engine::rocks;
     use engine::rocks::util::CFOptions;
     use engine::{CF_WRITE, LARGE_CFS};
-    use keys::Key;
+    use txn_types::Key;
 
     use super::*;
 

--- a/src/raftstore/coprocessor/split_check/half.rs
+++ b/src/raftstore/coprocessor/split_check/half.rs
@@ -175,10 +175,10 @@ mod tests {
 
     use crate::raftstore::coprocessor::properties::RangePropertiesCollectorFactory;
     use crate::raftstore::store::{SplitCheckRunner, SplitCheckTask};
-    use keys::Key;
     use tikv_util::config::ReadableSize;
     use tikv_util::escape;
     use tikv_util::worker::Runnable;
+    use txn_types::Key;
 
     use super::super::size::tests::must_split_at;
     use super::*;

--- a/src/raftstore/coprocessor/split_check/keys.rs
+++ b/src/raftstore/coprocessor/split_check/keys.rs
@@ -222,7 +222,6 @@ mod tests {
     use engine::rocks::{ColumnFamilyOptions, DBOptions, Writable};
     use engine::DB;
     use engine::{ALL_CFS, CF_DEFAULT, CF_WRITE, LARGE_CFS};
-    use keys::Key;
     use kvproto::metapb::{Peer, Region};
     use kvproto::pdpb::CheckPolicy;
     use std::cmp;
@@ -230,6 +229,7 @@ mod tests {
     use std::u64;
     use tempfile::Builder;
     use tikv_util::worker::Runnable;
+    use txn_types::Key;
 
     use super::*;
 

--- a/src/raftstore/coprocessor/split_check/size.rs
+++ b/src/raftstore/coprocessor/split_check/size.rs
@@ -351,7 +351,6 @@ pub mod tests {
     use engine::rocks::util::{new_engine_opt, CFOptions};
     use engine::rocks::{ColumnFamilyOptions, DBOptions, Writable};
     use engine::{ALL_CFS, CF_DEFAULT, CF_WRITE, LARGE_CFS};
-    use keys::Key;
     use kvproto::metapb::Peer;
     use kvproto::metapb::Region;
     use kvproto::pdpb::CheckPolicy;
@@ -361,6 +360,7 @@ pub mod tests {
     use tempfile::Builder;
     use tikv_util::config::ReadableSize;
     use tikv_util::worker::Runnable;
+    use txn_types::Key;
 
     use super::*;
 

--- a/src/raftstore/coprocessor/split_check/table.rs
+++ b/src/raftstore/coprocessor/split_check/table.rs
@@ -5,11 +5,11 @@ use std::cmp::Ordering;
 use engine::rocks::{SeekKey, DB};
 use engine::CF_WRITE;
 use engine::{IterOption, Iterable};
-use keys::Key;
 use kvproto::metapb::Region;
 use kvproto::pdpb::CheckPolicy;
 use tidb_query::codec::table as table_codec;
 use tikv_util::keybuilder::KeyBuilder;
+use txn_types::Key;
 
 use super::super::{
     Coprocessor, KeyEntry, ObserverContext, Result, SplitCheckObserver, SplitChecker,
@@ -228,11 +228,11 @@ mod tests {
     use engine::rocks::util::new_engine;
     use engine::rocks::Writable;
     use engine::ALL_CFS;
-    use keys::Key;
     use tidb_query::codec::table::{TABLE_PREFIX, TABLE_PREFIX_KEY_LEN};
     use tikv_util::codec::number::NumberEncoder;
     use tikv_util::config::ReadableSize;
     use tikv_util::worker::Runnable;
+    use txn_types::Key;
 
     use super::*;
     use crate::raftstore::coprocessor::{Config, CoprocessorHost};

--- a/src/raftstore/store/region_snapshot.rs
+++ b/src/raftstore/store/region_snapshot.rs
@@ -406,9 +406,10 @@ mod tests {
     use engine_rocks::RocksIOLimiter;
     use engine_rocks::{RocksSnapshot, RocksSstWriterBuilder};
     use engine_traits::{Peekable, SstWriter, SstWriterBuilder};
-    use keys::{data_key, Key};
+    use keys::data_key;
     use tikv_util::config::{ReadableDuration, ReadableSize};
     use tikv_util::worker;
+    use txn_types::Key;
 
     use super::*;
 

--- a/src/raftstore/store/worker/compact.rs
+++ b/src/raftstore/store/worker/compact.rs
@@ -262,7 +262,8 @@ mod tests {
     use crate::raftstore::coprocessor::properties::get_range_entries_and_versions;
     use crate::raftstore::coprocessor::properties::MvccPropertiesCollectorFactory;
     use crate::storage::mvcc::{TimeStamp, Write, WriteType};
-    use keys::{data_key, Key as MvccKey};
+    use keys::data_key;
+    use txn_types::Key;
 
     use super::*;
 
@@ -323,7 +324,7 @@ mod tests {
 
     fn mvcc_put(db: &DB, k: &[u8], v: &[u8], start_ts: TimeStamp, commit_ts: TimeStamp) {
         let cf = get_cf_handle(db, CF_WRITE).unwrap();
-        let k = MvccKey::from_encoded(data_key(k)).append_ts(commit_ts);
+        let k = Key::from_encoded(data_key(k)).append_ts(commit_ts);
         let w = Write::new(WriteType::Put, start_ts, Some(v.to_vec()));
         db.put_cf(cf, k.as_encoded(), &w.as_ref().to_bytes())
             .unwrap();
@@ -331,7 +332,7 @@ mod tests {
 
     fn delete(db: &DB, k: &[u8], commit_ts: TimeStamp) {
         let cf = get_cf_handle(db, CF_WRITE).unwrap();
-        let k = MvccKey::from_encoded(data_key(k)).append_ts(commit_ts);
+        let k = Key::from_encoded(data_key(k)).append_ts(commit_ts);
         db.delete_cf(cf, k.as_encoded()).unwrap();
     }
 

--- a/src/raftstore/store/worker/pd.rs
+++ b/src/raftstore/store/worker/pd.rs
@@ -28,11 +28,11 @@ use crate::raftstore::store::Callback;
 use crate::raftstore::store::StoreInfo;
 use crate::raftstore::store::{CasualMessage, PeerMsg, RaftCommand, RaftRouter};
 use crate::storage::FlowStatistics;
-use keys::UnixSecs;
 use pd_client::metrics::*;
 use pd_client::{Error, PdClient, RegionStat};
 use tikv_util::collections::HashMap;
 use tikv_util::metrics::ThreadInfoStatistics;
+use tikv_util::time::UnixSecs;
 use tikv_util::worker::{FutureRunnable as Runnable, FutureScheduler as Scheduler, Stopped};
 
 type RecordPairVec = Vec<pdpb::RecordPair>;

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -38,13 +38,13 @@ use crate::raftstore::store::{
 use crate::server::gc_worker::GcWorker;
 use crate::storage::mvcc::{Lock, LockType, TimeStamp, Write, WriteRef, WriteType};
 use crate::storage::{Engine, Iterator as EngineIterator};
-use keys::Key;
 use tikv_util::codec::bytes;
 use tikv_util::collections::HashSet;
 use tikv_util::config::ReadableSize;
 use tikv_util::escape;
 use tikv_util::keybuilder::KeyBuilder;
 use tikv_util::worker::Worker;
+use txn_types::Key;
 
 const GC_IO_LIMITER_CONFIG_NAME: &str = "gc.max_write_bytes_per_sec";
 

--- a/src/server/gc_worker.rs
+++ b/src/server/gc_worker.rs
@@ -1288,11 +1288,12 @@ mod tests {
     use crate::raftstore::store::util::new_peer;
     use crate::storage::kv::Result as EngineResult;
     use crate::storage::lock_manager::DummyLockManager;
-    use crate::storage::{Mutation, Options, Storage, TestEngineBuilder, TestStorageBuilder};
+    use crate::storage::{Options, Storage, TestEngineBuilder, TestStorageBuilder};
     use futures::Future;
     use kvproto::metapb;
     use std::collections::BTreeMap;
     use std::sync::mpsc::{channel, Receiver, Sender};
+    use txn_types::Mutation;
 
     struct MockSafePointProvider {
         rx: Receiver<TimeStamp>,

--- a/src/server/gc_worker.rs
+++ b/src/server/gc_worker.rs
@@ -31,11 +31,11 @@ use crate::storage::kv::{
 };
 use crate::storage::mvcc::{MvccReader, MvccTxn, TimeStamp};
 use crate::storage::{Callback, Error, ErrorInner, Result};
-use keys::Key;
 use pd_client::PdClient;
 use tikv_util::config::ReadableSize;
 use tikv_util::time::{duration_to_sec, SlowTimer};
 use tikv_util::worker::{self, Builder as WorkerBuilder, Runnable, ScheduleError, Worker};
+use txn_types::Key;
 
 /// After the GC scan of a key, output a message to the log if there are at least this many
 /// versions of the key.

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -13,7 +13,6 @@ use grpcio::{
     self, DuplexSink, Environment, RequestStream, RpcContext, RpcStatus, RpcStatusCode, UnarySink,
     WriteFlags,
 };
-use keys::TimeStamp;
 use kvproto::deadlock::*;
 use kvproto::metapb::Region;
 use pd_client::{PdClient, INVALID_ID};
@@ -28,6 +27,7 @@ use tikv_util::security::SecurityManager;
 use tikv_util::time::{Duration, Instant};
 use tikv_util::worker::{FutureRunnable, FutureScheduler, Stopped};
 use tokio_core::reactor::Handle;
+use txn_types::TimeStamp;
 
 /// `Locks` is a set of locks belonging to one transaction.
 struct Locks {

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -19,7 +19,6 @@ use crate::storage::{
     lock_manager::{Lock, LockManager as LockManagerTrait},
     ProcessResult, StorageCallback,
 };
-use keys::TimeStamp;
 use pd_client::PdClient;
 use spin::Mutex;
 use std::collections::hash_map::DefaultHasher;
@@ -30,6 +29,7 @@ use std::thread::JoinHandle;
 use tikv_util::collections::HashSet;
 use tikv_util::security::SecurityManager;
 use tikv_util::worker::FutureWorker;
+use txn_types::TimeStamp;
 
 const DETECTED_SLOTS_NUM: usize = 128;
 

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -418,9 +418,9 @@ fn extract_raw_key_from_process_result(pr: &ProcessResult) -> &[u8] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use keys::Key;
     use std::time::Duration;
     use test_util::KvGenerator;
+    use txn_types::Key;
 
     fn dummy_waiter(start_ts: TimeStamp, lock_ts: TimeStamp, hash: u64) -> Waiter {
         Waiter {

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -10,13 +10,13 @@ use engine::CfName;
 use engine::IterOption;
 use engine::CF_DEFAULT;
 use engine_traits::Peekable;
-use keys::{Key, Value};
 use kvproto::errorpb;
 use kvproto::kvrpcpb::Context;
 use kvproto::raft_cmdpb::{
     CmdType, DeleteRangeRequest, DeleteRequest, PutRequest, RaftCmdRequest, RaftCmdResponse,
     RaftRequestHeader, Request, Response,
 };
+use txn_types::{Key, Value};
 
 use super::metrics::*;
 use crate::raftstore::errors::Error as RaftServerError;

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -21,7 +21,7 @@ use crate::storage::mvcc::{
     WriteType,
 };
 use crate::storage::txn::{Error as TxnError, ErrorInner as TxnErrorInner};
-use crate::storage::{self, Engine, Mutation, Options, PointGetCommand, Storage, TxnStatus};
+use crate::storage::{self, Engine, Options, PointGetCommand, Storage, TxnStatus};
 use crate::storage::{Error as StorageError, ErrorInner as StorageErrorInner};
 use futures::executor::{self, Notify, Spawn};
 use futures::{future, Async, Future, Sink, Stream};
@@ -43,7 +43,7 @@ use tikv_util::mpsc::batch::{unbounded, BatchReceiver, Sender};
 use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 use tikv_util::worker::Scheduler;
 use tokio_threadpool::{Builder as ThreadPoolBuilder, ThreadPool};
-use txn_types::{self, Key, Value};
+use txn_types::{self, Key, Value, Mutation};
 
 const SCHEDULER_IS_BUSY: &str = "scheduler is busy";
 const GC_WORKER_IS_BUSY: &str = "gc worker is busy";
@@ -2777,7 +2777,7 @@ fn extract_key_error(err: &storage::Error) -> KeyError {
     key_error
 }
 
-fn extract_kv_pairs(res: storage::Result<Vec<storage::Result<keys::KvPair>>>) -> Vec<KvPair> {
+fn extract_kv_pairs(res: storage::Result<Vec<storage::Result<txn_types::KvPair>>>) -> Vec<KvPair> {
     match res {
         Ok(res) => res
             .into_iter()

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -43,7 +43,7 @@ use tikv_util::mpsc::batch::{unbounded, BatchReceiver, Sender};
 use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 use tikv_util::worker::Scheduler;
 use tokio_threadpool::{Builder as ThreadPoolBuilder, ThreadPool};
-use txn_types::{self, Key, Value, Mutation};
+use txn_types::{self, Key, Mutation, Value};
 
 const SCHEDULER_IS_BUSY: &str = "scheduler is busy";
 const GC_WORKER_IS_BUSY: &str = "gc worker is busy";

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -29,7 +29,6 @@ use grpcio::{
     ClientStreamingSink, DuplexSink, Error as GrpcError, RequestStream, RpcContext, RpcStatus,
     RpcStatusCode, ServerStreamingSink, UnarySink, WriteFlags,
 };
-use keys::{self, Key, Value};
 use kvproto::coprocessor::*;
 use kvproto::errorpb::{Error as RegionError, ServerIsBusy};
 use kvproto::kvrpcpb::{self, *};
@@ -44,6 +43,7 @@ use tikv_util::mpsc::batch::{unbounded, BatchReceiver, Sender};
 use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 use tikv_util::worker::Scheduler;
 use tokio_threadpool::{Builder as ThreadPoolBuilder, ThreadPool};
+use txn_types::{self, Key, Value};
 
 const SCHEDULER_IS_BUSY: &str = "scheduler is busy";
 const GC_WORKER_IS_BUSY: &str = "gc worker is busy";

--- a/src/storage/commands.rs
+++ b/src/storage/commands.rs
@@ -4,11 +4,9 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use kvproto::kvrpcpb::{CommandPri, Context, GetRequest, RawGetRequest};
 use tikv_util::collections::HashMap;
-use txn_types::Key;
+use txn_types::{Key, Lock, TimeStamp, Mutation};
 
 use crate::storage::metrics::{self, CommandPriority};
-use crate::storage::mvcc::{Lock, TimeStamp};
-use crate::storage::Mutation;
 
 /// Get a single value.
 pub struct PointGetCommand {

--- a/src/storage/commands.rs
+++ b/src/storage/commands.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use kvproto::kvrpcpb::{CommandPri, Context, GetRequest, RawGetRequest};
 use tikv_util::collections::HashMap;
-use txn_types::{Key, Lock, TimeStamp, Mutation};
+use txn_types::{Key, Lock, Mutation, TimeStamp};
 
 use crate::storage::metrics::{self, CommandPriority};
 

--- a/src/storage/commands.rs
+++ b/src/storage/commands.rs
@@ -2,9 +2,9 @@
 
 use std::fmt::{self, Debug, Display, Formatter};
 
-use keys::Key;
 use kvproto::kvrpcpb::{CommandPri, Context, GetRequest, RawGetRequest};
 use tikv_util::collections::HashMap;
+use txn_types::Key;
 
 use crate::storage::metrics::{self, CommandPriority};
 use crate::storage::mvcc::{Lock, TimeStamp};

--- a/src/storage/kv/btree_engine.rs
+++ b/src/storage/kv/btree_engine.rs
@@ -9,8 +9,8 @@ use std::sync::{Arc, RwLock};
 
 use engine::IterOption;
 use engine::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
-use keys::{Key, Value};
 use kvproto::kvrpcpb::Context;
+use txn_types::{Key, Value};
 
 use crate::storage::kv::{
     Callback as EngineCallback, CbContext, Cursor, Engine, Error as EngineError,

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -8,9 +8,9 @@ use std::{error, ptr, result};
 use engine::rocks::TablePropertiesCollection;
 use engine::IterOption;
 use engine::{CfName, CF_DEFAULT};
-use keys::{Key, Value};
 use kvproto::errorpb::Error as ErrorHeader;
 use kvproto::kvrpcpb::Context;
+use txn_types::{Key, Value};
 
 use crate::into_other::IntoOther;
 use crate::raftstore::coprocessor::SeekRegionCallback;

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -18,9 +18,9 @@ use engine::IterOption;
 use engine::{CfName, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use engine_rocks::RocksEngineIterator;
 use engine_traits::{Iterable, Iterator, Peekable, SeekKey};
-use keys::{Key, Value};
 use kvproto::kvrpcpb::Context;
 use tempfile::{Builder, TempDir};
+use txn_types::{Key, Value};
 
 use crate::storage::config::BlockCacheConfig;
 use tikv_util::escape;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -30,14 +30,13 @@ use futures::{future, Future};
 use kvproto::kvrpcpb::{Context, KeyRange, LockInfo};
 use tikv_util::collections::HashMap;
 use tikv_util::future_pool::FuturePool;
-use txn_types::{Key, KvPair, TimeStamp, Value};
+use txn_types::{Key, KvPair, TimeStamp, Value, Lock, TsSet,Mutation};
 
 use crate::storage::commands::{get_priority_tag, Command, CommandKind};
 use crate::storage::config::Config;
 use crate::storage::kv::with_tls_engine;
 use crate::storage::lock_manager::{DummyLockManager, LockManager};
 use crate::storage::metrics::*;
-use crate::storage::mvcc::{Lock, TsSet};
 use crate::storage::txn::scheduler::Scheduler as TxnScheduler;
 
 pub use self::commands::{Options, PointGetCommand};
@@ -51,7 +50,7 @@ pub use self::kv::{
 };
 pub use self::readpool_impl::{build_read_pool, build_read_pool_for_test};
 pub use self::txn::{Scanner, SnapshotStore, Store};
-pub use self::types::{Mutation, MvccInfo, ProcessResult, StorageCallback, TxnStatus};
+pub use self::types::{MvccInfo, ProcessResult, StorageCallback, TxnStatus};
 
 pub type Result<T> = std::result::Result<T, Error>;
 pub type Callback<T> = Box<dyn FnOnce(Result<T>) + Send>;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -27,10 +27,10 @@ use engine::{
     CfName, IterOption, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS, DATA_KEY_PREFIX_LEN,
 };
 use futures::{future, Future};
-use keys::{Key, KvPair, TimeStamp, Value};
 use kvproto::kvrpcpb::{Context, KeyRange, LockInfo};
 use tikv_util::collections::HashMap;
 use tikv_util::future_pool::FuturePool;
+use txn_types::{Key, KvPair, TimeStamp, Value};
 
 use crate::storage::commands::{get_priority_tag, Command, CommandKind};
 use crate::storage::config::Config;
@@ -55,18 +55,6 @@ pub use self::types::{Mutation, MvccInfo, ProcessResult, StorageCallback, TxnSta
 
 pub type Result<T> = std::result::Result<T, Error>;
 pub type Callback<T> = Box<dyn FnOnce(Result<T>) + Send>;
-
-// Short value max len must <= 255.
-pub const SHORT_VALUE_MAX_LEN: usize = 255;
-
-const SHORT_VALUE_PREFIX: u8 = b'v';
-const FOR_UPDATE_TS_PREFIX: u8 = b'f';
-const TXN_SIZE_PREFIX: u8 = b't';
-const MIN_COMMIT_TS_PREFIX: u8 = b'c';
-
-pub fn is_short_value(value: &[u8]) -> bool {
-    value.len() <= SHORT_VALUE_MAX_LEN
-}
 
 /// [`Storage`] implements transactional KV APIs and raw KV APIs on a given [`Engine`]. An [`Engine`]
 /// provides low level KV functionality. [`Engine`] has multiple implementations. When a TiKV server

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -30,7 +30,7 @@ use futures::{future, Future};
 use kvproto::kvrpcpb::{Context, KeyRange, LockInfo};
 use tikv_util::collections::HashMap;
 use tikv_util::future_pool::FuturePool;
-use txn_types::{Key, KvPair, TimeStamp, Value, Lock, TsSet,Mutation};
+use txn_types::{Key, KvPair, Lock, Mutation, TimeStamp, TsSet, Value};
 
 use crate::storage::commands::{get_priority_tag, Command, CommandKind};
 use crate::storage::config::Config;

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -9,7 +9,7 @@ mod txn;
 pub use self::reader::*;
 pub use self::txn::{MvccTxn, MAX_TXN_WRITE_SIZE};
 pub use crate::new_txn;
-pub use txn_types::{Lock, TimeStamp, LockType, Write, WriteRef, WriteType};
+pub use txn_types::{Lock, LockType, TimeStamp, Write, WriteRef, WriteType};
 
 use std::error;
 use std::fmt;
@@ -244,7 +244,9 @@ impl From<txn_types::Error> for ErrorInner {
         match err {
             txn_types::Error::Io(e) => ErrorInner::Io(e),
             txn_types::Error::Codec(e) => ErrorInner::Codec(e),
-            txn_types::Error::BadFormatLock | txn_types::Error::BadFormatWrite => ErrorInner::BadFormat(err),
+            txn_types::Error::BadFormatLock | txn_types::Error::BadFormatWrite => {
+                ErrorInner::BadFormat(err)
+            }
             txn_types::Error::KeyIsLocked(lock_info) => ErrorInner::KeyIsLocked(lock_info),
         }
     }

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -1039,37 +1039,4 @@ pub mod tests {
             expect
         );
     }
-
-    #[test]
-    fn test_ts_set() {
-        let s = TsSet::new(vec![]);
-        assert_eq!(s, TsSet::Empty);
-        assert!(!s.contains(1.into()));
-
-        let s = TsSet::vec(vec![]);
-        assert_eq!(s, TsSet::Empty);
-
-        let s = TsSet::from_u64s(vec![1, 2]);
-        assert_eq!(s, TsSet::Vec(Arc::new(vec![1.into(), 2.into()])));
-        assert!(s.contains(1.into()));
-        assert!(s.contains(2.into()));
-        assert!(!s.contains(3.into()));
-
-        let s2 = TsSet::vec(vec![1.into(), 2.into()]);
-        assert_eq!(s2, s);
-
-        let big_ts_list: Vec<TimeStamp> =
-            (0..=TS_SET_USE_VEC_LIMIT as u64).map(Into::into).collect();
-        let s = TsSet::new(big_ts_list.clone());
-        assert_eq!(
-            s,
-            TsSet::Set(Arc::new(big_ts_list.clone().into_iter().collect()))
-        );
-        assert!(s.contains(1.into()));
-        assert!(s.contains((TS_SET_USE_VEC_LIMIT as u64).into()));
-        assert!(!s.contains((TS_SET_USE_VEC_LIMIT as u64 + 1).into()));
-
-        let s = TsSet::vec(big_ts_list.clone());
-        assert_eq!(s, TsSet::Vec(Arc::new(big_ts_list)));
-    }
 }

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -270,9 +270,9 @@ mod tests {
 
     use engine_rocks::RocksSyncSnapshot;
     use kvproto::kvrpcpb::Context;
+    use txn_types::SHORT_VALUE_MAX_LEN;
 
     use crate::storage::mvcc::tests::*;
-    use crate::storage::SHORT_VALUE_MAX_LEN;
     use crate::storage::{CfStatistics, Engine, RocksEngine, TestEngineBuilder};
 
     fn new_multi_point_getter<E: Engine>(engine: &E, ts: TimeStamp) -> PointGetter<E::Snap> {

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -1,11 +1,10 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::storage::mvcc::write::{WriteRef, WriteType};
-use crate::storage::mvcc::{default_not_found_error, Lock, Result, TimeStamp, TsSet};
+use crate::storage::mvcc::{default_not_found_error, Result};
 use crate::storage::{Cursor, CursorBuilder, ScanMode, Snapshot, Statistics, CF_LOCK};
 use crate::storage::{CF_DEFAULT, CF_WRITE};
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, Value};
+use txn_types::{Key, Value, WriteRef, WriteType, TimeStamp, TsSet, Lock};
 
 /// `PointGetter` factory.
 pub struct PointGetterBuilder<S: Snapshot> {
@@ -176,7 +175,7 @@ impl<S: Snapshot> PointGetter<S> {
         if let Some(ref lock_value) = lock_value {
             self.statistics.lock.processed += 1;
             let lock = Lock::parse(lock_value)?;
-            lock.check_ts_conflict(user_key, self.ts, &self.bypass_locks)
+            lock.check_ts_conflict(user_key, self.ts, &self.bypass_locks).map_err(Into::into)
         } else {
             Ok(())
         }

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -4,8 +4,8 @@ use crate::storage::mvcc::write::{WriteRef, WriteType};
 use crate::storage::mvcc::{default_not_found_error, Lock, Result, TimeStamp, TsSet};
 use crate::storage::{Cursor, CursorBuilder, ScanMode, Snapshot, Statistics, CF_LOCK};
 use crate::storage::{CF_DEFAULT, CF_WRITE};
-use keys::{Key, Value};
 use kvproto::kvrpcpb::IsolationLevel;
+use txn_types::{Key, Value};
 
 /// `PointGetter` factory.
 pub struct PointGetterBuilder<S: Snapshot> {

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -4,7 +4,7 @@ use crate::storage::mvcc::{default_not_found_error, Result};
 use crate::storage::{Cursor, CursorBuilder, ScanMode, Snapshot, Statistics, CF_LOCK};
 use crate::storage::{CF_DEFAULT, CF_WRITE};
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, Value, WriteRef, WriteType, TimeStamp, TsSet, Lock};
+use txn_types::{Key, Lock, TimeStamp, TsSet, Value, WriteRef, WriteType};
 
 /// `PointGetter` factory.
 pub struct PointGetterBuilder<S: Snapshot> {
@@ -175,7 +175,8 @@ impl<S: Snapshot> PointGetter<S> {
         if let Some(ref lock_value) = lock_value {
             self.statistics.lock.processed += 1;
             let lock = Lock::parse(lock_value)?;
-            lock.check_ts_conflict(user_key, self.ts, &self.bypass_locks).map_err(Into::into)
+            lock.check_ts_conflict(user_key, self.ts, &self.bypass_locks)
+                .map_err(Into::into)
         } else {
             Ok(())
         }

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -431,12 +431,13 @@ mod tests {
     use crate::raftstore::store::RegionSnapshot;
     use crate::storage::kv::Modify;
     use crate::storage::mvcc::{MvccReader, MvccTxn};
-    use crate::storage::{Mutation, Options};
+    use crate::storage::Options;
     use engine::rocks::util::CFOptions;
     use engine::rocks::{self, ColumnFamilyOptions, DBOptions};
     use engine::rocks::{Writable, WriteBatch, DB};
     use engine::{ALL_CFS, CF_DEFAULT, CF_RAFT};
     use kvproto::metapb::{Peer, Region};
+    use txn_types::{Mutation, LockType};
     use std::sync::Arc;
     use std::u64;
 

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -8,8 +8,8 @@ use crate::storage::mvcc::{default_not_found_error, WriteRef};
 use crate::storage::mvcc::{Result, TimeStamp};
 use engine::IterOption;
 use engine::{CF_LOCK, CF_WRITE};
-use keys::{Key, Value};
 use kvproto::kvrpcpb::IsolationLevel;
+use txn_types::{Key, Value};
 
 const GC_MAX_ROW_VERSIONS_THRESHOLD: u64 = 100;
 

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -6,7 +6,7 @@ use crate::storage::mvcc::{default_not_found_error, Result};
 use engine::IterOption;
 use engine::{CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, Value, Lock, Write, WriteType, WriteRef, TimeStamp};
+use txn_types::{Key, Lock, TimeStamp, Value, Write, WriteRef, WriteType};
 
 const GC_MAX_ROW_VERSIONS_THRESHOLD: u64 = 100;
 
@@ -155,7 +155,9 @@ impl<S: Snapshot> MvccReader<S> {
     /// Returns the blocking lock as the `Err` variant.
     fn check_lock(&mut self, key: &Key, ts: TimeStamp) -> Result<()> {
         if let Some(lock) = self.load_lock(key)? {
-            return lock.check_ts_conflict(key, ts, &Default::default()).map_err(From::from);
+            return lock
+                .check_ts_conflict(key, ts, &Default::default())
+                .map_err(From::from);
         }
         Ok(())
     }
@@ -437,9 +439,9 @@ mod tests {
     use engine::rocks::{Writable, WriteBatch, DB};
     use engine::{ALL_CFS, CF_DEFAULT, CF_RAFT};
     use kvproto::metapb::{Peer, Region};
-    use txn_types::{Mutation, LockType};
     use std::sync::Arc;
     use std::u64;
+    use txn_types::{LockType, Mutation};
 
     struct RegionEngine {
         db: Arc<DB>,

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -4,10 +4,10 @@ use std::cmp::Ordering;
 
 use engine::CF_DEFAULT;
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, Value, Write, WriteType, TimeStamp, WriteRef};
+use txn_types::{Key, TimeStamp, Value, Write, WriteRef, WriteType};
 
 use crate::storage::kv::SEEK_BOUND;
-use crate::storage::mvcc::{Result, Error};
+use crate::storage::mvcc::{Error, Result};
 use crate::storage::{Cursor, Lock, Snapshot, Statistics};
 
 use super::ScannerConfig;
@@ -140,7 +140,8 @@ impl<S: Snapshot> BackwardScanner<S> {
                         };
                         result = lock
                             .check_ts_conflict(&current_user_key, ts, &self.cfg.bypass_locks)
-                            .map(|_| None).map_err(Into::into);
+                            .map(|_| None)
+                            .map_err(Into::into);
                     }
                     IsolationLevel::Rc => {}
                 }
@@ -211,7 +212,8 @@ impl<S: Snapshot> BackwardScanner<S> {
                 return Ok(self.handle_last_version(last_version, user_key)?);
             }
 
-            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write)).map_err(Error::from)?;
+            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write))
+                .map_err(Error::from)?;
             self.statistics.write.processed += 1;
 
             match write.write_type {

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -4,11 +4,10 @@ use std::cmp::Ordering;
 
 use engine::CF_DEFAULT;
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, Value};
+use txn_types::{Key, Value, Write, WriteType, TimeStamp, WriteRef};
 
 use crate::storage::kv::SEEK_BOUND;
-use crate::storage::mvcc::write::{Write, WriteType};
-use crate::storage::mvcc::{Result, TimeStamp, WriteRef};
+use crate::storage::mvcc::{Result, Error};
 use crate::storage::{Cursor, Lock, Snapshot, Statistics};
 
 use super::ScannerConfig;
@@ -141,7 +140,7 @@ impl<S: Snapshot> BackwardScanner<S> {
                         };
                         result = lock
                             .check_ts_conflict(&current_user_key, ts, &self.cfg.bypass_locks)
-                            .map(|_| None);
+                            .map(|_| None).map_err(Into::into);
                     }
                     IsolationLevel::Rc => {}
                 }
@@ -212,7 +211,7 @@ impl<S: Snapshot> BackwardScanner<S> {
                 return Ok(self.handle_last_version(last_version, user_key)?);
             }
 
-            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write))?;
+            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write)).map_err(Error::from)?;
             self.statistics.write.processed += 1;
 
             match write.write_type {

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -3,8 +3,8 @@
 use std::cmp::Ordering;
 
 use engine::CF_DEFAULT;
-use keys::{Key, Value};
 use kvproto::kvrpcpb::IsolationLevel;
+use txn_types::{Key, Value};
 
 use crate::storage::kv::SEEK_BOUND;
 use crate::storage::mvcc::write::{Write, WriteType};

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -4,10 +4,10 @@ use std::cmp::Ordering;
 
 use engine::CF_DEFAULT;
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, Value, WriteRef, WriteType, TimeStamp};
+use txn_types::{Key, TimeStamp, Value, WriteRef, WriteType};
 
 use crate::storage::kv::SEEK_BOUND;
-use crate::storage::mvcc::{Result, Error};
+use crate::storage::mvcc::{Error, Result};
 use crate::storage::{Cursor, Lock, Snapshot, Statistics};
 
 use super::ScannerConfig;
@@ -165,7 +165,8 @@ impl<S: Snapshot> ForwardScanner<S> {
                         };
                         result = lock
                             .check_ts_conflict(&current_user_key, ts, &self.cfg.bypass_locks)
-                            .map(|_| None).map_err(Into::into);
+                            .map(|_| None)
+                            .map_err(Into::into);
                     }
                     IsolationLevel::Rc => {}
                 }
@@ -256,7 +257,8 @@ impl<S: Snapshot> ForwardScanner<S> {
         // Now we must have reached the first key >= `${user_key}_${ts}`. However, we may
         // meet `Lock` or `Rollback`. In this case, more versions needs to be looked up.
         loop {
-            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write)).map_err(Error::from)?;
+            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write))
+                .map_err(Error::from)?;
             self.statistics.write.processed += 1;
 
             match write.write_type {

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -3,8 +3,8 @@
 use std::cmp::Ordering;
 
 use engine::CF_DEFAULT;
-use keys::{Key, Value};
 use kvproto::kvrpcpb::IsolationLevel;
+use txn_types::{Key, Value};
 
 use crate::storage::kv::SEEK_BOUND;
 use crate::storage::mvcc::write::{WriteRef, WriteType};

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -4,11 +4,10 @@ use std::cmp::Ordering;
 
 use engine::CF_DEFAULT;
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, Value};
+use txn_types::{Key, Value, WriteRef, WriteType, TimeStamp};
 
 use crate::storage::kv::SEEK_BOUND;
-use crate::storage::mvcc::write::{WriteRef, WriteType};
-use crate::storage::mvcc::{Result, TimeStamp};
+use crate::storage::mvcc::{Result, Error};
 use crate::storage::{Cursor, Lock, Snapshot, Statistics};
 
 use super::ScannerConfig;
@@ -166,7 +165,7 @@ impl<S: Snapshot> ForwardScanner<S> {
                         };
                         result = lock
                             .check_ts_conflict(&current_user_key, ts, &self.cfg.bypass_locks)
-                            .map(|_| None);
+                            .map(|_| None).map_err(Into::into);
                     }
                     IsolationLevel::Rc => {}
                 }
@@ -257,7 +256,7 @@ impl<S: Snapshot> ForwardScanner<S> {
         // Now we must have reached the first key >= `${user_key}_${ts}`. However, we may
         // meet `Lock` or `Rollback`. In this case, more versions needs to be looked up.
         loop {
-            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write))?;
+            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write)).map_err(Error::from)?;
             self.statistics.write.processed += 1;
 
             match write.write_type {

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -5,8 +5,8 @@ mod forward;
 mod txn_entry;
 
 use engine::{CfName, IterOption, CF_DEFAULT, CF_LOCK, CF_WRITE};
-use keys::{Key, Value};
 use kvproto::kvrpcpb::IsolationLevel;
+use txn_types::{Key, Value};
 
 use self::backward::BackwardScanner;
 use self::forward::ForwardScanner;

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -6,11 +6,11 @@ mod txn_entry;
 
 use engine::{CfName, IterOption, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, Value};
+use txn_types::{Key, Value, TimeStamp, TsSet};
 
 use self::backward::BackwardScanner;
 use self::forward::ForwardScanner;
-use crate::storage::mvcc::{default_not_found_error, Result, TimeStamp, TsSet};
+use crate::storage::mvcc::{default_not_found_error, Result};
 use crate::storage::txn::Result as TxnResult;
 use crate::storage::{
     CfStatistics, Cursor, CursorBuilder, Iterator, ScanMode, Scanner as StoreScanner, Snapshot,

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -6,7 +6,7 @@ mod txn_entry;
 
 use engine::{CfName, IterOption, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, Value, TimeStamp, TsSet};
+use txn_types::{Key, TimeStamp, TsSet, Value};
 
 use self::backward::BackwardScanner;
 use self::forward::ForwardScanner;

--- a/src/storage/mvcc/reader/scanner/txn_entry.rs
+++ b/src/storage/mvcc/reader/scanner/txn_entry.rs
@@ -5,11 +5,10 @@
 use std::cmp::Ordering;
 
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::Key;
+use txn_types::{Key, Write, WriteType, TimeStamp, WriteRef};
 
 use crate::storage::kv::SEEK_BOUND;
-use crate::storage::mvcc::write::{Write, WriteType};
-use crate::storage::mvcc::{Result, TimeStamp, WriteRef};
+use crate::storage::mvcc::{Result, Error};
 use crate::storage::txn::{Result as TxnResult, TxnEntry, TxnEntryScanner};
 use crate::storage::{Cursor, Lock, Snapshot, Statistics};
 
@@ -166,7 +165,7 @@ impl<S: Snapshot> Scanner<S> {
                         //       in the future.
                         result = lock
                             .check_ts_conflict(&current_user_key, ts, &self.cfg.bypass_locks)
-                            .map(|_| None);
+                            .map(|_| None).map_err(Into::into);
                     }
                     IsolationLevel::Rc => {}
                 }
@@ -257,7 +256,7 @@ impl<S: Snapshot> Scanner<S> {
         // Now we must have reached the first key >= `${user_key}_${ts}`. However, we may
         // meet `Lock` or `Rollback`. In this case, more versions needs to be looked up.
         loop {
-            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write))?;
+            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write)).map_err(Error::from)?;
             self.statistics.write.processed += 1;
 
             match write.write_type {

--- a/src/storage/mvcc/reader/scanner/txn_entry.rs
+++ b/src/storage/mvcc/reader/scanner/txn_entry.rs
@@ -5,10 +5,10 @@
 use std::cmp::Ordering;
 
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, Write, WriteType, TimeStamp, WriteRef};
+use txn_types::{Key, TimeStamp, Write, WriteRef, WriteType};
 
 use crate::storage::kv::SEEK_BOUND;
-use crate::storage::mvcc::{Result, Error};
+use crate::storage::mvcc::{Error, Result};
 use crate::storage::txn::{Result as TxnResult, TxnEntry, TxnEntryScanner};
 use crate::storage::{Cursor, Lock, Snapshot, Statistics};
 
@@ -165,7 +165,8 @@ impl<S: Snapshot> Scanner<S> {
                         //       in the future.
                         result = lock
                             .check_ts_conflict(&current_user_key, ts, &self.cfg.bypass_locks)
-                            .map(|_| None).map_err(Into::into);
+                            .map(|_| None)
+                            .map_err(Into::into);
                     }
                     IsolationLevel::Rc => {}
                 }
@@ -256,7 +257,8 @@ impl<S: Snapshot> Scanner<S> {
         // Now we must have reached the first key >= `${user_key}_${ts}`. However, we may
         // meet `Lock` or `Rollback`. In this case, more versions needs to be looked up.
         loop {
-            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write)).map_err(Error::from)?;
+            let write = WriteRef::parse(self.write_cursor.value(&mut self.statistics.write))
+                .map_err(Error::from)?;
             self.statistics.write.processed += 1;
 
             match write.write_type {

--- a/src/storage/mvcc/reader/scanner/txn_entry.rs
+++ b/src/storage/mvcc/reader/scanner/txn_entry.rs
@@ -4,8 +4,8 @@
 
 use std::cmp::Ordering;
 
-use keys::Key;
 use kvproto::kvrpcpb::IsolationLevel;
+use txn_types::Key;
 
 use crate::storage::kv::SEEK_BOUND;
 use crate::storage::mvcc::write::{Write, WriteType};

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -9,9 +9,9 @@ use crate::storage::kv::{Modify, ScanMode, Snapshot};
 use crate::storage::{
     is_short_value, Mutation, Options, Statistics, TxnStatus, CF_DEFAULT, CF_LOCK, CF_WRITE,
 };
-use keys::{Key, Value};
 use kvproto::kvrpcpb::IsolationLevel;
 use std::fmt;
+use txn_types::{Key, Value};
 
 pub const MAX_TXN_WRITE_SIZE: usize = 32 * 1024;
 
@@ -831,8 +831,8 @@ mod tests {
     use crate::storage::mvcc::tests::*;
     use crate::storage::mvcc::{Error, ErrorInner, MvccReader};
     use crate::storage::{TestEngineBuilder, SHORT_VALUE_MAX_LEN};
-    use keys::TimeStamp;
     use kvproto::kvrpcpb::Context;
+    use txn_types::TimeStamp;
 
     fn test_mvcc_txn_read_imp(k1: &[u8], k2: &[u8], v: &[u8]) {
         let engine = TestEngineBuilder::new().build().unwrap();

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -828,9 +828,9 @@ mod tests {
     use crate::storage::kv::Engine;
     use crate::storage::mvcc::tests::*;
     use crate::storage::mvcc::{Error, ErrorInner, MvccReader};
-    use crate::storage::{TestEngineBuilder, SHORT_VALUE_MAX_LEN};
+    use crate::storage::TestEngineBuilder;
     use kvproto::kvrpcpb::Context;
-    use txn_types::TimeStamp;
+    use txn_types::{TimeStamp, SHORT_VALUE_MAX_LEN};
 
     fn test_mvcc_txn_read_imp(k1: &[u8], k2: &[u8], v: &[u8]) {
         let engine = TestEngineBuilder::new().build().unwrap();

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -1,17 +1,15 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::lock::{Lock, LockType};
 use super::metrics::*;
 use super::reader::MvccReader;
-use super::write::{Write, WriteType};
-use super::{ErrorInner, Result, TimeStamp};
+use super::{ErrorInner, Result};
 use crate::storage::kv::{Modify, ScanMode, Snapshot};
 use crate::storage::{
-    is_short_value, Mutation, Options, Statistics, TxnStatus, CF_DEFAULT, CF_LOCK, CF_WRITE,
+    Options, Statistics, TxnStatus, CF_DEFAULT, CF_LOCK, CF_WRITE,
 };
 use kvproto::kvrpcpb::IsolationLevel;
 use std::fmt;
-use txn_types::{Key, Value};
+use txn_types::{is_short_value, Key, Value, Lock, LockType, Write, WriteType, Mutation, TimeStamp};
 
 pub const MAX_TXN_WRITE_SIZE: usize = 32 * 1024;
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -4,12 +4,12 @@ use super::metrics::*;
 use super::reader::MvccReader;
 use super::{ErrorInner, Result};
 use crate::storage::kv::{Modify, ScanMode, Snapshot};
-use crate::storage::{
-    Options, Statistics, TxnStatus, CF_DEFAULT, CF_LOCK, CF_WRITE,
-};
+use crate::storage::{Options, Statistics, TxnStatus, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::IsolationLevel;
 use std::fmt;
-use txn_types::{is_short_value, Key, Value, Lock, LockType, Write, WriteType, Mutation, TimeStamp};
+use txn_types::{
+    is_short_value, Key, Lock, LockType, Mutation, TimeStamp, Value, Write, WriteType,
+};
 
 pub const MAX_TXN_WRITE_SIZE: usize = 32 * 1024;
 

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use std::{mem, thread, u64};
 
 use futures::future;
-use keys::{Key, Value};
 use kvproto::kvrpcpb::{CommandPri, Context, LockInfo};
+use txn_types::{Key, Value};
 
 use crate::storage::kv::with_tls_engine;
 use crate::storage::kv::{CbContext, Modify, Result as EngineResult};

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -26,10 +26,10 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::u64;
 
-use keys::Key;
 use kvproto::kvrpcpb::CommandPri;
 use prometheus::HistogramTimer;
 use tikv_util::{collections::HashMap, time::SlowTimer};
+use txn_types::Key;
 
 use crate::storage::kv::{with_tls_engine, Result as EngineResult};
 use crate::storage::lock_manager::{self, LockManager};

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -9,7 +9,7 @@ use crate::storage::mvcc::{
 };
 use crate::storage::mvcc::{PointGetter, PointGetterBuilder, TimeStamp, TsSet};
 use crate::storage::{Snapshot, Statistics};
-use keys::{Key, KvPair, Value};
+use txn_types::{Key, KvPair, Value};
 
 use super::{Error, ErrorInner, Result};
 

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -877,7 +877,7 @@ mod tests {
         data.insert(
             Key::from_raw(b"zz"),
             Err(Error::from(ErrorInner::Mvcc(MvccError::from(
-                MvccErrorInner::BadFormatLock,
+                txn_types::Error::BadFormatLock,
             )))),
         );
 

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -9,7 +9,7 @@ use crate::storage::mvcc::{
 };
 use crate::storage::mvcc::{PointGetter, PointGetterBuilder};
 use crate::storage::{Snapshot, Statistics};
-use txn_types::{Key, KvPair, Value, TimeStamp, TsSet};
+use txn_types::{Key, KvPair, TimeStamp, TsSet, Value};
 
 use super::{Error, ErrorInner, Result};
 
@@ -134,7 +134,9 @@ impl TxnEntry {
                 } else {
                     let k = Key::from_encoded(write.0).truncate_ts()?;
                     let k = k.into_raw()?;
-                    let v = WriteRef::parse(&write.1).map_err(MvccError::from)?.to_owned();
+                    let v = WriteRef::parse(&write.1)
+                        .map_err(MvccError::from)?
+                        .to_owned();
                     let v = v.short_value.unwrap();
                     Ok((k, v))
                 }

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -7,9 +7,9 @@ use crate::storage::mvcc::{
     EntryScanner, Error as MvccError, ErrorInner as MvccErrorInner, Scanner as MvccScanner,
     ScannerBuilder, WriteRef,
 };
-use crate::storage::mvcc::{PointGetter, PointGetterBuilder, TimeStamp, TsSet};
+use crate::storage::mvcc::{PointGetter, PointGetterBuilder};
 use crate::storage::{Snapshot, Statistics};
-use txn_types::{Key, KvPair, Value};
+use txn_types::{Key, KvPair, Value, TimeStamp, TsSet};
 
 use super::{Error, ErrorInner, Result};
 
@@ -134,7 +134,7 @@ impl TxnEntry {
                 } else {
                     let k = Key::from_encoded(write.0).truncate_ts()?;
                     let k = k.into_raw()?;
-                    let v = WriteRef::parse(&write.1)?.to_owned();
+                    let v = WriteRef::parse(&write.1).map_err(MvccError::from)?.to_owned();
                     let v = v.short_value.unwrap();
                     Ok((k, v))
                 }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -6,9 +6,9 @@ use crate::storage::{
     mvcc::{Lock, TimeStamp, Write},
     Callback, Command, Error as StorageError, Result,
 };
-use keys::{Key, Value};
 use kvproto::kvrpcpb::LockInfo;
 use std::fmt::Debug;
+use txn_types::{Key, Value};
 
 /// `MvccInfo` stores all mvcc information of given key.
 /// Used by `MvccGetByKey` and `MvccGetByStartTs`.
@@ -19,48 +19,6 @@ pub struct MvccInfo {
     pub writes: Vec<(TimeStamp, Write)>,
     /// start_ts and value
     pub values: Vec<(TimeStamp, Value)>,
-}
-
-/// A row mutation.
-#[derive(Debug, Clone)]
-pub enum Mutation {
-    /// Put `Value` into `Key`, overwriting any existing value.
-    Put((Key, Value)),
-    /// Delete `Key`.
-    Delete(Key),
-    /// Set a lock on `Key`.
-    Lock(Key),
-    /// Put `Value` into `Key` if `Key` does not yet exist.
-    ///
-    /// Returns [`KeyError::AlreadyExists`](kvproto::kvrpcpb::KeyError::AlreadyExists) if the key already exists.
-    Insert((Key, Value)),
-}
-
-impl Mutation {
-    pub fn key(&self) -> &Key {
-        match self {
-            Mutation::Put((ref key, _)) => key,
-            Mutation::Delete(ref key) => key,
-            Mutation::Lock(ref key) => key,
-            Mutation::Insert((ref key, _)) => key,
-        }
-    }
-
-    pub fn into_key_value(self) -> (Key, Option<Value>) {
-        match self {
-            Mutation::Put((key, value)) => (key, Some(value)),
-            Mutation::Delete(key) => (key, None),
-            Mutation::Lock(key) => (key, None),
-            Mutation::Insert((key, value)) => (key, Some(value)),
-        }
-    }
-
-    pub fn is_insert(&self) -> bool {
-        match self {
-            Mutation::Insert(_) => true,
-            _ => false,
-        }
-    }
 }
 
 /// Represents the status of a transaction.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -52,6 +52,7 @@ crc32fast = "1.2"
 crc64fast = "0.1"
 crossbeam = "0.7.2"
 engine = { path = "../components/engine" }
+txn_types = { path = "../components/txn_types" }
 futures = "0.1"
 futures-cpupool = "0.1"
 grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default-features = false }

--- a/tests/benches/hierarchy/engine/mod.rs
+++ b/tests/benches/hierarchy/engine/mod.rs
@@ -1,10 +1,10 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use criterion::{black_box, BatchSize, Bencher, Criterion};
-use keys::{Key, Value};
 use kvproto::kvrpcpb::Context;
 use test_util::KvGenerator;
 use tikv::storage::kv::{Engine, Snapshot};
+use txn_types::{Key, Value};
 
 use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS, DEFAULT_KV_GENERATOR_SEED};
 

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -1,12 +1,12 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use criterion::{black_box, BatchSize, Bencher, Criterion};
-use keys::Key;
 use kvproto::kvrpcpb::Context;
 use test_util::KvGenerator;
 use tikv::storage::kv::Engine;
 use tikv::storage::mvcc::{self, MvccReader, MvccTxn, TimeStamp};
 use tikv::storage::{Mutation, Options};
+use txn_types::Key;
 
 use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS, DEFAULT_KV_GENERATOR_SEED};
 

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -4,9 +4,9 @@ use criterion::{black_box, BatchSize, Bencher, Criterion};
 use kvproto::kvrpcpb::Context;
 use test_util::KvGenerator;
 use tikv::storage::kv::Engine;
-use tikv::storage::mvcc::{self, MvccReader, MvccTxn, TimeStamp};
-use tikv::storage::{Mutation, Options};
-use txn_types::Key;
+use tikv::storage::mvcc::{self, MvccReader, MvccTxn};
+use tikv::storage::Options;
+use txn_types::{Key, Mutation, TimeStamp};
 
 use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS, DEFAULT_KV_GENERATOR_SEED};
 

--- a/tests/benches/hierarchy/storage/mod.rs
+++ b/tests/benches/hierarchy/storage/mod.rs
@@ -2,12 +2,12 @@
 
 use criterion::{black_box, BatchSize, Bencher, Criterion};
 use engine::CF_DEFAULT;
-use keys::Key;
 use kvproto::kvrpcpb::Context;
 use test_storage::SyncTestStorageBuilder;
 use test_util::KvGenerator;
 use tikv::storage::kv::Engine;
 use tikv::storage::Mutation;
+use txn_types::Key;
 
 use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS};
 

--- a/tests/benches/hierarchy/storage/mod.rs
+++ b/tests/benches/hierarchy/storage/mod.rs
@@ -6,8 +6,7 @@ use kvproto::kvrpcpb::Context;
 use test_storage::SyncTestStorageBuilder;
 use test_util::KvGenerator;
 use tikv::storage::kv::Engine;
-use tikv::storage::Mutation;
-use txn_types::Key;
+use txn_types::{Key, Mutation};
 
 use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS};
 

--- a/tests/benches/hierarchy/txn/mod.rs
+++ b/tests/benches/hierarchy/txn/mod.rs
@@ -1,12 +1,12 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use criterion::{black_box, BatchSize, Bencher, Criterion};
-use keys::{Key, TimeStamp};
 use kvproto::kvrpcpb::Context;
 use test_util::KvGenerator;
 use tikv::storage::kv::Engine;
 use tikv::storage::mvcc::{self, MvccTxn};
 use tikv::storage::{Mutation, Options};
+use txn_types::{Key, TimeStamp};
 
 use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS};
 

--- a/tests/benches/hierarchy/txn/mod.rs
+++ b/tests/benches/hierarchy/txn/mod.rs
@@ -5,8 +5,8 @@ use kvproto::kvrpcpb::Context;
 use test_util::KvGenerator;
 use tikv::storage::kv::Engine;
 use tikv::storage::mvcc::{self, MvccTxn};
-use tikv::storage::{Mutation, Options};
-use txn_types::{Key, TimeStamp};
+use tikv::storage::Options;
+use txn_types::{Key, Mutation, TimeStamp};
 
 use super::{BenchConfig, EngineFactory, DEFAULT_ITERATIONS};
 

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -16,7 +16,6 @@ use engine::rocks::DB;
 use engine::{ALL_CFS, CF_DEFAULT};
 use engine_rocks::RocksSnapshot;
 use engine_traits::Snapshot;
-use keys::Key;
 use tikv::raftstore::router::RaftStoreRouter;
 use tikv::raftstore::store::{
     cmd_resp, util, Callback, CasualMessage, RaftCommand, ReadResponse, RegionSnapshot,
@@ -26,6 +25,7 @@ use tikv::raftstore::Result;
 use tikv::server::raftkv::{CmdRes, RaftKv};
 use tikv::storage::kv::{Callback as EngineCallback, CbContext, Modify, Result as EngineResult};
 use tikv::storage::Engine;
+use txn_types::Key;
 
 #[derive(Clone)]
 struct SyncBenchRouter {

--- a/tests/benches/misc/storage/incremental_get.rs
+++ b/tests/benches/misc/storage/incremental_get.rs
@@ -4,8 +4,8 @@ use engine_rocks::RocksSyncSnapshot;
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 use test_storage::SyncTestStorageBuilder;
 use tidb_query::codec::table;
-use tikv::storage::{Engine, Mutation, SnapshotStore, Statistics, Store};
-use txn_types::Key;
+use tikv::storage::{Engine, SnapshotStore, Statistics, Store};
+use txn_types::{Key, Mutation};
 
 fn table_lookup_gen_data() -> (SnapshotStore<RocksSyncSnapshot>, Vec<Key>) {
     let store = SyncTestStorageBuilder::new().build().unwrap();

--- a/tests/benches/misc/storage/incremental_get.rs
+++ b/tests/benches/misc/storage/incremental_get.rs
@@ -1,11 +1,11 @@
 use test::{black_box, Bencher};
 
 use engine_rocks::RocksSyncSnapshot;
-use keys::Key;
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 use test_storage::SyncTestStorageBuilder;
 use tidb_query::codec::table;
 use tikv::storage::{Engine, Mutation, SnapshotStore, Statistics, Store};
+use txn_types::Key;
 
 fn table_lookup_gen_data() -> (SnapshotStore<RocksSyncSnapshot>, Vec<Key>) {
     let store = SyncTestStorageBuilder::new().build().unwrap();

--- a/tests/benches/misc/storage/scan.rs
+++ b/tests/benches/misc/storage/scan.rs
@@ -6,8 +6,7 @@ use kvproto::kvrpcpb::Context;
 
 use test_storage::SyncTestStorageBuilder;
 use test_util::*;
-use tikv::storage::Mutation;
-use txn_types::Key;
+use txn_types::{Key, Mutation};
 
 /// In mvcc kv is not actually deleted, which may cause performance issue
 /// when doing scan.

--- a/tests/benches/misc/storage/scan.rs
+++ b/tests/benches/misc/storage/scan.rs
@@ -4,10 +4,10 @@ use test::Bencher;
 
 use kvproto::kvrpcpb::Context;
 
-use keys::Key;
 use test_storage::SyncTestStorageBuilder;
 use test_util::*;
 use tikv::storage::Mutation;
+use txn_types::Key;
 
 /// In mvcc kv is not actually deleted, which may cause performance issue
 /// when doing scan.

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -9,13 +9,13 @@ use grpcio::*;
 use kvproto::kvrpcpb::{self, Context, Op, PrewriteRequest, RawPutRequest};
 use kvproto::tikvpb::TikvClient;
 
-use keys::Key;
 use test_raftstore::{must_get_equal, must_get_none, new_server_cluster};
 use tikv::storage;
 use tikv::storage::kv::{Error as KvError, ErrorInner as KvErrorInner};
 use tikv::storage::txn::{Error as TxnError, ErrorInner as TxnErrorInner};
 use tikv::storage::*;
 use tikv_util::HandyRwLock;
+use txn_types::Key;
 
 #[test]
 fn test_scheduler_leader_change_twice() {

--- a/tests/integrations/coprocessor/test_checksum.rs
+++ b/tests/integrations/coprocessor/test_checksum.rs
@@ -7,13 +7,13 @@ use kvproto::kvrpcpb::{Context, IsolationLevel};
 use protobuf::Message;
 use tipb::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse, ChecksumScanOn};
 
-use keys::TimeStamp;
 use test_coprocessor::*;
 use tidb_query::storage::scanner::{RangesScanner, RangesScannerOptions};
 use tidb_query::storage::Range;
 use tikv::coprocessor::dag::TiKVStorage;
 use tikv::coprocessor::*;
 use tikv::storage::{Engine, SnapshotStore};
+use txn_types::TimeStamp;
 
 fn new_checksum_request(range: KeyRange, scan_on: ChecksumScanOn) -> Request {
     let mut ctx = Context::default();

--- a/tests/integrations/raftstore/test_compact_after_delete.rs
+++ b/tests/integrations/raftstore/test_compact_after_delete.rs
@@ -3,10 +3,11 @@
 use engine::rocks::util::get_cf_handle;
 use engine::rocks::Range;
 use engine::CF_WRITE;
-use keys::{data_key, Key as MvccKey, DATA_MAX_KEY};
+use keys::{data_key, DATA_MAX_KEY};
 use test_raftstore::*;
 use tikv::storage::mvcc::{TimeStamp, Write, WriteType};
 use tikv_util::config::*;
+use txn_types::Key;
 
 fn gen_mvcc_put_kv(
     k: &[u8],
@@ -14,14 +15,14 @@ fn gen_mvcc_put_kv(
     start_ts: TimeStamp,
     commit_ts: TimeStamp,
 ) -> (Vec<u8>, Vec<u8>) {
-    let k = MvccKey::from_encoded(data_key(k));
+    let k = Key::from_encoded(data_key(k));
     let k = k.append_ts(commit_ts);
     let w = Write::new(WriteType::Put, start_ts, Some(v.to_vec()));
     (k.as_encoded().clone(), w.as_ref().to_bytes())
 }
 
 fn gen_delete_k(k: &[u8], commit_ts: TimeStamp) -> Vec<u8> {
-    let k = MvccKey::from_encoded(data_key(k));
+    let k = Key::from_encoded(data_key(k));
     let k = k.append_ts(commit_ts);
     k.as_encoded().clone()
 }

--- a/tests/integrations/raftstore/test_region_heartbeat.rs
+++ b/tests/integrations/raftstore/test_region_heartbeat.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
-use keys::UnixSecs as PdInstant;
 use test_raftstore::*;
 use tikv_util::config::*;
+use tikv_util::time::UnixSecs as PdInstant;
 use tikv_util::HandyRwLock;
 
 fn wait_down_peers<T: Simulator>(cluster: &Cluster<T>, count: u64, peer: Option<u64>) {

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -16,7 +16,6 @@ use raft::eraftpb;
 use engine::rocks::Writable;
 use engine::*;
 use engine::{CF_DEFAULT, CF_LOCK, CF_RAFT};
-use keys::Key;
 use tempfile::Builder;
 use test_raftstore::*;
 use tikv::coprocessor::REQ_TYPE_DAG;
@@ -27,6 +26,7 @@ use tikv::raftstore::store::SnapManager;
 use tikv::storage::mvcc::{Lock, LockType, TimeStamp};
 use tikv_util::worker::FutureWorker;
 use tikv_util::HandyRwLock;
+use txn_types::Key;
 
 fn must_new_cluster() -> (Cluster<ServerCluster>, metapb::Peer, Context) {
     let count = 1;

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -12,11 +12,10 @@ use tikv::server::gc_worker::{AutoGcConfig, GcConfig};
 use tikv::storage::kv::{Error as KvError, ErrorInner as KvErrorInner};
 use tikv::storage::mvcc::{Error as MvccError, ErrorInner as MvccErrorInner};
 use tikv::storage::txn::{Error as TxnError, ErrorInner as TxnErrorInner};
-use tikv::storage::{Engine, Mutation};
-use tikv::storage::{Error as StorageError, ErrorInner as SotrageErrorInner};
+use tikv::storage::{Engine, Error as StorageError, ErrorInner as StorageErrorInner};
 use tikv_util::collections::HashMap;
 use tikv_util::HandyRwLock;
-use txn_types::{Key, TimeStamp};
+use txn_types::{Key, Mutation, TimeStamp};
 
 fn new_raft_storage() -> (
     Cluster<ServerCluster>,
@@ -107,7 +106,7 @@ fn test_raft_storage_rollback_before_prewrite() {
     assert!(ret.is_err());
     let err = ret.unwrap_err();
     match err {
-        StorageError(box SotrageErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
+        StorageError(box StorageErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
             box MvccErrorInner::WriteConflict { .. },
         ))))) => {}
         _ => {
@@ -146,7 +145,7 @@ fn test_raft_storage_store_not_match() {
     ctx.set_peer(peer);
     assert!(storage.get(ctx.clone(), &key, 20).is_err());
     let res = storage.get(ctx.clone(), &key, 20);
-    if let StorageError(box SotrageErrorInner::Txn(TxnError(box TxnErrorInner::Engine(KvError(
+    if let StorageError(box StorageErrorInner::Txn(TxnError(box TxnErrorInner::Engine(KvError(
         box KvErrorInner::Request(ref e),
     ))))) = *res.as_ref().err().unwrap()
     {

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -3,7 +3,6 @@
 use std::thread;
 use std::time::Duration;
 
-use keys::{Key, TimeStamp};
 use kvproto::kvrpcpb::Context;
 use std::sync::mpsc::channel;
 use std::sync::Arc;
@@ -17,6 +16,7 @@ use tikv::storage::{Engine, Mutation};
 use tikv::storage::{Error as StorageError, ErrorInner as SotrageErrorInner};
 use tikv_util::collections::HashMap;
 use tikv_util::HandyRwLock;
+use txn_types::{Key, TimeStamp};
 
 fn new_raft_storage() -> (
     Cluster<ServerCluster>,

--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -9,12 +9,12 @@ use raft::eraftpb::MessageType;
 
 use engine::IterOption;
 use engine::{CfName, CF_DEFAULT};
-use keys::Key;
 use test_raftstore::*;
 use tikv::storage::kv::*;
 use tikv::storage::CfStatistics;
 use tikv_util::codec::bytes;
 use tikv_util::HandyRwLock;
+use txn_types::Key;
 
 #[test]
 fn test_raftkv() {

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -15,8 +15,8 @@ use test_storage::*;
 use tikv::server::gc_worker::DEFAULT_GC_BATCH_KEYS;
 use tikv::storage::mvcc::MAX_TXN_WRITE_SIZE;
 use tikv::storage::txn::RESOLVE_LOCK_BATCH_SIZE;
-use tikv::storage::{Engine, Mutation};
-use txn_types::{Key, TimeStamp};
+use tikv::storage::Engine;
+use txn_types::{Key, Mutation, TimeStamp};
 
 #[test]
 fn test_txn_store_get() {

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -11,12 +11,12 @@ use rand::random;
 use kvproto::kvrpcpb::{Context, LockInfo};
 
 use engine::{CF_DEFAULT, CF_LOCK};
-use keys::{Key, TimeStamp};
 use test_storage::*;
 use tikv::server::gc_worker::DEFAULT_GC_BATCH_KEYS;
 use tikv::storage::mvcc::MAX_TXN_WRITE_SIZE;
 use tikv::storage::txn::RESOLVE_LOCK_BATCH_SIZE;
 use tikv::storage::{Engine, Mutation};
+use txn_types::{Key, TimeStamp};
 
 #[test]
 fn test_txn_store_get() {


### PR DESCRIPTION
###  What have you changed?
Extract txn related types to a new component, so that `sst_importer` can use them to parse the key and value. This PR changes:
- move `UnixSecs` from `component/keys` to `component/tikv_util`
- move `timestamps.rs` and `types.rs` from `component/keys` to new `component/txn_types`
- extract `Mutation`, `write.rs` and `lock.rs` from `raftstore` to new `component/txn_types`

###  What is the type of the changes?
- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No

###  Does this PR affect `tidb-ansible`?
No

