### PR TITLE
storage: implement async commit prewrite (initial work)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4190,6 +4190,7 @@ version = "0.0.1"
 dependencies = [
  "futures 0.1.29",
  "kvproto",
+ "pd_client",
  "raftstore",
  "test_raftstore",
  "tikv",

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -475,6 +475,7 @@ impl TiKVServer {
             &self.config.storage,
             storage_read_pool_handle,
             lock_mgr.clone(),
+            self.pd_client.clone(),
             self.config.pessimistic_txn.pipelined,
         )
         .unwrap_or_else(|e| fatal!("failed to create raft storage: {}", e));

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -698,3 +698,13 @@ impl PdClient for RpcClient {
             .execute()
     }
 }
+
+pub struct DummyPdClient;
+
+impl DummyPdClient {
+    pub fn new() -> DummyPdClient {
+        DummyPdClient
+    }
+}
+
+impl PdClient for DummyPdClient {}

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -699,12 +699,20 @@ impl PdClient for RpcClient {
     }
 }
 
-pub struct DummyPdClient;
+pub struct DummyPdClient {
+    pub next_ts: TimeStamp,
+}
 
 impl DummyPdClient {
     pub fn new() -> DummyPdClient {
-        DummyPdClient
+        DummyPdClient {
+            next_ts: TimeStamp::zero(),
+        }
     }
 }
 
-impl PdClient for DummyPdClient {}
+impl PdClient for DummyPdClient {
+    fn get_tso(&self) -> PdFuture<TimeStamp> {
+        Box::new(future::ok(self.next_ts))
+    }
+}

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -23,7 +23,7 @@ mod util;
 
 mod config;
 pub mod errors;
-pub use self::client::RpcClient;
+pub use self::client::{DummyPdClient, RpcClient};
 pub use self::config::Config;
 pub use self::errors::{Error, Result};
 pub use self::util::validate_endpoints;

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -20,6 +20,7 @@ use super::*;
 use encryption::DataKeyManager;
 use engine_rocks::{RocksEngine, RocksSnapshot};
 use engine_traits::{KvEngines, MiscExt};
+use pd_client::DummyPdClient;
 use raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor};
 use raftstore::router::{RaftStoreBlackHole, RaftStoreRouter, ServerRaftStoreRouter};
 use raftstore::store::fsm::store::{StoreMeta, PENDING_VOTES_CAP};
@@ -196,6 +197,7 @@ impl Simulator for ServerCluster {
             &cfg.storage,
             storage_read_pool.handle(),
             lock_mgr.clone(),
+            Arc::new(DummyPdClient::new()),
             false,
         )?;
         self.storages.insert(node_id, raft_engine);

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -24,6 +24,7 @@ prost-codec = [
 futures = "0.1"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raftstore = { path = "../raftstore" }
+pd_client = { path = "../pd_client" }
 test_raftstore = { path = "../test_raftstore" }
 tikv = { path = "../../", default-features = false }
 tikv_util = { path = "../tikv_util" }

--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -443,6 +443,7 @@ impl<E: Engine> AssertionStorage<E> {
             )
             .unwrap();
         let locks: Vec<(&[u8], &[u8], TimeStamp)> = res
+            .locks
             .iter()
             .filter_map(|x| {
                 if let Err(StorageError(box StorageErrorInner::Txn(TxnError(

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -3,6 +3,7 @@
 use futures::Future;
 
 use kvproto::kvrpcpb::{Context, LockInfo};
+use pd_client::DummyPdClient;
 use raftstore::coprocessor::RegionInfoProvider;
 use tikv::server::gc_worker::{AutoGcConfig, GcConfig, GcSafePointProvider, GcWorker};
 use tikv::storage::config::Config;
@@ -81,7 +82,7 @@ impl<E: Engine> SyncTestStorageBuilder<E> {
 #[derive(Clone)]
 pub struct SyncTestStorage<E: Engine> {
     gc_worker: GcWorker<E>,
-    store: Storage<E, DummyLockManager>,
+    store: Storage<E, DummyLockManager, DummyPdClient>,
 }
 
 impl<E: Engine> SyncTestStorage<E> {
@@ -92,7 +93,7 @@ impl<E: Engine> SyncTestStorage<E> {
         self.gc_worker.start_auto_gc(cfg).unwrap();
     }
 
-    pub fn get_storage(&self) -> Storage<E, DummyLockManager> {
+    pub fn get_storage(&self) -> Storage<E, DummyLockManager, DummyPdClient> {
         self.store.clone()
     }
 

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -10,7 +10,8 @@ use tikv::storage::config::Config;
 use tikv::storage::kv::RocksEngine;
 use tikv::storage::lock_manager::DummyLockManager;
 use tikv::storage::{
-    txn::commands, Engine, Result, Storage, TestEngineBuilder, TestStorageBuilder, TxnStatus,
+    txn::commands, Engine, PrewriteResult, Result, Storage, TestEngineBuilder, TestStorageBuilder,
+    TxnStatus,
 };
 use tikv_util::collections::HashMap;
 use txn_types::{Key, KvPair, Mutation, TimeStamp, Value};
@@ -172,7 +173,7 @@ impl<E: Engine> SyncTestStorage<E> {
         mutations: Vec<Mutation>,
         primary: Vec<u8>,
         start_ts: impl Into<TimeStamp>,
-    ) -> Result<Vec<Result<()>>> {
+    ) -> Result<PrewriteResult> {
         wait_op!(|cb| self.store.sched_txn_command(
             commands::Prewrite::with_context(mutations, primary, start_ts.into(), ctx),
             cb,

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1266,6 +1266,7 @@ mod tests {
             rx.recv()
                 .unwrap()
                 .unwrap()
+                .locks
                 .into_iter()
                 .for_each(|r| r.unwrap());
         }

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -24,7 +24,7 @@ use crate::storage::kv::{
 use crate::storage::mvcc::{
     check_need_gc, check_region_need_gc, Error as MvccError, MvccReader, MvccTxn,
 };
-use pd_client::{ClusterVersion, PdClient};
+use pd_client::{ClusterVersion, DummyPdClient, PdClient};
 use raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor, RegionInfoProvider};
 use raftstore::router::ServerRaftStoreRouter;
 use raftstore::store::msg::StoreMsg;
@@ -321,6 +321,8 @@ impl<E: Engine> GcRunner<E> {
             Some(ScanMode::Forward),
             TimeStamp::zero(),
             !ctx.get_not_fill_cache(),
+            // TODO txn only used for GC, but this is hacky, maybe need an Option?
+            Arc::new(DummyPdClient::new()),
         );
         for k in keys {
             let gc_info = txn.gc(k.clone(), safe_point)?;
@@ -1007,7 +1009,7 @@ mod tests {
     /// Assert the data in `storage` is the same as `expected_data`. Keys in `expected_data` should
     /// be encoded form without ts.
     fn check_data<E: Engine>(
-        storage: &Storage<E, DummyLockManager>,
+        storage: &Storage<E, DummyLockManager, DummyPdClient>,
         expected_data: &BTreeMap<Vec<u8>, Vec<u8>>,
     ) {
         let scan_res = storage

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -33,17 +33,25 @@ const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
 
 /// Creates a new storage engine which is backed by the Raft consensus
 /// protocol.
-pub fn create_raft_storage<S>(
+pub fn create_raft_storage<S, P: PdClient + 'static>(
     engine: RaftKv<S>,
     cfg: &StorageConfig,
     read_pool: ReadPoolHandle,
     lock_mgr: LockManager,
+    pd_client: Arc<P>,
     pipelined_pessimistic_lock: bool,
-) -> Result<Storage<RaftKv<S>, LockManager>>
+) -> Result<Storage<RaftKv<S>, LockManager, P>>
 where
     S: RaftStoreRouter<RocksSnapshot> + 'static,
 {
-    let store = Storage::from_engine(engine, cfg, read_pool, lock_mgr, pipelined_pessimistic_lock)?;
+    let store = Storage::from_engine(
+        engine,
+        cfg,
+        read_pool,
+        lock_mgr,
+        pd_client,
+        pipelined_pessimistic_lock,
+    )?;
     Ok(store)
 }
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -11,6 +11,7 @@ use grpcio::{
     ChannelBuilder, EnvBuilder, Environment, ResourceQuota, Server as GrpcServer, ServerBuilder,
 };
 use kvproto::tikvpb::*;
+use pd_client::PdClient;
 use tokio_threadpool::{Builder as ThreadPoolBuilder, ThreadPool};
 use tokio_timer::timer::Handle;
 
@@ -72,7 +73,7 @@ impl<T: RaftStoreRouter<RocksSnapshot>, S: StoreAddrResolver + 'static> Server<T
     pub fn new<E: Engine, L: LockManager>(
         cfg: &Arc<Config>,
         security_mgr: &Arc<SecurityManager>,
-        storage: Storage<E, L>,
+        storage: Storage<E, L, impl PdClient + 'static>,
         cop: Endpoint<E>,
         raft_router: T,
         resolver: S,

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1710,9 +1710,12 @@ macro_rules! txn_command_future {
     };
 }
 
-txn_command_future!(future_prewrite, PrewriteRequest, PrewriteResponse, (v, resp) {
-    resp.set_errors(extract_key_errors(v).into())
-});
+txn_command_future!(future_prewrite, PrewriteRequest, PrewriteResponse, (v, resp) {{
+    if let Ok(v) = &v {
+        resp.set_min_commit_ts(v.min_commit_ts.into_inner());
+    }
+    resp.set_errors(extract_key_errors(v.map(|v| v.locks)).into());
+}});
 txn_command_future!(future_acquire_pessimistic_lock, PessimisticLockRequest, PessimisticLockResponse, (v, resp) {
     match v {
         Ok(Ok(res)) => resp.set_values(res.into_vec().into()),

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -34,6 +34,7 @@ use kvproto::kvrpcpb::*;
 use kvproto::raft_cmdpb::{CmdType, RaftCmdRequest, RaftRequestHeader, Request as RaftRequest};
 use kvproto::raft_serverpb::*;
 use kvproto::tikvpb::*;
+use pd_client::PdClient;
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::{Callback, CasualMessage};
 use security::{check_common_name, SecurityManager};
@@ -48,12 +49,16 @@ const GRPC_MSG_MAX_BATCH_SIZE: usize = 128;
 const GRPC_MSG_NOTIFY_SIZE: usize = 8;
 
 /// Service handles the RPC messages for the `Tikv` service.
-#[derive(Clone)]
-pub struct Service<T: RaftStoreRouter<RocksSnapshot> + 'static, E: Engine, L: LockManager> {
+pub struct Service<
+    T: RaftStoreRouter<RocksSnapshot> + 'static,
+    E: Engine,
+    L: LockManager,
+    P: PdClient + 'static,
+> {
     /// Used to handle requests related to GC.
     gc_worker: GcWorker<E>,
     // For handling KV requests.
-    storage: Storage<E, L>,
+    storage: Storage<E, L, P>,
     // For handling coprocessor requests.
     cop: Endpoint<E>,
     // For handling raft messages.
@@ -74,10 +79,40 @@ pub struct Service<T: RaftStoreRouter<RocksSnapshot> + 'static, E: Engine, L: Lo
     security_mgr: Arc<SecurityManager>,
 }
 
-impl<T: RaftStoreRouter<RocksSnapshot> + 'static, E: Engine, L: LockManager> Service<T, E, L> {
+impl<
+        T: RaftStoreRouter<RocksSnapshot> + Clone + 'static,
+        E: Engine + Clone,
+        L: LockManager + Clone,
+        P: PdClient + 'static,
+    > Clone for Service<T, E, L, P>
+{
+    fn clone(&self) -> Self {
+        Service {
+            gc_worker: self.gc_worker.clone(),
+            storage: self.storage.clone(),
+            cop: self.cop.clone(),
+            ch: self.ch.clone(),
+            snap_scheduler: self.snap_scheduler.clone(),
+            enable_req_batch: self.enable_req_batch,
+            req_batch_wait_duration: self.req_batch_wait_duration,
+            timer_pool: self.timer_pool.clone(),
+            grpc_thread_load: self.grpc_thread_load.clone(),
+            readpool_normal_thread_load: self.readpool_normal_thread_load.clone(),
+            security_mgr: self.security_mgr.clone(),
+        }
+    }
+}
+
+impl<
+        T: RaftStoreRouter<RocksSnapshot> + 'static,
+        E: Engine,
+        L: LockManager,
+        P: PdClient + 'static,
+    > Service<T, E, L, P>
+{
     /// Constructs a new `Service` which provides the `Tikv` service.
     pub fn new(
-        storage: Storage<E, L>,
+        storage: Storage<E, L, P>,
         gc_worker: GcWorker<E>,
         cop: Endpoint<E>,
         ch: T,
@@ -144,8 +179,12 @@ macro_rules! handle_request {
     }
 }
 
-impl<T: RaftStoreRouter<RocksSnapshot> + 'static, E: Engine, L: LockManager> Tikv
-    for Service<T, E, L>
+impl<
+        T: RaftStoreRouter<RocksSnapshot> + 'static,
+        E: Engine,
+        L: LockManager,
+        P: PdClient + 'static,
+    > Tikv for Service<T, E, L, P>
 {
     handle_request!(kv_get, future_get, GetRequest, GetResponse);
     handle_request!(kv_scan, future_scan, ScanRequest, ScanResponse);
@@ -1053,8 +1092,8 @@ pub fn poll_future_notify<F: Future<Item = (), Error = ()> + Send + 'static>(f: 
     notify.notify(0);
 }
 
-fn handle_batch_commands_request<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn handle_batch_commands_request<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     gc_worker: &GcWorker<E>,
     cop: &Endpoint<E>,
     peer: &str,
@@ -1152,8 +1191,8 @@ fn future_handle_empty(
     }
 }
 
-fn future_get<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_get<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: GetRequest,
 ) -> impl Future<Item = GetResponse, Error = Error> {
     storage
@@ -1177,8 +1216,8 @@ fn future_get<E: Engine, L: LockManager>(
         })
 }
 
-pub fn future_batch_get_command<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+pub fn future_batch_get_command<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     tx: Sender<(u64, batch_commands_response::Response)>,
     requests: Vec<u64>,
     commands: Vec<PointGetCommand>,
@@ -1232,8 +1271,8 @@ pub fn future_batch_get_command<E: Engine, L: LockManager>(
     })
 }
 
-fn future_scan<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_scan<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: ScanRequest,
 ) -> impl Future<Item = ScanResponse, Error = Error> {
     let end_key = if req.get_end_key().is_empty() {
@@ -1263,8 +1302,8 @@ fn future_scan<E: Engine, L: LockManager>(
         })
 }
 
-fn future_batch_get<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_batch_get<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: BatchGetRequest,
 ) -> impl Future<Item = BatchGetResponse, Error = Error> {
     let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
@@ -1299,8 +1338,8 @@ fn future_gc<E: Engine>(
     })
 }
 
-fn future_delete_range<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_delete_range<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: DeleteRangeRequest,
 ) -> impl Future<Item = DeleteRangeResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
@@ -1323,8 +1362,8 @@ fn future_delete_range<E: Engine, L: LockManager>(
     })
 }
 
-fn future_raw_get<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_raw_get<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: RawGetRequest,
 ) -> impl Future<Item = RawGetResponse, Error = Error> {
     storage
@@ -1344,8 +1383,8 @@ fn future_raw_get<E: Engine, L: LockManager>(
         })
 }
 
-pub fn future_raw_batch_get_command<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+pub fn future_raw_batch_get_command<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     tx: Sender<(u64, batch_commands_response::Response)>,
     requests: Vec<u64>,
     cf: String,
@@ -1399,8 +1438,8 @@ pub fn future_raw_batch_get_command<E: Engine, L: LockManager>(
     })
 }
 
-fn future_raw_batch_get<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_raw_batch_get<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: RawBatchGetRequest,
 ) -> impl Future<Item = RawBatchGetResponse, Error = Error> {
     let keys = req.take_keys().into();
@@ -1417,8 +1456,8 @@ fn future_raw_batch_get<E: Engine, L: LockManager>(
         })
 }
 
-fn future_raw_put<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_raw_put<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: RawPutRequest,
 ) -> impl Future<Item = RawPutResponse, Error = Error> {
     let (cb, future) = paired_future_callback();
@@ -1441,8 +1480,8 @@ fn future_raw_put<E: Engine, L: LockManager>(
     })
 }
 
-fn future_raw_batch_put<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_raw_batch_put<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: RawBatchPutRequest,
 ) -> impl Future<Item = RawBatchPutResponse, Error = Error> {
     let cf = req.take_cf();
@@ -1466,8 +1505,8 @@ fn future_raw_batch_put<E: Engine, L: LockManager>(
     })
 }
 
-fn future_raw_delete<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_raw_delete<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: RawDeleteRequest,
 ) -> impl Future<Item = RawDeleteResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
@@ -1484,8 +1523,8 @@ fn future_raw_delete<E: Engine, L: LockManager>(
     })
 }
 
-fn future_raw_batch_delete<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_raw_batch_delete<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: RawBatchDeleteRequest,
 ) -> impl Future<Item = RawBatchDeleteResponse, Error = Error> {
     let cf = req.take_cf();
@@ -1504,8 +1543,8 @@ fn future_raw_batch_delete<E: Engine, L: LockManager>(
     })
 }
 
-fn future_raw_scan<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_raw_scan<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: RawScanRequest,
 ) -> impl Future<Item = RawScanResponse, Error = Error> {
     let end_key = if req.get_end_key().is_empty() {
@@ -1534,8 +1573,8 @@ fn future_raw_scan<E: Engine, L: LockManager>(
         })
 }
 
-fn future_raw_batch_scan<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_raw_batch_scan<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: RawBatchScanRequest,
 ) -> impl Future<Item = RawBatchScanResponse, Error = Error> {
     storage
@@ -1558,8 +1597,8 @@ fn future_raw_batch_scan<E: Engine, L: LockManager>(
         })
 }
 
-fn future_raw_delete_range<E: Engine, L: LockManager>(
-    storage: &Storage<E, L>,
+fn future_raw_delete_range<E: Engine, L: LockManager, P: PdClient + 'static>(
+    storage: &Storage<E, L, P>,
     mut req: RawDeleteRangeRequest,
 ) -> impl Future<Item = RawDeleteRangeResponse, Error = Error> {
     let (cb, f) = paired_future_callback();
@@ -1583,8 +1622,8 @@ fn future_raw_delete_range<E: Engine, L: LockManager>(
 }
 
 // unimplemented
-fn future_ver_get<E: Engine, L: LockManager>(
-    _storage: &Storage<E, L>,
+fn future_ver_get<E: Engine, L: LockManager, P: PdClient + 'static>(
+    _storage: &Storage<E, L, P>,
     mut _req: VerGetRequest,
 ) -> impl Future<Item = VerGetResponse, Error = Error> {
     let resp = VerGetResponse::default();
@@ -1592,8 +1631,8 @@ fn future_ver_get<E: Engine, L: LockManager>(
 }
 
 // unimplemented
-fn future_ver_batch_get<E: Engine, L: LockManager>(
-    _storage: &Storage<E, L>,
+fn future_ver_batch_get<E: Engine, L: LockManager, P: PdClient + 'static>(
+    _storage: &Storage<E, L, P>,
     mut _req: VerBatchGetRequest,
 ) -> impl Future<Item = VerBatchGetResponse, Error = Error> {
     let resp = VerBatchGetResponse::default();
@@ -1601,8 +1640,8 @@ fn future_ver_batch_get<E: Engine, L: LockManager>(
 }
 
 // unimplemented
-fn future_ver_mut<E: Engine, L: LockManager>(
-    _storage: &Storage<E, L>,
+fn future_ver_mut<E: Engine, L: LockManager, P: PdClient + 'static>(
+    _storage: &Storage<E, L, P>,
     mut _req: VerMutRequest,
 ) -> impl Future<Item = VerMutResponse, Error = Error> {
     let resp = VerMutResponse::default();
@@ -1610,8 +1649,8 @@ fn future_ver_mut<E: Engine, L: LockManager>(
 }
 
 // unimplemented
-fn future_ver_batch_mut<E: Engine, L: LockManager>(
-    _storage: &Storage<E, L>,
+fn future_ver_batch_mut<E: Engine, L: LockManager, P: PdClient + 'static>(
+    _storage: &Storage<E, L, P>,
     mut _req: VerBatchMutRequest,
 ) -> impl Future<Item = VerBatchMutResponse, Error = Error> {
     let resp = VerBatchMutResponse::default();
@@ -1619,8 +1658,8 @@ fn future_ver_batch_mut<E: Engine, L: LockManager>(
 }
 
 // unimplemented
-fn future_ver_scan<E: Engine, L: LockManager>(
-    _storage: &Storage<E, L>,
+fn future_ver_scan<E: Engine, L: LockManager, P: PdClient + 'static>(
+    _storage: &Storage<E, L, P>,
     mut _req: VerScanRequest,
 ) -> impl Future<Item = VerScanResponse, Error = Error> {
     let resp = VerScanResponse::default();
@@ -1628,8 +1667,8 @@ fn future_ver_scan<E: Engine, L: LockManager>(
 }
 
 // unimplemented
-fn future_ver_delete_range<E: Engine, L: LockManager>(
-    _storage: &Storage<E, L>,
+fn future_ver_delete_range<E: Engine, L: LockManager, P: PdClient + 'static>(
+    _storage: &Storage<E, L, P>,
     mut _req: VerDeleteRangeRequest,
 ) -> impl Future<Item = VerDeleteRangeResponse, Error = Error> {
     let resp = VerDeleteRangeResponse::default();
@@ -1647,8 +1686,8 @@ fn future_cop<E: Engine>(
 
 macro_rules! txn_command_future {
     ($fn_name: ident, $req_ty: ident, $resp_ty: ident, ($req: ident) $prelude: stmt; ($v: ident, $resp: ident) { $else_branch: expr }) => {
-        fn $fn_name<E: Engine, L: LockManager>(
-            storage: &Storage<E, L>,
+        fn $fn_name<E: Engine, L: LockManager, P: PdClient + 'static>(
+            storage: &Storage<E, L, P>,
             $req: $req_ty,
         ) -> impl Future<Item = $resp_ty, Error = Error> {
             $prelude

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3732,6 +3732,7 @@ mod tests {
                     false,
                     3,
                     TimeStamp::default(),
+                    None,
                     Context::default(),
                 ),
                 expect_ok_callback(tx.clone(), 0),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -46,6 +46,7 @@ use engine_traits::{IterOptions, DATA_KEY_PREFIX_LEN};
 use futures::Future;
 use futures03::prelude::*;
 use kvproto::kvrpcpb::{CommandPri, Context, GetRequest, KeyRange, RawGetRequest};
+use pd_client::{DummyPdClient, PdClient};
 use raftstore::store::util::build_key_range;
 use rand::prelude::*;
 use std::sync::{atomic, Arc};
@@ -75,11 +76,11 @@ pub type Callback<T> = Box<dyn FnOnce(Result<T>) + Send>;
 /// to it, so that multiple versions can be saved at the same time.
 /// Raw operations use raw keys, which are saved directly to the engine without memcomparable-
 /// encoding and appending timestamp.
-pub struct Storage<E: Engine, L: LockManager> {
+pub struct Storage<E: Engine, L: LockManager, P: PdClient + 'static> {
     // TODO: Too many Arcs, would be slow when clone.
     engine: E,
 
-    sched: TxnScheduler<E, L>,
+    sched: TxnScheduler<E, L, P>,
 
     /// The thread pool used to run most read operations.
     read_pool: ReadPoolHandle,
@@ -93,7 +94,7 @@ pub struct Storage<E: Engine, L: LockManager> {
     max_key_size: usize,
 }
 
-impl<E: Engine, L: LockManager> Clone for Storage<E, L> {
+impl<E: Engine, L: LockManager, P: PdClient + 'static> Clone for Storage<E, L, P> {
     #[inline]
     fn clone(&self) -> Self {
         let refs = self.refs.fetch_add(1, atomic::Ordering::SeqCst);
@@ -112,7 +113,7 @@ impl<E: Engine, L: LockManager> Clone for Storage<E, L> {
     }
 }
 
-impl<E: Engine, L: LockManager> Drop for Storage<E, L> {
+impl<E: Engine, L: LockManager, P: PdClient + 'static> Drop for Storage<E, L, P> {
     #[inline]
     fn drop(&mut self) {
         let refs = self.refs.fetch_sub(1, atomic::Ordering::SeqCst);
@@ -144,18 +145,20 @@ macro_rules! check_key_size {
     };
 }
 
-impl<E: Engine, L: LockManager> Storage<E, L> {
+impl<E: Engine, L: LockManager, P: PdClient + 'static> Storage<E, L, P> {
     /// Create a `Storage` from given engine.
     pub fn from_engine(
         engine: E,
         config: &Config,
         read_pool: ReadPoolHandle,
         lock_mgr: L,
+        pd_client: Arc<P>,
         pipelined_pessimistic_lock: bool,
     ) -> Result<Self> {
         let sched = TxnScheduler::new(
             engine.clone(),
             lock_mgr,
+            pd_client,
             config.scheduler_concurrency,
             config.scheduler_worker_pool_size,
             config.scheduler_pending_write_threshold.0 as usize,
@@ -1337,7 +1340,7 @@ impl<E: Engine, L: LockManager> TestStorageBuilder<E, L> {
     }
 
     /// Build a `Storage<E>`.
-    pub fn build(self) -> Result<Storage<E, L>> {
+    pub fn build(self) -> Result<Storage<E, L, DummyPdClient>> {
         let read_pool = build_read_pool_for_test(
             &crate::config::StorageReadPoolConfig::default_for_test(),
             self.engine.clone(),
@@ -1348,6 +1351,7 @@ impl<E: Engine, L: LockManager> TestStorageBuilder<E, L> {
             &self.config,
             ReadPool::from(read_pool).handle(),
             self.lock_mgr,
+            Arc::new(DummyPdClient::new()),
             self.pipelined_pessimistic_lock,
         )
     }
@@ -1459,8 +1463,8 @@ pub mod test_util {
         )
     }
 
-    pub fn delete_pessimistic_lock<E: Engine, L: LockManager>(
-        storage: &Storage<E, L>,
+    pub fn delete_pessimistic_lock<E: Engine, L: LockManager, P: PdClient + 'static>(
+        storage: &Storage<E, L, P>,
         key: Key,
         start_ts: u64,
         for_update_ts: u64,
@@ -3321,9 +3325,11 @@ mod tests {
         expect_multi_values(
             results.clone().collect(),
             block_on(async {
-                let snapshot =
-                    <Storage<RocksEngine, DummyLockManager>>::snapshot(&engine, &ctx).await?;
-                <Storage<RocksEngine, DummyLockManager>>::forward_raw_scan(
+                let snapshot = <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::snapshot(
+                    &engine, &ctx,
+                )
+                .await?;
+                <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::forward_raw_scan(
                     &snapshot,
                     &"".to_string(),
                     &Key::from_encoded(b"c1".to_vec()),
@@ -3337,9 +3343,11 @@ mod tests {
         expect_multi_values(
             results.rev().collect(),
             block_on(async move {
-                let snapshot =
-                    <Storage<RocksEngine, DummyLockManager>>::snapshot(&engine, &ctx).await?;
-                <Storage<RocksEngine, DummyLockManager>>::reverse_raw_scan(
+                let snapshot = <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::snapshot(
+                    &engine, &ctx,
+                )
+                .await?;
+                <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::reverse_raw_scan(
                     &snapshot,
                     &"".to_string(),
                     &Key::from_encoded(b"d3".to_vec()),
@@ -3374,7 +3382,9 @@ mod tests {
             (b"c".to_vec(), b"c3".to_vec()),
         ]);
         assert_eq!(
-            <Storage<RocksEngine, DummyLockManager>>::check_key_ranges(&ranges, false),
+            <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::check_key_ranges(
+                &ranges, false
+            ),
             true
         );
 
@@ -3384,7 +3394,9 @@ mod tests {
             (b"c".to_vec(), vec![]),
         ]);
         assert_eq!(
-            <Storage<RocksEngine, DummyLockManager>>::check_key_ranges(&ranges, false),
+            <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::check_key_ranges(
+                &ranges, false
+            ),
             true
         );
 
@@ -3394,7 +3406,9 @@ mod tests {
             (b"c3".to_vec(), b"c".to_vec()),
         ]);
         assert_eq!(
-            <Storage<RocksEngine, DummyLockManager>>::check_key_ranges(&ranges, false),
+            <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::check_key_ranges(
+                &ranges, false
+            ),
             false
         );
 
@@ -3405,7 +3419,9 @@ mod tests {
             (b"a".to_vec(), vec![]),
         ]);
         assert_eq!(
-            <Storage<RocksEngine, DummyLockManager>>::check_key_ranges(&ranges, false),
+            <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::check_key_ranges(
+                &ranges, false
+            ),
             false
         );
 
@@ -3415,7 +3431,9 @@ mod tests {
             (b"c3".to_vec(), b"c".to_vec()),
         ]);
         assert_eq!(
-            <Storage<RocksEngine, DummyLockManager>>::check_key_ranges(&ranges, true),
+            <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::check_key_ranges(
+                &ranges, true
+            ),
             true
         );
 
@@ -3425,7 +3443,9 @@ mod tests {
             (b"a3".to_vec(), vec![]),
         ]);
         assert_eq!(
-            <Storage<RocksEngine, DummyLockManager>>::check_key_ranges(&ranges, true),
+            <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::check_key_ranges(
+                &ranges, true
+            ),
             true
         );
 
@@ -3435,7 +3455,9 @@ mod tests {
             (b"c".to_vec(), b"c3".to_vec()),
         ]);
         assert_eq!(
-            <Storage<RocksEngine, DummyLockManager>>::check_key_ranges(&ranges, true),
+            <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::check_key_ranges(
+                &ranges, true
+            ),
             false
         );
 
@@ -3445,7 +3467,9 @@ mod tests {
             (b"c3".to_vec(), vec![]),
         ]);
         assert_eq!(
-            <Storage<RocksEngine, DummyLockManager>>::check_key_ranges(&ranges, true),
+            <Storage<RocksEngine, DummyLockManager, DummyPdClient>>::check_key_ranges(
+                &ranges, true
+            ),
             false
         );
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -28,7 +28,7 @@ pub use self::{
     },
     read_pool::{build_read_pool, build_read_pool_for_test},
     txn::{ProcessResult, Scanner, SnapshotStore, Store},
-    types::{PessimisticLockRes, StorageCallback, TxnStatus},
+    types::{PessimisticLockRes, PrewriteResult, StorageCallback, TxnStatus},
 };
 
 use crate::read_pool::{ReadPool, ReadPoolHandle};

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -466,6 +466,7 @@ mod tests {
     use engine_traits::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
     use kvproto::kvrpcpb::IsolationLevel;
     use kvproto::metapb::{Peer, Region};
+    use pd_client::DummyPdClient;
     use raftstore::store::RegionSnapshot;
     use std::ops::Bound;
     use std::sync::Arc;
@@ -524,8 +525,8 @@ mod tests {
         fn prewrite(&mut self, m: Mutation, pk: &[u8], start_ts: impl Into<TimeStamp>) {
             let snap =
                 RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts.into(), true);
-            txn.prewrite(m, pk, false, 0, 0, TimeStamp::default())
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true, Arc::new(DummyPdClient::new()));
+            txn.prewrite(m, pk, &None, false, 0, 0, TimeStamp::default())
                 .unwrap();
             self.write(txn.into_modifies());
         }
@@ -538,7 +539,7 @@ mod tests {
         ) {
             let snap =
                 RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts.into(), true);
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true, Arc::new(DummyPdClient::new()));
             txn.pessimistic_prewrite(
                 m,
                 pk,
@@ -562,7 +563,7 @@ mod tests {
         ) {
             let snap =
                 RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts.into(), true);
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true, Arc::new(DummyPdClient::new()));
             txn.acquire_pessimistic_lock(
                 k,
                 pk,
@@ -584,7 +585,7 @@ mod tests {
         ) {
             let snap =
                 RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts.into(), true);
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true, Arc::new(DummyPdClient::new()));
             txn.commit(Key::from_raw(pk), commit_ts.into()).unwrap();
             self.write(txn.into_modifies());
         }
@@ -592,7 +593,7 @@ mod tests {
         fn rollback(&mut self, pk: &[u8], start_ts: impl Into<TimeStamp>) {
             let snap =
                 RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
-            let mut txn = MvccTxn::new(snap, start_ts.into(), true);
+            let mut txn = MvccTxn::new(snap, start_ts.into(), true, Arc::new(DummyPdClient::new()));
             txn.collapse_rollback(false);
             txn.rollback(Key::from_raw(pk)).unwrap();
             self.write(txn.into_modifies());
@@ -604,7 +605,12 @@ mod tests {
                     self.db.c().clone(),
                     self.region.clone(),
                 );
-                let mut txn = MvccTxn::new(snap, safe_point.into(), true);
+                let mut txn = MvccTxn::new(
+                    snap,
+                    safe_point.into(),
+                    true,
+                    Arc::new(DummyPdClient::new()),
+                );
                 txn.gc(Key::from_raw(pk), safe_point.into()).unwrap();
                 let modifies = txn.into_modifies();
                 if modifies.is_empty() {

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -47,7 +47,9 @@ use txn_types::{Key, TimeStamp};
 use crate::storage::lock_manager::WaitTimeout;
 use crate::storage::metrics;
 use crate::storage::txn::latch::{self, Latches};
-use crate::storage::types::{MvccInfo, PessimisticLockRes, StorageCallbackType, TxnStatus};
+use crate::storage::types::{
+    MvccInfo, PessimisticLockRes, PrewriteResult, StorageCallbackType, TxnStatus,
+};
 use crate::storage::Result;
 use tikv_util::collections::HashMap;
 
@@ -98,7 +100,7 @@ impl<T> From<TypedCommand<T>> for Command {
     }
 }
 
-impl From<PrewriteRequest> for TypedCommand<Vec<Result<()>>> {
+impl From<PrewriteRequest> for TypedCommand<PrewriteResult> {
     fn from(mut req: PrewriteRequest) -> Self {
         let for_update_ts = req.get_for_update_ts();
         if for_update_ts == 0 {

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -110,6 +110,11 @@ impl From<PrewriteRequest> for TypedCommand<Vec<Result<()>>> {
                 req.get_skip_constraint_check(),
                 req.get_txn_size(),
                 req.get_min_commit_ts().into(),
+                if req.get_use_async_commit() {
+                    Some(req.get_secondaries().into())
+                } else {
+                    None
+                },
                 req.take_context(),
             )
         } else {

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -24,6 +24,9 @@ command! {
             /// How many keys this transaction involved.
             txn_size: u64,
             min_commit_ts: TimeStamp,
+            /// All secondary keys in the whole transaction (i.e., as sent to all nodes, not only
+            /// this node). Only present if using async commit.
+            secondary_keys: Option<Vec<Vec<u8>>>,
         }
 }
 
@@ -67,6 +70,7 @@ impl Prewrite {
             false,
             0,
             TimeStamp::default(),
+            None,
             Context::default(),
         )
     }
@@ -86,6 +90,7 @@ impl Prewrite {
             false,
             0,
             TimeStamp::default(),
+            None,
             Context::default(),
         )
     }
@@ -104,6 +109,7 @@ impl Prewrite {
             false,
             0,
             TimeStamp::default(),
+            None,
             ctx,
         )
     }

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -1,7 +1,10 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::storage::txn::commands::{Command, CommandExt, TypedCommand};
-use crate::storage::{Context, Result};
+use crate::storage::{
+    txn::commands::{Command, CommandExt, TypedCommand},
+    types::PrewriteResult,
+    Context,
+};
 use txn_types::{Mutation, TimeStamp};
 
 command! {
@@ -10,7 +13,7 @@ command! {
     /// This prepares the system to commit the transaction. Later a [`Commit`](Command::Commit)
     /// or a [`Rollback`](Command::Rollback) should follow.
     Prewrite:
-        cmd_ty => Vec<Result<()>>,
+        cmd_ty => PrewriteResult,
         display => "kv::command::prewrite mutations({}) @ {} | {:?}", (mutations.len, start_ts, ctx),
         content => {
             /// The set of mutations to apply.
@@ -61,7 +64,7 @@ impl Prewrite {
         mutations: Vec<Mutation>,
         primary: Vec<u8>,
         start_ts: TimeStamp,
-    ) -> TypedCommand<Vec<Result<()>>> {
+    ) -> TypedCommand<PrewriteResult> {
         Prewrite::new(
             mutations,
             primary,
@@ -81,7 +84,7 @@ impl Prewrite {
         primary: Vec<u8>,
         start_ts: TimeStamp,
         lock_ttl: u64,
-    ) -> TypedCommand<Vec<Result<()>>> {
+    ) -> TypedCommand<PrewriteResult> {
         Prewrite::new(
             mutations,
             primary,
@@ -100,7 +103,7 @@ impl Prewrite {
         primary: Vec<u8>,
         start_ts: TimeStamp,
         ctx: Context,
-    ) -> TypedCommand<Vec<Result<()>>> {
+    ) -> TypedCommand<PrewriteResult> {
         Prewrite::new(
             mutations,
             primary,

--- a/src/storage/txn/commands/prewrite_pessimistic.rs
+++ b/src/storage/txn/commands/prewrite_pessimistic.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::storage::txn::commands::{Command, CommandExt, TypedCommand};
-use crate::storage::Result;
+use crate::storage::types::PrewriteResult;
 use txn_types::{Mutation, TimeStamp};
 
 command! {
@@ -10,7 +10,7 @@ command! {
     /// This prepares the system to commit the transaction. Later a [`Commit`](Command::Commit)
     /// or a [`Rollback`](Command::Rollback) should follow.
     PrewritePessimistic:
-        cmd_ty => Vec<Result<()>>,
+        cmd_ty => PrewriteResult,
         display => "kv::command::prewrite_pessimistic mutations({}) @ {} | {:?}", (mutations.len, start_ts, ctx),
         content => {
             /// The set of mutations to apply; the bool = is pessimistic lock.

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -11,7 +11,7 @@ mod process;
 mod store;
 
 use crate::storage::{
-    types::{MvccInfo, PessimisticLockRes, TxnStatus},
+    types::{MvccInfo, PessimisticLockRes, PrewriteResult, TxnStatus},
     Error as StorageError, Result as StorageResult,
 };
 use kvproto::kvrpcpb::LockInfo;
@@ -32,6 +32,9 @@ pub enum ProcessResult {
     Res,
     MultiRes {
         results: Vec<StorageResult<()>>,
+    },
+    PrewriteResult {
+        result: PrewriteResult,
     },
     MvccKey {
         mvcc: MvccInfo,

--- a/src/storage/txn/process.rs
+++ b/src/storage/txn/process.rs
@@ -234,6 +234,7 @@ pub(super) fn process_write_impl<S: Snapshot, L: LockManager>(
             txn_size,
             min_commit_ts,
             ctx,
+            ..
         }) => {
             let mut scan_mode = None;
             let rows = mutations.len();

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -585,6 +585,7 @@ mod tests {
     use engine_traits::CfName;
     use engine_traits::IterOptions;
     use kvproto::kvrpcpb::Context;
+    use pd_client::DummyPdClient;
     use std::sync::Arc;
 
     const KEY_PREFIX: &str = "key_prefix";
@@ -623,12 +624,18 @@ mod tests {
             let pk = primary_key.as_bytes();
             // do prewrite.
             {
-                let mut txn = MvccTxn::new(self.snapshot.clone(), START_TS, true);
+                let mut txn = MvccTxn::new(
+                    self.snapshot.clone(),
+                    START_TS,
+                    true,
+                    Arc::new(DummyPdClient::new()),
+                );
                 for key in &self.keys {
                     let key = key.as_bytes();
                     txn.prewrite(
                         Mutation::Put((Key::from_raw(key), key.to_vec())),
                         pk,
+                        &None,
                         false,
                         0,
                         0,
@@ -642,7 +649,12 @@ mod tests {
             self.refresh_snapshot();
             // do commit
             {
-                let mut txn = MvccTxn::new(self.snapshot.clone(), START_TS, true);
+                let mut txn = MvccTxn::new(
+                    self.snapshot.clone(),
+                    START_TS,
+                    true,
+                    Arc::new(DummyPdClient::new()),
+                );
                 for key in &self.keys {
                     let key = key.as_bytes();
                     txn.commit(Key::from_raw(key), COMMIT_TS).unwrap();

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -108,6 +108,12 @@ impl TxnStatus {
     }
 }
 
+#[derive(Debug)]
+pub struct PrewriteResult {
+    pub locks: Vec<Result<()>>,
+    pub min_commit_ts: TimeStamp,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum PessimisticLockRes {
     Values(Vec<Option<Value>>),
@@ -164,6 +170,7 @@ storage_callback! {
     MvccInfoByStartTs(Option<(Key, MvccInfo)>) ProcessResult::MvccStartTs { mvcc } => mvcc,
     Locks(Vec<kvrpcpb::LockInfo>) ProcessResult::Locks { locks } => locks,
     TxnStatus(TxnStatus) ProcessResult::TxnStatus { txn_status } => txn_status,
+    Prewrite(PrewriteResult) ProcessResult::PrewriteResult { result } => result,
     PessimisticLock(Result<PessimisticLockRes>) ProcessResult::PessimisticLockRes { res } => res,
 }
 

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -2,6 +2,8 @@
 
 use criterion::{black_box, BatchSize, Bencher, Criterion};
 use kvproto::kvrpcpb::Context;
+use pd_client::DummyPdClient;
+use std::sync::Arc;
 use test_util::KvGenerator;
 use tikv::storage::kv::{Engine, WriteData};
 use tikv::storage::mvcc::{self, MvccReader, MvccTxn};
@@ -20,7 +22,12 @@ where
 {
     let ctx = Context::default();
     let snapshot = engine.snapshot(&ctx).unwrap();
-    let mut txn = MvccTxn::new(snapshot, start_ts.into(), true);
+    let mut txn = MvccTxn::new(
+        snapshot,
+        start_ts.into(),
+        true,
+        Arc::new(DummyPdClient::new()),
+    );
 
     let kvs = KvGenerator::with_seed(
         config.key_length,
@@ -32,6 +39,7 @@ where
         txn.prewrite(
             Mutation::Put((Key::from_raw(&k), v.clone())),
             &k.clone(),
+            &None,
             false,
             0,
             0,
@@ -66,7 +74,7 @@ fn mvcc_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Bench
         |(mutations, snapshot)| {
             for (mutation, primary) in mutations {
                 let mut txn = mvcc::new_txn!(snapshot.clone(), 1, true);
-                txn.prewrite(mutation, &primary, false, 0, 0, TimeStamp::default())
+                txn.prewrite(mutation, &primary, &None, false, 0, 0, TimeStamp::default())
                     .unwrap();
             }
         },

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -49,6 +49,7 @@ fn test_scheduler_leader_change_twice() {
                 false,
                 0,
                 TimeStamp::default(),
+                None,
                 ctx0,
             ),
             Box::new(move |res: storage::Result<_>| {

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -207,6 +207,7 @@ fn write_test_data<E: Engine>(
                 ts,
             )
             .unwrap()
+            .locks
             .into_iter()
             .for_each(|res| res.unwrap());
         storage


### PR DESCRIPTION
This PR is ready to land (I hope) but not ready for use. I'm submitting now to get early feedback that the logic is correct, that it is low risk (i.e., if the client is not setting `use_async_commit`, then we are not doing anything differently, and that it is heading in the right direction.

This PR updates kvproto to a version with the async commit fields. Propagates them to the `Prewrite` command (optimistic transactions only for now), propagates a pd client through various layers to `MvccTxn` and uses that to get a timestamp from PD. It saves the secondary keys and timestamp to the lock of the primary key.

PTAL @youjiali1995 @MyonKeminta 

Release note

* No release note