### PR TITLE
Enable default proto feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ prost-codec = [
   "tikv_util/prost-codec",
   "sst_importer/prost-codec",
   "pd_client/prost-codec",
+  "tidb_query/prost-codec",
 ]
 protobuf-codec = [
   "tipb/protobuf-codec",
@@ -37,6 +38,7 @@ protobuf-codec = [
   "raft/protobuf-codec",
   "sst_importer/protobuf-codec",
   "pd_client/protobuf-codec",
+  "tidb_query/protobuf-codec",
 ]
 
 [lib]
@@ -57,7 +59,7 @@ crc64fast = "0.1"
 crossbeam = "0.7.2"
 derive-new = "0.5"
 derive_more = "0.15.0"
-engine = { path = "components/engine" }
+engine = { path = "components/engine", default-features = false }
 engine_rocks = { path = "components/engine_rocks" }
 engine_traits = { path = "components/engine_traits" }
 fail = "0.3"
@@ -82,11 +84,11 @@ mime = "0.3.13"
 more-asserts = "0.1"
 nix = "0.11"
 nom = "5.0.1"
-pd_client = { path = "components/pd_client" }
+pd_client = { path = "components/pd_client", default-features = false }
 prost = "0.5.0"
 protobuf = "2.8"
 quick-error = "1.2.2"
-raft = { version = "0.6.0-alpha" , default-features = false }
+raft = { version = "0.6.0-alpha", default-features = false }
 rand = "0.6.5"
 regex = "1.3"
 rev_lines = "0.2.1"
@@ -99,13 +101,13 @@ slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global
 slog-term = "2.4"
 slog_derive = "0.1"
 spin = "0.5"
-sst_importer = { path = "components/sst_importer" }
+sst_importer = { path = "components/sst_importer", default-features = false }
 sysinfo = { git = "https://github.com/tikv/sysinfo.git", branch = "tikv"}
 tempfile = "3.0"
 test_util = { path = "components/test_util" }
-tidb_query = { path = "components/tidb_query" }
+tidb_query = { path = "components/tidb_query", default-features = false }
 tikv_alloc = { path = "components/tikv_alloc", default-features = false }
-tikv_util = { path = "components/tikv_util" }
+tikv_util = { path = "components/tikv_util", default-features = false }
 time = "0.1"
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
 tokio-core = "0.1"

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -5,10 +5,12 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 jemalloc = ["rocksdb/jemalloc"]
 portable = ["rocksdb/portable"]
 sse = ["rocksdb/sse"]
-prost-codec = ["prost"]
+prost-codec = ["kvproto/prost-codec", "prost"]
+protobuf-codec = ["kvproto/protobuf-codec"]
 
 [dependencies]
 engine_traits = { path = "../engine_traits" }

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -33,5 +33,6 @@ rev = "d919ccd35976b9b84b8d03c07138c1cc05a36087"
 features = ["nightly", "push", "process"]
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = ["kvproto/protobuf-codec"]
 prost-codec = ["kvproto/prost-codec"]

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -35,5 +35,6 @@ tempfile = "3.0"
 test_sst_importer = { path = "../test_sst_importer" }
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = ["kvproto/protobuf-codec", "external_storage/protobuf-codec"]
 prost-codec = ["kvproto/prost-codec", "external_storage/prost-codec"]

--- a/components/tidb_query/Cargo.toml
+++ b/components/tidb_query/Cargo.toml
@@ -64,3 +64,8 @@ rev = "d919ccd35976b9b84b8d03c07138c1cc05a36087"
 [dev-dependencies]
 profiler = { path = "../profiler" }
 panic_hook = { path = "../panic_hook" }
+
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = ["kvproto/protobuf-codec"]
+prost-codec = ["kvproto/prost-codec"]

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
+protobuf-codec = ["raft/protobuf-codec"]
+prost-codec = ["raft/prost-codec", "prost"]
 failpoints = ["fail/failpoints"]
-prost-codec = ["prost"]
 
 [dependencies]
 backtrace = "0.3.9"


### PR DESCRIPTION
Signed-off-by: Dian Luo <andylokandy@hotmail.com>

###  What have you changed?

This PR fixed the compilation issue that breaks building submodules.

For example, 

```
> cd components/tikv_utils
> cargo check
```
then it comes out
```
error[E0599]: no method named `generate_files` found for type `&Builder` in the current scope
  --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/protobuf-build-0.10.0/src/lib.rs:56:14
   |
56 |         self.generate_files();
   |              ^^^^^^^^^^^^^^ method not found in `&Builder`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: could not compile `protobuf-build`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Unit test
- Integration test

