### PR TITLE
sst_importer: Fix MvccProperties didn't generated during restoring (#…

### DIFF
--- a/components/engine/src/cf.rs
+++ b/components/engine/src/cf.rs
@@ -9,3 +9,16 @@ pub const CF_RAFT: CfName = "raft";
 pub const LARGE_CFS: &[CfName] = &[CF_DEFAULT, CF_WRITE];
 pub const ALL_CFS: &[CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE, CF_RAFT];
 pub const DATA_CFS: &[CfName] = &[CF_DEFAULT, CF_LOCK, CF_WRITE];
+
+pub fn name_to_cf(name: &str) -> Option<CfName> {
+    if name.is_empty() {
+        return Some(CF_DEFAULT);
+    }
+    for c in ALL_CFS {
+        if name == *c {
+            return Some(c);
+        }
+    }
+
+    None
+}

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use engine::rocks::util::{compact_files_in_range, io_limiter::IOLimiter};
 use engine::rocks::{SstWriterBuilder, DB};
+use engine::name_to_cf;
 use futures::sync::mpsc;
 use futures::{future, Future, Stream};
 use futures_cpupool::{Builder, CpuPool};
@@ -153,6 +154,7 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
         let limiter = self.limiter.clone();
         let sst_writer = SstWriterBuilder::new()
             .set_db(self.engine.clone())
+            .set_cf(name_to_cf(req.get_sst().get_cf_name()).unwrap())
             .build(self.importer.get_path(req.get_sst()).to_str().unwrap())
             .unwrap();
 


### PR DESCRIPTION
…6349)

Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This PR cherry-picks #6349 , which fixes the bug that imported sst doesn't has MvccProperties.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

Cherry-picks: #6349 
