### PR TITLE
test: fix unstatble test test_update_raftstore_config and test_update_apply_store_config

### DIFF
--- a/tests/integrations/config/dynamic/pessimistic_txn.rs
+++ b/tests/integrations/config/dynamic/pessimistic_txn.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use pd_client::PdClient;
 use security::SecurityManager;
+use test_raftstore::TestPdClient;
 use tikv::config::*;
 use tikv::server::lock_manager::*;
 use tikv::server::resolve::{Callback, StoreAddrResolver};
@@ -18,9 +19,6 @@ fn test_config_validate() {
     invalid_cfg.wait_for_lock_timeout = ReadableDuration::millis(0);
     assert!(invalid_cfg.validate().is_err());
 }
-
-struct MockPdClient;
-impl PdClient for MockPdClient {}
 
 #[derive(Clone)]
 struct MockResolver;
@@ -39,7 +37,7 @@ fn setup(
     LockManager,
 ) {
     let mut lock_mgr = LockManager::new();
-    let pd_client = Arc::new(MockPdClient);
+    let pd_client = Arc::new(TestPdClient::new(0, true));
     let security_mgr = Arc::new(SecurityManager::new(&cfg.security).unwrap());
     lock_mgr
         .start(

--- a/tests/integrations/config/dynamic/pessimistic_txn.rs
+++ b/tests/integrations/config/dynamic/pessimistic_txn.rs
@@ -1,7 +1,6 @@
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
 
-use pd_client::PdClient;
 use security::SecurityManager;
 use test_raftstore::TestPdClient;
 use tikv::config::*;

--- a/tests/integrations/config/dynamic/raftstore.rs
+++ b/tests/integrations/config/dynamic/raftstore.rs
@@ -17,7 +17,6 @@ use tikv::import::SSTImporter;
 
 use engine::Engines;
 use engine_traits::ALL_CFS;
-use pd_client::PdClient;
 use tempfile::TempDir;
 use test_raftstore::TestPdClient;
 use tikv_util::config::VersionTrack;

--- a/tests/integrations/config/dynamic/raftstore.rs
+++ b/tests/integrations/config/dynamic/raftstore.rs
@@ -19,6 +19,7 @@ use engine::Engines;
 use engine_traits::ALL_CFS;
 use pd_client::PdClient;
 use tempfile::TempDir;
+use test_raftstore::TestPdClient;
 use tikv_util::config::VersionTrack;
 use tikv_util::worker::{FutureWorker, Worker};
 
@@ -32,9 +33,6 @@ impl Transport for MockTransport {
         unimplemented!()
     }
 }
-
-struct MockPdClient;
-impl PdClient for MockPdClient {}
 
 fn create_tmp_engine(dir: &TempDir) -> Engines {
     let db = Arc::new(
@@ -94,7 +92,7 @@ fn start_raftstore(
             cfg_track,
             engines.c(),
             MockTransport,
-            Arc::new(MockPdClient),
+            Arc::new(TestPdClient::new(0, true)),
             snap_mgr,
             pd_worker,
             store_meta,


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7643 close #7644 

Problem Summary:
`test_update_raftstore_config` and `test_update_apply_store_config` are unstable, because the tests may run long enough to trigger region heartbeat and call on `PdClient` but the `MockPdClient` did not implement the methods.

### What is changed and how it works?
Replace `MockPdClient` with `TestPdClient`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note