### PR TITLE
external_storage: fix crash when using s3

### DIFF
--- a/components/external_storage/examples/scli.rs
+++ b/components/external_storage/examples/scli.rs
@@ -41,9 +41,12 @@ pub struct Opt {
     /// Credential file path. For S3, use ~/.aws/credentials.
     #[structopt(short, long)]
     credential_file: Option<String>,
+    /// Remote endpoint
+    #[structopt(short, long)]
+    endpoint: Option<String>,
     /// Remote region.
     #[structopt(short, long)]
-    region: Option<u64>,
+    region: Option<String>,
     /// Remote bucket name.
     #[structopt(short, long)]
     bucket: Option<String>,
@@ -87,8 +90,11 @@ fn create_s3_storage(opt: &Opt) -> Result<Arc<dyn ExternalStorage>> {
         .ok_or_else(|| Error::new(ErrorKind::Other, "fail to parse credential"))?
         .clone();
 
-    if let Some(region) = opt.region {
-        config.region = format!("{}", region);
+    if let Some(endpoint) = &opt.endpoint {
+        config.endpoint = endpoint.to_string();
+    }
+    if let Some(region) = &opt.region {
+        config.region = region.to_string();
     } else {
         return Err(Error::new(ErrorKind::Other, "missing region"));
     }


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

###  What have you changed?

Fix "not currently running on the Tokio runtime" crash when read from or write to S3. The problem seems to be rusoto using tokio under the hood, which require use `tokio::runtime::Runtime::block_on` instead of `futures::executor::block_on`.

Also have minor update to the scli tool.

###  What is the type of the changes?
Bugfix

###  How is the PR tested?
Build the scli tool in example. Tested locally with the following commands:
```
./scli -b yiwu-test -c ~/.aws/credentials -f local.txt -s S3 -n remote.txt -p test -r us-west-2 -e s3.amazonaws.com save
./scli -b yiwu-test -c ~/.aws/credentials -f local_copy.txt -s S3 -n remote.txt -p test -r us-east-1 -e s3.amazonaws.com load
```

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No

###  Does this PR affect `tidb-ansible`?
No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

