### PR TITLE
lock_manager: more metrics

### DIFF
--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -568,10 +568,12 @@ where
         if self.inner.borrow().role != role {
             match role {
                 Role::Leader => {
-                    info!("became the leader of deadlock detector!"; "self_id" => self.store_id)
+                    info!("became the leader of deadlock detector!"; "self_id" => self.store_id);
+                    DETECTOR_LEADER_GAUGE.set(1);
                 }
                 Role::Follower => {
-                    info!("changed from the leader of deadlock detector to follower!"; "self_id" => self.store_id)
+                    info!("changed from the leader of deadlock detector to follower!"; "self_id" => self.store_id);
+                    DETECTOR_LEADER_GAUGE.set(0);
                 }
             }
         }

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -98,21 +98,7 @@ impl DetectTable {
 
     /// Returns the key hash which causes deadlock.
     pub fn detect(&mut self, txn_ts: TimeStamp, lock_ts: TimeStamp, lock_hash: u64) -> Option<u64> {
-        DETECTOR_HISTOGRAM_METRICS.with(|m| {
-            let res = m
-                .detect
-                .observe_closure_duration(|| self.detect_inner(txn_ts, lock_ts, lock_hash));
-            m.may_flush_all();
-            res
-        })
-    }
-
-    fn detect_inner(
-        &mut self,
-        txn_ts: TimeStamp,
-        lock_ts: TimeStamp,
-        lock_hash: u64,
-    ) -> Option<u64> {
+        let _timer = DETECT_DURATION_HISTOGRAM.start_coarse_timer();
         TASK_COUNTER_METRICS.with(|m| {
             m.detect.inc();
             m.may_flush_all()

--- a/src/server/lock_manager/metrics.rs
+++ b/src/server/lock_manager/metrics.rs
@@ -25,13 +25,6 @@ make_static_metric! {
             deadlock,
         },
     }
-
-    pub struct DetectorHistogramVec: LocalHistogram {
-        "type" => {
-            monitor_membership_change,
-            detect,
-        },
-    }
 }
 
 lazy_static! {
@@ -53,10 +46,9 @@ lazy_static! {
         exponential_buckets(0.0005, 2.0, 20).unwrap() // 0.5ms ~ 524s
     )
     .unwrap();
-    pub static ref DETECTOR_HISTOGRAM_VEC: HistogramVec = register_histogram_vec!(
-        "tikv_lock_manager_detector_histogram",
-        "Bucketed histogram of deadlock detector",
-        &["type"],
+    pub static ref DETECT_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "tikv_lock_manager_detect_duration",
+        "Duration of handling detect requests",
         exponential_buckets(0.0001, 2.0, 20).unwrap() // 0.1ms ~ 104s
     )
     .unwrap();
@@ -78,6 +70,4 @@ thread_local! {
         TLSMetricGroup::new(LocalTaskCounter::from(&TASK_COUNTER_VEC));
     pub static ERROR_COUNTER_METRICS: TLSMetricGroup<LocalErrorCounter> =
         TLSMetricGroup::new(LocalErrorCounter::from(&ERROR_COUNTER_VEC));
-    pub static DETECTOR_HISTOGRAM_METRICS: TLSMetricGroup<DetectorHistogramVec> =
-        TLSMetricGroup::new(DetectorHistogramVec::from(&DETECTOR_HISTOGRAM_VEC));
 }

--- a/src/server/lock_manager/metrics.rs
+++ b/src/server/lock_manager/metrics.rs
@@ -25,6 +25,13 @@ make_static_metric! {
             deadlock,
         },
     }
+
+    pub struct WaitTableStatusGauge: IntGauge {
+        "type" => {
+            locks,
+            txns,
+        },
+    }
 }
 
 lazy_static! {
@@ -52,7 +59,8 @@ lazy_static! {
         exponential_buckets(0.0001, 2.0, 20).unwrap() // 0.1ms ~ 104s
     )
     .unwrap();
-    pub static ref WAIT_TABLE_GAUGE: IntGaugeVec = register_int_gauge_vec!(
+    pub static ref WAIT_TABLE_STATUS_GAUGE: WaitTableStatusGauge = register_static_int_gauge_vec!(
+        WaitTableStatusGauge,
         "tikv_lock_manager_wait_table_status",
         "Status of the wait table",
         &["type"]

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -343,7 +343,7 @@ mod tests {
         assert!(lock_mgr.has_waiter());
         assert_elapsed(
             || expect_key_is_locked(f.wait().unwrap().unwrap().pop().unwrap(), lock_info),
-            3000,
+            2900,
             3200,
         );
         assert!(!lock_mgr.has_waiter());

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -325,7 +325,7 @@ impl WaitTable {
     /// Removes all waiters waiting for the lock.
     fn remove(&mut self, lock: Lock) {
         self.wait_table.remove(&lock.hash);
-        WAIT_TABLE_STATUS_GAUGE.locks.inc();
+        WAIT_TABLE_STATUS_GAUGE.locks.dec();
     }
 
     fn remove_waiter(&mut self, lock: Lock, waiter_ts: TimeStamp) -> Option<Waiter> {
@@ -335,7 +335,7 @@ impl WaitTable {
             .position(|waiter| waiter.start_ts == waiter_ts)?;
         let waiter = waiters.swap_remove(idx);
         self.waiter_count.fetch_sub(1, Ordering::SeqCst);
-        WAIT_TABLE_STATUS_GAUGE.txns.inc();
+        WAIT_TABLE_STATUS_GAUGE.txns.dec();
         if waiters.is_empty() {
             self.remove(lock);
         }
@@ -356,7 +356,7 @@ impl WaitTable {
             .0;
         let oldest = waiters.swap_remove(oldest_idx);
         self.waiter_count.fetch_sub(1, Ordering::SeqCst);
-        WAIT_TABLE_STATUS_GAUGE.txns.inc();
+        WAIT_TABLE_STATUS_GAUGE.txns.dec();
         Some((oldest, waiters))
     }
 

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -305,18 +305,27 @@ impl WaitTable {
 
     /// Returns the duplicated `Waiter` if there is.
     fn add_waiter(&mut self, waiter: Waiter) -> Option<Waiter> {
-        let waiters = self.wait_table.entry(waiter.lock.hash).or_default();
+        let waiters = self.wait_table.entry(waiter.lock.hash).or_insert_with(|| {
+            WAIT_TABLE_GAUGE.with_label_values(&["locks"]).inc();
+            Waiters::default()
+        });
         let old_idx = waiters.iter().position(|w| w.start_ts == waiter.start_ts);
         waiters.push(waiter);
-        let old = waiters.swap_remove(old_idx?);
-        self.waiter_count.fetch_sub(1, Ordering::SeqCst);
-        Some(old)
+        if let Some(old_idx) = old_idx {
+            let old = waiters.swap_remove(old_idx);
+            self.waiter_count.fetch_sub(1, Ordering::SeqCst);
+            Some(old)
+        } else {
+            WAIT_TABLE_GAUGE.with_label_values(&["txns"]).inc();
+            None
+        }
         // Here we don't increase waiter_count because it's already updated in LockManager::wait_for()
     }
 
     /// Removes all waiters waiting for the lock.
     fn remove(&mut self, lock: Lock) {
         self.wait_table.remove(&lock.hash);
+        WAIT_TABLE_GAUGE.with_label_values(&["locks"]).dec();
     }
 
     fn remove_waiter(&mut self, lock: Lock, waiter_ts: TimeStamp) -> Option<Waiter> {
@@ -326,8 +335,9 @@ impl WaitTable {
             .position(|waiter| waiter.start_ts == waiter_ts)?;
         let waiter = waiters.swap_remove(idx);
         self.waiter_count.fetch_sub(1, Ordering::SeqCst);
+        WAIT_TABLE_GAUGE.with_label_values(&["txns"]).dec();
         if waiters.is_empty() {
-            self.wait_table.remove(&lock.hash);
+            self.remove(lock);
         }
         Some(waiter)
     }
@@ -346,6 +356,7 @@ impl WaitTable {
             .0;
         let oldest = waiters.swap_remove(oldest_idx);
         self.waiter_count.fetch_sub(1, Ordering::SeqCst);
+        WAIT_TABLE_GAUGE.with_label_values(&["txns"]).dec();
         Some((oldest, waiters))
     }
 
@@ -646,7 +657,7 @@ pub mod tests {
                 core.run(delay.map(|not_cancelled| assert!(not_cancelled)))
                     .unwrap()
             },
-            100,
+            50,
             200,
         );
 
@@ -659,7 +670,7 @@ pub mod tests {
                 core.run(delay.map(|not_cancelled| assert!(not_cancelled)))
                     .unwrap()
             },
-            50,
+            20,
             100,
         );
 
@@ -672,7 +683,7 @@ pub mod tests {
                 core.run(delay.map(|not_cancelled| assert!(not_cancelled)))
                     .unwrap()
             },
-            100,
+            50,
             200,
         );
 
@@ -853,7 +864,7 @@ pub mod tests {
         waiter.reset_timeout(Instant::now() + Duration::from_millis(100));
         let (tx, rx) = mpsc::sync_channel(1);
         let f = waiter.on_timeout(move || tx.send(1).unwrap());
-        assert_elapsed(|| core.run(f).unwrap(), 100, 200);
+        assert_elapsed(|| core.run(f).unwrap(), 50, 200);
         rx.try_recv().unwrap();
 
         // The timeout handler shouldn't be invoked after waiter has been notified.
@@ -959,6 +970,7 @@ pub mod tests {
             ts: 2.into(),
             hash: 2,
         };
+
         wait_table.add_waiter(dummy_waiter(1.into(), lock.ts, lock.hash));
         // Increase waiter_count manually and assert the previous value is zero
         assert_eq!(waiter_count.fetch_add(1, Ordering::SeqCst), 0);
@@ -966,6 +978,7 @@ pub mod tests {
         waiter_count.fetch_add(1, Ordering::SeqCst);
         wait_table.add_waiter(dummy_waiter(1.into(), lock.ts, lock.hash));
         assert_eq!(waiter_count.load(Ordering::SeqCst), 1);
+        // Remove the waiter.
         wait_table.remove_waiter(lock, 1.into()).unwrap();
         assert_eq!(waiter_count.load(Ordering::SeqCst), 0);
         // Removing a non-existed waiter shouldn't decrease waiter count.
@@ -1043,7 +1056,7 @@ pub mod tests {
         );
         assert_elapsed(
             || expect_key_is_locked(f.wait().unwrap().unwrap().pop().unwrap(), lock_info),
-            1000,
+            900,
             1200,
         );
 
@@ -1058,7 +1071,7 @@ pub mod tests {
         );
         assert_elapsed(
             || expect_key_is_locked(f.wait().unwrap().unwrap().pop().unwrap(), lock_info),
-            100,
+            50,
             300,
         );
 
@@ -1073,7 +1086,7 @@ pub mod tests {
         );
         assert_elapsed(
             || expect_key_is_locked(f.wait().unwrap().unwrap().pop().unwrap(), lock_info),
-            1000,
+            900,
             1200,
         );
 
@@ -1154,7 +1167,7 @@ pub mod tests {
         lock_info.set_lock_version(lock.ts.into_inner() - 1);
         assert_elapsed(
             || expect_write_conflict(f.wait().unwrap(), waiter_ts, lock_info, *commit_ts.decr()),
-            wake_up_delay_duration,
+            wake_up_delay_duration - 50,
             wake_up_delay_duration + 200,
         );
 
@@ -1265,7 +1278,7 @@ pub mod tests {
         // The new waiter will be wake up after timeout.
         assert_elapsed(
             || expect_key_is_locked(f2.wait().unwrap().unwrap().pop().unwrap(), lock_info2),
-            1000,
+            900,
             1200,
         );
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
* Add metrics for wait table which record the counts of locks and txns.
* Add heartbeat of the leader of the deadlock detector.
* Remove unused metric.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Improvement (a change which is an improvement to an existing feature)


###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Manual test (add detailed scripts or steps below)

Because tests are run concurrently and the metrics are global, I can't test it in the test.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->
No

###  Does this PR affect `tidb-ansible`?
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->
https://github.com/pingcap/tidb-ansible/pull/1090

###  Any examples? (optional)
Wait table:
![image](https://user-images.githubusercontent.com/14819777/71664369-b185cd80-2d93-11ea-8399-549fc76bc77e.png)
Heartbeat of the leader of deadlock detector:
![image](https://user-images.githubusercontent.com/14819777/71664393-c5c9ca80-2d93-11ea-8311-4625b23c6075.png)


