### PR TITLE
Config: deprecate pessimistic transaction "enabled" config to always enable 

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -134,7 +134,7 @@ struct Engines {
 }
 
 struct Servers {
-    lock_mgr: Option<LockManager>,
+    lock_mgr: LockManager,
     server: Server<ServerRaftStoreRouter<RocksEngine>, resolve::PdStoreAddrResolver>,
     node: Node<RpcClient>,
     importer: Arc<SSTImporter>,
@@ -437,17 +437,12 @@ impl TiKVServer {
         // Create CoprocessorHost.
         let mut coprocessor_host = self.coprocessor_host.take().unwrap();
 
-        let lock_mgr = if self.config.pessimistic_txn.enabled {
-            let lock_mgr = LockManager::new();
-            cfg_controller.register(
-                tikv::config::Module::PessimisticTxn,
-                Box::new(lock_mgr.config_manager()),
-            );
-            lock_mgr.register_detector_role_change_observer(&mut coprocessor_host);
-            Some(lock_mgr)
-        } else {
-            None
-        };
+        let lock_mgr = LockManager::new();
+        cfg_controller.register(
+            tikv::config::Module::PessimisticTxn,
+            Box::new(lock_mgr.config_manager()),
+        );
+        lock_mgr.register_detector_role_change_observer(&mut coprocessor_host);
 
         let engines = self.engines.as_ref().unwrap();
 
@@ -687,27 +682,26 @@ impl TiKVServer {
         }
 
         // Lock manager.
-        if let Some(lock_mgr) = servers.lock_mgr.as_mut() {
-            if servers
-                .server
-                .register_service(create_deadlock(
-                    lock_mgr.deadlock_service(self.security_mgr.clone()),
-                ))
-                .is_some()
-            {
-                fatal!("failed to register deadlock service");
-            }
-
-            lock_mgr
-                .start(
-                    servers.node.id(),
-                    self.pd_client.clone(),
-                    self.resolver.clone(),
-                    self.security_mgr.clone(),
-                    &self.config.pessimistic_txn,
-                )
-                .unwrap_or_else(|e| fatal!("failed to start lock manager: {}", e));
+        if servers
+            .server
+            .register_service(create_deadlock(
+                servers.lock_mgr.deadlock_service(self.security_mgr.clone()),
+            ))
+            .is_some()
+        {
+            fatal!("failed to register deadlock service");
         }
+
+        servers
+            .lock_mgr
+            .start(
+                servers.node.id(),
+                self.pd_client.clone(),
+                self.resolver.clone(),
+                self.security_mgr.clone(),
+                &self.config.pessimistic_txn,
+            )
+            .unwrap_or_else(|e| fatal!("failed to start lock manager: {}", e));
 
         // Backup service.
         let mut backup_worker = Box::new(tikv_util::worker::Worker::new("backup-endpoint"));
@@ -825,9 +819,8 @@ impl TiKVServer {
 
         servers.node.stop();
         self.region_info_accessor.stop();
-        if let Some(lm) = servers.lock_mgr.as_mut() {
-            lm.stop();
-        }
+
+        servers.lock_mgr.stop();
 
         self.to_stop.into_iter().for_each(|s| s.stop());
     }

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -188,7 +188,7 @@ impl Simulator for ServerCluster {
             engine,
             &cfg.storage,
             storage_read_pool.handle(),
-            Some(lock_mgr.clone()),
+            lock_mgr.clone(),
             false,
         )?;
         self.storages.insert(node_id, raft_engine);

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -53,7 +53,8 @@ impl<E: Engine> SyncTestStorageBuilder<E> {
     }
 
     pub fn build(mut self) -> Result<SyncTestStorage<E>> {
-        let mut builder = TestStorageBuilder::from_engine(self.engine.clone());
+        let mut builder =
+            TestStorageBuilder::from_engine_and_lock_mgr(self.engine.clone(), DummyLockManager {});
         if let Some(config) = self.config.take() {
             builder = builder.config(config);
         }

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -1041,9 +1041,10 @@ mod tests {
         // Return Result from this function so we can use the `wait_op` macro here.
 
         let engine = TestEngineBuilder::new().build().unwrap();
-        let storage = TestStorageBuilder::from_engine(engine.clone())
-            .build()
-            .unwrap();
+        let storage =
+            TestStorageBuilder::from_engine_and_lock_mgr(engine.clone(), DummyLockManager {})
+                .build()
+                .unwrap();
         let db = engine.get_rocksdb();
         let mut gc_worker = GcWorker::new(
             engine,
@@ -1207,10 +1208,12 @@ mod tests {
         let engine = TestEngineBuilder::new().build().unwrap();
         let db = engine.get_rocksdb();
         let prefixed_engine = PrefixedEngine(engine);
-        let storage =
-            TestStorageBuilder::<_, DummyLockManager>::from_engine(prefixed_engine.clone())
-                .build()
-                .unwrap();
+        let storage = TestStorageBuilder::<_, DummyLockManager>::from_engine_and_lock_mgr(
+            prefixed_engine.clone(),
+            DummyLockManager {},
+        )
+        .build()
+        .unwrap();
         let mut gc_worker = GcWorker::new(
             prefixed_engine,
             Some(db.c().clone()),

--- a/src/server/lock_manager/config.rs
+++ b/src/server/lock_manager/config.rs
@@ -12,9 +12,6 @@ use tikv_util::config::ReadableDuration;
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
-    // Deprecated. The enable flag was only for compatible issue from v3.0 or older version.
-    #[config(skip)]
-    pub enabled: bool,
     #[serde(deserialize_with = "readable_duration_or_u64")]
     pub wait_for_lock_timeout: ReadableDuration,
     #[serde(deserialize_with = "readable_duration_or_u64")]
@@ -47,7 +44,6 @@ where
 impl Default for Config {
     fn default() -> Self {
         Self {
-            enabled: true,
             wait_for_lock_timeout: ReadableDuration::millis(1000),
             wake_up_delay_duration: ReadableDuration::millis(20),
             pipelined: false,

--- a/src/server/lock_manager/config.rs
+++ b/src/server/lock_manager/config.rs
@@ -12,6 +12,7 @@ use tikv_util::config::ReadableDuration;
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
+    // Deprecated. The enable flag was only for compatible issue from v3.0 or older version.
     #[config(skip)]
     pub enabled: bool,
     #[serde(deserialize_with = "readable_duration_or_u64")]
@@ -111,7 +112,6 @@ mod tests {
         "#;
 
         let config: Config = toml::from_str(conf).unwrap();
-        assert_eq!(config.enabled, false);
         assert_eq!(config.wait_for_lock_timeout.as_millis(), 10);
         assert_eq!(config.wake_up_delay_duration.as_millis(), 100);
         assert_eq!(config.pipelined, true);

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -37,7 +37,7 @@ pub fn create_raft_storage<S>(
     engine: RaftKv<S>,
     cfg: &StorageConfig,
     read_pool: ReadPoolHandle,
-    lock_mgr: Option<LockManager>,
+    lock_mgr: LockManager,
     pipelined_pessimistic_lock: bool,
 ) -> Result<Storage<RaftKv<S>, LockManager>>
 where

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -289,6 +289,7 @@ mod tests {
     use raftstore::store::*;
     use raftstore::Result as RaftStoreResult;
 
+    use crate::storage::lock_manager::DummyLockManager;
     use engine_rocks::RocksSnapshot;
     use kvproto::raft_cmdpb::RaftCmdRequest;
     use kvproto::raft_serverpb::RaftMessage;
@@ -379,7 +380,9 @@ mod tests {
         let mut cfg = Config::default();
         cfg.addr = "127.0.0.1:0".to_owned();
 
-        let storage = TestStorageBuilder::new().build().unwrap();
+        let storage = TestStorageBuilder::new(DummyLockManager {})
+            .build()
+            .unwrap();
         let mut gc_worker = GcWorker::new(
             storage.get_engine(),
             None,

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -56,9 +56,6 @@ quick_error! {
         InvalidCf (cf_name: String) {
             display("invalid cf name: {}", cf_name)
         }
-        PessimisticTxnNotEnabled {
-            display("pessimistic transaction is not enabled")
-        }
     }
 }
 

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -194,7 +194,7 @@ struct SchedulerInner<L: LockManager> {
     // used to control write flow
     running_write_bytes: AtomicUsize,
 
-    lock_mgr: Option<L>,
+    lock_mgr: L,
 
     pipelined_pessimistic_lock: bool,
 }
@@ -290,7 +290,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
     /// Creates a scheduler.
     pub fn new(
         engine: E,
-        lock_mgr: Option<L>,
+        lock_mgr: L,
         concurrency: usize,
         worker_pool_size: usize,
         sched_pending_write_threshold: usize,
@@ -519,7 +519,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
         debug!("command waits for lock released"; "cid" => cid);
         let tctx = self.inner.dequeue_task_context(cid);
         SCHED_STAGE_COUNTER_VEC.get(tctx.tag).lock_wait.inc();
-        self.inner.lock_mgr.as_ref().unwrap().wait_for(
+        self.inner.lock_mgr.wait_for(
             start_ts,
             tctx.cb.unwrap(),
             pr,

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -10,8 +10,9 @@ use kvproto::tikvpb::TikvClient;
 
 use test_raftstore::{must_get_equal, must_get_none, new_server_cluster};
 use tikv::storage::kv::{Error as KvError, ErrorInner as KvErrorInner};
+use tikv::storage::lock_manager::DummyLockManager;
 use tikv::storage::txn::{commands, Error as TxnError, ErrorInner as TxnErrorInner};
-use tikv::storage::{self, lock_manager::DummyLockManager, test_util::*, *};
+use tikv::storage::{self, test_util::*, *};
 use tikv_util::{collections::HashMap, HandyRwLock};
 use txn_types::Key;
 use txn_types::{Mutation, TimeStamp};
@@ -25,9 +26,12 @@ fn test_scheduler_leader_change_twice() {
     let peers = region0.get_peers();
     cluster.must_transfer_leader(region0.get_id(), peers[0].clone());
     let engine0 = cluster.sim.rl().storages[&peers[0].get_id()].clone();
-    let storage0 = TestStorageBuilder::<_, DummyLockManager>::from_engine(engine0)
-        .build()
-        .unwrap();
+    let storage0 = TestStorageBuilder::<_, DummyLockManager>::from_engine_and_lock_mgr(
+        engine0,
+        DummyLockManager {},
+    )
+    .build()
+    .unwrap();
 
     let mut ctx0 = Context::default();
     ctx0.set_region_id(region0.get_id());
@@ -202,8 +206,7 @@ fn test_pipelined_pessimistic_lock() {
     let scheduler_async_write_finish_fp = "scheduler_async_write_finish";
     let scheduler_pipelined_write_finish_fp = "scheduler_pipelined_write_finish";
 
-    let storage = TestStorageBuilder::new()
-        .set_lock_mgr(DummyLockManager {})
+    let storage = TestStorageBuilder::new(DummyLockManager {})
         .set_pipelined_pessimistic_lock(true)
         .build()
         .unwrap();

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -646,7 +646,6 @@ fn test_serde_custom_tikv_config() {
         compaction_filter_skip_version_check: true,
     };
     value.pessimistic_txn = PessimisticTxnConfig {
-        enabled: false,
         wait_for_lock_timeout: ReadableDuration::millis(10),
         wake_up_delay_duration: ReadableDuration::millis(100),
         pipelined: true,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->
Signed-off-by: Boyang Chen <boyang@confluent.io>

### What problem does this PR solve?

Issue Number: close #7652 

Problem Summary:
The existing code maintains a useless configuration to enable pessimistic transaction. Trying to deprecate the config as well as simplify the codebase.

### What is changed and how it works?

What's Changed:

- Remove if condition for the "enabled" config
- Remove Option type for lock manager in general


### Related changes

None

### Check List <!--REMOVE the items that are not applicable-->

Tests  

- Existing unit test coverage

Side effects

Nope

### Release note <!-- bugfixes or new feature need a release note -->