### PR TITLE
UCP: Migrate `GreatestInt` (Vectorize) from TiDB

### DIFF
--- a/components/tidb_query_vec_expr/src/impl_compare.rs
+++ b/components/tidb_query_vec_expr/src/impl_compare.rs
@@ -886,7 +886,6 @@ mod tests {
     fn test_greatest_int() {
         let cases = vec![
             (vec![None, None], None),
-            (vec![Some(1)], Some(1)),
             (vec![Some(1), Some(1)], Some(1)),
             (vec![Some(1), Some(-1), None], None),
             (vec![Some(-2), Some(-1), Some(1), Some(2)], Some(2)),

--- a/components/tidb_query_vec_expr/src/impl_compare.rs
+++ b/components/tidb_query_vec_expr/src/impl_compare.rs
@@ -227,7 +227,7 @@ pub fn coalesce<T: Evaluable>(args: &[&Option<T>]) -> Result<Option<T>> {
     Ok(None)
 }
 
-#[rpn_fn(varg)]
+#[rpn_fn(varg, min_args = 2)]
 #[inline]
 pub fn greatest_int(args: &[&Option<Int>]) -> Result<Option<Int>> {
     do_get_extremum(args, max)

--- a/components/tidb_query_vec_expr/src/lib.rs
+++ b/components/tidb_query_vec_expr/src/lib.rs
@@ -318,6 +318,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::LeTime => compare_fn_meta::<BasicComparer<DateTime, CmpOpLE>>(),
         ScalarFuncSig::LeDuration => compare_fn_meta::<BasicComparer<Duration, CmpOpLE>>(),
         ScalarFuncSig::LeJson => compare_fn_meta::<BasicComparer<Json, CmpOpLE>>(),
+        ScalarFuncSig::GreatestInt => greatest_int_fn_meta(),
         ScalarFuncSig::GtInt => map_int_sig(value, children, compare_mapper::<CmpOpGT>)?,
         ScalarFuncSig::GtReal => compare_fn_meta::<BasicComparer<Real, CmpOpGT>>(),
         ScalarFuncSig::GtDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpGT>>(),


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

UCP: #6743 

### What problem does this PR solve?

Issue Number: close #6743 

Problem Summary:

Port the function `GreatestInt` (Vectorize) from TiDB to coprocessor.

### What is changed and how it works?

* Add vectorized GreatestInt
* Add vectorized GreatestInt unit tests

### Check List <!--REMOVE the items that are not applicable-->

Tests

- Unit test