### PR TITLE
[Bug]fix bug which cause writebatch too small

### DIFF
--- a/components/engine_rocks/src/write_batch.rs
+++ b/components/engine_rocks/src/write_batch.rs
@@ -222,7 +222,7 @@ impl engine_traits::WriteBatch for RocksWriteBatchVec {
     }
 
     fn should_write_to_engine(&self) -> bool {
-        self.wbs.len() > WRITE_BATCH_MAX_BATCH
+        self.index >= WRITE_BATCH_MAX_BATCH
     }
 
     fn clear(&mut self) {
@@ -341,5 +341,7 @@ mod tests {
         assert!(!wb.should_write_to_engine());
         wb.put(b"aaa", b"bbb").unwrap();
         assert!(wb.should_write_to_engine());
+        wb.clear();
+        assert!(!wb.should_write_to_engine());
     }
 }


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

I made a mistake that is judging whether a `WriteBatchVec` should be written into `RocksDB` by the size of its vec. But I did not clear it vec to reduce allocate new object every time after writing into `RocksDB`. This bug will make TiKV writes `WriteBatchVec` into RocksDB at once even if there is only one key in it. And it will greatly reduce the performance of TiKV.

### What is changed and how it works?

Use `index` instead. It will judge by the real size of vector.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->