### PR TITLE
copr/string: remove unnecessary allocation

### DIFF
--- a/components/tidb_query/src/expr/builtin_string.rs
+++ b/components/tidb_query/src/expr/builtin_string.rs
@@ -213,7 +213,7 @@ impl ScalarFunc {
                 Cow::Owned(val) => Ok(Some(Cow::Owned(val[i..].to_owned()))),
             }
         } else {
-            Ok(Some(Cow::Owned(b"".to_vec())))
+            Ok(Some(Cow::Borrowed(b"")))
         }
     }
 
@@ -231,7 +231,7 @@ impl ScalarFunc {
                 Cow::Owned(val) => Ok(Some(Cow::Owned(val[..val.len() - i].to_owned()))),
             }
         } else {
-            Ok(Some(Cow::Owned(b"".to_vec())))
+            Ok(Some(Cow::Borrowed(b"")))
         }
     }
 
@@ -263,7 +263,7 @@ impl ScalarFunc {
         let i = try_opt!(self.children[1].eval_int(ctx, row));
         let (i, length_positive) = i64_to_usize(i, self.children[1].is_unsigned());
         if !length_positive || i == 0 {
-            return Ok(Some(Cow::Owned(b"".to_vec())));
+            return Ok(Some(Cow::Borrowed(b"")));
         }
         if s.chars().count() > i {
             let t = s.chars();
@@ -304,7 +304,7 @@ impl ScalarFunc {
         let i = try_opt!(self.children[1].eval_int(ctx, row));
         let (i, length_positive) = i64_to_usize(i, self.children[1].is_unsigned());
         if !length_positive || i == 0 {
-            return Ok(Some(Cow::Owned(b"".to_vec())));
+            return Ok(Some(Cow::Borrowed(b"")));
         }
         let len = s.chars().count();
         if len > i {


### PR DESCRIPTION
###  What have you changed?

By changing `Cow::Owned(b"".to_vec())` to `Cow::Borrowed(b"")`, we can remove
an unnecessary allocation incurred by `.to_vec()`.

###  What is the type of the changes?
- Engineering

###  How is the PR tested?

- Unit test

It has not been benchmarked yet. But I don't think there will be an observable difference in performance.

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No.

###  Does this PR affect `tidb-ansible`?

No.

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

