### PR TITLE
cop: avoid handling requests multiple times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4266,6 +4266,7 @@ dependencies = [
  "time",
  "tipb",
  "tipb_helper",
+ "tokio 0.2.9",
  "twoway",
  "uuid 0.8.1",
  "yatp",

--- a/components/tidb_query/Cargo.toml
+++ b/components/tidb_query/Cargo.toml
@@ -57,6 +57,7 @@ tidb_query_datatype = { path = "../tidb_query_datatype" }
 tikv_util = { path = "../tikv_util" }
 time = "0.1"
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
+tokio = { version = "0.2", features = ["sync"] }
 twoway = "0.2.0"
 uuid = { version = "0.8.1", features = ["v4"] }
 static_assertions = { version = "1.0", features = ["nightly"] }

--- a/components/tidb_query/src/error.rs
+++ b/components/tidb_query/src/error.rs
@@ -8,12 +8,6 @@ pub enum EvaluateError {
     #[fail(display = "Execution terminated due to exceeding the deadline")]
     DeadlineExceeded,
 
-    /// When resource is exhausted, new requests will be cancelled if its execution time
-    /// exceeds a small limit. But the cancelled request can be retried if there is free
-    /// resource later.
-    #[fail(display = "Execution cancelled due to exceeding execution time limit (will retry)")]
-    ExecutionTimeLimitExceeded,
-
     #[fail(display = "Invalid {} character string", charset)]
     InvalidCharacterString { charset: String },
 
@@ -33,7 +27,7 @@ impl EvaluateError {
             EvaluateError::InvalidCharacterString { .. } => 1300,
             EvaluateError::DeadlineExceeded => 9007,
             EvaluateError::Custom { code, .. } => *code,
-            EvaluateError::Other(_) | EvaluateError::ExecutionTimeLimitExceeded => 10000,
+            EvaluateError::Other(_) => 10000,
         }
     }
 }

--- a/components/tidb_query/src/metrics.rs
+++ b/components/tidb_query/src/metrics.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use prometheus::*;
-use prometheus_static_metric::make_static_metric;
+use prometheus_static_metric::*;
 
 use tikv_util::metrics::TLSMetricGroup;
 
@@ -28,6 +28,16 @@ make_static_metric! {
     pub struct LocalCoprExecutorCount: LocalIntCounter {
         "type" => ExecutorName,
     }
+
+    pub label_enum AcquireSemaphoreType {
+        acquired_generic,
+        acquired_heavy,
+        unacquired,
+    }
+
+    pub struct CoprAcquireSemaphoreTypeCounterVec: IntCounter {
+        "type" => AcquireSemaphoreType,
+    }
 }
 
 lazy_static::lazy_static! {
@@ -37,6 +47,14 @@ lazy_static::lazy_static! {
         &["type"]
     )
     .unwrap();
+    pub static ref COPR_ACQUIRE_SEMAPHORE_TYPE: CoprAcquireSemaphoreTypeCounterVec =
+        register_static_int_counter_vec!(
+            CoprAcquireSemaphoreTypeCounterVec,
+            "tikv_coprocessor_acquire_semaphore_type",
+            "The acquire type of the coprocessor semaphore",
+            &["type"],
+        )
+        .unwrap();
 }
 
 thread_local! {

--- a/src/coprocessor/error.rs
+++ b/src/coprocessor/error.rs
@@ -16,11 +16,6 @@ pub enum Error {
     #[fail(display = "Coprocessor task terminated due to exceeding the deadline")]
     DeadlineExceeded,
 
-    #[fail(
-        display = "Coprocessor task is cancelled due to exceeding the execution time limit (will retry)"
-    )]
-    ExecutionTimeLimitExceeded,
-
     #[fail(display = "Coprocessor task canceled due to exceeding max pending tasks")]
     MaxPendingTasksExceeded,
 

--- a/src/coprocessor/metrics.rs
+++ b/src/coprocessor/metrics.rs
@@ -8,7 +8,6 @@ use tikv_util::collections::HashMap;
 
 use prometheus::local::*;
 use prometheus::*;
-use prometheus_static_metric::*;
 
 lazy_static! {
     pub static ref COPR_REQ_HISTOGRAM_VEC: HistogramVec = register_histogram_vec!(
@@ -68,26 +67,6 @@ lazy_static! {
         "Total bytes of response body"
     )
     .unwrap();
-    pub static ref COPR_ACQUIRE_SEMAPHORE_TYPE: CoprAcquireSemaphoreResultCounterVec =
-        register_static_int_counter_vec!(
-            CoprAcquireSemaphoreResultCounterVec,
-            "tikv_coprocessor_acquire_semaphore_type",
-            "The acquire type of the coprocessor semaphore",
-            &["type"],
-        )
-        .unwrap();
-}
-
-make_static_metric! {
-    pub label_enum AcquireSemaphoreType {
-        acquired_generic,
-        acquired_heavy,
-        unacquired,
-    }
-
-    pub struct CoprAcquireSemaphoreResultCounterVec: IntCounter {
-        "type" => AcquireSemaphoreType,
-    }
 }
 
 pub struct CopLocalMetrics {

--- a/tests/benches/coprocessor_executors/util/mod.rs
+++ b/tests/benches/coprocessor_executors/util/mod.rs
@@ -42,16 +42,16 @@ pub fn build_dag_handler<TargetTxnStore: TxnStore + 'static>(
     let mut dag = DagRequest::default();
     dag.set_executors(executors.to_vec().into());
 
-    tikv::coprocessor::dag::build_handler(
+    tikv::coprocessor::dag::DagHandlerBuilder::new(
         black_box(dag),
         black_box(ranges.to_vec()),
         black_box(ToTxnStore::<TargetTxnStore>::to_store(store)),
-        None,
         tikv_util::deadline::Deadline::from_now(std::time::Duration::from_secs(10)),
         64,
         false,
-        enable_batch,
     )
+    .enable_batch_if_possible(enable_batch)
+    .build()
     .unwrap()
 }
 


### PR DESCRIPTION
###  What have you changed?

In #6582, a request in execution which fails to get a semaphore permit can be cancelled and rerun until a semaphore permit is acquired. However, the problem is that the coprocessor executors have inner state, so it is incorrect to rerun the request handler.

This PR changes the mechanism. The semaphore is passed into the runner. If the execution limit exceeds, the runner blocks itself through the semaphore. Now, the handler is not used more than once.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Unit test
- Manual test

I reproduced the bug according to #6676 in master. In this fixed version, the problem does not exist.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

Need to add this PR to the unified thread pool changelog as well.

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

Should fix #6676