### PR TITLE
raftstore: set wait_merge_state to none after resuming pending state

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -788,6 +788,10 @@ impl ApplyDelegate {
         apply_ctx: &mut ApplyContext,
         entry: &Entry,
     ) -> ApplyResult {
+        fail_point!("apply_yield_1000", self.region_id() == 1000, |_| {
+            ApplyResult::Yield
+        });
+
         let index = entry.get_index();
         let term = entry.get_term();
         let data = entry.get_data();
@@ -2533,6 +2537,8 @@ impl ApplyFsm {
             }
             self.delegate.ready_source_region_id = source_region_id;
         }
+        self.delegate.wait_merge_state = None;
+
         let mut state = self.delegate.yield_state.take().unwrap();
 
         if ctx.timer.is_none() {


### PR DESCRIPTION
Signed-off-by: Liqi Geng <gengliqiii@gmail.com>


###  What have you changed?

Set `wait_merge_state` to none after resuming pending state.
Otherwise, it may cause panic when executing the next commit merge command. 


###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.
