### PR TITLE
copr: implement macro match_template_collator

### DIFF
--- a/components/match_template/src/lib.rs
+++ b/components/match_template/src/lib.rs
@@ -24,6 +24,28 @@
 //! }
 //! ```
 //!
+//! In addition, substitution can vary on two sides of the arms.
+//! 
+//! For example,
+//! 
+//! ```ignore
+//! match_template! {
+//!     T = [Foo, Bar => Baz],
+//!     match Foo {
+//!         EvalType::T => { panic!("{}", EvalType::T); },
+//!     }
+//! }
+//! ```
+//!
+//! generates
+//!
+//! ```ignore
+//! match Foo {
+//!     EvalType::Foo => { panic!("{}", EvalType::Foo); },
+//!     EvalType::Bar => { panic!("{}", EvalType::Baz); },
+//! }
+//! ```
+//! 
 //! Wildcard match arm is also supported (but there will be no substitution).
 
 #[macro_use]
@@ -36,12 +58,138 @@ use syn::parse::{Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::*;
 
+#[proc_macro]
+pub fn match_template(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let mt = parse_macro_input!(input as MatchTemplate);
+    mt.expand().into()
+}
+struct MatchTemplate {
+    template_ident: Ident,
+    substitutes: Punctuated<Substitution, Token![,]>,
+    match_exp: Box<Expr>,
+    match_arm: Arm,
+    wildcard_match_arm: Option<Arm>,
+}
+
+impl Parse for MatchTemplate {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let template_ident = input.parse()?;
+        input.parse::<Token![=]>()?;
+        let substitutes_tokens;
+        bracketed!(substitutes_tokens in input);
+        let substitutes =
+            Punctuated::<Substitution, Token![,]>::parse_terminated(&substitutes_tokens)?;
+        input.parse::<Token![,]>()?;
+        let m: ExprMatch = input.parse()?;
+        assert!(!m.arms.is_empty(), "Expect at least 1 match arm");
+        assert!(m.arms.len() <= 2, "Expect at most 2 match arm");
+        let mut arms = m.arms.into_iter();
+
+        let mut arm = arms.next().unwrap();
+        assert!(arm.guard.is_none(), "Expect no match arm guard");
+        arm.comma = None;
+
+        let mut wildcard_arm = None;
+        if let Some(arm) = arms.next() {
+            assert!(arm.guard.is_none(), "Expect no match arm guard");
+            if let Pat::Wild(_) = arm.pat {
+                wildcard_arm = Some(arm);
+            } else {
+                panic!("Expect wildcard arm");
+            }
+        }
+
+        Ok(Self {
+            template_ident,
+            substitutes,
+            match_exp: m.expr,
+            match_arm: arm,
+            wildcard_match_arm: wildcard_arm,
+        })
+    }
+}
+
+impl MatchTemplate {
+    fn expand(self) -> TokenStream {
+        let Self {
+            template_ident,
+            substitutes,
+            match_exp,
+            match_arm,
+            wildcard_match_arm,
+        } = self;
+        let match_arms = substitutes.into_iter().map(|substitute| {
+            let mut folder = match substitute {
+                Substitution::Identical(ident) => MatchArmIdentFolder {
+                    template_ident: template_ident.clone(),
+                    left_ident: ident.clone(),
+                    right_ident: ident,
+                },
+                Substitution::Map(left_ident, right_ident) => MatchArmIdentFolder {
+                    template_ident: template_ident.clone(),
+                    left_ident,
+                    right_ident,
+                },
+            };
+            folder.fold_arm(match_arm.clone())
+        });
+        quote! {
+            match #match_exp {
+                #(#match_arms,)*
+                #wildcard_match_arm
+            }
+        }
+    }
+}
+
+enum Substitution {
+    Identical(Ident),
+    Map(Ident, Ident),
+}
+
+impl Parse for Substitution {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let first_ident = input.parse()?;
+        let fat_arrow: Option<Token![=>]> = input.parse()?;
+        if fat_arrow.is_some() {
+            let second_ident = input.parse()?;
+            Ok(Substitution::Map(first_ident, second_ident))
+        } else {
+            Ok(Substitution::Identical(first_ident))
+        }
+    }
+}
+
 struct MatchArmIdentFolder {
+    template_ident: Ident,
+    left_ident: Ident,
+    right_ident: Ident,
+}
+
+impl Fold for MatchArmIdentFolder {
+    fn fold_pat(&mut self, i: Pat) -> Pat {
+        ReplaceIdentFolder {
+            from_ident: self.template_ident.clone(),
+            to_ident: self.left_ident.clone(),
+        }
+        .fold_pat(i)
+    }
+
+    fn fold_expr(&mut self, i: Expr) -> Expr {
+        ReplaceIdentFolder {
+            from_ident: self.template_ident.clone(),
+            to_ident: self.right_ident.clone(),
+        }
+        .fold_expr(i)
+    }
+}
+
+struct ReplaceIdentFolder {
     from_ident: Ident,
     to_ident: Ident,
 }
 
-impl Fold for MatchArmIdentFolder {
+impl Fold for ReplaceIdentFolder {
     fn fold_macro(&mut self, i: Macro) -> Macro {
         let mut m = syn::fold::fold_macro(self, i);
         m.tokens = m
@@ -66,83 +214,6 @@ impl Fold for MatchArmIdentFolder {
             i
         }
     }
-}
-
-struct MatchTemplate {
-    token_ident: Ident,
-    substitutes_ident: Punctuated<Ident, Token![,]>,
-    match_exp: Box<Expr>,
-    match_arm: Arm,
-    wildcard_match_arm: Option<Arm>,
-}
-
-impl Parse for MatchTemplate {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let token_ident = input.parse()?;
-        input.parse::<Token![=]>()?;
-        let substitutes_content;
-        bracketed!(substitutes_content in input);
-        let substitutes_ident =
-            Punctuated::<Ident, Token![,]>::parse_terminated(&substitutes_content)?;
-        input.parse::<Token![,]>()?;
-        let m: ExprMatch = input.parse()?;
-        assert!(!m.arms.is_empty(), "Expect at least 1 match arm");
-        assert!(m.arms.len() <= 2, "Expect at most 2 match arm");
-        let mut arms = m.arms.into_iter();
-
-        let mut arm = arms.next().unwrap();
-        assert!(arm.guard.is_none(), "Expect no match arm guard");
-        arm.comma = None;
-
-        let mut wildcard_arm = None;
-        if let Some(arm) = arms.next() {
-            assert!(arm.guard.is_none(), "Expect no match arm guard");
-            if let Pat::Wild(_) = arm.pat {
-                wildcard_arm = Some(arm);
-            } else {
-                panic!("Expect wildcard arm");
-            }
-        }
-
-        Ok(Self {
-            token_ident,
-            substitutes_ident,
-            match_exp: m.expr,
-            match_arm: arm,
-            wildcard_match_arm: wildcard_arm,
-        })
-    }
-}
-
-impl MatchTemplate {
-    fn expand(self) -> TokenStream {
-        let Self {
-            token_ident,
-            substitutes_ident,
-            match_exp,
-            match_arm,
-            wildcard_match_arm,
-        } = self;
-        let match_arms = substitutes_ident.into_iter().map(|ident| {
-            MatchArmIdentFolder {
-                from_ident: token_ident.clone(),
-                to_ident: ident,
-            }
-            .fold_arm(match_arm.clone())
-        });
-        quote! {
-            match #match_exp {
-                #(#match_arms,)*
-                #wildcard_match_arm
-            }
-        }
-    }
-}
-
-#[proc_macro]
-pub fn match_template(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let mt = parse_macro_input!(input as MatchTemplate);
-    mt.expand().into()
 }
 
 #[cfg(test)]
@@ -187,6 +258,28 @@ mod tests {
                 VectorValue::Foo => EvalType::Foo,
                 VectorValue::Bar => EvalType::Bar,
                 _ => unreachable!(),
+            }
+        "#;
+        let expect_output_stream: TokenStream = expect_output.parse().unwrap();
+
+        let mt: MatchTemplate = syn::parse_str(input).unwrap();
+        let output = mt.expand();
+        assert_eq!(output.to_string(), expect_output_stream.to_string());
+    }
+
+    #[test]
+    fn test_map() {
+        let input = r#"
+            TT = [Foo, Bar => Baz],
+            match v {
+                VectorValue::TT => EvalType::TT,
+            }
+        "#;
+
+        let expect_output = r#"
+            match v {
+                VectorValue::Foo => EvalType::Foo,
+                VectorValue::Bar => EvalType::Baz,
             }
         "#;
         let expect_output_stream: TokenStream = expect_output.parse().unwrap();

--- a/components/match_template/src/lib.rs
+++ b/components/match_template/src/lib.rs
@@ -25,9 +25,9 @@
 //! ```
 //!
 //! In addition, substitution can vary on two sides of the arms.
-//! 
+//!
 //! For example,
-//! 
+//!
 //! ```ignore
 //! match_template! {
 //!     T = [Foo, Bar => Baz],
@@ -45,7 +45,7 @@
 //!     EvalType::Bar => { panic!("{}", EvalType::Baz); },
 //! }
 //! ```
-//! 
+//!
 //! Wildcard match arm is also supported (but there will be no substitution).
 
 #[macro_use]

--- a/components/tidb_query/src/batch/executors/fast_hash_aggr_executor.rs
+++ b/components/tidb_query/src/batch/executors/fast_hash_aggr_executor.rs
@@ -20,13 +20,11 @@ use crate::storage::IntervalRange;
 use crate::Result;
 use tikv_util::box_try;
 
-macro_rules! match_template_hashable {
-    ($t:tt, $($tail:tt)*) => {
-        match_template::match_template! {
-            $t = [Int, Real, Bytes, Duration, Decimal, DateTime],
-            $($tail)*
-        }
-    };
+pub macro match_template_hashable($t:tt, $($tail:tt)*) {
+    match_template::match_template! {
+        $t = [Int, Real, Bytes, Duration, Decimal, DateTime],
+        $($tail)*
+    }
 }
 
 /// Fast Hash Aggregation Executor uses hash when comparing group key. It only supports one

--- a/components/tidb_query/src/codec/batch/lazy_column.rs
+++ b/components/tidb_query/src/codec/batch/lazy_column.rs
@@ -7,7 +7,7 @@ use tikv_util::buffer_vec::BufferVec;
 use tipb::FieldType;
 
 use crate::codec::chunk::{ChunkColumnEncoder, Column};
-use crate::codec::data_type::VectorValue;
+use crate::codec::data_type::{match_template_evaluable, VectorValue};
 use crate::codec::datum_codec::RawDatumDecoder;
 use crate::codec::Result;
 use crate::expr::EvalContext;

--- a/components/tidb_query/src/codec/data_type/mod.rs
+++ b/components/tidb_query/src/codec/data_type/mod.rs
@@ -62,6 +62,13 @@ where
     }
 }
 
+pub macro match_template_evaluable($t:tt, $($tail:tt)*) {
+    match_template::match_template! {
+        $t = [Int, Real, Decimal, Bytes, DateTime, Duration, Json],
+        $($tail)*
+    }
+}
+
 /// A trait of all types that can be used during evaluation (eval type).
 pub trait Evaluable: Clone + std::fmt::Debug + Send + Sync + 'static {
     const EVAL_TYPE: EvalType;

--- a/components/tidb_query/src/codec/data_type/vector.rs
+++ b/components/tidb_query/src/codec/data_type/vector.rs
@@ -3,8 +3,8 @@
 use tidb_query_datatype::{EvalType, FieldTypeAccessor};
 use tipb::FieldType;
 
+use super::scalar::ScalarValueRef;
 use super::*;
-use crate::codec::data_type::scalar::ScalarValueRef;
 use crate::codec::mysql::decimal::DECIMAL_STRUCT_SIZE;
 use crate::codec::Result;
 

--- a/components/tidb_query/src/expr_util/collation/mod.rs
+++ b/components/tidb_query/src/expr_util/collation/mod.rs
@@ -10,48 +10,16 @@ use std::str::Utf8Error;
 
 use codec::prelude::*;
 
-#[derive(Fail, Debug)]
-#[fail(display = "Invalid input in charset {}", _0)]
-pub struct DecodeError(&'static str);
-
-impl From<Utf8Error> for DecodeError {
-    fn from(_: Utf8Error) -> Self {
-        DecodeError("UTF8")
-    }
-}
-
-#[derive(Fail, Debug)]
-pub enum DecodeOrWriteError {
-    #[fail(display = "{}", _0)]
-    Decode(DecodeError),
-
-    #[fail(display = "{}", _0)]
-    Write(codec::Error),
-}
-
-impl From<codec::Error> for DecodeOrWriteError {
-    fn from(e: codec::Error) -> Self {
-        DecodeOrWriteError::Write(e)
-    }
-}
-
-impl From<DecodeError> for DecodeOrWriteError {
-    fn from(e: DecodeError) -> Self {
-        DecodeOrWriteError::Decode(e)
-    }
-}
-
-impl From<DecodeError> for crate::error::EvaluateError {
-    fn from(e: DecodeError) -> Self {
-        crate::error::EvaluateError::InvalidCharacterString {
-            charset: e.0.to_string(),
-        }
-    }
-}
-
-impl From<DecodeOrWriteError> for crate::error::EvaluateError {
-    fn from(e: DecodeOrWriteError) -> Self {
-        crate::error::EvaluateError::Other(e.to_string())
+pub macro match_template_collator($t:tt, $($tail:tt)*) {
+    match_template::match_template! {
+        $t = [
+            Utf8Bin => CollatorUtf8Mb4Bin,
+            Utf8Mb4Bin => CollatorUtf8Mb4Bin,
+            Utf8GeneralCi => CollatorUtf8Mb4GeneralCi,
+            Utf8Mb4GeneralCi => CollatorUtf8Mb4GeneralCi,
+            Binary => CollatorBinary,
+        ],
+        $($tail)*
     }
 }
 
@@ -104,5 +72,50 @@ impl Collator for CollatorBinary {
 
         bstr.hash(state);
         Ok(())
+    }
+}
+
+#[derive(Fail, Debug)]
+#[fail(display = "Invalid input in charset {}", _0)]
+pub struct DecodeError(&'static str);
+
+impl From<Utf8Error> for DecodeError {
+    fn from(_: Utf8Error) -> Self {
+        DecodeError("UTF8")
+    }
+}
+
+#[derive(Fail, Debug)]
+pub enum DecodeOrWriteError {
+    #[fail(display = "{}", _0)]
+    Decode(DecodeError),
+
+    #[fail(display = "{}", _0)]
+    Write(codec::Error),
+}
+
+impl From<codec::Error> for DecodeOrWriteError {
+    fn from(e: codec::Error) -> Self {
+        DecodeOrWriteError::Write(e)
+    }
+}
+
+impl From<DecodeError> for DecodeOrWriteError {
+    fn from(e: DecodeError) -> Self {
+        DecodeOrWriteError::Decode(e)
+    }
+}
+
+impl From<DecodeError> for crate::error::EvaluateError {
+    fn from(e: DecodeError) -> Self {
+        crate::error::EvaluateError::InvalidCharacterString {
+            charset: e.0.to_string(),
+        }
+    }
+}
+
+impl From<DecodeOrWriteError> for crate::error::EvaluateError {
+    fn from(e: DecodeOrWriteError) -> Self {
+        crate::error::EvaluateError::Other(e.to_string())
     }
 }

--- a/components/tidb_query/src/lib.rs
+++ b/components/tidb_query/src/lib.rs
@@ -13,6 +13,7 @@
 #![feature(iter_order_by)]
 #![feature(test)]
 #![feature(int_error_matching)]
+#![feature(decl_macro)]
 // FIXME: rustc says there are redundant semicolons here but isn't
 // saying where as of nightly-2019-09-05
 // See https://github.com/rust-lang/rust/issues/63967

--- a/components/tidb_query/src/macros.rs
+++ b/components/tidb_query/src/macros.rs
@@ -1,14 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-macro_rules! match_template_evaluable {
-    ($t:tt, $($tail:tt)*) => {
-        match_template::match_template! {
-            $t = [Int, Real, Decimal, Bytes, DateTime, Duration, Json],
-            $($tail)*
-        }
-    };
-}
-
 macro_rules! other_err {
     ($msg:tt) => ({
         crate::Error::from(crate::error::EvaluateError::Other(

--- a/components/tidb_query/src/rpn_expr/mod.rs
+++ b/components/tidb_query/src/rpn_expr/mod.rs
@@ -42,16 +42,10 @@ use self::impl_string::*;
 use self::impl_time::*;
 
 fn map_string_compare_sig<Cmp: CmpOp>(ret_field_type: &FieldType) -> RpnFnMeta {
-    match ret_field_type.as_accessor().collation() {
-        Collation::Utf8GeneralCi => {
-            compare_fn_meta::<StringComparer<CollatorUtf8Mb4GeneralCi, Cmp>>()
+    match_template_collator! {
+        TT, match ret_field_type.as_accessor().collation() {
+            Collation::TT => compare_fn_meta::<StringComparer<TT, Cmp>>()
         }
-        Collation::Utf8Mb4GeneralCi => {
-            compare_fn_meta::<StringComparer<CollatorUtf8Mb4GeneralCi, Cmp>>()
-        }
-        Collation::Utf8Mb4Bin => compare_fn_meta::<StringComparer<CollatorUtf8Mb4Bin, Cmp>>(),
-        Collation::Binary => compare_fn_meta::<StringComparer<CollatorBinary, Cmp>>(),
-        Collation::Utf8Bin => compare_fn_meta::<StringComparer<CollatorUtf8Mb4Bin, Cmp>>(),
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Dian Luo <andylokandy@hotmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

1. Add a new pattern to proc macro `match_template`.

For example,

```rust
match_template! {
    T = [Foo, Bar => Baz],
    match Foo {
        EvalType::T => { panic!("{}", EvalType::T); },
    }
}
```

 generates

```rust
match Foo {
    EvalType::Foo => { panic!("{}", EvalType::Foo); },
    EvalType::Bar => { panic!("{}", EvalType::Baz); },
}
```

2. Add a new decl macro `match_template_collator!()` which maps collation variant to
a concrete `Collator` type, and it's used as

```rust
fn map_string_compare_sig<Cmp: CmpOp>(ret_field_type: &FieldType) -> RpnFnMeta {
    match_template_collator! {
        TT, match ret_field_type.as_accessor().collation() {
            Collation::TT => compare_fn_meta::<StringComparer<TT, Cmp>>()
        }
    }
}
```

3. For consistency, make `match_template_evaluable!()` and `match_template_hashable!()` decl macro 2.0 also.


###  What is the type of the changes?

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test
- Integration test