### PR TITLE
gc: only run compaction filter if cluster version is ok

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4549,6 +4549,7 @@ dependencies = [
  "regex",
  "rev_lines",
  "security",
+ "semver 0.10.0",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ parking_lot = "0.10"
 prometheus = { version = "0.8", features = ["nightly", "push"] }
 sst_importer = { path = "components/sst_importer" }
 sysinfo = "0.14"
+semver = "0.10"
 tempfile = "3.0"
 tidb_query_datatype = { path = "components/tidb_query_datatype" }
 tidb_query_common = { path = "components/tidb_query_common" }

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -397,6 +397,7 @@ impl TiKVServer {
             Some(engines.raft_router.clone()),
             Some(self.region_info_accessor.clone()),
             self.config.gc.clone(),
+            self.pd_client.cluster_version(),
         );
         gc_worker
             .start()

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -514,8 +514,10 @@ impl PdClient for RpcClient {
                     .with_label_values(&["store_heartbeat"])
                     .observe(duration_to_sec(timer.elapsed()));
                 check_resp_header(resp.get_header())?;
-                if cluster_version.set(resp.get_cluster_version()).is_err() {
-                    warn!("invalid cluster version: {}", resp.get_cluster_version());
+                match cluster_version.set(resp.get_cluster_version()) {
+                    Err(_) => warn!("invalid cluster version: {}", resp.get_cluster_version()),
+                    Ok(true) => info!("set cluster version to {}", resp.get_cluster_version()),
+                    _ => {}
                 };
                 Ok(resp)
             })) as PdFuture<_>

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -179,6 +179,7 @@ impl Simulator for ServerCluster {
             Some(raft_router.clone()),
             Some(region_info_accessor.clone()),
             cfg.gc.clone(),
+            Default::default(),
         );
         gc_worker.start().unwrap();
 

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -63,6 +63,7 @@ impl<E: Engine> SyncTestStorageBuilder<E> {
             None,
             None,
             self.gc_config.unwrap_or_default(),
+            Default::default(),
         );
         gc_worker.start()?;
 

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -21,7 +21,7 @@ const DEFAULT_DELETE_BATCH_COUNT: usize = 128;
 
 // The default version that can enable compaction filter for GC. This is necessary because after
 // compaction filter is enabled, it's impossible to fallback to ealier version which modifications
-// of GC are distributed to other replicas b Raft.
+// of GC are distributed to other replicas by Raft.
 const COMPACTION_FILTER_MINIMAL_VERSION: &str = "5.0.0";
 
 struct GcContext {

--- a/src/server/gc_worker/config.rs
+++ b/src/server/gc_worker/config.rs
@@ -10,11 +10,6 @@ pub const DEFAULT_GC_BATCH_KEYS: usize = 512;
 // No limit
 const DEFAULT_GC_MAX_WRITE_BYTES_PER_SEC: u64 = 0;
 
-// The default version that can enable compaction filter for GC. This is necessary because after
-// compaction filter is enabled, it's impossible to fallback to ealier version which modifications
-// of GC are distributed to other replicas b Raft.
-const DEFAULT_COMPACTION_FILTER_MINIMAL_VERSION: &str = "5.0.0";
-
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Configuration)]
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
@@ -23,7 +18,9 @@ pub struct GcConfig {
     pub batch_keys: usize,
     pub max_write_bytes_per_sec: ReadableSize,
     pub enable_compaction_filter: bool,
-    pub compaction_filter_minimal_version: String,
+    /// By default compaction_filter can only works if `cluster_version` is greater than 5.0.0.
+    /// Change `compaction_filter_skip_version_check` can enable it by force.
+    pub compaction_filter_skip_version_check: bool,
 }
 
 impl Default for GcConfig {
@@ -33,7 +30,7 @@ impl Default for GcConfig {
             batch_keys: DEFAULT_GC_BATCH_KEYS,
             max_write_bytes_per_sec: ReadableSize(DEFAULT_GC_MAX_WRITE_BYTES_PER_SEC),
             enable_compaction_filter: false,
-            compaction_filter_minimal_version: DEFAULT_COMPACTION_FILTER_MINIMAL_VERSION.to_owned(),
+            compaction_filter_skip_version_check: false,
         }
     }
 }
@@ -42,9 +39,6 @@ impl GcConfig {
     pub fn validate(&self) -> std::result::Result<(), Box<dyn std::error::Error>> {
         if self.batch_keys == 0 {
             return Err("gc.batch_keys should not be 0".into());
-        }
-        if semver::Version::parse(&self.compaction_filter_minimal_version).is_err() {
-            return Err("gc.compaction_filter_minimal_version is invalid".into());
         }
         Ok(())
     }

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -24,7 +24,7 @@ use crate::storage::kv::{
 use crate::storage::mvcc::{
     check_need_gc, check_region_need_gc, Error as MvccError, MvccReader, MvccTxn,
 };
-use pd_client::PdClient;
+use pd_client::{ClusterVersion, PdClient};
 use raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor, RegionInfoProvider};
 use raftstore::router::ServerRaftStoreRouter;
 use raftstore::store::msg::StoreMsg;
@@ -680,6 +680,7 @@ pub struct GcWorker<E: Engine> {
     applied_lock_collector: Option<Arc<AppliedLockCollector>>,
 
     gc_manager_handle: Arc<Mutex<Option<GcManagerHandle>>>,
+    cluster_version: ClusterVersion,
 }
 
 impl<E: Engine> Clone for GcWorker<E> {
@@ -699,6 +700,7 @@ impl<E: Engine> Clone for GcWorker<E> {
             worker_scheduler: self.worker_scheduler.clone(),
             applied_lock_collector: self.applied_lock_collector.clone(),
             gc_manager_handle: self.gc_manager_handle.clone(),
+            cluster_version: self.cluster_version.clone(),
         }
     }
 }
@@ -726,6 +728,7 @@ impl<E: Engine> GcWorker<E> {
         raft_store_router: Option<ServerRaftStoreRouter<RocksEngine>>,
         region_info_accessor: Option<RegionInfoAccessor>,
         cfg: GcConfig,
+        cluster_version: ClusterVersion,
     ) -> GcWorker<E> {
         let worker = Arc::new(Mutex::new(FutureWorker::new("gc-worker")));
         let worker_scheduler = worker.lock().unwrap().scheduler();
@@ -741,6 +744,7 @@ impl<E: Engine> GcWorker<E> {
             worker_scheduler,
             applied_lock_collector: None,
             gc_manager_handle: Arc::new(Mutex::new(None)),
+            cluster_version,
         }
     }
 
@@ -751,7 +755,9 @@ impl<E: Engine> GcWorker<E> {
         let safe_point = Arc::new(AtomicU64::new(0));
         if let Some(db) = self.local_storage.clone() {
             let safe_point = Arc::clone(&safe_point);
-            init_compaction_filter(db, safe_point, self.config_manager.clone());
+            let cfg_mgr = self.config_manager.clone();
+            let cluster_version = self.cluster_version.clone();
+            init_compaction_filter(db, safe_point, cfg_mgr, cluster_version);
         }
 
         let mut handle = self.gc_manager_handle.lock().unwrap();
@@ -761,6 +767,7 @@ impl<E: Engine> GcWorker<E> {
             safe_point,
             self.worker_scheduler.clone(),
             self.config_manager.clone(),
+            self.cluster_version.clone(),
         )
         .start()?;
         *handle = Some(new_handle);
@@ -1044,6 +1051,7 @@ mod tests {
             None,
             None,
             GcConfig::default(),
+            ClusterVersion::new(semver::Version::new(5, 0, 0)),
         );
         gc_worker.start().unwrap();
         // Convert keys to key value pairs, where the value is "value-{key}".
@@ -1209,6 +1217,7 @@ mod tests {
             None,
             None,
             GcConfig::default(),
+            ClusterVersion::default(),
         );
         gc_worker.start().unwrap();
 

--- a/src/server/gc_worker/mod.rs
+++ b/src/server/gc_worker/mod.rs
@@ -8,8 +8,8 @@ mod gc_worker;
 
 // TODO: Use separated error type for GCWorker instead.
 pub use crate::storage::{Callback, Error, ErrorInner, Result};
-use compaction_filter::init_compaction_filter;
 pub use compaction_filter::WriteCompactionFilterFactory;
+use compaction_filter::{init_compaction_filter, is_compaction_filter_allowd};
 pub use config::{GcConfig, GcWorkerConfigManager, DEFAULT_GC_BATCH_KEYS};
 pub use gc_manager::AutoGcConfig;
 pub use gc_worker::{GcSafePointProvider, GcTask, GcWorker, GC_MAX_EXECUTING_TASKS};

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -369,8 +369,14 @@ mod tests {
         cfg.addr = "127.0.0.1:0".to_owned();
 
         let storage = TestStorageBuilder::new().build().unwrap();
-        let mut gc_worker =
-            GcWorker::new(storage.get_engine(), None, None, None, Default::default());
+        let mut gc_worker = GcWorker::new(
+            storage.get_engine(),
+            None,
+            None,
+            None,
+            Default::default(),
+            Default::default(),
+        );
         gc_worker.start().unwrap();
 
         let (tx, rx) = mpsc::channel();

--- a/tests/failpoints/cases/test_gc_worker.rs
+++ b/tests/failpoints/cases/test_gc_worker.rs
@@ -11,7 +11,14 @@ use tikv::storage;
 fn test_gcworker_busy() {
     let snapshot_fp = "raftkv_async_snapshot";
     let (_cluster, engine, ctx) = new_raft_engine(3, "");
-    let mut gc_worker = GcWorker::new(engine, None, None, None, Default::default());
+    let mut gc_worker = GcWorker::new(
+        engine,
+        None,
+        None,
+        None,
+        Default::default(),
+        Default::default(),
+    );
     gc_worker.start().unwrap();
 
     fail::cfg(snapshot_fp, "pause").unwrap();

--- a/tests/integrations/config/dynamic/gc_worker.rs
+++ b/tests/integrations/config/dynamic/gc_worker.rs
@@ -25,7 +25,7 @@ fn setup_cfg_controller(
     cfg: TiKvConfig,
 ) -> (GcWorker<tikv::storage::kv::RocksEngine>, ConfigController) {
     let engine = TestEngineBuilder::new().build().unwrap();
-    let mut gc_worker = GcWorker::new(engine, None, None, None, cfg.gc.clone());
+    let mut gc_worker = GcWorker::new(engine, None, None, None, cfg.gc.clone(), Default::default());
     gc_worker.start().unwrap();
 
     let cfg_controller = ConfigController::new(cfg);

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -641,6 +641,7 @@ fn test_serde_custom_tikv_config() {
         batch_keys: 256,
         max_write_bytes_per_sec: ReadableSize::mb(10),
         enable_compaction_filter: true,
+        compaction_filter_minimal_version: "6.6.6".to_owned(),
     };
     value.pessimistic_txn = PessimisticTxnConfig {
         enabled: false,

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -641,7 +641,7 @@ fn test_serde_custom_tikv_config() {
         batch_keys: 256,
         max_write_bytes_per_sec: ReadableSize::mb(10),
         enable_compaction_filter: true,
-        compaction_filter_minimal_version: "6.6.6".to_owned(),
+        compaction_filter_skip_version_check: true,
     };
     value.pessimistic_txn = PessimisticTxnConfig {
         enabled: false,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -561,6 +561,7 @@ ratio-threshold = 1.2
 batch-keys = 256
 max-write-bytes-per-sec = "10MB"
 enable-compaction-filter = true
+compaction-filter-minimal-version = "6.6.6"
 
 [pessimistic-txn]
 enabled = false

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -561,7 +561,7 @@ ratio-threshold = 1.2
 batch-keys = 256
 max-write-bytes-per-sec = "10MB"
 enable-compaction-filter = true
-compaction-filter-minimal-version = "6.6.6"
+compaction-filter-skip-version-check = true
 
 [pessimistic-txn]
 enabled = false


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?
TiKV can't enable compaction filter during rolling update.

### What is changed and how it works?
Only enable compaction filter after cluster-version reaches specified point.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Unit test

Side effects

### Release note
- No release note