### PR TITLE
tidb_query: fix convert integer to duration

### DIFF
--- a/components/tidb_query/src/codec/mysql/duration.rs
+++ b/components/tidb_query/src/codec/mysql/duration.rs
@@ -483,6 +483,10 @@ impl Duration {
             micros.unwrap_or(0),
         );
 
+        if minute >= 60 || second > 60 {
+            return Err(Error::truncated_wrong_val("time", format!("{:?}", input)));
+        }
+
         if hour == 0 && minute == 0 && second == 0 && micros == 0 {
             neg = false;
         }
@@ -932,6 +936,8 @@ mod tests {
             (b"18446744073709551615:59:59", 0, None),
             (b"1::2:3", 0, None),
             (b"1.23 3", 0, None),
+            (b"1:62:3", 0, None),
+            (b"1:02:63", 0, None),
         ];
 
         for (input, fsp, expect) in cases {

--- a/components/tidb_query/src/rpn_expr/impl_cast.rs
+++ b/components/tidb_query/src/rpn_expr/impl_cast.rs
@@ -835,16 +835,14 @@ fn cast_int_as_duration(
         None => Ok(None),
         Some(val) => {
             let fsp = extra.ret_field_type.get_decimal() as i8;
-            Duration::from_i64_without_ctx(*val, fsp)
-                .map(Some)
-                .or_else(|err| {
-                    if err.is_overflow() {
-                        ctx.handle_overflow_err(err)?;
-                        Ok(None)
-                    } else {
-                        Err(err.into())
-                    }
-                })
+            Duration::from_i64(ctx, *val, fsp).map(Some).or_else(|err| {
+                if err.is_overflow() {
+                    ctx.handle_overflow_err(err)?;
+                    Ok(None)
+                } else {
+                    Err(err.into())
+                }
+            })
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

1. This PR fixes convert an integer to the duration while the integer greater than 10000000000, see: https://github.com/pingcap/tidb/blob/master/types/convert.go#L338:L338
2. This PR delete some duplicated test cases.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Bugfix (a change which fixes an issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test

