### PR TITLE
txn: use command! macro on ScanLock command

### DIFF
--- a/src/storage/txn/commands.rs
+++ b/src/storage/txn/commands.rs
@@ -482,32 +482,15 @@ command! {
     }
 }
 
-/// Scan locks from `start_key`, and find all locks whose timestamp is before `max_ts`.
-pub struct ScanLock {
-    /// The maximum transaction timestamp to scan.
-    pub max_ts: TimeStamp,
-    /// The key to start from. (`None` means start from the very beginning.)
-    pub start_key: Option<Key>,
-    /// The result limit.
-    pub limit: usize,
-}
-
-impl ScanLock {
-    pub fn new(
+command! {
+    /// Scan locks from `start_key`, and find all locks whose timestamp is before `max_ts`.
+    ScanLock -> Vec<LockInfo> {
+        /// The maximum transaction timestamp to scan.
         max_ts: TimeStamp,
+        /// The key to start from. (`None` means start from the very beginning.)
         start_key: Option<Key>,
+        /// The result limit.
         limit: usize,
-        ctx: Context,
-    ) -> TypedCommand<Vec<LockInfo>> {
-        Command {
-            ctx,
-            kind: CommandKind::ScanLock(ScanLock {
-                max_ts,
-                start_key,
-                limit,
-            }),
-        }
-        .into()
     }
 }
 


### PR DESCRIPTION
Signed-off-by: longfangsong <longfangsong@icloud.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Minor refactor in `storage/txn/command.rs`.

### What is changed and how it works?

`ScanLock`'s code seems the same as the `command!` macro generates, and for consistency, maybe we should using that macro instead of manually write it.

Tests <!-- At least one of them must be included. -->

- Unit test
