### PR TITLE
*: compile and test on modern Linux and AMD v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "cache-size"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c0e5b187b377be086db3ee0de5cbf7bfb4a8c590b639af4d3facbdd07586ae"
+checksum = "81d993443a01668ca909379dac9de6e858121d7fb2bc16de939dc166164cac1c"
 dependencies = [
  "raw-cpuid",
 ]
@@ -2294,6 +2294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26e041cd983acbc087e30fcba770380cfa352d0e392e175b2344ebaf7ea0602"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "num"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2396,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 
 [[package]]
 name = "opaque-debug"
@@ -4055,14 +4070,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.9.6"
-source = "git+https://github.com/tikv/sysinfo.git?branch=tikv#aa98faff1c586984857506c8add248ee304a7f81"
+version = "0.11.2"
+source = "git+https://github.com/tikv/sysinfo.git?branch=tikv2#6970da18c7f03c1fdb93af08fbe42f6dba3340fd"
 dependencies = [
  "cache-size",
  "cfg-if",
  "doc-comment",
  "libc",
+ "ntapi",
  "num_cpus",
+ "once_cell",
  "pnet_datalink",
  "rayon",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ slog-term = "2.4"
 slog_derive = "0.1"
 parking_lot = "0.10"
 sst_importer = { path = "components/sst_importer" }
-sysinfo = { git = "https://github.com/tikv/sysinfo.git", branch = "tikv"}
+sysinfo = { git = "https://github.com/tikv/sysinfo.git", branch = "tikv2"}
 tempfile = "3.0"
 tidb_query = { path = "components/tidb_query", default-features = false }
 tikv_alloc = { path = "components/tikv_alloc", default-features = false }

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -24,7 +24,7 @@ serde = "1.0"
 serde_derive = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
-sysinfo = { git = "https://github.com/tikv/sysinfo.git", branch = "tikv"}
+sysinfo = { git = "https://github.com/tikv/sysinfo.git", branch = "tikv2"}
 tikv_alloc = { path = "../tikv_alloc" }
 tikv_util = { path = "../tikv_util" }
 time = "0.1"

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -23,7 +23,7 @@ serde_derive = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 static_assertions = "1.1.0"
-sysinfo = { git = "https://github.com/tikv/sysinfo.git", branch = "tikv"}
+sysinfo = { git = "https://github.com/tikv/sysinfo.git", branch = "tikv2"}
 tikv_alloc = { path = "../tikv_alloc" }
 tikv_util = { path = "../tikv_util" }
 time = "0.1"

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -574,7 +574,6 @@ pub fn is_zero_duration(d: &Duration) -> bool {
 mod tests {
     use super::*;
 
-    use fs2;
     use raft::eraftpb::Entry;
     use std::rc::Rc;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -774,16 +773,13 @@ mod tests {
             .tempdir()
             .unwrap();
         let data_path = tmp_dir.path();
-        let disk_stats_before = fs2::statvfs(data_path).unwrap();
-        let cap1 = disk_stats_before.available_space();
         let reserve_size = 64 * 1024;
+        let placeholder_path = data_path.join(SPACE_PLACEHOLDER_FILE);
+
         reserve_space_for_recover(data_path, reserve_size).unwrap();
-        let disk_stats_after = fs2::statvfs(data_path).unwrap();
-        let cap2 = disk_stats_after.available_space();
-        assert_eq!(cap1 - cap2, reserve_size);
+        assert_eq!(placeholder_path.metadata().unwrap().len(), reserve_size);
+
         reserve_space_for_recover(data_path, 0).unwrap();
-        let disk_stats = fs2::statvfs(data_path).unwrap();
-        let cap3 = disk_stats.available_space();
-        assert_eq!(cap1, cap3);
+        assert!(!placeholder_path.exists());
     }
 }

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -114,6 +114,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         let cpu_num = sysinfo::get_logical_cores();
+
         Config {
             cluster_id: DEFAULT_CLUSTER_ID,
             addr: DEFAULT_LISTENING_ADDR.to_owned(),

--- a/src/server/service/diagnostics.rs
+++ b/src/server/service/diagnostics.rs
@@ -123,12 +123,14 @@ mod sys {
     use std::string::ToString;
 
     use kvproto::diagnosticspb::{ServerInfoItem, ServerInfoPair};
-    use sysinfo::{DiskExt, ProcessExt, SystemExt};
+    use sysinfo::{DiskExt, ProcessExt, ProcessorExt, SystemExt};
 
     fn cpu_load_info(collector: &mut Vec<ServerInfoItem>) {
+        let mut system = sysinfo::System::new();
+        system.refresh_system();
         // CPU load
         {
-            let load = sysinfo::get_avg_load();
+            let load = system.get_load_average();
             let infos = vec![
                 ("load1", load.one),
                 ("load5", load.five),
@@ -191,7 +193,7 @@ mod sys {
 
     fn mem_load_info(collector: &mut Vec<ServerInfoItem>) {
         let mut system = sysinfo::System::new();
-        system.refresh_all();
+        system.refresh_system();
         let total_memory = system.get_total_memory();
         let used_memory = system.get_used_memory();
         let free_memory = system.get_free_memory();
@@ -340,7 +342,11 @@ mod sys {
 
     fn cpu_hardware_info(collector: &mut Vec<ServerInfoItem>) {
         let mut system = sysinfo::System::new();
-        system.refresh_all();
+        system.refresh_system();
+        let proc = match system.get_processors().iter().next() {
+            Some(p) => p,
+            None => return,
+        };
         let mut infos = vec![
             (
                 "cpu-logical-cores",
@@ -350,10 +356,8 @@ mod sys {
                 "cpu-physical-cores",
                 sysinfo::get_physical_cores().to_string(),
             ),
-            (
-                "cpu-frequency",
-                format!("{}MHz", sysinfo::get_cpu_frequency()),
-            ),
+            ("cpu-frequency", format!("{}MHz", proc.get_frequency())),
+            ("cpu-vendor-id", proc.get_vendor_id().to_string()),
         ];
         // cache
         use sysinfo::cache_size;
@@ -386,7 +390,7 @@ mod sys {
 
     fn mem_hardware_info(collector: &mut Vec<ServerInfoItem>) {
         let mut system = sysinfo::System::new();
-        system.refresh_all();
+        system.refresh_system();
         let mut pair = ServerInfoPair::default();
         pair.set_key("capacity".to_string());
         pair.set_value(system.get_total_memory().to_string());
@@ -399,7 +403,7 @@ mod sys {
 
     fn disk_hardware_info(collector: &mut Vec<ServerInfoItem>) {
         let mut system = sysinfo::System::new();
-        system.refresh_all();
+        system.refresh_disks_list();
         let disks = system.get_disks();
         for disk in disks {
             let total = disk.get_total_space();
@@ -512,8 +516,8 @@ mod sys {
     #[allow(dead_code)]
     pub fn process_info(collector: &mut Vec<ServerInfoItem>) {
         let mut system = sysinfo::System::new();
-        system.refresh_all();
-        let processes = system.get_process_list();
+        system.refresh_processes();
+        let processes = system.get_processes();
         for (pid, p) in processes.iter() {
             if p.cmd().is_empty() {
                 continue;
@@ -686,24 +690,33 @@ mod sys {
             }
             // cpu
             let cpu_info = collector.iter().find(|x| x.get_tp() == "cpu").unwrap();
-            assert_eq!(
-                cpu_info
-                    .get_pairs()
-                    .iter()
-                    .map(|x| x.get_key())
-                    .collect::<Vec<&str>>(),
-                vec![
-                    "cpu-logical-cores",
-                    "cpu-physical-cores",
-                    "cpu-frequency",
-                    "l1-cache-size",
-                    "l1-cache-line-size",
-                    "l2-cache-size",
-                    "l2-cache-line-size",
-                    "l3-cache-size",
-                    "l3-cache-line-size",
-                ]
-            );
+            let vendor_id = cpu_info
+                .get_pairs()
+                .iter()
+                .find(|x| x.get_key() == "cpu-vendor-id")
+                .unwrap()
+                .get_value();
+            if vendor_id != "AuthenticAMD" {
+                assert_eq!(
+                    cpu_info
+                        .get_pairs()
+                        .iter()
+                        .map(|x| x.get_key())
+                        .collect::<Vec<&str>>(),
+                    vec![
+                        "cpu-logical-cores",
+                        "cpu-physical-cores",
+                        "cpu-frequency",
+                        "cpu-vendor-id",
+                        "l1-cache-size",
+                        "l1-cache-line-size",
+                        "l2-cache-size",
+                        "l2-cache-line-size",
+                        "l3-cache-size",
+                        "l3-cache-line-size",
+                    ]
+                );
+            }
             let mem_info = collector.iter().find(|x| x.get_tp() == "memory").unwrap();
             assert_eq!(
                 mem_info

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -5,6 +5,7 @@
 use engine::rocks::{Cache, LRUCacheOptions, MemoryAllocator};
 use libc::c_int;
 use std::error::Error;
+use sysinfo::SystemExt;
 use tikv_util::config::{self, ReadableSize, KB};
 
 pub const DEFAULT_DATA_DIR: &str = "./";
@@ -39,6 +40,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         let total_cpu = sysinfo::get_logical_cores();
+
         Config {
             data_dir: DEFAULT_DATA_DIR.to_owned(),
             gc_ratio_threshold: DEFAULT_GC_RATIO_THRESHOLD,
@@ -99,7 +101,6 @@ impl BlockCacheConfig {
         }
         let capacity = match self.capacity {
             None => {
-                use sysinfo::SystemExt;
                 let total_mem = sysinfo::System::new().get_total_memory() * KB;
                 ((total_mem as f64) * 0.45) as usize
             }


### PR DESCRIPTION
What have you changed?

Running the test suite on an AMD processor with Linux kernel 5.3 leads to a few errors.

This PR contains a number of small changes:

  *  update sysinfo so that we can correctly read /sys/block/.../stat files (format is changed in modern Linux kernels)
*    read the chip vendor_id from (the updated) sysinfo, and where this indicates an AMD chip, skip some parts of a test (due to a different data layout returned by CPUID).
*    change test_reserve_space_for_recover to not rely on space available on a disk. Because other processes might write to or delete from the disk, this test was very unreliable.
*    fix a log rotation test where the test set the 'accessed' time but the rotation code ignores that if it can read the file's 'created' time (presumably this test currently passes because the 'created' time can never be read).
*    fix some typos


What is the type of the changes?

    Bugfix (a change which fixes an issue)
    Engineering (engineering change which doesn't change any feature or fix any issue)

How is the PR tested?

    Unit test
    Integration test

Does this PR affect documentation (docs) or should it be mentioned in the release notes?

no
Does this PR affect tidb-ansible?

no