### PR TITLE
UCP: Migrate scalar function RpadUTF8 from TiDB

### DIFF
--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -153,7 +153,6 @@ pub fn rpad_utf8(
     }
 }
 
-
 #[rpn_fn]
 #[inline]
 pub fn lpad(arg: &Option<Bytes>, len: &Option<Int>, pad: &Option<Bytes>) -> Result<Option<Bytes>> {

--- a/components/tidb_query_vec_expr/src/lib.rs
+++ b/components/tidb_query_vec_expr/src/lib.rs
@@ -523,6 +523,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::HexStrArg => hex_str_arg_fn_meta(),
         ScalarFuncSig::LTrim => ltrim_fn_meta(),
         ScalarFuncSig::RTrim => rtrim_fn_meta(),
+        ScalarFuncSig::RpadUtf8 => rpad_utf8_fn_meta(),
         ScalarFuncSig::Lpad => lpad_fn_meta(),
         ScalarFuncSig::Trim1Arg => trim_1_arg_fn_meta(),
         ScalarFuncSig::FromBase64 => from_base64_fn_meta(),


### PR DESCRIPTION
Signed-off-by: Yiyiyimu <wosoyoung@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:

1. module [, module2, module3]: what's changed
2. *: what's changed
   -->
   UCP #6949

### What problem does this PR solve?

Issue Number: close #6949 <!-- REMOVE this line if no issue to close -->

### What is changed and how it works?

UCP: Migrate scalar function `RpadUTF8` from TiDB

Implement Rpad-UTF8 in vector expression, with reference of [RpadUTF8 in normal expression](https://github.com/tikv/tikv/blob/master/components/tidb_query_normal_expr/src/builtin_string.rs#L763) and Rpad in vector expression #7668 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Other notes
1. As one could find, I failed to implement `Result` with two variables. I tried to use tuple but failed, so I use two layer of `Result`. It's kind of ugly, could anyone give a hint on how to deal with this situation?
2. As #7668 (which is about vector expr of Rpad) is still being reviewed, there might be some conflicts between these two PR. I'll change mine if necessary.