### PR TITLE
raft_client: connect to other stores using peer_address (#5569)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.1#549d10f19d46e1cc22331f484b448262d3983cae"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.1#bb43ea8286627d00821d06f1be91f8fc698b4fd9"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2148,7 +2148,7 @@ name = "protoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2228,7 +2228,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,7 +2148,7 @@ name = "protoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2228,7 +2228,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -212,3 +212,12 @@ pub trait PdClient: Send + Sync {
 }
 
 const REQUEST_TIMEOUT: u64 = 2; // 2s
+
+/// Takes the peer address (for sending raft messages) from a store.
+pub fn take_peer_address(store: &mut metapb::Store) -> String {
+    if !store.get_peer_address().is_empty() {
+        store.take_peer_address()
+    } else {
+        store.take_address()
+    }
+}

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -211,7 +211,7 @@ mod tests {
     fn test_resolve_store_peer_addr() {
         let mut store = new_store("127.0.0.1:12345", metapb::StoreState::Up);
         store.set_peer_address("127.0.0.1:22345".to_string());
-        let runner = new_runner(store);
+        let mut runner = new_runner(store);
         assert_eq!(
             runner.get_address(0).unwrap(),
             "127.0.0.1:22345".to_string()


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
We plan to provide a heterogeneous engine with tikv, which may need to use different addresses to provide kv and raft services. Now kvproto has an optional `peer_address` to support this. 

The corresponding tikv modification is: use `peer_address` when connecting other nodes to send raft messages. (for backward compatibility: if `peer_address` is not set, `address` is still used)

###  What is the type of the changes?
- New feature (a change which adds functionality)

###  How is the PR tested?
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No

###  Does this PR affect `tidb-ansible`?
No

###  Refer to a related PR or issue link (optional)
cherry-pick: #5569