### PR TITLE
Support replication mode control

### DIFF
--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -11,6 +11,7 @@ use futures::{future, Future, Sink, Stream};
 use grpcio::{CallOption, EnvBuilder, WriteFlags};
 use kvproto::metapb;
 use kvproto::pdpb::{self, Member};
+use kvproto::replication_modepb::ReplicationStatus;
 
 use super::metrics::*;
 use super::util::{check_resp_header, sync_request, validate_endpoints, Inner, LeaderClient};
@@ -125,7 +126,11 @@ impl PdClient for RpcClient {
         Ok(self.cluster_id)
     }
 
-    fn bootstrap_cluster(&self, stores: metapb::Store, region: metapb::Region) -> Result<()> {
+    fn bootstrap_cluster(
+        &self,
+        stores: metapb::Store,
+        region: metapb::Region,
+    ) -> Result<Option<ReplicationStatus>> {
         let _timer = PD_REQUEST_HISTOGRAM_VEC
             .with_label_values(&["bootstrap_cluster"])
             .start_coarse_timer();
@@ -135,11 +140,11 @@ impl PdClient for RpcClient {
         req.set_store(stores);
         req.set_region(region);
 
-        let resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
+        let mut resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
             client.bootstrap_opt(&req, Self::call_option())
         })?;
         check_resp_header(resp.get_header())?;
-        Ok(())
+        Ok(resp.replication_status.take())
     }
 
     fn is_cluster_bootstrapped(&self) -> Result<bool> {
@@ -174,7 +179,7 @@ impl PdClient for RpcClient {
         Ok(resp.get_id())
     }
 
-    fn put_store(&self, store: metapb::Store) -> Result<()> {
+    fn put_store(&self, store: metapb::Store) -> Result<Option<ReplicationStatus>> {
         let _timer = PD_REQUEST_HISTOGRAM_VEC
             .with_label_values(&["put_store"])
             .start_coarse_timer();
@@ -183,12 +188,12 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_store(store);
 
-        let resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
+        let mut resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
             client.put_store_opt(&req, Self::call_option())
         })?;
         check_resp_header(resp.get_header())?;
 
-        Ok(())
+        Ok(resp.replication_status.take())
     }
 
     fn get_store(&self, store_id: u64) -> Result<metapb::Store> {

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -34,6 +34,7 @@ use std::ops::Deref;
 use futures::Future;
 use kvproto::metapb;
 use kvproto::pdpb;
+use kvproto::replication_modepb::ReplicationStatus;
 use tikv_util::time::UnixSecs;
 use txn_types::TimeStamp;
 
@@ -94,7 +95,11 @@ pub trait PdClient: Send + Sync {
     /// It may happen that multi nodes start at same time to try to
     /// bootstrap, but only one can succeed, while others will fail
     /// and must remove their created local Region data themselves.
-    fn bootstrap_cluster(&self, _stores: metapb::Store, _region: metapb::Region) -> Result<()> {
+    fn bootstrap_cluster(
+        &self,
+        _stores: metapb::Store,
+        _region: metapb::Region,
+    ) -> Result<Option<ReplicationStatus>> {
         unimplemented!();
     }
 
@@ -113,7 +118,7 @@ pub trait PdClient: Send + Sync {
     }
 
     /// Informs PD when the store starts or some store information changes.
-    fn put_store(&self, _store: metapb::Store) -> Result<()> {
+    fn put_store(&self, _store: metapb::Store) -> Result<Option<ReplicationStatus>> {
         unimplemented!();
     }
 

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -14,6 +14,7 @@ mod peer;
 mod peer_storage;
 mod read_queue;
 mod region_snapshot;
+mod replication_mode;
 mod snap;
 mod worker;
 
@@ -36,6 +37,7 @@ pub use self::peer_storage::{
     RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_TERM,
 };
 pub use self::region_snapshot::{new_temp_engine, RegionIterator, RegionSnapshot};
+pub use self::replication_mode::{GlobalReplicationState, StoreGroup};
 pub use self::snap::{
     check_abort, copy_snapshot,
     snap_io::{apply_sst_cf_file, build_sst_cf_file},

--- a/components/raftstore/src/store/replication_mode.rs
+++ b/components/raftstore/src/store/replication_mode.rs
@@ -1,0 +1,97 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use kvproto::metapb;
+use kvproto::replication_modepb::ReplicationStatus;
+use tikv_util::collections::{HashMap, HashMapEntry};
+
+/// A registry that maps store to a group.
+///
+/// A group ID is generated according to the label value. Stores with same
+/// label value will be mapped to the same group ID.
+#[derive(Default, Debug)]
+pub struct StoreGroup {
+    labels: HashMap<String, u64>,
+    stores: HashMap<u64, u64>,
+}
+
+impl StoreGroup {
+    /// Registers the store with given label value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the store is registered twice with different store ID.
+    pub fn register_store(&mut self, store_id: u64, label: String) -> u64 {
+        debug!("associated {} {}", store_id, label);
+        match self.stores.entry(store_id) {
+            HashMapEntry::Occupied(o) => {
+                assert_eq!(
+                    self.labels.get(&label),
+                    Some(o.get()),
+                    "store {:?}",
+                    store_id
+                );
+                *o.get()
+            }
+            HashMapEntry::Vacant(v) => {
+                let len = self.labels.len() as u64 + 1;
+                let id = *self.labels.entry(label).or_insert(len);
+                v.insert(id);
+                id
+            }
+        }
+    }
+
+    /// Gets the group ID of store.
+    #[inline]
+    pub fn group_id(&self, store_id: u64) -> Option<u64> {
+        self.stores.get(&store_id).cloned()
+    }
+}
+
+/// A global state that stores current replication mode and related metadata.
+#[derive(Default, Debug)]
+pub struct GlobalReplicationState {
+    pub status: ReplicationStatus,
+    pub group: StoreGroup,
+    pub group_buffer: Vec<(u64, u64)>,
+}
+
+impl GlobalReplicationState {
+    pub fn calculate_commit_group(&mut self, peers: &[metapb::Peer]) {
+        self.group_buffer.clear();
+        for p in peers {
+            if let Some(label_id) = self.group.group_id(p.store_id) {
+                self.group_buffer.push((p.id, label_id));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::util::new_peer;
+
+    #[test]
+    fn test_group_register() {
+        let mut state = GlobalReplicationState::default();
+        let group_id = state.group.register_store(1, "label 1".to_owned());
+        assert_eq!(state.group.group_id(1), Some(group_id));
+        assert_eq!(
+            state.group.register_store(2, "label 1".to_owned()),
+            group_id
+        );
+        assert_eq!(state.group.group_id(2), Some(group_id));
+        assert_eq!(
+            group_id,
+            state.group.register_store(1, "label 1".to_owned())
+        );
+        assert_ne!(
+            group_id,
+            state.group.register_store(3, "label 2".to_owned())
+        );
+
+        state.calculate_commit_group(&[new_peer(1, 1), new_peer(2, 2), new_peer(3, 3)]);
+        assert_eq!(state.group_buffer, vec![(1, 1), (2, 1), (3, 2)]);
+    }
+}

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -189,6 +189,7 @@ impl Simulator for NodeCluster {
             &cfg.server,
             Arc::new(VersionTrack::new(raft_store)),
             Arc::clone(&self.pd_client),
+            Arc::default(),
         );
 
         let (snap_mgr, snap_mgr_path) = if node_id == 0

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -222,7 +222,7 @@ impl Simulator for ServerCluster {
         let deadlock_service = lock_mgr.deadlock_service(security_mgr.clone());
 
         // Create pd client, snapshot manager, server.
-        let (worker, resolver) = resolve::new_resolver(Arc::clone(&self.pd_client)).unwrap();
+        let (worker, resolver, state) = resolve::new_resolver(Arc::clone(&self.pd_client)).unwrap();
         let snap_mgr = SnapManager::new(tmp_str, Some(router.clone()));
         let server_cfg = Arc::new(cfg.server.clone());
         let cop_read_pool = ReadPool::from(coprocessor::readpool_impl::build_read_pool_for_test(
@@ -282,6 +282,7 @@ impl Simulator for ServerCluster {
             &cfg.server,
             Arc::new(VersionTrack::new(raft_store)),
             Arc::clone(&self.pd_client),
+            state,
         );
 
         // Register the role change observer of the lock manager.

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -16,14 +16,14 @@ use engine_rocks::{CloneCompat, Compat, RocksEngine};
 use engine_traits::Peekable;
 use kvproto::metapb;
 use kvproto::raft_serverpb::StoreIdent;
+use kvproto::replication_modepb::ReplicationStatus;
 use pd_client::{Error as PdError, PdClient, INVALID_ID};
 use raftstore::coprocessor::dispatcher::CoprocessorHost;
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::fsm::store::StoreMeta;
 use raftstore::store::fsm::{ApplyRouter, RaftBatchSystem, RaftRouter};
-use raftstore::store::PdTask;
-use raftstore::store::SplitCheckTask;
 use raftstore::store::{self, initial_region, Config as StoreConfig, SnapManager, Transport};
+use raftstore::store::{GlobalReplicationState, PdTask, SplitCheckTask};
 use tikv_util::config::VersionTrack;
 use tikv_util::worker::FutureWorker;
 use tikv_util::worker::Worker;
@@ -57,6 +57,7 @@ pub struct Node<C: PdClient + 'static> {
     has_started: bool,
 
     pd_client: Arc<C>,
+    state: Arc<Mutex<GlobalReplicationState>>,
 }
 
 impl<C> Node<C>
@@ -69,6 +70,7 @@ where
         cfg: &ServerConfig,
         store_cfg: Arc<VersionTrack<StoreConfig>>,
         pd_client: Arc<C>,
+        state: Arc<Mutex<GlobalReplicationState>>,
     ) -> Node<C> {
         let mut store = metapb::Store::default();
         store.set_id(INVALID_ID);
@@ -109,6 +111,7 @@ where
             pd_client,
             system,
             has_started: false,
+            state,
         }
     }
 
@@ -151,6 +154,11 @@ where
             self.bootstrap_cluster(&engines, first_region)?;
         }
 
+        // Put store only if the cluster is bootstrapped.
+        info!("put store to PD"; "store" => ?&self.store);
+        let status = self.pd_client.put_store(self.store.clone())?;
+        self.load_all_stores(status);
+
         self.start_store(
             store_id,
             engines,
@@ -162,10 +170,6 @@ where
             importer,
             split_check_worker,
         )?;
-
-        // Put store only if the cluster is bootstrapped.
-        info!("put store to PD"; "store" => ?&self.store);
-        self.pd_client.put_store(self.store.clone())?;
 
         Ok(())
     }
@@ -216,6 +220,34 @@ where
     fn alloc_id(&self) -> Result<u64> {
         let id = self.pd_client.alloc_id()?;
         Ok(id)
+    }
+
+    fn load_all_stores(&mut self, status: Option<ReplicationStatus>) {
+        let status = match status {
+            Some(s) => s,
+            None => {
+                info!("no status is returned, using majority mode");
+                return;
+            }
+        };
+        info!("initializing replication mode"; "status" => ?status, "store_id" => self.store.id);
+        let stores = match self.pd_client.get_all_stores(false) {
+            Ok(stores) => stores,
+            Err(e) => panic!("failed to load all stores: {:?}", e),
+        };
+        let label_key = &status.get_dr_auto_sync().label_key;
+        let mut control = self.state.lock().unwrap();
+        for store in stores {
+            for l in store.get_labels() {
+                if l.key == *label_key {
+                    control
+                        .group
+                        .register_store(store.id, l.value.to_lowercase());
+                    break;
+                }
+            }
+        }
+        control.status = status;
     }
 
     fn bootstrap_store(&self, engines: &Engines) -> Result<u64> {

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -6,7 +6,6 @@ use std::time::Instant;
 
 use kvproto::metapb;
 use kvproto::replication_modepb::ReplicationMode;
-
 use pd_client::{take_peer_address, PdClient};
 use raftstore::store::GlobalReplicationState;
 use tikv_util::collections::HashMap;
@@ -75,7 +74,7 @@ impl<T: PdClient> Runner<T> {
         let mut s = box_try!(pd_client.get_store(store_id));
         let mut state = self.state.lock().unwrap();
         let label_key = &state.status.get_dr_auto_sync().label_key;
-        if state.status.mode == ReplicationMode::DrAutoSync {
+        if state.status.get_mode() == ReplicationMode::DrAutoSync {
             if state.group.group_id(store_id).is_none() {
                 for l in s.get_labels() {
                     if l.key == *label_key {

--- a/tests/integrations/raftstore/test_bootstrap.rs
+++ b/tests/integrations/raftstore/test_bootstrap.rs
@@ -63,6 +63,7 @@ fn test_node_bootstrap_with_prepared_data() {
         &cfg.server,
         Arc::new(VersionTrack::new(cfg.raft_store.clone())),
         Arc::clone(&pd_client),
+        Arc::default(),
     );
     let snap_mgr = SnapManager::new(tmp_mgr.path().to_str().unwrap(), Some(node.get_router()));
     let pd_worker = FutureWorker::new("test-pd-worker");


### PR DESCRIPTION


### What is changed and how it works?

Part of #7097.

This PR adds a global group registry that stores the group ID of every met store. The information will be used for further implement of label based replication.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
