### PR TITLE
raftstore: set wait_merge_state to none after resuming pending state

### DIFF
--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -791,6 +791,10 @@ impl ApplyDelegate {
         apply_ctx: &mut ApplyContext,
         entry: &Entry,
     ) -> ApplyResult {
+        fail_point!("apply_yield_1000", self.region_id() == 1000, |_| {
+            ApplyResult::Yield
+        });
+
         let index = entry.get_index();
         let term = entry.get_term();
         let data = entry.get_data();
@@ -2539,6 +2543,8 @@ impl ApplyFsm {
             }
             self.delegate.ready_source_region_id = source_region_id;
         }
+        self.delegate.wait_merge_state = None;
+
         let mut state = self.delegate.yield_state.take().unwrap();
 
         if ctx.timer.is_none() {

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -727,3 +727,42 @@ fn test_node_merge_restart_after_apply_premerge_before_apply_compact_log() {
     cluster.must_put(b"k123", b"v2");
     must_get_equal(&cluster.get_engine(3), b"k123", b"v2");
 }
+
+#[test]
+fn test_merge_cascade_merge_with_apply_yield() {
+    let _guard = crate::setup();
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_merge(&mut cluster);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    cluster.run();
+
+    let region = pd_client.get_region(b"k1").unwrap();
+    cluster.must_split(&region, b"k5");
+    let region = pd_client.get_region(b"k5").unwrap();
+    cluster.must_split(&region, b"k9");
+
+    for i in 0..10 {
+        cluster.must_put(format!("k{}", i).as_bytes(), b"v1");
+    }
+
+    let r1 = pd_client.get_region(b"k1").unwrap();
+    let r2 = pd_client.get_region(b"k5").unwrap();
+    let r3 = pd_client.get_region(b"k9").unwrap();
+
+    pd_client.must_merge(r2.get_id(), r1.get_id());
+    assert_eq!(r1.get_id(), 1000);
+    let apply_yield_1000_fp = "apply_yield_1000";
+    fail::cfg(apply_yield_1000_fp, "80%3*return()").unwrap();
+
+    for i in 0..10 {
+        cluster.must_put(format!("k{}", i).as_bytes(), b"v2");
+    }
+
+    pd_client.must_merge(r3.get_id(), r1.get_id());
+
+    for i in 0..10 {
+        cluster.must_put(format!("k{}", i).as_bytes(), b"v3");
+    }
+}


### PR DESCRIPTION
Signed-off-by: Liqi Geng <gengliqiii@gmail.com>


###  What have you changed?

cherry-pick https://github.com/tikv/tikv/pull/6615 to tycc-perf


###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.
