### PR TITLE
Fix incorrect processed / total keys counter

### DIFF
--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -1,6 +1,7 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use kvproto::kvrpcpb;
+use kvproto::kvrpcpb::ScanDetailV2;
 
 use crate::storage::kv::{PerfStatisticsDelta, PerfStatisticsInstant};
 
@@ -53,7 +54,7 @@ pub struct Tracker {
     schedule_wait_time: Duration, // Wait time spent on waiting for scheduling
     snapshot_wait_time: Duration, // Wait time spent on waiting for a snapshot
     handler_build_time: Duration, // Time spent on building the handler (not included in total wait time)
-    req_time: Duration,
+    req_lifetime: Duration,
     item_process_time: Duration,
     total_process_time: Duration,
     total_storage_stats: Statistics,
@@ -79,7 +80,7 @@ impl Tracker {
             schedule_wait_time: Duration::default(),
             snapshot_wait_time: Duration::default(),
             handler_build_time: Duration::default(),
-            req_time: Duration::default(),
+            req_lifetime: Duration::default(),
             item_process_time: Duration::default(),
             total_process_time: Duration::default(),
             total_storage_stats: Statistics::default(),
@@ -140,6 +141,7 @@ impl Tracker {
             self.total_perf_stats += perf_stats.delta();
         }
         self.current_stage = TrackerState::ItemFinished;
+        // TODO: Need to record time between Finish -> Begin Next?
     }
 
     pub fn collect_storage_statistics(&mut self, storage_stats: Statistics) {
@@ -148,6 +150,7 @@ impl Tracker {
 
     /// Get current item's ExecDetail according to previous collected metrics.
     /// TiDB asks for ExecDetail to be printed in its log.
+    /// WARN: TRY BEST NOT TO USE THIS FUNCTION.
     pub fn get_item_exec_details(&self) -> kvrpcpb::ExecDetails {
         assert_eq!(self.current_stage, TrackerState::ItemFinished);
         self.exec_details(self.item_process_time)
@@ -162,16 +165,32 @@ impl Tracker {
 
     fn exec_details(&self, measure: Duration) -> kvrpcpb::ExecDetails {
         let mut exec_details = kvrpcpb::ExecDetails::default();
-        if self.req_ctx.context.get_handle_time() {
-            let mut handle = kvrpcpb::HandleTime::default();
-            handle.set_process_ms((time::duration_to_sec(measure) * 1000.0) as i64);
-            handle.set_wait_ms((time::duration_to_sec(self.wait_time) * 1000.0) as i64);
-            exec_details.set_handle_time(handle);
-        }
-        if self.req_ctx.context.get_scan_detail() {
-            let detail = self.total_storage_stats.scan_detail();
-            exec_details.set_scan_detail(detail);
-        }
+
+        let mut handle = kvrpcpb::HandleTime::default();
+        handle.set_process_ms((time::duration_to_sec(measure) * 1000.0) as i64);
+        handle.set_wait_ms((time::duration_to_sec(self.wait_time) * 1000.0) as i64);
+        exec_details.set_handle_time(handle);
+
+        let detail = self.total_storage_stats.scan_detail();
+
+        let mut detail_v2 = ScanDetailV2::default();
+        detail_v2.set_processed_versions(self.total_storage_stats.write.processed_keys as u64);
+        detail_v2.set_total_versions(self.total_storage_stats.write.total_op_count() as u64);
+        detail_v2.set_rocksdb_delete_skipped_count(
+            self.total_perf_stats.0.internal_delete_skipped_count as u64,
+        );
+        detail_v2.set_rocksdb_key_skipped_count(
+            self.total_perf_stats.0.internal_key_skipped_count as u64,
+        );
+        detail_v2.set_rocksdb_block_cache_hit_count(
+            self.total_perf_stats.0.block_cache_hit_count as u64,
+        );
+        detail_v2.set_rocksdb_block_read_count(self.total_perf_stats.0.block_read_count as u64);
+        detail_v2.set_rocksdb_block_read_byte(self.total_perf_stats.0.block_read_byte as u64);
+
+        exec_details.set_use_scan_detail_v2(true);
+        exec_details.set_scan_detail(detail);
+        exec_details.set_scan_detail_v2(detail_v2);
         exec_details
     }
 
@@ -180,7 +199,7 @@ impl Tracker {
             self.current_stage == TrackerState::AllItemsBegan
                 || self.current_stage == TrackerState::ItemFinished
         );
-        self.req_time = Instant::now_coarse() - self.request_begin_at;
+        self.req_lifetime = Instant::now_coarse() - self.request_begin_at;
         self.current_stage = TrackerState::AllItemFinished;
         self.track();
     }
@@ -190,8 +209,9 @@ impl Tracker {
             return;
         }
 
-        // Print slow log if *process* time is long.
-        if time::duration_to_sec(self.total_process_time) > SLOW_QUERY_LOWER_BOUND {
+        let total_storage_stats = std::mem::take(&mut self.total_storage_stats);
+
+        if time::duration_to_sec(self.req_lifetime) > SLOW_QUERY_LOWER_BOUND {
             let some_table_id = self.req_ctx.first_range.as_ref().map(|range| {
                 tidb_query_datatype::codec::table::decode_table_id(range.get_start())
                     .unwrap_or_default()
@@ -199,58 +219,68 @@ impl Tracker {
 
             info!(#"slow_log", "slow-query";
                 "region_id" => self.req_ctx.context.get_region_id(),
-                "peer_id" => &self.req_ctx.peer,
-                "req_time" => ?self.req_time,
-                "total_process_time" => ?self.total_process_time,
+                "remote_host" => &self.req_ctx.peer,
+                "total_lifetime" => ?self.req_lifetime,
                 "wait_time" => ?self.wait_time,
-                "schedule_wait_time" => ?self.schedule_wait_time,
-                "snapshot_wait_time" => ?self.snapshot_wait_time,
+                "wait_time.schedule" => ?self.schedule_wait_time,
+                "wait_time.snapshot" => ?self.snapshot_wait_time,
                 "handler_build_time" => ?self.handler_build_time,
+                "total_process_time" => ?self.total_process_time,
                 "txn_start_ts" => self.req_ctx.txn_start_ts,
                 "table_id" => some_table_id,
                 "tag" => self.req_ctx.tag.get_str(),
-                "scan_is_desc" => self.req_ctx.is_desc_scan,
-                "scan_iter_ops" => self.total_storage_stats.total_op_count(),
-                "scan_iter_processed" => self.total_storage_stats.total_processed(),
-                "scan_ranges" => self.req_ctx.ranges_len,
-                "scan_first_range" => ?self.req_ctx.first_range,
+                "scan.is_desc" => self.req_ctx.is_desc_scan,
+                "scan.processed" => total_storage_stats.write.processed_keys,
+                "scan.total" => total_storage_stats.write.total_op_count(),
+                "scan.ranges" => self.req_ctx.ranges_len,
+                "scan.range.first" => ?self.req_ctx.first_range,
                 self.total_perf_stats,
             );
         }
 
-        let total_storage_stats = std::mem::take(&mut self.total_storage_stats);
-
         // req time
         COPR_REQ_HISTOGRAM_STATIC
             .get(self.req_ctx.tag)
-            .observe(time::duration_to_sec(self.req_time));
+            .observe(time::duration_to_sec(self.req_lifetime));
+
         // wait time
         COPR_REQ_WAIT_TIME_STATIC
             .get(self.req_ctx.tag)
             .all
             .observe(time::duration_to_sec(self.wait_time));
+
         // schedule wait time
         COPR_REQ_WAIT_TIME_STATIC
             .get(self.req_ctx.tag)
             .schedule
             .observe(time::duration_to_sec(self.schedule_wait_time));
+
         // snapshot wait time
         COPR_REQ_WAIT_TIME_STATIC
             .get(self.req_ctx.tag)
             .snapshot
             .observe(time::duration_to_sec(self.snapshot_wait_time));
-        // handle time
-        COPR_REQ_HANDLE_TIME_STATIC
-            .get(self.req_ctx.tag)
-            .observe(time::duration_to_sec(self.total_process_time));
+
         // handler build time
         COPR_REQ_HANDLER_BUILD_TIME_STATIC
             .get(self.req_ctx.tag)
             .observe(time::duration_to_sec(self.handler_build_time));
+
+        // handle time
+        COPR_REQ_HANDLE_TIME_STATIC
+            .get(self.req_ctx.tag)
+            .observe(time::duration_to_sec(self.total_process_time));
+
         // scan keys
         COPR_SCAN_KEYS_STATIC
             .get(self.req_ctx.tag)
-            .observe(total_storage_stats.total_processed() as f64);
+            .total
+            .observe(total_storage_stats.write.total_op_count() as f64);
+        COPR_SCAN_KEYS_STATIC
+            .get(self.req_ctx.tag)
+            .processed_keys
+            .observe(total_storage_stats.write.processed_keys as f64);
+
         // RocksDB perf stats
         COPR_ROCKSDB_PERF_COUNTER_STATIC
             .get(self.req_ctx.tag)

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -82,8 +82,7 @@ make_auto_flush_static_metric! {
     }
 
     pub label_enum GcKeysDetail {
-        total,
-        processed,
+        processed_keys,
         get,
         next,
         prev,

--- a/src/storage/kv/stats.rs
+++ b/src/storage/kv/stats.rs
@@ -5,8 +5,7 @@ use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::{ScanDetail, ScanInfo};
 pub use raftstore::store::{FlowStatistics, FlowStatsReporter};
 
-const STAT_TOTAL: &str = "total";
-const STAT_PROCESSED: &str = "processed";
+const STAT_PROCESSED_KEYS: &str = "processed_keys";
 const STAT_GET: &str = "get";
 const STAT_NEXT: &str = "next";
 const STAT_PREV: &str = "prev";
@@ -17,15 +16,16 @@ const STAT_OVER_SEEK_BOUND: &str = "over_seek_bound";
 /// Statistics collects the ops taken when fetching data.
 #[derive(Default, Clone, Debug)]
 pub struct CfStatistics {
-    // How many keys that's effective to user. This counter should be increased
-    // by the caller.
-    pub processed: usize,
+    // How many keys that's visible to user
+    pub processed_keys: usize,
+
     pub get: usize,
     pub next: usize,
     pub prev: usize,
     pub seek: usize,
     pub seek_for_prev: usize,
     pub over_seek_bound: usize,
+
     pub flow_stats: FlowStatistics,
 }
 
@@ -35,10 +35,9 @@ impl CfStatistics {
         self.get + self.next + self.prev + self.seek + self.seek_for_prev
     }
 
-    pub fn details(&self) -> [(&'static str, usize); 8] {
+    pub fn details(&self) -> [(&'static str, usize); 7] {
         [
-            (STAT_TOTAL, self.total_op_count()),
-            (STAT_PROCESSED, self.processed),
+            (STAT_PROCESSED_KEYS, self.processed_keys),
             (STAT_GET, self.get),
             (STAT_NEXT, self.next),
             (STAT_PREV, self.prev),
@@ -48,10 +47,9 @@ impl CfStatistics {
         ]
     }
 
-    pub fn details_enum(&self) -> [(GcKeysDetail, usize); 8] {
+    pub fn details_enum(&self) -> [(GcKeysDetail, usize); 7] {
         [
-            (GcKeysDetail::total, self.total_op_count()),
-            (GcKeysDetail::processed, self.processed),
+            (GcKeysDetail::processed_keys, self.processed_keys),
             (GcKeysDetail::get, self.get),
             (GcKeysDetail::next, self.next),
             (GcKeysDetail::prev, self.prev),
@@ -62,7 +60,7 @@ impl CfStatistics {
     }
 
     pub fn add(&mut self, other: &Self) {
-        self.processed = self.processed.saturating_add(other.processed);
+        self.processed_keys = self.processed_keys.saturating_add(other.processed_keys);
         self.get = self.get.saturating_add(other.get);
         self.next = self.next.saturating_add(other.next);
         self.prev = self.prev.saturating_add(other.prev);
@@ -72,9 +70,10 @@ impl CfStatistics {
         self.flow_stats.add(&other.flow_stats);
     }
 
+    /// Deprecated
     pub fn scan_info(&self) -> ScanInfo {
         let mut info = ScanInfo::default();
-        info.set_processed(self.processed as i64);
+        info.set_processed(self.processed_keys as i64);
         info.set_total(self.total_op_count() as i64);
         info
     }
@@ -88,15 +87,7 @@ pub struct Statistics {
 }
 
 impl Statistics {
-    pub fn total_op_count(&self) -> usize {
-        self.lock.total_op_count() + self.write.total_op_count() + self.data.total_op_count()
-    }
-
-    pub fn total_processed(&self) -> usize {
-        self.lock.processed + self.write.processed + self.data.processed
-    }
-
-    pub fn details(&self) -> [(&'static str, [(&'static str, usize); 8]); 3] {
+    pub fn details(&self) -> [(&'static str, [(&'static str, usize); 7]); 3] {
         [
             (CF_DEFAULT, self.data.details()),
             (CF_LOCK, self.lock.details()),
@@ -104,7 +95,7 @@ impl Statistics {
         ]
     }
 
-    pub fn details_enum(&self) -> [(GcKeysCF, [(GcKeysDetail, usize); 8]); 3] {
+    pub fn details_enum(&self) -> [(GcKeysCF, [(GcKeysDetail, usize); 7]); 3] {
         [
             (GcKeysCF::default, self.data.details_enum()),
             (GcKeysCF::lock, self.lock.details_enum()),
@@ -118,6 +109,7 @@ impl Statistics {
         self.data.add(&other.data);
     }
 
+    /// Deprecated
     pub fn scan_detail(&self) -> ScanDetail {
         let mut detail = ScanDetail::default();
         detail.set_data(self.data.scan_info());

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -162,8 +162,7 @@ make_auto_flush_static_metric! {
     }
 
     pub label_enum GcKeysDetail {
-        total,
-        processed,
+        processed_keys,
         get,
         next,
         prev,
@@ -229,8 +228,7 @@ impl Into<GcKeysCF> for ServerGcKeysCF {
 impl Into<GcKeysDetail> for ServerGcKeysDetail {
     fn into(self) -> GcKeysDetail {
         match self {
-            ServerGcKeysDetail::total => GcKeysDetail::total,
-            ServerGcKeysDetail::processed => GcKeysDetail::processed,
+            ServerGcKeysDetail::processed_keys => GcKeysDetail::processed_keys,
             ServerGcKeysDetail::get => GcKeysDetail::get,
             ServerGcKeysDetail::next => GcKeysDetail::next,
             ServerGcKeysDetail::prev => GcKeysDetail::prev,

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -81,10 +81,12 @@ impl<S: Snapshot> MvccReader<S> {
             self.statistics.data.get += 1;
             self.snapshot.get(&k)?
         };
-        self.statistics.data.processed += 1;
 
         match val {
-            Some(val) => Ok(val),
+            Some(val) => {
+                self.statistics.data.processed_keys += 1;
+                Ok(val)
+            }
             None => Err(default_not_found_error(key.to_raw()?, "get")),
         }
     }
@@ -110,10 +112,6 @@ impl<S: Snapshot> MvccReader<S> {
                 None => None,
             }
         };
-
-        if res.is_some() {
-            self.statistics.lock.processed += 1;
-        }
 
         Ok(res)
     }
@@ -155,7 +153,6 @@ impl<S: Snapshot> MvccReader<S> {
             return Ok(None);
         }
         let write = WriteRef::parse(cursor.value(&mut self.statistics.write))?.to_owned();
-        self.statistics.write.processed += 1;
         Ok(Some((commit_ts, write)))
     }
 
@@ -163,9 +160,10 @@ impl<S: Snapshot> MvccReader<S> {
     /// Returns the blocking lock as the `Err` variant.
     fn check_lock(&mut self, key: &Key, ts: TimeStamp) -> Result<()> {
         if let Some(lock) = self.load_lock(key)? {
-            return lock
-                .check_ts_conflict(key, ts, &Default::default())
-                .map_err(From::from);
+            if let Err(e) = lock.check_ts_conflict(key, ts, &Default::default()) {
+                self.statistics.lock.processed_keys += 1;
+                return Err(e.into());
+            }
         }
         Ok(())
     }
@@ -316,7 +314,7 @@ impl<S: Snapshot> MvccReader<S> {
             }
             cursor.next(&mut self.statistics.lock);
         }
-        self.statistics.lock.processed += locks.len();
+        self.statistics.lock.processed_keys += locks.len();
         // If we reach here, `cursor.valid()` is `false`, so there MUST be no more locks.
         Ok((locks, false))
     }
@@ -339,7 +337,7 @@ impl<S: Snapshot> MvccReader<S> {
                 return Ok((keys, None));
             }
             if keys.len() >= limit {
-                self.statistics.write.processed += keys.len();
+                self.statistics.write.processed_keys += keys.len();
                 return Ok((keys, start));
             }
             let key =

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -274,6 +274,7 @@ impl<S: Snapshot, P: ScanPolicy<S>> ForwardScanner<S, P> {
                         &mut self.cursors,
                         &mut self.statistics,
                     )? {
+                        self.statistics.write.processed_keys += 1;
                         return Ok(Some(output));
                     }
                 }
@@ -364,7 +365,6 @@ impl<S: Snapshot> ScanPolicy<S> for LatestKvPolicy {
     ) -> Result<HandleRes<Self::Output>> {
         let value: Option<Value> = loop {
             let write = WriteRef::parse(cursors.write.value(&mut statistics.write))?;
-            statistics.write.processed += 1;
 
             match write.write_type {
                 WriteType::Put => {
@@ -465,7 +465,6 @@ impl<S: Snapshot> ScanPolicy<S> for LatestEntryPolicy {
             }
             let write_value = cursors.write.value(&mut statistics.write);
             let write = WriteRef::parse(write_value)?;
-            statistics.write.processed += 1;
 
             match write.write_type {
                 WriteType::Put => {
@@ -547,6 +546,7 @@ fn scan_latest_handle_lock<S: Snapshot, T>(
     // Even if there is a lock error, we still need to step the cursor for future
     // calls.
     if result.is_err() {
+        statistics.lock.processed_keys += 1;
         cursors.move_write_cursor_to_next_user_key(&current_user_key, statistics)?;
     }
     result

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -317,7 +317,7 @@ where
             "near_load_data_by_write",
         ));
     }
-    statistics.data.processed += 1;
+    statistics.data.processed_keys += 1;
     Ok(default_cursor.value(&mut statistics.data).to_vec())
 }
 
@@ -342,7 +342,7 @@ where
             "near_reverse_load_data_by_write",
         ));
     }
-    statistics.data.processed += 1;
+    statistics.data.processed_keys += 1;
     Ok(default_cursor.value(&mut statistics.data).to_vec())
 }
 

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -1637,7 +1637,7 @@ fn test_exec_details() {
 
     let flags = &[0];
 
-    let mut ctx = Context::default();
+    let ctx = Context::default();
     let req = DAGSelect::from(&product).build_with(ctx, flags);
     let resp = handle_request(&endpoint, req);
     assert!(resp.has_exec_details());

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -1635,40 +1635,9 @@ fn test_exec_details() {
     let product = ProductTable::new();
     let (_, endpoint) = init_with_data(&product, &data);
 
-    // get none
-    let req = DAGSelect::from(&product).build();
-    let resp = handle_request(&endpoint, req);
-    assert!(resp.has_exec_details());
-    let exec_details = resp.get_exec_details();
-    assert!(!exec_details.has_handle_time());
-    assert!(!exec_details.has_scan_detail());
-
     let flags = &[0];
 
-    // get handle_time
     let mut ctx = Context::default();
-    ctx.set_handle_time(true);
-    let req = DAGSelect::from(&product).build_with(ctx, flags);
-    let resp = handle_request(&endpoint, req);
-    assert!(resp.has_exec_details());
-    let exec_details = resp.get_exec_details();
-    assert!(exec_details.has_handle_time());
-    assert!(!exec_details.has_scan_detail());
-
-    // get scan detail
-    let mut ctx = Context::default();
-    ctx.set_scan_detail(true);
-    let req = DAGSelect::from(&product).build_with(ctx, flags);
-    let resp = handle_request(&endpoint, req);
-    assert!(resp.has_exec_details());
-    let exec_details = resp.get_exec_details();
-    assert!(!exec_details.has_handle_time());
-    assert!(exec_details.has_scan_detail());
-
-    // get both
-    let mut ctx = Context::default();
-    ctx.set_scan_detail(true);
-    ctx.set_handle_time(true);
     let req = DAGSelect::from(&product).build_with(ctx, flags);
     let resp = handle_request(&endpoint, req);
     assert!(resp.has_exec_details());


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This PR fixed incorrect processed_keys / total_keys passed to TiDB, as well as missing RocksDB metrics.

### What is changed and how it works?

1. Changed processed -> processed_versions (number of visible versions in write CF)
2. Changed total -> total_versions (**approximate** number of all meet versions in write CF)
3. Added RocksDB PerfContext to the Coprocessor response.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test: WIP

### Release note <!-- bugfixes or new feature need a release note -->

- Report RocksDB metrics to TiDB
- Fix incorrect process_keys and total_keys