### PR TITLE
[DNM] raftstore: change the split flow path

### DIFF
--- a/components/batch-system/src/batch.rs
+++ b/components/batch-system/src/batch.rs
@@ -221,7 +221,7 @@ pub trait PollHandler<N, C> {
     fn handle_normal(&mut self, normal: &mut N) -> Option<usize>;
 
     /// This function is called at the end of every round.
-    fn end(&mut self, batch: &mut [Box<N>]);
+    fn end(&mut self, batch: &mut [Box<N>], control: &mut C);
 
     /// This function is called when batch system is going to sleep.
     fn pause(&mut self) {}
@@ -329,7 +329,8 @@ impl<N: Fsm, C: Fsm, Handler: PollHandler<N, C>> Poller<N, C, Handler> {
                 }
                 fsm_cnt += 1;
             }
-            self.handler.end(&mut batch.normals);
+            self.handler
+                .end(&mut batch.normals, batch.control.as_mut().unwrap());
 
             // Because release use `swap_remove` internally, so using pop here
             // to remove the correct FSM.

--- a/components/batch-system/src/router.rs
+++ b/components/batch-system/src/router.rs
@@ -218,6 +218,11 @@ where
         }
     }
 
+    #[inline]
+    pub fn force_send_control(&self, msg: C::Message) -> Result<(), SendError<C::Message>> {
+        self.control_box.force_send(msg, &self.control_scheduler)
+    }
+
     /// Try to notify all normal fsm a message.
     pub fn broadcast_normal(&self, mut msg_gen: impl FnMut() -> N::Message) {
         let mailboxes = self.normals.lock().unwrap();

--- a/components/batch-system/src/test_runner.rs
+++ b/components/batch-system/src/test_runner.rs
@@ -102,7 +102,7 @@ impl PollHandler<Runner, Runner> for Handler {
         self.handle(normal)
     }
 
-    fn end(&mut self, _normals: &mut [Box<Runner>]) {
+    fn end(&mut self, _normals: &mut [Box<Runner>], _: &mut Runner) {
         let mut c = self.metrics.lock().unwrap();
         *c += self.local;
         self.local = HandleMetrics::default();

--- a/components/keys/src/lib.rs
+++ b/components/keys/src/lib.rs
@@ -54,6 +54,7 @@ pub const SNAPSHOT_RAFT_STATE_SUFFIX: u8 = 0x04;
 
 // For region meta
 pub const REGION_STATE_SUFFIX: u8 = 0x01;
+pub const REGION_TEMP_STATE_SUFFIX: u8 = 0x05;
 
 #[inline]
 fn make_region_prefix(region_id: u64, suffix: u8) -> [u8; 11] {
@@ -184,6 +185,10 @@ pub fn region_meta_prefix(region_id: u64) -> [u8; 10] {
 
 pub fn region_state_key(region_id: u64) -> [u8; 11] {
     make_region_meta_key(region_id, REGION_STATE_SUFFIX)
+}
+
+pub fn region_temp_state_key(region_id: u64) -> [u8; 11] {
+    make_region_meta_key(region_id, REGION_TEMP_STATE_SUFFIX)
 }
 
 pub fn validate_data_key(key: &[u8]) -> bool {

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -24,8 +24,8 @@ pub use self::bootstrap::{
 pub use self::config::Config;
 pub use self::fsm::{new_compaction_listener, DestroyPeerJob, RaftRouter, StoreInfo};
 pub use self::msg::{
-    Callback, CasualMessage, PeerMsg, PeerTicks, RaftCommand, ReadCallback, ReadResponse,
-    SignificantMsg, StoreMsg, StoreTick, WriteCallback, WriteResponse,
+    Callback, CasualMessage, HandleSplitRegions, PeerMsg, PeerTicks, RaftCommand, ReadCallback,
+    ReadResponse, SignificantMsg, StoreMsg, StoreTick, WriteCallback, WriteResponse,
 };
 pub use self::peer::{
     Peer, PeerStat, ProposalContext, ReadExecutor, RequestInspector, RequestPolicy,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -148,7 +148,7 @@ pub struct ConsistencyState {
 }
 
 /// Statistics about raft peer.
-#[derive(Default, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct PeerStat {
     pub written_bytes: u64,
     pub written_keys: u64,

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1557,6 +1557,21 @@ pub fn write_peer_state<T: Mutable>(
     Ok(())
 }
 
+// The only use is to write a new peer state which is created by splitting
+pub fn write_peer_temp_state<T: Mutable>(kv_wb: &mut T, region: &metapb::Region) -> Result<()> {
+    let region_id = region.get_id();
+    let mut region_state = RegionLocalState::default();
+    region_state.set_state(PeerState::Normal);
+    region_state.set_region(region.clone());
+
+    kv_wb.put_msg_cf(
+        CF_RAFT,
+        &keys::region_temp_state_key(region_id),
+        &region_state,
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::coprocessor::CoprocessorHost;


### PR DESCRIPTION
Signed-off-by: Liqi Geng <gengliqiii@gmail.com>


### What problem does this PR solve?

Problem Summary:

The new region which is created by splitting may has already created before in some sophisticated cases.
So we must change the split flow path to check whether it should be created.
Add a new key `region_temp_state` to transition from one temporary state to the normal state if it can be created.

It's still in progress. (There are some details need to think twice and the tests have not been written yet. It needs many tests to make this PR reliable.)

### What is changed and how it works?

Change the split path

What's Changed:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

The time of creating a new peer by splitting will be longer than before but I think it's fine and I will test it.

### Release note <!-- bugfixes or new feature need a release note -->