### PR TITLE
mvcc, backup: consider deleted key when calculating max ts and min ts (#7935)

### DIFF
--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -746,6 +746,48 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_ts_filter_lost_delete() {
+        let dir = TempDir::new("test_ts_filter_lost_deletion").unwrap();
+        let path = dir.path().to_str().unwrap();
+        let region = make_region(1, vec![0], vec![]);
+
+        let db = open_db(&path, true);
+        let mut engine = RegionEngine::new(db.clone(), region.clone());
+
+        let key1 = &[1];
+        engine.put(key1, 2, 3);
+        engine.flush();
+        engine.compact();
+
+        // Delete key 1 commit ts@5 and GC@6
+        // Put key 2 commit ts@7
+        let key2 = &[2];
+        engine.put(key2, 6, 7);
+        engine.delete(key1, 4, 5);
+        engine.gc(key1, 6);
+        engine.flush();
+
+        // Scan kv with ts filter [1, 6].
+        let mut iopt = IterOption::default();
+        iopt.set_hint_min_ts(Bound::Included(1));
+        iopt.set_hint_max_ts(Bound::Included(6));
+
+        let snap = RegionSnapshot::from_raw(Arc::clone(&db), region);
+        let mut iter = snap.iter_cf(CF_WRITE, iopt).unwrap();
+
+        // Must not omit the latest deletion of key1 to prevent seeing outdated record.
+        assert_eq!(iter.seek_to_first().unwrap(), true);
+        assert_eq!(
+            Key::from_encoded_slice(iter.key())
+                .to_raw()
+                .unwrap()
+                .as_slice(),
+            key2
+        );
+        assert_eq!(iter.next().unwrap(), false);
+    }
+
     fn test_with_properties(path: &str, region: &Region) {
         let db = open_db(path, true);
         let mut engine = RegionEngine::new(Arc::clone(&db), region.clone());

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -246,14 +246,21 @@ impl<S: Snapshot> TxnEntryStore for SnapshotStore<S> {
     ) -> Result<EntryScanner<S>> {
         // Check request bounds with physical bound
         self.verify_range(&lower_bound, &upper_bound)?;
+        let (min_ts, max_ts) = if after_ts == 0 {
+            // Do not set min_ts and max_ts as it wants to read all versions.
+            (None, None)
+        } else {
+            // Scan ts in (after_ts, start_ts].
+            (Some(after_ts + 1), Some(self.start_ts))
+        };
         let scanner =
             ScannerBuilder::new(self.snapshot.clone(), self.start_ts, false /* desc */)
                 .range(lower_bound, upper_bound)
                 .omit_value(false)
                 .fill_cache(self.fill_cache)
                 .isolation_level(self.isolation_level)
-                .hint_min_ts(Some(after_ts + 1))
-                .hint_max_ts(Some(self.start_ts))
+                .hint_min_ts(min_ts)
+                .hint_max_ts(max_ts)
                 .build_entry_scanner(after_ts, output_delete)?;
 
         Ok(scanner)


### PR DESCRIPTION
### What problem does this PR solve?

Cherry pick #7935.

Delete key must be considered when calculating max ts and min ts in
order to prevent seeing GCed records, otherwise it causes
DefaultNotFound error or seeing inconsistent data.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue of backup fails with DefaultNotFound error.
