### PR TITLE
fix clippy style warning introduced by #5916

### DIFF
--- a/components/tidb_query/src/rpn_expr/impl_json.rs
+++ b/components/tidb_query/src/rpn_expr/impl_json.rs
@@ -212,12 +212,7 @@ fn json_length(args: &[ScalarValueRef]) -> Result<Option<Int>> {
         None => return Ok(None),
         Some(j) => j.to_owned(),
     };
-    let path_expr_list = parse_json_path_list(&args[1..])?;
-    if path_expr_list.is_none() {
-        Ok(None)
-    } else {
-        Ok(j.json_length(&path_expr_list.unwrap()))
-    }
+    Ok(parse_json_path_list(&args[1..])?.and_then(|path_expr_list| j.json_length(&path_expr_list)))
 }
 
 #[rpn_fn(raw_varg, min_args = 2, extra_validator = json_with_paths_validator)]


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

The original code checks if an `Option` is not `None` and `unwrap` it later. It leads to a clippy warning. This PR resolves it.

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No