### PR TITLE
cdc: check observe id before starting to observe

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -44,7 +44,7 @@ pub struct DownstreamID(usize);
 
 impl DownstreamID {
     pub fn new() -> DownstreamID {
-        DownstreamID(DOWNSTREAM_ID_ALLOC.fetch_add(1, Ordering::Relaxed))
+        DownstreamID(DOWNSTREAM_ID_ALLOC.fetch_add(1, Ordering::SeqCst))
     }
 }
 

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -265,6 +265,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
 
     fn on_deregister(&mut self, deregister: Deregister) {
         info!("cdc deregister region"; "deregister" => ?deregister);
+        println!("cdc deregister region {:?}", deregister);
         match deregister {
             Deregister::Downstream {
                 region_id,

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -265,7 +265,6 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
 
     fn on_deregister(&mut self, deregister: Deregister) {
         info!("cdc deregister region"; "deregister" => ?deregister);
-        println!("cdc deregister region {:?}", deregister);
         match deregister {
             Deregister::Downstream {
                 region_id,

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -27,7 +27,7 @@ pub struct ConnID(usize);
 
 impl ConnID {
     pub fn new() -> ConnID {
-        ConnID(CONNECTION_ID_ALLOC.fetch_add(1, Ordering::Relaxed))
+        ConnID(CONNECTION_ID_ALLOC.fetch_add(1, Ordering::SeqCst))
     }
 }
 

--- a/components/cdc/tests/failpoints/test_observe.rs
+++ b/components/cdc/tests/failpoints/test_observe.rs
@@ -14,11 +14,13 @@ use kvproto::kvrpcpb::*;
 use kvproto::raft_serverpb::RaftMessage;
 use pd_client::PdClient;
 use raft::eraftpb::MessageType;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::Duration;
 use test_raftstore::*;
 use tikv_util::config::ReadableDuration;
+use tikv_util::HandyRwLock;
 
 #[test]
 fn test_observe_duplicate_cmd() {
@@ -135,21 +137,32 @@ fn test_observe_duplicate_cmd() {
 #[test]
 fn test_delayed_change_cmd() {
     let mut cluster = new_server_cluster(1, 3);
-    cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(150);
+    configure_for_lease_read(&mut cluster, Some(50), Some(20));
+    cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(100);
+    cluster.pd_client.disable_default_operator();
     let mut suite = TestSuite::with_cluster(3, cluster);
-    let region = suite.cluster.get_region(&[]);
-    let leader = suite.cluster.leader_of_region(region.get_id()).unwrap();
+    suite.cluster.must_put(b"k1", b"v1");
+    let region = suite.cluster.pd_client.get_region(&[]).unwrap();
+    let leader = new_peer(1, 1);
+    suite
+        .cluster
+        .must_transfer_leader(region.get_id(), leader.clone());
     // Wait util lease expired
-    sleep_ms(200);
+    sleep_ms(300);
 
-    let (read_index_sx, read_index_rx) = mpsc::sync_channel::<RaftMessage>(10);
+    let (sx, rx) = mpsc::sync_channel::<RaftMessage>(1);
+    let send_flag = Arc::new(AtomicBool::new(true));
     let send_read_index_filter = RegionPacketFilter::new(region.get_id(), leader.get_store_id())
         .direction(Direction::Send)
-        .msg_type(MessageType::MsgReadIndex)
+        .msg_type(MessageType::MsgHeartbeat)
         .set_msg_callback(Arc::new(move |msg: &RaftMessage| {
-            read_index_sx.send(msg.clone()).unwrap();
+            if send_flag.compare_and_swap(true, false, Ordering::SeqCst) {
+                sx.send(msg.clone()).unwrap();
+            }
         }));
-    suite.cluster.add_send_filter(CloneFilterFactory(send_read_index_filter));
+    suite
+        .cluster
+        .add_send_filter(CloneFilterFactory(send_read_index_filter));
 
     let mut req = ChangeDataRequest::default();
     req.region_id = region.get_id();
@@ -161,14 +174,7 @@ fn test_delayed_change_cmd() {
         .wait()
         .unwrap();
 
-    read_index_rx.recv_timeout(Duration::from_secs(1)).unwrap();
-
-    let start_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
-    let mut mutation = Mutation::default();
-    mutation.set_op(Op::Put);
-    mutation.key = b"k".to_vec();
-    mutation.value = b"v".to_vec();
-    suite.must_kv_prewrite(region.get_id(), vec![mutation], b"k".to_vec(), start_ts);
+    suite.cluster.must_put(b"k2", b"v2");
 
     let (req_tx, resp_rx) = suite
         .get_region_cdc_client(region.get_id())
@@ -176,32 +182,33 @@ fn test_delayed_change_cmd() {
         .unwrap();
     event_feed_wrap.as_ref().replace(Some(resp_rx));
     let _req_tx = req_tx.send((req, WriteFlags::default())).wait().unwrap();
+    sleep_ms(200);
 
-    // Commit
-    let commit_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
-    suite.must_kv_commit(1, vec![b"k".to_vec()], start_ts, commit_ts);
+    suite
+        .cluster
+        .sim
+        .wl()
+        .clear_send_filters(leader.get_store_id());
+    rx.recv_timeout(Duration::from_secs(1)).unwrap();
 
-    let mut events = receive_event(false);
-    while events.len() < 2 {
-        events.extend(receive_event(false).into_iter());
-    }
-    assert_eq!(events.len(), 2);
-    for event in events {
-        match event.event.unwrap() {
-            Event_oneof_event::Entries(es) => match es.entries.len() {
-                1 => {
-                    assert_eq!(es.entries[0].get_type(), EventLogType::Commit, "{:?}", es);
+    let mut counter = 0;
+    loop {
+        for e in receive_event(true) {
+            match e.event.unwrap() {
+                Event_oneof_event::ResolvedTs(ts) => {
+                    assert_ne!(0, ts);
+                    counter += 1;
                 }
-                2 => {
+                Event_oneof_event::Entries(es) => {
+                    assert!(es.entries.len() == 1, "{:?}", es);
                     let e = &es.entries[0];
-                    assert_eq!(e.get_type(), EventLogType::Prewrite, "{:?}", es);
-                    let e = &es.entries[1];
                     assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
                 }
-                _ => panic!("{:?}", es),
-            },
-            Event_oneof_event::Error(e) => panic!("{:?}", e),
-            _ => panic!("unknown event"),
+                _ => panic!("unknown event"),
+            }
+        }
+        if counter > 3 {
+            break;
         }
     }
 

--- a/components/cdc/tests/failpoints/test_observe.rs
+++ b/components/cdc/tests/failpoints/test_observe.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 use crate::{new_event_feed, TestSuite};
+use crossbeam::channel;
 use futures::sink::Sink;
 use futures::Future;
 use grpcio::WriteFlags;
@@ -12,10 +13,13 @@ use kvproto::cdcpb::{
 };
 use kvproto::kvrpcpb::*;
 use pd_client::PdClient;
-use test_raftstore::sleep_ms;
+use raft::eraftpb::MessageType;
+use std::time::Duration;
+use test_raftstore::*;
+use tikv_util::config::ReadableDuration;
 
 #[test]
-fn test_stale_observe_cmd() {
+fn test_observe_duplicate_cmd() {
     let mut suite = TestSuite::new(3);
 
     let region = suite.cluster.get_region(&[]);
@@ -119,6 +123,83 @@ fn test_stale_observe_cmd() {
         }
         if counter > 5 {
             break;
+        }
+    }
+
+    event_feed_wrap.as_ref().replace(None);
+    suite.stop();
+}
+
+#[test]
+fn test_delayed_change_cmd() {
+    let mut cluster = new_server_cluster(1, 3);
+    cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(150);
+    let mut suite = TestSuite::with_cluster(cluster);
+    let region = suite.cluster.get_region(&[]);
+    let leader = cluster.leader_of_region(region.get_id()).unwrap();
+    // Wait util lease expired
+    sleep_ms(200);
+
+    let (read_index_sx, read_index_rx) = channel::unbounded::<RaftMessage>();
+    let send_read_index_filter = RegionPacketFilter::new(region.get_id(), leader.get_store_id())
+        .direction(Direction::Send)
+        .msg_type(MessageType::MsgReadIndex)
+        .set_msg_callback(Arc::new(move |msg: &RaftMessage| {
+            read_index_sx.send(msg.clone()).unwrap();
+        }));
+    cluster.add_send_filter(CloneFilterFactory(send_read_index_filter));
+
+    let mut req = ChangeDataRequest::default();
+    req.region_id = region.get_id();
+    req.set_region_epoch(region.get_region_epoch().clone());
+    let (req_tx, event_feed_wrap, receive_event) =
+        new_event_feed(suite.get_region_cdc_client(region.get_id()));
+    let _req_tx = req_tx
+        .send((req.clone(), WriteFlags::default()))
+        .wait()
+        .unwrap();
+
+    read_index_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+    let start_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = b"k";
+    mutation.value = b"v";
+    suite.must_kv_prewrite(region.get_id(), vec![mutation], b"k", start_ts);
+
+    let (req_tx, resp_rx) = suite
+        .get_region_cdc_client(region.get_id())
+        .event_feed()
+        .unwrap();
+    event_feed_wrap.as_ref().replace(Some(resp_rx));
+    let _req_tx = req_tx.send((req, WriteFlags::default())).wait().unwrap();
+
+    // Commit
+    let commit_ts = suite.cluster.pd_client.get_tso().wait().unwrap();
+    suite.must_kv_commit(1, vec![b"k"], start_ts, commit_ts);
+
+    let mut events = receive_event(false);
+    while events.len() < 2 {
+        events.extend(receive_event(false).into_iter());
+    }
+    assert_eq!(events.len(), 2);
+    for event in events {
+        match event.event.unwrap() {
+            Event_oneof_event::Entries(es) => match es.entries.len() {
+                1 => {
+                    assert_eq!(es.entries[0].get_type(), EventLogType::Commit, "{:?}", es);
+                }
+                2 => {
+                    let e = &es.entries[0];
+                    assert_eq!(e.get_type(), EventLogType::Prewrite, "{:?}", es);
+                    let e = &es.entries[1];
+                    assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+                }
+                _ => panic!("{:?}", es),
+            },
+            Event_oneof_event::Error(e) => panic!("{:?}", e),
+            _ => panic!("unknown event"),
         }
     }
 

--- a/components/cdc/tests/failpoints/test_observe.rs
+++ b/components/cdc/tests/failpoints/test_observe.rs
@@ -15,6 +15,7 @@ use kvproto::raft_serverpb::RaftMessage;
 use pd_client::PdClient;
 use raft::eraftpb::MessageType;
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::time::Duration;
 use test_raftstore::*;
 use tikv_util::config::ReadableDuration;

--- a/components/cdc/tests/failpoints/test_resolve.rs
+++ b/components/cdc/tests/failpoints/test_resolve.rs
@@ -106,30 +106,27 @@ fn test_stale_resolver() {
 
     event_feed_wrap.as_ref().replace(Some(resp_rx1));
     // Receive events
-    let mut events = receive_event(false);
-    while events.len() < 2 {
-        events.extend(receive_event(false).into_iter());
-    }
-    assert_eq!(events.len(), 2);
-    match events.remove(0).event.unwrap() {
-        Event_oneof_event::Entries(es) => {
-            assert!(es.entries.len() == 2, "{:?}", es);
-            let e = &es.entries[0];
-            assert_eq!(e.get_type(), EventLogType::Prewrite, "{:?}", es);
-            let e = &es.entries[1];
-            assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+    for _ in 0..2 {
+        let mut events = receive_event(false);
+        match events.pop().unwrap().event.unwrap() {
+            Event_oneof_event::Entries(es) => match es.entries.len() {
+                1 => {
+                    let e = &es.entries[0];
+                    assert_eq!(e.get_type(), EventLogType::Commit, "{:?}", es);
+                }
+                2 => {
+                    let e = &es.entries[0];
+                    assert_eq!(e.get_type(), EventLogType::Prewrite, "{:?}", es);
+                    let e = &es.entries[1];
+                    assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+                }
+                .. => {
+                    panic!("unexepected event length {:?}", es);
+                }
+            },
+            Event_oneof_event::Error(e) => panic!("{:?}", e),
+            _ => panic!("unknown event"),
         }
-        Event_oneof_event::Error(e) => panic!("{:?}", e),
-        _ => panic!("unknown event"),
-    }
-    match events.pop().unwrap().event.unwrap() {
-        Event_oneof_event::Entries(es) => {
-            assert!(es.entries.len() == 1, "{:?}", es);
-            let e = &es.entries[0];
-            assert_eq!(e.get_type(), EventLogType::Commit, "{:?}", es);
-        }
-        Event_oneof_event::Error(e) => panic!("{:?}", e),
-        _ => panic!("unknown event"),
     }
 
     event_feed_wrap.as_ref().replace(None);

--- a/components/cdc/tests/failpoints/test_resolve.rs
+++ b/components/cdc/tests/failpoints/test_resolve.rs
@@ -120,7 +120,7 @@ fn test_stale_resolver() {
                     let e = &es.entries[1];
                     assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
                 }
-                .. => {
+                _ => {
                     panic!("unexepected event length {:?}", es);
                 }
             },

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -232,7 +232,7 @@ fn test_cdc_not_leader() {
             }),
         ))
         .unwrap();
-    rx.recv_timeout(Duration::from_millis(200)).unwrap();
+    rx.recv_timeout(Duration::from_secs(1)).unwrap();
     assert!(suite
         .obs
         .get(&leader.get_store_id())

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -89,9 +89,11 @@ pub struct TestSuite {
 
 impl TestSuite {
     pub fn new(count: usize) -> TestSuite {
-        init();
-        let mut cluster = new_server_cluster(1, count);
+        Self::with_cluster(new_server_cluster(1, count))
+    }
 
+    pub fn with_cluster(mut cluster: Cluster<ServerCluster>) -> TestSuite {
+        init();
         let pd_cli = cluster.pd_client.clone();
         let mut endpoints = HashMap::default();
         let mut obs = HashMap::default();

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -89,10 +89,10 @@ pub struct TestSuite {
 
 impl TestSuite {
     pub fn new(count: usize) -> TestSuite {
-        Self::with_cluster(new_server_cluster(1, count))
+        Self::with_cluster(count, new_server_cluster(1, count))
     }
 
-    pub fn with_cluster(mut cluster: Cluster<ServerCluster>) -> TestSuite {
+    pub fn with_cluster(count: usize, mut cluster: Cluster<ServerCluster>) -> TestSuite {
         init();
         let pd_cli = cluster.pd_client.clone();
         let mut endpoints = HashMap::default();

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2444,7 +2444,7 @@ impl Debug for GenSnapTask {
 static OBSERVE_ID_ALLOC: AtomicUsize = AtomicUsize::new(0);
 
 /// A unique identifier for checking stale observed commands.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ObserveID(usize);
 
 impl ObserveID {
@@ -2908,7 +2908,7 @@ where
             } => (observe_id, region_id, None),
         };
         if let Some(observe_cmd) = self.delegate.observe_cmd.as_mut() {
-            if observe_cmd.id != observe_id {
+            if observe_cmd.id > observe_id {
                 notify_stale_req(self.delegate.term, cb);
                 return;
             }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2449,7 +2449,7 @@ pub struct ObserveID(usize);
 
 impl ObserveID {
     pub fn new() -> ObserveID {
-        ObserveID(OBSERVE_ID_ALLOC.fetch_add(1, Ordering::Relaxed))
+        ObserveID(OBSERVE_ID_ALLOC.fetch_add(1, Ordering::SeqCst))
     }
 }
 

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2901,25 +2901,18 @@ where
                 observe_id,
                 region_id,
                 enabled,
-            } => {
-                assert!(
-                    !self
-                        .delegate
-                        .observe_cmd
-                        .as_ref()
-                        .map_or(false, |o| o.enabled.load(Ordering::SeqCst)),
-                    "{} observer already exists {:?} {:?}",
-                    self.delegate.tag,
-                    self.delegate.observe_cmd,
-                    observe_id
-                );
-                (observe_id, region_id, Some(enabled))
-            }
+            } => (observe_id, region_id, Some(enabled)),
             ChangeCmd::Snapshot {
                 observe_id,
                 region_id,
             } => (observe_id, region_id, None),
         };
+        if let Some(observe_cmd) = self.delegate.observe_cmd.as_mut() {
+            if observe_cmd.id != observe_id {
+                notify_stale_req(self.delegate.term, cb);
+                return;
+            }
+        }
 
         assert_eq!(self.delegate.region_id(), region_id);
         let resp = match compare_region_epoch(
@@ -2942,19 +2935,32 @@ where
                     )),
                 }
             }
-            Err(e) => ReadResponse {
-                response: cmd_resp::new_error(e),
-                snapshot: None,
-            },
+            Err(e) => {
+                // Return error if epoch not match
+                cb.invoke_read(ReadResponse {
+                    response: cmd_resp::new_error(e),
+                    snapshot: None,
+                });
+                return;
+            }
         };
         if let Some(enabled) = enabled {
+            assert!(
+                !self
+                    .delegate
+                    .observe_cmd
+                    .as_ref()
+                    .map_or(false, |o| o.enabled.load(Ordering::SeqCst)),
+                "{} observer already exists {:?} {:?}",
+                self.delegate.tag,
+                self.delegate.observe_cmd,
+                observe_id
+            );
             // TODO(cdc): take observe_cmd when enabled is false.
             self.delegate.observe_cmd = Some(ObserveCmd {
                 id: observe_id,
                 enabled,
             });
-        } else if let Some(observe_cmd) = self.delegate.observe_cmd.as_mut() {
-            observe_cmd.id = observe_id;
         }
 
         cb.invoke_read(resp);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
Sometimes the ordering of read requests will be changed.

### What is changed and how it works?
Check observe id for rejecting stale observe cmd.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
N/A