### PR TITLE
raftstore: poll the newer peer list to check stale peer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#e0c6e8842f22790e4f26ba3abbd9e01983ab95f1"
+source = "git+https://github.com/gengliqi/kvproto.git?branch=add-check-stale-msg#7130d12228773aedbda43338dc7b1015f02b3f79"
 dependencies = [
  "futures 0.1.29",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,9 @@ protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "b6
 fail = { git = "https://github.com/tikv/fail-rs.git", rev = "2cf1175a1a5cc2c70bd20ebd45313afd69b558fc" }
 prometheus = { git = "https://github.com/tikv/rust-prometheus.git", rev = "fd122caa03de8e7e5e4fae9372583aebf19e39f6" }
 
+[patch.'https://github.com/pingcap/kvproto.git']
+kvproto = { git = "https://github.com/gengliqi/kvproto.git", branch = "add-check-stale-msg", default-features = false }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -963,7 +963,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             ExtraMessageType::MsgCheckStalePeerResponse => {
                 self.fsm.peer.on_check_stale_peer_response(
                     msg.get_region_epoch().get_conf_ver(),
-                    msg.mut_extra_msg().take_check_peers().into_vec(),
+                    msg.mut_extra_msg().take_check_peers().into(),
                 );
             }
         }
@@ -1036,7 +1036,10 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             if msg.has_extra_msg() {
                 // A learner can't vote so it sends the check-stale-peer msg to others to find out whether
                 // it is removed due to conf change or merge.
-                need_gc_msg |= msg.get_extra_msg().get_type() == ExtraMessageType::MsgCheckStalePeer
+                need_gc_msg |=
+                    msg.get_extra_msg().get_type() == ExtraMessageType::MsgCheckStalePeer;
+                // For backward compatibility
+                need_gc_msg |= msg.get_extra_msg().get_type() == ExtraMessageType::MsgRegionWakeUp;
             }
             // The message is stale and not in current region.
             self.ctx.handle_stale_msg(

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -948,7 +948,9 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         let extra_msg = msg.get_extra_msg();
         match extra_msg.get_type() {
             ExtraMessageType::MsgRegionWakeUp | ExtraMessageType::MsgCheckStalePeer => {
-                self.reset_raft_tick(GroupState::Ordered);
+                if self.fsm.group_state == GroupState::Idle {
+                    self.reset_raft_tick(GroupState::Ordered);
+                }
             }
             ExtraMessageType::MsgWantRollbackMerge => {
                 unimplemented!("remove this after #6584 merged")

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2880,12 +2880,15 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                     "peer_id" => self.fsm.peer_id(),
                     "expect" => %self.ctx.cfg.abnormal_leader_missing_duration,
                 );
+
                 self.ctx
                     .raft_metrics
                     .leader_missing
                     .lock()
                     .unwrap()
                     .insert(self.region_id());
+
+                self.fsm.peer.bcast_check_stale_peer_message(&mut self.ctx);
             }
             StaleState::ToValidate => {
                 // for peer B in case 1 above

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -901,7 +901,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         }
 
         if msg.has_extra_msg() {
-            self.on_extra_message(&msg);
+            self.on_extra_message(msg);
             return Ok(());
         }
 
@@ -944,8 +944,9 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         Ok(())
     }
 
-    fn on_extra_message(&mut self, msg: &RaftMessage) {
-        let extra_msg = msg.get_extra_msg();
+    fn on_extra_message(&mut self, mut msg: RaftMessage) {
+        let region_epoch = msg.get_region_epoch().clone();
+        let extra_msg = msg.mut_extra_msg();
         match extra_msg.get_type() {
             ExtraMessageType::MsgRegionWakeUp | ExtraMessageType::MsgCheckStalePeer => {
                 if self.fsm.group_state == GroupState::Idle {
@@ -958,8 +959,8 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             ExtraMessageType::MsgCheckStalePeerResponse => {
                 self.fsm.peer.on_check_stale_peer_response(
                     &mut self.ctx,
-                    msg.get_region_epoch().get_conf_ver(),
-                    extra_msg.get_check_peers(),
+                    region_epoch.get_conf_ver(),
+                    extra_msg.take_check_peers().into_vec(),
                 );
             }
         }

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -945,9 +945,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
     }
 
     fn on_extra_message(&mut self, mut msg: RaftMessage) {
-        let region_epoch = msg.get_region_epoch().clone();
-        let extra_msg = msg.mut_extra_msg();
-        match extra_msg.get_type() {
+        match msg.get_extra_msg().get_type() {
             ExtraMessageType::MsgRegionWakeUp | ExtraMessageType::MsgCheckStalePeer => {
                 if self.fsm.group_state == GroupState::Idle {
                     self.reset_raft_tick(GroupState::Ordered);
@@ -959,8 +957,8 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             ExtraMessageType::MsgCheckStalePeerResponse => {
                 self.fsm.peer.on_check_stale_peer_response(
                     &mut self.ctx,
-                    region_epoch.get_conf_ver(),
-                    extra_msg.take_check_peers().into_vec(),
+                    msg.get_region_epoch().get_conf_ver(),
+                    msg.mut_extra_msg().take_check_peers().into_vec(),
                 );
             }
         }

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1333,6 +1333,8 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
                 // it is removed due to conf change or merge.
                 need_gc_msg |=
                     msg.get_extra_msg().get_type() == ExtraMessageType::MsgCheckStalePeer;
+                // For backward compatibility
+                need_gc_msg |= msg.get_extra_msg().get_type() == ExtraMessageType::MsgRegionWakeUp;
             }
             let not_exist = util::find_peer(region, from_store_id).is_none();
             self.ctx

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -243,6 +243,10 @@ pub struct Peer {
 
     /// Time of the last attempt to wake up inactive leader.
     pub bcast_wake_up_time: Option<UtilInstant>,
+    /// The known newest conf version and its corresponding peer list
+    /// Send to these peers to check whether itself is stale.
+    pub check_stale_conf_ver: u64,
+    pub check_stale_peers: Vec<metapb::Peer>,
 }
 
 impl Peer {
@@ -321,6 +325,8 @@ impl Peer {
             peer_stat: PeerStat::default(),
             catch_up_logs: None,
             bcast_wake_up_time: None,
+            check_stale_conf_ver: 0,
+            check_stale_peers: vec![],
         };
 
         // If this region has only one peer and I am the one, campaign directly.
@@ -2053,7 +2059,7 @@ impl Peer {
                     || self.bcast_wake_up_time.as_ref().unwrap().elapsed()
                         >= Duration::from_millis(MIN_BCAST_WAKE_UP_INTERVAL))
             {
-                self.bcast_wake_up_message(&mut poll_ctx.trans);
+                self.bcast_wake_up_message(poll_ctx);
                 self.bcast_wake_up_time = Some(UtilInstant::now_coarse());
             }
             self.should_wake_up = true;
@@ -2593,9 +2599,9 @@ impl Peer {
         }
     }
 
-    pub fn bcast_wake_up_message<T: Transport>(&self, trans: &mut T) {
-        let region = self.raft_group.store().region();
-        for peer in region.get_peers() {
+    pub fn bcast_wake_up_message<T: Transport, C>(&self, ctx: &mut PollContext<T, C>) {
+        ctx.need_flush_trans = true;
+        for peer in self.region().get_peers() {
             if peer.get_id() == self.peer_id() {
                 continue;
             }
@@ -2606,7 +2612,7 @@ impl Peer {
             send_msg.set_to_peer(peer.clone());
             let extra_msg = send_msg.mut_extra_msg();
             extra_msg.set_type(ExtraMessageType::MsgRegionWakeUp);
-            if let Err(e) = trans.send(send_msg) {
+            if let Err(e) = ctx.trans.send(send_msg) {
                 error!(
                     "failed to send wake up message";
                     "region_id" => self.region_id,
@@ -2616,6 +2622,53 @@ impl Peer {
                     "err" => ?e,
                 );
             }
+        }
+    }
+
+    pub fn bcast_check_stale_peer_message<T: Transport, C>(&mut self, ctx: &mut PollContext<T, C>) {
+        ctx.need_flush_trans = true;
+        if self.check_stale_conf_ver < self.region().get_region_epoch().get_conf_ver() {
+            self.check_stale_conf_ver = self.region().get_region_epoch().get_conf_ver();
+            self.check_stale_peers = self.region().get_peers().to_vec();
+        }
+        for peer in &self.check_stale_peers {
+            if peer.get_id() == self.peer_id() {
+                continue;
+            }
+            let mut send_msg = RaftMessage::default();
+            send_msg.set_region_id(self.region_id);
+            send_msg.set_from_peer(self.peer.clone());
+            send_msg.set_region_epoch(self.region().get_region_epoch().clone());
+            send_msg.set_to_peer(peer.clone());
+            let extra_msg = send_msg.mut_extra_msg();
+            extra_msg.set_type(ExtraMessageType::MsgCheckStalePeer);
+            if let Err(e) = ctx.trans.send(send_msg) {
+                error!(
+                    "failed to send check stale peer message";
+                    "region_id" => self.region_id,
+                    "peer_id" => self.peer.get_id(),
+                    "target_peer_id" => peer.get_id(),
+                    "target_store_id" => peer.get_store_id(),
+                    "err" => ?e,
+                );
+            }
+        }
+    }
+
+    pub fn on_check_stale_peer_response<T: Transport, C>(
+        &mut self,
+        ctx: &mut PollContext<T, C>,
+        check_conf_ver: u64,
+        check_peers: &[metapb::Peer],
+    ) {
+        if self.check_stale_conf_ver < self.region().get_region_epoch().get_conf_ver() {
+            self.check_stale_conf_ver = self.region().get_region_epoch().get_conf_ver();
+            self.check_stale_peers = self.region().get_peers().to_vec();
+        }
+        if self.check_stale_conf_ver < check_conf_ver {
+            self.check_stale_conf_ver = check_conf_ver;
+            self.check_stale_peers = check_peers.to_vec();
+            self.bcast_check_stale_peer_message(ctx);
         }
     }
 }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2604,8 +2604,6 @@ impl Peer {
             if peer.get_id() == self.peer_id() {
                 continue;
             }
-            ctx.need_flush_trans = true;
-
             let mut send_msg = RaftMessage::default();
             send_msg.set_region_id(self.region_id);
             send_msg.set_from_peer(self.peer.clone());
@@ -2622,6 +2620,8 @@ impl Peer {
                     "target_store_id" => peer.get_store_id(),
                     "err" => ?e,
                 );
+            } else {
+                ctx.need_flush_trans = true;
             }
         }
     }
@@ -2635,8 +2635,6 @@ impl Peer {
             if peer.get_id() == self.peer_id() {
                 continue;
             }
-            ctx.need_flush_trans = true;
-
             let mut send_msg = RaftMessage::default();
             send_msg.set_region_id(self.region_id);
             send_msg.set_from_peer(self.peer.clone());
@@ -2653,6 +2651,8 @@ impl Peer {
                     "target_store_id" => peer.get_store_id(),
                     "err" => ?e,
                 );
+            } else {
+                ctx.need_flush_trans = true;
             }
         }
     }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2670,7 +2670,6 @@ impl Peer {
         if self.check_stale_conf_ver < check_conf_ver {
             self.check_stale_conf_ver = check_conf_ver;
             self.check_stale_peers = check_peers;
-            self.bcast_check_stale_peer_message(ctx);
         }
     }
 }

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -1027,7 +1027,7 @@ fn test_merge_isloated_not_in_merge_learner() {
     pd_client.must_remove_peer(right.get_id(), right_on_store1);
 
     pd_client.must_merge(left.get_id(), right.get_id());
-    // Add a new learner on store 2 to trigger peer 2 send wake-up msg to other peers
+    // Add a new learner on store 2 to trigger peer 2 send check-stale-peer msg to other peers
     pd_client.must_add_peer(right.get_id(), new_learner_peer(2, 5));
 
     cluster.must_put(b"k123", b"v123");
@@ -1075,11 +1075,58 @@ fn test_merge_isloated_stale_learner() {
 
     let new_left = pd_client.get_region(b"k1").unwrap();
     assert_ne!(left.get_id(), new_left.get_id());
-    // Add a new learner on store 2 to trigger peer 2 send wake-up msg to other peers
+    // Add a new learner on store 2 to trigger peer 2 send check-stale-peer msg to other peers
     pd_client.must_add_peer(new_left.get_id(), new_learner_peer(2, 5));
     cluster.must_put(b"k123", b"v123");
 
     cluster.run_node(2).unwrap();
     // We can see if the old peer 2 is destroyed
     must_get_equal(&cluster.get_engine(2), b"k123", b"v123");
+}
+
+/// Test if a learner can be destroyed properly in such conditions as follows
+/// 1. A peer is isolated
+/// 2. Be the last removed peer in its peer list
+/// 3. Then its region merges to another region.
+/// 4. Isolation disappears
+#[test]
+fn test_merge_isloated_not_in_merge_learner_2() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_merge(&mut cluster);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    cluster.run_conf_change();
+
+    let region = pd_client.get_region(b"k1").unwrap();
+    cluster.must_split(&region, b"k2");
+
+    let left = pd_client.get_region(b"k1").unwrap();
+    let right = pd_client.get_region(b"k2").unwrap();
+    let left_on_store1 = find_peer(&left, 1).unwrap().to_owned();
+    let right_on_store1 = find_peer(&right, 1).unwrap().to_owned();
+
+    pd_client.must_add_peer(left.get_id(), new_learner_peer(2, 2));
+    // Ensure this learner exists
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+
+    cluster.stop_node(2);
+
+    pd_client.must_add_peer(left.get_id(), new_peer(3, 3));
+    pd_client.must_remove_peer(left.get_id(), left_on_store1);
+
+    pd_client.must_add_peer(right.get_id(), new_peer(3, 4));
+    pd_client.must_remove_peer(right.get_id(), right_on_store1);
+    // The peer list of peer 2 is (1001, 1), (2, 2)
+    pd_client.must_remove_peer(left.get_id(), new_learner_peer(2, 2));
+
+    pd_client.must_merge(left.get_id(), right.get_id());
+
+    cluster.run_node(2).unwrap();
+    // When the abnormal leader missing duration has passed, the check-stale-peer msg will be sent to peer 1001.
+    // After that, a new peer list will be returned (2, 2) (3, 3).
+    // Then peer 2 sends the check-stale-peer msg to peer 3 and it will get a tombstone response.
+    // Finally peer 2 will be destroyed.
+    must_get_none(&cluster.get_engine(2), b"k1");
 }


### PR DESCRIPTION
Signed-off-by: Liqi Geng <gengliqiii@gmail.com>


### What problem does this PR solve?


Problem Summary:
A stale peer will not be destroyed in such conditions
1. Be isolated
2. Be the last removed peer in its peer list
3. Then its region merges to another region.

In this case, PD can not give any help because this region has merged and some related data has been deleted.
After isolation disappears, this peer will send vote msg to other peers in its peer list. But the other peers will ignore this msg and they still think this peer is valid because it exists in their peer list.
This PR introduces a new method to figure out the problem.

### What is changed and how it works?

What's Changed:
Add two new extra message type. `MsgCheckStalePeer` and `MsgCheckStalePeerResponse`.
`MsgCheckStalePeer` is split from `MsgRegionWakeUp`.
The peer can get the newer peer list from other tombstone peers. Then it can use this newer peer list to check if it is stale.

### Related changes

- Need to cherry-pick to the release branch


Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

No.

### Release note <!-- bugfixes or new feature need a release note -->
Fix an issue that a peer may not be destroyed after isolation recovery.