### PR TITLE
storage, raftstore: move RegionInfoProvider into raftstore

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -17,8 +17,9 @@ use kvproto::backup::*;
 use kvproto::kvrpcpb::{Context, IsolationLevel};
 use kvproto::metapb::*;
 use raft::StateRole;
+use tikv::raftstore::coprocessor::RegionInfoProvider;
 use tikv::raftstore::store::util::find_peer;
-use tikv::storage::kv::{Engine, RegionInfoProvider};
+use tikv::storage::kv::Engine;
 use tikv::storage::txn::{EntryBatch, SnapshotStore, TxnEntryScanner, TxnEntryStore};
 use tikv::storage::Statistics;
 use tikv_util::time::Limiter;
@@ -592,9 +593,9 @@ pub mod tests {
     use std::thread;
     use tempfile::TempDir;
     use tikv::raftstore::coprocessor::RegionCollector;
+    use tikv::raftstore::coprocessor::Result as CopResult;
     use tikv::raftstore::coprocessor::SeekRegionCallback;
     use tikv::raftstore::store::util::new_peer;
-    use tikv::storage::kv::Result as EngineResult;
     use tikv::storage::mvcc::tests::*;
     use tikv::storage::{RocksEngine, TestEngineBuilder};
     use tikv_util::time::Instant;
@@ -634,7 +635,7 @@ pub mod tests {
         }
     }
     impl RegionInfoProvider for MockRegionInfoProvider {
-        fn seek_region(&self, from: &[u8], callback: SeekRegionCallback) -> EngineResult<()> {
+        fn seek_region(&self, from: &[u8], callback: SeekRegionCallback) -> CopResult<()> {
             let from = from.to_vec();
             let regions = self.regions.lock().unwrap();
             if let Some(c) = self.cancel.as_ref() {

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -3,13 +3,13 @@
 use futures::Future;
 
 use kvproto::kvrpcpb::{Context, LockInfo};
+use tikv::raftstore::coprocessor::RegionInfoProvider;
 use tikv::server::gc_worker::{AutoGcConfig, GcConfig, GcSafePointProvider, GcWorker};
 use tikv::storage::config::Config;
 use tikv::storage::kv::RocksEngine;
 use tikv::storage::lock_manager::DummyLockManager;
 use tikv::storage::{
-    txn::commands, Engine, RegionInfoProvider, Result, Storage, TestEngineBuilder,
-    TestStorageBuilder, TxnStatus,
+    txn::commands, Engine, Result, Storage, TestEngineBuilder, TestStorageBuilder, TxnStatus,
 };
 use tikv_util::collections::HashMap;
 use txn_types::{Key, KvPair, Mutation, TimeStamp, Value};

--- a/src/raftstore/coprocessor/mod.rs
+++ b/src/raftstore/coprocessor/mod.rs
@@ -24,7 +24,7 @@ pub use self::dispatcher::{
 pub use self::error::{Error, Result};
 pub use self::region_info_accessor::{
     Callback as RegionInfoCallback, RegionCollector, RegionInfo, RegionInfoAccessor,
-    SeekRegionCallback,
+    RegionInfoProvider, SeekRegionCallback,
 };
 pub use self::split_check::{
     get_region_approximate_keys, get_region_approximate_keys_cf, get_region_approximate_middle,

--- a/src/raftstore/coprocessor/region_info_accessor.rs
+++ b/src/raftstore/coprocessor/region_info_accessor.rs
@@ -9,9 +9,8 @@ use std::time::Duration;
 use super::metrics::*;
 use super::{
     BoxRegionChangeObserver, BoxRoleObserver, Coprocessor, CoprocessorHost, ObserverContext,
-    RegionChangeEvent, RegionChangeObserver, RoleObserver,
+    RegionChangeEvent, RegionChangeObserver, Result, RoleObserver,
 };
-use crate::storage::kv::{RegionInfoProvider, Result as EngineResult};
 use keys::{data_end_key, data_key};
 use kvproto::metapb::Region;
 use raft::StateRole;
@@ -496,8 +495,24 @@ impl RegionInfoAccessor {
     }
 }
 
+pub trait RegionInfoProvider: Send + Clone + 'static {
+    /// Get a iterator of regions that contains `from` or have keys larger than `from`, and invoke
+    /// the callback to process the result.
+    fn seek_region(&self, _from: &[u8], _callback: SeekRegionCallback) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn find_region_by_id(
+        &self,
+        _reigon_id: u64,
+        _callback: Callback<Option<RegionInfo>>,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+}
+
 impl RegionInfoProvider for RegionInfoAccessor {
-    fn seek_region(&self, from: &[u8], callback: SeekRegionCallback) -> EngineResult<()> {
+    fn seek_region(&self, from: &[u8], callback: SeekRegionCallback) -> Result<()> {
         let msg = RegionInfoQuery::SeekRegion {
             from: from.to_vec(),
             callback,
@@ -511,7 +526,7 @@ impl RegionInfoProvider for RegionInfoAccessor {
         &self,
         region_id: u64,
         callback: Callback<Option<RegionInfo>>,
-    ) -> EngineResult<()> {
+    ) -> Result<()> {
         let msg = RegionInfoQuery::FindRegionById {
             region_id,
             callback,

--- a/src/server/gc_worker/mod.rs
+++ b/src/server/gc_worker/mod.rs
@@ -28,15 +28,14 @@ use raft::StateRole;
 use tokio_core::reactor::Handle;
 
 use crate::config::ConfigManager;
-use crate::raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor};
+use crate::raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor, RegionInfoProvider};
 use crate::raftstore::router::ServerRaftStoreRouter;
 use crate::raftstore::store::msg::StoreMsg;
 use crate::raftstore::store::util::find_peer;
 use crate::raftstore::store::RegionSnapshot;
 use crate::server::metrics::*;
 use crate::storage::kv::{
-    Engine, Error as EngineError, ErrorInner as EngineErrorInner, RegionInfoProvider, ScanMode,
-    Snapshot, Statistics,
+    Engine, Error as EngineError, ErrorInner as EngineErrorInner, ScanMode, Snapshot, Statistics,
 };
 use crate::storage::mvcc::{check_need_gc, Error as MvccError, MvccReader, MvccTxn};
 use crate::storage::{Callback, Error, ErrorInner, Result};
@@ -1647,6 +1646,7 @@ impl<E: Engine> GcWorker<E> {
 mod tests {
     use super::*;
     use crate::config::{ConfigController, TiKvConfig};
+    use crate::raftstore::coprocessor::Result as CopResult;
     use crate::raftstore::coprocessor::{RegionInfo, SeekRegionCallback};
     use crate::raftstore::store::util::new_peer;
     use crate::storage::kv::{
@@ -1696,7 +1696,7 @@ mod tests {
     }
 
     impl RegionInfoProvider for MockRegionInfoProvider {
-        fn seek_region(&self, from: &[u8], callback: SeekRegionCallback) -> EngineResult<()> {
+        fn seek_region(&self, from: &[u8], callback: SeekRegionCallback) -> CopResult<()> {
             let from = from.to_vec();
             callback(&mut self.regions.range(from..).map(|(_, v)| v));
             Ok(())

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -19,9 +19,6 @@ use kvproto::errorpb::Error as ErrorHeader;
 use kvproto::kvrpcpb::Context;
 use txn_types::{Key, Value};
 
-use crate::into_other::IntoOther;
-use crate::raftstore::coprocessor::{RegionInfo, RegionInfoCallback, SeekRegionCallback};
-
 pub use self::btree_engine::{BTreeEngine, BTreeEngineIterator, BTreeEngineSnapshot};
 pub use self::compact_listener::{CompactedEvent, CompactionListener};
 pub use self::cursor::{Cursor, CursorBuilder};
@@ -30,6 +27,7 @@ pub use self::rocksdb_engine::{RocksEngine, RocksSnapshot, TestEngineBuilder};
 pub use self::stats::{
     CfStatistics, FlowStatistics, FlowStatsReporter, Statistics, StatisticsSummary,
 };
+use crate::into_other::IntoOther;
 
 pub const SEEK_BOUND: u64 = 8;
 const DEFAULT_TIMEOUT_SECS: u64 = 5;
@@ -168,22 +166,6 @@ pub trait Iterator: Send {
     fn key(&self) -> &[u8];
     /// Only be called when `self.valid() == Ok(true)`.
     fn value(&self) -> &[u8];
-}
-
-pub trait RegionInfoProvider: Send + Clone + 'static {
-    /// Get a iterator of regions that contains `from` or have keys larger than `from`, and invoke
-    /// the callback to process the result.
-    fn seek_region(&self, _from: &[u8], _callback: SeekRegionCallback) -> Result<()> {
-        unimplemented!()
-    }
-
-    fn find_region_by_id(
-        &self,
-        _reigon_id: u64,
-        _callback: RegionInfoCallback<Option<RegionInfo>>,
-    ) -> Result<()> {
-        unimplemented!()
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -23,8 +23,8 @@ mod types;
 pub use self::{
     errors::{get_error_kind_from_header, get_tag_from_header, Error, ErrorHeaderKind, ErrorInner},
     kv::{
-        CfStatistics, Cursor, Engine, FlowStatistics, FlowStatsReporter, Iterator,
-        RegionInfoProvider, RocksEngine, ScanMode, Snapshot, Statistics, TestEngineBuilder,
+        CfStatistics, Cursor, Engine, FlowStatistics, FlowStatsReporter, Iterator, RocksEngine,
+        ScanMode, Snapshot, Statistics, TestEngineBuilder,
     },
     read_pool::{build_read_pool, build_read_pool_for_test},
     txn::{ProcessResult, Scanner, SnapshotStore, Store},

--- a/tests/integrations/storage/test_seek_region.rs
+++ b/tests/integrations/storage/test_seek_region.rs
@@ -5,8 +5,7 @@ use std::thread;
 use std::time::Duration;
 
 use test_raftstore::*;
-use tikv::raftstore::coprocessor::RegionInfoAccessor;
-use tikv::storage::kv::RegionInfoProvider;
+use tikv::raftstore::coprocessor::{RegionInfoAccessor, RegionInfoProvider};
 use tikv_util::collections::HashMap;
 use tikv_util::HandyRwLock;
 


### PR DESCRIPTION

###  What have you changed?

`RegionInfoProvider` should be defined in raftstore instead of storage.

###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No

