### PR TITLE
[DNM]raftstore&txn:  do not propose if previous pending commands will change epoch & add pipelined write callback

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2203,10 +2203,10 @@ pub fn get_change_peer_cmd(msg: &RaftCmdRequest) -> Option<&ChangePeerRequest> {
         return None;
     }
     let req = msg.get_admin_request();
-    if !req.has_change_peer() {
+    if req.get_cmd_type() != AdminCmdType::ChangePeer {
         return None;
     }
-
+    assert!(req.has_change_peer());
     Some(req.get_change_peer())
 }
 

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -21,6 +21,7 @@ use crate::store::metrics::RaftEventDurationType;
 use crate::store::util::KeysInfoFormatter;
 use crate::store::SnapKey;
 use engine_rocks::CompactedEvent;
+use tikv_util::callback::Callback as UtilCallback;
 use tikv_util::escape;
 
 use super::RegionSnapshot;
@@ -314,11 +315,11 @@ impl<S: Snapshot> fmt::Debug for CasualMessage<S> {
 
 /// Raft command is the command that is expected to be proposed by the
 /// leader of the target raft group.
-#[derive(Debug)]
 pub struct RaftCommand<S: Snapshot> {
     pub send_time: Instant,
     pub request: RaftCmdRequest,
     pub callback: Callback<S>,
+    pub pw_callback: Option<UtilCallback<()>>,
 }
 
 impl<S: Snapshot> RaftCommand<S> {
@@ -328,7 +329,21 @@ impl<S: Snapshot> RaftCommand<S> {
             request,
             callback,
             send_time: Instant::now(),
+            pw_callback: None,
         }
+    }
+}
+
+impl<S> fmt::Debug for RaftCommand<S>
+where
+    S: Snapshot,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("RaftCommand")
+            .field("send_time", &self.send_time)
+            .field("request", &self.request)
+            .field("callback", &self.callback)
+            .finish()
     }
 }
 

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -351,7 +351,7 @@ impl Simulator for NodeCluster {
             .get(&node_id)
             .cloned()
             .unwrap();
-        router.send_command(request, cb)
+        router.send_command(request, cb, None)
     }
 
     fn send_raft_msg(&mut self, msg: raft_serverpb::RaftMessage) -> Result<()> {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -383,7 +383,7 @@ impl Simulator for ServerCluster {
             None => return Err(box_err!("missing sender for store {}", node_id)),
             Some(meta) => meta.sim_router.clone(),
         };
-        router.send_command(request, cb)
+        router.send_command(request, cb, None)
     }
 
     fn send_raft_msg(&mut self, raft_msg: raft_serverpb::RaftMessage) -> Result<()> {

--- a/components/test_raftstore/src/transport_simulate.rs
+++ b/components/test_raftstore/src/transport_simulate.rs
@@ -192,7 +192,7 @@ impl<C: RaftStoreRouter<RocksSnapshot>> RaftStoreRouter<RocksSnapshot> for Simul
     }
 
     fn send_command(&self, req: RaftCmdRequest, cb: Callback<RocksSnapshot>) -> Result<()> {
-        self.ch.send_command(req, cb)
+        self.ch.send_command(req, cb, None)
     }
 
     fn casual_send(&self, region_id: u64, msg: CasualMessage<RocksSnapshot>) -> Result<()> {

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -268,7 +268,7 @@ impl<Router: RaftStoreRouter<RocksSnapshot>> ImportSst for ImportSSTService<Rout
         cmd.mut_requests().push(ingest);
 
         let (cb, future) = paired_future_callback();
-        if let Err(e) = self.router.send_command(cmd, Callback::Write(cb)) {
+        if let Err(e) = self.router.send_command(cmd, Callback::Write(cb), None) {
             let mut resp = IngestResponse::default();
             resp.set_error(e.into());
             ctx.spawn(sink.success(resp).map_err(|e| {

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -946,6 +946,7 @@ mod tests {
     use kvproto::metapb;
     use std::collections::BTreeMap;
     use std::sync::mpsc::channel;
+    use tikv_util::callback::Callback as UtilCallback;
     use tikv_util::codec::number::NumberEncoder;
     use tikv_util::future::paired_future_callback;
     use txn_types::Mutation;
@@ -967,6 +968,7 @@ mod tests {
             ctx: &Context,
             mut batch: WriteData,
             callback: EngineCallback<()>,
+            _: Option<UtilCallback<()>>,
         ) -> EngineResult<()> {
             batch.modifies.iter_mut().for_each(|modify| match modify {
                 Modify::Delete(_, ref mut key) => {

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -518,7 +518,7 @@ fn region_detail<T: RaftStoreRouter<RocksSnapshot>>(
 
     let (tx, rx) = oneshot::channel();
     let cb = Callback::Read(Box::new(|resp| tx.send(resp).unwrap()));
-    future::result(raft_router.send_command(raft_cmd, cb))
+    future::result(raft_router.send_command(raft_cmd, cb, None))
         .map_err(|e| Error::Other(Box::new(e)))
         .and_then(move |_| {
             rx.map_err(|e| Error::Other(Box::new(e)))
@@ -555,7 +555,7 @@ fn consistency_check<T: RaftStoreRouter<RocksSnapshot>>(
 
     let (tx, rx) = oneshot::channel();
     let cb = Callback::Read(Box::new(|resp| tx.send(resp).unwrap()));
-    future::result(raft_router.send_command(raft_cmd, cb))
+    future::result(raft_router.send_command(raft_cmd, cb, None))
         .map_err(|e| Error::Other(Box::new(e)))
         .and_then(move |_| {
             rx.map_err(|e| Error::Other(Box::new(e)))

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -768,7 +768,7 @@ impl<T: RaftStoreRouter<RocksSnapshot> + 'static, E: Engine, L: LockManager> Tik
 
         let (cb, future) = paired_future_callback();
 
-        if let Err(e) = self.ch.send_command(cmd, Callback::Read(cb)) {
+        if let Err(e) = self.ch.send_command(cmd, Callback::Read(cb), None) {
             self.send_fail_status(ctx, sink, Error::from(e), RpcStatusCode::RESOURCE_EXHAUSTED);
             return;
         }

--- a/src/storage/kv/btree_engine.rs
+++ b/src/storage/kv/btree_engine.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, RwLock};
 
 use engine_traits::{CfName, IterOptions, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::Context;
+use tikv_util::callback::Callback as UtilCallback;
 use txn_types::{Key, Value};
 
 use crate::storage::kv::{
@@ -75,6 +76,7 @@ impl Engine for BTreeEngine {
         _ctx: &Context,
         batch: WriteData,
         cb: EngineCallback<()>,
+        _: Option<UtilCallback<()>>,
     ) -> EngineResult<()> {
         if batch.modifies.is_empty() {
             return Err(EngineError::from(EngineErrorInner::EmptyRequest));

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -19,6 +19,7 @@ use tempfile::{Builder, TempDir};
 use txn_types::{Key, Value};
 
 use crate::storage::config::BlockCacheConfig;
+use tikv_util::callback::Callback as UtilCallback;
 use tikv_util::escape;
 use tikv_util::worker::{Runnable, Scheduler, Worker};
 
@@ -267,7 +268,13 @@ fn write_modifies(
 impl Engine for RocksEngine {
     type Snap = Arc<RocksSnapshot>;
 
-    fn async_write(&self, _: &Context, batch: WriteData, cb: Callback<()>) -> Result<()> {
+    fn async_write(
+        &self,
+        _: &Context,
+        batch: WriteData,
+        cb: Callback<()>,
+        _: Option<UtilCallback<()>>,
+    ) -> Result<()> {
         fail_point!("rockskv_async_write", |_| Err(box_err!("write failed")));
 
         if batch.modifies.is_empty() {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -609,6 +609,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
             &ctx,
             WriteData::from_modifies(modifies),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.delete_range.inc();
         Ok(())
@@ -831,6 +832,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                 value,
             )]),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_put.inc();
         Ok(())
@@ -860,6 +862,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
             &ctx,
             WriteData::from_modifies(modifies),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_batch_put.inc();
         Ok(())
@@ -882,6 +885,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                 Key::from_encoded(key),
             )]),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_delete.inc();
         Ok(())
@@ -912,6 +916,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
             &ctx,
             WriteData::from_modifies(vec![Modify::DeleteRange(cf, start_key, end_key, false)]),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_delete_range.inc();
         Ok(())
@@ -936,6 +941,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
             &ctx,
             WriteData::from_modifies(modifies),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_batch_delete.inc();
         Ok(())

--- a/tests/integrations/raftstore/test_multi.rs
+++ b/tests/integrations/raftstore/test_multi.rs
@@ -477,6 +477,7 @@ fn test_node_leader_change_with_log_overlap() {
                 assert!(resp.response.get_header().has_error());
                 assert!(resp.response.get_header().get_error().has_stale_command());
             })),
+            None,
         )
         .unwrap();
 
@@ -727,6 +728,7 @@ fn test_node_dropped_proposal() {
             Callback::Write(Box::new(move |resp: WriteResponse| {
                 let _ = tx.send(resp.response);
             })),
+            None,
         )
         .unwrap();
 


### PR DESCRIPTION
Signed-off-by: Liqi Geng <gengliqiii@gmail.com>


### What problem does this PR solve?

Problem Summary:
This work is part of https://github.com/tikv/tikv/issues/7980

### What is changed and how it works?

What's Changed:
1. do not propose if previous pending commands will change epoch
2. add pipelined write callback. Call this callback only after raftstore believes this proposal can be committed in future(it does its best to achieve this goal).

It is not finished yet.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Side effects

No.

### Release note <!-- bugfixes or new feature need a release note -->
* No release note