### PR TITLE
fix(copr): handle invalid datetime for `datediff`

### DIFF
--- a/components/tidb_query/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query/src/codec/mysql/time/mod.rs
@@ -772,6 +772,43 @@ impl TimeArgs {
     }
 }
 
+#[doc(hidden)]
+#[cfg(test)]
+impl TimeArgs {
+    // Create TimeArgs from values directly, for test usage only.
+    pub fn new_raw(
+        year: u32,
+        month: u32,
+        day: u32,
+        hour: u32,
+        minute: u32,
+        second: u32,
+        micro: u32,
+        fsp: i8,
+        time_type: TimeType,
+    ) -> Self {
+        TimeArgs {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            micro,
+            fsp,
+            time_type,
+        }
+    }
+}
+
+#[doc(hidden)]
+#[cfg(test)]
+impl Time {
+    pub fn unchecked_new(config: TimeArgs) -> Self {
+        Self::unchecked_new_impl(config)
+    }
+}
+
 // Utility
 impl Time {
     fn from_slice(
@@ -894,7 +931,7 @@ impl Time {
         )
     }
 
-    fn unchecked_new(config: TimeArgs) -> Self {
+    fn unchecked_new_impl(config: TimeArgs) -> Self {
         let mut time = Time(0);
         let TimeArgs {
             year,
@@ -928,10 +965,10 @@ impl Time {
             config.fsp = 0;
         }
 
-        let unchecked_time = Self::unchecked_new(config.clone());
-        Ok(Self::unchecked_new(config.check(ctx).ok_or_else(|| {
-            Error::incorrect_datetime_value(unchecked_time)
-        })?))
+        let unchecked_time = Self::unchecked_new_impl(config.clone());
+        Ok(Self::unchecked_new_impl(config.check(ctx).ok_or_else(
+            || Error::incorrect_datetime_value(unchecked_time),
+        )?))
     }
 
     fn check_month_and_day(


### PR DESCRIPTION
Signed-off-by: Zhu Zihao <all_but_last@163.com>


----

# 

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

For `date_diff` function in `builtin_time.rs`, if first arg is `None` and second
arg is an invalid datetime, it will be ignored, but MySQL will handle this
situation.

``` sql
-- Expect warning or error based on SQL mode but return NULL directly.
INSERT INTO table (col) VALUES (datediff(NULL, '2000-00-00 12:11:20'))
```

Related: https://github.com/tikv/tikv/pull/6043#discussion_r351969596

###  What is the type of the changes?

Pick one of the following and delete the others:

- Bugfix (a change which fixes an issue)

###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No


###  Does this PR affect `tidb-ansible`?

No