### PR TITLE
raft_client: enlarge batch raft message buffer (#7522)

### DIFF
--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -28,7 +28,7 @@ use tokio_timer::timer::Handle;
 const MAX_GRPC_RECV_MSG_LEN: i32 = 10 * 1024 * 1024;
 const MAX_GRPC_SEND_MSG_LEN: i32 = 10 * 1024 * 1024;
 // When merge raft messages into a batch message, leave a buffer.
-const GRPC_SEND_MSG_BUF: usize = 4096;
+const GRPC_SEND_MSG_BUF: usize = 64 * 1024;
 
 const RAFT_MSG_MAX_BATCH_SIZE: usize = 128;
 const RAFT_MSG_NOTIFY_SIZE: usize = 8;


### PR DESCRIPTION
Signed-off-by: qupeng qupeng@pingcap.com

Cherry pick #7522.

### Release note <!-- bugfixes or new feature need a release note -->
Enlarge batch raft message buffer to avoid too long messages