### PR TITLE
tests: properly exit tests

### DIFF
--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -3936,6 +3936,8 @@ mod tests {
         checker.check(b"k3", b"k31", 1, &[3, 5, 7], false);
         checker.check(b"k31", b"k32", 24, &[25, 26, 27], true);
         checker.check(b"k32", b"k4", 28, &[29, 30, 31], true);
+
+        system.shutdown();
     }
 
     #[test]

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -2184,7 +2184,15 @@ mod tests {
         (router, apply_router, system, apply_system)
     }
 
-    fn start_raftstore(cfg: TiKvConfig) -> (ConfigController, RaftRouter, ApplyRouter) {
+    fn start_raftstore(
+        cfg: TiKvConfig,
+    ) -> (
+        ConfigController,
+        RaftRouter,
+        ApplyRouter,
+        BatchSystem<PeerFsm, StoreFsm>,
+        ApplyBatchSystem,
+    ) {
         let (raft_router, apply_router, mut system, mut apply_system) =
             create_batch_system(&cfg.raft_store);
         let (_, engines) = create_tmp_engine("store-config");
@@ -2236,7 +2244,13 @@ mod tests {
         );
         system.spawn("store-config".to_owned(), builder);
         apply_system.spawn("apply-config".to_owned(), apply_poller_builder);
-        (cfg_controller, raft_router, apply_router)
+        (
+            cfg_controller,
+            raft_router,
+            apply_router,
+            system,
+            apply_system,
+        )
     }
 
     fn validate_store<F>(router: &RaftRouter, f: F)
@@ -2275,7 +2289,8 @@ mod tests {
     fn test_update_raftstore_config() {
         let mut config = TiKvConfig::default();
         config.validate().unwrap();
-        let (mut cfg_controller, router, _) = start_raftstore(config.clone());
+        let (mut cfg_controller, router, _, mut system, mut apply_system) =
+            start_raftstore(config.clone());
 
         let incoming = config.clone();
         let raft_store = incoming.raft_store.clone();
@@ -2300,6 +2315,9 @@ mod tests {
         validate_store(&router, move |cfg: &Config| {
             assert_eq!(cfg, &raft_store);
         });
+
+        apply_system.shutdown();
+        system.shutdown();
     }
 
     #[test]
@@ -2307,7 +2325,8 @@ mod tests {
         let mut config = TiKvConfig::default();
         config.raft_store.sync_log = true;
         config.validate().unwrap();
-        let (mut cfg_controller, raft_router, apply_router) = start_raftstore(config.clone());
+        let (mut cfg_controller, raft_router, apply_router, mut system, mut apply_system) =
+            start_raftstore(config.clone());
 
         // register region
         let region_id = 1;
@@ -2339,6 +2358,9 @@ mod tests {
         validate_apply(&apply_router, region_id, |sync_log| {
             assert_eq!(sync_log, false);
         });
+
+        apply_system.shutdown();
+        system.shutdown();
     }
 
     #[test]

--- a/src/raftstore/store/worker/split_check.rs
+++ b/src/raftstore/store/worker/split_check.rs
@@ -349,19 +349,20 @@ mod tests {
 
     use tempfile::Builder;
 
-    fn setup(cfg: TiKvConfig) -> (ConfigController, Scheduler<Task>) {
-        let engine = {
-            let path = Builder::new().prefix("test-config").tempdir().unwrap();
-            Arc::new(
-                rocks::util::new_engine(
-                    path.path().join("db").to_str().unwrap(),
-                    None,
-                    &["split-check-config"],
-                    None,
-                )
-                .unwrap(),
+    fn tmp_engine() -> Arc<DB> {
+        let path = Builder::new().prefix("test-config").tempdir().unwrap();
+        Arc::new(
+            rocks::util::new_engine(
+                path.path().join("db").to_str().unwrap(),
+                None,
+                &["split-check-config"],
+                None,
             )
-        };
+            .unwrap(),
+        )
+    }
+
+    fn setup(cfg: TiKvConfig, engine: Arc<DB>) -> (ConfigController, Worker<Task>) {
         let (router, _) = sync_channel(1);
         let runner = Runner::new(
             engine,
@@ -375,7 +376,7 @@ mod tests {
         let mut cfg_controller = ConfigController::new(cfg);
         cfg_controller.register("coprocessor", Box::new(worker.scheduler()));
 
-        (cfg_controller, worker.scheduler())
+        (cfg_controller, worker)
     }
 
     fn validate<F>(scheduler: &Scheduler<Task>, f: F)
@@ -396,7 +397,9 @@ mod tests {
     fn test_update_split_check_config() {
         let mut cfg = TiKvConfig::default();
         cfg.validate().unwrap();
-        let (mut cfg_controller, scheduler) = setup(cfg.clone());
+        let engine = tmp_engine();
+        let (mut cfg_controller, mut worker) = setup(cfg.clone(), engine.clone());
+        let scheduler = worker.scheduler();
 
         let cop_config = cfg.coprocessor.clone();
         let mut incoming = cfg.clone();
@@ -423,5 +426,7 @@ mod tests {
         validate(&scheduler, move |cfg: &Config| {
             assert_eq!(cfg, &cop_config);
         });
+
+        worker.stop().unwrap().join().unwrap();
     }
 }


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Properly release resource before the end of a test:
- for `BatchSystem` call `shutdown` before exit the test
- for `Worker` call `stop` before exit the test
- move `Arc<DB>` to the test body, so it can drop properly in the end of the test

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

