### PR TITLE
txn: reorganise a few items and imports

### DIFF
--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -1,8 +1,8 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::timestamp::{TimeStamp, TsSet};
-use super::types::{Key, Mutation, Value, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
-use super::{Error, Result};
+use crate::timestamp::{TimeStamp, TsSet};
+use crate::types::{Key, Mutation, Value, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
+use crate::{Error, Result};
 use byteorder::ReadBytesExt;
 use derive_new::new;
 use kvproto::kvrpcpb::{LockInfo, Op};

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -1,9 +1,9 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::lock::LockType;
-use super::timestamp::TimeStamp;
-use super::types::{Value, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
-use super::{Error, Result};
+use crate::lock::LockType;
+use crate::timestamp::TimeStamp;
+use crate::types::{Value, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
+use crate::{Error, Result};
 use codec::prelude::NumberDecoder;
 use tikv_util::codec::number::{NumberEncoder, MAX_VAR_U64_LEN};
 

--- a/src/server/gc_worker.rs
+++ b/src/server/gc_worker.rs
@@ -1288,7 +1288,7 @@ mod tests {
     use crate::raftstore::store::util::new_peer;
     use crate::storage::kv::Result as EngineResult;
     use crate::storage::lock_manager::DummyLockManager;
-    use crate::storage::{Options, Storage, TestEngineBuilder, TestStorageBuilder};
+    use crate::storage::{txn::Options, Storage, TestEngineBuilder, TestStorageBuilder};
     use futures::Future;
     use kvproto::metapb;
     use std::collections::BTreeMap;

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -20,8 +20,10 @@ use crate::storage::mvcc::{
     Error as MvccError, ErrorInner as MvccErrorInner, LockType, TimeStamp, Write as MvccWrite,
     WriteType,
 };
-use crate::storage::txn::{Error as TxnError, ErrorInner as TxnErrorInner};
-use crate::storage::{self, Engine, Options, PointGetCommand, Storage, TxnStatus};
+use crate::storage::txn::{
+    Error as TxnError, ErrorInner as TxnErrorInner, Options, PointGetCommand,
+};
+use crate::storage::{self, Engine, Storage, TxnStatus};
 use crate::storage::{Error as StorageError, ErrorInner as StorageErrorInner};
 use futures::executor::{self, Notify, Spawn};
 use futures::{future, Async, Future, Sink, Stream};

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -6,12 +6,12 @@ use std::io::Error as IoError;
 
 use kvproto::errorpb;
 
-use crate::storage::{kv::Error as EngineError, mvcc, txn};
+use crate::storage::{kv, mvcc, txn};
 
 quick_error! {
     #[derive(Debug)]
     pub enum ErrorInner {
-        Engine(err: EngineError) {
+        Engine(err: kv::Error) {
             from()
             cause(err)
             description(err.description())

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -1,5 +1,12 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
+mod btree_engine;
+mod compact_listener;
+mod cursor;
+mod perf_context;
+mod rocksdb_engine;
+mod stats;
+
 use std::cell::UnsafeCell;
 use std::fmt;
 use std::time::Duration;
@@ -14,13 +21,6 @@ use txn_types::{Key, Value};
 
 use crate::into_other::IntoOther;
 use crate::raftstore::coprocessor::SeekRegionCallback;
-
-mod btree_engine;
-mod compact_listener;
-mod cursor;
-mod perf_context;
-mod rocksdb_engine;
-mod stats;
 
 pub use self::btree_engine::{BTreeEngine, BTreeEngineIterator, BTreeEngineSnapshot};
 pub use self::compact_listener::{CompactedEvent, CompactionListener};

--- a/src/storage/lock_manager.rs
+++ b/src/storage/lock_manager.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::storage::{types::ProcessResult, StorageCallback, TimeStamp};
+use crate::storage::{txn::ProcessResult, StorageCallback, TimeStamp};
 
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 pub struct Lock {

--- a/src/storage/lock_manager.rs
+++ b/src/storage/lock_manager.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::storage::{txn::ProcessResult, StorageCallback, TimeStamp};
+use crate::storage::{txn::ProcessResult, types::StorageCallback};
+use txn_types::TimeStamp;
 
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 pub struct Lock {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -9,48 +9,51 @@
 //! is used by the [`Server`](server::Server). The [`BTreeEngine`](storage::kv::BTreeEngine) and
 //! [`RocksEngine`](storage::RocksEngine) are used for testing only.
 
-mod commands;
 pub mod config;
-mod errors;
 pub mod kv;
 pub mod lock_manager;
-mod metrics;
 pub mod mvcc;
-mod readpool_impl;
 pub mod txn;
+
+mod commands;
+mod errors;
+mod metrics;
+mod readpool_impl;
 mod types;
 
-use std::cmp;
-use std::sync::{atomic, Arc};
+pub use self::{
+    commands::{Options, PointGetCommand},
+    errors::{get_error_kind_from_header, get_tag_from_header, Error, ErrorHeaderKind, ErrorInner},
+    kv::{
+        CfStatistics, Cursor, CursorBuilder, Engine, Error as EngineError,
+        ErrorInner as EngineErrorInner, FlowStatistics, FlowStatsReporter, Iterator, Modify,
+        RegionInfoProvider, RocksEngine, ScanMode, Snapshot, Statistics, TestEngineBuilder,
+    },
+    readpool_impl::{build_read_pool, build_read_pool_for_test},
+    txn::{Scanner, SnapshotStore, Store},
+    types::{MvccInfo, ProcessResult, StorageCallback, TxnStatus},
+};
 
+use crate::storage::{
+    commands::{get_priority_tag, Command, CommandKind},
+    config::Config,
+    kv::with_tls_engine,
+    lock_manager::{DummyLockManager, LockManager},
+    metrics::*,
+    mvcc::Lock,
+    txn::scheduler::Scheduler as TxnScheduler,
+};
 use engine::{
     CfName, IterOption, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS, DATA_KEY_PREFIX_LEN,
 };
 use futures::{future, Future};
 use kvproto::kvrpcpb::{Context, KeyRange, LockInfo};
-use tikv_util::collections::HashMap;
-use tikv_util::future_pool::FuturePool;
-use txn_types::{Key, KvPair, Lock, Mutation, TimeStamp, TsSet, Value};
-
-use crate::storage::commands::{get_priority_tag, Command, CommandKind};
-use crate::storage::config::Config;
-use crate::storage::kv::with_tls_engine;
-use crate::storage::lock_manager::{DummyLockManager, LockManager};
-use crate::storage::metrics::*;
-use crate::storage::txn::scheduler::Scheduler as TxnScheduler;
-
-pub use self::commands::{Options, PointGetCommand};
-pub use self::errors::{
-    get_error_kind_from_header, get_tag_from_header, Error, ErrorHeaderKind, ErrorInner,
+use std::{
+    cmp,
+    sync::{atomic, Arc},
 };
-pub use self::kv::{
-    CfStatistics, Cursor, CursorBuilder, Engine, Error as EngineError,
-    ErrorInner as EngineErrorInner, FlowStatistics, FlowStatsReporter, Iterator, Modify,
-    RegionInfoProvider, RocksEngine, ScanMode, Snapshot, Statistics, TestEngineBuilder,
-};
-pub use self::readpool_impl::{build_read_pool, build_read_pool_for_test};
-pub use self::txn::{Scanner, SnapshotStore, Store};
-pub use self::types::{MvccInfo, ProcessResult, StorageCallback, TxnStatus};
+use tikv_util::{collections::HashMap, future_pool::FuturePool};
+use txn_types::{Key, KvPair, Mutation, TimeStamp, TsSet, Value};
 
 pub type Result<T> = std::result::Result<T, Error>;
 pub type Callback<T> = Box<dyn FnOnce(Result<T>) + Send>;
@@ -1551,8 +1554,10 @@ mod tests {
 
     use crate::storage::txn::{Error as TxnError, ErrorInner as TxnErrorInner};
     use kvproto::kvrpcpb::CommandPri;
-    use std::fmt::Debug;
-    use std::sync::mpsc::{channel, Sender};
+    use std::{
+        fmt::Debug,
+        sync::mpsc::{channel, Sender},
+    };
     use tikv_util::config::ReadableSize;
 
     fn expect_none(x: Result<Option<Value>>) {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -23,29 +23,26 @@ mod types;
 pub use self::{
     errors::{get_error_kind_from_header, get_tag_from_header, Error, ErrorHeaderKind, ErrorInner},
     kv::{
-        CfStatistics, Cursor, CursorBuilder, Engine, Error as EngineError,
-        ErrorInner as EngineErrorInner, FlowStatistics, FlowStatsReporter, Iterator, Modify,
+        CfStatistics, Cursor, Engine, FlowStatistics, FlowStatsReporter, Iterator,
         RegionInfoProvider, RocksEngine, ScanMode, Snapshot, Statistics, TestEngineBuilder,
     },
     readpool_impl::{build_read_pool, build_read_pool_for_test},
-    txn::{Options, PointGetCommand, ProcessResult, Scanner, SnapshotStore, Store},
+    txn::{Options, ProcessResult, Scanner, SnapshotStore, Store},
     types::{MvccInfo, StorageCallback, TxnStatus},
 };
 
 use crate::storage::{
     config::Config,
-    kv::with_tls_engine,
+    kv::{with_tls_engine, Error as EngineError, ErrorInner as EngineErrorInner, Modify},
     lock_manager::{DummyLockManager, LockManager},
     metrics::*,
-    mvcc::Lock,
     txn::{
         commands::{get_priority_tag, Command, CommandKind},
         scheduler::Scheduler as TxnScheduler,
+        PointGetCommand,
     },
 };
-use engine::{
-    CfName, IterOption, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS, DATA_KEY_PREFIX_LEN,
-};
+use engine::{CfName, IterOption, ALL_CFS, CF_DEFAULT, DATA_CFS, DATA_KEY_PREFIX_LEN};
 use futures::{future, Future};
 use kvproto::kvrpcpb::{Context, KeyRange, LockInfo};
 use std::{

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -15,14 +15,12 @@ pub mod lock_manager;
 pub mod mvcc;
 pub mod txn;
 
-mod commands;
 mod errors;
 mod metrics;
 mod readpool_impl;
 mod types;
 
 pub use self::{
-    commands::{Options, PointGetCommand},
     errors::{get_error_kind_from_header, get_tag_from_header, Error, ErrorHeaderKind, ErrorInner},
     kv::{
         CfStatistics, Cursor, CursorBuilder, Engine, Error as EngineError,
@@ -30,18 +28,20 @@ pub use self::{
         RegionInfoProvider, RocksEngine, ScanMode, Snapshot, Statistics, TestEngineBuilder,
     },
     readpool_impl::{build_read_pool, build_read_pool_for_test},
-    txn::{Scanner, SnapshotStore, Store},
-    types::{MvccInfo, ProcessResult, StorageCallback, TxnStatus},
+    txn::{Options, PointGetCommand, ProcessResult, Scanner, SnapshotStore, Store},
+    types::{MvccInfo, StorageCallback, TxnStatus},
 };
 
 use crate::storage::{
-    commands::{get_priority_tag, Command, CommandKind},
     config::Config,
     kv::with_tls_engine,
     lock_manager::{DummyLockManager, LockManager},
     metrics::*,
     mvcc::Lock,
-    txn::scheduler::Scheduler as TxnScheduler,
+    txn::{
+        commands::{get_priority_tag, Command, CommandKind},
+        scheduler::Scheduler as TxnScheduler,
+    },
 };
 use engine::{
     CfName, IterOption, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_WRITE, DATA_CFS, DATA_KEY_PREFIX_LEN,

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -282,7 +282,9 @@ pub fn default_not_found_error(key: Vec<u8>, hint: &str) -> Error {
 
 pub mod tests {
     use super::*;
-    use crate::storage::{Engine, Modify, Options, ScanMode, Snapshot, TxnStatus};
+    use crate::storage::kv::{Engine, Modify, ScanMode, Snapshot};
+    use crate::storage::txn::commands::Options;
+    use crate::storage::types::TxnStatus;
     use engine::CF_WRITE;
     use kvproto::kvrpcpb::{Context, IsolationLevel};
     use txn_types::Key;

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -9,7 +9,10 @@ mod txn;
 pub use self::reader::*;
 pub use self::txn::{MvccTxn, MAX_TXN_WRITE_SIZE};
 pub use crate::new_txn;
-pub use txn_types::{Lock, LockType, TimeStamp, Write, WriteRef, WriteType};
+pub use txn_types::{
+    Key, Lock, LockType, Mutation, TimeStamp, Value, Write, WriteRef, WriteType,
+    SHORT_VALUE_MAX_LEN,
+};
 
 use std::error;
 use std::fmt;
@@ -279,7 +282,7 @@ pub fn default_not_found_error(key: Vec<u8>, hint: &str) -> Error {
 
 pub mod tests {
     use super::*;
-    use crate::storage::{Engine, Modify, Mutation, Options, ScanMode, Snapshot, TxnStatus};
+    use crate::storage::{Engine, Modify, Options, ScanMode, Snapshot, TxnStatus};
     use engine::CF_WRITE;
     use kvproto::kvrpcpb::{Context, IsolationLevel};
     use txn_types::Key;

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -1,8 +1,8 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use crate::storage::kv::{Cursor, CursorBuilder, ScanMode, Snapshot, Statistics};
 use crate::storage::mvcc::{default_not_found_error, Result};
-use crate::storage::{Cursor, CursorBuilder, ScanMode, Snapshot, Statistics, CF_LOCK};
-use crate::storage::{CF_DEFAULT, CF_WRITE};
+use engine::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::IsolationLevel;
 use txn_types::{Key, Lock, TimeStamp, TsSet, Value, WriteRef, WriteType};
 
@@ -273,8 +273,8 @@ mod tests {
     use kvproto::kvrpcpb::Context;
     use txn_types::SHORT_VALUE_MAX_LEN;
 
+    use crate::storage::kv::{CfStatistics, Engine, RocksEngine, TestEngineBuilder};
     use crate::storage::mvcc::tests::*;
-    use crate::storage::{CfStatistics, Engine, RocksEngine, TestEngineBuilder};
 
     fn new_multi_point_getter<E: Engine>(engine: &E, ts: TimeStamp) -> PointGetter<E::Snap> {
         let snapshot = engine.snapshot(&Context::default()).unwrap();

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -3,8 +3,7 @@
 use crate::raftstore::coprocessor::properties::MvccProperties;
 use crate::storage::kv::{Cursor, ScanMode, Snapshot, Statistics};
 use crate::storage::mvcc::{default_not_found_error, Result};
-use engine::IterOption;
-use engine::{CF_LOCK, CF_WRITE};
+use engine::{IterOption, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::IsolationLevel;
 use txn_types::{Key, Lock, TimeStamp, Value, Write, WriteRef, WriteType};
 
@@ -433,7 +432,7 @@ mod tests {
     use crate::raftstore::store::RegionSnapshot;
     use crate::storage::kv::Modify;
     use crate::storage::mvcc::{MvccReader, MvccTxn};
-    use crate::storage::Options;
+    use crate::storage::txn::commands::Options;
     use engine::rocks::util::CFOptions;
     use engine::rocks::{self, ColumnFamilyOptions, DBOptions};
     use engine::rocks::{Writable, WriteBatch, DB};

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -4,13 +4,11 @@ use std::cmp::Ordering;
 
 use engine::CF_DEFAULT;
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, TimeStamp, Value, Write, WriteRef, WriteType};
-
-use crate::storage::kv::SEEK_BOUND;
-use crate::storage::mvcc::{Error, Result};
-use crate::storage::{Cursor, Lock, Snapshot, Statistics};
+use txn_types::{Key, Lock, TimeStamp, Value, Write, WriteRef, WriteType};
 
 use super::ScannerConfig;
+use crate::storage::kv::{Cursor, Snapshot, Statistics, SEEK_BOUND};
+use crate::storage::mvcc::{Error, Result};
 
 // When there are many versions for the user key, after several tries,
 // we will use seek to locate the right position. But this will turn around
@@ -370,9 +368,9 @@ impl<S: Snapshot> BackwardKvScanner<S> {
 mod tests {
     use super::super::ScannerBuilder;
     use super::*;
+    use crate::storage::kv::{Engine, TestEngineBuilder};
     use crate::storage::mvcc::tests::*;
     use crate::storage::Scanner;
-    use crate::storage::{Engine, TestEngineBuilder};
     use kvproto::kvrpcpb::Context;
 
     #[test]

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -4,13 +4,11 @@ use std::cmp::Ordering;
 
 use engine::CF_DEFAULT;
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, TimeStamp, Value, WriteRef, WriteType};
-
-use crate::storage::kv::SEEK_BOUND;
-use crate::storage::mvcc::Result;
-use crate::storage::{Cursor, Lock, Snapshot, Statistics};
+use txn_types::{Key, Lock, TimeStamp, Value, WriteRef, WriteType};
 
 use super::ScannerConfig;
+use crate::storage::kv::{Cursor, Snapshot, Statistics, SEEK_BOUND};
+use crate::storage::mvcc::Result;
 
 /// Defines the behavior of the scanner.
 pub trait ScanPolicy<S: Snapshot> {
@@ -429,9 +427,9 @@ pub type ForwardKvScanner<S> = ForwardScanner<S, LatestKvPolicy>;
 mod tests {
     use super::super::ScannerBuilder;
     use super::*;
+    use crate::storage::kv::{Engine, TestEngineBuilder};
     use crate::storage::mvcc::tests::*;
     use crate::storage::Scanner;
-    use crate::storage::{Engine, TestEngineBuilder};
 
     use kvproto::kvrpcpb::Context;
 

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -10,12 +10,11 @@ use txn_types::{Key, TimeStamp, TsSet, Value};
 
 use self::backward::BackwardKvScanner;
 use self::forward::{ForwardKvScanner, ForwardScanner, LatestKvPolicy};
-use crate::storage::mvcc::{default_not_found_error, Result};
-use crate::storage::txn::Result as TxnResult;
-use crate::storage::{
-    CfStatistics, Cursor, CursorBuilder, Iterator, ScanMode, Scanner as StoreScanner, Snapshot,
-    Statistics,
+use crate::storage::kv::{
+    CfStatistics, Cursor, CursorBuilder, Iterator, ScanMode, Snapshot, Statistics,
 };
+use crate::storage::mvcc::{default_not_found_error, Result};
+use crate::storage::txn::{Result as TxnResult, Scanner as StoreScanner};
 
 pub use self::txn_entry::Scanner as EntryScanner;
 
@@ -276,12 +275,10 @@ pub fn has_data_in_range<S: Snapshot>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::kv::Engine;
+    use crate::storage::kv::{Engine, RocksEngine, TestEngineBuilder};
     use crate::storage::mvcc::tests::*;
     use crate::storage::mvcc::{Error as MvccError, ErrorInner as MvccErrorInner};
     use crate::storage::txn::{Error as TxnError, ErrorInner as TxnErrorInner};
-    use crate::storage::RocksEngine;
-    use crate::storage::TestEngineBuilder;
     use kvproto::kvrpcpb::Context;
 
     // Collect data from the scanner and assert it equals to `expected`, which is a collection of

--- a/src/storage/mvcc/reader/scanner/txn_entry.rs
+++ b/src/storage/mvcc/reader/scanner/txn_entry.rs
@@ -5,14 +5,12 @@
 use std::cmp::Ordering;
 
 use kvproto::kvrpcpb::IsolationLevel;
-use txn_types::{Key, TimeStamp, Write, WriteRef, WriteType};
-
-use crate::storage::kv::SEEK_BOUND;
-use crate::storage::mvcc::{Error, Result};
-use crate::storage::txn::{Result as TxnResult, TxnEntry, TxnEntryScanner};
-use crate::storage::{Cursor, Lock, Snapshot, Statistics};
+use txn_types::{Key, Lock, TimeStamp, Write, WriteRef, WriteType};
 
 use super::ScannerConfig;
+use crate::storage::kv::{Cursor, Snapshot, Statistics, SEEK_BOUND};
+use crate::storage::mvcc::{Error, Result};
+use crate::storage::txn::{Result as TxnResult, TxnEntry, TxnEntryScanner};
 
 /// A dedicate scanner that outputs content in each CF.
 ///
@@ -366,8 +364,8 @@ impl<S: Snapshot> Scanner<S> {
 mod tests {
     use super::super::ScannerBuilder;
     use super::*;
+    use crate::storage::kv::{Engine, TestEngineBuilder};
     use crate::storage::mvcc::tests::*;
-    use crate::storage::{Engine, TestEngineBuilder};
 
     use kvproto::kvrpcpb::Context;
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -1,10 +1,12 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::metrics::*;
-use super::reader::MvccReader;
-use super::{ErrorInner, Result};
-use crate::storage::kv::{Modify, ScanMode, Snapshot};
-use crate::storage::{Options, Statistics, TxnStatus, CF_DEFAULT, CF_LOCK, CF_WRITE};
+use crate::storage::kv::{Modify, ScanMode, Snapshot, Statistics};
+use crate::storage::mvcc::metrics::*;
+use crate::storage::mvcc::reader::MvccReader;
+use crate::storage::mvcc::{ErrorInner, Result};
+use crate::storage::txn::commands::Options;
+use crate::storage::types::TxnStatus;
+use engine::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::IsolationLevel;
 use std::fmt;
 use txn_types::{
@@ -825,10 +827,9 @@ macro_rules! new_txn {
 mod tests {
     use super::*;
 
-    use crate::storage::kv::Engine;
+    use crate::storage::kv::{Engine, TestEngineBuilder};
     use crate::storage::mvcc::tests::*;
     use crate::storage::mvcc::{Error, ErrorInner, MvccReader};
-    use crate::storage::TestEngineBuilder;
     use kvproto::kvrpcpb::Context;
     use txn_types::{TimeStamp, SHORT_VALUE_MAX_LEN};
 

--- a/src/storage/readpool_impl.rs
+++ b/src/storage/readpool_impl.rs
@@ -8,8 +8,9 @@ use std::time::Duration;
 use prometheus::local::*;
 
 use crate::config::StorageReadPoolConfig;
-use crate::storage::kv::{destroy_tls_engine, set_tls_engine};
-use crate::storage::{FlowStatistics, FlowStatsReporter, Statistics};
+use crate::storage::kv::{
+    destroy_tls_engine, set_tls_engine, FlowStatistics, FlowStatsReporter, Statistics,
+};
 use tikv_util::collections::HashMap;
 use tikv_util::future_pool::{Builder, Config, FuturePool};
 
@@ -188,9 +189,7 @@ pub fn tls_collect_scan_details(cmd: &'static str, stats: &Statistics) {
 pub fn tls_collect_read_flow(region_id: u64, statistics: &Statistics) {
     TLS_STORAGE_METRICS.with(|m| {
         let map = &mut m.borrow_mut().local_read_flow_stats;
-        let flow_stats = map
-            .entry(region_id)
-            .or_insert_with(crate::storage::FlowStatistics::default);
+        let flow_stats = map.entry(region_id).or_insert_with(FlowStatistics::default);
         flow_stats.add(&statistics.write.flow_stats);
         flow_stats.add(&statistics.data.flow_stats);
     });

--- a/src/storage/txn/commands.rs
+++ b/src/storage/txn/commands.rs
@@ -10,10 +10,10 @@ use crate::storage::metrics::{self, CommandPriority};
 
 /// Get a single value.
 pub struct PointGetCommand {
-    pub(super) ctx: Context,
-    pub(super) key: Key,
+    pub ctx: Context,
+    pub key: Key,
     /// None if this is a raw get, Some if this is a transactional get.
-    pub(super) ts: Option<TimeStamp>,
+    pub ts: Option<TimeStamp>,
 }
 
 impl PointGetCommand {

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -10,7 +10,10 @@ mod latch;
 mod process;
 mod store;
 
-use crate::storage::{Error as StorageError, MvccInfo, Result as StorageResult, TxnStatus};
+use crate::storage::{
+    types::{MvccInfo, TxnStatus},
+    Error as StorageError, Result as StorageResult,
+};
 use kvproto::kvrpcpb::LockInfo;
 use std::error;
 use std::fmt;

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -2,23 +2,39 @@
 
 //! Storage Transactions
 
-mod latch;
-mod process;
+pub mod commands;
 pub mod sched_pool;
 pub mod scheduler;
+
+mod latch;
+mod process;
 mod store;
 
+use crate::storage::{Error as StorageError, MvccInfo, Result as StorageResult, TxnStatus};
+use kvproto::kvrpcpb::LockInfo;
 use std::error;
 use std::fmt;
 use std::io::Error as IoError;
+use txn_types::{Key, TimeStamp};
 
-use crate::storage::mvcc::TimeStamp;
-
+pub use self::commands::{Command, CommandKind, Options, PointGetCommand};
 pub use self::process::RESOLVE_LOCK_BATCH_SIZE;
 pub use self::scheduler::{Msg, Scheduler};
 pub use self::store::{EntryBatch, TxnEntry, TxnEntryScanner, TxnEntryStore};
 pub use self::store::{FixtureStore, FixtureStoreScanner};
 pub use self::store::{Scanner, SnapshotStore, Store};
+
+/// Process result of a command.
+pub enum ProcessResult {
+    Res,
+    MultiRes { results: Vec<StorageResult<()>> },
+    MvccKey { mvcc: MvccInfo },
+    MvccStartTs { mvcc: Option<(Key, MvccInfo)> },
+    Locks { locks: Vec<LockInfo> },
+    TxnStatus { txn_status: TxnStatus },
+    NextCommand { cmd: Command },
+    Failed { err: StorageError },
+}
 
 quick_error! {
     #[derive(Debug)]

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -16,11 +16,12 @@ use crate::storage::mvcc::{
     has_data_in_range, Error as MvccError, ErrorInner as MvccErrorInner, Lock as MvccLock,
     MvccReader, MvccTxn, TimeStamp, Write, MAX_TXN_WRITE_SIZE,
 };
-use crate::storage::txn::{sched_pool::*, scheduler::Msg, Error, ErrorInner, Result};
-use crate::storage::types::ProcessResult;
+use crate::storage::txn::{
+    sched_pool::*, scheduler::Msg, Command, CommandKind, Error, ErrorInner, ProcessResult, Result,
+};
 use crate::storage::{
     metrics::{self, KV_COMMAND_KEYWRITE_HISTOGRAM_VEC, SCHED_STAGE_COUNTER_VEC},
-    Command, CommandKind, Engine, Error as StorageError, ErrorInner as StorageErrorInner, MvccInfo,
+    Engine, Error as StorageError, ErrorInner as StorageErrorInner, MvccInfo,
     Result as StorageResult, ScanMode, Snapshot, Statistics, TxnStatus,
 };
 use engine::CF_WRITE;

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -9,8 +9,10 @@ use futures::future;
 use kvproto::kvrpcpb::{CommandPri, Context, LockInfo};
 use txn_types::{Key, Value};
 
-use crate::storage::kv::with_tls_engine;
-use crate::storage::kv::{CbContext, Modify, Result as EngineResult};
+use crate::storage::kv::{
+    with_tls_engine, CbContext, Engine, Modify, Result as EngineResult, ScanMode, Snapshot,
+    Statistics,
+};
 use crate::storage::lock_manager::{self, Lock, LockManager};
 use crate::storage::mvcc::{
     has_data_in_range, Error as MvccError, ErrorInner as MvccErrorInner, Lock as MvccLock,
@@ -21,8 +23,8 @@ use crate::storage::txn::{
 };
 use crate::storage::{
     metrics::{self, KV_COMMAND_KEYWRITE_HISTOGRAM_VEC, SCHED_STAGE_COUNTER_VEC},
-    Engine, Error as StorageError, ErrorInner as StorageErrorInner, MvccInfo,
-    Result as StorageResult, ScanMode, Snapshot, Statistics, TxnStatus,
+    types::{MvccInfo, TxnStatus},
+    Error as StorageError, ErrorInner as StorageErrorInner, Result as StorageResult,
 };
 use engine::CF_WRITE;
 use tikv_util::collections::HashMap;

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -9,9 +9,8 @@ use tikv_util::collections::HashMap;
 use tikv_util::future_pool::Builder as FuturePoolBuilder;
 use tikv_util::future_pool::FuturePool;
 
-use crate::storage::kv::{destroy_tls_engine, set_tls_engine};
+use crate::storage::kv::{destroy_tls_engine, set_tls_engine, Engine, Statistics};
 use crate::storage::metrics::*;
-use crate::storage::{Engine, Statistics};
 
 pub struct SchedLocalMetrics {
     local_scan_details: HashMap<&'static str, Statistics>,

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -38,13 +38,13 @@ use crate::storage::metrics::{
     SCHED_LATCH_HISTOGRAM_VEC, SCHED_STAGE_COUNTER_VEC, SCHED_TOO_BUSY_COUNTER_VEC,
     SCHED_WRITING_BYTES_GAUGE,
 };
+use crate::storage::txn::commands::{Command, CommandKind};
 use crate::storage::txn::latch::{Latches, Lock};
 use crate::storage::txn::process::{Executor, MsgScheduler, Task};
 use crate::storage::txn::sched_pool::SchedPool;
-use crate::storage::txn::Error;
+use crate::storage::txn::{Error, ProcessResult};
 use crate::storage::{
-    Command, CommandKind, Engine, Error as StorageError, ErrorInner as StorageErrorInner,
-    ProcessResult, StorageCallback, TimeStamp,
+    Engine, Error as StorageError, ErrorInner as StorageErrorInner, StorageCallback, TimeStamp,
 };
 
 const TASKS_SLOTS_NUM: usize = 1 << 12; // 4096 slots.

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -29,22 +29,24 @@ use std::u64;
 use kvproto::kvrpcpb::CommandPri;
 use prometheus::HistogramTimer;
 use tikv_util::{collections::HashMap, time::SlowTimer};
-use txn_types::Key;
+use txn_types::{Key, TimeStamp};
 
-use crate::storage::kv::{with_tls_engine, Result as EngineResult};
+use crate::storage::kv::{with_tls_engine, Engine, Result as EngineResult};
 use crate::storage::lock_manager::{self, LockManager};
 use crate::storage::metrics::{
     self, SCHED_COMMANDS_PRI_COUNTER_VEC_STATIC, SCHED_CONTEX_GAUGE, SCHED_HISTOGRAM_VEC_STATIC,
     SCHED_LATCH_HISTOGRAM_VEC, SCHED_STAGE_COUNTER_VEC, SCHED_TOO_BUSY_COUNTER_VEC,
     SCHED_WRITING_BYTES_GAUGE,
 };
-use crate::storage::txn::commands::{Command, CommandKind};
-use crate::storage::txn::latch::{Latches, Lock};
-use crate::storage::txn::process::{Executor, MsgScheduler, Task};
-use crate::storage::txn::sched_pool::SchedPool;
-use crate::storage::txn::{Error, ProcessResult};
+use crate::storage::txn::{
+    commands::{Command, CommandKind},
+    latch::{Latches, Lock},
+    process::{Executor, MsgScheduler, Task},
+    sched_pool::SchedPool,
+    Error, ProcessResult,
+};
 use crate::storage::{
-    Engine, Error as StorageError, ErrorInner as StorageErrorInner, StorageCallback, TimeStamp,
+    types::StorageCallback, Error as StorageError, ErrorInner as StorageErrorInner,
 };
 
 const TASKS_SLOTS_NUM: usize = 1 << 12; // 4096 slots.
@@ -534,9 +536,9 @@ fn gen_command_lock(latches: &Latches, cmd: &Command) -> Lock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::mvcc;
+    use crate::storage::mvcc::{self, Mutation};
+    use crate::storage::txn::commands::Options;
     use crate::storage::txn::latch::*;
-    use crate::storage::{Mutation, Options};
     use kvproto::kvrpcpb::Context;
 
     #[test]

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -2,16 +2,14 @@
 
 use kvproto::kvrpcpb::IsolationLevel;
 
+use super::{Error, ErrorInner, Result};
+use crate::storage::kv::{Snapshot, Statistics};
 use crate::storage::metrics::*;
 use crate::storage::mvcc::{
-    EntryScanner, Error as MvccError, ErrorInner as MvccErrorInner, Scanner as MvccScanner,
-    ScannerBuilder, WriteRef,
+    EntryScanner, Error as MvccError, ErrorInner as MvccErrorInner, PointGetter,
+    PointGetterBuilder, Scanner as MvccScanner, ScannerBuilder,
 };
-use crate::storage::mvcc::{PointGetter, PointGetterBuilder};
-use crate::storage::{Snapshot, Statistics};
-use txn_types::{Key, KvPair, TimeStamp, TsSet, Value};
-
-use super::{Error, ErrorInner, Result};
+use txn_types::{Key, KvPair, TimeStamp, TsSet, Value, WriteRef};
 
 pub trait Store: Send {
     /// The scanner type returned by `scanner()`.
@@ -516,11 +514,12 @@ impl Scanner for FixtureStoreScanner {
 mod tests {
     use super::*;
     use crate::storage::kv::{
-        Engine, Result as EngineResult, RocksEngine, RocksSnapshot, ScanMode,
+        Cursor, Engine, Iterator, Result as EngineResult, RocksEngine, RocksSnapshot, ScanMode,
+        TestEngineBuilder,
     };
-    use crate::storage::mvcc::MvccTxn;
-    use crate::storage::{CfName, Cursor, Iterator, Mutation, Options, TestEngineBuilder};
-    use engine::IterOption;
+    use crate::storage::mvcc::{Mutation, MvccTxn};
+    use crate::storage::txn::commands::Options;
+    use engine::{CfName, IterOption};
     use kvproto::kvrpcpb::Context;
 
     const KEY_PREFIX: &str = "key_prefix";

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -4,7 +4,8 @@
 
 use crate::storage::{
     mvcc::{Lock, TimeStamp, Write},
-    Callback, Command, Error as StorageError, Result,
+    txn::ProcessResult,
+    Callback, Result,
 };
 use kvproto::kvrpcpb::LockInfo;
 use std::fmt::Debug;
@@ -59,18 +60,6 @@ pub enum StorageCallback {
     MvccInfoByStartTs(Callback<Option<(Key, MvccInfo)>>),
     Locks(Callback<Vec<LockInfo>>),
     TxnStatus(Callback<TxnStatus>),
-}
-
-/// Process result of a command.
-pub enum ProcessResult {
-    Res,
-    MultiRes { results: Vec<Result<()>> },
-    MvccKey { mvcc: MvccInfo },
-    MvccStartTs { mvcc: Option<(Key, MvccInfo)> },
-    Locks { locks: Vec<LockInfo> },
-    TxnStatus { txn_status: TxnStatus },
-    NextCommand { cmd: Command },
-    Failed { err: StorageError },
 }
 
 impl StorageCallback {

--- a/tests/benches/coprocessor_executors/util/store.rs
+++ b/tests/benches/coprocessor_executors/util/store.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use tikv::storage::kv::RocksSnapshot;
-use tikv::storage::txn::{FixtureStore, SnapshotStore};
+use tikv::storage::txn::{FixtureStore, SnapshotStore, Store};
 
 /// `MemStore` is a store provider that operates directly over a BTreeMap.
 pub type MemStore = FixtureStore;
@@ -14,7 +14,7 @@ pub trait StoreDescriber {
     fn name() -> String;
 }
 
-impl<S: tikv::storage::Store> StoreDescriber for S {
+impl<S: Store> StoreDescriber for S {
     default fn name() -> String {
         unimplemented!()
     }


### PR DESCRIPTION
###  What have you changed?

Move `commands` and `ProcessResult` from the root of `storage` to `txn` where they are used. Reorganises imports so that items are imported from where they are declared rather than re-exports, etc.

Extracted from #6203

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

PTAL @AndreMouche  @sticnarf 
