### PR TITLE
diagnostics: Fix panic when a NIC doesn't have a mac address

### DIFF
--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -377,11 +377,18 @@ fn disk_hardware_info(collector: &mut Vec<ServerInfoItem>) {
     }
 }
 
+fn mac_address(mac: Option<pnet_datalink::MacAddr>) -> String {
+    match mac {
+        Some(mac) => mac.to_string(),
+        None => "none".to_string(),
+    }
+}
+
 fn nic_hardware_info(collector: &mut Vec<ServerInfoItem>) {
     let nics = pnet_datalink::interfaces();
     for nic in nics.into_iter() {
         let mut infos = vec![
-            ("mac", nic.mac_address().to_string()),
+            ("mac", mac_address(nic.mac)),
             ("flag", nic.flags.to_string()),
             ("index", nic.index.to_string()),
             ("is-up", nic.is_up().to_string()),


### PR DESCRIPTION
Signed-off-by: Kaige Ye <yekaige2010@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

`pnet_datalink::NetworkInterface::mac_address()` will panic if the NIC doesn't have a mac address. For example, a point-to-point link doesn't have mac address.


### What is changed and how it works?

What's Changed:

Return a string "none" when the `NIC.mac` is `None` 

### Check List

Tests

- Manual test

  * add a point-to-point interface (e.g. with `WireGuard` or `OpenVPN` or just `ip tunnel add`)
  * run `tiup playground`
  * visit http://localhost:2379/dashboard/#cluster-info/host
  * check tikv logs
      - without this patch, tikv panics
      - with this patch, no panic any more


