### PR TITLE
Fix Prost build

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -179,8 +179,7 @@ impl TiKVServer {
     /// - If the max open file descriptor limit is not high enough to support
     ///   the main database and the raft database.
     fn init_config(mut config: TiKvConfig, pd_client: Arc<RpcClient>) -> ConfigController {
-        let mut version = Default::default();
-        if config.dynamic_config {
+        let version = if config.dynamic_config {
             // Advertise address and cluster id can not be changed
             if config.server.advertise_addr.is_empty() {
                 config.server.advertise_addr = config.server.addr.clone();
@@ -200,8 +199,10 @@ impl TiKVServer {
             cfg.log_file = log_file;
             cfg.dynamic_config = true;
             config = cfg;
-            version = v;
-        }
+            v
+        } else {
+            Default::default()
+        };
 
         validate_and_persist_config(&mut config, true);
         check_system_config(&config);

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -16,9 +16,9 @@ slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global
 protobuf = "2.8"
 futures = "0.1"
 tokio-threadpool = "0.1"
-grpcio = { version = "0.5.0-alpha.3", features = [ "openssl-vendored" ] }
-raft = "0.6.0-alpha"
-kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+grpcio = { version = "0.5.0-alpha.3", features = [ "openssl-vendored" ], default-features = false }
+raft = { version = "0.6.0-alpha", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 tikv_util = { path = "../tikv_util" }
 resolved_ts = { path = "../resolved_ts" }
 pd_client = { path = "../pd_client" }

--- a/tests/integrations/pd/mock/server.rs
+++ b/tests/integrations/pd/mock/server.rs
@@ -175,7 +175,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
         let header = Service::header();
         let fut = resp
             .send_all(req.map(move |_| {
-                let mut r = TsoResponse::new();
+                let mut r = TsoResponse::default();
                 r.set_header(header.clone());
                 r.mut_timestamp().physical = 42;
                 (r, WriteFlags::default())


### PR DESCRIPTION
###  What have you changed?

Fix the build when `PROST=1`. This is mostly just setting `--no-default-features` for the cdc crate.

I also addressed a Clippy warning in cmd/server.rs, I'm not sure why that has appeared, but I agree with the Clippy suggestion.

PTAL @breeswish  @overvenus 

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

