### PR TITLE
[DNM] tidb_query: fix cast string to int inconsistent with TiDB

### DIFF
--- a/components/tidb_query/src/rpn_expr/impl_cast.rs
+++ b/components/tidb_query/src/rpn_expr/impl_cast.rs
@@ -41,7 +41,13 @@ fn get_cast_fn_rpn_meta(
                 cast_real_as_uint_fn_meta()
             }
         }
-        (EvalType::Bytes, EvalType::Int) => cast_string_as_int_or_uint_fn_meta(),
+        (EvalType::Bytes, EvalType::Int) => {
+            if from_field_type.is_binary_string_like() {
+                cast_binary_string_as_int_fn_meta()
+            } else {
+                cast_string_as_int_fn_meta()
+            }
+        }
         (EvalType::Decimal, EvalType::Int) => {
             if !to_field_type.is_unsigned() {
                 cast_any_as_any_fn_meta::<Decimal, Int>()
@@ -288,7 +294,7 @@ fn cast_real_as_uint(
 
 #[rpn_fn(capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
-fn cast_string_as_int_or_uint(
+fn cast_string_as_int(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
     metadata: &tipb::InUnionMetadata,
@@ -355,6 +361,17 @@ fn cast_string_as_int_or_uint(
                     },
                 }
             }
+        }
+    }
+}
+
+#[rpn_fn(capture = [ctx])]
+fn cast_binary_string_as_int(ctx: &mut EvalContext, val: &Option<Bytes>) -> Result<Option<Int>> {
+    match val {
+        None => Ok(None),
+        Some(val) => {
+            let r = binary_literal::to_uint(ctx, val)? as i64;
+            Ok(Some(r))
         }
     }
 }
@@ -1375,25 +1392,6 @@ mod tests {
         }
     }
 
-    fn check_warnings(ctx: &EvalContext, err_code: Vec<i32>, log: &str) {
-        assert_eq!(
-            ctx.warnings.warning_cnt,
-            err_code.len(),
-            "{}, warnings: {:?}",
-            log,
-            ctx.warnings.warnings
-        );
-        for i in 0..err_code.len() {
-            let e1 = err_code[i];
-            let e2 = ctx.warnings.warnings[i].get_code();
-            assert_eq!(
-                e1, e2,
-                "log: {}, ctx_warnings: {:?}, expect_warning: {:?}",
-                log, ctx.warnings.warnings, err_code
-            );
-        }
-    }
-
     fn check_result<R: Debug + PartialEq>(expect: Option<&R>, res: &Result<Option<R>>, log: &str) {
         assert!(res.is_ok(), "{}", log);
         let res = res.as_ref().unwrap();
@@ -1562,8 +1560,15 @@ mod tests {
     }
 
     #[test]
-    fn test_string_as_int_or_uint() {
-        test_none_with_ctx_and_extra_and_metadata(cast_string_as_int_or_uint);
+    fn test_cast_string_as_int() {
+        // None
+        {
+            let output: Option<Int> = RpnFnScalarEvaluator::new()
+                .push_param(ScalarValue::Bytes(None))
+                .evaluate(ScalarFuncSig::CastStringAsInt)
+                .unwrap();
+            assert_eq!(output, None);
+        }
 
         #[derive(Debug)]
         enum Cond {
@@ -1644,9 +1649,9 @@ mod tests {
             // FIXME: in mysql, this case will return 18446744073709551615
             //  and `show warnings` will show
             //  `| Warning | 1292 | Truncated incorrect INTEGER value: '18446744073709551616'`
-            //  fix this cast_string_as_int_or_uint after fix TiDB's
+            //  fix this cast_string_as_int after fix TiDB's
             // ("18446744073709551616", 18446744073709551615 as i64, Some(ERR_TRUNCATE_WRONG_VALUE) , Cond::Unsigned)
-            // FIXME: our cast_string_as_int_or_uint's err handle is not exactly same as TiDB's
+            // FIXME: our cast_string_as_int's err handle is not exactly same as TiDB's
             // ("18446744073709551616", 18446744073709551615u64 as i64, Some(ERR_TRUNCATE_WRONG_VALUE), Cond::InSelectStmt),
 
             // has prefix `-` and in_union and unsigned
@@ -1660,7 +1665,7 @@ mod tests {
                 vec![],
                 Cond::None,
             ),
-            // FIXME: our cast_string_as_int_or_uint's err handle is not exactly same as TiDB's
+            // FIXME: our cast_string_as_int's err handle is not exactly same as TiDB's
             (
                 "-9223372036854775809",
                 -9223372036854775808i64,
@@ -1682,30 +1687,82 @@ mod tests {
             ),
         ];
 
-        for (input, expect, err_code, cond) in cs {
-            let mut ctx = CtxConfig {
-                overflow_as_warning: true,
-                truncate_as_warning: true,
-                ..CtxConfig::default()
-            }
-            .into();
-            let metadata = make_metadata(cond.in_union());
-            let rft = FieldTypeConfig {
-                unsigned: cond.is_unsigned(),
-                ..FieldTypeConfig::default()
-            }
-            .into();
-            let extra = make_extra(&rft);
-
-            let val = Some(Vec::from(input.as_bytes()));
-            let r = cast_string_as_int_or_uint(&mut ctx, &extra, &metadata, &val);
-
-            let log = format!(
-                "input: {}, expect: {}, expect_err_code: {:?}, cond: {:?}, output: {:?}",
-                input, expect, err_code, cond, r
+        for (input, expected, mut err_code, cond) in cs {
+            let (result, ctx) = RpnFnScalarEvaluator::new()
+                .context(CtxConfig {
+                    overflow_as_warning: true,
+                    truncate_as_warning: true,
+                    ..CtxConfig::default()
+                })
+                .metadata(Box::new(make_metadata(cond.in_union())))
+                .push_param(ScalarValue::Bytes(Some(input.as_bytes().to_owned())))
+                .evaluate_raw(
+                    FieldTypeConfig {
+                        tp: Some(FieldTypeTp::LongLong),
+                        unsigned: cond.is_unsigned(),
+                        ..FieldTypeConfig::default()
+                    },
+                    ScalarFuncSig::CastStringAsInt,
+                );
+            let output: Option<Int> = result.unwrap().into();
+            assert_eq!(
+                output.unwrap(),
+                expected,
+                "input:{:?}, expected:{:?}, cond:{:?}",
+                input,
+                expected,
+                cond,
             );
-            check_result(Some(&expect), &r, log.as_str());
-            check_warnings(&ctx, err_code, log.as_str());
+            let mut got_warnings = ctx
+                .warnings
+                .warnings
+                .iter()
+                .map(|w| w.get_code())
+                .collect::<Vec<i32>>();
+            got_warnings.sort();
+            err_code.sort();
+            assert_eq!(
+                ctx.warnings.warning_cnt,
+                err_code.len(),
+                "input:{:?}, expected:{:?}, warnings:{:?}",
+                input,
+                expected,
+                got_warnings,
+            );
+            assert_eq!(got_warnings, err_code);
+        }
+
+        // binary literal
+        let cases = vec![
+            (vec![0x01, 0x02, 0x03], Some(0x010203 as i64)),
+            (vec![0x01, 0x02, 0x03, 0x4], Some(0x01020304 as i64)),
+            (
+                vec![0x01, 0x02, 0x03, 0x4, 0x05, 0x06, 0x06, 0x06, 0x06],
+                None,
+            ),
+        ];
+        for (input, expected) in cases {
+            let output: Result<Option<Int>> = RpnFnScalarEvaluator::new()
+                .return_field_type(FieldTypeConfig {
+                    tp: Some(FieldTypeTp::LongLong),
+                    ..FieldTypeConfig::default()
+                })
+                .push_param_with_field_type(
+                    input.clone(),
+                    FieldTypeConfig {
+                        tp: Some(FieldTypeTp::VarString),
+                        collation: Some(Collation::Binary),
+                        ..FieldTypeConfig::default()
+                    },
+                )
+                .evaluate(ScalarFuncSig::CastStringAsInt);
+
+            if let Some(exp) = expected {
+                assert!(output.is_ok(), "input: {:?}", input);
+                assert_eq!(output.unwrap().unwrap(), exp, "input={:?}", input);
+            } else {
+                assert!(output.is_err());
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Please explain in detail what the changes are in this PR and why they are needed:

- Summarize your change
- How does this PR work? Include a brief introduction for any changed logic (optional)
- Separately describe each logical change (optional)
- Describe any limitations of the current code (optional)

Don't assume reviewers understand the original issue.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- New feature (a change which adds functionality)
- Improvement (a change which is an improvement to an existing feature)
- Bugfix (a change which fixes an issue)
- Engineering (engineering change which doesn't change any feature or fix any issue)
- Misc (other changes)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->

###  Does this PR affect `tidb-ansible`?
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->
###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

