### PR TITLE
UCP: Migrate scalar function `GreatestTime` (Vectorize) from TiDB

### DIFF
--- a/components/tidb_query_vec_expr/src/impl_compare.rs
+++ b/components/tidb_query_vec_expr/src/impl_compare.rs
@@ -1030,6 +1030,13 @@ mod tests {
                 ],
                 Some(b"2018-04-03 00:00:00.000000".to_owned().to_vec()),
             ),
+            (
+                vec![
+                    Some(b"2012-12-12 12:00:39".to_owned().to_vec()),
+                    Some(vec![0, 159, 146, 150]), // Invalid utf-8 bytes
+                ],
+                None,
+            ),
         ];
 
         for (row, expected) in cases {

--- a/components/tidb_query_vec_expr/src/impl_compare.rs
+++ b/components/tidb_query_vec_expr/src/impl_compare.rs
@@ -989,39 +989,39 @@ mod tests {
             (vec![None, None], None),
             (
                 vec![
-                    Some("2012-12-12 12:00:39".as_bytes().to_vec()),
-                    Some("2012-12-24 12:00:39".as_bytes().to_vec()),
+                    Some(b"2012-12-12 12:00:39".to_owned().to_vec()),
+                    Some(b"2012-12-24 12:00:39".to_owned().to_vec()),
                     None,
                 ],
                 None,
             ),
             (
                 vec![
-                    Some("2012-12-12 12:00:39".as_bytes().to_vec()),
-                    Some("2012-12-24 12:00:39".as_bytes().to_vec()),
-                    Some("2012-12-31 12:00:39".as_bytes().to_vec()),
+                    Some(b"2012-12-12 12:00:39".to_owned().to_vec()),
+                    Some(b"2012-12-24 12:00:39".to_owned().to_vec()),
+                    Some(b"2012-12-31 12:00:39".to_owned().to_vec()),
                 ],
-                Some("2012-12-31 12:00:39".as_bytes().to_vec()),
+                Some(b"2012-12-31 12:00:39".to_owned().to_vec()),
             ),
             (
                 vec![
-                    Some("2012-12-12 12:00:39".as_bytes().to_vec()),
-                    Some("2012-12-24 12:00:39".as_bytes().to_vec()),
-                    Some("2012-12-31 12:00:39".as_bytes().to_vec()),
-                    Some("invalid_time".as_bytes().to_vec()),
+                    Some(b"2012-12-12 12:00:39".to_owned().to_vec()),
+                    Some(b"2012-12-24 12:00:39".to_owned().to_vec()),
+                    Some(b"2012-12-31 12:00:39".to_owned().to_vec()),
+                    Some(b"invalid_time".to_owned().to_vec()),
                 ],
                 None,
             ),
             (
                 vec![
-                    Some("2012-12-12 12:00:39".as_bytes().to_vec()),
-                    Some("2012-12-24 12:00:39".as_bytes().to_vec()),
-                    Some("2012-12-31 12:00:39".as_bytes().to_vec()),
-                    Some("2012-12-12 12:00:38.12003800000".as_bytes().to_vec()),
-                    Some("2012-12-31 12:00:39.120050".as_bytes().to_vec()),
-                    Some("2018-04-03 00:00:00.000000".as_bytes().to_vec()),
+                    Some(b"2012-12-12 12:00:39".to_owned().to_vec()),
+                    Some(b"2012-12-24 12:00:39".to_owned().to_vec()),
+                    Some(b"2012-12-31 12:00:39".to_owned().to_vec()),
+                    Some(b"2012-12-12 12:00:38.12003800000".to_owned().to_vec()),
+                    Some(b"2012-12-31 12:00:39.120050".to_owned().to_vec()),
+                    Some(b"2018-04-03 00:00:00.000000".to_owned().to_vec()),
                 ],
-                Some("2018-04-03 00:00:00.000000".as_bytes().to_vec()),
+                Some(b"2018-04-03 00:00:00.000000".to_owned().to_vec()),
             ),
         ];
 

--- a/components/tidb_query_vec_expr/src/lib.rs
+++ b/components/tidb_query_vec_expr/src/lib.rs
@@ -320,6 +320,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::LeJson => compare_fn_meta::<BasicComparer<Json, CmpOpLE>>(),
         ScalarFuncSig::GreatestInt => greatest_int_fn_meta(),
         ScalarFuncSig::GreatestReal => greatest_real_fn_meta(),
+        ScalarFuncSig::GreatestTime => greatest_time_fn_meta(),
         ScalarFuncSig::GtInt => map_int_sig(value, children, compare_mapper::<CmpOpGT>)?,
         ScalarFuncSig::GtReal => compare_fn_meta::<BasicComparer<Real, CmpOpGT>>(),
         ScalarFuncSig::GtDecimal => compare_fn_meta::<BasicComparer<Decimal, CmpOpGT>>(),


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

UCP: #6747 

### What problem does this PR solve?

Issue Number: close #6747 

Problem Summary:

Port the function `GreatestTime` (Vectorize) from TiDB to coprocessor.

### What is changed and how it works?

* Add vectorized GreatestTime
* Add vectorized GreatestTime unit tests

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
