### PR TITLE
txn: write protected rollback when cleanup with missing lock (#7365)

### DIFF
--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -587,14 +587,11 @@ impl<S: Snapshot> MvccTxn<S> {
                             self.collapse_prev_rollback(key.clone())?;
                         }
 
-                        // Insert a Rollback to Write CF in case that a stale prewrite command
-                        // is received after a cleanup command.
-                        // Pessimistic transactions prewrite successfully only if all its
-                        // pessimistic locks exist. So collapsing the rollback of a pessimistic
-                        // lock is safe. After a pessimistic transaction acquires all its locks,
-                        // it is impossible that neither a lock nor a write record is found.
-                        // Therefore, we don't need to protect the rollback here.
-                        let write = Write::new_rollback(ts, false);
+                        // Insert a Rollback to Write CF in case that a stale prewrite
+                        // command is received after a cleanup command.
+                        // The rollback must be protected, see more on
+                        // [issue #7364](https://github.com/tikv/tikv/issues/7364)
+                        let write = Write::new_rollback(ts, true);
                         self.put_write(key, ts, write.to_bytes());
                         Ok(false)
                     }
@@ -1007,9 +1004,9 @@ mod tests {
 
         // Try to cleanup another transaction's lock. Does nothing.
         must_cleanup(&engine, k, ts(10, 1), ts(120, 0));
-        // If there is no exisiting lock when cleanup, it cannot be a pessimistic transaction,
-        // so the rollback needn't be protected.
-        must_get_rollback_protected(&engine, k, ts(10, 1), false);
+        // If there is no exisiting lock when cleanup, it may be a pessimistic transaction,
+        // so the rollback should be protected.
+        must_get_rollback_protected(&engine, k, ts(10, 1), true);
         must_locked(&engine, k, ts(10, 0));
 
         // TTL expired. The lock should be removed.
@@ -1616,13 +1613,11 @@ mod tests {
         must_unlocked(&engine, k);
         must_get_commit_ts(&engine, k, 30, 31);
 
-        // Rollback collapsed.
+        // Rollback.
         must_rollback_collapsed(&engine, k, 32);
         must_rollback_collapsed(&engine, k, 33);
         must_acquire_pessimistic_lock_err(&engine, k, k, 32, 32);
-        // Currently we cannot avoid this.
-        must_acquire_pessimistic_lock(&engine, k, k, 32, 34);
-        must_pessimistic_rollback(&engine, k, 32, 34);
+        must_acquire_pessimistic_lock_err(&engine, k, k, 32, 34);
         must_unlocked(&engine, k);
 
         // Acquire lock when there is lock with different for_update_ts.


### PR DESCRIPTION
cherry-pick #7365 to release-3.0

---

Signed-off-by: Dian Luo <andylokandy@hotmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Closes https://github.com/tikv/tikv/issues/7364

`MvccTxn::check_txn_status_missing_lock()` now writes protected on rollback.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

Fix the bug that a repeated "resolve lock" request may break the atomicity of transactions.