### PR TITLE
*: update afl version from 0.6.0 to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,13 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "afl"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59206260f98d163b3ca42fb29fe551dbcda1d43cf70a244066b2a0666a8fb2a9"
+checksum = "2797f92fb146a37560af914b5d5328f8330d6a39b6eaf00f5b184ac73c0c81e7"
 dependencies = [
  "cc",
  "clap",
+ "libc",
  "rustc_version",
  "xdg",
 ]

--- a/fuzz/fuzzer-afl/Cargo.toml
+++ b/fuzz/fuzzer-afl/Cargo.toml
@@ -9,5 +9,5 @@ protobuf-codec = ["fuzz-targets/protobuf-codec"]
 prost-codec = ["fuzz-targets/prost-codec"]
 
 [dependencies]
-afl = "0.6"
+afl = "0.8"
 fuzz-targets = { path = "../targets", default-features = false }


### PR DESCRIPTION
fix issue #7675

Signed-off-by: XiaochenCui <jcnlcxc.new@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7675

Problem Summary: cargo check error on mac: failed to run custom build command for `afl v0.6.0`

### What is changed and how it works?

What's Changed:

Update afl version from 0.6.0 to 0.8.0

### Related changes

no

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

no

### Release note <!-- bugfixes or new feature need a release note -->