### PR TITLE
bump v3.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.
 + backup 
     + Change the name of the backup file from `start_key` to the hash value of `start_key` to reduce the file name's length for easy reading (https://github.com/tikv/tikv/pull/6198)
     + Disable RocksDB's `force_consistency_checks` check to avoid false positives in the consistency check [#6249](https://github.com/tikv/tikv/pull/6249)
-    + Add the incremental backup feature [#6286] (https://github.com/tikv/tikv/pull/6286)
+    + Add the incremental backup feature [#6286](https://github.com/tikv/tikv/pull/6286)
 
 + sst_importer
     + Fix the issue that the SST file does not have MVCC properties during  restoring [#6378](https://github.com/tikv/tikv/pull/6378)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.
     + Add the incremental backup feature [#6286](https://github.com/tikv/tikv/pull/6286)
 
 + sst_importer
-    + Fix the issue that the SST file does not have MVCC properties during  restoring [#6378](https://github.com/tikv/tikv/pull/6378)
+    + Fix the issue that the SST file does not have MVCC properties during restoring [#6378](https://github.com/tikv/tikv/pull/6378)
     + Add the monitoring items such as `tikv_import_download_duration`, `tikv_import_download_bytes`, `tikv_import_ingest_duration`, `tikv_import_ingest_bytes`, and `tikv_import_error_counter` to observe the overheads of downloading and ingesting SST files [#6404](https://github.com/tikv/tikv/pull/6404)
 + raftstore
     + Fix the issue of Follower Read that the follower reads stale data when the leader changes, thus breaking transaction isolation [#6343](https://github.com/tikv/tikv/pull/6343)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 All notable changes to this project are documented in this file.
 See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.md) and [PD Changelog](https://github.com/pingcap/pd/blob/master/CHANGELOG.md).
 
+## [3.1.0-beta.1]
++ backup 
+    + Change the name of the backup file from `start_key` to the hash value of `start_key` to reduce the file name's length for easy reading (https://github.com/tikv/tikv/pull/6198)
+    + Disable RocksDB's `force_consistency_checks` check to avoid false positives in the consistency check [#6249](https://github.com/tikv/tikv/pull/6249)
+    + Add the incremental backup feature [#6286] (https://github.com/tikv/tikv/pull/6286)
+
++ sst_importer
+    + Fix the issue that the SST file does not have MVCC properties during  restoring [#6378](https://github.com/tikv/tikv/pull/6378)
+    + Add the monitoring items such as `tikv_import_download_duration`, `tikv_import_download_bytes`, `tikv_import_ingest_duration`, `tikv_import_ingest_bytes`, and `tikv_import_error_counter` to observe the overheads of downloading and ingesting SST files [#6404](https://github.com/tikv/tikv/pull/6404)
++ raftstore
+    + Fix the issue of Follower Read that the follower reads stale data when the leader changes, thus breaking transaction isolation [#6343](https://github.com/tikv/tikv/pull/6343)
+
 ## [3.1.0-beta]
 
 + Support the distributed backup and restore feature [#5532](https://github.com/tikv/tikv/pull/5532)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_raftstore 0.0.1",
  "test_util 0.0.1",
- "tikv 3.1.0-beta",
+ "tikv 3.1.0-beta.1",
  "tikv_alloc 0.1.0",
  "tikv_util 0.1.0",
  "tokio-threadpool 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -375,7 +375,7 @@ dependencies = [
  "signal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
- "tikv 3.1.0-beta",
+ "tikv 3.1.0-beta.1",
  "tikv_alloc 0.1.0",
  "tikv_util 0.1.0",
  "toml 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -940,7 +940,7 @@ version = "0.0.1"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tikv 3.1.0-beta",
+ "tikv 3.1.0-beta.1",
  "tikv_util 0.1.0",
 ]
 
@@ -2911,7 +2911,7 @@ dependencies = [
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.1)",
  "protobuf 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_storage 0.0.1",
- "tikv 3.1.0-beta",
+ "tikv 3.1.0-beta.1",
  "tikv_util 0.1.0",
  "tipb 0.0.1 (git+https://github.com/pingcap/tipb.git?branch=release-3.1)",
 ]
@@ -2931,7 +2931,7 @@ dependencies = [
  "slog 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-global 0.1.0 (git+https://github.com/breeswish/slog-global.git?rev=91904ade)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tikv 3.1.0-beta",
+ "tikv 3.1.0-beta.1",
  "tikv_util 0.1.0",
  "tokio-threadpool 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2944,7 +2944,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvproto 0.0.1 (git+https://github.com/pingcap/kvproto.git?branch=release-3.1)",
  "test_raftstore 0.0.1",
- "tikv 3.1.0-beta",
+ "tikv 3.1.0-beta.1",
  "tikv_util 0.1.0",
 ]
 
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "tikv"
-version = "3.1.0-beta"
+version = "3.1.0-beta.1"
 dependencies = [
  "arrow 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv"
-version = "3.1.0-beta"
+version = "3.1.0-beta.1"
 authors = ["The TiKV Authors"]
 description = "A distributed transactional key-value database powered by Rust and Raft"
 license = "Apache-2.0"


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

bump v3.1.0-beta.1

+ backup 
    + Change the name of the backup file from `start_key` to the hash value of `start_key` to reduce the file name's length for easy reading (https://github.com/tikv/tikv/pull/6198)
    + Disable RocksDB's `force_consistency_checks` check to avoid false positives in the consistency check [#6249](https://github.com/tikv/tikv/pull/6249)
    + Add the incremental backup feature [#6286] (https://github.com/tikv/tikv/pull/6286)

+ sst_importer
    + Fix the issue that the SST file does not have MVCC properties during  restoring [#6378](https://github.com/tikv/tikv/pull/6378)
    + Add the monitoring items such as `tikv_import_download_duration`, `tikv_import_download_bytes`, `tikv_import_ingest_duration`, `tikv_import_ingest_bytes`, and `tikv_import_error_counter` to observe the overheads of downloading and ingesting SST files [#6404](https://github.com/tikv/tikv/pull/6404)
+ raftstore
    + Fix the issue of Follower Read that the follower reads stale data when the leader changes, thus breaking transaction isolation [#6343](https://github.com/tikv/tikv/pull/6343)