### PR TITLE
Remove jemalloc check from ci_test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,6 @@ test:
 # This is used for CI test
 ci_test:
 	cargo test --no-default-features --features "${ENABLE_FEATURES}" --all --all-targets --no-run --message-format=json
-	bash scripts/check-bins-for-jemalloc.sh
 
 ## Static analysis
 ## ---------------


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

CI always check jemalloc in another step, so no need to check jemalloc inside Makefile.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)
