### PR TITLE
*: Add config to avoid logging user data to info log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "keys",
  "kvproto",
  "lazy_static",
+ "log_wrappers",
  "prometheus",
  "raft",
  "raftstore",
@@ -474,9 +475,9 @@ dependencies = [
  "failure",
  "futures 0.1.29",
  "grpcio",
- "hex 0.4.2",
  "kvproto",
  "lazy_static",
+ "log_wrappers",
  "panic_hook",
  "pd_client",
  "prometheus",
@@ -596,6 +597,7 @@ dependencies = [
  "kvproto",
  "libc",
  "log",
+ "log_wrappers",
  "nix 0.11.1",
  "pd_client",
  "prometheus",
@@ -1118,7 +1120,7 @@ dependencies = [
 name = "engine_traits"
 version = "0.0.1"
 dependencies = [
- "hex 0.4.2",
+ "log_wrappers",
  "protobuf",
  "quick-error",
  "slog",
@@ -2104,6 +2106,8 @@ name = "log_wrappers"
 version = "0.0.1"
 dependencies = [
  "hex 0.4.2",
+ "kvproto",
+ "protobuf",
  "slog",
  "slog-term",
  "tikv_alloc",
@@ -2605,10 +2609,10 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.29",
  "grpcio",
- "hex 0.4.2",
  "kvproto",
  "lazy_static",
  "log",
+ "log_wrappers",
  "prometheus",
  "quick-error",
  "serde",
@@ -3364,6 +3368,7 @@ name = "resolved_ts"
 version = "0.0.1"
 dependencies = [
  "hex 0.4.2",
+ "log_wrappers",
  "slog",
  "slog-global",
  "tikv_util",
@@ -3886,6 +3891,7 @@ dependencies = [
  "keys",
  "kvproto",
  "lazy_static",
+ "log_wrappers",
  "prometheus",
  "quick-error",
  "serde",
@@ -5160,6 +5166,7 @@ dependencies = [
  "farmhash",
  "hex 0.4.2",
  "kvproto",
+ "log_wrappers",
  "quick-error",
  "slog",
  "tikv_alloc",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -66,6 +66,7 @@ keys = { path = "../components/keys" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
+log_wrappers = { path = "../components/log_wrappers" }
 nix = "0.11"
 pd_client = { path = "../components/pd_client" }
 prometheus = { version = "0.8", features = ["nightly", "push"] }

--- a/cmd/src/setup.rs
+++ b/cmd/src/setup.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use chrono::Local;
 use clap::ArgMatches;
+use kvproto::encryptionpb::EncryptionMethod;
 use tikv::config::{check_critical_config, persist_config, MetricConfig, TiKvConfig};
 use tikv_util::collections::HashMap;
 use tikv_util::{self, logger};
@@ -109,6 +110,15 @@ pub fn initial_logger(config: &TiKvConfig) {
             });
         };
     };
+
+    // Set redact_info_log.
+    let redact_info_log = if let Some(redact_info_log) = config.security.redact_info_log {
+        redact_info_log
+    } else {
+        config.encryption.data_encryption_method != EncryptionMethod::Plaintext
+    };
+    log_wrappers::set_redact_info_log(redact_info_log);
+
     LOG_INITIALIZED.store(true, Ordering::SeqCst);
 }
 

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -54,6 +54,7 @@ hex = "0.4"
 keys = { path = "../keys" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
+log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.8", default-features = false, features = ["nightly", "push"] }
 raft = { version = "0.6.0-alpha", default-features = false }
 raftstore = { path = "../raftstore" }

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -652,8 +652,8 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
                 Ok((mut files, stat)) => {
                     debug!("backup region finish";
                         "region" => ?brange.region,
-                        "start_key" => hex::encode_upper(&start_key),
-                        "end_key" => hex::encode_upper(&end_key),
+                        "start_key" => log_wrappers::Key(&start_key),
+                        "end_key" => log_wrappers::Key(&end_key),
                         "details" => ?stat);
                     summary.add(&stat);
                     // Fill key range and ts.
@@ -668,8 +668,8 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
                 Err(e) => {
                     error!("backup region failed";
                         "region" => ?brange.region,
-                        "start_key" => hex::encode_upper(response.get_start_key()),
-                        "end_key" => hex::encode_upper(response.get_end_key()),
+                        "start_key" => log_wrappers::Key(&response.get_start_key()),
+                        "end_key" => log_wrappers::Key(&response.get_end_key()),
                         "error" => ?e);
                     response.set_error(e.into());
                 }

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -34,12 +34,12 @@ mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
 
 [dependencies]
-hex = "0.4"
 engine_rocks = { path = "../engine_rocks" }
 failure = "0.1"
 futures = "0.1"
 grpcio = { version = "0.5", default-features = false, features = ["openssl-vendored"] }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+log_wrappers = { path = "../log_wrappers" }
 pd_client = { path = "../pd_client" }
 raft = { version = "0.6.0-alpha", default-features = false }
 raftstore = { path = "../raftstore" }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -679,7 +679,7 @@ fn decode_write(key: Vec<u8>, value: &[u8], row: &mut EventRow) -> bool {
         WriteType::Delete => (EventRowOpType::Delete, EventLogType::Commit),
         WriteType::Rollback => (EventRowOpType::Unknown, EventLogType::Rollback),
         other => {
-            debug!("skip write record"; "write" => ?other, "key" => hex::encode_upper(key));
+            debug!("skip write record"; "write" => ?other, "key" => log_wrappers::Key(&key));
             return true;
         }
     };
@@ -710,7 +710,7 @@ fn decode_lock(key: Vec<u8>, value: &[u8], row: &mut EventRow) -> bool {
             debug!("skip lock record";
                 "type" => ?other,
                 "start_ts" => ?lock.ts,
-                "key" => hex::encode_upper(key),
+                "key" => log_wrappers::Key(&key),
                 "for_update_ts" => ?lock.for_update_ts);
             return true;
         }

--- a/components/engine_traits/Cargo.toml
+++ b/components/engine_traits/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-hex = "0.4"
+log_wrappers = { path = "../log_wrappers" }
 protobuf = "2"
 quick-error = "1.2.3"
 tikv_alloc = { path = "../tikv_alloc" }

--- a/components/engine_traits/src/errors.rs
+++ b/components/engine_traits/src/errors.rs
@@ -14,7 +14,7 @@ quick_error! {
         NotInRange( key: Vec<u8>, region_id: u64, start: Vec<u8>, end: Vec<u8>) {
             display(
                 "Key {} is out of [region {}] [{}, {})",
-                hex::encode_upper(&key), region_id, hex::encode_upper(&start), hex::encode_upper(&end)
+                log_wrappers::Key(&key), region_id, log_wrappers::Key(&start), log_wrappers::Key(&end)
             )
         }
         Protobuf(err: protobuf::ProtobufError) {

--- a/components/log_wrappers/Cargo.toml
+++ b/components/log_wrappers/Cargo.toml
@@ -6,6 +6,8 @@ publish = false
 
 [dependencies]
 hex = "0.4"
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+protobuf = "2.8"
 slog = "2.3"
 slog-term = "2.4"
 tikv_alloc = { path = "../tikv_alloc" }

--- a/components/log_wrappers/src/lib.rs
+++ b/components/log_wrappers/src/lib.rs
@@ -7,6 +7,14 @@ extern crate slog;
 #[allow(unused_extern_crates)]
 extern crate tikv_alloc;
 
+use std::{
+    fmt,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+pub mod proto;
+pub use crate::proto::*;
+
 pub mod test_util;
 
 /// Wraps any `Display` type, use `Display` as `slog::Value`.
@@ -76,6 +84,14 @@ fn test_debug() {
     assert_eq!(&buffer.as_string(), "TIME INFO foo, bar: None\n");
 }
 
+// Log user data to info log only when this flag is set to false.
+static REDACT_INFO_LOG: AtomicBool = AtomicBool::new(false);
+
+/// Set whether we should avoid user data to slog.
+pub fn set_redact_info_log(v: bool) {
+    REDACT_INFO_LOG.store(v, Ordering::SeqCst);
+}
+
 pub struct Key<'a>(pub &'a [u8]);
 
 impl<'a> slog::Value for Key<'a> {
@@ -86,7 +102,119 @@ impl<'a> slog::Value for Key<'a> {
         key: slog::Key,
         serializer: &mut dyn slog::Serializer,
     ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{}", hex::encode_upper(self.0)))
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            serializer.emit_arguments(key, &format_args!("<key>"))
+        } else {
+            serializer.emit_arguments(key, &format_args!("{}", hex::encode_upper(self.0)))
+        }
+    }
+}
+
+impl<'a> fmt::Display for Key<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            // Print placeholder instead of the key itself.
+            write!(f, "<key>")
+        } else {
+            write!(f, "{}", hex::encode_upper(self.0))
+        }
+    }
+}
+
+impl<'a> fmt::Debug for Key<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            // Print placeholder instead of the key itself.
+            write!(f, "<key>")
+        } else {
+            write!(f, "{}", hex::encode_upper(self.0))
+        }
+    }
+}
+
+pub struct Value<'a>(pub &'a [u8]);
+
+impl<'a> slog::Value for Value<'a> {
+    #[inline]
+    fn serialize(
+        &self,
+        _record: &::slog::Record<'_>,
+        key: slog::Key,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            serializer.emit_arguments(key, &format_args!("<value>"))
+        } else {
+            serializer.emit_arguments(key, &format_args!("{}", hex::encode_upper(self.0)))
+        }
+    }
+}
+
+impl<'a> fmt::Display for Value<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            // Print placeholder instead of the key itself.
+            write!(f, "<value>")
+        } else {
+            write!(f, "{}", hex::encode_upper(self.0))
+        }
+    }
+}
+
+impl<'a> fmt::Debug for Value<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            // Print placeholder instead of the key itself.
+            write!(f, "<value>")
+        } else {
+            write!(f, "{}", hex::encode_upper(self.0))
+        }
+    }
+}
+
+pub struct Prefix<'a>(pub &'a [u8]);
+
+impl<'a> slog::Value for Prefix<'a> {
+    #[inline]
+    fn serialize(
+        &self,
+        _record: &::slog::Record<'_>,
+        key: slog::Key,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            serializer.emit_arguments(key, &format_args!("<prefix>"))
+        } else {
+            serializer.emit_arguments(key, &format_args!("{}", hex::encode_upper(self.0)))
+        }
+    }
+}
+
+impl<'a> fmt::Display for Prefix<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            // Print placeholder instead of the key itself.
+            write!(f, "<prefix>")
+        } else {
+            write!(f, "{}", hex::encode_upper(self.0))
+        }
+    }
+}
+
+impl<'a> fmt::Debug for Prefix<'a> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            // Print placeholder instead of the key itself.
+            write!(f, "<prefix>")
+        } else {
+            write!(f, "{}", hex::encode_upper(self.0))
+        }
     }
 }
 
@@ -97,4 +225,14 @@ fn test_log_key() {
     let logger = buffer.build_logger();
     slog_info!(logger, "foo"; "bar" => Key(b"\xAB \xCD"));
     assert_eq!(&buffer.as_string(), "TIME INFO foo, bar: AB20CD\n");
+}
+
+#[cfg(test)]
+#[test]
+fn test_redact_info_log() {
+    let buffer = crate::test_util::SyncLoggerBuffer::new();
+    let logger = buffer.build_logger();
+    set_redact_info_log(true);
+    slog_info!(logger, "foo"; "bar" => Key(b"\xAB \xCD"));
+    assert_eq!(&buffer.as_string(), "TIME INFO foo\n");
 }

--- a/components/log_wrappers/src/proto.rs
+++ b/components/log_wrappers/src/proto.rs
@@ -1,0 +1,319 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use crate::REDACT_INFO_LOG;
+
+use kvproto::{
+    import_sstpb::{Range, RewriteRule, SstMeta},
+    metapb::Region,
+    pdpb::Merge,
+    raft_cmdpb::{
+        AdminRequest, BatchSplitRequest, CommitMergeRequest, DeleteRangeRequest, DeleteRequest,
+        GetRequest, IngestSstRequest, PrepareMergeRequest, PrewriteRequest, PutRequest,
+        RaftCmdRequest, Request, SplitRequest,
+    },
+};
+use protobuf::PbPrint;
+use std::{fmt, sync::atomic::Ordering};
+
+pub struct ProtobufValue<'a, T>(pub &'a T);
+
+impl<'a, T> slog::Value for ProtobufValue<'a, T>
+where
+    ProtobufValue<'a, T>: fmt::Debug,
+{
+    #[inline]
+    fn serialize(
+        &self,
+        _record: &::slog::Record<'_>,
+        key: slog::Key,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        serializer.emit_arguments(key, &format_args!("{:?}", self))
+    }
+}
+
+impl<'a, T> PbPrint for ProtobufValue<'a, T>
+where
+    ProtobufValue<'a, T>: fmt::Debug,
+{
+    #[inline]
+    fn fmt(&self, name: &str, buf: &mut String) {
+        protobuf::push_message_start(name, buf);
+        buf.push_str(&format!(" {:?} }}", self));
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, Region> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            let mut s = String::new();
+            PbPrint::fmt(&self.0.id, "id", &mut s);
+            s.push_str(" start_key: <start_key>");
+            s.push_str(" end_key: <end_key>");
+            PbPrint::fmt(&self.0.region_epoch, "region_epoch", &mut s);
+            PbPrint::fmt(&self.0.peers, "peers", &mut s);
+            write!(f, "{}", s)
+        } else {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, Merge> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut s = String::new();
+        let target = format!("{:?}", ProtobufValue(self.0.get_target()));
+        PbPrint::fmt(&target, "target", &mut s);
+        write!(f, "{}", s)
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, Range> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            let mut s = String::new();
+            s.push_str(" start: <start>");
+            s.push_str(" end: <end>");
+            write!(f, "{}", s)
+        } else {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, RewriteRule> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            let mut s = String::new();
+            s.push_str(" old_key_prefix: <old_key_prefix>");
+            s.push_str(" new_key_prefix: <new_key_prefix>");
+            PbPrint::fmt(&self.0.new_timestamp, "new_timestamp", &mut s);
+            write!(f, "{}", s)
+        } else {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, SstMeta> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut s = String::new();
+        PbPrint::fmt(&self.0.uuid, "uuid", &mut s);
+        let range = ProtobufValue(self.0.get_range());
+        PbPrint::fmt(&range, "range", &mut s);
+        PbPrint::fmt(&self.0.crc32, "crc32", &mut s);
+        PbPrint::fmt(&self.0.length, "length", &mut s);
+        PbPrint::fmt(&self.0.cf_name, "cf_name", &mut s);
+        PbPrint::fmt(&self.0.region_id, "region_id", &mut s);
+        PbPrint::fmt(&self.0.region_epoch, "region_epoch", &mut s);
+        write!(f, "{}", s)
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, GetRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            let mut s = String::new();
+            PbPrint::fmt(&self.0.cf, "cf", &mut s);
+            s.push_str(" key: <key>");
+            write!(f, "{}", s)
+        } else {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, PutRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            let mut s = String::new();
+            PbPrint::fmt(&self.0.cf, "cf", &mut s);
+            s.push_str(" key: <key>");
+            s.push_str(" value: <value>");
+            write!(f, "{}", s)
+        } else {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, DeleteRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            let mut s = String::new();
+            PbPrint::fmt(&self.0.cf, "cf", &mut s);
+            s.push_str(" key: <key>");
+            write!(f, "{}", s)
+        } else {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, DeleteRangeRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            let mut s = String::new();
+            PbPrint::fmt(&self.0.cf, "cf", &mut s);
+            s.push_str(" start_key: <start_key>");
+            s.push_str(" end_key: <end_key>");
+            PbPrint::fmt(&self.0.notify_only, "notify_only", &mut s);
+            write!(f, "{}", s)
+        } else {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, PrewriteRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            let mut s = String::new();
+            s.push_str(" key: <key>");
+            s.push_str(" value: <value>");
+            PbPrint::fmt(&self.0.lock, "lock", &mut s);
+            write!(f, "{}", s)
+        } else {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, IngestSstRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut s = String::new();
+        let sst = ProtobufValue(self.0.get_sst());
+        PbPrint::fmt(&sst, "sst", &mut s);
+        write!(f, "{}", s)
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, Request> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut s = String::new();
+        PbPrint::fmt(&self.0.cmd_type, "cmd_type", &mut s);
+        let get = ProtobufValue(self.0.get_get());
+        PbPrint::fmt(&get, "get", &mut s);
+        let put = ProtobufValue(self.0.get_put());
+        PbPrint::fmt(&put, "put", &mut s);
+        let delete = ProtobufValue(self.0.get_delete());
+        PbPrint::fmt(&delete, "delete", &mut s);
+        PbPrint::fmt(&self.0.snap, "snap", &mut s);
+        let prewrite = ProtobufValue(self.0.get_prewrite());
+        PbPrint::fmt(&prewrite, "prewrite", &mut s);
+        let delete_range = ProtobufValue(self.0.get_delete_range());
+        PbPrint::fmt(&delete_range, "delete_range", &mut s);
+        let ingest_sst = ProtobufValue(self.0.get_ingest_sst());
+        PbPrint::fmt(&ingest_sst, "ingest_sst", &mut s);
+        PbPrint::fmt(&self.0.read_index, "read_index", &mut s);
+        write!(f, "{}", s)
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, SplitRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if REDACT_INFO_LOG.load(Ordering::SeqCst) {
+            let mut s = String::new();
+            s.push_str(" split_key: <split_key>");
+            PbPrint::fmt(&self.0.new_region_id, "new_region_id", &mut s);
+            PbPrint::fmt(&self.0.new_peer_ids, "new_peer_ids", &mut s);
+            PbPrint::fmt(&self.0.right_derive, "right_derive", &mut s);
+            write!(f, "{}", s)
+        } else {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, BatchSplitRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut s = String::new();
+        let requests = self
+            .0
+            .get_requests()
+            .iter()
+            .map(ProtobufValue)
+            .collect::<Vec<_>>();
+        PbPrint::fmt(&requests, "requests", &mut s);
+        PbPrint::fmt(&self.0.right_derive, "right_derive", &mut s);
+        write!(f, "{}", s)
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, PrepareMergeRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut s = String::new();
+        PbPrint::fmt(&self.0.min_index, "min_index", &mut s);
+        let target = ProtobufValue(self.0.get_target());
+        PbPrint::fmt(&target, "target", &mut s);
+        write!(f, "{}", s)
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, CommitMergeRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut s = String::new();
+        let source = ProtobufValue(self.0.get_source());
+        PbPrint::fmt(&source, "source", &mut s);
+        PbPrint::fmt(&self.0.commit, "commit", &mut s);
+        PbPrint::fmt(&self.0.entries, "entries", &mut s);
+        write!(f, "{}", s)
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, AdminRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut s = String::new();
+        PbPrint::fmt(&self.0.cmd_type, "cmd_type", &mut s);
+        PbPrint::fmt(&self.0.change_peer, "change_peer", &mut s);
+        let split = ProtobufValue(self.0.get_split());
+        PbPrint::fmt(&split, "split", &mut s);
+        PbPrint::fmt(&self.0.compact_log, "compact_log", &mut s);
+        PbPrint::fmt(&self.0.transfer_leader, "transfer_leader", &mut s);
+        PbPrint::fmt(&self.0.verify_hash, "verify_hash", &mut s);
+        let prepare_merge = ProtobufValue(self.0.get_prepare_merge());
+        PbPrint::fmt(&prepare_merge, "prepare_merge", &mut s);
+        let commit_merge = ProtobufValue(self.0.get_commit_merge());
+        PbPrint::fmt(&commit_merge, "commit_merge", &mut s);
+        PbPrint::fmt(&self.0.rollback_merge, "rollback_merge", &mut s);
+        let splits = ProtobufValue(self.0.get_splits());
+        PbPrint::fmt(&splits, "splits", &mut s);
+        write!(f, "{}", s)
+    }
+}
+
+impl<'a> fmt::Debug for ProtobufValue<'a, RaftCmdRequest> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut s = String::new();
+        PbPrint::fmt(&self.0.header, "header", &mut s);
+        let requests = self
+            .0
+            .get_requests()
+            .iter()
+            .map(ProtobufValue)
+            .collect::<Vec<_>>();
+        PbPrint::fmt(&requests, "requests", &mut s);
+        let admin_request = ProtobufValue(self.0.get_admin_request());
+        PbPrint::fmt(&admin_request, "admin_request", &mut s);
+        PbPrint::fmt(&self.0.status_request, "status_request", &mut s);
+        write!(f, "{}", s)
+    }
+}

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -19,10 +19,10 @@ prost-codec = [
 [dependencies]
 futures = "0.1"
 grpcio = { version = "0.5", default-features = false, features = ["openssl-vendored"] }
-hex = "0.4"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
+log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.8", features = ["nightly", "push"] }
 quick-error = "1.2.3"
 serde = "1.0"

--- a/components/pd_client/src/errors.rs
+++ b/components/pd_client/src/errors.rs
@@ -31,7 +31,7 @@ quick_error! {
             display("unknown error {:?}", err)
         }
         RegionNotFound(key: Vec<u8>) {
-            display("region is not found for key {}", hex::encode_upper(key))
+            display("region is not found for key {}", log_wrappers::Key(&key))
         }
         StoreTombstone(msg: String) {
             display("store is tombstone {:?}", msg)

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -9,7 +9,6 @@ extern crate quick_error;
 extern crate serde_derive;
 #[macro_use]
 extern crate slog_global;
-extern crate hex;
 extern crate kvproto;
 
 #[allow(unused_extern_crates)]

--- a/components/raftstore/src/coprocessor/split_check/table.rs
+++ b/components/raftstore/src/coprocessor/split_check/table.rs
@@ -160,8 +160,8 @@ where
             }
             _ => panic!(
                 "start_key {} and end_key {} out of order",
-                hex::encode_upper(encoded_start_key),
-                hex::encode_upper(encoded_end_key)
+                log_wrappers::Key(&encoded_start_key),
+                log_wrappers::Key(&encoded_end_key)
             ),
         }
         host.add_checker(Box::new(Checker {

--- a/components/raftstore/src/coprocessor/split_observer.rs
+++ b/components/raftstore/src/coprocessor/split_observer.rs
@@ -46,9 +46,9 @@ impl SplitObserver {
             Ok(()) => Ok(key),
             Err(_) => Err(format!(
                 "key {} should be in ({}, {})",
-                hex::encode_upper(&key),
-                hex::encode_upper(region.get_start_key()),
-                hex::encode_upper(region.get_end_key()),
+                log_wrappers::Key(&key),
+                log_wrappers::Key(&region.get_start_key()),
+                log_wrappers::Key(&region.get_end_key()),
             )),
         }
     }

--- a/components/raftstore/src/errors.rs
+++ b/components/raftstore/src/errors.rs
@@ -49,9 +49,9 @@ quick_error! {
         }
         KeyNotInRegion(key: Vec<u8>, region: metapb::Region) {
             display("key {} is not in region key range [{}, {}) for region {}",
-                    hex::encode_upper(key),
-                    hex::encode_upper(region.get_start_key()),
-                    hex::encode_upper(region.get_end_key()),
+                    log_wrappers::Key(&key),
+                    log_wrappers::Key(&region.get_start_key()),
+                    log_wrappers::Key(&region.get_end_key()),
                     region.get_id())
         }
         Other(err: Box<dyn error::Error + Sync + Send>) {

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -791,7 +791,9 @@ impl<T, C> RaftPollerBuilder<T, C> {
             let region = local_state.get_region();
             if local_state.get_state() == PeerState::Tombstone {
                 tombstone_count += 1;
-                debug!("region is tombstone"; "region" => ?region, "store_id" => store_id);
+                debug!("region is tombstone";
+                       "region" => log_wrappers::ProtobufValue(region),
+                       "store_id" => store_id);
                 self.clear_stale_meta(&mut kv_wb, &mut raft_wb, &local_state);
                 return Ok(true);
             }
@@ -816,7 +818,9 @@ impl<T, C> RaftPollerBuilder<T, C> {
                 region,
             ));
             if local_state.get_state() == PeerState::Merging {
-                info!("region is merging"; "region" => ?region, "store_id" => store_id);
+                info!("region is merging";
+                      "region" => log_wrappers::ProtobufValue(region),
+                      "store_id" => store_id);
                 merging_count += 1;
                 peer.set_pending_merge_state(local_state.get_merge_state().to_owned());
             }
@@ -844,7 +848,7 @@ impl<T, C> RaftPollerBuilder<T, C> {
 
         // schedule applying snapshot after raft writebatch were written.
         for region in applying_regions {
-            info!("region is applying snapshot"; "region" => ?region, "store_id" => store_id);
+            info!("region is applying snapshot"; "region" => log_wrappers::ProtobufValue(&region), "store_id" => store_id);
             let (tx, mut peer) = PeerFsm::create(
                 store_id,
                 &self.cfg.value(),
@@ -1471,7 +1475,7 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
                 "msg is overlapped with exist region";
                 "region_id" => region_id,
                 "msg" => ?msg,
-                "exist_region" => ?exist_region,
+                "exist_region" => log_wrappers::ProtobufValue(exist_region),
             );
             if util::is_first_vote_msg(msg.get_message()) {
                 meta.pending_votes.push(msg.to_owned());

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1181,7 +1181,7 @@ impl Peer {
                         "peer_id" => self.peer.get_id(),
                         "apply_index" => self.get_store().applied_index(),
                         "last_applying_index" => self.last_applying_idx,
-                        "overlap_region" => ?r,
+                        "overlap_region" => log_wrappers::ProtobufValue(r),
                     );
                     return None;
                 }
@@ -2890,7 +2890,7 @@ where
                     panic!(
                         "[region {}] failed to get {} with cf {}: {:?}",
                         region.get_id(),
-                        hex::encode_upper(key),
+                        log_wrappers::Key(&key),
                         cf,
                         e
                     )
@@ -2902,7 +2902,7 @@ where
                     panic!(
                         "[region {}] failed to get {}: {:?}",
                         region.get_id(),
-                        hex::encode_upper(key),
+                        log_wrappers::Key(&key),
                         e
                     )
                 })

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1114,7 +1114,7 @@ where
             "apply snapshot with state ok";
             "region_id" => self.region.get_id(),
             "peer_id" => self.peer_id,
-            "region" => ?region,
+            "region" => log_wrappers::ProtobufValue(&region),
             "state" => ?ctx.apply_state,
         );
 

--- a/components/raftstore/src/store/region_snapshot.rs
+++ b/components/raftstore/src/store/region_snapshot.rs
@@ -214,14 +214,14 @@ where
             set_panic_mark();
             panic!(
                 "failed to get value of key {} in region {}: {:?}",
-                hex::encode_upper(&key),
+                log_wrappers::Key(&key),
                 self.region.get_id(),
                 e,
             );
         } else {
             error!(
                 "failed to get value of key in cf";
-                "key" => hex::encode_upper(&key),
+                "key" => log_wrappers::Key(&key),
                 "region" => self.region.get_id(),
                 "cf" => cf,
                 "error" => ?e,

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -628,13 +628,13 @@ impl<
         let mut it = self.0.clone();
         match it.len() {
             0 => write!(f, "(no key)"),
-            1 => write!(f, "key {}", hex::encode_upper(it.next().unwrap())),
+            1 => write!(f, "key {}", log_wrappers::Key(it.next().unwrap())),
             _ => write!(
                 f,
                 "{} keys range from {} to {}",
                 it.len(),
-                hex::encode_upper(it.next().unwrap()),
-                hex::encode_upper(it.next_back().unwrap())
+                log_wrappers::Key(it.next().unwrap()),
+                log_wrappers::Key(it.next_back().unwrap())
             ),
         }
     }

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -475,7 +475,7 @@ where
                         "try to split region";
                         "region_id" => region.get_id(),
                         "new_region_id" => resp.get_new_region_id(),
-                        "region" => ?region,
+                        "region" => log_wrappers::ProtobufValue(&region),
                         "task"=>task,
                     );
 
@@ -523,7 +523,7 @@ where
                             "try to batch split region";
                             "region_id" => region.get_id(),
                             "new_region_ids" => ?resp.get_ids(),
-                            "region" => ?region,
+                            "region" => log_wrappers::ProtobufValue(&region),
                             "task" => task,
                         );
 
@@ -749,7 +749,7 @@ where
                                  destroyed soon";
                                 "region_id" => local_region.get_id(),
                                 "peer_id" => peer.get_id(),
-                                "pd_region" => ?pd_region
+                                "pd_region" => log_wrappers::ProtobufValue(&pd_region)
                             );
                             PD_VALIDATE_PEER_COUNTER_VEC
                                 .with_label_values(&["peer stale"])
@@ -765,7 +765,7 @@ where
                             "peer is still a valid member of region";
                             "region_id" => local_region.get_id(),
                             "peer_id" => peer.get_id(),
-                            "pd_region" => ?pd_region
+                            "pd_region" => log_wrappers::ProtobufValue(&pd_region)
                         );
                         PD_VALIDATE_PEER_COUNTER_VEC
                             .with_label_values(&["peer valid"])
@@ -851,7 +851,7 @@ where
                     PD_HEARTBEAT_COUNTER_VEC.with_label_values(&["merge"]).inc();
 
                     let merge = resp.take_merge();
-                    info!("try to merge"; "region_id" => region_id, "merge" => ?merge);
+                    info!("try to merge"; "region_id" => region_id, "merge" => log_wrappers::ProtobufValue(&merge));
                     let req = new_merge_request(merge);
                     send_admin_request(&router, region_id, epoch, peer, req, Callback::None)
                 } else {

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -177,8 +177,8 @@ impl PendingDeleteRanges {
             panic!(
                 "[region {}] register deleting data in [{}, {}) failed due to overlap",
                 region_id,
-                hex::encode_upper(&start_key),
-                hex::encode_upper(&end_key),
+                log_wrappers::Key(&start_key),
+                log_wrappers::Key(&end_key)
             );
         }
         let info = StalePeerInfo {
@@ -509,7 +509,7 @@ where
             assert!(
                 self.pending_delete_ranges.remove(&key).is_some(),
                 "cleanup pending_delete_ranges {} should exist",
-                hex::encode_upper(&key)
+                log_wrappers::Key(&key)
             );
         }
     }

--- a/components/resolved_ts/Cargo.toml
+++ b/components/resolved_ts/Cargo.toml
@@ -10,6 +10,7 @@ prost-codec = ["txn_types/prost-codec"]
 
 [dependencies]
 hex = "0.4"
+log_wrappers = { path = "../log_wrappers" }
 tikv_util = { path = "../tikv_util" }
 txn_types = { path = "../txn_types" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/components/resolved_ts/src/lib.rs
+++ b/components/resolved_ts/src/lib.rs
@@ -46,7 +46,7 @@ impl Resolver {
     pub fn track_lock(&mut self, start_ts: TimeStamp, key: Vec<u8>) {
         debug!(
             "track lock {}@{}, region {}",
-            hex::encode_upper(key.clone()),
+            log_wrappers::Key(&key),
             start_ts,
             self.region_id
         );
@@ -61,7 +61,7 @@ impl Resolver {
     ) {
         debug!(
             "untrack lock {}@{}, commit@{}, region {}",
-            hex::encode_upper(key.clone()),
+            log_wrappers::Key(&key),
             start_ts,
             commit_ts.clone().unwrap_or_else(TimeStamp::zero),
             self.region_id,

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -34,6 +34,7 @@ hex = "0.4"
 keys = { path = "../keys" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
+log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.8", default-features = false }
 quick-error = "1.2.3"
 serde = "1.0"

--- a/components/sst_importer/src/errors.rs
+++ b/components/sst_importer/src/errors.rs
@@ -97,8 +97,8 @@ quick_error! {
             display("\
                 {} has wrong prefix: key {} does not start with {}",
                 what,
-                hex::encode_upper(&key),
-                hex::encode_upper(&prefix),
+                log_wrappers::Key(&key),
+                log_wrappers::Prefix(&prefix),
             )
         }
         BadFormat(msg: String) {

--- a/components/test_util/src/security.rs
+++ b/components/test_util/src/security.rs
@@ -16,6 +16,7 @@ pub fn new_security_cfg(cn: Option<HashSet<String>>) -> SecurityConfig {
         key_path: format!("{}", p.join("data/key.pem").display()),
         override_ssl_target: "".to_owned(),
         cert_allowed_cn: cn.unwrap_or_default(),
+        redact_info_log: Some(true),
     }
 }
 

--- a/components/tikv_util/src/security.rs
+++ b/components/tikv_util/src/security.rs
@@ -24,6 +24,7 @@ pub struct SecurityConfig {
     #[serde(skip)]
     pub override_ssl_target: String,
     pub cert_allowed_cn: HashSet<String>,
+    pub redact_info_log: Option<bool>,
 }
 
 impl Default for SecurityConfig {
@@ -34,6 +35,7 @@ impl Default for SecurityConfig {
             key_path: String::new(),
             override_ssl_target: String::new(),
             cert_allowed_cn: HashSet::default(),
+            redact_info_log: None,
         }
     }
 }

--- a/components/txn_types/Cargo.toml
+++ b/components/txn_types/Cargo.toml
@@ -15,6 +15,7 @@ hex = "0.4"
 derive-new = "0.5"
 codec = { path = "../codec" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+log_wrappers = { path = "../log_wrappers" }
 slog = "2.3"
 quick-error = "1.2.3"
 tikv_alloc = { path = "../tikv_alloc" }

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -214,13 +214,13 @@ impl Clone for Key {
 
 impl Debug for Key {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(&hex::encode_upper(&self.0))
+        write!(f, "{}", log_wrappers::Key(&self.0))
     }
 }
 
 impl Display for Key {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(&hex::encode_upper(&self.0))
+        write!(f, "{}", log_wrappers::Key(&self.0))
     }
 }
 

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -778,6 +778,11 @@
 # cert-path = ""
 # key-path = ""
 # cert-allowed-cn = []
+#
+## Avoid outputing data (e.g. user keys) to info log. It currently does not avoid printing
+## user data altogether, but greatly reduce those logs.
+## Default is true when encryption is enabled and default to false otherwise.
+# redact-info-log = false
 
 [import]
 ## Number of threads to handle RPC requests.

--- a/src/server/gc_worker/gc_manager.rs
+++ b/src/server/gc_worker/gc_manager.rs
@@ -2,7 +2,6 @@
 
 use kvproto::kvrpcpb::Context;
 use kvproto::metapb;
-use log_wrappers::DisplayValue;
 use raft::StateRole;
 use std::cmp::Ordering;
 use std::sync::mpsc;
@@ -527,12 +526,12 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider> GcManager<S, R> {
         // TODO: Find a better way to handle errors. Maybe we should retry.
         debug!(
             "trying gc"; "region_id" => ctx.get_region_id(), "region_epoch" => ?ctx.region_epoch.as_ref(),
-            "end_key" => next_key.as_ref().map(DisplayValue)
+            "end_key" => ?next_key
         );
         if let Err(e) = sync_gc(&self.worker_scheduler, ctx.clone(), self.safe_point) {
             error!(
                 "failed gc"; "region_id" => ctx.get_region_id(), "region_epoch" => ?ctx.region_epoch.as_ref(),
-                "end_key" => next_key.as_ref().map(DisplayValue),
+                "end_key" => ?next_key,
                 "err" => ?e
             );
         }

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -253,8 +253,8 @@ impl<E: Engine> GcRunner<E> {
                 error!(
                     "failed to get range properties from write cf";
                     "region_id" => ctx.get_region_id(),
-                    "start_key" => hex::encode_upper(&start_key),
-                    "end_key" => hex::encode_upper(&end_key),
+                    "start_key" => log_wrappers::Key(&start_key),
+                    "end_key" => log_wrappers::Key(&end_key),
                     "err" => ?e,
                 );
                 return true;

--- a/src/storage/kv/cursor.rs
+++ b/src/storage/kv/cursor.rs
@@ -364,14 +364,14 @@ impl<I: Iterator> Cursor<I> {
             panic!(
                 "failed to iterate: {:?}, min_key: {:?}, max_key: {:?}",
                 e,
-                self.min_key.as_ref().map(|v| hex::encode_upper(v)),
-                self.max_key.as_ref().map(|v| hex::encode_upper(v)),
+                self.min_key.as_ref().map(|v| log_wrappers::Key(&v)),
+                self.max_key.as_ref().map(|v| log_wrappers::Key(&v)),
             );
         } else {
             error!(
                 "failed to iterate";
-                "min_key" => ?self.min_key.as_ref().map(|v| hex::encode_upper(v)),
-                "max_key" => ?self.max_key.as_ref().map(|v| hex::encode_upper(v)),
+                "min_key" => ?self.min_key.as_ref().map(|v| log_wrappers::Key(&v)),
+                "max_key" => ?self.max_key.as_ref().map(|v| log_wrappers::Key(&v)),
                 "error" => ?e,
             );
             Err(e)

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -49,37 +49,37 @@ quick_error! {
             display("txn already committed @{}", commit_ts)
         }
         PessimisticLockRolledBack { start_ts: TimeStamp, key: Vec<u8> } {
-            display("pessimistic lock already rollbacked, start_ts:{}, key:{}", start_ts, hex::encode_upper(key))
+            display("pessimistic lock already rollbacked, start_ts:{}, key:{}", start_ts, log_wrappers::Key(&key))
         }
         TxnLockNotFound { start_ts: TimeStamp, commit_ts: TimeStamp, key: Vec<u8> } {
-            display("txn lock not found {}-{} key:{}", start_ts, commit_ts, hex::encode_upper(key))
+            display("txn lock not found {}-{} key:{}", start_ts, commit_ts, log_wrappers::Key(&key))
         }
         TxnNotFound { start_ts:  TimeStamp, key: Vec<u8> } {
-            display("txn not found {} key: {}", start_ts, hex::encode_upper(key))
+            display("txn not found {} key: {}", start_ts, log_wrappers::Key(&key))
         }
         LockTypeNotMatch { start_ts: TimeStamp, key: Vec<u8>, pessimistic: bool } {
-            display("lock type not match, start_ts:{}, key:{}, pessimistic:{}", start_ts, hex::encode_upper(key), pessimistic)
+            display("lock type not match, start_ts:{}, key:{}, pessimistic:{}", start_ts, log_wrappers::Key(&key), pessimistic)
         }
         WriteConflict { start_ts: TimeStamp, conflict_start_ts: TimeStamp, conflict_commit_ts: TimeStamp, key: Vec<u8>, primary: Vec<u8> } {
             display("write conflict, start_ts:{}, conflict_start_ts:{}, conflict_commit_ts:{}, key:{}, primary:{}",
-                    start_ts, conflict_start_ts, conflict_commit_ts, hex::encode_upper(key), hex::encode_upper(primary))
+                    start_ts, conflict_start_ts, conflict_commit_ts, log_wrappers::Key(&key), log_wrappers::Key(&primary))
         }
         Deadlock { start_ts: TimeStamp, lock_ts: TimeStamp, lock_key: Vec<u8>, deadlock_key_hash: u64 } {
             display("deadlock occurs between txn:{} and txn:{}, lock_key:{}, deadlock_key_hash:{}",
-                    start_ts, lock_ts, hex::encode_upper(lock_key), deadlock_key_hash)
+                    start_ts, lock_ts, log_wrappers::Key(&lock_key), deadlock_key_hash)
         }
         AlreadyExist { key: Vec<u8> } {
-            display("key {} already exists", hex::encode_upper(key))
+            display("key {} already exists", log_wrappers::Key(&key))
         }
         DefaultNotFound { key: Vec<u8> } {
-            display("default not found: key:{}, maybe read truncated/dropped table data?", hex::encode_upper(key))
+            display("default not found: key:{}, maybe read truncated/dropped table data?", log_wrappers::Key(&key))
         }
         CommitTsExpired { start_ts: TimeStamp, commit_ts: TimeStamp, key: Vec<u8>, min_commit_ts: TimeStamp } {
-            display("try to commit key {} with commit_ts {} but min_commit_ts is {}", hex::encode_upper(key), commit_ts, min_commit_ts)
+            display("try to commit key {} with commit_ts {} but min_commit_ts is {}", log_wrappers::Key(&key), commit_ts, min_commit_ts)
         }
         KeyVersion { display("bad format key(version)") }
         PessimisticLockNotFound { start_ts: TimeStamp, key: Vec<u8> } {
-            display("pessimistic lock not found, start_ts:{}, key:{}", start_ts, hex::encode_upper(key))
+            display("pessimistic lock not found, start_ts:{}, key:{}", start_ts, log_wrappers::Key(&key))
         }
         Other(err: Box<dyn error::Error + Sync + Send>) {
             from()
@@ -253,7 +253,7 @@ pub fn default_not_found_error(key: Vec<u8>, hint: &str) -> Error {
         set_panic_mark();
         panic!(
             "default value not found for key {:?} when {}",
-            hex::encode_upper(&key),
+            log_wrappers::Key(&key),
             hint,
         );
     } else {

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -110,10 +110,10 @@ quick_error! {
                         lower_bound: Option<Vec<u8>>,
                         upper_bound: Option<Vec<u8>>} {
             display("Request range exceeds bound, request range:[{}, end:{}), physical bound:[{}, {})",
-                        start.as_ref().map(hex::encode_upper).unwrap_or_else(|| "(none)".to_owned()),
-                        end.as_ref().map(hex::encode_upper).unwrap_or_else(|| "(none)".to_owned()),
-                        lower_bound.as_ref().map(hex::encode_upper).unwrap_or_else(|| "(none)".to_owned()),
-                        upper_bound.as_ref().map(hex::encode_upper).unwrap_or_else(|| "(none)".to_owned()))
+                        start.as_ref().map(|v| format!("{}", log_wrappers::Key(&v)).to_owned()).unwrap_or_else(|| "(none)".to_owned()),
+                        end.as_ref().map(|v| format!("{}", log_wrappers::Key(&v)).to_owned()).unwrap_or_else(|| "(none)".to_owned()),
+                        lower_bound.as_ref().map(|v| format!("{}", log_wrappers::Key(&v)).to_owned()).unwrap_or_else(|| "(none)".to_owned()),
+                        upper_bound.as_ref().map(|v| format!("{}", log_wrappers::Key(&v)).to_owned()).unwrap_or_else(|| "(none)".to_owned()))
         }
     }
 }

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -110,10 +110,10 @@ quick_error! {
                         lower_bound: Option<Vec<u8>>,
                         upper_bound: Option<Vec<u8>>} {
             display("Request range exceeds bound, request range:[{}, end:{}), physical bound:[{}, {})",
-                        start.as_ref().map(|v| format!("{}", log_wrappers::Key(&v)).to_owned()).unwrap_or_else(|| "(none)".to_owned()),
-                        end.as_ref().map(|v| format!("{}", log_wrappers::Key(&v)).to_owned()).unwrap_or_else(|| "(none)".to_owned()),
-                        lower_bound.as_ref().map(|v| format!("{}", log_wrappers::Key(&v)).to_owned()).unwrap_or_else(|| "(none)".to_owned()),
-                        upper_bound.as_ref().map(|v| format!("{}", log_wrappers::Key(&v)).to_owned()).unwrap_or_else(|| "(none)".to_owned()))
+                        start.as_ref().map(|v| format!("{}", log_wrappers::Key(&v))).unwrap_or_else(|| "(none)".to_owned()),
+                        end.as_ref().map(|v| format!("{}", log_wrappers::Key(&v))).unwrap_or_else(|| "(none)".to_owned()),
+                        lower_bound.as_ref().map(|v| format!("{}", log_wrappers::Key(&v))).unwrap_or_else(|| "(none)".to_owned()),
+                        upper_bound.as_ref().map(|v| format!("{}", log_wrappers::Key(&v))).unwrap_or_else(|| "(none)".to_owned()))
         }
     }
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -605,6 +605,7 @@ fn test_serde_custom_tikv_config() {
         key_path: "invalid path".to_owned(),
         override_ssl_target: "".to_owned(),
         cert_allowed_cn,
+        redact_info_log: Some(true),
     };
     value.encryption = EncryptionConfig {
         data_encryption_method: EncryptionMethod::Aes128Ctr,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -532,6 +532,7 @@ key-path = "invalid path"
 cert-allowed-cn = [
     "example.tikv.com",
 ]
+redact-info-log = true
 
 [encryption]
 data-encryption-method = "aes128-ctr"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Add a new config `security.redact-info-log` which avoid printing user data (mostly user keys) to info log. Currently the config doesn't avoid printing user data altogether, but greatly reduce those logs.

Problem Summary:

### What is changed and how it works?

Manually go over all the slog call site and error type messages and wrap those data keys being log with `log_wrappers::Key`. For protobuf structs which can contain user keys and values add a `log_wrappers::ProtobufValue` types which can also filter the output. The behavior is controlled by the `REDACT_INFO_LOG` atomic flag, which is set on tikv server start. If the config is not set by user, the filtering is default on if encryption is enabled and default off otherwise.

### Related changes

No

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Manually run with `tiup playground` and a light sysbench workload. Some sample input:

default (same as before):
```
[2020/05/07 07:39:13.727 +08:00] [INFO] [peer.rs:327] ["on split"] [split_keys="key 7480000000000000FF0500000000000000F8"] [peer_id=3] [region_id=2]
[2020/05/07 07:39:13.728 +08:00] [INFO] [pd.rs:523] ["try to batch split region"] [task=batch_split] [region="id: 2 region_epoch { conf_ver: 1 version: 1 } peers { id: 3 store_id: 1 }"] [new_region_ids="[new_region_id: 4 new_peer_ids: 5]"] [region_id=2]
[2020/05/07 07:39:13.734 +08:00] [INFO] [apply.rs:1216] ["execute admin command"] [command="cmd_type: BatchSplit splits { requests { split_key: 7480000000000000FF0500000000000000F8 new_region_id: 4 new_peer_ids: 5 } right_derive: true }"] [index=32] [term=6] [peer_id=3] [region_id=2]
[2020/05/07 07:39:13.734 +08:00] [INFO] [apply.rs:1788] ["split region"] [keys="key 7480000000000000FF0500000000000000F8"] [region="id: 2 region_epoch { conf_ver: 1 version: 1 } peers { id: 3 store_id: 1 }"] [peer_id=3] [region_id=2]
[2020/05/07 07:39:13.750 +08:00] [INFO] [peer.rs:1630] ["notify pd with split"] [split_count=2] [peer_id=3] [region_id=2]
[2020/05/07 07:39:13.750 +08:00] [INFO] [peer.rs:1672] ["insert new region"] [region="id: 4 end_key: 7480000000000000FF0500000000000000F8 region_epoch { conf_ver: 1 version: 2 } peers { id: 5 store_id: 1 }"] [region_id=4]
```

`security.redact-info-log=true` or when encryption is enabled:
```
[2020/05/08 08:48:42.301 +08:00] [INFO] [peer.rs:327] ["on split"] [split_keys="key <key>"] [peer_id=3] [region_id=2]
[2020/05/08 08:48:42.301 +08:00] [INFO] [pd.rs:523] ["try to batch split region"] [task=batch_split] [region="id: 2 start_key: <start_key> end_key: <end_key> region_epoch { conf_ver: 1 version: 1 } peers { id: 3 store_id: 1 }"] [new_region_ids="[new_region_id: 4 new_peer_ids: 5]"] [region_id=2]
[2020/05/08 08:48:42.307 +08:00] [INFO] [apply.rs:1239] ["execute admin command"] [command="cmd_type: BatchSplit split {  split_key: <split_key> } prepare_merge { target {  start_key: <start_key> end_key: <end_key> } } commit_merge { source {  start_key: <start_key> end_key: <end_key> } } splits { requests {  split_key: <split_key> new_region_id: 4 new_peer_ids: 5 } right_derive: true }"] [index=32] [term=6] [peer_id=3] [region_id=2]
[2020/05/08 08:48:42.307 +08:00] [INFO] [apply.rs:1816] ["split region"] [keys="key <key>"] [region="id: 2 start_key: <start_key> end_key: <end_key> region_epoch { conf_ver: 1 version: 1 } peers { id: 3 store_id: 1 }"] [peer_id=3] [region_id=2]
[2020/05/08 08:48:42.323 +08:00] [INFO] [peer.rs:1630] ["notify pd with split"] [split_count=2] [peer_id=3] [region_id=2]
[2020/05/08 08:48:42.323 +08:00] [INFO] [peer.rs:1672] ["insert new region"] [region="id: 4 start_key: <start_key> end_key: <end_key> region_epoch { conf_ver: 1 version: 2 } peers { id: 5 store_id: 1 }"] [region_id=4]
```

### Release note <!-- bugfixes or new feature need a release note -->

* Add `security.redact-info-log` config which can reduce logging user data to info log.