### PR TITLE
Refactor Lock to be more explicit about optimistic vs pessimistic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.51.0"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18270cdd7065ec045a6bb4bdcd5144d14a78b3aedb3bc5111e688773ac8b9ad0"
+checksum = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -260,15 +260,15 @@ dependencies = [
  "clang-sys",
  "clap",
  "env_logger",
- "fxhash",
  "lazy_static",
  "log",
  "peeking_take_while",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
+ "proc-macro2 1.0.4",
+ "quote 1.0.2",
  "regex",
+ "rustc-hash",
  "shlex",
- "which",
+ "which 3.1.0",
 ]
 
 [[package]]
@@ -2801,7 +2801,7 @@ dependencies = [
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types",
  "tempfile",
- "which",
+ "which 2.0.1",
 ]
 
 [[package]]
@@ -3452,6 +3452,15 @@ name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+
+[[package]]
+name = "rustc-hash"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "rustc_version"
@@ -4991,6 +5000,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 dependencies = [
  "failure",
+ "libc",
+]
+
+[[package]]
+name = "which"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
+dependencies = [
  "libc",
 ]
 

--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -16,8 +16,8 @@ mod write;
 use std::fmt;
 use std::io;
 
-pub use lock::{Lock, LockType};
-pub use timestamp::{TimeStamp, TsSet};
+pub use lock::{Lock, LockType, TransactionKind};
+pub use timestamp::{NonZeroTimeStamp, TimeStamp, TsSet};
 pub use types::{is_short_value, Key, KvPair, Mutation, Value, SHORT_VALUE_MAX_LEN};
 pub use write::{Write, WriteRef, WriteType};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 #![feature(box_patterns)]
 #![feature(shrink_to)]
 #![feature(drain_filter)]
+#![feature(associated_type_bounds)]
 
 #[macro_use]
 extern crate bitflags;

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -1541,7 +1541,7 @@ mod tests {
     use tempfile::Builder;
 
     use super::*;
-    use crate::storage::mvcc::{Lock, LockType};
+    use crate::storage::mvcc::{Lock, LockType, TransactionKind};
     use engine::rocks;
     use engine::rocks::util::{new_engine_opt, CFOptions};
     use engine::Mutable;
@@ -1848,11 +1848,11 @@ mod tests {
             let key = keys::data_key(encoded_key.as_encoded().as_slice());
             let lock = Lock::new(
                 tp,
+                TransactionKind::Optimistic,
                 value.to_vec(),
                 version,
                 0,
                 None,
-                TimeStamp::zero(),
                 0,
                 TimeStamp::zero(),
             );
@@ -2254,11 +2254,11 @@ mod tests {
             };
             let lock = Lock::new(
                 tp,
+                TransactionKind::Optimistic,
                 vec![],
                 ts.into(),
                 0,
                 v,
-                TimeStamp::zero(),
                 0,
                 TimeStamp::zero(),
             );

--- a/src/server/gc_worker/applied_lock_collector.rs
+++ b/src/server/gc_worker/applied_lock_collector.rs
@@ -432,7 +432,7 @@ mod tests {
     use kvproto::metapb::Region;
     use kvproto::raft_cmdpb::{PutRequest, RaftCmdRequest};
     use std::sync::mpsc::channel;
-    use txn_types::LockType;
+    use txn_types::{LockType, TransactionKind};
 
     fn lock_info_to_kv(mut lock_info: LockInfo) -> (Vec<u8>, Vec<u8>) {
         let key = Key::from_raw(lock_info.get_key()).into_encoded();
@@ -444,11 +444,11 @@ mod tests {
                 Op::PessimisticLock => LockType::Pessimistic,
                 _ => unreachable!(),
             },
+            TransactionKind::Optimistic,
             lock_info.take_primary_lock(),
             lock_info.get_lock_version().into(),
             lock_info.get_lock_ttl(),
             None,
-            0.into(),
             lock_info.get_txn_size(),
             0.into(),
         );

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -114,6 +114,7 @@ impl<T: RaftStoreRouter + 'static, E: Engine, L: LockManager> Service<T, E, L> {
     }
 }
 
+/// Implements a request handler function from the `Tikv` trait for a specific request.
 macro_rules! handle_request {
     ($fn_name: ident, $future_name: ident, $req_ty: ident, $resp_ty: ident) => {
         fn $fn_name(&mut self, ctx: RpcContext<'_>, req: $req_ty, sink: UnarySink<$resp_ty>) {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -781,9 +781,9 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
         keys: Vec<Vec<u8>>,
         callback: Callback<()>,
     ) -> Result<()> {
-        let cf = Self::rawkv_cf(&cf)?;
         check_key_size!(keys.iter(), self.max_key_size, callback);
 
+        let cf = Self::rawkv_cf(&cf)?;
         let requests = keys
             .into_iter()
             .map(|k| Modify::Delete(cf, Key::from_encoded(k)))

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -774,11 +774,11 @@ mod test_util {
             };
             let lock_value = Lock::new(
                 lt,
+                self.for_update_ts.into(),
                 self.primary.clone(),
                 self.start_ts,
                 0,
                 short,
-                self.for_update_ts,
                 0,
                 0.into(),
             );

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -762,7 +762,7 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
             for (current_key, current_lock) in key_locks {
                 if let Some(txn_to_keys) = txn_to_keys.as_mut() {
                     txn_to_keys
-                        .entry((current_lock.ts, !current_lock.for_update_ts.is_zero()))
+                        .entry((current_lock.ts, current_lock.txn_kind.is_pessimistic()))
                         .and_modify(|key_hashes: &mut Option<Vec<u64>>| {
                             if let Some(key_hashes) = key_hashes {
                                 key_hashes.push(current_key.gen_hash());

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -500,9 +500,10 @@ impl<E: Engine, L: LockManager> MsgScheduler for Scheduler<E, L> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::mvcc::{self, Mutation};
+    use crate::storage::mvcc::{self, Mutation, TransactionKind};
     use crate::storage::txn::{commands, latch::*};
     use kvproto::kvrpcpb::Context;
+    use std::convert::TryInto;
     use txn_types::Key;
 
     #[test]
@@ -528,7 +529,7 @@ mod tests {
                 10.into(),
                 0,
                 false,
-                TimeStamp::default(),
+                20.try_into().unwrap(),
                 Some(WaitTimeout::Default),
                 Context::default(),
             )
@@ -552,7 +553,7 @@ mod tests {
             commands::PessimisticRollback::new(
                 vec![Key::from_raw(b"k")],
                 10.into(),
-                20.into(),
+                20.try_into().unwrap(),
                 Context::default(),
             )
             .into(),
@@ -563,11 +564,11 @@ mod tests {
                     Key::from_raw(b"k"),
                     mvcc::Lock::new(
                         mvcc::LockType::Put,
+                        TransactionKind::Optimistic,
                         b"k".to_vec(),
                         10.into(),
                         20,
                         None,
-                        TimeStamp::zero(),
                         0,
                         TimeStamp::zero(),
                     ),

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -23,10 +23,10 @@ use tikv::import::SSTImporter;
 use tikv::raftstore::coprocessor::CoprocessorHost;
 use tikv::raftstore::store::fsm::store::StoreMeta;
 use tikv::raftstore::store::SnapManager;
-use tikv::storage::mvcc::{Lock, LockType, TimeStamp};
+use tikv::storage::mvcc::{Lock, LockType, TransactionKind};
 use tikv_util::worker::FutureWorker;
 use tikv_util::HandyRwLock;
-use txn_types::Key;
+use txn_types::{Key, TimeStamp};
 
 fn must_new_cluster() -> (Cluster<ServerCluster>, metapb::Peer, Context) {
     let count = 1;
@@ -859,11 +859,11 @@ fn test_debug_scan_mvcc() {
     for k in &keys {
         let v = Lock::new(
             LockType::Put,
+            TransactionKind::Optimistic,
             b"pk".to_vec(),
             1.into(),
             10,
             None,
-            TimeStamp::zero(),
             0,
             TimeStamp::zero(),
         )


### PR DESCRIPTION
###  What have you changed?

This is the final part of https://github.com/tikv/tikv/pull/6203. It makes it explicit whether a transaction is optimistic or pessimistic.

PTAL @MyonKeminta @youjiali1995 

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)
