### PR TITLE
Make fuzzing work.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,8 +1386,12 @@ version = "0.0.1"
 dependencies = [
  "byteorder",
  "failure",
+ "grpcio",
+ "kvproto",
+ "protobuf-build 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tidb_query",
  "tikv_util",
+ "tipb",
 ]
 
 [[package]]

--- a/fuzz/cli.rs
+++ b/fuzz/cli.rs
@@ -250,13 +250,13 @@ fn run_afl(target: &str) -> Result<(), Error> {
 fn run_honggfuzz(target: &str) -> Result<(), Error> {
     pre_check(
         Command::new("cargo").args(&["hfuzz", "version"]),
-        "cargo install hfuzz --version 0.5.34",
+        "cargo install honggfuzz --version 0.5.45",
     )?;
 
     let fuzzer = Fuzzer::Honggfuzz;
 
     let mut rust_flags = env::var("RUSTFLAGS").unwrap_or_default();
-    rust_flags.push_str("-Z sanitizer=address");
+    rust_flags.push_str(" -Z sanitizer=address");
 
     let hfuzz_args = format!(
         "-f {} \

--- a/fuzz/targets/Cargo.toml
+++ b/fuzz/targets/Cargo.toml
@@ -4,14 +4,18 @@ version = "0.0.1"
 publish = false
 edition = "2018"
 
-[features]
-prost-codec = ["tikv_util/prost-codec"]
-
 [lib]
 path = "mod.rs"
 
+# Due to some complexity in the way fuzz targets are built, we need to depend on some upstream crates
+# here in order to pass the "protobuf-codec" feature. If you want to fuzz with Prost, you'll need to
+# s/protobuf-codec/prost-codec/g
 [dependencies]
 byteorder = "1"
 failure = "0.1"
+grpcio = { version = "0.5.0-alpha.5", features = [ "openssl-vendored", "protobuf-codec" ], default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, features = [ "protobuf-codec" ] }
+protobuf-build = { version = "0.10", default-features = false, features = ["grpcio-protobuf-codec"] }
 tidb_query = { path = "../../components/tidb_query" }
 tikv_util = { path = "../../components/tikv_util" }
+tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false, features = [ "protobuf-codec" ] }


### PR DESCRIPTION
Fixes a Cargo error and adds a new make target, fuzz.

###  What have you changed?

There is a bit of complexity passing the right features to dependencies when fuzzing. This PR fixes that by adding dependencies to fuzz-targets. I also add a make target to make fuzzing more convenient.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)
- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?

- Manual test (add detailed scripts or steps below)

`make test` and `FUZZ_TARGET=fuzz_codec_bytes make test`

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
no

###  Does this PR affect `tidb-ansible`?
no

###  Refer to a related PR or issue link (optional)

Fixes #6591

PTAL @zhouqiang-cl @breeswish 

