### PR TITLE
config: get the current using config through status config

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -40,7 +40,7 @@ use tikv::{
         store::{
             fsm,
             fsm::store::{RaftBatchSystem, RaftRouter, StoreMeta, PENDING_VOTES_CAP},
-            new_compaction_listener, LocalReader, SnapManagerBuilder,
+            new_compaction_listener, LocalReader, PdTask, SnapManagerBuilder,
         },
     },
     read_pool::{ReadPool, ReadPoolRunner},
@@ -60,7 +60,7 @@ use tikv_util::{
     check_environment_variables,
     security::SecurityManager,
     time::Monitor,
-    worker::{FutureWorker, Worker},
+    worker::{FutureScheduler, FutureWorker, Worker},
 };
 use yatp::{
     pool::CloneRunnerBuilder,
@@ -118,6 +118,7 @@ struct Engines {
 }
 
 struct Servers {
+    pd_sender: FutureScheduler<PdTask>,
     lock_mgr: Option<LockManager>,
     server: Server<ServerRaftStoreRouter, resolve::PdStoreAddrResolver>,
     node: Node<RpcClient>,
@@ -436,7 +437,7 @@ impl TiKVServer {
         } else {
             let cop_read_pools = coprocessor::readpool_impl::build_read_pool(
                 &self.config.readpool.coprocessor,
-                pd_sender,
+                pd_sender.clone(),
                 engines.engine.clone(),
             );
             ReadPool::from(cop_read_pools)
@@ -491,6 +492,7 @@ impl TiKVServer {
         }
 
         self.servers = Some(Servers {
+            pd_sender,
             lock_mgr,
             server,
             node,
@@ -616,22 +618,23 @@ impl TiKVServer {
     }
 
     fn run_server(&mut self, server_config: Arc<ServerConfig>) {
-        let server = &mut self.servers.as_mut().unwrap().server;
+        let server = self.servers.as_mut().unwrap();
         server
+            .server
             .build_and_bind()
             .unwrap_or_else(|e| fatal!("failed to build server: {}", e));
         server
+            .server
             .start(server_config, self.security_mgr.clone())
             .unwrap_or_else(|e| fatal!("failed to start server: {}", e));
 
         // Create a status server.
         let status_enabled =
             self.config.metric.address.is_empty() && !self.config.server.status_addr.is_empty();
-        // FIXME: How to keep config updated?
         if status_enabled {
             let mut status_server = Box::new(StatusServer::new(
                 self.config.server.status_thread_pool_size,
-                self.config.clone(),
+                server.pd_sender.clone(),
             ));
             // Start the status server.
             if let Err(e) = status_server.start(self.config.server.status_addr.clone()) {

--- a/components/tidb_query/src/rpn_expr/impl_arithmetic.rs
+++ b/components/tidb_query/src/rpn_expr/impl_arithmetic.rs
@@ -114,11 +114,12 @@ impl ArithmeticOp for RealPlus {
     type T = Real;
 
     fn calc(lhs: &Real, rhs: &Real) -> Result<Option<Real>> {
-        let res = *lhs + *rhs;
-        if res.is_infinite() {
+        if (**lhs > 0f64 && **rhs > (std::f64::MAX - **lhs))
+            || (**lhs < 0f64 && **rhs < (-std::f64::MAX - **lhs))
+        {
             return Err(Error::overflow("DOUBLE", &format!("({} + {})", lhs, rhs)).into());
         }
-        Ok(Some(res))
+        Ok(Some(*lhs + *rhs))
     }
 }
 
@@ -582,6 +583,12 @@ mod tests {
                 false,
             ),
             (Real::new(1e308).ok(), Real::new(1e308).ok(), None, true),
+            (
+                Real::new(std::f64::MAX - 1f64).ok(),
+                Real::new(2f64).ok(),
+                None,
+                true,
+            ),
         ];
         for (lhs, rhs, expected, is_err) in test_cases {
             let output = RpnFnScalarEvaluator::new()

--- a/components/tikv_util/src/worker/future.rs
+++ b/components/tikv_util/src/worker/future.rs
@@ -45,6 +45,11 @@ pub struct Scheduler<T> {
     metrics_pending_task_count: IntGauge,
 }
 
+pub fn dummy_scheduler<T: Display>() -> Scheduler<T> {
+    let (tx, _) = unbounded();
+    Scheduler::new("dummy future scheduler".to_owned(), tx)
+}
+
 impl<T: Display> Scheduler<T> {
     fn new<S: Into<String>>(name: S, sender: UnboundedSender<Option<T>>) -> Scheduler<T> {
         let name = name.into();

--- a/components/tikv_util/src/worker/mod.rs
+++ b/components/tikv_util/src/worker/mod.rs
@@ -32,6 +32,7 @@ use crate::mpsc::{self, Receiver, Sender};
 use crate::time::{Instant, SlowTimer};
 use crate::timer::Timer;
 
+pub use self::future::dummy_scheduler as dummy_future_scheduler;
 pub use self::future::Runnable as FutureRunnable;
 pub use self::future::Scheduler as FutureScheduler;
 pub use self::future::{Stopped, Worker as FutureWorker};

--- a/src/raftstore/store/worker/pd.rs
+++ b/src/raftstore/store/worker/pd.rs
@@ -779,13 +779,13 @@ impl<T: PdClient + ConfigClient> Runner<T> {
 
     fn handle_refresh_config(&mut self, handle: &Handle) {
         let config_handler = &mut self.config_handler;
-        info!(
+        debug!(
             "refresh config";
             "component id" => config_handler.get_id(),
             "version" => ?config_handler.get_version()
         );
         if let Err(e) = config_handler.refresh_config(self.pd_client.clone()) {
-            error!(
+            warn!(
                 "failed to refresh config";
                 "component id" => config_handler.get_id(),
                 "version" => ?config_handler.get_version(),

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -213,7 +213,10 @@ impl StatusServer {
         pd_sender: &FutureScheduler<PdTask>,
     ) -> Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send> {
         let (cfg_sender, rx) = oneshot::channel();
-        if let Err(_) = pd_sender.schedule(PdTask::GetConfig { cfg_sender }) {
+        if pd_sender
+            .schedule(PdTask::GetConfig { cfg_sender })
+            .is_err()
+        {
             error!("failed to schedule GetConfig task");
         }
         let res = rx.then(|res| {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

This pr add support for getting the current using config (i.e after dynamic changed) through status server.

###  What is the type of the changes?

- Improvement (a change which is an improvement to an existing feature)

###  How is the PR tested?

- Unit test
- Manual test (`curl $status_addr/config`)

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No

###  Does this PR affect `tidb-ansible`?
No

