### PR TITLE
tidb_query: fix UB causing by `from_raw_parts`

### DIFF
--- a/components/tidb_query_datatype/src/codec/row/v2/row_slice.rs
+++ b/components/tidb_query_datatype/src/codec/row/v2/row_slice.rs
@@ -193,9 +193,9 @@ impl<'a, T: PrimInt> LEBytes<'a, T> {
             return Err(0);
         }
         let mut base = 0usize;
-
-        // Note that the count of ids is not greater than (2 >> 16). The number
-        // of binary search steps will not over 16 unless the data is corruted.
+        
+        // Note that the count of ids is not greater than u16::MAX. The number
+        // of binary search steps will not over 16 unless the data is corrupted.
         // Let's relex to 20.
         let mut steps = 20usize;
 

--- a/components/tidb_query_datatype/src/codec/row/v2/row_slice.rs
+++ b/components/tidb_query_datatype/src/codec/row/v2/row_slice.rs
@@ -193,13 +193,21 @@ impl<'a, T: PrimInt> LEBytes<'a, T> {
             return Err(0);
         }
         let mut base = 0usize;
-        while size > 1 {
+
+        // Note that the count of ids is not greater than (2 >> 16). The number
+        // of binary search steps will not over 16 unless the data is corruted.
+        // Let's relex to 20.
+        let mut steps = 20usize;
+
+        while steps > 0 && size > 1 {
             let half = size / 2;
             let mid = base + half;
             let cmp = self.get_unchecked(mid).cmp(value);
             base = if cmp == Greater { base } else { mid };
             size -= half;
+            steps -= 1;
         }
+
         let cmp = self.get_unchecked(base).cmp(value);
         if cmp == Equal {
             Ok(base)

--- a/components/tidb_query_datatype/src/codec/row/v2/row_slice.rs
+++ b/components/tidb_query_datatype/src/codec/row/v2/row_slice.rs
@@ -193,8 +193,8 @@ impl<'a, T: PrimInt> LEBytes<'a, T> {
             return Err(0);
         }
         let mut base = 0usize;
-        
-        // Note that the count of ids is not greater than u16::MAX. The number
+
+        // Note that the count of ids is not greater than `u16::MAX`. The number
         // of binary search steps will not over 16 unless the data is corrupted.
         // Let's relex to 20.
         let mut steps = 20usize;

--- a/fuzz/targets/mod.rs
+++ b/fuzz/targets/mod.rs
@@ -296,3 +296,19 @@ pub fn fuzz_coprocessor_codec_duration_from_parse(data: &[u8]) -> Result<()> {
     let d = Duration::parse(&mut EvalContext::default(), &buf, fsp)?;
     fuzz_duration(d, cursor)
 }
+
+pub fn fuzz_coprocessor_codec_row_v2_binary_search(data: &[u8]) -> Result<()> {
+    use tidb_query_datatype::codec::row::v2::RowSlice;
+
+    let mut cursor = Cursor::new(data);
+    let id = cursor.read_as_i64()?;
+    let first_byte = cursor.read_as_u8()?;
+
+    if first_byte == 128 {
+        let row_slice = RowSlice::from_bytes(&data[8..])?;
+        let _ = row_slice.search_in_non_null_ids(id);
+        let _ = row_slice.search_in_null_ids(id);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Signed-off-by: zhongzc <zhongzc_arch@outlook.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7613 

Problem Summary:

From stdlib doc:
> Behavior is undefined if any of the following conditions are violated:
> * data must be valid for reads for len * mem::size_of::<T>() many bytes, and it must be properly __aligned__.
> * ...

We didn't provide this promise.


### What is changed and how it works?

What's Changed:

Introduce a new type `LEBytes`. Implement `binary_search` for this type by explicitly calling `std::ptr::read_unaligned`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test