### PR TITLE
pd_worker: skip collecting load in tests

### DIFF
--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1184,7 +1184,7 @@ impl RaftBatchSystem {
             self.router.clone(),
             engines.kv,
             workers.pd_worker.scheduler(),
-            cfg.pd_store_heartbeat_tick_interval.as_secs(),
+            cfg.pd_store_heartbeat_tick_interval.0,
             auto_split_controller,
         );
         box_try!(workers.pd_worker.start(pd_runner));

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -305,6 +305,10 @@ where
     ) -> Result<(), io::Error> {
         let mut timer_cnt = 0; // to run functions with different intervals in a loop
         let collect_interval = self.collect_interval;
+        if self.thread_info_interval < self.collect_interval {
+            info!("running in test mode, skip starting monitor.");
+            return Ok(());
+        }
         let thread_info_interval = self
             .thread_info_interval
             .div_duration_f64(self.collect_interval) as i32;
@@ -430,10 +434,10 @@ where
         router: RaftRouter<E>,
         db: E,
         scheduler: Scheduler<Task<E>>,
-        store_heartbeat_interval: u64,
+        store_heartbeat_interval: Duration,
         auto_split_controller: AutoSplitController,
     ) -> Runner<E, T> {
-        let interval = Duration::from_secs(store_heartbeat_interval) / Self::INTERVAL_DIVISOR;
+        let interval = store_heartbeat_interval / Self::INTERVAL_DIVISOR;
         let mut stats_monitor = StatsMonitor::new(interval, scheduler.clone());
         if let Err(e) = stats_monitor.start(auto_split_controller) {
             error!("failed to start stats collector, error = {:?}", e);


### PR DESCRIPTION

### What problem does this PR solve?

In tests, store heartbeat interval can be very small that cause dividing
zero error.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
