### PR TITLE
do not encode key in batch raw get

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1489,7 +1489,7 @@ mod tests {
     use super::*;
 
     use crate::storage::txn::{Error as TxnError, ErrorInner as TxnErrorInner};
-    use kvproto::kvrpcpb::CommandPri;
+    use kvproto::kvrpcpb::{CommandPri, RawGetRequest};
     use std::{
         fmt::Debug,
         sync::mpsc::{channel, Sender},
@@ -2741,7 +2741,9 @@ mod tests {
         let cmds = test_data
             .iter()
             .map(|&(ref k, _)| {
-                PointGetCommand::from_key_ts(Key::from_encoded(k.clone()), Some(0.into()))
+                let mut req = RawGetRequest::default();
+                req.set_key(k.clone());
+                PointGetCommand::from_raw_get(&mut req)
             })
             .collect();
         let results: Vec<Option<Vec<u8>>> = test_data.into_iter().map(|(_, v)| Some(v)).collect();


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

When intra-TiKV batch is enabled, the keys in `RawGetRequest`s  are also encoded in turning it to a `PointGetCommand`. However, we shouldn't encode keys if it's a raw get. This PR fixes it.

Fix https://github.com/tikv/tikv/issues/6437

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No