### PR TITLE
copr: use memcpy in read/write decimal chunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3682,6 +3682,7 @@ dependencies = [
  "slog",
  "slog-global",
  "smallvec",
+ "static_assertions 1.1.0",
  "tidb_query_codegen",
  "tidb_query_datatype",
  "tikv_util",

--- a/components/tidb_query/Cargo.toml
+++ b/components/tidb_query/Cargo.toml
@@ -50,6 +50,7 @@ tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
 tipb_helper = { path = "../tipb_helper" }
 twoway = "0.2.0"
 uuid = { version = "0.8.1", features = ["v4"] }
+static_assertions = { version = "1.0", features = ["nightly"] }
 
 [dependencies.prometheus]
 git = "https://github.com/pingcap/rust-prometheus.git"

--- a/components/tidb_query/src/codec/mysql/decimal.rs
+++ b/components/tidb_query/src/codec/mysql/decimal.rs
@@ -899,6 +899,8 @@ fn do_mul(lhs: &Decimal, rhs: &Decimal) -> Res<Decimal> {
 /// `DECIMAL_STRUCT_SIZE`is the struct size of `Decimal`.
 pub const DECIMAL_STRUCT_SIZE: usize = 40;
 
+const_assert_eq!(DECIMAL_STRUCT_SIZE, mem::size_of::<Decimal>());
+
 /// `Decimal` represents a decimal value.
 #[repr(C)]
 #[derive(Clone, Debug)]
@@ -2095,7 +2097,6 @@ pub trait DecimalEncoder: NumberEncoder {
     }
 
     fn write_decimal_to_chunk(&mut self, v: &Decimal) -> Result<()> {
-        const_assert_eq!(DECIMAL_STRUCT_SIZE, mem::size_of::<Decimal>());
         let data = unsafe {
             let p = v as *const Decimal as *const u8;
             std::slice::from_raw_parts(p, DECIMAL_STRUCT_SIZE)

--- a/components/tidb_query/src/lib.rs
+++ b/components/tidb_query/src/lib.rs
@@ -19,6 +19,8 @@
 // FIXME: ditto. probably a result of the above
 #![allow(clippy::no_effect)]
 
+#[macro_use]
+extern crate static_assertions;
 #[macro_use(error, debug, warn)]
 extern crate slog_global;
 #[macro_use(box_err, box_try, try_opt)]


### PR DESCRIPTION
PCP https://github.com/tikv/tikv/issues/6282

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

- Use the same memory layout of Decimal as the TiDB's
- Use `memcpy` to read/write Decimal's chunk

###  What is the type of the changes?

Pick one of the following and delete the others:

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?
- Unit test
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No

###  Does this PR affect `tidb-ansible`?
No
###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

