### PR TITLE
copr: migrate `rpn_fn` interface to be compatible with proposed `ChunkedVec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4368,6 +4368,7 @@ dependencies = [
  "profiler",
  "prometheus-static-metric",
  "protobuf",
+ "static_assertions",
  "tidb_query_codegen",
  "tidb_query_common",
  "tidb_query_datatype",

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -6,7 +6,7 @@
 //!
 //! ```ignore
 //! #[rpn_fn]
-//! fn foo(x: &Option<u32>) -> Result<Option<u8>> {
+//! fn foo(x: Option<&u32>) -> Result<Option<u8>> {
 //!     Ok(None)
 //! }
 //! ```
@@ -17,16 +17,16 @@
 //!
 //! If neither `varg` or `raw_varg` are supplied, then the generated arguments
 //! follow from the supplied function's arguments. Each argument must have a type
-//! `&Option<T>` for some `T`.
+//! `Option<&T>` for some `T`.
 //!
 //! ### `varg`
 //!
 //! The RPN operator takes a variable number of arguments. The arguments are passed
-//! as a `&[&Option<T>]`. E.g.,
+//! as a `&[Option<&T>]`. E.g.,
 //!
 //! ```ignore
 //! #[rpn_fn(varg)]
-//! pub fn foo(args: &[&Option<Int>]) -> Result<Option<Real>> {
+//! pub fn foo(args: &[Option<&Int>]) -> Result<Option<Real>> {
 //!     // Your RPN function logic
 //! }
 //! ```
@@ -99,7 +99,7 @@
 //! ```ignore
 //! // This generates `with_context_fn_meta() -> RpnFnMeta`
 //! #[rpn_fn(capture = [ctx])]
-//! fn with_context(ctx: &mut EvalContext, param: &Option<Decimal>) -> Result<Option<Int>> {
+//! fn with_context(ctx: &mut EvalContext, param: Option<&Decimal>) -> Result<Option<Int>> {
 //!     // Your RPN function logic
 //! }
 //! ```
@@ -142,13 +142,13 @@
 //! first argument is a scalar. The code may look like:
 //!
 //! ```ignore
-//! fn regex_match_impl(regex: &Regex, text: &Option<Bytes>) -> Result<Option<i32>> {
+//! fn regex_match_impl(regex: &Regex, text: Option<&Bytes>) -> Result<Option<i32>> {
 //!     // match text
 //! }
 //!
 //! #[rpn_fn]
-//! fn regex_match(regex: &Option<Bytes>, text: &Option<Bytes>) -> Result<Option<i32>> {
-//!     let regex = build_regex(regex);
+//! fn regex_match(regex: Option<&Bytes>, text: Option<&Bytes>) -> Result<Option<i32>> {
+//!     let regex = build_regex(regex.cloned());
 //!     regex_match_impl(&regex, text)
 //! }
 //!
@@ -180,7 +180,7 @@
 //!
 //! ```ignore
 //! #[rpn_fn(varg)]
-//! pub fn foo(args: &[&Option<Int>]) -> Result<Option<Real>> {
+//! pub fn foo(args: &[Option<&Int>]) -> Result<Option<Real>> {
 //!     // Your RPN function logic
 //! }
 //! ```

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -1037,6 +1037,7 @@ impl NormalRpnFn {
             self.metadata_type.is_some() || self.metadata_mapper.is_some(),
         );
         let extract2 = extract.clone();
+        let extract3 = extract.clone();
         let call_arg2 = extract.clone();
         let metadata_type_checker = generate_metadata_type_checker(
             &self.metadata_type,
@@ -1065,6 +1066,7 @@ impl NormalRpnFn {
                     let mut result = Vec::with_capacity(output_rows);
                     for row_index in 0..output_rows {
                         #(let (#extract, arg) = arg.extract(row_index));*;
+                        #(let #extract3 = #extract3.as_ref());*;
                         result.push( #fn_ident #ty_generics_turbofish ( #(#captures,)* #(#call_arg),* )?);
                     }
                     Ok(tidb_query_datatype::codec::data_type::Evaluable::into_vector_value(result))

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -655,7 +655,7 @@ impl VargsRpnFn {
         let fn_arg = item_fn.sig.inputs.iter().nth(attr.captures.len()).unwrap();
         let arg_type =
             parse2::<VargsRpnFnSignatureParam>(fn_arg.into_token_stream()).map_err(|_| {
-                Error::new_spanned(fn_arg, "Expect parameter type to be like `&[&Option<T>]`")
+                Error::new_spanned(fn_arg, "Expect parameter type to be like `&[Option<&T>]`")
             })?;
 
         let ret_type = parse2::<RpnFnSignatureReturnType>(

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -746,9 +746,10 @@ impl VargsRpnFn {
                         let mut vargs_buf = vargs_buf.borrow_mut();
                         let args_len = args.len();
                         vargs_buf.resize(args_len, None);
-                        let mut vargs_buf : Vec<Option<&#arg_type>> = Vec::with_capacity(args_len);
+                        let mut vargs_buf = Vec::new();
                         let mut result = Vec::with_capacity(output_rows);
                         for row_index in 0..output_rows {
+                            vargs_buf.clear();
                             for arg_index in 0..args_len {
                                 let scalar_arg = args[arg_index].get_logical_scalar_ref(row_index);
                                 let arg: &Option<#arg_type> = Evaluable::borrow_scalar_value_ref(&scalar_arg);

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -745,14 +745,14 @@ impl VargsRpnFn {
                         use tidb_query_datatype::codec::data_type::Evaluable;
                         let mut vargs_buf = vargs_buf.borrow_mut();
                         let args_len = args.len();
-                        vargs_buf.resize(args_len, None);
+                        vargs_buf.resize(args_len, 0);
                         let mut result = Vec::with_capacity(output_rows);
                         for row_index in 0..output_rows {
                             for arg_index in 0..args_len {
                                 let scalar_arg = args[arg_index].get_logical_scalar_ref(row_index);
                                 let arg: &Option<#arg_type> = Evaluable::borrow_scalar_value_ref(&scalar_arg);
                                 let arg: Option<&#arg_type> = arg.as_ref();
-                                let arg: Option<&usize> = unsafe { std::mem::transmute::<Option<&#arg_type>, Option<&usize>>(arg) };
+                                let arg: usize = unsafe { std::mem::transmute::<Option<&#arg_type>, usize>(arg) };
                                 vargs_buf[arg_index] = arg;
                             }
                             result.push(#fn_ident #ty_generics_turbofish( #(#captures,)*

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -420,8 +420,7 @@ impl parse::Parse for VargsRpnFnSignatureParam {
         input.parse::<Token![&]>()?;
         let slice_inner;
         bracketed!(slice_inner in input);
-        slice_inner.parse::<Token![&]>()?;
-        let et = slice_inner.parse::<RpnFnEvaluableType>()?;
+        let et = slice_inner.parse::<RpnFnRefEvaluableType>()?;
         Ok(Self {
             _pat: pat,
             eval_type: et.eval_type,

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -751,8 +751,11 @@ impl VargsRpnFn {
                         let mut result = Vec::with_capacity(output_rows);
                         for row_index in 0..output_rows {
                             for arg_index in 0..args_len {
-                                let scalar_arg: &Option<#arg_type> = args[arg_index].get_logical_scalar_ref(row_index).as_ref();
-                                let arg: Option<&#arg_type> = scalar_arg.as_ref();
+                                let scalar_arg = args[arg_index].get_logical_scalar_ref(row_index);
+                                let arg: &Option<#arg_type> = Evaluable::borrow_scalar_value_ref(&scalar_arg);
+                                let arg = arg as *const Option<#arg_type> as usize;
+                                let arg: &'static Option<#arg_type> = unsafe { &* (arg as *const Option<#arg_type>) };
+                                let arg: Option<&#arg_type> = arg.as_ref();
                                 vargs_buf.push(arg);
                             }
                             result.push(#fn_ident #ty_generics_turbofish( #(#captures,)* &vargs_buf)?);

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -1052,6 +1052,7 @@ impl NormalRpnFn {
         );
         let extract2 = extract.clone();
         let extract3 = extract.clone();
+        let extract4 = extract.clone();
         let call_arg2 = extract.clone();
         let metadata_type_checker = generate_metadata_type_checker(
             &self.metadata_type,
@@ -1061,6 +1062,7 @@ impl NormalRpnFn {
             quote! {
                 let arg: &#tp = unsafe { &*std::ptr::null() };
                 #(let (#extract2, arg) = arg.extract(0));*;
+                #(let #extract4 = #extract4.as_ref());*;
                 #fn_ident #ty_generics_turbofish ( #(#captures,)* #(#call_arg2),* ).ok();
             },
         );

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -751,8 +751,8 @@ impl VargsRpnFn {
                         let mut result = Vec::with_capacity(output_rows);
                         for row_index in 0..output_rows {
                             for arg_index in 0..args_len {
-                                let scalar_arg = args[arg_index].get_logical_scalar_ref(row_index);
-                                let arg: Option<&#arg_type> = scalar_arg.into();
+                                let scalar_arg: &Option<#arg_type> = args[arg_index].get_logical_scalar_ref(row_index).as_ref();
+                                let arg: Option<&#arg_type> = scalar_arg.as_ref();
                                 vargs_buf.push(arg);
                             }
                             result.push(#fn_ident #ty_generics_turbofish( #(#captures,)* &vargs_buf)?);

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -372,7 +372,6 @@ impl parse::Parse for RpnFnEvaluableType {
     }
 }
 
-
 /// Parses an evaluable type like `Option<&T>`.
 struct RpnFnRefEvaluableType {
     eval_type: TypePath,
@@ -1194,7 +1193,7 @@ mod tests_normal {
         let item_fn = parse_str(
             r#"
             #[inline]
-            fn foo(arg0: &Option<Int>, arg1: &Option<Real>) -> tidb_query_common::Result<Option<Decimal>> {
+            fn foo(arg0: Option<&Int>, arg1: Option<&Real>) -> tidb_query_common::Result<Option<Decimal>> {
                 Ok(None)
             }
         "#,
@@ -1272,6 +1271,8 @@ mod tests_normal {
                     for row_index in 0..output_rows {
                         let (arg0, arg) = arg.extract(row_index);
                         let (arg1, arg) = arg.extract(row_index);
+                        let arg0 = arg0.as_ref();
+                        let arg1 = arg1.as_ref();
                         result.push(foo(arg0, arg1)?);
                     }
                     Ok(tidb_query_datatype::codec::data_type::Evaluable::into_vector_value(result))
@@ -1357,7 +1358,7 @@ mod tests_normal {
     fn generic_fn() -> NormalRpnFn {
         let item_fn = parse_str(
             r#"
-            fn foo<A: M, B>(arg0: &Option<A::X>) -> Result<Option<B>>
+            fn foo<A: M, B>(arg0: Option<&A::X>) -> Result<Option<B>>
             where B: N<A> {
                 Ok(None)
             }
@@ -1439,6 +1440,7 @@ mod tests_normal {
                     let mut result = Vec::with_capacity(output_rows);
                     for row_index in 0..output_rows {
                         let (arg0, arg) = arg.extract(row_index);
+                        let arg0 = arg0.as_ref();
                         result.push(foo :: <A, B> (arg0)?);
                     }
                     Ok(tidb_query_datatype::codec::data_type::Evaluable::into_vector_value(result))
@@ -1536,7 +1538,7 @@ mod tests_normal {
         let item_fn = parse_str(
             r#"
             #[inline]
-            fn foo(ctx: &mut EvalContext, arg0: &Option<Int>, arg1: &Option<Real>) -> Result<Option<Decimal>> {
+            fn foo(ctx: &mut EvalContext, arg0: Option<&Int>, arg1: Option<&Real>) -> Result<Option<Decimal>> {
                 Ok(None)
             }
         "#,
@@ -1586,6 +1588,8 @@ mod tests_normal {
                     for row_index in 0..output_rows {
                         let (arg0, arg) = arg.extract(row_index);
                         let (arg1, arg) = arg.extract(row_index);
+                        let arg0 = arg0.as_ref();
+                        let arg1 = arg1.as_ref();
                         result.push(foo(ctx, arg0, arg1)?);
                     }
                     Ok(tidb_query_datatype::codec::data_type::Evaluable::into_vector_value(result))

--- a/components/tidb_query_vec_executors/src/selection_executor.rs
+++ b/components/tidb_query_vec_executors/src/selection_executor.rs
@@ -398,8 +398,8 @@ mod tests {
 
     /// This function returns 1 when the value is even, 0 otherwise.
     #[rpn_fn]
-    fn is_even(v: &Option<i64>) -> Result<Option<i64>> {
-        let r = match v {
+    fn is_even(v: Option<&i64>) -> Result<Option<i64>> {
+        let r = match v.cloned() {
             None => Some(0),
             Some(v) => {
                 if v % 2 == 0 {
@@ -593,10 +593,10 @@ mod tests {
     fn test_predicate_error() {
         /// This function returns error when value is None.
         #[rpn_fn]
-        fn foo(v: &Option<i64>) -> Result<Option<i64>> {
-            match v {
+        fn foo(v: Option<&i64>) -> Result<Option<i64>> {
+            match v.cloned() {
                 None => Err(other_err!("foo")),
-                Some(v) => Ok(Some(*v)),
+                Some(v) => Ok(Some(v)),
             }
         }
 

--- a/components/tidb_query_vec_expr/Cargo.toml
+++ b/components/tidb_query_vec_expr/Cargo.toml
@@ -23,6 +23,7 @@ tikv_util = { path = "../tikv_util" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
 twoway = "0.2.0"
 uuid = { version = "0.8.1", features = ["v4"] }
+static_assertions = { version = "1.0", features = ["nightly"] }
 
 [dependencies.prometheus-static-metric]
 git = "https://github.com/tikv/rust-prometheus.git"

--- a/components/tidb_query_vec_expr/src/impl_arithmetic.rs
+++ b/components/tidb_query_vec_expr/src/impl_arithmetic.rs
@@ -11,8 +11,8 @@ use tidb_query_datatype::expr::EvalContext;
 #[rpn_fn]
 #[inline]
 pub fn arithmetic<A: ArithmeticOp>(
-    arg0: &Option<A::T>,
-    arg1: &Option<A::T>,
+    arg0: Option<&A::T>,
+    arg1: Option<&A::T>,
 ) -> Result<Option<A::T>> {
     if let (Some(lhs), Some(rhs)) = (arg0, arg1) {
         A::calc(lhs, rhs)
@@ -26,8 +26,8 @@ pub fn arithmetic<A: ArithmeticOp>(
 #[inline]
 pub fn arithmetic_with_ctx<A: ArithmeticOpWithCtx>(
     ctx: &mut EvalContext,
-    arg0: &Option<A::T>,
-    arg1: &Option<A::T>,
+    arg0: Option<&A::T>,
+    arg1: Option<&A::T>,
 ) -> Result<Option<A::T>> {
     if let (Some(lhs), Some(rhs)) = (arg0, arg1) {
         A::calc(ctx, lhs, rhs)
@@ -459,8 +459,8 @@ impl ArithmeticOp for UintDivideInt {
 #[inline]
 fn int_divide_decimal(
     ctx: &mut EvalContext,
-    lhs: &Option<Decimal>,
-    rhs: &Option<Decimal>,
+    lhs: Option<&Decimal>,
+    rhs: Option<&Decimal>,
 ) -> Result<Option<Int>> {
     let result = try_opt!(arithmetic_with_ctx::<DecimalDivide>(ctx, lhs, rhs)).as_i64();
 

--- a/components/tidb_query_vec_expr/src/impl_cast.rs
+++ b/components/tidb_query_vec_expr/src/impl_cast.rs
@@ -465,7 +465,7 @@ fn cast_unsigned_int_as_signed_or_unsigned_real(val: Option<&Int>) -> Result<Opt
 #[rpn_fn]
 #[inline]
 fn cast_real_as_signed_real(val: Option<&Real>) -> Result<Option<Real>> {
-    Ok(*val)
+    Ok(val.map(|x| *x))
 }
 
 #[rpn_fn(capture = [metadata], metadata_type = tipb::InUnionMetadata)]
@@ -956,11 +956,11 @@ fn cast_int_as_time(
     extra: &RpnFnCallExtra,
     val: Option<&Int>,
 ) -> Result<Option<Time>> {
-    if let Some(val) = *val {
+    if let Some(val) = val {
         // Parse `val` as a `u64`
         Time::parse_from_i64(
             ctx,
-            val,
+            *val,
             extra.ret_field_type.as_accessor().tp().try_into()?,
             extra.ret_field_type.get_decimal() as i8,
         )
@@ -1052,7 +1052,8 @@ fn cast_time_as_time(
     extra: &RpnFnCallExtra,
     val: Option<&Time>,
 ) -> Result<Option<Time>> {
-    if let Some(mut val) = val {
+    if let Some(val) = val {
+        let mut val = val.clone();
         val.set_time_type(extra.ret_field_type.as_accessor().tp().try_into()?)?;
         val.round_frac(ctx, extra.ret_field_type.get_decimal() as i8)
             .map(Some)
@@ -1068,10 +1069,10 @@ fn cast_duration_as_time(
     extra: &RpnFnCallExtra,
     val: Option<&Duration>,
 ) -> Result<Option<Time>> {
-    if let Some(val) = *val {
+    if let Some(val) = val {
         Time::from_duration(
             ctx,
-            val,
+            *val,
             extra.ret_field_type.as_accessor().tp().try_into()?,
         )
         .and_then(|now| now.round_frac(ctx, extra.ret_field_type.get_decimal() as i8))
@@ -1194,7 +1195,7 @@ mod tests {
         let extra = RpnFnCallExtra {
             ret_field_type: &ret_field_type,
         };
-        let r = func(&mut ctx, &extra, &None).unwrap();
+        let r = func(&mut ctx, &extra, None).unwrap();
         assert!(r.is_none());
     }
 
@@ -1203,7 +1204,7 @@ mod tests {
         F: Fn(&mut EvalContext, Option<&Input>) -> Result<Option<Ret>>,
     {
         let mut ctx = EvalContext::default();
-        let r = func(&mut ctx, &None).unwrap();
+        let r = func(&mut ctx, None).unwrap();
         assert!(r.is_none());
     }
 
@@ -1215,7 +1216,7 @@ mod tests {
         let extra = RpnFnCallExtra {
             ret_field_type: &ret_field_type,
         };
-        let r = func(&extra, &None).unwrap();
+        let r = func(&extra, None).unwrap();
         assert!(r.is_none());
     }
 
@@ -1224,7 +1225,7 @@ mod tests {
         F: Fn(&tipb::InUnionMetadata, Option<&Input>) -> Result<Option<Ret>>,
     {
         let metadata = make_metadata(true);
-        let r = func(&metadata, &None).unwrap();
+        let r = func(&metadata, None).unwrap();
         assert!(r.is_none());
     }
 
@@ -1234,7 +1235,7 @@ mod tests {
     {
         let mut ctx = EvalContext::default();
         let metadata = make_metadata(true);
-        let r = func(&mut ctx, &metadata, &None).unwrap();
+        let r = func(&mut ctx, &metadata, None).unwrap();
         assert!(r.is_none());
     }
 
@@ -1253,7 +1254,7 @@ mod tests {
             ret_field_type: &ret_field_type,
         };
         let metadata = make_metadata(true);
-        let r = func(&mut ctx, &extra, &metadata, &None).unwrap();
+        let r = func(&mut ctx, &extra, &metadata, None).unwrap();
         assert!(r.is_none());
     }
 
@@ -1261,7 +1262,7 @@ mod tests {
     where
         F: Fn(Option<&Input>) -> Result<Option<Ret>>,
     {
-        let r = func(&None).unwrap();
+        let r = func(None).unwrap();
         assert!(r.is_none());
     }
 
@@ -1427,7 +1428,7 @@ mod tests {
             (u64::MAX as i64, u64::MAX as i64),
         ];
         for (input, expect) in cs {
-            let r = cast_int_as_int_others(&Some(input));
+            let r = cast_int_as_int_others(Some(&input));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
         }
@@ -1452,7 +1453,7 @@ mod tests {
         ];
         for (input, expect, in_union) in cs {
             let metadata = make_metadata(in_union);
-            let r = cast_signed_int_as_unsigned_int(&metadata, &Some(input));
+            let r = cast_signed_int_as_unsigned_int(&metadata, Some(&input));
             let r = r.map(|x| x.map(|x| x as u64));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -1482,7 +1483,7 @@ mod tests {
                 ..CtxConfig::default()
             }
             .into();
-            let r = cast_any_as_any::<Real, Int>(&mut ctx, &Real::new(input).ok());
+            let r = cast_any_as_any::<Real, Int>(&mut ctx, Real::new(input).as_ref().ok());
             let log = make_log(&input, &result, &r);
             check_result(Some(&result), &r, log.as_str());
             check_overflow(&ctx, overflow, log.as_str());
@@ -1505,7 +1506,11 @@ mod tests {
         for (input, expect) in cs {
             let mut ctx = EvalContext::default();
             let metadata = make_metadata(true);
-            let r = cast_real_as_uint(&mut ctx, &metadata, &Some(Real::new(input).unwrap()));
+            let r = cast_real_as_uint(
+                &mut ctx,
+                &metadata,
+                Some(Real::new(input).as_ref().unwrap()),
+            );
             let r = r.map(|x| x.map(|x| x as u64));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -1533,7 +1538,7 @@ mod tests {
             }
             .into();
             let metadata = make_metadata(false);
-            let r = cast_real_as_uint(&mut ctx, &metadata, &Real::new(input).ok());
+            let r = cast_real_as_uint(&mut ctx, &metadata, Real::new(input).as_ref().ok());
             let r = r.map(|x| x.map(|x| x as u64));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -1555,7 +1560,11 @@ mod tests {
             }
             .into();
             let metadata = make_metadata(false);
-            let r = cast_real_as_uint(&mut ctx, &metadata, &Some(Real::new(input).unwrap()));
+            let r = cast_real_as_uint(
+                &mut ctx,
+                &metadata,
+                Some(Real::new(input).as_ref().unwrap()),
+            );
             let r = r.map(|x| x.map(|x| x as u64));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -1812,7 +1821,7 @@ mod tests {
                 ..CtxConfig::default()
             }
             .into();
-            let r = cast_any_as_any::<Decimal, Int>(&mut ctx, &Some(input));
+            let r = cast_any_as_any::<Decimal, Int>(&mut ctx, Some(&input));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
             check_warning(&ctx, err_code, log.as_str());
@@ -1854,7 +1863,7 @@ mod tests {
             let mut ctx = EvalContext::default();
             let metadata = make_metadata(true);
 
-            let r = cast_decimal_as_uint(&mut ctx, &metadata, &Some(input));
+            let r = cast_decimal_as_uint(&mut ctx, &metadata, Some(&input));
             let r = r.map(|x| x.map(|x| x as u64));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -1892,7 +1901,7 @@ mod tests {
             .into();
             let metadata = make_metadata(false);
 
-            let r = cast_decimal_as_uint(&mut ctx, &metadata, &Some(input));
+            let r = cast_decimal_as_uint(&mut ctx, &metadata, Some(&input));
             let r = r.map(|x| x.map(|x| x as u64));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -1924,7 +1933,7 @@ mod tests {
         ];
 
         for (input, expect) in cs {
-            let r = cast_any_as_any::<Time, Int>(&mut ctx, &Some(input));
+            let r = cast_any_as_any::<Time, Int>(&mut ctx, Some(&input));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
         }
@@ -2177,7 +2186,7 @@ mod tests {
                 ..CtxConfig::default()
             }
             .into();
-            let r = cast_any_as_any::<Duration, Int>(&mut ctx, &Some(input));
+            let r = cast_any_as_any::<Duration, Int>(&mut ctx, Some(&input));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
         }
@@ -2239,7 +2248,7 @@ mod tests {
                 ..CtxConfig::default()
             }
             .into();
-            let r = cast_any_as_any::<Json, Int>(&mut ctx, &Some(input.clone()));
+            let r = cast_any_as_any::<Json, Int>(&mut ctx, Some(&input.clone()));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
             check_overflow(&ctx, overflow, log.as_str());
@@ -2279,7 +2288,7 @@ mod tests {
                 ..CtxConfig::default()
             }
             .into();
-            let r = cast_json_as_uint(&mut ctx, &Some(input.clone()));
+            let r = cast_json_as_uint(&mut ctx, Some(&input.clone()));
             let r = r.map(|x| x.map(|x| x as u64));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -2321,7 +2330,7 @@ mod tests {
                 ..CtxConfig::default()
             }
             .into();
-            let r = cast_json_as_uint(&mut ctx, &Some(input.clone()));
+            let r = cast_json_as_uint(&mut ctx, Some(&input.clone()));
             let r = r.map(|x| x.map(|x| x as u64));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -2341,7 +2350,7 @@ mod tests {
         ];
 
         for (input, expect) in cs {
-            let r = cast_signed_int_as_signed_real(&Some(input));
+            let r = cast_signed_int_as_signed_real(Some(&input));
             let r = r.map(|x| x.map(|x| x.into_inner()));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -2369,7 +2378,7 @@ mod tests {
         ];
         for (input, expect, in_union) in cs {
             let metadata = make_metadata(in_union);
-            let r = cast_signed_int_as_unsigned_real(&metadata, &Some(input));
+            let r = cast_signed_int_as_unsigned_real(&metadata, Some(&input));
             let r = r.map(|x| x.map(|x| x.into_inner()));
             let log = format!(
                 "input: {}, expect: {}, in_union: {}",
@@ -2390,7 +2399,7 @@ mod tests {
             (i64::MAX as u64, i64::MAX as u64 as f64),
         ];
         for (input, expect) in cs {
-            let r = cast_unsigned_int_as_signed_or_unsigned_real(&Some(input as i64));
+            let r = cast_unsigned_int_as_signed_or_unsigned_real(Some(&(input as i64)));
             let r = r.map(|x| x.map(|x| x.into_inner()));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -2413,7 +2422,7 @@ mod tests {
             (u64::MAX as f64, u64::MAX as f64),
         ];
         for (input, expect) in cs {
-            let r = cast_real_as_signed_real(&Some(Real::new(input).unwrap()));
+            let r = cast_real_as_signed_real(Some(Real::new(input).as_ref().unwrap()));
             let r = r.map(|x| x.map(|x| x.into_inner()));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -2447,7 +2456,7 @@ mod tests {
 
         for (input, expect, in_union) in cs {
             let metadata = make_metadata(in_union);
-            let r = cast_real_as_unsigned_real(&metadata, &Some(Real::new(input).unwrap()));
+            let r = cast_real_as_unsigned_real(&metadata, Some(Real::new(input).as_ref().unwrap()));
             let r = r.map(|x| x.map(|x| x.into_inner()));
             let log = format!(
                 "input: {}, expect: {}, in_union: {}",
@@ -2898,7 +2907,7 @@ mod tests {
         ];
         for (input, expect) in cs {
             let mut ctx = EvalContext::default();
-            let r = cast_any_as_any::<Decimal, Real>(&mut ctx, &Some(input));
+            let r = cast_any_as_any::<Decimal, Real>(&mut ctx, Some(&input));
             let r = r.map(|x| x.map(|x| x.into_inner()));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -2962,7 +2971,7 @@ mod tests {
             }
             .into();
             let metadata = make_metadata(in_union);
-            let r = cast_decimal_as_unsigned_real(&mut ctx, &metadata, &Some(input));
+            let r = cast_decimal_as_unsigned_real(&mut ctx, &metadata, Some(&input));
             let r = r.map(|x| x.map(|x| x.into_inner()));
             let log = format!(
                 "input: {}, expect: {}, in_union: {}, expect_overflow: {}, result: {:?}",
@@ -3000,7 +3009,7 @@ mod tests {
 
         for (input, expect) in cs {
             let mut ctx = EvalContext::default();
-            let r = cast_any_as_any::<Time, Real>(&mut ctx, &Some(input));
+            let r = cast_any_as_any::<Time, Real>(&mut ctx, Some(&input));
             let r = r.map(|x| x.map(|x| x.into_inner()));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -3032,7 +3041,7 @@ mod tests {
         ];
         for (input, expect) in cs {
             let mut ctx = EvalContext::default();
-            let r = cast_any_as_any::<Duration, Real>(&mut ctx, &Some(input));
+            let r = cast_any_as_any::<Duration, Real>(&mut ctx, Some(&input));
             let r = r.map(|x| x.map(|x| x.into_inner()));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -3084,7 +3093,7 @@ mod tests {
                 ..CtxConfig::default()
             }
             .into();
-            let r = cast_any_as_any::<Json, Real>(&mut ctx, &Some(input.clone()));
+            let r = cast_any_as_any::<Json, Real>(&mut ctx, Some(&input.clone()));
             let r = r.map(|x| x.map(|x| x.into_inner()));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -3339,7 +3348,7 @@ mod tests {
                 .into();
                 let extra = make_extra(&rft);
 
-                let r = cast_func(&mut ctx, &extra, &Some(input.clone()));
+                let r = cast_func(&mut ctx, &extra, Some(&input.clone()));
 
                 let mut expect = bytes.clone();
                 if *pad_zero && flen > expect.len() as isize {
@@ -3403,8 +3412,8 @@ mod tests {
         test_as_string_helper(
             cs,
             |ctx, extra, val| {
-                let val = val.map(|x| x as i64);
-                cast_uint_as_string(ctx, extra, &val)
+                let val = val.map(|x| *x as i64);
+                cast_uint_as_string(ctx, extra, val.as_ref())
             },
             "cast_uint_as_string",
         );
@@ -3435,7 +3444,7 @@ mod tests {
                 cast_float_real_as_string(
                     ctx,
                     extra,
-                    &val.map(|x| Real::new(f64::from(x)).unwrap()),
+                    val.map(|x| Real::new(f64::from(*x)).unwrap()).as_ref(),
                 )
             },
             "cast_float_real_as_string",
@@ -3479,7 +3488,7 @@ mod tests {
         test_as_string_helper(
             cs,
             |ctx, extra, val| {
-                cast_any_as_string::<Real>(ctx, extra, &val.map(|x| Real::new(x).unwrap()))
+                cast_any_as_string::<Real>(ctx, extra, val.map(|x| Real::new(*x).unwrap()).as_ref())
             },
             "cast_any_as_string::<Real>",
         );
@@ -3691,7 +3700,7 @@ mod tests {
 
         for (input, expect) in cs {
             let mut ctx = EvalContext::default();
-            let r = cast_any_as_any::<Json, Bytes>(&mut ctx, &Some(input.clone()));
+            let r = cast_any_as_any::<Json, Bytes>(&mut ctx, Some(&input.clone()));
             let r = r.map(|x| x.map(|x| unsafe { String::from_utf8_unchecked(x) }));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
@@ -4052,7 +4061,7 @@ mod tests {
                     }
                     .into();
                     let cast_func_res =
-                        cast_func(&mut ctx, &extra, &metadata, &Some(input.clone()));
+                        cast_func(&mut ctx, &extra, &metadata, Some(&input.clone()));
 
                     let mut ctx = CtxConfig {
                         overflow_as_warning,
@@ -4220,8 +4229,8 @@ mod tests {
         test_as_decimal_helper(
             cs,
             |ctx, extra, metadata, val| {
-                let val = val.map(|x| Real::new(x).unwrap());
-                cast_real_as_decimal(ctx, extra, metadata, &val)
+                let val = val.map(|x| Real::new(*x).unwrap());
+                cast_real_as_decimal(ctx, extra, metadata, val.as_ref())
             },
             |x| x.to_string(),
             "cast_real_as_decimal",
@@ -4479,7 +4488,7 @@ mod tests {
             cs,
             |ctx, extra, _, val| {
                 let val = val.map(|x| x.as_bytes().to_vec());
-                cast_any_as_decimal::<Bytes>(ctx, extra, &val)
+                cast_any_as_decimal::<Bytes>(ctx, extra, val.as_ref())
             },
             |x| (*x).to_string(),
             "cast_string_as_signed_decimal",
@@ -4686,7 +4695,7 @@ mod tests {
             cs,
             |ctx, extra, metadata, val| {
                 let val = val.map(|x| x.as_bytes().to_vec());
-                cast_string_as_unsigned_decimal(ctx, extra, metadata, &val)
+                cast_string_as_unsigned_decimal(ctx, extra, metadata, val.as_ref())
             },
             |x| (*x).to_string(),
             "cast_string_as_unsigned_decimal",
@@ -5185,7 +5194,7 @@ mod tests {
                 .into();
                 let extra = make_extra(&rft);
 
-                let result = func_cast(&mut ctx, &extra, &Some(val.clone()));
+                let result = func_cast(&mut ctx, &extra, Some(&val.clone()));
 
                 let val_str = func_to_cast_str(&val);
                 let base_expect = Duration::parse(&mut ctx, val_str.as_bytes(), fsp);
@@ -5252,8 +5261,8 @@ mod tests {
             |x| x.to_string(),
             |x| x.to_string(),
             |ctx, extra, val| {
-                let val = val.map(|x| Real::new(x).unwrap());
-                cast_real_as_duration(ctx, extra, &val)
+                let val = val.map(|x| Real::new(*x).unwrap());
+                cast_real_as_duration(ctx, extra, val.as_ref())
             },
             "cast_real_as_duration",
         )
@@ -5383,7 +5392,7 @@ mod tests {
             let input_time = Time::parse_datetime(&mut ctx, s, fsp, true).unwrap();
             let expect_time =
                 Duration::parse(&mut ctx, expect.as_bytes(), expect_fsp as i8).unwrap();
-            let result = cast_time_as_duration(&mut ctx, &extra, &Some(input_time));
+            let result = cast_time_as_duration(&mut ctx, &extra, Some(&input_time));
             let result_str = result.as_ref().map(|x| x.as_ref().map(|x| x.to_string()));
             let log = format!(
                 "input: {}, fsp: {}, expect_fsp: {}, expect: {}, output: {:?}",
@@ -5418,7 +5427,7 @@ mod tests {
             let mut ctx = EvalContext::default();
             let dur = Duration::parse(&mut ctx, input.as_bytes(), input_fsp).unwrap();
             let expect = Duration::parse(&mut ctx, expect.as_bytes(), output_fsp).unwrap();
-            let r = cast_duration_as_duration(&extra, &Some(dur));
+            let r = cast_duration_as_duration(&extra, Some(&dur));
 
             let result_str = r.as_ref().map(|x| x.map(|x| x.to_string()));
             let log = format!(
@@ -5498,7 +5507,7 @@ mod tests {
         ];
         for (input, expect) in cs {
             let mut ctx = EvalContext::default();
-            let r = cast_any_as_any::<Int, Json>(&mut ctx, &Some(input));
+            let r = cast_any_as_any::<Int, Json>(&mut ctx, Some(&input));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
         }
@@ -5514,7 +5523,7 @@ mod tests {
             (i64::MAX as u64, Json::from_u64(i64::MAX as u64).unwrap()),
         ];
         for (input, expect) in cs {
-            let r = cast_uint_as_json(&Some(input as i64));
+            let r = cast_uint_as_json(Some(&(input as i64)));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
         }
@@ -5530,7 +5539,7 @@ mod tests {
             (i64::MAX, Json::from_bool(true).unwrap()),
         ];
         for (input, expect) in cs {
-            let result = cast_bool_as_json(&Some(input));
+            let result = cast_bool_as_json(Some(&input));
             let log = make_log(&input, &expect, &result);
             check_result(Some(&expect), &result, log.as_str());
         }
@@ -5554,7 +5563,7 @@ mod tests {
         ];
         for (input, expect) in cs {
             let mut ctx = EvalContext::default();
-            let r = cast_any_as_any::<Real, Json>(&mut ctx, &Real::new(input).ok());
+            let r = cast_any_as_any::<Real, Json>(&mut ctx, Real::new(input).as_ref().ok());
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
         }
@@ -5634,7 +5643,7 @@ mod tests {
                 fta.set_flag(FieldTypeFlag::PARSE_TO_JSON);
             }
             let extra = make_extra(&rft);
-            let result = cast_string_as_json(&extra, &Some(input.clone().into_bytes()));
+            let result = cast_string_as_json(&extra, Some(&input.clone().into_bytes()));
             let result_str = result.as_ref().map(|x| x.as_ref().map(|x| x.to_string()));
             let log = format!(
                 "input: {}, parse_to_json: {}, expect: {:?}, result: {:?}",
@@ -5672,7 +5681,7 @@ mod tests {
 
         for (input, expect) in cs {
             let mut ctx = EvalContext::default();
-            let r = cast_any_as_any::<Decimal, Json>(&mut ctx, &Some(input));
+            let r = cast_any_as_any::<Decimal, Json>(&mut ctx, Some(&input));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
         }
@@ -5719,7 +5728,7 @@ mod tests {
         ];
         for (input, time_type, expect) in cs {
             let mut ctx = EvalContext::default();
-            let result = cast_any_as_any::<Time, Json>(&mut ctx, &Some(input));
+            let result = cast_any_as_any::<Time, Json>(&mut ctx, Some(&input));
             let result_str = result.as_ref().map(|x| x.as_ref().map(|x| x.to_string()));
             let log = format!(
                 "input: {}, expect_time_type: {:?}, real_time_type: {:?}, expect: {}, result: {:?}",
@@ -5752,7 +5761,7 @@ mod tests {
 
         for (input, expect) in cs {
             let mut ctx = EvalContext::default();
-            let result = cast_any_as_any::<Duration, Json>(&mut ctx, &Some(input));
+            let result = cast_any_as_any::<Duration, Json>(&mut ctx, Some(&input));
             let log = make_log(&input, &expect, &result);
             check_result(Some(&expect), &result, log.as_str());
         }
@@ -5786,7 +5795,7 @@ mod tests {
 
         for input in cs {
             let expect = input.clone();
-            let result = cast_json_as_json(&Some(input.clone()));
+            let result = cast_json_as_json(Some(&input.clone()));
             let log = make_log(&input, &expect, &result);
             check_result(Some(&expect), &result, log.as_str());
         }

--- a/components/tidb_query_vec_expr/src/impl_cast.rs
+++ b/components/tidb_query_vec_expr/src/impl_cast.rs
@@ -465,7 +465,7 @@ fn cast_unsigned_int_as_signed_or_unsigned_real(val: Option<&Int>) -> Result<Opt
 #[rpn_fn]
 #[inline]
 fn cast_real_as_signed_real(val: Option<&Real>) -> Result<Option<Real>> {
-    Ok(val.map(|x| *x))
+    Ok(val.cloned())
 }
 
 #[rpn_fn(capture = [metadata], metadata_type = tipb::InUnionMetadata)]

--- a/components/tidb_query_vec_expr/src/impl_cast.rs
+++ b/components/tidb_query_vec_expr/src/impl_cast.rs
@@ -249,7 +249,7 @@ pub fn map_cast_func(expr: &Expr) -> Result<RpnFnMeta> {
 #[inline]
 fn cast_signed_int_as_unsigned_int(
     metadata: &tipb::InUnionMetadata,
-    val: &Option<Int>,
+    val: Option<&Int>,
 ) -> Result<Option<Int>> {
     match val {
         None => Ok(None),
@@ -266,7 +266,7 @@ fn cast_signed_int_as_unsigned_int(
 
 #[rpn_fn]
 #[inline]
-fn cast_int_as_int_others(val: &Option<Int>) -> Result<Option<Int>> {
+fn cast_int_as_int_others(val: Option<&Int>) -> Result<Option<Int>> {
     match val {
         None => Ok(None),
         Some(val) => Ok(Some(*val)),
@@ -278,7 +278,7 @@ fn cast_int_as_int_others(val: &Option<Int>) -> Result<Option<Int>> {
 fn cast_real_as_uint(
     ctx: &mut EvalContext,
     metadata: &tipb::InUnionMetadata,
-    val: &Option<Real>,
+    val: Option<&Real>,
 ) -> Result<Option<Int>> {
     match val {
         None => Ok(None),
@@ -305,7 +305,7 @@ fn cast_string_as_int(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
     metadata: &tipb::InUnionMetadata,
-    val: &Option<Bytes>,
+    val: Option<&Bytes>,
 ) -> Result<Option<Int>> {
     match val {
         None => Ok(None),
@@ -373,7 +373,7 @@ fn cast_string_as_int(
 }
 
 #[rpn_fn(capture = [ctx])]
-fn cast_binary_string_as_int(ctx: &mut EvalContext, val: &Option<Bytes>) -> Result<Option<Int>> {
+fn cast_binary_string_as_int(ctx: &mut EvalContext, val: Option<&Bytes>) -> Result<Option<Int>> {
     match val {
         None => Ok(None),
         Some(val) => {
@@ -388,7 +388,7 @@ fn cast_binary_string_as_int(ctx: &mut EvalContext, val: &Option<Bytes>) -> Resu
 fn cast_decimal_as_uint(
     ctx: &mut EvalContext,
     metadata: &tipb::InUnionMetadata,
-    val: &Option<Decimal>,
+    val: Option<&Decimal>,
 ) -> Result<Option<Int>> {
     match val {
         None => Ok(None),
@@ -406,7 +406,7 @@ fn cast_decimal_as_uint(
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-fn cast_json_as_uint(ctx: &mut EvalContext, val: &Option<Json>) -> Result<Option<Int>> {
+fn cast_json_as_uint(ctx: &mut EvalContext, val: Option<&Json>) -> Result<Option<Int>> {
     match val {
         None => Ok(None),
         Some(j) => {
@@ -425,7 +425,7 @@ fn cast_json_as_uint(ctx: &mut EvalContext, val: &Option<Json>) -> Result<Option
 
 #[rpn_fn]
 #[inline]
-fn cast_signed_int_as_signed_real(val: &Option<Int>) -> Result<Option<Real>> {
+fn cast_signed_int_as_signed_real(val: Option<&Int>) -> Result<Option<Real>> {
     match val {
         None => Ok(None),
         Some(val) => Ok(Real::new(*val as f64).ok()),
@@ -436,7 +436,7 @@ fn cast_signed_int_as_signed_real(val: &Option<Int>) -> Result<Option<Real>> {
 #[inline]
 fn cast_signed_int_as_unsigned_real(
     metadata: &tipb::InUnionMetadata,
-    val: &Option<Int>,
+    val: Option<&Int>,
 ) -> Result<Option<Real>> {
     match val {
         None => Ok(None),
@@ -455,7 +455,7 @@ fn cast_signed_int_as_unsigned_real(
 // so we can merge uint to signed/unsigned real in one function
 #[rpn_fn]
 #[inline]
-fn cast_unsigned_int_as_signed_or_unsigned_real(val: &Option<Int>) -> Result<Option<Real>> {
+fn cast_unsigned_int_as_signed_or_unsigned_real(val: Option<&Int>) -> Result<Option<Real>> {
     match val {
         None => Ok(None),
         Some(val) => Ok(Real::new(*val as u64 as f64).ok()),
@@ -464,7 +464,7 @@ fn cast_unsigned_int_as_signed_or_unsigned_real(val: &Option<Int>) -> Result<Opt
 
 #[rpn_fn]
 #[inline]
-fn cast_real_as_signed_real(val: &Option<Real>) -> Result<Option<Real>> {
+fn cast_real_as_signed_real(val: Option<&Real>) -> Result<Option<Real>> {
     Ok(*val)
 }
 
@@ -472,7 +472,7 @@ fn cast_real_as_signed_real(val: &Option<Real>) -> Result<Option<Real>> {
 #[inline]
 fn cast_real_as_unsigned_real(
     metadata: &tipb::InUnionMetadata,
-    val: &Option<Real>,
+    val: Option<&Real>,
 ) -> Result<Option<Real>> {
     match val {
         None => Ok(None),
@@ -492,7 +492,7 @@ fn cast_real_as_unsigned_real(
 fn cast_string_as_signed_real(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Bytes>,
+    val: Option<&Bytes>,
 ) -> Result<Option<Real>> {
     match val {
         None => Ok(None),
@@ -509,7 +509,7 @@ fn cast_string_as_signed_real(
 fn cast_binary_string_as_signed_real(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Bytes>,
+    val: Option<&Bytes>,
 ) -> Result<Option<Real>> {
     match val {
         None => Ok(None),
@@ -527,7 +527,7 @@ fn cast_string_as_unsigned_real(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
     metadata: &tipb::InUnionMetadata,
-    val: &Option<Bytes>,
+    val: Option<&Bytes>,
 ) -> Result<Option<Real>> {
     match val {
         None => Ok(None),
@@ -547,7 +547,7 @@ fn cast_string_as_unsigned_real(
 fn cast_binary_string_as_unsigned_real(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Bytes>,
+    val: Option<&Bytes>,
 ) -> Result<Option<Real>> {
     match val {
         None => Ok(None),
@@ -564,7 +564,7 @@ fn cast_binary_string_as_unsigned_real(
 fn cast_decimal_as_unsigned_real(
     ctx: &mut EvalContext,
     metadata: &tipb::InUnionMetadata,
-    val: &Option<Decimal>,
+    val: Option<&Decimal>,
 ) -> Result<Option<Real>> {
     match val {
         None => Ok(None),
@@ -593,7 +593,7 @@ fn cast_decimal_as_unsigned_real(
 fn cast_any_as_string<T: ConvertTo<Bytes> + Evaluable>(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<T>,
+    val: Option<&T>,
 ) -> Result<Option<Bytes>> {
     match val {
         None => Ok(None),
@@ -609,7 +609,7 @@ fn cast_any_as_string<T: ConvertTo<Bytes> + Evaluable>(
 fn cast_uint_as_string(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Int>,
+    val: Option<&Int>,
 ) -> Result<Option<Bytes>> {
     match val {
         None => Ok(None),
@@ -625,7 +625,7 @@ fn cast_uint_as_string(
 fn cast_float_real_as_string(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Real>,
+    val: Option<&Real>,
 ) -> Result<Option<Bytes>> {
     match val {
         None => Ok(None),
@@ -645,7 +645,7 @@ fn cast_float_real_as_string(
 fn cast_string_as_string(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Bytes>,
+    val: Option<&Bytes>,
 ) -> Result<Option<Bytes>> {
     match val {
         None => Ok(None),
@@ -689,7 +689,7 @@ fn cast_as_string_helper(
 fn cast_unsigned_int_as_signed_or_unsigned_decimal(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<i64>,
+    val: Option<&i64>,
 ) -> Result<Option<Decimal>> {
     match val {
         None => Ok(None),
@@ -712,7 +712,7 @@ fn cast_signed_int_as_unsigned_decimal(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
     metadata: &tipb::InUnionMetadata,
-    val: &Option<i64>,
+    val: Option<&i64>,
 ) -> Result<Option<Decimal>> {
     match val {
         None => Ok(None),
@@ -737,7 +737,7 @@ fn cast_real_as_decimal(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
     metadata: &tipb::InUnionMetadata,
-    val: &Option<Real>,
+    val: Option<&Real>,
 ) -> Result<Option<Decimal>> {
     match val {
         None => Ok(None),
@@ -763,7 +763,7 @@ fn cast_string_as_unsigned_decimal(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
     metadata: &tipb::InUnionMetadata,
-    val: &Option<Bytes>,
+    val: Option<&Bytes>,
 ) -> Result<Option<Decimal>> {
     match val {
         None => Ok(None),
@@ -789,7 +789,7 @@ fn cast_string_as_unsigned_decimal(
 fn cast_decimal_as_signed_decimal(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Decimal>,
+    val: Option<&Decimal>,
 ) -> Result<Option<Decimal>> {
     match val {
         None => Ok(None),
@@ -807,7 +807,7 @@ fn cast_decimal_as_unsigned_decimal(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
     metadata: &tipb::InUnionMetadata,
-    val: &Option<Decimal>,
+    val: Option<&Decimal>,
 ) -> Result<Option<Decimal>> {
     match val {
         None => Ok(None),
@@ -831,7 +831,7 @@ fn cast_decimal_as_unsigned_decimal(
 fn cast_any_as_decimal<From: Evaluable + ConvertTo<Decimal>>(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<From>,
+    val: Option<&From>,
 ) -> Result<Option<Decimal>> {
     match val {
         None => Ok(None),
@@ -853,7 +853,7 @@ fn cast_any_as_decimal<From: Evaluable + ConvertTo<Decimal>>(
 fn cast_int_as_duration(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Int>,
+    val: Option<&Int>,
 ) -> Result<Option<Duration>> {
     match val {
         None => Ok(None),
@@ -876,7 +876,7 @@ fn cast_int_as_duration(
 fn cast_time_as_duration(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<DateTime>,
+    val: Option<&DateTime>,
 ) -> Result<Option<Duration>> {
     match val {
         None => Ok(None),
@@ -891,7 +891,7 @@ fn cast_time_as_duration(
 #[inline]
 fn cast_duration_as_duration(
     extra: &RpnFnCallExtra,
-    val: &Option<Duration>,
+    val: Option<&Duration>,
 ) -> Result<Option<Duration>> {
     match val {
         None => Ok(None),
@@ -906,7 +906,7 @@ macro_rules! cast_as_duration {
         fn $as_uint_fn(
             ctx: &mut EvalContext,
             extra: &RpnFnCallExtra,
-            val: &Option<$ty>,
+            val: Option<&$ty>,
         ) -> Result<Option<Duration>> {
             match val {
                 None => Ok(None),
@@ -954,7 +954,7 @@ cast_as_duration!(
 fn cast_int_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Int>,
+    val: Option<&Int>,
 ) -> Result<Option<Time>> {
     if let Some(val) = *val {
         // Parse `val` as a `u64`
@@ -981,7 +981,7 @@ fn cast_int_as_time(
 fn cast_real_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Real>,
+    val: Option<&Real>,
 ) -> Result<Option<Time>> {
     if let Some(val) = val {
         // Convert `val` to a string first and then parse it as a float string.
@@ -1004,7 +1004,7 @@ fn cast_real_as_time(
 fn cast_string_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Bytes>,
+    val: Option<&Bytes>,
 ) -> Result<Option<Time>> {
     if let Some(val) = val {
         // Convert `val` to a string first and then parse it as a float string.
@@ -1027,7 +1027,7 @@ fn cast_string_as_time(
 fn cast_decimal_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Decimal>,
+    val: Option<&Decimal>,
 ) -> Result<Option<Time>> {
     if let Some(val) = val {
         // Convert `val` to a string first and then parse it as a string.
@@ -1050,7 +1050,7 @@ fn cast_decimal_as_time(
 fn cast_time_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Time>,
+    val: Option<&Time>,
 ) -> Result<Option<Time>> {
     if let Some(mut val) = val {
         val.set_time_type(extra.ret_field_type.as_accessor().tp().try_into()?)?;
@@ -1066,7 +1066,7 @@ fn cast_time_as_time(
 fn cast_duration_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
-    val: &Option<Duration>,
+    val: Option<&Duration>,
 ) -> Result<Option<Time>> {
     if let Some(val) = *val {
         Time::from_duration(
@@ -1092,7 +1092,7 @@ fn cast_duration_as_time(
 
 #[rpn_fn]
 #[inline]
-fn cast_bool_as_json(val: &Option<Int>) -> Result<Option<Json>> {
+fn cast_bool_as_json(val: Option<&Int>) -> Result<Option<Json>> {
     match val {
         None => Ok(None),
         Some(val) => Ok(Some(Json::from_bool(*val != 0)?)),
@@ -1101,7 +1101,7 @@ fn cast_bool_as_json(val: &Option<Int>) -> Result<Option<Json>> {
 
 #[rpn_fn]
 #[inline]
-fn cast_uint_as_json(val: &Option<Int>) -> Result<Option<Json>> {
+fn cast_uint_as_json(val: Option<&Int>) -> Result<Option<Json>> {
     match val {
         None => Ok(None),
         Some(val) => Ok(Some(Json::from_u64(*val as u64)?)),
@@ -1110,7 +1110,7 @@ fn cast_uint_as_json(val: &Option<Int>) -> Result<Option<Json>> {
 
 #[rpn_fn(capture = [extra])]
 #[inline]
-fn cast_string_as_json(extra: &RpnFnCallExtra<'_>, val: &Option<Bytes>) -> Result<Option<Json>> {
+fn cast_string_as_json(extra: &RpnFnCallExtra<'_>, val: Option<&Bytes>) -> Result<Option<Json>> {
     match val {
         None => Ok(None),
         Some(val) => {
@@ -1135,7 +1135,7 @@ fn cast_string_as_json(extra: &RpnFnCallExtra<'_>, val: &Option<Bytes>) -> Resul
 
 #[rpn_fn]
 #[inline]
-fn cast_json_as_json(val: &Option<Json>) -> Result<Option<Json>> {
+fn cast_json_as_json(val: Option<&Json>) -> Result<Option<Json>> {
     match val {
         None => Ok(None),
         Some(val) => Ok(Some(val.clone())),
@@ -1146,7 +1146,7 @@ fn cast_json_as_json(val: &Option<Json>) -> Result<Option<Json>> {
 #[inline]
 fn cast_any_as_any<From: ConvertTo<To> + Evaluable, To: Evaluable>(
     ctx: &mut EvalContext,
-    val: &Option<From>,
+    val: Option<&From>,
 ) -> Result<Option<To>> {
     match val {
         None => Ok(None),
@@ -1187,7 +1187,7 @@ mod tests {
 
     fn test_none_with_ctx_and_extra<F, Input, Ret>(func: F)
     where
-        F: Fn(&mut EvalContext, &RpnFnCallExtra, &Option<Input>) -> Result<Option<Ret>>,
+        F: Fn(&mut EvalContext, &RpnFnCallExtra, Option<&Input>) -> Result<Option<Ret>>,
     {
         let mut ctx = EvalContext::default();
         let ret_field_type: FieldType = FieldType::default();
@@ -1200,7 +1200,7 @@ mod tests {
 
     fn test_none_with_ctx<F, Input, Ret>(func: F)
     where
-        F: Fn(&mut EvalContext, &Option<Input>) -> Result<Option<Ret>>,
+        F: Fn(&mut EvalContext, Option<&Input>) -> Result<Option<Ret>>,
     {
         let mut ctx = EvalContext::default();
         let r = func(&mut ctx, &None).unwrap();
@@ -1209,7 +1209,7 @@ mod tests {
 
     fn test_none_with_extra<F, Input, Ret>(func: F)
     where
-        F: Fn(&RpnFnCallExtra, &Option<Input>) -> Result<Option<Ret>>,
+        F: Fn(&RpnFnCallExtra, Option<&Input>) -> Result<Option<Ret>>,
     {
         let ret_field_type: FieldType = FieldType::default();
         let extra = RpnFnCallExtra {
@@ -1221,7 +1221,7 @@ mod tests {
 
     fn test_none_with_metadata<F, Input, Ret>(func: F)
     where
-        F: Fn(&tipb::InUnionMetadata, &Option<Input>) -> Result<Option<Ret>>,
+        F: Fn(&tipb::InUnionMetadata, Option<&Input>) -> Result<Option<Ret>>,
     {
         let metadata = make_metadata(true);
         let r = func(&metadata, &None).unwrap();
@@ -1230,7 +1230,7 @@ mod tests {
 
     fn test_none_with_ctx_and_metadata<F, Input, Ret>(func: F)
     where
-        F: Fn(&mut EvalContext, &tipb::InUnionMetadata, &Option<Input>) -> Result<Option<Ret>>,
+        F: Fn(&mut EvalContext, &tipb::InUnionMetadata, Option<&Input>) -> Result<Option<Ret>>,
     {
         let mut ctx = EvalContext::default();
         let metadata = make_metadata(true);
@@ -1244,7 +1244,7 @@ mod tests {
             &mut EvalContext,
             &RpnFnCallExtra,
             &tipb::InUnionMetadata,
-            &Option<Input>,
+            Option<&Input>,
         ) -> Result<Option<Ret>>,
     {
         let mut ctx = EvalContext::default();
@@ -1259,7 +1259,7 @@ mod tests {
 
     fn test_none_with_nothing<F, Input, Ret>(func: F)
     where
-        F: Fn(&Option<Input>) -> Result<Option<Ret>>,
+        F: Fn(Option<&Input>) -> Result<Option<Ret>>,
     {
         let r = func(&None).unwrap();
         assert!(r.is_none());
@@ -3102,7 +3102,7 @@ mod tests {
         cast_func: FnCast,
         func_name: &str,
     ) where
-        FnCast: Fn(&mut EvalContext, &RpnFnCallExtra, &Option<T>) -> Result<Option<Bytes>>,
+        FnCast: Fn(&mut EvalContext, &RpnFnCallExtra, Option<&T>) -> Result<Option<Bytes>>,
     {
         #[derive(Clone, Copy)]
         enum FlenType {
@@ -3718,7 +3718,7 @@ mod tests {
             &mut EvalContext,
             &RpnFnCallExtra,
             &tipb::InUnionMetadata,
-            &Option<T>,
+            Option<&T>,
         ) -> Result<Option<Decimal>>,
         FnToStr: Fn(&T) -> String,
     {
@@ -5164,7 +5164,7 @@ mod tests {
         func_cast: FnCast,
         func_name: &str,
     ) where
-        FnCast: Fn(&mut EvalContext, &RpnFnCallExtra, &Option<T>) -> Result<Option<Duration>>,
+        FnCast: Fn(&mut EvalContext, &RpnFnCallExtra, Option<&T>) -> Result<Option<Duration>>,
     {
         // cast_real_as_duration call `Duration::parse`, directly,
         // and `Duration::parse`, is test in duration.rs.

--- a/components/tidb_query_vec_expr/src/impl_cast.rs
+++ b/components/tidb_query_vec_expr/src/impl_cast.rs
@@ -1053,7 +1053,7 @@ fn cast_time_as_time(
     val: Option<&Time>,
 ) -> Result<Option<Time>> {
     if let Some(val) = val {
-        let mut val = val.clone();
+        let mut val = *val;
         val.set_time_type(extra.ret_field_type.as_accessor().tp().try_into()?)?;
         val.round_frac(ctx, extra.ret_field_type.get_decimal() as i8)
             .map(Some)

--- a/components/tidb_query_vec_expr/src/impl_compare.rs
+++ b/components/tidb_query_vec_expr/src/impl_compare.rs
@@ -224,7 +224,7 @@ impl CmpOp for CmpOpNullEQ {
 pub fn coalesce<T: Evaluable>(args: &[Option<&T>]) -> Result<Option<T>> {
     for arg in args {
         if arg.is_some() {
-            return Ok((*arg).clone());
+            return Ok(arg.cloned());
         }
     }
     Ok(None)
@@ -292,7 +292,7 @@ where
                         return Ok(None);
                     }
                     Some(v) => {
-                        res = chooser(res, *v);
+                        res = chooser(res, **v);
                     }
                 }
             }

--- a/components/tidb_query_vec_expr/src/impl_compare.rs
+++ b/components/tidb_query_vec_expr/src/impl_compare.rs
@@ -13,7 +13,7 @@ use tidb_query_datatype::expr::EvalContext;
 
 #[rpn_fn]
 #[inline]
-pub fn compare<C: Comparer>(lhs: &Option<C::T>, rhs: &Option<C::T>) -> Result<Option<i64>>
+pub fn compare<C: Comparer>(lhs: Option<&C::T>, rhs: Option<&C::T>) -> Result<Option<i64>>
 where
     C: Comparer,
 {
@@ -23,7 +23,7 @@ where
 pub trait Comparer {
     type T: Evaluable;
 
-    fn compare(lhs: &Option<Self::T>, rhs: &Option<Self::T>) -> Result<Option<i64>>;
+    fn compare(lhs: Option<&Self::T>, rhs: Option<&Self::T>) -> Result<Option<i64>>;
 }
 
 pub struct BasicComparer<T: Evaluable + Ord, F: CmpOp> {
@@ -34,7 +34,7 @@ impl<T: Evaluable + Ord, F: CmpOp> Comparer for BasicComparer<T, F> {
     type T = T;
 
     #[inline]
-    fn compare(lhs: &Option<T>, rhs: &Option<T>) -> Result<Option<i64>> {
+    fn compare(lhs: Option<&T>, rhs: Option<&T>) -> Result<Option<i64>> {
         Ok(match (lhs, rhs) {
             (None, None) => F::compare_null(),
             (None, _) | (_, None) => F::compare_partial_null(),
@@ -51,7 +51,7 @@ impl<C: Collator, F: CmpOp> Comparer for StringComparer<C, F> {
     type T = Bytes;
 
     #[inline]
-    fn compare(lhs: &Option<Bytes>, rhs: &Option<Bytes>) -> Result<Option<i64>> {
+    fn compare(lhs: Option<&Bytes>, rhs: Option<&Bytes>) -> Result<Option<i64>> {
         Ok(match (lhs, rhs) {
             (None, None) => F::compare_null(),
             (None, _) | (_, None) => F::compare_partial_null(),
@@ -71,7 +71,7 @@ impl<F: CmpOp> Comparer for UintUintComparer<F> {
     type T = Int;
 
     #[inline]
-    fn compare(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<i64>> {
+    fn compare(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<i64>> {
         Ok(match (lhs, rhs) {
             (None, None) => F::compare_null(),
             (None, _) | (_, None) => F::compare_partial_null(),
@@ -92,7 +92,7 @@ impl<F: CmpOp> Comparer for UintIntComparer<F> {
     type T = Int;
 
     #[inline]
-    fn compare(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<i64>> {
+    fn compare(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<i64>> {
         Ok(match (lhs, rhs) {
             (None, None) => F::compare_null(),
             (None, _) | (_, None) => F::compare_partial_null(),
@@ -116,7 +116,7 @@ impl<F: CmpOp> Comparer for IntUintComparer<F> {
     type T = Int;
 
     #[inline]
-    fn compare(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<i64>> {
+    fn compare(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<i64>> {
         Ok(match (lhs, rhs) {
             (None, None) => F::compare_null(),
             (None, _) | (_, None) => F::compare_partial_null(),
@@ -221,7 +221,7 @@ impl CmpOp for CmpOpNullEQ {
 
 #[rpn_fn(varg)]
 #[inline]
-pub fn coalesce<T: Evaluable>(args: &[&Option<T>]) -> Result<Option<T>> {
+pub fn coalesce<T: Evaluable>(args: &[Option<&T>]) -> Result<Option<T>> {
     for arg in args {
         if arg.is_some() {
             return Ok((*arg).clone());
@@ -232,19 +232,19 @@ pub fn coalesce<T: Evaluable>(args: &[&Option<T>]) -> Result<Option<T>> {
 
 #[rpn_fn(varg, min_args = 2)]
 #[inline]
-pub fn greatest_int(args: &[&Option<Int>]) -> Result<Option<Int>> {
+pub fn greatest_int(args: &[Option<&Int>]) -> Result<Option<Int>> {
     do_get_extremum(args, max)
 }
 
 #[rpn_fn(varg, min_args = 2)]
 #[inline]
-pub fn greatest_real(args: &[&Option<Real>]) -> Result<Option<Real>> {
+pub fn greatest_real(args: &[Option<&Real>]) -> Result<Option<Real>> {
     do_get_extremum(args, |x, y| x.max(y))
 }
 
 #[rpn_fn(varg, min_args = 2, capture = [ctx])]
 #[inline]
-pub fn greatest_time(ctx: &mut EvalContext, args: &[&Option<Bytes>]) -> Result<Option<Bytes>> {
+pub fn greatest_time(ctx: &mut EvalContext, args: &[Option<&Bytes>]) -> Result<Option<Bytes>> {
     let mut greatest = None;
     for arg in args {
         match arg {
@@ -276,7 +276,7 @@ pub fn greatest_time(ctx: &mut EvalContext, args: &[&Option<Bytes>]) -> Result<O
 }
 
 #[inline]
-fn do_get_extremum<T, E>(args: &[&Option<T>], chooser: E) -> Result<Option<T>>
+fn do_get_extremum<T, E>(args: &[Option<&T>], chooser: E) -> Result<Option<T>>
 where
     T: Ord + Copy,
     E: Fn(T, T) -> T,

--- a/components/tidb_query_vec_expr/src/impl_compare_in.rs
+++ b/components/tidb_query_vec_expr/src/impl_compare_in.rs
@@ -166,7 +166,7 @@ pub struct CompareInMeta<T: Eq + Hash> {
 #[inline]
 pub fn compare_in_by_hash<T: InByHash>(
     metadata: &CompareInMeta<T::StoreKey>,
-    args: &[&Option<T::Key>],
+    args: &[Option<&T::Key>],
 ) -> Result<Option<Int>> {
     assert!(!args.is_empty());
     let base_val = args[0];
@@ -236,7 +236,7 @@ fn init_compare_in_data<T: InByHash>(expr: &mut Expr) -> Result<CompareInMeta<T:
 
 #[rpn_fn(varg, min_args = 1)]
 #[inline]
-pub fn compare_in_by_compare<T: InByCompare>(args: &[&Option<T>]) -> Result<Option<Int>> {
+pub fn compare_in_by_compare<T: InByCompare>(args: &[Option<&T>]) -> Result<Option<Int>> {
     assert!(!args.is_empty());
     let base_val = args[0];
     match base_val {

--- a/components/tidb_query_vec_expr/src/impl_compare_in.rs
+++ b/components/tidb_query_vec_expr/src/impl_compare_in.rs
@@ -249,7 +249,7 @@ pub fn compare_in_by_compare<T: InByCompare>(args: &[Option<&T>]) -> Result<Opti
                         default_ret = None;
                     }
                     Some(v) => {
-                        if v == base_val {
+                        if *v == base_val {
                             return Ok(Some(1));
                         }
                     }

--- a/components/tidb_query_vec_expr/src/impl_control.rs
+++ b/components/tidb_query_vec_expr/src/impl_control.rs
@@ -7,7 +7,7 @@ use tidb_query_datatype::codec::data_type::*;
 
 #[rpn_fn]
 #[inline]
-fn if_null<T: Evaluable>(lhs: &Option<T>, rhs: &Option<T>) -> Result<Option<T>> {
+fn if_null<T: Evaluable>(lhs: Option<&T>, rhs: Option<&T>) -> Result<Option<T>> {
     if lhs.is_some() {
         return Ok(lhs.clone());
     }
@@ -20,12 +20,12 @@ pub fn case_when<T: Evaluable>(args: &[ScalarValueRef<'_>]) -> Result<Option<T>>
     for chunk in args.chunks(2) {
         if chunk.len() == 1 {
             // Else statement
-            let ret: &Option<T> = Evaluable::borrow_scalar_value_ref(&chunk[0]);
+            let ret: Option<&T> = Evaluable::borrow_scalar_value_ref(&chunk[0]);
             return Ok(ret.clone());
         }
-        let cond: &Option<Int> = Evaluable::borrow_scalar_value_ref(&chunk[0]);
+        let cond: Option<&Int> = Evaluable::borrow_scalar_value_ref(&chunk[0]);
         if cond.unwrap_or(0) != 0 {
-            let ret: &Option<T> = Evaluable::borrow_scalar_value_ref(&chunk[1]);
+            let ret: Option<&T> = Evaluable::borrow_scalar_value_ref(&chunk[1]);
             return Ok(ret.clone());
         }
     }
@@ -35,9 +35,9 @@ pub fn case_when<T: Evaluable>(args: &[ScalarValueRef<'_>]) -> Result<Option<T>>
 #[rpn_fn]
 #[inline]
 fn if_condition<T: Evaluable>(
-    condition: &Option<Int>,
-    value_if_true: &Option<T>,
-    value_if_false: &Option<T>,
+    condition: Option<&Int>,
+    value_if_true: Option<&T>,
+    value_if_false: Option<&T>,
 ) -> Result<Option<T>> {
     Ok(if condition.unwrap_or(0) != 0 {
         value_if_true

--- a/components/tidb_query_vec_expr/src/impl_control.rs
+++ b/components/tidb_query_vec_expr/src/impl_control.rs
@@ -9,9 +9,9 @@ use tidb_query_datatype::codec::data_type::*;
 #[inline]
 fn if_null<T: Evaluable>(lhs: Option<&T>, rhs: Option<&T>) -> Result<Option<T>> {
     if lhs.is_some() {
-        return Ok(lhs.clone());
+        return Ok(lhs.cloned());
     }
-    Ok(rhs.clone())
+    Ok(rhs.cloned())
 }
 
 #[rpn_fn(raw_varg, extra_validator = case_when_validator::<T>)]
@@ -20,12 +20,12 @@ pub fn case_when<T: Evaluable>(args: &[ScalarValueRef<'_>]) -> Result<Option<T>>
     for chunk in args.chunks(2) {
         if chunk.len() == 1 {
             // Else statement
-            let ret: Option<&T> = Evaluable::borrow_scalar_value_ref(&chunk[0]);
+            let ret: &Option<T> = Evaluable::borrow_scalar_value_ref(&chunk[0]);
             return Ok(ret.clone());
         }
-        let cond: Option<&Int> = Evaluable::borrow_scalar_value_ref(&chunk[0]);
+        let cond: &Option<Int> = Evaluable::borrow_scalar_value_ref(&chunk[0]);
         if cond.unwrap_or(0) != 0 {
-            let ret: Option<&T> = Evaluable::borrow_scalar_value_ref(&chunk[1]);
+            let ret: &Option<T> = Evaluable::borrow_scalar_value_ref(&chunk[1]);
             return Ok(ret.clone());
         }
     }
@@ -39,12 +39,11 @@ fn if_condition<T: Evaluable>(
     value_if_true: Option<&T>,
     value_if_false: Option<&T>,
 ) -> Result<Option<T>> {
-    Ok(if condition.unwrap_or(0) != 0 {
-        value_if_true
+    Ok(if condition.cloned().unwrap_or(0) != 0 {
+        value_if_true.cloned()
     } else {
-        value_if_false
-    }
-    .clone())
+        value_if_false.cloned()
+    })
 }
 
 fn case_when_validator<T: Evaluable>(expr: &tipb::Expr) -> Result<()> {

--- a/components/tidb_query_vec_expr/src/impl_encryption.rs
+++ b/components/tidb_query_vec_expr/src/impl_encryption.rs
@@ -17,7 +17,7 @@ const SHA512: i64 = 512;
 
 #[rpn_fn]
 #[inline]
-pub fn md5(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn md5(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     match arg {
         Some(arg) => hex_digest(MessageDigest::md5(), arg).map(Some),
         None => Ok(None),
@@ -26,7 +26,7 @@ pub fn md5(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn sha1(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn sha1(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     match arg {
         Some(arg) => hex_digest(MessageDigest::sha1(), arg).map(Some),
         None => Ok(None),
@@ -37,8 +37,8 @@ pub fn sha1(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
 #[inline]
 pub fn sha2(
     ctx: &mut EvalContext,
-    input: &Option<Bytes>,
-    hash_length: &Option<Int>,
+    input: Option<&Bytes>,
+    hash_length: Option<&Int>,
 ) -> Result<Option<Bytes>> {
     match (input, hash_length) {
         (Some(input), Some(hash_length)) => {
@@ -68,7 +68,7 @@ fn hex_digest(hashtype: MessageDigest, input: &[u8]) -> Result<Bytes> {
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn uncompressed_length(ctx: &mut EvalContext, arg: &Option<Bytes>) -> Result<Option<Int>> {
+pub fn uncompressed_length(ctx: &mut EvalContext, arg: Option<&Bytes>) -> Result<Option<Int>> {
     use byteorder::{ByteOrder, LittleEndian};
     Ok(arg.as_ref().map(|s| {
         if s.is_empty() {
@@ -84,7 +84,7 @@ pub fn uncompressed_length(ctx: &mut EvalContext, arg: &Option<Bytes>) -> Result
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn random_bytes(_ctx: &mut EvalContext, arg: &Option<Int>) -> Result<Option<Bytes>> {
+pub fn random_bytes(_ctx: &mut EvalContext, arg: Option<&Int>) -> Result<Option<Bytes>> {
     match arg {
         Some(arg) => {
             if *arg < 1 || *arg > MAX_RAND_BYTES_LENGTH {

--- a/components/tidb_query_vec_expr/src/impl_json.rs
+++ b/components/tidb_query_vec_expr/src/impl_json.rs
@@ -49,7 +49,9 @@ fn json_modify(args: &[ScalarValueRef], mt: ModifyType) -> Result<Option<Json>> 
     assert!(args.len() >= 2);
     // base Json argument
     let base: &Option<Json> = args[0].as_ref();
-    let base = base.as_ref().map_or(Json::none(), |json| Ok(json.to_owned()))?;
+    let base = base
+        .as_ref()
+        .map_or(Json::none(), |json| Ok(json.to_owned()))?;
 
     let buf_size = args.len() / 2;
 
@@ -62,7 +64,9 @@ fn json_modify(args: &[ScalarValueRef], mt: ModifyType) -> Result<Option<Json>> 
 
         path_expr_list.push(try_opt!(parse_json_path(path.as_ref())));
 
-        let value = value.as_ref().map_or(Json::none(), |json| Ok(json.to_owned()))?;
+        let value = value
+            .as_ref()
+            .map_or(Json::none(), |json| Ok(json.to_owned()))?;
         values.push(value);
     }
     Ok(Some(base.as_ref().modify(&path_expr_list, values, mt)?))

--- a/components/tidb_query_vec_expr/src/impl_json.rs
+++ b/components/tidb_query_vec_expr/src/impl_json.rs
@@ -11,7 +11,7 @@ use tidb_query_datatype::codec::mysql::json::*;
 
 #[rpn_fn]
 #[inline]
-fn json_depth(arg: &Option<Json>) -> Result<Option<i64>> {
+fn json_depth(arg: Option<&Json>) -> Result<Option<i64>> {
     match arg {
         Some(j) => Ok(Some(j.as_ref().depth()?)),
         None => Ok(None),
@@ -20,7 +20,7 @@ fn json_depth(arg: &Option<Json>) -> Result<Option<i64>> {
 
 #[rpn_fn]
 #[inline]
-fn json_type(arg: &Option<Json>) -> Result<Option<Bytes>> {
+fn json_type(arg: Option<&Json>) -> Result<Option<Bytes>> {
     Ok(arg
         .as_ref()
         .map(|json_arg| Bytes::from(json_arg.as_ref().json_type())))
@@ -48,7 +48,7 @@ fn json_replace(args: &[ScalarValueRef]) -> Result<Option<Json>> {
 fn json_modify(args: &[ScalarValueRef], mt: ModifyType) -> Result<Option<Json>> {
     assert!(args.len() >= 2);
     // base Json argument
-    let base: &Option<Json> = args[0].as_ref();
+    let base: Option<&Json> = args[0].as_ref();
     let base = base
         .as_ref()
         .map_or(Json::none(), |json| Ok(json.to_owned()))?;
@@ -59,8 +59,8 @@ fn json_modify(args: &[ScalarValueRef], mt: ModifyType) -> Result<Option<Json>> 
     let mut values = Vec::with_capacity(buf_size);
 
     for chunk in args[1..].chunks(2) {
-        let path: &Option<Bytes> = chunk[0].as_ref();
-        let value: &Option<Json> = chunk[1].as_ref();
+        let path: Option<&Bytes> = chunk[0].as_ref();
+        let value: Option<&Json> = chunk[1].as_ref();
 
         path_expr_list.push(try_opt!(parse_json_path(path)));
 
@@ -72,7 +72,7 @@ fn json_modify(args: &[ScalarValueRef], mt: ModifyType) -> Result<Option<Json>> 
     Ok(Some(base.as_ref().modify(&path_expr_list, values, mt)?))
 }
 
-/// validate the arguments are `(&Option<Json>, &[(Option<Bytes>, Option<Json>)])`
+/// validate the arguments are `(Option<&Json>, &[(Option<Bytes>, Option<Json>)])`
 fn json_modify_validator(expr: &tipb::Expr) -> Result<()> {
     let children = expr.get_children();
     assert!(children.len() >= 2);
@@ -91,7 +91,7 @@ fn json_modify_validator(expr: &tipb::Expr) -> Result<()> {
 
 #[rpn_fn(varg)]
 #[inline]
-fn json_array(args: &[&Option<Json>]) -> Result<Option<Json>> {
+fn json_array(args: &[Option<&Json>]) -> Result<Option<Json>> {
     let mut jsons = vec![];
     for arg in args {
         match arg {
@@ -116,14 +116,14 @@ fn json_object_validator(expr: &tipb::Expr) -> Result<()> {
     Ok(())
 }
 
-/// Required args like `&[(&Option<Byte>, &Option<Json>)]`.
+/// Required args like `&[(Option<&Byte>, Option<&Json>)]`.
 #[rpn_fn(raw_varg, extra_validator = json_object_validator)]
 #[inline]
 fn json_object(raw_args: &[ScalarValueRef]) -> Result<Option<Json>> {
     let mut pairs = BTreeMap::new();
     for chunk in raw_args.chunks(2) {
         assert_eq!(chunk.len(), 2);
-        let key: &Option<Bytes> = chunk[0].as_ref();
+        let key: Option<&Bytes> = chunk[0].as_ref();
         if key.is_none() {
             return Err(other_err!(
                 "Data truncation: JSON documents may not contain NULL member names."
@@ -132,7 +132,7 @@ fn json_object(raw_args: &[ScalarValueRef]) -> Result<Option<Json>> {
         let key = String::from_utf8(key.as_ref().unwrap().to_owned())
             .map_err(|e| tidb_query_datatype::codec::Error::from(e))?;
 
-        let value: &Option<Json> = chunk[1].as_ref();
+        let value: Option<&Json> = chunk[1].as_ref();
         let value = match value {
             None => Json::none()?,
             Some(v) => v.to_owned(),
@@ -147,7 +147,7 @@ fn json_object(raw_args: &[ScalarValueRef]) -> Result<Option<Json>> {
 // arguments of json_merge should not be less than 2.
 #[rpn_fn(varg, min_args = 2)]
 #[inline]
-pub fn json_merge(args: &[&Option<Json>]) -> Result<Option<Json>> {
+pub fn json_merge(args: &[Option<&Json>]) -> Result<Option<Json>> {
     // min_args = 2, so it's ok to call args[0]
     if args[0].is_none() {
         return Ok(None);
@@ -165,16 +165,16 @@ pub fn json_merge(args: &[&Option<Json>]) -> Result<Option<Json>> {
 
 #[rpn_fn]
 #[inline]
-fn json_unquote(arg: &Option<Json>) -> Result<Option<Bytes>> {
+fn json_unquote(arg: Option<&Json>) -> Result<Option<Bytes>> {
     arg.as_ref().map_or(Ok(None), |json_arg| {
         Ok(Some(Bytes::from(json_arg.as_ref().unquote()?)))
     })
 }
 
-// Args should be like `(&Option<Json> , &[&Option<Bytes>])`.
+// Args should be like `(Option<&Json> , &[Option<&Bytes>])`.
 fn json_with_paths_validator(expr: &tipb::Expr) -> Result<()> {
     assert!(expr.get_children().len() >= 2);
-    // args should be like `&Option<Json> , &[&Option<Bytes>]`.
+    // args should be like `Option<&Json> , &[Option<&Bytes>]`.
     valid_paths(expr)
 }
 
@@ -191,7 +191,7 @@ fn valid_paths(expr: &tipb::Expr) -> Result<()> {
 #[inline]
 fn json_extract(args: &[ScalarValueRef]) -> Result<Option<Json>> {
     assert!(args.len() >= 2);
-    let j: &Option<Json> = args[0].as_ref();
+    let j: Option<&Json> = args[0].as_ref();
     let j = match j.as_ref() {
         None => return Ok(None),
         Some(j) => j.to_owned(),
@@ -202,7 +202,7 @@ fn json_extract(args: &[ScalarValueRef]) -> Result<Option<Json>> {
     Ok(j.as_ref().extract(&path_expr_list)?)
 }
 
-// Args should be like `(&Option<Json> , &[&Option<Bytes>])`.
+// Args should be like `(Option<&Json> , &[Option<&Bytes>])`.
 fn json_with_path_validator(expr: &tipb::Expr) -> Result<()> {
     assert!(expr.get_children().len() == 2 || expr.get_children().len() == 1);
     valid_paths(expr)
@@ -224,7 +224,7 @@ fn json_keys(args: &[ScalarValueRef]) -> Result<Option<Json>> {
 #[inline]
 fn json_length(args: &[ScalarValueRef]) -> Result<Option<Int>> {
     assert!(!args.is_empty() && args.len() <= 2);
-    let j: &Option<Json> = args[0].as_ref();
+    let j: Option<&Json> = args[0].as_ref();
     let j = match j.as_ref() {
         None => return Ok(None),
         Some(j) => j.to_owned(),
@@ -239,7 +239,7 @@ fn json_length(args: &[ScalarValueRef]) -> Result<Option<Int>> {
 #[inline]
 fn json_remove(args: &[ScalarValueRef]) -> Result<Option<Json>> {
     assert!(args.len() >= 2);
-    let j: &Option<Json> = args[0].as_ref();
+    let j: Option<&Json> = args[0].as_ref();
     let j = match j.as_ref() {
         None => return Ok(None),
         Some(j) => j.to_owned(),
@@ -253,7 +253,7 @@ fn json_remove(args: &[ScalarValueRef]) -> Result<Option<Json>> {
 fn parse_json_path_list(args: &[ScalarValueRef]) -> Result<Option<Vec<PathExpression>>> {
     let mut path_expr_list = Vec::with_capacity(args.len());
     for arg in args {
-        let json_path: &Option<Bytes> = arg.as_ref();
+        let json_path: Option<&Bytes> = arg.as_ref();
 
         path_expr_list.push(try_opt!(parse_json_path(json_path)));
     }
@@ -261,7 +261,7 @@ fn parse_json_path_list(args: &[ScalarValueRef]) -> Result<Option<Vec<PathExpres
 }
 
 #[inline]
-fn parse_json_path(path: &Option<Bytes>) -> Result<Option<PathExpression>> {
+fn parse_json_path(path: Option<&Bytes>) -> Result<Option<PathExpression>> {
     let json_path = match path.as_ref() {
         None => return Ok(None),
         Some(p) => std::str::from_utf8(&p).map_err(tidb_query_datatype::codec::Error::from),

--- a/components/tidb_query_vec_expr/src/impl_like.rs
+++ b/components/tidb_query_vec_expr/src/impl_like.rs
@@ -10,9 +10,9 @@ use tidb_query_shared_expr::*;
 #[rpn_fn]
 #[inline]
 pub fn like<C: Collator>(
-    target: &Option<Bytes>,
-    pattern: &Option<Bytes>,
-    escape: &Option<i64>,
+    target: Option<&Bytes>,
+    pattern: Option<&Bytes>,
+    escape: Option<&i64>,
 ) -> Result<Option<i64>> {
     match (target, pattern, escape) {
         (Some(target), Some(pattern), Some(escape)) => {

--- a/components/tidb_query_vec_expr/src/impl_math.rs
+++ b/components/tidb_query_vec_expr/src/impl_math.rs
@@ -345,19 +345,19 @@ pub fn exp(arg: Option<&Real>) -> Result<Option<Real>> {
 #[inline]
 #[rpn_fn]
 fn sin(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.map_or(None, |arg| Real::new(arg.sin()).ok()))
+    Ok(arg.and_then(|arg| Real::new(arg.sin()).ok()))
 }
 
 #[inline]
 #[rpn_fn]
 fn cos(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.map_or(None, |arg| Real::new(arg.cos()).ok()))
+    Ok(arg.and_then(|arg| Real::new(arg.cos()).ok()))
 }
 
 #[inline]
 #[rpn_fn]
 fn tan(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.map_or(None, |arg| Real::new(arg.tan()).ok()))
+    Ok(arg.and_then(|arg| Real::new(arg.tan()).ok()))
 }
 
 #[inline]
@@ -417,19 +417,19 @@ fn degrees(arg: Option<&Real>) -> Result<Option<Real>> {
 #[inline]
 #[rpn_fn]
 pub fn asin(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.map_or(None, |arg| Real::new(arg.asin()).ok()))
+    Ok(arg.and_then(|arg| Real::new(arg.asin()).ok()))
 }
 
 #[inline]
 #[rpn_fn]
 pub fn acos(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.map_or(None, |arg| Real::new(arg.acos()).ok()))
+    Ok(arg.and_then(|arg| Real::new(arg.acos()).ok()))
 }
 
 #[inline]
 #[rpn_fn]
 pub fn atan_1_arg(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.map_or(None, |arg| Real::new(arg.atan()).ok()))
+    Ok(arg.and_then(|arg| Real::new(arg.atan()).ok()))
 }
 
 #[inline]

--- a/components/tidb_query_vec_expr/src/impl_math.rs
+++ b/components/tidb_query_vec_expr/src/impl_math.rs
@@ -321,7 +321,9 @@ fn sqrt(arg: Option<&Real>) -> Result<Option<Real>> {
 #[inline]
 #[rpn_fn]
 fn radians(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.cloned().and_then(|n| Real::new(*n * std::f64::consts::PI / 180_f64).ok()))
+    Ok(arg
+        .cloned()
+        .and_then(|n| Real::new(*n * std::f64::consts::PI / 180_f64).ok()))
 }
 
 #[inline]

--- a/components/tidb_query_vec_expr/src/impl_math.rs
+++ b/components/tidb_query_vec_expr/src/impl_math.rs
@@ -263,7 +263,7 @@ fn abs_int(arg: Option<&Int>) -> Result<Option<Int>> {
 #[rpn_fn]
 #[inline]
 fn abs_uint(arg: Option<&Int>) -> Result<Option<Int>> {
-    Ok(*arg)
+    Ok(arg.cloned())
 }
 
 #[rpn_fn]
@@ -290,7 +290,7 @@ fn abs_decimal(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
 #[inline]
 #[rpn_fn]
 fn sign(arg: Option<&Real>) -> Result<Option<Int>> {
-    Ok(arg.and_then(|n| {
+    Ok(arg.cloned().and_then(|n| {
         if *n > 0f64 {
             Some(1)
         } else if *n == 0f64 {
@@ -304,7 +304,7 @@ fn sign(arg: Option<&Real>) -> Result<Option<Int>> {
 #[inline]
 #[rpn_fn]
 fn sqrt(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.and_then(|n| {
+    Ok(arg.cloned().and_then(|n| {
         if *n < 0f64 {
             None
         } else {
@@ -321,7 +321,7 @@ fn sqrt(arg: Option<&Real>) -> Result<Option<Real>> {
 #[inline]
 #[rpn_fn]
 fn radians(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.and_then(|n| Real::new(*n * std::f64::consts::PI / 180_f64).ok()))
+    Ok(arg.cloned().and_then(|n| Real::new(*n * std::f64::consts::PI / 180_f64).ok()))
 }
 
 #[inline]
@@ -401,7 +401,7 @@ fn rand() -> Result<Option<Real>> {
 #[inline]
 #[rpn_fn]
 fn rand_with_seed_first_gen(seed: Option<&i64>) -> Result<Option<Real>> {
-    let mut rng = MySQLRng::new_with_seed(seed.unwrap_or(0));
+    let mut rng = MySQLRng::new_with_seed(seed.cloned().unwrap_or(0));
     let res = rng.gen();
     Ok(Real::new(res).ok())
 }
@@ -467,7 +467,7 @@ pub fn round_real(arg: Option<&Real>) -> Result<Option<Real>> {
 #[inline]
 #[rpn_fn]
 pub fn round_int(arg: Option<&Int>) -> Result<Option<Int>> {
-    Ok(*arg)
+    Ok(arg.cloned())
 }
 
 #[inline]
@@ -488,8 +488,8 @@ pub fn round_dec(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
 #[inline]
 #[rpn_fn]
 pub fn truncate_int_with_int(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<Option<Int>> {
-    match (arg0, arg1) {
-        (&Some(x), &Some(d)) => {
+    match (arg0.cloned(), arg1.cloned()) {
+        (Some(x), Some(d)) => {
             if d >= 0 {
                 Ok(Some(x))
             } else {
@@ -507,8 +507,8 @@ pub fn truncate_int_with_int(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<O
 #[inline]
 #[rpn_fn]
 pub fn truncate_int_with_uint(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<Option<Int>> {
-    match (arg0, arg1) {
-        (&Some(x), &Some(_)) => Ok(Some(x)),
+    match (arg0.cloned(), arg1.cloned()) {
+        (Some(x), Some(_)) => Ok(Some(x)),
         _ => Ok(None),
     }
 }
@@ -516,8 +516,8 @@ pub fn truncate_int_with_uint(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<
 #[inline]
 #[rpn_fn]
 pub fn truncate_real_with_int(arg0: Option<&Real>, arg1: Option<&Int>) -> Result<Option<Real>> {
-    match (arg0, arg1) {
-        (&Some(x), &Some(d)) => {
+    match (arg0.cloned(), arg1.cloned()) {
+        (Some(x), Some(d)) => {
             let d = if d >= 0 {
                 d.min(i64::from(i32::max_value())) as i32
             } else {
@@ -532,8 +532,8 @@ pub fn truncate_real_with_int(arg0: Option<&Real>, arg1: Option<&Int>) -> Result
 #[inline]
 #[rpn_fn]
 pub fn truncate_real_with_uint(arg0: Option<&Real>, arg1: Option<&Int>) -> Result<Option<Real>> {
-    match (arg0, arg1) {
-        (&Some(x), &Some(d)) => {
+    match (arg0.cloned(), arg1.cloned()) {
+        (Some(x), Some(d)) => {
             let d = (d as u64).min(i32::max_value() as u64) as i32;
             Ok(Some(truncate_real(x, d)))
         }

--- a/components/tidb_query_vec_expr/src/impl_math.rs
+++ b/components/tidb_query_vec_expr/src/impl_math.rs
@@ -40,7 +40,7 @@ pub fn pi() -> Result<Option<Real>> {
 
 #[rpn_fn]
 #[inline]
-pub fn crc32(arg: &Option<Bytes>) -> Result<Option<Int>> {
+pub fn crc32(arg: Option<&Bytes>) -> Result<Option<Int>> {
     Ok(arg
         .as_ref()
         .map(|bytes| i64::from(tikv_util::file::calc_crc32_bytes(&bytes))))
@@ -48,14 +48,14 @@ pub fn crc32(arg: &Option<Bytes>) -> Result<Option<Int>> {
 
 #[inline]
 #[rpn_fn]
-pub fn log_1_arg(arg: &Option<Real>) -> Result<Option<Real>> {
+pub fn log_1_arg(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| f64_to_real(n.ln())))
 }
 
 #[inline]
 #[rpn_fn]
 #[allow(clippy::float_cmp)]
-pub fn log_2_arg(arg0: &Option<Real>, arg1: &Option<Real>) -> Result<Option<Real>> {
+pub fn log_2_arg(arg0: Option<&Real>, arg1: Option<&Real>) -> Result<Option<Real>> {
     Ok(match (arg0, arg1) {
         (Some(base), Some(n)) => {
             if **base <= 0f64 || **base == 1f64 || **n <= 0f64 {
@@ -70,13 +70,13 @@ pub fn log_2_arg(arg0: &Option<Real>, arg1: &Option<Real>) -> Result<Option<Real
 
 #[inline]
 #[rpn_fn]
-pub fn log2(arg: &Option<Real>) -> Result<Option<Real>> {
+pub fn log2(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| f64_to_real(n.log2())))
 }
 
 #[inline]
 #[rpn_fn]
-pub fn log10(arg: &Option<Real>) -> Result<Option<Real>> {
+pub fn log10(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| f64_to_real(n.log10())))
 }
 
@@ -91,7 +91,7 @@ fn f64_to_real(n: f64) -> Option<Real> {
 
 #[inline]
 #[rpn_fn(capture = [ctx])]
-pub fn ceil<C: Ceil>(ctx: &mut EvalContext, arg: &Option<C::Input>) -> Result<Option<C::Output>> {
+pub fn ceil<C: Ceil>(ctx: &mut EvalContext, arg: Option<&C::Input>) -> Result<Option<C::Output>> {
     if let Some(arg) = arg {
         C::ceil(ctx, arg)
     } else {
@@ -171,7 +171,7 @@ impl Ceil for CeilIntToInt {
 }
 
 #[rpn_fn(capture = [ctx])]
-pub fn floor<T: Floor>(ctx: &mut EvalContext, arg: &Option<T::Input>) -> Result<Option<T::Output>> {
+pub fn floor<T: Floor>(ctx: &mut EvalContext, arg: Option<&T::Input>) -> Result<Option<T::Output>> {
     if let Some(arg) = arg {
         T::floor(ctx, arg)
     } else {
@@ -250,7 +250,7 @@ impl Floor for FloorIntToInt {
 
 #[rpn_fn]
 #[inline]
-fn abs_int(arg: &Option<Int>) -> Result<Option<Int>> {
+fn abs_int(arg: Option<&Int>) -> Result<Option<Int>> {
     match arg {
         None => Ok(None),
         Some(arg) => match (*arg).checked_abs() {
@@ -262,13 +262,13 @@ fn abs_int(arg: &Option<Int>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
-fn abs_uint(arg: &Option<Int>) -> Result<Option<Int>> {
+fn abs_uint(arg: Option<&Int>) -> Result<Option<Int>> {
     Ok(*arg)
 }
 
 #[rpn_fn]
 #[inline]
-fn abs_real(arg: &Option<Real>) -> Result<Option<Real>> {
+fn abs_real(arg: Option<&Real>) -> Result<Option<Real>> {
     match arg {
         Some(arg) => Ok(Some(num_traits::Signed::abs(arg))),
         None => Ok(None),
@@ -277,7 +277,7 @@ fn abs_real(arg: &Option<Real>) -> Result<Option<Real>> {
 
 #[rpn_fn]
 #[inline]
-fn abs_decimal(arg: &Option<Decimal>) -> Result<Option<Decimal>> {
+fn abs_decimal(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
     match arg {
         Some(arg) => {
             let res: codec::Result<Decimal> = arg.to_owned().abs().into();
@@ -289,7 +289,7 @@ fn abs_decimal(arg: &Option<Decimal>) -> Result<Option<Decimal>> {
 
 #[inline]
 #[rpn_fn]
-fn sign(arg: &Option<Real>) -> Result<Option<Int>> {
+fn sign(arg: Option<&Real>) -> Result<Option<Int>> {
     Ok(arg.and_then(|n| {
         if *n > 0f64 {
             Some(1)
@@ -303,7 +303,7 @@ fn sign(arg: &Option<Real>) -> Result<Option<Int>> {
 
 #[inline]
 #[rpn_fn]
-fn sqrt(arg: &Option<Real>) -> Result<Option<Real>> {
+fn sqrt(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| {
         if *n < 0f64 {
             None
@@ -320,13 +320,13 @@ fn sqrt(arg: &Option<Real>) -> Result<Option<Real>> {
 
 #[inline]
 #[rpn_fn]
-fn radians(arg: &Option<Real>) -> Result<Option<Real>> {
+fn radians(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| Real::new(*n * std::f64::consts::PI / 180_f64).ok()))
 }
 
 #[inline]
 #[rpn_fn]
-pub fn exp(arg: &Option<Real>) -> Result<Option<Real>> {
+pub fn exp(arg: Option<&Real>) -> Result<Option<Real>> {
     match arg {
         Some(x) => {
             let ret = x.exp();
@@ -342,25 +342,25 @@ pub fn exp(arg: &Option<Real>) -> Result<Option<Real>> {
 
 #[inline]
 #[rpn_fn]
-fn sin(arg: &Option<Real>) -> Result<Option<Real>> {
+fn sin(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.map_or(None, |arg| Real::new(arg.sin()).ok()))
 }
 
 #[inline]
 #[rpn_fn]
-fn cos(arg: &Option<Real>) -> Result<Option<Real>> {
+fn cos(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.map_or(None, |arg| Real::new(arg.cos()).ok()))
 }
 
 #[inline]
 #[rpn_fn]
-fn tan(arg: &Option<Real>) -> Result<Option<Real>> {
+fn tan(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.map_or(None, |arg| Real::new(arg.tan()).ok()))
 }
 
 #[inline]
 #[rpn_fn]
-fn cot(arg: &Option<Real>) -> Result<Option<Real>> {
+fn cot(arg: Option<&Real>) -> Result<Option<Real>> {
     match arg {
         Some(arg) => {
             let tan = arg.tan();
@@ -377,7 +377,7 @@ fn cot(arg: &Option<Real>) -> Result<Option<Real>> {
 
 #[inline]
 #[rpn_fn]
-fn pow(lhs: &Option<Real>, rhs: &Option<Real>) -> Result<Option<Real>> {
+fn pow(lhs: Option<&Real>, rhs: Option<&Real>) -> Result<Option<Real>> {
     match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => {
             let pow = (lhs.into_inner()).pow(rhs.into_inner());
@@ -400,7 +400,7 @@ fn rand() -> Result<Option<Real>> {
 
 #[inline]
 #[rpn_fn]
-fn rand_with_seed_first_gen(seed: &Option<i64>) -> Result<Option<Real>> {
+fn rand_with_seed_first_gen(seed: Option<&i64>) -> Result<Option<Real>> {
     let mut rng = MySQLRng::new_with_seed(seed.unwrap_or(0));
     let res = rng.gen();
     Ok(Real::new(res).ok())
@@ -408,31 +408,31 @@ fn rand_with_seed_first_gen(seed: &Option<i64>) -> Result<Option<Real>> {
 
 #[inline]
 #[rpn_fn]
-fn degrees(arg: &Option<Real>) -> Result<Option<Real>> {
+fn degrees(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| Real::new(n.to_degrees()).ok()))
 }
 
 #[inline]
 #[rpn_fn]
-pub fn asin(arg: &Option<Real>) -> Result<Option<Real>> {
+pub fn asin(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.map_or(None, |arg| Real::new(arg.asin()).ok()))
 }
 
 #[inline]
 #[rpn_fn]
-pub fn acos(arg: &Option<Real>) -> Result<Option<Real>> {
+pub fn acos(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.map_or(None, |arg| Real::new(arg.acos()).ok()))
 }
 
 #[inline]
 #[rpn_fn]
-pub fn atan_1_arg(arg: &Option<Real>) -> Result<Option<Real>> {
+pub fn atan_1_arg(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.map_or(None, |arg| Real::new(arg.atan()).ok()))
 }
 
 #[inline]
 #[rpn_fn]
-pub fn atan_2_args(arg0: &Option<Real>, arg1: &Option<Real>) -> Result<Option<Real>> {
+pub fn atan_2_args(arg0: Option<&Real>, arg1: Option<&Real>) -> Result<Option<Real>> {
     Ok(match (arg0, arg1) {
         (Some(arg0), Some(arg1)) => Real::new(arg0.atan2(arg1.into_inner())).ok(),
         _ => None,
@@ -442,9 +442,9 @@ pub fn atan_2_args(arg0: &Option<Real>, arg1: &Option<Real>) -> Result<Option<Re
 #[inline]
 #[rpn_fn]
 pub fn conv(
-    n: &Option<Bytes>,
-    from_base: &Option<Int>,
-    to_base: &Option<Int>,
+    n: Option<&Bytes>,
+    from_base: Option<&Int>,
+    to_base: Option<&Int>,
 ) -> Result<Option<Bytes>> {
     use tidb_query_shared_expr::conv::conv as conv_impl;
     if let (Some(n), Some(from_base), Some(to_base)) = (n, from_base, to_base) {
@@ -457,7 +457,7 @@ pub fn conv(
 
 #[inline]
 #[rpn_fn]
-pub fn round_real(arg: &Option<Real>) -> Result<Option<Real>> {
+pub fn round_real(arg: Option<&Real>) -> Result<Option<Real>> {
     match arg {
         Some(arg) => Ok(Real::new(arg.round()).ok()),
         None => Ok(None),
@@ -466,13 +466,13 @@ pub fn round_real(arg: &Option<Real>) -> Result<Option<Real>> {
 
 #[inline]
 #[rpn_fn]
-pub fn round_int(arg: &Option<Int>) -> Result<Option<Int>> {
+pub fn round_int(arg: Option<&Int>) -> Result<Option<Int>> {
     Ok(*arg)
 }
 
 #[inline]
 #[rpn_fn]
-pub fn round_dec(arg: &Option<Decimal>) -> Result<Option<Decimal>> {
+pub fn round_dec(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
     match arg {
         Some(arg) => {
             let res: codec::Result<Decimal> = arg
@@ -487,7 +487,7 @@ pub fn round_dec(arg: &Option<Decimal>) -> Result<Option<Decimal>> {
 
 #[inline]
 #[rpn_fn]
-pub fn truncate_int_with_int(arg0: &Option<Int>, arg1: &Option<Int>) -> Result<Option<Int>> {
+pub fn truncate_int_with_int(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<Option<Int>> {
     match (arg0, arg1) {
         (&Some(x), &Some(d)) => {
             if d >= 0 {
@@ -506,7 +506,7 @@ pub fn truncate_int_with_int(arg0: &Option<Int>, arg1: &Option<Int>) -> Result<O
 
 #[inline]
 #[rpn_fn]
-pub fn truncate_int_with_uint(arg0: &Option<Int>, arg1: &Option<Int>) -> Result<Option<Int>> {
+pub fn truncate_int_with_uint(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<Option<Int>> {
     match (arg0, arg1) {
         (&Some(x), &Some(_)) => Ok(Some(x)),
         _ => Ok(None),
@@ -515,7 +515,7 @@ pub fn truncate_int_with_uint(arg0: &Option<Int>, arg1: &Option<Int>) -> Result<
 
 #[inline]
 #[rpn_fn]
-pub fn truncate_real_with_int(arg0: &Option<Real>, arg1: &Option<Int>) -> Result<Option<Real>> {
+pub fn truncate_real_with_int(arg0: Option<&Real>, arg1: Option<&Int>) -> Result<Option<Real>> {
     match (arg0, arg1) {
         (&Some(x), &Some(d)) => {
             let d = if d >= 0 {
@@ -531,7 +531,7 @@ pub fn truncate_real_with_int(arg0: &Option<Real>, arg1: &Option<Int>) -> Result
 
 #[inline]
 #[rpn_fn]
-pub fn truncate_real_with_uint(arg0: &Option<Real>, arg1: &Option<Int>) -> Result<Option<Real>> {
+pub fn truncate_real_with_uint(arg0: Option<&Real>, arg1: Option<&Int>) -> Result<Option<Real>> {
     match (arg0, arg1) {
         (&Some(x), &Some(d)) => {
             let d = (d as u64).min(i32::max_value() as u64) as i32;

--- a/components/tidb_query_vec_expr/src/impl_math.rs
+++ b/components/tidb_query_vec_expr/src/impl_math.rs
@@ -290,10 +290,10 @@ fn abs_decimal(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
 #[inline]
 #[rpn_fn]
 fn sign(arg: Option<&Real>) -> Result<Option<Int>> {
-    Ok(arg.cloned().and_then(|n| {
-        if *n > 0f64 {
+    Ok(arg.and_then(|n| {
+        if **n > 0f64 {
             Some(1)
-        } else if *n == 0f64 {
+        } else if **n == 0f64 {
             Some(0)
         } else {
             Some(-1)
@@ -304,8 +304,8 @@ fn sign(arg: Option<&Real>) -> Result<Option<Int>> {
 #[inline]
 #[rpn_fn]
 fn sqrt(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.cloned().and_then(|n| {
-        if *n < 0f64 {
+    Ok(arg.and_then(|n| {
+        if **n < 0f64 {
             None
         } else {
             let res = n.sqrt();
@@ -321,9 +321,7 @@ fn sqrt(arg: Option<&Real>) -> Result<Option<Real>> {
 #[inline]
 #[rpn_fn]
 fn radians(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg
-        .cloned()
-        .and_then(|n| Real::new(*n * std::f64::consts::PI / 180_f64).ok()))
+    Ok(arg.and_then(|n| Real::new(**n * std::f64::consts::PI / 180_f64).ok()))
 }
 
 #[inline]
@@ -490,16 +488,16 @@ pub fn round_dec(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
 #[inline]
 #[rpn_fn]
 pub fn truncate_int_with_int(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<Option<Int>> {
-    match (arg0.cloned(), arg1.cloned()) {
+    match (arg0, arg1) {
         (Some(x), Some(d)) => {
-            if d >= 0 {
-                Ok(Some(x))
+            if *d >= 0 {
+                Ok(Some(*x))
             } else {
-                if d <= -(I64_TEN_POWS.len() as i64) {
+                if *d <= -(I64_TEN_POWS.len() as i64) {
                     return Ok(Some(0));
                 }
-                let shift = I64_TEN_POWS[-d as usize];
-                Ok(Some(x / shift * shift))
+                let shift = I64_TEN_POWS[-*d as usize];
+                Ok(Some(*x / shift * shift))
             }
         }
         _ => Ok(None),
@@ -509,8 +507,8 @@ pub fn truncate_int_with_int(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<O
 #[inline]
 #[rpn_fn]
 pub fn truncate_int_with_uint(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<Option<Int>> {
-    match (arg0.cloned(), arg1.cloned()) {
-        (Some(x), Some(_)) => Ok(Some(x)),
+    match (arg0, arg1) {
+        (Some(x), Some(_)) => Ok(Some(*x)),
         _ => Ok(None),
     }
 }
@@ -518,14 +516,14 @@ pub fn truncate_int_with_uint(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<
 #[inline]
 #[rpn_fn]
 pub fn truncate_real_with_int(arg0: Option<&Real>, arg1: Option<&Int>) -> Result<Option<Real>> {
-    match (arg0.cloned(), arg1.cloned()) {
+    match (arg0, arg1) {
         (Some(x), Some(d)) => {
-            let d = if d >= 0 {
-                d.min(i64::from(i32::max_value())) as i32
+            let d = if *d >= 0 {
+                (*d).min(i64::from(i32::max_value())) as i32
             } else {
-                d.max(i64::from(i32::min_value())) as i32
+                (*d).max(i64::from(i32::min_value())) as i32
             };
-            Ok(Some(truncate_real(x, d)))
+            Ok(Some(truncate_real(*x, d)))
         }
         _ => Ok(None),
     }
@@ -534,10 +532,10 @@ pub fn truncate_real_with_int(arg0: Option<&Real>, arg1: Option<&Int>) -> Result
 #[inline]
 #[rpn_fn]
 pub fn truncate_real_with_uint(arg0: Option<&Real>, arg1: Option<&Int>) -> Result<Option<Real>> {
-    match (arg0.cloned(), arg1.cloned()) {
+    match (arg0, arg1) {
         (Some(x), Some(d)) => {
-            let d = (d as u64).min(i32::max_value() as u64) as i32;
-            Ok(Some(truncate_real(x, d)))
+            let d = (*d as u64).min(i32::max_value() as u64) as i32;
+            Ok(Some(truncate_real(*x, d)))
         }
         _ => Ok(None),
     }

--- a/components/tidb_query_vec_expr/src/impl_miscellaneous.rs
+++ b/components/tidb_query_vec_expr/src/impl_miscellaneous.rs
@@ -22,7 +22,7 @@ const PREFIX_MAPPED: [u8; 12] = [
 #[inline]
 pub fn any_value<T: Evaluable>(args: &[Option<&T>]) -> Result<Option<T>> {
     if let Some(arg) = args.first() {
-        Ok((*arg).clone())
+        Ok(arg.cloned())
     } else {
         Ok(None)
     }
@@ -40,7 +40,7 @@ pub fn inet_aton(addr: Option<&Bytes>) -> Result<Option<Int>> {
 #[rpn_fn]
 #[inline]
 pub fn inet_ntoa(arg: Option<&Int>) -> Result<Option<Bytes>> {
-    Ok(arg
+    Ok(arg.cloned()
         .and_then(|arg| u32::try_from(arg).ok())
         .map(|arg| format!("{}", Ipv4Addr::from(arg)).into_bytes()))
 }

--- a/components/tidb_query_vec_expr/src/impl_miscellaneous.rs
+++ b/components/tidb_query_vec_expr/src/impl_miscellaneous.rs
@@ -20,7 +20,7 @@ const PREFIX_MAPPED: [u8; 12] = [
 
 #[rpn_fn(varg)]
 #[inline]
-pub fn any_value<T: Evaluable>(args: &[&Option<T>]) -> Result<Option<T>> {
+pub fn any_value<T: Evaluable>(args: &[Option<&T>]) -> Result<Option<T>> {
     if let Some(arg) = args.first() {
         Ok((*arg).clone())
     } else {
@@ -30,7 +30,7 @@ pub fn any_value<T: Evaluable>(args: &[&Option<T>]) -> Result<Option<T>> {
 
 #[rpn_fn]
 #[inline]
-pub fn inet_aton(addr: &Option<Bytes>) -> Result<Option<Int>> {
+pub fn inet_aton(addr: Option<&Bytes>) -> Result<Option<Int>> {
     Ok(addr
         .as_ref()
         .map(|addr| String::from_utf8_lossy(addr))
@@ -39,7 +39,7 @@ pub fn inet_aton(addr: &Option<Bytes>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
-pub fn inet_ntoa(arg: &Option<Int>) -> Result<Option<Bytes>> {
+pub fn inet_ntoa(arg: Option<&Int>) -> Result<Option<Bytes>> {
     Ok(arg
         .and_then(|arg| u32::try_from(arg).ok())
         .map(|arg| format!("{}", Ipv4Addr::from(arg)).into_bytes()))
@@ -47,7 +47,7 @@ pub fn inet_ntoa(arg: &Option<Int>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn inet6_aton(input: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn inet6_aton(input: Option<&Bytes>) -> Result<Option<Bytes>> {
     let input = match input {
         Some(input) => String::from_utf8_lossy(input),
         None => return Ok(None),
@@ -63,7 +63,7 @@ pub fn inet6_aton(input: &Option<Bytes>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn inet6_ntoa(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn inet6_ntoa(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     Ok(arg.as_ref().and_then(|s| {
         if s.len() == IPV6_LENGTH {
             let v: &[u8; 16] = s.as_slice().try_into().unwrap();
@@ -79,7 +79,7 @@ pub fn inet6_ntoa(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn is_ipv4(addr: &Option<Bytes>) -> Result<Option<Int>> {
+pub fn is_ipv4(addr: Option<&Bytes>) -> Result<Option<Int>> {
     Ok(match addr {
         Some(addr) => match std::str::from_utf8(addr) {
             Ok(addr) => {
@@ -97,7 +97,7 @@ pub fn is_ipv4(addr: &Option<Bytes>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
-pub fn is_ipv4_compat(addr: &Option<Bytes>) -> Result<Option<i64>> {
+pub fn is_ipv4_compat(addr: Option<&Bytes>) -> Result<Option<i64>> {
     Ok(addr.as_ref().map_or(Some(0), |addr| {
         if addr.len() != IPV6_LENGTH || !addr.starts_with(&PREFIX_COMPAT) {
             Some(0)
@@ -109,7 +109,7 @@ pub fn is_ipv4_compat(addr: &Option<Bytes>) -> Result<Option<i64>> {
 
 #[rpn_fn]
 #[inline]
-pub fn is_ipv4_mapped(addr: &Option<Bytes>) -> Result<Option<i64>> {
+pub fn is_ipv4_mapped(addr: Option<&Bytes>) -> Result<Option<i64>> {
     Ok(addr.as_ref().map_or(Some(0), |addr| {
         if addr.len() != IPV6_LENGTH || !addr.starts_with(&PREFIX_MAPPED) {
             Some(0)
@@ -121,7 +121,7 @@ pub fn is_ipv4_mapped(addr: &Option<Bytes>) -> Result<Option<i64>> {
 
 #[rpn_fn]
 #[inline]
-pub fn is_ipv6(addr: &Option<Bytes>) -> Result<Option<Int>> {
+pub fn is_ipv6(addr: Option<&Bytes>) -> Result<Option<Int>> {
     Ok(match addr {
         Some(addr) => match std::str::from_utf8(addr) {
             Ok(addr) => {

--- a/components/tidb_query_vec_expr/src/impl_miscellaneous.rs
+++ b/components/tidb_query_vec_expr/src/impl_miscellaneous.rs
@@ -40,7 +40,8 @@ pub fn inet_aton(addr: Option<&Bytes>) -> Result<Option<Int>> {
 #[rpn_fn]
 #[inline]
 pub fn inet_ntoa(arg: Option<&Int>) -> Result<Option<Bytes>> {
-    Ok(arg.cloned()
+    Ok(arg
+        .cloned()
         .and_then(|arg| u32::try_from(arg).ok())
         .map(|arg| format!("{}", Ipv4Addr::from(arg)).into_bytes()))
 }

--- a/components/tidb_query_vec_expr/src/impl_op.rs
+++ b/components/tidb_query_vec_expr/src/impl_op.rs
@@ -41,7 +41,7 @@ pub fn logical_xor(arg0: Option<&i64>, arg1: Option<&i64>) -> Result<Option<i64>
 #[rpn_fn]
 #[inline]
 pub fn unary_not_int(arg: Option<&Int>) -> Result<Option<i64>> {
-    Ok(arg.map(|v| (v == 0) as i64))
+    Ok(arg.cloned().map(|v| (v == 0) as i64))
 }
 
 #[rpn_fn]
@@ -61,7 +61,7 @@ pub fn unary_not_decimal(arg: Option<&Decimal>) -> Result<Option<i64>> {
 pub fn unary_minus_uint(arg: Option<&Int>) -> Result<Option<Int>> {
     use std::cmp::Ordering::*;
 
-    match *arg {
+    match arg.cloned() {
         Some(val) => {
             let uval = val as u64;
             match uval.cmp(&(std::i64::MAX as u64 + 1)) {
@@ -77,7 +77,7 @@ pub fn unary_minus_uint(arg: Option<&Int>) -> Result<Option<Int>> {
 #[rpn_fn]
 #[inline]
 pub fn unary_minus_int(arg: Option<&Int>) -> Result<Option<Int>> {
-    match *arg {
+    match arg.cloned() {
         Some(val) => {
             if val == std::i64::MIN {
                 Err(Error::overflow("BIGINT", &format!("-{}", val)).into())
@@ -92,13 +92,13 @@ pub fn unary_minus_int(arg: Option<&Int>) -> Result<Option<Int>> {
 #[rpn_fn]
 #[inline]
 pub fn unary_minus_real(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.map(|val| -val))
+    Ok(arg.cloned().map(|val| -val))
 }
 
 #[rpn_fn]
 #[inline]
 pub fn unary_minus_decimal(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
-    Ok(arg.as_ref().map(|val| -*val))
+    Ok(arg.map(|val| -*val))
 }
 
 #[rpn_fn]
@@ -158,9 +158,9 @@ impl KeepNull for KeepNullOff {
 #[inline]
 pub fn int_is_true<K: KeepNull>(arg: Option<&Int>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
-        arg.map(|v| (v != 0) as i64)
+        arg.cloned().map(|v| (v != 0) as i64)
     } else {
-        Some(arg.map_or(0, |v| (v != 0) as i64))
+        Some(arg.cloned().map_or(0, |v| (v != 0) as i64))
     })
 }
 
@@ -188,9 +188,9 @@ pub fn decimal_is_true<K: KeepNull>(arg: Option<&Decimal>) -> Result<Option<i64>
 #[inline]
 pub fn int_is_false<K: KeepNull>(arg: Option<&Int>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
-        arg.map(|v| (v == 0) as i64)
+        arg.cloned().map(|v| (v == 0) as i64)
     } else {
-        Some(arg.map_or(0, |v| (v == 0) as i64))
+        Some(arg.cloned().map_or(0, |v| (v == 0) as i64))
     })
 }
 

--- a/components/tidb_query_vec_expr/src/impl_op.rs
+++ b/components/tidb_query_vec_expr/src/impl_op.rs
@@ -8,7 +8,7 @@ use tidb_query_datatype::codec::Error;
 
 #[rpn_fn]
 #[inline]
-pub fn logical_and(lhs: &Option<i64>, rhs: &Option<i64>) -> Result<Option<i64>> {
+pub fn logical_and(lhs: Option<&i64>, rhs: Option<&i64>) -> Result<Option<i64>> {
     Ok(match (lhs, rhs) {
         (Some(0), _) | (_, Some(0)) => Some(0),
         (None, _) | (_, None) => None,
@@ -18,7 +18,7 @@ pub fn logical_and(lhs: &Option<i64>, rhs: &Option<i64>) -> Result<Option<i64>> 
 
 #[rpn_fn]
 #[inline]
-pub fn logical_or(arg0: &Option<i64>, arg1: &Option<i64>) -> Result<Option<i64>> {
+pub fn logical_or(arg0: Option<&i64>, arg1: Option<&i64>) -> Result<Option<i64>> {
     // This is a standard Kleene OR used in SQL where
     // `null OR false == null` and `null OR true == true`
     Ok(match (arg0, arg1) {
@@ -30,7 +30,7 @@ pub fn logical_or(arg0: &Option<i64>, arg1: &Option<i64>) -> Result<Option<i64>>
 
 #[rpn_fn]
 #[inline]
-pub fn logical_xor(arg0: &Option<i64>, arg1: &Option<i64>) -> Result<Option<i64>> {
+pub fn logical_xor(arg0: Option<&i64>, arg1: Option<&i64>) -> Result<Option<i64>> {
     // evaluates to 1 if an odd number of operands is nonzero, otherwise 0 is returned.
     Ok(match (arg0, arg1) {
         (Some(arg0), Some(arg1)) => Some(((*arg0 == 0) ^ (*arg1 == 0)) as i64),
@@ -40,25 +40,25 @@ pub fn logical_xor(arg0: &Option<i64>, arg1: &Option<i64>) -> Result<Option<i64>
 
 #[rpn_fn]
 #[inline]
-pub fn unary_not_int(arg: &Option<Int>) -> Result<Option<i64>> {
+pub fn unary_not_int(arg: Option<&Int>) -> Result<Option<i64>> {
     Ok(arg.map(|v| (v == 0) as i64))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn unary_not_real(arg: &Option<Real>) -> Result<Option<i64>> {
+pub fn unary_not_real(arg: Option<&Real>) -> Result<Option<i64>> {
     Ok(arg.map(|v| (v.into_inner() == 0f64) as i64))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn unary_not_decimal(arg: &Option<Decimal>) -> Result<Option<i64>> {
+pub fn unary_not_decimal(arg: Option<&Decimal>) -> Result<Option<i64>> {
     Ok(arg.as_ref().map(|v| v.is_zero() as i64))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn unary_minus_uint(arg: &Option<Int>) -> Result<Option<Int>> {
+pub fn unary_minus_uint(arg: Option<&Int>) -> Result<Option<Int>> {
     use std::cmp::Ordering::*;
 
     match *arg {
@@ -76,7 +76,7 @@ pub fn unary_minus_uint(arg: &Option<Int>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
-pub fn unary_minus_int(arg: &Option<Int>) -> Result<Option<Int>> {
+pub fn unary_minus_int(arg: Option<&Int>) -> Result<Option<Int>> {
     match *arg {
         Some(val) => {
             if val == std::i64::MIN {
@@ -91,25 +91,25 @@ pub fn unary_minus_int(arg: &Option<Int>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
-pub fn unary_minus_real(arg: &Option<Real>) -> Result<Option<Real>> {
+pub fn unary_minus_real(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.map(|val| -val))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn unary_minus_decimal(arg: &Option<Decimal>) -> Result<Option<Decimal>> {
+pub fn unary_minus_decimal(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
     Ok(arg.as_ref().map(|val| -*val))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn is_null<T: Evaluable>(arg: &Option<T>) -> Result<Option<i64>> {
+pub fn is_null<T: Evaluable>(arg: Option<&T>) -> Result<Option<i64>> {
     Ok(Some(arg.is_none() as i64))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn bit_and(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
+pub fn bit_and(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => Some(lhs & rhs),
         _ => None,
@@ -118,7 +118,7 @@ pub fn bit_and(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
-pub fn bit_or(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
+pub fn bit_or(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => Some(lhs | rhs),
         _ => None,
@@ -127,7 +127,7 @@ pub fn bit_or(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
-pub fn bit_xor(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
+pub fn bit_xor(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => Some(lhs ^ rhs),
         _ => None,
@@ -136,7 +136,7 @@ pub fn bit_xor(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
-pub fn bit_neg(arg: &Option<Int>) -> Result<Option<Int>> {
+pub fn bit_neg(arg: Option<&Int>) -> Result<Option<Int>> {
     Ok(arg.map(|arg| !arg))
 }
 
@@ -156,7 +156,7 @@ impl KeepNull for KeepNullOff {
 
 #[rpn_fn]
 #[inline]
-pub fn int_is_true<K: KeepNull>(arg: &Option<Int>) -> Result<Option<i64>> {
+pub fn int_is_true<K: KeepNull>(arg: Option<&Int>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
         arg.map(|v| (v != 0) as i64)
     } else {
@@ -166,7 +166,7 @@ pub fn int_is_true<K: KeepNull>(arg: &Option<Int>) -> Result<Option<i64>> {
 
 #[rpn_fn]
 #[inline]
-pub fn real_is_true<K: KeepNull>(arg: &Option<Real>) -> Result<Option<i64>> {
+pub fn real_is_true<K: KeepNull>(arg: Option<&Real>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
         arg.map(|v| (v.into_inner() != 0f64) as i64)
     } else {
@@ -176,7 +176,7 @@ pub fn real_is_true<K: KeepNull>(arg: &Option<Real>) -> Result<Option<i64>> {
 
 #[rpn_fn]
 #[inline]
-pub fn decimal_is_true<K: KeepNull>(arg: &Option<Decimal>) -> Result<Option<i64>> {
+pub fn decimal_is_true<K: KeepNull>(arg: Option<&Decimal>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
         arg.map(|v| !v.is_zero() as i64)
     } else {
@@ -186,7 +186,7 @@ pub fn decimal_is_true<K: KeepNull>(arg: &Option<Decimal>) -> Result<Option<i64>
 
 #[rpn_fn]
 #[inline]
-pub fn int_is_false<K: KeepNull>(arg: &Option<Int>) -> Result<Option<i64>> {
+pub fn int_is_false<K: KeepNull>(arg: Option<&Int>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
         arg.map(|v| (v == 0) as i64)
     } else {
@@ -196,7 +196,7 @@ pub fn int_is_false<K: KeepNull>(arg: &Option<Int>) -> Result<Option<i64>> {
 
 #[rpn_fn]
 #[inline]
-pub fn real_is_false<K: KeepNull>(arg: &Option<Real>) -> Result<Option<i64>> {
+pub fn real_is_false<K: KeepNull>(arg: Option<&Real>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
         arg.map(|v| (v.into_inner() == 0f64) as i64)
     } else {
@@ -206,7 +206,7 @@ pub fn real_is_false<K: KeepNull>(arg: &Option<Real>) -> Result<Option<i64>> {
 
 #[rpn_fn]
 #[inline]
-fn decimal_is_false<K: KeepNull>(arg: &Option<Decimal>) -> Result<Option<i64>> {
+fn decimal_is_false<K: KeepNull>(arg: Option<&Decimal>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
         arg.map(|v| v.is_zero() as i64)
     } else {
@@ -216,7 +216,7 @@ fn decimal_is_false<K: KeepNull>(arg: &Option<Decimal>) -> Result<Option<i64>> {
 
 #[rpn_fn]
 #[inline]
-fn left_shift(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
+fn left_shift(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => {
             if *rhs as u64 >= 64 {
@@ -231,7 +231,7 @@ fn left_shift(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
-fn right_shift(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
+fn right_shift(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => {
             if *rhs as u64 >= 64 {

--- a/components/tidb_query_vec_expr/src/impl_op.rs
+++ b/components/tidb_query_vec_expr/src/impl_op.rs
@@ -41,7 +41,7 @@ pub fn logical_xor(arg0: Option<&i64>, arg1: Option<&i64>) -> Result<Option<i64>
 #[rpn_fn]
 #[inline]
 pub fn unary_not_int(arg: Option<&Int>) -> Result<Option<i64>> {
-    Ok(arg.cloned().map(|v| (v == 0) as i64))
+    Ok(arg.map(|v| (*v == 0) as i64))
 }
 
 #[rpn_fn]
@@ -61,13 +61,13 @@ pub fn unary_not_decimal(arg: Option<&Decimal>) -> Result<Option<i64>> {
 pub fn unary_minus_uint(arg: Option<&Int>) -> Result<Option<Int>> {
     use std::cmp::Ordering::*;
 
-    match arg.cloned() {
+    match arg {
         Some(val) => {
-            let uval = val as u64;
+            let uval = *val as u64;
             match uval.cmp(&(std::i64::MAX as u64 + 1)) {
                 Greater => Err(Error::overflow("BIGINT", &format!("-{}", uval)).into()),
                 Equal => Ok(Some(std::i64::MIN)),
-                Less => Ok(Some(-val)),
+                Less => Ok(Some(-*val)),
             }
         }
         None => Ok(None),
@@ -77,12 +77,12 @@ pub fn unary_minus_uint(arg: Option<&Int>) -> Result<Option<Int>> {
 #[rpn_fn]
 #[inline]
 pub fn unary_minus_int(arg: Option<&Int>) -> Result<Option<Int>> {
-    match arg.cloned() {
+    match arg {
         Some(val) => {
-            if val == std::i64::MIN {
-                Err(Error::overflow("BIGINT", &format!("-{}", val)).into())
+            if *val == std::i64::MIN {
+                Err(Error::overflow("BIGINT", &format!("-{}", *val)).into())
             } else {
-                Ok(Some(-val))
+                Ok(Some(-*val))
             }
         }
         None => Ok(None),
@@ -92,7 +92,7 @@ pub fn unary_minus_int(arg: Option<&Int>) -> Result<Option<Int>> {
 #[rpn_fn]
 #[inline]
 pub fn unary_minus_real(arg: Option<&Real>) -> Result<Option<Real>> {
-    Ok(arg.cloned().map(|val| -val))
+    Ok(arg.map(|val| -*val))
 }
 
 #[rpn_fn]
@@ -158,9 +158,9 @@ impl KeepNull for KeepNullOff {
 #[inline]
 pub fn int_is_true<K: KeepNull>(arg: Option<&Int>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
-        arg.cloned().map(|v| (v != 0) as i64)
+        arg.map(|v| (*v != 0) as i64)
     } else {
-        Some(arg.cloned().map_or(0, |v| (v != 0) as i64))
+        Some(arg.map_or(0, |v| (*v != 0) as i64))
     })
 }
 
@@ -188,9 +188,9 @@ pub fn decimal_is_true<K: KeepNull>(arg: Option<&Decimal>) -> Result<Option<i64>
 #[inline]
 pub fn int_is_false<K: KeepNull>(arg: Option<&Int>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
-        arg.cloned().map(|v| (v == 0) as i64)
+        arg.map(|v| (*v == 0) as i64)
     } else {
-        Some(arg.cloned().map_or(0, |v| (v == 0) as i64))
+        Some(arg.map_or(0, |v| (*v == 0) as i64))
     })
 }
 

--- a/components/tidb_query_vec_expr/src/impl_other.rs
+++ b/components/tidb_query_vec_expr/src/impl_other.rs
@@ -6,7 +6,7 @@ use tidb_query_datatype::codec::data_type::Int;
 
 #[rpn_fn]
 #[inline]
-pub fn bit_count(arg: &Option<Int>) -> Result<Option<Int>> {
+pub fn bit_count(arg: Option<&Int>) -> Result<Option<Int>> {
     Ok(arg.map(|v| Int::from(v.count_ones())))
 }
 

--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -620,8 +620,8 @@ pub fn from_base64(bs: Option<&Bytes>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn quote(input: &Option<Bytes>) -> Result<Option<Bytes>> {
-    match input.as_ref() {
+pub fn quote(input: Option<&Bytes>) -> Result<Option<Bytes>> {
+    match input {
         Some(bytes) => {
             let mut result = Vec::with_capacity(bytes.len() * 2 + 2);
             result.push(b'\'');
@@ -2420,12 +2420,12 @@ mod tests {
         for (input, expect) in cases {
             let input = Bytes::from(input);
             let expect_vec = Bytes::from(expect);
-            let got = quote(&Some(input)).unwrap();
+            let got = quote(Some(&input)).unwrap();
             assert_eq!(got, Some(expect_vec))
         }
 
         // check for null
-        let got = quote(&None).unwrap();
+        let got = quote(None).unwrap();
         assert_eq!(got, Some(Bytes::from("NULL")))
     }
 }

--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -421,7 +421,7 @@ fn field<T: Evaluable + PartialEq>(args: &[Option<&T>]) -> Result<Option<Int>> {
         Some(val) => args
             .iter()
             .skip(1)
-            .position(|&i| i.as_ref() == Some(val))
+            .position(|&i| i == Some(val))
             .map_or(0, |pos| (pos + 1) as i64),
     }))
 }
@@ -456,7 +456,7 @@ fn elt_validator(expr: &tipb::Expr) -> Result<()> {
 #[rpn_fn]
 #[inline]
 pub fn space(len: Option<&Int>) -> Result<Option<Bytes>> {
-    Ok(match *len {
+    Ok(match len.cloned() {
         Some(len) => {
             if len > i64::from(tidb_query_datatype::MAX_BLOB_WIDTH) {
                 None
@@ -668,11 +668,11 @@ mod tests {
             (Some(b"4D7953514C".to_vec()), Some(b"MySQL".to_vec())),
             (Some(b"GG".to_vec()), None),
             (
-                hex_str_arg(&Some(b"string".to_vec())).unwrap(),
+                hex_str_arg(Some(&b"string".to_vec())).unwrap(),
                 Some(b"string".to_vec()),
             ),
             (
-                hex_str_arg(&Some(b"1267".to_vec())).unwrap(),
+                hex_str_arg(Some(&b"1267".to_vec())).unwrap(),
                 Some(b"1267".to_vec()),
             ),
             (Some(b"41\0".to_vec()), None),

--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -15,25 +15,25 @@ const SPACE: u8 = 0o40u8;
 
 #[rpn_fn]
 #[inline]
-pub fn bin(num: &Option<Int>) -> Result<Option<Bytes>> {
+pub fn bin(num: Option<&Int>) -> Result<Option<Bytes>> {
     Ok(num.as_ref().map(|i| Bytes::from(format!("{:b}", i))))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn oct_int(num: &Option<Int>) -> Result<Option<Bytes>> {
+pub fn oct_int(num: Option<&Int>) -> Result<Option<Bytes>> {
     Ok(num.as_ref().map(|i| Bytes::from(format!("{:o}", i))))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn length(arg: &Option<Bytes>) -> Result<Option<i64>> {
+pub fn length(arg: Option<&Bytes>) -> Result<Option<i64>> {
     Ok(arg.as_ref().map(|bytes| bytes.len() as i64))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn unhex(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn unhex(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     if let Some(content) = arg {
         // hex::decode will fail on odd-length content
         // but mysql won't
@@ -51,13 +51,13 @@ pub fn unhex(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn bit_length(arg: &Option<Bytes>) -> Result<Option<i64>> {
+pub fn bit_length(arg: Option<&Bytes>) -> Result<Option<i64>> {
     Ok(arg.as_ref().map(|bytes| bytes.len() as i64 * 8))
 }
 
 #[rpn_fn(varg, min_args = 1)]
 #[inline]
-pub fn concat(args: &[&Option<Bytes>]) -> Result<Option<Bytes>> {
+pub fn concat(args: &[Option<&Bytes>]) -> Result<Option<Bytes>> {
     let mut output = Bytes::new();
     for arg in args {
         if let Some(s) = arg {
@@ -71,7 +71,7 @@ pub fn concat(args: &[&Option<Bytes>]) -> Result<Option<Bytes>> {
 
 #[rpn_fn(varg, min_args = 2)]
 #[inline]
-pub fn concat_ws(args: &[&Option<Bytes>]) -> Result<Option<Bytes>> {
+pub fn concat_ws(args: &[Option<&Bytes>]) -> Result<Option<Bytes>> {
     if let Some(sep) = args[0] {
         let rest = &args[1..];
         Ok(Some(
@@ -87,7 +87,7 @@ pub fn concat_ws(args: &[&Option<Bytes>]) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn ascii(arg: &Option<Bytes>) -> Result<Option<i64>> {
+pub fn ascii(arg: Option<&Bytes>) -> Result<Option<i64>> {
     Ok(arg.as_ref().map(|bytes| {
         if bytes.is_empty() {
             0
@@ -99,7 +99,7 @@ pub fn ascii(arg: &Option<Bytes>) -> Result<Option<i64>> {
 
 #[rpn_fn]
 #[inline]
-pub fn reverse_utf8(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn reverse_utf8(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     Ok(arg.as_ref().map(|bytes| {
         let s = String::from_utf8_lossy(bytes);
         s.chars().rev().collect::<String>().into_bytes()
@@ -108,13 +108,13 @@ pub fn reverse_utf8(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn hex_int_arg(arg: &Option<Int>) -> Result<Option<Bytes>> {
+pub fn hex_int_arg(arg: Option<&Int>) -> Result<Option<Bytes>> {
     Ok(arg.as_ref().map(|i| format!("{:X}", i).into_bytes()))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn ltrim(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn ltrim(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     Ok(arg.as_ref().map(|bytes| {
         let pos = bytes.iter().position(|&x| x != SPACE);
         if let Some(i) = pos {
@@ -127,7 +127,7 @@ pub fn ltrim(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn rtrim(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn rtrim(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     Ok(arg.as_ref().map(|bytes| {
         let pos = bytes.iter().rposition(|&x| x != SPACE);
         if let Some(i) = pos {
@@ -140,7 +140,7 @@ pub fn rtrim(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn lpad(arg: &Option<Bytes>, len: &Option<Int>, pad: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn lpad(arg: Option<&Bytes>, len: Option<&Int>, pad: Option<&Bytes>) -> Result<Option<Bytes>> {
     match (arg, len, pad) {
         (Some(arg), Some(len), Some(pad)) => {
             match validate_target_len_for_pad(*len < 0, *len, arg.len(), 1, pad.is_empty()) {
@@ -168,9 +168,9 @@ pub fn lpad(arg: &Option<Bytes>, len: &Option<Int>, pad: &Option<Bytes>) -> Resu
 #[rpn_fn]
 #[inline]
 pub fn lpad_utf8(
-    arg: &Option<Bytes>,
-    len: &Option<Int>,
-    pad: &Option<Bytes>,
+    arg: Option<&Bytes>,
+    len: Option<&Int>,
+    pad: Option<&Bytes>,
 ) -> Result<Option<Bytes>> {
     match (arg, len, pad) {
         (Some(arg), Some(len), Some(pad)) => {
@@ -206,7 +206,7 @@ pub fn lpad_utf8(
 
 #[rpn_fn]
 #[inline]
-pub fn rpad(arg: &Option<Bytes>, len: &Option<Int>, pad: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn rpad(arg: Option<&Bytes>, len: Option<&Int>, pad: Option<&Bytes>) -> Result<Option<Bytes>> {
     match (arg, len, pad) {
         (Some(arg), Some(len), Some(pad)) => {
             match validate_target_len_for_pad(*len < 0, *len, arg.len(), 1, pad.is_empty()) {
@@ -230,9 +230,9 @@ pub fn rpad(arg: &Option<Bytes>, len: &Option<Int>, pad: &Option<Bytes>) -> Resu
 #[rpn_fn]
 #[inline]
 pub fn replace(
-    s: &Option<Bytes>,
-    from_str: &Option<Bytes>,
-    to_str: &Option<Bytes>,
+    s: Option<&Bytes>,
+    from_str: Option<&Bytes>,
+    to_str: Option<&Bytes>,
 ) -> Result<Option<Bytes>> {
     Ok(match (s, from_str, to_str) {
         (Some(s), Some(from_str), Some(to_str)) => {
@@ -256,7 +256,7 @@ pub fn replace(
 
 #[rpn_fn]
 #[inline]
-pub fn left(lhs: &Option<Bytes>, rhs: &Option<Int>) -> Result<Option<Bytes>> {
+pub fn left(lhs: Option<&Bytes>, rhs: Option<&Int>) -> Result<Option<Bytes>> {
     match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => {
             if *rhs <= 0 {
@@ -275,7 +275,7 @@ pub fn left(lhs: &Option<Bytes>, rhs: &Option<Int>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn left_utf8(lhs: &Option<Bytes>, rhs: &Option<Int>) -> Result<Option<Bytes>> {
+pub fn left_utf8(lhs: Option<&Bytes>, rhs: Option<&Int>) -> Result<Option<Bytes>> {
     match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => {
             if *rhs <= 0 {
@@ -299,7 +299,7 @@ pub fn left_utf8(lhs: &Option<Bytes>, rhs: &Option<Int>) -> Result<Option<Bytes>
 
 #[rpn_fn]
 #[inline]
-pub fn right(lhs: &Option<Bytes>, rhs: &Option<Int>) -> Result<Option<Bytes>> {
+pub fn right(lhs: Option<&Bytes>, rhs: Option<&Int>) -> Result<Option<Bytes>> {
     match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => {
             if *rhs <= 0 {
@@ -318,7 +318,7 @@ pub fn right(lhs: &Option<Bytes>, rhs: &Option<Int>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn right_utf8(lhs: &Option<Bytes>, rhs: &Option<Int>) -> Result<Option<Bytes>> {
+pub fn right_utf8(lhs: Option<&Bytes>, rhs: Option<&Int>) -> Result<Option<Bytes>> {
     match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => {
             if *rhs <= 0 {
@@ -348,7 +348,7 @@ pub fn right_utf8(lhs: &Option<Bytes>, rhs: &Option<Int>) -> Result<Option<Bytes
 
 #[rpn_fn]
 #[inline]
-pub fn upper_utf8(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn upper_utf8(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     match arg.as_ref() {
         Some(bytes) => match str::from_utf8(bytes) {
             Ok(s) => Ok(Some(s.to_uppercase().into_bytes())),
@@ -360,19 +360,19 @@ pub fn upper_utf8(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn upper(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn upper(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     Ok(arg.as_ref().map(|b| b.to_vec()))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn hex_str_arg(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn hex_str_arg(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     Ok(arg.as_ref().map(|b| hex::encode_upper(b).into_bytes()))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn locate_2_args(substr: &Option<Bytes>, s: &Option<Bytes>) -> Result<Option<i64>> {
+pub fn locate_2_args(substr: Option<&Bytes>, s: Option<&Bytes>) -> Result<Option<i64>> {
     let (substr, s) = match (substr, s) {
         (Some(v1), Some(v2)) => (v1, v2),
         _ => return Ok(None),
@@ -385,7 +385,7 @@ pub fn locate_2_args(substr: &Option<Bytes>, s: &Option<Bytes>) -> Result<Option
 
 #[rpn_fn]
 #[inline]
-pub fn reverse(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn reverse(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     Ok(arg.as_ref().map(|bytes| {
         let mut s = bytes.to_vec();
         s.reverse();
@@ -396,9 +396,9 @@ pub fn reverse(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
 #[rpn_fn]
 #[inline]
 pub fn locate_3_args(
-    substr: &Option<Bytes>,
-    s: &Option<Bytes>,
-    pos: &Option<Int>,
+    substr: Option<&Bytes>,
+    s: Option<&Bytes>,
+    pos: Option<&Int>,
 ) -> Result<Option<Int>> {
     if let (Some(substr), Some(s), Some(pos)) = (substr, s, pos) {
         if *pos < 1 || *pos as usize > s.len() + 1 {
@@ -414,7 +414,7 @@ pub fn locate_3_args(
 
 #[rpn_fn(varg, min_args = 1)]
 #[inline]
-fn field<T: Evaluable + PartialEq>(args: &[&Option<T>]) -> Result<Option<Int>> {
+fn field<T: Evaluable + PartialEq>(args: &[Option<&T>]) -> Result<Option<Int>> {
     Ok(Some(match args[0] {
         // As per the MySQL doc, if the first argument is NULL, this function always returns 0.
         None => 0,
@@ -442,7 +442,7 @@ pub fn elt(raw_args: &[ScalarValueRef]) -> Result<Option<Bytes>> {
     })
 }
 
-/// validate the arguments are `(&Option<Int>, &[&Option<Bytes>)])`
+/// validate the arguments are `(Option<&Int>, &[Option<&Bytes>)])`
 fn elt_validator(expr: &tipb::Expr) -> Result<()> {
     let children = expr.get_children();
     assert!(children.len() >= 2);
@@ -455,7 +455,7 @@ fn elt_validator(expr: &tipb::Expr) -> Result<()> {
 
 #[rpn_fn]
 #[inline]
-pub fn space(len: &Option<Int>) -> Result<Option<Bytes>> {
+pub fn space(len: Option<&Int>) -> Result<Option<Bytes>> {
     Ok(match *len {
         Some(len) => {
             if len > i64::from(tidb_query_datatype::MAX_BLOB_WIDTH) {
@@ -472,7 +472,7 @@ pub fn space(len: &Option<Int>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn strcmp(left: &Option<Bytes>, right: &Option<Bytes>) -> Result<Option<i64>> {
+pub fn strcmp(left: Option<&Bytes>, right: Option<&Bytes>) -> Result<Option<i64>> {
     use std::cmp::Ordering::*;
     Ok(match (left, right) {
         (Some(left), Some(right)) => Some(match left.cmp(right) {
@@ -486,7 +486,7 @@ pub fn strcmp(left: &Option<Bytes>, right: &Option<Bytes>) -> Result<Option<i64>
 
 #[rpn_fn]
 #[inline]
-pub fn instr_utf8(s: &Option<Bytes>, substr: &Option<Bytes>) -> Result<Option<Int>> {
+pub fn instr_utf8(s: Option<&Bytes>, substr: Option<&Bytes>) -> Result<Option<Int>> {
     if let (Some(s), Some(substr)) = (s, substr) {
         let s = String::from_utf8_lossy(s);
         let substr = String::from_utf8_lossy(substr);
@@ -502,7 +502,7 @@ pub fn instr_utf8(s: &Option<Bytes>, substr: &Option<Bytes>) -> Result<Option<In
 
 #[rpn_fn]
 #[inline]
-pub fn find_in_set(s: &Option<Bytes>, str_list: &Option<Bytes>) -> Result<Option<Int>> {
+pub fn find_in_set(s: Option<&Bytes>, str_list: Option<&Bytes>) -> Result<Option<Int>> {
     Ok(match (s, str_list) {
         (Some(s), Some(str_list)) => {
             if str_list.is_empty() {
@@ -522,7 +522,7 @@ pub fn find_in_set(s: &Option<Bytes>, str_list: &Option<Bytes>) -> Result<Option
 
 #[rpn_fn]
 #[inline]
-pub fn trim_1_arg(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn trim_1_arg(arg: Option<&Bytes>) -> Result<Option<Bytes>> {
     Ok(arg.as_ref().map(|bytes| {
         let l_pos = bytes.iter().position(|&x| x != SPACE);
         if let Some(i) = l_pos {
@@ -537,9 +537,9 @@ pub fn trim_1_arg(arg: &Option<Bytes>) -> Result<Option<Bytes>> {
 #[rpn_fn]
 #[inline]
 pub fn trim_3_args(
-    arg: &Option<Bytes>,
-    pat: &Option<Bytes>,
-    direction: &Option<i64>,
+    arg: Option<&Bytes>,
+    pat: Option<&Bytes>,
+    direction: Option<&i64>,
 ) -> Result<Option<Bytes>> {
     if let (Some(arg), Some(pat), Some(direction)) = (arg, pat, direction) {
         match TrimDirection::from_i64(*direction) {
@@ -557,13 +557,13 @@ pub fn trim_3_args(
 
 #[rpn_fn]
 #[inline]
-pub fn char_length(bs: &Option<Bytes>) -> Result<Option<Int>> {
+pub fn char_length(bs: Option<&Bytes>) -> Result<Option<Int>> {
     Ok(bs.as_ref().map(|b| b.len() as i64))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn char_length_utf8(bs: &Option<Bytes>) -> Result<Option<Int>> {
+pub fn char_length_utf8(bs: Option<&Bytes>) -> Result<Option<Int>> {
     match bs.as_ref() {
         Some(bytes) => match str::from_utf8(bytes) {
             Ok(s) => Ok(Some(s.chars().count() as i64)),
@@ -575,7 +575,7 @@ pub fn char_length_utf8(bs: &Option<Bytes>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
-pub fn to_base64(bs: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn to_base64(bs: Option<&Bytes>) -> Result<Option<Bytes>> {
     match bs.as_ref() {
         Some(bytes) => {
             if bytes.len() > tidb_query_datatype::MAX_BLOB_WIDTH as usize {
@@ -598,7 +598,7 @@ pub fn to_base64(bs: &Option<Bytes>) -> Result<Option<Bytes>> {
 
 #[rpn_fn]
 #[inline]
-pub fn from_base64(bs: &Option<Bytes>) -> Result<Option<Bytes>> {
+pub fn from_base64(bs: Option<&Bytes>) -> Result<Option<Bytes>> {
     match bs.as_ref() {
         Some(bytes) => {
             let input_copy = strip_whitespace(bytes);

--- a/components/tidb_query_vec_expr/src/impl_time.rs
+++ b/components/tidb_query_vec_expr/src/impl_time.rs
@@ -17,8 +17,8 @@ use tidb_query_datatype::expr::SqlMode;
 #[inline]
 pub fn date_format(
     ctx: &mut EvalContext,
-    t: &Option<DateTime>,
-    layout: &Option<Bytes>,
+    t: Option<&DateTime>,
+    layout: Option<&Bytes>,
 ) -> Result<Option<Bytes>> {
     use std::str::from_utf8;
 
@@ -44,8 +44,8 @@ pub fn date_format(
 #[inline]
 pub fn week_with_mode(
     ctx: &mut EvalContext,
-    t: &Option<DateTime>,
-    m: &Option<Int>,
+    t: Option<&DateTime>,
+    m: Option<&Int>,
 ) -> Result<Option<Int>> {
     if t.is_none() || m.is_none() {
         return Ok(None);
@@ -62,7 +62,7 @@ pub fn week_with_mode(
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn week_day(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<Int>> {
+pub fn week_day(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     if t.is_none() {
         return Ok(None);
     }
@@ -78,7 +78,7 @@ pub fn week_day(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<In
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn day_of_week(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<Int>> {
+pub fn day_of_week(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     if t.is_none() {
         return Ok(None);
     }
@@ -94,7 +94,7 @@ pub fn day_of_week(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn day_of_year(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<Int>> {
+pub fn day_of_year(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     if t.is_none() {
         return Ok(None);
     }
@@ -110,7 +110,7 @@ pub fn day_of_year(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn week_of_year(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<Int>> {
+pub fn week_of_year(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     if t.is_none() {
         return Ok(None);
     }
@@ -126,7 +126,7 @@ pub fn week_of_year(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Optio
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn to_days(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<Int>> {
+pub fn to_days(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     let t = match t {
         Some(v) => v,
         _ => return Ok(None),
@@ -141,7 +141,7 @@ pub fn to_days(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<Int
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn from_days(ctx: &mut EvalContext, arg: &Option<Int>) -> Result<Option<Time>> {
+pub fn from_days(ctx: &mut EvalContext, arg: Option<&Int>) -> Result<Option<Time>> {
     arg.map_or(Ok(None), |daynr: Int| {
         let time = Time::from_days(ctx, daynr as u32)?;
         Ok(Some(time))
@@ -150,37 +150,37 @@ pub fn from_days(ctx: &mut EvalContext, arg: &Option<Int>) -> Result<Option<Time
 
 #[rpn_fn]
 #[inline]
-pub fn month(t: &Option<DateTime>) -> Result<Option<Int>> {
+pub fn month(t: Option<&DateTime>) -> Result<Option<Int>> {
     t.map_or(Ok(None), |time| Ok(Some(Int::from(time.month()))))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn hour(t: &Option<Duration>) -> Result<Option<Int>> {
+pub fn hour(t: Option<&Duration>) -> Result<Option<Int>> {
     Ok(t.as_ref().map(|t| i64::from(t.hours())))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn minute(t: &Option<Duration>) -> Result<Option<Int>> {
+pub fn minute(t: Option<&Duration>) -> Result<Option<Int>> {
     Ok(t.as_ref().map(|t| i64::from(t.minutes())))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn second(t: &Option<Duration>) -> Result<Option<Int>> {
+pub fn second(t: Option<&Duration>) -> Result<Option<Int>> {
     Ok(t.as_ref().map(|t| i64::from(t.secs())))
 }
 
 #[rpn_fn]
 #[inline]
-pub fn micro_second(t: &Option<Duration>) -> Result<Option<Int>> {
+pub fn micro_second(t: Option<&Duration>) -> Result<Option<Int>> {
     Ok(t.as_ref().map(|t| i64::from(t.subsec_micros())))
 }
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn year(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<Int>> {
+pub fn year(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     let t = match t {
         Some(v) => v,
         _ => return Ok(None),
@@ -199,7 +199,7 @@ pub fn year(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<Int>> 
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn day_of_month(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<Int>> {
+pub fn day_of_month(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     let t = match t {
         Some(v) => v,
         _ => return Ok(None),
@@ -218,7 +218,7 @@ pub fn day_of_month(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Optio
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn day_name(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<Bytes>> {
+pub fn day_name(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Bytes>> {
     match t {
         Some(t) => {
             if t.invalid_zero() {
@@ -234,7 +234,7 @@ pub fn day_name(ctx: &mut EvalContext, t: &Option<DateTime>) -> Result<Option<By
 
 #[rpn_fn]
 #[inline]
-pub fn period_add(p: &Option<Int>, n: &Option<Int>) -> Result<Option<Int>> {
+pub fn period_add(p: Option<&Int>, n: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (p, n) {
         (Some(p), Some(n)) => {
             if *p == 0 {
@@ -251,7 +251,7 @@ pub fn period_add(p: &Option<Int>, n: &Option<Int>) -> Result<Option<Int>> {
 
 #[rpn_fn]
 #[inline]
-pub fn period_diff(p1: &Option<Int>, p2: &Option<Int>) -> Result<Option<Int>> {
+pub fn period_diff(p1: Option<&Int>, p2: Option<&Int>) -> Result<Option<Int>> {
     match (p1, p2) {
         (Some(p1), Some(p2)) => Ok(Some(
             DateTime::period_to_month(*p1 as u64) as i64
@@ -263,7 +263,7 @@ pub fn period_diff(p1: &Option<Int>, p2: &Option<Int>) -> Result<Option<Int>> {
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn last_day(ctx: &mut EvalContext, t: &Option<Time>) -> Result<Option<Time>> {
+pub fn last_day(ctx: &mut EvalContext, t: Option<&Time>) -> Result<Option<Time>> {
     if t.is_none() {
         return Ok(None);
     }

--- a/components/tidb_query_vec_expr/src/impl_time.rs
+++ b/components/tidb_query_vec_expr/src/impl_time.rs
@@ -50,7 +50,7 @@ pub fn week_with_mode(
     if t.is_none() || m.is_none() {
         return Ok(None);
     }
-    let (t, m) = (t.as_ref().unwrap(), m.as_ref().unwrap());
+    let (t, m) = (t.unwrap(), m.unwrap());
     if t.invalid_zero() {
         return ctx
             .handle_invalid_time_error(Error::incorrect_datetime_value(&format!("{}", t)))
@@ -142,7 +142,7 @@ pub fn to_days(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int
 #[rpn_fn(capture = [ctx])]
 #[inline]
 pub fn from_days(ctx: &mut EvalContext, arg: Option<&Int>) -> Result<Option<Time>> {
-    arg.map_or(Ok(None), |daynr: Int| {
+    arg.cloned().map_or(Ok(None), |daynr: Int| {
         let time = Time::from_days(ctx, daynr as u32)?;
         Ok(Some(time))
     })

--- a/components/tidb_query_vec_expr/src/types/expr_builder.rs
+++ b/components/tidb_query_vec_expr/src/types/expr_builder.rs
@@ -468,43 +468,43 @@ mod tests {
 
     /// An RPN function for test. It accepts 1 int argument, returns float.
     #[rpn_fn]
-    fn fn_a(_v: &Option<i64>) -> Result<Option<Real>> {
+    fn fn_a(_v: Option<&i64>) -> Result<Option<Real>> {
         unreachable!()
     }
 
     /// An RPN function for test. It accepts 2 float arguments, returns int.
     #[rpn_fn]
-    fn fn_b(_v1: &Option<Real>, _v2: &Option<Real>) -> Result<Option<i64>> {
+    fn fn_b(_v1: Option<&Real>, _v2: Option<&Real>) -> Result<Option<i64>> {
         unreachable!()
     }
 
     /// An RPN function for test. It accepts 3 int arguments, returns int.
     #[rpn_fn]
-    fn fn_c(_v1: &Option<i64>, _v2: &Option<i64>, _v3: &Option<i64>) -> Result<Option<i64>> {
+    fn fn_c(_v1: Option<&i64>, _v2: Option<&i64>, _v3: Option<&i64>) -> Result<Option<i64>> {
         unreachable!()
     }
 
     /// An RPN function for test. It accepts 3 float arguments, returns float.
     #[rpn_fn]
-    fn fn_d(_v1: &Option<Real>, _v2: &Option<Real>, _v3: &Option<Real>) -> Result<Option<Real>> {
+    fn fn_d(_v1: Option<&Real>, _v2: Option<&Real>, _v3: Option<&Real>) -> Result<Option<Real>> {
         unreachable!()
     }
 
     /// This function is only used when testing with the validator.
     #[rpn_fn]
-    fn fn_e(_v1: &Option<Int>, _v2: &Option<Real>) -> Result<Option<Bytes>> {
+    fn fn_e(_v1: Option<&Int>, _v2: Option<&Real>) -> Result<Option<Bytes>> {
         unreachable!()
     }
 
     /// This function is only used when testing with the validator.
     #[rpn_fn(varg)]
-    fn fn_f(_v: &[&Option<Int>]) -> Result<Option<Real>> {
+    fn fn_f(_v: &[Option<&Int>]) -> Result<Option<Real>> {
         unreachable!()
     }
 
     /// This function is only used when testing with the validator.
     #[rpn_fn(varg, min_args = 2)]
-    fn fn_g(_v: &[&Option<Real>]) -> Result<Option<Int>> {
+    fn fn_g(_v: &[Option<&Real>]) -> Result<Option<Int>> {
         unreachable!()
     }
 

--- a/components/tidb_query_vec_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_vec_expr/src/types/expr_eval.rs
@@ -459,7 +459,7 @@ mod tests {
         /// foo(v) performs v * 2.
         #[rpn_fn]
         fn foo(v: Option<&Real>) -> Result<Option<Real>> {
-            Ok(v.map(|v| v * 2.0))
+            Ok(v.map(|v| *v * 2.0))
         }
 
         let exp = RpnExpressionBuilder::new_for_test()
@@ -574,7 +574,7 @@ mod tests {
         /// foo(v) performs v1 + float(v2) - 1.
         #[rpn_fn]
         fn foo(v1: Option<&Real>, v2: Option<&i64>) -> Result<Option<Real>> {
-            Ok(Some(v1.unwrap() + v2.unwrap() as f64 - 1.0))
+            Ok(Some(*v1.unwrap() + *v2.unwrap() as f64 - 1.0))
         }
 
         let exp = RpnExpressionBuilder::new_for_test()
@@ -605,7 +605,7 @@ mod tests {
         /// foo(v) performs v1 - v2.
         #[rpn_fn]
         fn foo(v1: Option<&Real>, v2: Option<&Real>) -> Result<Option<Real>> {
-            Ok(Some(v1.unwrap() - v2.unwrap()))
+            Ok(Some(*v1.unwrap() - *v2.unwrap()))
         }
 
         let mut columns = LazyBatchColumnVec::from(vec![{
@@ -643,7 +643,7 @@ mod tests {
         /// foo(v) performs v1 - float(v2).
         #[rpn_fn]
         fn foo(v1: Option<&Real>, v2: Option<&i64>) -> Result<Option<Real>> {
-            Ok(Some(v1.unwrap() - v2.unwrap() as f64))
+            Ok(Some(*v1.unwrap() - *v2.unwrap() as f64))
         }
 
         let mut columns = LazyBatchColumnVec::from(vec![{
@@ -682,7 +682,7 @@ mod tests {
         #[rpn_fn]
         fn foo(v1: Option<&Real>, v2: Option<&i64>) -> Result<Option<i64>> {
             Ok(Some(
-                (v1.unwrap().into_inner() * 2.5 - (v2.unwrap() as f64) * 3.5) as i64,
+                (v1.unwrap().into_inner() * 2.5 - (*v2.unwrap() as f64) * 3.5) as i64,
             ))
         }
 
@@ -831,7 +831,7 @@ mod tests {
         /// fn_a(v1, v2, v3) performs v1 * v2 - v3.
         #[rpn_fn]
         fn fn_a(v1: Option<&Real>, v2: Option<&Real>, v3: Option<&Real>) -> Result<Option<Real>> {
-            Ok(Some(v1.unwrap() * v2.unwrap() - v3.unwrap()))
+            Ok(Some(*v1.unwrap() * *v2.unwrap() - *v3.unwrap()))
         }
 
         /// fn_b() returns 42.0.
@@ -929,7 +929,7 @@ mod tests {
         /// foo(v) performs v * 2.
         #[rpn_fn]
         fn foo(v: Option<&Real>) -> Result<Option<Real>> {
-            Ok(v.map(|v| v * 2.0))
+            Ok(v.map(|v| *v * 2.0))
         }
 
         // foo() only accepts 1 parameter but we will give 2.
@@ -954,7 +954,7 @@ mod tests {
         /// Expects real argument, receives int argument.
         #[rpn_fn]
         fn foo(v: Option<&Real>) -> Result<Option<Real>> {
-            Ok(v.map(|v| v * 2.5))
+            Ok(v.map(|v| *v * 2.5))
         }
 
         let exp = RpnExpressionBuilder::new_for_test()
@@ -986,13 +986,13 @@ mod tests {
         /// fn_a(a: int, b: float, c: int) performs: float(a) - b * float(c)
         #[rpn_fn]
         fn fn_a(a: Option<&i64>, b: Option<&Real>, c: Option<&i64>) -> Result<Option<Real>> {
-            Ok(Real::new(a.unwrap() as f64 - b.unwrap().into_inner() * c.unwrap() as f64).ok())
+            Ok(Real::new(*a.unwrap() as f64 - b.unwrap().into_inner() * *c.unwrap() as f64).ok())
         }
 
         /// fn_b(a: float, b: int) performs: a * (float(b) - 1.5)
         #[rpn_fn]
         fn fn_b(a: Option<&Real>, b: Option<&i64>) -> Result<Option<Real>> {
-            Ok(Real::new(a.unwrap().into_inner() * (b.unwrap() as f64 - 1.5)).ok())
+            Ok(Real::new(a.unwrap().into_inner() * (*b.unwrap() as f64 - 1.5)).ok())
         }
 
         /// fn_c() returns: int(42)
@@ -1095,7 +1095,7 @@ mod tests {
         #[rpn_fn(varg, capture = [metadata], metadata_mapper = prepare_b::<T>)]
         fn fn_b<T: Evaluable>(metadata: &String, v: &[Option<&T>]) -> Result<Option<T>> {
             assert_eq!(metadata, &format!("{}", std::mem::size_of::<T>()));
-            Ok(v[0].clone())
+            Ok(v[0].cloned())
         }
 
         fn prepare_b<T: Evaluable>(_expr: &mut Expr) -> Result<String> {

--- a/components/tidb_query_vec_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_vec_expr/src/types/expr_eval.rs
@@ -458,7 +458,7 @@ mod tests {
     fn test_eval_unary_function_scalar() {
         /// foo(v) performs v * 2.
         #[rpn_fn]
-        fn foo(v: &Option<Real>) -> Result<Option<Real>> {
+        fn foo(v: Option<&Real>) -> Result<Option<Real>> {
             Ok(v.map(|v| v * 2.0))
         }
 
@@ -488,7 +488,7 @@ mod tests {
     fn test_eval_unary_function_vector() {
         /// foo(v) performs v + 5.
         #[rpn_fn]
-        fn foo(v: &Option<i64>) -> Result<Option<i64>> {
+        fn foo(v: Option<&i64>) -> Result<Option<i64>> {
             Ok(v.map(|v| v + 5))
         }
 
@@ -522,7 +522,7 @@ mod tests {
     fn test_eval_unary_function_raw_column() {
         /// foo(v) performs v + 5.
         #[rpn_fn]
-        fn foo(v: &Option<i64>) -> Result<Option<i64>> {
+        fn foo(v: Option<&i64>) -> Result<Option<i64>> {
             Ok(Some(v.unwrap() + 5))
         }
 
@@ -573,7 +573,7 @@ mod tests {
     fn test_eval_binary_function_scalar_scalar() {
         /// foo(v) performs v1 + float(v2) - 1.
         #[rpn_fn]
-        fn foo(v1: &Option<Real>, v2: &Option<i64>) -> Result<Option<Real>> {
+        fn foo(v1: Option<&Real>, v2: Option<&i64>) -> Result<Option<Real>> {
             Ok(Some(v1.unwrap() + v2.unwrap() as f64 - 1.0))
         }
 
@@ -604,7 +604,7 @@ mod tests {
     fn test_eval_binary_function_vector_scalar() {
         /// foo(v) performs v1 - v2.
         #[rpn_fn]
-        fn foo(v1: &Option<Real>, v2: &Option<Real>) -> Result<Option<Real>> {
+        fn foo(v1: Option<&Real>, v2: Option<&Real>) -> Result<Option<Real>> {
             Ok(Some(v1.unwrap() - v2.unwrap()))
         }
 
@@ -642,7 +642,7 @@ mod tests {
     fn test_eval_binary_function_scalar_vector() {
         /// foo(v) performs v1 - float(v2).
         #[rpn_fn]
-        fn foo(v1: &Option<Real>, v2: &Option<i64>) -> Result<Option<Real>> {
+        fn foo(v1: Option<&Real>, v2: Option<&i64>) -> Result<Option<Real>> {
             Ok(Some(v1.unwrap() - v2.unwrap() as f64))
         }
 
@@ -680,7 +680,7 @@ mod tests {
     fn test_eval_binary_function_vector_vector() {
         /// foo(v) performs int(v1*2.5 - float(v2)*3.5).
         #[rpn_fn]
-        fn foo(v1: &Option<Real>, v2: &Option<i64>) -> Result<Option<i64>> {
+        fn foo(v1: Option<&Real>, v2: Option<&i64>) -> Result<Option<i64>> {
             Ok(Some(
                 (v1.unwrap().into_inner() * 2.5 - (v2.unwrap() as f64) * 3.5) as i64,
             ))
@@ -732,7 +732,7 @@ mod tests {
     fn test_eval_binary_function_raw_column() {
         /// foo(v1, v2) performs v1 * v2.
         #[rpn_fn]
-        fn foo(v1: &Option<i64>, v2: &Option<i64>) -> Result<Option<i64>> {
+        fn foo(v1: Option<&i64>, v2: Option<&i64>) -> Result<Option<i64>> {
             Ok(Some(v1.unwrap() * v2.unwrap()))
         }
 
@@ -784,7 +784,7 @@ mod tests {
     fn test_eval_ternary_function() {
         /// foo(v) performs v1 - v2 * v3.
         #[rpn_fn]
-        fn foo(v1: &Option<i64>, v2: &Option<i64>, v3: &Option<i64>) -> Result<Option<i64>> {
+        fn foo(v1: Option<&i64>, v2: Option<&i64>, v3: Option<&i64>) -> Result<Option<i64>> {
             Ok(Some(v1.unwrap() - v2.unwrap() * v3.unwrap()))
         }
 
@@ -830,7 +830,7 @@ mod tests {
     fn test_eval_comprehensive() {
         /// fn_a(v1, v2, v3) performs v1 * v2 - v3.
         #[rpn_fn]
-        fn fn_a(v1: &Option<Real>, v2: &Option<Real>, v3: &Option<Real>) -> Result<Option<Real>> {
+        fn fn_a(v1: Option<&Real>, v2: Option<&Real>, v3: Option<&Real>) -> Result<Option<Real>> {
             Ok(Some(v1.unwrap() * v2.unwrap() - v3.unwrap()))
         }
 
@@ -842,13 +842,13 @@ mod tests {
 
         /// fn_c(v1, v2) performs float(v2 - v1).
         #[rpn_fn]
-        fn fn_c(v1: &Option<i64>, v2: &Option<i64>) -> Result<Option<Real>> {
+        fn fn_c(v1: Option<&i64>, v2: Option<&i64>) -> Result<Option<Real>> {
             Ok(Real::new((v2.unwrap() - v1.unwrap()) as f64).ok())
         }
 
         /// fn_d(v1, v2) performs v1 + v2 * 2.
         #[rpn_fn]
-        fn fn_d(v1: &Option<i64>, v2: &Option<i64>) -> Result<Option<i64>> {
+        fn fn_d(v1: Option<&i64>, v2: Option<&i64>) -> Result<Option<i64>> {
             Ok(Some(v1.unwrap() + v2.unwrap() * 2))
         }
 
@@ -908,7 +908,7 @@ mod tests {
     #[test]
     fn test_eval_fail_1() {
         #[rpn_fn]
-        fn foo(_v: &Option<i64>) -> Result<Option<i64>> {
+        fn foo(_v: Option<&i64>) -> Result<Option<i64>> {
             unreachable!()
         }
 
@@ -928,7 +928,7 @@ mod tests {
     fn test_eval_fail_2() {
         /// foo(v) performs v * 2.
         #[rpn_fn]
-        fn foo(v: &Option<Real>) -> Result<Option<Real>> {
+        fn foo(v: Option<&Real>) -> Result<Option<Real>> {
             Ok(v.map(|v| v * 2.0))
         }
 
@@ -953,7 +953,7 @@ mod tests {
     fn test_eval_fail_3() {
         /// Expects real argument, receives int argument.
         #[rpn_fn]
-        fn foo(v: &Option<Real>) -> Result<Option<Real>> {
+        fn foo(v: Option<&Real>) -> Result<Option<Real>> {
             Ok(v.map(|v| v * 2.5))
         }
 
@@ -985,13 +985,13 @@ mod tests {
 
         /// fn_a(a: int, b: float, c: int) performs: float(a) - b * float(c)
         #[rpn_fn]
-        fn fn_a(a: &Option<i64>, b: &Option<Real>, c: &Option<i64>) -> Result<Option<Real>> {
+        fn fn_a(a: Option<&i64>, b: Option<&Real>, c: Option<&i64>) -> Result<Option<Real>> {
             Ok(Real::new(a.unwrap() as f64 - b.unwrap().into_inner() * c.unwrap() as f64).ok())
         }
 
         /// fn_b(a: float, b: int) performs: a * (float(b) - 1.5)
         #[rpn_fn]
-        fn fn_b(a: &Option<Real>, b: &Option<i64>) -> Result<Option<Real>> {
+        fn fn_b(a: Option<&Real>, b: Option<&i64>) -> Result<Option<Real>> {
             Ok(Real::new(a.unwrap().into_inner() * (b.unwrap() as f64 - 1.5)).ok())
         }
 
@@ -1003,7 +1003,7 @@ mod tests {
 
         /// fn_d(a: float) performs: int(a)
         #[rpn_fn]
-        fn fn_d(a: &Option<Real>) -> Result<Option<i64>> {
+        fn fn_d(a: Option<&Real>) -> Result<Option<i64>> {
             Ok(Some(a.unwrap().into_inner() as i64))
         }
 
@@ -1082,7 +1082,7 @@ mod tests {
 
         #[allow(clippy::trivially_copy_pass_by_ref)]
         #[rpn_fn(capture = [metadata], metadata_mapper = prepare_a::<T>)]
-        fn fn_a<T: Evaluable>(metadata: &i64, v: &Option<Int>) -> Result<Option<Int>> {
+        fn fn_a<T: Evaluable>(metadata: &i64, v: Option<&Int>) -> Result<Option<Int>> {
             assert_eq!(*metadata, 42);
             Ok(v.map(|v| v + *metadata))
         }
@@ -1093,7 +1093,7 @@ mod tests {
 
         #[allow(clippy::trivially_copy_pass_by_ref, clippy::ptr_arg)]
         #[rpn_fn(varg, capture = [metadata], metadata_mapper = prepare_b::<T>)]
-        fn fn_b<T: Evaluable>(metadata: &String, v: &[&Option<T>]) -> Result<Option<T>> {
+        fn fn_b<T: Evaluable>(metadata: &String, v: &[Option<&T>]) -> Result<Option<T>> {
             assert_eq!(metadata, &format!("{}", std::mem::size_of::<T>()));
             Ok(v[0].clone())
         }

--- a/components/tidb_query_vec_expr/src/types/function.rs
+++ b/components/tidb_query_vec_expr/src/types/function.rs
@@ -274,7 +274,7 @@ pub fn validate_expr_arguments_lte(expr: &Expr, args: usize) -> Result<()> {
 }
 
 thread_local! {
-    pub static VARG_PARAM_BUF: std::cell::RefCell<Vec<usize>> =
+    pub static VARG_PARAM_BUF: std::cell::RefCell<Vec<Option<usize>>> =
         std::cell::RefCell::new(Vec::with_capacity(20));
 
     pub static RAW_VARG_PARAM_BUF: std::cell::RefCell<Vec<ScalarValueRef<'static>>> =

--- a/components/tidb_query_vec_expr/src/types/function.rs
+++ b/components/tidb_query_vec_expr/src/types/function.rs
@@ -30,9 +30,7 @@ use tipb::{Expr, FieldType};
 
 use super::RpnStackNode;
 use tidb_query_common::Result;
-use tidb_query_datatype::codec::data_type::{
-    Bytes, DateTime, Decimal, Duration, Evaluable, Int, Json, Real, ScalarValueRef, VectorValue,
-};
+use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::expr::EvalContext;
 
 /// Metadata of an RPN function.

--- a/components/tidb_query_vec_expr/src/types/function.rs
+++ b/components/tidb_query_vec_expr/src/types/function.rs
@@ -280,16 +280,16 @@ pub fn validate_expr_arguments_lte(expr: &Expr, args: usize) -> Result<()> {
 // `rpn_fn`. In this way, we can reduce overhead of allocating new Vec.
 // According to https://doc.rust-lang.org/std/mem/fn.size_of.html ,
 // &T and Option<&T> has the same size.
-assert_eq_size!(&Int, Option<&Int>);
-assert_eq_size!(&Real, Option<&Real>);
-assert_eq_size!(&Decimal, Option<&Decimal>);
-assert_eq_size!(&Bytes, Option<&Bytes>);
-assert_eq_size!(&DateTime, Option<&DateTime>);
-assert_eq_size!(&Duration, Option<&Duration>);
-assert_eq_size!(&Json, Option<&Json>);
+assert_eq_size!(usize, Option<&Int>);
+assert_eq_size!(usize, Option<&Real>);
+assert_eq_size!(usize, Option<&Decimal>);
+assert_eq_size!(usize, Option<&Bytes>);
+assert_eq_size!(usize, Option<&DateTime>);
+assert_eq_size!(usize, Option<&Duration>);
+assert_eq_size!(usize, Option<&Json>);
 
 thread_local! {
-    pub static VARG_PARAM_BUF: std::cell::RefCell<Vec<Option<&'static usize>>> =
+    pub static VARG_PARAM_BUF: std::cell::RefCell<Vec<usize>> =
         std::cell::RefCell::new(Vec::with_capacity(20));
 
     pub static RAW_VARG_PARAM_BUF: std::cell::RefCell<Vec<ScalarValueRef<'static>>> =


### PR DESCRIPTION
Signed-off-by: Alex Chi iskyzh@gmail.com

### What problem does this PR solve?

**Problem Summary**

This PR changes all vectorized functions to have signature like `do_something(a: Option<&Int>, b: Option<&Json>`.

**Overview**

In [RFC: Using chunk format in coprocessor framework](https://github.com/tikv/rfcs/pull/43/files), we proposed a `ChunkedVec` struct to support Chunk-based computing. We plan to:

1. Migrate current co-processor framework to use interface compatible with `ChunkedVec`. 

This is done by adding new functionalities on current `Vec<Option<T>>`. The detailed plan can be found at [Full Chunk-based Computing PR Roadmap](https://github.com/skyzh/tikv/issues/2).

2. Introduce `ChunkedVec`.

After migrating co-processor to have interface compatible with proposed `ChunkedVec`, we can introduce `ChunkedVec` into TiKV. Then, we may further optimize performance by merging null parameters, etc.

### What is changed and how it works?

Proposal: [RFC: Using chunk format in coprocessor framework](https://github.com/tikv/rfcs/pull/43/files)

What's Changed:

**`tidb_query_codegen`**

* introduce `RpnFnRefEvaluableType` in `rpn_functions`, so as to accept type like `Option<&T>`.
* `rpn_fn` and `rpn_fn(vargs)` now accepts function signature like `Option<&T>` and `&[Option<&T>]`.
* `NormalRpnFn` calls `as_ref` on `&Option<T>`, and pass `Option<&T>` to built-in functions.
* `VargsRpnFn` calls `as_ref` on borrowed `ScalarValueRef`, and pass `&[Option<&T>]` to built-in functions.
* <del>`VargsRpnFn` now use a stack local `vargs_buf` instead of previous thread local one. That's because `Option<&T>` and `usize` have different memory layout, and cannot be directly transmuted. This may be solved in upcoming PRs.</del>
* use `Option<&usize>` as type of global vector cache. `Option<&T>` has same size as `&T` as long as it is a `Sized` type.
* docs and compile error messages are updated.

**`tidb_query_vec_expr`**
* all built-in functions and corresponding tests are modified to have new signature.

**`tidb_query_vec_executors`**
* fix tests in selection_executor to be compatible with new interface.

Tests <!-- At least one of them must be included. -->

- Unit test
