### PR TITLE
test: add github workflow to auto-assign failed test issue to solid tests project

### DIFF
--- a/.github/workflows/assign_failed_test_project.yml
+++ b/.github/workflows/assign_failed_test_project.yml
@@ -17,5 +17,5 @@ jobs:
         github.event.issue.user.login == 'sre-bot' &&
         contains(github.event.issue.labels.*.name, 'component/test-bench')
       with:
-        project: 'https://github.com/pingcap/tidb/projects/14'
+        project: 'https://github.com/pingcap/tikv/projects/14'
         column_name: 'To do(in history)'

--- a/.github/workflows/assign_failed_test_project.yml
+++ b/.github/workflows/assign_failed_test_project.yml
@@ -1,0 +1,21 @@
+name: Auto Assign Failed Test Issue to Solid Tests Project
+
+on:
+  issues:
+    types: [created]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_bench_test_project:
+    runs-on: ubuntu-latest
+    name: Assign to Solid Tests Project
+    steps:
+    - name: Run issues assignment to project Solid Tests Kanban
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: |
+        github.event.issue.user.login == 'sre-bot' &&
+        contains(github.event.issue.labels.*.name, 'component/test-bench')
+      with:
+        project: 'https://github.com/pingcap/tidb/projects/14'
+        column_name: 'To do(in history)'

--- a/.github/workflows/assign_failed_test_project.yml
+++ b/.github/workflows/assign_failed_test_project.yml
@@ -17,5 +17,5 @@ jobs:
         github.event.issue.user.login == 'sre-bot' &&
         contains(github.event.issue.labels.*.name, 'component/test-bench')
       with:
-        project: 'https://github.com/pingcap/tikv/projects/14'
+        project: 'https://github.com/tikv/tikv/projects/14'
         column_name: 'To do(in history)'


### PR DESCRIPTION
Signed-off-by: glorv <glorvs@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
We have created a daily report job to find tests on our CI that fails occasionnally and auto create issures for them. This github workflow will auto assign these issues to `Solid Tests` project so we can manage them easier.

Similar workflow for tidb is [here](https://github.com/pingcap/tidb/blob/master/.github/workflows/assign_project.yml)

- Summarize your change

Don't assume reviewers understand the original issue.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Misc (other changes)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->

