### PR TITLE
[Cherry-pick] backup: fix panic after meeting empty short value

### DIFF
--- a/components/backup/src/writer.rs
+++ b/components/backup/src/writer.rs
@@ -299,14 +299,14 @@ mod tests {
             ],
             &[
                 (
-                    engine_traits::CF_DEFAULT,
+                    engine::CF_DEFAULT,
                     &[
                         (&keys::data_key(&[b'a']), &[b'a']),
                         (&keys::data_key(&[]), &[]),
                     ],
                 ),
                 (
-                    engine_traits::CF_WRITE,
+                    engine::CF_WRITE,
                     &[
                         (&keys::data_key(&[b'a']), &[b'a']),
                         (&keys::data_key(&[b'b']), &[]),

--- a/components/backup/src/writer.rs
+++ b/components/backup/src/writer.rs
@@ -276,10 +276,16 @@ mod tests {
         let mut writer = BackupWriter::new(db, "foo2", Limiter::new(INFINITY)).unwrap();
         writer
             .write(
-                vec![TxnEntry::Commit {
-                    default: (vec![b'a'], vec![b'a']),
-                    write: (vec![b'a'], vec![b'a']),
-                }]
+                vec![
+                    TxnEntry::Commit {
+                        default: (vec![b'a'], vec![b'a']),
+                        write: (vec![b'a'], vec![b'a']),
+                    },
+                    TxnEntry::Commit {
+                        default: (vec![], vec![]),
+                        write: (vec![b'b'], vec![]),
+                    },
+                ]
                 .into_iter(),
                 false,
             )
@@ -292,8 +298,20 @@ mod tests {
                 (engine::CF_WRITE, &temp.path().join(files[1].get_name())),
             ],
             &[
-                (engine::CF_DEFAULT, &[(&keys::data_key(&[b'a']), &[b'a'])]),
-                (engine::CF_WRITE, &[(&keys::data_key(&[b'a']), &[b'a'])]),
+                (
+                    engine_traits::CF_DEFAULT,
+                    &[
+                        (&keys::data_key(&[b'a']), &[b'a']),
+                        (&keys::data_key(&[]), &[]),
+                    ],
+                ),
+                (
+                    engine_traits::CF_WRITE,
+                    &[
+                        (&keys::data_key(&[b'a']), &[b'a']),
+                        (&keys::data_key(&[b'b']), &[]),
+                    ],
+                ),
             ],
         );
     }

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -116,7 +116,7 @@ impl TxnEntry {
                     let k = Key::from_encoded(write.0).truncate_ts()?;
                     let k = k.into_raw()?;
                     let v = Write::parse(&write.1)?;
-                    let v = v.short_value.unwrap();
+                    let v = v.short_value.unwrap_or_else(Vec::default);
                     Ok((k, v))
                 }
             }


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Pick https://github.com/tikv/tikv/pull/6718

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Bugfix (a change which fixes an issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->
No.
###  Does this PR affect `tidb-ansible`?
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->
No.


