### PR TITLE
server: Add advertise status addr

### DIFF
--- a/cmd/src/bin/tikv-server.rs
+++ b/cmd/src/bin/tikv-server.rs
@@ -75,6 +75,13 @@ fn main() {
                 .help("Set the HTTP listening address for the status report service"),
         )
         .arg(
+            Arg::with_name("advertise-status-addr")
+                .long("advertise-status-addr")
+                .takes_value(true)
+                .value_name("IP:PORT")
+                .help("Set the advertise listening address for the client communication of status report service"),
+        )
+        .arg(
             Arg::with_name("data-dir")
                 .long("data-dir")
                 .short("s")

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -777,6 +777,7 @@ impl TiKVServer {
             // Start the status server.
             if let Err(e) = status_server.start(
                 self.config.server.status_addr.clone(),
+                self.config.server.advertise_status_addr.clone(),
                 &self.config.security,
             ) {
                 error!(

--- a/cmd/src/setup.rs
+++ b/cmd/src/setup.rs
@@ -156,6 +156,10 @@ pub fn overwrite_config_with_cmd_args(config: &mut TiKvConfig, matches: &ArgMatc
         config.server.status_addr = status_addr.to_owned();
     }
 
+    if let Some(advertise_status_addr) = matches.value_of("advertise-status-addr") {
+        config.server.advertise_status_addr = advertise_status_addr.to_owned();
+    }
+
     if let Some(data_dir) = matches.value_of("data-dir") {
         config.storage.data_dir = data_dir.to_owned();
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1925,6 +1925,8 @@ mod readpool_tests {
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct TiKvConfig {
+    #[doc(hidden)]
+    #[serde(skip_serializing)]
     #[config(hidden)]
     pub cfg_path: String,
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -62,6 +62,11 @@ pub struct Config {
 
     // These are related to TiKV status.
     pub status_addr: String,
+
+    // Status server's advertise listening address for outer communication.
+    // If not set, the status server's listening address will be used.
+    pub advertise_status_addr: String,
+
     pub status_thread_pool_size: usize,
 
     pub max_grpc_send_msg_len: i32,
@@ -125,6 +130,7 @@ impl Default for Config {
             labels: HashMap::default(),
             advertise_addr: DEFAULT_ADVERTISE_LISTENING_ADDR.to_owned(),
             status_addr: DEFAULT_STATUS_ADDR.to_owned(),
+            advertise_status_addr: DEFAULT_ADVERTISE_LISTENING_ADDR.to_owned(),
             status_thread_pool_size: 1,
             max_grpc_send_msg_len: DEFAULT_MAX_GRPC_SEND_MSG_LEN,
             grpc_compression_type: GrpcCompressionType::None,
@@ -185,12 +191,30 @@ impl Config {
                 self.advertise_addr
             ));
         }
+        if self.status_addr.is_empty() && !self.advertise_status_addr.is_empty() {
+            return Err(box_err!("status-addr can not be empty"));
+        }
         if !self.status_addr.is_empty() {
             box_try!(config::check_addr(&self.status_addr));
+            if !self.advertise_status_addr.is_empty() {
+                box_try!(config::check_addr(&self.advertise_status_addr));
+            } else {
+                info!(
+                    "no advertise-status-addr is specified, falling back to status-addr";
+                    "status-addr" => %self.status_addr
+                );
+                self.advertise_status_addr = self.status_addr.clone();
+            }
+            if self.advertise_status_addr.starts_with("0.0.0.0") {
+                return Err(box_err!(
+                    "invalid advertise-status-addr: {:?}",
+                    self.advertise_status_addr
+                ));
+            }
         }
-        if self.status_addr == self.advertise_addr {
+        if self.advertise_status_addr == self.advertise_addr {
             return Err(box_err!(
-                "status-addr has already been used: {:?}",
+                "advertise-status-addr has already been used: {:?}",
                 self.advertise_addr
             ));
         }
@@ -286,8 +310,10 @@ mod tests {
     fn test_config_validate() {
         let mut cfg = Config::default();
         assert!(cfg.advertise_addr.is_empty());
+        assert!(cfg.advertise_status_addr.is_empty());
         cfg.validate().unwrap();
         assert_eq!(cfg.addr, cfg.advertise_addr);
+        assert_eq!(cfg.status_addr, cfg.advertise_status_addr);
 
         let mut invalid_cfg = cfg.clone();
         invalid_cfg.concurrent_send_snap_limit = 0;
@@ -311,9 +337,15 @@ mod tests {
         invalid_cfg.advertise_addr = "127.0.0.1:1000".to_owned();
         invalid_cfg.validate().unwrap();
 
+        invalid_cfg = Config::default();
+        invalid_cfg.status_addr = "0.0.0.0:1000".to_owned();
+        assert!(invalid_cfg.validate().is_err());
+        invalid_cfg.advertise_status_addr = "127.0.0.1:1000".to_owned();
+        invalid_cfg.validate().unwrap();
+
         let mut invalid_cfg = cfg.clone();
         invalid_cfg.advertise_addr = "127.0.0.1:1000".to_owned();
-        invalid_cfg.status_addr = "127.0.0.1:1000".to_owned();
+        invalid_cfg.advertise_status_addr = "127.0.0.1:1000".to_owned();
         assert!(invalid_cfg.validate().is_err());
 
         let mut invalid_cfg = cfg.clone();

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -80,8 +80,12 @@ where
         } else {
             store.set_address(cfg.advertise_addr.clone())
         }
+        if cfg.advertise_status_addr.is_empty() {
+            store.set_status_address(cfg.status_addr.clone());
+        } else {
+            store.set_status_address(cfg.advertise_status_addr.clone())
+        }
         store.set_version(env!("CARGO_PKG_VERSION").to_string());
-        store.set_status_address(cfg.status_addr.clone());
 
         if let Ok(path) = std::env::current_exe() {
             if let Some(path) = path.parent() {

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -885,6 +885,7 @@ mod tests {
 
     use crate::config::{ConfigController, TiKvConfig};
     use crate::server::status_server::StatusServer;
+    use configuration::Configuration;
     use engine_rocks::RocksSnapshot;
     use raftstore::store::transport::CasualRouter;
     use raftstore::store::CasualMessage;
@@ -970,7 +971,7 @@ mod tests {
                     let v = body.to_vec();
                     let resp_json = String::from_utf8_lossy(&v).to_string();
                     let cfg = TiKvConfig::default();
-                    serde_json::to_string(&cfg)
+                    serde_json::to_string(&cfg.get_encoder())
                         .map(|cfg_json| {
                             assert_eq!(resp_json, cfg_json);
                         })

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -987,7 +987,8 @@ mod tests {
     fn test_status_service_fail_endpoints() {
         let _guard = fail::FailScenario::setup();
         let mut status_server = StatusServer::new(1, None, ConfigController::default(), MockRouter);
-        let _ = status_server.start("127.0.0.1:0".to_string(), &SecurityConfig::default());
+        let addr = "127.0.0.1:0".to_owned();
+        let _ = status_server.start(addr.clone(), addr, &SecurityConfig::default());
         let client = Client::new();
         let addr = status_server.listening_addr().to_string();
 
@@ -1119,7 +1120,8 @@ mod tests {
     fn test_status_service_fail_endpoints_can_trigger_fails() {
         let _guard = fail::FailScenario::setup();
         let mut status_server = StatusServer::new(1, None, ConfigController::default(), MockRouter);
-        let _ = status_server.start("127.0.0.1:0".to_string(), &SecurityConfig::default());
+        let addr = "127.0.0.1:0".to_owned();
+        let _ = status_server.start(addr.clone(), addr, &SecurityConfig::default());
         let client = Client::new();
         let addr = status_server.listening_addr().to_string();
 

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -63,6 +63,7 @@ fn test_serde_custom_tikv_config() {
         labels: map! { "a".to_owned() => "b".to_owned() },
         advertise_addr: "example.com:443".to_owned(),
         status_addr: "example.com:443".to_owned(),
+        advertise_status_addr: "example.com:443".to_owned(),
         status_thread_pool_size: 1,
         max_grpc_send_msg_len: 6 * (1 << 20),
         concurrent_send_snap_limit: 4,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -35,6 +35,7 @@ stack-size = "12MB"
 addr = "example.com:443"
 advertise-addr = "example.com:443"
 status-addr = "example.com:443"
+advertise-status-addr = "example.com:443"
 status-thread-pool-size = 1
 max-grpc-send-msg-len = 6291456
 grpc-compression-type = "gzip"

--- a/tests/integrations/server/status_server.rs
+++ b/tests/integrations/server/status_server.rs
@@ -46,8 +46,9 @@ fn test_region_meta_endpoint() {
     assert!(router.is_some());
     let mut status_server =
         StatusServer::new(1, None, ConfigController::default(), router.unwrap());
+    let addr = "127.0.0.1:0".to_owned();
     assert!(status_server
-        .start("127.0.0.1:0".to_string(), &SecurityConfig::default())
+        .start(addr.clone(), addr, &SecurityConfig::default())
         .is_ok());
     let check_task = Box::pin(check(status_server.listening_addr(), region_id));
     rt::run(Compat::new(check_task).map_err(|err| panic!("{}", err)));


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7920 

Problem Summary:
Instead of the status server's listening address, using an advertise address to register to `PD` for outer communication.

### What is changed and how it works?

What's Changed:
Add `--advertise-status-addr` flag to `tikv-server`, if not specified it will be set to the `status-addr` and it will be used to register to `PD`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test

### Release note <!-- bugfixes or new feature need a release note -->
- Add `--advertise-status-addr` flag to specify the status address to advertise