### PR TITLE
raftstore: add metrics for observing apply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,8 @@ dependencies = [
  "criterion",
  "crossbeam",
  "derive_more 0.99.3",
+ "lazy_static",
+ "prometheus",
  "slog",
  "slog-global",
  "tikv_util",

--- a/components/batch-system/Cargo.toml
+++ b/components/batch-system/Cargo.toml
@@ -9,10 +9,12 @@ test-runner = ["derive_more"]
 
 [dependencies]
 crossbeam = "0.7"
+lazy_static = "1.3"
 tikv_util = { path = "../tikv_util" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 derive_more = { version = "0.99", optional = true }
+prometheus = { version = "0.8", features = ["nightly", "push"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/batch-system/benches/batch-system.rs
+++ b/components/batch-system/benches/batch-system.rs
@@ -22,7 +22,7 @@ fn end_hook(tx: &std::sync::mpsc::Sender<()>) -> Message {
 /// A better router and lightweight batch scheduling can lead to better result.
 fn bench_spawn_many(c: &mut Criterion) {
     let (control_tx, control_fsm) = Runner::new(100000);
-    let (router, mut system) = batch_system::create_system(2, 2, control_tx, control_fsm);
+    let (router, mut system) = batch_system::create_system(2, 2, 2, control_tx, control_fsm);
     system.spawn("test".to_owned(), Builder::new());
     const ID_LIMIT: u64 = 32;
     const MESSAGE_LIMIT: usize = 256;
@@ -55,7 +55,7 @@ fn bench_spawn_many(c: &mut Criterion) {
 /// all available threads as soon as possible.
 fn bench_imbalance(c: &mut Criterion) {
     let (control_tx, control_fsm) = Runner::new(100000);
-    let (router, mut system) = batch_system::create_system(2, 2, control_tx, control_fsm);
+    let (router, mut system) = batch_system::create_system(2, 2, 2, control_tx, control_fsm);
     system.spawn("test".to_owned(), Builder::new());
     const ID_LIMIT: u64 = 10;
     const MESSAGE_LIMIT: usize = 512;
@@ -90,7 +90,7 @@ fn bench_imbalance(c: &mut Criterion) {
 /// A good scheduling algorithm should not starve the quick tasks.
 fn bench_fairness(c: &mut Criterion) {
     let (control_tx, control_fsm) = Runner::new(100000);
-    let (router, mut system) = batch_system::create_system(2, 2, control_tx, control_fsm);
+    let (router, mut system) = batch_system::create_system(2, 2, 2, control_tx, control_fsm);
     system.spawn("test".to_owned(), Builder::new());
     for id in 0..10 {
         let (normal_tx, normal_fsm) = Runner::new(100000);

--- a/components/batch-system/benches/router.rs
+++ b/components/batch-system/benches/router.rs
@@ -6,7 +6,7 @@ use criterion::*;
 
 fn bench_send(c: &mut Criterion) {
     let (control_tx, control_fsm) = Runner::new(100000);
-    let (router, mut system) = batch_system::create_system(2, 2, control_tx, control_fsm);
+    let (router, mut system) = batch_system::create_system(2, 2, 2, control_tx, control_fsm);
     system.spawn("test".to_owned(), Builder::new());
     let (normal_tx, normal_fsm) = Runner::new(100000);
     let normal_box = BasicMailbox::new(normal_tx, normal_fsm);

--- a/components/batch-system/src/batch.rs
+++ b/components/batch-system/src/batch.rs
@@ -160,7 +160,6 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
     pub fn reschedule(&mut self, router: &BatchRouter<N, C>, index: usize) {
         let mut fsm = self.normals.swap_remove(index);
         self.counters.swap_remove(index);
-        fsm.before_reschedule();
         router.normal_scheduler.schedule(fsm);
     }
 
@@ -303,6 +302,7 @@ impl<N: Fsm, C: Fsm, Handler: PollHandler<N, C>> Poller<N, C, Handler> {
                         // it's possible all the hot regions are fetched in a batch the
                         // next time.
                         if hot_fsm_count % 2 == 0 {
+                            p.before_reschedule();
                             reschedule_fsms.push((i, ReschedulePolicy::Schedule));
                             continue;
                         }

--- a/components/batch-system/src/batch.rs
+++ b/components/batch-system/src/batch.rs
@@ -296,7 +296,7 @@ impl<N: Fsm, C: Fsm, Handler: PollHandler<N, C>> Poller<N, C, Handler> {
                 if p.is_stopped() {
                     reschedule_fsms.push((i, ReschedulePolicy::Remove));
                 } else {
-                    if batch.counters[i] > 3 {
+                    if batch.counters[i] > 10 {
                         hot_fsm_count += 1;
                         // We should only reschedule a half of the hot regions, otherwise,
                         // it's possible all the hot regions are fetched in a batch the

--- a/components/batch-system/src/batch.rs
+++ b/components/batch-system/src/batch.rs
@@ -158,7 +158,7 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
 
     /// Schedule the normal FSM located at `index`.
     pub fn reschedule(&mut self, router: &BatchRouter<N, C>, index: usize) {
-        let mut fsm = self.normals.swap_remove(index);
+        let fsm = self.normals.swap_remove(index);
         self.counters.swap_remove(index);
         router.normal_scheduler.schedule(fsm);
     }

--- a/components/batch-system/src/fsm.rs
+++ b/components/batch-system/src/fsm.rs
@@ -44,6 +44,10 @@ pub trait Fsm {
     {
         None
     }
+
+    fn after_scheduled(&mut self) {}
+
+    fn before_reschedule(&mut self) {}
 }
 
 pub struct FsmState<N> {

--- a/components/batch-system/src/lib.rs
+++ b/components/batch-system/src/lib.rs
@@ -7,10 +7,15 @@ extern crate tikv_util;
 #[cfg(feature = "test-runner")]
 #[macro_use]
 extern crate derive_more;
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate prometheus;
 
 mod batch;
 mod fsm;
 mod mailbox;
+mod metrics;
 mod router;
 
 #[cfg(feature = "test-runner")]

--- a/components/batch-system/src/metrics.rs
+++ b/components/batch-system/src/metrics.rs
@@ -1,0 +1,10 @@
+use prometheus::IntCounterVec;
+
+lazy_static! {
+    pub static ref RESCHEDULE_FSM_COUNT: IntCounterVec = register_int_counter_vec!(
+        "batch_system_reschedule_count",
+        "The count of rescheduled fsms",
+        &["tag"]
+    )
+    .unwrap();
+}

--- a/components/batch-system/tests/cases/batch.rs
+++ b/components/batch-system/tests/cases/batch.rs
@@ -9,7 +9,7 @@ use tikv_util::mpsc;
 #[test]
 fn test_batch() {
     let (control_tx, control_fsm) = Runner::new(10);
-    let (router, mut system) = batch_system::create_system(2, 2, control_tx, control_fsm);
+    let (router, mut system) = batch_system::create_system(2, 2, 2, control_tx, control_fsm);
     let builder = Builder::new();
     let metrics = builder.metrics.clone();
     system.spawn("test".to_owned(), builder);

--- a/components/batch-system/tests/cases/router.rs
+++ b/components/batch-system/tests/cases/router.rs
@@ -28,7 +28,7 @@ fn test_basic() {
     let (control_tx, mut control_fsm) = Runner::new(10);
     let (control_drop_tx, control_drop_rx) = mpsc::unbounded();
     control_fsm.sender = Some(control_drop_tx);
-    let (router, mut system) = batch_system::create_system(2, 2, control_tx, control_fsm);
+    let (router, mut system) = batch_system::create_system(2, 2, 2, control_tx, control_fsm);
     let builder = Builder::new();
     system.spawn("test".to_owned(), builder);
 

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -161,6 +161,10 @@ pub struct Config {
     pub hibernate_regions: bool,
     #[config(hidden)]
     pub early_apply: bool,
+    #[config(hidden)]
+    pub apply_yield_count: usize,
+    #[config(hidden)]
+    pub reschedule_count: usize,
 
     // Deprecated! These two configuration has been moved to Coprocessor.
     // They are preserved for compatibility check.
@@ -240,6 +244,8 @@ impl Default for Config {
             future_poll_size: 1,
             hibernate_regions: true,
             early_apply: true,
+            apply_yield_count: 8,
+            reschedule_count: 16,
 
             // They are preserved for compatibility check.
             region_max_size: ReadableSize(0),

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -940,7 +940,7 @@ where
 
             if should_write_to_engine(&cmd) || apply_ctx.kv_wb().should_write_to_engine() {
                 apply_ctx.commit(self);
-                if self.written_count >= 16 {
+                if self.written_count >= 4 {
                     return ApplyResult::Yield;
                 }
                 self.written_count += 1;

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3008,8 +3008,14 @@ where
             }
         }
         if let Some(timer) = channel_timer {
-            let elapsed = duration_to_sec(timer.elapsed());
-            APPLY_TASK_WAIT_TIME_HISTOGRAM.observe(elapsed);
+            let elapsed = timer.elapsed();
+            slow_log!(
+                elapsed,
+                "region {} apply {:?} wait too long",
+                self.delegate.region_id(),
+                self.delegate.apply_state,
+            );
+            APPLY_TASK_WAIT_TIME_HISTOGRAM.observe(duration_to_sec(elapsed));
         }
     }
 }

--- a/components/raftstore/src/store/fsm/metrics.rs
+++ b/components/raftstore/src/store/fsm/metrics.rs
@@ -34,6 +34,12 @@ lazy_static! {
         exponential_buckets(1.0, 2.0, 20).unwrap()
     )
     .unwrap();
+    pub static ref APPLY_EXECUTE_DURATION: Histogram = register_histogram!(
+        "tikv_raftstore_apply_execute_wait_duration_secs",
+        "The interval of a fsm was handled",
+        exponential_buckets(1.0, 2.0, 20).unwrap()
+    )
+    .unwrap();
 }
 
 #[derive(Default)]

--- a/components/raftstore/src/store/fsm/metrics.rs
+++ b/components/raftstore/src/store/fsm/metrics.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use prometheus::{exponential_buckets, Histogram};
+use prometheus::{exponential_buckets, Histogram, IntCounter};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -8,6 +8,29 @@ lazy_static! {
     pub static ref APPLY_PROPOSAL: Histogram = register_histogram!(
         "tikv_raftstore_apply_proposal",
         "The count of proposals sent by a region at once",
+        exponential_buckets(1.0, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref APPLY_BATCH_BYTES: Histogram = register_histogram!(
+        "tikv_raftstore_apply_batch_bytes",
+        "Histogram of bytes each apply commit",
+        exponential_buckets(1.0, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref APPLY_BATCH_KEYS: Histogram = register_histogram!(
+        "tikv_raftstore_apply_batch_keys",
+        "Histogram of keys each apply commit",
+        exponential_buckets(1.0, 2.0, 30).unwrap()
+    )
+    .unwrap();
+    pub static ref APPLY_YIELD_COUNT: IntCounter = register_int_counter!(
+        "tikv_raftstore_apply_yield_count",
+        "The count of yield fsms"
+    )
+    .unwrap();
+    pub static ref APPLY_RESCHEDULE_WAIT_DURATION: Histogram = register_histogram!(
+        "tikv_raftstore_apply_reschedule_wait_duration_secs",
+        "The interval of a fsm was rescheduled",
         exponential_buckets(1.0, 2.0, 20).unwrap()
     )
     .unwrap();

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1232,6 +1232,7 @@ pub fn create_raft_batch_system(cfg: &Config) -> (RaftRouter<RocksEngine>, RaftB
     let (router, system) = batch_system::create_system(
         cfg.store_pool_size,
         cfg.store_max_batch_size,
+        cfg.reschedule_count,
         store_tx,
         store_fsm,
     );


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Lack of metrics for observing apply progress.

### What is changed and how it works?

What's Changed:
Add metrics for batch system and apply worker.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->
Add more metrics for observing apply progress.