### PR TITLE
UCP: Migrate non-vectorized SecToTime from TiDB

### DIFF
--- a/components/tidb_query_normal_expr/src/scalar_function.rs
+++ b/components/tidb_query_normal_expr/src/scalar_function.rs
@@ -315,7 +315,8 @@ impl ScalarFunc {
             | ScalarFuncSig::OctInt
             | ScalarFuncSig::JsonDepthSig
             | ScalarFuncSig::RandomBytes
-            | ScalarFuncSig::JsonKeysSig => (1, 1),
+            | ScalarFuncSig::JsonKeysSig
+            | ScalarFuncSig::SecToTime => (1, 1),
 
             ScalarFuncSig::JsonKeys2ArgsSig | ScalarFuncSig::JsonLengthSig => (1, 2),
 
@@ -977,6 +978,8 @@ dispatch_call! {
         SubDurationAndDuration => sub_duration_and_duration,
         SubDurationAndString => sub_duration_and_string,
         SubTimeDurationNull => sub_time_duration_null,
+
+        SecToTime => sec_to_time,
     }
     JSON_CALLS {
         CastIntAsJson => cast_int_as_json,


### PR DESCRIPTION
Signed-off-by: Alex Chi iskyzh@gmail.com

UCP #6873

Checklist #5751

### What problem does this PR solve?

Issue Number: close #6873

Problem Summary:

### What is changed and how it works?

Migrate `SecToTime` from TiDB

What's Changed:

### Check List

Tests

- Unit test