### PR TITLE
tests: Fix failing test_physical_scan_lock

### DIFF
--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -548,7 +548,7 @@ fn test_physical_scan_lock() {
         &[],
     );
     check_result(
-        &must_physical_scan_lock(&client, ctx, 30, &[b'k', 3], 5),
+        &must_physical_scan_lock(&client, ctx, 30, &[b'k', 13], 5),
         &all_locks[3..8],
     );
 }


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

It's reported that the `test_physical_scan_lock` in integration tests fails when running test locally. It's because of scanning from wrong key in the test code (scanning from `k3` while the data set is `k10`, `k11`, ..., and it means to scan from `k13`). This makes the test surely to fail, however the CI passed. It's needed to check whether the CI is abnormal.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No
