### PR TITLE
test:  fix auto-assign workflow trigger event

### DIFF
--- a/.github/workflows/assign_failed_test_project.yml
+++ b/.github/workflows/assign_failed_test_project.yml
@@ -2,7 +2,7 @@ name: Auto Assign Failed Test Issue to Solid Tests Project
 
 on:
   issues:
-    types: [created]
+    types: [labeled]
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Signed-off-by: glorv <glorvs@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?
In #7102 I add a Github workflow to auto-assign issues for failed test cases in our CI to project `Solid Tests`. Because these issues were created with labels, so I select `created` as trigger event. But after I manually tested in my private repo, It seems Github only recognize `labeled` event for labels even if issues were created with labels.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Bugfix (fix #7102 )

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Manual test
- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->

###  Does this PR affect `tidb-ansible`?
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->
###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

