### PR TITLE
raftstore: disable hibernate region by default

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -246,7 +246,7 @@ impl Default for Config {
             store_max_batch_size: 256,
             store_pool_size: 2,
             future_poll_size: 1,
-            hibernate_regions: true,
+            hibernate_regions: false,
             early_apply: true,
 
             // They are preserved for compatibility check.

--- a/tests/integrations/raftstore/test_region_heartbeat.rs
+++ b/tests/integrations/raftstore/test_region_heartbeat.rs
@@ -81,6 +81,7 @@ fn test_server_down_peers_with_hibernate_regions() {
     // by design. So here use a short check interval to trigger region heartbeat
     // more frequently.
     cluster.cfg.raft_store.peer_stale_state_check_interval = ReadableDuration::millis(500);
+    cluster.cfg.raft_store.hibernate_regions = true;
     test_down_peers(&mut cluster);
 }
 

--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -120,6 +120,7 @@ fn test_replica_read_not_applied() {
 #[test]
 fn test_replica_read_on_hibernate() {
     let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.raft_store.hibernate_regions = true;
 
     configure_for_lease_read(&mut cluster, Some(50), Some(20));
     // let max_lease = Duration::from_secs(2);
@@ -184,6 +185,7 @@ fn test_replica_read_on_hibernate() {
 #[test]
 fn test_read_hibernated_region() {
     let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.raft_store.hibernate_regions = true;
     // Initialize the cluster.
     configure_for_lease_read(&mut cluster, Some(100), Some(8));
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration(Duration::from_millis(1));


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Hibernate region is still experimenting and can be conflict with replication mode. So disable it by default.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
Disable hibernate region by default