### PR TITLE
txn: Remove Command and rename CommandKind to Command

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -33,13 +33,12 @@ pub use self::{
 
 use crate::read_pool::{ReadPool, ReadPoolHandle};
 use crate::storage::metrics::CommandKind;
-use crate::storage::txn::Command;
 use crate::storage::{
     config::Config,
     kv::{with_tls_engine, Modify, WriteData},
     lock_manager::{DummyLockManager, LockManager},
     metrics::*,
-    txn::{commands::TypedCommand, scheduler::Scheduler as TxnScheduler},
+    txn::{commands::TypedCommand, scheduler::Scheduler as TxnScheduler, Command},
     types::StorageCallbackType,
 };
 use engine_traits::{CfName, ALL_CFS, CF_DEFAULT, DATA_CFS};


### PR DESCRIPTION
Signed-off-by: longfangsong <longfangsong@icloud.com>

### What problem does this PR solve?

The only field in `Command` struct is `kind: CommandKind`, so we can use `CommandKind`(should be renamed into `Command`) directly.

### What is changed and how it works?

Rename the old CommandKind into Command and use it to replace the old Command struct, which only field is the CommandKind.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test