### PR TITLE
engine: Remove duplicate DATA_KEY_PREFIX_LEN definition

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -8,8 +8,8 @@ use std::sync::atomic::*;
 use std::sync::*;
 use std::time::*;
 
-use engine::{DATA_KEY_PREFIX_LEN, DB};
-use engine_traits::{name_to_cf, CfName, IterOptions};
+use engine::DB;
+use engine_traits::{name_to_cf, CfName, IterOptions, DATA_KEY_PREFIX_LEN};
 use external_storage::*;
 use futures::channel::mpsc::*;
 use kvproto::backup::*;

--- a/components/backup/tests/integrations/test_backup.rs
+++ b/components/backup/tests/integrations/test_backup.rs
@@ -13,9 +13,8 @@ use futures_util::io::AsyncReadExt;
 use grpcio::{ChannelBuilder, Environment};
 
 use backup::Task;
-use engine::*;
 use engine_traits::IterOptions;
-use engine_traits::{CfName, CF_DEFAULT, CF_WRITE};
+use engine_traits::{CfName, CF_DEFAULT, CF_WRITE, DATA_KEY_PREFIX_LEN};
 use external_storage::*;
 use kvproto::backup::*;
 use kvproto::import_sstpb::*;

--- a/components/engine/src/lib.rs
+++ b/components/engine/src/lib.rs
@@ -14,8 +14,6 @@ pub use crate::rocks::{CFHandle, DBIterator, Env, Range, ReadOptions, WriteOptio
 mod errors;
 pub use crate::errors::*;
 
-pub const DATA_KEY_PREFIX_LEN: usize = 1;
-
 #[derive(Clone, Debug)]
 pub struct Engines {
     pub kv: Arc<DB>,


### PR DESCRIPTION

### What problem does this PR solve?

Remove duplicate definition of `DATA_KEY_PREFIX_LEN` from engine crate in favor of engine_traits crate.

### What is changed and how it works?
### Related changes

https://github.com/tikv/tikv/issues/6402

### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.