### PR TITLE
rust-rocksdb: rocksdb: avoid `IterKey::UpdateInternalKey()` in `BlockIter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x#3366f124f3eeb0ff2bf1c2fe4c984c9aef902cf4"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x#59b517d606c9111c1d233b77a49cddece02f96d7"
 dependencies = [
  "bzip2-sys 0.1.9+1.0.8 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x#3366f124f3eeb0ff2bf1c2fe4c984c9aef902cf4"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x#59b517d606c9111c1d233b77a49cddece02f96d7"
 dependencies = [
  "bzip2-sys 0.1.9+1.0.8 (git+https://github.com/alexcrichton/bzip2-rs.git)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2292,7 +2292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x#3366f124f3eeb0ff2bf1c2fe4c984c9aef902cf4"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-3.x#59b517d606c9111c1d233b77a49cddece02f96d7"
 dependencies = [
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: cherry-pick fix for #7939 

### What is changed and how it works?

What's Changed: cherry-pick fix for #7939 

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

CI

### Release note <!-- bugfixes or new feature need a release note -->

* Fix potential wrong result read from ingested file.