### PR TITLE
coprocessor: differentiate real/int/decimal for `not` expression (#5005)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git?branch=release-2.1#d45097684124a665f0017d08074cdee97150dc76"
+source = "git+https://github.com/pingcap/tipb.git?branch=release-2.1#79a721ff4a15618239745e85933570aab87b1acb"
 dependencies = [
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/coprocessor/dag/expr/scalar_function.rs
+++ b/src/coprocessor/dag/expr/scalar_function.rs
@@ -173,7 +173,9 @@ impl ScalarFunc {
             | ScalarFuncSig::DayOfWeek
             | ScalarFuncSig::DayOfYear
             | ScalarFuncSig::Year
-            | ScalarFuncSig::UnaryNot
+            | ScalarFuncSig::UnaryNotInt
+            | ScalarFuncSig::UnaryNotReal
+            | ScalarFuncSig::UnaryNotDecimal
             | ScalarFuncSig::UnaryMinusInt
             | ScalarFuncSig::UnaryMinusReal
             | ScalarFuncSig::UnaryMinusDecimal
@@ -543,7 +545,9 @@ dispatch_call! {
         LogicalOr => logical_or,
         LogicalXor => logical_xor,
 
-        UnaryNot => unary_not,
+        UnaryNotInt => unary_not_int,
+        UnaryNotReal => unary_not_real,
+        UnaryNotDecimal => unary_not_decimal,
         UnaryMinusInt => unary_minus_int,
         IntIsNull => int_is_null,
         IntIsFalse => int_is_false,
@@ -939,7 +943,9 @@ mod test {
                     ScalarFuncSig::DayOfWeek,
                     ScalarFuncSig::DayOfYear,
                     ScalarFuncSig::Year,
-                    ScalarFuncSig::UnaryNot,
+                    ScalarFuncSig::UnaryNotInt,
+                    ScalarFuncSig::UnaryNotReal,
+                    ScalarFuncSig::UnaryNotDecimal,
                     ScalarFuncSig::UnaryMinusInt,
                     ScalarFuncSig::UnaryMinusReal,
                     ScalarFuncSig::UnaryMinusDecimal,


### PR DESCRIPTION
cherry-pick https://github.com/tikv/tikv/pull/5005

TiPB change: https://github.com/pingcap/tipb/pull/149
TiDB change: https://github.com/pingcap/tidb/pull/15915