### PR TITLE
Fix broken URL for "Try TiKV and TiDB"

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We provide multiple deployment methods, but it is recommended to use our Ansible
 
 ### Testing deployment
 
-- [Try TiKV and TiDB](https://github.com/pingcap/docs/blob/master/dev/how-to/get-started/deploy-tidb-from-docker-compose.md)
+- [Try TiKV and TiDB](./docs/how-to/get-started/deploy-using-docker-compose.md)
 
     You can use [`tidb-docker-compose`](https://github.com/pingcap/tidb-docker-compose/) to quickly test TiKV and TiDB on a single machine. This is the easiest way. For other ways, see [TiDB documentation](https://pingcap.com/docs/).
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We provide multiple deployment methods, but it is recommended to use our Ansible
 
 ### Testing deployment
 
-- [Try TiKV and TiDB](./docs/how-to/get-started/deploy-using-docker-compose.md)
+- [Try TiKV and TiDB](https://tikv.org/docs/3.0/tasks/try/)
 
     You can use [`tidb-docker-compose`](https://github.com/pingcap/tidb-docker-compose/) to quickly test TiKV and TiDB on a single machine. This is the easiest way. For other ways, see [TiDB documentation](https://pingcap.com/docs/).
 


### PR DESCRIPTION
###  What have you changed?
The link for `Try TiKV and TiDB` under [Try TiKV](https://github.com/tikv/tikv#testing-deployment) in  README leads to `404`.

Updated the URL to point to [this](https://tikv.org/docs/3.0/tasks/try/) instead.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Misc (other changes)

###  How is the PR tested?
- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->

###  Does this PR affect `tidb-ansible`?
No
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->
###  Refer to a related PR or issue link (optional)
#6688 

