### PR TITLE
cdc: check failpoints feature for failpoint tests

### DIFF
--- a/components/cdc/tests/integrations/mod.rs
+++ b/components/cdc/tests/integrations/mod.rs
@@ -10,11 +10,13 @@ pub fn init() {
     INIT.call_once(test_util::setup_for_ci);
 }
 
+#[cfg(feature = "failpoints")]
 fn setup_fail<'a>() -> fail::FailScenario<'a> {
     INIT.call_once(test_util::setup_for_ci);
     fail::FailScenario::setup()
 }
 
+#[cfg(feature = "failpoints")]
 #[test]
 fn test_setup_fail() {
     let _ = std::thread::spawn(move || {

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -707,6 +707,7 @@ fn test_region_split() {
     suite.stop();
 }
 
+#[cfg(feature = "failpoints")]
 #[test]
 fn test_failed_pending_batch() {
     let _guard = super::setup_fail();


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
Check failpoints feature for failpoint tests.
Since `test_setup_fail` would hang after adding `-Zprofile` to `RUSTFLAGS`.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Bugfix (a change which fixes an issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test
