### PR TITLE
raftstore: add metrics for observing apply for 3.0.5.hotfix

### DIFF
--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -120,6 +120,8 @@ pub struct Config {
     pub store_pool_size: usize,
     pub future_poll_size: usize,
     pub hibernate_regions: bool,
+    pub apply_yield_count: usize,
+    pub reschedule_count: usize,
 
     // Deprecated! These two configuration has been moved to Coprocessor.
     // They are preserved for compatibility check.
@@ -193,6 +195,8 @@ impl Default for Config {
             store_pool_size: 2,
             future_poll_size: 1,
             hibernate_regions: false,
+            apply_yield_count: 1,
+            reschedule_count: 3,
 
             // They are preserved for compatibility check.
             region_max_size: ReadableSize(0),

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -2645,9 +2645,10 @@ impl ApplyFsm {
             let elapsed = timer.elapsed();
             if elapsed.as_secs() >= 30 {
                 info!(
-                    "region {} apply {:?} wait too long",
+                    "region {} apply {:?} wait too long, takes {:?}",
                     self.delegate.region_id(),
                     self.delegate.apply_state,
+                    elapsed,
                 );
             }
             APPLY_TASK_WAIT_TIME_HISTOGRAM.observe(duration_to_sec(elapsed));

--- a/src/raftstore/store/fsm/batch.rs
+++ b/src/raftstore/store/fsm/batch.rs
@@ -445,7 +445,7 @@ where
         for i in 0..self.pool_size {
             let handler = builder.build();
             let mut poller = Poller {
-                tag: name_prefix.clone(),
+                tag: format!("{}-{}", name_prefix, i),
                 router: self.router.clone(),
                 fsm_receiver: self.receiver.clone(),
                 handler,

--- a/src/raftstore/store/fsm/batch.rs
+++ b/src/raftstore/store/fsm/batch.rs
@@ -144,7 +144,8 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
 
     fn push(&mut self, fsm: FsmTypes<N, C>) -> bool {
         match fsm {
-            FsmTypes::Normal(n) => {
+            FsmTypes::Normal(mut n) => {
+                n.after_scheduled();
                 self.normals.push(n);
                 self.counters.push(0);
             }

--- a/src/raftstore/store/fsm/metrics.rs
+++ b/src/raftstore/store/fsm/metrics.rs
@@ -19,13 +19,13 @@ lazy_static! {
     pub static ref APPLY_RESCHEDULE_WAIT_DURATION: Histogram = register_histogram!(
         "tikv_raftstore_apply_reschedule_wait_duration_secs",
         "The interval of a fsm was rescheduled",
-        exponential_buckets(1.0, 2.0, 20).unwrap()
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
     )
     .unwrap();
     pub static ref APPLY_EXECUTE_DURATION: Histogram = register_histogram!(
         "tikv_raftstore_apply_execute_wait_duration_secs",
         "The interval of a fsm was handled",
-        exponential_buckets(1.0, 2.0, 20).unwrap()
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
     )
     .unwrap();
     pub static ref RESCHEDULE_FSM_COUNT: IntCounterVec = register_int_counter_vec!(

--- a/src/raftstore/store/fsm/metrics.rs
+++ b/src/raftstore/store/fsm/metrics.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use prometheus::{exponential_buckets, Histogram};
+use prometheus::{exponential_buckets, Histogram, IntCounter, IntCounterVec};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -9,6 +9,29 @@ lazy_static! {
         "tikv_raftstore_apply_proposal",
         "The count of proposals sent by a region at once",
         exponential_buckets(1.0, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref APPLY_YIELD_COUNT: IntCounter = register_int_counter!(
+        "tikv_raftstore_apply_yield_count",
+        "The count of yield fsms"
+    )
+    .unwrap();
+    pub static ref APPLY_RESCHEDULE_WAIT_DURATION: Histogram = register_histogram!(
+        "tikv_raftstore_apply_reschedule_wait_duration_secs",
+        "The interval of a fsm was rescheduled",
+        exponential_buckets(1.0, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref APPLY_EXECUTE_DURATION: Histogram = register_histogram!(
+        "tikv_raftstore_apply_execute_wait_duration_secs",
+        "The interval of a fsm was handled",
+        exponential_buckets(1.0, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref RESCHEDULE_FSM_COUNT: IntCounterVec = register_int_counter_vec!(
+        "batch_system_reschedule_count",
+        "The count of rescheduled fsms",
+        &["tag"]
     )
     .unwrap();
 }

--- a/src/raftstore/store/fsm/router.rs
+++ b/src/raftstore/store/fsm/router.rs
@@ -498,7 +498,7 @@ mod tests {
         let (control_tx, mut control_fsm) = new_runner(10);
         let (control_drop_tx, control_drop_rx) = mpsc::unbounded();
         control_fsm.sender = Some(control_drop_tx);
-        let (router, mut system) = batch::create_system(2, 2, control_tx, control_fsm);
+        let (router, mut system) = batch::create_system(2, 2, 3, control_tx, control_fsm);
         let builder = Builder::new();
         system.spawn("test".to_owned(), builder);
 
@@ -595,7 +595,7 @@ mod tests {
     #[bench]
     fn bench_send(b: &mut Bencher) {
         let (control_tx, control_fsm) = new_runner(100000);
-        let (router, mut system) = batch::create_system(2, 2, control_tx, control_fsm);
+        let (router, mut system) = batch::create_system(2, 2, 3, control_tx, control_fsm);
         let builder = Builder::new();
         system.spawn("test".to_owned(), builder);
         let (normal_tx, normal_fsm) = new_runner(100000);

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -1151,9 +1151,11 @@ pub fn create_raft_batch_system(cfg: &Config) -> (RaftRouter, RaftBatchSystem) {
     let (router, system) = batch::create_system(
         cfg.store_pool_size,
         cfg.store_max_batch_size,
+        cfg.reschedule_count,
         store_tx,
         store_fsm,
     );
+    APPLY_PENDING_BYTES_GAUGE.set(0);
     let system = RaftBatchSystem {
         system,
         workers: None,

--- a/src/raftstore/store/metrics.rs
+++ b/src/raftstore/store/metrics.rs
@@ -223,4 +223,18 @@ lazy_static! {
             "tikv_raftstore_read_index_pending",
             "pending read index count"
         ).unwrap();
+
+    pub static ref APPLY_PENDING_BYTES_GAUGE: IntGauge =
+        register_int_gauge!(
+            "tikv_apply_pending_bytes",
+            "The bytes pending in the channel"
+        )
+        .unwrap();
+    pub static ref RESCHEDULE_FSM_COUNT: IntCounterVec =
+        register_int_counter_vec!(
+            "batch_system_reschedule_count",
+            "The count of rescheduled fsms",
+            &["tag"]
+        )
+        .unwrap();
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -161,6 +161,8 @@ fn test_serde_custom_tikv_config() {
         store_pool_size: 3,
         future_poll_size: 2,
         hibernate_regions: true,
+        apply_yield_count: 1,
+        reschedule_count: 3,
     };
     value.pd = PdConfig::new(vec!["example.com:443".to_owned()]);
     value.rocksdb = DbConfig {


### PR DESCRIPTION
Signed-off-by: Liqi Geng <gengliqiii@gmail.com>

### What problem does this PR solve?

Cherry-pick some code of https://github.com/tikv/tikv/pull/7702

### What is changed and how it works?

What's Changed:

Make yield and reschedule counter configurable
Add more metrics

### Related changes

No.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

No.

### Release note <!-- bugfixes or new feature need a release note -->
* No release note