### PR TITLE
copr: Time use deterministic fsp_tt while type == Date

### DIFF
--- a/components/tidb_query/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query/src/codec/mysql/time/mod.rs
@@ -181,7 +181,7 @@ bitfield! {
     // 1. `type` bit 0 represent `DateTime`
     // 2. `type` bit 1 represent `Timestamp`
     //
-    // Since `Date` does not require `fsp`, we could use `fsp` == 0b111 to represent it.
+    // Since `Date` does not require `fsp`, we could use `fsp_tt` == 0b1110 to represent it.
     #[inline]
     u8, get_fsp_tt, set_fsp_tt: 3, 0;
 }
@@ -1033,8 +1033,7 @@ impl Time {
     fn set_tt(&mut self, time_type: TimeType) {
         let ft = self.get_fsp_tt();
         let mask = match time_type {
-            // Set `fsp_tt` to 0b111x
-            TimeType::Date => ft | 0b1110,
+            TimeType::Date => 0b1110,
             TimeType::DateTime => ft & 0b1110,
             TimeType::Timestamp => ft | 1,
         };


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

While type of Time is Date, `fsp_tt` field `0b1110` instead of `0b111x`, so that we can obtain deterministic time memory layout.

Don't assume reviewers understand the original issue.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

###  Refer to a related PR or issue link (optional)

Related to pingcap/tidb#14191

