### PR TITLE
copr: add non-vectorize JsonValidJson

### DIFF
--- a/components/tidb_query_normal_expr/src/scalar_function.rs
+++ b/components/tidb_query_normal_expr/src/scalar_function.rs
@@ -308,7 +308,8 @@ impl ScalarFunc {
             | ScalarFuncSig::OctInt
             | ScalarFuncSig::JsonDepthSig
             | ScalarFuncSig::RandomBytes
-            | ScalarFuncSig::JsonKeysSig => (1, 1),
+            | ScalarFuncSig::JsonKeysSig
+            | ScalarFuncSig::JsonValidJsonSig => (1, 1),
 
             ScalarFuncSig::JsonKeys2ArgsSig | ScalarFuncSig::JsonLengthSig => (1, 2),
 
@@ -741,6 +742,7 @@ dispatch_call! {
         Strcmp => strcmp,
         Instr => instr,
         JsonLengthSig => json_length,
+        JsonValidJsonSig => json_valid_json,
         Ord => ord,
         InstrUtf8 => instr_utf8,
         JsonDepthSig => json_depth,


### PR DESCRIPTION
Signed-off-by: aooohooo <aooohooo123@gmail.com>

UCP #6798 

Checklist #5751 

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #6798  <!-- REMOVE this line if no issue to close -->

Problem Summary: add non-vectorize JsonValidJson

### What is changed and how it works?

What's Changed: Port the scalar function JsonValidJson from TiDB to coprocessor.

### Related changes

- No

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->