### PR TITLE
Makefile: don't try to use SSE on ARM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,11 @@ ROCKSDB_SYS_PORTABLE=0
 RUST_TEST_THREADS ?= 2
 endif
 
+# Disable SSE on ARM
+ifeq ($(shell uname -p),aarch64)
+ROCKSDB_SYS_SSE=0
+endif
+
 # Build portable binary by default unless disable explicitly
 ifneq ($(ROCKSDB_SYS_PORTABLE),0)
 ENABLE_FEATURES += portable


### PR DESCRIPTION
Signed-off-by: Brian Anderson <andersrb@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Makefile commands like `make clippy` don't work on arm targets.

### What is changed and how it works?

When the host is an ARM host, turn off SSE. This won't work in cross-compile scenarios, but I imagine the Makefile doesn't support cross-compiling at present.

### Related changes



### Check List <!--REMOVE the items that are not applicable-->



### Release note <!-- bugfixes or new feature need a release note -->

- No release note