### PR TITLE
raftstore: speed up conf change

### DIFF
--- a/components/tidb_query/src/rpn_expr/impl_encryption.rs
+++ b/components/tidb_query/src/rpn_expr/impl_encryption.rs
@@ -290,12 +290,10 @@ mod tests {
         ];
 
         for len in overflow_tests {
-            assert!(
-                RpnFnScalarEvaluator::new()
-                    .push_param(len)
-                    .evaluate::<Bytes>(ScalarFuncSig::RandomBytes)
-                    .is_err(),
-            );
+            assert!(RpnFnScalarEvaluator::new()
+                .push_param(len)
+                .evaluate::<Bytes>(ScalarFuncSig::RandomBytes)
+                .is_err(),);
         }
 
         //test NULL case

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -361,6 +361,11 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 self.fsm.group_state = GroupState::Chaos;
                 self.register_raft_base_tick();
             }
+            CasualMessage::SnapshotGenerated => {
+                // Resume snapshot handling again to avoid waiting another heartbeat.
+                self.fsm.peer.ping();
+                self.fsm.has_ready = true;
+            }
             CasualMessage::Test(cb) => cb(self.fsm),
         }
     }
@@ -1472,6 +1477,9 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 let id = peer.get_id();
                 self.fsm.peer.peer_heartbeats.insert(id, now);
                 if self.fsm.peer.is_leader() {
+                    // Speed up snapshot instead of waiting another heartbeat.
+                    self.fsm.peer.ping();
+                    self.fsm.has_ready = true;
                     self.fsm.peer.peers_start_pending_time.push((id, now));
                 }
                 self.fsm.peer.recent_conf_change_time = now;

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -1129,8 +1129,9 @@ impl RaftBatchSystem {
             cfg.use_delete_range,
             cfg.clean_stale_peer_delay.0,
             Arc::clone(&workers.coprocessor_host),
+            self.router(),
         );
-        let timer = RegionRunner::new_timer();
+        let timer = region_runner.new_timer();
         box_try!(workers.region_worker.start_with_timer(region_runner, timer));
 
         let raftlog_gc_runner = RaftlogGcRunner::new(None);

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -218,6 +218,8 @@ pub enum CasualMessage {
     ClearRegionSize,
     /// Indicate a target region is overlapped.
     RegionOverlapped,
+    /// Notifies that a new snapshot has been generated.
+    SnapshotGenerated,
 
     /// A test only message, it is useful when we want to access
     /// peer's internal state.
@@ -263,6 +265,7 @@ impl fmt::Debug for CasualMessage {
                 "clear region size"
             },
             CasualMessage::RegionOverlapped => write!(fmt, "RegionOverlapped"),
+            CasualMessage::SnapshotGenerated => write!(fmt, "SnapshotGenerated"),
             CasualMessage::Test(_) => write!(fmt, "Test"),
         }
     }

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1243,6 +1243,13 @@ impl Peer {
             .raft_group
             .has_ready_since(Some(self.last_applying_idx))
         {
+            // Generating snapshot task won't set ready for raft group.
+            if let Some(gen_task) = self.mut_store().take_gen_snap_task() {
+                self.pending_request_snapshot_count
+                    .fetch_add(1, Ordering::SeqCst);
+                ctx.apply_router
+                    .schedule_task(self.region_id, ApplyTask::Snapshot(gen_task));
+            }
             return None;
         }
 

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -1972,6 +1972,7 @@ mod tests {
         let mut worker = Worker::new("region-worker");
         let sched = worker.scheduler();
         let mut s = new_storage_from_ents(sched.clone(), &td, &ents);
+        let (router, _) = mpsc::sync_channel(100);
         let runner = RegionRunner::new(
             s.engines.clone(),
             mgr,
@@ -1979,6 +1980,7 @@ mod tests {
             true,
             Duration::from_secs(0),
             Arc::new(CoprocessorHost::default()),
+            router,
         );
         worker.start(runner).unwrap();
         let snap = s.snapshot(0);
@@ -2296,6 +2298,7 @@ mod tests {
         let mut worker = Worker::new("snap-manager");
         let sched = worker.scheduler();
         let s1 = new_storage_from_ents(sched.clone(), &td1, &ents);
+        let (router, _) = mpsc::sync_channel(100);
         let runner = RegionRunner::new(
             s1.engines.clone(),
             mgr,
@@ -2303,6 +2306,7 @@ mod tests {
             true,
             Duration::from_secs(0),
             Arc::new(CoprocessorHost::default()),
+            router,
         );
         worker.start(runner).unwrap();
         assert!(s1.snapshot(0).is_err());

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -24,7 +24,10 @@ use crate::raftstore::store::peer_storage::{
     JOB_STATUS_PENDING, JOB_STATUS_RUNNING,
 };
 use crate::raftstore::store::snap::{plain_file_used, Error, Result, SNAPSHOT_CFS};
-use crate::raftstore::store::{self, check_abort, ApplyOptions, SnapEntry, SnapKey, SnapManager};
+use crate::raftstore::store::transport::CasualRouter;
+use crate::raftstore::store::{
+    self, check_abort, ApplyOptions, CasualMessage, SnapEntry, SnapKey, SnapManager,
+};
 use tikv_util::threadpool::{DefaultContext, ThreadPool, ThreadPoolBuilder};
 use tikv_util::time;
 use tikv_util::timer::Timer;
@@ -203,7 +206,7 @@ impl PendingDeleteRanges {
 }
 
 #[derive(Clone)]
-struct SnapContext {
+struct SnapContext<R> {
     engines: Engines,
     batch_size: usize,
     mgr: SnapManager<RocksEngine>,
@@ -211,9 +214,10 @@ struct SnapContext {
     clean_stale_peer_delay: Duration,
     pending_delete_ranges: PendingDeleteRanges,
     coprocessor_host: Arc<CoprocessorHost>,
+    router: R,
 }
 
-impl SnapContext {
+impl<R: CasualRouter> SnapContext<R> {
     /// Generates the snapshot of the Region.
     fn generate_snap(
         &self,
@@ -239,6 +243,10 @@ impl SnapContext {
                 "err" => %e,
             );
         }
+        // The error can be ignored as snapshot will be sent in next heartbeat in the end.
+        let _ = self
+            .router
+            .send(region_id, CasualMessage::SnapshotGenerated);
         Ok(())
     }
 
@@ -513,16 +521,16 @@ impl SnapContext {
     }
 }
 
-pub struct Runner {
+pub struct Runner<R> {
     pool: ThreadPool<DefaultContext>,
-    ctx: SnapContext,
+    ctx: SnapContext<R>,
 
     // we may delay some apply tasks if level 0 files to write stall threshold,
     // pending_applies records all delayed apply task, and will check again later
     pending_applies: VecDeque<Task>,
 }
 
-impl Runner {
+impl<R: CasualRouter> Runner<R> {
     pub fn new(
         engines: Engines,
         mgr: SnapManager<RocksEngine>,
@@ -530,7 +538,8 @@ impl Runner {
         use_delete_range: bool,
         clean_stale_peer_delay: Duration,
         coprocessor_host: Arc<CoprocessorHost>,
-    ) -> Runner {
+        router: R,
+    ) -> Runner<R> {
         Runner {
             pool: ThreadPoolBuilder::with_default_factory(thd_name!("snap-generator"))
                 .thread_count(GENERATE_POOL_SIZE)
@@ -543,12 +552,13 @@ impl Runner {
                 clean_stale_peer_delay,
                 pending_delete_ranges: PendingDeleteRanges::default(),
                 coprocessor_host,
+                router,
             },
             pending_applies: VecDeque::new(),
         }
     }
 
-    pub fn new_timer() -> Timer<Event> {
+    pub fn new_timer(&self) -> Timer<Event> {
         let mut timer = Timer::new(2);
         timer.add_task(
             Duration::from_millis(PENDING_APPLY_CHECK_INTERVAL),
@@ -577,7 +587,10 @@ impl Runner {
     }
 }
 
-impl Runnable<Task> for Runner {
+impl<R> Runnable<Task> for Runner<R>
+where
+    R: CasualRouter + Send + Clone + 'static,
+{
     fn run(&mut self, task: Task) {
         match task {
             Task::Gen {
@@ -635,7 +648,10 @@ pub enum Event {
     CheckApply,
 }
 
-impl RunnableWithTimer<Task, Event> for Runner {
+impl<R> RunnableWithTimer<Task, Event> for Runner<R>
+where
+    R: CasualRouter + Send + Clone + 'static,
+{
     fn on_timeout(&mut self, timer: &mut Timer<Event>, event: Event) {
         match event {
             Event::CheckApply => {
@@ -668,7 +684,7 @@ mod tests {
     use crate::raftstore::store::peer_storage::JOB_STATUS_PENDING;
     use crate::raftstore::store::snap::tests::get_test_db_for_regions;
     use crate::raftstore::store::worker::RegionRunner;
-    use crate::raftstore::store::{SnapKey, SnapManager};
+    use crate::raftstore::store::{CasualMessage, SnapKey, SnapManager};
     use engine::rocks;
     use engine::rocks::{ColumnFamilyOptions, Writable, WriteBatch};
     use engine::Engines;
@@ -809,6 +825,7 @@ mod tests {
         let mgr = SnapManager::new(snap_dir.path().to_str().unwrap(), None);
         let mut worker = Worker::new("snap-manager");
         let sched = worker.scheduler();
+        let (router, receiver) = mpsc::sync_channel(1);
         let runner = RegionRunner::new(
             engines.clone(),
             mgr,
@@ -816,6 +833,7 @@ mod tests {
             true,
             Duration::from_secs(0),
             Arc::new(CoprocessorHost::default()),
+            router,
         );
         let mut timer = Timer::new(1);
         timer.add_task(Duration::from_millis(100), Event::CheckApply);
@@ -833,6 +851,12 @@ mod tests {
                 })
                 .unwrap();
             let s1 = rx.recv().unwrap();
+            match receiver.recv() {
+                Ok((region_id, CasualMessage::SnapshotGenerated)) => {
+                    assert_eq!(region_id, id);
+                }
+                msg => panic!("expected SnapshotGenerated, but got {:?}", msg),
+            }
             let data = s1.get_data();
             let key = SnapKey::from_snap(&s1).unwrap();
             let mgr = SnapManager::<RocksEngine>::new(snap_dir.path().to_str().unwrap(), None);

--- a/tests/integrations/raftstore/test_conf_change.rs
+++ b/tests/integrations/raftstore/test_conf_change.rs
@@ -930,7 +930,6 @@ where
 /// Tests if conf change relies on heartbeat.
 #[test]
 fn test_conf_change_fast() {
-    test_util::init_log_for_test();
     let mut cluster = new_server_cluster(0, 3);
     // Sets heartbeat timeout to more than 5 seconds. It also changes the election timeout,
     // but it's OK as the cluster starts with only one peer, it will campaigns immediately.

--- a/tests/integrations/raftstore/test_conf_change.rs
+++ b/tests/integrations/raftstore/test_conf_change.rs
@@ -3,7 +3,7 @@
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::*;
 
 use futures::Future;
 
@@ -938,8 +938,10 @@ fn test_conf_change_fast() {
     pd_client.disable_default_operator();
     let r1 = cluster.run_conf_change();
     cluster.must_put(b"k1", b"v1");
+    let timer = Instant::now();
     // If conf change relies on heartbeat, it will take more than 5 seconds to finish,
     // hence it must timeout.
     pd_client.must_add_peer(r1, new_peer(2, 2));
     must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+    assert!(timer.elapsed() < Duration::from_secs(5));
 }


### PR DESCRIPTION
###  What have you changed?

It speeds up conf change by sending more heartbeats. The heartbeats are
not frequent and the overhead is quite small.

###  What is the type of the changes?

- Bugfix

###  How is the PR tested?

- Unit test
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No.

###  Does this PR affect `tidb-ansible`?
No

###  Refer to a related PR or issue link (optional)

Close #6420.

