### PR TITLE
[WIP]Use reverse Poland notation as default expression of AggrDefinitionParser

### DIFF
--- a/components/tidb_query_vec_aggr/src/parser.rs
+++ b/components/tidb_query_vec_aggr/src/parser.rs
@@ -8,6 +8,7 @@ use crate::AggrFunction;
 use tidb_query_common::Result;
 use tidb_query_datatype::expr::EvalContext;
 use tidb_query_vec_expr::RpnExpression;
+use tidb_query_vec_expr::RpnExpressionBuilder;
 
 /// Parse a specific aggregate function definition from protobuf.
 ///
@@ -41,7 +42,7 @@ pub trait AggrDefinitionParser {
     ) -> Result<Box<dyn AggrFunction>> {
         Self::parse_rpn(
             &self,
-            expr_to_rpn(aggr_def),
+            RpnExpressionBuilder::build_from_expr_tree(aggr_def, ctx, src_schema.len())?,
             ctx,
             src_schema,
             out_schema,
@@ -62,11 +63,6 @@ pub trait AggrDefinitionParser {
             "This struct neither implemented parse nor parse_rpn, which is not expected."
         )
     }
-}
-
-#[inline]
-fn expr_to_rpn(_aggr_def: Expr) -> RpnExpression {
-    unimplemented!()
 }
 
 #[inline]

--- a/components/tidb_query_vec_aggr/src/parser.rs
+++ b/components/tidb_query_vec_aggr/src/parser.rs
@@ -38,7 +38,33 @@ pub trait AggrDefinitionParser {
         src_schema: &[FieldType],
         out_schema: &mut Vec<FieldType>,
         out_exp: &mut Vec<RpnExpression>,
-    ) -> Result<Box<dyn AggrFunction>>;
+    ) -> Result<Box<dyn AggrFunction>> {
+        Self::parse_rpn(
+            &self,
+            expr_to_rpn(aggr_def),
+            ctx,
+            src_schema,
+            out_schema,
+            out_exp,
+        )
+    }
+
+    #[inline]
+    fn parse_rpn(
+        &self,
+        _aggr_def: Vec<RpnExpression>,
+        _ctx: &mut EvalContext,
+        _src_schema: &[FieldType],
+        _out_schema: &mut Vec<FieldType>,
+        _out_exp: &mut Vec<RpnExpression>,
+    ) -> Result<Box<dyn AggrFunction>> {
+        unimplemented!("This struct neither implemented parse nor parse_rpn, which is not expected.")
+    }
+}
+
+#[inline]
+fn expr_to_rpn(_aggr_def: Expr) -> Vec<RpnExpression> {
+    unimplemented!()
 }
 
 #[inline]

--- a/components/tidb_query_vec_aggr/src/parser.rs
+++ b/components/tidb_query_vec_aggr/src/parser.rs
@@ -52,18 +52,20 @@ pub trait AggrDefinitionParser {
     #[inline]
     fn parse_rpn(
         &self,
-        _aggr_def: Vec<RpnExpression>,
+        _aggr_def: RpnExpression,
         _ctx: &mut EvalContext,
         _src_schema: &[FieldType],
         _out_schema: &mut Vec<FieldType>,
         _out_exp: &mut Vec<RpnExpression>,
     ) -> Result<Box<dyn AggrFunction>> {
-        unimplemented!("This struct neither implemented parse nor parse_rpn, which is not expected.")
+        unimplemented!(
+            "This struct neither implemented parse nor parse_rpn, which is not expected."
+        )
     }
 }
 
 #[inline]
-fn expr_to_rpn(_aggr_def: Expr) -> Vec<RpnExpression> {
+fn expr_to_rpn(_aggr_def: Expr) -> RpnExpression {
     unimplemented!()
 }
 

--- a/components/tidb_query_vec_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_vec_expr/src/types/expr_eval.rs
@@ -271,6 +271,7 @@ impl RpnExpression {
                         field_type: ret_field_type,
                     });
                 }
+                RpnExpressionNode::Operator { .. } => unimplemented!(),
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
A step of https://github.com/tikv/tikv/issues/6281 , generally make as rpn expression as the default expression for all coprocessors.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test