### PR TITLE
*: update raft to include aggressive flow control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,14 +2011,20 @@ dependencies = [
 [[package]]
 name = "raft"
 version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tikv/raft-rs?rev=9782199fa6318f94bf0974129664d974b03f8f11#9782199fa6318f94bf0974129664d974b03f8f11"
 dependencies = [
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "raft"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+replace = "raft 0.4.3 (git+https://github.com/tikv/raft-rs?rev=9782199fa6318f94bf0974129664d974b03f8f11)"
 
 [[package]]
 name = "rand"
@@ -3699,6 +3705,7 @@ dependencies = [
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum raft 0.4.3 (git+https://github.com/tikv/raft-rs?rev=9782199fa6318f94bf0974129664d974b03f8f11)" = "<none>"
 "checksum raft 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "43648985159f2c4c25f934182a63b0dd4c5cc06a5ae96e5d40e12c3a3785abde"
 "checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ default-features = false
 [replace]
 "log:0.3.9" = { git = "https://github.com/busyjay/log", branch = "use-static-module" }
 "log:0.4.6" = { git = "https://github.com/busyjay/log", branch = "revert-to-static" }
+"raft:0.4.3" = { git = "https://github.com/tikv/raft-rs", rev = "9782199fa6318f94bf0974129664d974b03f8f11" }
 
 [dev-dependencies]
 panic_hook = { path = "components/panic_hook" }

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -469,7 +469,7 @@ impl Storage for PeerStorage {
         Ok(self.last_index())
     }
 
-    fn snapshot(&self) -> raft::Result<Snapshot> {
+    fn snapshot(&self, _request_index: u64) -> raft::Result<Snapshot> {
         self.snapshot()
     }
 }


### PR DESCRIPTION
###  What have you changed?

Update raft to introduce aggressive flow control. See also tikv/raft-rs#340 and #6670.

Should be merged after #6993 is ported to release-3.0.

###  What is the type of the changes?
- Bugfix

###  How is the PR tested?
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
Yes.

###  Does this PR affect `tidb-ansible`?
No.

###  Refer to a related PR or issue link (optional)

#6670, tikv/raft-rs#340.
