### PR TITLE
Add maximum and minimum timestamp hint for iterator (#6194)

### DIFF
--- a/components/engine/src/iterable.rs
+++ b/components/engine/src/iterable.rs
@@ -1,8 +1,10 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::DATA_KEY_PREFIX_LEN;
-pub use crate::rocks::{DBIterator, ReadOptions, DB};
+pub use crate::rocks::{DBIterator, ReadOptions, TableFilter, TableProperties, DB};
 use crate::Result;
+use std::ops::Bound;
+use tikv_util::codec::number;
 use tikv_util::keybuilder::KeyBuilder;
 
 #[derive(Clone, PartialEq)]
@@ -16,6 +18,10 @@ pub struct IterOption {
     upper_bound: Option<KeyBuilder>,
     prefix_same_as_start: bool,
     fill_cache: bool,
+    // hint for we will only scan data with commit ts >= hint_min_ts
+    hint_min_ts: Option<u64>,
+    // hint for we will only scan data with commit ts <= hint_max_ts
+    hint_max_ts: Option<u64>,
     // only supported when Titan enabled, otherwise it doesn't take effect.
     titan_key_only: bool,
     seek_mode: SeekMode,
@@ -30,6 +36,8 @@ impl IterOption {
         IterOption {
             lower_bound,
             upper_bound,
+            hint_min_ts: None,
+            hint_max_ts: None,
             prefix_same_as_start: false,
             fill_cache,
             titan_key_only: false,
@@ -67,6 +75,34 @@ impl IterOption {
     pub fn set_lower_bound(&mut self, bound: &[u8], reserved_prefix_len: usize) {
         let builder = KeyBuilder::from_slice(bound, reserved_prefix_len, 0);
         self.lower_bound = Some(builder);
+    }
+
+    #[inline]
+    pub fn set_hint_min_ts(&mut self, bound_ts: Bound<u64>) {
+        match bound_ts {
+            Bound::Included(ts) => self.hint_min_ts = Some(ts),
+            Bound::Excluded(ts) => self.hint_min_ts = Some(ts + 1),
+            Bound::Unbounded => self.hint_min_ts = None,
+        }
+    }
+
+    #[inline]
+    pub fn hint_min_ts(&self) -> Option<u64> {
+        self.hint_min_ts
+    }
+
+    #[inline]
+    pub fn hint_max_ts(&self) -> Option<u64> {
+        self.hint_max_ts
+    }
+
+    #[inline]
+    pub fn set_hint_max_ts(&mut self, bound_ts: Bound<u64>) {
+        match bound_ts {
+            Bound::Included(ts) => self.hint_max_ts = Some(ts),
+            Bound::Excluded(ts) => self.hint_max_ts = Some(ts - 1),
+            Bound::Unbounded => self.hint_max_ts = None,
+        }
     }
 
     pub fn set_vec_lower_bound(&mut self, bound: Vec<u8>) {
@@ -117,12 +153,19 @@ impl IterOption {
         } else if self.prefix_same_as_start {
             opts.set_prefix_same_as_start(true);
         }
+
+        if self.hint_min_ts().is_some() || self.hint_max_ts().is_some() {
+            let ts_filter = TsFilter::new(self.hint_min_ts(), self.hint_max_ts());
+            opts.set_table_filter(Box::new(ts_filter))
+        }
+
         if let Some(builder) = self.lower_bound {
             opts.set_iterate_lower_bound(builder.build());
         }
         if let Some(builder) = self.upper_bound {
             opts.set_iterate_upper_bound(builder.build());
         }
+
         opts
     }
 }
@@ -132,11 +175,63 @@ impl Default for IterOption {
         IterOption {
             lower_bound: None,
             upper_bound: None,
+            hint_min_ts: None,
+            hint_max_ts: None,
             prefix_same_as_start: false,
             fill_cache: true,
             titan_key_only: false,
             seek_mode: SeekMode::TotalOrder,
         }
+    }
+}
+
+struct TsFilter {
+    hint_min_ts: Option<u64>,
+    hint_max_ts: Option<u64>,
+}
+
+impl TsFilter {
+    fn new(hint_min_ts: Option<u64>, hint_max_ts: Option<u64>) -> TsFilter {
+        TsFilter {
+            hint_min_ts,
+            hint_max_ts,
+        }
+    }
+}
+
+impl TableFilter for TsFilter {
+    fn table_filter(&self, props: &TableProperties) -> bool {
+        if self.hint_max_ts.is_none() && self.hint_min_ts.is_none() {
+            return true;
+        }
+
+        let user_props = props.user_collected_properties();
+
+        if let Some(hint_min_ts) = self.hint_min_ts {
+            // TODO avoid hard code after refactor MvccProperties from
+            // tikv/src/raftstore/coprocessor/ into some component about engine.
+            if let Some(mut p) = user_props.get("tikv.max_ts") {
+                if let Ok(get_max) = number::decode_u64(&mut p) {
+                    if get_max < hint_min_ts {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        if let Some(hint_max_ts) = self.hint_max_ts {
+            // TODO avoid hard code after refactor MvccProperties from
+            // tikv/src/raftstore/coprocessor/ into some component about engine.
+            if let Some(mut p) = user_props.get("tikv.min_ts") {
+                if let Ok(get_min) = number::decode_u64(&mut p) {
+                    if get_min > hint_max_ts {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        true
     }
 }
 
@@ -203,4 +298,27 @@ where
     }
 
     it.status().map_err(From::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ops::Bound;
+
+    #[test]
+    fn test_hint_ts() {
+        let mut ops = IterOption::default();
+        assert_eq!(ops.hint_min_ts(), None);
+        assert_eq!(ops.hint_max_ts(), None);
+
+        ops.set_hint_min_ts(Bound::Included(1));
+        ops.set_hint_max_ts(Bound::Included(10));
+        assert_eq!(ops.hint_min_ts(), Some(1));
+        assert_eq!(ops.hint_max_ts(), Some(10));
+
+        ops.set_hint_min_ts(Bound::Excluded(1));
+        ops.set_hint_max_ts(Bound::Excluded(10));
+        assert_eq!(ops.hint_min_ts(), Some(2));
+        assert_eq!(ops.hint_max_ts(), Some(9));
+    }
 }

--- a/components/engine/src/rocks/mod.rs
+++ b/components/engine/src/rocks/mod.rs
@@ -20,9 +20,9 @@ pub use engine_rocksdb::{
     EnvOptions, EventListener, ExternalSstFileInfo, FlushJobInfo, HistogramData,
     IngestExternalFileOptions, IngestionInfo, Kv, LRUCacheOptions, MemoryAllocator, PerfContext,
     Range, RateLimiter, ReadOptions, SeekKey, SequentialFile, SliceTransform, SstFileWriter,
-    TablePropertiesCollection, TablePropertiesCollector, TablePropertiesCollectorFactory,
-    TitanBlobIndex, TitanDBOptions, UserCollectedProperties, Writable, WriteBatch, WriteOptions,
-    WriteStallCondition, WriteStallInfo, DB,
+    TableFilter, TableProperties, TablePropertiesCollection, TablePropertiesCollector,
+    TablePropertiesCollectorFactory, TitanBlobIndex, TitanDBOptions, UserCollectedProperties,
+    Writable, WriteBatch, WriteOptions, WriteStallCondition, WriteStallInfo, DB,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
Signed-off-by: Jiahao Huang <july2993@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
pick #6194 

Please explain in detail what the changes are in this PR and why they are needed:

- Add `hint_min_ts` and `hint_max_ts` for `IterOptions`.
- Implements `TableFilter` `TsFilter` which can skip scanning some unrelate SST files.
- Add test `test_ts_filter` to verify the options works for the iterator.

After this pr, we can add the hint option for maximum or minimum commit ts for the iterator, it helps performance by avoiding scan some SST files totally for the rocksdb engine.


###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)


###  How is the PR tested?
Please select the tests that you ran to verify your changes:
- Unit test


###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?



###  Does this PR affect `tidb-ansible`?
no

###  Refer to a related PR or issue link (optional)
#6065
###  Benchmark result if necessary (optional)

###  Any examples? (optional)

