### PR TITLE
extern_storage: replace clap yaml with structopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "393356ed99aa7bff0ac486dde592633b83ab02bd254d8c209d5b9f1d0f533480"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -141,7 +141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8df72488e87761e772f14ae0c2480396810e51b2c2ade912f97f0f7e5b95e3c"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -264,7 +264,7 @@ dependencies = [
  "log",
  "peeking_take_while",
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "regex",
  "rustc-hash",
  "shlex",
@@ -524,7 +524,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
- "yaml-rust",
 ]
 
 [[package]]
@@ -624,7 +623,7 @@ name = "configuration_derive"
 version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -858,7 +857,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "strsim 0.9.2",
  "syn 1.0.5",
 ]
@@ -870,7 +869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cd3e432e52c0810b72898296a69d66b1d78d1517dff6cde7a130557a55a62c1"
 dependencies = [
  "darling_core",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -892,7 +891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -1043,14 +1042,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 dependencies = [
  "backtrace",
- "version_check",
+ "version_check 0.1.5",
 ]
 
 [[package]]
 name = "external_storage"
 version = "0.0.1"
 dependencies = [
- "clap",
  "futures 0.1.29",
  "futures 0.3.4",
  "futures-executor",
@@ -1065,6 +1063,7 @@ dependencies = [
  "rust-ini",
  "slog",
  "slog-global",
+ "structopt 0.3.11",
  "tempfile",
  "tikv_alloc",
  "tokio 0.1.22",
@@ -1099,7 +1098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
  "synstructure",
 ]
@@ -1274,7 +1273,7 @@ checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -1325,7 +1324,7 @@ dependencies = [
  "cargo_metadata",
  "lazy_static",
  "regex",
- "structopt",
+ "structopt 0.2.18",
 ]
 
 [[package]]
@@ -1398,7 +1397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb3f5b7d8d70c9bd23cf29b2b38094661418fb0ea79f1b0cc2019a11d6f5429"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -2016,7 +2015,7 @@ name = "match_template"
 version = "0.0.1"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -2263,7 +2262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
  "memchr",
- "version_check",
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -2273,7 +2272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c433f4d505fe6ce7ff78523d2fa13a0b9f2690e181fc26168bcbe5ccc5d14e07"
 dependencies = [
  "memchr",
- "version_check",
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -2306,7 +2305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -2558,7 +2557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -2638,13 +2637,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 
 [[package]]
+name = "proc-macro-error"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7959c6467d962050d639361f7703b2051c43036d03493c36f01d440fdd3138a"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.5",
+ "version_check 0.9.1",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4002d9f55991d5e019fb940a90e1a95eb80c24e77cb2462dd4dc869604d543a"
+dependencies = [
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.5",
+ "syn-mid",
+ "version_check 0.9.1",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -2732,7 +2757,7 @@ source = "git+https://github.com/tikv/rust-prometheus.git?rev=d919ccd35976b9b84b
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -2773,7 +2798,7 @@ dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -2807,7 +2832,7 @@ dependencies = [
  "prost-build",
  "protobuf",
  "protobuf-codegen",
- "quote 1.0.2",
+ "quote 1.0.3",
  "regex",
  "syn 1.0.5",
 ]
@@ -2847,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2 1.0.9",
 ]
@@ -3507,7 +3532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -3766,7 +3791,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 dependencies = [
  "clap",
- "structopt-derive",
+ "structopt-derive 0.2.18",
+]
+
+[[package]]
+name = "structopt"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fe43617218c0805c6eb37160119dc3c548110a67786da7218d1c6555212f073"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive 0.4.4",
 ]
 
 [[package]]
@@ -3779,6 +3815,19 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e79c80e0f4efd86ca960218d4e056249be189ff1c42824dcd9a7f51a56f0bd"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.5",
 ]
 
 [[package]]
@@ -3805,8 +3854,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.5",
 ]
 
 [[package]]
@@ -3816,7 +3876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
  "unicode-xid 0.2.0",
 ]
@@ -4052,7 +4112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45ba8d810d9c48fc456b7ad54574e8bfb7c7918a57ad7a6e6a0985d7959e8597"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -4127,7 +4187,7 @@ dependencies = [
  "darling",
  "heck",
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -4473,7 +4533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4b1e7ed7d5d4c2af3d999904b0eebe76544897cdbfb2b9684bed2174ab20f7c"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
 ]
 
@@ -4707,7 +4767,7 @@ version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e2e6bd1e59e56598518beb94fd6db628ded570326f0a98c679a304bd9f00150"
 dependencies = [
- "version_check",
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -4818,6 +4878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
 name = "vlog"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4889,7 +4955,7 @@ dependencies = [
  "lazy_static",
  "log",
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
  "wasm-bindgen-shared",
 ]
@@ -4912,7 +4978,7 @@ version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f6fde1d36e75a714b5fe0cffbb78978f222ea6baebb726af13c78869fdb4205"
 dependencies = [
- "quote 1.0.2",
+ "quote 1.0.3",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4923,7 +4989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25bda4168030a6412ea8a047e27238cadf56f0e53516e1e83fec0a8b7c786f6d"
 dependencies = [
  "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.5",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -5037,12 +5103,6 @@ name = "xml-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
-
-[[package]]
-name = "yaml-rust"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 
 [[package]]
 name = "yatp"

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "0.1.22", default-features = false, features = ["codec"] }
 url = "2.0"
 
 [dev-dependencies]
-clap = { version = "2.32", features = ["yaml"] }
+structopt = "0.3"
 rusoto_mock = "0.42.0"
 tempfile = "3.1"
 rust-ini = "0.14.0"

--- a/components/external_storage/examples/scli.rs
+++ b/components/external_storage/examples/scli.rs
@@ -3,7 +3,6 @@ use std::io::{Error, ErrorKind, Result};
 use std::path::Path;
 use std::sync::Arc;
 
-use clap::{App, ArgMatches};
 use external_storage::{
     create_storage, make_local_backend, make_noop_backend, make_s3_backend, ExternalStorage,
 };
@@ -11,139 +10,118 @@ use futures::executor::block_on;
 use futures_util::io::{copy, AllowStdIo};
 use ini::ini::Ini;
 use kvproto::backup::S3;
+use structopt::clap::arg_enum;
+use structopt::StructOpt;
 
-static CMD: &str = r#"
-name: storagecli
-version: "0.1"
-about: an example using storage to save and load a file
-
-settings:
-    - ArgRequiredElseHelp
-    - SubcommandRequiredElseHelp
-
-args:
-    - storage:
-        help: storage backend
-        short: s
-        long: storage
-        takes_value: true
-        case_insensitive: true
-        possible_values: ["noop", "local", "s3"]
-        required: true
-    - file:
-        help: local file to load from or save to
-        short: f
-        long: file
-        takes_value: true
-        required: true
-    - name:
-        help: remote name of the file to load from or save to
-        short: n
-        long: name
-        takes_value: true
-        required: true
-    - path:
-        help: path to use for local storage
-        short: p
-        long: path
-        takes_value: true
-    - credential_file:
-        help: credential file path. For S3, use ~/.aws/credentials
-        short: c
-        long: credential_file
-        takes_value: true
-    - region:
-        help: remote region
-        short: r
-        long: region
-        takes_value: true
-    - bucket:
-        help: remote bucket name
-        short: b
-        long: bucket
-        takes_value: true
-    - prefix:
-        help: remote path prefix
-        short: x
-        long: prefix
-        takes_value: true
-
-subcommands:
-    - save:
-        about: save file to storage
-    - load:
-        about: load file from storage
-"#;
-
-fn create_s3_storage(matches: &ArgMatches) -> Result<Arc<dyn ExternalStorage>> {
-    let mut config = S3::default();
-    match matches.value_of("credential_file") {
-        Some(credential_file) => {
-            let ini = Ini::load_from_file(credential_file).map_err(|e| {
-                Error::new(
-                    ErrorKind::Other,
-                    format!("Failed to parse credential file as ini: {}", e),
-                )
-            })?;
-            let props = ini
-                .section(Some("default"))
-                .ok_or_else(|| Error::new(ErrorKind::Other, "fail to parse section"))?;
-            config.access_key = props
-                .get("aws_access_key_id")
-                .ok_or_else(|| Error::new(ErrorKind::Other, "fail to parse credential"))?
-                .clone();
-            config.secret_access_key = props
-                .get("aws_secret_access_key")
-                .ok_or_else(|| Error::new(ErrorKind::Other, "fail to parse credential"))?
-                .clone();
-        }
-        _ => return Err(Error::new(ErrorKind::Other, "missing credential_file")),
+arg_enum! {
+    #[derive(Debug)]
+    enum StorageType {
+        Noop,
+        Local,
+        S3,
     }
-    if let Some(region) = matches.value_of("region") {
-        config.region = region.to_string();
+}
+
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case", name = "scli", version = "0.1")]
+/// An example using storage to save and load a file.
+pub struct Opt {
+    /// Storage backend.
+    #[structopt(short, long, possible_values = &StorageType::variants(), case_insensitive = true)]
+    storage: StorageType,
+    /// Local file to load from or save to.
+    #[structopt(short, long)]
+    file: String,
+    /// Remote name of the file to load from or save to.
+    #[structopt(short, long)]
+    name: String,
+    /// Path to use for local storage.
+    #[structopt(short, long)]
+    path: String,
+    /// Credential file path. For S3, use ~/.aws/credentials.
+    #[structopt(short, long)]
+    credential_file: Option<String>,
+    /// Remote region.
+    #[structopt(short, long)]
+    region: Option<u64>,
+    /// Remote bucket name.
+    #[structopt(short, long)]
+    bucket: Option<String>,
+    /// Remote path prefix
+    #[structopt(short = "x", long)]
+    prefix: Option<String>,
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(StructOpt)]
+#[structopt(rename_all = "kebab-case")]
+enum Command {
+    /// Save file to storage.
+    Save,
+    /// Load file from storage.
+    Load,
+}
+
+fn create_s3_storage(opt: &Opt) -> Result<Arc<dyn ExternalStorage>> {
+    let mut config = S3::default();
+    let ini = match &opt.credential_file {
+        Some(credential_file) => Ini::load_from_file(credential_file).map_err(|e| {
+            Error::new(
+                ErrorKind::Other,
+                format!("Failed to parse credential file as ini: {}", e),
+            )
+        })?,
+        _ => return Err(Error::new(ErrorKind::Other, "missing credential_file")),
+    };
+
+    let props = ini
+        .section(Some("default"))
+        .ok_or_else(|| Error::new(ErrorKind::Other, "fail to parse section"))?;
+    config.access_key = props
+        .get("aws_access_key_id")
+        .ok_or_else(|| Error::new(ErrorKind::Other, "fail to parse credential"))?
+        .clone();
+    config.secret_access_key = props
+        .get("aws_secret_access_key")
+        .ok_or_else(|| Error::new(ErrorKind::Other, "fail to parse credential"))?
+        .clone();
+
+    if let Some(region) = opt.region {
+        config.region = format!("{}", region);
     } else {
         return Err(Error::new(ErrorKind::Other, "missing region"));
     }
-    if let Some(bucket) = matches.value_of("bucket") {
+    if let Some(bucket) = &opt.bucket {
         config.bucket = bucket.to_string();
     } else {
         return Err(Error::new(ErrorKind::Other, "missing bucket"));
     }
-    if let Some(prefix) = matches.value_of("prefix") {
+    if let Some(prefix) = &opt.prefix {
         config.prefix = prefix.to_string();
     }
     create_storage(&make_s3_backend(config))
 }
 
 fn process() -> Result<()> {
-    let yaml = &clap::YamlLoader::load_from_str(CMD).unwrap()[0];
-    let app = App::from_yaml(yaml);
-    let matches = app.get_matches();
-
-    let storage = match matches.value_of("storage") {
-        Some("noop") => create_storage(&make_noop_backend())?,
-        Some("local") => match matches.value_of("path") {
-            Some(path) => create_storage(&make_local_backend(Path::new(&path)))?,
-            _ => return Err(Error::new(ErrorKind::Other, "missing path")),
-        },
-        Some("s3") => create_s3_storage(&matches)?,
-        _ => return Err(Error::new(ErrorKind::Other, "storage unrecognized")),
+    let opt = Opt::from_args();
+    let storage = match opt.storage {
+        StorageType::Noop => create_storage(&make_noop_backend())?,
+        StorageType::Local => create_storage(&make_local_backend(Path::new(&opt.path)))?,
+        StorageType::S3 => create_s3_storage(&opt)?,
     };
 
-    let file_path = matches.value_of("file").unwrap();
-    let name = matches.value_of("name").unwrap();
-    match matches.subcommand_name() {
-        Some("save") => {
-            let file = File::open(file_path)?;
+    match opt.command {
+        Command::Save => {
+            let file = File::open(&opt.file)?;
             let file_size = file.metadata()?.len();
-            storage.write(name, Box::new(AllowStdIo::new(file)), file_size)?;
+            storage.write(&opt.name, Box::new(AllowStdIo::new(file)), file_size)?;
         }
-        Some("load") => {
-            let mut file = AllowStdIo::new(File::create(file_path)?);
-            let reader = storage.read(name)?;
+        Command::Load => {
+            let reader = storage.read(&opt.name)?;
+            let mut file = AllowStdIo::new(File::create(&opt.file)?);
             block_on(copy(reader, &mut file))?;
         }
-        _ => return Err(Error::new(ErrorKind::Other, "subcommand unrecognized")),
     }
 
     Ok(())


### PR DESCRIPTION
###  What have you changed?

According to RUSTSEC-2018-0006, we should not use yaml-rust < 0.4.1,
which is depended by clap. So I rewrite the usage using structopt.

After this PR we can enable audit check in CI again.

Close #7004.

###  What is the type of the changes?
- Bugfix

###  How is the PR tested?
- Manual test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No.

###  Does this PR affect `tidb-ansible`?
No.
