### PR TITLE
*: Remove incorrect alert rule about coprocessor wait second

### DIFF
--- a/metrics/alertmanager/tikv.rules.yml
+++ b/metrics/alertmanager/tikv.rules.yml
@@ -241,18 +241,6 @@ groups:
       value: '{{ $value }}'
       summary: TiKV scheduler command duration seconds more than 1s
 
-  - alert: tikv_coprocessor_request_wait_seconds
-    expr: delta( tikv_coprocessor_request_wait_seconds_count[10m] )  > 0
-    for: 1m
-    labels:
-      env: ENV_LABELS_ENV
-      level: warning
-      expr:  delta( tikv_coprocessor_request_wait_seconds_count[10m] )  > 0
-    annotations:
-      description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values: {{ $value }}'
-      value: '{{ $value }}'
-      summary: TiKV coprocessor request wait seconds
-
   - alert: TiKV_coprocessor_request_error
     expr: increase(tikv_coprocessor_request_error{reason!="lock"}[10m]) > 100
     for: 1m


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Remove an incorrect alert rule about coprocessor wait second

### Related changes

- Need to cherry-pick to the release branch
  - Release 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

No release note