### PR TITLE
*: unify read pools by default

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -31,7 +31,7 @@
 ## (Experimental) Whether to use a single thread pool to serve all the read requests. If it is
 ## set to `true`, the `readpool.storage` and `readpool.coprocessor` sections will be invalid and
 ## be ignored automatically.
-# unify-read-pool = false
+# unify-read-pool = true
 
 # Configurations for the single thread pool serving read requests.
 # It only takes effect when `unify-read-pool` is `true`.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -40,7 +40,7 @@
 # min-thread-count = 1
 
 ## The maximum working thread count of the thread pool.
-## The default value is the max(4, LOGICAL_CPU_NUM * 0.8).
+## The default value is max(4, LOGICAL_CPU_NUM * 0.8).
 # max-thread-count = 8
 
 ## Size of the stack for each thread in the thread pool.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1656,7 +1656,7 @@ impl ReadPoolConfig {
 impl Default for ReadPoolConfig {
     fn default() -> ReadPoolConfig {
         ReadPoolConfig {
-            unify_read_pool: false,
+            unify_read_pool: true,
             unified: Default::default(),
             storage: Default::default(),
             coprocessor: Default::default(),


### PR DESCRIPTION
###  What have you changed?

To encourage people to use the new thread pool for all read requests, this PR modifies the `unify-read-pool` config to `true`.

Enabling the new thread pool at 4.0 pre-GA stage by default helps us find bugs or regressions. The feedbacks will decide whether it can be enabled by default when 4.0 GA is released.

Currently the new thread pool has some functions missing, but PRs are coming with 4.0.0-beta.1 release.

- [x] *: add metrics for unified read pool #6534
- [x] *: add stack size and max task number limit to unified read pool #6597

###  What is the type of the changes?

- Misc (other changes)

###  How is the PR tested?

- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

Yes. I will do it later when pushing the related docs.

###  Does this PR affect `tidb-ansible`?

Yes. I will also do it later.

