### PR TITLE
pre-transfer-leader: use log term instead of term

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -2268,7 +2268,7 @@ impl Peer {
         msg.set_to(self.leader_id());
         msg.set_msg_type(eraftpb::MessageType::MsgTransferLeader);
         msg.set_index(self.get_store().applied_index());
-        msg.set_term(self.term());
+        msg.set_log_term(self.term());
         self.raft_group.raft.msgs.push(msg);
     }
 

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1825,7 +1825,10 @@ impl Peer {
         msg.set_to(peer.get_id());
         msg.set_msg_type(eraftpb::MessageType::MsgTransferLeader);
         msg.set_from(self.peer_id());
-        msg.set_term(self.term());
+        // log term here represents the term of last log. For leader, the term of last
+        // log is always its current term. Not just set term because raft library forbids
+        // setting it for MsgTransferLeader messages.
+        msg.set_log_term(self.term());
         self.raft_group.raft.msgs.push(msg);
         true
     }
@@ -2219,7 +2222,9 @@ impl Peer {
         ctx: &mut PollContext<T, C>,
         msg: &eraftpb::Message,
     ) {
-        if msg.get_term() != self.term() {
+        // log_term is set by original leader, represents the term last log is written
+        // in, which should be equal to the original leader's term.
+        if msg.get_log_term() != self.term() {
             return;
         }
 


### PR DESCRIPTION
###  What have you changed?

raft-rs forbids setting term for MsgTransferLeader, so use log term
instead.

###  What is the type of the changes?
- Bugfix

###  How is the PR tested?
- Manual test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No.

###  Does this PR affect `tidb-ansible`?
No.
