### PR TITLE
build: remove unstable build option -Zconfig-profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,9 +342,8 @@ docker:
 
 # Cargo only has two non-test profiles, dev and release, and we have
 # more than two use cases for which a cargo profile is required. This
-# is a hack to manage more cargo profiles, written in
-# `etc/cargo.config.*`. These make use of the unstable
-# `-Zconfig-profile` cargo option to specify profiles in
+# is a hack to manage more cargo profiles, written in `etc/cargo.config.*`.
+# So we use cargo `config-profile` feature to specify profiles in
 # `.cargo/config`, which `scripts/run-cargo.sh copies into place.
 #
 # Presently the only thing this is used for is the `dist_release`

--- a/scripts/run-cargo.sh
+++ b/scripts/run-cargo.sh
@@ -44,7 +44,6 @@ fi
 
 if [[ -n "$X_CARGO_CONFIG_FILE" ]]; then
     echo "using $X_CARGO_CONFIG_FILE"
-    args="$args -Zunstable-options -Zconfig-profile"
     mkdir .cargo 2> /dev/null || true
     set -x
     cp "$X_CARGO_CONFIG_FILE" .cargo/config


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Remove unstable build option `-Zconfig-profile` as this option is already stabled by https://github.com/rust-lang/cargo/pull/7823 in [1.43.0](https://github.com/XAMPPRocky/rust/blob/master/RELEASES.md)

```
$ make dist_release
error: unknown `-Z` flag specified: config-profile
```

### What is changed and how it works?

What's Changed:
fix build script by remove outdated build option


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects


### Release note <!-- bugfixes or new feature need a release note -->