### PR TITLE
encryption: Fix crash after disable encryption or change encryption method

### DIFF
--- a/components/encryption/src/manager/mod.rs
+++ b/components/encryption/src/manager/mod.rs
@@ -260,9 +260,10 @@ impl Dicts {
             // creation time.
             let (_, key) = self.current_data_key();
 
-            // Generate a new data key if the current data key was
-            // exposed and the master key backend is secure.
-            if !(key.was_exposed && master_key.is_secure()) {
+            // Generate a new data key if
+            //   1. encryption method is not the same, or
+            //   2. the current data key was exposed and the new master key is secure.
+            if compat(method) == key.method && !(key.was_exposed && master_key.is_secure()) {
                 let creation_time = UNIX_EPOCH + Duration::from_secs(key.creation_time);
                 match now.duration_since(creation_time) {
                     Ok(duration) => {

--- a/components/encryption/src/master_key/metadata.rs
+++ b/components/encryption/src/master_key/metadata.rs
@@ -2,13 +2,15 @@
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MetadataKey {
+    Method,
     Iv,
     AesGcmTag,
     KmsVendor,
     KmsCiphertextKey,
 }
 
-const METADATA_KEY_IV: &str = "IV";
+const METADATA_KEY_METHOD: &str = "method";
+const METADATA_KEY_IV: &str = "iv";
 const METADATA_KEY_AES_GCM_TAG: &str = "aes_gcm_tag";
 const METADATA_KEY_KMS_VENDOR: &str = "kms_vendor";
 const METADATA_KEY_KMS_ENCRYPTED_KEY: &str = "kms_ciphertext_key";
@@ -16,10 +18,29 @@ const METADATA_KEY_KMS_ENCRYPTED_KEY: &str = "kms_ciphertext_key";
 impl MetadataKey {
     pub fn as_str(self) -> &'static str {
         match self {
+            MetadataKey::Method => METADATA_KEY_METHOD,
             MetadataKey::Iv => METADATA_KEY_IV,
             MetadataKey::AesGcmTag => METADATA_KEY_AES_GCM_TAG,
             MetadataKey::KmsVendor => METADATA_KEY_KMS_VENDOR,
             MetadataKey::KmsCiphertextKey => METADATA_KEY_KMS_ENCRYPTED_KEY,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum MetadataMethod {
+    Plaintext,
+    Aes256Gcm,
+}
+
+const METADATA_METHOD_PLAINTEXT: &[u8] = b"plaintext";
+const METADATA_METHOD_AES256_GCM: &[u8] = b"aes256-gcm";
+
+impl MetadataMethod {
+    pub fn as_slice(self) -> &'static [u8] {
+        match self {
+            MetadataMethod::Plaintext => METADATA_METHOD_PLAINTEXT,
+            MetadataMethod::Aes256Gcm => METADATA_METHOD_AES256_GCM,
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
Fixing two issues with encryption:
1. TiKV will crash with protobuf error when disable encryption using the following config
```
[encryption]
data-encryption-method: plaintext
[encryption.previous-master-key]
{...master key config here}
```
The problem is that when TiKV initialize encryption and try to read `key_dict`, in the first round plaintext backend is used, since no master key is specified. Plaintext backend cannot tell if the content feed to it should plaintext or not, and return `WrongMasterKey` error properly.

2. TiKV will crash when change encryption method and restart. That's caused by tikv reusing the same data key before restart, even when encryption method had changed. The key is send to rocksdb for new files, and rocksdb will return key length mismatch error.

### What is changed and how it works?

What's Changed:
* Add encryption method as metadata in `EncryptedContent`. In particular plaintext backend will store "plaintext" as it's method and check against it. If method not match on "decrypt", return `WrongMasterKey`.
* On restart if encryption method doesn't match current data key's encryption method, generate a new data key.

### Related changes
no

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
Manual test the above scenarios. Unit test will be added in later PRs.

### Release note <!-- bugfixes or new feature need a release note -->