### PR TITLE
cmd: add uid flag for TIKV_LOCK_FILES

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -302,16 +302,12 @@ impl TiKVServer {
             .expect("failed to parse into a socket address");
         let cur_ip = cur_addr.ip();
         let cur_port = cur_addr.port();
-        let lock_dir: String;
 
-        #[cfg(target_os = "linux")]
-        {
-            lock_dir = format!("{}_TIKV_LOCK_FILES", unsafe { libc::getuid() });
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            lock_dir = "TIKV_LOCK_FILES".to_owned();
-        }
+        let lock_dir = if cfg!(unix) {
+            format!("{}_TIKV_LOCK_FILES", unsafe { libc::getuid() })
+        } else {
+            "TIKV_LOCK_FILES".to_owned()
+        };
 
         let search_base = env::temp_dir().join(&lock_dir);
         std::fs::create_dir_all(&search_base)

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -306,7 +306,7 @@ impl TiKVServer {
 
         let search_base = env::temp_dir().join(&lock_dir);
         std::fs::create_dir_all(&search_base)
-            .unwrap_or_else(|_| panic!("create {} failed", lock_dir));
+            .unwrap_or_else(|_| panic!("create {} failed", search_base.display()));
 
         for result in fs::read_dir(&search_base).unwrap() {
             if let Ok(entry) = result {
@@ -922,12 +922,12 @@ fn try_lock_conflict_addr<P: AsRef<Path>>(path: P) -> File {
     f
 }
 
-#[cfg(target_family = "unix")]
+#[cfg(unix)]
 fn get_lock_dir() -> String {
     format!("{}_TIKV_LOCK_FILES", unsafe { libc::getuid() })
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(unix))]
 fn get_lock_dir() -> String {
     "TIKV_LOCK_FILES".to_owned()
 }

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -314,7 +314,8 @@ impl TiKVServer {
         }
 
         let search_base = env::temp_dir().join(&lock_dir);
-        std::fs::create_dir_all(&search_base).expect(&format!("create {} failed", lock_dir));
+        std::fs::create_dir_all(&search_base)
+            .unwrap_or_else(|_| panic!("create {} failed", lock_dir));
 
         for result in fs::read_dir(&search_base).unwrap() {
             if let Ok(entry) = result {


### PR DESCRIPTION
Signed-off-by: TXXT <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

To allow multiple users create tikv and get rid of permission problem.
close #7462 

### What is changed and how it works?

Add UID for each TIKV_LOCK_FILES directory

### Related changes

- Need to cherry-pick to the release 4.0

### Check List <!--REMOVE the items that are not applicable-->

- Unit test
- Integration test

Side effects

No
