### PR TITLE
txn: don't push min_commit_ts if caller_start_ts is max u64

### DIFF
--- a/components/txn_types/src/timestamp.rs
+++ b/components/txn_types/src/timestamp.rs
@@ -54,6 +54,10 @@ impl TimeStamp {
         self.0 == 0
     }
 
+    pub fn is_max(self) -> bool {
+        self.0 == std::u64::MAX
+    }
+
     pub fn into_inner(self) -> u64 {
         self.0
     }

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1739,7 +1739,10 @@ txn_command_future!(future_check_txn_status, CheckTxnStatusRequest, CheckTxnStat
                     min_commit_ts,
                 } => {
                     resp.set_lock_ttl(lock_ttl);
-                    if min_commit_ts > caller_start_ts {
+                    // If the caller_start_ts is max, it's a point get in the autocommit transaction.
+                    // Even though the min_commit_ts is not pushed, the point get can ingore the lock
+                    // next time because it's not committed. So we pretend it has been pushed.
+                    if min_commit_ts > caller_start_ts || caller_start_ts.is_max() {
                         resp.set_action(Action::MinCommitTsPushed);
                     }
                 }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -895,11 +895,17 @@ impl<S: Snapshot> MvccTxn<S> {
                     return Ok((TxnStatus::TtlExpire, released));
                 }
 
-                // If lock.minCommitTS is 0, it's not a large transaction and we can't push forward
-                // its minCommitTS otherwise the transaction can't be committed by old version TiDB
+                // If lock.min_commit_ts is 0, it's not a large transaction and we can't push forward
+                // its min_commit_ts otherwise the transaction can't be committed by old version TiDB
                 // during rolling update.
-                // If this is a large transaction and the lock is active, push forward the minCommitTS.
-                if !lock.min_commit_ts.is_zero() && caller_start_ts >= lock.min_commit_ts {
+                if !lock.min_commit_ts.is_zero()
+                    // If the caller_start_ts is max, it's a point get in the autocommit transaction.
+                    // We don't push forward lock's min_commit_ts and the point get can ingore the lock
+                    // next time because it's not committed.
+                    && !caller_start_ts.is_max()
+                    // Push forward the min_commit_ts so that reading won't be blocked by locks.
+                    && caller_start_ts >= lock.min_commit_ts
+                {
                     lock.min_commit_ts = caller_start_ts.next();
 
                     if lock.min_commit_ts < current_ts {
@@ -2593,6 +2599,29 @@ mod tests {
         );
         must_large_txn_locked(&engine, k, ts(300, 0), 100, TimeStamp::zero(), false);
         must_rollback(&engine, k, ts(300, 0));
+
+        must_prewrite_put_for_large_txn(&engine, k, v, k, ts(310, 0), 100, 0);
+        must_large_txn_locked(&engine, k, ts(310, 0), 100, ts(310, 1), false);
+        // Don't push forward the min_commit_ts if caller_start_ts is max.
+        must_check_txn_status(
+            &engine,
+            k,
+            ts(310, 0),
+            TimeStamp::max(),
+            ts(320, 0),
+            r,
+            uncommitted(100, ts(310, 1)),
+        );
+        must_commit(&engine, k, ts(310, 0), ts(315, 0));
+        must_check_txn_status(
+            &engine,
+            k,
+            ts(310, 0),
+            TimeStamp::max(),
+            ts(320, 0),
+            r,
+            committed(ts(315, 0)),
+        );
     }
 
     #[test]

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -108,7 +108,8 @@ fn must_kv_prewrite(client: &TikvClient, ctx: Context, muts: Vec<Mutation>, pk: 
     prewrite_req.set_mutations(muts.into_iter().collect());
     prewrite_req.primary_lock = pk;
     prewrite_req.start_version = ts;
-    prewrite_req.lock_ttl = prewrite_req.start_version + 1;
+    prewrite_req.lock_ttl = 3000;
+    prewrite_req.min_commit_ts = prewrite_req.start_version + 1;
     let prewrite_resp = client.kv_prewrite(&prewrite_req).unwrap();
     assert!(
         !prewrite_resp.has_region_error(),
@@ -519,7 +520,7 @@ fn test_physical_scan_lock() {
             lock_info.set_primary_lock(k.clone());
             lock_info.set_lock_version(ts);
             lock_info.set_key(k);
-            lock_info.set_lock_ttl(ts + 1);
+            lock_info.set_lock_ttl(3000);
             lock_info.set_lock_type(Op::Put);
             lock_info
         })
@@ -1031,4 +1032,54 @@ fn test_pessimistic_lock() {
         }
         must_kv_pessimistic_rollback(&client, ctx.clone(), k.clone(), 40);
     }
+}
+
+#[test]
+fn test_check_txn_status_with_max_ts() {
+    fn must_check_txn_status(
+        client: &TikvClient,
+        ctx: Context,
+        key: &[u8],
+        lock_ts: u64,
+        caller_start_ts: u64,
+        current_ts: u64,
+    ) -> CheckTxnStatusResponse {
+        let mut req = CheckTxnStatusRequest::default();
+        req.set_context(ctx);
+        req.set_primary_key(key.to_vec());
+        req.set_lock_ts(lock_ts);
+        req.set_caller_start_ts(caller_start_ts);
+        req.set_current_ts(current_ts);
+
+        let resp = client.kv_check_txn_status(&req).unwrap();
+        assert!(!resp.has_region_error(), "{:?}", resp.get_region_error());
+        assert!(resp.error.is_none(), "{:?}", resp.get_error());
+        return resp;
+    }
+
+    let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
+    let (k, v) = (b"key".to_vec(), b"value".to_vec());
+    let lock_ts = 10;
+
+    // Prewrite
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.set_key(k.clone());
+    mutation.set_value(v.clone());
+    must_kv_prewrite(&client, ctx.clone(), vec![mutation], k.clone(), lock_ts);
+
+    // Should return MinCommitTsPushed even if caller_start_ts is max.
+    let status = must_check_txn_status(
+        &client,
+        ctx.clone(),
+        &k,
+        lock_ts,
+        std::u64::MAX,
+        lock_ts + 1,
+    );
+    assert_eq!(status.lock_ttl, 3000);
+    assert_eq!(status.action, Action::MinCommitTsPushed);
+
+    // The min_commit_ts of k shouldn't be pushed.
+    must_kv_commit(&client, ctx, vec![k], lock_ts, lock_ts + 1, lock_ts + 1);
 }


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
TiDB uses max u64 as start ts when doing point get in the autocommit transaction. If it meets locks, it will lead to `min_commit_ts` overflow. See https://github.com/pingcap/tidb/issues/16778.

### What is changed and how it works?

What's Changed:
Don't push `min_commit_ts` if `caller_start_ts` is max u64.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

### Release note <!-- bugfixes or new feature need a release note -->
Fix the issue that the min commit timestamp of a transaction may overflows which breaks data safety.