### PR TITLE
raftstore: Replace uses of raw_util::new_engine with util::new_engine

### DIFF
--- a/components/raftstore/src/coprocessor/split_check/table.rs
+++ b/components/raftstore/src/coprocessor/split_check/table.rs
@@ -226,17 +226,14 @@ fn is_same_table(left_key: &[u8], right_key: &[u8]) -> bool {
 mod tests {
     use std::io::Write;
     use std::sync::mpsc;
-    use std::sync::Arc;
 
     use kvproto::metapb::Peer;
     use kvproto::pdpb::CheckPolicy;
     use tempfile::Builder;
 
     use crate::store::{CasualMessage, SplitCheckRunner, SplitCheckTask};
-    use engine_rocks::raw::Writable;
-    use engine_rocks::raw_util::new_engine;
-    use engine_rocks::Compat;
-    use engine_traits::ALL_CFS;
+    use engine_rocks::util::new_engine;
+    use engine_traits::{ALL_CFS, SyncMutable};
     use tidb_query_datatype::codec::table::{TABLE_PREFIX, TABLE_PREFIX_KEY_LEN};
     use tikv_util::codec::number::NumberEncoder;
     use tikv_util::config::ReadableSize;
@@ -262,8 +259,7 @@ mod tests {
             .tempdir()
             .unwrap();
         let engine =
-            Arc::new(new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap());
-        let write_cf = engine.cf_handle(CF_WRITE).unwrap();
+            new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
 
         let mut region = Region::default();
         region.set_id(1);
@@ -277,7 +273,7 @@ mod tests {
             let mut key = gen_table_prefix(i);
             key.extend_from_slice(padding);
             let k = keys::data_key(Key::from_raw(&key).as_encoded());
-            engine.put_cf(write_cf, &k, &k).unwrap();
+            engine.put_cf(CF_WRITE, &k, &k).unwrap();
             data_keys.push(k)
         }
 
@@ -294,7 +290,7 @@ mod tests {
                         .map(|id| Key::from_raw(&gen_table_prefix(id)).into_encoded())
                         .unwrap_or_else(Vec::new),
                 );
-                assert_eq!(last_key_of_region(engine.c(), &region).unwrap(), want);
+                assert_eq!(last_key_of_region(&engine, &region).unwrap(), want);
             }
         };
 
@@ -317,8 +313,7 @@ mod tests {
             .tempdir()
             .unwrap();
         let engine =
-            Arc::new(new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap());
-        let write_cf = engine.cf_handle(CF_WRITE).unwrap();
+            new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
 
         let mut region = Region::default();
         region.set_id(1);
@@ -341,7 +336,7 @@ mod tests {
         cfg.region_split_keys = 1000000000;
         // Try to ignore the ApproximateRegionSize
         let coprocessor = CoprocessorHost::new(stx);
-        let mut runnable = SplitCheckRunner::new(engine.c().clone(), tx, coprocessor, cfg);
+        let mut runnable = SplitCheckRunner::new(engine.clone(), tx, coprocessor, cfg);
 
         type Case = (Option<Vec<u8>>, Option<Vec<u8>>, Option<i64>);
         let mut check_cases = |cases: Vec<Case>| {
@@ -401,7 +396,7 @@ mod tests {
             let mut key = gen_table_prefix(i);
             key.extend_from_slice(padding);
             let s = keys::data_key(Key::from_raw(&key).as_encoded());
-            engine.put_cf(write_cf, &s, &s).unwrap();
+            engine.put_cf(CF_WRITE, &s, &s).unwrap();
         }
 
         check_cases(vec![
@@ -428,7 +423,7 @@ mod tests {
             let mut key = gen_table_prefix(3);
             key.extend_from_slice(format!("{:?}{}", padding, i).as_bytes());
             let s = keys::data_key(Key::from_raw(&key).as_encoded());
-            engine.put_cf(write_cf, &s, &s).unwrap();
+            engine.put_cf(CF_WRITE, &s, &s).unwrap();
         }
 
         check_cases(vec![
@@ -449,10 +444,10 @@ mod tests {
             // m is less than t and is the prefix of meta keys.
             let key = format!("m{:?}{}", padding, i);
             let s = keys::data_key(Key::from_raw(key.as_bytes()).as_encoded());
-            engine.put_cf(write_cf, &s, &s).unwrap();
+            engine.put_cf(CF_WRITE, &s, &s).unwrap();
             let key = format!("u{:?}{}", padding, i);
             let s = keys::data_key(Key::from_raw(key.as_bytes()).as_encoded());
-            engine.put_cf(write_cf, &s, &s).unwrap();
+            engine.put_cf(CF_WRITE, &s, &s).unwrap();
         }
 
         check_cases(vec![

--- a/components/raftstore/src/coprocessor/split_check/table.rs
+++ b/components/raftstore/src/coprocessor/split_check/table.rs
@@ -233,7 +233,7 @@ mod tests {
 
     use crate::store::{CasualMessage, SplitCheckRunner, SplitCheckTask};
     use engine_rocks::util::new_engine;
-    use engine_traits::{ALL_CFS, SyncMutable};
+    use engine_traits::{SyncMutable, ALL_CFS};
     use tidb_query_datatype::codec::table::{TABLE_PREFIX, TABLE_PREFIX_KEY_LEN};
     use tikv_util::codec::number::NumberEncoder;
     use tikv_util::config::ReadableSize;
@@ -258,8 +258,7 @@ mod tests {
             .prefix("test_last_key_of_region")
             .tempdir()
             .unwrap();
-        let engine =
-            new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
+        let engine = new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
 
         let mut region = Region::default();
         region.set_id(1);
@@ -312,8 +311,7 @@ mod tests {
             .prefix("test_table_check_observer")
             .tempdir()
             .unwrap();
-        let engine =
-            new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
+        let engine = new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
 
         let mut region = Region::default();
         region.set_id(1);

--- a/components/raftstore/src/store/bootstrap.rs
+++ b/components/raftstore/src/store/bootstrap.rs
@@ -116,11 +116,9 @@ pub fn clear_prepare_bootstrap_key(engines: &KvEngines<RocksEngine, RocksEngine>
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
     use tempfile::Builder;
 
     use super::*;
-    use engine_rocks::Compat;
     use engine_traits::KvEngines;
     use engine_traits::{Peekable, CF_DEFAULT};
 
@@ -128,28 +126,26 @@ mod tests {
     fn test_bootstrap() {
         let path = Builder::new().prefix("var").tempdir().unwrap();
         let raft_path = path.path().join("raft");
-        let kv_engine = Arc::new(
-            engine_rocks::raw_util::new_engine(
+        let kv_engine =
+            engine_rocks::util::new_engine(
                 path.path().to_str().unwrap(),
                 None,
                 &[CF_DEFAULT, CF_RAFT],
                 None,
             )
-            .unwrap(),
-        );
-        let raft_engine = Arc::new(
-            engine_rocks::raw_util::new_engine(
+            .unwrap();
+        let raft_engine =
+            engine_rocks::util::new_engine(
                 raft_path.to_str().unwrap(),
                 None,
                 &[CF_DEFAULT],
                 None,
             )
-            .unwrap(),
-        );
+            .unwrap();
         let shared_block_cache = false;
         let engines = KvEngines::new(
-            kv_engine.c().clone(),
-            raft_engine.c().clone(),
+            kv_engine.clone(),
+            raft_engine.clone(),
             shared_block_cache,
         );
         let region = initial_region(1, 1, 1);
@@ -159,22 +155,18 @@ mod tests {
 
         assert!(prepare_bootstrap_cluster(&engines, &region).is_ok());
         assert!(kv_engine
-            .c()
             .get_value(keys::PREPARE_BOOTSTRAP_KEY)
             .unwrap()
             .is_some());
         assert!(kv_engine
-            .c()
             .get_value_cf(CF_RAFT, &keys::region_state_key(1))
             .unwrap()
             .is_some());
         assert!(kv_engine
-            .c()
             .get_value_cf(CF_RAFT, &keys::apply_state_key(1))
             .unwrap()
             .is_some());
         assert!(raft_engine
-            .c()
             .get_value(&keys::raft_state_key(1))
             .unwrap()
             .is_some());
@@ -182,14 +174,14 @@ mod tests {
         assert!(clear_prepare_bootstrap_key(&engines).is_ok());
         assert!(clear_prepare_bootstrap_cluster(&engines, 1).is_ok());
         assert!(is_range_empty(
-            kv_engine.c(),
+            &kv_engine,
             CF_RAFT,
             &keys::region_meta_prefix(1),
             &keys::region_meta_prefix(2)
         )
         .unwrap());
         assert!(is_range_empty(
-            raft_engine.c(),
+            &raft_engine,
             CF_DEFAULT,
             &keys::region_raft_prefix(1),
             &keys::region_raft_prefix(2)

--- a/components/raftstore/src/store/bootstrap.rs
+++ b/components/raftstore/src/store/bootstrap.rs
@@ -126,28 +126,18 @@ mod tests {
     fn test_bootstrap() {
         let path = Builder::new().prefix("var").tempdir().unwrap();
         let raft_path = path.path().join("raft");
-        let kv_engine =
-            engine_rocks::util::new_engine(
-                path.path().to_str().unwrap(),
-                None,
-                &[CF_DEFAULT, CF_RAFT],
-                None,
-            )
-            .unwrap();
+        let kv_engine = engine_rocks::util::new_engine(
+            path.path().to_str().unwrap(),
+            None,
+            &[CF_DEFAULT, CF_RAFT],
+            None,
+        )
+        .unwrap();
         let raft_engine =
-            engine_rocks::util::new_engine(
-                raft_path.to_str().unwrap(),
-                None,
-                &[CF_DEFAULT],
-                None,
-            )
-            .unwrap();
+            engine_rocks::util::new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None)
+                .unwrap();
         let shared_block_cache = false;
-        let engines = KvEngines::new(
-            kv_engine.clone(),
-            raft_engine.clone(),
-            shared_block_cache,
-        );
+        let engines = KvEngines::new(kv_engine.clone(), raft_engine.clone(), shared_block_cache);
         let region = initial_region(1, 1, 1);
 
         assert!(bootstrap_store(&engines, 1, 1).is_ok());

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1724,11 +1724,9 @@ mod tests {
         sched: Scheduler<RegionTask<RocksSnapshot>>,
         path: &TempDir,
     ) -> PeerStorage<RocksEngine, RocksEngine> {
-        let kv_db =
-            new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
+        let kv_db = new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
         let raft_path = path.path().join(Path::new("raft"));
-        let raft_db =
-            new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None).unwrap();
+        let raft_db = new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None).unwrap();
         let shared_block_cache = false;
         let engines = KvEngines::new(kv_db, raft_db, shared_block_cache);
         bootstrap_store(&engines, 1, 1).unwrap();
@@ -2555,8 +2553,7 @@ mod tests {
         let sched = worker.scheduler();
         let kv_db = new_engine(td.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
         let raft_path = td.path().join(Path::new("raft"));
-        let raft_db =
-            new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None).unwrap();
+        let raft_db = new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None).unwrap();
         let shared_block_cache = false;
         let engines = KvEngines::new(kv_db, raft_db, shared_block_cache);
         bootstrap_store(&engines, 1, 1).unwrap();

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1700,8 +1700,8 @@ mod tests {
     use crate::store::worker::RegionRunner;
     use crate::store::worker::RegionTask;
     use crate::store::{bootstrap_store, initial_region, prepare_bootstrap_cluster};
-    use engine_rocks::raw_util::new_engine;
-    use engine_rocks::{Compat, RocksEngine, RocksSnapshot, RocksWriteBatch};
+    use engine_rocks::util::new_engine;
+    use engine_rocks::{RocksEngine, RocksSnapshot, RocksWriteBatch};
     use engine_traits::KvEngines;
     use engine_traits::{Iterable, SyncMutable, WriteBatchExt};
     use engine_traits::{ALL_CFS, CF_DEFAULT};
@@ -1725,12 +1725,12 @@ mod tests {
         path: &TempDir,
     ) -> PeerStorage<RocksEngine, RocksEngine> {
         let kv_db =
-            Arc::new(new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap());
+            new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
         let raft_path = path.path().join(Path::new("raft"));
         let raft_db =
-            Arc::new(new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None).unwrap());
+            new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None).unwrap();
         let shared_block_cache = false;
-        let engines = KvEngines::new(kv_db.c().clone(), raft_db.c().clone(), shared_block_cache);
+        let engines = KvEngines::new(kv_db, raft_db, shared_block_cache);
         bootstrap_store(&engines, 1, 1).unwrap();
 
         let region = initial_region(1, 1, 1);
@@ -2553,12 +2553,12 @@ mod tests {
         let td = Builder::new().prefix("tikv-store-test").tempdir().unwrap();
         let worker = Worker::new("snap-manager");
         let sched = worker.scheduler();
-        let kv_db = Arc::new(new_engine(td.path().to_str().unwrap(), None, ALL_CFS, None).unwrap());
+        let kv_db = new_engine(td.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
         let raft_path = td.path().join(Path::new("raft"));
         let raft_db =
-            Arc::new(new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None).unwrap());
+            new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None).unwrap();
         let shared_block_cache = false;
-        let engines = KvEngines::new(kv_db.c().clone(), raft_db.c().clone(), shared_block_cache);
+        let engines = KvEngines::new(kv_db, raft_db, shared_block_cache);
         bootstrap_store(&engines, 1, 1).unwrap();
 
         let region = initial_region(1, 1, 1);

--- a/components/raftstore/src/store/worker/consistency_check.rs
+++ b/components/raftstore/src/store/worker/consistency_check.rs
@@ -149,9 +149,9 @@ mod tests {
     use byteorder::{BigEndian, WriteBytesExt};
     use engine_rocks::util::new_engine;
     use engine_rocks::RocksSnapshot;
-    use engine_traits::{CF_DEFAULT, CF_RAFT, SyncMutable, KvEngine};
+    use engine_traits::{KvEngine, SyncMutable, CF_DEFAULT, CF_RAFT};
     use kvproto::metapb::*;
-    use std::sync::{mpsc};
+    use std::sync::mpsc;
     use std::time::Duration;
     use tempfile::Builder;
     use tikv_util::worker::Runnable;

--- a/components/raftstore/src/store/worker/consistency_check.rs
+++ b/components/raftstore/src/store/worker/consistency_check.rs
@@ -147,12 +147,11 @@ where
 mod tests {
     use super::*;
     use byteorder::{BigEndian, WriteBytesExt};
-    use engine_rocks::raw::Writable;
-    use engine_rocks::raw_util::new_engine;
+    use engine_rocks::util::new_engine;
     use engine_rocks::RocksSnapshot;
-    use engine_traits::{CF_DEFAULT, CF_RAFT};
+    use engine_traits::{CF_DEFAULT, CF_RAFT, SyncMutable, KvEngine};
     use kvproto::metapb::*;
-    use std::sync::{mpsc, Arc};
+    use std::sync::{mpsc};
     use std::time::Duration;
     use tempfile::Builder;
     use tikv_util::worker::Runnable;
@@ -167,7 +166,6 @@ mod tests {
             None,
         )
         .unwrap();
-        let db = Arc::new(db);
 
         let mut region = Region::default();
         region.mut_peers().push(Peer::default());
@@ -190,7 +188,7 @@ mod tests {
         runner.run(Task::<RocksSnapshot>::ComputeHash {
             index: 10,
             region: region.clone(),
-            snap: RocksSnapshot::new(Arc::clone(&db)),
+            snap: db.snapshot(),
         });
         let mut checksum_bytes = vec![];
         checksum_bytes.write_u32::<BigEndian>(sum).unwrap();

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -126,10 +126,9 @@ impl<E: KvEngine> Runnable<Task<E>> for Runner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use engine_rocks::raw_util::new_engine;
-    use engine_rocks::RocksEngine;
+    use engine_rocks::util::new_engine;
     use engine_traits::{KvEngine, WriteBatchExt, CF_DEFAULT};
-    use std::sync::{mpsc, Arc};
+    use std::sync::{mpsc};
     use std::time::Duration;
     use tempfile::Builder;
 
@@ -137,8 +136,6 @@ mod tests {
     fn test_gc_raft_log() {
         let path = Builder::new().prefix("gc-raft-log-test").tempdir().unwrap();
         let raft_db = new_engine(path.path().to_str().unwrap(), None, &[CF_DEFAULT], None).unwrap();
-        let raft_db = Arc::new(raft_db);
-        let raft_db = RocksEngine::from_db(raft_db);
 
         let (tx, rx) = mpsc::channel();
         let mut runner = Runner::new(Some(tx));

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -128,7 +128,7 @@ mod tests {
     use super::*;
     use engine_rocks::util::new_engine;
     use engine_traits::{KvEngine, WriteBatchExt, CF_DEFAULT};
-    use std::sync::{mpsc};
+    use std::sync::mpsc;
     use std::time::Duration;
     use tempfile::Builder;
 

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -576,9 +576,8 @@ mod tests {
         Receiver<RaftCommand<RocksSnapshot>>,
     ) {
         let path = Builder::new().prefix(path).tempdir().unwrap();
-        let db =
-            engine_rocks::util::new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None)
-                .unwrap();
+        let db = engine_rocks::util::new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None)
+            .unwrap();
         let (ch, rx) = sync_channel(1);
         let reader = LocalReader {
             store_meta,

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -577,14 +577,14 @@ mod tests {
     ) {
         let path = Builder::new().prefix(path).tempdir().unwrap();
         let db =
-            engine_rocks::raw_util::new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None)
+            engine_rocks::util::new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None)
                 .unwrap();
         let (ch, rx) = sync_channel(1);
         let reader = LocalReader {
             store_meta,
             store_id: Cell::new(Some(store_id)),
             router: ch,
-            kv_engine: RocksEngine::from_db(Arc::new(db)),
+            kv_engine: db,
             delegates: RefCell::new(HashMap::default()),
             metrics: Default::default(),
             tag: "foo".to_owned(),


### PR DESCRIPTION

### What problem does this PR solve?

Removing uses of raw rocksdb APIs per https://github.com/tikv/tikv/issues/6402.

### What is changed and how it works?

This replaces a few uses of raw_util::new_engine with util::new_engine.

The only remaining uses of raw rocksdb apis in raftstore are tied to "properties collectors", like RangePropertiesCollector, MvccPropertiesCollector.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Type checking.

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.