### PR TITLE
backup,config: set backup thread pool size via config instead of gRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
 name = "backup"
 version = "0.0.1"
 dependencies = [
+ "configuration",
  "crc64fast",
  "engine_rocks",
  "engine_traits",

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -711,6 +711,11 @@ impl TiKVServer {
             engines.engine.clone(),
             self.region_info_accessor.clone(),
             engines.engines.kv.as_inner().clone(),
+            self.config.backup.clone(),
+        );
+        self.cfg_controller.as_mut().unwrap().register(
+            tikv::config::Module::Backup,
+            Box::new(backup_endpoint.get_config_manager()),
         );
         let backup_timer = backup_endpoint.new_timer();
         backup_worker

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -41,6 +41,7 @@ mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
 
 [dependencies]
+configuration = { path = "../configuration" }
 crc64fast = "0.1"
 engine_rocks = { path = "../engine_rocks" }
 engine_traits = { path = "../engine_traits" }

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -1,13 +1,13 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::cell::RefCell;
-use std::cmp;
 use std::f64::INFINITY;
 use std::fmt;
 use std::sync::atomic::*;
 use std::sync::*;
 use std::time::*;
 
+use configuration::Configuration;
 use engine_rocks::raw::DB;
 use engine_traits::{name_to_cf, CfName, IterOptions, DATA_KEY_PREFIX_LEN};
 use external_storage::*;
@@ -18,6 +18,7 @@ use kvproto::metapb::*;
 use raft::StateRole;
 use raftstore::coprocessor::RegionInfoProvider;
 use raftstore::store::util::find_peer;
+use tikv::config::BackupConfig;
 use tikv::storage::kv::{Engine, ScanMode, Snapshot};
 use tikv::storage::txn::{EntryBatch, SnapshotStore, TxnEntryScanner, TxnEntryStore};
 use tikv::storage::Statistics;
@@ -52,7 +53,6 @@ struct Request {
 /// Backup Task.
 pub struct Task {
     request: Request,
-    concurrency: u32,
     pub(crate) resp: UnboundedSender<BackupResponse>,
 }
 
@@ -113,7 +113,6 @@ impl Task {
                 is_raw_kv: req.get_is_raw_kv(),
                 cf,
             },
-            concurrency: req.get_concurrency(),
             resp,
         };
         Ok((task, cancel))
@@ -319,6 +318,23 @@ impl BackupRange {
 
 type BackupRes = (Vec<File>, Statistics);
 
+#[derive(Clone)]
+pub struct ConfigManager(Arc<RwLock<BackupConfig>>);
+
+impl configuration::ConfigManager for ConfigManager {
+    fn dispatch(&mut self, change: configuration::ConfigChange) -> configuration::Result<()> {
+        self.0.write().unwrap().update(change);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl ConfigManager {
+    fn set_num_threads(&self, num_threads: usize) {
+        self.0.write().unwrap().num_threads = num_threads;
+    }
+}
+
 /// The endpoint of backup.
 ///
 /// It coordinates backup tasks and dispatches them to different workers.
@@ -327,6 +343,7 @@ pub struct Endpoint<E: Engine, R: RegionInfoProvider> {
     pool: RefCell<ControlThreadPool>,
     pool_idle_threshold: u64,
     db: Arc<DB>,
+    config_manager: ConfigManager,
 
     pub(crate) engine: E,
     pub(crate) region_info: R,
@@ -494,8 +511,45 @@ impl ControlThreadPool {
     }
 }
 
+#[test]
+fn test_control_thread_pool_adjust_keep_tasks() {
+    use std::thread::sleep;
+
+    let counter = Arc::new(AtomicU32::new(0));
+    let mut pool = ControlThreadPool::new();
+    pool.adjust_with(3);
+
+    for i in 0..8 {
+        let ctr = counter.clone();
+        pool.spawn(move || {
+            sleep(Duration::from_millis(100));
+            ctr.fetch_or(1 << i, Ordering::SeqCst);
+        });
+    }
+
+    sleep(Duration::from_millis(150));
+    pool.adjust_with(4);
+
+    for i in 8..16 {
+        let ctr = counter.clone();
+        pool.spawn(move || {
+            sleep(Duration::from_millis(100));
+            ctr.fetch_or(1 << i, Ordering::SeqCst);
+        });
+    }
+
+    sleep(Duration::from_millis(250));
+    assert_eq!(counter.load(Ordering::SeqCst), 0xffff);
+}
+
 impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
-    pub fn new(store_id: u64, engine: E, region_info: R, db: Arc<DB>) -> Endpoint<E, R> {
+    pub fn new(
+        store_id: u64,
+        engine: E,
+        region_info: R,
+        db: Arc<DB>,
+        config: BackupConfig,
+    ) -> Endpoint<E, R> {
         Endpoint {
             store_id,
             engine,
@@ -503,6 +557,7 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
             pool: RefCell::new(ControlThreadPool::new()),
             pool_idle_threshold: IDLE_THREADPOOL_DURATION,
             db,
+            config_manager: ConfigManager(Arc::new(RwLock::new(config))),
         }
     }
 
@@ -510,6 +565,10 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
         let mut timer = Timer::new(1);
         timer.add_task(Duration::from_millis(self.pool_idle_threshold), ());
         timer
+    }
+
+    pub fn get_config_manager(&self) -> ConfigManager {
+        self.config_manager.clone()
     }
 
     fn spawn_backup_worker(
@@ -586,11 +645,7 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
     }
 
     pub fn handle_backup_task(&self, task: Task) {
-        let Task {
-            request,
-            resp,
-            concurrency,
-        } = task;
+        let Task { request, resp } = task;
         let start = Instant::now();
         let start_key = if request.start_key.is_empty() {
             None
@@ -621,7 +676,7 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
             request.is_raw_kv,
             request.cf,
         )));
-        let concurrency = cmp::max(1, concurrency) as usize;
+        let concurrency = self.config_manager.0.read().unwrap().num_threads;
         self.pool.borrow_mut().adjust_with(concurrency);
         for _ in 0..concurrency {
             self.spawn_backup_worker(prs.clone(), request.clone(), res_tx.clone());
@@ -846,7 +901,13 @@ pub mod tests {
         let db = rocks.get_rocksdb();
         (
             temp,
-            Endpoint::new(1, rocks, MockRegionInfoProvider::new(), db),
+            Endpoint::new(
+                1,
+                rocks,
+                MockRegionInfoProvider::new(),
+                db,
+                BackupConfig { num_threads: 4 },
+            ),
         )
     }
 
@@ -945,7 +1006,6 @@ pub mod tests {
                         cf: engine_traits::CF_DEFAULT,
                     },
                     resp: tx,
-                    concurrency: 4,
                 };
                 endpoint.handle_backup_task(task);
                 let resps: Vec<_> = block_on(rx.collect());
@@ -1037,7 +1097,6 @@ pub mod tests {
             req.set_end_key(vec![b'5']);
             req.set_start_version(0);
             req.set_end_version(ts.into_inner());
-            req.set_concurrency(4);
             let (tx, rx) = unbounded();
             // Empty path should return an error.
             Task::new(req.clone(), tx.clone()).unwrap_err();
@@ -1238,25 +1297,19 @@ pub mod tests {
 
         let (tx, _) = unbounded();
 
-        // at lease spwan one thread
-        req.set_concurrency(0);
-        let (task, _) = Task::new(req.clone(), tx.clone()).unwrap();
-        endpoint.handle_backup_task(task);
-        assert!(endpoint.pool.borrow().size == 1);
-
         // expand thread pool is needed
-        req.set_concurrency(15);
+        endpoint.get_config_manager().set_num_threads(15);
         let (task, _) = Task::new(req.clone(), tx.clone()).unwrap();
         endpoint.handle_backup_task(task);
         assert!(endpoint.pool.borrow().size == 15);
 
         // shrink thread pool only if there are too many idle threads
-        req.set_concurrency(10);
+        endpoint.get_config_manager().set_num_threads(10);
         let (task, _) = Task::new(req.clone(), tx.clone()).unwrap();
         endpoint.handle_backup_task(task);
         assert!(endpoint.pool.borrow().size == 15);
 
-        req.set_concurrency(3);
+        endpoint.get_config_manager().set_num_threads(3);
         let (task, _) = Task::new(req, tx).unwrap();
         endpoint.handle_backup_task(task);
         assert!(endpoint.pool.borrow().size == 3);
@@ -1294,8 +1347,13 @@ pub mod tests {
         req.set_end_key(vec![]);
         req.set_start_version(1);
         req.set_end_version(1);
-        req.set_concurrency(10);
         req.set_storage_backend(make_noop_backend());
+
+        endpoint
+            .lock()
+            .unwrap()
+            .get_config_manager()
+            .set_num_threads(10);
 
         let (tx, resp_rx) = unbounded();
         let (task, _) = Task::new(req, tx).unwrap();

--- a/components/backup/tests/integrations/test_backup.rs
+++ b/components/backup/tests/integrations/test_backup.rs
@@ -25,6 +25,7 @@ use tempfile::Builder;
 use test_raftstore::*;
 use tidb_query_common::storage::scanner::{RangesScanner, RangesScannerOptions};
 use tidb_query_common::storage::{IntervalRange, Range};
+use tikv::config::BackupConfig;
 use tikv::coprocessor::checksum_crc64_xor;
 use tikv::coprocessor::dag::TiKVStorage;
 use tikv::storage::kv::Engine;
@@ -81,6 +82,7 @@ impl TestSuite {
                 sim.storages[&id].clone(),
                 sim.region_info_accessors[&id].clone(),
                 engines.kv.as_inner().clone(),
+                BackupConfig { num_threads: 4 },
             );
             let mut worker = Worker::new(format!("backup-{}", id));
             worker.start(backup_endpoint).unwrap();

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -849,7 +849,7 @@
 
 [backup]
 ## Number of threads to perform backup tasks.
-## The default value is set to CPU_NUM * 0.75.
+## The default value is set to min(CPU_NUM * 0.75, 32).
 # num-threads = 24
 
 [pessimistic-txn]

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -847,6 +847,11 @@
 ## Stream channel window size, stream will be blocked on channel full.
 # stream-channel-window = 128
 
+[backup]
+## Number of threads to perform backup tasks.
+## The default value is set to CPU_NUM * 0.75.
+# num-threads = 24
+
 [pessimistic-txn]
 ## Enable pessimistic transaction
 # enabled = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -1980,7 +1980,7 @@ impl Default for BackupConfig {
         let cpu_num = SysQuota::new().cpu_cores_quota();
         Self {
             // use at most 75% of vCPU by default
-            num_threads: (cpu_num - cpu_num / 4).max(1),
+            num_threads: (cpu_num - cpu_num / 4).clamp(1, 32),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1962,6 +1962,32 @@ mod readpool_tests {
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Configuration)]
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
+pub struct BackupConfig {
+    pub num_threads: usize,
+}
+
+impl BackupConfig {
+    pub fn validate(&self) -> Result<(), Box<dyn Error>> {
+        if self.num_threads == 0 {
+            return Err("backup.num_threads cannot be 0".into());
+        }
+        Ok(())
+    }
+}
+
+impl Default for BackupConfig {
+    fn default() -> Self {
+        let cpu_num = SysQuota::new().cpu_cores_quota();
+        Self {
+            // use at most 75% of vCPU by default
+            num_threads: (cpu_num - cpu_num / 4).max(1),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Configuration)]
+#[serde(default)]
+#[serde(rename_all = "kebab-case")]
 pub struct TiKvConfig {
     #[doc(hidden)]
     #[serde(skip_serializing)]
@@ -2028,6 +2054,9 @@ pub struct TiKvConfig {
     pub import: ImportConfig,
 
     #[config(submodule)]
+    pub backup: BackupConfig,
+
+    #[config(submodule)]
     pub pessimistic_txn: PessimisticTxnConfig,
 
     #[config(submodule)]
@@ -2060,6 +2089,7 @@ impl Default for TiKvConfig {
             storage: StorageConfig::default(),
             security: SecurityConfig::default(),
             import: ImportConfig::default(),
+            backup: BackupConfig::default(),
             pessimistic_txn: PessimisticTxnConfig::default(),
             gc: GcConfig::default(),
             split: SplitConfig::default(),
@@ -2142,6 +2172,7 @@ impl TiKvConfig {
         self.coprocessor.validate()?;
         self.security.validate()?;
         self.import.validate()?;
+        self.backup.validate()?;
         self.pessimistic_txn.validate()?;
         self.gc.validate()?;
         Ok(())
@@ -2537,6 +2568,7 @@ pub enum Module {
     Security,
     Encryption,
     Import,
+    Backup,
     PessimisticTxn,
     Gc,
     Split,
@@ -2558,6 +2590,7 @@ impl From<&str> for Module {
             "storage" => Module::Storage,
             "security" => Module::Security,
             "import" => Module::Import,
+            "backup" => Module::Backup,
             "pessimistic_txn" => Module::PessimisticTxn,
             "gc" => Module::Gc,
             n => Module::Unknown(n.to_owned()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 #![feature(box_patterns)]
 #![feature(shrink_to)]
 #![feature(drain_filter)]
+#![feature(clamp)]
 
 #[macro_use(fail_point)]
 extern crate fail;

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -631,6 +631,7 @@ fn test_serde_custom_tikv_config() {
             previous_master_key: MasterKeyConfig::Plaintext,
         },
     };
+    value.backup = BackupConfig { num_threads: 456 };
     value.import = ImportConfig {
         num_threads: 123,
         stream_channel_window: 123,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -552,6 +552,9 @@ path = "/master/key/path"
 [security.encryption.previous-master-key]
 type = "plaintext"
 
+[backup]
+num-threads = 456
+
 [import]
 num-threads = 123
 stream-channel-window = 123


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close pingcap/br#394, close #8076. 

Problem Summary:

### What is changed and how it works?

This is the companion PR of pingcap/br#396. 

In #5553, the `backup` component gained ability to an adjustable thread pool size. The size is provided via the incoming gRPC request. Given [how the ThreadPool is implemented in TiKV](https://github.com/tikv/tikv/blob/b45e052df8fb5d66aa8b3a77b5c992ddbfbb79df/components/tikv_util/src/threadpool.rs#L204-L219), a user can easily (accidentally) DoS all TiKV servers by setting the thread pool size to a huge number like 2<sup>32</sup>-1. 

Furthermore, when we provide the thread pool size through gRPC, the backup client (BR) must determine the suitable concurrency number in some ad-hoc way. 

This PR solves both issue by moving the thread pool size back as a TiKV config:

```toml
[backup]
num-threads = 24
```

The default value is set to (0.75 × Number of CPUs) to better utilize the available resources. The value can still be dynamically configured, but given this more practical default value it should be much less needed.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

* A new configuration `backup.num-threads` is introduced to control the backup thread pool size.