### PR TITLE
tidb_query_vec_executors: Fixed stack-borrowing undefined-behavior

### DIFF
--- a/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
@@ -277,7 +277,6 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SlowHashAggregationImp
             )?;
         }
 
-        let buffer_ptr = (&*self.group_key_buffer).into();
         for logical_row_idx in 0..logical_rows_len {
             let offset_begin = self.group_key_buffer.len();
 
@@ -361,6 +360,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SlowHashAggregationImp
                 }
             }
 
+            let buffer_ptr = (&*self.group_key_buffer).into();
             // Extra column is not included in `GroupKeyRefUnsafe` to avoid being aggr on.
             let group_key_ref_unsafe = GroupKeyRefUnsafe {
                 buffer_ptr,


### PR DESCRIPTION
### What problem does this PR solve?

This fixes undefined behavior in tidb_query_vec_executors. Miri reports a [stacked borrowing] error as described below.

[stacked borrowing]: https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md

Note that stacked borrowing is a way to model Rust's use of unsafe pointers, but is not officially part of Rust's memory model. Thus, this is not truly undefined behavior today, but could be eventually.

I don't understand the stacked borrowing rules enough to understand why the
existing code is a violation. It is creating a mutable unsafe pointer; then
taking some immutable borrows to the same data while doing nothing with that
pointer; then later using the pointer.

Simply moving the creation of the unsafe pointer to immediately before it
is used removes the error.

cc @RalfJung not sure if you like being tagged on miri stacked borrow reports. If you have time though maybe you could explain what's going on here.

Found with miri, which reports:

```
error: Undefined Behavior: trying to reborrow for SharedReadOnly, but parent tag <1121039> does not have an appropriate item in the borrow sta
ck
   --> components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs:281:32
    |
281 |             let offset_begin = self.group_key_buffer.len();
    |                                ^^^^^^^^^^^^^^^^^^^^^ trying to reborrow for SharedReadOnly, but parent tag <1121039> does not have an ap
propriate item in the borrow stack
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
```

Signed-off-by: Brian Anderson <andersrb@gmail.com>

