### PR TITLE
sst_importer: skip validation in ingest temporary

### DIFF
--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -400,7 +400,10 @@ impl ImportDir {
         engine.prepare_sst_for_ingestion(&path.save, &path.clone)?;
         let length = meta.get_length();
         let crc32 = meta.get_crc32();
-        if length != 0 || crc32 != 0 {
+        // FIXME perform validate_sst_for_ingestion after we can handle sst file size correctly.
+        // currently we can not handle sst file size after rewrite,
+        // we need re-compute length & crc32 and fill back to sstMeta.
+        if length != 0 && crc32 != 0 {
             // we only validate if the length and CRC32 are explicitly provided.
             engine.validate_sst_for_ingestion(cf, &path.clone, length, crc32)?;
             IMPORTER_INGEST_BYTES.observe(length as _)


### PR DESCRIPTION


<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/br/issues/163

Problem Summary:
* when we perform rewrite in download sst, the length of sstMeta will change, so it will cause panic in next vaildation.

### What is changed and how it works?
This PR skip validation before ingest sst, so we can avoid panic since file length doesn't match.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->