### PR TITLE
Txn: move some commands functionality around.

### DIFF
--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -583,10 +583,16 @@ impl<E: Engine> AssertionStorage<E> {
     pub fn scan_locks_ok(
         &self,
         max_ts: impl Into<TimeStamp>,
-        start_key: Vec<u8>,
+        start_key: &[u8],
         limit: usize,
         expect: Vec<LockInfo>,
     ) {
+        let start_key = if start_key.is_empty() {
+            None
+        } else {
+            Some(Key::from_raw(&start_key))
+        };
+
         assert_eq!(
             self.store
                 .scan_locks(self.ctx.clone(), max_ts.into(), start_key, limit)

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -172,7 +172,7 @@ impl<E: Engine> SyncTestStorage<E> {
     ) -> Result<Vec<Result<()>>> {
         wait_op!(|cb| self.store.sched_txn_command(
             commands::Prewrite::with_context(mutations, primary, start_ts.into(), ctx),
-            cb
+            cb,
         ))
         .unwrap()
     }
@@ -186,7 +186,7 @@ impl<E: Engine> SyncTestStorage<E> {
     ) -> Result<TxnStatus> {
         wait_op!(|cb| self.store.sched_txn_command(
             commands::Commit::new(keys, start_ts.into(), commit_ts.into(), ctx),
-            cb
+            cb,
         ))
         .unwrap()
     }
@@ -200,7 +200,7 @@ impl<E: Engine> SyncTestStorage<E> {
     ) -> Result<()> {
         wait_op!(|cb| self.store.sched_txn_command(
             commands::Cleanup::new(key, start_ts.into(), current_ts.into(), ctx),
-            cb
+            cb,
         ))
         .unwrap()
     }
@@ -213,7 +213,7 @@ impl<E: Engine> SyncTestStorage<E> {
     ) -> Result<()> {
         wait_op!(|cb| self.store.sched_txn_command(
             commands::Rollback::new(keys, start_ts.into().into(), ctx),
-            cb
+            cb,
         ))
         .unwrap()
     }
@@ -222,12 +222,12 @@ impl<E: Engine> SyncTestStorage<E> {
         &self,
         ctx: Context,
         max_ts: impl Into<TimeStamp>,
-        start_key: Vec<u8>,
+        start_key: Option<Key>,
         limit: usize,
     ) -> Result<Vec<LockInfo>> {
         wait_op!(|cb| self.store.sched_txn_command(
-            commands::ScanLock::new(max_ts.into(), &start_key, limit, ctx),
-            cb
+            commands::ScanLock::new(max_ts.into(), start_key, limit, ctx),
+            cb,
         ))
         .unwrap()
     }
@@ -245,7 +245,7 @@ impl<E: Engine> SyncTestStorage<E> {
         );
         wait_op!(|cb| self.store.sched_txn_command(
             commands::ResolveLock::new(txn_status, None, vec![], ctx),
-            cb
+            cb,
         ))
         .unwrap()
     }
@@ -258,7 +258,7 @@ impl<E: Engine> SyncTestStorage<E> {
         let txn_status: HashMap<TimeStamp, TimeStamp> = txns.into_iter().collect();
         wait_op!(|cb| self.store.sched_txn_command(
             commands::ResolveLock::new(txn_status, None, vec![], ctx),
-            cb
+            cb,
         ))
         .unwrap()
     }

--- a/src/server/gc_worker/mod.rs
+++ b/src/server/gc_worker/mod.rs
@@ -2108,16 +2108,16 @@ mod tests {
         let start_ts = start_ts.into();
 
         // Write these data to the storage.
-        wait_op!(|cb| storage.prewrite(
+        wait_op!(|cb| storage.sched_txn_command(
             commands::Prewrite::with_defaults(mutations, primary, start_ts),
-            cb
+            cb,
         ))
         .unwrap()
         .unwrap();
 
         // Commit.
         let keys: Vec<_> = init_keys.iter().map(|k| Key::from_raw(k)).collect();
-        wait_op!(|cb| storage.commit(
+        wait_op!(|cb| storage.sched_txn_command(
             commands::Commit::new(keys, start_ts, commit_ts.into(), Context::default()),
             cb
         ))
@@ -2413,7 +2413,7 @@ mod tests {
 
             let (tx, rx) = channel();
             storage
-                .prewrite(
+                .sched_txn_command(
                     commands::Prewrite::with_defaults(vec![mutation], k, lock_ts.into()),
                     Box::new(move |res| tx.send(res).unwrap()),
                 )

--- a/src/server/gc_worker/mod.rs
+++ b/src/server/gc_worker/mod.rs
@@ -1653,7 +1653,7 @@ mod tests {
         self, Callback as EngineCallback, Modify, Result as EngineResult, TestEngineBuilder,
     };
     use crate::storage::lock_manager::DummyLockManager;
-    use crate::storage::{Storage, TestStorageBuilder};
+    use crate::storage::{txn::commands, Storage, TestStorageBuilder};
     use futures::Future;
     use kvproto::kvrpcpb::Op;
     use kvproto::metapb;
@@ -2109,14 +2109,7 @@ mod tests {
 
         // Write these data to the storage.
         wait_op!(|cb| storage.prewrite(
-            Context::default(),
-            mutations,
-            primary,
-            start_ts,
-            0,
-            false,
-            0,
-            TimeStamp::default(),
+            commands::Prewrite::with_defaults(mutations, primary, start_ts),
             cb
         ))
         .unwrap()
@@ -2124,9 +2117,12 @@ mod tests {
 
         // Commit.
         let keys: Vec<_> = init_keys.iter().map(|k| Key::from_raw(k)).collect();
-        wait_op!(|cb| storage.commit(Context::default(), keys, start_ts, commit_ts.into(), cb))
-            .unwrap()
-            .unwrap();
+        wait_op!(|cb| storage.commit(
+            commands::Commit::new(keys, start_ts, commit_ts.into(), Context::default()),
+            cb
+        ))
+        .unwrap()
+        .unwrap();
 
         // Assert these data is successfully written to the storage.
         check_data(&storage, &data);
@@ -2418,14 +2414,7 @@ mod tests {
             let (tx, rx) = channel();
             storage
                 .prewrite(
-                    Context::default(),
-                    vec![mutation],
-                    k,
-                    lock_ts.into(),
-                    0,
-                    false,
-                    0,
-                    TimeStamp::default(),
+                    commands::Prewrite::with_defaults(vec![mutation], k, lock_ts.into()),
                     Box::new(move |res| tx.send(res).unwrap()),
                 )
                 .unwrap();

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -10,7 +10,7 @@ use crate::server::service::kv::{
     batch_commands_request, batch_commands_response, future_batch_get_command,
     future_raw_batch_get_command, poll_future_notify,
 };
-use crate::storage::{kv::Engine, lock_manager::LockManager, txn::PointGetCommand, Storage};
+use crate::storage::{kv::Engine, lock_manager::LockManager, PointGetCommand, Storage};
 use kvproto::kvrpcpb::*;
 use tikv_util::collections::HashMap;
 use tikv_util::metrics::HistogramReader;

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -430,6 +430,52 @@ impl<T: RaftStoreRouter + 'static, E: Engine, L: LockManager> Tikv for Service<T
         ctx.spawn(future);
     }
 
+    fn mvcc_get_by_key(
+        &mut self,
+        ctx: RpcContext<'_>,
+        req: MvccGetByKeyRequest,
+        sink: UnarySink<MvccGetByKeyResponse>,
+    ) {
+        let timer = GRPC_MSG_HISTOGRAM_VEC.mvcc_get_by_key.start_coarse_timer();
+
+        let future = future_mvcc_get_by_key(&self.storage, req)
+            .and_then(|res| sink.success(res).map_err(Error::from))
+            .map(|_| timer.observe_duration())
+            .map_err(move |e| {
+                debug!("kv rpc failed";
+                    "request" => "mvcc_get_by_key",
+                    "err" => ?e
+                );
+                GRPC_MSG_FAIL_COUNTER.mvcc_get_by_key.inc();
+            });
+
+        ctx.spawn(future);
+    }
+
+    fn mvcc_get_by_start_ts(
+        &mut self,
+        ctx: RpcContext<'_>,
+        req: MvccGetByStartTsRequest,
+        sink: UnarySink<MvccGetByStartTsResponse>,
+    ) {
+        let timer = GRPC_MSG_HISTOGRAM_VEC
+            .mvcc_get_by_start_ts
+            .start_coarse_timer();
+
+        let future = future_mvcc_get_by_start_ts(&self.storage, req)
+            .and_then(|res| sink.success(res).map_err(Error::from))
+            .map(|_| timer.observe_duration())
+            .map_err(move |e| {
+                debug!("kv rpc failed";
+                    "request" => "mvcc_get_by_start_ts",
+                    "err" => ?e
+                );
+                GRPC_MSG_FAIL_COUNTER.mvcc_get_by_start_ts.inc();
+            });
+
+        ctx.spawn(future);
+    }
+
     fn raw_get(
         &mut self,
         ctx: RpcContext<'_>,
@@ -945,87 +991,6 @@ impl<T: RaftStoreRouter + 'static, E: Engine, L: LockManager> Tikv for Service<T
             let status = RpcStatus::new(RpcStatusCode::RESOURCE_EXHAUSTED, Some(err_msg));
             ctx.spawn(sink.fail(status).map_err(|_| ()));
         }
-    }
-
-    fn mvcc_get_by_key(
-        &mut self,
-        ctx: RpcContext<'_>,
-        req: MvccGetByKeyRequest,
-        sink: UnarySink<MvccGetByKeyResponse>,
-    ) {
-        let timer = GRPC_MSG_HISTOGRAM_VEC.mvcc_get_by_key.start_coarse_timer();
-
-        let (cb, f) = paired_future_callback();
-        let res = self.storage.mvcc_by_key(req.into(), cb);
-
-        let future = AndThenWith::new(res, f.map_err(Error::from))
-            .and_then(|v| {
-                let mut resp = MvccGetByKeyResponse::default();
-                if let Some(err) = extract_region_error(&v) {
-                    resp.set_region_error(err);
-                } else {
-                    match v {
-                        Ok(mvcc) => {
-                            resp.set_info(mvcc.into_proto());
-                        }
-                        Err(e) => resp.set_error(format!("{}", e)),
-                    };
-                }
-                sink.success(resp).map_err(Error::from)
-            })
-            .map(|_| timer.observe_duration())
-            .map_err(move |e| {
-                debug!("kv rpc failed";
-                    "request" => "mvcc_get_by_key",
-                    "err" => ?e
-                );
-                GRPC_MSG_FAIL_COUNTER.mvcc_get_by_key.inc();
-            });
-
-        ctx.spawn(future);
-    }
-
-    fn mvcc_get_by_start_ts(
-        &mut self,
-        ctx: RpcContext<'_>,
-        req: MvccGetByStartTsRequest,
-        sink: UnarySink<MvccGetByStartTsResponse>,
-    ) {
-        let timer = GRPC_MSG_HISTOGRAM_VEC
-            .mvcc_get_by_start_ts
-            .start_coarse_timer();
-
-        let (cb, f) = paired_future_callback();
-        let res = self.storage.mvcc_by_start_ts(req.into(), cb);
-
-        let future = AndThenWith::new(res, f.map_err(Error::from))
-            .and_then(|v| {
-                let mut resp = MvccGetByStartTsResponse::default();
-                if let Some(err) = extract_region_error(&v) {
-                    resp.set_region_error(err);
-                } else {
-                    match v {
-                        Ok(Some((k, vv))) => {
-                            resp.set_key(k.into_raw().unwrap());
-                            resp.set_info(vv.into_proto());
-                        }
-                        Ok(None) => {
-                            resp.set_info(Default::default());
-                        }
-                        Err(e) => resp.set_error(format!("{}", e)),
-                    }
-                }
-                sink.success(resp).map_err(Error::from)
-            })
-            .map(|_| timer.observe_duration())
-            .map_err(move |e| {
-                debug!("kv rpc failed";
-                    "request" => "mvcc_get_by_start_ts",
-                    "err" => ?e
-                );
-                GRPC_MSG_FAIL_COUNTER.mvcc_get_by_start_ts.inc();
-            });
-        ctx.spawn(future);
     }
 
     fn split_region(
@@ -1704,7 +1669,7 @@ fn future_prewrite<E: Engine, L: LockManager>(
     req: PrewriteRequest,
 ) -> impl Future<Item = PrewriteResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
-    let res = storage.prewrite(req.into(), cb);
+    let res = storage.sched_txn_command(req.into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
         let mut resp = PrewriteResponse::default();
@@ -1722,7 +1687,7 @@ fn future_acquire_pessimistic_lock<E: Engine, L: LockManager>(
     req: PessimisticLockRequest,
 ) -> impl Future<Item = PessimisticLockResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
-    let res = storage.acquire_pessimistic_lock(req.into(), cb);
+    let res = storage.sched_txn_command(req.into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
         let mut resp = PessimisticLockResponse::default();
@@ -1740,7 +1705,7 @@ fn future_pessimistic_rollback<E: Engine, L: LockManager>(
     req: PessimisticRollbackRequest,
 ) -> impl Future<Item = PessimisticRollbackResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
-    let res = storage.pessimistic_rollback(req.into(), cb);
+    let res = storage.sched_txn_command(req.into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
         let mut resp = PessimisticRollbackResponse::default();
@@ -1758,7 +1723,7 @@ fn future_commit<E: Engine, L: LockManager>(
     req: CommitRequest,
 ) -> impl Future<Item = CommitResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
-    let res = storage.commit(req.into(), cb);
+    let res = storage.sched_txn_command(req.into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
         let mut resp = CommitResponse::default();
@@ -1782,7 +1747,7 @@ fn future_cleanup<E: Engine, L: LockManager>(
     req: CleanupRequest,
 ) -> impl Future<Item = CleanupResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
-    let res = storage.cleanup(req.into(), cb);
+    let res = storage.sched_txn_command(req.into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
         let mut resp = CleanupResponse::default();
@@ -1822,7 +1787,7 @@ fn future_batch_rollback<E: Engine, L: LockManager>(
     req: BatchRollbackRequest,
 ) -> impl Future<Item = BatchRollbackResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
-    let res = storage.rollback(req.into(), cb);
+    let res = storage.sched_txn_command(req.into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
         let mut resp = BatchRollbackResponse::default();
@@ -1840,7 +1805,7 @@ fn future_txn_heart_beat<E: Engine, L: LockManager>(
     req: TxnHeartBeatRequest,
 ) -> impl Future<Item = TxnHeartBeatResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
-    let res = storage.txn_heart_beat(req.into(), cb);
+    let res = storage.sched_txn_command(req.into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
         let mut resp = TxnHeartBeatResponse::default();
@@ -1869,7 +1834,7 @@ fn future_check_txn_status<E: Engine, L: LockManager>(
     let caller_start_ts = req.get_caller_start_ts().into();
 
     let (cb, f) = paired_future_callback();
-    let res = storage.check_txn_status(req.into(), cb);
+    let res = storage.sched_txn_command(req.into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(move |v| {
         let mut resp = CheckTxnStatusResponse::default();
@@ -1906,7 +1871,7 @@ fn future_scan_lock<E: Engine, L: LockManager>(
     req: ScanLockRequest,
 ) -> impl Future<Item = ScanLockResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
-    let res = storage.scan_locks(req.into(), cb);
+    let res = storage.sched_txn_command(req.into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
         let mut resp = ScanLockResponse::default();
@@ -1927,7 +1892,7 @@ fn future_resolve_lock<E: Engine, L: LockManager>(
     req: ResolveLockRequest,
 ) -> impl Future<Item = ResolveLockResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
-    let res = storage.resolve_lock(req.into(), cb);
+    let res = storage.sched_txn_command(req.into(), cb);
 
     AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
         let mut resp = ResolveLockResponse::default();
@@ -1935,6 +1900,56 @@ fn future_resolve_lock<E: Engine, L: LockManager>(
             resp.set_region_error(err);
         } else if let Err(e) = v {
             resp.set_error(extract_key_error(&e));
+        }
+        resp
+    })
+}
+
+fn future_mvcc_get_by_key<E: Engine, L: LockManager>(
+    storage: &Storage<E, L>,
+    req: MvccGetByKeyRequest,
+) -> impl Future<Item = MvccGetByKeyResponse, Error = Error> {
+    let (cb, f) = paired_future_callback();
+    let res = storage.sched_txn_command(req.into(), cb);
+
+    AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
+        let mut resp = MvccGetByKeyResponse::default();
+        if let Some(err) = extract_region_error(&v) {
+            resp.set_region_error(err);
+        } else {
+            match v {
+                Ok(mvcc) => {
+                    resp.set_info(mvcc.into_proto());
+                }
+                Err(e) => resp.set_error(format!("{}", e)),
+            }
+        }
+        resp
+    })
+}
+
+fn future_mvcc_get_by_start_ts<E: Engine, L: LockManager>(
+    storage: &Storage<E, L>,
+    req: MvccGetByStartTsRequest,
+) -> impl Future<Item = MvccGetByStartTsResponse, Error = Error> {
+    let (cb, f) = paired_future_callback();
+    let res = storage.sched_txn_command(req.into(), cb);
+
+    AndThenWith::new(res, f.map_err(Error::from)).map(|v| {
+        let mut resp = MvccGetByStartTsResponse::default();
+        if let Some(err) = extract_region_error(&v) {
+            resp.set_region_error(err);
+        } else {
+            match v {
+                Ok(Some((k, vv))) => {
+                    resp.set_key(k.into_raw().unwrap());
+                    resp.set_info(vv.into_proto());
+                }
+                Ok(None) => {
+                    resp.set_info(Default::default());
+                }
+                Err(e) => resp.set_error(format!("{}", e)),
+            }
         }
         resp
     })

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -21,8 +21,7 @@ use crate::storage::{
     },
     kv::Engine,
     lock_manager::{LockManager, WaitTimeout},
-    txn::PointGetCommand,
-    Storage, TxnStatus,
+    PointGetCommand, Storage, TxnStatus,
 };
 use futures::executor::{self, Notify, Spawn};
 use futures::{future, Async, Future, Sink, Stream};

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -566,8 +566,6 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
     /// If `notify_only` is set, the data will not be immediately deleted, but the operation will
     /// still be replicated via Raft. This is used to notify that the data will be deleted by
     /// `unsafe_destroy_range` soon.
-    ///
-    /// Schedules a [`CommandKind::DeleteRange`].
     pub fn delete_range(
         &self,
         ctx: Context,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -38,16 +38,15 @@ use crate::storage::{
     lock_manager::{DummyLockManager, LockManager, WaitTimeout},
     metrics::*,
     txn::{
-        commands::{self, get_priority_tag, Command},
+        commands::{self, Command},
         scheduler::Scheduler as TxnScheduler,
-        PointGetCommand,
     },
     types::MvccInfo,
 };
 use engine::{CfName, IterOption, ALL_CFS, CF_DEFAULT, DATA_CFS, DATA_KEY_PREFIX_LEN};
 use futures::Future;
 use futures03::prelude::*;
-use kvproto::kvrpcpb::{Context, KeyRange, LockInfo};
+use kvproto::kvrpcpb::{CommandPri, Context, GetRequest, KeyRange, LockInfo, RawGetRequest};
 use rand::prelude::*;
 use std::sync::{atomic, Arc};
 use tikv_util::collections::HashMap;
@@ -557,6 +556,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
             min_commit_ts,
             ctx,
         );
+
         self.schedule(cmd, StorageCallback::Booleans(callback))?;
         KV_COMMAND_COUNTER_VEC_STATIC.prewrite.inc();
         Ok(())
@@ -1376,6 +1376,51 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
         self.schedule(cmd, StorageCallback::MvccInfoByStartTs(callback))?;
         KV_COMMAND_COUNTER_VEC_STATIC.start_ts_mvcc.inc();
         Ok(())
+    }
+}
+
+/// Get a single value.
+pub struct PointGetCommand {
+    pub ctx: Context,
+    pub key: Key,
+    /// None if this is a raw get, Some if this is a transactional get.
+    pub ts: Option<TimeStamp>,
+}
+
+impl PointGetCommand {
+    pub fn from_get(request: &mut GetRequest) -> Self {
+        PointGetCommand {
+            ctx: request.take_context(),
+            key: Key::from_raw(request.get_key()),
+            ts: Some(request.get_version().into()),
+        }
+    }
+
+    pub fn from_raw_get(request: &mut RawGetRequest) -> Self {
+        PointGetCommand {
+            ctx: request.take_context(),
+            // FIXME: It is weird in semantics because the key in the request is actually in the
+            // raw format. We should fix it when the meaning of type `Key` is well defined.
+            key: Key::from_encoded(request.take_key()),
+            ts: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn from_key_ts(key: Key, ts: Option<TimeStamp>) -> Self {
+        PointGetCommand {
+            ctx: Context::default(),
+            key,
+            ts,
+        }
+    }
+}
+
+fn get_priority_tag(priority: CommandPri) -> CommandPriority {
+    match priority {
+        CommandPri::Low => CommandPriority::low,
+        CommandPri::Normal => CommandPriority::normal,
+        CommandPri::High => CommandPriority::high,
     }
 }
 
@@ -4136,5 +4181,35 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
+    }
+
+    #[test]
+    fn test_construct_point_get_command_from_get_request() {
+        let mut context = Context::default();
+        context.set_region_id(1);
+        let raw_key = b"raw_key".to_vec();
+        let version = 10;
+        let mut req = GetRequest::default();
+        req.set_context(context.clone());
+        req.set_key(raw_key.clone());
+        req.set_version(version);
+        let cmd = PointGetCommand::from_get(&mut req);
+        assert_eq!(cmd.ctx, context);
+        assert_eq!(cmd.key, Key::from_raw(&raw_key));
+        assert_eq!(cmd.ts, Some(TimeStamp::new(version)));
+    }
+
+    #[test]
+    fn test_construct_point_get_command_from_raw_get_request() {
+        let mut context = Context::default();
+        context.set_region_id(1);
+        let raw_key = b"raw_key".to_vec();
+        let mut req = RawGetRequest::default();
+        req.set_context(context.clone());
+        req.set_key(raw_key.clone());
+        let cmd = PointGetCommand::from_raw_get(&mut req);
+        assert_eq!(cmd.ctx, context);
+        assert_eq!(cmd.key.into_encoded(), raw_key);
+        assert_eq!(cmd.ts, None);
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3226,14 +3226,14 @@ mod tests {
 
         storage
             .sched_txn_command(
-                commands::ScanLock::new(99.into(), &[], 10, Context::default()),
+                commands::ScanLock::new(99.into(), None, 10, Context::default()),
                 expect_value_callback(tx.clone(), 0, vec![]),
             )
             .unwrap();
         rx.recv().unwrap();
         storage
             .sched_txn_command(
-                commands::ScanLock::new(100.into(), &[], 10, Context::default()),
+                commands::ScanLock::new(100.into(), None, 10, Context::default()),
                 expect_value_callback(
                     tx.clone(),
                     0,
@@ -3244,7 +3244,12 @@ mod tests {
         rx.recv().unwrap();
         storage
             .sched_txn_command(
-                commands::ScanLock::new(100.into(), b"a", 10, Context::default()),
+                commands::ScanLock::new(
+                    100.into(),
+                    Some(Key::from_raw(b"a")),
+                    10,
+                    Context::default(),
+                ),
                 expect_value_callback(
                     tx.clone(),
                     0,
@@ -3255,14 +3260,19 @@ mod tests {
         rx.recv().unwrap();
         storage
             .sched_txn_command(
-                commands::ScanLock::new(100.into(), b"y", 10, Context::default()),
+                commands::ScanLock::new(
+                    100.into(),
+                    Some(Key::from_raw(b"y")),
+                    10,
+                    Context::default(),
+                ),
                 expect_value_callback(tx.clone(), 0, vec![lock_y.clone(), lock_z.clone()]),
             )
             .unwrap();
         rx.recv().unwrap();
         storage
             .sched_txn_command(
-                commands::ScanLock::new(101.into(), &[], 10, Context::default()),
+                commands::ScanLock::new(101.into(), None, 10, Context::default()),
                 expect_value_callback(
                     tx.clone(),
                     0,
@@ -3280,7 +3290,7 @@ mod tests {
         rx.recv().unwrap();
         storage
             .sched_txn_command(
-                commands::ScanLock::new(101.into(), &[], 4, Context::default()),
+                commands::ScanLock::new(101.into(), None, 4, Context::default()),
                 expect_value_callback(
                     tx.clone(),
                     0,
@@ -3291,7 +3301,12 @@ mod tests {
         rx.recv().unwrap();
         storage
             .sched_txn_command(
-                commands::ScanLock::new(101.into(), b"b", 4, Context::default()),
+                commands::ScanLock::new(
+                    101.into(),
+                    Some(Key::from_raw(b"b")),
+                    4,
+                    Context::default(),
+                ),
                 expect_value_callback(
                     tx.clone(),
                     0,
@@ -3307,7 +3322,12 @@ mod tests {
         rx.recv().unwrap();
         storage
             .sched_txn_command(
-                commands::ScanLock::new(101.into(), b"b", 0, Context::default()),
+                commands::ScanLock::new(
+                    101.into(),
+                    Some(Key::from_raw(b"b")),
+                    0,
+                    Context::default(),
+                ),
                 expect_value_callback(tx, 0, vec![lock_b, lock_c, lock_x, lock_y, lock_z]),
             )
             .unwrap();
@@ -3418,7 +3438,7 @@ mod tests {
                 // All locks should be resolved except for a, b and c.
                 storage
                     .sched_txn_command(
-                        commands::ScanLock::new(ts, &[], 0, Context::default()),
+                        commands::ScanLock::new(ts, None, 0, Context::default()),
                         expect_value_callback(
                             tx.clone(),
                             0,
@@ -3479,7 +3499,7 @@ mod tests {
         };
         storage
             .sched_txn_command(
-                commands::ScanLock::new(99.into(), &[], 0, Context::default()),
+                commands::ScanLock::new(99.into(), None, 0, Context::default()),
                 expect_value_callback(tx.clone(), 0, vec![lock_a]),
             )
             .unwrap();
@@ -3540,7 +3560,7 @@ mod tests {
         };
         storage
             .sched_txn_command(
-                commands::ScanLock::new(101.into(), &[], 0, Context::default()),
+                commands::ScanLock::new(101.into(), None, 0, Context::default()),
                 expect_value_callback(tx, 0, vec![lock_a]),
             )
             .unwrap();

--- a/src/storage/txn/commands.rs
+++ b/src/storage/txn/commands.rs
@@ -1,8 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::fmt::{self, Debug, Display, Formatter};
+use std::iter::{self, FromIterator};
 
-use kvproto::kvrpcpb::{CommandPri, Context};
+use kvproto::kvrpcpb::*;
 use tikv_util::collections::HashMap;
 use txn_types::{Key, Lock, Mutation, TimeStamp};
 
@@ -21,6 +22,191 @@ use crate::storage::txn::latch::{self, Latches};
 pub struct Command {
     pub ctx: Context,
     pub kind: CommandKind,
+}
+
+impl From<PrewriteRequest> for Command {
+    fn from(mut req: PrewriteRequest) -> Command {
+        let for_update_ts = req.get_for_update_ts();
+        if for_update_ts == 0 {
+            Prewrite::new(
+                req.take_mutations().into_iter().map(Into::into).collect(),
+                req.take_primary_lock(),
+                req.get_start_version().into(),
+                req.get_lock_ttl(),
+                req.get_skip_constraint_check(),
+                req.get_txn_size(),
+                req.get_min_commit_ts().into(),
+                req.take_context(),
+            )
+        } else {
+            let is_pessimistic_lock = req.take_is_pessimistic_lock();
+            let mutations = req
+                .take_mutations()
+                .into_iter()
+                .map(Into::into)
+                .zip(is_pessimistic_lock.into_iter())
+                .collect();
+            PrewritePessimistic::new(
+                mutations,
+                req.take_primary_lock(),
+                req.get_start_version().into(),
+                req.get_lock_ttl(),
+                for_update_ts.into(),
+                req.get_txn_size(),
+                req.get_min_commit_ts().into(),
+                req.take_context(),
+            )
+        }
+    }
+}
+
+impl From<PessimisticLockRequest> for Command {
+    fn from(mut req: PessimisticLockRequest) -> Command {
+        let keys = req
+            .take_mutations()
+            .into_iter()
+            .map(|x| match x.get_op() {
+                Op::PessimisticLock => (
+                    Key::from_raw(x.get_key()),
+                    x.get_assertion() == Assertion::NotExist,
+                ),
+                _ => panic!("mismatch Op in pessimistic lock mutations"),
+            })
+            .collect();
+
+        AcquirePessimisticLock::new(
+            keys,
+            req.take_primary_lock(),
+            req.get_start_version().into(),
+            req.get_lock_ttl(),
+            req.get_is_first_lock(),
+            req.get_for_update_ts().into(),
+            WaitTimeout::from_encoded(req.get_wait_timeout()),
+            req.take_context(),
+        )
+    }
+}
+
+impl From<CommitRequest> for Command {
+    fn from(mut req: CommitRequest) -> Command {
+        let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
+
+        Commit::new(
+            keys,
+            req.get_start_version().into(),
+            req.get_commit_version().into(),
+            req.take_context(),
+        )
+    }
+}
+
+impl From<CleanupRequest> for Command {
+    fn from(mut req: CleanupRequest) -> Command {
+        Cleanup::new(
+            Key::from_raw(req.get_key()),
+            req.get_start_version().into(),
+            req.get_current_ts().into(),
+            req.take_context(),
+        )
+    }
+}
+
+impl From<BatchRollbackRequest> for Command {
+    fn from(mut req: BatchRollbackRequest) -> Command {
+        let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
+        Rollback::new(keys, req.get_start_version().into(), req.take_context())
+    }
+}
+
+impl From<PessimisticRollbackRequest> for Command {
+    fn from(mut req: PessimisticRollbackRequest) -> Command {
+        let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
+
+        PessimisticRollback::new(
+            keys,
+            req.get_start_version().into(),
+            req.get_for_update_ts().into(),
+            req.take_context(),
+        )
+    }
+}
+
+impl From<TxnHeartBeatRequest> for Command {
+    fn from(mut req: TxnHeartBeatRequest) -> Command {
+        TxnHeartBeat::new(
+            Key::from_raw(req.get_primary_lock()),
+            req.get_start_version().into(),
+            req.get_advise_lock_ttl(),
+            req.take_context(),
+        )
+    }
+}
+
+impl From<CheckTxnStatusRequest> for Command {
+    fn from(mut req: CheckTxnStatusRequest) -> Command {
+        CheckTxnStatus::new(
+            Key::from_raw(req.get_primary_key()),
+            req.get_lock_ts().into(),
+            req.get_caller_start_ts().into(),
+            req.get_current_ts().into(),
+            req.get_rollback_if_not_exist(),
+            req.take_context(),
+        )
+    }
+}
+
+impl From<ScanLockRequest> for Command {
+    fn from(mut req: ScanLockRequest) -> Command {
+        ScanLock::new(
+            req.get_max_version().into(),
+            &req.take_start_key(),
+            req.get_limit() as usize,
+            req.take_context(),
+        )
+    }
+}
+
+impl From<ResolveLockRequest> for Command {
+    fn from(mut req: ResolveLockRequest) -> Command {
+        let resolve_keys: Vec<Key> = req
+            .get_keys()
+            .iter()
+            .map(|key| Key::from_raw(key))
+            .collect();
+        let txn_status = if req.get_start_version() > 0 {
+            HashMap::from_iter(iter::once((
+                req.get_start_version().into(),
+                req.get_commit_version().into(),
+            )))
+        } else {
+            HashMap::from_iter(
+                req.take_txn_infos()
+                    .into_iter()
+                    .map(|info| (info.txn.into(), info.status.into())),
+            )
+        };
+
+        if resolve_keys.is_empty() {
+            ResolveLock::new(txn_status, None, vec![], req.take_context())
+        } else {
+            let start_ts: TimeStamp = req.get_start_version().into();
+            assert!(!start_ts.is_zero());
+            let commit_ts = req.get_commit_version().into();
+            ResolveLockLite::new(start_ts, commit_ts, resolve_keys, req.take_context())
+        }
+    }
+}
+
+impl From<MvccGetByKeyRequest> for Command {
+    fn from(mut req: MvccGetByKeyRequest) -> Command {
+        MvccByKey::new(Key::from_raw(req.get_key()), req.take_context())
+    }
+}
+
+impl From<MvccGetByStartTsRequest> for Command {
+    fn from(mut req: MvccGetByStartTsRequest) -> Command {
+        MvccByStartTs::new(req.get_start_ts().into(), req.take_context())
+    }
 }
 
 /// The prewrite phase of a transaction. The first phase of 2PC.
@@ -65,6 +251,61 @@ impl Prewrite {
             }),
         }
     }
+
+    #[cfg(test)]
+    pub fn with_defaults(
+        mutations: Vec<Mutation>,
+        primary: Vec<u8>,
+        start_ts: TimeStamp,
+    ) -> Command {
+        Prewrite::new(
+            mutations,
+            primary,
+            start_ts,
+            0,
+            false,
+            0,
+            TimeStamp::default(),
+            Context::default(),
+        )
+    }
+
+    #[cfg(test)]
+    pub fn with_lock_ttl(
+        mutations: Vec<Mutation>,
+        primary: Vec<u8>,
+        start_ts: TimeStamp,
+        lock_ttl: u64,
+    ) -> Command {
+        Prewrite::new(
+            mutations,
+            primary,
+            start_ts,
+            lock_ttl,
+            false,
+            0,
+            TimeStamp::default(),
+            Context::default(),
+        )
+    }
+
+    pub fn with_context(
+        mutations: Vec<Mutation>,
+        primary: Vec<u8>,
+        start_ts: TimeStamp,
+        ctx: Context,
+    ) -> Command {
+        Prewrite::new(
+            mutations,
+            primary,
+            start_ts,
+            0,
+            false,
+            0,
+            TimeStamp::default(),
+            ctx,
+        )
+    }
 }
 
 /// The prewrite phase of a transaction using pessimistic locking. The first phase of 2PC.
@@ -86,7 +327,7 @@ pub struct PrewritePessimistic {
 }
 
 impl PrewritePessimistic {
-    pub fn new(
+    fn new(
         mutations: Vec<(Mutation, bool)>,
         primary: Vec<u8>,
         start_ts: TimeStamp,
@@ -335,7 +576,12 @@ pub struct ScanLock {
 }
 
 impl ScanLock {
-    pub fn new(max_ts: TimeStamp, start_key: Option<Key>, limit: usize, ctx: Context) -> Command {
+    pub fn new(max_ts: TimeStamp, start_key: &[u8], limit: usize, ctx: Context) -> Command {
+        let start_key = if start_key.is_empty() {
+            None
+        } else {
+            Some(Key::from_raw(start_key))
+        };
         Command {
             ctx,
             kind: CommandKind::ScanLock(ScanLock {

--- a/src/storage/txn/commands.rs
+++ b/src/storage/txn/commands.rs
@@ -8,6 +8,7 @@ use txn_types::{Key, Lock, Mutation, TimeStamp};
 
 use crate::storage::lock_manager::WaitTimeout;
 use crate::storage::metrics::{self, CommandPriority};
+use crate::storage::txn::latch::{self, Latches};
 
 /// Get a single value.
 pub struct PointGetCommand {
@@ -696,6 +697,49 @@ impl Command {
             _ => {}
         }
         bytes
+    }
+
+    pub fn gen_lock(&self, latches: &Latches) -> latch::Lock {
+        match &self.kind {
+            CommandKind::Prewrite(Prewrite { mutations, .. }) => {
+                let keys: Vec<&Key> = mutations.iter().map(|x| x.key()).collect();
+                latches.gen_lock(&keys)
+            }
+            CommandKind::PrewritePessimistic(PrewritePessimistic { mutations, .. }) => {
+                let keys: Vec<&Key> = mutations.iter().map(|(x, _)| x.key()).collect();
+                latches.gen_lock(&keys)
+            }
+            CommandKind::ResolveLock(ResolveLock { key_locks, .. }) => {
+                let keys: Vec<&Key> = key_locks.iter().map(|x| &x.0).collect();
+                latches.gen_lock(&keys)
+            }
+            CommandKind::AcquirePessimisticLock(AcquirePessimisticLock { keys, .. }) => {
+                let keys: Vec<&Key> = keys.iter().map(|x| &x.0).collect();
+                latches.gen_lock(&keys)
+            }
+            CommandKind::ResolveLockLite(ResolveLockLite { resolve_keys, .. }) => {
+                latches.gen_lock(resolve_keys)
+            }
+            CommandKind::Commit(Commit { keys, .. })
+            | CommandKind::Rollback(Rollback { keys, .. })
+            | CommandKind::PessimisticRollback(PessimisticRollback { keys, .. }) => {
+                latches.gen_lock(keys)
+            }
+            CommandKind::Cleanup(Cleanup { key, .. }) => latches.gen_lock(&[key]),
+            CommandKind::Pause(Pause { keys, .. }) => latches.gen_lock(keys),
+            CommandKind::TxnHeartBeat(TxnHeartBeat { primary_key, .. }) => {
+                latches.gen_lock(&[primary_key])
+            }
+            CommandKind::CheckTxnStatus(CheckTxnStatus { primary_key, .. }) => {
+                latches.gen_lock(&[primary_key])
+            }
+
+            // Avoid using wildcard _ here to avoid forgetting add new commands here.
+            CommandKind::ScanLock(_)
+            | CommandKind::DeleteRange(_)
+            | CommandKind::MvccByKey(_)
+            | CommandKind::MvccByStartTs(_) => latch::Lock::new(vec![]),
+        }
     }
 }
 

--- a/src/storage/txn/commands.rs
+++ b/src/storage/txn/commands.rs
@@ -2,50 +2,13 @@
 
 use std::fmt::{self, Debug, Display, Formatter};
 
-use kvproto::kvrpcpb::{CommandPri, Context, GetRequest, RawGetRequest};
+use kvproto::kvrpcpb::{CommandPri, Context};
 use tikv_util::collections::HashMap;
 use txn_types::{Key, Lock, Mutation, TimeStamp};
 
 use crate::storage::lock_manager::WaitTimeout;
-use crate::storage::metrics::{self, CommandPriority};
+use crate::storage::metrics;
 use crate::storage::txn::latch::{self, Latches};
-
-/// Get a single value.
-pub struct PointGetCommand {
-    pub ctx: Context,
-    pub key: Key,
-    /// None if this is a raw get, Some if this is a transactional get.
-    pub ts: Option<TimeStamp>,
-}
-
-impl PointGetCommand {
-    pub fn from_get(request: &mut GetRequest) -> Self {
-        PointGetCommand {
-            ctx: request.take_context(),
-            key: Key::from_raw(request.get_key()),
-            ts: Some(request.get_version().into()),
-        }
-    }
-
-    pub fn from_raw_get(request: &mut RawGetRequest) -> Self {
-        PointGetCommand {
-            ctx: request.take_context(),
-            // FIXME: It is weird in semantics because the key in the request is actually in the
-            // raw format. We should fix it when the meaning of type `Key` is well defined.
-            key: Key::from_encoded(request.take_key()),
-            ts: None,
-        }
-    }
-
-    #[cfg(test)]
-    pub fn from_key_ts(key: Key, ts: Option<TimeStamp>) -> Self {
-        PointGetCommand {
-            ctx: Context::default(),
-            key,
-            ts,
-        }
-    }
-}
 
 /// Store Transaction scheduler commands.
 ///
@@ -572,10 +535,6 @@ impl Command {
         }
     }
 
-    pub fn priority_tag(&self) -> CommandPriority {
-        get_priority_tag(self.ctx.get_priority())
-    }
-
     pub fn need_flow_control(&self) -> bool {
         !self.readonly() && self.priority() != CommandPri::High
     }
@@ -884,48 +843,5 @@ impl Display for Command {
 impl Debug for Command {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self)
-    }
-}
-
-pub fn get_priority_tag(priority: CommandPri) -> CommandPriority {
-    match priority {
-        CommandPri::Low => CommandPriority::low,
-        CommandPri::Normal => CommandPriority::normal,
-        CommandPri::High => CommandPriority::high,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_construct_point_get_command_from_get_request() {
-        let mut context = Context::default();
-        context.set_region_id(1);
-        let raw_key = b"raw_key".to_vec();
-        let version = 10;
-        let mut req = GetRequest::default();
-        req.set_context(context.clone());
-        req.set_key(raw_key.clone());
-        req.set_version(version);
-        let cmd = PointGetCommand::from_get(&mut req);
-        assert_eq!(cmd.ctx, context);
-        assert_eq!(cmd.key, Key::from_raw(&raw_key));
-        assert_eq!(cmd.ts, Some(TimeStamp::new(version)));
-    }
-
-    #[test]
-    fn test_construct_point_get_command_from_raw_get_request() {
-        let mut context = Context::default();
-        context.set_region_id(1);
-        let raw_key = b"raw_key".to_vec();
-        let mut req = RawGetRequest::default();
-        req.set_context(context.clone());
-        req.set_key(raw_key.clone());
-        let cmd = PointGetCommand::from_raw_get(&mut req);
-        assert_eq!(cmd.ctx, context);
-        assert_eq!(cmd.key.into_encoded(), raw_key);
-        assert_eq!(cmd.ts, None);
     }
 }

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -20,7 +20,7 @@ use std::fmt;
 use std::io::Error as IoError;
 use txn_types::{Key, TimeStamp};
 
-pub use self::commands::{Command, PointGetCommand};
+pub use self::commands::Command;
 pub use self::process::RESOLVE_LOCK_BATCH_SIZE;
 pub use self::scheduler::{Msg, Scheduler};
 pub use self::store::{EntryBatch, TxnEntry, TxnEntryScanner, TxnEntryStore};

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -1108,16 +1108,7 @@ mod tests {
     ) -> Result<()> {
         let ctx = Context::default();
         let snap = engine.snapshot(&ctx)?;
-        let cmd = Prewrite::new(
-            mutations,
-            primary,
-            TimeStamp::from(start_ts),
-            0,
-            false,
-            0,
-            TimeStamp::default(),
-            ctx,
-        );
+        let cmd = Prewrite::with_defaults(mutations, primary, TimeStamp::from(start_ts));
         let m = DummyLockManager {};
         let ret = process_write_impl(cmd, snap, Some(m), statistics)?;
         if let ProcessResult::MultiRes { results } = ret.pr {

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -422,7 +422,8 @@ fn process_read_impl<E: Engine>(
                         next_scan_key,
                         kv_pairs,
                         cmd.ctx.clone(),
-                    ),
+                    )
+                    .into(),
                 })
             }
         }
@@ -825,7 +826,8 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
                 ProcessResult::Res
             } else {
                 ProcessResult::NextCommand {
-                    cmd: ResolveLock::new(txn_status, scan_key.take(), vec![], cmd.ctx.clone()),
+                    cmd: ResolveLock::new(txn_status, scan_key.take(), vec![], cmd.ctx.clone())
+                        .into(),
                 }
             };
 
@@ -1108,7 +1110,7 @@ mod tests {
     ) -> Result<()> {
         let ctx = Context::default();
         let snap = engine.snapshot(&ctx)?;
-        let cmd = Prewrite::with_defaults(mutations, primary, TimeStamp::from(start_ts));
+        let cmd = Prewrite::with_defaults(mutations, primary, TimeStamp::from(start_ts)).into();
         let m = DummyLockManager {};
         let ret = process_write_impl(cmd, snap, Some(m), statistics)?;
         if let ProcessResult::MultiRes { results } = ret.pr {
@@ -1140,7 +1142,7 @@ mod tests {
             ctx,
         );
         let m = DummyLockManager {};
-        let ret = process_write_impl(cmd, snap, Some(m), statistics)?;
+        let ret = process_write_impl(cmd.into(), snap, Some(m), statistics)?;
         let ctx = Context::default();
         engine.write(&ctx, ret.to_be_write).unwrap();
         Ok(())

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -46,7 +46,8 @@ use crate::storage::txn::{
     Error, ProcessResult,
 };
 use crate::storage::{
-    types::StorageCallback, Error as StorageError, ErrorInner as StorageErrorInner,
+    get_priority_tag, types::StorageCallback, Error as StorageError,
+    ErrorInner as StorageErrorInner,
 };
 
 const TASKS_SLOTS_NUM: usize = 1 << 12; // 4096 slots.
@@ -322,7 +323,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
         debug!("received new command"; "cid" => cid, "cmd" => ?cmd);
 
         let tag = cmd.tag();
-        let priority_tag = cmd.priority_tag();
+        let priority_tag = get_priority_tag(cmd.priority());
         let task = Task::new(cid, cmd);
         // TODO: enqueue_task should return an reference of the tctx.
         self.inner.enqueue_task(task, callback);

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -510,7 +510,7 @@ mod tests {
         let mut temp_map = HashMap::default();
         temp_map.insert(10.into(), 20.into());
         let readonly_cmds: Vec<Command> = vec![
-            commands::ScanLock::new(5.into(), &[], 0, Context::default()).into(),
+            commands::ScanLock::new(5.into(), None, 0, Context::default()).into(),
             commands::ResolveLock::new(temp_map.clone(), None, vec![], Context::default()).into(),
             commands::MvccByKey::new(Key::from_raw(b"k"), Context::default()).into(),
             commands::MvccByStartTs::new(25.into(), Context::default()).into(),

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -509,18 +509,19 @@ mod tests {
     fn test_command_latches() {
         let mut temp_map = HashMap::default();
         temp_map.insert(10.into(), 20.into());
-        let readonly_cmds = vec![
-            commands::ScanLock::new(5.into(), &[], 0, Context::default()),
-            commands::ResolveLock::new(temp_map.clone(), None, vec![], Context::default()),
-            commands::MvccByKey::new(Key::from_raw(b"k"), Context::default()),
-            commands::MvccByStartTs::new(25.into(), Context::default()),
+        let readonly_cmds: Vec<Command> = vec![
+            commands::ScanLock::new(5.into(), &[], 0, Context::default()).into(),
+            commands::ResolveLock::new(temp_map.clone(), None, vec![], Context::default()).into(),
+            commands::MvccByKey::new(Key::from_raw(b"k"), Context::default()).into(),
+            commands::MvccByStartTs::new(25.into(), Context::default()).into(),
         ];
-        let write_cmds = vec![
+        let write_cmds: Vec<Command> = vec![
             commands::Prewrite::with_defaults(
                 vec![Mutation::Put((Key::from_raw(b"k"), b"v".to_vec()))],
                 b"k".to_vec(),
                 10.into(),
-            ),
+            )
+            .into(),
             commands::AcquirePessimisticLock::new(
                 vec![(Key::from_raw(b"k"), false)],
                 b"k".to_vec(),
@@ -530,26 +531,31 @@ mod tests {
                 TimeStamp::default(),
                 Some(WaitTimeout::Default),
                 Context::default(),
-            ),
+            )
+            .into(),
             commands::Commit::new(
                 vec![Key::from_raw(b"k")],
                 10.into(),
                 20.into(),
                 Context::default(),
-            ),
+            )
+            .into(),
             commands::Cleanup::new(
                 Key::from_raw(b"k"),
                 10.into(),
                 20.into(),
                 Context::default(),
-            ),
-            commands::Rollback::new(vec![Key::from_raw(b"k")], 10.into(), Context::default()),
+            )
+            .into(),
+            commands::Rollback::new(vec![Key::from_raw(b"k")], 10.into(), Context::default())
+                .into(),
             commands::PessimisticRollback::new(
                 vec![Key::from_raw(b"k")],
                 10.into(),
                 20.into(),
                 Context::default(),
-            ),
+            )
+            .into(),
             commands::ResolveLock::new(
                 temp_map,
                 None,
@@ -567,14 +573,17 @@ mod tests {
                     ),
                 )],
                 Context::default(),
-            ),
+            )
+            .into(),
             commands::ResolveLockLite::new(
                 10.into(),
                 TimeStamp::zero(),
                 vec![Key::from_raw(b"k")],
                 Context::default(),
-            ),
-            commands::TxnHeartBeat::new(Key::from_raw(b"k"), 10.into(), 100, Context::default()),
+            )
+            .into(),
+            commands::TxnHeartBeat::new(Key::from_raw(b"k"), 10.into(), 100, Context::default())
+                .into(),
         ];
 
         let latches = Latches::new(1024);

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -510,21 +510,16 @@ mod tests {
         let mut temp_map = HashMap::default();
         temp_map.insert(10.into(), 20.into());
         let readonly_cmds = vec![
-            commands::ScanLock::new(5.into(), None, 0, Context::default()),
+            commands::ScanLock::new(5.into(), &[], 0, Context::default()),
             commands::ResolveLock::new(temp_map.clone(), None, vec![], Context::default()),
             commands::MvccByKey::new(Key::from_raw(b"k"), Context::default()),
             commands::MvccByStartTs::new(25.into(), Context::default()),
         ];
         let write_cmds = vec![
-            commands::Prewrite::new(
+            commands::Prewrite::with_defaults(
                 vec![Mutation::Put((Key::from_raw(b"k"), b"v".to_vec()))],
                 b"k".to_vec(),
                 10.into(),
-                0,
-                false,
-                0,
-                TimeStamp::default(),
-                Context::default(),
             ),
             commands::AcquirePessimisticLock::new(
                 vec![(Key::from_raw(b"k"), false)],

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -29,7 +29,7 @@ use std::u64;
 use kvproto::kvrpcpb::CommandPri;
 use prometheus::HistogramTimer;
 use tikv_util::{collections::HashMap, time::SlowTimer};
-use txn_types::{Key, TimeStamp};
+use txn_types::TimeStamp;
 
 use crate::storage::kv::{with_tls_engine, Engine, Result as EngineResult};
 use crate::storage::lock_manager::{self, LockManager, WaitTimeout};
@@ -39,11 +39,7 @@ use crate::storage::metrics::{
     SCHED_WRITING_BYTES_GAUGE,
 };
 use crate::storage::txn::{
-    commands::{
-        AcquirePessimisticLock, CheckTxnStatus, Cleanup, Command, CommandKind, Commit, Pause,
-        PessimisticRollback, Prewrite, PrewritePessimistic, ResolveLock, ResolveLockLite, Rollback,
-        TxnHeartBeat,
-    },
+    commands::Command,
     latch::{Latches, Lock},
     process::{Executor, MsgScheduler, Task},
     sched_pool::SchedPool,
@@ -124,7 +120,7 @@ struct TaskContext {
 impl TaskContext {
     fn new(task: Task, latches: &Latches, cb: StorageCallback) -> TaskContext {
         let tag = task.cmd().tag();
-        let lock = gen_command_lock(latches, task.cmd());
+        let lock = task.cmd().gen_lock(latches);
         // Write command should acquire write lock.
         if !task.cmd().readonly() && !lock.is_write_lock() {
             panic!("write lock is expected for command {}", task.cmd());
@@ -500,71 +496,26 @@ impl<E: Engine, L: LockManager> MsgScheduler for Scheduler<E, L> {
     }
 }
 
-fn gen_command_lock(latches: &Latches, cmd: &Command) -> Lock {
-    match cmd.kind {
-        CommandKind::Prewrite(Prewrite { ref mutations, .. }) => {
-            let keys: Vec<&Key> = mutations.iter().map(|x| x.key()).collect();
-            latches.gen_lock(&keys)
-        }
-        CommandKind::PrewritePessimistic(PrewritePessimistic { ref mutations, .. }) => {
-            let keys: Vec<&Key> = mutations.iter().map(|(x, _)| x.key()).collect();
-            latches.gen_lock(&keys)
-        }
-        CommandKind::ResolveLock(ResolveLock { ref key_locks, .. }) => {
-            let keys: Vec<&Key> = key_locks.iter().map(|x| &x.0).collect();
-            latches.gen_lock(&keys)
-        }
-        CommandKind::AcquirePessimisticLock(AcquirePessimisticLock { ref keys, .. }) => {
-            let keys: Vec<&Key> = keys.iter().map(|x| &x.0).collect();
-            latches.gen_lock(&keys)
-        }
-        CommandKind::ResolveLockLite(ResolveLockLite {
-            ref resolve_keys, ..
-        }) => latches.gen_lock(resolve_keys),
-        CommandKind::Commit(Commit { ref keys, .. })
-        | CommandKind::Rollback(Rollback { ref keys, .. })
-        | CommandKind::PessimisticRollback(PessimisticRollback { ref keys, .. }) => {
-            latches.gen_lock(keys)
-        }
-        CommandKind::Cleanup(Cleanup { ref key, .. }) => latches.gen_lock(&[key]),
-        CommandKind::Pause(Pause { ref keys, .. }) => latches.gen_lock(keys),
-        CommandKind::TxnHeartBeat(TxnHeartBeat {
-            ref primary_key, ..
-        }) => latches.gen_lock(&[primary_key]),
-        CommandKind::CheckTxnStatus(CheckTxnStatus {
-            ref primary_key, ..
-        }) => latches.gen_lock(&[primary_key]),
-
-        // Avoid using wildcard _ here to avoid forgetting add new commands here.
-        CommandKind::ScanLock(_)
-        | CommandKind::DeleteRange(_)
-        | CommandKind::MvccByKey(_)
-        | CommandKind::MvccByStartTs(_) => Lock::new(vec![]),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::storage::mvcc::{self, Mutation};
-    use crate::storage::txn::{
-        commands::{MvccByKey, MvccByStartTs, ScanLock},
-        latch::*,
-    };
+    use crate::storage::txn::{commands, latch::*};
     use kvproto::kvrpcpb::Context;
+    use txn_types::Key;
 
     #[test]
     fn test_command_latches() {
         let mut temp_map = HashMap::default();
         temp_map.insert(10.into(), 20.into());
         let readonly_cmds = vec![
-            ScanLock::new(5.into(), None, 0, Context::default()),
-            ResolveLock::new(temp_map.clone(), None, vec![], Context::default()),
-            MvccByKey::new(Key::from_raw(b"k"), Context::default()),
-            MvccByStartTs::new(25.into(), Context::default()),
+            commands::ScanLock::new(5.into(), None, 0, Context::default()),
+            commands::ResolveLock::new(temp_map.clone(), None, vec![], Context::default()),
+            commands::MvccByKey::new(Key::from_raw(b"k"), Context::default()),
+            commands::MvccByStartTs::new(25.into(), Context::default()),
         ];
         let write_cmds = vec![
-            Prewrite::new(
+            commands::Prewrite::new(
                 vec![Mutation::Put((Key::from_raw(b"k"), b"v".to_vec()))],
                 b"k".to_vec(),
                 10.into(),
@@ -574,7 +525,7 @@ mod tests {
                 TimeStamp::default(),
                 Context::default(),
             ),
-            AcquirePessimisticLock::new(
+            commands::AcquirePessimisticLock::new(
                 vec![(Key::from_raw(b"k"), false)],
                 b"k".to_vec(),
                 10.into(),
@@ -584,26 +535,26 @@ mod tests {
                 Some(WaitTimeout::Default),
                 Context::default(),
             ),
-            Commit::new(
+            commands::Commit::new(
                 vec![Key::from_raw(b"k")],
                 10.into(),
                 20.into(),
                 Context::default(),
             ),
-            Cleanup::new(
+            commands::Cleanup::new(
                 Key::from_raw(b"k"),
                 10.into(),
                 20.into(),
                 Context::default(),
             ),
-            Rollback::new(vec![Key::from_raw(b"k")], 10.into(), Context::default()),
-            PessimisticRollback::new(
+            commands::Rollback::new(vec![Key::from_raw(b"k")], 10.into(), Context::default()),
+            commands::PessimisticRollback::new(
                 vec![Key::from_raw(b"k")],
                 10.into(),
                 20.into(),
                 Context::default(),
             ),
-            ResolveLock::new(
+            commands::ResolveLock::new(
                 temp_map,
                 None,
                 vec![(
@@ -621,13 +572,13 @@ mod tests {
                 )],
                 Context::default(),
             ),
-            ResolveLockLite::new(
+            commands::ResolveLockLite::new(
                 10.into(),
                 TimeStamp::zero(),
                 vec![Key::from_raw(b"k")],
                 Context::default(),
             ),
-            TxnHeartBeat::new(Key::from_raw(b"k"), 10.into(), 100, Context::default()),
+            commands::TxnHeartBeat::new(Key::from_raw(b"k"), 10.into(), 100, Context::default()),
         ];
 
         let latches = Latches::new(1024);
@@ -635,14 +586,14 @@ mod tests {
             .into_iter()
             .enumerate()
             .map(|(id, cmd)| {
-                let mut lock = gen_command_lock(&latches, &cmd);
+                let mut lock = cmd.gen_lock(&latches);
                 assert_eq!(latches.acquire(&mut lock, id as u64), id == 0);
                 lock
             })
             .collect();
 
         for (id, cmd) in readonly_cmds.iter().enumerate() {
-            let mut lock = gen_command_lock(&latches, cmd);
+            let mut lock = cmd.gen_lock(&latches);
             assert!(latches.acquire(&mut lock, id as u64));
         }
 

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -154,3 +154,43 @@ impl StorageCallback {
         }
     }
 }
+
+pub trait StorageCallbackType: Sized {
+    fn callback(cb: Callback<Self>) -> StorageCallback;
+}
+
+impl StorageCallbackType for () {
+    fn callback(cb: Callback<Self>) -> StorageCallback {
+        StorageCallback::Boolean(cb)
+    }
+}
+
+impl StorageCallbackType for Vec<Result<()>> {
+    fn callback(cb: Callback<Self>) -> StorageCallback {
+        StorageCallback::Booleans(cb)
+    }
+}
+
+impl StorageCallbackType for MvccInfo {
+    fn callback(cb: Callback<Self>) -> StorageCallback {
+        StorageCallback::MvccInfoByKey(cb)
+    }
+}
+
+impl StorageCallbackType for Option<(Key, MvccInfo)> {
+    fn callback(cb: Callback<Self>) -> StorageCallback {
+        StorageCallback::MvccInfoByStartTs(cb)
+    }
+}
+
+impl StorageCallbackType for Vec<kvrpcpb::LockInfo> {
+    fn callback(cb: Callback<Self>) -> StorageCallback {
+        StorageCallback::Locks(cb)
+    }
+}
+
+impl StorageCallbackType for TxnStatus {
+    fn callback(cb: Callback<Self>) -> StorageCallback {
+        StorageCallback::TxnStatus(cb)
+    }
+}

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -12,7 +12,7 @@ use kvproto::tikvpb::TikvClient;
 use test_raftstore::{must_get_equal, must_get_none, new_server_cluster};
 use tikv::storage;
 use tikv::storage::kv::{Error as KvError, ErrorInner as KvErrorInner};
-use tikv::storage::txn::{Error as TxnError, ErrorInner as TxnErrorInner};
+use tikv::storage::txn::{commands, Error as TxnError, ErrorInner as TxnErrorInner};
 use tikv::storage::*;
 use tikv_util::HandyRwLock;
 use txn_types::Key;
@@ -39,15 +39,17 @@ fn test_scheduler_leader_change_twice() {
     let (prewrite_tx, prewrite_rx) = channel();
     fail::cfg(snapshot_fp, "pause").unwrap();
     storage0
-        .prewrite(
-            ctx0,
-            vec![Mutation::Put((Key::from_raw(b"k"), b"v".to_vec()))],
-            b"k".to_vec(),
-            10.into(),
-            0,
-            false,
-            0,
-            TimeStamp::default(),
+        .sched_txn_command(
+            commands::Prewrite::new(
+                vec![Mutation::Put((Key::from_raw(b"k"), b"v".to_vec()))],
+                b"k".to_vec(),
+                10.into(),
+                0,
+                false,
+                0,
+                TimeStamp::default(),
+                ctx0,
+            ),
             Box::new(move |res: storage::Result<_>| {
                 prewrite_tx.send(res).unwrap();
             }),

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -52,7 +52,7 @@ fn test_raft_storage() {
     assert!(storage.get(ctx.clone(), &key, 20).is_err());
     assert!(storage.batch_get(ctx.clone(), &[key.clone()], 20).is_err());
     assert!(storage.scan(ctx.clone(), key, None, 1, false, 20).is_err());
-    assert!(storage.scan_locks(ctx, 20, b"".to_vec(), 100).is_err());
+    assert!(storage.scan_locks(ctx, 20, None, 100).is_err());
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn test_raft_storage_store_not_match() {
     }
     assert!(storage.batch_get(ctx.clone(), &[key.clone()], 20).is_err());
     assert!(storage.scan(ctx.clone(), key, None, 1, false, 20).is_err());
-    assert!(storage.scan_locks(ctx, 20, b"".to_vec(), 100).is_err());
+    assert!(storage.scan_locks(ctx, 20, None, 100).is_err());
 }
 
 #[test]

--- a/tests/integrations/storage/test_storage.rs
+++ b/tests/integrations/storage/test_storage.rs
@@ -465,18 +465,18 @@ fn test_txn_store_scan_lock() {
         vec![Some((b"k1", b"v1")), None, None, None, None],
     );
 
-    store.scan_locks_ok(10, b"".to_vec(), 1, vec![lock(b"p1", b"p1", 5)]);
+    store.scan_locks_ok(10, b"", 1, vec![lock(b"p1", b"p1", 5)]);
 
     store.scan_locks_ok(
         10,
-        b"s".to_vec(),
+        b"s",
         2,
         vec![lock(b"s1", b"p1", 5), lock(b"s2", b"p2", 10)],
     );
 
     store.scan_locks_ok(
         10,
-        b"".to_vec(),
+        b"",
         0,
         vec![
             lock(b"p1", b"p1", 5),
@@ -488,7 +488,7 @@ fn test_txn_store_scan_lock() {
 
     store.scan_locks_ok(
         10,
-        b"".to_vec(),
+        b"",
         100,
         vec![
             lock(b"p1", b"p1", 5),
@@ -525,7 +525,7 @@ fn test_txn_store_resolve_lock() {
     store.get_none(b"s1", 30);
     store.get_ok(b"p2", 20, b"v10");
     store.get_ok(b"s2", 30, b"v10");
-    store.scan_locks_ok(30, b"".to_vec(), 100, vec![]);
+    store.scan_locks_ok(30, b"", 100, vec![]);
 }
 
 fn test_txn_store_resolve_lock_batch(key_prefix_len: usize, n: usize) {
@@ -572,7 +572,7 @@ fn test_txn_store_resolve_lock_in_a_batch() {
     store.get_none(b"s1", 30);
     store.get_ok(b"p2", 30, b"v10");
     store.get_ok(b"s2", 30, b"v10");
-    store.scan_locks_ok(30, b"".to_vec(), 100, vec![]);
+    store.scan_locks_ok(30, b"", 100, vec![]);
 }
 
 #[test]


### PR DESCRIPTION
###  What have you changed?

Following up from earlier refactoring, this PR moves some command functionality around to make things a bit tidier. This is mostly just to move things closer to where there are used/belong. The most interesting change is moving the decoding of protobufs into `Command` objects from server/service/kv to storage/txn/commands, the motivation is that the kv service should be fairly minimal and not have knowledge of storage internals.

In addition I remove one unused command.

###  What is the type of the changes?

Engineering (engineering change which doesn't change any feature or fix any issue)


PTAL @MyonKeminta @youjiali1995 
