### PR TITLE
external_storage: fix GCS download error, support GCS endpoints, and refactoring

### DIFF
--- a/components/external_storage/src/util.rs
+++ b/components/external_storage/src/util.rs
@@ -57,6 +57,14 @@ pub fn error_stream(e: io::Error) -> impl Stream<Item = io::Result<Bytes>> + Unp
 }
 
 /// Runs a future on the current thread involving external storage.
+///
+/// # Caveat
+///
+/// This function must never be nested. The future invoked by
+/// `block_on_external_io` must never call `block_on_external_io` again itself,
+/// otherwise the executor's states may be disrupted.
+///
+/// This means the future must only use async functions.
 // FIXME: get rid of this function, so that futures_executor::block_on is sufficient.
 pub fn block_on_external_io<F: Future>(f: F) -> F::Output {
     // we need a Tokio runtime rather than futures_executor::block_on because

--- a/components/sst_importer/src/errors.rs
+++ b/components/sst_importer/src/errors.rs
@@ -87,7 +87,7 @@ quick_error! {
         }
         CannotReadExternalStorage(url: String, name: String, err: IoError) {
             cause(err)
-            display("Cannot read {}/{}", url, name)
+            display("Cannot read {}/{}: {}", url, name, err)
         }
         WrongKeyPrefix(what: &'static str, key: Vec<u8>, prefix: Vec<u8>) {
             display("\

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{self, Write};
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -123,11 +123,11 @@ impl SSTImporter {
         );
         match self.do_download::<E>(meta, backend, name, rewrite_rule, speed_limiter, sst_writer) {
             Ok(r) => {
-                info!("download"; "meta" => ?meta, "url" => %url_of_backend(backend), "range" => ?r);
+                info!("download"; "meta" => ?meta, "name" => name, "range" => ?r);
                 Ok(r)
             }
             Err(e) => {
-                error!("download failed"; "meta" => ?meta, "url" => %url_of_backend(backend), "err" => %e);
+                error!("download failed"; "meta" => ?meta, "name" => name, "err" => %e);
                 Err(e)
             }
         }
@@ -163,8 +163,18 @@ impl SSTImporter {
                     Error::CannotReadExternalStorage(url.to_string(), name.to_owned(), e)
                 })?;
             if meta.length != 0 && meta.length != file_length {
-                let reason = format!("length {}, expect {}", file_length, meta.length);
-                return Err(Error::FileCorrupted(path.temp, reason));
+                let reason = format!(
+                    "downloaded size {}, expected {}, local path {}",
+                    file_length,
+                    meta.length,
+                    path.temp.display()
+                );
+                let reason = io::Error::new(io::ErrorKind::InvalidData, reason);
+                return Err(Error::CannotReadExternalStorage(
+                    url.to_string(),
+                    name.to_owned(),
+                    reason,
+                ));
             }
             IMPORTER_DOWNLOAD_BYTES.observe(file_length as _);
             OpenOptions::new()

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -123,11 +123,11 @@ impl SSTImporter {
         );
         match self.do_download::<E>(meta, backend, name, rewrite_rule, speed_limiter, sst_writer) {
             Ok(r) => {
-                info!("download"; "meta" => ?meta, "range" => ?r);
+                info!("download"; "meta" => ?meta, "url" => %url_of_backend(backend), "range" => ?r);
                 Ok(r)
             }
             Err(e) => {
-                error!("download failed"; "meta" => ?meta, "err" => %e);
+                error!("download failed"; "meta" => ?meta, "url" => %url_of_backend(backend), "err" => %e);
                 Err(e)
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7625

Problem Summary:

It was found that the GCS external_storage can only download 8 KB of data. This PR fixes the issue.

Additionally, tame_gcs hard-coded the request URLs, making the custom endpoint ineffective (EmbarkStudios/tame-gcs#21). This PR also workarounds the issue through URL rewriting.

### What is changed and how it works?

What's Changed:

The problem is caused by using `block_on_external_io` recursively. This seems to break Tokio's executor and caused the download stream to end after a single call of `poll_read` (where the buffer size is 8 KB). 

This PR fixes the problem by removing all nested `block_on_external_io` and replace them by `async fn`.

### Related changes

- Need to cherry-pick to the release branch
   * need to cherry-pick to release-4.0.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
    * Restore through `fake-gcs-server` works.

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

Restoring a backup archive from GCS now works.