### PR TITLE
cdc: fix pd client was blocked by get_tso

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -158,6 +158,7 @@ pub struct Endpoint<T> {
     timer: SteadyTimer,
     min_ts_interval: Duration,
     scan_batch_size: usize,
+    tso_worker: ThreadPool,
 
     workers: ThreadPool,
 }
@@ -170,11 +171,13 @@ impl<T: CasualRouter<RocksEngine>> Endpoint<T> {
         observer: CdcObserver,
     ) -> Endpoint<T> {
         let workers = Builder::new().name_prefix("cdcwkr").pool_size(4).build();
+        let tso_worker = Builder::new().name_prefix("tso").pool_size(1).build();
         let ep = Endpoint {
             capture_regions: HashMap::default(),
             connections: HashMap::default(),
             scheduler,
             pd_client,
+            tso_worker,
             timer: SteadyTimer::default(),
             workers,
             raft_router,
@@ -416,7 +419,7 @@ impl<T: CasualRouter<RocksEngine>> Endpoint<T> {
                 }
             },
         );
-        self.pd_client.spawn(Box::new(fut) as _);
+        self.tso_worker.spawn(fut);
     }
 
     fn on_open_conn(&mut self, conn: Conn) {

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -617,14 +617,6 @@ impl PdClient for RpcClient {
             .request(req, executor, LEADER_CHANGE_RETRY)
             .execute()
     }
-
-    fn spawn(&self, future: PdFuture<()>) {
-        self.leader_client
-            .inner
-            .rl()
-            .client_stub
-            .spawn(future.map_err(|_| ()));
-    }
 }
 
 impl ConfigClient for RpcClient {

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -238,11 +238,6 @@ pub trait PdClient: Send + Sync {
     fn get_tso(&self) -> PdFuture<TimeStamp> {
         unimplemented!()
     }
-
-    /// Spawns a PD future on the client.
-    fn spawn(&self, _: PdFuture<()>) {
-        unimplemented!()
-    }
 }
 
 /// ConfigClient used for manage config


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/7124

Problem Summary: CDC endpoint creates a tick for getting tso periodically by using pd client. When the connection to pd is broken, it will try to reconnect and wait for the response, but the action for reconnecting is at the same thread, then this thread will be blocked forever.

### What is changed and how it works?

Create a new thread for retrying to reconnect and waiting for the response.

What's Changed:

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  I don't see any way to verify it by the unit test.

### Release note <!-- bugfixes or new feature need a release note -->
Fix the bug that causes the pd client is blocked forever when the pd leader is restarted or transferred.
