### PR TITLE
Improve memory defragmentation

### DIFF
--- a/components/tikv_util/src/metrics/threads_linux.rs
+++ b/components/tikv_util/src/metrics/threads_linux.rs
@@ -474,8 +474,8 @@ impl TidRetriever {
             } else {
                 self.tid_buffer = new_tid_buffer;
                 self.tid_buffer_update_interval = TID_MIN_UPDATE_INTERVAL;
-                self.tid_buffer_last_update = Instant::now();
             }
+            self.tid_buffer_last_update = Instant::now();
         }
 
         &self.tid_buffer


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

There was [a PR](https://github.com/tikv/tikv/pull/7306) fixing the memory fragmentation issue. However there is a bug in the PR that the defragmentation will not be very effective after running for a long time. This PR fixes it.

### What is changed and how it works?

What's Changed: Bug fix.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

- Manual test: Tested a cluster that has been started for > 1 day, confirmed that `sys_getdents` are now called by 10 minutes interval, instead of 15 secods.

```
[pid 64038] 15:24:16.579973 getdents(556</data3/wenxuan_kv1_exp/data/snap>, /* 2 entries */, 32768) = 48 <0.000037>
[pid 64038] 15:24:16.580232 getdents(556</data3/wenxuan_kv1_exp/data/snap>, /* 0 entries */, 32768) = 0 <0.000027>
[pid 64039] 15:25:16.582008 getdents(555</data3/wenxuan_kv1_exp/data/snap>, /* 2 entries */, 32768) = 48 <0.000026>
[pid 64039] 15:25:16.582121 getdents(555</data3/wenxuan_kv1_exp/data/snap>, /* 0 entries */, 32768) = 0 <0.000013>
[pid 64039] 15:26:16.584170 getdents(555</data3/wenxuan_kv1_exp/data/snap>, /* 2 entries */, 32768) = 48 <0.000048>
[pid 64039] 15:26:16.584302 getdents(555</data3/wenxuan_kv1_exp/data/snap>, /* 0 entries */, 32768) = 0 <0.000023>
[pid 64039] 15:27:16.586493 getdents(3</data3/wenxuan_kv1_exp/data/snap>, /* 2 entries */, 32768) = 48 <0.000038>
[pid 64039] 15:27:16.586632 getdents(3</data3/wenxuan_kv1_exp/data/snap>, /* 0 entries */, 32768) = 0 <0.000022>
[pid 64078] 15:27:16.671043 getdents(3</proc/63302/task>, /* 187 entries */, 32768) = 5968 <0.000183>
[pid 64078] 15:27:16.671527 getdents(3</proc/63302/task>, /* 0 entries */, 32768) = 0 <0.000016>
[pid 64039] 15:28:16.588570 getdents(539</data3/wenxuan_kv1_exp/data/snap>, /* 2 entries */, 32768) = 48 <0.000046>
[pid 64039] 15:28:16.588703 getdents(539</data3/wenxuan_kv1_exp/data/snap>, /* 0 entries */, 32768) = 0 <0.000021>
[pid 64039] 15:29:16.590764 getdents(556</data3/wenxuan_kv1_exp/data/snap>, /* 2 entries */, 32768) = 48 <0.000028>
[pid 64039] 15:29:16.590885 getdents(556</data3/wenxuan_kv1_exp/data/snap>, /* 0 entries */, 32768) = 0 <0.000041>
[pid 64038] 15:30:16.593033 getdents(513</data3/wenxuan_kv1_exp/data/snap>, /* 2 entries */, 32768) = 48 <0.000030>
[pid 64038] 15:30:16.593173 getdents(513</data3/wenxuan_kv1_exp/data/snap>, /* 0 entries */, 32768) = 0 <0.000027>
[pid 64038] 15:31:16.595139 getdents(555</data3/wenxuan_kv1_exp/data/snap>, /* 2 entries */, 32768) = 48 <0.000064>
[pid 64038] 15:31:16.595302 getdents(555</data3/wenxuan_kv1_exp/data/snap>, /* 0 entries */, 32768) = 0 <0.000016>
[pid 64039] 15:32:16.597362 getdents(556</data3/wenxuan_kv1_exp/data/snap>, /* 2 entries */, 32768) = 48 <0.000039>
[pid 64039] 15:32:16.597480 getdents(556</data3/wenxuan_kv1_exp/data/snap>, /* 0 entries */, 32768) = 0 <0.000022>
```

### Release note <!-- bugfixes or new feature need a release note -->

Improve memory defragmentation.