### PR TITLE
copr: separate expression signature `Upper` to `Upper` and `UpperUtf8`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#44f75c9bef33cef5c39e0e0e4fed71b15c735313"
+source = "git+https://github.com/pingcap/tipb.git#568726749cb746b365cca389ceb4043ca6a2f250"
 dependencies = [
  "bytes 0.4.12",
  "lazy_static",

--- a/components/tidb_query/src/expr/builtin_string.rs
+++ b/components/tidb_query/src/expr/builtin_string.rs
@@ -319,17 +319,23 @@ impl ScalarFunc {
     }
 
     #[inline]
+    pub fn upper_utf8<'a, 'b: 'a>(
+        &'b self,
+        ctx: &mut EvalContext,
+        row: &'a [Datum],
+    ) -> Result<Option<Cow<'a, [u8]>>> {
+        let s = try_opt!(self.children[0].eval_string_and_decode(ctx, row));
+        Ok(Some(Cow::Owned(s.to_uppercase().into_bytes())))
+    }
+
+    #[inline]
     pub fn upper<'a, 'b: 'a>(
         &'b self,
         ctx: &mut EvalContext,
         row: &'a [Datum],
     ) -> Result<Option<Cow<'a, [u8]>>> {
-        if self.children[0].field_type().is_binary_string_like() {
-            let s = try_opt!(self.children[0].eval_string(ctx, row));
-            return Ok(Some(s));
-        }
-        let s = try_opt!(self.children[0].eval_string_and_decode(ctx, row));
-        Ok(Some(Cow::Owned(s.to_uppercase().into_bytes())))
+        let s = try_opt!(self.children[0].eval_string(ctx, row));
+        Ok(Some(s))
     }
 
     #[inline]
@@ -1733,8 +1739,7 @@ mod tests {
     }
 
     #[test]
-    fn test_upper() {
-        // Test non-binary string case
+    fn test_upper_utf8() {
         let cases = vec![
             (
                 Datum::Bytes(b"hello".to_vec()),
@@ -1763,13 +1768,15 @@ mod tests {
         let mut ctx = EvalContext::default();
         for (input, exp) in cases {
             let input = datum_expr(input);
-            let op = scalar_func_expr(ScalarFuncSig::Upper, &[input]);
+            let op = scalar_func_expr(ScalarFuncSig::UpperUtf8, &[input]);
             let op = Expression::build(&mut ctx, op).unwrap();
             let got = op.eval(&mut ctx, &[]).unwrap();
             assert_eq!(got, exp);
         }
+    }
 
-        // Test binary string case
+    #[test]
+    fn test_upper() {
         let cases = vec![
             (
                 Datum::Bytes(b"hello".to_vec()),

--- a/components/tidb_query/src/expr/scalar_function.rs
+++ b/components/tidb_query/src/expr/scalar_function.rs
@@ -254,6 +254,7 @@ impl ScalarFunc {
             | ScalarFuncSig::ReverseUtf8
             | ScalarFuncSig::Reverse
             | ScalarFuncSig::Quote
+            | ScalarFuncSig::UpperUtf8
             | ScalarFuncSig::Upper
             | ScalarFuncSig::Lower
             | ScalarFuncSig::Length
@@ -989,6 +990,7 @@ dispatch_call! {
         RightUtf8 => right_utf8,
         Left => left,
         Right => right,
+        UpperUtf8 => upper_utf8,
         Upper => upper,
         Lower => lower,
         DateFormatSig => date_format,
@@ -1378,6 +1380,7 @@ mod tests {
                     ScalarFuncSig::ReverseUtf8,
                     ScalarFuncSig::Reverse,
                     ScalarFuncSig::Lower,
+                    ScalarFuncSig::UpperUtf8,
                     ScalarFuncSig::Upper,
                     ScalarFuncSig::IsIPv4,
                     ScalarFuncSig::IsIPv4Compat,

--- a/components/tidb_query/src/rpn_expr/impl_string.rs
+++ b/components/tidb_query/src/rpn_expr/impl_string.rs
@@ -4,7 +4,6 @@ use std::str;
 use tidb_query_codegen::rpn_fn;
 
 use crate::codec::data_type::*;
-use crate::rpn_expr::types::RpnFnCallExtra;
 use crate::Result;
 use tidb_query_datatype::*;
 
@@ -236,22 +235,22 @@ pub fn right_utf8(lhs: &Option<Bytes>, rhs: &Option<Int>) -> Result<Option<Bytes
     }
 }
 
-#[rpn_fn(capture = [extra])]
+#[rpn_fn]
 #[inline]
-pub fn upper(extra: &RpnFnCallExtra, arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn upper_utf8(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
     match arg.as_ref() {
-        Some(bytes) => {
-            if extra.ret_field_type.as_accessor().is_binary_string_like() {
-                return Ok(Some(bytes.to_vec()));
-            }
-
-            match str::from_utf8(bytes) {
-                Ok(s) => Ok(Some(s.to_uppercase().into_bytes())),
-                Err(err) => Err(box_err!("invalid input value: {:?}", err)),
-            }
-        }
+        Some(bytes) => match str::from_utf8(bytes) {
+            Ok(s) => Ok(Some(s.to_uppercase().into_bytes())),
+            Err(err) => Err(box_err!("invalid input value: {:?}", err)),
+        },
         _ => Ok(None),
     }
+}
+
+#[rpn_fn]
+#[inline]
+pub fn upper(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+    Ok(arg.as_ref().map(|b| b.to_vec()))
 }
 
 #[rpn_fn]
@@ -395,7 +394,7 @@ mod tests {
     use super::*;
 
     use std::{f64, i64};
-    use tipb::{FieldType, ScalarFuncSig};
+    use tipb::ScalarFuncSig;
 
     use crate::rpn_expr::types::test_util::RpnFnScalarEvaluator;
 
@@ -1079,7 +1078,7 @@ mod tests {
     }
 
     #[test]
-    fn test_upper() {
+    fn test_upper_utf8() {
         let cases = vec![
             (Some(b"hello".to_vec()), Some(b"HELLO".to_vec())),
             (Some(b"123".to_vec()), Some(b"123".to_vec())),
@@ -1103,24 +1102,44 @@ mod tests {
         ];
 
         for (arg, exp) in cases {
-            // Test binary string case
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(arg.clone())
+                .evaluate(ScalarFuncSig::UpperUtf8)
+                .unwrap();
+            assert_eq!(output, exp);
+        }
+    }
+
+    #[test]
+    fn test_upper() {
+        let cases = vec![
+            (Some(b"hello".to_vec()), Some(b"hello".to_vec())),
+            (Some(b"123".to_vec()), Some(b"123".to_vec())),
+            (
+                Some("café".as_bytes().to_vec()),
+                Some("café".as_bytes().to_vec()),
+            ),
+            (
+                Some("数据库".as_bytes().to_vec()),
+                Some("数据库".as_bytes().to_vec()),
+            ),
+            (
+                Some("ночь на окраине москвы".as_bytes().to_vec()),
+                Some("ночь на окраине москвы".as_bytes().to_vec()),
+            ),
+            (
+                Some("قاعدة البيانات".as_bytes().to_vec()),
+                Some("قاعدة البيانات".as_bytes().to_vec()),
+            ),
+            (None, None),
+        ];
+
+        for (arg, exp) in cases {
             let output = RpnFnScalarEvaluator::new()
                 .push_param(arg.clone())
                 .evaluate(ScalarFuncSig::Upper)
                 .unwrap();
             assert_eq!(output, exp);
-
-            // Test non-binary string case
-            let mut ft = FieldType::default();
-            ft.as_mut_accessor()
-                .set_tp(FieldTypeTp::String)
-                .set_collation(Collation::Binary);
-            let output = RpnFnScalarEvaluator::new()
-                .push_param(arg.clone())
-                .return_field_type(ft)
-                .evaluate(ScalarFuncSig::Upper)
-                .unwrap();
-            assert_eq!(output, arg);
         }
     }
 

--- a/components/tidb_query/src/rpn_expr/mod.rs
+++ b/components/tidb_query/src/rpn_expr/mod.rs
@@ -447,6 +447,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::LeftUtf8 => left_utf8_fn_meta(),
         ScalarFuncSig::Right => right_fn_meta(),
         ScalarFuncSig::RightUtf8 => right_utf8_fn_meta(),
+        ScalarFuncSig::UpperUtf8 => upper_utf8_fn_meta(),
         ScalarFuncSig::Upper => upper_fn_meta(),
         ScalarFuncSig::Locate2Args => locate_2_args_fn_meta(),
         ScalarFuncSig::Locate3Args => locate_3_args_fn_meta(),


### PR DESCRIPTION
Signed-off-by: wangwangwar <wangwangwar@gmail.com>

### What have you changed?

Separate expression signatuer `Upper` to `Upper` and `UpperUtf8`.

### What is the type of the changes?

Improvement

### How is the PR tested?

- Unit test
- Integration test

### Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No. It should not change the behavior.

### Does this PR affect tidb-ansible?

No

###  Refer to a related PR or issue link (optional)


###  Benchmark result if necessary (optional)

###  Any examples? (optional)


