### PR TITLE
raftstore: allow disable early apply

### DIFF
--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -120,6 +120,7 @@ pub struct Config {
     pub store_pool_size: usize,
     pub future_poll_size: usize,
     pub hibernate_regions: bool,
+    pub early_apply: bool,
 
     // Deprecated! These two configuration has been moved to Coprocessor.
     // They are preserved for compatibility check.
@@ -193,6 +194,7 @@ impl Default for Config {
             store_pool_size: 2,
             future_poll_size: 1,
             hibernate_regions: true,
+            early_apply: true,
 
             // They are preserved for compatibility check.
             region_max_size: ReadableSize(0),

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -650,6 +650,9 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
 
     pub fn post_raft_ready_append(&mut self, mut ready: Ready, invoke_ctx: InvokeContext) {
         let is_merging = self.fsm.peer.pending_merge_state.is_some();
+        if !self.ctx.cfg.early_apply {
+            self.handle_raft_ready_apply(&mut ready, &invoke_ctx);
+        }
         let res = self
             .fsm
             .peer

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -480,7 +480,7 @@ impl<T: Transport, C: PdClient> RaftPoller<T, C> {
             self.poll_ctx.need_flush_trans = false;
         }
         let ready_cnt = self.poll_ctx.ready_res.len();
-        if ready_cnt != 0 {
+        if ready_cnt != 0 && self.poll_ctx.cfg.early_apply {
             let mut batch_pos = 0;
             let mut ready_res = mem::replace(&mut self.poll_ctx.ready_res, vec![]);
             for (ready, invoke_ctx) in &mut ready_res {

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -165,6 +165,7 @@ fn test_serde_custom_tikv_config() {
         store_pool_size: 3,
         future_poll_size: 2,
         hibernate_regions: false,
+        early_apply: false,
     };
     value.pd = PdConfig::new(vec!["example.com:443".to_owned()]);
     let titan_cf_config = TitanCfConfig {

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -136,6 +136,7 @@ store-max-batch-size = 21
 store-pool-size = 3
 future-poll-size = 2
 hibernate-regions = false
+early-apply = false
 
 [coprocessor]
 split-region-on-table = true


### PR DESCRIPTION
###  What have you changed?

Allow disable early apply on perf branch. So the performance enhancement can still be utilized without worrying the consistency.

###  What is the type of the changes?

- Improvement

###  How is the PR tested?

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.