### PR TITLE
Replace uses of DB with RocksEngine in tikv

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -375,11 +375,11 @@ impl TiKVServer {
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
         cfg_controller.register(
             tikv::config::Module::Rocksdb,
-            Box::new(DBConfigManger::new(engines.kv.clone(), DBType::Kv)),
+            Box::new(DBConfigManger::new(engines.kv.c().clone(), DBType::Kv)),
         );
         cfg_controller.register(
             tikv::config::Module::Raftdb,
-            Box::new(DBConfigManger::new(engines.raft.clone(), DBType::Raft)),
+            Box::new(DBConfigManger::new(engines.raft.c().clone(), DBType::Raft)),
         );
 
         let engine = RaftKv::new(raft_router.clone());

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -396,7 +396,7 @@ impl TiKVServer {
         let engines = self.engines.as_ref().unwrap();
         let mut gc_worker = GcWorker::new(
             engines.engine.clone(),
-            Some(engines.engines.kv.clone()),
+            Some(engines.engines.kv.c().clone()),
             Some(engines.raft_router.clone()),
             Some(self.region_info_accessor.clone()),
             self.config.gc.clone(),

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -619,7 +619,7 @@ impl TiKVServer {
         let import_service = ImportSSTService::new(
             self.config.import.clone(),
             engines.raft_router.clone(),
-            engines.engines.kv.clone(),
+            engines.engines.kv.c().clone(),
             servers.importer.clone(),
             self.security_mgr.clone(),
         );

--- a/components/engine_panic/src/cf_options.rs
+++ b/components/engine_panic/src/cf_options.rs
@@ -32,4 +32,10 @@ impl ColumnFamilyOptions for PanicColumnFamilyOptions {
     fn set_titandb_options(&mut self, opts: &Self::TitanDBOptions) {
         panic!()
     }
+    fn get_target_file_size_base(&self) -> u64 {
+        panic!()
+    }
+    fn get_disable_auto_compactions(&self) -> bool {
+        panic!()
+    }
 }

--- a/components/engine_rocks/src/cf_options.rs
+++ b/components/engine_rocks/src/cf_options.rs
@@ -51,4 +51,12 @@ impl ColumnFamilyOptions for RocksColumnFamilyOptions {
     fn set_titandb_options(&mut self, opts: &Self::TitanDBOptions) {
         self.0.set_titandb_options(opts.as_raw())
     }
+
+    fn get_target_file_size_base(&self) -> u64 {
+        self.0.get_target_file_size_base()
+    }
+
+    fn get_disable_auto_compactions(&self) -> bool {
+        self.0.get_disable_auto_compactions()
+    }
 }

--- a/components/engine_traits/src/cf_options.rs
+++ b/components/engine_traits/src/cf_options.rs
@@ -13,4 +13,6 @@ pub trait ColumnFamilyOptions {
     fn get_block_cache_capacity(&self) -> u64;
     fn set_block_cache_capacity(&self, capacity: u64) -> Result<(), String>;
     fn set_titandb_options(&mut self, opts: &Self::TitanDBOptions);
+    fn get_target_file_size_base(&self) -> u64;
+    fn get_disable_auto_compactions(&self) -> bool;
 }

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -197,7 +197,7 @@ impl Simulator for ServerCluster {
         let import_service = ImportSSTService::new(
             cfg.import.clone(),
             sim_router.clone(),
-            Arc::clone(&engines.kv),
+            engines.kv.c().clone(),
             Arc::clone(&importer),
             security_mgr.clone(),
         );

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -171,7 +171,7 @@ impl Simulator for ServerCluster {
 
         let mut gc_worker = GcWorker::new(
             engine.clone(),
-            Some(engines.kv.clone()),
+            Some(engines.kv.c().clone()),
             Some(raft_router.clone()),
             Some(region_info_accessor.clone()),
             cfg.gc.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,16 +39,16 @@ use crate::storage::config::{Config as StorageConfig, DEFAULT_DATA_DIR, DEFAULT_
 use encryption::EncryptionConfig;
 use engine::rocks::util::config::{self as rocks_config, BlobRunMode, CompressionType};
 use engine::rocks::util::{
-    db_exist, get_cf_handle, CFOptions, FixedPrefixSliceTransform, FixedSuffixSliceTransform,
+    db_exist, CFOptions, FixedPrefixSliceTransform, FixedSuffixSliceTransform,
     NoopSliceTransform,
 };
-use engine::DB;
 use engine_rocks::properties::MvccPropertiesCollectorFactory;
 use engine_rocks::{
     RangePropertiesCollectorFactory, RocksEventListener, DEFAULT_PROP_KEYS_INDEX_DISTANCE,
-    DEFAULT_PROP_SIZE_INDEX_DISTANCE,
+    DEFAULT_PROP_SIZE_INDEX_DISTANCE, RocksEngine,
 };
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+use engine_traits::{DBOptionsExt, CFHandleExt, ColumnFamilyOptions as ColumnFamilyOptionsTrait};
 use keys::region_raft_prefix_len;
 use pd_client::{Config as PdConfig, ConfigClient, Error as PdError};
 use raftstore::coprocessor::Config as CopConfig;
@@ -1176,12 +1176,12 @@ pub enum DBType {
 }
 
 pub struct DBConfigManger {
-    db: Arc<DB>,
+    db: RocksEngine,
     db_type: DBType,
 }
 
 impl DBConfigManger {
-    pub fn new(db: Arc<DB>, db_type: DBType) -> Self {
+    pub fn new(db: RocksEngine, db_type: DBType) -> Self {
         DBConfigManger { db, db_type }
     }
 }
@@ -1194,7 +1194,7 @@ impl DBConfigManger {
 
     fn set_cf_config(&self, cf: &str, opts: &[(&str, &str)]) -> Result<(), Box<dyn Error>> {
         self.validate_cf(cf)?;
-        let handle = get_cf_handle(&self.db, cf)?;
+        let handle = self.db.cf_handle(cf)?;
         self.db.set_options_cf(handle, opts)?;
         // Write config to metric
         for (cfg_name, cfg_value) in opts {
@@ -1214,7 +1214,7 @@ impl DBConfigManger {
 
     fn set_block_cache_size(&self, cf: &str, size: ReadableSize) -> Result<(), Box<dyn Error>> {
         self.validate_cf(cf)?;
-        let handle = get_cf_handle(&self.db, cf)?;
+        let handle = self.db.cf_handle(cf)?;
         let opt = self.db.get_options_cf(handle);
         opt.set_block_cache_capacity(size.0)?;
         // Write config to metric
@@ -2642,6 +2642,7 @@ mod tests {
 
     use super::*;
     use engine::rocks::util::new_engine_opt;
+    use engine_traits::DBOptions as DBOptionsTrait;
     use kvproto::configpb::Version;
     use slog::Level;
     use std::cmp::Ordering;
@@ -2831,10 +2832,10 @@ mod tests {
         assert_eq!(cmp_version(&v1, &v2), Ordering::Less);
     }
 
-    fn new_engines(cfg: TiKvConfig) -> (Arc<DB>, ConfigController) {
+    fn new_engines(cfg: TiKvConfig) -> (RocksEngine, ConfigController) {
         let tmp = Builder::new().prefix("test_debug").tempdir().unwrap();
         let path = tmp.path().to_str().unwrap();
-        let engine = Arc::new(
+        let engine = RocksEngine::from_db(Arc::new(
             new_engine_opt(
                 path,
                 DBOptions::new(),
@@ -2846,7 +2847,7 @@ mod tests {
                 ],
             )
             .unwrap(),
-        );
+        ));
 
         let mut cfg_controller = ConfigController::new(cfg, Default::default(), false);
         cfg_controller.register(

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,16 +39,15 @@ use crate::storage::config::{Config as StorageConfig, DEFAULT_DATA_DIR, DEFAULT_
 use encryption::EncryptionConfig;
 use engine::rocks::util::config::{self as rocks_config, BlobRunMode, CompressionType};
 use engine::rocks::util::{
-    db_exist, CFOptions, FixedPrefixSliceTransform, FixedSuffixSliceTransform,
-    NoopSliceTransform,
+    db_exist, CFOptions, FixedPrefixSliceTransform, FixedSuffixSliceTransform, NoopSliceTransform,
 };
 use engine_rocks::properties::MvccPropertiesCollectorFactory;
 use engine_rocks::{
-    RangePropertiesCollectorFactory, RocksEventListener, DEFAULT_PROP_KEYS_INDEX_DISTANCE,
-    DEFAULT_PROP_SIZE_INDEX_DISTANCE, RocksEngine,
+    RangePropertiesCollectorFactory, RocksEngine, RocksEventListener,
+    DEFAULT_PROP_KEYS_INDEX_DISTANCE, DEFAULT_PROP_SIZE_INDEX_DISTANCE,
 };
+use engine_traits::{CFHandleExt, ColumnFamilyOptions as ColumnFamilyOptionsTrait, DBOptionsExt};
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
-use engine_traits::{DBOptionsExt, CFHandleExt, ColumnFamilyOptions as ColumnFamilyOptionsTrait};
 use keys::region_raft_prefix_len;
 use pd_client::{Config as PdConfig, ConfigClient, Error as PdError};
 use raftstore::coprocessor::Config as CopConfig;

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -13,7 +13,7 @@ use kvproto::import_sstpb::*;
 use kvproto::raft_cmdpb::*;
 
 use crate::server::CONFIG_ROCKSDB_GAUGE;
-use engine_rocks::{RocksEngine};
+use engine_rocks::RocksEngine;
 use engine_traits::{SstExt, SstWriterBuilder};
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::Callback;
@@ -88,12 +88,8 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
             }
 
             match req.get_mode() {
-                SwitchMode::Normal => {
-                    switcher.enter_normal_mode(&self.engine, mf)
-                }
-                SwitchMode::Import => {
-                    switcher.enter_import_mode(&self.engine, mf)
-                }
+                SwitchMode::Normal => switcher.enter_normal_mode(&self.engine, mf),
+                SwitchMode::Import => switcher.enter_import_mode(&self.engine, mf),
             }
         };
         match res {

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -7,9 +7,7 @@ use std::sync::mpsc;
 use std::sync::{atomic, Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use engine::rocks::util::get_cf_handle;
-use engine::rocks::DB;
-use engine_rocks::{Compat, RocksEngine};
+use engine_rocks::{RocksEngine};
 use engine_traits::{MiscExt, TablePropertiesExt};
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 use futures::Future;
@@ -136,7 +134,7 @@ impl Display for GcTask {
 /// Used to perform GC operations on the engine.
 struct GcRunner<E: Engine> {
     engine: E,
-    local_storage: Option<Arc<DB>>,
+    local_storage: Option<RocksEngine>,
     raft_store_router: Option<ServerRaftStoreRouter>,
     region_info_accessor: Option<RegionInfoAccessor>,
 
@@ -152,7 +150,7 @@ struct GcRunner<E: Engine> {
 impl<E: Engine> GcRunner<E> {
     pub fn new(
         engine: E,
-        local_storage: Option<Arc<DB>>,
+        local_storage: Option<RocksEngine>,
         raft_store_router: Option<ServerRaftStoreRouter>,
         cfg_tracker: Tracker<GcConfig>,
         region_info_accessor: Option<RegionInfoAccessor>,
@@ -248,7 +246,6 @@ impl<E: Engine> GcRunner<E> {
         let end_key = keys::data_end_key(region_info.region.get_end_key());
 
         let collection = match db
-            .c()
             .get_range_properties_cf(CF_WRITE, &start_key, &end_key)
         {
             Ok(c) => c,
@@ -429,9 +426,8 @@ impl<E: Engine> GcRunner<E> {
         // First, call delete_files_in_range to free as much disk space as possible
         let delete_files_start_time = Instant::now();
         for cf in cfs {
-            let cf_handle = get_cf_handle(local_storage, cf).unwrap();
             local_storage
-                .delete_files_in_range_cf(cf_handle, &start_data_key, &end_data_key, false)
+                .delete_files_in_range_cf(cf, &start_data_key, &end_data_key, false)
                 .map_err(|e| {
                     let e: Error = box_err!(e);
                     warn!(
@@ -451,7 +447,6 @@ impl<E: Engine> GcRunner<E> {
         for cf in cfs {
             // TODO: set use_delete_range with config here.
             local_storage
-                .c()
                 .delete_all_in_range_cf(cf, &start_data_key, &end_data_key, false)
                 .map_err(|e| {
                     let e: Error = box_err!(e);
@@ -505,7 +500,7 @@ impl<E: Engine> GcRunner<E> {
         let mut fake_region = metapb::Region::default();
         // Add a peer to pass initialized check.
         fake_region.mut_peers().push(metapb::Peer::default());
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), fake_region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.clone(), fake_region);
 
         let mut reader = MvccReader::new(snap, Some(ScanMode::Forward), false, IsolationLevel::Si);
         let (locks, _) = reader.scan_locks(Some(start_key), |l| l.ts <= max_ts, limit)?;
@@ -660,7 +655,7 @@ pub fn sync_gc(
 pub struct GcWorker<E: Engine> {
     engine: E,
     /// `local_storage` represent the underlying RocksDB of the `engine`.
-    local_storage: Option<Arc<DB>>,
+    local_storage: Option<RocksEngine>,
     /// `raft_store_router` is useful to signal raftstore clean region size informations.
     raft_store_router: Option<ServerRaftStoreRouter>,
     /// Access the region's meta before getting snapshot, which will wake hibernating regions up.
@@ -724,7 +719,7 @@ impl<E: Engine> Drop for GcWorker<E> {
 impl<E: Engine> GcWorker<E> {
     pub fn new(
         engine: E,
-        local_storage: Option<Arc<DB>>,
+        local_storage: Option<RocksEngine>,
         raft_store_router: Option<ServerRaftStoreRouter>,
         region_info_accessor: Option<RegionInfoAccessor>,
         cfg: GcConfig,
@@ -931,6 +926,7 @@ mod tests {
     use tikv_util::codec::number::NumberEncoder;
     use tikv_util::future::paired_future_callback;
     use txn_types::Mutation;
+    use engine_rocks::Compat;
 
     /// A wrapper of engine that adds the 'z' prefix to keys internally.
     /// For test engines, they writes keys into db directly, but in production a 'z' prefix will be
@@ -1027,7 +1023,7 @@ mod tests {
             .build()
             .unwrap();
         let db = engine.get_rocksdb();
-        let mut gc_worker = GcWorker::new(engine, Some(db), None, None, GcConfig::default());
+        let mut gc_worker = GcWorker::new(engine, Some(db.c().clone()), None, None, GcConfig::default());
         gc_worker.start().unwrap();
         // Convert keys to key value pairs, where the value is "value-{key}".
         let data: BTreeMap<_, _> = init_keys
@@ -1186,7 +1182,7 @@ mod tests {
             .build()
             .unwrap();
         let mut gc_worker =
-            GcWorker::new(prefixed_engine, Some(db), None, None, GcConfig::default());
+            GcWorker::new(prefixed_engine, Some(db.c().clone()), None, None, GcConfig::default());
         gc_worker.start().unwrap();
 
         let physical_scan_lock = |max_ts: u64, start_key, limit| {

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -498,7 +498,7 @@ impl<E: Engine> GcRunner<E> {
         let mut fake_region = metapb::Region::default();
         // Add a peer to pass initialized check.
         fake_region.mut_peers().push(metapb::Peer::default());
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.clone(), fake_region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db, fake_region);
 
         let mut reader = MvccReader::new(snap, Some(ScanMode::Forward), false, IsolationLevel::Si);
         let (locks, _) = reader.scan_locks(Some(start_key), |l| l.ts <= max_ts, limit)?;


### PR DESCRIPTION
### What problem does this PR solve?

Part of https://github.com/tikv/tikv/issues/6402

Problem Summary:

Replace uses of engine::DB with engine_rocks::RocksEngine.

### What is changed and how it works?

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

cargo test --all --no-run


### Release note <!-- bugfixes or new feature need a release note -->