### PR TITLE
cdc: check applied index term

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2759,7 +2759,7 @@ impl ApplyFsm {
             )));
             return;
         }
-        let (observe_id, region_id, region_epoch, enabled) = match cmd {
+        let (region_id, region_epoch, enabled) = match cmd {
             ChangeCmd::RegisterObserver {
                 region_id,
                 region_epoch,

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -509,9 +509,14 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             )));
             return;
         }
-        self.ctx
-            .apply_router
-            .schedule_task(self.region_id(), ApplyTask::Change { cmd, cb })
+        self.ctx.apply_router.schedule_task(
+            self.region_id(),
+            ApplyTask::Change {
+                term: self.fsm.peer.term(),
+                cmd,
+                cb,
+            },
+        )
     }
 
     fn on_significant_msg(&mut self, msg: SignificantMsg) {


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: after transferring leader, the new leader may apply slower than the previous leader, the lock resolver would not observe a lock which is written by the previous leader, thus would advance the resolved ts improperly.

### What is changed and how it works?

What's Changed: check applied index term before starting to observe cmd.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
N/A