### PR TITLE
UCP: Migrate scalar function `FromBase64` from TiDB (#6933)

### DIFF
--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -492,6 +492,18 @@ pub fn to_base64(bs: &Option<Bytes>) -> Result<Option<Bytes>> {
     }
 }
 
+#[rpn_fn]
+#[inline]
+pub fn from_base64(base64_bytes: &Option<Bytes>) -> Result<Option<Bytes>> {
+    match base64_bytes.as_ref() {
+        Some(bytes) => match base64::decode(bytes) {
+            Ok(data) => Ok(Some(data)),
+            Err(_) => Ok(Some(Vec::new())),
+        },
+        _ => Ok(None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -535,6 +547,7 @@ mod tests {
             assert_eq!(output, expect_output);
         }
     }
+
     #[test]
     fn test_oct_int() {
         let cases = vec![
@@ -1915,6 +1928,26 @@ mod tests {
             let output = RpnFnScalarEvaluator::new()
                 .push_param(param)
                 .evaluate::<Bytes>(ScalarFuncSig::ToBase64)
+                .unwrap();
+            assert_eq!(output, expected_output);
+        }
+    }
+
+    #[test]
+    fn test_from_base64() {
+        let cases = vec![
+            ("", ""),
+            (
+                "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent8fX4=",
+                " !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+            )
+        ];
+        for (arg, expected) in cases {
+            let param = Some(arg.to_string().into_bytes());
+            let expected_output = Some(expected.to_string().into_bytes());
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(param)
+                .evaluate::<Bytes>(ScalarFuncSig::FromBase64)
                 .unwrap();
             assert_eq!(output, expected_output);
         }

--- a/components/tidb_query_vec_expr/src/lib.rs
+++ b/components/tidb_query_vec_expr/src/lib.rs
@@ -537,6 +537,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::CharLength => char_length_fn_meta(),
         ScalarFuncSig::CharLengthUtf8 => char_length_utf8_fn_meta(),
         ScalarFuncSig::ToBase64 => to_base64_fn_meta(),
+        ScalarFuncSig::FromBase64 => from_base64_fn_meta(),
         // impl_time
         ScalarFuncSig::DateFormatSig => date_format_fn_meta(),
         ScalarFuncSig::WeekOfYear => week_of_year_fn_meta(),


### PR DESCRIPTION
Signed-off-by: Jiannuan <gan.jiannuan@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #6933  <!-- REMOVE this line if no issue to close -->

Problem Summary: Migrate scalar function `FromBase64` from TiDB 

### What is changed and how it works?

Implemented scalar function **FromBase64**

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test