### PR TITLE
Fix two instances of undefined behavior in codec crate

### DIFF
--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -1055,12 +1055,11 @@ mod tests {
             let output_len = unsafe {
                 let src_ptr = buffer.as_mut_ptr().add(encoded_prefix_len);
                 let slice_len = buffer.len() - encoded_prefix_len;
-                let src = std::slice::from_raw_parts(src_ptr, slice_len);
-                let dest = std::slice::from_raw_parts_mut(src_ptr, slice_len);
+                let buf = std::slice::from_raw_parts_mut(src_ptr, slice_len);
                 if is_desc {
-                    MemComparableByteCodec::try_decode_first_desc(src, dest).unwrap()
+                    MemComparableByteCodec::try_decode_first_in_place_desc(buf).unwrap()
                 } else {
-                    MemComparableByteCodec::try_decode_first(src, dest).unwrap()
+                    MemComparableByteCodec::try_decode_first_in_place(buf).unwrap()
                 }
             };
             assert_eq!(output_len.0, encoded_len);


### PR DESCRIPTION
### What problem does this PR solve?

Fix two instances of undefined behavior in codec crate, in in `MemComparableBytesCodec::try_decode_first_internal` and one in its tests.

Case 1: This function constructs a pointer called `src_ptr_next` to the next place it is going to need to look for data to decode. In the error case, this pointer points beyond its allocation, which is not allowed, and is undefined behavior. This patch changes that code path to use the `offset_from` function to instead calculate whether the difference from the current, valid pointer, to the next location, will be in-bounds.

Case 2: A test case is constructing two overlapping slices, one of them mutable, in order to test the behavior of the decoder for overlapping slices. This is undefined behavior. I've changed the test to use the `in_place` versions of the functions, which don't require overlapping slices.