### PR TITLE
external_storage: pass sse_kms_key_id to S3 (#7627)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-4.0#104857294b03016733aadebeb69fc2257f5df1e3"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-4.0#3500763f0214225246d8822fe467733a20ded8c7"
 dependencies = [
  "futures 0.1.29",
  "grpcio",

--- a/components/external_storage/src/s3.rs
+++ b/components/external_storage/src/s3.rs
@@ -98,6 +98,7 @@ impl ExternalStorage for S3Storage {
             content_length: Some(content_length as i64),
             acl: get_var(&self.config.acl),
             server_side_encryption: get_var(&self.config.sse),
+            ssekms_key_id: get_var(&self.config.sse_kms_key_id),
             storage_class: get_var(&self.config.storage_class),
             ..Default::default()
         };


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

cherry-pick #7627 to release-4.0

---

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Pass sse_kms_key_id when backup to S3. This is to support using user owned KMS key for server-side encryption.

### What is changed and how it works?

What's Changed:
Pass sse_kms_key_id when backup to S3.

### Related changes

depends on kvproto change: https://github.com/pingcap/kvproto/pull/607

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
Manual test with BR.

### Release note <!-- bugfixes or new feature need a release note -->
Support using user owned KMS key for server-side encryption when backup to S3.