### PR TITLE
Makefile:add dist_release rule which is same with release for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ build:
 run:
 	cargo run --features "${ENABLE_FEATURES}" --bin tikv-server
 
+dist_release: release
+
 release:
 	@cargo build --release --features "${ENABLE_FEATURES}"
 	@mkdir -p ${BIN_PATH}


### PR DESCRIPTION
###  What have you changed?
These days I'm working on merging all tikv build jobs from branches into ONE Jenkins CI job, to make our CI neater and manageable.

Since we have  compiled tikv-server with:
- `make dist_release` on master/release-3.x branches
- `make release` on release-2.x branches,which actually equals with `make dist_release` 

This PR adds `dist_release` to Makefile so we can run `make dist_release` on all branches.

###  What is the type of the changes?
- Misc (other changes)



