### PR TITLE
txn: check timestamp overflow

### DIFF
--- a/components/backup/tests/integrations/test_backup.rs
+++ b/components/backup/tests/integrations/test_backup.rs
@@ -364,7 +364,7 @@ fn test_backup_and_import() {
         vec![],   // end
         0.into(), // begin_ts
         backup_ts,
-        &tmp.path().join(format!("{}", backup_ts.next())),
+        &tmp.path().join(format!("{}", backup_ts.next().unwrap())),
     );
     let resps2 = block_on(rx.collect::<Vec<_>>());
     assert!(resps2[0].get_files().is_empty(), "{:?}", resps2);
@@ -422,7 +422,8 @@ fn test_backup_and_import() {
         vec![],   // end
         0.into(), // begin_ts
         backup_ts,
-        &tmp.path().join(format!("{}", backup_ts.next().next())),
+        &tmp.path()
+            .join(format!("{}", backup_ts.next().unwrap().next().unwrap())),
     );
     let resps3 = block_on(rx.collect::<Vec<_>>());
     assert_eq!(files1, resps3[0].files);
@@ -523,7 +524,7 @@ fn test_backup_rawkv() {
         vec![], // start
         vec![], // end
         cf.clone(),
-        &tmp.path().join(format!("{}", backup_ts.next())),
+        &tmp.path().join(format!("{}", backup_ts.next().unwrap())),
     );
     let resps2 = block_on(rx.collect::<Vec<_>>());
     assert!(resps2[0].get_files().is_empty(), "{:?}", resps2);
@@ -581,7 +582,8 @@ fn test_backup_rawkv() {
         vec![b'a'], // start
         vec![b'z'], // end
         cf,
-        &tmp.path().join(format!("{}", backup_ts.next().next())),
+        &tmp.path()
+            .join(format!("{}", backup_ts.next().unwrap().next().unwrap())),
     );
     let resps3 = block_on(rx.collect::<Vec<_>>());
     assert_eq!(files1, resps3[0].files);

--- a/components/txn_types/src/timestamp.rs
+++ b/components/txn_types/src/timestamp.rs
@@ -32,21 +32,23 @@ impl TimeStamp {
         self.0 >> TSO_PHYSICAL_SHIFT_BITS
     }
 
-    pub fn next(self) -> TimeStamp {
-        TimeStamp(self.0 + 1)
+    pub fn next(self) -> Option<TimeStamp> {
+        self.0.checked_add(1).map(TimeStamp)
     }
 
-    pub fn prev(self) -> TimeStamp {
-        TimeStamp(self.0 - 1)
+    pub fn prev(self) -> Option<TimeStamp> {
+        self.0.checked_sub(1).map(TimeStamp)
     }
 
+    // Only used in tests.
     pub fn incr(&mut self) -> &mut TimeStamp {
-        self.0 += 1;
+        *self = self.next().unwrap();
         self
     }
 
+    // Only used in tests.
     pub fn decr(&mut self) -> &mut TimeStamp {
-        self.0 -= 1;
+        *self = self.prev().unwrap();
         self
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4055,7 +4055,7 @@ mod tests {
                 for_update_ts,
                 None,
                 return_values,
-                for_update_ts.next(),
+                for_update_ts.next().unwrap(),
                 Context::default(),
             )
         }

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -812,7 +812,7 @@ pub mod tests {
         lock_ttl: u64,
     ) {
         let for_update_ts = for_update_ts.into();
-        let min_commit_ts = for_update_ts.next();
+        let min_commit_ts = for_update_ts.next().unwrap();
         must_acquire_pessimistic_lock_impl(
             engine,
             key,

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -200,7 +200,7 @@ impl<S: Snapshot> MvccReader<S> {
                     WriteType::Delete => {
                         return Ok(None);
                     }
-                    WriteType::Lock | WriteType::Rollback => ts = commit_ts.prev(),
+                    WriteType::Lock | WriteType::Rollback => ts = commit_ts.prev().unwrap(),
                 },
                 None => return Ok(None),
             }
@@ -225,7 +225,7 @@ impl<S: Snapshot> MvccReader<S> {
             if commit_ts <= start_ts {
                 break;
             }
-            seek_ts = commit_ts.prev();
+            seek_ts = commit_ts.prev().unwrap();
         }
         Ok(None)
     }

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -926,7 +926,7 @@ fn find_mvcc_infos_by_key<S: Snapshot>(
         let opt = reader.seek_write(key, ts)?;
         match opt {
             Some((commit_ts, write)) => {
-                ts = commit_ts.prev();
+                ts = commit_ts.prev().unwrap();
                 writes.push((commit_ts, write));
             }
             None => break,

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -332,7 +332,7 @@ impl<S: Snapshot> TxnEntryStore for SnapshotStore<S> {
                 .fill_cache(self.fill_cache)
                 .isolation_level(self.isolation_level)
                 .bypass_locks(self.bypass_locks.clone())
-                .hint_min_ts(Some(after_ts.next()))
+                .hint_min_ts(Some(after_ts.next().unwrap()))
                 .hint_max_ts(Some(self.start_ts))
                 .build_entry_scanner(after_ts, output_delete)?;
 
@@ -643,7 +643,7 @@ mod tests {
         fn store(&self) -> SnapshotStore<RocksSnapshot> {
             SnapshotStore::new(
                 self.snapshot.clone(),
-                COMMIT_TS.next(),
+                COMMIT_TS.next().unwrap(),
                 IsolationLevel::Si,
                 true,
                 Default::default(),

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -210,7 +210,7 @@ fn write_test_data<E: Engine>(
             .into_iter()
             .for_each(|res| res.unwrap());
         storage
-            .commit(ctx.clone(), vec![Key::from_raw(k)], ts, ts.next())
+            .commit(ctx.clone(), vec![Key::from_raw(k)], ts, ts.next().unwrap())
             .unwrap();
         ts.incr().incr();
     }


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
TiDB uses max u64 as start ts when doing point get in the autocommit transaction. If it meets locks, it will lead to `min_commit_ts` overflow. See https://github.com/pingcap/tidb/issues/16778.

### What is changed and how it works?

What's Changed:
Check timestamp overflow.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

### Release note <!-- bugfixes or new feature need a release note -->
Fix the issue that the min commit timestamp of a transaction may overflows which breaks data safety.