### PR TITLE
Add some unit benchmarks

### DIFF
--- a/tests/benches/misc/storage/mod.rs
+++ b/tests/benches/misc/storage/mod.rs
@@ -2,4 +2,73 @@
 
 mod incremental_get;
 mod key;
+mod point_get;
 mod scan;
+mod snapshot;
+
+use engine_rocks::RocksSnapshot;
+use kvproto::kvrpcpb::{Context, IsolationLevel};
+use std::sync::Arc;
+use test_storage::{SyncTestStorage, SyncTestStorageBuilder};
+use tidb_query_datatype::codec::table;
+use tikv::storage::{Engine, RocksEngine, SnapshotStore};
+use txn_types::{Key, Mutation};
+
+const TABLE_ID: i64 = 5;
+
+fn prepare_table_data(keys: usize, value_size: usize) -> SyncTestStorage<RocksEngine> {
+    let store = SyncTestStorageBuilder::new().build().unwrap();
+    let mut mutations = Vec::new();
+    let mut k = Vec::new();
+    for i in 0..keys {
+        let user_key = table::encode_row_key(TABLE_ID, i as i64);
+        let user_value = vec![b'x'; value_size];
+        let key = Key::from_raw(&user_key);
+        let mutation = Mutation::Put((key.clone(), user_value));
+        mutations.push(mutation);
+        k.push(key);
+    }
+
+    let pk = table::encode_row_key(TABLE_ID, 0);
+
+    store
+        .prewrite(Context::default(), mutations, pk, 1)
+        .unwrap();
+    store.commit(Context::default(), k, 1, 2).unwrap();
+
+    let engine = store.get_engine();
+    let db = engine.get_rocksdb();
+    db.compact_range_cf(db.cf_handle("write").unwrap(), None, None);
+    db.compact_range_cf(db.cf_handle("default").unwrap(), None, None);
+    db.compact_range_cf(db.cf_handle("lock").unwrap(), None, None);
+
+    return store;
+}
+
+fn make_key(handle: i64) -> Key {
+    Key::from_raw(&table::encode_row_key(TABLE_ID, handle))
+}
+
+fn prepare_get_keys(keys: usize, step: usize) -> Vec<Key> {
+    let mut get_keys = Vec::new();
+    let mut ki = 0;
+    for _ in 0..keys {
+        get_keys.push(make_key(ki));
+        ki += step as i64;
+    }
+    get_keys
+}
+
+fn new_snapshot_store(storage: &SyncTestStorage<RocksEngine>) -> SnapshotStore<Arc<RocksSnapshot>> {
+    let engine = storage.get_engine();
+    let snapshot = engine.snapshot(&Context::default()).unwrap();
+    let store = SnapshotStore::new(
+        snapshot,
+        10.into(),
+        IsolationLevel::Si,
+        true,
+        Default::default(),
+        false,
+    );
+    store
+}

--- a/tests/benches/misc/storage/point_get.rs
+++ b/tests/benches/misc/storage/point_get.rs
@@ -1,0 +1,27 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use test::{black_box, Bencher};
+use tikv::storage::{Statistics, Store};
+
+fn bench_impl(b: &mut Bencher, value_size: usize) {
+    let s = super::prepare_table_data(30000, value_size);
+    let key = super::make_key(15000);
+    let store = super::new_snapshot_store(&s);
+    b.iter(|| {
+        let mut stats = Statistics::default();
+        let v = black_box(&store).get(black_box(&key), &mut stats);
+        black_box(v.unwrap().unwrap());
+    });
+}
+
+/// Point get single key in a 30000 key space (value size = 64).
+#[bench]
+fn bench_short(b: &mut Bencher) {
+    bench_impl(b, 64);
+}
+
+/// Point get single key in a 30000 key space (value size = 1024).
+#[bench]
+fn bench_long(b: &mut Bencher) {
+    bench_impl(b, 1024);
+}

--- a/tests/benches/misc/storage/scan.rs
+++ b/tests/benches/misc/storage/scan.rs
@@ -1,12 +1,48 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use test::Bencher;
-
 use kvproto::kvrpcpb::Context;
-
+use test::{black_box, Bencher};
 use test_storage::SyncTestStorageBuilder;
 use test_util::*;
+use tikv::storage::{Scanner, Store};
 use txn_types::{Key, Mutation};
+
+fn bench_scan_asc_impl(b: &mut Bencher, value_size: usize) {
+    let s = super::prepare_table_data(30000, value_size);
+    let lower = super::make_key(14000);
+    let upper = super::make_key(14100);
+    let store = super::new_snapshot_store(&s);
+    b.iter(|| {
+        let lower = test::black_box(&lower).clone();
+        let upper = test::black_box(&upper).clone();
+        let mut scanner = store
+            .scanner(false, false, false, Some(lower), Some(upper))
+            .unwrap();
+        let mut n = 0;
+        loop {
+            let ret = scanner.next().unwrap();
+            if ret.is_none() {
+                break;
+            }
+            let kv = ret.unwrap();
+            black_box(kv);
+            n += 1;
+        }
+        assert_eq!(n, 100);
+    })
+}
+
+/// Ascending scan 100 keys single key in a 30000 key space (value size = 64).
+#[bench]
+fn bench_scan_asc_short(b: &mut Bencher) {
+    bench_scan_asc_impl(b, 64);
+}
+
+/// Ascending scan 100 keys single key in a 30000 key space (value size = 1024).
+#[bench]
+fn bench_scan_asc_long(b: &mut Bencher) {
+    bench_scan_asc_impl(b, 1024);
+}
 
 /// In mvcc kv is not actually deleted, which may cause performance issue
 /// when doing scan.

--- a/tests/benches/misc/storage/snapshot.rs
+++ b/tests/benches/misc/storage/snapshot.rs
@@ -1,0 +1,15 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use kvproto::kvrpcpb::Context;
+use test::{black_box, Bencher};
+use tikv::storage::Engine;
+
+#[bench]
+fn bench_rocksdb_snapshot(b: &mut Bencher) {
+    let s = super::prepare_table_data(1000, 64);
+    let engine = s.get_engine();
+    b.iter(|| {
+        let snapshot = black_box(&engine).snapshot(&Context::default()).unwrap();
+        black_box(snapshot);
+    });
+}


### PR DESCRIPTION
Signed-off-by: Breezewish <breezewish@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This PR adds unit benchmarks for point get, snapshot and scan. This makes it possible to estimate performance impact when introducing new things (like tracing) by simply comparing time cost.

### What is changed and how it works?

Add benchmarks.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

- Manual test (add detailed scripts or steps below)

On internal IDC (Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz):

```
test storage::incremental_get::bench_get_far                          ... bench:   3,310,193 ns/iter (+/- 577,578) // 500 keys, value len = 64
test storage::incremental_get::bench_get_near                         ... bench:   3,124,606 ns/iter (+/- 436,004) // 500 keys, value len = 64
test storage::incremental_get::bench_incremental_get_far              ... bench:   1,508,194 ns/iter (+/- 62,467) // 500 keys, value len = 64
test storage::incremental_get::bench_incremental_get_near             ... bench:   1,413,070 ns/iter (+/- 167,657) // 500 keys, value len = 64
test storage::point_get::bench_long                                   ... bench:       8,193 ns/iter (+/- 739) // 1 key, value len = 1024
test storage::point_get::bench_short                                  ... bench:       5,842 ns/iter (+/- 588) // 1 key, value len = 64
test storage::scan::bench_scan_asc_long                               ... bench:      98,143 ns/iter (+/- 9,117) // 100 keys, value len = 1024
test storage::scan::bench_scan_asc_short                              ... bench:      53,012 ns/iter (+/- 6,917) // 100 keys, value len = 64
test storage::snapshot::bench_rocksdb_snapshot                        ... bench:       6,294 ns/iter (+/- 102)
```

### Release note <!-- bugfixes or new feature need a release note -->

(no need)