### PR TITLE
external_storage: fix sst writer error with s3 storage, plus refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
 name = "external_storage"
 version = "0.0.1"
 dependencies = [
+ "bytes 0.5.3",
  "futures 0.3.4",
  "futures-executor",
  "futures-io",
@@ -1115,7 +1116,6 @@ dependencies = [
  "tempfile",
  "tikv_alloc",
  "tokio 0.2.13",
- "tokio-util 0.3.0",
  "url",
 ]
 
@@ -1546,7 +1546,7 @@ dependencies = [
  "log",
  "slab",
  "tokio 0.2.13",
- "tokio-util 0.2.0",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4559,7 +4559,6 @@ checksum = "0fa5e81d6bc4e67fe889d5783bd2a128ab2e0cfa487e0be16b6a8d177b101616"
 dependencies = [
  "bytes 0.5.3",
  "fnv",
- "futures-core",
  "iovec",
  "lazy_static",
  "libc",
@@ -4814,21 +4813,6 @@ checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 dependencies = [
  "bytes 0.5.3",
  "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio 0.2.13",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af67cdce2b40f8dffb0ee04c853a24217b5d0d3e358f0f5ccc0b5332174ed9a8"
-dependencies = [
- "bytes 0.5.3",
- "futures-core",
- "futures-io",
  "futures-sink",
  "log",
  "pin-project-lite",

--- a/components/backup/tests/integrations/test_backup.rs
+++ b/components/backup/tests/integrations/test_backup.rs
@@ -378,7 +378,7 @@ fn test_backup_and_import() {
     sst_meta.set_uuid(uuid::Uuid::new_v4().as_bytes().to_vec());
     let mut metas = vec![];
     for f in files1.clone().into_iter() {
-        let mut reader = storage.read(&f.name).unwrap();
+        let mut reader = storage.read(&f.name);
         let mut content = vec![];
         block_on(reader.read_to_end(&mut content)).unwrap();
         let mut m = sst_meta.clone();
@@ -537,7 +537,7 @@ fn test_backup_rawkv() {
     sst_meta.set_uuid(uuid::Uuid::new_v4().as_bytes().to_vec());
     let mut metas = vec![];
     for f in files1.clone().into_iter() {
-        let mut reader = storage.read(&f.name).unwrap();
+        let mut reader = storage.read(&f.name);
         let mut content = vec![];
         block_on(reader.read_to_end(&mut content)).unwrap();
         let mut m = sst_meta.clone();

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -31,4 +31,3 @@ structopt = "0.3"
 rusoto_mock = "0.43.0"
 tempfile = "3.1"
 rust-ini = "0.14.0"
-# tikv_util = { path = "../tikv_util" }

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -23,11 +23,12 @@ slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debu
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 tikv_alloc = { path = "../tikv_alloc" }
 tokio = "0.2.13"
-tokio-util = { version = "0.3.0", features = ["codec", "compat"] }
 url = "2.0"
+bytes = "0.5.3"
 
 [dev-dependencies]
 structopt = "0.3"
 rusoto_mock = "0.43.0"
 tempfile = "3.1"
 rust-ini = "0.14.0"
+# tikv_util = { path = "../tikv_util" }

--- a/components/external_storage/examples/scli.rs
+++ b/components/external_storage/examples/scli.rs
@@ -124,7 +124,7 @@ fn process() -> Result<()> {
             storage.write(&opt.name, Box::new(AllowStdIo::new(file)), file_size)?;
         }
         Command::Load => {
-            let reader = storage.read(&opt.name)?;
+            let reader = storage.read(&opt.name);
             let mut file = AllowStdIo::new(File::create(&opt.file)?);
             block_on(copy(reader, &mut file))?;
         }

--- a/components/external_storage/src/lib.rs
+++ b/components/external_storage/src/lib.rs
@@ -29,6 +29,8 @@ mod noop;
 pub use noop::NoopStorage;
 mod s3;
 pub use s3::S3Storage;
+mod util;
+pub use util::block_on_external_io;
 
 /// Create a new storage from the given storage backend description.
 pub fn create_storage(backend: &StorageBackend) -> io::Result<Arc<dyn ExternalStorage>> {
@@ -131,23 +133,23 @@ pub trait ExternalStorage: Sync + Send + 'static {
     fn write(
         &self,
         name: &str,
-        reader: Box<dyn AsyncRead + Sync + Send + Unpin>,
+        reader: Box<dyn AsyncRead + Send + Unpin>,
         content_length: u64,
     ) -> io::Result<()>;
     /// Read all contents of the given path.
-    fn read(&self, name: &str) -> io::Result<Box<dyn AsyncRead + Unpin>>;
+    fn read(&self, name: &str) -> Box<dyn AsyncRead + Unpin + '_>;
 }
 
 impl ExternalStorage for Arc<dyn ExternalStorage> {
     fn write(
         &self,
         name: &str,
-        reader: Box<dyn AsyncRead + Sync + Send + Unpin>,
+        reader: Box<dyn AsyncRead + Send + Unpin>,
         content_length: u64,
     ) -> io::Result<()> {
         (**self).write(name, reader, content_length)
     }
-    fn read(&self, name: &str) -> io::Result<Box<dyn AsyncRead + Unpin>> {
+    fn read(&self, name: &str) -> Box<dyn AsyncRead + Unpin + '_> {
         (**self).read(name)
     }
 }

--- a/components/external_storage/src/local.rs
+++ b/components/external_storage/src/local.rs
@@ -8,10 +8,13 @@ use std::sync::Arc;
 
 use futures_executor::block_on;
 use futures_io::AsyncRead;
-use futures_util::io::{copy, AllowStdIo};
+use futures_util::{
+    io::{copy, AllowStdIo},
+    stream::TryStreamExt,
+};
 use rand::Rng;
 
-use super::ExternalStorage;
+use super::{util::error_stream, ExternalStorage};
 
 const LOCAL_STORAGE_TMP_DIR: &str = "localtmp";
 const LOCAL_STORAGE_TMP_FILE_SUFFIX: &str = "tmp";
@@ -58,7 +61,7 @@ impl ExternalStorage for LocalStorage {
     fn write(
         &self,
         name: &str,
-        reader: Box<dyn AsyncRead + Sync + Send + Unpin + 'static>,
+        reader: Box<dyn AsyncRead + Send + Unpin>,
         _content_length: u64,
     ) -> io::Result<()> {
         // Storage does not support dir,
@@ -92,11 +95,13 @@ impl ExternalStorage for LocalStorage {
         self.base_dir.sync_all()
     }
 
-    fn read(&self, name: &str) -> io::Result<Box<dyn AsyncRead + Unpin>> {
+    fn read(&self, name: &str) -> Box<dyn AsyncRead + Unpin + '_> {
         debug!("read file from local storage";
             "name" => %name, "base" => %self.base.display());
-        let file = File::open(self.base.join(name))?;
-        Ok(Box::new(AllowStdIo::new(file)))
+        match File::open(self.base.join(name)) {
+            Ok(file) => Box::new(AllowStdIo::new(file)) as _,
+            Err(e) => Box::new(error_stream(e).into_async_read()) as _,
+        }
     }
 }
 

--- a/components/external_storage/src/noop.rs
+++ b/components/external_storage/src/noop.rs
@@ -18,15 +18,15 @@ impl ExternalStorage for NoopStorage {
     fn write(
         &self,
         _name: &str,
-        reader: Box<dyn AsyncRead + Sync + Send + Unpin>,
+        reader: Box<dyn AsyncRead + Send + Unpin>,
         _content_length: u64,
     ) -> io::Result<()> {
         // we must still process the entire reader to run the SHA-256 hasher.
         block_on(copy(reader, &mut AllowStdIo::new(io::sink()))).map(drop)
     }
 
-    fn read(&self, _name: &str) -> io::Result<Box<dyn AsyncRead + Unpin>> {
-        Ok(Box::new(AllowStdIo::new(io::empty())) as _)
+    fn read(&self, _name: &str) -> Box<dyn AsyncRead + Unpin + '_> {
+        Box::new(AllowStdIo::new(io::empty()))
     }
 }
 
@@ -47,7 +47,7 @@ mod tests {
             magic_contents.len() as u64,
         )
         .unwrap();
-        let mut reader = noop.read("a.log").unwrap();
+        let mut reader = noop.read("a.log");
         let mut buf = vec![];
         block_on(reader.read_to_end(&mut buf)).unwrap();
         assert!(buf.is_empty());

--- a/components/external_storage/src/s3.rs
+++ b/components/external_storage/src/s3.rs
@@ -2,13 +2,8 @@
 
 use std::io::{Error, ErrorKind, Result};
 
-use futures::stream::StreamExt;
 use futures_io::AsyncRead;
-use tokio::runtime::Runtime;
-use tokio_util::{
-    codec::{BytesCodec, FramedRead},
-    compat::{FuturesAsyncReadCompatExt, Tokio02AsyncReadCompatExt},
-};
+use futures_util::{future::FutureExt, stream::TryStreamExt};
 
 use rusoto_core::region;
 use rusoto_core::request::DispatchSignedRequest;
@@ -17,8 +12,13 @@ use rusoto_core::{ByteStream, RusotoError};
 use rusoto_credential::{DefaultCredentialsProvider, StaticProvider};
 use rusoto_s3::*;
 
-use super::ExternalStorage;
+use super::{
+    util::{block_on_external_io, error_stream, AsyncReadAsSyncStreamOfBytes},
+    ExternalStorage,
+};
 use kvproto::backup::S3 as Config;
+
+const READ_BUF_SIZE: usize = 1024 * 1024 * 2;
 
 /// S3 compatible storage
 #[derive(Clone)]
@@ -34,7 +34,7 @@ impl S3Storage {
         // than 100MB. See https://github.com/rusoto/rusoto/pull/1227
         // for more information.
         let mut http_config = HttpConfig::new();
-        http_config.read_buf_size(1024 * 1024 * 2);
+        http_config.read_buf_size(READ_BUF_SIZE);
         let http_dispatcher = HttpClient::new_with_config(http_config).unwrap();
 
         S3Storage::with_request_dispatcher(config, http_dispatcher)
@@ -95,7 +95,7 @@ impl ExternalStorage for S3Storage {
     fn write(
         &self,
         name: &str,
-        reader: Box<dyn AsyncRead + Sync + Send + Unpin>,
+        reader: Box<dyn AsyncRead + Send + Unpin>,
         content_length: u64,
     ) -> Result<()> {
         let key = self.maybe_prefix_key(name);
@@ -111,8 +111,7 @@ impl ExternalStorage for S3Storage {
             key,
             bucket: self.config.bucket.clone(),
             body: Some(ByteStream::new(
-                FramedRead::new(reader.compat(), BytesCodec::new())
-                    .map(|bytes| Ok(bytes?.freeze())),
+                AsyncReadAsSyncStreamOfBytes::with_capacity(reader, READ_BUF_SIZE),
             )),
             content_length: Some(content_length as i64),
             acl: get_var(&self.config.acl),
@@ -120,42 +119,39 @@ impl ExternalStorage for S3Storage {
             storage_class: get_var(&self.config.storage_class),
             ..Default::default()
         };
-        let mut runtime = Runtime::new().map_err(|e| {
-            Error::new(
-                ErrorKind::Other,
-                format!("failed to create tokio runtime {}", e),
-            )
-        })?;
-        runtime
-            .block_on(self.client.put_object(req))
+        block_on_external_io(self.client.put_object(req))
             .map(|_| ())
             .map_err(|e| Error::new(ErrorKind::Other, format!("failed to put object {}", e)))
     }
 
-    fn read(&self, name: &str) -> Result<Box<dyn AsyncRead + Unpin>> {
+    fn read(&self, name: &str) -> Box<dyn AsyncRead + Unpin + '_> {
         let key = self.maybe_prefix_key(name);
+        let bucket = self.config.bucket.clone();
         debug!("read file from s3 storage"; "key" => %key);
         let req = GetObjectRequest {
             key,
-            bucket: self.config.bucket.clone(),
+            bucket: bucket.clone(),
             ..Default::default()
         };
-        let mut runtime = Runtime::new().map_err(|e| {
-            Error::new(
-                ErrorKind::Other,
-                format!("failed to create tokio runtime {}", e),
-            )
-        })?;
-        runtime
-            .block_on(self.client.get_object(req))
-            .map(|out| Box::new(out.body.unwrap().into_async_read().compat()) as _)
-            .map_err(|e| match e {
-                RusotoError::Service(GetObjectError::NoSuchKey(key)) => Error::new(
-                    ErrorKind::NotFound,
-                    format!("no key {} at bucket {}", key, self.config.bucket),
-                ),
-                e => Error::new(ErrorKind::Other, format!("failed to get object {}", e)),
-            })
+        Box::new(
+            self.client
+                .get_object(req)
+                .map(move |future| match future {
+                    Ok(out) => out.body.unwrap(),
+                    Err(RusotoError::Service(GetObjectError::NoSuchKey(key))) => {
+                        ByteStream::new(error_stream(Error::new(
+                            ErrorKind::NotFound,
+                            format!("not key {} not at bucket {}", key, bucket),
+                        )))
+                    }
+                    Err(e) => ByteStream::new(error_stream(Error::new(
+                        ErrorKind::Other,
+                        format!("failed to get object {}", e),
+                    ))),
+                })
+                .flatten_stream()
+                .into_async_read(),
+        )
     }
 }
 
@@ -218,9 +214,9 @@ mod tests {
             magic_contents.len() as u64,
         )
         .unwrap();
-        let mut reader = s.read("mykey").unwrap();
+        let mut reader = s.read("mykey");
         let mut buf = Vec::new();
-        let ret = futures::executor::block_on(reader.read_to_end(&mut buf));
+        let ret = block_on_external_io(reader.read_to_end(&mut buf));
         assert!(ret.unwrap() == 0);
         assert!(buf.is_empty());
     }
@@ -255,9 +251,9 @@ mod tests {
             )
             .unwrap();
 
-        let mut reader = storage.read("huge_file").unwrap();
+        let mut reader = storage.read("huge_file");
         let mut buf = Vec::new();
-        futures::executor::block_on(reader.read_to_end(&mut buf)).unwrap();
+        block_on_external_io(reader.read_to_end(&mut buf)).unwrap();
         assert_eq!(buf.len(), LEN);
         assert_eq!(buf.iter().position(|b| *b != 50_u8), None);
     }

--- a/components/external_storage/src/s3.rs
+++ b/components/external_storage/src/s3.rs
@@ -141,7 +141,7 @@ impl ExternalStorage for S3Storage {
                     Err(RusotoError::Service(GetObjectError::NoSuchKey(key))) => {
                         ByteStream::new(error_stream(Error::new(
                             ErrorKind::NotFound,
-                            format!("not key {} not at bucket {}", key, bucket),
+                            format!("no key {} at bucket {}", key, bucket),
                         )))
                     }
                     Err(e) => ByteStream::new(error_stream(Error::new(

--- a/components/external_storage/src/util.rs
+++ b/components/external_storage/src/util.rs
@@ -1,0 +1,69 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use bytes::Bytes;
+use futures::stream::{self, Stream};
+use futures_io::AsyncRead;
+use std::{
+    future::Future,
+    io, iter,
+    marker::Unpin,
+    pin::Pin,
+    sync::Mutex,
+    task::{Context, Poll},
+};
+
+/// Wrapper of an `AsyncRead` instance, exposed as a `Sync` `Stream` of `Bytes`.
+pub struct AsyncReadAsSyncStreamOfBytes<R> {
+    // we need this Mutex to ensure the type is Sync (provided R is Send).
+    // this is because rocksdb::SequentialFile is *not* Sync
+    // (according to the documentation it cannot be Sync either,
+    // requiring "external synchronization".)
+    reader: Mutex<R>,
+    // we use this member to ensure every call to `poll_next()` reuse the same
+    // buffer.
+    buf: Vec<u8>,
+}
+
+impl<R> AsyncReadAsSyncStreamOfBytes<R> {
+    pub fn with_capacity(reader: R, capacity: usize) -> Self {
+        Self {
+            reader: Mutex::new(reader),
+            buf: vec![0; capacity],
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin> Stream for AsyncReadAsSyncStreamOfBytes<R> {
+    type Item = io::Result<Bytes>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        let reader = this.reader.get_mut().expect("lock was poisoned");
+        let read_size = Pin::new(reader).poll_read(cx, &mut this.buf);
+
+        match read_size {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(Ok(0)) => Poll::Ready(None),
+            Poll::Ready(Ok(n)) => Poll::Ready(Some(Ok(Bytes::copy_from_slice(&this.buf[..n])))),
+        }
+    }
+}
+
+pub fn error_stream(e: io::Error) -> impl Stream<Item = io::Result<Bytes>> + Unpin + Send + Sync {
+    stream::iter(iter::once(Err(e)))
+}
+
+/// Runs a future on the current thread involving external storage.
+// FIXME: get rid of this function, so that futures_executor::block_on is sufficient.
+pub fn block_on_external_io<F: Future>(f: F) -> F::Output {
+    // we need a Tokio runtime rather than futures_executor::block_on because
+    // Tokio futures require Tokio executor.
+    tokio::runtime::Builder::new()
+        .basic_scheduler()
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("failed to create Tokio runtime")
+        .block_on(f)
+}

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -15,8 +15,7 @@ use uuid::{Builder as UuidBuilder, Uuid};
 use engine_traits::{IngestExternalFileOptions, KvEngine};
 use engine_traits::{Iterator, CF_WRITE};
 use engine_traits::{SeekKey, SstReader, SstWriter};
-use external_storage::{create_storage, url_of_backend};
-use futures_executor::block_on;
+use external_storage::{block_on_external_io, create_storage, url_of_backend};
 use futures_util::io::{copy, AllowStdIo};
 use keys;
 use tikv_util::time::Limiter;
@@ -140,15 +139,16 @@ impl SSTImporter {
 
         // prepare to download the file from the external_storage
         let ext_storage = create_storage(backend)?;
-        let ext_reader = ext_storage
-            .read(name)
-            .map_err(|e| Error::CannotReadExternalStorage(url.to_string(), name.to_owned(), e))?;
+        let ext_reader = ext_storage.read(name);
         let ext_reader = speed_limiter.limit(ext_reader);
 
         // do the I/O copy from external_storage to the local file.
         {
             let mut file_writer = AllowStdIo::new(File::create(&path.temp)?);
-            let file_length = block_on(copy(ext_reader, &mut file_writer))?;
+            let file_length =
+                block_on_external_io(copy(ext_reader, &mut file_writer)).map_err(|e| {
+                    Error::CannotReadExternalStorage(url.to_string(), name.to_owned(), e)
+                })?;
             if meta.length != 0 && meta.length != file_length {
                 let reason = format!("length {}, expect {}", file_length, meta.length);
                 return Err(Error::FileCorrupted(path.temp, reason));

--- a/components/tikv_util/src/file.rs
+++ b/components/tikv_util/src/file.rs
@@ -89,8 +89,7 @@ pub fn sha256(input: &[u8]) -> Result<Vec<u8>, ErrorStack> {
 
 /// Wrapper of a reader which computes its SHA-256 hash while reading.
 pub struct Sha256Reader<R> {
-    // Use mutex on reader to provide Sync trait to Sha256Reader.
-    reader: Mutex<R>,
+    reader: R,
     hasher: Arc<Mutex<Hasher>>,
 }
 
@@ -100,7 +99,7 @@ impl<R> Sha256Reader<R> {
         let hasher = Arc::new(Mutex::new(Hasher::new(MessageDigest::sha256())?));
         Ok((
             Sha256Reader {
-                reader: Mutex::new(reader),
+                reader,
                 hasher: hasher.clone(),
             },
             hasher,
@@ -110,8 +109,8 @@ impl<R> Sha256Reader<R> {
 
 impl<R: Read> Read for Sha256Reader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let len = self.reader.get_mut().unwrap().read(buf)?;
-        (*self.hasher).lock().unwrap().update(&buf[..len])?;
+        let len = self.reader.read(buf)?;
+        self.hasher.lock().unwrap().update(&buf[..len])?;
         Ok(len)
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.
-->

###  What have you changed?

In #7117, the `rusoto` package (for using AWS S3) was upgraded to 0.43.0, which requires Tokio to upgrade from 0.1 to 0.2. This is a major breaking change of Tokio. During adoption of the new API, it seems the writer is broken, in that only the first 512 KB is written out. This has caused BR integration tests to fail in the last few days.

In this PR, we have completely removed the `FramedRead` adapter (which performs the (futures_io AsyncRead → Tokio 0.2 AsyncRead → TryStream of Bytes) conversion), and rather implement an `AsyncReadAsSyncStreamOfBytes` to directly produce a TryStream of Bytes under our control.

This PR also refactored `ExternalStorage::read()` to return a `Box<dyn AsyncRead>` instead of `io::Result<Box<dyn AsyncRead>>`. This allows the S3 reader to be truly async.

###  What is the type of the changes?
- Bugfix (a change which fixes an issue)
- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?

- Unit test

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?

No

###  Does this PR affect `tidb-ansible`?

No

###  Refer to a related PR or issue link (optional)

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

