### PR TITLE
UCP 7220: Print panic info into tikv_stderr.log

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -208,7 +208,7 @@ impl TiKVServer {
         validate_and_persist_config(&mut config, true);
         check_system_config(&config);
 
-        tikv_util::set_panic_hook(false, &config.storage.data_dir);
+        tikv_util::set_panic_hook(false, &config.storage.data_dir, &config.panic_log_file);
 
         info!(
             "using config";
@@ -520,12 +520,12 @@ impl TiKVServer {
             coprocessor_host.clone(),
             self.config.coprocessor.clone(),
         );
+
         split_check_worker.start(split_check_runner).unwrap();
         cfg_controller.register(
             tikv::config::Module::Coprocessor,
             Box::new(SplitCheckConfigManager(split_check_worker.scheduler())),
         );
-
         self.config
             .raft_store
             .validate()
@@ -550,7 +550,6 @@ impl TiKVServer {
         );
 
         let raft_router = node.get_router();
-
         node.start(
             engines.engines.clone(),
             server.transport(),

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -21,7 +21,7 @@ extern crate test;
 
 use std::collections::hash_map::Entry;
 use std::collections::vec_deque::{Iter, VecDeque};
-use std::fs::File;
+use std::fs::{ File };
 use std::io;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
@@ -440,7 +440,7 @@ impl<T> Drop for MustConsumeVec<T> {
 }
 
 /// Exit the whole process when panic.
-pub fn set_panic_hook(panic_abort: bool, data_dir: &str) {
+pub fn set_panic_hook(panic_abort: bool, data_dir: &str, panic_log_file: &str) {
     use std::panic;
     use std::process;
 
@@ -461,6 +461,7 @@ pub fn set_panic_hook(panic_abort: bool, data_dir: &str) {
 
     let data_dir = data_dir.to_string();
     let orig_hook = panic::take_hook();
+    let panic_log_file = panic_log_file.to_string();
     panic::set_hook(Box::new(move |info: &panic::PanicInfo<'_>| {
         use slog::Drain;
         if slog_global::borrow_global().is_enabled(::slog::Level::Error) {
@@ -477,6 +478,10 @@ pub fn set_panic_hook(panic_abort: bool, data_dir: &str) {
                 .location()
                 .map(|l| format!("{}:{}", l.file(), l.line()));
             let bt = backtrace::Backtrace::new();
+
+            // redirect to stderr file
+            logger::redirect_panic_log(&panic_log_file);
+
             crit!("{}", msg;
                 "thread_name" => name,
                 "location" => loc.unwrap_or_else(|| "<unknown>".to_owned()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1845,6 +1845,9 @@ pub struct TiKvConfig {
     pub slow_log_threshold: ReadableDuration,
 
     #[config(skip)]
+    pub panic_log_file: String,
+
+    #[config(skip)]
     pub log_rotation_timespan: ReadableDuration,
 
     #[config(skip)]
@@ -1907,6 +1910,7 @@ impl Default for TiKvConfig {
             log_file: "".to_owned(),
             slow_log_file: "".to_owned(),
             slow_log_threshold: ReadableDuration::secs(1),
+            panic_log_file: "tikv_stderr.log".to_owned(),
             log_rotation_timespan: ReadableDuration::hours(24),
             log_rotation_size: ReadableSize::mb(300),
             panic_when_unexpected_key_or_data: false,


### PR DESCRIPTION
Signed-off-by: skbysp@gmail.com <yaoshiping@dianwoda.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7220  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:
redirect panic log to a file, which default is `tikv_stderr.log` and can be setted in config `panic-log-file`
### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects
I think it seems no side effect

### Release note <!-- bugfixes or new feature need a release note -->