### PR TITLE
raftstore: use batch split for auto-split

### DIFF
--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -453,6 +453,7 @@ where
         }
     }
 
+    // Deprecate
     fn handle_ask_split(
         &self,
         handle: &Handle,

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -505,6 +505,7 @@ where
         peer: metapb::Peer,
         right_derive: bool,
         callback: Callback<E>,
+        task: String,
     ) {
         let router = self.router.clone();
         let scheduler = self.scheduler.clone();
@@ -519,6 +520,7 @@ where
                             "region_id" => region.get_id(),
                             "new_region_ids" => ?resp.get_ids(),
                             "region" => ?region,
+                            "task" => task,
                         );
 
                         let req = new_batch_split_region_request(
@@ -913,6 +915,7 @@ where
         }
 
         match task {
+            // AskSplit has deprecated, use AskBatchSplit
             Task::AskSplit {
                 region,
                 split_key,
@@ -926,7 +929,7 @@ where
                 peer,
                 right_derive,
                 callback,
-                String::from("AskSplit"),
+                String::from("ask_split"),
             ),
             Task::AskBatchSplit {
                 region,
@@ -941,20 +944,21 @@ where
                 peer,
                 right_derive,
                 callback,
+                String::from("batch_split"),
             ),
             Task::AutoSplit { split_infos } => {
                 for split_info in split_infos {
                     if let Ok(Some(region)) =
                         self.pd_client.get_region_by_id(split_info.region_id).wait()
                     {
-                        self.handle_ask_split(
+                        self.handle_ask_batch_split(
                             handle,
                             region,
-                            split_info.split_key,
+                            vec![split_info.split_key],
                             split_info.peer,
                             true,
                             Callback::None,
-                            String::from("AutoSplit"),
+                            String::from("auto_split"),
                         );
                     }
                 }


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
close: https://github.com/tikv/tikv/issues/7653


Problem Summary:
TiFlash do not know the `Split` command.
What's Changed:


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test