### PR TITLE
raftstore/apply: skip notification for synchronous destroy

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -499,7 +499,12 @@ impl Peer {
             );
             return None;
         }
+        // If initialized is false, it implicitly means applyfsm does not exist now.
         let initialized = self.get_store().is_initialized();
+        // If async_remove is true, it means peerfsm needs to be removed after its
+        // corresponding applyfsm was removed.
+        // If it is false, it means either applyfsm does not exist or there is no task
+        // in applyfsm so it's ok to remove peerfsm immediately.
         let async_remove = if self.is_applying_snapshot() {
             if !self.mut_store().cancel_applying_snap() {
                 info!(

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -567,6 +567,7 @@ impl Runner {
 
     /// Tries to apply pending tasks if there is some.
     fn handle_pending_applies(&mut self) {
+        fail_point!("apply_pending_snapshot", |_| {});
         while !self.pending_applies.is_empty() {
             // should not handle too many applies than the number of files that can be ingested.
             // check level 0 every time because we can not make sure how does the number of level 0 files change.

--- a/tests/failpoints/cases/test_snap.rs
+++ b/tests/failpoints/cases/test_snap.rs
@@ -217,3 +217,61 @@ fn assert_snapshot(snap_dir: &str, region_id: u64, exist: bool) {
         }
     }
 }
+
+// A peer on store 3 is isolated and is applying snapshot. (add failpoint so it's always pending)
+// Then two conf change happens, this peer is removed and a new peer is added on store 3.
+// Then isolation clear, this peer will be destroyed because of a bigger peer id in msg.
+// Peerfsm can be destroyed synchronously because snapshot state is pending and can be canceled.
+// I.e. async_remove is false.
+#[test]
+fn test_destroy_peer_on_pending_snapshot() {
+    let _guard = crate::setup();
+
+    let mut cluster = new_server_cluster(0, 4);
+    configure_for_snapshot(&mut cluster);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let r1 = cluster.run_conf_change();
+    pd_client.must_add_peer(r1, new_peer(2, 2));
+    pd_client.must_add_peer(r1, new_peer(3, 3));
+
+    cluster.must_put(b"k1", b"v1");
+    // Ensure peer 3 is initialized.
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+
+    cluster.add_send_filter(IsolationFilterFactory::new(3));
+
+    for i in 0..20 {
+        cluster.must_put(format!("k1{}", i).as_bytes(), b"v1");
+    }
+
+    let apply_snapshot_fp = "apply_pending_snapshot";
+    fail::cfg(apply_snapshot_fp, "return()").unwrap();
+
+    cluster.clear_send_filters();
+    // Wait for leader send snapshot.
+    sleep_ms(100);
+
+    cluster.add_send_filter(IsolationFilterFactory::new(3));
+
+    pd_client.must_remove_peer(r1, new_peer(3, 3));
+    pd_client.must_add_peer(r1, new_peer(4, 4));
+
+    pd_client.must_remove_peer(r1, new_peer(4, 4));
+    pd_client.must_add_peer(r1, new_peer(3, 5));
+
+    let destroy_peer_fp = "destroy_peer";
+    fail::cfg(destroy_peer_fp, "pause").unwrap();
+    cluster.clear_send_filters();
+    // Wait for leader send msg to peer 3.
+    // Then destroy peer 3 and create peer 5.
+    sleep_ms(100);
+    fail::remove(destroy_peer_fp);
+
+    fail::remove(apply_snapshot_fp);
+    // After peer 5 has applied snapshot, data should be got.
+    must_get_equal(&cluster.get_engine(3), b"k119", b"v1");
+}


### PR DESCRIPTION
cherry-pick https://github.com/tikv/tikv/pull/6004 to release 3.1

Signed-off-by: Liqi Geng <gengliqiii@gmail.com>

###  What have you changed?

No need to send destroy reply to peerfsm if it will be destroyed synchronously. If not, panic will happen because peerfsm is destroyed twice. 
It rarely happens because a destroy can do synchronously only when an applying snapshot is in the pending state. Also, when applying a snapshot, it is not possible to merge or conf change, the other choices are rare, e.g. peer id in msg is bigger than itself, which needs two conf change.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/issues/5365