### PR TITLE
tidb_query_vec_executors: Replace servo_arc with std Arc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3728,16 +3728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "servo_arc"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
-dependencies = [
- "nodrop",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3910,12 +3900,6 @@ dependencies = [
  "txn_types",
  "uuid",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "standback"
@@ -4536,7 +4520,6 @@ dependencies = [
  "hex 0.3.2",
  "kvproto",
  "match_template",
- "servo_arc",
  "slog",
  "slog-global",
  "smallvec 0.6.10",

--- a/components/tidb_query_vec_executors/Cargo.toml
+++ b/components/tidb_query_vec_executors/Cargo.toml
@@ -10,7 +10,6 @@ codec = { path = "../codec" }
 hex = "0.3"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 match_template = { path = "../match_template" }
-servo_arc = "0.1.1"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 smallvec = "0.6"

--- a/components/tidb_query_vec_executors/src/top_n_executor.rs
+++ b/components/tidb_query_vec_executors/src/top_n_executor.rs
@@ -3,8 +3,7 @@
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::ptr::NonNull;
-
-use servo_arc::Arc;
+use std::sync::Arc;
 
 use tipb::{Expr, FieldType, TopN};
 


### PR DESCRIPTION
### What problem does this PR solve?

servo_arc contains undefined behavior that surfaces in our test suite, as
reported by miri:

> https://github.com/servo/servo/issues/26358

This fixes the problem by using the standard Arc type. This means that these Arcs will be larger to make room for weak pointers.

In the linked issue I have suggested that servo publish an updated servo_arc.