### PR TITLE
raftstore: add peer msg process duration metrics

### DIFF
--- a/components/engine_rocks/src/lib.rs
+++ b/components/engine_rocks/src/lib.rs
@@ -15,7 +15,6 @@
 //! Please read the engine_trait crate docs before hacking.
 
 #![cfg_attr(test, feature(test))]
-
 #[allow(unused_extern_crates)]
 extern crate tikv_alloc;
 

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2160,8 +2160,8 @@ where
                     *is_ready = true;
                 }
                 RAFT_EVENT_DURATION
-                        .get(RaftEventDurationType::destroy_peer)
-                        .observe(duration_to_sec(timer.saturating_elapsed()) as f64);
+                    .get(RaftEventDurationType::destroy_peer)
+                    .observe(duration_to_sec(timer.saturating_elapsed()) as f64);
             }
         }
         if self.fsm.peer.unsafe_recovery_state.is_some() {

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -161,6 +161,7 @@ make_auto_flush_static_metric! {
         heartbeat_pd,
         update_replication_mode,
         destroy,
+        other,
     }
 
     pub label_enum CompactionGuardAction {

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -145,6 +145,22 @@ make_auto_flush_static_metric! {
         consistency_check,
         cleanup_import_sst,
         raft_engine_purge,
+        peer_msg,
+        destroy_peer,
+        split_region,
+        peer_gc_snap,
+        merge_result,
+        raft_message,
+        raft_command,
+        tick,
+        apply_res,
+        significant_msg,
+        start,
+        noop,
+        casual_message,
+        heartbeat_pd,
+        update_replication_mode,
+        destroy,
     }
 
     pub label_enum CompactionGuardAction {
@@ -599,6 +615,13 @@ lazy_static! {
         ).unwrap();
     pub static ref RAFT_EVENT_DURATION: RaftEventDuration =
         auto_flush_from!(RAFT_EVENT_DURATION_VEC, RaftEventDuration);
+
+    pub static ref PEER_MSG_LEN: Histogram =
+        register_histogram!(
+            "tikv_raftstore_peer_msg_len",
+            "Length of peer msg.",
+            exponential_buckets(1.0, 2.0, 20).unwrap() // max 1000s
+        ).unwrap();
 
     pub static ref RAFT_READ_INDEX_PENDING_DURATION: Histogram =
         register_histogram!(

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -589,6 +589,24 @@ pub enum PeerMsg<EK: KvEngine> {
     Destroy(u64),
 }
 
+impl<EK: KvEngine> PeerMsg<EK> {
+    pub fn tag(&self) -> RaftEventDurationType {
+        match self {
+            PeerMsg::RaftMessage(_) => RaftEventDurationType::raft_message,
+            PeerMsg::RaftCommand(_) => RaftEventDurationType::raft_command,
+            PeerMsg::Tick(_) => RaftEventDurationType::tick,
+            PeerMsg::ApplyRes { res: _ } => RaftEventDurationType::apply_res,
+            PeerMsg::SignificantMsg(_) => RaftEventDurationType::significant_msg,
+            PeerMsg::Start => RaftEventDurationType::start,
+            PeerMsg::Noop => RaftEventDurationType::noop,
+            PeerMsg::CasualMessage(_) => RaftEventDurationType::casual_message,
+            PeerMsg::HeartbeatPd => RaftEventDurationType::heartbeat_pd,
+            PeerMsg::UpdateReplicationMode => RaftEventDurationType::update_replication_mode,
+            PeerMsg::Destroy(_) => RaftEventDurationType::destroy,
+        }
+    }
+}
+
 impl<EK: KvEngine> fmt::Debug for PeerMsg<EK> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -603,6 +603,7 @@ impl<EK: KvEngine> PeerMsg<EK> {
             PeerMsg::HeartbeatPd => RaftEventDurationType::heartbeat_pd,
             PeerMsg::UpdateReplicationMode => RaftEventDurationType::update_replication_mode,
             PeerMsg::Destroy(_) => RaftEventDurationType::destroy,
+            _ => RaftEventDurationType::other,
         }
     }
 }

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -408,6 +408,14 @@ fn grpc_error_is_unimplemented(e: &grpcio::Error) -> bool {
     }
 }
 
+fn grpc_error_is_connect_err(e: &grpcio::Error) -> bool {
+    if let grpcio::Error::RpcFailure(ref status) = e {
+        status.code() == RpcStatusCode::UNAVAILABLE && status.message() == "failed to connect to all addresses"
+    } else {
+        false
+    }
+}
+
 /// Struct tracks the lifetime of a `raft` or `batch_raft` RPC.
 struct AsyncRaftSender<R, M, B, E> {
     sender: ClientCStreamSender<M>,
@@ -536,10 +544,17 @@ where
     }
 }
 
+#[derive(PartialEq)]
+enum RaftCallRes {
+    UnImplemented,
+    Disconnected(bool), // bool indicates whether it's ever connected
+    Closed,
+}
+
 struct RaftCall<R, M, B, E> {
     sender: AsyncRaftSender<R, M, B, E>,
     receiver: ClientCStreamReceiver<Done>,
-    lifetime: Option<oneshot::Sender<()>>,
+    lifetime: Option<oneshot::Sender<RaftCallRes>>,
     store_id: u64,
 }
 
@@ -549,29 +564,33 @@ where
     B: Buffer<OutputMessage = M> + Unpin,
     E: KvEngine,
 {
-    fn clean_up(&mut self, sink_err: Option<grpcio::Error>, recv_err: Option<grpcio::Error>) {
-        error!("connection aborted"; "store_id" => self.store_id, "sink_error" => ?sink_err, "receiver_err" => ?recv_err, "addr" => %self.sender.addr);
-
-        if let Some(tx) = self.lifetime.take() {
-            let should_fallback = [sink_err, recv_err]
-                .iter()
-                .any(|e| e.as_ref().map_or(false, grpc_error_is_unimplemented));
-            if should_fallback {
-                // Asks backend to fallback.
-                let _ = tx.send(());
-                return;
-            }
-        }
-        self.sender.router.broadcast_unreachable(self.store_id);
-    }
-
     async fn poll(&mut self) {
         let res = futures::join!(&mut self.sender, &mut self.receiver);
         if let (Ok(()), Ok(Done { .. })) = res {
             info!("connection close"; "store_id" => self.store_id, "addr" => %self.sender.addr);
+            if let Some(tx) = self.lifetime.take() {
+                let _ = tx.send(RaftCallRes::Closed);
+            }
             return;
         }
-        self.clean_up(res.0.err(), res.1.err());
+
+        let (sink_err, recv_err) = (res.0.err(), res.1.err());
+        error!("connection aborted"; "store_id" => self.store_id, "sink_error" => ?sink_err, "receiver_err" => ?recv_err, "addr" => %self.sender.addr);
+        if let Some(tx) = self.lifetime.take() {
+            let errs = [sink_err, recv_err];
+            let should_fallback = errs.iter().any(|e| e.as_ref().map_or(false, grpc_error_is_unimplemented));
+            
+            let res = if should_fallback {
+                // Asks backend to fallback.
+                RaftCallRes::UnImplemented
+            } else {
+                let ever_connected = !errs.iter().any(|e| e.as_ref().map_or(false, grpc_error_is_connect_err));
+
+                RaftCallRes::Disconnected(ever_connected)
+            };
+            let _ = tx.send(res);
+            return;
+        }
     }
 }
 
@@ -690,7 +709,7 @@ where
         TikvClient::new(channel)
     }
 
-    fn batch_call(&self, client: &TikvClient, addr: String) -> oneshot::Receiver<()> {
+    fn batch_call(&self, client: &TikvClient, addr: String) -> oneshot::Receiver<RaftCallRes> {
         let (batch_sink, batch_stream) = client.batch_raft().unwrap();
         let (tx, rx) = oneshot::channel();
         let mut call = RaftCall {
@@ -715,7 +734,7 @@ where
         rx
     }
 
-    fn call(&self, client: &TikvClient, addr: String) -> oneshot::Receiver<()> {
+    fn call(&self, client: &TikvClient, addr: String) -> oneshot::Receiver<RaftCallRes> {
         let (sink, stream) = client.raft().unwrap();
         let (tx, rx) = oneshot::channel();
         let mut call = RaftCall {
@@ -808,8 +827,8 @@ async fn start<S, R, E>(
         };
         let client = back_end.connect(&addr);
         let f = back_end.batch_call(&client, addr.clone());
-        let mut res = f.await;
-        if res == Ok(()) {
+        let mut res = f.await; // block here until the stream call is closed or aborted.
+        if res == Ok(RaftCallRes::UnImplemented) {
             // If the call is setup successfully, it will never finish. Returning `Ok(())` means the
             // batch_call is not supported, we are probably connect to an old version of TiKV. So we
             // need to fallback to use legacy API.
@@ -817,11 +836,11 @@ async fn start<S, R, E>(
             res = f.await;
         }
         match res {
-            Ok(()) => {
+            Ok(RaftCallRes::UnImplemented) => {
                 error!("connection fail"; "store_id" => back_end.store_id, "addr" => addr, "err" => "require fallback even with legacy API");
             }
-            Err(_) => {
-                error!("connection abort"; "store_id" => back_end.store_id, "addr" => addr);
+            Ok(RaftCallRes::Disconnected(ever_connected)) => {
+                error!("connection abort"; "store_id" => back_end.store_id, "addr" => addr, "ever_connected" => ever_connected);
                 if retry_times > 1 {
                     // Clears pending messages to avoid consuming high memory when one node is shutdown.
                     back_end.clear_pending_message("unreachable");
@@ -831,10 +850,21 @@ async fn start<S, R, E>(
                         .with_label_values(&["unreachable", &back_end.store_id.to_string()])
                         .inc_by(1);
                 }
-                back_end
-                    .builder
-                    .router
-                    .broadcast_unreachable(back_end.store_id);
+                
+                if retry_times == 1 || ever_connected { 
+                    back_end
+                        .builder
+                        .router
+                        .broadcast_unreachable(back_end.store_id);
+                }
+            }
+            Ok(RaftCallRes::Closed) | Err(_) => {
+                error!("connection close"; "store_id" => back_end.store_id, "addr" => addr);
+                let mut pool = pool.lock().unwrap();
+                if let Some(s) = pool.connections.remove(&(back_end.store_id, conn_id)) {
+                    s.set_conn_state(ConnState::Disconnected);
+                }
+                return;
             }
         }
     }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -371,7 +371,8 @@ pub mod test_router {
         fn send(
             &self,
             cmd: RaftCommand<RocksSnapshot>,
-        ) -> std::result::Result<(), crossbeam::channel::TrySendError<RaftCommand<RocksSnapshot>>> {
+        ) -> std::result::Result<(), crossbeam::channel::TrySendError<RaftCommand<RocksSnapshot>>>
+        {
             let _ = self.tx.send(Either::Left(PeerMsg::RaftCommand(cmd)));
             Ok(())
         }
@@ -397,8 +398,12 @@ pub mod test_router {
 
     impl RaftStoreRouter<RocksEngine> for TestRaftStoreRouter {
         fn send_raft_msg(&self, msg: RaftMessage) -> RaftStoreResult<()> {
-            let _ = self.tx.send(Either::Left(PeerMsg::RaftMessage(InspectedRaftMessage{
-                heap_size:0, msg})));
+            let _ = self
+                .tx
+                .send(Either::Left(PeerMsg::RaftMessage(InspectedRaftMessage {
+                    heap_size: 0,
+                    msg,
+                })));
             Ok(())
         }
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -337,7 +337,6 @@ pub mod test_router {
     use std::sync::mpsc::*;
 
     use engine_rocks::{RocksEngine, RocksSnapshot};
-    use engine_traits::{KvEngine, Snapshot};
     use kvproto::raft_serverpb::RaftMessage;
     use raftstore::{store::*, Result as RaftStoreResult};
 
@@ -345,13 +344,13 @@ pub mod test_router {
 
     #[derive(Clone)]
     pub struct TestRaftStoreRouter {
-        tx: Sender<usize>,
+        tx: Sender<Either<PeerMsg<RocksEngine>, StoreMsg<RocksEngine>>>,
         significant_msg_sender: Sender<SignificantMsg<RocksSnapshot>>,
     }
 
     impl TestRaftStoreRouter {
         pub fn new(
-            tx: Sender<usize>,
+            tx: Sender<Either<PeerMsg<RocksEngine>, StoreMsg<RocksEngine>>>,
             significant_msg_sender: Sender<SignificantMsg<RocksSnapshot>>,
         ) -> TestRaftStoreRouter {
             TestRaftStoreRouter {
@@ -362,25 +361,25 @@ pub mod test_router {
     }
 
     impl StoreRouter<RocksEngine> for TestRaftStoreRouter {
-        fn send(&self, _: StoreMsg<RocksEngine>) -> RaftStoreResult<()> {
-            let _ = self.tx.send(1);
+        fn send(&self, msg: StoreMsg<RocksEngine>) -> RaftStoreResult<()> {
+            let _ = self.tx.send(Either::Right(msg));
             Ok(())
         }
     }
 
-    impl<S: Snapshot> ProposalRouter<S> for TestRaftStoreRouter {
+    impl ProposalRouter<RocksSnapshot> for TestRaftStoreRouter {
         fn send(
             &self,
-            _: RaftCommand<S>,
-        ) -> std::result::Result<(), crossbeam::channel::TrySendError<RaftCommand<S>>> {
-            let _ = self.tx.send(1);
+            cmd: RaftCommand<RocksSnapshot>,
+        ) -> std::result::Result<(), crossbeam::channel::TrySendError<RaftCommand<RocksSnapshot>>> {
+            let _ = self.tx.send(Either::Left(PeerMsg::RaftCommand(cmd)));
             Ok(())
         }
     }
 
-    impl<EK: KvEngine> CasualRouter<EK> for TestRaftStoreRouter {
-        fn send(&self, _: u64, _: CasualMessage<EK>) -> RaftStoreResult<()> {
-            let _ = self.tx.send(1);
+    impl CasualRouter<RocksEngine> for TestRaftStoreRouter {
+        fn send(&self, _: u64, msg: CasualMessage<RocksEngine>) -> RaftStoreResult<()> {
+            let _ = self.tx.send(Either::Left(PeerMsg::CasualMessage(msg)));
             Ok(())
         }
     }
@@ -397,13 +396,14 @@ pub mod test_router {
     }
 
     impl RaftStoreRouter<RocksEngine> for TestRaftStoreRouter {
-        fn send_raft_msg(&self, _: RaftMessage) -> RaftStoreResult<()> {
-            let _ = self.tx.send(1);
+        fn send_raft_msg(&self, msg: RaftMessage) -> RaftStoreResult<()> {
+            let _ = self.tx.send(Either::Left(PeerMsg::RaftMessage(InspectedRaftMessage{
+                heap_size:0, msg})));
             Ok(())
         }
 
-        fn broadcast_normal(&self, _: impl FnMut() -> PeerMsg<RocksEngine>) {
-            let _ = self.tx.send(1);
+        fn broadcast_normal(&self, mut f: impl FnMut() -> PeerMsg<RocksEngine>) {
+            let _ = self.tx.send(Either::Left(f()));
         }
     }
 }

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -21,19 +21,18 @@ use kvproto::{
 };
 use raft::eraftpb::Entry;
 use raftstore::{
-    store::StoreMsg,
     errors::DiscardReason,
     router::{RaftStoreBlackHole, RaftStoreRouter},
+    store::StoreMsg,
 };
 use tikv::server::{
     self, load_statistics::ThreadLoadPool, resolve, resolve::Callback, Config, ConnectionBuilder,
     RaftClient, StoreAddrResolver, TestRaftStoreRouter,
 };
 use tikv_util::{
-    Either,
-    config::ReadableDuration,
-    config::VersionTrack,
+    config::{ReadableDuration, VersionTrack},
     worker::{Builder as WorkerBuilder, LazyWorker},
+    Either,
 };
 
 use super::*;
@@ -211,7 +210,6 @@ fn test_raft_client_reconnect() {
     drop(mock_server);
 }
 
-
 #[test]
 // Test raft_client reports store unreachable only once until being connected again
 fn test_raft_client_report_unreachable() {
@@ -228,7 +226,7 @@ fn test_raft_client_report_unreachable() {
 
     // server is disconnected
     mock_server.shutdown();
-    drop(mock_server); 
+    drop(mock_server);
 
     raft_client.send(RaftMessage::default()).unwrap();
     let msg = rx.recv_timeout(Duration::from_millis(50)).unwrap();
@@ -245,7 +243,7 @@ fn test_raft_client_report_unreachable() {
     let mut mock_server = create_mock_server_on(service, port);
 
     (0..50).for_each(|_| raft_client.send(RaftMessage::default()).unwrap());
-    raft_client.flush(); 
+    raft_client.flush();
     check_msg_count(500, &msg_count, 50);
 
     // server is disconnected

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -21,6 +21,7 @@ use kvproto::{
 };
 use raft::eraftpb::Entry;
 use raftstore::{
+    store::StoreMsg,
     errors::DiscardReason,
     router::{RaftStoreBlackHole, RaftStoreRouter},
 };
@@ -29,6 +30,8 @@ use tikv::server::{
     RaftClient, StoreAddrResolver, TestRaftStoreRouter,
 };
 use tikv_util::{
+    Either,
+    config::ReadableDuration,
     config::VersionTrack,
     worker::{Builder as WorkerBuilder, LazyWorker},
 };
@@ -60,6 +63,7 @@ where
 {
     let env = Arc::new(Environment::new(2));
     let cfg = Arc::new(VersionTrack::new(Config::default()));
+    cfg.update(|c| c.raft_client_backoff_step = ReadableDuration::millis(10));
     let security_mgr = Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap());
     let worker = LazyWorker::new("test-raftclient");
     let loads = Arc::new(ThreadLoadPool::with_threshold(1000));
@@ -188,13 +192,13 @@ fn test_raft_client_reconnect() {
     mock_server.shutdown();
     drop(mock_server);
 
-    rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    rx.recv_timeout(Duration::from_millis(50)).unwrap();
 
     for _ in 0..100 {
         raft_client.send(RaftMessage::default()).unwrap();
     }
     raft_client.flush();
-    rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    rx.recv_timeout(Duration::from_millis(50)).unwrap();
 
     // `send` should success after the mock server restarted.
     let service = MockKvForRaft::new(Arc::clone(&msg_count), batch_msg_count, true);
@@ -205,6 +209,56 @@ fn test_raft_client_reconnect() {
     check_msg_count(3000, &msg_count, 100);
 
     drop(mock_server);
+}
+
+
+#[test]
+// Test raft_client reports store unreachable only once until being connected again
+fn test_raft_client_report_unreachable() {
+    test_util::init_log_for_test();
+    let msg_count = Arc::new(AtomicUsize::new(0));
+    let batch_msg_count = Arc::new(AtomicUsize::new(0));
+    let service = MockKvForRaft::new(Arc::clone(&msg_count), Arc::clone(&batch_msg_count), true);
+    let (mut mock_server, port) = create_mock_server(service, 60100, 60200).unwrap();
+
+    let (tx, rx) = mpsc::channel();
+    let (significant_msg_sender, _significant_msg_receiver) = mpsc::channel();
+    let router = TestRaftStoreRouter::new(tx, significant_msg_sender);
+    let mut raft_client = get_raft_client(router, StaticResolver::new(port));
+
+    // server is disconnected
+    mock_server.shutdown();
+    drop(mock_server); 
+
+    raft_client.send(RaftMessage::default()).unwrap();
+    let msg = rx.recv_timeout(Duration::from_millis(50)).unwrap();
+    if let Either::Right(StoreMsg::StoreUnreachable { store_id }) = msg {
+        assert_eq!(store_id, 0);
+    } else {
+        panic!("expect StoreUnreachable");
+    }
+    // no more unreachable message is sent until it's connected again.
+    assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+
+    // restart the mock server.
+    let service = MockKvForRaft::new(Arc::clone(&msg_count), batch_msg_count, true);
+    let mut mock_server = create_mock_server_on(service, port);
+
+    (0..50).for_each(|_| raft_client.send(RaftMessage::default()).unwrap());
+    raft_client.flush(); 
+    check_msg_count(500, &msg_count, 50);
+
+    // server is disconnected
+    mock_server.take().unwrap().shutdown();
+
+    let msg = rx.recv_timeout(Duration::from_millis(50)).unwrap();
+    if let Either::Right(StoreMsg::StoreUnreachable { store_id }) = msg {
+        assert_eq!(store_id, 0);
+    } else {
+        panic!("expect StoreUnreachable");
+    }
+    // no more unreachable message is sent until it's connected again.
+    assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
 }
 
 #[test]


### PR DESCRIPTION
### What problem does this PR solve?

Add peer msg process duration to help investigate latency spike.

### What is changed and how it works?

- Add some peer msg process duration metrics
- Make `append log duration` only count the time of `handle_raft_ready`

### Related changes

- No

### Check List <!--REMOVE the items that are not applicable-->

- No code

### Release note <!-- bugfixes or new feature need a release note -->
- Add peer msg process duration metrics