### PR TITLE
tidb_query: supports group by a constant

### DIFF
--- a/components/tidb_query_vec_executors/src/fast_hash_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/fast_hash_aggr_executor.rs
@@ -21,7 +21,7 @@ use tidb_query_datatype::codec::collation::{match_template_collator, SortKey};
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::expr::{EvalConfig, EvalContext};
 use tidb_query_vec_aggr::*;
-use tidb_query_vec_expr::{RpnExpression, RpnExpressionBuilder};
+use tidb_query_vec_expr::{RpnExpression, RpnExpressionBuilder, RpnStackNode};
 
 pub macro match_template_hashable($t:tt, $($tail:tt)*) {
     match_template::match_template! {
@@ -92,9 +92,6 @@ impl BatchFastHashAggregationExecutor<Box<dyn BatchExecutor<StorageStats = ()>>>
         }
 
         RpnExpressionBuilder::check_expr_tree_supported(def)?;
-        if RpnExpressionBuilder::is_expr_eval_to_scalar(def)? {
-            return Err(other_err!("Group by expression is not a column"));
-        }
 
         let aggr_definitions = descriptor.get_agg_func();
         for def in aggr_definitions {
@@ -238,7 +235,6 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for FastHashAggregationImp
     ) -> Result<()> {
         // 1. Calculate which group each src row belongs to.
         self.states_offset_each_logical_row.clear();
-
         let group_by_result = self.group_by_exp.eval(
             &mut entities.context,
             entities.src.schema(),
@@ -246,57 +242,82 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for FastHashAggregationImp
             input_logical_rows,
             input_logical_rows.len(),
         )?;
-        // Unwrap is fine because we have verified the group by expression before.
-        let group_by_value = group_by_result.vector_value().unwrap();
-        let group_by_physical_vec = group_by_value.as_ref();
-        let group_by_logical_rows = group_by_value.logical_rows();
 
-        match_template::match_template! {
-            TT = [Int, Real, Duration, Decimal, DateTime],
-            match group_by_physical_vec {
-                VectorValue::TT(v) => {
-                    if let Groups::TT(group) = &mut self.groups {
-                        calc_groups_each_row(
-                            v,
-                            group_by_logical_rows,
-                            &entities.each_aggr_fn,
-                            group,
-                            &mut self.states,
-                            &mut self.states_offset_each_logical_row,
-                            |val| Ok(val)
-                        )?;
-                    } else {
-                        panic!();
-                    }
-                },
-                VectorValue::Bytes(v) => {
-                    if let Groups::Bytes(group) = &mut self.groups {
-                        match_template_collator!(
-                            TT,
-                            match self.group_by_field_type.collation().map_err(tidb_query_datatype::codec::Error::from)? {
-                                Collation::TT => {
-                                    #[allow(clippy::transmute_ptr_to_ptr)]
-                                    let group: &mut HashMap<Option<SortKey<Bytes, TT>>, usize> =
-                                        unsafe { std::mem::transmute(group) };
-                                    calc_groups_each_row(
-                                        v,
-                                        group_by_logical_rows,
-                                        &entities.each_aggr_fn,
-                                        group,
-                                        &mut self.states,
-                                        &mut self.states_offset_each_logical_row,
-                                        |val| Ok(SortKey::map_option(val)?)
-                                    )?;
-                                }
+        match group_by_result {
+            RpnStackNode::Scalar { value, .. } => {
+                match_template::match_template! {
+                    TT = [Int, Bytes, Real, Duration, Decimal, DateTime],
+                    match value {
+                        ScalarValue::TT(v) => {
+                            if let Groups::TT(group) = &mut self.groups {
+                                extend_states_for_each_row(
+                                    v,
+                                    &entities.each_aggr_fn,
+                                    group,
+                                    &mut self.states,
+                                    input_logical_rows.len(),
+                                    &mut self.states_offset_each_logical_row,
+                                )?;
+                            } else {
+                                panic!();
                             }
-                        )
-                    } else {
-                        panic!();
+                        },
+                        _ => unreachable!(),
                     }
-                },
-                _ => unreachable!(),
+                }
             }
-        }
+            RpnStackNode::Vector { value, .. } => {
+                let group_by_physical_vec = value.as_ref();
+                let group_by_logical_rows = value.logical_rows();
+
+                match_template::match_template! {
+                    TT = [Int, Real, Duration, Decimal, DateTime],
+                    match group_by_physical_vec {
+                        VectorValue::TT(v) => {
+                            if let Groups::TT(group) = &mut self.groups {
+                                calc_groups_each_row(
+                                    v,
+                                    group_by_logical_rows,
+                                    &entities.each_aggr_fn,
+                                    group,
+                                    &mut self.states,
+                                    &mut self.states_offset_each_logical_row,
+                                    |val| Ok(val)
+                                )?;
+                            } else {
+                                panic!();
+                            }
+                        },
+                        VectorValue::Bytes(v) => {
+                            if let Groups::Bytes(group) = &mut self.groups {
+                                match_template_collator!(
+                                    TT,
+                                    match self.group_by_field_type.collation().map_err(tidb_query_datatype::codec::Error::from)? {
+                                        Collation::TT => {
+                                            #[allow(clippy::transmute_ptr_to_ptr)]
+                                            let group: &mut HashMap<Option<SortKey<Bytes, TT>>, usize> =
+                                                unsafe { std::mem::transmute(group) };
+                                            calc_groups_each_row(
+                                                v,
+                                                group_by_logical_rows,
+                                                &entities.each_aggr_fn,
+                                                group,
+                                                &mut self.states,
+                                                &mut self.states_offset_each_logical_row,
+                                                |val| Ok(SortKey::map_option(val)?)
+                                            )?;
+                                        }
+                                    }
+                                )
+                            } else {
+                                panic!();
+                            }
+                        },
+                        _ => unreachable!(),
+                    }
+                }
+            }
+        };
 
         // 2. Update states according to the group.
         HashAggregationHelper::update_each_row_states_by_offset(
@@ -392,6 +413,35 @@ where
     Ok(())
 }
 
+fn extend_states_for_each_row<T>(
+    scalar_value: &Option<T>,
+    aggr_fns: &[Box<dyn AggrFunction>],
+    group: &mut HashMap<Option<T>, usize>,
+    states: &mut Vec<Box<dyn AggrFunctionState>>,
+    logical_row_len: usize,
+    states_offset_each_logical_row: &mut Vec<usize>,
+) -> Result<()>
+where
+    T: Hash + Eq + Clone,
+{
+    if group.is_empty() {
+        group.insert(scalar_value.clone(), 0);
+        for aggr_fn in aggr_fns {
+            states.push(aggr_fn.create_state());
+        }
+    } else if !group.contains_key(scalar_value) {
+        // As a constant group-by expression, all scalar results it produce
+        // should be the same.
+        panic!();
+    }
+
+    for _ in 0..logical_row_len {
+        states_offset_each_logical_row.push(0);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -405,14 +455,13 @@ mod tests {
     use tidb_query_datatype::expr::EvalWarnings;
     use tidb_query_vec_expr::impl_arithmetic::{arithmetic_fn_meta, RealPlus};
     use tidb_query_vec_expr::{RpnExpression, RpnExpressionBuilder};
+    use tipb::ExprType;
+    use tipb_helper::ExprDefBuilder;
 
     // Test cases also cover BatchSlowHashAggregationExecutor.
 
     #[test]
     fn test_it_works_integration() {
-        use tipb::ExprType;
-        use tipb_helper::ExprDefBuilder;
-
         // This test creates a hash aggregation executor with the following aggregate functions:
         // - COUNT(1)
         // - COUNT(col_1 + 5.0)
@@ -537,6 +586,92 @@ mod tests {
             assert_eq!(
                 &ordered_column,
                 &[Real::new(7.0).ok(), Real::new(1.5).ok(), None]
+            );
+        }
+    }
+
+    #[test]
+    fn test_group_by_a_constant() {
+        use tipb::ExprType;
+        use tipb_helper::ExprDefBuilder;
+
+        let group_by_exp = || {
+            RpnExpressionBuilder::new_for_test()
+                .push_constant_for_test(1) // Group by a constant
+                .build_for_test()
+        };
+
+        let aggr_definitions = || {
+            vec![
+                ExprDefBuilder::aggr_func(ExprType::Count, FieldTypeTp::LongLong)
+                    .push_child(ExprDefBuilder::constant_int(1))
+                    .build(),
+                ExprDefBuilder::aggr_func(ExprType::Count, FieldTypeTp::LongLong)
+                    .push_child(
+                        ExprDefBuilder::scalar_func(ScalarFuncSig::PlusReal, FieldTypeTp::Double)
+                            .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::Double))
+                            .push_child(ExprDefBuilder::constant_real(5.0)),
+                    )
+                    .build(),
+                ExprDefBuilder::aggr_func(ExprType::Avg, FieldTypeTp::Double)
+                    .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::Double))
+                    .build(),
+            ]
+        };
+
+        let exec_fast = |src_exec| {
+            Box::new(BatchFastHashAggregationExecutor::new_for_test(
+                src_exec,
+                group_by_exp(),
+                aggr_definitions(),
+                AllAggrDefinitionParser,
+            )) as Box<dyn BatchExecutor<StorageStats = ()>>
+        };
+
+        let exec_slow = |src_exec| {
+            Box::new(BatchSlowHashAggregationExecutor::new_for_test(
+                src_exec,
+                vec![group_by_exp()],
+                aggr_definitions(),
+                AllAggrDefinitionParser,
+            )) as Box<dyn BatchExecutor<StorageStats = ()>>
+        };
+        let executor_builders: Vec<Box<dyn FnOnce(MockExecutor) -> _>> =
+            // vec![Box::new(exec_fast)];
+            vec![Box::new(exec_fast), Box::new(exec_slow)];
+
+        for exec_builder in executor_builders {
+            let src_exec = make_src_executor_1();
+            let mut exec = exec_builder(src_exec);
+
+            let r = exec.next_batch(1);
+            assert!(r.logical_rows.is_empty());
+            assert_eq!(r.physical_columns.rows_len(), 0);
+            assert!(!r.is_drained.unwrap());
+
+            let r = exec.next_batch(1);
+            assert!(r.logical_rows.is_empty());
+            assert_eq!(r.physical_columns.rows_len(), 0);
+            assert!(!r.is_drained.unwrap());
+
+            let mut r = exec.next_batch(1);
+            assert_eq!(&r.logical_rows, &[0]);
+            assert_eq!(r.physical_columns.rows_len(), 1);
+            assert_eq!(r.physical_columns.columns_len(), 5); // 4 result column, 1 group by column
+
+            r.physical_columns[4]
+                .ensure_all_decoded_for_test(&mut EvalContext::default(), &exec.schema()[4])
+                .unwrap();
+
+            // Group by a constant, So should be only one group.
+            assert_eq!(r.physical_columns[4].decoded().as_int_slice().len(), 1);
+
+            assert_eq!(r.physical_columns[0].decoded().as_int_slice(), &[Some(5)]);
+            assert_eq!(r.physical_columns[1].decoded().as_int_slice(), &[Some(4)]);
+            assert_eq!(r.physical_columns[2].decoded().as_int_slice(), &[Some(2)]);
+            assert_eq!(
+                r.physical_columns[3].decoded().as_real_slice(),
+                &[Real::new(8.5).ok()]
             );
         }
     }

--- a/components/tidb_query_vec_executors/src/fast_hash_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/fast_hash_aggr_executor.rs
@@ -250,7 +250,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for FastHashAggregationImp
                     match value {
                         ScalarValue::TT(v) => {
                             if let Groups::TT(group) = &mut self.groups {
-                                extend_states_for_each_row(
+                                handle_scalar_group_each_row(
                                     v,
                                     &entities.each_aggr_fn,
                                     group,
@@ -413,7 +413,7 @@ where
     Ok(())
 }
 
-fn extend_states_for_each_row<T>(
+fn handle_scalar_group_each_row<T>(
     scalar_value: &Option<T>,
     aggr_fns: &[Box<dyn AggrFunction>],
     group: &mut HashMap<Option<T>, usize>,

--- a/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
@@ -290,7 +290,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SlowHashAggregationImp
                         self.group_key_offsets.push(self.group_key_buffer.len());
                     }
                     RpnStackNode::Scalar { value, field_type } => {
-                        if let None = self.cached_encoded_result[i] {
+                        if self.cached_encoded_result[i].is_none() {
                             let mut cache_result = vec![];
                             value.as_scalar_value_ref().encode_sort_key(
                                 field_type,
@@ -330,7 +330,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SlowHashAggregationImp
                         debug_assert!(value.eval_type() == EvalType::Bytes);
 
                         let i = i + self.group_by_exps.len();
-                        if let None = self.cached_encoded_result[i] {
+                        if self.cached_encoded_result[i].is_none() {
                             let mut cache_result = vec![];
                             value.as_scalar_value_ref().encode(
                                 field_type,

--- a/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
@@ -480,11 +480,15 @@ mod tests {
         // - AVG(col_0 + 5.0)
         // And group by:
         // - col_4
+        // - 1 (Constant)
         // - col_0 + 1
 
         let group_by_exps = vec![
             RpnExpressionBuilder::new_for_test()
                 .push_column_ref_for_test(4)
+                .build_for_test(),
+            RpnExpressionBuilder::new_for_test()
+                .push_constant_for_test(1)
                 .build_for_test(),
             RpnExpressionBuilder::new_for_test()
                 .push_column_ref_for_test(0)
@@ -526,48 +530,79 @@ mod tests {
 
         let mut r = exec.next_batch(1);
         // col_4 (sort_key),    col_0 + 1 can result in:
-        // aaa,                 8
-        // aa,                  NULL
-        // ááá,                 2.5
         // NULL,                NULL
-        // Thus there are 4 groups.
+        // aa,                  NULL
+        // aaa,                 8
+        // ááá,                 2.5
         assert_eq!(&r.logical_rows, &[0, 1, 2, 3]);
         assert_eq!(r.physical_columns.rows_len(), 4);
-        assert_eq!(r.physical_columns.columns_len(), 5); // 3 result column, 2 group by column
+        assert_eq!(r.physical_columns.columns_len(), 6); // 3 result column, 3 group by column
 
         let mut ctx = EvalContext::default();
-        // Let's check the two group by column first.
+        // Let's check the three group by column first.
         r.physical_columns[3]
             .ensure_all_decoded_for_test(&mut ctx, &exec.schema()[3])
             .unwrap();
+        r.physical_columns[4]
+            .ensure_all_decoded_for_test(&mut EvalContext::default(), &exec.schema()[4])
+            .unwrap();
+        r.physical_columns[5]
+            .ensure_all_decoded_for_test(&mut EvalContext::default(), &exec.schema()[5])
+            .unwrap();
+
+        // The row order is not defined. Let's sort it by the group by column before asserting.
+        let mut sort_column: Vec<(usize, _)> = r.physical_columns[3]
+            .decoded()
+            .as_bytes_slice()
+            .iter()
+            .enumerate()
+            .collect();
+        sort_column.sort_by(|a, b| a.1.cmp(&b.1));
+
+        // Use the order of the sorted column to sort other columns
+        let ordered_column: Vec<_> = sort_column
+            .iter()
+            .map(|(idx, _)| r.physical_columns[3].decoded().as_bytes_slice()[*idx].clone())
+            .collect();
         assert_eq!(
-            r.physical_columns[3].decoded().as_bytes_slice(),
+            &ordered_column,
             &[
-                Some("aaa".as_bytes().to_vec()),
-                Some("aa".as_bytes().to_vec()),
-                Some("ááá".as_bytes().to_vec()),
                 None,
+                Some(b"aa".to_vec()),
+                Some(b"aaa".to_vec()),
+                Some("ááá".as_bytes().to_vec())
             ]
         );
-        r.physical_columns[4]
-            .ensure_all_decoded_for_test(&mut ctx, &exec.schema()[4])
-            .unwrap();
         assert_eq!(
-            r.physical_columns[4].decoded().as_real_slice(),
-            &[Real::new(8.0).ok(), None, Real::new(2.5).ok(), None]
+            r.physical_columns[4].decoded().as_int_slice(),
+            &[Some(1), Some(1), Some(1), Some(1)]
+        );
+        let ordered_column: Vec<_> = sort_column
+            .iter()
+            .map(|(idx, _)| r.physical_columns[5].decoded().as_real_slice()[*idx].clone())
+            .collect();
+        assert_eq!(
+            &ordered_column,
+            &[None, None, Real::new(8.0).ok(), Real::new(2.5).ok()]
         );
 
+        let ordered_column: Vec<_> = sort_column
+            .iter()
+            .map(|(idx, _)| r.physical_columns[0].decoded().as_int_slice()[*idx].clone())
+            .collect();
+        assert_eq!(&ordered_column, &[Some(1), Some(2), Some(1), Some(1)]);
+        let ordered_column: Vec<_> = sort_column
+            .iter()
+            .map(|(idx, _)| r.physical_columns[1].decoded().as_int_slice()[*idx].clone())
+            .collect();
+        assert_eq!(&ordered_column, &[Some(0), Some(0), Some(1), Some(1)]);
+        let ordered_column: Vec<_> = sort_column
+            .iter()
+            .map(|(idx, _)| r.physical_columns[2].decoded().as_real_slice()[*idx].clone())
+            .collect();
         assert_eq!(
-            r.physical_columns[0].decoded().as_int_slice(),
-            &[Some(1), Some(2), Some(1), Some(1)]
-        );
-        assert_eq!(
-            r.physical_columns[1].decoded().as_int_slice(),
-            &[Some(1), Some(0), Some(1), Some(0)]
-        );
-        assert_eq!(
-            r.physical_columns[2].decoded().as_real_slice(),
-            &[Real::new(12.0).ok(), None, Real::new(6.5).ok(), None]
+            &ordered_column,
+            &[None, None, Real::new(12.0).ok(), Real::new(6.5).ok()]
         );
     }
 }

--- a/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
@@ -579,7 +579,7 @@ mod tests {
         );
         let ordered_column: Vec<_> = sort_column
             .iter()
-            .map(|(idx, _)| r.physical_columns[5].decoded().as_real_slice()[*idx].clone())
+            .map(|(idx, _)| r.physical_columns[5].decoded().as_real_slice()[*idx])
             .collect();
         assert_eq!(
             &ordered_column,
@@ -588,17 +588,17 @@ mod tests {
 
         let ordered_column: Vec<_> = sort_column
             .iter()
-            .map(|(idx, _)| r.physical_columns[0].decoded().as_int_slice()[*idx].clone())
+            .map(|(idx, _)| r.physical_columns[0].decoded().as_int_slice()[*idx])
             .collect();
         assert_eq!(&ordered_column, &[Some(1), Some(2), Some(1), Some(1)]);
         let ordered_column: Vec<_> = sort_column
             .iter()
-            .map(|(idx, _)| r.physical_columns[1].decoded().as_int_slice()[*idx].clone())
+            .map(|(idx, _)| r.physical_columns[1].decoded().as_int_slice()[*idx])
             .collect();
         assert_eq!(&ordered_column, &[Some(0), Some(0), Some(1), Some(1)]);
         let ordered_column: Vec<_> = sort_column
             .iter()
-            .map(|(idx, _)| r.physical_columns[2].decoded().as_real_slice()[*idx].clone())
+            .map(|(idx, _)| r.physical_columns[2].decoded().as_real_slice()[*idx])
             .collect();
         assert_eq!(
             &ordered_column,

--- a/components/tidb_query_vec_executors/src/stream_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/stream_aggr_executor.rs
@@ -62,7 +62,6 @@ impl BatchStreamAggregationExecutor<Box<dyn BatchExecutor<StorageStats = ()>>> {
         assert!(!group_by_definitions.is_empty());
         for def in group_by_definitions {
             RpnExpressionBuilder::check_expr_tree_supported(def)?;
-            // Works for both vector and scalar. No need to check as other aggregation executor.
         }
 
         let aggr_definitions = descriptor.get_agg_func();


### PR DESCRIPTION
Signed-off-by: zhongzc <zhongzc_arch@outlook.com>

### What problem does this PR solve?

close pingcap/tidb#15488

At pingcap/tidb#15541, @tangenta attempted to eliminate the GROUP BY expression to resolve the problem, as I indicated in the issue. However, we later found that the behaviors are unexpected when the table is empty.
So, I chose to let tikv copr support GROUP BY a constant now.

### What is changed and how it works?

- Remove the check for Scalar being GROUP BY expression.
- Support Scalar(constant) as a group key.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test