### PR TITLE
tidb_query: fix RealPlus overflow inconsistent with tidb

### DIFF
--- a/components/tidb_query/src/rpn_expr/impl_arithmetic.rs
+++ b/components/tidb_query/src/rpn_expr/impl_arithmetic.rs
@@ -114,11 +114,12 @@ impl ArithmeticOp for RealPlus {
     type T = Real;
 
     fn calc(lhs: &Real, rhs: &Real) -> Result<Option<Real>> {
-        let res = *lhs + *rhs;
-        if res.is_infinite() {
+        if (**lhs > 0f64 && **rhs > (std::f64::MAX - **lhs))
+            || (**lhs < 0f64 && **rhs < (-std::f64::MAX - **lhs))
+        {
             return Err(Error::overflow("DOUBLE", &format!("({} + {})", lhs, rhs)).into());
         }
-        Ok(Some(res))
+        Ok(Some(*lhs + *rhs))
     }
 }
 
@@ -582,6 +583,12 @@ mod tests {
                 false,
             ),
             (Real::new(1e308).ok(), Real::new(1e308).ok(), None, true),
+            (
+                Real::new(std::f64::MAX - 1f64).ok(),
+                Real::new(2f64).ok(),
+                None,
+                true,
+            ),
         ];
         for (lhs, rhs, expected, is_err) in test_cases {
             let output = RpnFnScalarEvaluator::new()


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

The logic of handling overflow while plus two real number inconsistent with TiDB, this PR tries to fix it. See: https://github.com/pingcap/tidb/blob/master/expression/builtin_arithmetic.go#L288:L288

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->

- Bugfix (a change which fixes an issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test

