### PR TITLE
Make tikv-ctl used via relative path when encryption is enabled

### DIFF
--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -76,14 +76,19 @@ fn new_debug_executor(
             kv_db_opts.set_env(env.clone());
             kv_db_opts.set_paranoid_checks(!skip_paranoid_checks);
             let kv_cfs_opts = cfg.rocksdb.build_cf_opts(&cache);
+            let kv_path = PathBuf::from(kv_path).canonicalize().unwrap();
+            let kv_path = kv_path.to_str().unwrap();
             let kv_db = rocks::util::new_engine_opt(kv_path, kv_db_opts, kv_cfs_opts).unwrap();
 
-            let raft_path = raft_db.map(ToString::to_string).unwrap_or_else(|| {
-                let db_path = PathBuf::from(format!("{}/../raft", kv_path))
-                    .canonicalize()
-                    .unwrap();
-                String::from(db_path.to_str().unwrap())
-            });
+            let mut raft_path = raft_db
+                .map(ToString::to_string)
+                .unwrap_or_else(|| format!("{}/../raft", kv_path));
+            raft_path = PathBuf::from(raft_path)
+                .canonicalize()
+                .unwrap()
+                .to_str()
+                .map(ToString::to_string)
+                .unwrap();
             let mut raft_db_opts = cfg.raftdb.build_opt();
             raft_db_opts.set_env(env);
             let raft_db_cf_opts = cfg.raftdb.build_cf_opts(&cache);


### PR DESCRIPTION
Signed-off-by: TXXT <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

close #7886 

Problem Summary:
relative path cannot be key in encryption dictionary, let's canonicalize it.

### What is changed and how it works?

canonicalize `kv_path` and `raft_path`

### Related changes

None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

No

### Release note <!-- bugfixes or new feature need a release note -->
- Fix bug where tikv-ctl does not support relative path