### PR TITLE
txn: don't protect rollback for BatchRollback

### DIFF
--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -622,7 +622,7 @@ pub mod tests {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
-        txn.cleanup(Key::from_raw(key), current_ts).unwrap();
+        txn.cleanup(Key::from_raw(key), current_ts, true).unwrap();
         write(engine, &ctx, txn.into_modifies());
     }
 
@@ -635,7 +635,8 @@ pub mod tests {
         let ctx = Context::default();
         let snapshot = engine.snapshot(&ctx).unwrap();
         let mut txn = MvccTxn::new(snapshot, start_ts, true).unwrap();
-        txn.cleanup(Key::from_raw(key), current_ts).unwrap_err()
+        txn.cleanup(Key::from_raw(key), current_ts, true)
+            .unwrap_err()
     }
 
     pub fn must_txn_heart_beat<E: Engine>(

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -646,7 +646,9 @@ fn process_write_impl<S: Snapshot, L: LockMgr>(
             let key_hashes = gen_key_hashes_if_needed(&lock_mgr, &keys);
 
             let mut txn = MvccTxn::new(snapshot, start_ts, !ctx.get_not_fill_cache())?;
-            let is_pessimistic_txn = txn.cleanup(keys.pop().unwrap(), current_ts)?;
+            // The rollback must be protected, see more on
+            // [issue #7364](https://github.com/tikv/tikv/issues/7364)
+            let is_pessimistic_txn = txn.cleanup(keys.pop().unwrap(), current_ts, true)?;
 
             wake_up_waiters_if_needed(&lock_mgr, start_ts, key_hashes, 0, is_pessimistic_txn);
             statistics.add(&txn.take_statistics());


### PR DESCRIPTION
cherry-pick #7494 to release-3.0

---

Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7490 

Problem Summary: rollback calls cleanup and it writes protected rollback record for all non-exsitent keys which may causes performance regression in heavy contention workload with optimistic transaction. See #7435

### What is changed and how it works?

What's Changed: Only cleanup or check_txn_status need to write the protected rollback record.

### Related changes

- Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

Do not protect rollback records written by BatchRollback to improve performance when there are many write conflicts in optimistic transactions.