### PR TITLE
tnx_types: Reduce Error Size

### DIFF
--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -1,5 +1,8 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+#![feature(box_patterns)]
+#![feature(specialization)]
+
 #[macro_use]
 extern crate quick_error;
 #[allow(unused_extern_crates)]
@@ -10,6 +13,7 @@ mod timestamp;
 mod types;
 mod write;
 
+use std::fmt;
 use std::io;
 
 pub use lock::{Lock, LockType};
@@ -19,7 +23,7 @@ pub use write::{Write, WriteRef, WriteType};
 
 quick_error! {
     #[derive(Debug)]
-    pub enum Error {
+    pub enum ErrorInner {
         Io(err: io::Error) {
             from()
             cause(err)
@@ -39,15 +43,60 @@ quick_error! {
     }
 }
 
+impl ErrorInner {
+    pub fn maybe_clone(&self) -> Option<ErrorInner> {
+        match self {
+            ErrorInner::Codec(e) => e.maybe_clone().map(ErrorInner::Codec),
+            ErrorInner::BadFormatLock => Some(ErrorInner::BadFormatLock),
+            ErrorInner::BadFormatWrite => Some(ErrorInner::BadFormatWrite),
+            ErrorInner::KeyIsLocked(info) => Some(ErrorInner::KeyIsLocked(info.clone())),
+            ErrorInner::Io(_) => None,
+        }
+    }
+}
+
+pub struct Error(pub Box<ErrorInner>);
+
 impl Error {
     pub fn maybe_clone(&self) -> Option<Error> {
-        match self {
-            Error::Codec(e) => e.maybe_clone().map(Error::Codec),
-            Error::BadFormatLock => Some(Error::BadFormatLock),
-            Error::BadFormatWrite => Some(Error::BadFormatWrite),
-            Error::KeyIsLocked(info) => Some(Error::KeyIsLocked(info.clone())),
-            Error::Io(_) => None,
-        }
+        self.0.maybe_clone().map(Error::from)
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        std::error::Error::description(&self.0)
+    }
+
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        std::error::Error::source(&self.0)
+    }
+}
+
+impl From<ErrorInner> for Error {
+    #[inline]
+    fn from(e: ErrorInner) -> Self {
+        Error(Box::new(e))
+    }
+}
+
+impl<T: Into<ErrorInner>> From<T> for Error {
+    #[inline]
+    default fn from(err: T) -> Self {
+        let err = err.into();
+        err.into()
     }
 }
 

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -2,7 +2,7 @@
 
 use crate::timestamp::{TimeStamp, TsSet};
 use crate::types::{Key, Mutation, Value, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
-use crate::{Error, Result};
+use crate::{Error, ErrorInner, Result};
 use byteorder::ReadBytesExt;
 use derive_new::new;
 use kvproto::kvrpcpb::{LockInfo, Op};
@@ -99,9 +99,9 @@ impl Lock {
 
     pub fn parse(mut b: &[u8]) -> Result<Lock> {
         if b.is_empty() {
-            return Err(Error::BadFormatLock);
+            return Err(Error::from(ErrorInner::BadFormatLock));
         }
-        let lock_type = LockType::from_u8(b.read_u8()?).ok_or(Error::BadFormatLock)?;
+        let lock_type = LockType::from_u8(b.read_u8()?).ok_or(ErrorInner::BadFormatLock)?;
         let primary = bytes::decode_compact_bytes(&mut b)?;
         let ts = number::decode_var_u64(&mut b)?.into();
         let ttl = if b.is_empty() {
@@ -199,7 +199,9 @@ impl Lock {
         }
 
         // There is a pending lock. Client should wait or clean it.
-        Err(Error::KeyIsLocked(self.into_lock_info(raw_key)))
+        Err(Error::from(ErrorInner::KeyIsLocked(
+            self.into_lock_info(raw_key),
+        )))
     }
 }
 

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -3,7 +3,7 @@
 use crate::lock::LockType;
 use crate::timestamp::TimeStamp;
 use crate::types::{Value, SHORT_VALUE_MAX_LEN, SHORT_VALUE_PREFIX};
-use crate::{Error, Result};
+use crate::{Error, ErrorInner, Result};
 use codec::prelude::NumberDecoder;
 use tikv_util::codec::number::{NumberEncoder, MAX_VAR_U64_LEN};
 
@@ -107,8 +107,8 @@ impl Write {
     pub fn parse_type(mut b: &[u8]) -> Result<WriteType> {
         let write_type_bytes = b
             .read_u8()
-            .map_err(|_| Error::from(Error::BadFormatWrite))?;
-        WriteType::from_u8(write_type_bytes).ok_or_else(|| Error::from(Error::BadFormatWrite))
+            .map_err(|_| Error::from(ErrorInner::BadFormatWrite))?;
+        WriteType::from_u8(write_type_bytes).ok_or_else(|| Error::from(ErrorInner::BadFormatWrite))
     }
 
     #[inline]
@@ -132,12 +132,12 @@ impl WriteRef<'_> {
     pub fn parse(mut b: &[u8]) -> Result<WriteRef<'_>> {
         let write_type_bytes = b
             .read_u8()
-            .map_err(|_| Error::from(Error::BadFormatWrite))?;
+            .map_err(|_| Error::from(ErrorInner::BadFormatWrite))?;
         let write_type = WriteType::from_u8(write_type_bytes)
-            .ok_or_else(|| Error::from(Error::BadFormatWrite))?;
+            .ok_or_else(|| Error::from(ErrorInner::BadFormatWrite))?;
         let start_ts = b
             .read_var_u64()
-            .map_err(|_| Error::from(Error::BadFormatWrite))?
+            .map_err(|_| Error::from(ErrorInner::BadFormatWrite))?
             .into();
         if b.is_empty() {
             return Ok(WriteRef {
@@ -149,12 +149,12 @@ impl WriteRef<'_> {
 
         let flag = b
             .read_u8()
-            .map_err(|_| Error::from(Error::BadFormatWrite))?;
+            .map_err(|_| Error::from(ErrorInner::BadFormatWrite))?;
         assert_eq!(flag, SHORT_VALUE_PREFIX, "invalid flag [{}] in write", flag);
 
         let len = b
             .read_u8()
-            .map_err(|_| Error::from(Error::BadFormatWrite))?;
+            .map_err(|_| Error::from(ErrorInner::BadFormatWrite))?;
         if len as usize != b.len() {
             panic!(
                 "short value len [{}] not equal to content len [{}]",

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -245,12 +245,15 @@ impl From<codec::Error> for ErrorInner {
 impl From<txn_types::Error> for ErrorInner {
     fn from(err: txn_types::Error) -> Self {
         match err {
-            txn_types::Error::Io(e) => ErrorInner::Io(e),
-            txn_types::Error::Codec(e) => ErrorInner::Codec(e),
-            txn_types::Error::BadFormatLock | txn_types::Error::BadFormatWrite => {
+            txn_types::Error(box txn_types::ErrorInner::Io(e)) => ErrorInner::Io(e),
+            txn_types::Error(box txn_types::ErrorInner::Codec(e)) => ErrorInner::Codec(e),
+            txn_types::Error(box txn_types::ErrorInner::BadFormatLock)
+            | txn_types::Error(box txn_types::ErrorInner::BadFormatWrite) => {
                 ErrorInner::BadFormat(err)
             }
-            txn_types::Error::KeyIsLocked(lock_info) => ErrorInner::KeyIsLocked(lock_info),
+            txn_types::Error(box txn_types::ErrorInner::KeyIsLocked(lock_info)) => {
+                ErrorInner::KeyIsLocked(lock_info)
+            }
         }
     }
 }

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -883,7 +883,7 @@ mod tests {
         data.insert(
             Key::from_raw(b"zz"),
             Err(Error::from(ErrorInner::Mvcc(MvccError::from(
-                txn_types::Error::BadFormatLock,
+                txn_types::Error::from(txn_types::ErrorInner::BadFormatLock),
             )))),
         );
 

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -16,7 +16,7 @@ use tikv::storage::txn::{commands, Error as TxnError, ErrorInner as TxnErrorInne
 use tikv::storage::*;
 use tikv_util::HandyRwLock;
 use txn_types::Key;
-use txn_types::*;
+use txn_types::{Mutation, TimeStamp};
 
 #[test]
 fn test_scheduler_leader_change_twice() {


### PR DESCRIPTION
Signed-off-by: Steven Gu asongala@163.com
 
###  What have you changed?

Tries to fix Issue #6467. Reference PR #5979 to fix `tnx_types::Error`.

- Replaces original Error with ErrorInner.
- Defines a new Error as `pub struct Error(pub Box<ErrorInner>)`.
- Fixes the all compiling errors.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.

###  Refer to a related PR or issue link (optional)

Issue #6467 and PR #5979