### PR TITLE
Cargo: upgrade openssl to 1.1.1g

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,9 +2493,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.6.0+1.1.1d"
+version = "111.9.0+1.1.1g"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c2da1de8a7a3f860919c01540b03a6db16de042405a8a07a5e9d0b4b825d9c"
+checksum = "a2dbe10ddd1eb335aba3780eb2eaa13e1b7b441d2562fd962398740927f39ec4"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:
Address OpenSSL issue CVE-2020-1967 https://www.openssl.org/news/secadv/20200421.txt

### Related changes

- Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

Address OpenSSL issue CVE-2020-1967