### PR TITLE
copr: add non-vectorized make_date

### DIFF
--- a/components/tidb_query_normal_expr/src/scalar_function.rs
+++ b/components/tidb_query_normal_expr/src/scalar_function.rs
@@ -126,6 +126,7 @@ impl ScalarFunc {
             | ScalarFuncSig::Substring2Args
             | ScalarFuncSig::Repeat
             | ScalarFuncSig::DateDiff
+            | ScalarFuncSig::MakeDate
             | ScalarFuncSig::AddDatetimeAndDuration
             | ScalarFuncSig::AddDatetimeAndString
             | ScalarFuncSig::AddDurationAndDuration
@@ -932,6 +933,7 @@ dispatch_call! {
         SubDatetimeAndString => sub_datetime_and_string,
         SubTimeDateTimeNull => sub_time_datetime_null,
         FromDays => from_days,
+        MakeDate => make_date,
 
         IfNullTime => if_null_time,
         IfTime => if_time,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

UCP #6870

Checklist #5751

### What problem does this PR solve?

Issue Number: close #6870 

Problem Summary:

### What is changed and how it works?

Add non-vectorized function make_date. It should work like MySQL function MakeDate. I am not sure if case when MySQL function returns NULL is correct in this PR. 

What's Changed:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test