### PR TITLE
diagnose: fix disk used percent information

### DIFF
--- a/src/server/service/diagnostics.rs
+++ b/src/server/service/diagnostics.rs
@@ -438,7 +438,7 @@ mod sys {
             let free = disk.get_available_space();
             let used = total - free;
             let free_pct = (free as f64) / (total as f64);
-            let used_pct = (free as f64) / (total as f64);
+            let used_pct = (used as f64) / (total as f64);
             let infos = vec![
                 ("type", format!("{:?}", disk.get_type())),
                 (


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

before

```sql
mysql>select * from `CLUSTER_HARDWARE` where device_type="disk" and type='tikv' and name like "%percent%"
+------+-----------------+-------------+-------------+--------------+--------+
| TYPE | INSTANCE        | DEVICE_TYPE | DEVICE_NAME | NAME         | VALUE  |
+------+-----------------+-------------+-------------+--------------+--------+
| tikv | 127.0.0.1:20160 | disk        | mac         | free-percent | 0.26   |
| tikv | 127.0.0.1:20160 | disk        | mac         | used-percent | 0.26   | -- It's wrong.
+------+-----------------+-------------+-------------+--------------+--------+
```


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->