### PR TITLE
raftstore: add metrics for the bytes of pending apply cmds

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2975,6 +2975,11 @@ where
                     if channel_timer.is_none() {
                         channel_timer = Some(start);
                     }
+                    let mut log_size = 0;
+                    for entry in apply.entries.iter() {
+                        log_size += entry.get_data().len() as i64;
+                    }
+                    APPLY_PENDING_BYTES_GAUGE.sub(log_size);
                     self.handle_apply(apply_ctx, apply);
                     if let Some(ref mut state) = self.delegate.yield_state {
                         state.pending_msgs = drainer.collect();
@@ -3339,6 +3344,7 @@ pub fn create_apply_batch_system(cfg: &Config) -> (ApplyRouter, ApplyBatchSystem
         tx,
         Box::new(ControlFsm),
     );
+    APPLY_PENDING_BYTES_GAUGE.set(0);
     (ApplyRouter { router }, ApplyBatchSystem { system })
 }
 

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -455,8 +455,15 @@ lazy_static! {
             "collect topN of read qps",
         &["order"]
         ).unwrap();
+
     pub static ref RAFT_ENTRIES_CACHES_GAUGE: IntGauge = register_int_gauge!(
         "tikv_raft_entries_caches",
         "Total memory size of raft entries caches"
         ).unwrap();
+
+    pub static ref APPLY_PENDING_BYTES_GAUGE: IntGauge = register_int_gauge!(
+        "tikv_apply_pending_bytes",
+        "The bytes pending in the channel"
+    )
+    .unwrap();
 }


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
We found sometimes tikv could OOM and the apply wait is much high.
Note: sometimes this metric could be imprecise when TiKV was shutdown or ApplyFSM was destroyed.

### What is changed and how it works?

What's Changed:
Add a metric for observing the bytes of pending apply cmds.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->
* Add metrics for the bytes of pending apply cmds