### PR TITLE
sst_importer: do not change block_cache_size in import mode

### DIFF
--- a/components/test_sst_importer/src/lib.rs
+++ b/components/test_sst_importer/src/lib.rs
@@ -26,10 +26,18 @@ pub use engine_rocks::RocksEngine as TestEngine;
 pub const PROP_TEST_MARKER_CF_NAME: &[u8] = b"tikv.test_marker_cf_name";
 
 pub fn new_test_engine(path: &str, cfs: &[&str]) -> RocksEngine {
+    new_test_engine_with_options(path, cfs, |_, _| {})
+}
+
+pub fn new_test_engine_with_options<F>(path: &str, cfs: &[&str], mut apply: F) -> RocksEngine
+where
+    F: FnMut(&str, &mut ColumnFamilyOptions),
+{
     let cf_opts = cfs
         .iter()
         .map(|cf| {
             let mut opt = ColumnFamilyOptions::new();
+            apply(*cf, &mut opt);
             opt.add_table_properties_collector_factory(
                 "tikv.test_properties",
                 Box::new(TestPropertiesCollectorFactory::new(*cf)),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

"Import mode" was used by TiKV Importer to speed up import by skewing the balance towards write speed. It works by dynamically changing these 5 CF options:

* block_cache_size
* level0_stop_writes_trigger
* level0_slowdown_writes_trigger
* soft_pending_compaction_bytes_limit
* hard_pending_compaction_bytes_limit

Previously, these are hard-coded as [4 GiB, 1 GiB, 1 GiB, 0, 0] respectively. However, there is a bug in TiKV which prevents lowered block_cache_size from restored to a higher value when shared cache was enabled. This makes switching to import mode permanently lose write efficiency.

Setting block_cache_size to 4 GiB was originally an attempt to prevent OOM due to too many L0 files back in TiKV 2.0. We are now 2 major versions later and probably this is no longer needed. So we just stop overwriting block_cache_size in import mode to fix #6545.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

#6545 

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

## Release note

* No longer overwrite `block_cache_size` after using Lightning / BR.