### PR TITLE
[DNM] change default_cf default block_size to 4k

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -496,7 +496,7 @@
 ## The data block size. RocksDB compresses data based on the unit of block.
 ## Similar to page in other databases, block is the smallest unit cached in block-cache. Note that
 ## the block size specified here corresponds to uncompressed data.
-# block-size = "64KB"
+# block-size = "4KB"
 
 ## If you're doing point lookups you definitely want to turn bloom filters on. We use bloom filters
 ## to avoid unnecessary disk reads. Default bits_per_key is 10, which yields ~1% false positive

--- a/src/config.rs
+++ b/src/config.rs
@@ -397,7 +397,7 @@ cf_config!(DefaultCfConfig);
 impl Default for DefaultCfConfig {
     fn default() -> DefaultCfConfig {
         DefaultCfConfig {
-            block_size: ReadableSize::kb(64),
+            block_size: ReadableSize::kb(4),
             block_cache_size: ReadableSize::mb(memory_mb_for_cf(false, CF_DEFAULT) as u64),
             disable_block_cache: false,
             cache_index_and_filter_blocks: true,


### PR DESCRIPTION
###  What have you changed?
Change default block size of default_cf from 64k to 4k. This is to reduce IO read-amp for point-lookup and short-range scan for rocksdb. Per current benchmark by @pentium3, the change improve YCSB workload C (point-lookup) throughput by 70%, but with workload E (short range-scan) regress by 25%. It also slightly improve sysbench update-index by 3%, which is a write-heavy workload. In some of the benchmarks, cache memory fragmentation is also reduced, but the result is not very evident.

One drawback of the change is it can make compression ratio worst. A very raw test with some compression benchmark set shows compression ratio can have 4%-110% regression (110% means compressed size more than double) for ZSTD compression. So it really depend on actual data. This can make user upgrade from older version with 64k default block size suddenly get out-of-space. One of the solution is to use dictionary compression, which essentially make rocksdb compress per SST file, instead of per block #6502.
https://internal.pingcap.net/confluence/display/TT/2019-03+Compression+ratio+of+various+block+sizes

###  What is the type of the changes?
Improvement

###  How is the PR tested?
See benchmarks

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
need to update config template in ansible accordingly.

###  Does this PR affect `tidb-ansible`?
May need to keep old default for existing user on ansible side: https://github.com/pingcap/tidb-ansible/issues/1126

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)
https://docs.google.com/document/d/14xLrM8oeVHJ7ABYbqwyv7SfQgxpSi2yKZXt_D-oQpME/edit?usp=sharing

###  Any examples? (optional)

