### PR TITLE
server: support cluster_version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,7 +1863,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/hicqu/kvproto?branch=store-heartbeat-cluster-version#76ef595714bb074accfc4af21f4adbfaa807d3d9"
+source = "git+https://github.com/pingcap/kvproto.git#8037ca08f377c8f041ff4a2bf9a7cdbce5479d9a"
 dependencies = [
  "futures 0.1.29",
  "grpcio",
@@ -2923,12 +2923,13 @@ dependencies = [
 
 [[package]]
 name = "protobuf-build"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f3ca050cd02aa2ee07f8e227871ebe8c12cf076ff7c6bf82fdd41dc81af874"
+checksum = "62e8796ce8d382b0a59f53772a00728799f4d78fc478d4f85e6ca864d67130e0"
 dependencies = [
  "bitflags",
  "grpcio-compiler",
+ "proc-macro2",
  "prost-build",
  "protobuf",
  "protobuf-codegen",
@@ -4258,6 +4259,7 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "security",
+ "semver 0.10.0",
  "serde_json",
  "slog",
  "slog-global",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
 dependencies = [
- "semver",
+ "semver 0.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1863,7 +1863,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#6f5f6ae6671fe18f2e5521e6eb28ba9e359b6e59"
+source = "git+https://github.com/hicqu/kvproto?branch=store-heartbeat-cluster-version#76ef595714bb074accfc4af21f4adbfaa807d3d9"
 dependencies = [
  "futures 0.1.29",
  "grpcio",
@@ -2585,6 +2585,7 @@ dependencies = [
  "prometheus",
  "quick-error",
  "security",
+ "semver 0.10.0",
  "serde",
  "serde_derive",
  "slog",
@@ -3489,7 +3490,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -3595,6 +3596,15 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
  "serde",
+]
+
+[[package]]
+name = "semver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+dependencies = [
+ "semver-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,9 @@ protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "b6
 fail = { git = "https://github.com/tikv/fail-rs.git", rev = "2cf1175a1a5cc2c70bd20ebd45313afd69b558fc" }
 prometheus = { git = "https://github.com/tikv/rust-prometheus.git", rev = "fd122caa03de8e7e5e4fae9372583aebf19e39f6" }
 
+[patch."https://github.com/pingcap/kvproto"]
+kvproto = { git = "https://github.com/hicqu/kvproto", branch = "store-heartbeat-cluster-version", default-features = false }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,9 +182,6 @@ protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "b6
 fail = { git = "https://github.com/tikv/fail-rs.git", rev = "2cf1175a1a5cc2c70bd20ebd45313afd69b558fc" }
 prometheus = { git = "https://github.com/tikv/rust-prometheus.git", rev = "fd122caa03de8e7e5e4fae9372583aebf19e39f6" }
 
-[patch."https://github.com/pingcap/kvproto"]
-kvproto = { git = "https://github.com/hicqu/kvproto", branch = "store-heartbeat-cluster-version", default-features = false }
-
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -35,3 +35,4 @@ tikv_alloc = { path = "../tikv_alloc" }
 tikv_util = { path = "../tikv_util" }
 tokio-timer = "0.2"
 txn_types = { path = "../txn_types" }
+semver = "0.10"

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -30,11 +30,13 @@ pub use self::util::validate_endpoints;
 pub use self::util::RECONNECT_INTERVAL_SEC;
 
 use std::ops::Deref;
+use std::sync::{Arc, RwLock};
 
 use futures::Future;
 use kvproto::metapb;
 use kvproto::pdpb;
 use kvproto::replication_modepb::{RegionReplicationStatus, ReplicationStatus};
+use semver::{SemVerError, Version};
 use tikv_util::time::UnixSecs;
 use txn_types::TimeStamp;
 
@@ -202,7 +204,7 @@ pub trait PdClient: Send + Sync {
     }
 
     /// Sends store statistics regularly.
-    fn store_heartbeat(&self, _stats: pdpb::StoreStats) -> PdFuture<Option<ReplicationStatus>> {
+    fn store_heartbeat(&self, _stats: pdpb::StoreStats) -> PdFuture<pdpb::StoreHeartbeatResponse> {
         unimplemented!();
     }
 
@@ -253,5 +255,27 @@ pub fn take_peer_address(store: &mut metapb::Store) -> String {
         store.take_peer_address()
     } else {
         store.take_address()
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct ClusterVersion {
+    version: Arc<RwLock<Option<Version>>>,
+}
+
+impl ClusterVersion {
+    pub fn get(&self) -> Option<Version> {
+        self.version.read().unwrap().clone()
+    }
+
+    fn set(&self, version: &str) -> std::result::Result<(), SemVerError> {
+        let new = Version::parse(version)?;
+        let mut holder = self.version.write().unwrap();
+        match &mut *holder {
+            Some(ref mut old) if *old < new => *old = new,
+            Some(_) => {}
+            None => *holder = Some(new),
+        }
+        Ok(())
     }
 }

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -26,7 +26,7 @@ use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 use tikv_util::{Either, HandyRwLock};
 use tokio_timer::timer::Handle;
 
-use super::{Config, Error, PdFuture, Result, REQUEST_TIMEOUT};
+use super::{ClusterVersion, Config, Error, PdFuture, Result, REQUEST_TIMEOUT};
 
 pub struct Inner {
     env: Arc<Environment>,
@@ -41,6 +41,8 @@ pub struct Inner {
     on_reconnect: Option<Box<dyn Fn() + Sync + Send + 'static>>,
 
     last_update: Instant,
+
+    pub cluster_version: ClusterVersion,
 }
 
 pub struct HeartbeatReceiver {
@@ -110,6 +112,7 @@ impl LeaderClient {
                 on_reconnect: None,
 
                 last_update: Instant::now(),
+                cluster_version: ClusterVersion::default(),
             })),
         }
     }

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -705,8 +705,8 @@ where
             .map_err(|e| {
                 error!("store heartbeat failed"; "err" => ?e);
             })
-            .map(move |status| {
-                if let Some(status) = status {
+            .map(move |mut resp| {
+                if let Some(status) = resp.replication_status.take() {
                     let _ = router.send_control(StoreMsg::UpdateReplicationMode(status));
                 }
             });

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -122,7 +122,6 @@ criterion = "0.3"
 criterion-cpu-time = "0.1"
 arrow = "0.10"
 rand_xorshift = "0.2"
-
 engine_rocks = { path = "../components/engine_rocks" }
 engine_traits = { path = "../components/engine_traits" }
 external_storage = { path = "../components/external_storage" }
@@ -141,6 +140,7 @@ test_raftstore = { path = "../components/test_raftstore" }
 byteorder = "1.2"
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["rt-core"] }
+semver = "0.10"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 criterion-papi = "0.1"

--- a/tests/integrations/pd/mock/mocker/service.rs
+++ b/tests/integrations/pd/mock/mocker/service.rs
@@ -17,6 +17,7 @@ pub struct Service {
     stores: Mutex<HashMap<u64, Store>>,
     regions: Mutex<HashMap<u64, Region>>,
     leaders: Mutex<HashMap<u64, Peer>>,
+    cluster_version: Mutex<String>,
 }
 
 impl Service {
@@ -28,6 +29,7 @@ impl Service {
             stores: Mutex::new(HashMap::default()),
             regions: Mutex::new(HashMap::default()),
             leaders: Mutex::new(HashMap::default()),
+            cluster_version: Mutex::new(String::default()),
         }
     }
 
@@ -41,6 +43,10 @@ impl Service {
     pub fn add_store(&self, store: Store) {
         let store_id = store.get_id();
         self.stores.lock().unwrap().insert(store_id, store);
+    }
+
+    pub fn set_cluster_version(&self, version: String) {
+        *self.cluster_version.lock().unwrap() = version;
     }
 }
 
@@ -229,6 +235,7 @@ impl PdMocker for Service {
         let mut resp = StoreHeartbeatResponse::default();
         let header = Service::header();
         resp.set_header(header);
+        resp.set_cluster_version(self.cluster_version.lock().unwrap().to_owned());
         Some(Ok(resp))
     }
 


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

PD distributes cluster version to TiKVs. So that TiKV can do some special things when rolling update.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.