### PR TITLE
copr: table scan ignores point get while encounter common handle

### DIFF
--- a/components/tidb_query_vec_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_vec_executors/src/table_scan_executor.rs
@@ -73,6 +73,7 @@ impl<S: Storage> BatchTableScanExecutor<S> {
             // columns with the same column id are given, we will only preserve the *last* one.
         }
 
+        let no_common_handle = primary_column_ids.is_empty();
         let imp = TableScanExecutorImpl {
             context: EvalContext::new(config),
             schema,
@@ -88,7 +89,7 @@ impl<S: Storage> BatchTableScanExecutor<S> {
             key_ranges,
             is_backward,
             is_key_only,
-            accept_point_range: primary_column_ids_set.is_empty(),
+            accept_point_range: no_common_handle,
         })?;
         Ok(Self(wrapper))
     }

--- a/components/tidb_query_vec_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_vec_executors/src/table_scan_executor.rs
@@ -49,7 +49,7 @@ impl<S: Storage> BatchTableScanExecutor<S> {
         let mut columns_default_value = Vec::with_capacity(columns_info.len());
         let mut column_id_index = HashMap::default();
 
-        let primary_column_ids_set = primary_column_ids.iter().cloned().collect::<HashSet<_>>();
+        let primary_column_ids_set = primary_column_ids.iter().collect::<HashSet<_>>();
         for (index, mut ci) in columns_info.into_iter().enumerate() {
             // For each column info, we need to extract the following info:
             // - Corresponding field type (push into `schema`).

--- a/components/tidb_query_vec_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_vec_executors/src/table_scan_executor.rs
@@ -49,7 +49,7 @@ impl<S: Storage> BatchTableScanExecutor<S> {
         let mut columns_default_value = Vec::with_capacity(columns_info.len());
         let mut column_id_index = HashMap::default();
 
-        let primary_column_ids_set = primary_column_ids.iter().collect::<HashSet<_>>();
+        let primary_column_ids_set = primary_column_ids.iter().cloned().collect::<HashSet<_>>();
         for (index, mut ci) in columns_info.into_iter().enumerate() {
             // For each column info, we need to extract the following info:
             // - Corresponding field type (push into `schema`).
@@ -88,7 +88,7 @@ impl<S: Storage> BatchTableScanExecutor<S> {
             key_ranges,
             is_backward,
             is_key_only,
-            accept_point_range: true,
+            accept_point_range: primary_column_ids_set.is_empty(),
         })?;
         Ok(Self(wrapper))
     }


### PR DESCRIPTION
Signed-off-by: Iosmanthus Teng <myosmanthustree@gmail.com>


### What problem does this PR solve?
`BatchTableScanExecutor` ignores point get while encounter common handles keys.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- bugfixes or new feature need a release note -->

* `BatchTableScanExecutor` ignores point get while encountering common handle keys.