### PR TITLE
*: Fix MsgWantRollbackMerge not covered compile error after update kvproto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.1#c211b473fe439e5635e63471714ab7ec758b5071"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-3.1#3a6b8b9cb29e46141990b024577ee67299accf2b"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
@@ -2881,7 +2881,7 @@ version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1a649b870f7fe03c965bf2fa6728361f6abbb6f3b72079515af8cb56d769cf"
 dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8",
 ]
 
 [[package]]
@@ -2970,7 +2970,7 @@ version = "0.4.3"
 source = "git+https://github.com/tikv/raft-rs?rev=9782199fa6318f94bf0974129664d974b03f8f11#9782199fa6318f94bf0974129664d974b03f8f11"
 dependencies = [
  "fxhash",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8",
  "protobuf",
  "quick-error 1.2.2",
  "rand 0.5.5",

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -861,6 +861,9 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             ExtraMessageType::MsgRegionWakeUp => {
                 self.reset_raft_tick(GroupState::Ordered);
             }
+            ExtraMessageType::MsgWantRollbackMerge => {
+                unimplemented!("remove this after #6584 merged")
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: #7112 doesn't cherry-pick a change from #6715, which is only need after updating kvproto. Pick it back and update kvproto.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: Pick missing change from #6715 and update kvproto.

### Related changes

N/A.

### Check List <!--REMOVE the items that are not applicable-->

CI

### Release note <!-- bugfixes or new feature need a release note -->

* No release note