### PR TITLE
encryption: validate KMS key id

### DIFF
--- a/components/encryption/src/config.rs
+++ b/components/encryption/src/config.rs
@@ -42,13 +42,23 @@ pub struct FileCofnig {
     pub path: String,
 }
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, Configuration)]
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct KmsConfig {
     pub key_id: String,
 
+    // Providing access_key and secret_access_key is recommended as it has
+    // security risk.
+    #[doc(hidden)]
+    // We don's want to write access_key and secret_access_key to config file
+    // accidentally.
+    #[serde(skip_serializing)]
+    #[config(skip)]
     pub access_key: String,
+    #[doc(hidden)]
+    #[serde(skip_serializing)]
+    #[config(skip)]
     pub secret_access_key: String,
 
     pub region: String,

--- a/components/encryption/src/master_key/file.rs
+++ b/components/encryption/src/master_key/file.rs
@@ -119,7 +119,7 @@ mod tests {
         encrypted_content1
             .mut_metadata()
             .get_mut(MetadataKey::AesGcmTag.as_str())
-            .unwrap()[0] += 1;
+            .unwrap()[0] ^= 0b11111111u8;
         assert_matches!(
             backend.decrypt(&encrypted_content1).unwrap_err(),
             Error::Crypter(_)

--- a/components/encryption/src/master_key/kms.rs
+++ b/components/encryption/src/master_key/kms.rs
@@ -83,6 +83,8 @@ impl AwsKms {
                 if let RusotoError::Service(DecryptError::IncorrectKey(e)) = e {
                     Error::WrongMasterKey(e.into())
                 } else {
+                    // To keep it simple, retry all errors, even though only
+                    // some of them are retriable.
                     Error::Other(e.into())
                 }
             })
@@ -141,10 +143,7 @@ where
             }
         }
     }
-    panic!(
-        "kms request failed in {} times, err: {:?}",
-        retry_limit, last_err
-    )
+    Err(Error::Other(box_err!("{:?}", last_err)))
 }
 
 struct Inner {

--- a/components/encryption/src/master_key/kms.rs
+++ b/components/encryption/src/master_key/kms.rs
@@ -9,6 +9,8 @@ use futures::future::{self, TryFutureExt};
 use kvproto::encryptionpb::EncryptedContent;
 use rusoto_core::request::DispatchSignedRequest;
 use rusoto_core::request::HttpClient;
+use rusoto_core::RusotoError;
+use rusoto_kms::DecryptError;
 use rusoto_kms::{DecryptRequest, GenerateDataKeyRequest, Kms, KmsClient};
 use tokio::runtime::{Builder, Runtime};
 
@@ -69,7 +71,7 @@ impl AwsKms {
             // Use default algorithm SYMMETRIC_DEFAULT.
             encryption_algorithm: None,
             // Use key_id encoded in ciphertext.
-            key_id: None,
+            key_id: Some(self.current_key_id.clone()),
             // Encryption context and grant tokens are not used.
             encryption_context: None,
             grant_tokens: None,
@@ -77,10 +79,14 @@ impl AwsKms {
         let runtime = &mut self.runtime;
         let client = &self.client;
         let decrypt_response = retry(runtime, || {
-            client
-                .decrypt(decrypt_request.clone())
-                .map_err(|e| Error::Other(e.into()))
-        });
+            client.decrypt(decrypt_request.clone()).map_err(|e| {
+                if let RusotoError::Service(DecryptError::IncorrectKey(e)) = e {
+                    Error::WrongMasterKey(e.into())
+                } else {
+                    Error::Other(e.into())
+                }
+            })
+        })?;
         let plaintext = decrypt_response.plaintext.unwrap().as_ref().to_vec();
         Ok(plaintext)
     }
@@ -99,20 +105,22 @@ impl AwsKms {
             client
                 .generate_data_key(generate_request.clone())
                 .map_err(|e| Error::Other(e.into()))
-        });
+        })
+        .unwrap();
         let ciphertext_key = generate_response.ciphertext_blob.unwrap().as_ref().to_vec();
         let plaintext_key = generate_response.plaintext.unwrap().as_ref().to_vec();
         Ok((ciphertext_key, plaintext_key))
     }
 }
 
-fn retry<T, U, F>(runtime: &mut Runtime, mut func: F) -> T
+fn retry<T, U, F>(runtime: &mut Runtime, mut func: F) -> Result<T>
 where
     F: FnMut() -> U,
     U: Future<Output = Result<T>> + std::marker::Unpin,
 {
     let retry_limit = 6;
     let timeout_duration = Duration::from_secs(10);
+    let mut last_err = None;
     for _ in 0..retry_limit {
         let fut = func();
 
@@ -120,16 +128,23 @@ where
             let timeout = tokio::time::delay_for(timeout_duration);
             future::select(fut, timeout).await
         }) {
-            future::Either::Left((Ok(resp), _)) => return resp,
+            future::Either::Left((Ok(resp), _)) => return Ok(resp),
             future::Either::Left((Err(e), _)) => {
                 error!("kms request failed"; "error"=>?e);
+                if let Error::WrongMasterKey(e) = e {
+                    return Err(Error::WrongMasterKey(e));
+                }
+                last_err = Some(e);
             }
             future::Either::Right((_, _)) => {
                 error!("kms request timeout"; "timeout" => ?timeout_duration);
             }
         }
     }
-    panic!("kms request failed in {} times", retry_limit)
+    panic!(
+        "kms request failed in {} times, err: {:?}",
+        retry_limit, last_err
+    )
 }
 
 struct Inner {
@@ -406,5 +421,35 @@ mod tests {
         backend
             .decrypt_content(&ciphertext_key_not_found)
             .unwrap_err();
+    }
+
+    #[test]
+    fn test_kms_wrong_key_id() {
+        let config = KmsConfig {
+            key_id: "test_key_id".to_string(),
+            region: "ap-southeast-2".to_string(),
+            access_key: "abc".to_string(),
+            secret_access_key: "xyz".to_string(),
+            endpoint: String::new(),
+        };
+
+        // IncorrectKeyException
+        //
+        // HTTP Status Code: 400
+        // Json, see:
+        // https://github.com/rusoto/rusoto/blob/mock-v0.43.0/rusoto/services/kms/src/generated.rs#L1970
+        // https://github.com/rusoto/rusoto/blob/mock-v0.43.0/rusoto/core/src/proto/json/error.rs#L7
+        // https://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html#API_Decrypt_Errors
+        let dispatcher = MockRequestDispatcher::with_status(400).with_body(
+            r#"{
+                "__type": "IncorrectKeyException",
+                "Message": "mock"
+            }"#,
+        );
+        let mut aws_kms = AwsKms::with_request_dispatcher(&config, dispatcher).unwrap();
+        match aws_kms.decrypt(b"invalid") {
+            Err(Error::WrongMasterKey(_)) => (),
+            other => panic!("{:?}", other),
+        }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

KMS backend should provide master key ID in order to validate ciphertext and key ID are matched. 

Also, it hides access_key and secret_access_key as they are not supposed to config manually in most cases.

### Related changes

- Need to cherry-pick to the release branch
- Fixes #7687 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

Fix encryption at rest KMS key validation.