### PR TITLE
fix unstable test_replica_read::test_read_after_cleanup_range_for_snap

### DIFF
--- a/tests/failpoints/cases/test_replica_read.rs
+++ b/tests/failpoints/cases/test_replica_read.rs
@@ -1,12 +1,12 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use crossbeam::channel;
 use engine::{Peekable, CF_RAFT, DB};
 use fail;
 use kvproto::raft_serverpb::{PeerState, RaftApplyState, RaftMessage, RegionLocalState};
 use raft::eraftpb::MessageType;
 use std::mem;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -96,7 +96,7 @@ fn test_duplicate_read_index_ctx() {
 
     // Delay all raft messages to peer 1.
     let dropped_msgs = Arc::new(Mutex::new(Vec::new()));
-    let (sx, rx) = mpsc::sync_channel::<()>(2);
+    let (sx, rx) = channel::unbounded();
     let recv_filter = Box::new(
         RegionPacketFilter::new(region.get_id(), 1)
             .direction(Direction::Recv)
@@ -291,19 +291,19 @@ fn test_read_after_cleanup_range_for_snap() {
     assert_eq!(cluster.leader_of_region(region.get_id()).unwrap(), p1);
     cluster.stop_node(3);
     (0..10).for_each(|_| cluster.must_put(b"k1", b"v1"));
-    // Ensure logs are compacted.
-    must_truncated_to(cluster.get_engine(3), r1, 8);
+    // Ensure logs are compacted, then node 1 will send a snapshot to node 3 later
+    must_truncated_to(cluster.get_engine(1), r1, 8);
 
     fail::cfg("send_snapshot", "pause").unwrap();
     cluster.run_node(3).unwrap();
     // Sleep for a while to ensure peer 3 receives a HeartBeat
     thread::sleep(Duration::from_millis(500));
 
+    // Add filter for delaying ReadIndexResp and MsgSnapshot
     let dropped_msgs = Arc::new(Mutex::new(Vec::new()));
-    let (read_index_sx, read_index_rx) = mpsc::sync_channel::<RaftMessage>(1);
-    let (snap_sx, snap_rx) = mpsc::sync_channel::<RaftMessage>(1);
-    let (heartbeat_sx, heartbeat_rx) = mpsc::sync_channel::<RaftMessage>(1);
-    let is_recv_heartbeat = AtomicBool::new(false);
+    let (read_index_sx, read_index_rx) = channel::unbounded::<RaftMessage>();
+    let (snap_sx, snap_rx) = channel::unbounded::<RaftMessage>();
+    let (heartbeat_sx, heartbeat_rx) = channel::unbounded::<RaftMessage>();
     let recv_filter = Box::new(
         RegionPacketFilter::new(region.get_id(), 3)
             .direction(Direction::Recv)
@@ -315,9 +315,7 @@ fn test_read_after_cleanup_range_for_snap() {
                 } else if msg.get_message().get_msg_type() == MessageType::MsgSnapshot {
                     snap_sx.send(msg.clone()).unwrap();
                 } else if msg.get_message().get_msg_type() == MessageType::MsgHeartbeat {
-                    if is_recv_heartbeat.compare_and_swap(false, true, Ordering::SeqCst) {
-                        heartbeat_sx.send(msg.clone()).unwrap();
-                    }
+                    heartbeat_sx.send(msg.clone()).unwrap();
                 }
             })),
     );
@@ -333,7 +331,7 @@ fn test_read_after_cleanup_range_for_snap() {
     );
     request.mut_header().set_peer(p3.clone());
     request.mut_header().set_replica_read(true);
-    // send request to peer 3
+    // Send follower read request to peer 3
     let (cb1, rx1) = make_cb(&request);
     cluster
         .sim
@@ -354,6 +352,7 @@ fn test_read_after_cleanup_range_for_snap() {
     router.send_raft_message(read_index_msg.clone()).unwrap();
     fail::cfg("pause_on_peer_collect_message", "off").unwrap();
     must_get_none(&cluster.get_engine(3), b"k0");
+    // Should not receive resp
     rx1.recv_timeout(Duration::from_millis(500)).unwrap_err();
     fail::cfg("apply_snap_cleanup_range", "off").unwrap();
     rx1.recv_timeout(Duration::from_secs(5)).unwrap();


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Fix unstable test.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Bugfix (a change which fixes an issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->
No.

###  Does this PR affect `tidb-ansible`?
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->
No.

###  Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/issues/6083
