### PR TITLE
util: stablize test tikv_util::future_pool::test_tick

### DIFF
--- a/components/tikv_util/src/future_pool/mod.rs
+++ b/components/tikv_util/src/future_pool/mod.rs
@@ -271,7 +271,7 @@ mod tests {
         assert!(rx.try_recv().is_err());
 
         spawn_future_and_wait(&pool, TICK_INTERVAL / 20);
-        assert_eq!(rx.try_recv().unwrap(), 0);
+        assert_eq!(rx.recv_timeout(Duration::from_micros(50)).unwrap(), 0);
         assert!(rx.try_recv().is_err());
 
         // Tick is not emitted if there is no task
@@ -280,12 +280,12 @@ mod tests {
 
         // Tick is emitted since long enough time has passed
         spawn_future_and_wait(&pool, TICK_INTERVAL / 20);
-        assert_eq!(rx.try_recv().unwrap(), 1);
+        assert_eq!(rx.recv_timeout(Duration::from_micros(50)).unwrap(), 1);
         assert!(rx.try_recv().is_err());
 
         // Tick is emitted immediately after a long task
         spawn_future_and_wait(&pool, TICK_INTERVAL * 2);
-        assert_eq!(rx.try_recv().unwrap(), 2);
+        assert_eq!(rx.recv_timeout(Duration::from_micros(50)).unwrap(), 2);
         assert!(rx.try_recv().is_err());
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #7393 

Problem Summary: After #7348, tikv_util::future_pool::test_tick fails occasionally. It's because the handle returned by `spawned_handle` is ready before `on_tick` is executed.

### What is changed and how it works?

What's Changed: Use `recv_timeout` instead of the original `try_recv` because the `on_tick` function may be executed after trying to fetch values from the channel.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

I run `repeat 100 { cargo test --package tikv_util --lib -- future_pool::tests::test_tick --exact & }` and all succeed.