### PR TITLE
tidb_query: add missing collation id for ascii_bin and latin1_bin

### DIFF
--- a/components/tidb_query_datatype/src/def/field_type.rs
+++ b/components/tidb_query_datatype/src/def/field_type.rs
@@ -118,7 +118,7 @@ impl Collation {
     pub fn from_i32(n: i32) -> Result<Self, DataTypeError> {
         match n {
             -33 | -45 => Ok(Collation::Utf8Mb4GeneralCi),
-            -46 | -83 => Ok(Collation::Utf8Mb4Bin),
+            -46 | -83 | -65 | -47 => Ok(Collation::Utf8Mb4Bin),
             -63 | 63 => Ok(Collation::Binary),
             n if n >= 0 => Ok(Collation::Utf8Mb4BinNoPadding),
             n => Err(DataTypeError::UnsupportedCollation { code: n }),


### PR DESCRIPTION
Signed-off-by: bb7133 <bb7133@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7914

Problem Summary:

### What is changed and how it works?
TiDB allows `ascii_bin` and `latin1_bin` collation when the new collation framework is enabled, however TiKV does not recognize their IDs(-65 and -47). An error is reported when they're pushed-down to TiKV.

What's Changed:

It is quite easy to support them: we use the `Utf8Mb4Bin` collator to handle them, just like what we did for `utf8_bin`.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- To be added

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->
- Fix the issue that `ascii_bin` and `latin1_bin` is not supported by TiKV for new collation framework.