### PR TITLE
cdc: fix unstable test

### DIFF
--- a/components/cdc/tests/failpoints/test_register.rs
+++ b/components/cdc/tests/failpoints/test_register.rs
@@ -167,27 +167,23 @@ fn test_connections_register() {
     suite.cluster.must_split(&region, b"k0");
     fail::remove(fp);
     // Receive events from conn 2
-    let mut events = receive_event(false);
-    while events.len() < 2 {
-        events.extend(receive_event(false).into_iter());
-    }
-    assert_eq!(events.len(), 2, "{:?}", events.len());
-    match events.remove(0).event.unwrap() {
-        Event_oneof_event::Entries(es) => {
-            assert!(es.entries.len() == 2, "{:?}", es);
-            let e = &es.entries[0];
-            assert_eq!(e.get_type(), EventLogType::Prewrite, "{:?}", es);
-            let e = &es.entries[1];
-            assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+    loop {
+        let mut events = receive_event(false);
+        assert_eq!(events.len(), 1, "{:?}", events);
+        match events.pop().unwrap().event.unwrap() {
+            Event_oneof_event::Error(err) => {
+                assert!(err.has_epoch_not_match(), "{:?}", err);
+                break;
+            }
+            Event_oneof_event::Entries(es) => {
+                assert!(es.entries.len() == 2, "{:?}", es);
+                let e = &es.entries[0];
+                assert_eq!(e.get_type(), EventLogType::Prewrite, "{:?}", es);
+                let e = &es.entries[1];
+                assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+            }
+            _ => panic!("unknown event"),
         }
-        Event_oneof_event::Error(e) => panic!("{:?}", e),
-        _ => panic!("unknown event"),
-    }
-    match events.pop().unwrap().event.unwrap() {
-        Event_oneof_event::Error(err) => {
-            assert!(err.has_epoch_not_match(), "{:?}", err);
-        }
-        _ => panic!("unknown event"),
     }
 
     event_feed_wrap.as_ref().replace(None);


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Sometimes `test_connections_register` would fail.

### What is changed and how it works?

What's Changed:
Use loop to fix `test_connections_register`.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
* N/A