### PR TITLE
status_server: support dumping region meta by http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "coarsetime"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bac87404ed1c708d9cdd0094449e70aadc1ab73c291d2cf536e946a413594e5"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
 name = "codec"
 version = "0.0.1"
 dependencies = [
@@ -1056,8 +1066,6 @@ dependencies = [
  "prometheus",
  "protobuf",
  "rocksdb",
- "serde",
- "serde_derive",
  "slog",
  "slog-global",
  "sysinfo",
@@ -1081,6 +1089,8 @@ dependencies = [
 name = "engine_rocks"
 version = "0.0.1"
 dependencies = [
+ "coarsetime",
+ "configuration",
  "encryption",
  "engine",
  "engine_traits",
@@ -1092,12 +1102,15 @@ dependencies = [
  "prometheus-static-metric",
  "rand 0.7.3",
  "rocksdb",
+ "serde",
+ "serde_derive",
  "slog",
  "slog-global",
  "tempfile",
  "tikv_alloc",
  "tikv_util",
  "time 0.1.42",
+ "toml",
  "txn_types",
 ]
 

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -27,8 +27,8 @@ use raftstore::{
         config::RaftstoreConfigManager,
         fsm,
         fsm::store::{RaftBatchSystem, RaftRouter, StoreMeta, PENDING_VOTES_CAP},
-        new_compaction_listener, AutoSplitController, LocalReader, SnapManagerBuilder,
-        SplitCheckRunner, SplitConfigManager,
+        new_compaction_listener, AutoSplitController, GlobalReplicationState, LocalReader,
+        SnapManagerBuilder, SplitCheckRunner, SplitConfigManager,
     },
 };
 use std::{
@@ -121,6 +121,7 @@ struct TiKVServer {
     router: RaftRouter<RocksEngine>,
     system: Option<RaftBatchSystem>,
     resolver: resolve::PdStoreAddrResolver,
+    state: Arc<Mutex<GlobalReplicationState>>,
     store_path: PathBuf,
     encryption_key_manager: Option<Arc<DataKeyManager>>,
     engines: Option<Engines>,
@@ -163,11 +164,12 @@ impl TiKVServer {
 
         let store_path = Path::new(&config.storage.data_dir).to_owned();
 
-        let (resolve_worker, resolver) = resolve::new_resolver(Arc::clone(&pd_client))
-            .unwrap_or_else(|e| fatal!("failed to start address resolver: {}", e));
-
         // Initialize raftstore channels.
         let (router, system) = fsm::create_raft_batch_system(&config.raft_store);
+
+        let (resolve_worker, resolver, state) = resolve::new_resolver(Arc::clone(&pd_client))
+            .unwrap_or_else(|e| fatal!("failed to start address resolver: {}", e));
+
         let mut coprocessor_host = Some(CoprocessorHost::new(router.clone()));
         let region_info_accessor = RegionInfoAccessor::new(coprocessor_host.as_mut().unwrap());
         region_info_accessor.start();
@@ -180,6 +182,7 @@ impl TiKVServer {
             router,
             system: Some(system),
             resolver,
+            state,
             store_path,
             encryption_key_manager: None,
             engines: None,
@@ -565,6 +568,7 @@ impl TiKVServer {
             &server_config,
             raft_store,
             self.pd_client.clone(),
+            self.state.clone(),
         );
 
         node.start(

--- a/components/configuration/src/lib.rs
+++ b/components/configuration/src/lib.rs
@@ -18,10 +18,7 @@ pub enum ConfigValue {
     Usize(usize),
     Bool(bool),
     String(String),
-    // `String` represent config field that has type `String`,
-    // `Other` represent config field with type that can be
-    // coverted to `String` as temporary representation i.e enum type.
-    Other(String),
+    BlobRunMode(String),
     Module(ConfigChange),
     Skip,
 }
@@ -38,7 +35,7 @@ impl Display for ConfigValue {
             ConfigValue::Usize(v) => write!(f, "{}", v),
             ConfigValue::Bool(v) => write!(f, "{}", v),
             ConfigValue::String(v) => write!(f, "{}", v),
-            ConfigValue::Other(v) => write!(f, "{}", v),
+            ConfigValue::BlobRunMode(v) => write!(f, "{}", v),
             ConfigValue::Module(v) => write!(f, "{:?}", v),
             ConfigValue::Skip => write!(f, "ConfigValue::Skip"),
         }

--- a/components/engine/Cargo.toml
+++ b/components/engine/Cargo.toml
@@ -17,8 +17,6 @@ hex = "0.4"
 lazy_static = "1.3"
 prometheus = { version = "0.8", features = ["nightly", "push"] }
 protobuf = "2.8"
-serde = "1.0"
-serde_derive = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 sysinfo = { git = "https://github.com/tikv/sysinfo.git", branch = "tikv"}

--- a/components/engine/src/lib.rs
+++ b/components/engine/src/lib.rs
@@ -8,8 +8,6 @@ extern crate slog_global;
 extern crate prometheus;
 #[macro_use]
 extern crate lazy_static;
-#[macro_use]
-extern crate serde_derive;
 #[allow(unused_extern_crates)]
 extern crate tikv_alloc;
 

--- a/components/engine/src/rocks/util/mod.rs
+++ b/components/engine/src/rocks/util/mod.rs
@@ -1,6 +1,5 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-pub mod config;
 pub mod engine_metrics;
 pub mod stats;
 

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -31,6 +31,10 @@ tikv_util = { path = "../tikv_util" }
 txn_types = { path = "../txn_types"}
 lazy_static = "1.4.0"
 time = "0.1"
+configuration = { path = "../configuration" }
+serde = "1.0"
+serde_derive = "1.0"
+coarsetime = "0.1"
 
 [dependencies.rocksdb]
 git = "https://github.com/tikv/rust-rocksdb.git"
@@ -45,3 +49,4 @@ rev = "fd122caa03de8e7e5e4fae9372583aebf19e39f6"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 tempfile = "3.0"
 rand = "0.7"
+toml = "0.4"

--- a/components/engine_rocks/src/config.rs
+++ b/components/engine_rocks/src/config.rs
@@ -3,6 +3,7 @@
 use configuration::ConfigValue;
 pub use rocksdb::PerfLevel;
 use rocksdb::{DBCompressionType, DBTitanDBBlobRunMode};
+use std::str::FromStr;
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -128,13 +129,13 @@ pub enum BlobRunMode {
 
 impl From<BlobRunMode> for ConfigValue {
     fn from(mode: BlobRunMode) -> ConfigValue {
-        ConfigValue::Other(format!("k{:?}", mode))
+        ConfigValue::BlobRunMode(format!("k{:?}", mode))
     }
 }
 
 impl Into<BlobRunMode> for ConfigValue {
     fn into(self) -> BlobRunMode {
-        if let ConfigValue::Other(s) = self {
+        if let ConfigValue::BlobRunMode(s) = self {
             match s.as_str() {
                 "kNormal" => BlobRunMode::Normal,
                 "kReadOnly" => BlobRunMode::ReadOnly,
@@ -142,7 +143,22 @@ impl Into<BlobRunMode> for ConfigValue {
                 m => panic!("expect: kNormal, kReadOnly or kFallback, got: {:?}", m),
             }
         } else {
-            panic!("expect: ConfigValue::Other, got: {:?}", self);
+            panic!("expect: ConfigValue::BlobRunMode, got: {:?}", self);
+        }
+    }
+}
+
+impl FromStr for BlobRunMode {
+    type Err = String;
+    fn from_str(s: &str) -> Result<BlobRunMode, String> {
+        match s {
+            "normal" => Ok(BlobRunMode::Normal),
+            "read-only" => Ok(BlobRunMode::ReadOnly),
+            "fallback" => Ok(BlobRunMode::Fallback),
+            m => Err(format!(
+                "expect: normal, read-only or fallback, got: {:?}",
+                m
+            )),
         }
     }
 }

--- a/components/engine_rocks/src/config.rs
+++ b/components/engine_rocks/src/config.rs
@@ -1,7 +1,8 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::rocks::{DBCompressionType, DBTitanDBBlobRunMode};
 use configuration::ConfigValue;
+pub use rocksdb::PerfLevel;
+use rocksdb::{DBCompressionType, DBTitanDBBlobRunMode};
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -38,7 +39,7 @@ pub mod compression_type_level_serde {
     use serde::ser::SerializeSeq;
     use serde::{Deserializer, Serializer};
 
-    use crate::rocks::DBCompressionType;
+    use rocksdb::DBCompressionType;
 
     pub fn serialize<S>(ts: &[DBCompressionType; 7], serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -163,7 +164,7 @@ macro_rules! numeric_enum_mod {
 
             use serde::{Serializer, Deserializer};
             use serde::de::{self, Unexpected, Visitor};
-            use crate::rocks::$enum;
+            use rocksdb::$enum;
 
             pub fn serialize<S>(mode: &$enum, serializer: S) -> Result<S::Ok, S::Error>
                 where S: Serializer
@@ -199,7 +200,7 @@ macro_rules! numeric_enum_mod {
             #[cfg(test)]
             mod tests {
                 use toml;
-                use crate::rocks::$enum;
+                use rocksdb::$enum;
 
                 #[test]
                 fn test_serde() {
@@ -251,10 +252,20 @@ numeric_enum_mod! {recovery_mode_serde DBRecoveryMode {
     SkipAnyCorruptedRecords = 3,
 }}
 
+numeric_enum_mod! {perf_level_serde PerfLevel {
+    Uninitialized = 0,
+    Disable = 1,
+    EnableCount = 2,
+    EnableTimeExceptForMutex = 3,
+    EnableTimeAndCPUTimeExceptForMutex = 4,
+    EnableTime = 5,
+    OutOfBounds = 6,
+}}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rocks::DBCompressionType;
+    use rocksdb::DBCompressionType;
 
     #[test]
     fn test_parse_compression_type() {

--- a/components/engine_rocks/src/lib.rs
+++ b/components/engine_rocks/src/lib.rs
@@ -23,6 +23,9 @@ extern crate tikv_util;
 #[macro_use]
 extern crate slog_global;
 
+#[macro_use]
+extern crate serde_derive;
+
 #[cfg(test)]
 extern crate test;
 
@@ -77,4 +80,9 @@ pub use rocks_metrics_defs::*;
 pub mod event_listener;
 pub use event_listener::*;
 
+pub mod config;
+pub use config::*;
 pub mod encryption;
+
+pub use rocksdb::set_perf_level;
+pub use rocksdb::PerfContext;

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -11,6 +11,7 @@ use futures::{future, Future, Sink, Stream};
 use grpcio::{CallOption, EnvBuilder, WriteFlags};
 use kvproto::metapb;
 use kvproto::pdpb::{self, Member};
+use kvproto::replication_modepb::ReplicationStatus;
 
 use super::metrics::*;
 use super::util::{check_resp_header, sync_request, validate_endpoints, Inner, LeaderClient};
@@ -125,7 +126,11 @@ impl PdClient for RpcClient {
         Ok(self.cluster_id)
     }
 
-    fn bootstrap_cluster(&self, stores: metapb::Store, region: metapb::Region) -> Result<()> {
+    fn bootstrap_cluster(
+        &self,
+        stores: metapb::Store,
+        region: metapb::Region,
+    ) -> Result<Option<ReplicationStatus>> {
         let _timer = PD_REQUEST_HISTOGRAM_VEC
             .with_label_values(&["bootstrap_cluster"])
             .start_coarse_timer();
@@ -135,11 +140,11 @@ impl PdClient for RpcClient {
         req.set_store(stores);
         req.set_region(region);
 
-        let resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
+        let mut resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
             client.bootstrap_opt(&req, Self::call_option())
         })?;
         check_resp_header(resp.get_header())?;
-        Ok(())
+        Ok(resp.replication_status.take())
     }
 
     fn is_cluster_bootstrapped(&self) -> Result<bool> {
@@ -174,7 +179,7 @@ impl PdClient for RpcClient {
         Ok(resp.get_id())
     }
 
-    fn put_store(&self, store: metapb::Store) -> Result<()> {
+    fn put_store(&self, store: metapb::Store) -> Result<Option<ReplicationStatus>> {
         let _timer = PD_REQUEST_HISTOGRAM_VEC
             .with_label_values(&["put_store"])
             .start_coarse_timer();
@@ -183,12 +188,12 @@ impl PdClient for RpcClient {
         req.set_header(self.header());
         req.set_store(store);
 
-        let resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
+        let mut resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
             client.put_store_opt(&req, Self::call_option())
         })?;
         check_resp_header(resp.get_header())?;
 
-        Ok(())
+        Ok(resp.replication_status.take())
     }
 
     fn get_store(&self, store_id: u64) -> Result<metapb::Store> {

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -34,6 +34,7 @@ use std::ops::Deref;
 use futures::Future;
 use kvproto::metapb;
 use kvproto::pdpb;
+use kvproto::replication_modepb::ReplicationStatus;
 use tikv_util::time::UnixSecs;
 use txn_types::TimeStamp;
 
@@ -94,7 +95,11 @@ pub trait PdClient: Send + Sync {
     /// It may happen that multi nodes start at same time to try to
     /// bootstrap, but only one can succeed, while others will fail
     /// and must remove their created local Region data themselves.
-    fn bootstrap_cluster(&self, _stores: metapb::Store, _region: metapb::Region) -> Result<()> {
+    fn bootstrap_cluster(
+        &self,
+        _stores: metapb::Store,
+        _region: metapb::Region,
+    ) -> Result<Option<ReplicationStatus>> {
         unimplemented!();
     }
 
@@ -113,7 +118,7 @@ pub trait PdClient: Send + Sync {
     }
 
     /// Informs PD when the store starts or some store information changes.
-    fn put_store(&self, _store: metapb::Store) -> Result<()> {
+    fn put_store(&self, _store: metapb::Store) -> Result<Option<ReplicationStatus>> {
         unimplemented!();
     }
 

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -9,6 +9,8 @@ use crate::{coprocessor, Result};
 use configuration::{
     rollback_or, ConfigChange, ConfigManager, ConfigValue, Configuration, RollbackCollector,
 };
+use engine_rocks::config as rocks_config;
+use engine_rocks::PerfLevel;
 use tikv_util::config::{ReadableDuration, ReadableSize, VersionTrack};
 
 lazy_static! {
@@ -170,6 +172,9 @@ pub struct Config {
     #[serde(skip_serializing)]
     #[config(skip)]
     pub region_split_size: ReadableSize,
+    #[serde(with = "rocks_config::perf_level_serde")]
+    #[config(skip)]
+    pub perf_level: PerfLevel,
 }
 
 impl Default for Config {
@@ -239,6 +244,7 @@ impl Default for Config {
             // They are preserved for compatibility check.
             region_max_size: ReadableSize(0),
             region_split_size: ReadableSize(0),
+            perf_level: PerfLevel::Disable,
         }
     }
 }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -15,7 +15,9 @@ use std::{cmp, usize};
 
 use batch_system::{BasicMailbox, BatchRouter, BatchSystem, Fsm, HandlerBuilder, PollHandler};
 use crossbeam::channel::{TryRecvError, TrySendError};
+
 use engine_rocks::RocksEngine;
+use engine_rocks::{PerfContext, PerfLevel};
 use engine_traits::{KvEngine, Snapshot, WriteBatch, WriteBatchVecExt};
 use engine_traits::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use kvproto::import_sstpb::SstMeta;
@@ -32,12 +34,17 @@ use uuid::Builder as UuidBuilder;
 
 use crate::coprocessor::{Cmd, CoprocessorHost};
 use crate::store::fsm::{RaftPollerBuilder, RaftRouter};
+use crate::store::metrics::APPLY_PERF_CONTEXT_TIME_HISTOGRAM_STATIC;
 use crate::store::metrics::*;
 use crate::store::msg::{Callback, PeerMsg, ReadResponse, SignificantMsg};
 use crate::store::peer::Peer;
 use crate::store::peer_storage::{self, write_initial_apply_state, write_peer_state};
-use crate::store::util::KeysInfoFormatter;
 use crate::store::util::{check_region_epoch, compare_region_epoch};
+use crate::store::util::{KeysInfoFormatter, PerfContextStatistics};
+
+use crate::observe_perf_context_type;
+use crate::report_perf_context;
+
 use crate::store::{cmd_resp, util, Config, RegionSnapshot};
 use crate::{Error, Result};
 use sst_importer::SSTImporter;
@@ -348,6 +355,8 @@ where
     sync_log_hint: bool,
     // Whether to use the delete range API instead of deleting one by one.
     use_delete_range: bool,
+
+    perf_context_statistics: PerfContextStatistics,
 }
 
 impl<E, W> ApplyContext<E, W>
@@ -385,6 +394,7 @@ where
             sync_log_hint: false,
             exec_ctx: None,
             use_delete_range: cfg.use_delete_range,
+            perf_context_statistics: PerfContextStatistics::new(cfg.perf_level),
         }
     }
 
@@ -458,6 +468,10 @@ where
                 .unwrap_or_else(|e| {
                     panic!("failed to write to engine: {:?}", e);
                 });
+            report_perf_context!(
+                self.perf_context_statistics,
+                APPLY_PERF_CONTEXT_TIME_HISTOGRAM_STATIC
+            );
             self.sync_log_hint = false;
             let data_size = self.kv_wb().data_size();
             if data_size > APPLY_WB_SHRINK_SIZE {
@@ -3069,6 +3083,7 @@ where
             }
             self.apply_ctx.enable_sync_log = incoming.sync_log;
         }
+        self.apply_ctx.perf_context_statistics.start();
     }
 
     /// There is no control fsm in apply poller.

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -4,6 +4,14 @@ use prometheus::*;
 use prometheus_static_metric::*;
 
 make_auto_flush_static_metric! {
+    pub label_enum PerfContextType {
+        write_wal_time,
+        write_memtable_time,
+        pre_and_post_process,
+        write_thread_wait,
+        db_mutex_lock_nanos,
+        report_time,
+    }
     pub label_enum ProposalType {
         all,
         local_read,
@@ -161,6 +169,9 @@ make_auto_flush_static_metric! {
 
     pub struct SnapValidVec : LocalIntCounter {
         "type" => SnapValidationType
+    }
+    pub struct PerfContextTimeDuration : LocalHistogram {
+        "type" => PerfContextType
     }
 }
 
@@ -415,6 +426,28 @@ lazy_static! {
             "tikv_raftstore_read_index_pending",
             "pending read index count"
         ).unwrap();
+
+    pub static ref APPLY_PERF_CONTEXT_TIME_HISTOGRAM: HistogramVec =
+        register_histogram_vec!(
+            "tikv_raftstore_apply_perf_context_time_duration_secs",
+            "Bucketed histogram of request wait time duration",
+            &["type"],
+            exponential_buckets(0.0005, 2.0, 20).unwrap()
+        ).unwrap();
+
+    pub static ref STORE_PERF_CONTEXT_TIME_HISTOGRAM: HistogramVec =
+        register_histogram_vec!(
+            "tikv_raftstore_store_perf_context_time_duration_secs",
+            "Bucketed histogram of request wait time duration",
+            &["type"],
+            exponential_buckets(0.0005, 2.0, 20).unwrap()
+        ).unwrap();
+
+    pub static ref APPLY_PERF_CONTEXT_TIME_HISTOGRAM_STATIC: PerfContextTimeDuration=
+        auto_flush_from!(APPLY_PERF_CONTEXT_TIME_HISTOGRAM, PerfContextTimeDuration);
+
+    pub static ref STORE_PERF_CONTEXT_TIME_HISTOGRAM_STATIC: PerfContextTimeDuration=
+        auto_flush_from!(STORE_PERF_CONTEXT_TIME_HISTOGRAM, PerfContextTimeDuration);
 
     pub static ref READ_QPS_TOPN: GaugeVec =
         register_gauge_vec!(

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -5,6 +5,8 @@ pub mod config;
 pub mod fsm;
 pub mod msg;
 pub mod transport;
+
+#[macro_use]
 pub mod util;
 
 mod bootstrap;

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -16,6 +16,7 @@ mod peer;
 mod peer_storage;
 mod read_queue;
 mod region_snapshot;
+mod replication_mode;
 mod snap;
 mod worker;
 
@@ -38,6 +39,7 @@ pub use self::peer_storage::{
     RAFT_INIT_LOG_INDEX, RAFT_INIT_LOG_TERM,
 };
 pub use self::region_snapshot::{new_temp_engine, RegionIterator, RegionSnapshot};
+pub use self::replication_mode::{GlobalReplicationState, StoreGroup};
 pub use self::snap::{
     check_abort, copy_snapshot,
     snap_io::{apply_sst_cf_file, build_sst_cf_file},

--- a/components/raftstore/src/store/replication_mode.rs
+++ b/components/raftstore/src/store/replication_mode.rs
@@ -1,0 +1,97 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use kvproto::metapb;
+use kvproto::replication_modepb::ReplicationStatus;
+use tikv_util::collections::{HashMap, HashMapEntry};
+
+/// A registry that maps store to a group.
+///
+/// A group ID is generated according to the label value. Stores with same
+/// label value will be mapped to the same group ID.
+#[derive(Default, Debug)]
+pub struct StoreGroup {
+    labels: HashMap<String, u64>,
+    stores: HashMap<u64, u64>,
+}
+
+impl StoreGroup {
+    /// Registers the store with given label value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the store is registered twice with different store ID.
+    pub fn register_store(&mut self, store_id: u64, label: String) -> u64 {
+        debug!("associated {} {}", store_id, label);
+        match self.stores.entry(store_id) {
+            HashMapEntry::Occupied(o) => {
+                assert_eq!(
+                    self.labels.get(&label),
+                    Some(o.get()),
+                    "store {:?}",
+                    store_id
+                );
+                *o.get()
+            }
+            HashMapEntry::Vacant(v) => {
+                let len = self.labels.len() as u64 + 1;
+                let id = *self.labels.entry(label).or_insert(len);
+                v.insert(id);
+                id
+            }
+        }
+    }
+
+    /// Gets the group ID of store.
+    #[inline]
+    pub fn group_id(&self, store_id: u64) -> Option<u64> {
+        self.stores.get(&store_id).cloned()
+    }
+}
+
+/// A global state that stores current replication mode and related metadata.
+#[derive(Default, Debug)]
+pub struct GlobalReplicationState {
+    pub status: ReplicationStatus,
+    pub group: StoreGroup,
+    pub group_buffer: Vec<(u64, u64)>,
+}
+
+impl GlobalReplicationState {
+    pub fn calculate_commit_group(&mut self, peers: &[metapb::Peer]) {
+        self.group_buffer.clear();
+        for p in peers {
+            if let Some(label_id) = self.group.group_id(p.store_id) {
+                self.group_buffer.push((p.id, label_id));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::util::new_peer;
+
+    #[test]
+    fn test_group_register() {
+        let mut state = GlobalReplicationState::default();
+        let group_id = state.group.register_store(1, "label 1".to_owned());
+        assert_eq!(state.group.group_id(1), Some(group_id));
+        assert_eq!(
+            state.group.register_store(2, "label 1".to_owned()),
+            group_id
+        );
+        assert_eq!(state.group.group_id(2), Some(group_id));
+        assert_eq!(
+            group_id,
+            state.group.register_store(1, "label 1".to_owned())
+        );
+        assert_ne!(
+            group_id,
+            state.group.register_store(3, "label 2".to_owned())
+        );
+
+        state.calculate_commit_group(&[new_peer(1, 1), new_peer(2, 2), new_peer(3, 3)]);
+        assert_eq!(state.group_buffer, vec![(1, 1), (2, 1), (3, 2)]);
+    }
+}

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -5,17 +5,18 @@ use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use std::{fmt, u64};
 
+use engine_rocks::{set_perf_level, PerfContext, PerfLevel};
 use kvproto::kvrpcpb::KeyRange;
 use kvproto::metapb;
 use kvproto::raft_cmdpb::{AdminCmdType, RaftCmdRequest};
 use protobuf::{self, Message};
 use raft::eraftpb::{self, ConfChangeType, ConfState, MessageType};
 use raft::INVALID_INDEX;
+use tikv_util::time::monotonic_raw_now;
 use time::{Duration, Timespec};
 
 use super::peer_storage;
 use crate::{Error, Result};
-use tikv_util::time::monotonic_raw_now;
 use tikv_util::Either;
 
 pub fn find_peer(region: &metapb::Region, store_id: u64) -> Option<&metapb::Peer> {
@@ -641,6 +642,71 @@ impl<
 
 pub fn integration_on_half_fail_quorum_fn(voters: usize) -> usize {
     (voters + 1) / 2 + 1
+}
+
+#[macro_export]
+macro_rules! report_perf_context {
+    ($ctx: expr, $metric: ident) => {
+        if $ctx.perf_level != PerfLevel::Disable {
+            let perf_context = PerfContext::get();
+            let pre_and_post_process = perf_context.write_pre_and_post_process_time();
+            let write_thread_wait = perf_context.write_thread_wait_nanos();
+            observe_perf_context_type!($ctx, perf_context, $metric, write_wal_time);
+            observe_perf_context_type!($ctx, perf_context, $metric, write_memtable_time);
+            observe_perf_context_type!($ctx, perf_context, $metric, db_mutex_lock_nanos);
+            observe_perf_context_type!($ctx, $metric, pre_and_post_process);
+            observe_perf_context_type!($ctx, $metric, write_thread_wait);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! observe_perf_context_type {
+    ($s:expr, $metric: expr, $v:ident) => {
+        $metric.$v.observe((($v) - $s.$v) as f64 / 1_000_000_000.0);
+        $s.$v = $v;
+    };
+    ($s:expr, $context: expr, $metric: expr, $v:ident) => {
+        let $v = $context.$v();
+        $metric.$v.observe((($v) - $s.$v) as f64 / 1_000_000_000.0);
+        $s.$v = $v;
+    };
+}
+
+pub struct PerfContextStatistics {
+    pub perf_level: PerfLevel,
+    pub write_wal_time: u64,
+    pub pre_and_post_process: u64,
+    pub write_memtable_time: u64,
+    pub write_thread_wait: u64,
+    pub db_mutex_lock_nanos: u64,
+}
+
+impl PerfContextStatistics {
+    /// Create an instance which stores instant statistics values, retrieved at creation.
+    pub fn new(perf_level: PerfLevel) -> Self {
+        PerfContextStatistics {
+            perf_level,
+            write_wal_time: 0,
+            pre_and_post_process: 0,
+            write_thread_wait: 0,
+            write_memtable_time: 0,
+            db_mutex_lock_nanos: 0,
+        }
+    }
+
+    pub fn start(&mut self) {
+        if self.perf_level == PerfLevel::Disable {
+            return;
+        }
+        PerfContext::get().reset();
+        set_perf_level(self.perf_level);
+        self.write_wal_time = 0;
+        self.pre_and_post_process = 0;
+        self.db_mutex_lock_nanos = 0;
+        self.write_thread_wait = 0;
+        self.write_memtable_time = 0;
+    }
 }
 
 #[cfg(test)]

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -189,6 +189,7 @@ impl Simulator for NodeCluster {
             &cfg.server,
             Arc::new(VersionTrack::new(raft_store)),
             Arc::clone(&self.pd_client),
+            Arc::default(),
         );
 
         let (snap_mgr, snap_mgr_path) = if node_id == 0

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -221,7 +221,7 @@ impl Simulator for ServerCluster {
         let deadlock_service = lock_mgr.deadlock_service(security_mgr.clone());
 
         // Create pd client, snapshot manager, server.
-        let (worker, resolver) = resolve::new_resolver(Arc::clone(&self.pd_client)).unwrap();
+        let (worker, resolver, state) = resolve::new_resolver(Arc::clone(&self.pd_client)).unwrap();
         let snap_mgr = SnapManager::new(tmp_str, Some(router.clone()));
         let server_cfg = Arc::new(cfg.server.clone());
         let cop_read_pool = ReadPool::from(coprocessor::readpool_impl::build_read_pool_for_test(
@@ -281,6 +281,7 @@ impl Simulator for ServerCluster {
             &cfg.server,
             Arc::new(VersionTrack::new(raft_store)),
             Arc::clone(&self.pd_client),
+            state,
         );
 
         // Register the role change observer of the lock manager.

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -17,9 +17,9 @@ use kvproto::raft_cmdpb::{AdminRequest, RaftCmdRequest, RaftCmdResponse, Request
 use kvproto::raft_serverpb::{PeerState, RaftLocalState, RegionLocalState};
 use raft::eraftpb::ConfChangeType;
 
-use engine::rocks::util::config::BlobRunMode;
 use engine::rocks::DB;
 use engine::*;
+use engine_rocks::config::BlobRunMode;
 use engine_rocks::{CompactionListener, RocksCompactionJobInfo};
 use engine_rocks::{Compat, RocksEngine};
 use engine_traits::{Iterable, Peekable};

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -964,6 +964,151 @@ impl<T> Tracker<T> {
     }
 }
 
+use std::collections::HashMap;
+
+/// TomlLine use to parse one line content of a toml file
+#[derive(Debug)]
+enum TomlLine {
+    // the `Keys` from "[`Keys`]"
+    Table(String),
+    // the `Keys` from "`Keys` = value"
+    KVPair(String),
+    // Comment, empty line, etc.
+    Unknown,
+}
+
+impl TomlLine {
+    fn encode_kv(key: &str, val: &str) -> String {
+        format!("{} = {}", key, val)
+    }
+
+    // parse kv pair from format of "`Keys` = value"
+    fn parse_kv(s: &str) -> TomlLine {
+        let mut v: Vec<_> = s.split('=').map(|s| s.trim().to_owned()).rev().collect();
+        if v.is_empty() || v.len() > 2 || TomlLine::parse_key(v[v.len() - 1].as_str()).is_none() {
+            return TomlLine::Unknown;
+        }
+        TomlLine::KVPair(v.pop().unwrap())
+    }
+
+    fn parse(s: &str) -> TomlLine {
+        let s = s.trim();
+        // try to parse table from format of "[`Keys`]"
+        if let Some(k) = s.strip_prefix('[').map(|s| s.strip_suffix(']')).flatten() {
+            return match TomlLine::parse_key(k) {
+                Some(k) => TomlLine::Table(k),
+                None => TomlLine::Unknown,
+            };
+        }
+        // remove one prefix of '#' if exist
+        let kv = s.strip_prefix('#').unwrap_or(s);
+        TomlLine::parse_kv(kv)
+    }
+
+    // Parse `Keys`, only bare keys and dotted keys are supportted
+    // bare keys only contains chars of A-Za-z0-9_-
+    // dotted keys are a sequence of bare key joined with a '.'
+    fn parse_key(s: &str) -> Option<String> {
+        if s.is_empty() || s.starts_with('.') || s.ends_with('.') {
+            return None;
+        }
+        let ks: Vec<_> = s.split('.').map(str::trim).collect();
+        let is_valid_key = |s: &&str| -> bool {
+            s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || "-_".contains(c))
+        };
+        if ks.iter().all(is_valid_key) {
+            return Some(ks.join("."));
+        }
+        None
+    }
+
+    fn concat_key(k1: &str, k2: &str) -> String {
+        match (k1.is_empty(), k2.is_empty()) {
+            (false, false) => format!("{}.{}", k1, k2),
+            (_, true) => k1.to_owned(),
+            (true, _) => k2.to_owned(),
+        }
+    }
+
+    // get the prefix keys: "`Keys`.bare_key" -> Keys
+    fn get_prefix(key: &str) -> String {
+        key.rsplitn(2, '.').last().unwrap().to_owned()
+    }
+}
+
+/// TomlWriter use to update the config file and only cover the most commom toml
+/// format that used by tikv config file, toml format like: quoted keys, multi-line
+/// value, inline table, etc, are not supported, see https://github.com/toml-lang/toml
+/// for more detail.
+pub struct TomlWriter {
+    dst: Vec<u8>,
+    current_table: String,
+}
+
+impl TomlWriter {
+    pub fn new() -> TomlWriter {
+        TomlWriter {
+            dst: Vec::new(),
+            current_table: "".to_owned(),
+        }
+    }
+
+    pub fn write_change(&mut self, src: String, mut change: HashMap<String, String>) {
+        for line in src.lines() {
+            match TomlLine::parse(&line) {
+                TomlLine::Table(keys) => {
+                    self.write_current_table(&mut change);
+                    self.write(line.as_bytes());
+                    self.current_table = keys;
+                }
+                TomlLine::KVPair(keys) => {
+                    match change.remove(&TomlLine::concat_key(&self.current_table, &keys)) {
+                        None => self.write(line.as_bytes()),
+                        Some(chg) => self.write(TomlLine::encode_kv(&keys, &chg).as_bytes()),
+                    }
+                }
+                TomlLine::Unknown => self.write(line.as_bytes()),
+            }
+        }
+        if change.is_empty() {
+            return;
+        }
+        while !change.is_empty() {
+            self.current_table = TomlLine::get_prefix(change.keys().last().unwrap());
+            self.new_line();
+            self.write(format!("[{}]", self.current_table).as_bytes());
+            self.write_current_table(&mut change);
+        }
+        self.new_line();
+    }
+
+    fn write_current_table(&mut self, change: &mut HashMap<String, String>) {
+        let keys: Vec<_> = change
+            .keys()
+            .filter_map(|k| k.split('.').last())
+            .map(str::to_owned)
+            .collect();
+        for k in keys {
+            if let Some(chg) = change.remove(&TomlLine::concat_key(&self.current_table, &k)) {
+                self.write(TomlLine::encode_kv(&k, &chg).as_bytes());
+            }
+        }
+    }
+
+    fn write(&mut self, s: &[u8]) {
+        self.dst.extend_from_slice(s);
+        self.new_line();
+    }
+    fn new_line(&mut self) {
+        self.dst.push(b'\n');
+    }
+
+    pub fn finish(self) -> Vec<u8> {
+        self.dst
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs::File;
@@ -1312,5 +1457,67 @@ mod tests {
         }
 
         assert!(trackers.iter_mut().all(|tr| tr.any_new().is_none()));
+    }
+
+    #[test]
+    fn test_toml_writer() {
+        let cfg = r#"
+## commet1
+log-level = "info"
+
+[readpool.storage]
+## commet2
+normal-concurrency = 1
+# high-concurrency = 1
+
+## commet3
+[readpool.coprocessor]
+normal-concurrency = 1
+
+[rocksdb.defaultcf]
+compression-per-level = ["no", "no", "no", "no", "no", "no", "no"]
+"#;
+        let mut m = HashMap::new();
+        m.insert("log-file".to_owned(), "log-file-name".to_owned());
+        m.insert("readpool.storage.xxx".to_owned(), "zzz".to_owned());
+        m.insert(
+            "readpool.storage.high-concurrency".to_owned(),
+            "345".to_owned(),
+        );
+        m.insert(
+            "readpool.coprocessor.normal-concurrency".to_owned(),
+            "123".to_owned(),
+        );
+        m.insert("not-in-file-config1.xxx.yyy".to_owned(), "100".to_owned());
+        m.insert(
+            "rocksdb.defaultcf.compression-per-level".to_owned(),
+            "[\"no\", \"no\", \"lz4\", \"lz4\", \"lz4\", \"zstd\", \"zstd\"]".to_owned(),
+        );
+
+        let mut t = TomlWriter::new();
+        t.write_change(cfg.to_owned(), m);
+        let expect = r#"
+## commet1
+log-level = "info"
+
+log-file = log-file-name
+[readpool.storage]
+## commet2
+normal-concurrency = 1
+high-concurrency = 345
+
+## commet3
+xxx = zzz
+[readpool.coprocessor]
+normal-concurrency = 123
+
+[rocksdb.defaultcf]
+compression-per-level = ["no", "no", "lz4", "lz4", "lz4", "zstd", "zstd"]
+
+[not-in-file-config1.xxx]
+yyy = 100
+
+"#;
+        assert_eq!(expect.as_bytes(), t.finish().as_slice());
     }
 }

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![cfg_attr(test, feature(test))]
+#![feature(str_strip)]
 
 #[macro_use(fail_point)]
 extern crate fail;

--- a/components/txn_types/src/timestamp.rs
+++ b/components/txn_types/src/timestamp.rs
@@ -54,6 +54,10 @@ impl TimeStamp {
         self.0 == 0
     }
 
+    pub fn is_max(self) -> bool {
+        self.0 == std::u64::MAX
+    }
+
     pub fn into_inner(self) -> u64 {
         self.0
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,10 +33,10 @@ use crate::server::Config as ServerConfig;
 use crate::server::CONFIG_ROCKSDB_GAUGE;
 use crate::storage::config::{Config as StorageConfig, DEFAULT_DATA_DIR, DEFAULT_ROCKSDB_SUB_DIR};
 use encryption::EncryptionConfig;
-use engine::rocks::util::config::{self as rocks_config, BlobRunMode, CompressionType};
 use engine::rocks::util::{
     db_exist, CFOptions, FixedPrefixSliceTransform, FixedSuffixSliceTransform, NoopSliceTransform,
 };
+use engine_rocks::config::{self as rocks_config, BlobRunMode, CompressionType};
 use engine_rocks::properties::MvccPropertiesCollectorFactory;
 use engine_rocks::{
     RangePropertiesCollectorFactory, RocksEngine, RocksEventListener,

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ use pd_client::Config as PdConfig;
 use raftstore::coprocessor::Config as CopConfig;
 use raftstore::store::Config as RaftstoreConfig;
 use raftstore::store::SplitConfig;
-use tikv_util::config::{self, ReadableDuration, ReadableSize, GB, MB};
+use tikv_util::config::{self, ReadableDuration, ReadableSize, TomlWriter, GB, MB};
 use tikv_util::future_pool;
 use tikv_util::security::SecurityConfig;
 use tikv_util::sys::sys_quota::SysQuota;
@@ -1851,6 +1851,9 @@ mod readpool_tests {
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct TiKvConfig {
+    #[config(hidden)]
+    pub cfg_path: String,
+
     #[config(skip)]
     pub enable_dynamic_config: bool,
 
@@ -1928,6 +1931,7 @@ pub struct TiKvConfig {
 impl Default for TiKvConfig {
     fn default() -> TiKvConfig {
         TiKvConfig {
+            cfg_path: "".to_owned(),
             enable_dynamic_config: true,
             log_level: slog::Level::Info,
             log_file: "".to_owned(),
@@ -1987,6 +1991,14 @@ impl TiKvConfig {
         self.storage.validate()?;
 
         self.raft_store.region_split_check_diff = self.coprocessor.region_split_size / 16;
+
+        if self.cfg_path.is_empty() {
+            self.cfg_path = Path::new(&self.storage.data_dir)
+                .join(LAST_CONFIG_FILE)
+                .to_str()
+                .unwrap()
+                .to_owned();
+        }
 
         let default_raftdb_path = config::canonicalize_sub_path(&self.storage.data_dir, "raft")?;
         if self.raft_store.raftdb_path.is_empty() {
@@ -2205,7 +2217,9 @@ impl TiKvConfig {
     pub fn from_file<P: AsRef<Path>>(path: P) -> Self {
         (|| -> Result<Self, Box<dyn Error>> {
             let s = fs::read_to_string(&path)?;
-            Ok(::toml::from_str(&s)?)
+            let mut cfg: TiKvConfig = toml::from_str(&s)?;
+            cfg.cfg_path = path.as_ref().display().to_string();
+            Ok(cfg)
         })()
         .unwrap_or_else(|e| {
             panic!(
@@ -2234,6 +2248,7 @@ impl TiKvConfig {
         let tmp = tempfile::tempdir()?;
         let mut cfg = TiKvConfig::default();
         cfg.storage.data_dir = tmp.path().display().to_string();
+        cfg.cfg_path = tmp.path().join(LAST_CONFIG_FILE).display().to_string();
         Ok((cfg, tmp))
     }
 }
@@ -2297,6 +2312,17 @@ pub fn persist_config(config: &TiKvConfig) -> Result<(), String> {
         ));
     }
 
+    Ok(())
+}
+
+pub fn write_config<P: AsRef<Path>>(tem_dir: P, path: P, content: &[u8]) -> CfgResult<()> {
+    let tmp_cfg_path = tem_dir.as_ref().join(TMP_CONFIG_FILE);
+    {
+        let mut f = fs::File::create(&tmp_cfg_path)?;
+        f.write_all(content)?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp_cfg_path, &path)?;
     Ok(())
 }
 
@@ -2366,11 +2392,54 @@ fn to_change_value(v: &str, typed: &ConfigValue) -> CfgResult<ConfigValue> {
         ConfigValue::I32(_) => ConfigValue::from(v.parse::<i32>()?),
         ConfigValue::Usize(_) => ConfigValue::from(v.parse::<usize>()?),
         ConfigValue::Bool(_) => ConfigValue::from(v.parse::<bool>()?),
+        ConfigValue::BlobRunMode(_) => ConfigValue::from(v.parse::<BlobRunMode>()?),
         ConfigValue::String(_) => ConfigValue::String(v.to_owned()),
-        ConfigValue::Other(_) => ConfigValue::Other(v.to_owned()),
         _ => unreachable!(),
     };
     Ok(res)
+}
+
+fn to_toml_encode(change: HashMap<String, String>) -> CfgResult<HashMap<String, String>> {
+    fn helper(mut fields: Vec<String>, typed: &ConfigChange) -> CfgResult<bool> {
+        if let Some(mut f) = fields.pop() {
+            if f == "raftstore" {
+                f = "raft_store".to_owned();
+            } else {
+                f = f.replace("-", "_");
+            }
+            match typed.get(&f) {
+                None | Some(ConfigValue::Skip) => {
+                    Err(format!("failed to get fields: {}", f).into())
+                }
+                Some(ConfigValue::Module(m)) => helper(fields, m),
+                Some(c) => {
+                    if !fields.is_empty() {
+                        return Err(format!("unexpect fields: {:?}", fields).into());
+                    }
+                    match c {
+                        ConfigValue::Duration(_)
+                        | ConfigValue::Size(_)
+                        | ConfigValue::String(_)
+                        | ConfigValue::BlobRunMode(_) => Ok(true),
+                        _ => Ok(false),
+                    }
+                }
+            }
+        } else {
+            Err("failed to get field".to_owned().into())
+        }
+    };
+    let mut dst = HashMap::new();
+    for (name, value) in change {
+        let fields: Vec<_> = name.as_str().split('.').collect();
+        let fields: Vec<_> = fields.into_iter().map(|s| s.to_owned()).rev().collect();
+        if helper(fields, &TIKVCONFIG_TYPED)? {
+            dst.insert(name, format!("\"{}\"", value));
+        } else {
+            dst.insert(name, value);
+        }
+    }
+    Ok(dst)
 }
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
@@ -2434,7 +2503,7 @@ impl ConfigController {
     }
 
     pub fn update(&mut self, change: HashMap<String, String>) -> CfgResult<()> {
-        let diff = to_config_change(change)?;
+        let diff = to_config_change(change.clone())?;
         {
             let mut incoming = self.current.clone();
             incoming.update(diff.clone());
@@ -2461,10 +2530,23 @@ impl ConfigController {
         }
         debug!("all config change had been dispatched"; "change" => ?to_update);
         self.current.update(to_update);
-        // TODO: persist config to the orignal config file
-        if let Err(e) = persist_config(&self.current) {
-            return Err(e.into());
-        }
+        // Write change to the config file
+        let content = {
+            let change = to_toml_encode(change)?;
+            let src = if Path::new(&self.current.cfg_path).exists() {
+                fs::read_to_string(&self.current.cfg_path)?
+            } else {
+                String::new()
+            };
+            let mut t = TomlWriter::new();
+            t.write_change(src, change);
+            t.finish()
+        };
+        write_config(
+            &self.current.storage.data_dir,
+            &self.current.cfg_path,
+            &content,
+        )?;
         Ok(())
     }
 
@@ -2703,6 +2785,43 @@ mod tests {
             change.insert(name, value);
             assert!(to_config_change(change).is_err());
         }
+    }
+
+    #[test]
+    fn test_to_toml_encode() {
+        let mut change = HashMap::new();
+        change.insert(
+            "raftstore.pd-heartbeat-tick-interval".to_owned(),
+            "1h".to_owned(),
+        );
+        change.insert(
+            "coprocessor.region-split-keys".to_owned(),
+            "10000".to_owned(),
+        );
+        change.insert("gc.max-write-bytes-per-sec".to_owned(), "100MB".to_owned());
+        change.insert("raftstore.sync-log".to_owned(), "false".to_owned());
+        change.insert(
+            "rocksdb.defaultcf.titan.blob-run-mode".to_owned(),
+            "read-only".to_owned(),
+        );
+        let res = to_toml_encode(change).unwrap();
+        assert_eq!(
+            res.get("raftstore.pd-heartbeat-tick-interval"),
+            Some(&"\"1h\"".to_owned())
+        );
+        assert_eq!(
+            res.get("coprocessor.region-split-keys"),
+            Some(&"10000".to_owned())
+        );
+        assert_eq!(
+            res.get("gc.max-write-bytes-per-sec"),
+            Some(&"\"100MB\"".to_owned())
+        );
+        assert_eq!(res.get("raftstore.sync-log"), Some(&"false".to_owned()));
+        assert_eq!(
+            res.get("rocksdb.defaultcf.titan.blob-run-mode"),
+            Some(&"\"read-only\"".to_owned())
+        );
     }
 
     fn new_engines(cfg: TiKvConfig) -> (RocksEngine, ConfigController) {

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -16,15 +16,15 @@ use engine_rocks::{CloneCompat, Compat, RocksEngine};
 use engine_traits::Peekable;
 use kvproto::metapb;
 use kvproto::raft_serverpb::StoreIdent;
+use kvproto::replication_modepb::ReplicationStatus;
 use pd_client::{Error as PdError, PdClient, INVALID_ID};
 use raftstore::coprocessor::dispatcher::CoprocessorHost;
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::fsm::store::StoreMeta;
 use raftstore::store::fsm::{ApplyRouter, RaftBatchSystem, RaftRouter};
 use raftstore::store::AutoSplitController;
-use raftstore::store::PdTask;
-use raftstore::store::SplitCheckTask;
 use raftstore::store::{self, initial_region, Config as StoreConfig, SnapManager, Transport};
+use raftstore::store::{GlobalReplicationState, PdTask, SplitCheckTask};
 use tikv_util::config::VersionTrack;
 use tikv_util::worker::FutureWorker;
 use tikv_util::worker::Worker;
@@ -58,6 +58,7 @@ pub struct Node<C: PdClient + 'static> {
     has_started: bool,
 
     pd_client: Arc<C>,
+    state: Arc<Mutex<GlobalReplicationState>>,
 }
 
 impl<C> Node<C>
@@ -70,6 +71,7 @@ where
         cfg: &ServerConfig,
         store_cfg: Arc<VersionTrack<StoreConfig>>,
         pd_client: Arc<C>,
+        state: Arc<Mutex<GlobalReplicationState>>,
     ) -> Node<C> {
         let mut store = metapb::Store::default();
         store.set_id(INVALID_ID);
@@ -110,6 +112,7 @@ where
             pd_client,
             system,
             has_started: false,
+            state,
         }
     }
 
@@ -153,6 +156,11 @@ where
             self.bootstrap_cluster(&engines, first_region)?;
         }
 
+        // Put store only if the cluster is bootstrapped.
+        info!("put store to PD"; "store" => ?&self.store);
+        let status = self.pd_client.put_store(self.store.clone())?;
+        self.load_all_stores(status);
+
         self.start_store(
             store_id,
             engines,
@@ -165,10 +173,6 @@ where
             split_check_worker,
             auto_split_controller,
         )?;
-
-        // Put store only if the cluster is bootstrapped.
-        info!("put store to PD"; "store" => ?&self.store);
-        self.pd_client.put_store(self.store.clone())?;
 
         Ok(())
     }
@@ -219,6 +223,34 @@ where
     fn alloc_id(&self) -> Result<u64> {
         let id = self.pd_client.alloc_id()?;
         Ok(id)
+    }
+
+    fn load_all_stores(&mut self, status: Option<ReplicationStatus>) {
+        let status = match status {
+            Some(s) => s,
+            None => {
+                info!("no status is returned, using majority mode");
+                return;
+            }
+        };
+        info!("initializing replication mode"; "status" => ?status, "store_id" => self.store.id);
+        let stores = match self.pd_client.get_all_stores(false) {
+            Ok(stores) => stores,
+            Err(e) => panic!("failed to load all stores: {:?}", e),
+        };
+        let label_key = &status.get_dr_auto_sync().label_key;
+        let mut control = self.state.lock().unwrap();
+        for store in stores {
+            for l in store.get_labels() {
+                if l.key == *label_key {
+                    control
+                        .group
+                        .register_store(store.id, l.value.to_lowercase());
+                    break;
+                }
+            }
+        }
+        control.status = status;
     }
 
     fn bootstrap_store(&self, engines: &Engines) -> Result<u64> {

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -1,12 +1,13 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::fmt::{self, Display, Formatter};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use kvproto::metapb;
-
+use kvproto::replication_modepb::ReplicationMode;
 use pd_client::{take_peer_address, PdClient};
+use raftstore::store::GlobalReplicationState;
 use tikv_util::collections::HashMap;
 use tikv_util::worker::{Runnable, Scheduler, Worker};
 
@@ -44,6 +45,7 @@ struct StoreAddr {
 struct Runner<T: PdClient> {
     pd_client: Arc<T>,
     store_addrs: HashMap<u64, StoreAddr>,
+    state: Arc<Mutex<GlobalReplicationState>>,
 }
 
 impl<T: PdClient> Runner<T> {
@@ -70,6 +72,19 @@ impl<T: PdClient> Runner<T> {
     fn get_address(&self, store_id: u64) -> Result<String> {
         let pd_client = Arc::clone(&self.pd_client);
         let mut s = box_try!(pd_client.get_store(store_id));
+        let mut state = self.state.lock().unwrap();
+        let label_key = &state.status.get_dr_auto_sync().label_key;
+        if state.status.get_mode() == ReplicationMode::DrAutoSync {
+            if state.group.group_id(store_id).is_none() {
+                for l in s.get_labels() {
+                    if l.key == *label_key {
+                        state.group.register_store(store_id, l.value.clone());
+                        break;
+                    }
+                }
+            }
+        }
+        drop(state);
         if s.get_state() == metapb::StoreState::Tombstone {
             RESOLVE_STORE_COUNTER_STATIC.tombstone.inc();
             return Err(box_err!("store {} has been removed", store_id));
@@ -106,19 +121,26 @@ impl PdStoreAddrResolver {
 }
 
 /// Creates a new `PdStoreAddrResolver`.
-pub fn new_resolver<T>(pd_client: Arc<T>) -> Result<(Worker<Task>, PdStoreAddrResolver)>
+pub fn new_resolver<T>(
+    pd_client: Arc<T>,
+) -> Result<(
+    Worker<Task>,
+    PdStoreAddrResolver,
+    Arc<Mutex<GlobalReplicationState>>,
+)>
 where
     T: PdClient + 'static,
 {
     let mut worker = Worker::new("addr-resolver");
-
+    let state = Arc::new(Mutex::new(GlobalReplicationState::default()));
     let runner = Runner {
         pd_client,
         store_addrs: HashMap::default(),
+        state: state.clone(),
     };
     box_try!(worker.start(runner));
     let resolver = PdStoreAddrResolver::new(worker.scheduler());
-    Ok((worker, resolver))
+    Ok((worker, resolver, state))
 }
 
 impl StoreAddrResolver for PdStoreAddrResolver {
@@ -177,6 +199,7 @@ mod tests {
         Runner {
             pd_client: Arc::new(client),
             store_addrs: HashMap::default(),
+            state: Default::default(),
         }
     }
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1739,7 +1739,10 @@ txn_command_future!(future_check_txn_status, CheckTxnStatusRequest, CheckTxnStat
                     min_commit_ts,
                 } => {
                     resp.set_lock_ttl(lock_ttl);
-                    if min_commit_ts > caller_start_ts {
+                    // If the caller_start_ts is max, it's a point get in the autocommit transaction.
+                    // Even though the min_commit_ts is not pushed, the point get can ingore the lock
+                    // next time because it's not committed. So we pretend it has been pushed.
+                    if min_commit_ts > caller_start_ts || caller_start_ts.is_max() {
                         resp.set_action(Action::MinCommitTsPushed);
                     }
                 }

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -407,6 +407,70 @@ impl StatusServer {
         )
     }
 
+    /// Serialize region info to json.
+    ///
+    /// ## Example
+    ///
+    /// ```text
+    /// {
+    ///     "size": {
+    ///         "default": 4096,
+    ///         "write": 2048,
+    ///         "lock": 1024
+    ///     },
+    ///     "region_local_state": {
+    ///         "state": "normal",
+    ///         "merge_state": {
+    ///             "min_index": 0,
+    ///             "commit": 16,
+    ///             "target" {
+    ///                 "id": 1,
+    ///                 "start_key": b"aaa",
+    ///                 "end_key": b"bbb",
+    ///                 "region_epoch": {
+    ///                     "conf_ver": 3,
+    ///                     "version": 4
+    ///                 },
+    ///                 "peers": [
+    ///                     {"id": 0, "store_id": 0, "is_learner": false },
+    ///                     {"id": 2, "store_id": 2, "is_learner": false }
+    ///                 ]
+    ///             }
+    ///         },
+    ///         "region": {
+    ///             "id": 0,
+    ///             "start_key": b"aaa",
+    ///             "end_key": b"ccc",
+    ///             "region_epoch": {
+    ///                 "conf_ver": 3,
+    ///                 "version": 5
+    ///             },
+    ///             "peers": [
+    ///                 {"id": 1, "store_id": 1, "is_learner": false },
+    ///                 {"id": 2, "store_id": 2, "is_learner": false }
+    ///             ]
+    ///         }
+    ///     },
+    ///     "raft_apply_state": {
+    ///         "applied_index": 16,
+    ///         "last_commit_index": 15,
+    ///         "commit_index": 16,
+    ///         "commit_term": 2,
+    ///         "truncated_state": {
+    ///             "index": 16,
+    ///             "term": 2
+    ///         }
+    ///     },
+    ///     "raft_local_state": {
+    ///         "last_index": 16,
+    ///         "hard_state": {
+    ///             "term": 2,
+    ///             "vote": 2,
+    ///             "commit": 16
+    ///         }
+    ///     }
+    /// }
+    /// ```
     fn region_info_json(
         size_info: Vec<(&str, usize)>,
         region_info: RegionInfo,
@@ -1177,27 +1241,5 @@ mod tests {
             let _ = handle.wait();
         }
         status_server.stop();
-    }
-
-    #[test]
-    fn test_region_info_json() {
-        use kvproto::metapb::*;
-        use kvproto::raft_serverpb::*;
-        use serde_json::json;
-        use super::RegionInfo;
-
-        let expect = json!({
-            "size": {
-                "default": 4096,
-                "write": 2048,
-                "lock": 1024
-            },
-            "region_local_state": {
-                "state": "normal",
-                "merge_state": {
-                    "min_index": 0
-                }
-            }
-        });
     }
 }

--- a/src/server/status_server.rs
+++ b/src/server/status_server.rs
@@ -1178,4 +1178,26 @@ mod tests {
         }
         status_server.stop();
     }
+
+    #[test]
+    fn test_region_info_json() {
+        use kvproto::metapb::*;
+        use kvproto::raft_serverpb::*;
+        use serde_json::json;
+        use super::RegionInfo;
+
+        let expect = json!({
+            "size": {
+                "default": 4096,
+                "write": 2048,
+                "lock": 1024
+            },
+            "region_local_state": {
+                "state": "normal",
+                "merge_state": {
+                    "min_index": 0
+                }
+            }
+        });
+    }
 }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -895,11 +895,17 @@ impl<S: Snapshot> MvccTxn<S> {
                     return Ok((TxnStatus::TtlExpire, released));
                 }
 
-                // If lock.minCommitTS is 0, it's not a large transaction and we can't push forward
-                // its minCommitTS otherwise the transaction can't be committed by old version TiDB
+                // If lock.min_commit_ts is 0, it's not a large transaction and we can't push forward
+                // its min_commit_ts otherwise the transaction can't be committed by old version TiDB
                 // during rolling update.
-                // If this is a large transaction and the lock is active, push forward the minCommitTS.
-                if !lock.min_commit_ts.is_zero() && caller_start_ts >= lock.min_commit_ts {
+                if !lock.min_commit_ts.is_zero()
+                    // If the caller_start_ts is max, it's a point get in the autocommit transaction.
+                    // We don't push forward lock's min_commit_ts and the point get can ingore the lock
+                    // next time because it's not committed.
+                    && !caller_start_ts.is_max()
+                    // Push forward the min_commit_ts so that reading won't be blocked by locks.
+                    && caller_start_ts >= lock.min_commit_ts
+                {
                     lock.min_commit_ts = caller_start_ts.next();
 
                     if lock.min_commit_ts < current_ts {
@@ -2593,6 +2599,29 @@ mod tests {
         );
         must_large_txn_locked(&engine, k, ts(300, 0), 100, TimeStamp::zero(), false);
         must_rollback(&engine, k, ts(300, 0));
+
+        must_prewrite_put_for_large_txn(&engine, k, v, k, ts(310, 0), 100, 0);
+        must_large_txn_locked(&engine, k, ts(310, 0), 100, ts(310, 1), false);
+        // Don't push forward the min_commit_ts if caller_start_ts is max.
+        must_check_txn_status(
+            &engine,
+            k,
+            ts(310, 0),
+            TimeStamp::max(),
+            ts(320, 0),
+            r,
+            uncommitted(100, ts(310, 1)),
+        );
+        must_commit(&engine, k, ts(310, 0), ts(315, 0));
+        must_check_txn_status(
+            &engine,
+            k,
+            ts(310, 0),
+            TimeStamp::max(),
+            ts(320, 0),
+            r,
+            committed(ts(315, 0)),
+        );
     }
 
     #[test]

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -7,10 +7,10 @@ use std::path::PathBuf;
 use slog::Level;
 
 use encryption::{EncryptionConfig, FileCofnig, MasterKeyConfig};
-use engine::rocks::util::config::{BlobRunMode, CompressionType};
 use engine::rocks::{
     CompactionPriority, DBCompactionStyle, DBCompressionType, DBRateLimiterMode, DBRecoveryMode,
 };
+use engine_rocks::config::{BlobRunMode, CompressionType, PerfLevel};
 use kvproto::encryptionpb::EncryptionMethod;
 use pd_client::Config as PdConfig;
 use raftstore::coprocessor::Config as CopConfig;
@@ -184,6 +184,7 @@ fn test_serde_custom_tikv_config() {
         future_poll_size: 2,
         hibernate_regions: false,
         early_apply: false,
+        perf_level: PerfLevel::EnableTime,
     };
     value.pd = PdConfig::new(vec!["example.com:443".to_owned()]);
     let titan_cf_config = TitanCfConfig {

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -148,6 +148,7 @@ store-pool-size = 3
 future-poll-size = 2
 hibernate-regions = false
 early-apply = false
+perf-level = 5
 
 [coprocessor]
 split-region-on-table = false

--- a/tests/integrations/raftstore/test_bootstrap.rs
+++ b/tests/integrations/raftstore/test_bootstrap.rs
@@ -63,6 +63,7 @@ fn test_node_bootstrap_with_prepared_data() {
         &cfg.server,
         Arc::new(VersionTrack::new(cfg.raft_store.clone())),
         Arc::clone(&pd_client),
+        Arc::default(),
     );
     let snap_mgr = SnapManager::new(tmp_mgr.path().to_str().unwrap(), Some(node.get_router()));
     let pd_worker = FutureWorker::new("test-pd-worker");

--- a/tests/integrations/raftstore/test_service.rs
+++ b/tests/integrations/raftstore/test_service.rs
@@ -108,7 +108,8 @@ fn must_kv_prewrite(client: &TikvClient, ctx: Context, muts: Vec<Mutation>, pk: 
     prewrite_req.set_mutations(muts.into_iter().collect());
     prewrite_req.primary_lock = pk;
     prewrite_req.start_version = ts;
-    prewrite_req.lock_ttl = prewrite_req.start_version + 1;
+    prewrite_req.lock_ttl = 3000;
+    prewrite_req.min_commit_ts = prewrite_req.start_version + 1;
     let prewrite_resp = client.kv_prewrite(&prewrite_req).unwrap();
     assert!(
         !prewrite_resp.has_region_error(),
@@ -519,7 +520,7 @@ fn test_physical_scan_lock() {
             lock_info.set_primary_lock(k.clone());
             lock_info.set_lock_version(ts);
             lock_info.set_key(k);
-            lock_info.set_lock_ttl(ts + 1);
+            lock_info.set_lock_ttl(3000);
             lock_info.set_lock_type(Op::Put);
             lock_info
         })
@@ -1031,4 +1032,54 @@ fn test_pessimistic_lock() {
         }
         must_kv_pessimistic_rollback(&client, ctx.clone(), k.clone(), 40);
     }
+}
+
+#[test]
+fn test_check_txn_status_with_max_ts() {
+    fn must_check_txn_status(
+        client: &TikvClient,
+        ctx: Context,
+        key: &[u8],
+        lock_ts: u64,
+        caller_start_ts: u64,
+        current_ts: u64,
+    ) -> CheckTxnStatusResponse {
+        let mut req = CheckTxnStatusRequest::default();
+        req.set_context(ctx);
+        req.set_primary_key(key.to_vec());
+        req.set_lock_ts(lock_ts);
+        req.set_caller_start_ts(caller_start_ts);
+        req.set_current_ts(current_ts);
+
+        let resp = client.kv_check_txn_status(&req).unwrap();
+        assert!(!resp.has_region_error(), "{:?}", resp.get_region_error());
+        assert!(resp.error.is_none(), "{:?}", resp.get_error());
+        return resp;
+    }
+
+    let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
+    let (k, v) = (b"key".to_vec(), b"value".to_vec());
+    let lock_ts = 10;
+
+    // Prewrite
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.set_key(k.clone());
+    mutation.set_value(v.clone());
+    must_kv_prewrite(&client, ctx.clone(), vec![mutation], k.clone(), lock_ts);
+
+    // Should return MinCommitTsPushed even if caller_start_ts is max.
+    let status = must_check_txn_status(
+        &client,
+        ctx.clone(),
+        &k,
+        lock_ts,
+        std::u64::MAX,
+        lock_ts + 1,
+    );
+    assert_eq!(status.lock_ttl, 3000);
+    assert_eq!(status.action, Action::MinCommitTsPushed);
+
+    // The min_commit_ts of k shouldn't be pushed.
+    must_kv_commit(&client, ctx, vec![k], lock_ts, lock_ts + 1, lock_ts + 1);
 }


### PR DESCRIPTION
UCP #7626
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7626 <!-- REMOVE this line if no issue to close -->

Problem Summary:
We already support dumping region info by tikv-ctl, but

1. it's not easy to use comparing to REST API
2. it lacks raft memory information.

When we support label based replication, the information can become more critical for problem diagnosis.

The output better in JSON, should include everything in raft status, raft local state, apply state and region local state.

### What is changed and how it works?

What's Changed:
1. register a new endpoint `/region` on `StatusServer`
2. add method `set_debugger` for `StatusServer`
3. add method `run_status_server` for `tikv_server::TiKVServer`

The `StatusServer::debugger` is `None` by default, users of crate `tikv` should set debugger manually otherwise a `500 INTERNAL SERVER ERROR` will return when requesting endpoint `/region`.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests
Currently none

### Release note <!-- bugfixes or new feature need a release note -->