### PR TITLE
perf hashskiplist for raftdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#4ad6d0a7b35d30e7c67f6cfdff7d97874f330123"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=hashskiplist#c4c03dda0d49e68f61ae822762dc09f42f7a81e2"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#4ad6d0a7b35d30e7c67f6cfdff7d97874f330123"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=hashskiplist#c4c03dda0d49e68f61ae822762dc09f42f7a81e2"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -2689,7 +2689,7 @@ checksum = "2089e4031214d129e201f8c3c8c2fe97cd7322478a0d1cdf78e7029b0042efdb"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#4ad6d0a7b35d30e7c67f6cfdff7d97874f330123"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=hashskiplist#c4c03dda0d49e68f61ae822762dc09f42f7a81e2"
 dependencies = [
  "libc",
  "librocksdb_sys",
@@ -4176,7 +4176,7 @@ dependencies = [
 [[package]]
 name = "zstd-sys"
 version = "1.4.15+zstd.1.4.4"
-source = "git+https://github.com/gyscos/zstd-rs.git#9bdc44501ec3279e83d9bfe1ebc953bb7cf000b9"
+source = "git+https://github.com/gyscos/zstd-rs.git#c0e8491d460311117bacd0262374f8b973ec8b69"
 dependencies = [
  "cc",
  "glob",

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -35,8 +35,9 @@ rev = "b668f3911d6569de2e1e8b2672fccec1cc8298be"
 features = ["nightly", "push", "process"]
 
 [dependencies.rocksdb]
-git = "https://github.com/pingcap/rust-rocksdb.git"
+git = "https://github.com/Little-Wallace/rust-rocksdb.git"
 package = "rocksdb"
+branch = "hashskiplist"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -35,8 +35,9 @@ rev = "b668f3911d6569de2e1e8b2672fccec1cc8298be"
 features = ["nightly", "push", "process"]
 
 [dependencies.rocksdb]
-git = "https://github.com/pingcap/rust-rocksdb.git"
+git = "https://github.com/Little-Wallace/rust-rocksdb.git"
 package = "rocksdb"
+branch = "hashskiplist"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -257,6 +257,7 @@ fn test_serde_custom_tikv_config() {
             prop_size_index_distance: 4000000,
             prop_keys_index_distance: 40000,
             enable_doubly_skiplist: false,
+            enable_hash_skiplist: false,
         },
         writecf: WriteCfConfig {
             block_size: ReadableSize::kb(12),
@@ -311,6 +312,7 @@ fn test_serde_custom_tikv_config() {
             prop_size_index_distance: 4000000,
             prop_keys_index_distance: 40000,
             enable_doubly_skiplist: true,
+            enable_hash_skiplist: false,
         },
         lockcf: LockCfConfig {
             block_size: ReadableSize::kb(12),
@@ -365,6 +367,7 @@ fn test_serde_custom_tikv_config() {
             prop_size_index_distance: 4000000,
             prop_keys_index_distance: 40000,
             enable_doubly_skiplist: true,
+            enable_hash_skiplist: false,
         },
         raftcf: RaftCfConfig {
             block_size: ReadableSize::kb(12),
@@ -419,6 +422,7 @@ fn test_serde_custom_tikv_config() {
             prop_size_index_distance: 4000000,
             prop_keys_index_distance: 40000,
             enable_doubly_skiplist: true,
+            enable_hash_skiplist: false,
         },
         titan: titan_db_config.clone(),
     };
@@ -489,7 +493,8 @@ fn test_serde_custom_tikv_config() {
             titan: titan_cf_config.clone(),
             prop_size_index_distance: 4000000,
             prop_keys_index_distance: 40000,
-            enable_doubly_skiplist: true,
+            enable_doubly_skiplist: false,
+            enable_hash_skiplist: false,
         },
         titan: titan_db_config.clone(),
     };
@@ -536,7 +541,7 @@ fn test_serde_custom_tikv_config() {
     };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");
-    let load = toml::from_str(&custom).unwrap();
+    let load : TiKvConfig = toml::from_str(&custom).unwrap();
     assert_eq!(value, load);
     let dump = toml::to_string_pretty(&load).unwrap();
     let load_from_dump = toml::from_str(&dump).unwrap();

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -541,7 +541,7 @@ fn test_serde_custom_tikv_config() {
     };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");
-    let load : TiKvConfig = toml::from_str(&custom).unwrap();
+    let load: TiKvConfig = toml::from_str(&custom).unwrap();
     assert_eq!(value, load);
     let dump = toml::to_string_pretty(&load).unwrap();
     let load_from_dump = toml::from_str(&dump).unwrap();

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -222,6 +222,7 @@ force-consistency-checks = false
 prop-size-index-distance = 4000000
 prop-keys-index-distance = 40000
 enable-doubly-skiplist = false
+enable-hash-skiplist = false
 
 [rocksdb.defaultcf.titan]
 min-blob-size = "2018B"
@@ -275,6 +276,7 @@ hard-pending-compaction-bytes-limit = "12GB"
 force-consistency-checks = false
 prop-size-index-distance = 4000000
 prop-keys-index-distance = 40000
+enable-hash-skiplist = false
 
 [rocksdb.lockcf]
 block-size = "12KB"
@@ -317,6 +319,7 @@ hard-pending-compaction-bytes-limit = "12GB"
 force-consistency-checks = false
 prop-size-index-distance = 4000000
 prop-keys-index-distance = 40000
+enable-hash-skiplist = false
 
 [rocksdb.raftcf]
 block-size = "12KB"
@@ -359,6 +362,7 @@ hard-pending-compaction-bytes-limit = "12GB"
 force-consistency-checks = false
 prop-size-index-distance = 4000000
 prop-keys-index-distance = 40000
+enable-hash-skiplist = false
 
 [raftdb]
 wal-recovery-mode = 3
@@ -433,6 +437,8 @@ hard-pending-compaction-bytes-limit = "12GB"
 force-consistency-checks = false
 prop-size-index-distance = 4000000
 prop-keys-index-distance = 40000
+enable-doubly-skiplist = false
+enable-hash-skiplist = false
 
 [raftdb.defaultcf.titan]
 min-blob-size = "2018B"


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Enable hash-skiplist for memtable of raftdb, which may reduce latency of writing into raftdb.
Hash-skiplist combines hashtable and skiplist, it performances good at point-get and write, but is terrible for 'scan'.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

- Unit test in RocksDB

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

