### PR TITLE
 backup: do fill in the file size of each SST file in the response (#6664)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.1#7ccc45d0063f5d09766aa71225b4b1c6d1a3ac3b"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.1#6498825ecb5f570981cea9afe02d79b39aa44c6c"
 dependencies = [
  "bytes",
  "futures 0.1.29",
@@ -2717,7 +2717,7 @@ version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1a649b870f7fe03c965bf2fa6728361f6abbb6f3b72079515af8cb56d769cf"
 dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2807,7 +2807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43648985159f2c4c25f934182a63b0dd4c5cc06a5ae96e5d40e12c3a3785abde"
 dependencies = [
  "fxhash",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf",
  "quick-error 1.2.2",
  "rand 0.5.5",

--- a/components/backup/src/writer.rs
+++ b/components/backup/src/writer.rs
@@ -89,6 +89,8 @@ impl Writer {
         file.set_crc64xor(self.checksum);
         file.set_total_kvs(self.total_kvs);
         file.set_total_bytes(self.total_bytes);
+        file.set_cf(cf.to_owned());
+        file.set_size(sst_info.file_size());
         Ok(file)
     }
 

--- a/components/backup/tests/integrations/test_backup.rs
+++ b/components/backup/tests/integrations/test_backup.rs
@@ -387,15 +387,19 @@ fn test_backup_meta() {
     let mut checksum = 0;
     let mut total_kvs = 0;
     let mut total_bytes = 0;
+    let mut total_size = 0;
     for f in files {
         checksum ^= f.get_crc64xor();
         total_kvs += f.get_total_kvs();
         total_bytes += f.get_total_bytes();
+        total_size += f.get_size();
     }
     assert_eq!(total_kvs, key_count);
     assert_eq!(total_kvs, admin_total_kvs);
     assert_eq!(total_bytes, admin_total_bytes);
     assert_eq!(checksum, admin_checksum);
+    assert_eq!(total_size, 2205);
+    // please update this number (must be > 0) when the test failed
 
     suite.stop();
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Cherry-pick #6664 to release-3.1.

###  What is the type of the changes?

- Bugfix (a change which fixes an issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

pingcap/br#163

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

