### PR TITLE
tests: Fix unstable tests test_read_index_when_transfer_leader_1 and test_thread_pool_shutdown_when_idle

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -1277,23 +1277,23 @@ pub mod tests {
         req.set_concurrency(10);
         req.set_storage_backend(make_noop_backend());
 
-        let (tx, _) = futures::sync::mpsc::unbounded();
+        let (tx, resp_rx) = futures::sync::mpsc::unbounded();
         let (task, _) = Task::new(req, tx).unwrap();
 
         // if not task arrive after create the thread pool is empty
         assert_eq!(endpoint.lock().unwrap().pool.borrow().size, 0);
 
         scheduler.send(Some(task)).unwrap();
-        // wait the task send to worker
-        thread::sleep(Duration::from_millis(10));
+        // wait until the task finish
+        let _ = resp_rx.into_future().wait();
         assert_eq!(endpoint.lock().unwrap().pool.borrow().size, 10);
 
         // thread pool not yet shutdown
         thread::sleep(Duration::from_millis(50));
         assert_eq!(endpoint.lock().unwrap().pool.borrow().size, 10);
 
-        // thread pool shutdown if not task arrive for 100ms
-        thread::sleep(Duration::from_millis(50));
+        // thread pool shutdown if not task arrive more than 100ms
+        thread::sleep(Duration::from_millis(100));
         assert_eq!(endpoint.lock().unwrap().pool.borrow().size, 0);
     }
     // TODO: region err in txn(engine(request))

--- a/tests/integrations/raftstore/test_lease_read.rs
+++ b/tests/integrations/raftstore/test_lease_read.rs
@@ -394,6 +394,7 @@ fn test_read_index_when_transfer_leader_1() {
         RegionPacketFilter::new(r1.get_id(), old_leader.get_store_id())
             .direction(Direction::Recv)
             .skip(MessageType::MsgTransferLeader)
+            .skip(MessageType::MsgAppendResponse)
             .when(Arc::new(AtomicBool::new(true)))
             .reserve_dropped(Arc::clone(&dropped_msgs)),
     );

--- a/tests/integrations/raftstore/test_lease_read.rs
+++ b/tests/integrations/raftstore/test_lease_read.rs
@@ -390,22 +390,35 @@ fn test_read_index_when_transfer_leader_1() {
 
     // Delay all raft messages to peer 1.
     let dropped_msgs = Arc::new(Mutex::new(Vec::new()));
-    let filter = Box::new(
-        RegionPacketFilter::new(r1.get_id(), old_leader.get_store_id())
-            .direction(Direction::Recv)
-            .skip(MessageType::MsgTransferLeader)
-            .skip(MessageType::MsgAppendResponse)
-            .when(Arc::new(AtomicBool::new(true)))
-            .reserve_dropped(Arc::clone(&dropped_msgs)),
+    let (region_id, store_id) = (r1.get_id(), old_leader.get_store_id());
+    let append_resp = Arc::new(AtomicBool::new(true));
+    let filter = |msg: MessageType, when: Option<Arc<AtomicBool>>| {
+        Box::new(
+            RegionPacketFilter::new(region_id, store_id)
+                .direction(Direction::Recv)
+                .skip(msg)
+                .when(when.unwrap_or(Arc::new(AtomicBool::new(true))))
+                .reserve_dropped(Arc::clone(&dropped_msgs)),
+        )
+    };
+    cluster.sim.wl().add_recv_filter(
+        old_leader.get_id(),
+        filter(MessageType::MsgTransferLeader, None),
     );
-    cluster
-        .sim
-        .wl()
-        .add_recv_filter(old_leader.get_id(), filter);
+    cluster.sim.wl().add_recv_filter(
+        old_leader.get_id(),
+        filter(
+            MessageType::MsgAppendResponse,
+            Some(Arc::clone(&append_resp)),
+        ),
+    );
 
     let resp1 = read_on_old_leader!();
 
+    // don't drop MsgAppendResponse to ensure transfer leader success
+    append_resp.store(false, Ordering::SeqCst);
     cluster.must_transfer_leader(r1.get_id(), new_peer(3, 3));
+    append_resp.store(true, Ordering::SeqCst);
 
     let resp2 = read_on_old_leader!();
 


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

Fix unstable test:
fix #7082 test_thread_pool_shutdown_when_idle: this test failed because the thread pool did not shutdown immediately after the configured time, but the test did take in count of the task process time, this pr fix it by first wait the task finish and have a more relax check.

fix #5163 test_thread_pool_shutdown_when_idle: this test failed because can not transfer leader, which happened because read index may propose an empty entry and the transferee did not have new enough log + leader can not receive `MsgAppendResponse` because filter, this pr fix it by skip `MsgAppendResponse` in filter.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Bugfix (a change which fixes an issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- Unit test
- Integration test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
No

###  Does this PR affect `tidb-ansible`?
No

