### PR TITLE
raftstore, backup: fix test_read_hibernated_region & test_writer

### DIFF
--- a/components/backup/src/writer.rs
+++ b/components/backup/src/writer.rs
@@ -229,7 +229,7 @@ mod tests {
                 },
             )
             .unwrap();
-            assert_eq!(map.len(), kv.len(), "{:?} {:?}", map, kv);
+            assert_eq!(map.len(), kv.len(), "{} {:?} {:?}", cf, map, kv);
             for (k, v) in *kv {
                 assert_eq!(&v.to_vec(), map.get(&k.to_vec()).unwrap());
             }
@@ -298,13 +298,7 @@ mod tests {
                 (engine::CF_WRITE, &temp.path().join(files[1].get_name())),
             ],
             &[
-                (
-                    engine::CF_DEFAULT,
-                    &[
-                        (&keys::data_key(&[b'a']), &[b'a']),
-                        (&keys::data_key(&[]), &[]),
-                    ],
-                ),
+                (engine::CF_DEFAULT, &[(&keys::data_key(&[b'a']), &[b'a'])]),
                 (
                     engine::CF_WRITE,
                     &[

--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -158,6 +158,7 @@ fn test_read_hibernated_region() {
     // Initialize the cluster.
     configure_for_lease_read(&mut cluster, Some(100), Some(8));
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration(Duration::from_millis(1));
+    cluster.cfg.raft_store.hibernate_regions = true;
     cluster.pd_client.disable_default_operator();
     let r1 = cluster.run_conf_change();
     let p2 = new_peer(2, 2);


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

TiKV 3.x disables hibernate regions by default.😢
Fix the test by enabling hibernate regions. 

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Bugfix (a change which fixes an issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test


Close #6974