### PR TITLE
WIP:  Add the Put/BatchPut RPC interface, and implement tikv-server side logic(#7295)

### DIFF
--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -18,7 +18,7 @@ use std::io;
 
 pub use lock::{Lock, LockType};
 pub use timestamp::{TimeStamp, TsSet};
-pub use types::{is_short_value, Key, KvPair, Mutation, Value, SHORT_VALUE_MAX_LEN};
+pub use types::{is_short_value, Key, KvPair, Mutation, Value, Version, SHORT_VALUE_MAX_LEN};
 pub use write::{Write, WriteRef, WriteType};
 
 quick_error! {

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -33,7 +33,34 @@ pub type KvPair = (Vec<u8>, Value);
 ///
 /// TODO: implement methods
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct Version(u64);
+pub struct Version(Vec<u8>);
+
+impl Version {
+    // Returns Version byte array(not encoded) from timestamp or specified version(u64)
+    #[inline]
+    pub fn from_raw(version: u64) -> Version {
+        let mut encoded = Vec::with_capacity(8);
+        // Being 8 bytes(u64) serialize u64 to byte array to be included in key
+        let bytes: Vec<u8> = version.to_be_bytes();
+        Version(encoded)
+    }
+
+    // Returns timestamp or specified version from version byte array(not encoded)
+    #[inline]
+    pub fn into_raw(self) -> Result<u64, codec::Error> {
+        let v = self.0;
+        // Being 8 bytes(u64), deserialize byte array into u64
+        let converted: u64 = ((v[0] as u64) << 0)
+            + ((v[1] as u64) << 8)
+            + ((v[2] as u64) << 16)
+            + ((v[3] as u64) << 24)
+            + ((v[4] as u64) << 32)
+            + ((v[5] as u64) << 40)
+            + ((v[6] as u64) << 48)
+            + ((v[7] as u64) << 56);
+        Ok(converted)
+    }
+}
 
 /// Key type.
 ///

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -24,6 +24,17 @@ pub type Value = Vec<u8>;
 /// encoded bytes.
 pub type KvPair = (Vec<u8>, Value);
 
+/// Version type.
+///
+/// Keys have 2 types of binary representation - raw and encoded. The raw
+/// representation is for public interface(timestamp or integer value set by developer), the encoded representation is for
+/// internal storage. We can get both representations from an instance of this
+/// type.
+///
+/// TODO: implement methods
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Version(u64);
+
 /// Key type.
 ///
 /// Keys have 2 types of binary representation - raw and encoded. The raw

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -38,10 +38,9 @@ impl Version {
     // Returns Version byte array(not encoded) from timestamp or specified version(u64)
     #[inline]
     pub fn from_raw(version: u64) -> Version {
-        let mut encoded = Vec::with_capacity(8);
         // Being 8 bytes(u64), serialize u64 to little endian byte array to include in key
         let bytes: Vec<u8> = version.to_le_bytes().to_vec();
-        Version(encoded)
+        Version(bytes)
     }
 
     // Returns timestamp or specified version from version byte array(not encoded)

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -39,8 +39,8 @@ impl Version {
     #[inline]
     pub fn from_raw(version: u64) -> Version {
         let mut encoded = Vec::with_capacity(8);
-        // Being 8 bytes(u64), serialize u64 to byte array to include in key
-        let bytes: Vec<u8> = version.to_le_bytes();
+        // Being 8 bytes(u64), serialize u64 to little endian byte array to include in key
+        let bytes: Vec<u8> = version.to_le_bytes().to_vec();
         Version(encoded)
     }
 
@@ -49,7 +49,7 @@ impl Version {
     pub fn into_raw(self) -> Result<u64, codec::Error> {
         let v = self.0;
         // Being 8 bytes(u64), deserialize byte array into u64
-        // TODO: choose
+        // Deserialize little endian byte array to u64
         let converted: u64 = ((v[0] as u64) << 0)
             + ((v[1] as u64) << 8)
             + ((v[2] as u64) << 16)

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -31,7 +31,6 @@ pub type KvPair = (Vec<u8>, Value);
 /// internal storage. We can get both representations from an instance of this
 /// type.
 ///
-/// TODO: implement methods
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Version(Vec<u8>);
 
@@ -40,8 +39,8 @@ impl Version {
     #[inline]
     pub fn from_raw(version: u64) -> Version {
         let mut encoded = Vec::with_capacity(8);
-        // Being 8 bytes(u64) serialize u64 to byte array to be included in key
-        let bytes: Vec<u8> = version.to_be_bytes();
+        // Being 8 bytes(u64), serialize u64 to byte array to include in key
+        let bytes: Vec<u8> = version.to_le_bytes();
         Version(encoded)
     }
 
@@ -50,6 +49,7 @@ impl Version {
     pub fn into_raw(self) -> Result<u64, codec::Error> {
         let v = self.0;
         // Being 8 bytes(u64), deserialize byte array into u64
+        // TODO: choose
         let converted: u64 = ((v[0] as u64) << 0)
             + ((v[1] as u64) << 8)
             + ((v[2] as u64) << 16)

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -13,7 +13,7 @@ use std::{error, ptr, result};
 
 use engine_rocks::RocksTablePropertiesCollection;
 use engine_traits::IterOptions;
-use engine_traits::{CfName, CF_DEFAULT};
+use engine_traits::{CfName, CF_DEFAULT, CF_VER_DEFAULT};
 use futures03::prelude::*;
 use kvproto::errorpb::Error as ErrorHeader;
 use kvproto::kvrpcpb::Context;
@@ -96,9 +96,9 @@ pub trait Engine: Send + Clone + 'static {
         self.put_cf(ctx, CF_DEFAULT, key, value)
     }
 
-    fn ver_put(&self, ctx: &Context, key: Key, version: Version, value: Value) -> Result<()> {
+    fn ver_put(&self, ctx: &Context, key: Key, _version: Version, value: Value) -> Result<()> {
         // TODO: encode version and include in key
-        self.put_cf(ctx, CF_DEFAULT, key, value)
+        self.put_cf(ctx, CF_VER_DEFAULT, key, value)
     }
 
     fn put_cf(&self, ctx: &Context, cf: CfName, key: Key, value: Value) -> Result<()> {

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -17,7 +17,7 @@ use engine_traits::{CfName, CF_DEFAULT};
 use futures03::prelude::*;
 use kvproto::errorpb::Error as ErrorHeader;
 use kvproto::kvrpcpb::Context;
-use txn_types::{Key, Value};
+use txn_types::{Key, Value, Version};
 
 pub use self::btree_engine::{BTreeEngine, BTreeEngineIterator, BTreeEngineSnapshot};
 pub use self::cursor::{Cursor, CursorBuilder};
@@ -93,6 +93,11 @@ pub trait Engine: Send + Clone + 'static {
     }
 
     fn put(&self, ctx: &Context, key: Key, value: Value) -> Result<()> {
+        self.put_cf(ctx, CF_DEFAULT, key, value)
+    }
+
+    fn ver_put(&self, ctx: &Context, key: Key, version: Version, value: Value) -> Result<()> {
+        // TODO: encode version and include in key
         self.put_cf(ctx, CF_DEFAULT, key, value)
     }
 


### PR DESCRIPTION

### What problem does this PR solve?

WIP: it solves

 Add the Put/BatchPut RPC interface, and implement tikv-server side logic from #7259

Problem Summary:

Proposal: [VerKV ](https://github.com/tikv/tikv/issues/7295)

What's Changed:

### Related changes

<Current> 
- Add Version type in `src/components/txn_types/src/types.rs`
- Add `ver_put` method in Engine in storage layer `src/storage/kv/mod.rs`

To handle other requests from RPC interface `ver_get`, `ver_put`, or `ver_mut`, I think Version type is needed.

Version type has two representation; raw and encoded.
raw representation will be used for public interface and encoded representation is for internal storage which needs to be included in key. 

