### PR TITLE
tests: added more tests for pipelined acquire pessimistic lock

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4089,7 +4089,7 @@ mod tests {
             storage
                 .sched_txn_command(
                     commands::Commit::new(
-                        vec![key.clone()],
+                        vec![key],
                         start_ts.into(),
                         commit_ts.into(),
                         Context::default(),
@@ -4149,7 +4149,7 @@ mod tests {
 
         if !pipelined_pessimistic_lock {
             // No amending if not pipelined_pessimistic_lock
-            expect_prewrite_result(&storage, key.clone(), 10, 10, false, None);
+            expect_prewrite_result(&storage, key, 10, 10, false, None);
         } else {
             // Should be Amended if it's inserting key
             expect_prewrite_result(&storage, key.clone(), 10, 10, true, None);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4170,12 +4170,12 @@ mod tests {
             rx.recv().unwrap();
 
             // Can't ammend when another txn locked the key
-            expect_prewrite_result(&storage, key.clone(), 25, 25, false, None);
-            commit_changes(&storage, key.clone(), 30, 31);
-            expect_prewrite_result(&storage, key.clone(), 30, 30, false, None);
-            expect_prewrite_result(&storage, key.clone(), 31, 31, false, None);
-            expect_prewrite_result(&storage, key.clone(), 32, 32, true, None);
-            expect_prewrite_result(&storage, key.clone(), 32, 32, true, Some(33));
+            expect_prewrite_result(&storage, key, 25, 25, false, None);
+            commit_changes(&storage, key, 30, 31);
+            expect_prewrite_result(&storage, key, 30, 30, false, None);
+            expect_prewrite_result(&storage, key, 31, 31, false, None);
+            expect_prewrite_result(&storage, key, 32, 32, true, None);
+            expect_prewrite_result(&storage, key, 32, 32, true, Some(33));
         }
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4137,8 +4137,8 @@ mod tests {
             rx.recv().unwrap();
 
             if should_succeed {
-                if commit_ts.is_some() {
-                    commit_changes(&storage, &key, start_ts, commit_ts.unwrap());
+                if let Some(commit_ts) = commit_ts {
+                    commit_changes(&storage, &key, start_ts, commit_ts);
                 } else {
                     delete_pessimistic_lock(&storage, key.clone(), start_ts, for_update_ts);
                 }

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -280,6 +280,7 @@ impl<E: Engine, S: MsgScheduler, L: LockManager> Executor<E, S, L> {
                     };
                     // The callback to receive async results of write prepare from the storage engine.
                     let engine_cb = Box::new(move |(_, result)| {
+                        fail_point!("pipelined_txn_write_finished");
                         sched_pool
                             .pool
                             .spawn(move || {
@@ -308,6 +309,7 @@ impl<E: Engine, S: MsgScheduler, L: LockManager> Executor<E, S, L> {
                         let err = e.into();
                         Msg::FinishedWithErr { cid, err, tag }
                     } else if pipelined {
+                        fail_point!("pipelined_txn_return_to_caller");
                         // The write task is scheduled to engine successfully.
                         // Respond to client early.
                         Msg::PipelinedWrite {

--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -2,6 +2,7 @@
 
 use fail;
 use tikv::storage::mvcc::tests::*;
+use tikv::storage::tests_util::*;
 use tikv::storage::TestEngineBuilder;
 
 #[test]
@@ -15,4 +16,14 @@ fn test_txn_failpoints() {
     fail::cfg("commit", "delay(100)").unwrap();
     must_commit(&engine, k, 10, 20);
     fail::remove("commit");
+}
+
+#[test]
+fn test_pipelined_txn_failpoints() {
+    fail::cfg("pipelined_txn_write_finished", "delay(200)").unwrap();
+    test_pessimistic_lock_impl(true);
+    fail::remove("pipelined_txn_write_finished");
+    fail::cfg("pipelined_txn_return_to_caller", "delay(00)").unwrap();
+    test_pessimistic_lock_impl(true);
+    fail::remove("pipelined_txn_return_to_caller");
 }


### PR DESCRIPTION
Signed-off-by: Liu Cong <innerr@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
  - Add more test cases to pipelined-acquire-pessimistic-lock: #6984

### What is changed and how it works?
  - Add unittest cases
  - Add failpoint to test pipelined-txn under different event order 

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects
  - No