### PR TITLE
ucp 7143 wait-for-lock-timeout and wake-up-delay-duration readable

### DIFF
--- a/components/test_raftstore/src/common-test.toml
+++ b/components/test_raftstore/src/common-test.toml
@@ -103,5 +103,5 @@ num-threads = 1
 [gc]
 
 [pessimistic-txn]
-wait-for-lock-timeout = 3000
-wake-up-delay-duration = 100
+wait-for-lock-timeout = "3s"
+wake-up-delay-duration = "100ms"

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -792,15 +792,15 @@
 ## Enable pessimistic transaction
 # enabled = true
 
-## The default and maximum delay in milliseconds before responding to TiDB when pessimistic
+## The default and maximum delay before responding to TiDB when pessimistic
 ## transactions encounter locks
-# wait-for-lock-timeout = 1000
+# wait-for-lock-timeout = "1s"
 
 ## If more than one transaction is waiting for the same lock, only the one with smallest
 ## start timestamp will be waked up immediately when the lock is released. Others will
-## be waked up after `wake_up_delay_duration(ms)` to reduce contention and make the oldest
+## be waked up after `wake_up_delay_duration` to reduce contention and make the oldest
 ## one more likely acquires the lock.
-# wake-up-delay-duration = 20
+# wake-up-delay-duration = "20ms"
 
 ## Enable pipelined pessimistic lock, only effect when processing perssimistic transactions
 ## Enabled this will improve performance, but slightly increase the transcation failure rate

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -361,8 +361,8 @@ impl Scheduler {
         self.notify_scheduler(Task::ChangeRole(role));
     }
 
-    pub fn change_ttl(&self, t: u64) {
-        self.notify_scheduler(Task::ChangeTTL(Duration::from_millis(t)));
+    pub fn change_ttl(&self, t: Duration) {
+        self.notify_scheduler(Task::ChangeTTL(t));
     }
 
     #[cfg(any(test, feature = "testexport"))]
@@ -532,7 +532,7 @@ where
             waiter_mgr_scheduler,
             inner: Rc::new(RefCell::new(Inner {
                 role: Role::Follower,
-                detect_table: DetectTable::new(Duration::from_millis(cfg.wait_for_lock_timeout)),
+                detect_table: DetectTable::new(cfg.wait_for_lock_timeout.into()),
             })),
         }
     }

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -279,6 +279,7 @@ mod tests {
     use self::waiter_manager::tests::*;
     use super::*;
     use raftstore::coprocessor::RegionChangeEvent;
+    use tikv_util::config::ReadableDuration;
     use tikv_util::security::SecurityConfig;
 
     use std::thread;
@@ -293,8 +294,8 @@ mod tests {
 
         let mut lock_mgr = LockManager::new();
         let mut cfg = Config::default();
-        cfg.wait_for_lock_timeout = 3000;
-        cfg.wake_up_delay_duration = 100;
+        cfg.wait_for_lock_timeout = ReadableDuration::millis(3000);
+        cfg.wake_up_delay_duration = ReadableDuration::millis(100);
         lock_mgr.register_detector_role_change_observer(&mut coprocessor_host);
         lock_mgr
             .start(

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -24,6 +24,7 @@ use std::time::{Duration, Instant};
 use futures::{Async, Future, Poll};
 use kvproto::deadlock::WaitForEntry;
 use prometheus::HistogramTimer;
+use tikv_util::config::ReadableDuration;
 use tokio_core::reactor::Handle;
 
 struct DelayInner {
@@ -117,11 +118,11 @@ pub enum Task {
         deadlock_key_hash: u64,
     },
     ChangeConfig {
-        timeout: Option<u64>,
-        delay: Option<u64>,
+        timeout: Option<ReadableDuration>,
+        delay: Option<ReadableDuration>,
     },
     #[cfg(any(test, feature = "testexport"))]
-    Validate(Box<dyn FnOnce(u64, u64) + Send>),
+    Validate(Box<dyn FnOnce(ReadableDuration, ReadableDuration) + Send>),
 }
 
 /// Debug for task.
@@ -432,12 +433,16 @@ impl Scheduler {
         });
     }
 
-    pub fn change_config(&self, timeout: Option<u64>, delay: Option<u64>) {
+    pub fn change_config(
+        &self,
+        timeout: Option<ReadableDuration>,
+        delay: Option<ReadableDuration>,
+    ) {
         self.notify_scheduler(Task::ChangeConfig { timeout, delay });
     }
 
     #[cfg(any(test, feature = "testexport"))]
-    pub fn validate(&self, f: Box<dyn FnOnce(u64, u64) + Send>) {
+    pub fn validate(&self, f: Box<dyn FnOnce(ReadableDuration, ReadableDuration) + Send>) {
         self.notify_scheduler(Task::Validate(f));
     }
 }
@@ -447,12 +452,12 @@ pub struct WaiterManager {
     wait_table: Rc<RefCell<WaitTable>>,
     detector_scheduler: DetectorScheduler,
     /// It is the default and maximum timeout of waiter.
-    default_wait_for_lock_timeout: u64,
+    default_wait_for_lock_timeout: ReadableDuration,
     /// If more than one waiters are waiting for the same lock, only the
     /// oldest one will be waked up immediately when the lock is released.
     /// Others will be waked up after `wake_up_delay_duration` to reduce
     /// contention and make the oldest one more likely acquires the lock.
-    wake_up_delay_duration: u64,
+    wake_up_delay_duration: ReadableDuration,
 }
 
 unsafe impl Send for WaiterManager {}
@@ -472,7 +477,8 @@ impl WaiterManager {
     }
 
     pub fn normalize_deadline(&self, timeout: WaitTimeout) -> Instant {
-        Instant::now() + timeout.into_duration_with_ceiling(self.default_wait_for_lock_timeout)
+        Instant::now()
+            + timeout.into_duration_with_ceiling(self.default_wait_for_lock_timeout.as_millis())
     }
 
     fn handle_wait_for(&mut self, handle: &Handle, waiter: Waiter) {
@@ -505,7 +511,8 @@ impl WaiterManager {
         if wait_table.is_empty() {
             return;
         }
-        let new_timeout = Instant::now() + Duration::from_millis(self.wake_up_delay_duration);
+        let duration: Duration = self.wake_up_delay_duration.into();
+        let new_timeout = Instant::now() + duration;
         for hash in hashes {
             let lock = Lock { ts: lock_ts, hash };
             if let Some((mut oldest, others)) = wait_table.remove_oldest_waiter(lock) {
@@ -546,7 +553,11 @@ impl WaiterManager {
             });
     }
 
-    fn handle_config_change(&mut self, timeout: Option<u64>, delay: Option<u64>) {
+    fn handle_config_change(
+        &mut self,
+        timeout: Option<ReadableDuration>,
+        delay: Option<ReadableDuration>,
+    ) {
         if let Some(timeout) = timeout {
             self.default_wait_for_lock_timeout = timeout;
         }
@@ -555,8 +566,8 @@ impl WaiterManager {
         }
         info!(
             "Waiter manager config changed";
-            "default_wait_for_lock_timeout" => self.default_wait_for_lock_timeout,
-            "wake_up_delay_duration" => self.wake_up_delay_duration
+            "default_wait_for_lock_timeout" => self.default_wait_for_lock_timeout.to_string(),
+            "wake_up_delay_duration" => self.wake_up_delay_duration.to_string()
         );
     }
 }
@@ -621,9 +632,11 @@ pub mod tests {
     use tikv_util::worker::FutureWorker;
 
     use std::sync::mpsc;
+    use std::time::Duration;
 
     use kvproto::kvrpcpb::LockInfo;
     use rand::prelude::*;
+    use tikv_util::config::ReadableDuration;
     use tokio_core::reactor::Core;
 
     fn dummy_waiter(start_ts: TimeStamp, lock_ts: TimeStamp, hash: u64) -> Waiter {
@@ -1034,8 +1047,8 @@ pub mod tests {
         let detector_scheduler = DetectorScheduler::new(detect_worker.scheduler());
 
         let mut cfg = Config::default();
-        cfg.wait_for_lock_timeout = wait_for_lock_timeout;
-        cfg.wake_up_delay_duration = wake_up_delay_duration;
+        cfg.wait_for_lock_timeout = ReadableDuration::millis(wait_for_lock_timeout);
+        cfg.wake_up_delay_duration = ReadableDuration::millis(wake_up_delay_duration);
         let mut waiter_mgr_worker = FutureWorker::new("test-waiter-manager");
         let waiter_mgr_runner =
             WaiterManager::new(Arc::new(AtomicUsize::new(0)), detector_scheduler, &cfg);

--- a/tests/integrations/config/dynamic/pessimistic_txn.rs
+++ b/tests/integrations/config/dynamic/pessimistic_txn.rs
@@ -6,6 +6,7 @@ use tikv::config::*;
 use tikv::server::lock_manager::*;
 use tikv::server::resolve::{Callback, StoreAddrResolver};
 use tikv::server::{Error, Result};
+use tikv_util::config::ReadableDuration;
 use tikv_util::security::SecurityManager;
 
 #[test]
@@ -14,7 +15,7 @@ fn test_config_validate() {
     cfg.validate().unwrap();
 
     let mut invalid_cfg = Config::default();
-    invalid_cfg.wait_for_lock_timeout = 0;
+    invalid_cfg.wait_for_lock_timeout = ReadableDuration::millis(0);
     assert!(invalid_cfg.validate().is_err());
 }
 
@@ -63,7 +64,7 @@ fn setup(
 
 fn validate_waiter<F>(router: &WaiterMgrScheduler, f: F)
 where
-    F: FnOnce(u64, u64) + Send + 'static,
+    F: FnOnce(ReadableDuration, ReadableDuration) + Send + 'static,
 {
     let (tx, rx) = mpsc::channel();
     router.validate(Box::new(move |v1, v2| {
@@ -90,8 +91,8 @@ fn test_lock_manager_cfg_update() {
     const DEFAULT_TIMEOUT: u64 = 3000;
     const DEFAULT_DELAY: u64 = 100;
     let mut cfg = TiKvConfig::default();
-    cfg.pessimistic_txn.wait_for_lock_timeout = DEFAULT_TIMEOUT;
-    cfg.pessimistic_txn.wake_up_delay_duration = DEFAULT_DELAY;
+    cfg.pessimistic_txn.wait_for_lock_timeout = ReadableDuration::millis(DEFAULT_TIMEOUT);
+    cfg.pessimistic_txn.wake_up_delay_duration = ReadableDuration::millis(DEFAULT_DELAY);
     cfg.validate().unwrap();
     let (mut cfg_controller, waiter, deadlock, mut lock_mgr) = setup(cfg.clone());
 
@@ -100,23 +101,29 @@ fn test_lock_manager_cfg_update() {
     incoming.raft_store.raft_log_gc_threshold = 2000;
     let rollback = cfg_controller.update_or_rollback(incoming).unwrap();
     assert_eq!(rollback.right(), Some(true));
-    validate_waiter(&waiter, move |timeout: u64, delay: u64| {
-        assert_eq!(timeout, DEFAULT_TIMEOUT);
-        assert_eq!(delay, DEFAULT_DELAY);
-    });
+    validate_waiter(
+        &waiter,
+        move |timeout: ReadableDuration, delay: ReadableDuration| {
+            assert_eq!(timeout.as_millis(), DEFAULT_TIMEOUT);
+            assert_eq!(delay.as_millis(), DEFAULT_DELAY);
+        },
+    );
     validate_dead_lock(&deadlock, move |ttl: u64| {
         assert_eq!(ttl, DEFAULT_TIMEOUT);
     });
 
     // only update wake_up_delay_duration
     let mut incoming = cfg.clone();
-    incoming.pessimistic_txn.wake_up_delay_duration = 500;
+    incoming.pessimistic_txn.wake_up_delay_duration = ReadableDuration::millis(500);
     let rollback = cfg_controller.update_or_rollback(incoming).unwrap();
     assert_eq!(rollback.right(), Some(true));
-    validate_waiter(&waiter, move |timeout: u64, delay: u64| {
-        assert_eq!(timeout, DEFAULT_TIMEOUT);
-        assert_eq!(delay, 500);
-    });
+    validate_waiter(
+        &waiter,
+        move |timeout: ReadableDuration, delay: ReadableDuration| {
+            assert_eq!(timeout.as_millis(), DEFAULT_TIMEOUT);
+            assert_eq!(delay.as_millis(), 500);
+        },
+    );
     validate_dead_lock(&deadlock, move |ttl: u64| {
         // dead lock ttl should not change
         assert_eq!(ttl, DEFAULT_TIMEOUT);
@@ -124,30 +131,36 @@ fn test_lock_manager_cfg_update() {
 
     // only update wait_for_lock_timeout
     let mut incoming = cfg.clone();
-    incoming.pessimistic_txn.wait_for_lock_timeout = 4000;
+    incoming.pessimistic_txn.wait_for_lock_timeout = ReadableDuration::millis(4000);
     // keep wake_up_delay_duration the same as last update
-    incoming.pessimistic_txn.wake_up_delay_duration = 500;
+    incoming.pessimistic_txn.wake_up_delay_duration = ReadableDuration::millis(500);
     let rollback = cfg_controller.update_or_rollback(incoming).unwrap();
     assert_eq!(rollback.right(), Some(true));
-    validate_waiter(&waiter, move |timeout: u64, delay: u64| {
-        assert_eq!(timeout, 4000);
-        // wake_up_delay_duration should be the same as last update
-        assert_eq!(delay, 500);
-    });
+    validate_waiter(
+        &waiter,
+        move |timeout: ReadableDuration, delay: ReadableDuration| {
+            assert_eq!(timeout.as_millis(), 4000);
+            // wake_up_delay_duration should be the same as last update
+            assert_eq!(delay.as_millis(), 500);
+        },
+    );
     validate_dead_lock(&deadlock, move |ttl: u64| {
         assert_eq!(ttl, 4000);
     });
 
     // update both config
     let mut incoming = cfg;
-    incoming.pessimistic_txn.wait_for_lock_timeout = 4321;
-    incoming.pessimistic_txn.wake_up_delay_duration = 123;
+    incoming.pessimistic_txn.wait_for_lock_timeout = ReadableDuration::millis(4321);
+    incoming.pessimistic_txn.wake_up_delay_duration = ReadableDuration::millis(123);
     let rollback = cfg_controller.update_or_rollback(incoming).unwrap();
     assert_eq!(rollback.right(), Some(true));
-    validate_waiter(&waiter, move |timeout: u64, delay: u64| {
-        assert_eq!(timeout, 4321);
-        assert_eq!(delay, 123);
-    });
+    validate_waiter(
+        &waiter,
+        move |timeout: ReadableDuration, delay: ReadableDuration| {
+            assert_eq!(timeout.as_millis(), 4321);
+            assert_eq!(delay.as_millis(), 123);
+        },
+    );
     validate_dead_lock(&deadlock, move |ttl: u64| {
         assert_eq!(ttl, 4321);
     });

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -572,8 +572,8 @@ fn test_serde_custom_tikv_config() {
     };
     value.pessimistic_txn = PessimisticTxnConfig {
         enabled: false,
-        wait_for_lock_timeout: 10,
-        wake_up_delay_duration: 100,
+        wait_for_lock_timeout: ReadableDuration::millis(10),
+        wake_up_delay_duration: ReadableDuration::millis(100),
         pipelined: true,
     };
 

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -488,7 +488,7 @@ max-write-bytes-per-sec = "10MB"
 
 [pessimistic-txn]
 enabled = false
-wait-for-lock-timeout = 10
-wake-up-delay-duration = 100
+wait-for-lock-timeout = "10ms"
+wake-up-delay-duration = "100ms"
 pipelined = true
 

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -489,6 +489,6 @@ max-write-bytes-per-sec = "10MB"
 [pessimistic-txn]
 enabled = false
 wait-for-lock-timeout = "10ms"
-wake-up-delay-duration = "100ms"
+wake-up-delay-duration = 100 # test backward compatible
 pipelined = true
 


### PR DESCRIPTION
UCP #7143 

Signed-off-by: ssebo <ssebo.zzz@gmail.com>

###  What have you changed?
change wake-up-delay-duration and wait-for-lock-timeout from u64 to ReadableDuration

###  What is the type of the changes?
<!--
Pick one of the following and delete the others:
-->

- Engineering (engineering change which doesn't change any feature or fix any issue)

###  How is the PR tested?
<!--
Please select the tests that you ran to verify your changes:
-->
CI

###  Does this PR affect documentation (docs) or should it be mentioned in the release notes?
no

###  Does this PR affect `tidb-ansible`?

https://github.com/pingcap/tidb-ansible/pull/1216

###  Refer to a related PR or issue link (optional)

https://github.com/tikv/tikv/issues/7143

###  Benchmark result if necessary (optional)

###  Any examples? (optional)

