### PR TITLE
add unified read pool configs to config template

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -27,6 +27,21 @@
 ## Set it small are good to debug and tuning.
 # refresh-config-interval = "30s"
 
+[readpool]
+## (Experimental) Whether to use a single thread pool to serve all the read requests. If it is
+## set to `true`, the `readpool.storage` and `readpool.coprocessor` sections will be invalid and
+## be ignored automatically.
+# unify-read-pool = false
+
+# Configurations for the single thread pool serving read requests.
+# It only takes effect when `unify-read-pool` is `true`.
+[readpool.unified]
+## The minimal working thread count of the thread pool.
+# min-thread-count = 1
+## The maximum working thread count of the thread pool.
+## The default value is the max(4, LOGICAL_CPU_NUM * 0.8).
+# max-thread-count = 8
+
 [readpool.storage]
 ## Size of the thread pool for high-priority operations.
 # high-concurrency = 4


### PR DESCRIPTION
###  What have you changed?

This PR adds unified read pool configs to config template. These configs are already supported by TiKV.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

The corresponding tidb-ansible PR: https://github.com/pingcap/tidb-ansible/pull/1112