### PR TITLE
test: fix check split bug in pd

### DIFF
--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -917,9 +917,8 @@ impl TestPdClient {
             return false;
         }
 
-        assert!(left.get_region_epoch().get_version() > region.get_region_epoch().get_version());
-        assert!(right.get_region_epoch().get_version() > region.get_region_epoch().get_version());
-        true
+        left.get_region_epoch().get_version() > region.get_region_epoch().get_version()
+            && right.get_region_epoch().get_version() > region.get_region_epoch().get_version()
     }
 
     pub fn get_store_stats(&self, store_id: u64) -> Option<pdpb::StoreStats> {


### PR DESCRIPTION
cherry-pick #7841 to release-3.1

---

Signed-off-by: Liqi Geng <gengliqiii@gmail.com>


### What problem does this PR solve?

Problem Summary:

Fix check split bug in pd.

### What is changed and how it works?

What's Changed:

It's possible that a left region has an old epoch so I remove the assert in `check_split`.
1. r1  => [0, 10)  r2 => [10, 20)
r1 merge to r2
2. r2 => [0, 20)
r2 split
3. r3 => [0, 10) r2 => [10, 20)
When r1 reports to PD again, the `check_split` will panic.

Move `test_node_merge_write_data_to_source_region_after_merging` test to failpoint test.
This is a mistake.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

No.

### Release note <!-- bugfixes or new feature need a release note -->

* No release note