### PR TITLE
update: rusoto crate and use from_k8s_env()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_core"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8d624cb48fcaca612329e4dd544380aa329ef338e83d3a90f5b7897e631971"
+checksum = "841ca8f73e7498ba39146ab43acea906bbbb807d92ec0b7ea4b6293d2621f80d"
 dependencies = [
  "async-trait",
  "base64 0.12.0",
@@ -3313,9 +3313,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_credential"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3e7cdf483d7198d9bca7414746d3ba656239e89e467b715d0571912f0b492f"
+checksum = "60669ddc1bdbb83ce225593649d36b4c5f6bf9db47cc1ab3e81281abffc853f4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3333,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_kms"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167c735c81ca560f7cd9914f99eabada7b5b66b3b14d7e4401507c68ebca02bb"
+checksum = "9c5a083f44d08db76d4deedd7527bb215dd008fa08f4b1d8ca40071522bdbcb7"
 dependencies = [
  "async-trait",
  "bytes 0.5.3",
@@ -3347,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_mock"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20617d47af0e8ce5c46f4b8243b13f6e72b67c1c2853a2a1bb9af8729f79f8eb"
+checksum = "6fb65b30ea51d8f975eba8e03e6c10ed247f11a6f1b8fa225c2b844e98113366"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3362,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_s3"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b6bc3221ae5a2c036d5757eee68a2ffb6b7f87b8a83adbf4271c8133fdee01c"
+checksum = "eebe039c71a8ab54ce6614e2967ef034bb3202f306e4025901f620cdfa5680c8"
 dependencies = [
  "async-trait",
  "bytes 0.5.3",
@@ -3375,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_signature"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62940a2bd479900a1bf8935b8f254d3e19368ac3ac4570eb4bd48eb46551a1b7"
+checksum = "9eddff187ac18c5a91d9ccda9353f30cf531620dce437c4db661dfe2e23b2029"
 dependencies = [
  "base64 0.12.0",
  "bytes 0.5.3",
@@ -3394,15 +3394,15 @@ dependencies = [
  "rustc_version",
  "serde",
  "sha2",
- "time 0.2.9",
+ "time 0.2.16",
  "tokio 0.2.13",
 ]
 
 [[package]]
 name = "rusoto_sts"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83d166cfb294672db98a60159c4a81a8169c6c91054a275cb812158c73815e5"
+checksum = "8b42c2d24e32a1646bdb1d5d83c49f977ffd26b52aff0cdcd239774628db81ee"
 dependencies = [
  "async-trait",
  "bytes 0.5.3",
@@ -3467,17 +3467,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustversion"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3819,9 +3808,9 @@ dependencies = [
 
 [[package]]
 name = "standback"
-version = "0.2.1"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edf667ea8f60afc06d6aeec079d20d5800351109addec1faea678a8663da4e1"
+checksum = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
 
 [[package]]
 name = "static-metric-proc-macros"
@@ -4665,16 +4654,16 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.9"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6329a7835505d46f5f3a9a2c237f8d6bf5ca6f0015decb3698ba57fcdbb609ba"
+checksum = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
 dependencies = [
  "cfg-if",
  "libc",
- "rustversion",
  "standback",
  "stdweb",
  "time-macros",
+ "version_check 0.9.1",
  "winapi 0.3.8",
 ]
 

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -29,9 +29,9 @@ slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debu
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 tikv_alloc = { path = "../tikv_alloc" }
 tikv_util = { path = "../tikv_util" }
-rusoto_core = "0.43.0"
-rusoto_kms = { version = "0.43.0", features = ["serialize_structs"] }
-rusoto_credential = "0.43.0"
+rusoto_core = "0.44.0"
+rusoto_kms = { version = "0.44.0", features = ["serialize_structs"] }
+rusoto_credential = "0.44.0"
 rusoto_util = { path = "../rusoto_util" }
 bytes = "0.4"
 tokio = { version = "0.2", features = ["time", "rt-core"] }
@@ -41,7 +41,7 @@ futures = "0.3"
 matches = "0.1.8"
 tempfile = "3.1"
 toml = "0.4"
-rusoto_mock = "0.43.0"
+rusoto_mock = "0.44.0"
 rust-ini = "0.14.0"
 structopt = "0.3"
 test_util = { path = "../test_util" }

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -19,8 +19,8 @@ kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = f
 hyper = "0.13.3"
 hyper-tls = "0.4.1"
 rand = "0.7"
-rusoto_core = "0.43.0"
-rusoto_s3 = "0.43.0"
+rusoto_core = "0.44.0"
+rusoto_s3 = "0.44.0"
 rusoto_util = { path = "../rusoto_util" }
 serde_json = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
@@ -34,6 +34,6 @@ url = "2.0"
 
 [dev-dependencies]
 structopt = "0.3"
-rusoto_mock = "0.43.0"
+rusoto_mock = "0.44.0"
 tempfile = "3.1"
 rust-ini = "0.14.0"

--- a/components/rusoto_util/Cargo.toml
+++ b/components/rusoto_util/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-rusoto_core = "0.43.0"
-rusoto_credential = "0.43.0"
-rusoto_sts = "0.43.0"
+rusoto_core = "0.44.0"
+rusoto_credential = "0.44.0"
+rusoto_sts = "0.44.0"

--- a/components/rusoto_util/src/lib.rs
+++ b/components/rusoto_util/src/lib.rs
@@ -8,7 +8,7 @@ use rusoto_core::{
 };
 use rusoto_credential::{
     AutoRefreshingProvider, AwsCredentials, ChainProvider, CredentialsError, ProvideAwsCredentials,
-    StaticProvider, 
+    StaticProvider,
 };
 use rusoto_sts::WebIdentityProvider;
 

--- a/components/rusoto_util/src/lib.rs
+++ b/components/rusoto_util/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::env::{var, VarError};
 use std::io::{self, Error, ErrorKind};
 
 use rusoto_core::{
@@ -9,7 +8,7 @@ use rusoto_core::{
 };
 use rusoto_credential::{
     AutoRefreshingProvider, AwsCredentials, ChainProvider, CredentialsError, ProvideAwsCredentials,
-    StaticProvider, Variable,
+    StaticProvider, 
 };
 use rusoto_sts::WebIdentityProvider;
 
@@ -105,11 +104,6 @@ impl ProvideAwsCredentials for CredentialsProvider {
     }
 }
 
-const AWS_WEB_IDENTITY_TOKEN_FILE: &str = "AWS_WEB_IDENTITY_TOKEN_FILE";
-const AWS_ROLE_ARN: &str = "AWS_ROLE_ARN";
-const AWS_ROLE_SESSION_NAME: &str = "AWS_ROLE_SESSION_NAME";
-const DEFAULT_SESSION_NAME: &str = "WebIdentitySession";
-
 // Same as rusoto_credentials::DefaultCredentialsProvider with extra
 // rusoto_sts::WebIdentityProvider support.
 pub struct DefaultCredentialsProvider {
@@ -123,29 +117,7 @@ impl Default for DefaultCredentialsProvider {
     fn default() -> DefaultCredentialsProvider {
         DefaultCredentialsProvider {
             default_provider: ChainProvider::new(),
-            // We should be using WebIdentityProvider::from_k8s_env(), after the issue have been
-            // fixed: https://github.com/rusoto/rusoto/pull/1724
-            web_identity_provider: WebIdentityProvider::new(
-                // Get token file name from env var, then read from the file.
-                Variable::dynamic(|| {
-                    Variable::from_text_file(
-                        Variable::<String, CredentialsError>::from_env_var(
-                            AWS_WEB_IDENTITY_TOKEN_FILE,
-                        )
-                        .resolve()?,
-                    )
-                    .resolve()
-                }),
-                Variable::from_env_var(AWS_ROLE_ARN),
-                // As AWS_ROLE_SESSION_NAME is optional, we cannot use Variable::from_env_var.
-                Some(Variable::dynamic(|| {
-                    match var(AWS_ROLE_SESSION_NAME).map(|v| v.trim().to_owned()) {
-                        Ok(v) if !v.is_empty() => Ok(v),
-                        Ok(_) | Err(VarError::NotPresent) => Ok(DEFAULT_SESSION_NAME.to_owned()),
-                        Err(e) => Err(CredentialsError::from(e)),
-                    }
-                })),
-            ),
+            web_identity_provider: WebIdentityProvider::from_k8s_env(),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
- Update rusoto v0.43 ~> v0.44.
- WebIdentityProvider::from_k8s_env() instead of coded logic for self procuring env variables.

Problem Summary:

### What is changed and how it works?
rusoto crates updated to latest release. Use of from_k8s_env which manages logic of getting env variables.

Tests <!-- At least one of them must be included. -->

- Integration test
```
Running target/debug/deps/tikv_ctl-e75f90565218c988

running 2 tests
test tests::test_from_hex ... ok
test tests::test_gen_random_bytes ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```