### PR TITLE
copr: refactor `Duration` parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.0.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca"
+checksum = "c433f4d505fe6ce7ff78523d2fa13a0b9f2690e181fc26168bcbe5ccc5d14e07"
 dependencies = [
  "lexical-core",
  "memchr",
@@ -3878,7 +3878,7 @@ dependencies = [
  "kvproto",
  "lazy_static",
  "match_template",
- "nom 5.0.1",
+ "nom 5.1.0",
  "num",
  "num-traits",
  "openssl",
@@ -3980,7 +3980,7 @@ dependencies = [
  "more-asserts",
  "murmur3",
  "nix 0.11.1",
- "nom 5.0.1",
+ "nom 5.1.0",
  "panic_hook",
  "pd_client",
  "pprof",

--- a/components/tidb_query/Cargo.toml
+++ b/components/tidb_query/Cargo.toml
@@ -23,7 +23,7 @@ indexmap = { version = "1.0", features = ["serde-1"] }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 match_template = { path = "../match_template" }
-nom = "5.0.1"
+nom = "5.1.0"
 num = { version = "0.2", default-features = false }
 num-traits = "0.2"
 openssl = { version = "0.10" }

--- a/components/tidb_query/src/codec/mysql/duration.rs
+++ b/components/tidb_query/src/codec/mysql/duration.rs
@@ -99,7 +99,7 @@ mod parser {
         let len = input
             .iter()
             .position(|&c| !pattern(c))
-            .unwrap_or_else(||input.len());
+            .unwrap_or_else(|| input.len());
 
         if len >= n {
             Some((&input[len..], &input[..len]))
@@ -123,7 +123,7 @@ mod parser {
         let (rest, _) = space(&input[1..], 0)?;
         rest.get(0)
             .filter(|&&c| c == b'.')
-            .or_else(||rest.get(0).filter(|&&c| c.is_ascii_digit()))?;
+            .or_else(|| rest.get(0).filter(|&&c| c.is_ascii_digit()))?;
         Some((rest, true))
     }
 
@@ -201,7 +201,7 @@ mod parser {
             rest = remain;
             hhmmss
         } else {
-            let hhmmss = [day/10000, (day/100) %100,day%100,0];
+            let hhmmss = [day / 10000, (day / 100) % 100, day % 100, 0];
             day = 0;
             hhmmss
         };


### PR DESCRIPTION
* Remove `nom`

Signed-off-by: Iosmanthus Teng <myosmanthustree@gmail.com>

###  What have you changed?
Remove `nom` and fix some bugs of `Duration` parser which are found out by `randgen` test.

Don't assume reviewers understand the original issue.

###  What is the type of changes?
- Improvement (a change which is an improvement to an existing feature)
- Bugfix (a change which fixes an issue)

###  How is the PR tested?
- Unit test
