### PR TITLE
Use aHash instead of FxHash

### DIFF
--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -21,7 +21,7 @@ fail = "0.3"
 futures = "0.1"
 futures03 = { package = "futures", version = "0.3" }
 futures-cpupool = "0.1"
-fxhash = "0.2.1"
+ahash = "0.2.18"
 grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default-features = false }
 hex = "0.3"
 lazy_static = "1.3"

--- a/components/tikv_util/src/collections.rs
+++ b/components/tikv_util/src/collections.rs
@@ -1,13 +1,13 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
-use fxhash;
+use ahash;
 use std::cmp::Eq;
 use std::hash::Hash;
 
 pub type HashMap<K, V> =
-    std::collections::HashMap<K, V, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
-pub type HashSet<T> = std::collections::HashSet<T, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
+    std::collections::HashMap<K, V, ahash::ABuildHasher>;
+pub type HashSet<T> = std::collections::HashSet<T, ahash::ABuildHasher>;
 pub use std::collections::hash_map::Entry as HashMapEntry;
 
 pub fn hash_set_with_capacity<T: Hash + Eq>(capacity: usize) -> HashSet<T> {
-    HashSet::with_capacity_and_hasher(capacity, fxhash::FxBuildHasher::default())
+    HashSet::with_capacity_and_hasher(capacity, ahash::ABuildHasher)
 }


### PR DESCRIPTION
Signed-off-by: jiannuan <gan.jiannuan@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
Use aHash instead of FxHash 
###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->

###  Does this PR affect `tidb-ansible`?
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->
###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

