### PR TITLE
raftstore: destroy apply fsm when pending_remove flag is set during resuming

### DIFF
--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -742,6 +742,10 @@ impl ApplyDelegate {
         }
 
         apply_ctx.finish_for(self, results);
+
+        if self.pending_remove {
+            self.destroy(apply_ctx);
+        }
     }
 
     fn update_metrics(&mut self, apply_ctx: &ApplyContext) {
@@ -772,7 +776,7 @@ impl ApplyDelegate {
         apply_ctx: &mut ApplyContext,
         entry: &Entry,
     ) -> ApplyResult {
-        fail_point!("apply_yield_1000", self.region_id() == 1000, |_| {
+        fail_point!("yield_apply_1000", self.region_id() == 1000, |_| {
             ApplyResult::Yield
         });
 
@@ -819,6 +823,11 @@ impl ApplyDelegate {
         apply_ctx: &mut ApplyContext,
         entry: &Entry,
     ) -> ApplyResult {
+        // Although conf change can't yield in normal case, it is convenient to
+        // simulate yield before applying a conf change log.
+        fail_point!("yield_apply_conf_change_3", self.id() == 3, |_| {
+            ApplyResult::Yield
+        });
         let index = entry.get_index();
         let term = entry.get_term();
         let conf_change: ConfChange = util::parse_data_at(entry.get_data(), index, &self.tag);
@@ -2406,10 +2415,6 @@ impl ApplyFsm {
             .handle_raft_committed_entries(apply_ctx, apply.entries);
         if self.delegate.yield_state.is_some() {
             return;
-        }
-
-        if self.delegate.pending_remove {
-            self.delegate.destroy(apply_ctx);
         }
     }
 

--- a/tests/failpoints/cases/test_conf_change.rs
+++ b/tests/failpoints/cases/test_conf_change.rs
@@ -1,5 +1,7 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::sync::Arc;
+
 use fail;
 use futures::Future;
 use raft::eraftpb::ConfChangeType;

--- a/tests/failpoints/cases/test_conf_change.rs
+++ b/tests/failpoints/cases/test_conf_change.rs
@@ -204,3 +204,40 @@ fn test_stale_peer_cache() {
     fail::cfg("stale_peer_cache_2", "return").unwrap();
     cluster.must_put(b"k2", b"v2");
 }
+
+#[test]
+fn test_handle_conf_change_when_apply_fsm_resume_pending_state() {
+    let _guard = crate::setup();
+    let mut cluster = new_node_cluster(0, 3);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let r1 = cluster.run_conf_change();
+    pd_client.must_add_peer(r1, new_peer(2, 2));
+    pd_client.must_add_peer(r1, new_peer(3, 3));
+
+    cluster.must_put(b"k", b"v");
+
+    let region = pd_client.get_region(b"k").unwrap();
+
+    let peer_on_store1 = find_peer(&region, 1).unwrap().to_owned();
+    cluster.must_transfer_leader(region.get_id(), peer_on_store1);
+
+    let yield_apply_conf_change_3_fp = "yield_apply_conf_change_3";
+    fail::cfg(yield_apply_conf_change_3_fp, "return()").unwrap();
+
+    // Make store 1 and 3 become quorum
+    cluster.add_send_filter(IsolationFilterFactory::new(2));
+
+    pd_client.must_remove_peer(r1, new_peer(3, 3));
+    // Wait for peer fsm to send committed entries to apply fsm
+    sleep_ms(100);
+    fail::remove(yield_apply_conf_change_3_fp);
+    cluster.clear_send_filters();
+    // Add new peer 4 to store 3
+    pd_client.must_add_peer(r1, new_peer(3, 4));
+
+    for i in 0..10 {
+        cluster.must_put(format!("kk{}", i).as_bytes(), b"v1");
+    }
+}

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -773,8 +773,8 @@ fn test_merge_cascade_merge_with_apply_yield() {
 
     pd_client.must_merge(r2.get_id(), r1.get_id());
     assert_eq!(r1.get_id(), 1000);
-    let apply_yield_1000_fp = "apply_yield_1000";
-    fail::cfg(apply_yield_1000_fp, "80%3*return()").unwrap();
+    let yield_apply_1000_fp = "yield_apply_1000";
+    fail::cfg(yield_apply_1000_fp, "80%3*return()").unwrap();
 
     for i in 0..10 {
         cluster.must_put(format!("k{}", i).as_bytes(), b"v2");


### PR DESCRIPTION
Signed-off-by: Liqi Geng <gengliqiii@gmail.com>


###  What have you changed?

cherry pick https://github.com/tikv/tikv/pull/6692 to release-3.1

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.

