### PR TITLE
copr: Port of the scalar function AddDurationAndString from TiDB

### DIFF
--- a/components/tidb_query_vec_expr/src/impl_time.rs
+++ b/components/tidb_query_vec_expr/src/impl_time.rs
@@ -964,13 +964,9 @@ mod tests {
         let cases = vec![
             (None, Some(b"11:30:45.123456".to_vec()), None),
             (None, None, None),
+            (zero_duration, zero_duration_string.clone(), zero_duration),
             (
-                zero_duration.clone(),
-                zero_duration_string.clone(),
-                zero_duration.clone(),
-            ),
-            (
-                zero_duration.clone(),
+                zero_duration,
                 Some(b"01:00:00".to_vec()),
                 Some(Duration::parse(&mut ctx, b"01:00:00", 6).unwrap()),
             ),

--- a/components/tidb_query_vec_expr/src/lib.rs
+++ b/components/tidb_query_vec_expr/src/lib.rs
@@ -557,6 +557,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::PeriodAdd => period_add_fn_meta(),
         ScalarFuncSig::PeriodDiff => period_diff_fn_meta(),
         ScalarFuncSig::LastDay => last_day_fn_meta(),
+        ScalarFuncSig::AddDurationAndString => add_duration_and_string_fn_meta(),
         _ => return Err(other_err!(
             "ScalarFunction {:?} is not supported in batch mode",
             value


### PR DESCRIPTION
### What problem does this PR solve?

close #6847 
UCP #6847 

### What is changed and how it works?

What's Changed: Port the scalar function AddDurationAndString from TiDB to coprocessor.

### Related changes

n/a

### Check List

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
n/a