### PR TITLE
cdc: fix deregister ABA problem and support cancel incremental scan 

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -596,8 +596,9 @@ impl TiKVServer {
             raft_router,
             cdc_ob,
         );
+        let cdc_timer = cdc_endpoint.new_timer();
         cdc_worker
-            .start(cdc_endpoint)
+            .start_with_timer(cdc_endpoint, cdc_timer)
             .unwrap_or_else(|e| fatal!("failed to start cdc: {}", e));
         self.to_stop.push(cdc_worker);
 

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -362,11 +363,9 @@ impl<T: 'static + RaftStoreRouter> Endpoint<T> {
             "region_id" => region_id,
             "conn_id" => ?conn.get_id(),
             "downstream_id" => ?downstream.get_id());
-        let mut enabled = None;
         let mut is_new_delegate = false;
         let delegate = self.capture_regions.entry(region_id).or_insert_with(|| {
             let d = Delegate::new(region_id);
-            enabled = Some(d.enabled());
             is_new_delegate = true;
             d
         });
@@ -384,7 +383,9 @@ impl<T: 'static + RaftStoreRouter> Endpoint<T> {
             batch_size,
             observe_id: delegate.id,
             checkpoint_ts: checkpoint_ts.into(),
-            build_resolver: enabled.is_some(),
+            build_resolver: is_new_delegate,
+            // TODO: make the cancellation at Downstream level instead of Region level.
+            cancel: delegate.enabled(),
         };
         if !delegate.subscribe(downstream) {
             conn.unsubscribe(request.get_region_id());
@@ -393,7 +394,7 @@ impl<T: 'static + RaftStoreRouter> Endpoint<T> {
             }
             return;
         }
-        let change_cmd = if let Some(enabled) = enabled {
+        let change_cmd = if is_new_delegate {
             // The region has never been registered.
             // Subscribe the change events of the region.
             let old_id = self.observer.subscribe_region(region_id, delegate.id);
@@ -408,7 +409,7 @@ impl<T: 'static + RaftStoreRouter> Endpoint<T> {
             ChangeCmd::RegisterObserver {
                 observe_id: delegate.id,
                 region_id,
-                enabled,
+                enabled: delegate.enabled(),
             }
         } else {
             ChangeCmd::Snapshot {
@@ -598,6 +599,7 @@ struct Initializer {
     batch_size: usize,
 
     build_resolver: bool,
+    cancel: Arc<AtomicBool>,
 }
 
 impl Initializer {
@@ -633,8 +635,6 @@ impl Initializer {
             "downstream_id" => ?downstream_id,
             "observe_id" => ?self.observe_id);
 
-        // TODO: Add a cancellation mechanism so that the scanning can be canceled if it doesn't
-        // finish when the region is deregistered.
         let mut resolver = if self.build_resolver {
             Some(Resolver::new(region_id))
         } else {
@@ -652,6 +652,13 @@ impl Initializer {
             .unwrap();
         let mut done = false;
         while !done {
+            if !self.cancel.load(Ordering::SeqCst) {
+                info!("async incremental scan canceled";
+                    "region_id" => region_id,
+                    "downstream_id" => ?downstream_id,
+                    "observe_id" => ?self.observe_id);
+                return;
+            }
             let entries = match Self::scan_batch(&mut scanner, self.batch_size, resolver.as_mut()) {
                 Ok(res) => res,
                 Err(e) => {
@@ -872,6 +879,7 @@ mod tests {
             batch_size: 1,
 
             build_resolver: true,
+            cancel: Arc::new(AtomicBool::new(true)),
         };
 
         (receiver_worker, pool, initializer, rx)
@@ -934,12 +942,25 @@ mod tests {
         check_result();
 
         initializer.build_resolver = false;
-        initializer.async_incremental_scan(snap, region);
+        initializer.async_incremental_scan(snap.clone(), region.clone());
 
         loop {
             let task = rx.recv_timeout(Duration::from_secs(1));
             match task {
                 Ok(Task::IncrementalScan { .. }) => continue,
+                Ok(t) => panic!("unepxected task {} received", t),
+                Err(RecvTimeoutError::Timeout) => break,
+                Err(e) => panic!("unexpected err {:?}", e),
+            }
+        }
+
+        // Test cancellation.
+        initializer.cancel.store(false, Ordering::SeqCst);
+        initializer.async_incremental_scan(snap, region);
+
+        loop {
+            let task = rx.recv_timeout(Duration::from_secs(1));
+            match task {
                 Ok(t) => panic!("unepxected task {} received", t),
                 Err(RecvTimeoutError::Timeout) => break,
                 Err(e) => panic!("unexpected err {:?}", e),

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -356,6 +356,9 @@ impl<T: 'static + RaftStoreRouter> Endpoint<T> {
         downstream.set_sink(conn.get_sink());
         if !conn.subscribe(request.get_region_id(), downstream.get_id()) {
             downstream.sink_duplicate_error(request.get_region_id());
+            error!("duplicate register";
+                "region_id" => region_id,
+                "downstream_id" => ?downstream.get_id());
             return;
         }
 

--- a/components/cdc/src/metrics.rs
+++ b/components/cdc/src/metrics.rs
@@ -28,4 +28,9 @@ lazy_static! {
     .unwrap();
     pub static ref CDC_PENDING_CMD_BYTES_GAUGE: IntGauge =
         register_int_gauge!("tikv_cdc_pending_cmd_bytes", "Bytes of pending cdc cmds").unwrap();
+    pub static ref CDC_CAPTURED_REGION_COUNT: IntGauge = register_int_gauge!(
+        "tikv_cdc_captured_region_total",
+        "Total number of CDC captured regions"
+    )
+    .unwrap();
 }

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -7,7 +7,7 @@ use raft::StateRole;
 use raftstore::coprocessor::*;
 use raftstore::store::fsm::ObserveID;
 use raftstore::Error as RaftStoreError;
-use tikv_util::collections::HashSet;
+use tikv_util::collections::HashMap;
 use tikv_util::worker::Scheduler;
 
 use crate::endpoint::{Deregister, Task};
@@ -23,7 +23,7 @@ pub struct CdcObserver {
     sched: Scheduler<Task>,
     // A shared registry for managing observed regions.
     // TODO: it may become a bottleneck, find a better way to manage the registry.
-    observe_regions: Arc<RwLock<HashSet<u64>>>,
+    observe_regions: Arc<RwLock<HashMap<u64, ObserveID>>>,
     cmd_batches: RefCell<Vec<CmdBatch>>,
 }
 
@@ -55,18 +55,36 @@ impl CdcObserver {
 
     /// Subscribe an region, the observer will sink events of the region into
     /// its scheduler.
-    pub fn subscribe_region(&self, region_id: u64) {
-        self.observe_regions.write().unwrap().insert(region_id);
+    ///
+    /// Return pervious ObserveID if there is one.
+    pub fn subscribe_region(&self, region_id: u64, observe_id: ObserveID) -> Option<ObserveID> {
+        self.observe_regions
+            .write()
+            .unwrap()
+            .insert(region_id, observe_id)
     }
 
     /// Stops observe the region.
-    pub fn unsubscribe_region(&self, region_id: u64) {
-        self.observe_regions.write().unwrap().remove(&region_id);
+    ///
+    /// Return ObserverID if unsubscribe successfully.
+    pub fn unsubscribe_region(&self, region_id: u64, observe_id: ObserveID) -> Option<ObserveID> {
+        let mut regions = self.observe_regions.write().unwrap();
+        // To avoid ABA problem, we must check the unique ObserveID.
+        if let Some(oid) = regions.get(&region_id) {
+            if *oid == observe_id {
+                return regions.remove(&region_id);
+            }
+        }
+        None
     }
 
     /// Check whether the region is subscribed or not.
-    pub fn is_subscribed(&self, region_id: u64) -> bool {
-        self.observe_regions.read().unwrap().contains(&region_id)
+    pub fn is_subscribed(&self, region_id: u64) -> Option<ObserveID> {
+        self.observe_regions
+            .read()
+            .unwrap()
+            .get(&region_id)
+            .cloned()
     }
 }
 
@@ -102,11 +120,12 @@ impl RoleObserver for CdcObserver {
     fn on_role_change(&self, ctx: &mut ObserverContext<'_>, role: StateRole) {
         if role != StateRole::Leader {
             let region_id = ctx.region().get_id();
-            if self.is_subscribed(region_id) {
+            if let Some(observe_id) = self.is_subscribed(region_id) {
                 // Unregister all downstreams.
                 let store_err = RaftStoreError::NotLeader(region_id, None);
                 let deregister = Deregister::Region {
                     region_id,
+                    observe_id,
                     err: CdcError::Request(store_err.into()),
                 };
                 if let Err(e) = self.sched.schedule(Task::Deregister(deregister)) {
@@ -126,11 +145,12 @@ impl RegionChangeObserver for CdcObserver {
     ) {
         if let RegionChangeEvent::Destroy = event {
             let region_id = ctx.region().get_id();
-            if self.is_subscribed(region_id) {
+            if let Some(observe_id) = self.is_subscribed(region_id) {
                 // Unregister all downstreams.
                 let store_err = RaftStoreError::RegionNotFound(region_id);
                 let deregister = Deregister::Region {
                     region_id,
+                    observe_id,
                     err: CdcError::Request(store_err.into()),
                 };
                 if let Err(e) = self.sched.schedule(Task::Deregister(deregister)) {
@@ -177,12 +197,18 @@ mod tests {
         observer.on_role_change(&mut ctx, StateRole::Follower);
         rx.recv_timeout(Duration::from_millis(10)).unwrap_err();
 
-        observer.subscribe_region(1);
+        let oid = ObserveID::new();
+        observer.subscribe_region(1, oid);
         let mut ctx = ObserverContext::new(&region);
         observer.on_role_change(&mut ctx, StateRole::Follower);
         match rx.recv_timeout(Duration::from_millis(10)).unwrap().unwrap() {
-            Task::Deregister(Deregister::Region { region_id, .. }) => {
+            Task::Deregister(Deregister::Region {
+                region_id,
+                observe_id,
+                ..
+            }) => {
                 assert_eq!(region_id, 1);
+                assert_eq!(observe_id, oid);
             }
             _ => panic!("unexpected task"),
         };
@@ -191,8 +217,12 @@ mod tests {
         observer.on_role_change(&mut ctx, StateRole::Leader);
         rx.recv_timeout(Duration::from_millis(10)).unwrap_err();
 
+        // unsubscribed fail if observer id is different.
+        assert_eq!(observer.unsubscribe_region(1, ObserveID::new()), None);
+
         // No event if it is unsubscribed.
-        observer.unsubscribe_region(1);
+        let oid_ = observer.unsubscribe_region(1, oid).unwrap();
+        assert_eq!(oid_, oid);
         observer.on_role_change(&mut ctx, StateRole::Follower);
         rx.recv_timeout(Duration::from_millis(10)).unwrap_err();
 

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -237,7 +237,7 @@ fn test_cdc_not_leader() {
         .obs
         .get(&leader.get_store_id())
         .unwrap()
-        .is_subscribed(1));
+        .is_subscribed(1).is_some());
 
     // Transfer leader.
     let peer = suite
@@ -260,7 +260,7 @@ fn test_cdc_not_leader() {
         .obs
         .get(&leader.get_store_id())
         .unwrap()
-        .is_subscribed(1));
+        .is_subscribed(1).is_some());
 
     // Sleep a while to make sure the stream is deregistered.
     sleep_ms(200);
@@ -290,7 +290,7 @@ fn test_cdc_not_leader() {
         .obs
         .get(&leader.get_store_id())
         .unwrap()
-        .is_subscribed(1));
+        .is_subscribed(1).is_some());
 
     event_feed_wrap.as_ref().replace(None);
     suite.stop();

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -237,7 +237,8 @@ fn test_cdc_not_leader() {
         .obs
         .get(&leader.get_store_id())
         .unwrap()
-        .is_subscribed(1).is_some());
+        .is_subscribed(1)
+        .is_some());
 
     // Transfer leader.
     let peer = suite
@@ -260,7 +261,8 @@ fn test_cdc_not_leader() {
         .obs
         .get(&leader.get_store_id())
         .unwrap()
-        .is_subscribed(1).is_some());
+        .is_subscribed(1)
+        .is_some());
 
     // Sleep a while to make sure the stream is deregistered.
     sleep_ms(200);
@@ -290,7 +292,8 @@ fn test_cdc_not_leader() {
         .obs
         .get(&leader.get_store_id())
         .unwrap()
-        .is_subscribed(1).is_some());
+        .is_subscribed(1)
+        .is_some());
 
     event_feed_wrap.as_ref().replace(None);
     suite.stop();

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2785,11 +2785,17 @@ impl ApplyFsm {
                 region_id,
                 enabled,
             } => {
-                assert!(!self
-                    .delegate
-                    .observe_cmd
-                    .as_ref()
-                    .map_or(false, |o| o.enabled.load(Ordering::SeqCst)));
+                assert!(
+                    !self
+                        .delegate
+                        .observe_cmd
+                        .as_ref()
+                        .map_or(false, |o| o.enabled.load(Ordering::SeqCst)),
+                    "{} observer already exists {:?} {:?}",
+                    self.delegate.tag,
+                    self.delegate.observe_cmd,
+                    observe_id
+                );
                 (observe_id, region_id, Some(enabled))
             }
             ChangeCmd::Snapshot {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

1. cdc: deregister region only when ObserveID matches
2. cdc: add a metric that record captured region number 
3. cdc: support cancel incremental scan

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

Fix deregister ABA problem and support cancel incremental scan.