### PR TITLE
Makefile: fix test failure issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ run-test:
 	if [[ "`uname`" == "Linux" ]]; then \
 		export MALLOC_CONF=prof:true,prof_active:false && \
 		cargo test --features "${ENABLE_FEATURES} mem-profiling" ${EXTRA_CARGO_ARGS} -p tikv_alloc -- --nocapture --ignored && \
-		cargo test test_pprof_heap_service --features "${ENABLE_FEATURES} mem-profiling" ${EXTRA_CARGO_ARGS} -p tikv --lib -- -- nocapture; \
+		cargo test --features "${ENABLE_FEATURES} mem-profiling" ${EXTRA_CARGO_ARGS} -p tikv --lib -- -- nocapture --ignored; \
 	fi
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -234,10 +234,11 @@ run-test:
 	export RUST_BACKTRACE=1 && \
 	cargo test --workspace \
 		--exclude fuzzer-honggfuzz --exclude fuzzer-afl --exclude fuzzer-libfuzzer \
-		--features "${ENABLE_FEATURES} mem-profiling" ${EXTRA_CARGO_ARGS} -- --nocapture && \
+		--features "${ENABLE_FEATURES}" ${EXTRA_CARGO_ARGS} -- --nocapture && \
 	if [[ "`uname`" == "Linux" ]]; then \
 		export MALLOC_CONF=prof:true,prof_active:false && \
-		cargo test --features "${ENABLE_FEATURES} mem-profiling" ${EXTRA_CARGO_ARGS} -p tikv_alloc -- --nocapture --ignored; \
+		cargo test --features "${ENABLE_FEATURES} mem-profiling" ${EXTRA_CARGO_ARGS} -p tikv_alloc -- --nocapture --ignored && \
+		cargo test test_pprof_heap_service --features "${ENABLE_FEATURES} mem-profiling" ${EXTRA_CARGO_ARGS} -p tikv --lib -- -- nocapture; \
 	fi
 
 .PHONY: test

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -1376,6 +1376,7 @@ mod tests {
 
     #[cfg(feature = "mem-profiling")]
     #[test]
+    #[ignore]
     fn test_pprof_heap_service() {
         let mut status_server = StatusServer::new(
             1,


### PR DESCRIPTION
Signed-off-by: Xintao <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

close #7956 

### What is changed and how it works?

Removed the `mem-profiling` feature of the default tests

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

No

### Release note <!-- bugfixes or new feature need a release note -->
- Fix the bug that `Makefile` cannot run tests