### PR TITLE
*: fix some test errors on AMD and/or modern Linux kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
  "serde_derive",
  "slog",
  "slog-global",
- "sysinfo",
+ "sysinfo 0.9.6",
  "tempfile",
  "tikv_alloc",
  "tikv_util",
@@ -1050,7 +1050,7 @@ dependencies = [
  "slog",
  "slog-global",
  "static_assertions 1.1.0",
- "sysinfo",
+ "sysinfo 0.9.6",
  "tempfile",
  "tikv_alloc",
  "tikv_util",
@@ -2283,6 +2283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26e041cd983acbc087e30fcba770380cfa352d0e392e175b2344ebaf7ea0602"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "num"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,6 +2385,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 
 [[package]]
 name = "opaque-debug"
@@ -4058,6 +4073,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.11.2"
+source = "git+https://github.com/tikv/sysinfo.git?branch=tikv2#2e70ddd897e1d716fc63b5a11e5fa9953f6f6b8c"
+dependencies = [
+ "cache-size",
+ "cfg-if",
+ "doc-comment",
+ "libc",
+ "ntapi",
+ "num_cpus",
+ "once_cell",
+ "pnet_datalink",
+ "rayon",
+ "walkdir",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4436,7 +4469,7 @@ dependencies = [
  "slog-term",
  "slog_derive",
  "sst_importer",
- "sysinfo",
+ "sysinfo 0.11.2",
  "tempfile",
  "test_sst_importer",
  "test_util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ slog-term = "2.4"
 slog_derive = "0.1"
 parking_lot = "0.10"
 sst_importer = { path = "components/sst_importer" }
-sysinfo = { git = "https://github.com/tikv/sysinfo.git", branch = "tikv"}
+sysinfo = { git = "https://github.com/tikv/sysinfo.git", branch = "tikv2"}
 tempfile = "3.0"
 tidb_query = { path = "components/tidb_query", default-features = false }
 tikv_alloc = { path = "components/tikv_alloc", default-features = false }

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -574,7 +574,6 @@ pub fn is_zero_duration(d: &Duration) -> bool {
 mod tests {
     use super::*;
 
-    use fs2;
     use raft::eraftpb::Entry;
     use std::rc::Rc;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -774,16 +773,13 @@ mod tests {
             .tempdir()
             .unwrap();
         let data_path = tmp_dir.path();
-        let disk_stats_before = fs2::statvfs(data_path).unwrap();
-        let cap1 = disk_stats_before.available_space();
         let reserve_size = 64 * 1024;
+        let placeholder_path = data_path.join(SPACE_PLACEHOLDER_FILE);
+
         reserve_space_for_recover(data_path, reserve_size).unwrap();
-        let disk_stats_after = fs2::statvfs(data_path).unwrap();
-        let cap2 = disk_stats_after.available_space();
-        assert_eq!(cap1 - cap2, reserve_size);
+        assert_eq!(placeholder_path.metadata().unwrap().len(), reserve_size);
+
         reserve_space_for_recover(data_path, 0).unwrap();
-        let disk_stats = fs2::statvfs(data_path).unwrap();
-        let cap3 = disk_stats.available_space();
-        assert_eq!(cap1, cap3);
+        assert!(!placeholder_path.exists());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ use engine::rocks::{
     TitanDBOptions,
 };
 use slog;
+use sysinfo::SystemExt;
 
 use crate::import::Config as ImportConfig;
 use crate::server::gc_worker::GcConfig;
@@ -64,7 +65,6 @@ const LAST_CONFIG_FILE: &str = "last_tikv.toml";
 const MAX_BLOCK_SIZE: usize = 32 * MB as usize;
 
 fn memory_mb_for_cf(is_raft_db: bool, cf: &str) -> usize {
-    use sysinfo::SystemExt;
     let total_mem = sysinfo::System::new().get_total_memory() * KB;
     let (ratio, min, max) = match (is_raft_db, cf) {
         (true, CF_DEFAULT) => (0.02, RAFT_MIN_MEM, RAFT_MAX_MEM),
@@ -142,7 +142,8 @@ fn get_background_job_limit(
     default_sub_compactions: u32,
     default_background_gc: i32,
 ) -> (i32, u32, i32) {
-    let cpu_num = sysinfo::get_logical_cores();
+    let cpu_num = sysinfo::System::new().get_processors().len();
+
     // At the minimum, we should have two background jobs: one for flush and one for compaction.
     // Otherwise, the number of background jobs should not exceed cpu_num - 1.
     // By default, rocksdb assign (max_background_jobs / 4) threads dedicated for flush, and
@@ -1352,7 +1353,8 @@ const UNIFIED_READPOOL_MIN_CONCURRENCY: usize = 4;
 // FIXME: Use macros to generate it if yatp is used elsewhere besides readpool.
 impl Default for UnifiedReadPoolConfig {
     fn default() -> UnifiedReadPoolConfig {
-        let cpu_num = sysinfo::get_logical_cores();
+        let cpu_num = sysinfo::System::new().get_processors().len();
+
         let mut concurrency = (cpu_num as f64 * 0.8) as usize;
         concurrency = cmp::max(UNIFIED_READPOOL_MIN_CONCURRENCY, concurrency);
         Self {
@@ -1558,7 +1560,8 @@ readpool_config!(StorageReadPoolConfig, storage_read_pool_test, "storage");
 
 impl Default for StorageReadPoolConfig {
     fn default() -> Self {
-        let cpu_num = sysinfo::get_logical_cores();
+        let cpu_num = sysinfo::System::new().get_processors().len();
+
         let mut concurrency = (cpu_num as f64 * 0.5) as usize;
         concurrency = cmp::max(DEFAULT_STORAGE_READPOOL_MIN_CONCURRENCY, concurrency);
         concurrency = cmp::min(DEFAULT_STORAGE_READPOOL_MAX_CONCURRENCY, concurrency);
@@ -1584,7 +1587,8 @@ readpool_config!(
 
 impl Default for CoprReadPoolConfig {
     fn default() -> Self {
-        let cpu_num = sysinfo::get_logical_cores();
+        let cpu_num = sysinfo::System::new().get_processors().len();
+
         let mut concurrency = (cpu_num as f64 * 0.8) as usize;
         concurrency = cmp::max(DEFAULT_COPROCESSOR_READPOOL_MIN_CONCURRENCY, concurrency);
         Self {

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -4,6 +4,7 @@ use std::{i32, isize};
 
 use super::Result;
 use grpcio::CompressionAlgorithms;
+use sysinfo::SystemExt;
 
 use tikv_util::collections::HashMap;
 use tikv_util::config::{self, ReadableDuration, ReadableSize};
@@ -113,7 +114,8 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Config {
-        let cpu_num = sysinfo::get_logical_cores();
+        let cpu_num = sysinfo::System::new().get_processors().len();
+
         Config {
             cluster_id: DEFAULT_CLUSTER_ID,
             addr: DEFAULT_LISTENING_ADDR.to_owned(),

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -5,6 +5,7 @@
 use engine::rocks::{Cache, LRUCacheOptions, MemoryAllocator};
 use libc::c_int;
 use std::error::Error;
+use sysinfo::SystemExt;
 use tikv_util::config::{self, ReadableSize, KB};
 
 pub const DEFAULT_DATA_DIR: &str = "./";
@@ -38,7 +39,8 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Config {
-        let total_cpu = sysinfo::get_logical_cores();
+        let total_cpu = sysinfo::System::new().get_processors().len();
+
         Config {
             data_dir: DEFAULT_DATA_DIR.to_owned(),
             gc_ratio_threshold: DEFAULT_GC_RATIO_THRESHOLD,
@@ -99,7 +101,6 @@ impl BlockCacheConfig {
         }
         let capacity = match self.capacity {
             None => {
-                use sysinfo::SystemExt;
                 let total_mem = sysinfo::System::new().get_total_memory() * KB;
                 ((total_mem as f64) * 0.45) as usize
             }


### PR DESCRIPTION

###  What have you changed?

Running the test suite on an AMD processor with Linux kernel 5.3 leads to a few errors.

This PR depends on changes to our fork of sysinfo, it should not land before [this PR](https://github.com/tikv/sysinfo/pull/1) and updating Cargo.toml.

This PR contains a number of small changes:

* update sysinfo so that we can correctly read `/sys/block/.../stat` files (format is changed in modern Linux kernels)
* read the chip vendor_id from (the updated) sysinfo, and where this indicates an AMD chip, skip some parts of a test (due to a different data layout returned by CPUID).
* mark some code in docs as `ignore` so they are ignored by doctests
* change `test_reserve_space_for_recover` to not rely on space available on a disk. Because other processes might write to or delete from the disk, this test was very unreliable.
* fix a log rotation test where the test set the 'accessed' time but the rotation code ignores that if it can read the file's 'created' time (presumably this test currently passes because the 'created' time can never be read).
* fix some typos

PTAL @lonng @Little-Wallace 

###  What is the type of the changes?
- Bugfix (a change which fixes an issue)
- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?

- Unit test
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
no

###  Does this PR affect `tidb-ansible`?
no
