### PR TITLE
update rust-rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 dependencies = [
  "either",
 ]
@@ -1646,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#d10a04ff8a2ee4e4f887955025aef4d8499d8f9b"
+source = "git+https://github.com/tikv/rust-rocksdb.git#72e45c3f3283302c825d53c3cd7154f4cd9e8f5b"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#d10a04ff8a2ee4e4f887955025aef4d8499d8f9b"
+source = "git+https://github.com/tikv/rust-rocksdb.git#72e45c3f3283302c825d53c3cd7154f4cd9e8f5b"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -2948,7 +2948,7 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/pingcap/rust-rocksdb.git#d10a04ff8a2ee4e4f887955025aef4d8499d8f9b"
+source = "git+https://github.com/tikv/rust-rocksdb.git#72e45c3f3283302c825d53c3cd7154f4cd9e8f5b"
 dependencies = [
  "libc",
  "librocksdb_sys",
@@ -4501,9 +4501,10 @@ dependencies = [
 [[package]]
 name = "zstd-sys"
 version = "1.4.15+zstd.1.4.4"
-source = "git+https://github.com/gyscos/zstd-rs.git#c0e8491d460311117bacd0262374f8b973ec8b69"
+source = "git+https://github.com/gyscos/zstd-rs.git#3df21bbc06a5257967ca7f30ba33a6512e0cde4b"
 dependencies = [
  "cc",
  "glob",
+ "itertools",
  "libc",
 ]

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -37,7 +37,7 @@ rev = "d919ccd35976b9b84b8d03c07138c1cc05a36087"
 features = ["nightly", "push", "process"]
 
 [dependencies.rocksdb]
-git = "https://github.com/pingcap/rust-rocksdb.git"
+git = "https://github.com/tikv/rust-rocksdb.git"
 package = "rocksdb"
 
 [dev-dependencies]

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -35,7 +35,7 @@ rev = "d919ccd35976b9b84b8d03c07138c1cc05a36087"
 features = ["nightly", "push", "process"]
 
 [dependencies.rocksdb]
-git = "https://github.com/pingcap/rust-rocksdb.git"
+git = "https://github.com/tikv/rust-rocksdb.git"
 package = "rocksdb"
 
 [dev-dependencies]


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

###  What have you changed?

Update rust-rocksdb with the following changes. 
```
72e45c3 2020-01-08 yiwu@pingcap.com     Update rocksdb to cb7efe6d7 (#419)
1ef6fe7 2019-12-31 sre-bot@pingcap.com  titan: update master build status link (#417)
```
Changes to rocksdb repo:
```
cb7efe6d7 2020-01-08 zbk602423539@gmail.. Add oldest snapshot sequence property (#6228) (#141)
c7d775168 2020-01-07 zbk602423539@gmail.. statistics: make ticker and histogram extendible (#136)
ebec1bd8a 2020-01-07 bupt2013211450@gma.. add multibatch write into memtable (#131)
4dcfb8789 2020-01-07 zbk602423539@gmail.. fix invalid register for .seh_savexmm (#140)
```
Also update rust-rocksdb repo link to tikv/rust-rocksdb.

###  What is the type of the changes?
Engineering

###  How is the PR tested?
CI

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
no
###  Does this PR affect `tidb-ansible`?
no
###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

