### PR TITLE
encryption: fix flaky test_mem_backend_authenticate

### DIFF
--- a/components/encryption/src/master_key/mem.rs
+++ b/components/encryption/src/master_key/mem.rs
@@ -119,7 +119,7 @@ mod tests {
         encrypted_content1
             .mut_metadata()
             .get_mut(MetadataKey::AesGcmTag.as_str())
-            .unwrap()[0] += 1;
+            .unwrap()[0] ^= 0b11111111u8;
         backend.decrypt_content(&encrypted_content1).unwrap_err();
 
         // Must tag not found.


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7839 

Problem Summary: IV is randomly generated number. adding 1 to it could cause potential integer overflow.

### What is changed and how it works?

What's Changed: Instead of adding to it we use bit-wise operation to modify it.

### Related changes

The fix is the same as done in #7665 to another similar test.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
local run the failing test

### Release note <!-- bugfixes or new feature need a release note -->

* No release note