### PR TITLE
raftstore: Replace KvEngine type parameters with Snapshot typarams

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use engine_rocks::RocksEngine;
+use engine_rocks::{RocksEngine, RocksSnapshot};
 use futures::future::Future;
 use kvproto::cdcpb::*;
 use kvproto::metapb::Region;
@@ -606,7 +606,7 @@ struct Initializer {
 }
 
 impl Initializer {
-    fn on_change_cmd(&self, mut resp: ReadResponse<RocksEngine>) {
+    fn on_change_cmd(&self, mut resp: ReadResponse<RocksSnapshot>) {
         if let Some(region_snapshot) = resp.snapshot {
             assert_eq!(self.region_id, region_snapshot.get_region().get_id());
             let region = region_snapshot.get_region().clone();

--- a/components/raftstore/src/router.rs
+++ b/components/raftstore/src/router.rs
@@ -21,7 +21,7 @@ where
     fn send_raft_msg(&self, msg: RaftMessage) -> RaftStoreResult<()>;
 
     /// Sends RaftCmdRequest to local store.
-    fn send_command(&self, req: RaftCmdRequest, cb: Callback<E>) -> RaftStoreResult<()>;
+    fn send_command(&self, req: RaftCmdRequest, cb: Callback<E::Snapshot>) -> RaftStoreResult<()>;
 
     /// Sends a significant message. We should guarantee that the message can't be dropped.
     fn significant_send(&self, region_id: u64, msg: SignificantMsg) -> RaftStoreResult<()>;
@@ -72,7 +72,7 @@ where
     }
 
     /// Sends RaftCmdRequest to local store.
-    fn send_command(&self, _: RaftCmdRequest, _: Callback<E>) -> RaftStoreResult<()> {
+    fn send_command(&self, _: RaftCmdRequest, _: Callback<E::Snapshot>) -> RaftStoreResult<()> {
         Ok(())
     }
 
@@ -142,7 +142,7 @@ where
             .map_err(|e| handle_send_error(region_id, e))
     }
 
-    fn send_command(&self, req: RaftCmdRequest, cb: Callback<E>) -> RaftStoreResult<()> {
+    fn send_command(&self, req: RaftCmdRequest, cb: Callback<E::Snapshot>) -> RaftStoreResult<()> {
         let cmd = RaftCommand::new(req, cb);
         if LocalReader::<RaftRouter<E>, E>::acceptable(&cmd.request) {
             self.local_reader.execute_raft_command(cmd);

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -257,19 +257,19 @@ impl ExecContext {
     }
 }
 
-struct ApplyCallback<E>
+struct ApplyCallback<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
     region: Region,
-    cbs: Vec<(Option<Callback<E::Snapshot>>, RaftCmdResponse)>,
+    cbs: Vec<(Option<Callback<S>>, RaftCmdResponse)>,
 }
 
-impl<E> ApplyCallback<E>
+impl<S> ApplyCallback<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
-    fn new(region: Region) -> ApplyCallback<E> {
+    fn new(region: Region) -> ApplyCallback<S> {
         let cbs = vec![];
         ApplyCallback { region, cbs }
     }
@@ -283,7 +283,7 @@ where
         }
     }
 
-    fn push(&mut self, cb: Option<Callback<E::Snapshot>>, resp: RaftCmdResponse) {
+    fn push(&mut self, cb: Option<Callback<S>>, resp: RaftCmdResponse) {
         self.cbs.push((cb, resp));
     }
 }
@@ -326,7 +326,7 @@ where
     router: ApplyRouter,
     notifier: Notifier<E>,
     engine: E,
-    cbs: MustConsumeVec<ApplyCallback<E>>,
+    cbs: MustConsumeVec<ApplyCallback<E::Snapshot>>,
     apply_res: Vec<ApplyRes<E>>,
     exec_ctx: Option<ExecContext>,
 

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3337,7 +3337,7 @@ mod tests {
     use crate::store::msg::WriteResponse;
     use crate::store::peer_storage::RAFT_INIT_LOG_INDEX;
     use crate::store::util::{new_learner_peer, new_peer};
-    use engine_rocks::{util::new_engine, RocksEngine, RocksWriteBatch, WRITE_BATCH_MAX_KEYS};
+    use engine_rocks::{util::new_engine, RocksEngine, RocksWriteBatch, WRITE_BATCH_MAX_KEYS, RocksSnapshot};
     use engine_traits::{Peekable as PeekableTrait, WriteBatchExt};
     use kvproto::metapb::{self, RegionEpoch};
     use kvproto::raft_cmdpb::*;
@@ -4180,7 +4180,7 @@ mod tests {
                     region_id: 1,
                     enabled: enabled.clone(),
                 },
-                cb: Callback::Read(Box::new(|resp: ReadResponse<_>| {
+                cb: Callback::Read(Box::new(|resp: ReadResponse<RocksSnapshot>| {
                     assert!(!resp.response.get_header().has_error());
                     assert!(resp.snapshot.is_some());
                     let snap = resp.snapshot.unwrap();

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2322,20 +2322,20 @@ where
     }
 }
 
-pub struct RegionProposal<E>
+pub struct RegionProposal<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
     pub id: u64,
     pub region_id: u64,
-    pub props: Vec<Proposal<E::Snapshot>>,
+    pub props: Vec<Proposal<S>>,
 }
 
-impl<E> RegionProposal<E>
+impl<S> RegionProposal<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
-    pub fn new(id: u64, region_id: u64, props: Vec<Proposal<E::Snapshot>>) -> RegionProposal<E> {
+    pub fn new(id: u64, region_id: u64, props: Vec<Proposal<S>>) -> RegionProposal<S> {
         RegionProposal {
             id,
             region_id,
@@ -2467,7 +2467,7 @@ where
         apply: Apply,
     },
     Registration(Registration),
-    Proposal(RegionProposal<E>),
+    Proposal(RegionProposal<E::Snapshot>),
     LogsUpToDate(CatchUpLogs),
     Noop,
     Destroy(Destroy),
@@ -2668,7 +2668,7 @@ where
     }
 
     /// Handles proposals, and appends the commands to the apply delegate.
-    fn handle_proposal(&mut self, region_proposal: RegionProposal<E>) {
+    fn handle_proposal(&mut self, region_proposal: RegionProposal<E::Snapshot>) {
         let (region_id, peer_id) = (self.delegate.region_id(), self.delegate.id());
         let propose_num = region_proposal.props.len();
         assert_eq!(self.delegate.id, region_proposal.id);

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2298,21 +2298,21 @@ impl Registration {
     }
 }
 
-pub struct Proposal<E>
+pub struct Proposal<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
     is_conf_change: bool,
     index: u64,
     term: u64,
-    pub cb: Callback<E::Snapshot>,
+    pub cb: Callback<S>,
 }
 
-impl<E> Proposal<E>
+impl<S> Proposal<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
-    pub fn new(is_conf_change: bool, index: u64, term: u64, cb: Callback<E::Snapshot>) -> Proposal<E> {
+    pub fn new(is_conf_change: bool, index: u64, term: u64, cb: Callback<S>) -> Proposal<S> {
         Proposal {
             is_conf_change,
             index,
@@ -2328,14 +2328,14 @@ where
 {
     pub id: u64,
     pub region_id: u64,
-    pub props: Vec<Proposal<E>>,
+    pub props: Vec<Proposal<E::Snapshot>>,
 }
 
 impl<E> RegionProposal<E>
 where
     E: KvEngine,
 {
-    pub fn new(id: u64, region_id: u64, props: Vec<Proposal<E>>) -> RegionProposal<E> {
+    pub fn new(id: u64, region_id: u64, props: Vec<Proposal<E::Snapshot>>) -> RegionProposal<E> {
         RegionProposal {
             id,
             region_id,

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2922,7 +2922,7 @@ where
                 }
                 ReadResponse {
                     response: Default::default(),
-                    snapshot: Some(RegionSnapshot::<E>::from_snapshot(
+                    snapshot: Some(RegionSnapshot::<E::Snapshot>::from_snapshot(
                         apply_ctx.engine.snapshot().into_sync(),
                         self.delegate.region.clone(),
                     )),

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -15,8 +15,8 @@ use std::{cmp, usize};
 
 use batch_system::{BasicMailbox, BatchRouter, BatchSystem, Fsm, HandlerBuilder, PollHandler};
 use crossbeam::channel::{TryRecvError, TrySendError};
-use engine_rocks::{RocksEngine, RocksSnapshot};
 use engine_rocks::{PerfContext, PerfLevel};
+use engine_rocks::{RocksEngine, RocksSnapshot};
 use engine_traits::{KvEngine, Snapshot, WriteBatch, WriteBatchVecExt};
 use engine_traits::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use kvproto::import_sstpb::SstMeta;
@@ -194,8 +194,7 @@ impl Range {
 }
 
 #[derive(Debug)]
-pub enum ExecResult<S>
-{
+pub enum ExecResult<S> {
     ChangePeer(ChangePeer),
     CompactLog {
         state: RaftTruncatedState,
@@ -235,8 +234,7 @@ pub enum ExecResult<S>
 }
 
 /// The possible returned value when applying logs.
-pub enum ApplyResult<S>
-{
+pub enum ApplyResult<S> {
     None,
     Yield,
     /// Additional result that needs to be sent back to raftstore.
@@ -986,7 +984,12 @@ where
         }
     }
 
-    fn find_cb(&mut self, index: u64, term: u64, is_conf_change: bool) -> Option<Callback<E::Snapshot>> {
+    fn find_cb(
+        &mut self,
+        index: u64,
+        term: u64,
+        is_conf_change: bool,
+    ) -> Option<Callback<E::Snapshot>> {
         let (region_id, peer_id) = (self.region_id(), self.id());
         if is_conf_change {
             if let Some(mut cmd) = self.pending_cmds.take_conf_change() {
@@ -3345,7 +3348,9 @@ mod tests {
     use crate::store::msg::WriteResponse;
     use crate::store::peer_storage::RAFT_INIT_LOG_INDEX;
     use crate::store::util::{new_learner_peer, new_peer};
-    use engine_rocks::{util::new_engine, RocksEngine, RocksWriteBatch, WRITE_BATCH_MAX_KEYS, RocksSnapshot};
+    use engine_rocks::{
+        util::new_engine, RocksEngine, RocksSnapshot, RocksWriteBatch, WRITE_BATCH_MAX_KEYS,
+    };
     use engine_traits::{Peekable as PeekableTrait, WriteBatchExt};
     use kvproto::metapb::{self, RegionEpoch};
     use kvproto::raft_cmdpb::*;

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -620,7 +620,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         }
     }
 
-    pub fn collect_ready(&mut self, proposals: &mut Vec<RegionProposal<RocksEngine>>) {
+    pub fn collect_ready(&mut self, proposals: &mut Vec<RegionProposal<RocksSnapshot>>) {
         let has_ready = self.fsm.has_ready;
         self.fsm.has_ready = false;
         if !has_ready || self.fsm.stopped {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2189,7 +2189,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
 
     fn on_ready_result(
         &mut self,
-        exec_results: &mut VecDeque<ExecResult<RocksEngine>>,
+        exec_results: &mut VecDeque<ExecResult<RocksSnapshot>>,
         metrics: &ApplyMetrics,
     ) {
         // handle executing committed log results
@@ -2215,7 +2215,6 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                     region,
                     index,
                     snap,
-                    _phantom,
                 } => self.on_ready_compute_hash(region, index, snap),
                 ExecResult::VerifyHash { index, hash } => self.on_ready_verify_hash(index, hash),
                 ExecResult::DeleteRange { .. } => {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -133,7 +133,7 @@ impl<E: KvEngine> PeerFsm<E> {
     pub fn create(
         store_id: u64,
         cfg: &Config,
-        sched: Scheduler<RegionTask<RocksEngine>>,
+        sched: Scheduler<RegionTask<RocksSnapshot>>,
         engines: KvEngines<RocksEngine, RocksEngine>,
         region: &metapb::Region,
     ) -> Result<SenderFsmPair<E>> {
@@ -177,7 +177,7 @@ impl<E: KvEngine> PeerFsm<E> {
     pub fn replicate(
         store_id: u64,
         cfg: &Config,
-        sched: Scheduler<RegionTask<RocksEngine>>,
+        sched: Scheduler<RegionTask<RocksSnapshot>>,
         engines: KvEngines<RocksEngine, RocksEngine>,
         region_id: u64,
         peer: metapb::Peer,

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -504,7 +504,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         &mut self,
         cmd: ChangeCmd,
         region_epoch: RegionEpoch,
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
     ) {
         let region_id = self.region_id();
         let msg =
@@ -599,7 +599,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         self.fsm.peer.raft_group.report_snapshot(to_peer_id, status)
     }
 
-    fn on_leader_callback(&mut self, cb: Callback<RocksEngine>) {
+    fn on_leader_callback(&mut self, cb: Callback<RocksSnapshot>) {
         let msg = new_read_index_request(
             self.region_id(),
             self.region().get_region_epoch().clone(),
@@ -2383,7 +2383,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         }
     }
 
-    fn propose_raft_command(&mut self, mut msg: RaftCmdRequest, cb: Callback<RocksEngine>) {
+    fn propose_raft_command(&mut self, mut msg: RaftCmdRequest, cb: Callback<RocksSnapshot>) {
         match self.pre_propose_raft_command(&msg) {
             Ok(Some(resp)) => {
                 cb.invoke_with_response(resp);
@@ -2641,7 +2641,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         &mut self,
         region_epoch: metapb::RegionEpoch,
         split_keys: Vec<Vec<u8>>,
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
     ) {
         if let Err(e) = self.validate_split_region(&region_epoch, &split_keys) {
             cb.invoke_with_response(new_error(e));

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -200,7 +200,7 @@ pub struct PollContext<T, C: 'static> {
     pub cfg: Config,
     pub store: metapb::Store,
     pub pd_scheduler: FutureScheduler<PdTask<RocksEngine>>,
-    pub consistency_check_scheduler: Scheduler<ConsistencyCheckTask<RocksEngine>>,
+    pub consistency_check_scheduler: Scheduler<ConsistencyCheckTask<RocksSnapshot>>,
     pub split_check_scheduler: Scheduler<SplitCheckTask>,
     // handle Compact, CleanupSST task
     pub cleanup_scheduler: Scheduler<CleanupTask>,
@@ -724,7 +724,7 @@ pub struct RaftPollerBuilder<T, C> {
     pub cfg: Arc<VersionTrack<Config>>,
     pub store: metapb::Store,
     pd_scheduler: FutureScheduler<PdTask<RocksEngine>>,
-    consistency_check_scheduler: Scheduler<ConsistencyCheckTask<RocksEngine>>,
+    consistency_check_scheduler: Scheduler<ConsistencyCheckTask<RocksSnapshot>>,
     split_check_scheduler: Scheduler<SplitCheckTask>,
     cleanup_scheduler: Scheduler<CleanupTask>,
     raftlog_gc_scheduler: Scheduler<RaftlogGcTask<RocksEngine>>,
@@ -967,7 +967,7 @@ where
 
 struct Workers {
     pd_worker: FutureWorker<PdTask<RocksEngine>>,
-    consistency_check_worker: Worker<ConsistencyCheckTask<RocksEngine>>,
+    consistency_check_worker: Worker<ConsistencyCheckTask<RocksSnapshot>>,
     split_check_worker: Worker<SplitCheckTask>,
     // handle Compact, CleanupSST task
     cleanup_worker: Worker<CleanupTask>,

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2,7 +2,7 @@
 
 use batch_system::{BasicMailbox, BatchRouter, BatchSystem, Fsm, HandlerBuilder, PollHandler};
 use crossbeam::channel::{TryRecvError, TrySendError};
-use engine_rocks::{RocksCompactionJobInfo, RocksEngine, RocksWriteBatch, RocksWriteBatchVec};
+use engine_rocks::{RocksCompactionJobInfo, RocksEngine, RocksWriteBatch, RocksWriteBatchVec, RocksSnapshot};
 use engine_traits::{
     CompactExt, CompactionJobInfo, Iterable, KvEngine, KvEngines, MiscExt, Mutable, Peekable,
     WriteBatch, WriteBatchExt, WriteBatchVecExt, WriteOptions,
@@ -205,7 +205,7 @@ pub struct PollContext<T, C: 'static> {
     // handle Compact, CleanupSST task
     pub cleanup_scheduler: Scheduler<CleanupTask>,
     pub raftlog_gc_scheduler: Scheduler<RaftlogGcTask<RocksEngine>>,
-    pub region_scheduler: Scheduler<RegionTask<RocksEngine>>,
+    pub region_scheduler: Scheduler<RegionTask<RocksSnapshot>>,
     pub apply_router: ApplyRouter,
     pub router: RaftRouter<RocksEngine>,
     pub importer: Arc<SSTImporter>,
@@ -728,7 +728,7 @@ pub struct RaftPollerBuilder<T, C> {
     split_check_scheduler: Scheduler<SplitCheckTask>,
     cleanup_scheduler: Scheduler<CleanupTask>,
     raftlog_gc_scheduler: Scheduler<RaftlogGcTask<RocksEngine>>,
-    pub region_scheduler: Scheduler<RegionTask<RocksEngine>>,
+    pub region_scheduler: Scheduler<RegionTask<RocksSnapshot>>,
     apply_router: ApplyRouter,
     pub router: RaftRouter<RocksEngine>,
     pub importer: Arc<SSTImporter>,
@@ -972,7 +972,7 @@ struct Workers {
     // handle Compact, CleanupSST task
     cleanup_worker: Worker<CleanupTask>,
     raftlog_gc_worker: Worker<RaftlogGcTask<RocksEngine>>,
-    region_worker: Worker<RegionTask<RocksEngine>>,
+    region_worker: Worker<RegionTask<RocksSnapshot>>,
     coprocessor_host: CoprocessorHost<RocksEngine>,
     future_poller: ThreadPool,
 }

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -176,8 +176,8 @@ impl<E: KvEngine> RaftRouter<E> {
     #[inline]
     pub fn send_raft_command(
         &self,
-        cmd: RaftCommand<E>,
-    ) -> std::result::Result<(), TrySendError<RaftCommand<E>>> {
+        cmd: RaftCommand<E::Snapshot>,
+    ) -> std::result::Result<(), TrySendError<RaftCommand<E::Snapshot>>> {
         let region_id = cmd.request.get_header().get_region_id();
         match self.send(region_id, PeerMsg::RaftCommand(cmd)) {
             Ok(()) => Ok(()),

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -3,7 +3,9 @@
 use batch_system::{BasicMailbox, BatchRouter, BatchSystem, Fsm, HandlerBuilder, PollHandler};
 use crossbeam::channel::{TryRecvError, TrySendError};
 use engine_rocks::{PerfContext, PerfLevel};
-use engine_rocks::{RocksCompactionJobInfo, RocksEngine, RocksWriteBatch, RocksWriteBatchVec, RocksSnapshot};
+use engine_rocks::{
+    RocksCompactionJobInfo, RocksEngine, RocksSnapshot, RocksWriteBatch, RocksWriteBatchVec,
+};
 use engine_traits::{
     CompactExt, CompactionJobInfo, Iterable, KvEngine, KvEngines, MiscExt, Mutable, Peekable,
     WriteBatch, WriteBatchExt, WriteBatchVecExt, WriteOptions,

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -466,7 +466,7 @@ pub struct RaftPoller<T: 'static, C: 'static> {
     previous_metrics: RaftMetrics,
     timer: TiInstant,
     poll_ctx: PollContext<T, C>,
-    pending_proposals: Vec<RegionProposal<RocksEngine>>,
+    pending_proposals: Vec<RegionProposal<RocksSnapshot>>,
     messages_per_tick: usize,
     cfg_tracker: Tracker<Config>,
 }

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -38,7 +38,10 @@ pub struct WriteResponse {
 // This is only necessary because of seeming limitations in derive(Clone) w/r/t
 // generics. If it can be deleted in the future in favor of derive, it should
 // be.
-impl<S> Clone for ReadResponse<S> where S: Snapshot {
+impl<S> Clone for ReadResponse<S>
+where
+    S: Snapshot,
+{
     fn clone(&self) -> ReadResponse<S> {
         ReadResponse {
             response: self.response.clone(),

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -24,15 +24,27 @@ use tikv_util::escape;
 
 use super::RegionSnapshot;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ReadResponse<E: KvEngine> {
     pub response: RaftCmdResponse,
-    pub snapshot: Option<RegionSnapshot<E>>,
+    pub snapshot: Option<RegionSnapshot<E::Snapshot>>,
 }
 
 #[derive(Debug)]
 pub struct WriteResponse {
     pub response: RaftCmdResponse,
+}
+
+// This is only necessary because of seeming limitations in derive(Clone) w/r/t
+// generics. If it can be deleted in the future in favor of derive, it should
+// be.
+impl<E> Clone for ReadResponse<E> where E: KvEngine {
+    fn clone(&self) -> ReadResponse<E> {
+        ReadResponse {
+            response: self.response.clone(),
+            snapshot: self.snapshot.clone(),
+        }
+    }
 }
 
 pub type ReadCallback<E> = Box<dyn FnOnce(ReadResponse<E>) + Send>;

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -294,15 +294,15 @@ impl<E: KvEngine> fmt::Debug for CasualMessage<E> {
 /// Raft command is the command that is expected to be proposed by the
 /// leader of the target raft group.
 #[derive(Debug)]
-pub struct RaftCommand<E: KvEngine> {
+pub struct RaftCommand<S: Snapshot> {
     pub send_time: Instant,
     pub request: RaftCmdRequest,
-    pub callback: Callback<E::Snapshot>,
+    pub callback: Callback<S>,
 }
 
-impl<E: KvEngine> RaftCommand<E> {
+impl<S: Snapshot> RaftCommand<S> {
     #[inline]
-    pub fn new(request: RaftCmdRequest, callback: Callback<E::Snapshot>) -> RaftCommand<E> {
+    pub fn new(request: RaftCmdRequest, callback: Callback<S>) -> RaftCommand<S> {
         RaftCommand {
             request,
             callback,
@@ -320,7 +320,7 @@ pub enum PeerMsg<E: KvEngine> {
     /// Raft command is the command that is expected to be proposed by the
     /// leader of the target raft group. If it's failed to be sent, callback
     /// usually needs to be called before dropping in case of resource leak.
-    RaftCommand(RaftCommand<E>),
+    RaftCommand(RaftCommand<E::Snapshot>),
     /// Tick is periodical task. If target peer doesn't exist there is a potential
     /// that the raft node will not work anymore.
     Tick(PeerTicks),

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -177,7 +177,7 @@ pub struct Peer {
     pub peer_heartbeats: HashMap<u64, Instant>,
 
     proposals: ProposalQueue,
-    apply_proposals: Vec<Proposal<RocksEngine>>,
+    apply_proposals: Vec<Proposal<RocksSnapshot>>,
 
     leader_missing_time: Option<Instant>,
     leader_lease: Lease,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -249,7 +249,7 @@ impl Peer {
     pub fn new(
         store_id: u64,
         cfg: &Config,
-        sched: Scheduler<RegionTask<RocksEngine>>,
+        sched: Scheduler<RegionTask<RocksSnapshot>>,
         engines: KvEngines<RocksEngine, RocksEngine>,
         region: &metapb::Region,
         peer: metapb::Peer,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1673,7 +1673,7 @@ impl Peer {
     pub fn propose<T: Transport, C>(
         &mut self,
         ctx: &mut PollContext<T, C>,
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
         req: RaftCmdRequest,
         mut err_resp: RaftCmdResponse,
     ) -> bool {
@@ -1734,7 +1734,7 @@ impl Peer {
         poll_ctx: &mut PollContext<T, C>,
         mut meta: ProposalMeta,
         is_conf_change: bool,
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
     ) {
         // Try to renew leader lease on every consistent read/write request.
         if poll_ctx.current_time.is_none() {
@@ -1934,7 +1934,7 @@ impl Peer {
         &mut self,
         ctx: &mut PollContext<T, C>,
         req: RaftCmdRequest,
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
     ) {
         ctx.raft_metrics.propose.local_read += 1;
         cb.invoke_read(self.handle_read(ctx, req, false, Some(self.get_store().committed_index())))
@@ -1998,7 +1998,7 @@ impl Peer {
         poll_ctx: &mut PollContext<T, C>,
         req: RaftCmdRequest,
         mut err_resp: RaftCmdResponse,
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
     ) -> bool {
         if let Err(e) = self.pre_read_index() {
             debug!(
@@ -2363,7 +2363,7 @@ impl Peer {
         &mut self,
         ctx: &mut PollContext<T, C>,
         req: RaftCmdRequest,
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
     ) -> bool {
         ctx.raft_metrics.propose.transfer_leader += 1;
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1074,7 +1074,7 @@ impl Peer {
         self.get_store().last_index() >= index && self.get_store().last_term() >= term
     }
 
-    pub fn take_apply_proposals(&mut self) -> Option<RegionProposal<RocksEngine>> {
+    pub fn take_apply_proposals(&mut self) -> Option<RegionProposal<RocksSnapshot>> {
         if self.apply_proposals.is_empty() {
             return None;
         }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -8,7 +8,7 @@ use std::sync::{atomic, Arc};
 use std::time::{Duration, Instant};
 use std::{cmp, mem, u64, usize};
 
-use engine_rocks::RocksEngine;
+use engine_rocks::{RocksEngine, RocksSnapshot};
 use engine_traits::{KvEngine, KvEngines, Peekable, Snapshot, WriteBatchExt, WriteOptions};
 use kvproto::metapb;
 use kvproto::pdpb::PeerStats;
@@ -2448,7 +2448,7 @@ impl Peer {
         req: RaftCmdRequest,
         check_epoch: bool,
         read_index: Option<u64>,
-    ) -> ReadResponse<RocksEngine> {
+    ) -> ReadResponse<RocksSnapshot> {
         let mut resp = ReadExecutor::new(
             ctx.engines.kv.clone(),
             check_epoch,
@@ -2813,7 +2813,7 @@ where
         msg: &RaftCmdRequest,
         region: &metapb::Region,
         read_index: Option<u64>,
-    ) -> ReadResponse<E> {
+    ) -> ReadResponse<E::Snapshot> {
         if self.check_epoch {
             if let Err(e) = check_region_epoch(msg, region, true) {
                 debug!(

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1583,7 +1583,7 @@ mod tests {
     use crate::store::{bootstrap_store, initial_region, prepare_bootstrap_cluster};
     use engine::rocks::util::new_engine;
     use engine::Engines;
-    use engine_rocks::{CloneCompat, Compat, RocksEngine, RocksWriteBatch, RocksSnapshot};
+    use engine_rocks::{CloneCompat, Compat, RocksEngine, RocksSnapshot, RocksWriteBatch};
     use engine_traits::{Iterable, SyncMutable, WriteBatchExt};
     use engine_traits::{ALL_CFS, CF_DEFAULT};
     use kvproto::raft_serverpb::RaftSnapshotData;

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -523,7 +523,7 @@ where
 
     snap_state: RefCell<SnapState>,
     gen_snap_task: RefCell<Option<GenSnapTask>>,
-    region_sched: Scheduler<RegionTask<EK>>,
+    region_sched: Scheduler<RegionTask<EK::Snapshot>>,
     snap_tried_cnt: RefCell<usize>,
 
     cache: EntryCache,
@@ -575,7 +575,7 @@ where
     pub fn new(
         engines: KvEngines<EK, ER>,
         region: &metapb::Region,
-        region_sched: Scheduler<RegionTask<EK>>,
+        region_sched: Scheduler<RegionTask<EK::Snapshot>>,
         peer_id: u64,
         tag: String,
     ) -> Result<PeerStorage<EK, ER>> {
@@ -1584,7 +1584,7 @@ mod tests {
     use crate::store::{bootstrap_store, initial_region, prepare_bootstrap_cluster};
     use engine::rocks::util::new_engine;
     use engine::Engines;
-    use engine_rocks::{CloneCompat, Compat, RocksEngine, RocksWriteBatch};
+    use engine_rocks::{CloneCompat, Compat, RocksEngine, RocksWriteBatch, RocksSnapshot};
     use engine_traits::{Iterable, SyncMutable, WriteBatchExt};
     use engine_traits::{ALL_CFS, CF_DEFAULT};
     use kvproto::raft_serverpb::RaftSnapshotData;
@@ -1603,7 +1603,7 @@ mod tests {
     use super::*;
 
     fn new_storage(
-        sched: Scheduler<RegionTask<RocksEngine>>,
+        sched: Scheduler<RegionTask<RocksSnapshot>>,
         path: &TempDir,
     ) -> PeerStorage<RocksEngine, RocksEngine> {
         let kv_db =
@@ -1655,7 +1655,7 @@ mod tests {
     }
 
     fn new_storage_from_ents(
-        sched: Scheduler<RegionTask<RocksEngine>>,
+        sched: Scheduler<RegionTask<RocksSnapshot>>,
         path: &TempDir,
         ents: &[Entry],
     ) -> PeerStorage<RocksEngine, RocksEngine> {
@@ -1902,7 +1902,7 @@ mod tests {
     fn generate_and_schedule_snapshot(
         gen_task: GenSnapTask,
         engines: &KvEngines<RocksEngine, RocksEngine>,
-        sched: &Scheduler<RegionTask<RocksEngine>>,
+        sched: &Scheduler<RegionTask<RocksSnapshot>>,
     ) -> Result<()> {
         let apply_state: RaftApplyState = engines
             .kv
@@ -1915,7 +1915,7 @@ mod tests {
             .get_msg::<Entry>(&keys::raft_log_key(gen_task.region_id, idx))
             .unwrap()
             .unwrap();
-        gen_task.generate_and_schedule_snapshot(
+        gen_task.generate_and_schedule_snapshot::<RocksEngine>(
             engines.kv.clone().snapshot(),
             entry.get_term(),
             apply_state,

--- a/components/raftstore/src/store/read_queue.rs
+++ b/components/raftstore/src/store/read_queue.rs
@@ -7,7 +7,7 @@ use crate::store::fsm::apply;
 use crate::store::metrics::*;
 use crate::store::{Callback, Config};
 
-use engine_rocks::{RocksSnapshot};
+use engine_rocks::RocksSnapshot;
 use kvproto::raft_cmdpb::RaftCmdRequest;
 use tikv_util::collections::HashMap;
 use tikv_util::time::{duration_to_sec, monotonic_raw_now};

--- a/components/raftstore/src/store/read_queue.rs
+++ b/components/raftstore/src/store/read_queue.rs
@@ -7,7 +7,7 @@ use crate::store::fsm::apply;
 use crate::store::metrics::*;
 use crate::store::{Callback, Config};
 
-use engine_rocks::RocksEngine;
+use engine_rocks::{RocksSnapshot};
 use kvproto::raft_cmdpb::RaftCmdRequest;
 use tikv_util::collections::HashMap;
 use tikv_util::time::{duration_to_sec, monotonic_raw_now};
@@ -19,7 +19,7 @@ const READ_QUEUE_SHRINK_SIZE: usize = 64;
 
 pub struct ReadIndexRequest {
     pub id: Uuid,
-    pub cmds: MustConsumeVec<(RaftCmdRequest, Callback<RocksEngine>)>,
+    pub cmds: MustConsumeVec<(RaftCmdRequest, Callback<RocksSnapshot>)>,
     pub renew_lease_time: Timespec,
     pub read_index: Option<u64>,
     // `true` means it's in `ReadIndexQueue::reads`.
@@ -32,7 +32,7 @@ impl ReadIndexRequest {
         self.id.as_bytes()
     }
 
-    pub fn push_command(&mut self, req: RaftCmdRequest, cb: Callback<RocksEngine>) {
+    pub fn push_command(&mut self, req: RaftCmdRequest, cb: Callback<RocksSnapshot>) {
         RAFT_READ_INDEX_PENDING_COUNT.inc();
         self.cmds.push((req, cb));
     }
@@ -40,7 +40,7 @@ impl ReadIndexRequest {
     pub fn with_command(
         id: Uuid,
         req: RaftCmdRequest,
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
         renew_lease_time: Timespec,
     ) -> Self {
         RAFT_READ_INDEX_PENDING_COUNT.inc();

--- a/components/raftstore/src/store/region_snapshot.rs
+++ b/components/raftstore/src/store/region_snapshot.rs
@@ -42,10 +42,7 @@ where
         RegionSnapshot::from_snapshot(db.snapshot().into_sync(), region)
     }
 
-    pub fn from_snapshot(
-        snap: S::SyncSnapshot,
-        region: Region,
-    ) -> RegionSnapshot<S> {
+    pub fn from_snapshot(snap: S::SyncSnapshot, region: Region) -> RegionSnapshot<S> {
         RegionSnapshot {
             snap,
             region: Arc::new(region),

--- a/components/raftstore/src/store/region_snapshot.rs
+++ b/components/raftstore/src/store/region_snapshot.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use crate::store::{util, PeerStorage};
 use crate::{Error, Result};
-use engine_rocks::RocksEngine;
+use engine_rocks::{RocksEngine, RocksSnapshot};
 use engine_traits::util::check_key_in_range;
 use engine_traits::CF_RAFT;
 use engine_traits::{Error as EngineError, Iterable, Iterator};
@@ -23,29 +23,29 @@ use tikv_util::{panic_when_unexpected_key_or_data, set_panic_mark};
 ///
 /// Only data within a region can be accessed.
 #[derive(Debug)]
-pub struct RegionSnapshot<E: KvEngine> {
-    snap: <E::Snapshot as Snapshot>::SyncSnapshot,
+pub struct RegionSnapshot<S: Snapshot> {
+    snap: S::SyncSnapshot,
     region: Arc<Region>,
     apply_index: Arc<AtomicU64>,
 }
 
-impl<E> RegionSnapshot<E>
+impl<S> RegionSnapshot<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
     #[allow(clippy::new_ret_no_self)] // temporary until this returns RegionSnapshot<E>
-    pub fn new(ps: &PeerStorage<RocksEngine, RocksEngine>) -> RegionSnapshot<RocksEngine> {
+    pub fn new(ps: &PeerStorage<RocksEngine, RocksEngine>) -> RegionSnapshot<RocksSnapshot> {
         RegionSnapshot::from_snapshot(ps.raw_snapshot().into_sync(), ps.region().clone())
     }
 
-    pub fn from_raw(db: RocksEngine, region: Region) -> RegionSnapshot<RocksEngine> {
+    pub fn from_raw(db: RocksEngine, region: Region) -> RegionSnapshot<RocksSnapshot> {
         RegionSnapshot::from_snapshot(db.snapshot().into_sync(), region)
     }
 
     pub fn from_snapshot(
-        snap: <E::Snapshot as Snapshot>::SyncSnapshot,
+        snap: S::SyncSnapshot,
         region: Region,
-    ) -> RegionSnapshot<E> {
+    ) -> RegionSnapshot<S> {
         RegionSnapshot {
             snap,
             region: Arc::new(region),
@@ -84,11 +84,11 @@ where
         }
     }
 
-    pub fn iter(&self, iter_opt: IterOptions) -> RegionIterator<E> {
+    pub fn iter(&self, iter_opt: IterOptions) -> RegionIterator<S> {
         RegionIterator::new(&self.snap, Arc::clone(&self.region), iter_opt)
     }
 
-    pub fn iter_cf(&self, cf: &str, iter_opt: IterOptions) -> Result<RegionIterator<E>> {
+    pub fn iter_cf(&self, cf: &str, iter_opt: IterOptions) -> Result<RegionIterator<S>> {
         Ok(RegionIterator::new_cf(
             &self.snap,
             Arc::clone(&self.region),
@@ -127,7 +127,7 @@ where
         self.scan_impl(self.iter_cf(cf, iter_opt)?, start_key, f)
     }
 
-    fn scan_impl<F>(&self, mut it: RegionIterator<E>, start_key: &[u8], mut f: F) -> Result<()>
+    fn scan_impl<F>(&self, mut it: RegionIterator<S>, start_key: &[u8], mut f: F) -> Result<()>
     where
         F: FnMut(&[u8], &[u8]) -> Result<bool>,
     {
@@ -149,9 +149,9 @@ where
     }
 }
 
-impl<E> Clone for RegionSnapshot<E>
+impl<S> Clone for RegionSnapshot<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
     fn clone(&self) -> Self {
         RegionSnapshot {
@@ -162,11 +162,11 @@ where
     }
 }
 
-impl<E> Peekable for RegionSnapshot<E>
+impl<S> Peekable for RegionSnapshot<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
-    type DBVector = <E::Snapshot as Peekable>::DBVector;
+    type DBVector = <S as Peekable>::DBVector;
 
     fn get_value_opt(
         &self,
@@ -206,9 +206,9 @@ where
     }
 }
 
-impl<E> RegionSnapshot<E>
+impl<S> RegionSnapshot<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
     #[inline(never)]
     fn handle_get_value_error(&self, e: EngineError, cf: &str, key: &[u8]) -> EngineError {
@@ -237,8 +237,8 @@ where
 /// `RegionIterator` wrap a rocksdb iterator and only allow it to
 /// iterate in the region. It behaves as if underlying
 /// db only contains one region.
-pub struct RegionIterator<E: KvEngine> {
-    iter: <E::Snapshot as Iterable>::Iterator,
+pub struct RegionIterator<S: Snapshot> {
+    iter: <S as Iterable>::Iterator,
     region: Arc<Region>,
 }
 
@@ -267,15 +267,15 @@ fn update_upper_bound(iter_opt: &mut IterOptions, region: &Region) {
 }
 
 // we use engine::rocks's style iterator, doesn't need to impl std iterator.
-impl<E> RegionIterator<E>
+impl<S> RegionIterator<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
     pub fn new(
-        snap: &<E::Snapshot as Snapshot>::SyncSnapshot,
+        snap: &S::SyncSnapshot,
         region: Arc<Region>,
         mut iter_opt: IterOptions,
-    ) -> RegionIterator<E> {
+    ) -> RegionIterator<S> {
         update_lower_bound(&mut iter_opt, &region);
         update_upper_bound(&mut iter_opt, &region);
         let iter = snap
@@ -285,11 +285,11 @@ where
     }
 
     pub fn new_cf(
-        snap: &<E::Snapshot as Snapshot>::SyncSnapshot,
+        snap: &S::SyncSnapshot,
         region: Arc<Region>,
         mut iter_opt: IterOptions,
         cf: &str,
-    ) -> RegionIterator<E> {
+    ) -> RegionIterator<S> {
         update_lower_bound(&mut iter_opt, &region);
         update_upper_bound(&mut iter_opt, &region);
         let iter = snap
@@ -396,7 +396,7 @@ mod tests {
     use crate::store::PeerStorage;
     use crate::Result;
 
-    use engine_rocks::RocksEngine;
+    use engine_rocks::{RocksEngine, RocksSnapshot};
     use engine_traits::{CompactExt, KvEngines, MiscExt, Peekable, SyncMutable};
     use keys::data_key;
     use kvproto::metapb::{Peer, Region};
@@ -498,7 +498,7 @@ mod tests {
         let key3 = b"key3";
         engines.kv.put_msg(&data_key(key3), &r).expect("");
 
-        let snap = RegionSnapshot::<RocksEngine>::new(&store);
+        let snap = RegionSnapshot::<RocksSnapshot>::new(&store);
         let v3 = snap.get_msg(key3).expect("");
         assert_eq!(v3, Some(r));
 
@@ -515,9 +515,9 @@ mod tests {
         let path = Builder::new().prefix("test-raftstore").tempdir().unwrap();
         let engines = new_temp_engine(&path);
         let (store, _) = load_default_dataset(engines);
-        let snap = RegionSnapshot::<RocksEngine>::new(&store);
+        let snap = RegionSnapshot::<RocksSnapshot>::new(&store);
 
-        let check_seek_result = |snap: &RegionSnapshot<RocksEngine>,
+        let check_seek_result = |snap: &RegionSnapshot<RocksSnapshot>,
                                  lower_bound: Option<&[u8]>,
                                  upper_bound: Option<&[u8]>,
                                  seek_table: &Vec<(
@@ -533,7 +533,7 @@ mod tests {
             );
             let mut iter = snap.iter(iter_opt);
             for (seek_key, in_range, seek_exp, prev_exp) in seek_table.clone() {
-                let check_res = |iter: &RegionIterator<RocksEngine>,
+                let check_res = |iter: &RegionIterator<RocksSnapshot>,
                                  res: Result<bool>,
                                  exp: Option<(&[u8], &[u8])>| {
                     if !in_range {
@@ -599,7 +599,7 @@ mod tests {
         let path = Builder::new().prefix("test-raftstore").tempdir().unwrap();
         let engines = new_temp_engine(&path);
         let (store, _) = load_multiple_levels_dataset(engines);
-        let snap = RegionSnapshot::<RocksEngine>::new(&store);
+        let snap = RegionSnapshot::<RocksSnapshot>::new(&store);
 
         seek_table = vec![
             (b"a01", false, None, None),
@@ -627,7 +627,7 @@ mod tests {
         let engines = new_temp_engine(&path);
         let (store, base_data) = load_default_dataset(engines.clone());
 
-        let snap = RegionSnapshot::<RocksEngine>::new(&store);
+        let snap = RegionSnapshot::<RocksSnapshot>::new(&store);
         let mut data = vec![];
         snap.scan(b"a2", &[0xFF, 0xFF], false, |key, value| {
             data.push((key.to_vec(), value.to_vec()));
@@ -662,7 +662,7 @@ mod tests {
         let mut region = Region::default();
         region.mut_peers().push(Peer::default());
         let store = new_peer_storage(engines.clone(), &region);
-        let snap = RegionSnapshot::<RocksEngine>::new(&store);
+        let snap = RegionSnapshot::<RocksSnapshot>::new(&store);
         data.clear();
         snap.scan(b"", &[0xFF, 0xFF], false, |key, value| {
             data.push((key.to_vec(), value.to_vec()));
@@ -688,7 +688,7 @@ mod tests {
 
         // test iterator with upper bound
         let store = new_peer_storage(engines, &region);
-        let snap = RegionSnapshot::<RocksEngine>::new(&store);
+        let snap = RegionSnapshot::<RocksSnapshot>::new(&store);
         let mut iter = snap.iter(IterOptions::new(
             None,
             Some(KeyBuilder::from_slice(b"a5", DATA_PREFIX_KEY.len(), 0)),
@@ -711,7 +711,7 @@ mod tests {
         let engines = new_temp_engine(&path);
         let (store, test_data) = load_default_dataset(engines);
 
-        let snap = RegionSnapshot::<RocksEngine>::new(&store);
+        let snap = RegionSnapshot::<RocksSnapshot>::new(&store);
         let mut iter_opt = IterOptions::default();
         iter_opt.set_lower_bound(b"a3", 1);
         let mut iter = snap.iter(iter_opt);

--- a/components/raftstore/src/store/transport.rs
+++ b/components/raftstore/src/store/transport.rs
@@ -23,7 +23,10 @@ pub trait CasualRouter<E: KvEngine> {
 }
 
 /// Routes proposal to target region.
-pub trait ProposalRouter<S> where S: Snapshot {
+pub trait ProposalRouter<S>
+where
+    S: Snapshot,
+{
     fn send(&self, cmd: RaftCommand<S>) -> std::result::Result<(), TrySendError<RaftCommand<S>>>;
 }
 
@@ -47,7 +50,10 @@ impl<E: KvEngine> CasualRouter<E> for RaftRouter<E> {
 
 impl<E: KvEngine> ProposalRouter<E::Snapshot> for RaftRouter<E> {
     #[inline]
-    fn send(&self, cmd: RaftCommand<E::Snapshot>) -> std::result::Result<(), TrySendError<RaftCommand<E::Snapshot>>> {
+    fn send(
+        &self,
+        cmd: RaftCommand<E::Snapshot>,
+    ) -> std::result::Result<(), TrySendError<RaftCommand<E::Snapshot>>> {
         self.send_raft_command(cmd)
     }
 }

--- a/components/raftstore/src/store/worker/consistency_check.rs
+++ b/components/raftstore/src/store/worker/consistency_check.rs
@@ -7,21 +7,16 @@ use kvproto::metapb::Region;
 
 use crate::store::{CasualMessage, CasualRouter};
 use engine_rocks::RocksEngine;
+use engine_traits::Snapshot;
 use engine_traits::CF_RAFT;
-use engine_traits::{Snapshot};
 use tikv_util::worker::Runnable;
 
 use super::metrics::*;
 use crate::store::metrics::*;
 
 /// Consistency checking task.
-pub enum Task<S>
-{
-    ComputeHash {
-        index: u64,
-        region: Region,
-        snap: S,
-    },
+pub enum Task<S> {
+    ComputeHash { index: u64, region: Region, snap: S },
 }
 
 impl<S> Task<S>
@@ -154,7 +149,7 @@ mod tests {
     use byteorder::{BigEndian, WriteBytesExt};
     use engine::rocks::util::new_engine;
     use engine::rocks::Writable;
-    use engine_rocks::{RocksSnapshot};
+    use engine_rocks::RocksSnapshot;
     use engine_traits::{CF_DEFAULT, CF_RAFT};
     use kvproto::metapb::*;
     use std::sync::{mpsc, Arc};

--- a/components/raftstore/src/store/worker/consistency_check.rs
+++ b/components/raftstore/src/store/worker/consistency_check.rs
@@ -8,29 +8,27 @@ use kvproto::metapb::Region;
 use crate::store::{CasualMessage, CasualRouter};
 use engine_rocks::RocksEngine;
 use engine_traits::CF_RAFT;
-use engine_traits::{Iterable, KvEngine, Peekable, Snapshot};
+use engine_traits::{Snapshot};
 use tikv_util::worker::Runnable;
 
 use super::metrics::*;
 use crate::store::metrics::*;
 
 /// Consistency checking task.
-pub enum Task<E>
-where
-    E: KvEngine,
+pub enum Task<S>
 {
     ComputeHash {
         index: u64,
         region: Region,
-        snap: E::Snapshot,
+        snap: S,
     },
 }
 
-impl<E> Task<E>
+impl<S> Task<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
-    pub fn compute_hash(region: Region, index: u64, snap: E::Snapshot) -> Task<E> {
+    pub fn compute_hash(region: Region, index: u64, snap: S) -> Task<S> {
         Task::ComputeHash {
             region,
             index,
@@ -39,9 +37,9 @@ where
     }
 }
 
-impl<E> Display for Task<E>
+impl<S> Display for Task<S>
 where
-    E: KvEngine,
+    S: Snapshot,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
@@ -62,9 +60,9 @@ impl<C: CasualRouter<RocksEngine>> Runner<C> {
     }
 
     /// Computes the hash of the Region.
-    fn compute_hash<E>(&mut self, region: Region, index: u64, snap: E::Snapshot)
+    fn compute_hash<S>(&mut self, region: Region, index: u64, snap: S)
     where
-        E: KvEngine,
+        S: Snapshot,
     {
         let region_id = region.get_id();
         info!(
@@ -134,18 +132,18 @@ impl<C: CasualRouter<RocksEngine>> Runner<C> {
     }
 }
 
-impl<C, E> Runnable<Task<E>> for Runner<C>
+impl<C, S> Runnable<Task<S>> for Runner<C>
 where
     C: CasualRouter<RocksEngine>,
-    E: KvEngine,
+    S: Snapshot,
 {
-    fn run(&mut self, task: Task<E>) {
+    fn run(&mut self, task: Task<S>) {
         match task {
             Task::ComputeHash {
                 region,
                 index,
                 snap,
-            } => self.compute_hash::<E>(region, index, snap),
+            } => self.compute_hash::<S>(region, index, snap),
         }
     }
 }
@@ -156,7 +154,7 @@ mod tests {
     use byteorder::{BigEndian, WriteBytesExt};
     use engine::rocks::util::new_engine;
     use engine::rocks::Writable;
-    use engine_rocks::{RocksEngine, RocksSnapshot};
+    use engine_rocks::{RocksSnapshot};
     use engine_traits::{CF_DEFAULT, CF_RAFT};
     use kvproto::metapb::*;
     use std::sync::{mpsc, Arc};
@@ -194,7 +192,7 @@ mod tests {
         // hash should also contains region state key.
         digest.update(&keys::region_state_key(region.get_id()));
         let sum = digest.finalize();
-        runner.run(Task::<RocksEngine>::ComputeHash {
+        runner.run(Task::<RocksSnapshot>::ComputeHash {
             index: 10,
             region: region.clone(),
             snap: RocksSnapshot::new(Arc::clone(&db)),

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -78,7 +78,7 @@ where
         peer: metapb::Peer,
         // If true, right Region derives origin region_id.
         right_derive: bool,
-        callback: Callback<E>,
+        callback: Callback<E::Snapshot>,
     },
     AskBatchSplit {
         region: metapb::Region,
@@ -86,7 +86,7 @@ where
         peer: metapb::Peer,
         // If true, right Region derives origin region_id.
         right_derive: bool,
-        callback: Callback<E>,
+        callback: Callback<E::Snapshot>,
     },
     Heartbeat {
         term: u64,
@@ -388,7 +388,7 @@ where
         split_key: Vec<u8>,
         peer: metapb::Peer,
         right_derive: bool,
-        callback: Callback<E>,
+        callback: Callback<E::Snapshot>,
     ) {
         let router = self.router.clone();
         let f = self.pd_client.ask_split(region.clone()).then(move |resp| {
@@ -429,7 +429,7 @@ where
         mut split_keys: Vec<Vec<u8>>,
         peer: metapb::Peer,
         right_derive: bool,
-        callback: Callback<E>,
+        callback: Callback<E::Snapshot>,
     ) {
         let router = self.router.clone();
         let scheduler = self.scheduler.clone();
@@ -1009,7 +1009,7 @@ fn send_admin_request<E>(
     epoch: metapb::RegionEpoch,
     peer: metapb::Peer,
     request: AdminRequest,
-    callback: Callback<E>,
+    callback: Callback<E::Snapshot>,
 ) where
     E: KvEngine,
 {

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -157,7 +157,7 @@ impl Progress {
 
 pub struct LocalReader<C, E>
 where
-    C: ProposalRouter<E>,
+    C: ProposalRouter<E::Snapshot>,
     E: KvEngine,
 {
     store_id: Cell<Option<u64>>,
@@ -187,7 +187,7 @@ impl<E: KvEngine> LocalReader<RaftRouter<E>, E> {
 
 impl<C, E> LocalReader<C, E>
 where
-    C: ProposalRouter<E>,
+    C: ProposalRouter<E::Snapshot>,
     E: KvEngine,
 {
     fn redirect(&self, mut cmd: RaftCommand<E::Snapshot>) {
@@ -389,7 +389,7 @@ where
 
 impl<C, E> Clone for LocalReader<C, E>
 where
-    C: ProposalRouter<E> + Clone,
+    C: ProposalRouter<E::Snapshot> + Clone,
     E: KvEngine,
 {
     fn clone(&self) -> Self {

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -46,8 +46,7 @@ const CLEANUP_MAX_DURATION: Duration = Duration::from_secs(5);
 
 /// Region related task
 #[derive(Debug)]
-pub enum Task<S>
-{
+pub enum Task<S> {
     Gen {
         region_id: u64,
         last_applied_index_term: u64,
@@ -69,8 +68,7 @@ pub enum Task<S>
     },
 }
 
-impl<S> Task<S>
-{
+impl<S> Task<S> {
     pub fn destroy(region_id: u64, start_key: Vec<u8>, end_key: Vec<u8>) -> Task<S> {
         Task::Destroy {
             region_id,
@@ -80,8 +78,7 @@ impl<S> Task<S>
     }
 }
 
-impl<S> Display for Task<S>
-{
+impl<S> Display for Task<S> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             Task::Gen { region_id, .. } => write!(f, "Snap gen for {}", region_id),

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -46,15 +46,13 @@ const CLEANUP_MAX_DURATION: Duration = Duration::from_secs(5);
 
 /// Region related task
 #[derive(Debug)]
-pub enum Task<E>
-where
-    E: KvEngine,
+pub enum Task<S>
 {
     Gen {
         region_id: u64,
         last_applied_index_term: u64,
         last_applied_state: RaftApplyState,
-        kv_snap: E::Snapshot,
+        kv_snap: S,
         notifier: SyncSender<RaftSnapshot>,
     },
     Apply {
@@ -71,11 +69,9 @@ where
     },
 }
 
-impl<E> Task<E>
-where
-    E: KvEngine,
+impl<S> Task<S>
 {
-    pub fn destroy(region_id: u64, start_key: Vec<u8>, end_key: Vec<u8>) -> Task<E> {
+    pub fn destroy(region_id: u64, start_key: Vec<u8>, end_key: Vec<u8>) -> Task<S> {
         Task::Destroy {
             region_id,
             start_key,
@@ -84,9 +80,7 @@ where
     }
 }
 
-impl<E> Display for Task<E>
-where
-    E: KvEngine,
+impl<S> Display for Task<S>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
@@ -553,7 +547,7 @@ where
     ctx: SnapContext<EK, ER, R>,
     // we may delay some apply tasks if level 0 files to write stall threshold,
     // pending_applies records all delayed apply task, and will check again later
-    pending_applies: VecDeque<Task<EK>>,
+    pending_applies: VecDeque<Task<EK::Snapshot>>,
 }
 
 impl<EK, ER, R> Runner<EK, ER, R>
@@ -619,13 +613,13 @@ where
     }
 }
 
-impl<EK, ER, R> Runnable<Task<EK>> for Runner<EK, ER, R>
+impl<EK, ER, R> Runnable<Task<EK::Snapshot>> for Runner<EK, ER, R>
 where
     EK: KvEngine,
     ER: KvEngine,
     R: CasualRouter<EK> + Send + Clone + 'static,
 {
-    fn run(&mut self, task: Task<EK>) {
+    fn run(&mut self, task: Task<EK::Snapshot>) {
         match task {
             Task::Gen {
                 region_id,
@@ -687,7 +681,7 @@ pub enum Event {
     CheckApply,
 }
 
-impl<EK, ER, R> RunnableWithTimer<Task<EK>, Event> for Runner<EK, ER, R>
+impl<EK, ER, R> RunnableWithTimer<Task<EK::Snapshot>, Event> for Runner<EK, ER, R>
 where
     EK: KvEngine,
     ER: KvEngine,

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -56,7 +56,7 @@ pub trait Simulator {
         &self,
         node_id: u64,
         request: RaftCmdRequest,
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
     ) -> Result<()>;
     fn send_raft_msg(&mut self, msg: RaftMessage) -> Result<()>;
     fn get_snap_dir(&self, node_id: u64) -> String;
@@ -1014,7 +1014,7 @@ impl<T: Simulator> Cluster<T> {
         &mut self,
         region: &metapb::Region,
         split_key: &[u8],
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
     ) {
         let leader = self.leader_of_region(region.get_id()).unwrap();
         let router = self.sim.rl().get_router(leader.get_store_id()).unwrap();

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -13,7 +13,7 @@ use raft::SnapshotStatus;
 
 use super::*;
 use engine::*;
-use engine_rocks::{Compat, RocksEngine};
+use engine_rocks::{Compat, RocksEngine, RocksSnapshot};
 use engine_traits::Peekable;
 use raftstore::coprocessor::config::SplitCheckConfigManager;
 use raftstore::coprocessor::CoprocessorHost;
@@ -325,7 +325,7 @@ impl Simulator for NodeCluster {
         &self,
         node_id: u64,
         request: RaftCmdRequest,
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
     ) -> Result<()> {
         if !self
             .trans

--- a/components/test_raftstore/src/router.rs
+++ b/components/test_raftstore/src/router.rs
@@ -2,7 +2,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use engine_rocks::RocksEngine;
+use engine_rocks::{RocksEngine, RocksSnapshot};
 use kvproto::raft_cmdpb::RaftCmdRequest;
 use kvproto::raft_serverpb::RaftMessage;
 use raftstore::errors::{Error as RaftStoreError, Result as RaftStoreResult};
@@ -54,7 +54,7 @@ impl RaftStoreRouter<RocksEngine> for MockRaftStoreRouter {
     fn send_raft_msg(&self, _: RaftMessage) -> RaftStoreResult<()> {
         unimplemented!()
     }
-    fn send_command(&self, _: RaftCmdRequest, _: Callback<RocksEngine>) -> RaftStoreResult<()> {
+    fn send_command(&self, _: RaftCmdRequest, _: Callback<RocksSnapshot>) -> RaftStoreResult<()> {
         unimplemented!()
     }
     fn broadcast_unreachable(&self, _: u64) {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -15,7 +15,7 @@ use tempfile::{Builder, TempDir};
 
 use super::*;
 use engine::Engines;
-use engine_rocks::{Compat, RocksEngine};
+use engine_rocks::{Compat, RocksEngine, RocksSnapshot};
 use raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor};
 use raftstore::router::{RaftStoreBlackHole, RaftStoreRouter, ServerRaftStoreRouter};
 use raftstore::store::fsm::store::{StoreMeta, PENDING_VOTES_CAP};
@@ -370,7 +370,7 @@ impl Simulator for ServerCluster {
         &self,
         node_id: u64,
         request: RaftCmdRequest,
-        cb: Callback<RocksEngine>,
+        cb: Callback<RocksSnapshot>,
     ) -> Result<()> {
         let router = match self.metas.get(&node_id) {
             None => return Err(box_err!("missing sender for store {}", node_id)),

--- a/components/test_raftstore/src/transport_simulate.rs
+++ b/components/test_raftstore/src/transport_simulate.rs
@@ -9,7 +9,7 @@ use std::{mem, thread, time, usize};
 
 use rand;
 
-use engine_rocks::RocksEngine;
+use engine_rocks::{RocksEngine, RocksSnapshot};
 use kvproto::raft_cmdpb::RaftCmdRequest;
 use kvproto::raft_serverpb::RaftMessage;
 use raft::eraftpb::MessageType;
@@ -193,7 +193,7 @@ impl<C: RaftStoreRouter<RocksEngine>> RaftStoreRouter<RocksEngine> for SimulateT
         filter_send(&self.filters, msg, |m| self.ch.send_raft_msg(m))
     }
 
-    fn send_command(&self, req: RaftCmdRequest, cb: Callback<RocksEngine>) -> Result<()> {
+    fn send_command(&self, req: RaftCmdRequest, cb: Callback<RocksSnapshot>) -> Result<()> {
         self.ch.send_command(req, cb)
     }
 

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -21,7 +21,7 @@ use engine::rocks::util::config::BlobRunMode;
 use engine::rocks::DB;
 use engine::*;
 use engine_rocks::{CompactionListener, RocksCompactionJobInfo};
-use engine_rocks::{Compat, RocksEngine};
+use engine_rocks::{Compat, RocksEngine, RocksSnapshot};
 use engine_traits::{Iterable, Peekable};
 use raftstore::store::fsm::RaftRouter;
 use raftstore::store::*;
@@ -342,7 +342,7 @@ pub fn make_cb(cmd: &RaftCmdRequest) -> (Callback<RocksEngine>, mpsc::Receiver<R
 
     let (tx, rx) = mpsc::channel();
     let cb = if is_read {
-        Callback::Read(Box::new(move |resp: ReadResponse<RocksEngine>| {
+        Callback::Read(Box::new(move |resp: ReadResponse<RocksSnapshot>| {
             // we don't care error actually.
             let _ = tx.send(resp.response);
         }))

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -324,7 +324,7 @@ pub fn new_pd_merge_region(target_region: metapb::Region) -> RegionHeartbeatResp
     resp
 }
 
-pub fn make_cb(cmd: &RaftCmdRequest) -> (Callback<RocksEngine>, mpsc::Receiver<RaftCmdResponse>) {
+pub fn make_cb(cmd: &RaftCmdRequest) -> (Callback<RocksSnapshot>, mpsc::Receiver<RaftCmdResponse>) {
     let mut is_read;
     let mut is_write;
     is_read = cmd.has_status_request();

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc;
 use std::sync::{atomic, Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use engine_rocks::RocksEngine;
+use engine_rocks::{RocksEngine, RocksSnapshot};
 use engine_traits::{MiscExt, TablePropertiesExt};
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 use futures::Future;
@@ -501,7 +501,7 @@ impl<E: Engine> GcRunner<E> {
         let mut fake_region = metapb::Region::default();
         // Add a peer to pass initialized check.
         fake_region.mut_peers().push(metapb::Peer::default());
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db, fake_region);
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db, fake_region);
 
         let mut reader = MvccReader::new(snap, Some(ScanMode::Forward), false, IsolationLevel::Si);
         let (locks, _) = reader.scan_locks(Some(start_key), |l| l.ts <= max_ts, limit)?;
@@ -939,7 +939,7 @@ mod tests {
 
     impl Engine for PrefixedEngine {
         // Use RegionSnapshot which can remove the z prefix internally.
-        type Snap = RegionSnapshot<RocksEngine>;
+        type Snap = RegionSnapshot<RocksSnapshot>;
 
         fn async_write(
             &self,

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -146,7 +146,7 @@ fn on_write_result(mut write_resp: WriteResponse, req_cnt: usize) -> (CbContext,
 }
 
 fn on_read_result(
-    mut read_resp: ReadResponse<RocksEngine>,
+    mut read_resp: ReadResponse<RocksSnapshot>,
     req_cnt: usize,
 ) -> (CbContext, Result<CmdRes>) {
     let cb_ctx = new_ctx(&read_resp.response);

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -1,6 +1,6 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_rocks::{RocksEngine, RocksTablePropertiesCollection, RocksSnapshot};
+use engine_rocks::{RocksEngine, RocksSnapshot, RocksTablePropertiesCollection};
 use engine_traits::CfName;
 use engine_traits::IterOptions;
 use engine_traits::CF_DEFAULT;

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -1,6 +1,6 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_rocks::{RocksEngine, RocksTablePropertiesCollection};
+use engine_rocks::{RocksEngine, RocksTablePropertiesCollection, RocksSnapshot};
 use engine_traits::CfName;
 use engine_traits::IterOptions;
 use engine_traits::CF_DEFAULT;
@@ -112,7 +112,7 @@ pub struct RaftKv<S: RaftStoreRouter<RocksEngine> + 'static> {
 
 pub enum CmdRes {
     Resp(Vec<Response>),
-    Snap(RegionSnapshot<RocksEngine>),
+    Snap(RegionSnapshot<RocksSnapshot>),
 }
 
 fn new_ctx(resp: &RaftCmdResponse) -> CbContext {
@@ -269,7 +269,7 @@ impl<S: RaftStoreRouter<RocksEngine>> Debug for RaftKv<S> {
 }
 
 impl<S: RaftStoreRouter<RocksEngine>> Engine for RaftKv<S> {
-    type Snap = RegionSnapshot<RocksEngine>;
+    type Snap = RegionSnapshot<RocksSnapshot>;
 
     fn async_write(
         &self,
@@ -402,8 +402,8 @@ impl<S: RaftStoreRouter<RocksEngine>> Engine for RaftKv<S> {
     }
 }
 
-impl Snapshot for RegionSnapshot<RocksEngine> {
-    type Iter = RegionIterator<RocksEngine>;
+impl Snapshot for RegionSnapshot<RocksSnapshot> {
+    type Iter = RegionIterator<RocksSnapshot>;
 
     fn get(&self, key: &Key) -> kv::Result<Option<Value>> {
         fail_point!("raftkv_snapshot_get", |_| Err(box_err!(
@@ -459,7 +459,7 @@ impl Snapshot for RegionSnapshot<RocksEngine> {
     }
 }
 
-impl EngineIterator for RegionIterator<RocksEngine> {
+impl EngineIterator for RegionIterator<RocksSnapshot> {
     fn next(&mut self) -> kv::Result<bool> {
         RegionIterator::next(self).map_err(KvError::from)
     }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -289,7 +289,7 @@ mod tests {
     use raftstore::store::*;
     use raftstore::Result as RaftStoreResult;
 
-    use engine_rocks::RocksEngine;
+    use engine_rocks::{RocksEngine, RocksSnapshot};
     use kvproto::raft_cmdpb::RaftCmdRequest;
     use kvproto::raft_serverpb::RaftMessage;
     use tikv_util::security::SecurityConfig;
@@ -326,7 +326,7 @@ mod tests {
             Ok(())
         }
 
-        fn send_command(&self, _: RaftCmdRequest, _: Callback<RocksEngine>) -> RaftStoreResult<()> {
+        fn send_command(&self, _: RaftCmdRequest, _: Callback<RocksSnapshot>) -> RaftStoreResult<()> {
             self.tx.send(1).unwrap();
             Ok(())
         }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -326,7 +326,11 @@ mod tests {
             Ok(())
         }
 
-        fn send_command(&self, _: RaftCmdRequest, _: Callback<RocksSnapshot>) -> RaftStoreResult<()> {
+        fn send_command(
+            &self,
+            _: RaftCmdRequest,
+            _: Callback<RocksSnapshot>,
+        ) -> RaftStoreResult<()> {
             self.tx.send(1).unwrap();
             Ok(())
         }

--- a/src/storage/kv/cursor.rs
+++ b/src/storage/kv/cursor.rs
@@ -498,7 +498,7 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
 
 #[cfg(test)]
 mod tests {
-    use engine_rocks::RocksEngine;
+    use engine_rocks::{RocksEngine, RocksSnapshot};
     use engine_traits::{IterOptions, KvEngines, SyncMutable};
     use keys::data_key;
     use kvproto::metapb::{Peer, Region};
@@ -537,7 +537,7 @@ mod tests {
         let engines = new_temp_engine(&path);
         let (region, test_data) = load_default_dataset(engines.clone());
 
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(engines.kv.clone(), region);
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(engines.kv.clone(), region);
         let mut statistics = CfStatistics::default();
         let it = snap.iter(IterOptions::default());
         let mut iter = Cursor::new(it, ScanMode::Mixed);
@@ -588,7 +588,7 @@ mod tests {
         // test last region
         let mut region = Region::default();
         region.mut_peers().push(Peer::default());
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(engines.kv, region);
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(engines.kv, region);
         let it = snap.iter(IterOptions::default());
         let mut iter = Cursor::new(it, ScanMode::Mixed);
         assert!(!iter

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -461,7 +461,7 @@ mod tests {
     use engine::rocks::DB;
     use engine::rocks::{self, ColumnFamilyOptions, DBOptions};
     use engine_rocks::properties::MvccPropertiesCollectorFactory;
-    use engine_rocks::{Compat, RocksEngine};
+    use engine_rocks::{Compat, RocksSnapshot};
     use engine_traits::{Mutable, TablePropertiesExt, WriteBatchExt};
     use engine_traits::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
     use kvproto::kvrpcpb::IsolationLevel;
@@ -523,7 +523,7 @@ mod tests {
 
         fn prewrite(&mut self, m: Mutation, pk: &[u8], start_ts: impl Into<TimeStamp>) {
             let snap =
-                RegionSnapshot::<RocksEngine>::from_raw(self.db.c().clone(), self.region.clone());
+                RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
             let mut txn = MvccTxn::new(snap, start_ts.into(), true);
             txn.prewrite(m, pk, false, 0, 0, TimeStamp::default())
                 .unwrap();
@@ -537,7 +537,7 @@ mod tests {
             start_ts: impl Into<TimeStamp>,
         ) {
             let snap =
-                RegionSnapshot::<RocksEngine>::from_raw(self.db.c().clone(), self.region.clone());
+                RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
             let mut txn = MvccTxn::new(snap, start_ts.into(), true);
             txn.pessimistic_prewrite(
                 m,
@@ -561,7 +561,7 @@ mod tests {
             for_update_ts: impl Into<TimeStamp>,
         ) {
             let snap =
-                RegionSnapshot::<RocksEngine>::from_raw(self.db.c().clone(), self.region.clone());
+                RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
             let mut txn = MvccTxn::new(snap, start_ts.into(), true);
             txn.acquire_pessimistic_lock(
                 k,
@@ -583,7 +583,7 @@ mod tests {
             commit_ts: impl Into<TimeStamp>,
         ) {
             let snap =
-                RegionSnapshot::<RocksEngine>::from_raw(self.db.c().clone(), self.region.clone());
+                RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
             let mut txn = MvccTxn::new(snap, start_ts.into(), true);
             txn.commit(Key::from_raw(pk), commit_ts.into()).unwrap();
             self.write(txn.into_modifies());
@@ -591,7 +591,7 @@ mod tests {
 
         fn rollback(&mut self, pk: &[u8], start_ts: impl Into<TimeStamp>) {
             let snap =
-                RegionSnapshot::<RocksEngine>::from_raw(self.db.c().clone(), self.region.clone());
+                RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
             let mut txn = MvccTxn::new(snap, start_ts.into(), true);
             txn.collapse_rollback(false);
             txn.rollback(Key::from_raw(pk)).unwrap();
@@ -600,7 +600,7 @@ mod tests {
 
         fn gc(&mut self, pk: &[u8], safe_point: impl Into<TimeStamp> + Copy) {
             loop {
-                let snap = RegionSnapshot::<RocksEngine>::from_raw(
+                let snap = RegionSnapshot::<RocksSnapshot>::from_raw(
                     self.db.c().clone(),
                     self.region.clone(),
                 );
@@ -754,7 +754,7 @@ mod tests {
         engine.put(&[12], 11, 12);
         engine.flush();
 
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
 
         let tests = vec![
             // set nothing.
@@ -911,7 +911,7 @@ mod tests {
         engine.prewrite_pessimistic_lock(m, k, 45);
         engine.commit(k, 45, 50);
 
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
         // Let's assume `50_45 PUT` means a commit version with start ts is 45 and commit ts
@@ -989,7 +989,7 @@ mod tests {
         engine.prewrite_pessimistic_lock(m, k, 1);
         engine.commit(k, 1, 4);
 
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         let (commit_ts, write_type) = reader.get_txn_commit_info(&key, 2.into()).unwrap().unwrap();
         assert_eq!(commit_ts, 3.into());
@@ -1033,7 +1033,7 @@ mod tests {
         // Let's assume `2_1 PUT` means a commit version with start ts is 1 and commit ts
         // is 2.
         // Commit versions: [25_23 PUT, 20_10 PUT, 17_15 PUT, 7_7 Rollback, 5_1 PUT, 3_3 Rollback].
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
         let k = Key::from_raw(k);
@@ -1085,7 +1085,7 @@ mod tests {
         engine.prewrite(m2, k2, 1);
         engine.commit(k2, 1, 2);
 
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
         let (commit_ts, write) = reader
@@ -1102,7 +1102,7 @@ mod tests {
 
         // Test seek_write touches region's end.
         let region1 = make_region(1, vec![], Key::from_raw(b"k1").into_encoded());
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region1);
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region1);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
         assert!(reader.seek_write(&k, 2.into()).unwrap().is_none());
@@ -1152,7 +1152,7 @@ mod tests {
         let m = Mutation::Put((Key::from_raw(k), v.to_vec()));
         engine.prewrite(m, k, 24);
 
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
         // Let's assume `2_1 PUT` means a commit version with start ts is 1 and commit ts
@@ -1215,7 +1215,7 @@ mod tests {
         engine.prewrite(Mutation::Put((Key::from_raw(k2), v.to_vec())), k1, 5);
         engine.prewrite(Mutation::Lock(Key::from_raw(k3)), k1, 5);
 
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         // Ignore the lock if read ts is less than the lock version
         assert!(reader.check_lock(&Key::from_raw(k1), 4.into()).is_ok());
@@ -1236,7 +1236,7 @@ mod tests {
 
         // Commit the primary lock only
         engine.commit(k1, 5, 7);
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         // Then reading the primary key should succeed
         assert!(reader.check_lock(&Key::from_raw(k1), 6.into()).is_ok());
@@ -1248,7 +1248,7 @@ mod tests {
 
         // Pessimistic locks
         engine.acquire_pessimistic_lock(Key::from_raw(k4), k4, 9, 9);
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         // Pessimistic locks don't block any read operation
         assert!(reader.check_lock(&Key::from_raw(k4), 10.into()).is_ok());
@@ -1342,7 +1342,7 @@ mod tests {
         // Creates a reader and scan locks,
         let check_scan_lock =
             |start_key: Option<Key>, limit, expect_res: &[_], expect_is_remain| {
-                let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
+                let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
                 let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
                 let res = reader
                     .scan_locks(start_key.as_ref(), |l| l.ts <= 10.into(), limit)
@@ -1400,7 +1400,7 @@ mod tests {
         let m = Mutation::Put((Key::from_raw(k), long_value.to_vec()));
         engine.prewrite(m, k, 10);
 
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         let key = Key::from_raw(k);
 
@@ -1424,7 +1424,7 @@ mod tests {
 
         // Commit the long value
         engine.commit(k, 10, 11);
-        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         for &skip_lock_check in &[false, true] {
             assert_eq!(

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -1342,7 +1342,8 @@ mod tests {
         // Creates a reader and scan locks,
         let check_scan_lock =
             |start_key: Option<Key>, limit, expect_res: &[_], expect_is_remain| {
-                let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
+                let snap =
+                    RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
                 let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
                 let res = reader
                     .scan_locks(start_key.as_ref(), |l| l.ts <= 10.into(), limit)

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -118,7 +118,7 @@ fn bench_async_snapshots_noop(b: &mut test::Bencher) {
                 }
             });
         let cb: Callback<RocksEngine> =
-            Callback::Read(Box::new(move |resp: ReadResponse<RocksEngine>| {
+            Callback::Read(Box::new(move |resp: ReadResponse<RocksSnapshot>| {
                 let res = CmdRes::Snap(resp.snapshot.unwrap());
                 cb2((CbContext::new(), Ok(res)));
             }));

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -69,7 +69,7 @@ impl RaftStoreRouter<RocksEngine> for SyncBenchRouter {
         Ok(())
     }
 
-    fn send_command(&self, req: RaftCmdRequest, cb: Callback<RocksEngine>) -> Result<()> {
+    fn send_command(&self, req: RaftCmdRequest, cb: Callback<RocksSnapshot>) -> Result<()> {
         self.invoke(RaftCommand::new(req, cb));
         Ok(())
     }
@@ -117,7 +117,7 @@ fn bench_async_snapshots_noop(b: &mut test::Bencher) {
                     cb1((ctx, Ok(snap)));
                 }
             });
-        let cb: Callback<RocksEngine> =
+        let cb: Callback<RocksSnapshot> =
             Callback::Read(Box::new(move |resp: ReadResponse<RocksSnapshot>| {
                 let res = CmdRes::Snap(resp.snapshot.unwrap());
                 cb2((CbContext::new(), Ok(res)));

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -106,8 +106,8 @@ fn bench_async_snapshots_noop(b: &mut test::Bencher) {
     };
 
     b.iter(|| {
-        let cb1: EngineCallback<RegionSnapshot<RocksEngine>> = Box::new(
-            move |(_, res): (CbContext, EngineResult<RegionSnapshot<RocksEngine>>)| {
+        let cb1: EngineCallback<RegionSnapshot<RocksSnapshot>> = Box::new(
+            move |(_, res): (CbContext, EngineResult<RegionSnapshot<RocksSnapshot>>)| {
                 assert!(res.is_ok());
             },
         );
@@ -147,7 +147,7 @@ fn bench_async_snapshot(b: &mut test::Bencher) {
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader);
     b.iter(|| {
-        let on_finished: EngineCallback<RegionSnapshot<RocksEngine>> = Box::new(move |results| {
+        let on_finished: EngineCallback<RegionSnapshot<RocksSnapshot>> = Box::new(move |results| {
             let _ = test::black_box(results);
         });
         kv.async_snapshot(&ctx, on_finished).unwrap();

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -40,7 +40,7 @@ impl SyncBenchRouter {
 }
 
 impl SyncBenchRouter {
-    fn invoke(&self, cmd: RaftCommand<RocksEngine>) {
+    fn invoke(&self, cmd: RaftCommand<RocksSnapshot>) {
         let mut response = RaftCmdResponse::default();
         cmd_resp::bind_term(&mut response, 1);
         match cmd.callback {

--- a/tests/integrations/storage/test_titan.rs
+++ b/tests/integrations/storage/test_titan.rs
@@ -388,7 +388,7 @@ fn test_delete_files_in_range_for_titan() {
     r.mut_peers().push(Peer::default());
     r.set_start_key(b"a".to_vec());
     r.set_end_key(b"z".to_vec());
-    let snapshot = RegionSnapshot::<RocksEngine>::from_raw(engines1.kv.clone(), r);
+    let snapshot = RegionSnapshot::<RocksSnapshot>::from_raw(engines1.kv.clone(), r);
     let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
         .range(Some(Key::from_raw(b"a")), None)
         .build()


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This is some cleanup work. After @Little-Wallace removed the engine type parameter from the Snapshot trait, many raftstore types no longer need to know about engines.

This begins removing `KvEngine` typarams from raftstore in favor of `Snapshot` typarams. There's more to do here, but the patch is starting to bitrot, so I want to land what I have.

### What is changed and how it works?


### Related changes

### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->