### PR TITLE
txn: only wake up waiters when locks are indeed released (#7379)

### DIFF
--- a/benches/misc/storage/key.rs
+++ b/benches/misc/storage/key.rs
@@ -1,0 +1,31 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use rand::{self, Rng, RngCore};
+use tikv::coprocessor::codec::{datum, table, Datum};
+use tikv::storage::Key;
+
+#[inline]
+fn gen_rand_str(len: usize) -> Vec<u8> {
+    let mut rand_str = vec![0; len];
+    rand::thread_rng().fill_bytes(&mut rand_str);
+    rand_str
+}
+
+#[bench]
+fn bench_row_key_gen_hash(b: &mut test::Bencher) {
+    let id: i64 = rand::thread_rng().gen();
+    let row_key = Key::from_raw(&table::encode_row_key(id, id));
+    b.iter(|| {
+        test::black_box(row_key.gen_hash());
+    });
+}
+
+#[bench]
+fn bench_index_key_gen_hash(b: &mut test::Bencher) {
+    let id: i64 = rand::thread_rng().gen();
+    let encoded_index_val = datum::encode_key(&[Datum::Bytes(gen_rand_str(64))]).unwrap();
+    let index_key = Key::from_raw(&table::encode_index_seek_key(id, id, &encoded_index_val));
+    b.iter(|| {
+        test::black_box(index_key.gen_hash());
+    });
+}

--- a/benches/misc/storage/mod.rs
+++ b/benches/misc/storage/mod.rs
@@ -1,3 +1,4 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
+mod key;
 mod scan;

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -230,20 +230,12 @@ impl LockMgr for LockManager {
         }
     }
 
-    fn wake_up(
-        &self,
-        lock_ts: u64,
-        hashes: Option<Vec<u64>>,
-        commit_ts: u64,
-        is_pessimistic_txn: bool,
-    ) {
+    fn wake_up(&self, lock_ts: u64, hashes: Vec<u64>, commit_ts: u64, is_pessimistic_txn: bool) {
         // If `hashes` is some, there may be some waiters waiting for these locks.
         // Try to wake up them.
-        if self.has_waiter() {
-            if let Some(hashes) = hashes {
-                self.waiter_mgr_scheduler
-                    .wake_up(lock_ts, hashes, commit_ts);
-            }
+        if !hashes.is_empty() && self.has_waiter() {
+            self.waiter_mgr_scheduler
+                .wake_up(lock_ts, hashes, commit_ts);
         }
         // If a pessimistic transaction is committed or rolled back and it once sent requests to
         // detect deadlock, clean up its wait-for entries in the deadlock detector.
@@ -326,7 +318,7 @@ mod tests {
         let (waiter, lock_info, f) = new_test_waiter(waiter_ts, lock.ts, lock.hash);
         lock_mgr.wait_for(waiter.start_ts, waiter.cb, waiter.pr, waiter.lock, true, 0);
         assert!(lock_mgr.has_waiter());
-        lock_mgr.wake_up(lock.ts, Some(vec![lock.hash]), 30, false);
+        lock_mgr.wake_up(lock.ts, vec![lock.hash], 30, false);
         assert_elapsed(
             || expect_write_conflict(f.wait().unwrap(), waiter_ts, lock_info, 30),
             0,
@@ -361,7 +353,7 @@ mod tests {
             200,
         );
         // Waiter2 releases its lock.
-        lock_mgr.wake_up(20, Some(vec![20]), 20, true);
+        lock_mgr.wake_up(20, vec![20], 20, true);
         assert_elapsed(
             || expect_write_conflict(f1.wait().unwrap(), 10, lock_info1, 20),
             0,
@@ -383,24 +375,24 @@ mod tests {
             );
             assert!(lock_mgr.has_waiter());
             assert_eq!(lock_mgr.remove_from_detected(30), !is_first_lock);
-            lock_mgr.wake_up(40, Some(vec![40]), 40, false);
+            lock_mgr.wake_up(40, vec![40], 40, false);
             f.wait().unwrap().unwrap_err();
         }
         assert!(!lock_mgr.has_waiter());
 
         // If key_hashes is none, no wake up.
         let prev_wake_up = TASK_COUNTER_VEC.wake_up.get();
-        lock_mgr.wake_up(10, None, 10, false);
+        lock_mgr.wake_up(10, vec![], 10, false);
         assert_eq!(TASK_COUNTER_VEC.wake_up.get(), prev_wake_up);
 
         // If it's non-pessimistic-txn, no clean up.
         let prev_clean_up = TASK_COUNTER_VEC.clean_up.get();
-        lock_mgr.wake_up(10, None, 10, false);
+        lock_mgr.wake_up(10, vec![], 10, false);
         assert_eq!(TASK_COUNTER_VEC.clean_up.get(), prev_clean_up);
 
         // If the txn doesn't wait for locks, no clean up.
         let prev_clean_up = TASK_COUNTER_VEC.clean_up.get();
-        lock_mgr.wake_up(10, None, 10, true);
+        lock_mgr.wake_up(10, vec![], 10, true);
         assert_eq!(TASK_COUNTER_VEC.clean_up.get(), prev_clean_up);
 
         // If timeout is negative, no wait for.

--- a/src/storage/lock_manager/mod.rs
+++ b/src/storage/lock_manager/mod.rs
@@ -33,13 +33,7 @@ pub trait LockMgr: Clone + Send + 'static {
     );
 
     /// The locks with `lock_ts` and `hashes` are released, trys to wake up transactions.
-    fn wake_up(
-        &self,
-        lock_ts: u64,
-        hashes: Option<Vec<u64>>,
-        commit_ts: u64,
-        is_pessimistic_txn: bool,
-    );
+    fn wake_up(&self, lock_ts: u64, hashes: Vec<u64>, commit_ts: u64, is_pessimistic_txn: bool);
 
     /// Returns true if there are waiters in the `LockMgr`.
     ///
@@ -68,7 +62,7 @@ impl LockMgr for DummyLockMgr {
     fn wake_up(
         &self,
         _lock_ts: u64,
-        _hashes: Option<Vec<u64>>,
+        _hashes: Vec<u64>,
         _commit_ts: u64,
         _is_pessimistic_txn: bool,
     ) {

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -8,7 +8,7 @@ mod write;
 
 pub use self::lock::{Lock, LockType};
 pub use self::reader::*;
-pub use self::txn::{MvccTxn, MAX_TXN_WRITE_SIZE};
+pub use self::txn::{MvccTxn, ReleasedLock, MAX_TXN_WRITE_SIZE};
 pub use self::write::{Write, WriteType};
 
 use std::error;

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -20,6 +20,25 @@ pub struct GcInfo {
     pub is_completed: bool,
 }
 
+/// `ReleasedLock` contains the information of the lock released by `commit`, `rollback` and so on.
+/// It's used by `LockManager` to wake up transactions waiting for locks.
+#[derive(Debug)]
+pub struct ReleasedLock {
+    /// The hash value of the lock.
+    pub hash: u64,
+    /// Whether it is a pessimistic lock.
+    pub pessimistic: bool,
+}
+
+impl ReleasedLock {
+    fn new(key: &Key, pessimistic: bool) -> Self {
+        Self {
+            hash: key.gen_hash(),
+            pessimistic,
+        }
+    }
+}
+
 pub struct MvccTxn<S: Snapshot> {
     reader: MvccReader<S>,
     gc_reader: MvccReader<S>,
@@ -72,6 +91,10 @@ impl<S: Snapshot> MvccTxn<S> {
         self.collapse_rollback = collapse;
     }
 
+    pub fn set_start_ts(&mut self, start_ts: u64) {
+        self.start_ts = start_ts;
+    }
+
     pub fn into_modifies(self) -> Vec<Modify> {
         self.writes
     }
@@ -113,9 +136,11 @@ impl<S: Snapshot> MvccTxn<S> {
         self.put_lock(key, &lock);
     }
 
-    fn unlock_key(&mut self, key: Key) {
+    fn unlock_key(&mut self, key: Key, pessimistic: bool) -> Option<ReleasedLock> {
+        let released = ReleasedLock::new(&key, pessimistic);
         self.write_size += CF_LOCK.len() + key.as_encoded().len();
         self.writes.push(Modify::Delete(CF_LOCK, key));
+        Some(released)
     }
 
     fn put_value(&mut self, key: Key, ts: u64, value: Value) {
@@ -171,7 +196,12 @@ impl<S: Snapshot> MvccTxn<S> {
         }
     }
 
-    fn rollback_lock(&mut self, key: Key, lock: &Lock, is_pessimistic_txn: bool) -> Result<()> {
+    fn rollback_lock(
+        &mut self,
+        key: Key,
+        lock: &Lock,
+        is_pessimistic_txn: bool,
+    ) -> Result<Option<ReleasedLock>> {
         // If prewrite type is DEL or LOCK or PESSIMISTIC, it is no need to delete value.
         if lock.short_value.is_none() && lock.lock_type == LockType::Put {
             self.delete_value(key.clone(), lock.ts);
@@ -181,11 +211,10 @@ impl<S: Snapshot> MvccTxn<S> {
         let protected: bool = is_pessimistic_txn && key.is_encoded_from(&lock.primary);
         let write = Write::new_rollback(self.start_ts, protected);
         self.put_write(key.clone(), self.start_ts, write.to_bytes());
-        self.unlock_key(key.clone());
         if self.collapse_rollback {
-            self.collapse_prev_rollback(key)?;
+            self.collapse_prev_rollback(key.clone())?;
         }
-        Ok(())
+        Ok(self.unlock_key(key, is_pessimistic_txn))
     }
 
     fn check_data_constraint(
@@ -472,7 +501,7 @@ impl<S: Snapshot> MvccTxn<S> {
         Ok(())
     }
 
-    pub fn commit(&mut self, key: Key, commit_ts: u64) -> Result<bool> {
+    pub fn commit(&mut self, key: Key, commit_ts: u64) -> Result<Option<ReleasedLock>> {
         let (lock_type, short_value, is_pessimistic_txn) = match self.reader.load_lock(&key)? {
             Some(ref mut lock) if lock.ts == self.start_ts => {
                 // It's an abnormal routine since pessimistic locks shouldn't be committed in our
@@ -519,7 +548,7 @@ impl<S: Snapshot> MvccTxn<S> {
                     | Some((_, WriteType::Delete))
                     | Some((_, WriteType::Lock)) => {
                         MVCC_DUPLICATE_CMD_COUNTER_VEC.commit.inc();
-                        Ok(false)
+                        Ok(None)
                     }
                 };
             }
@@ -530,11 +559,10 @@ impl<S: Snapshot> MvccTxn<S> {
             short_value,
         );
         self.put_write(key.clone(), commit_ts, write.to_bytes());
-        self.unlock_key(key);
-        Ok(is_pessimistic_txn)
+        Ok(self.unlock_key(key, is_pessimistic_txn))
     }
 
-    pub fn rollback(&mut self, key: Key) -> Result<bool> {
+    pub fn rollback(&mut self, key: Key) -> Result<Option<ReleasedLock>> {
         self.cleanup(key, 0)
     }
 
@@ -544,7 +572,7 @@ impl<S: Snapshot> MvccTxn<S> {
     ///
     /// Returns whether the lock is a pessimistic lock. Returns error if the key has already been
     /// committed.
-    pub fn cleanup(&mut self, key: Key, current_ts: u64) -> Result<bool> {
+    pub fn cleanup(&mut self, key: Key, current_ts: u64) -> Result<Option<ReleasedLock>> {
         match self.reader.load_lock(&key)? {
             Some(ref lock) if lock.ts == self.start_ts => {
                 // If current_ts is not 0, check the Lock's TTL.
@@ -558,8 +586,7 @@ impl<S: Snapshot> MvccTxn<S> {
                 }
 
                 let is_pessimistic_txn = lock.for_update_ts != 0;
-                self.rollback_lock(key, lock, is_pessimistic_txn)?;
-                Ok(is_pessimistic_txn)
+                self.rollback_lock(key, lock, is_pessimistic_txn)
             }
             _ => {
                 match self.reader.get_txn_commit_info(&key, self.start_ts)? {
@@ -567,7 +594,7 @@ impl<S: Snapshot> MvccTxn<S> {
                         if write_type == WriteType::Rollback {
                             // return Ok on Rollback already exist
                             MVCC_DUPLICATE_CMD_COUNTER_VEC.rollback.inc();
-                            Ok(false)
+                            Ok(None)
                         } else {
                             MVCC_CONFLICT_COUNTER.rollback_committed.inc();
                             info!(
@@ -593,7 +620,7 @@ impl<S: Snapshot> MvccTxn<S> {
                         // [issue #7364](https://github.com/tikv/tikv/issues/7364)
                         let write = Write::new_rollback(ts, true);
                         self.put_write(key, ts, write.to_bytes());
-                        Ok(false)
+                        Ok(None)
                     }
                 }
             }
@@ -601,16 +628,20 @@ impl<S: Snapshot> MvccTxn<S> {
     }
 
     /// Delete any pessimistic lock with small for_update_ts belongs to this transaction.
-    pub fn pessimistic_rollback(&mut self, key: Key, for_update_ts: u64) -> Result<()> {
+    pub fn pessimistic_rollback(
+        &mut self,
+        key: Key,
+        for_update_ts: u64,
+    ) -> Result<Option<ReleasedLock>> {
         if let Some(lock) = self.reader.load_lock(&key)? {
             if lock.lock_type == LockType::Pessimistic
                 && lock.ts == self.start_ts
                 && lock.for_update_ts <= for_update_ts
             {
-                self.unlock_key(key);
+                return Ok(self.unlock_key(key, true));
             }
         }
-        Ok(())
+        Ok(None)
     }
 
     fn collapse_prev_rollback(&mut self, key: Key) -> Result<()> {

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -11,7 +11,8 @@ use crate::storage::kv::with_tls_engine;
 use crate::storage::kv::{CbContext, Modify, Result as EngineResult};
 use crate::storage::lock_manager::{self, LockMgr};
 use crate::storage::mvcc::{
-    Error as MvccError, Lock as MvccLock, MvccReader, MvccTxn, Write, MAX_TXN_WRITE_SIZE,
+    Error as MvccError, Lock as MvccLock, MvccReader, MvccTxn, ReleasedLock, Write,
+    MAX_TXN_WRITE_SIZE,
 };
 use crate::storage::txn::{sched_pool::*, scheduler::Msg, Error, Result};
 use crate::storage::{
@@ -473,28 +474,37 @@ fn process_read_impl<E: Engine>(
     }
 }
 
-// If lock_mgr has waiters, there may be some transactions waiting for these keys,
-// so calculates keys' hashes to wake up them.
-fn gen_key_hashes_if_needed<L: LockMgr>(lock_mgr: &Option<L>, keys: &[Key]) -> Option<Vec<u64>> {
-    lock_mgr.as_ref().and_then(|lm| {
-        if lm.has_waiter() {
-            Some(lock_manager::gen_key_hashes(keys))
-        } else {
-            None
-        }
-    })
+#[derive(Default)]
+struct ReleasedLocks {
+    start_ts: u64,
+    commit_ts: u64,
+    hashes: Vec<u64>,
+    pessimistic: bool,
 }
 
-// Wake up pessimistic transactions that waiting for these locks
-fn wake_up_waiters_if_needed<L: LockMgr>(
-    lock_mgr: &Option<L>,
-    lock_ts: u64,
-    key_hashes: Option<Vec<u64>>,
-    commit_ts: u64,
-    is_pessimistic_txn: bool,
-) {
-    if let Some(lm) = lock_mgr {
-        lm.wake_up(lock_ts, key_hashes, commit_ts, is_pessimistic_txn);
+impl ReleasedLocks {
+    fn new(start_ts: u64, commit_ts: u64) -> Self {
+        Self {
+            start_ts,
+            commit_ts,
+            ..Default::default()
+        }
+    }
+
+    fn push(&mut self, lock: Option<ReleasedLock>) {
+        if let Some(lock) = lock {
+            self.hashes.push(lock.hash);
+            if !self.pessimistic {
+                self.pessimistic = lock.pessimistic;
+            }
+        }
+    }
+
+    // Wake up pessimistic transactions that waiting for these locks.
+    fn wake_up<L: LockMgr>(self, lock_mgr: Option<&L>) {
+        if let Some(lm) = lock_mgr {
+            lm.wake_up(self.start_ts, self.hashes, self.commit_ts, self.pessimistic);
+        }
     }
 }
 
@@ -615,23 +625,15 @@ fn process_write_impl<S: Snapshot, L: LockMgr>(
                     commit_ts,
                 });
             }
-            // Pessimistic txn needs key_hashes to wake up waiters
-            let key_hashes = gen_key_hashes_if_needed(&lock_mgr, &keys);
-
             let mut txn = MvccTxn::new(snapshot, lock_ts, !ctx.get_not_fill_cache())?;
-            let mut is_pessimistic_txn = false;
             let rows = keys.len();
+            // Pessimistic txn needs key_hashes to wake up waiters
+            let mut released_locks = ReleasedLocks::new(lock_ts, commit_ts);
             for k in keys {
-                is_pessimistic_txn = txn.commit(k, commit_ts)?;
+                released_locks.push(txn.commit(k, commit_ts)?);
             }
+            released_locks.wake_up(lock_mgr.as_ref());
 
-            wake_up_waiters_if_needed(
-                &lock_mgr,
-                lock_ts,
-                key_hashes,
-                commit_ts,
-                is_pessimistic_txn,
-            );
             statistics.add(&txn.take_statistics());
             (ProcessResult::Res, txn.into_modifies(), rows, ctx, None)
         }
@@ -642,13 +644,12 @@ fn process_write_impl<S: Snapshot, L: LockMgr>(
             current_ts,
             ..
         } => {
-            let mut keys = vec![key];
-            let key_hashes = gen_key_hashes_if_needed(&lock_mgr, &keys);
-
             let mut txn = MvccTxn::new(snapshot, start_ts, !ctx.get_not_fill_cache())?;
-            let is_pessimistic_txn = txn.cleanup(keys.pop().unwrap(), current_ts)?;
 
-            wake_up_waiters_if_needed(&lock_mgr, start_ts, key_hashes, 0, is_pessimistic_txn);
+            let mut released_locks = ReleasedLocks::new(start_ts, 0);
+            released_locks.push(txn.cleanup(key, current_ts)?);
+            released_locks.wake_up(lock_mgr.as_ref());
+
             statistics.add(&txn.take_statistics());
             (ProcessResult::Res, txn.into_modifies(), 1, ctx, None)
         }
@@ -658,16 +659,15 @@ fn process_write_impl<S: Snapshot, L: LockMgr>(
             start_ts,
             ..
         } => {
-            let key_hashes = gen_key_hashes_if_needed(&lock_mgr, &keys);
-
             let mut txn = MvccTxn::new(snapshot, start_ts, !ctx.get_not_fill_cache())?;
-            let mut is_pessimistic_txn = false;
-            let rows = keys.len();
-            for k in keys {
-                is_pessimistic_txn = txn.rollback(k)?;
-            }
 
-            wake_up_waiters_if_needed(&lock_mgr, start_ts, key_hashes, 0, is_pessimistic_txn);
+            let rows = keys.len();
+            let mut released_locks = ReleasedLocks::new(start_ts, 0);
+            for k in keys {
+                released_locks.push(txn.rollback(k)?);
+            }
+            released_locks.wake_up(lock_mgr.as_ref());
+
             statistics.add(&txn.take_statistics());
             (ProcessResult::Res, txn.into_modifies(), rows, ctx, None)
         }
@@ -678,15 +678,15 @@ fn process_write_impl<S: Snapshot, L: LockMgr>(
             for_update_ts,
         } => {
             assert!(lock_mgr.is_some());
-            let key_hashes = gen_key_hashes_if_needed(&lock_mgr, &keys);
-
             let mut txn = MvccTxn::new(snapshot, start_ts, !ctx.get_not_fill_cache())?;
-            let rows = keys.len();
-            for k in keys {
-                txn.pessimistic_rollback(k, for_update_ts)?;
-            }
 
-            wake_up_waiters_if_needed(&lock_mgr, start_ts, key_hashes, 0, true);
+            let rows = keys.len();
+            let mut released_locks = ReleasedLocks::new(start_ts, 0);
+            for k in keys {
+                released_locks.push(txn.pessimistic_rollback(k, for_update_ts)?);
+            }
+            released_locks.wake_up(lock_mgr.as_ref());
+
             statistics.add(&txn.take_statistics());
             (
                 ProcessResult::MultiRes { results: vec![] },
@@ -702,71 +702,43 @@ fn process_write_impl<S: Snapshot, L: LockMgr>(
             mut scan_key,
             key_locks,
         } => {
-            // Map (txn's start_ts, is_pessimistic_txn) => Option<key_hashes>
-            let (mut txn_to_keys, has_waiter) = if let Some(lm) = lock_mgr.as_ref() {
-                (Some(HashMap::default()), lm.has_waiter())
-            } else {
-                (None, false)
-            };
+            let mut txn = MvccTxn::new(snapshot, 0, !ctx.get_not_fill_cache())?;
 
             let mut scan_key = scan_key.take();
-            let mut modifies: Vec<Modify> = vec![];
-            let mut write_size = 0;
             let rows = key_locks.len();
+            // Map txn's start_ts to ReleasedLocks
+            let mut released_locks = HashMap::default();
             for (current_key, current_lock) in key_locks {
-                if let Some(txn_to_keys) = txn_to_keys.as_mut() {
-                    txn_to_keys
-                        .entry((current_lock.ts, current_lock.for_update_ts != 0))
-                        .and_modify(|key_hashes: &mut Option<Vec<u64>>| {
-                            if let Some(key_hashes) = key_hashes {
-                                key_hashes.push(lock_manager::gen_key_hash(&current_key));
-                            }
-                        })
-                        .or_insert_with(|| {
-                            if has_waiter {
-                                Some(vec![lock_manager::gen_key_hash(&current_key)])
-                            } else {
-                                None
-                            }
-                        });
-                }
+                txn.set_start_ts(current_lock.ts);
+                let commit_ts = *txn_status
+                    .get(&current_lock.ts)
+                    .expect("txn status not found");
 
-                let mut txn =
-                    MvccTxn::new(snapshot.clone(), current_lock.ts, !ctx.get_not_fill_cache())?;
-                let status = txn_status.get(&current_lock.ts);
-                let commit_ts = match status {
-                    Some(ts) => *ts,
-                    None => panic!("txn status {} not found.", current_lock.ts),
-                };
-                if commit_ts > 0 {
-                    if current_lock.ts >= commit_ts {
-                        return Err(Error::InvalidTxnTso {
-                            start_ts: current_lock.ts,
-                            commit_ts,
-                        });
-                    }
-                    txn.commit(current_key.clone(), commit_ts)?;
+                let released = if commit_ts == 0 {
+                    txn.rollback(current_key.clone())?
+                } else if commit_ts > current_lock.ts {
+                    txn.commit(current_key.clone(), commit_ts)?
                 } else {
-                    txn.rollback(current_key.clone())?;
-                }
-                write_size += txn.write_size();
+                    return Err(Error::InvalidTxnTso {
+                        start_ts: current_lock.ts,
+                        commit_ts,
+                    });
+                };
+                released_locks
+                    .entry(current_lock.ts)
+                    .or_insert_with(|| ReleasedLocks::new(current_lock.ts, commit_ts))
+                    .push(released);
 
-                statistics.add(&txn.take_statistics());
-                modifies.append(&mut txn.into_modifies());
-
-                if write_size >= MAX_TXN_WRITE_SIZE {
+                if txn.write_size() >= MAX_TXN_WRITE_SIZE {
                     scan_key = Some(current_key);
                     break;
                 }
             }
-            if let Some(txn_to_keys) = txn_to_keys {
-                txn_to_keys
-                    .into_iter()
-                    .for_each(|((ts, is_pessimistic_txn), key_hashes)| {
-                        wake_up_waiters_if_needed(&lock_mgr, ts, key_hashes, 0, is_pessimistic_txn);
-                    });
-            }
+            released_locks
+                .into_iter()
+                .for_each(|(_, released_locks)| released_locks.wake_up(lock_mgr.as_ref()));
 
+            statistics.add(&txn.take_statistics());
             let pr = if scan_key.is_none() {
                 ProcessResult::Res
             } else {
@@ -780,7 +752,7 @@ fn process_write_impl<S: Snapshot, L: LockMgr>(
                 }
             };
 
-            (pr, modifies, rows, ctx, None)
+            (pr, txn.into_modifies(), rows, ctx, None)
         }
         Command::ResolveLockLite {
             ctx,
@@ -788,28 +760,21 @@ fn process_write_impl<S: Snapshot, L: LockMgr>(
             commit_ts,
             resolve_keys,
         } => {
-            let key_hashes = gen_key_hashes_if_needed(&lock_mgr, &resolve_keys);
-
             let mut txn = MvccTxn::new(snapshot.clone(), start_ts, !ctx.get_not_fill_cache())?;
+
             let rows = resolve_keys.len();
-            let mut is_pessimistic_txn = false;
             // ti-client guarantees the size of resolve_keys will not too large, so no necessary
             // to control the write_size as ResolveLock.
+            let mut released_locks = ReleasedLocks::new(start_ts, commit_ts);
             for key in resolve_keys {
-                if commit_ts > 0 {
-                    is_pessimistic_txn = txn.commit(key, commit_ts)?;
+                released_locks.push(if commit_ts > 0 {
+                    txn.commit(key, commit_ts)?
                 } else {
-                    is_pessimistic_txn = txn.rollback(key)?;
-                }
+                    txn.rollback(key)?
+                });
             }
+            released_locks.wake_up(lock_mgr.as_ref());
 
-            wake_up_waiters_if_needed(
-                &lock_mgr,
-                start_ts,
-                key_hashes,
-                commit_ts,
-                is_pessimistic_txn,
-            );
             statistics.add(&txn.take_statistics());
             (ProcessResult::Res, txn.into_modifies(), rows, ctx, None)
         }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -205,6 +205,11 @@ impl Key {
     pub fn is_encoded_from(&self, raw_key: &[u8]) -> bool {
         bytes::is_encoded_from(&self.0, raw_key, false)
     }
+
+    /// TiDB uses the same hash algorithm.
+    pub fn gen_hash(&self) -> u64 {
+        farmhash::fingerprint64(&self.to_raw().unwrap())
+    }
 }
 
 impl Clone for Key {


### PR DESCRIPTION
cherry-pick #7379 to release-3.0

---

Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Problem Summary:
TiKV will wake up waiters as long as it receives requests that may release locks, e.g., `pessimistic_rollback`, `rollback`, `commit`. If a request doesn't release locks, typically the lock doesn't exist, it needn't wake up waiters.

In TiDB, if a pessimistic DML meets write conflict, it will use `pessimistic_rollback` to clean up all locks it needs to lock in this DML and then retry the DML. If a transaction is waked up and there are other transactions waiting for the lock, these transactions will be waked up by `pessimistic_rollback` one by one. It dramatically affects performance and results in useless retry.

### What is changed and how it works?
What's Changed:
Only wake up waiters when locks are indeed released and small refactor.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

I think existing tests are enough and I benched it using sysbench with the workload below:
```sql
con:query(CREATE TABLE wmtest(k INT PRIMARY KEY, v INT))
con:query(string.format("UPDATE wmtest SET v = v + 1 WHERE k IN (%d, 1)", sysbench.rand.uniform(2, sysbench.opt.table_size)))
```
master:

| threads | tps | avg lat(ms) | .95 lat(ms) | .99 retry count|
| -------- | ---- | ---- | ---- | ---- |
| 1 | 783 | 1.28 | 1.79 | 0 |
| 100 | 71 | 1393 | 2493 | 800 |
| 500 | 16 | 30111 | 72316 | 1457 |
| 1000 | 12 | 71181 | 100000 | 654 |

This PR:
| threads | tps | avg lat(ms) | .95 lat(ms) |  .99 retry count |
| -------- | ---- | ---- | ---- | ---- |
| 100 | 772 | 129 | 155 | 1 |
| 500 | 724 | 688 | 787 | 1 |
| 1000 | 647 | 1534 | 1903 | 5 |

![image](https://user-images.githubusercontent.com/14819777/78778513-f8581480-79cd-11ea-8596-4f6f6ace03e2.png)

### Release note <!-- bugfixes or new feature need a release note -->
Fix the issue that needless wake-up results in useless retry and performance reduction in heavy contention workloads.