### PR TITLE
tests: fix protobuf_codec typo

### DIFF
--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -157,7 +157,7 @@ fn test_node_merge_with_slow_learner() {
 
 /// Test whether merge will be aborted if prerequisites is not met.
 // FIXME(nrc) failing on CI only
-#[cfg(feature = "protobuf_codec")]
+#[cfg(feature = "protobuf-codec")]
 #[test]
 fn test_node_merge_prerequisites_check() {
     let mut cluster = new_node_cluster(0, 3);

--- a/tests/integrations/raftstore/test_prevote.rs
+++ b/tests/integrations/raftstore/test_prevote.rs
@@ -213,7 +213,7 @@ fn test_prevote_reboot_minority_followers() {
 }
 
 // Test isolating a minority of the cluster and make sure that the remove themselves.
-#[cfg(feature = "protobuf_codec")]
+#[cfg(feature = "protobuf-codec")]
 fn test_pair_isolated<T: Simulator>(cluster: &mut Cluster<T>) {
     let region = 1;
     let pd_client = Arc::clone(&cluster.pd_client);
@@ -234,7 +234,7 @@ fn test_pair_isolated<T: Simulator>(cluster: &mut Cluster<T>) {
 }
 
 // FIXME(nrc) failing on CI only
-#[cfg(feature = "protobuf_codec")]
+#[cfg(feature = "protobuf-codec")]
 #[test]
 fn test_server_pair_isolated() {
     let mut cluster = new_server_cluster(0, 5);

--- a/tests/integrations/raftstore/test_region_heartbeat.rs
+++ b/tests/integrations/raftstore/test_region_heartbeat.rs
@@ -181,7 +181,7 @@ fn test_region_heartbeat_timestamp() {
 }
 
 // FIXME(nrc) failing on CI only
-#[cfg(feature = "protobuf_codec")]
+#[cfg(feature = "protobuf-codec")]
 #[test]
 fn test_region_heartbeat_term() {
     let mut cluster = new_server_cluster(0, 3);


### PR DESCRIPTION
###  What have you changed?

Fix a typo in `cfg(feature)`, using an underscore rather than a hyphen.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

PTAL @breeswish @overvenus 
