### PR TITLE
txn: use Commit to clean up pessimistic locks (#6353)

### DIFF
--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -603,7 +603,7 @@ pub mod tests {
                 core.run(delay.map(|not_cancelled| assert!(not_cancelled)))
                     .unwrap()
             },
-            50,
+            30,
             100,
         );
 
@@ -1079,7 +1079,7 @@ pub mod tests {
             // Waiters2's lifetime can't exceed it timeout.
             assert_elapsed(
                 || expect_write_conflict(f2.wait().unwrap(), 30, lock_info2, 15),
-                50,
+                30,
                 100,
             );
             tx.send(()).unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
Cherry-pick #6353  and #6304 
