### PR TITLE
tests: make read_on_replica stable

### DIFF
--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -132,6 +132,7 @@ fn test_read_index_on_replica() {
 fn test_read_on_replica() {
     let count = 3;
     let mut cluster = new_server_cluster(0, count);
+    cluster.cfg.raft_store.hibernate_regions = false;
     cluster.run();
 
     let k1 = b"k1";


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #6072 <!-- REMOVE this line if no issue to close -->

Problem Summary:

When region is hibernated, first replica read after restart can fail.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test