### PR TITLE
[cherry-pick] cdc: remove scan cache & add observe id (#7278)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,9 +461,12 @@ dependencies = [
  "failure",
  "futures 0.1.29",
  "grpcio",
+ "hex 0.4.0",
  "kvproto",
+ "lazy_static",
  "panic_hook",
  "pd_client",
+ "prometheus",
  "raft",
  "raftstore",
  "resolved_ts",
@@ -3312,6 +3315,8 @@ name = "resolved_ts"
 version = "0.0.1"
 dependencies = [
  "hex 0.4.0",
+ "slog",
+ "slog-global",
  "tikv_util",
  "txn_types",
 ]

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -34,6 +34,7 @@ mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
 
 [dependencies]
+hex = "0.4"
 engine_rocks = { path = "../engine_rocks" }
 failure = "0.1"
 futures = "0.1"
@@ -50,6 +51,8 @@ tikv_util = { path = "../tikv_util" }
 tokio-threadpool = "0.1"
 txn_types = { path = "../txn_types" }
 fail = "0.3"
+lazy_static = "1.3"
+prometheus = { version = "0.8", default-features = false, features = ["nightly", "push", "process"] }
 
 [dev-dependencies]
 engine = { path = "../engine" }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -22,6 +22,7 @@ use kvproto::cdcpb::{
 use kvproto::metapb::{Region, RegionEpoch};
 use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest, AdminResponse, CmdType, Request};
 use raftstore::coprocessor::{Cmd, CmdBatch};
+use raftstore::store::fsm::ObserveID;
 use raftstore::store::util::compare_region_epoch;
 use raftstore::Error as RaftStoreError;
 use resolved_ts::Resolver;
@@ -30,10 +31,11 @@ use tikv_util::collections::HashMap;
 use tikv_util::mpsc::batch::Sender as BatchSender;
 use txn_types::{Key, Lock, LockType, TimeStamp, WriteRef, WriteType};
 
+use crate::metrics::*;
 use crate::{Error, Result};
 
-static DOWNSTREAM_ID_ALLOC: AtomicUsize = AtomicUsize::new(0);
 const EVENT_MAX_SIZE: usize = 6 * 1024 * 1024; // 6MB
+static DOWNSTREAM_ID_ALLOC: AtomicUsize = AtomicUsize::new(0);
 
 /// A unique identifier of a Downstream.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -112,8 +114,8 @@ impl Downstream {
 struct Pending {
     // Batch of RaftCommand observed from raftstore
     multi_batch: Vec<CmdBatch>,
-    downstreams: Vec<Downstream>,
-    scan: Vec<(DownstreamID, Vec<Option<TxnEntry>>)>,
+    cmd_bytes: usize,
+    pub downstreams: Vec<Downstream>,
 }
 
 /// A CDC delegate of a raftstore region peer.
@@ -121,6 +123,7 @@ struct Pending {
 /// It converts raft commands into CDC events and broadcast to downstreams.
 /// It also track trancation on the fly in order to compute resolved ts.
 pub struct Delegate {
+    pub id: ObserveID,
     pub region_id: u64,
     region: Option<Region>,
     pub downstreams: Vec<Downstream>,
@@ -135,6 +138,7 @@ impl Delegate {
     pub fn new(region_id: u64) -> Delegate {
         Delegate {
             region_id,
+            id: ObserveID::new(),
             downstreams: Vec::new(),
             resolver: None,
             region: None,
@@ -248,6 +252,12 @@ impl Delegate {
         } else {
             &self.downstreams
         };
+        assert!(
+            !downstreams.is_empty(),
+            "region {} miss downstream, event: {:?}",
+            self.region_id,
+            change_data_event,
+        );
         for i in 0..downstreams.len() - 1 {
             downstreams[i].sink_event(change_data_event.clone(), size);
         }
@@ -261,7 +271,8 @@ impl Delegate {
     pub fn on_region_ready(&mut self, resolver: Resolver, region: Region) -> Result<()> {
         assert!(
             self.resolver.is_none(),
-            "region resolver should not be ready"
+            "region {} resolver should not be ready",
+            self.region_id,
         );
         self.resolver = Some(resolver);
         self.region = Some(region);
@@ -270,29 +281,27 @@ impl Delegate {
             for downstream in pending.downstreams {
                 self.subscribe(downstream);
             }
-            for (downstream_id, entries) in pending.scan {
-                self.on_scan(downstream_id, entries);
-            }
             for batch in pending.multi_batch {
                 self.on_batch(batch)?;
             }
+            CDC_PENDING_CMD_BYTES_GAUGE.sub(pending.cmd_bytes as i64);
         }
         info!("region is ready"; "region_id" => self.region_id);
         Ok(())
     }
 
     /// Try advance and broadcast resolved ts.
-    pub fn on_min_ts(&mut self, min_ts: TimeStamp) {
+    pub fn on_min_ts(&mut self, min_ts: TimeStamp) -> Option<TimeStamp> {
         if self.resolver.is_none() {
             debug!("region resolver not ready";
                 "region_id" => self.region_id, "min_ts" => min_ts);
-            return;
+            return None;
         }
         debug!("try to advance ts"; "region_id" => self.region_id, "min_ts" => min_ts);
         let resolver = self.resolver.as_mut().unwrap();
         let resolved_ts = match resolver.resolve(min_ts) {
             Some(rts) => rts,
-            None => return,
+            None => return None,
         };
         debug!("resolved ts updated";
             "region_id" => self.region_id, "resolved_ts" => resolved_ts);
@@ -300,11 +309,21 @@ impl Delegate {
         change_data_event.region_id = self.region_id;
         change_data_event.event = Some(Event_oneof_event::ResolvedTs(resolved_ts.into_inner()));
         self.broadcast(change_data_event, 0);
+        CDC_RESOLVED_TS_GAP_HISTOGRAM
+            .observe((min_ts.physical() - resolved_ts.physical()) as f64 / 1000f64);
+        Some(resolved_ts)
     }
 
     pub fn on_batch(&mut self, batch: CmdBatch) -> Result<()> {
+        // Stale CmdBatch, drop it sliently.
+        if batch.observe_id != self.id {
+            return Ok(());
+        }
         if let Some(pending) = self.pending.as_mut() {
+            let cmd_bytes = batch.size();
             pending.multi_batch.push(batch);
+            pending.cmd_bytes += cmd_bytes;
+            CDC_PENDING_CMD_BYTES_GAUGE.add(cmd_bytes as i64);
             return Ok(());
         }
         for cmd in batch.into_iter(self.region_id) {
@@ -329,14 +348,15 @@ impl Delegate {
     }
 
     pub fn on_scan(&mut self, downstream_id: DownstreamID, entries: Vec<Option<TxnEntry>>) {
-        if let Some(pending) = self.pending.as_mut() {
-            pending.scan.push((downstream_id, entries));
-            return;
-        }
-        let d = if let Some(d) = self.downstreams.iter_mut().find(|d| d.id == downstream_id) {
+        let downstreams = if let Some(pending) = self.pending.as_mut() {
+            &pending.downstreams
+        } else {
+            &self.downstreams
+        };
+        let downstream = if let Some(d) = downstreams.iter().find(|d| d.id == downstream_id) {
             d
         } else {
-            warn!("downstream not found"; "downstream_id" => ?downstream_id);
+            warn!("downstream not found"; "downstream_id" => ?downstream_id, "region_id" => self.region_id);
             return;
         };
 
@@ -407,7 +427,7 @@ impl Delegate {
                 let mut change_data_event = Event::default();
                 change_data_event.region_id = self.region_id;
                 change_data_event.event = Some(Event_oneof_event::Entries(event_entries));
-                d.sink_event(change_data_event, s);
+                downstream.sink_event(change_data_event, s);
             }
         }
     }
@@ -546,7 +566,7 @@ fn decode_write(key: Vec<u8>, value: &[u8], row: &mut EventRow) -> bool {
         WriteType::Delete => (EventRowOpType::Delete, EventLogType::Commit),
         WriteType::Rollback => (EventRowOpType::Unknown, EventLogType::Rollback),
         other => {
-            debug!("skip write record"; "write" => ?other);
+            debug!("skip write record"; "write" => ?other, "key" => hex::encode_upper(key));
             return true;
         }
     };
@@ -574,9 +594,10 @@ fn decode_lock(key: Vec<u8>, value: &[u8], row: &mut EventRow) -> bool {
         LockType::Put => EventRowOpType::Put,
         LockType::Delete => EventRowOpType::Delete,
         other => {
-            info!("skip lock record";
+            debug!("skip lock record";
                 "type" => ?other,
                 "start_ts" => ?lock.ts,
+                "key" => hex::encode_upper(key),
                 "for_update_ts" => ?lock.for_update_ts);
             return true;
         }
@@ -628,7 +649,7 @@ mod tests {
         delegate.subscribe(downstream);
         let enabled = delegate.enabled();
         assert!(enabled.load(Ordering::SeqCst));
-        let mut resolver = Resolver::new();
+        let mut resolver = Resolver::new(region_id);
         resolver.init();
         delegate.on_region_ready(resolver, region).unwrap();
 
@@ -815,12 +836,6 @@ mod tests {
             None,
         ];
         delegate.on_scan(downstream_id, entries);
-        assert_eq!(delegate.pending.as_ref().unwrap().scan.len(), 1);
-
-        let mut resolver = Resolver::new();
-        resolver.init();
-        delegate.on_region_ready(resolver, region).unwrap();
-
         // Flush all pending entries.
         let mut row1 = EventRow::default();
         row1.start_ts = 1;
@@ -839,5 +854,9 @@ mod tests {
         let mut row3 = EventRow::default();
         set_event_row_type(&mut row3, EventLogType::Initialized);
         check_event(vec![row1, row2, row3]);
+
+        let mut resolver = Resolver::new(region_id);
+        resolver.init();
+        delegate.on_region_ready(resolver, region).unwrap();
     }
 }

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -11,7 +11,7 @@ use kvproto::metapb::Region;
 use pd_client::PdClient;
 use raftstore::coprocessor::CmdBatch;
 use raftstore::router::RaftStoreRouter;
-use raftstore::store::fsm::ChangeCmd;
+use raftstore::store::fsm::{ChangeCmd, ObserveID};
 use raftstore::store::msg::{Callback, ReadResponse, SignificantMsg};
 use resolved_ts::Resolver;
 use tikv::storage::kv::Snapshot;
@@ -19,12 +19,14 @@ use tikv::storage::mvcc::{DeltaScanner, ScannerBuilder};
 use tikv::storage::txn::TxnEntry;
 use tikv::storage::txn::TxnEntryScanner;
 use tikv_util::collections::HashMap;
+use tikv_util::time::Instant;
 use tikv_util::timer::SteadyTimer;
 use tikv_util::worker::{Runnable, ScheduleError, Scheduler};
 use tokio_threadpool::{Builder, Sender as PoolSender, ThreadPool};
 use txn_types::{Key, Lock, LockType, TimeStamp};
 
 use crate::delegate::{Delegate, Downstream, DownstreamID};
+use crate::metrics::*;
 use crate::service::{Conn, ConnID};
 use crate::{CdcObserver, Error, Result};
 
@@ -47,9 +49,10 @@ impl fmt::Display for Deregister {
         write!(f, "{:?}", self)
     }
 }
+
 impl fmt::Debug for Deregister {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut de = f.debug_struct("CdcTask");
+        let mut de = f.debug_struct("Deregister");
         match self {
             Deregister::Downstream {
                 ref region_id,
@@ -96,7 +99,7 @@ pub enum Task {
         min_ts: TimeStamp,
     },
     ResolverReady {
-        region_id: u64,
+        observe_id: ObserveID,
         region: Region,
         resolver: Resolver,
     },
@@ -113,6 +116,7 @@ impl fmt::Display for Task {
         write!(f, "{:?}", self)
     }
 }
+
 impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut de = f.debug_struct("CdcTask");
@@ -123,21 +127,42 @@ impl fmt::Debug for Task {
                 ref conn_id,
                 ..
             } => de
+                .field("type", &"register")
                 .field("register request", request)
                 .field("request", request)
                 .field("id", &downstream.get_id())
                 .field("conn_id", conn_id)
                 .finish(),
-            Task::Deregister(deregister) => de.field("deregister", deregister).finish(),
-            Task::OpenConn { ref conn } => de.field("conn_id", &conn.get_id()).finish(),
-            Task::MultiBatch { multi } => de.field("multibatch", &multi.len()).finish(),
-            Task::MinTS { ref min_ts } => de.field("min_ts", min_ts).finish(),
-            Task::ResolverReady { ref region_id, .. } => de.field("region_id", region_id).finish(),
+            Task::Deregister(deregister) => de
+                .field("type", &"deregister")
+                .field("deregister", deregister)
+                .finish(),
+            Task::OpenConn { ref conn } => de
+                .field("type", &"open_conn")
+                .field("conn_id", &conn.get_id())
+                .finish(),
+            Task::MultiBatch { multi } => de
+                .field("type", &"multibatch")
+                .field("multibatch", &multi.len())
+                .finish(),
+            Task::MinTS { ref min_ts } => {
+                de.field("type", &"mit_ts").field("min_ts", min_ts).finish()
+            }
+            Task::ResolverReady {
+                ref observe_id,
+                ref region,
+                ..
+            } => de
+                .field("type", &"resolver_ready")
+                .field("observe_id", &observe_id)
+                .field("region_id", &region.get_id())
+                .finish(),
             Task::IncrementalScan {
                 ref region_id,
                 ref downstream_id,
                 ref entries,
             } => de
+                .field("type", &"incremental_scan")
                 .field("region_id", &region_id)
                 .field("downstream", &downstream_id)
                 .field("scan_entries", &entries.len())
@@ -294,10 +319,11 @@ impl<T: RaftStoreRouter> Endpoint<T> {
             workers,
             sched,
             region_id,
-            downstream_id,
             conn_id,
-            checkpoint_ts: checkpoint_ts.into(),
+            downstream_id,
             batch_size,
+            observe_id: delegate.id,
+            checkpoint_ts: checkpoint_ts.into(),
             build_resolver: enabled.is_some(),
         };
         if !delegate.subscribe(downstream) {
@@ -313,12 +339,14 @@ impl<T: RaftStoreRouter> Endpoint<T> {
             self.observer.subscribe_region(region_id);
 
             ChangeCmd::RegisterObserver {
+                observe_id: delegate.id,
                 region_id,
                 region_epoch: request.take_region_epoch(),
                 enabled,
             }
         } else {
             ChangeCmd::Snapshot {
+                observe_id: delegate.id,
                 region_id,
                 region_epoch: request.take_region_epoch(),
             }
@@ -378,24 +406,38 @@ impl<T: RaftStoreRouter> Endpoint<T> {
         }
     }
 
-    fn on_region_ready(&mut self, region_id: u64, resolver: Resolver, region: Region) {
+    fn on_region_ready(&mut self, observe_id: ObserveID, resolver: Resolver, region: Region) {
+        let region_id = region.get_id();
         if let Some(delegate) = self.capture_regions.get_mut(&region_id) {
-            if let Err(e) = delegate.on_region_ready(resolver, region) {
-                assert!(delegate.has_failed());
-                // Delegate has error, deregister the corresponding region.
-                let deregister = Deregister::Region { region_id, err: e };
-                if let Err(e) = self.scheduler.schedule(Task::Deregister(deregister)) {
-                    error!("schedule cdc task failed"; "error" => ?e);
+            if delegate.id == observe_id {
+                if let Err(e) = delegate.on_region_ready(resolver, region) {
+                    assert!(delegate.has_failed());
+                    // Delegate has error, deregister the corresponding region.
+                    let deregister = Deregister::Region { region_id, err: e };
+                    self.on_deregister(deregister);
                 }
+            } else {
+                debug!("stale region ready"; "region_id" => region.get_id(), "observe_id" => ?observe_id, "current_id" => ?delegate.id);
             }
         } else {
-            warn!("region not found on region ready (finish building resolver)"; "region_id" => region_id);
+            debug!("region not found on region ready (finish building resolver)"; "region_id" => region.get_id());
         }
     }
 
     fn on_min_ts(&mut self, min_ts: TimeStamp) {
-        for delegate in self.capture_regions.values_mut() {
-            delegate.on_min_ts(min_ts);
+        let mut min_resolved_ts = TimeStamp::max();
+        let mut min_ts_region_id = 0;
+        for (region_id, delegate) in self.capture_regions.iter_mut() {
+            if let Some(resolved_ts) = delegate.on_min_ts(min_ts) {
+                if resolved_ts < min_resolved_ts {
+                    min_resolved_ts = resolved_ts;
+                    min_ts_region_id = *region_id;
+                }
+            }
+        }
+        if min_ts_region_id > 0 {
+            CDC_MIN_RESOLVED_TS_REGION.set(min_ts_region_id as i64);
+            CDC_MIN_RESOLVED_TS.set(min_resolved_ts.physical() as i64);
         }
         self.register_min_ts_event();
     }
@@ -436,6 +478,7 @@ struct Initializer {
     sched: Scheduler<Task>,
 
     region_id: u64,
+    observe_id: ObserveID,
     downstream_id: DownstreamID,
     conn_id: ConnID,
     checkpoint_ts: TimeStamp,
@@ -472,13 +515,15 @@ impl Initializer {
     fn async_incremental_scan<S: Snapshot + 'static>(&self, snap: S, region: Region) {
         let downstream_id = self.downstream_id;
         let conn_id = self.conn_id;
+        let observe_id = self.observe_id;
         let sched = self.sched.clone();
         let batch_size = self.batch_size;
         let checkpoint_ts = self.checkpoint_ts;
         let build_resolver = self.build_resolver;
         info!("async incremental scan";
             "region_id" => region.get_id(),
-            "downstream_id" => ?downstream_id);
+            "downstream_id" => ?downstream_id,
+            "observe_id" => ?observe_id);
 
         // spawn the task to a thread pool.
         // TODO: Add a cancellation mechanism so that the scanning can be canceled if it doesn't
@@ -487,13 +532,14 @@ impl Initializer {
         self.workers
             .spawn(lazy(move || {
                 let mut resolver = if build_resolver {
-                    Some(Resolver::new())
+                    Some(Resolver::new(region_id))
                 } else {
                     None
                 };
 
                 fail_point!("cdc_incremental_scan_start");
 
+                let start = Instant::now_coarse();
                 // Time range: (checkpoint_ts, current]
                 let current = TimeStamp::max();
                 let mut scanner = ScannerBuilder::new(snap, current, false)
@@ -525,7 +571,6 @@ impl Initializer {
                         done = true;
                     }
                     debug!("cdc scan entries"; "len" => entries.len());
-                    fail_point!("before_schedule_incremental_scan");
                     let scanned = Task::IncrementalScan {
                         region_id,
                         downstream_id,
@@ -538,9 +583,10 @@ impl Initializer {
                 }
 
                 if let Some(resolver) = resolver {
-                    Self::finish_building_resolver(resolver, region, sched);
+                    Self::finish_building_resolver(observe_id, resolver, region, sched);
                 }
 
+                CDC_SCAN_DURATION_HISTOGRAM.observe(start.elapsed().as_secs_f64());
                 Ok(())
             }))
             .unwrap();
@@ -582,7 +628,12 @@ impl Initializer {
         Ok(entries)
     }
 
-    fn finish_building_resolver(mut resolver: Resolver, region: Region, sched: Scheduler<Task>) {
+    fn finish_building_resolver(
+        observe_id: ObserveID,
+        mut resolver: Resolver,
+        region: Region,
+        sched: Scheduler<Task>,
+    ) {
         resolver.init();
         if resolver.locks().is_empty() {
             info!(
@@ -595,13 +646,15 @@ impl Initializer {
                 "resolver initialized";
                 "region_id" => region.get_id(),
                 "resolved_ts" => rts,
-                "lock_count" => resolver.locks().len()
+                "lock_count" => resolver.locks().len(),
+                "observe_id" => ?observe_id,
             );
         }
 
-        info!("schedule resolver ready"; "region_id" => region.get_id());
+        fail_point!("before_schedule_resolver_ready");
+        info!("schedule resolver ready"; "region_id" => region.get_id(), "observe_id" => ?observe_id);
         if let Err(e) = sched.schedule(Task::ResolverReady {
-            region_id: region.get_id(),
+            observe_id,
             resolver,
             region,
         }) {
@@ -621,10 +674,10 @@ impl<T: RaftStoreRouter> Runnable<Task> for Endpoint<T> {
                 conn_id,
             } => self.on_register(request, downstream, conn_id),
             Task::ResolverReady {
-                region_id,
+                observe_id,
                 resolver,
                 region,
-            } => self.on_region_ready(region_id, resolver, region),
+            } => self.on_region_ready(observe_id, resolver, region),
             Task::Deregister(deregister) => self.on_deregister(deregister),
             Task::IncrementalScan {
                 region_id,
@@ -697,6 +750,7 @@ mod tests {
             sched: receiver_worker.scheduler(),
 
             region_id: 1,
+            observe_id: ObserveID::new(),
             downstream_id: DownstreamID::new(),
             conn_id: ConnID::new(),
             checkpoint_ts: 1.into(),

--- a/components/cdc/src/lib.rs
+++ b/components/cdc/src/lib.rs
@@ -12,6 +12,7 @@ extern crate fail;
 mod delegate;
 mod endpoint;
 mod errors;
+mod metrics;
 mod observer;
 mod service;
 

--- a/components/cdc/src/metrics.rs
+++ b/components/cdc/src/metrics.rs
@@ -1,0 +1,31 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use lazy_static::*;
+use prometheus::*;
+
+lazy_static! {
+    pub static ref CDC_RESOLVED_TS_GAP_HISTOGRAM: Histogram = register_histogram!(
+        "tikv_cdc_resolved_ts_gap_seconds",
+        "Bucketed histogram of the gap between cdc resolved ts and current tso",
+        exponential_buckets(0.001, 2.0, 24).unwrap()
+    )
+    .unwrap();
+    pub static ref CDC_SCAN_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "tikv_cdc_scan_duration_seconds",
+        "Bucketed histogram of cdc async scan duration",
+        exponential_buckets(0.0001, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref CDC_MIN_RESOLVED_TS_REGION: IntGauge = register_int_gauge!(
+        "tikv_cdc_min_resolved_ts_region",
+        "The region which has minimal resolved ts"
+    )
+    .unwrap();
+    pub static ref CDC_MIN_RESOLVED_TS: IntGauge = register_int_gauge!(
+        "tikv_cdc_min_resolved_ts",
+        "The minimal resolved ts for current regions"
+    )
+    .unwrap();
+    pub static ref CDC_PENDING_CMD_BYTES_GAUGE: IntGauge =
+        register_int_gauge!("tikv_cdc_pending_cmd_bytes", "Bytes of pending cdc cmds").unwrap();
+}

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, RwLock};
 
 use raft::StateRole;
 use raftstore::coprocessor::*;
+use raftstore::store::fsm::ObserveID;
 use raftstore::Error as RaftStoreError;
 use tikv_util::collections::HashSet;
 use tikv_util::worker::Scheduler;
@@ -72,19 +73,22 @@ impl CdcObserver {
 impl Coprocessor for CdcObserver {}
 
 impl CmdObserver for CdcObserver {
-    fn on_prepare_for_apply(&self, region_id: u64) {
-        self.cmd_batches.borrow_mut().push(CmdBatch::new(region_id));
+    fn on_prepare_for_apply(&self, observe_id: ObserveID, region_id: u64) {
+        self.cmd_batches
+            .borrow_mut()
+            .push(CmdBatch::new(observe_id, region_id));
     }
 
-    fn on_apply_cmd(&self, region_id: u64, cmd: Cmd) {
+    fn on_apply_cmd(&self, observe_id: ObserveID, region_id: u64, cmd: Cmd) {
         self.cmd_batches
             .borrow_mut()
             .last_mut()
             .expect("should exist some cmd batch")
-            .push(region_id, cmd);
+            .push(observe_id, region_id, cmd);
     }
 
     fn on_flush_apply(&self) {
+        fail_point!("before_cdc_flush_apply");
         if !self.cmd_batches.borrow().is_empty() {
             let batches = self.cmd_batches.replace(Vec::default());
             if let Err(e) = self.sched.schedule(Task::MultiBatch { multi: batches }) {
@@ -148,9 +152,11 @@ mod tests {
     fn test_register_and_deregister() {
         let (scheduler, rx) = tikv_util::worker::dummy_scheduler();
         let observer = CdcObserver::new(scheduler);
+        let observe_id = ObserveID::new();
 
-        observer.on_prepare_for_apply(0);
+        observer.on_prepare_for_apply(observe_id, 0);
         observer.on_apply_cmd(
+            observe_id,
             0,
             Cmd::new(0, RaftCmdRequest::default(), RaftCmdResponse::default()),
         );

--- a/components/cdc/tests/failpoints/mod.rs
+++ b/components/cdc/tests/failpoints/mod.rs
@@ -1,2 +1,4 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
-mod test_cdc;
+mod test_observe;
+mod test_register;
+mod test_resolve;

--- a/components/cdc/tests/failpoints/test_observe.rs
+++ b/components/cdc/tests/failpoints/test_observe.rs
@@ -1,0 +1,127 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+use crate::{new_event_feed, TestSuite};
+use futures::sink::Sink;
+use futures::Future;
+use grpcio::WriteFlags;
+#[cfg(not(feature = "prost-codec"))]
+use kvproto::cdcpb::*;
+#[cfg(feature = "prost-codec")]
+use kvproto::cdcpb::{
+    event::{Event as Event_oneof_event, LogType as EventLogType},
+    ChangeDataRequest,
+};
+use kvproto::kvrpcpb::*;
+use pd_client::PdClient;
+use test_raftstore::sleep_ms;
+
+#[test]
+fn test_stale_observe_cmd() {
+    let mut suite = TestSuite::new(3);
+
+    let region = suite.cluster.get_region(&[]);
+    let mut req = ChangeDataRequest::default();
+    req.region_id = region.get_id();
+    req.set_region_epoch(region.get_region_epoch().clone());
+    let (req_tx, event_feed_wrap, receive_event) =
+        new_event_feed(suite.get_region_cdc_client(region.get_id()));
+    let _req_tx = req_tx
+        .send((req.clone(), WriteFlags::default()))
+        .wait()
+        .unwrap();
+    let mut events = receive_event(false);
+    assert_eq!(events.len(), 1);
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Entries(es) => {
+            assert!(es.entries.len() == 1, "{:?}", es);
+            let e = &es.entries[0];
+            assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+        }
+        Event_oneof_event::Error(e) => panic!("{:?}", e),
+        _ => panic!("unknown event"),
+    }
+
+    let (k, v) = ("key1".to_owned(), "value".to_owned());
+    // Prewrite
+    let start_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.clone().into_bytes();
+    mutation.value = v.into_bytes();
+    suite.must_kv_prewrite(
+        region.get_id(),
+        vec![mutation],
+        k.clone().into_bytes(),
+        start_ts,
+    );
+    let mut events = receive_event(false);
+    assert_eq!(events.len(), 1);
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Entries(entries) => {
+            assert_eq!(entries.entries.len(), 1);
+            assert_eq!(entries.entries[0].get_type(), EventLogType::Prewrite);
+        }
+        _ => panic!("unknown event"),
+    }
+    let fp = "before_cdc_flush_apply";
+    fail::cfg(fp, "pause").unwrap();
+
+    // Async commit
+    let commit_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
+    let commit_resp =
+        suite.async_kv_commit(region.get_id(), vec![k.into_bytes()], start_ts, commit_ts);
+    sleep_ms(200);
+    // Close previous connection and open a new one twice time
+    let (req_tx, resp_rx) = suite
+        .get_region_cdc_client(region.get_id())
+        .event_feed()
+        .unwrap();
+    event_feed_wrap.as_ref().replace(Some(resp_rx));
+    let _req_tx = req_tx
+        .send((req.clone(), WriteFlags::default()))
+        .wait()
+        .unwrap();
+    let (req_tx, resp_rx) = suite
+        .get_region_cdc_client(region.get_id())
+        .event_feed()
+        .unwrap();
+    event_feed_wrap.as_ref().replace(Some(resp_rx));
+    let _req_tx = req_tx.send((req, WriteFlags::default())).wait().unwrap();
+    fail::remove(fp);
+    // Receive Commit response
+    commit_resp.wait().unwrap();
+    let mut events = receive_event(false);
+    assert_eq!(events.len(), 1);
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Entries(es) => {
+            assert!(es.entries.len() == 2, "{:?}", es);
+            let e = &es.entries[0];
+            assert_eq!(e.get_type(), EventLogType::Committed, "{:?}", es);
+            let e = &es.entries[1];
+            assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+        }
+        Event_oneof_event::Error(e) => panic!("{:?}", e),
+        _ => panic!("unknown event"),
+    }
+
+    // Make sure resolved ts can be advanced normally even with few tso failures.
+    let mut counter = 0;
+    loop {
+        // Even if there is no write,
+        // resolved ts should be advanced regularly.
+        for e in receive_event(true) {
+            match e.event.unwrap() {
+                Event_oneof_event::ResolvedTs(ts) => {
+                    assert_ne!(0, ts);
+                    counter += 1;
+                }
+                _ => panic!("unknown event"),
+            }
+        }
+        if counter > 5 {
+            break;
+        }
+    }
+
+    event_feed_wrap.as_ref().replace(None);
+    suite.stop();
+}

--- a/components/cdc/tests/failpoints/test_register.rs
+++ b/components/cdc/tests/failpoints/test_register.rs
@@ -1,4 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+use std::thread;
+use std::time::Duration;
+
 use crate::{new_event_feed, TestSuite};
 use futures::sink::Sink;
 use futures::Future;
@@ -10,15 +13,20 @@ use kvproto::cdcpb::{
     event::{Event as Event_oneof_event, LogType as EventLogType},
     ChangeDataRequest,
 };
+use kvproto::kvrpcpb::*;
+use kvproto::metapb::RegionEpoch;
+use pd_client::PdClient;
 use raft::StateRole;
 use raftstore::coprocessor::{ObserverContext, RoleObserver};
 use test_raftstore::sleep_ms;
 
+// TODO: Remove this test after the pending cmd batch is removed.
 #[test]
 fn test_failed_pending_batch() {
+    // For test that a pending cmd batch contains a error like epoch not match.
     let mut suite = TestSuite::new(3);
 
-    let fp = "before_schedule_incremental_scan";
+    let fp = "cdc_incremental_scan_start";
     fail::cfg(fp, "pause").unwrap();
 
     let region = suite.cluster.get_region(&[]);
@@ -105,6 +113,88 @@ fn test_region_ready_after_deregister() {
     // Then CDC should not panic
     fail::remove(fp);
     receive_event(false);
+
+    event_feed_wrap.as_ref().replace(None);
+    suite.stop();
+}
+
+#[test]
+fn test_connections_register() {
+    let mut suite = TestSuite::new(3);
+
+    let fp = "cdc_incremental_scan_start";
+    fail::cfg(fp, "pause").unwrap();
+
+    let (k, v) = ("key1".to_owned(), "value".to_owned());
+    // Region info
+    let region = suite.cluster.get_region(&[]);
+    // Prewrite
+    let start_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.clone().into_bytes();
+    mutation.value = v.into_bytes();
+    suite.must_kv_prewrite(region.get_id(), vec![mutation], k.into_bytes(), start_ts);
+
+    let mut req = ChangeDataRequest::default();
+    req.region_id = region.get_id();
+    req.set_region_epoch(RegionEpoch::default());
+
+    let (req_tx, event_feed_wrap, receive_event) = new_event_feed(suite.get_region_cdc_client(1));
+    let req_tx = req_tx
+        .send((req.clone(), WriteFlags::default()))
+        .wait()
+        .unwrap();
+    let mut events = receive_event(false);
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Error(err) => {
+            assert!(err.has_epoch_not_match(), "{:?}", err);
+        }
+        _ => panic!("unknown event"),
+    }
+
+    // Conn 1
+    req.set_region_epoch(region.get_region_epoch().clone());
+    let _req_tx1 = req_tx
+        .send((req.clone(), WriteFlags::default()))
+        .wait()
+        .unwrap();
+    thread::sleep(Duration::from_secs(1));
+    // Close conn 1
+    event_feed_wrap.as_ref().replace(None);
+    // Conn 2
+    let (req_tx, resp_rx) = suite
+        .get_region_cdc_client(region.get_id())
+        .event_feed()
+        .unwrap();
+    let _req_tx1 = req_tx.send((req, WriteFlags::default())).wait().unwrap();
+    event_feed_wrap.as_ref().replace(Some(resp_rx));
+    // Split region.
+    suite.cluster.must_split(&region, b"k0");
+    fail::remove(fp);
+    // Receive events from conn 2
+    let mut events = receive_event(false);
+    while events.len() < 2 {
+        events.extend(receive_event(false).into_iter());
+    }
+    assert_eq!(events.len(), 2, "{:?}", events.len());
+    match events.remove(0).event.unwrap() {
+        Event_oneof_event::Entries(es) => {
+            assert!(es.entries.len() == 2, "{:?}", es);
+            let e = &es.entries[0];
+            assert_eq!(e.get_type(), EventLogType::Prewrite, "{:?}", es);
+            let e = &es.entries[1];
+            assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+        }
+        Event_oneof_event::Error(e) => panic!("{:?}", e),
+        _ => panic!("unknown event"),
+    }
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Error(err) => {
+            assert!(err.has_epoch_not_match(), "{:?}", err);
+        }
+        _ => panic!("unknown event"),
+    }
 
     event_feed_wrap.as_ref().replace(None);
     suite.stop();

--- a/components/cdc/tests/failpoints/test_resolve.rs
+++ b/components/cdc/tests/failpoints/test_resolve.rs
@@ -1,0 +1,139 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+use crate::{new_event_feed, TestSuite};
+use futures::sink::Sink;
+use futures::Future;
+use grpcio::WriteFlags;
+#[cfg(not(feature = "prost-codec"))]
+use kvproto::cdcpb::*;
+#[cfg(feature = "prost-codec")]
+use kvproto::cdcpb::{
+    event::{Event as Event_oneof_event, LogType as EventLogType},
+    ChangeDataRequest,
+};
+use kvproto::kvrpcpb::*;
+use pd_client::PdClient;
+use test_raftstore::sleep_ms;
+
+#[test]
+fn test_stale_resolver() {
+    let mut suite = TestSuite::new(3);
+
+    let fp = "before_schedule_resolver_ready";
+    fail::cfg(fp, "pause").unwrap();
+
+    // Close previous connection and open a new one twice time
+    let region = suite.cluster.get_region(&[]);
+    let mut req = ChangeDataRequest::default();
+    req.region_id = region.get_id();
+    req.set_region_epoch(region.get_region_epoch().clone());
+    let (req_tx, event_feed_wrap, receive_event) =
+        new_event_feed(suite.get_region_cdc_client(region.get_id()));
+    let _req_tx = req_tx
+        .send((req.clone(), WriteFlags::default()))
+        .wait()
+        .unwrap();
+    // Sleep for a while to wait the scan is done
+    sleep_ms(200);
+
+    let (k, v) = ("key1".to_owned(), "value".to_owned());
+    // Prewrite
+    let start_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.clone().into_bytes();
+    mutation.value = v.into_bytes();
+    suite.must_kv_prewrite(
+        region.get_id(),
+        vec![mutation],
+        k.clone().into_bytes(),
+        start_ts,
+    );
+
+    // Block next scan
+    let fp1 = "cdc_incremental_scan_start";
+    fail::cfg(fp1, "pause").unwrap();
+    // Close previous connection and open two new connections
+    let (req_tx, resp_rx) = suite
+        .get_region_cdc_client(region.get_id())
+        .event_feed()
+        .unwrap();
+    event_feed_wrap.as_ref().replace(Some(resp_rx));
+    let _req_tx = req_tx
+        .send((req.clone(), WriteFlags::default()))
+        .wait()
+        .unwrap();
+    let (req_tx1, resp_rx1) = suite
+        .get_region_cdc_client(region.get_id())
+        .event_feed()
+        .unwrap();
+    let _req_tx1 = req_tx1.send((req, WriteFlags::default())).wait().unwrap();
+    // Unblock the first scan
+    fail::remove(fp);
+    // Sleep for a while to wait the wrong resolver init
+    sleep_ms(100);
+    // Async commit
+    let commit_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
+    let commit_resp =
+        suite.async_kv_commit(region.get_id(), vec![k.into_bytes()], start_ts, commit_ts);
+    // Receive Commit response
+    commit_resp.wait().unwrap();
+    // Unblock all scans
+    fail::remove(fp1);
+    // Receive events
+    let mut events = receive_event(false);
+    while events.len() < 2 {
+        events.extend(receive_event(false).into_iter());
+    }
+    assert_eq!(events.len(), 2);
+    match events.remove(0).event.unwrap() {
+        Event_oneof_event::Entries(es) => {
+            assert!(es.entries.len() == 2, "{:?}", es);
+            let e = &es.entries[0];
+            assert_eq!(e.get_type(), EventLogType::Prewrite, "{:?}", es);
+            let e = &es.entries[1];
+            assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+        }
+        Event_oneof_event::Error(e) => panic!("{:?}", e),
+        _ => panic!("unknown event"),
+    }
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Entries(es) => {
+            assert!(es.entries.len() == 1, "{:?}", es);
+            let e = &es.entries[0];
+            assert_eq!(e.get_type(), EventLogType::Commit, "{:?}", es);
+        }
+        Event_oneof_event::Error(e) => panic!("{:?}", e),
+        _ => panic!("unknown event"),
+    }
+
+    event_feed_wrap.as_ref().replace(Some(resp_rx1));
+    // Receive events
+    let mut events = receive_event(false);
+    while events.len() < 2 {
+        events.extend(receive_event(false).into_iter());
+    }
+    assert_eq!(events.len(), 2);
+    match events.remove(0).event.unwrap() {
+        Event_oneof_event::Entries(es) => {
+            assert!(es.entries.len() == 2, "{:?}", es);
+            let e = &es.entries[0];
+            assert_eq!(e.get_type(), EventLogType::Prewrite, "{:?}", es);
+            let e = &es.entries[1];
+            assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+        }
+        Event_oneof_event::Error(e) => panic!("{:?}", e),
+        _ => panic!("unknown event"),
+    }
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Entries(es) => {
+            assert!(es.entries.len() == 1, "{:?}", es);
+            let e = &es.entries[0];
+            assert_eq!(e.get_type(), EventLogType::Commit, "{:?}", es);
+        }
+        Event_oneof_event::Error(e) => panic!("{:?}", e),
+        _ => panic!("unknown event"),
+    }
+
+    event_feed_wrap.as_ref().replace(None);
+    suite.stop();
+}

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -75,8 +75,6 @@ fn test_cdc_basic() {
         _ => panic!("unknown event"),
     }
 
-    // Commit
-    let commit_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
     let mut counter = 0;
     loop {
         // Even if there is no write,
@@ -90,6 +88,8 @@ fn test_cdc_basic() {
             break;
         }
     }
+    // Commit
+    let commit_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
     suite.must_kv_commit(1, vec![k.into_bytes()], start_ts, commit_ts);
     let mut events = receive_event(false);
     assert_eq!(events.len(), 1);
@@ -140,6 +140,8 @@ fn test_cdc_basic() {
         Event_oneof_event::Error(e) => panic!("{:?}", e),
         _ => panic!("unknown event"),
     }
+    // Sleep a while to make sure the stream is registered.
+    sleep_ms(200);
     scheduler
         .schedule(Task::Validate(
             1,
@@ -210,7 +212,8 @@ fn test_cdc_not_leader() {
         }
         _ => panic!("unknown event"),
     }
-
+    // Sleep a while to make sure the stream is registered.
+    sleep_ms(200);
     // There must be a delegate.
     let scheduler = suite
         .endpoints
@@ -389,6 +392,9 @@ fn test_cdc_scan() {
     let (req_tx, event_feed_wrap, receive_event) = new_event_feed(suite.get_region_cdc_client(1));
     let _req_tx = req_tx.send((req, WriteFlags::default())).wait().unwrap();
     let mut events = receive_event(false);
+    if events.len() == 1 {
+        events.extend(receive_event(false).into_iter());
+    }
     assert_eq!(events.len(), 2, "{:?}", events);
     match events.remove(0).event.unwrap() {
         // Batch size is set to 2.

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use futures::{Future, Stream};
 use grpcio::{ChannelBuilder, Environment};
-use grpcio::{ClientDuplexReceiver, ClientDuplexSender};
+use grpcio::{ClientDuplexReceiver, ClientDuplexSender, ClientUnaryReceiver};
 #[cfg(feature = "prost-codec")]
 use kvproto::cdcpb::{
     create_change_data, event::Event as Event_oneof_event, ChangeDataClient, ChangeDataEvent,
@@ -198,6 +198,23 @@ impl TestSuite {
             commit_resp.get_region_error()
         );
         assert!(!commit_resp.has_error(), "{:?}", commit_resp.get_error());
+    }
+
+    pub fn async_kv_commit(
+        &mut self,
+        region_id: u64,
+        keys: Vec<Vec<u8>>,
+        start_ts: TimeStamp,
+        commit_ts: TimeStamp,
+    ) -> ClientUnaryReceiver<CommitResponse> {
+        let mut commit_req = CommitRequest::default();
+        commit_req.set_context(self.get_context(region_id));
+        commit_req.start_version = start_ts.into_inner();
+        commit_req.set_keys(keys.into_iter().collect());
+        commit_req.commit_version = commit_ts.into_inner();
+        self.get_tikv_client(region_id)
+            .kv_commit_async(&commit_req)
+            .unwrap()
     }
 
     pub fn get_context(&mut self, region_id: u64) -> Context {

--- a/components/raftstore/src/coprocessor/dispatcher.rs
+++ b/components/raftstore/src/coprocessor/dispatcher.rs
@@ -407,13 +407,20 @@ impl CoprocessorHost {
         );
     }
 
-    pub fn prepare_for_apply(&self, region_id: u64) {
+    pub fn prepare_for_apply(&self, observe_id: ObserveID, region_id: u64) {
         for cmd_ob in &self.registry.cmd_observers {
-            cmd_ob.observer.inner().on_prepare_for_apply(region_id)
+            cmd_ob
+                .observer
+                .inner()
+                .on_prepare_for_apply(observe_id, region_id);
         }
     }
 
-    pub fn on_apply_cmd(&self, region_id: u64, cmd: Cmd) {
+    pub fn on_apply_cmd(&self, observe_id: ObserveID, region_id: u64, cmd: Cmd) {
+        assert!(
+            !self.registry.cmd_observers.is_empty(),
+            "CmdObserver is not registered"
+        );
         for i in 0..self.registry.cmd_observers.len() - 1 {
             self.registry
                 .cmd_observers
@@ -421,7 +428,7 @@ impl CoprocessorHost {
                 .unwrap()
                 .observer
                 .inner()
-                .on_apply_cmd(region_id, cmd.clone())
+                .on_apply_cmd(observe_id, region_id, cmd.clone())
         }
         self.registry
             .cmd_observers
@@ -429,7 +436,7 @@ impl CoprocessorHost {
             .unwrap()
             .observer
             .inner()
-            .on_apply_cmd(region_id, cmd)
+            .on_apply_cmd(observe_id, region_id, cmd)
     }
 
     pub fn on_flush_apply(&self) {
@@ -561,10 +568,10 @@ mod tests {
     }
 
     impl CmdObserver for TestCoprocessor {
-        fn on_prepare_for_apply(&self, _: u64) {
+        fn on_prepare_for_apply(&self, _: ObserveID, _: u64) {
             self.called.fetch_add(11, Ordering::SeqCst);
         }
-        fn on_apply_cmd(&self, _: u64, _: Cmd) {
+        fn on_apply_cmd(&self, _: ObserveID, _: u64, _: Cmd) {
             self.called.fetch_add(12, Ordering::SeqCst);
         }
         fn on_flush_apply(&self) {
@@ -637,9 +644,14 @@ mod tests {
         assert_all!(&[&ob.called], &[45]);
         host.pre_apply_sst_from_snapshot(&region, "default", "");
         assert_all!(&[&ob.called], &[55]);
-        host.prepare_for_apply(0);
+        let observe_id = ObserveID::new();
+        host.prepare_for_apply(observe_id, 0);
         assert_all!(&[&ob.called], &[66]);
-        host.on_apply_cmd(0, Cmd::new(0, RaftCmdRequest::default(), query_resp));
+        host.on_apply_cmd(
+            observe_id,
+            0,
+            Cmd::new(0, RaftCmdRequest::default(), query_resp),
+        );
         assert_all!(&[&ob.called], &[78]);
         host.on_flush_apply();
         assert_all!(&[&ob.called], &[91]);

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -35,6 +35,7 @@ pub use self::split_check::{
     Host as SplitCheckerHost, KeysCheckObserver, SizeCheckObserver, TableCheckObserver,
 };
 
+use crate::store::fsm::ObserveID;
 pub use crate::store::KeyEntry;
 
 /// Coprocessor is used to provide a convenient way to inject code to
@@ -182,20 +183,23 @@ impl Cmd {
 
 #[derive(Clone, Debug)]
 pub struct CmdBatch {
+    pub observe_id: ObserveID,
     pub region_id: u64,
-    cmds: Vec<Cmd>,
+    pub cmds: Vec<Cmd>,
 }
 
 impl CmdBatch {
-    pub fn new(region_id: u64) -> CmdBatch {
+    pub fn new(observe_id: ObserveID, region_id: u64) -> CmdBatch {
         CmdBatch {
+            observe_id,
             region_id,
             cmds: Vec::new(),
         }
     }
 
-    pub fn push(&mut self, region_id: u64, cmd: Cmd) {
+    pub fn push(&mut self, observe_id: ObserveID, region_id: u64, cmd: Cmd) {
         assert_eq!(region_id, self.region_id);
+        assert_eq!(observe_id, self.observe_id);
         self.cmds.push(cmd)
     }
 
@@ -211,13 +215,34 @@ impl CmdBatch {
     pub fn is_empty(&self) -> bool {
         self.cmds.is_empty()
     }
+
+    pub fn size(&self) -> usize {
+        let mut cmd_bytes = 0;
+        for cmd in self.cmds.iter() {
+            let Cmd {
+                ref request,
+                ref response,
+                ..
+            } = cmd;
+            if !response.get_header().has_error() {
+                if !request.has_admin_request() {
+                    for req in request.requests.iter() {
+                        let put = req.get_put();
+                        cmd_bytes += put.get_key().len();
+                        cmd_bytes += put.get_value().len();
+                    }
+                }
+            }
+        }
+        cmd_bytes
+    }
 }
 
 pub trait CmdObserver: Coprocessor {
     /// Hook to call after preparing for applying write requests.
-    fn on_prepare_for_apply(&self, region_id: u64);
+    fn on_prepare_for_apply(&self, observe_id: ObserveID, region_id: u64);
     /// Hook to call after applying a write request.
-    fn on_apply_cmd(&self, region_id: u64, cmd: Cmd);
+    fn on_apply_cmd(&self, observe_id: ObserveID, region_id: u64, cmd: Cmd);
     /// Hook to call after flushing writes to db.
     fn on_flush_apply(&self);
 }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -353,10 +353,10 @@ impl ApplyContext {
         self.cbs.push(ApplyCallback::new(delegate.region.clone()));
         self.last_applied_index = delegate.apply_state.get_applied_index();
 
-        if let Some(enabled) = &delegate.observe_cmd {
+        if let Some(observe_cmd) = &delegate.observe_cmd {
             let region_id = delegate.region_id();
-            if enabled.load(Ordering::Acquire) {
-                self.host.prepare_for_apply(region_id);
+            if observe_cmd.enabled.load(Ordering::Acquire) {
+                self.host.prepare_for_apply(observe_cmd.id, region_id);
             } else {
                 info!("region is no longer observerd";
                     "region_id" => region_id);
@@ -413,6 +413,9 @@ impl ApplyContext {
             self.kv_wb_last_bytes = 0;
             self.kv_wb_last_keys = 0;
         }
+        // Call it before invoking callback for preventing Commit is executed before Prewrite is observed.
+        self.host.on_flush_apply();
+
         for cbs in self.cbs.drain(..) {
             cbs.invoke_all(&self.host);
         }
@@ -478,8 +481,6 @@ impl ApplyContext {
                 );
             }
         }
-
-        self.host.on_flush_apply();
 
         let elapsed = t.elapsed();
         STORE_APPLY_LOG_HISTOGRAM.observe(duration_to_sec(elapsed) as f64);
@@ -683,8 +684,8 @@ pub struct ApplyDelegate {
     /// The latest synced apply index.
     last_sync_apply_index: u64,
 
-    /// Indicates whether to observe executed cmds.
-    observe_cmd: Option<Arc<AtomicBool>>,
+    /// Info about cmd observer.
+    observe_cmd: Option<ObserveCmd>,
 
     /// The local metrics, and it will be flushed periodically.
     metrics: ApplyMetrics,
@@ -971,9 +972,11 @@ impl ApplyDelegate {
         // store will call it after handing exec result.
         cmd_resp::bind_term(&mut resp, self.term);
         let cmd_cb = self.find_cb(index, term, is_conf_change);
-        if self.observe_cmd.is_some() {
+        if let Some(observe_cmd) = self.observe_cmd.as_ref() {
             let cmd = Cmd::new(index, cmd, resp.clone());
-            apply_ctx.host.on_apply_cmd(self.region_id(), cmd);
+            apply_ctx
+                .host
+                .on_apply_cmd(observe_cmd.id, self.region_id(), cmd);
         }
 
         apply_ctx.cbs.last_mut().unwrap().push(cmd_cb, resp);
@@ -2345,14 +2348,39 @@ impl Debug for GenSnapTask {
     }
 }
 
+static OBSERVE_ID_ALLOC: AtomicUsize = AtomicUsize::new(0);
+
+/// A unique identifier for checking stale observed commands.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct ObserveID(usize);
+
+impl ObserveID {
+    pub fn new() -> ObserveID {
+        ObserveID(OBSERVE_ID_ALLOC.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+struct ObserveCmd {
+    id: ObserveID,
+    enabled: Arc<AtomicBool>,
+}
+
+impl Debug for ObserveCmd {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ObserveCmd").field("id", &self.id).finish()
+    }
+}
+
 #[derive(Debug)]
 pub enum ChangeCmd {
     RegisterObserver {
+        observe_id: ObserveID,
         region_id: u64,
         region_epoch: RegionEpoch,
         enabled: Arc<AtomicBool>,
     },
     Snapshot {
+        observe_id: ObserveID,
         region_id: u64,
         region_epoch: RegionEpoch,
     },
@@ -2742,8 +2770,9 @@ impl ApplyFsm {
         cmd: ChangeCmd,
         cb: Callback<RocksEngine>,
     ) {
-        let (region_id, region_epoch, enabled) = match cmd {
+        let (observe_id, region_id, region_epoch, enabled) = match cmd {
             ChangeCmd::RegisterObserver {
+                observe_id,
                 region_id,
                 region_epoch,
                 enabled,
@@ -2752,13 +2781,14 @@ impl ApplyFsm {
                     .delegate
                     .observe_cmd
                     .as_ref()
-                    .map_or(false, |e| e.load(Ordering::Relaxed)));
-                (region_id, region_epoch, Some(enabled))
+                    .map_or(false, |o| o.enabled.load(Ordering::SeqCst)));
+                (observe_id, region_id, region_epoch, Some(enabled))
             }
             ChangeCmd::Snapshot {
+                observe_id,
                 region_id,
                 region_epoch,
-            } => (region_id, region_epoch, None),
+            } => (observe_id, region_id, region_epoch, None),
         };
 
         assert_eq!(self.delegate.region_id(), region_id);
@@ -2787,10 +2817,16 @@ impl ApplyFsm {
                 snapshot: None,
             },
         };
-        if enabled.is_some() {
+        if let Some(enabled) = enabled {
             // TODO(cdc): take observe_cmd when enabled is false.
-            self.delegate.observe_cmd = enabled;
+            self.delegate.observe_cmd = Some(ObserveCmd {
+                id: observe_id,
+                enabled,
+            });
+        } else if let Some(observe_cmd) = self.delegate.observe_cmd.as_mut() {
+            observe_cmd.id = observe_id;
         }
+
         cb.invoke_read(resp);
     }
 
@@ -3651,16 +3687,18 @@ mod tests {
     }
 
     impl CmdObserver for ApplyObserver {
-        fn on_prepare_for_apply(&self, region_id: u64) {
-            self.cmd_batches.borrow_mut().push(CmdBatch::new(region_id));
+        fn on_prepare_for_apply(&self, observe_id: ObserveID, region_id: u64) {
+            self.cmd_batches
+                .borrow_mut()
+                .push(CmdBatch::new(observe_id, region_id));
         }
 
-        fn on_apply_cmd(&self, region_id: u64, cmd: Cmd) {
+        fn on_apply_cmd(&self, observe_id: ObserveID, region_id: u64, cmd: Cmd) {
             self.cmd_batches
                 .borrow_mut()
                 .last_mut()
                 .expect("should exist some cmd batch")
-                .push(region_id, cmd);
+                .push(observe_id, region_id, cmd);
         }
 
         fn on_flush_apply(&self) {
@@ -3998,10 +4036,12 @@ mod tests {
         router.schedule_task(1, Msg::apply(Apply::new(1, 2, vec![put_entry], 1, 2, 2)));
         // Register cmd observer to region 1.
         let enabled = Arc::new(AtomicBool::new(true));
+        let observe_id = ObserveID::new();
         router.schedule_task(
             1,
             Msg::Change {
                 cmd: ChangeCmd::RegisterObserver {
+                    observe_id,
                     region_id: 1,
                     region_epoch: region_epoch.clone(),
                     enabled: enabled.clone(),
@@ -4063,6 +4103,7 @@ mod tests {
             2,
             Msg::Change {
                 cmd: ChangeCmd::RegisterObserver {
+                    observe_id,
                     region_id: 2,
                     region_epoch,
                     enabled,
@@ -4221,10 +4262,12 @@ mod tests {
 
         router.schedule_task(1, Msg::Registration(reg.clone()));
         let enabled = Arc::new(AtomicBool::new(true));
+        let observe_id = ObserveID::new();
         router.schedule_task(
             1,
             Msg::Change {
                 cmd: ChangeCmd::RegisterObserver {
+                    observe_id,
                     region_id: 1,
                     region_epoch: region_epoch.clone(),
                     enabled: enabled.clone(),
@@ -4378,6 +4421,7 @@ mod tests {
             1,
             Msg::Change {
                 cmd: ChangeCmd::RegisterObserver {
+                    observe_id,
                     region_id: 1,
                     region_epoch,
                     enabled: Arc::new(AtomicBool::new(true)),

--- a/components/raftstore/src/store/fsm/mod.rs
+++ b/components/raftstore/src/store/fsm/mod.rs
@@ -12,7 +12,7 @@ pub mod store;
 pub use self::apply::{
     create_apply_batch_system, Apply, ApplyBatchSystem, ApplyMetrics, ApplyRes, ApplyRouter,
     Builder as ApplyPollerBuilder, CatchUpLogs, ChangeCmd, ChangePeer, ExecResult, GenSnapTask,
-    Msg as ApplyTask, Notifier as ApplyNotifier, Proposal, RegionProposal, Registration,
+    Msg as ApplyTask, Notifier as ApplyNotifier, ObserveID, Proposal, RegionProposal, Registration,
     TaskRes as ApplyTaskRes,
 };
 pub use self::peer::{DestroyPeerJob, GroupState, PeerFsm};

--- a/components/resolved_ts/Cargo.toml
+++ b/components/resolved_ts/Cargo.toml
@@ -12,3 +12,5 @@ prost-codec = ["txn_types/prost-codec"]
 hex = "0.4"
 tikv_util = { path = "../tikv_util" }
 txn_types = { path = "../txn_types" }
+slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
+slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/7325

Problem Summary: TiKV may OOM or panic while running cdc.

### What is changed and how it works?

What's Changed:
* Remove the scan cache for reducing the memory usage
* Add ObserveID to region `Delegate`, `Initializer`, `CmdBatch` for check stale observe cmd and stale resolver
* Add more metrics

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
N/A
