### PR TITLE
tidb_query: fix log_2args rpn function inconsistent with tidb

### DIFF
--- a/components/tidb_query/src/rpn_expr/impl_math.rs
+++ b/components/tidb_query/src/rpn_expr/impl_math.rs
@@ -34,7 +34,13 @@ pub fn log_1_arg(arg: &Option<Real>) -> Result<Option<Real>> {
 #[rpn_fn]
 pub fn log_2_arg(arg0: &Option<Real>, arg1: &Option<Real>) -> Result<Option<Real>> {
     Ok(match (arg0, arg1) {
-        (Some(base), Some(n)) => f64_to_real(n.log(**base)),
+        (Some(base), Some(n)) => {
+            if **base <= 0f64 || **base == 1f64 || **n <= 0f64 {
+                None
+            } else {
+                f64_to_real(n.log(**base))
+            }
+        }
         _ => None,
     })
 }
@@ -524,6 +530,9 @@ mod tests {
             (Some(2.0_f64), Some(1.0_f64), Some(Real::from(0.0_f64))),
             (Some(0.5_f64), Some(0.25_f64), Some(Real::from(2.0_f64))),
             (Some(-0.23323_f64), Some(2.0_f64), None),
+            (Some(0_f64), Some(123_f64), None),
+            (Some(1_f64), Some(123_f64), None),
+            (Some(1123_f64), Some(0_f64), None),
             (None, None, None),
             (Some(2.0_f64), None, None),
             (None, Some(2.0_f64), None),


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Fix log_2args rpn function inconsistent with TiDB. reference: https://github.com/pingcap/tidb/blob/8cbacf0d7c4612e6b5fa89836ca170af11eb81b2/expression/builtin_math.go#L882

MySQL
```
mysql> select log(100,1);
+------------+
| log(100,1) |
+------------+
|          0 |
+------------+
1 row in set (0.00 sec)

mysql> select log(0,1);
+----------+
| log(0,1) |
+----------+
|     NULL |
+----------+
1 row in set, 1 warning (0.00 sec)

mysql> select log(1,1);
+----------+
| log(1,1) |
+----------+
|     NULL |
+----------+
1 row in set, 1 warning (0.00 sec)

mysql> select log(1,10);
+-----------+
| log(1,10) |
+-----------+
|      NULL |
+-----------+
1 row in set, 1 warning (0.00 sec)
```

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->

- Bugfix (a change which fixes an issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test

