### PR TITLE
Server: adding binary_path to store for tikv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
  "grpcio",
  "hex 0.3.2",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "lazy_static",
  "prometheus",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -447,7 +447,7 @@ dependencies = [
  "futures 0.1.29",
  "grpcio",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "log",
  "pd_client",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -563,7 +563,7 @@ dependencies = [
  "grpcio",
  "hex 0.3.2",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "libc",
  "log",
  "nix 0.11.1",
@@ -998,7 +998,7 @@ dependencies = [
  "configuration",
  "engine_traits",
  "hex 0.3.2",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "lazy_static",
  "prometheus",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1033,7 +1033,7 @@ dependencies = [
  "engine",
  "engine_traits",
  "hex 0.3.2",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "lazy_static",
  "prometheus",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1097,7 +1097,7 @@ dependencies = [
  "futures-executor",
  "futures-io",
  "futures-util",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "rand 0.7.2",
  "rusoto_core",
  "rusoto_credential",
@@ -1825,7 +1825,7 @@ dependencies = [
  "derive_more",
  "failure",
  "hex 0.3.2",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "panic_hook",
  "tikv_alloc",
 ]
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#a965739f8162eda4f60ffa4352172ea67e9ec6d1"
+source = "git+https://github.com/mwish-pingcap-company-repos/kvproto.git?branch=dev-store#6bb1faaf50cf0a65da48bbb971b2fa9c1d68110e"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
@@ -1845,6 +1845,12 @@ dependencies = [
  "protobuf-build 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft-proto 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "kvproto"
+version = "0.0.2"
+source = "git+https://github.com/pingcap/kvproto.git#a965739f8162eda4f60ffa4352172ea67e9ec6d1"
+replace = "kvproto 0.0.2 (git+https://github.com/mwish-pingcap-company-repos/kvproto.git?branch=dev-store)"
 
 [[package]]
 name = "lazy_static"
@@ -2533,7 +2539,7 @@ dependencies = [
  "futures 0.1.29",
  "grpcio",
  "hex 0.3.2",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "lazy_static",
  "log",
  "prometheus",
@@ -3845,7 +3851,7 @@ dependencies = [
  "grpcio",
  "hex 0.3.2",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "lazy_static",
  "prometheus",
  "quick-error",
@@ -4055,7 +4061,7 @@ version = "0.0.1"
 dependencies = [
  "futures 0.1.29",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_storage",
@@ -4077,7 +4083,7 @@ dependencies = [
  "grpcio",
  "hex 0.3.2",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "pd_client",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4100,7 +4106,7 @@ dependencies = [
  "engine_rocks",
  "engine_traits",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "uuid 0.7.4",
 ]
 
@@ -4110,7 +4116,7 @@ version = "0.0.1"
 dependencies = [
  "futures 0.1.29",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "test_raftstore",
  "tikv",
  "tikv_util",
@@ -4153,7 +4159,7 @@ dependencies = [
  "grpcio",
  "hex 0.3.2",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "panic_hook",
  "pd_client",
  "profiler",
@@ -4238,7 +4244,7 @@ dependencies = [
  "flate2",
  "hex 0.3.2",
  "indexmap",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "lazy_static",
  "match_template",
  "nom 5.1.0",
@@ -4336,7 +4342,7 @@ dependencies = [
  "hyper",
  "itertools",
  "keys",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "lazy_static",
  "libc",
  "log",
@@ -4809,7 +4815,7 @@ dependencies = [
  "derive-new",
  "farmhash",
  "hex 0.3.2",
- "kvproto",
+ "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
  "panic_hook",
  "quick-error",
  "slog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
  "grpcio",
  "hex 0.3.2",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "lazy_static",
  "prometheus",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -447,7 +447,7 @@ dependencies = [
  "futures 0.1.29",
  "grpcio",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "log",
  "pd_client",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -563,7 +563,7 @@ dependencies = [
  "grpcio",
  "hex 0.3.2",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "libc",
  "log",
  "nix 0.11.1",
@@ -998,7 +998,7 @@ dependencies = [
  "configuration",
  "engine_traits",
  "hex 0.3.2",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "lazy_static",
  "prometheus",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1033,7 +1033,7 @@ dependencies = [
  "engine",
  "engine_traits",
  "hex 0.3.2",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "lazy_static",
  "prometheus",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1097,7 +1097,7 @@ dependencies = [
  "futures-executor",
  "futures-io",
  "futures-util",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "rand 0.7.2",
  "rusoto_core",
  "rusoto_credential",
@@ -1825,7 +1825,7 @@ dependencies = [
  "derive_more",
  "failure",
  "hex 0.3.2",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "panic_hook",
  "tikv_alloc",
 ]
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/mwish-pingcap-company-repos/kvproto.git?branch=dev-store#6bb1faaf50cf0a65da48bbb971b2fa9c1d68110e"
+source = "git+https://github.com/pingcap/kvproto.git#7f1b9fd3a03f9269d8915d304bfe23b84def11a1"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
@@ -1845,12 +1845,6 @@ dependencies = [
  "protobuf-build 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft-proto 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "kvproto"
-version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#a965739f8162eda4f60ffa4352172ea67e9ec6d1"
-replace = "kvproto 0.0.2 (git+https://github.com/mwish-pingcap-company-repos/kvproto.git?branch=dev-store)"
 
 [[package]]
 name = "lazy_static"
@@ -2539,7 +2533,7 @@ dependencies = [
  "futures 0.1.29",
  "grpcio",
  "hex 0.3.2",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "lazy_static",
  "log",
  "prometheus",
@@ -3851,7 +3845,7 @@ dependencies = [
  "grpcio",
  "hex 0.3.2",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "lazy_static",
  "prometheus",
  "quick-error",
@@ -4061,7 +4055,7 @@ version = "0.0.1"
 dependencies = [
  "futures 0.1.29",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_storage",
@@ -4083,7 +4077,7 @@ dependencies = [
  "grpcio",
  "hex 0.3.2",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "pd_client",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raft 0.6.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4106,7 +4100,7 @@ dependencies = [
  "engine_rocks",
  "engine_traits",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "uuid 0.7.4",
 ]
 
@@ -4116,7 +4110,7 @@ version = "0.0.1"
 dependencies = [
  "futures 0.1.29",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "test_raftstore",
  "tikv",
  "tikv_util",
@@ -4159,7 +4153,7 @@ dependencies = [
  "grpcio",
  "hex 0.3.2",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "panic_hook",
  "pd_client",
  "profiler",
@@ -4244,7 +4238,7 @@ dependencies = [
  "flate2",
  "hex 0.3.2",
  "indexmap",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "lazy_static",
  "match_template",
  "nom 5.1.0",
@@ -4342,7 +4336,7 @@ dependencies = [
  "hyper",
  "itertools",
  "keys",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "lazy_static",
  "libc",
  "log",
@@ -4815,7 +4809,7 @@ dependencies = [
  "derive-new",
  "farmhash",
  "hex 0.3.2",
- "kvproto 0.0.2 (git+https://github.com/pingcap/kvproto.git)",
+ "kvproto",
  "panic_hook",
  "quick-error",
  "slog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,8 +157,6 @@ zipf = "5.0.1"
 "protobuf-codegen:2.8.0" = { git = "https://github.com/nrc/rust-protobuf", branch = "v2.8" }
 "prost:0.5.0" = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
 "protobuf-build:0.10.0" = { git = "https://github.com/tikv/protobuf-build", rev="42e52b9311f7fb31bbbe089fef5a24ec0392f9ce" }
-# TODO: remove this and change the hash when https://github.com/pingcap/kvproto/pull/551 is merged.
-"https://github.com/pingcap/kvproto.git#kvproto:0.0.2" = { git = "https://github.com/mwish-pingcap-company-repos/kvproto.git", branch = "dev-store", default-features = false}
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ zipf = "5.0.1"
 "protobuf-codegen:2.8.0" = { git = "https://github.com/nrc/rust-protobuf", branch = "v2.8" }
 "prost:0.5.0" = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
 "protobuf-build:0.10.0" = { git = "https://github.com/tikv/protobuf-build", rev="42e52b9311f7fb31bbbe089fef5a24ec0392f9ce" }
+# TODO: remove this and change the hash when https://github.com/pingcap/kvproto/pull/551 is merged.
 "https://github.com/pingcap/kvproto.git#kvproto:0.0.2" = { git = "https://github.com/mwish-pingcap-company-repos/kvproto.git", branch = "dev-store", default-features = false}
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ zipf = "5.0.1"
 "protobuf-codegen:2.8.0" = { git = "https://github.com/nrc/rust-protobuf", branch = "v2.8" }
 "prost:0.5.0" = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
 "protobuf-build:0.10.0" = { git = "https://github.com/tikv/protobuf-build", rev="42e52b9311f7fb31bbbe089fef5a24ec0392f9ce" }
+"https://github.com/pingcap/kvproto.git#kvproto:0.0.2" = { git = "https://github.com/mwish-pingcap-company-repos/kvproto.git", branch = "dev-store", default-features = false}
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs" }

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -79,6 +79,14 @@ where
         }
         store.set_version(env!("CARGO_PKG_VERSION").to_string());
         store.set_status_address(cfg.status_addr.clone());
+
+        match std::env::current_exe() {
+            Ok(path) => {
+                store.set_binary_path(path.file_name().unwrap().to_string_lossy().into_string());
+            }
+            Err(_) => {}
+        };
+
         store.set_start_timestamp(chrono::Local::now().timestamp());
         store.set_git_hash(
             option_env!("TIKV_BUILD_GIT_HASH")

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -80,12 +80,9 @@ where
         store.set_version(env!("CARGO_PKG_VERSION").to_string());
         store.set_status_address(cfg.status_addr.clone());
 
-        match std::env::current_exe() {
-            Ok(path) => {
-                // `file_name` Returns [`None`] if the path terminates in `..`, so it's safe to unwrap.
-                store.set_binary_path(path.file_name().unwrap().to_string_lossy().to_string());
-            }
-            Err(_) => {}
+        if let Ok(path) = std::env::current_exe() {
+            // `file_name` Returns [`None`] if the path terminates in `..`, so it's safe to unwrap.
+            store.set_binary_path(path.file_name().unwrap().to_string_lossy().to_string());
         };
 
         store.set_start_timestamp(chrono::Local::now().timestamp());

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -81,8 +81,7 @@ where
         store.set_status_address(cfg.status_addr.clone());
 
         if let Ok(path) = std::env::current_exe() {
-            // `file_name` Returns [`None`] if the path terminates in `..`, so it's safe to unwrap.
-            store.set_binary_path(path.file_name().unwrap().to_string_lossy().to_string());
+            store.set_binary_path(path.to_string_lossy().to_string());
         };
 
         store.set_start_timestamp(chrono::Local::now().timestamp());

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -82,7 +82,8 @@ where
 
         match std::env::current_exe() {
             Ok(path) => {
-                store.set_binary_path(path.file_name().unwrap().to_string_lossy().into_string());
+                // `file_name` Returns [`None`] if the path terminates in `..`, so it's safe to unwrap.
+                store.set_binary_path(path.file_name().unwrap().to_string_lossy().to_string());
             }
             Err(_) => {}
         };


### PR DESCRIPTION
Signed-off-by: mapleFU <1506118561@qq.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Please explain in detail what the changes are in this PR and why they are needed:

This pr is related to [kvproto#551](https://github.com/pingcap/kvproto/pull/551). TiKV need to support upload it's binary path to PD. 

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- New feature (a change which adds functionality)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->

- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->

###  Does this PR affect `tidb-ansible`?
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->

No

###  Refer to a related PR or issue link (optional)

* [kvproto#551](https://github.com/pingcap/kvproto/pull/551)

