### PR TITLE
external_storage: pass sse_kms_key_id to S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#e0c6e8842f22790e4f26ba3abbd9e01983ab95f1"
+source = "git+https://github.com/yiwu-arbug/kvproto.git?branch=enc_sse#59c57423475e7266bcf437c02cf87db49b300adb"
 dependencies = [
  "futures 0.1.29",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/yiwu-arbug/kvproto.git?branch=enc_sse#59c57423475e7266bcf437c02cf87db49b300adb"
+source = "git+https://github.com/pingcap/kvproto.git#038e31959c2a66085aad455db6e34fa4e98a58f9"
 dependencies = [
  "futures 0.1.29",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,9 @@ protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "b6
 fail = { git = "https://github.com/tikv/fail-rs.git", rev = "2cf1175a1a5cc2c70bd20ebd45313afd69b558fc" }
 prometheus = { git = "https://github.com/tikv/rust-prometheus.git", rev = "fd122caa03de8e7e5e4fae9372583aebf19e39f6" }
 
+[patch."https://github.com/pingcap/kvproto.git"]
+kvproto = { git = "https://github.com/yiwu-arbug/kvproto.git", branch = "enc_sse" }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,9 +173,6 @@ protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "b6
 fail = { git = "https://github.com/tikv/fail-rs.git", rev = "2cf1175a1a5cc2c70bd20ebd45313afd69b558fc" }
 prometheus = { git = "https://github.com/tikv/rust-prometheus.git", rev = "fd122caa03de8e7e5e4fae9372583aebf19e39f6" }
 
-[patch."https://github.com/pingcap/kvproto.git"]
-kvproto = { git = "https://github.com/yiwu-arbug/kvproto.git", branch = "enc_sse" }
-
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/components/external_storage/src/s3.rs
+++ b/components/external_storage/src/s3.rs
@@ -94,6 +94,7 @@ impl ExternalStorage for S3Storage {
             content_length: Some(content_length as i64),
             acl: get_var(&self.config.acl),
             server_side_encryption: get_var(&self.config.sse),
+            ssekms_key_id: get_var(&self.config.sse_kms_key_id),
             storage_class: get_var(&self.config.storage_class),
             ..Default::default()
         };


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Pass sse_kms_key_id when backup to S3. This is to support using user owned KMS key for server-side encryption.

### What is changed and how it works?

What's Changed:
Pass sse_kms_key_id when backup to S3.

### Related changes

depends on kvproto change: https://github.com/pingcap/kvproto/pull/607

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
Manual test with BR.

### Release note <!-- bugfixes or new feature need a release note -->
Support using user owned KMS key for server-side encryption when backup to S3.