### PR TITLE
storage: fix wrong write size of resolve lock

### DIFF
--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -778,7 +778,6 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
             let mut txn = MvccTxn::new(snapshot, TimeStamp::zero(), !cmd.ctx.get_not_fill_cache());
 
             let mut scan_key = scan_key.take();
-            let mut write_size = 0;
             let rows = key_locks.len();
             // Map txn's start_ts to ReleasedLocks
             let mut released_locks = HashMap::default();
@@ -803,8 +802,7 @@ fn process_write_impl<S: Snapshot, L: LockManager>(
                     .or_insert_with(|| ReleasedLocks::new(current_lock.ts, commit_ts))
                     .push(released);
 
-                write_size += txn.write_size();
-                if write_size >= MAX_TXN_WRITE_SIZE {
+                if txn.write_size() >= MAX_TXN_WRITE_SIZE {
                     scan_key = Some(current_key);
                     break;
                 }


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Problem Summary:
Now we use one MvccTxn to process resolve lock requests. The write size shouldn't be accumulated.

### What is changed and how it works?
What's Changed:
Don't accumulate write size of resolve lock.

### Related changes
It's introduced in #7379. I have fixed it when cherry pick it to release branches, so needn't cherry pick this PR.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->