### PR TITLE
copr: fix documentation for function::Arg

### DIFF
--- a/components/tidb_query_vec_expr/src/types/function.rs
+++ b/components/tidb_query_vec_expr/src/types/function.rs
@@ -118,7 +118,7 @@ pub trait ArgDef: std::fmt::Debug {}
 ///
 /// For example, if an RPN function foo(Int, Real, Decimal) is applied to input of a scalar of
 /// integer, a vector of reals and a vector of decimals, the constructed `ArgDef` will be
-/// `Arg<ScalarArg<Int>, Arg<VectorValue<Real>, Arg<VectorValue<Decimal>, Null>>>`. `Null`
+/// `Arg<ScalarArg<Int>, <Arg<VectorValue<Real>, Arg<VectorValue<Decimal>, Null>>>`. `Null`
 /// indicates the end of the argument list.
 #[derive(Debug)]
 pub struct Arg<A: RpnFnArg, Rem: ArgDef> {


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

### What problem does this PR solve?

Docs for `function::Arg` in `tide_query_vec_expr` seems to be incorrect. The type mentioned in example has one angle bracket unpaired.

### What is changed and how it works?

Update docs.

### Related changes
