### PR TITLE
raftstore: set term in read index response

### DIFF
--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -1905,7 +1905,6 @@ impl Peer {
             "request_id" => ?read.id,
             "region_id" => self.region_id,
             "peer_id" => self.peer.get_id(),
-            "uuid" => ?read.id,
         );
     }
 
@@ -2014,7 +2013,6 @@ impl Peer {
             "region_id" => self.region_id,
             "peer_id" => self.peer.get_id(),
             "is_leader" => self.is_leader(),
-            "uuid" => ?id,
         );
 
         // TimeoutNow has been sent out, so we need to propose explicitly to

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -734,6 +734,7 @@ impl Peer {
             if let LeaseState::Valid = state {
                 let mut resp = eraftpb::Message::default();
                 resp.set_msg_type(MessageType::MsgReadIndexResp);
+                resp.term = self.term();
                 resp.to = m.from;
                 resp.index = self.get_store().committed_index();
                 resp.set_entries(m.take_entries());

--- a/src/raftstore/store/read_queue.rs
+++ b/src/raftstore/store/read_queue.rs
@@ -21,6 +21,8 @@ pub struct ReadIndexRequest {
     pub cmds: MustConsumeVec<(RaftCmdRequest, Callback)>,
     pub renew_lease_time: Timespec,
     pub read_index: Option<u64>,
+    // `true` means it's in `ReadIndexQueue::reads`.
+    in_contexts: bool,
 }
 
 impl ReadIndexRequest {
@@ -48,6 +50,7 @@ impl ReadIndexRequest {
             cmds,
             renew_lease_time,
             read_index: None,
+            in_contexts: false,
         }
     }
 }
@@ -135,8 +138,9 @@ impl ReadIndexQueue {
         self.contexts.clear();
     }
 
-    pub fn push_back(&mut self, read: ReadIndexRequest, is_leader: bool) {
+    pub fn push_back(&mut self, mut read: ReadIndexRequest, is_leader: bool) {
         if !is_leader {
+            read.in_contexts = true;
             let offset = self.handled_cnt + self.reads.len();
             self.contexts.insert(read.id, offset);
         }
@@ -173,8 +177,20 @@ impl ReadIndexQueue {
     {
         let (mut min_changed_offset, mut max_changed_offset) = (usize::MAX, 0);
         for (uuid, index) in states {
-            if let Some(offset) = self.contexts.remove(&uuid) {
-                let offset = offset.checked_sub(self.handled_cnt).unwrap();
+            if let Some(raw_offset) = self.contexts.remove(&uuid) {
+                let offset = match raw_offset.checked_sub(self.handled_cnt) {
+                    Some(offset) => offset,
+                    None => panic!(
+                        "advance_replica_reads uuid: {}, offset: {}, handled: {}",
+                        uuid, raw_offset, self.handled_cnt
+                    ),
+                };
+                assert_eq!(
+                    self.reads[offset].id, uuid,
+                    "ReadIndexQueue::reads[{}].uuid: {}, but want: {}",
+                    raw_offset, self.reads[offset].id, uuid
+                );
+                self.reads[offset].in_contexts = false;
                 if let Some(occur_index) = self.reads[offset].read_index {
                     if occur_index < index {
                         continue;
@@ -233,7 +249,15 @@ impl ReadIndexQueue {
         }
         self.ready_cnt -= 1;
         self.handled_cnt += 1;
-        self.reads.pop_front()
+        let mut res = self
+            .reads
+            .pop_front()
+            .expect("read_queue is empty but ready_cnt > 0");
+        if res.in_contexts {
+            res.in_contexts = false;
+            self.contexts.remove(&res.id);
+        }
+        Some(res)
     }
 
     /// Raft could have not been ready to handle the poped task. So put it back into the queue.
@@ -307,7 +331,7 @@ mod tests {
     }
 
     #[test]
-    fn test_role_change() {
+    fn test_become_leader_then_become_follower() {
         let mut queue = ReadIndexQueue::default();
         queue.handled_cnt = 100;
 
@@ -385,5 +409,31 @@ mod tests {
         while let Some(mut read) = queue.pop_front() {
             read.cmds.clear();
         }
+    }
+
+    #[test]
+    fn test_advance_replica_reads_out_of_order() {
+        let mut queue = ReadIndexQueue::default();
+        queue.handled_cnt = 100;
+
+        let ids: [Uuid; 2] = [Uuid::new_v4(), Uuid::new_v4()];
+        for i in 0..2 {
+            // Push a pending read comand when the peer is follower.
+            let req = ReadIndexRequest::with_command(
+                ids[i],
+                RaftCmdRequest::default(),
+                Callback::None,
+                Timespec::new(0, 0),
+            );
+            queue.push_back(req, false);
+        }
+
+        queue.advance_replica_reads(vec![(ids[1], 100)]);
+        assert_eq!(queue.ready_cnt, 2);
+        while let Some(mut read) = queue.pop_front() {
+            read.cmds.clear();
+        }
+
+        queue.advance_replica_reads(vec![(ids[0], 100)]);
     }
 }

--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -9,9 +9,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use kvproto::raft_serverpb::RaftMessage;
-use tikv::pd::PdClient;
 use raft::eraftpb::MessageType;
 use test_raftstore::*;
+use tikv::pd::PdClient;
 use tikv::raftstore::Result;
 use tikv_util::config::*;
 use tikv_util::HandyRwLock;

--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -9,11 +9,43 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use kvproto::raft_serverpb::RaftMessage;
+use tikv::pd::PdClient;
 use raft::eraftpb::MessageType;
 use test_raftstore::*;
 use tikv::raftstore::Result;
 use tikv_util::config::*;
 use tikv_util::HandyRwLock;
+
+#[derive(Default)]
+struct CommitToFilter {
+    // map[peer_id] -> committed index.
+    committed: Arc<Mutex<HashMap<u64, u64>>>,
+}
+
+impl CommitToFilter {
+    fn new(committed: Arc<Mutex<HashMap<u64, u64>>>) -> Self {
+        Self { committed }
+    }
+}
+
+impl Filter for CommitToFilter {
+    fn before(&self, msgs: &mut Vec<RaftMessage>) -> Result<()> {
+        let mut committed = self.committed.lock().unwrap();
+        for msg in msgs.iter_mut() {
+            let cmt = msg.get_message().get_commit();
+            if cmt != 0 {
+                let to = msg.get_message().get_to();
+                committed.insert(to, cmt);
+                msg.mut_message().set_commit(0);
+            }
+        }
+        Ok(())
+    }
+
+    fn after(&self, _: Result<()>) -> Result<()> {
+        Ok(())
+    }
+}
 
 #[test]
 fn test_replica_read_not_applied() {
@@ -209,33 +241,43 @@ fn test_read_hibernated_region() {
     assert!(!resp2.get_header().has_error(), "{:?}", resp2);
 }
 
-#[derive(Default)]
-struct CommitToFilter {
-    // map[peer_id] -> committed index.
-    committed: Arc<Mutex<HashMap<u64, u64>>>,
-}
+/// The read index response can advance the commit index.
+/// But in previous implemtation, we forget to set term in read index response
+/// which causes panic in raft-rs. This test is to reproduce the case.
+#[test]
+fn test_replica_read_on_stale_peer() {
+    let mut cluster = new_node_cluster(0, 3);
 
-impl CommitToFilter {
-    fn new(committed: Arc<Mutex<HashMap<u64, u64>>>) -> Self {
-        Self { committed }
-    }
-}
+    configure_for_lease_read(&mut cluster, Some(50), Some(30));
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
 
-impl Filter for CommitToFilter {
-    fn before(&self, msgs: &mut Vec<RaftMessage>) -> Result<()> {
-        let mut committed = self.committed.lock().unwrap();
-        for msg in msgs.iter_mut() {
-            let cmt = msg.get_message().get_commit();
-            if cmt != 0 {
-                let to = msg.get_message().get_to();
-                committed.insert(to, cmt);
-                msg.mut_message().set_commit(0);
-            }
-        }
-        Ok(())
-    }
+    cluster.run();
 
-    fn after(&self, _: Result<()>) -> Result<()> {
-        Ok(())
-    }
+    let region = pd_client.get_region(b"k1").unwrap();
+
+    let peer_on_store1 = find_peer(&region, 1).unwrap().to_owned();
+    cluster.must_transfer_leader(region.get_id(), peer_on_store1);
+    let peer_on_store3 = find_peer(&region, 3).unwrap().to_owned();
+
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+
+    let filter = Box::new(
+        RegionPacketFilter::new(region.get_id(), 3)
+            .direction(Direction::Recv)
+            .msg_type(MessageType::MsgAppend),
+    );
+    cluster.sim.wl().add_recv_filter(3, filter);
+    cluster.must_put(b"k2", b"v2");
+    let resp1_ch = async_read_on_peer(
+        &mut cluster,
+        peer_on_store3.clone(),
+        region.clone(),
+        b"k2",
+        true,
+        true,
+    );
+    // must be timeout
+    assert!(resp1_ch.recv_timeout(Duration::from_micros(100)).is_err());
 }


### PR DESCRIPTION
Signed-off-by: Liqi Geng <gengliqiii@gmail.com>

### What problem does this PR solve?

cherry-pick https://github.com/tikv/tikv/pull/7372 to release 3.1

Problem Summary:

TiKV may panic in raft-rs because of tikv/raft-rs#346 and the subtle hack code.
Some details in https://github.com/tikv/tikv/issues/7353#issuecomment-608247067

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

No