### PR TITLE
test: fix tikv::server::service::diagnostics::test_load_info on Linux

### DIFF
--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -204,7 +204,7 @@ fn io_load_info(prev_io: HashMap<String, ioload::IoLoad>, collector: &mut Vec<Se
             Some(p) => p,
             None => continue,
         };
-        let infos = vec![
+        let mut infos = vec![
             ("read_io/s", rate(cur.read_io, prev.read_io)),
             ("read_merges/s", rate(cur.read_merges, prev.read_merges)),
             (
@@ -226,6 +226,26 @@ fn io_load_info(prev_io: HashMap<String, ioload::IoLoad>, collector: &mut Vec<Se
                 rate(cur.time_in_queue, prev.time_in_queue),
             ),
         ];
+        infos.extend(
+            [
+                ("discard_io/s", cur.discard_io, prev.discard_io),
+                ("discard_merged/s", cur.discard_merged, prev.discard_merged),
+                (
+                    "discard_sectors/s",
+                    cur.discard_sectors,
+                    prev.discard_sectors,
+                ),
+                ("discard_ticks/s", cur.discard_ticks, prev.discard_ticks),
+            ]
+            .iter()
+            .filter_map(|(name, cur_stat, prev_stat)| {
+                if let (Some(cur_stat), Some(prev_stat)) = (cur_stat, prev_stat) {
+                    Some((*name, rate(*cur_stat, *prev_stat)))
+                } else {
+                    None
+                }
+            }),
+        );
         let mut pairs = vec![];
         for info in infos.into_iter() {
             let mut pair = ServerInfoPair::default();
@@ -505,6 +525,7 @@ mod tests {
     fn test_load_info() {
         let prev_cpu = cpu_time_snapshot();
         let mut system = sysinfo::System::new();
+        system.refresh_networks_list();
         system.refresh_all();
         let prev_nic = system
             .get_networks()
@@ -514,9 +535,9 @@ mod tests {
         let prev_io = ioload::IoLoad::snapshot();
         let mut collector = vec![];
         load_info((prev_cpu, prev_nic, prev_io), &mut collector);
-        #[cfg(linux)]
+        #[cfg(target_os = "linux")]
         let tps = vec!["cpu", "memory", "net", "io"];
-        #[cfg(not(linux))]
+        #[cfg(not(target_os = "linux"))]
         let tps = vec!["cpu", "memory"];
         for tp in tps.into_iter() {
             assert!(


### PR DESCRIPTION
### What is changed and how it works?

`tikv::server::service::diagnostics::test_load_info` previously use an incorrect `#[cfg()]`. As a result, io and net stats are not collected on Linux. But actually the test has a problem that it forgot to refresh network list. This PR fixes it.

Collecting IO statistics fails on Linux 4.19+ because some new stats are added. This PR also make it work for Linux 4.19+.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit tes

### Release note <!-- bugfixes or new feature need a release note -->

Fix network and IO statistics on Linux 4.19+.