### PR TITLE
Store encryption_key_manager in TiKVServer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "cdc",
  "chrono",
  "clap",
+ "encryption",
  "engine",
  "engine_rocks",
  "engine_traits",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -55,6 +55,7 @@ backup = { path = "../components/backup", default-features = false }
 cdc = { path = "../components/cdc" }
 chrono = "0.4"
 clap = "2.32"
+encryption = { path = "../components/encryption" }
 engine = { path = "../components/engine" }
 engine_rocks = { path = "../components/engine_rocks" }
 engine_traits = { path = "../components/engine_traits" }

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -9,6 +9,7 @@
 //! We keep these components in the `TiKVServer` struct.
 
 use crate::{setup::*, signal_handler};
+use encryption::DataKeyManager;
 use engine::rocks;
 use engine_rocks::{encryption::get_env, Compat, RocksEngine};
 use engine_traits::{KvEngines, MetricsFlusher};
@@ -91,6 +92,7 @@ pub fn run_tikv(config: TiKvConfig) {
 
     tikv.init_fs();
     tikv.init_yatp();
+    tikv.init_encryption();
     tikv.init_engines();
     let gc_worker = tikv.init_gc_worker();
     let server_config = tikv.init_servers(&gc_worker);
@@ -118,6 +120,7 @@ struct TiKVServer {
     system: Option<RaftBatchSystem>,
     resolver: resolve::PdStoreAddrResolver,
     store_path: PathBuf,
+    encryption_key_manager: Option<Arc<DataKeyManager>>,
     engines: Option<Engines>,
     servers: Option<Servers>,
     region_info_accessor: RegionInfoAccessor,
@@ -176,6 +179,7 @@ impl TiKVServer {
             system: Some(system),
             resolver,
             store_path,
+            encryption_key_manager: None,
             engines: None,
             servers: None,
             region_info_accessor,
@@ -321,8 +325,15 @@ impl TiKVServer {
         prometheus::register(Box::new(yatp::metrics::MULTILEVEL_LEVEL_ELAPSED.clone())).unwrap();
     }
 
+    fn init_encryption(&mut self) {
+        self.encryption_key_manager =
+            DataKeyManager::from_config(&self.config.encryption, &self.config.storage.data_dir)
+                .unwrap()
+                .map(|key_manager| Arc::new(key_manager));
+    }
+
     fn init_engines(&mut self) {
-        let env = get_env(&self.config.storage.data_dir, &self.config.encryption).unwrap();
+        let env = get_env(self.encryption_key_manager.clone(), None).unwrap();
         let block_cache = self.config.storage.block_cache.build_shared_cache();
 
         let raft_db_path = Path::new(&self.config.raft_store.raftdb_path);

--- a/components/encryption/src/manager/mod.rs
+++ b/components/encryption/src/manager/mod.rs
@@ -10,7 +10,7 @@ use engine_traits::{EncryptionKeyManager, FileEncryptionInfo};
 use kvproto::encryptionpb::{DataKey, EncryptionMethod, FileDictionary, FileInfo, KeyDictionary};
 use protobuf::Message;
 
-use crate::config::MasterKeyConfig;
+use crate::config::{EncryptionConfig, MasterKeyConfig};
 use crate::crypter::{self, compat, Iv};
 use crate::encrypted_file::EncryptedFile;
 use crate::master_key::{create_backend, Backend, PlaintextBackend};
@@ -289,6 +289,19 @@ pub struct DataKeyManager {
 }
 
 impl DataKeyManager {
+    pub fn from_config(
+        config: &EncryptionConfig,
+        dict_path: &str,
+    ) -> Result<Option<DataKeyManager>> {
+        Self::new(
+            &config.master_key,
+            &config.previous_master_key,
+            config.method,
+            config.data_key_rotation_period.into(),
+            dict_path,
+        )
+    }
+
     pub fn new(
         master_key_config: &MasterKeyConfig,
         previous_master_key_config: &MasterKeyConfig,


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

### What problem does this PR solve?
Small refactor to store `encryption::DataKeyManager` in `TiKVServer`. The key manager can later be shared by snapshot and backup logic to take care of encryptions.

Problem Summary:

### What is changed and how it works?

What's Changed:
small refactor.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests 
- Manual test (add detailed scripts or steps below)
manual test run tikv with encryption enabled and with go-ycsb workload
