### PR TITLE
[DNM] Support Execution Summary in non-cachable data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#705501101234770886dff3c7434de7c88fcc7188"
+source = "git+https://github.com/pingcap/kvproto.git?branch=non_cachable_data#dedb6515aed04f386aa7165eedfcbd36c928ed81"
 dependencies = [
  "bytes",
  "futures 0.1.29",
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#44f75c9bef33cef5c39e0e0e4fed71b15c735313"
+source = "git+https://github.com/pingcap/tipb.git?branch=non_cacheable_data#4ef5577ce0e06e89cc8c9d9c55cbbd33e28040b2"
 dependencies = [
  "bytes",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ itertools = "0.8"
 hyper = { version = "0.12", default-features = false, features = ["runtime"] }
 keys = { path = "components/keys" }
 txn_types = { path = "components/txn_types" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 lazy_static = "1.3"
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
@@ -107,7 +107,7 @@ tidb_query = { path = "components/tidb_query" }
 tikv_alloc = { path = "components/tikv_alloc", default-features = false }
 tikv_util = { path = "components/tikv_util" }
 time = "0.1"
-tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
+tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false, branch = "non_cacheable_data" }
 tokio-core = "0.1"
 tokio-executor = "0.1"
 tokio-fs = "0.1.6"

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -39,7 +39,7 @@ grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default
 hex = "0.3"
 keys = { path = "../components/keys" }
 txn_types = { path = "../components/txn_types" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 nix = "0.11"

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -20,7 +20,7 @@ grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default
 hex = "0.3"
 keys = { path = "../keys" }
 txn_types = { path = "../txn_types" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 lazy_static = "1.3"
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -13,7 +13,7 @@ prost-codec = ["prost"]
 [dependencies]
 engine_traits = { path = "../engine_traits" }
 hex = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 lazy_static = "1.3"
 prost = { version = "0.5", optional = true }
 protobuf = "2.8"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -13,7 +13,7 @@ sse = ["rocksdb/sse"]
 engine = { path = "../engine" }
 engine_traits = { path = "../engine_traits" }
 hex = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 lazy_static = "1.3"
 protobuf = "2"
 quick-error = "1.2.2"

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -12,7 +12,7 @@ slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global
 tempfile = "3.0"
 tikv_alloc = { path = "../tikv_alloc", default-features = false }
 url = "2.0"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 
 [features]
 prost-codec = ["kvproto/prost-codec"]

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -9,7 +9,7 @@ byteorder = "1.2"
 derive_more = "0.15.0"
 failure = "0.1"
 hex = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 slog = "2.3"
 
 tikv_alloc = { path = "../tikv_alloc", default-features = false }

--- a/components/log_wrappers/Cargo.toml
+++ b/components/log_wrappers/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 hex = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 slog = "2.3"
 slog-term = "2.4"
 tikv_alloc = { path = "../tikv_alloc", default-features = false }

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -9,7 +9,7 @@ futures = "0.1"
 grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default-features = false }
 hex = "0.3"
 keys = { path = "../keys" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 protobuf = "2.8"

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -13,7 +13,7 @@ grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default
 hex = "0.3"
 keys = { path = "../keys" }
 txn_types = { path = "../txn_types" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 lazy_static = "1.3"
 quick-error = "1.2.2"
 serde = "1.0"

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -11,11 +11,11 @@ prost-codec = ["prost"]
 futures = "0.1"
 keys = { path = "../keys" }
 txn_types = { path = "../txn_types" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 prost = { version = "0.5", optional = true }
 protobuf = "2"
 test_storage = { path = "../test_storage" }
 tidb_query = { path = "../tidb_query" }
 tikv = { path = "../../", default-features = false}
 tikv_util = { path = "../tikv_util" }
-tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
+tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false, branch = "non_cacheable_data" }

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -12,7 +12,7 @@ futures-cpupool = "0.1"
 grpcio = { version = "0.5.0-alpha.5", features = ["openssl-vendored"], default-features = false }
 hex = "0.3"
 keys = { path = "../keys" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 pd_client = { path = "../pd_client" }
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha" , default-features = false }

--- a/components/test_sst_importer/Cargo.toml
+++ b/components/test_sst_importer/Cargo.toml
@@ -15,5 +15,5 @@ engine = { path = "../engine" }
 engine_rocks = { path = "../engine_rocks" }
 engine_traits = { path = "../engine_traits" }
 keys = { path = "../keys" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 uuid = { version = "0.7", features = [ "serde", "v4" ] }

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 futures = "0.1"
 keys = { path = "../keys" }
 txn_types = { path = "../txn_types" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 test_raftstore = { path = "../test_raftstore" }
 tikv = { path = "../../", default-features = false }
 tikv_util = { path = "../tikv_util" }

--- a/components/tidb_query/Cargo.toml
+++ b/components/tidb_query/Cargo.toml
@@ -20,7 +20,7 @@ failure = "0.1"
 flate2 = { version = "1.0", features = ["zlib"], default-features = false }
 hex = "0.3"
 indexmap = { version = "1.0", features = ["serde-1"] }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 lazy_static = "1.3"
 match_template = { path = "../match_template" }
 nom = "5.0.1"
@@ -45,7 +45,7 @@ tidb_query_codegen = { path = "../tidb_query_codegen" }
 tidb_query_datatype = { path = "../tidb_query_datatype" }
 tikv_util = { path = "../tikv_util" }
 time = "0.1"
-tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
+tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false, branch = "non_cacheable_data" }
 
 tipb_helper = { path = "../tipb_helper" }
 twoway = "0.2.0"

--- a/components/tidb_query/src/expr/scalar_function.rs
+++ b/components/tidb_query/src/expr/scalar_function.rs
@@ -389,6 +389,7 @@ impl ScalarFunc {
 
             // unimplemented signature
             ScalarFuncSig::TruncateUint
+            | ScalarFuncSig::UpperUtf8
             | ScalarFuncSig::AesDecryptIv
             | ScalarFuncSig::AesEncryptIv
             | ScalarFuncSig::Encode

--- a/components/tidb_query_datatype/Cargo.toml
+++ b/components/tidb_query_datatype/Cargo.toml
@@ -10,4 +10,4 @@ bitflags = "1.0"
 failure = "0.1"
 num-traits = "0.2"
 tikv_alloc = { path = "../tikv_alloc", default-features = false }
-tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
+tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false, branch = "non_cacheable_data" }

--- a/components/tipb_helper/Cargo.toml
+++ b/components/tipb_helper/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 [dependencies]
 codec = { path = "../codec" }
 tidb_query_datatype = { path = "../tidb_query_datatype" }
-tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
+tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false, branch = "non_cacheable_data" }

--- a/components/txn_types/Cargo.toml
+++ b/components/txn_types/Cargo.toml
@@ -11,7 +11,7 @@ derive_more = "0.15.0"
 hex = "0.3"
 derive-new = "0.5"
 codec = { path = "../codec" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 slog = "2.3"
 quick-error = "1.2.2"
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -59,7 +59,7 @@ futures-cpupool = "0.1"
 futures03 = { package = "futures", version = "0.3", features = ["executor"] }
 grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored" ], default-features = false }
 hex = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, branch = "non_cachable_data" }
 pd_client = { path = "../components/pd_client" }
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha" , default-features = false }
@@ -70,7 +70,7 @@ tempfile = "3.0"
 tidb_query = { path = "../components/tidb_query" }
 tikv = { path = "../", default-features = false }
 tikv_util = { path = "../components/tikv_util" }
-tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
+tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false, branch = "non_cacheable_data" }
 tokio-threadpool = "0.1.13"
 toml = "0.4"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }

--- a/tests/benches/coprocessor_executors/util/mod.rs
+++ b/tests/benches/coprocessor_executors/util/mod.rs
@@ -12,6 +12,7 @@ use criterion::black_box;
 use criterion::measurement::Measurement;
 
 use kvproto::coprocessor::KeyRange;
+use tipb::DagRequestNonCacheablePartial;
 use tipb::Executor as PbExecutor;
 
 use test_coprocessor::*;
@@ -44,6 +45,7 @@ pub fn build_dag_handler<TargetTxnStore: TxnStore + 'static>(
 
     tikv::coprocessor::dag::build_handler(
         black_box(dag),
+        DagRequestNonCacheablePartial::default(),
         black_box(ranges.to_vec()),
         0,
         black_box(ToTxnStore::<TargetTxnStore>::to_store(store)),


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This PR supports responding execution summary in non-cacheable-data field for better caching.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

- Unit test
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->

###  Does this PR affect `tidb-ansible`?
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->
###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

