### PR TITLE
tidb_query: fix cast string to real inconsistent with TiDB

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,20 +31,21 @@ Pick one of the following and delete the others:
 <!--
 Please select the tests that you ran to verify your changes:
 -->
-- [ ] Unit test
-- [ ] Integration test
-- [ ] Manual test (add detailed scripts or steps below)
-- [ ] No code
+- Unit test
+- Integration test
+- Manual test (add detailed scripts or steps below)
+- No code
 
 ###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
-
+<!--
 - If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
 - If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
+-->
 
 ###  Does this PR affect `tidb-ansible`?
-
+<!--
 If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-
+-->
 ###  Refer to a related PR or issue link (optional)
 
 ###  Benchmark result if necessary (optional)

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -166,8 +166,8 @@
 //!         let (regex, arg) = self.extract(0);
 //!         let regex = build_regex(regex);
 //!         let mut result = Vec::with_capacity(output_rows);
-//!         for row in 0..output_rows {
-//!             let (text, _) = arg.extract(row);
+//!         for row_index in 0..output_rows {
+//!             let (text, _) = arg.extract(row_index);
 //!             result.push(regex_match_impl(&regex, text)?);
 //!         }
 //!         Ok(Evaluable::into_vector_value(result))
@@ -603,8 +603,10 @@ fn generate_metadata_type_checker(
                     extra: &mut crate::rpn_expr::RpnFnCallExtra<'_>,
                     expr: &mut ::tipb::Expr,
                 ) #where_clause {
-                    let metadata = #metadata_expr;
-                    #fn_body
+                    for row_index in 0..output_rows {
+                        let metadata = #metadata_expr;
+                        #fn_body
+                    }
                 }
             };
         }
@@ -1061,8 +1063,8 @@ impl NormalRpnFn {
                     #downcast_metadata
                     let arg = &self;
                     let mut result = Vec::with_capacity(output_rows);
-                    for row in 0..output_rows {
-                        #(let (#extract, arg) = arg.extract(row));*;
+                    for row_index in 0..output_rows {
+                        #(let (#extract, arg) = arg.extract(row_index));*;
                         result.push( #fn_ident #ty_generics_turbofish ( #(#captures,)* #(#call_arg),* )?);
                     }
                     Ok(crate::codec::data_type::Evaluable::into_vector_value(result))
@@ -1246,9 +1248,9 @@ mod tests_normal {
                 ) -> crate::Result<crate::codec::data_type::VectorValue> {
                     let arg = &self;
                     let mut result = Vec::with_capacity(output_rows);
-                    for row in 0..output_rows {
-                        let (arg0, arg) = arg.extract(row);
-                        let (arg1, arg) = arg.extract(row);
+                    for row_index in 0..output_rows {
+                        let (arg0, arg) = arg.extract(row_index);
+                        let (arg1, arg) = arg.extract(row_index);
                         result.push(foo(arg0, arg1)?);
                     }
                     Ok(crate::codec::data_type::Evaluable::into_vector_value(result))
@@ -1414,8 +1416,8 @@ mod tests_normal {
                 ) -> crate::Result<crate::codec::data_type::VectorValue> {
                     let arg = &self;
                     let mut result = Vec::with_capacity(output_rows);
-                    for row in 0..output_rows {
-                        let (arg0, arg) = arg.extract(row);
+                    for row_index in 0..output_rows {
+                        let (arg0, arg) = arg.extract(row_index);
                         result.push(foo :: <A, B> (arg0)?);
                     }
                     Ok(crate::codec::data_type::Evaluable::into_vector_value(result))
@@ -1560,9 +1562,9 @@ mod tests_normal {
                 ) -> crate::Result<crate::codec::data_type::VectorValue> {
                     let arg = &self;
                     let mut result = Vec::with_capacity(output_rows);
-                    for row in 0..output_rows {
-                        let (arg0, arg) = arg.extract(row);
-                        let (arg1, arg) = arg.extract(row);
+                    for row_index in 0..output_rows {
+                        let (arg0, arg) = arg.extract(row_index);
+                        let (arg1, arg) = arg.extract(row_index);
                         result.push(foo(ctx, arg0, arg1)?);
                     }
                     Ok(crate::codec::data_type::Evaluable::into_vector_value(result))


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Fix cast string to real inconsistent with TiDB, the former implementation does not handle the case in which the input parameter is binary string.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->

- Bugfix (a change which fixes an issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test

