### PR TITLE
raft_client: calculate batch size more approximately

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1497,6 +1497,9 @@ macro_rules! readpool_config {
             }
 
             pub fn validate(&self) -> Result<(), Box<dyn Error>> {
+                if self.use_unified_pool() {
+                    return Ok(());
+                }
                 if self.high_concurrency == 0 {
                     return Err(format!(
                         "readpool.{}.high-concurrency should be > 0",
@@ -1599,6 +1602,11 @@ macro_rules! readpool_config {
                 assert!(invalid_cfg.validate().is_err());
                 invalid_cfg.max_tasks_per_worker_low = 100;
                 assert!(cfg.validate().is_ok());
+
+                let mut invalid_but_unified = cfg.clone();
+                invalid_but_unified.use_unified_pool = Some(true);
+                invalid_but_unified.low_concurrency = 0;
+                assert!(invalid_but_unified.validate().is_ok());
             }
         }
     };
@@ -1695,10 +1703,9 @@ impl ReadPoolConfig {
     pub fn validate(&self) -> Result<(), Box<dyn Error>> {
         if self.is_unified_pool_enabled() {
             self.unified.validate()?;
-        } else {
-            self.storage.validate()?;
-            self.coprocessor.validate()?;
         }
+        self.storage.validate()?;
+        self.coprocessor.validate()?;
         Ok(())
     }
 }
@@ -1759,28 +1766,6 @@ mod readpool_tests {
 
     #[test]
     fn test_unified_enabled() {
-        // Allow invalid storage and coprocessor config when yatp is used.
-        let unified = UnifiedReadPoolConfig::default();
-        assert!(unified.validate().is_ok());
-        let storage = StorageReadPoolConfig {
-            use_unified_pool: Some(true),
-            high_concurrency: 0,
-            ..Default::default()
-        };
-        assert!(storage.validate().is_err());
-        let coprocessor = CoprReadPoolConfig {
-            high_concurrency: 0,
-            ..Default::default()
-        };
-        assert!(coprocessor.validate().is_err());
-        let cfg = ReadPoolConfig {
-            unified,
-            storage,
-            coprocessor,
-        };
-        assert!(cfg.is_unified_pool_enabled());
-        assert!(cfg.validate().is_ok());
-
         // Yatp config must be valid when yatp is used.
         let unified = UnifiedReadPoolConfig {
             min_thread_count: 0,
@@ -1820,6 +1805,51 @@ mod readpool_tests {
 
         cfg.coprocessor.use_unified_pool = Some(false);
         assert!(!cfg.is_unified_pool_enabled());
+    }
+
+    #[test]
+    fn test_partially_unified() {
+        let storage = StorageReadPoolConfig {
+            use_unified_pool: Some(false),
+            low_concurrency: 0,
+            ..Default::default()
+        };
+        assert!(!storage.use_unified_pool());
+        let coprocessor = CoprReadPoolConfig {
+            use_unified_pool: Some(true),
+            ..Default::default()
+        };
+        assert!(coprocessor.use_unified_pool());
+        let mut cfg = ReadPoolConfig {
+            storage,
+            coprocessor,
+            ..Default::default()
+        };
+        assert!(cfg.is_unified_pool_enabled());
+        assert!(cfg.validate().is_err());
+        cfg.storage.low_concurrency = 1;
+        assert!(cfg.validate().is_ok());
+
+        let storage = StorageReadPoolConfig {
+            use_unified_pool: Some(true),
+            ..Default::default()
+        };
+        assert!(storage.use_unified_pool());
+        let coprocessor = CoprReadPoolConfig {
+            use_unified_pool: Some(false),
+            low_concurrency: 0,
+            ..Default::default()
+        };
+        assert!(!coprocessor.use_unified_pool());
+        let mut cfg = ReadPoolConfig {
+            storage,
+            coprocessor,
+            ..Default::default()
+        };
+        assert!(cfg.is_unified_pool_enabled());
+        assert!(cfg.validate().is_err());
+        cfg.coprocessor.low_concurrency = 1;
+        assert!(cfg.validate().is_ok());
     }
 }
 

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -1,10 +1,10 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::ffi::CString;
+use std::i64;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use std::i64;
 
 use super::load_statistics::ThreadLoad;
 use super::metrics::*;

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -242,7 +242,7 @@ impl<T: RaftStoreRouter<RocksEngine>> RaftClient<T> {
 struct RaftMsgCollector(usize);
 impl BatchCollector<Vec<RaftMessage>, RaftMessage> for RaftMsgCollector {
     fn collect(&mut self, v: &mut Vec<RaftMessage>, e: RaftMessage) -> Option<RaftMessage> {
-        let mut msg_size = e.start_key.len() + e.end_key.len() + mem::size_of::<RaftMessage>();
+        let mut msg_size = e.start_key.len() + e.end_key.len();
         for entry in e.get_message().get_entries() {
             msg_size += entry.data.len();
         }

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -4,7 +4,7 @@ use std::ffi::CString;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use std::{i64, mem};
+use std::i64;
 
 use super::load_statistics::ThreadLoad;
 use super::metrics::*;

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -1,10 +1,10 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::ffi::CString;
-use std::i64;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use std::{i64, mem};
 
 use super::load_statistics::ThreadLoad;
 use super::metrics::*;
@@ -17,7 +17,6 @@ use grpcio::{
 };
 use kvproto::raft_serverpb::RaftMessage;
 use kvproto::tikvpb::{BatchRaftMessage, TikvClient};
-use protobuf::Message;
 use raftstore::router::RaftStoreRouter;
 use tikv_util::collections::{HashMap, HashMapEntry};
 use tikv_util::mpsc::batch::{self, BatchCollector, Sender as BatchSender};
@@ -28,7 +27,7 @@ use tokio_timer::timer::Handle;
 const MAX_GRPC_RECV_MSG_LEN: i32 = 10 * 1024 * 1024;
 const MAX_GRPC_SEND_MSG_LEN: i32 = 10 * 1024 * 1024;
 // When merge raft messages into a batch message, leave a buffer.
-const GRPC_SEND_MSG_BUF: usize = 4096;
+const GRPC_SEND_MSG_BUF: usize = 64 * 1024;
 
 const RAFT_MSG_MAX_BATCH_SIZE: usize = 128;
 const RAFT_MSG_NOTIFY_SIZE: usize = 8;
@@ -243,9 +242,9 @@ impl<T: RaftStoreRouter<RocksEngine>> RaftClient<T> {
 struct RaftMsgCollector(usize);
 impl BatchCollector<Vec<RaftMessage>, RaftMessage> for RaftMsgCollector {
     fn collect(&mut self, v: &mut Vec<RaftMessage>, e: RaftMessage) -> Option<RaftMessage> {
-        let mut msg_size = 0;
+        let mut msg_size = e.start_key.len() + e.end_key.len() + mem::size_of::<RaftMessage>();
         for entry in e.get_message().get_entries() {
-            msg_size += entry.compute_size() as usize;
+            msg_size += entry.data.len();
         }
         if self.0 > 0 && self.0 + msg_size + GRPC_SEND_MSG_BUF >= MAX_GRPC_SEND_MSG_LEN as usize {
             self.0 = 0;


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

Calculate batch raft message size more approximately. Try best to avoid error like:
```
 ["RPC batch_raft fail"] [err="Some(RpcFailure(RpcStatus { status: ResourceExhausted, details: Some(\"Sent message larger than max (10525503 vs. 10485760)\") }))"] [sink_err=Some(RemoteStopped)] [to_addr=10.240.97.140:20160]
```

### What is changed and how it works?

Enlarge the batch buff from 4k to 64k, and consider size of `RaftMessage` itself.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note