### PR TITLE
copr: Add non-vectorize to_seconds

### DIFF
--- a/components/tidb_query/src/codec/mysql/time/extension.rs
+++ b/components/tidb_query/src/codec/mysql/time/extension.rs
@@ -49,6 +49,7 @@ pub trait DateTimeExtension {
     fn year_week(&self, mode: WeekMode) -> (i32, i32);
     fn abbr_day_of_month(&self) -> &'static str;
     fn day_number(&self) -> i32;
+    fn second_number(&self) -> i64;
 }
 
 impl DateTimeExtension for Time {
@@ -144,6 +145,15 @@ impl DateTimeExtension for Time {
     /// returns the days since 0000-00-00
     fn day_number(&self) -> i32 {
         calc_day_number(self.year() as i32, self.month() as i32, self.day() as i32)
+    }
+
+    /// returns the seconds since 0000-00-00 00:00:00
+    fn second_number(&self) -> i64 {
+        let days = self.day_number();
+        days as i64 * 86400
+            + self.hour() as i64 * 3600
+            + self.minute() as i64 * 60
+            + self.second() as i64
     }
 }
 

--- a/components/tidb_query/src/expr/scalar_function.rs
+++ b/components/tidb_query/src/expr/scalar_function.rs
@@ -293,6 +293,7 @@ impl ScalarFunc {
             | ScalarFuncSig::Uncompress
             | ScalarFuncSig::UncompressedLength
             | ScalarFuncSig::ToDays
+            | ScalarFuncSig::ToSeconds
             | ScalarFuncSig::FromDays
             | ScalarFuncSig::Ord
             | ScalarFuncSig::OctInt
@@ -504,7 +505,6 @@ impl ScalarFunc {
             | ScalarFuncSig::TimeStringTimeDiff
             | ScalarFuncSig::TimeTimeTimeDiff
             | ScalarFuncSig::TimeToSec
-            | ScalarFuncSig::ToSeconds
             | ScalarFuncSig::UnixTimestampCurrent
             | ScalarFuncSig::UnixTimestampDec
             | ScalarFuncSig::UnixTimestampInt
@@ -788,6 +788,7 @@ dispatch_call! {
         WeekOfYear => week_of_year,
         Year => year,
         ToDays => to_days,
+        ToSeconds => to_seconds,
         DateDiff => date_diff,
         PeriodAdd => period_add,
         PeriodDiff => period_diff,

--- a/components/tidb_query/src/expr/scalar_function.rs
+++ b/components/tidb_query/src/expr/scalar_function.rs
@@ -1656,7 +1656,6 @@ mod tests {
             ScalarFuncSig::TimeStringTimeDiff,
             ScalarFuncSig::TimeTimeTimeDiff,
             ScalarFuncSig::TimeToSec,
-            ScalarFuncSig::ToSeconds,
             ScalarFuncSig::UnixTimestampCurrent,
             ScalarFuncSig::UnixTimestampDec,
             ScalarFuncSig::UnixTimestampInt,


### PR DESCRIPTION
Signed-off-by: Poytr1 <pooytr1@gmail.com>

PCP #5751
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

- Add Non-Vectorize `to_seconds`

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->
No
###  Does this PR affect `tidb-ansible`?
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->
No

