### PR TITLE
copr: remove `replace` from ChunkedVec interface

### DIFF
--- a/components/tidb_query_datatype/src/codec/batch/lazy_column.rs
+++ b/components/tidb_query_datatype/src/codec/batch/lazy_column.rs
@@ -171,11 +171,19 @@ impl LazyBatchColumn {
         match_template_evaluable! {
             TT, match &mut decoded_column {
                 VectorValue::TT(vec) => {
+                    let mut decode_bitmap = Vec::with_capacity(raw_vec_len);
                     for _ in 0..raw_vec_len {
-                        vec.push(None);
+                        decode_bitmap.push(false);
                     }
                     for row_index in logical_rows {
-                        vec.replace(*row_index, raw_vec[*row_index].decode(field_type, ctx)?);
+                        decode_bitmap[*row_index] = true;
+                    }
+                    for i in 0..raw_vec_len {
+                        if decode_bitmap[i] {
+                            vec.push(raw_vec[i].decode(field_type, ctx)?);
+                        } else {
+                            vec.push(None);
+                        }
                     }
                 }
             }

--- a/components/tidb_query_datatype/src/codec/data_type/not_chunked_vec.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/not_chunked_vec.rs
@@ -53,10 +53,6 @@ impl<T: Sized + Clone> NotChunkedVec<T> {
         self.data.push(value)
     }
 
-    pub fn replace(&mut self, idx: usize, value: Option<T>) {
-        self.data[idx] = value
-    }
-
     pub fn len(&self) -> usize {
         self.data.len()
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

As the proposed `ChunkedVec` only support append, we cannot implement replace on `ChunkedVec` interface.

### What is changed and how it works?


Proposal: [RFC: Using chunk format in coprocessor framework](https://github.com/tikv/rfcs/pull/43/)

Related Issue: #7724

What's Changed:

* Remove `replace` from `ChunkedVec` interface.
* Pre-build bitmap before decoding column.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test