### PR TITLE
cdc: unsubscribe pending downstream from conn

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -257,6 +257,8 @@ impl Delegate {
                 info!("fail to subscribe downstream";
                     "region_id" => region.get_id(),
                     "downstream_id" => ?downstream.get_id(),
+                    "conn_id" => ?downstream.get_conn_id(),
+                    "req_id" => downstream.req_id,
                     "err" => ?e);
                 let err = Error::Request(e.into());
                 let change_data_error = self.error_event(err);

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -138,7 +138,7 @@ impl ChangeData for Service {
         let recv_req = stream.for_each(move |request| {
             let region_epoch = request.get_region_epoch().clone();
             let req_id = request.get_request_id();
-            let downstream = Downstream::new(peer.clone(), region_epoch, req_id);
+            let downstream = Downstream::new(peer.clone(), region_epoch, req_id, conn_id);
             scheduler
                 .schedule(Task::Register {
                     request,

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -45,6 +45,8 @@ fn test_cdc_basic() {
         }
     });
 
+    // Sleep a while to make sure the stream is registered.
+    sleep_ms(200);
     // There must be a delegate.
     let scheduler = suite.endpoints.values().next().unwrap().scheduler();
     scheduler

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -656,6 +656,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         region_epoch: RegionEpoch,
         cb: Callback<RocksSnapshot>,
     ) {
+        fail_point!("raft_on_capture_change");
         let region_id = self.region_id();
         let msg =
             new_read_index_request(region_id, region_epoch.clone(), self.fsm.peer.peer.clone());


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
TiKV would return `duplicated error` after a pending downstream was unsubscribed.

### What is changed and how it works?
What's Changed:
Cleanup the information of an unsubscribed downstream correctly in `on_region_ready`.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* Bugfix for TiKV returns `duplicated error` to TiCDC.