### PR TITLE
kv_service: fix batch empty request deadlock

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -24,6 +24,7 @@ use crate::storage::{
 use engine_rocks::RocksEngine;
 use futures::executor::{self, Notify, Spawn};
 use futures::{future, Async, Future, Sink, Stream};
+use futures::future::Either;
 use grpcio::{
     ClientStreamingSink, DuplexSink, Error as GrpcError, RequestStream, RpcContext, RpcStatus,
     RpcStatusCode, ServerStreamingSink, UnarySink, WriteFlags,
@@ -1132,14 +1133,16 @@ fn handle_batch_commands_request<E: Engine, L: LockManager>(
 fn future_handle_empty(
     req: BatchCommandsEmptyRequest,
 ) -> impl Future<Item = BatchCommandsEmptyResponse, Error = Error> {
-    tikv_util::timer::GLOBAL_TIMER_HANDLE
-        .delay(std::time::Instant::now() + std::time::Duration::from_millis(req.get_delay_time()))
-        .map(move |_| {
-            let mut res = BatchCommandsEmptyResponse::default();
-            res.set_test_id(req.get_test_id());
-            res
-        })
-        .map_err(|_| unreachable!())
+    let mut res = BatchCommandsEmptyResponse::default();
+    res.set_test_id(req.get_test_id());
+    if req.get_delay_time() < 10 {
+        Either::A(future::result(Ok(res)))
+    } else {
+        Either::B(tikv_util::timer::GLOBAL_TIMER_HANDLE
+            .delay(std::time::Instant::now() + std::time::Duration::from_millis(req.get_delay_time()))
+            .map(move |_| res)
+            .map_err(|_| unreachable!()))
+    }
 }
 
 fn future_get<E: Engine, L: LockManager>(

--- a/src/server/service/mod.rs
+++ b/src/server/service/mod.rs
@@ -8,3 +8,4 @@ mod kv;
 pub use self::debug::Service as DebugService;
 pub use self::diagnostics::Service as DiagnosticsService;
 pub use self::kv::Service as KvService;
+pub use self::kv::{batch_commands_request, batch_commands_response};

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -2,12 +2,13 @@
 
 use futures::{Future, Sink, Stream};
 use grpcio::*;
-use kvproto::tikvpb::BatchCommandsRequest;
+use kvproto::tikvpb::*;
 use kvproto::tikvpb::TikvClient;
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
 use test_raftstore::new_server_cluster;
+use tikv::server::service::batch_commands_request;
 use tikv_util::HandyRwLock;
 
 #[test]
@@ -27,6 +28,51 @@ fn test_batch_commands() {
         let mut batch_req = BatchCommandsRequest::default();
         for i in 0..10 {
             batch_req.mut_requests().push(Default::default());
+            batch_req.mut_request_ids().push(i);
+        }
+        match sender.send((batch_req, WriteFlags::default())).wait() {
+            Ok(s) => sender = s,
+            Err(e) => panic!("tikv client send fail: {:?}", e),
+        }
+    }
+
+    let (tx, rx) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        // We have send 10k requests to the server, so we should get 10k responses.
+        let mut count = 0;
+        for x in receiver
+            .wait()
+            .map(move |b| b.unwrap().get_responses().len())
+        {
+            count += x;
+            if count == 10000 {
+                tx.send(1).unwrap();
+                return;
+            }
+        }
+    });
+    rx.recv_timeout(Duration::from_secs(1)).unwrap();
+}
+
+#[test]
+fn test_empty_commands() {
+    let mut cluster = new_server_cluster(0, 1);
+    cluster.run();
+
+    let leader = cluster.get_region(b"").get_peers()[0].clone();
+    let addr = cluster.sim.rl().get_addr(leader.get_store_id()).to_owned();
+
+    let env = Arc::new(Environment::new(1));
+    let channel = ChannelBuilder::new(env).connect(&addr);
+    let client = TikvClient::new(channel);
+
+    let (mut sender, receiver) = client.batch_commands().unwrap();
+    for _ in 0..1000 {
+        let mut batch_req = BatchCommandsRequest::default();
+        for i in 0..10 {
+            let mut req = batch_commands_request::Request::default();
+            req.cmd = Some(batch_commands_request::request::Cmd::Empty(Default::default()));
+            batch_req.mut_requests().push(req);
             batch_req.mut_request_ids().push(i);
         }
         match sender.send((batch_req, WriteFlags::default())).wait() {

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -2,8 +2,8 @@
 
 use futures::{Future, Sink, Stream};
 use grpcio::*;
-use kvproto::tikvpb::*;
 use kvproto::tikvpb::TikvClient;
+use kvproto::tikvpb::*;
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
@@ -71,7 +71,9 @@ fn test_empty_commands() {
         let mut batch_req = BatchCommandsRequest::default();
         for i in 0..10 {
             let mut req = batch_commands_request::Request::default();
-            req.cmd = Some(batch_commands_request::request::Cmd::Empty(Default::default()));
+            req.cmd = Some(batch_commands_request::request::Cmd::Empty(
+                Default::default(),
+            ));
             batch_req.mut_requests().push(req);
             batch_req.mut_request_ids().push(i);
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7493 <!-- REMOVE this line if no issue to close -->

Problem Summary:

When request's delay is 0, it's possible that tokio-timer calls notify directly inside notify, which leads to deadlock. This PR fixes the issue by returning the result directly when delay is small.

To prevent all these problems, it's a good practice to avoid poll in place. In place polling is source of most the lock issues. Even only polling once can still lead to deadlock, see tikv/grpc-rs#395. The permanent fix for similar issue is removing `BatchCommandsNotify` and find a better way to reduce context switch.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

kv_service: fix deadlock when batch empty requests with zero delay is handled