### PR TITLE
backup: break one key scan when met delete version

### DIFF
--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -472,11 +472,15 @@ impl<S: Snapshot> ScanPolicy<S> for LatestEntryPolicy {
                         write: entry_write,
                     });
                 }
-                WriteType::Delete if self.output_delete => {
-                    break Some(TxnEntry::Commit {
-                        default: (Vec::new(), Vec::new()),
-                        write: (write_key.to_vec(), write_value.to_vec()),
-                    });
+                WriteType::Delete => {
+                    if self.output_delete {
+                        break Some(TxnEntry::Commit {
+                            default: (Vec::new(), Vec::new()),
+                            write: (write_key.to_vec(), write_value.to_vec()),
+                        });
+                    } else {
+                        break None;
+                    }
                 }
                 _ => {}
             }
@@ -1428,14 +1432,16 @@ mod latest_entry_tests {
 
         // Scanning entries in (10, 15] should get None
         check(15, 10, true, vec![]);
-        // Scanning entries without delete in (7, 10]  should get None
+        // Scanning entries without delete in (7, 10] should get None
         check(10, 7, false, vec![]);
-        // Scanning entries include delete in (7, 10]  should get entry_b_10
+        // Scanning entries include delete in (7, 10] should get entry_b_10
         check(10, 7, true, vec![&entry_b_10]);
         // Scanning entries include delete in (3, 10] should get a_7 and b_10
         check(10, 3, true, vec![&entry_a_7, &entry_b_10]);
         // Scanning entries in (0, 5] should get a_3 and b_1
         check(5, 0, true, vec![&entry_a_3, &entry_b_1]);
+        // Scanning entries without delete in (0, 10] should get a_7
+        check(10, 0, false, vec![&entry_a_7]);
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
Break loop when met delete version during handle one write key

Backup scanner should skip one key already has delete version, otherwise it will backup the version before delete version.




###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test



###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
N/A

###  Does this PR affect `tidb-ansible`?
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->
###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

