### PR TITLE
dianostics: change the memory unit from KB to byte

### DIFF
--- a/src/server/service/diagnostics.rs
+++ b/src/server/service/diagnostics.rs
@@ -124,6 +124,7 @@ mod sys {
 
     use kvproto::diagnosticspb::{ServerInfoItem, ServerInfoPair};
     use sysinfo::{DiskExt, ProcessExt, SystemExt};
+    use tikv_util::config::KB;
 
     fn cpu_load_info(collector: &mut Vec<ServerInfoItem>) {
         // CPU load
@@ -192,12 +193,12 @@ mod sys {
     fn mem_load_info(collector: &mut Vec<ServerInfoItem>) {
         let mut system = sysinfo::System::new();
         system.refresh_all();
-        let total_memory = system.get_total_memory();
-        let used_memory = system.get_used_memory();
-        let free_memory = system.get_free_memory();
-        let total_swap = system.get_total_swap();
-        let used_swap = system.get_used_swap();
-        let free_swap = system.get_free_swap();
+        let total_memory = system.get_total_memory() * KB;
+        let used_memory = system.get_used_memory() * KB;
+        let free_memory = system.get_free_memory() * KB;
+        let total_swap = system.get_total_swap() * KB;
+        let used_swap = system.get_used_swap() * KB;
+        let free_swap = system.get_free_swap() * KB;
         let used_memory_pct = (used_memory as f64) / (total_memory as f64);
         let free_memory_pct = (free_memory as f64) / (total_memory as f64);
         let used_swap_pct = (used_swap as f64) / (total_swap as f64);
@@ -389,7 +390,7 @@ mod sys {
         system.refresh_all();
         let mut pair = ServerInfoPair::default();
         pair.set_key("capacity".to_string());
-        pair.set_value(system.get_total_memory().to_string());
+        pair.set_value((system.get_total_memory() * KB).to_string());
         let mut item = ServerInfoItem::default();
         item.set_tp("memory".to_string());
         item.set_name("memory".to_string());


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

Signed-off-by: crazycs520 <crazycs520@gmail.com>

###  What have you changed?

Before this PR, memory info unit is KB in hardware info and load info.

This PR change the memory info unit to byte in hardware info and load info, just keep consistent with the disk unit.

Don't assume reviewers understand the original issue.

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->
- Misc (other changes)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
- No code

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
<!--
- If there is a document change, please file a PR in ([docs](https://github.com/tikv/website/tree/master/content)) and add the PR number here.
- If this PR should be mentioned in the release note, please update the [release notes](https://github.com/tikv/tikv/blob/master/CHANGELOG.md).
-->

###  Does this PR affect `tidb-ansible`?
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->
 NO

###  Any examples? (optional)

before
```sql
mysql>select * from `CLUSTER_HARDWARE` where device_type="memory"
+------+-----------------+-------------+-------------+----------+-------------+
| TYPE | INSTANCE        | DEVICE_TYPE | DEVICE_NAME | NAME     | VALUE       |
+------+-----------------+-------------+-------------+----------+-------------+
| tidb | 127.0.0.1:10080 | memory      | memory      | capacity | 51539607552 |
| pd   | 127.0.0.1:2379  | memory      | memory      | capacity | 51539607552 |
| tikv | 127.0.0.1:20160 | memory      | memory      | capacity | 50331648    |
+------+-----------------+-------------+-------------+----------+-------------+
```

now
```sql
mysql>select * from `CLUSTER_HARDWARE` where device_type="memory"
+------+-----------------+-------------+-------------+----------+-------------+
| TYPE | INSTANCE        | DEVICE_TYPE | DEVICE_NAME | NAME     | VALUE       |
+------+-----------------+-------------+-------------+----------+-------------+
| tidb | 127.0.0.1:10080 | memory      | memory      | capacity | 51539607552 |
| pd   | 127.0.0.1:2379  | memory      | memory      | capacity | 51539607552 |
| tikv | 127.0.0.1:20160 | memory      | memory      | capacity | 51539607552 |
+------+-----------------+-------------+-------------+----------+-------------+

```
