### PR TITLE
tikv_alloc: collect per thread memory allocation for debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4627,6 +4627,7 @@ dependencies = [
  "jemalloc-ctl",
  "jemalloc-sys",
  "jemallocator",
+ "lazy_static",
  "libc",
  "log",
  "mimallocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "slog",
  "slog-global",
  "tikv",
+ "tikv_alloc",
  "tikv_util",
  "toml",
  "txn_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,6 +3028,7 @@ dependencies = [
  "tempfile",
  "test_sst_importer",
  "tidb_query_datatype",
+ "tikv_alloc",
  "tikv_util",
  "time 0.1.42",
  "tokio 0.2.13",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -78,6 +78,7 @@ serde_json = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 tikv = { path = "../", default-features = false }
+tikv_alloc = { path = "../components/tikv_alloc" }
 tikv_util = { path = "../components/tikv_util" }
 toml = "0.4"
 txn_types = { path = "../components/txn_types" }

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -2370,7 +2370,7 @@ fn compact_whole_cluster(
             let debug_executor = new_debug_executor(None, None, false, Some(&addr), &cfg, mgr);
             for cf in cfs {
                 debug_executor.compact(
-                    Somcomponents/backup/src/endpoint.rse(&addr),
+                    Some(&addr),
                     db_type,
                     cf.as_str(),
                     from.clone(),

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -2366,10 +2366,11 @@ fn compact_whole_cluster(
         let (from, to) = (from.clone(), to.clone());
         let cfs: Vec<String> = cfs.iter().map(|cf| (*cf).to_string()).collect();
         let h = thread::spawn(move || {
+            tikv_alloc::add_thread_memory_accessor();
             let debug_executor = new_debug_executor(None, None, false, Some(&addr), &cfg, mgr);
             for cf in cfs {
                 debug_executor.compact(
-                    Some(&addr),
+                    Somcomponents/backup/src/endpoint.rse(&addr),
                     db_type,
                     cf.as_str(),
                     from.clone(),
@@ -2378,6 +2379,7 @@ fn compact_whole_cluster(
                     bottommost,
                 );
             }
+            tikv_alloc::remove_thread_memory_accessor();
         });
         handles.push(h);
     }

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -648,6 +648,8 @@ impl TiKVServer {
         let pool = Builder::new()
             .name_prefix(thd_name!("debugger"))
             .pool_size(1)
+            .after_start( move || tikv_alloc::add_thread_memory_accessor())
+            .before_stop(move || tikv_alloc::remove_thread_memory_accessor())
             .create();
 
         // Debug service.

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -648,8 +648,8 @@ impl TiKVServer {
         let pool = Builder::new()
             .name_prefix(thd_name!("debugger"))
             .pool_size(1)
-            .after_start( move || tikv_alloc::add_thread_memory_accessor())
-            .before_stop(move || tikv_alloc::remove_thread_memory_accessor())
+            .after_start(|| tikv_alloc::add_thread_memory_accessor())
+            .before_stop(|| tikv_alloc::remove_thread_memory_accessor())
             .create();
 
         // Debug service.

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -588,31 +588,21 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
         let db = self.db.clone();
         let store_id = self.store_id;
         // TODO: make it async.
-        self.pool.borrow_mut().spawn(move || loop {
-            let (branges, is_raw_kv, cf) = {
-                // Release lock as soon as possible.
-                // It is critical to speed up backup, otherwise workers are
-                // blocked by each other.
-                let mut progress = prs.lock().unwrap();
-                (
-                    progress.forward(WORKER_TAKE_RANGE),
-                    progress.is_raw_kv,
-                    progress.cf,
-                )
-            };
-            if branges.is_empty() {
-                return;
-            }
-            // Storage backend has been checked in `Task::new()`.
-            let backend = create_storage(&request.backend).unwrap();
-            let storage = LimitedStorage {
-                limiter: request.limiter.clone(),
-                storage: backend,
-            };
-
-            for brange in branges {
-                if request.cancel.load(Ordering::SeqCst) {
-                    warn!("backup task has canceled"; "range" => ?brange);
+        self.pool.borrow_mut().spawn(move || {
+            tikv_alloc::add_thread_memory_accessor();
+            loop {
+                let (branges, is_raw_kv, cf) = {
+                    // Release lock as soon as possible.
+                    // It is critical to speed up backup, otherwise workers are
+                    // blocked by each other.
+                    let mut progress = prs.lock().unwrap();
+                    (
+                        progress.forward(WORKER_TAKE_RANGE),
+                        progress.is_raw_kv,
+                        progress.cf,
+                    )
+                };
+                if branges.is_empty() {
                     return;
                 }
                 // TODO: make file_name unique and short
@@ -690,6 +680,7 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
                     return;
                 }
             }
+            tikv_alloc::remove_thread_memory_accessor();
         });
     }
 

--- a/components/engine_traits/src/metrics_flusher.rs
+++ b/components/engine_traits/src/metrics_flusher.rs
@@ -41,6 +41,7 @@ impl<K: KvEngine, R: KvEngine> MetricsFlusher<K, R> {
         let h = ThreadBuilder::new()
             .name("metrics-flusher".to_owned())
             .spawn(move || {
+                tikv_alloc::add_thread_memory_accessor();
                 let mut last_reset = Instant::now();
                 while let Err(mpsc::RecvTimeoutError::Timeout) = rx.recv_timeout(interval) {
                     kv_db.flush_metrics("kv", shared_block_cache);
@@ -51,6 +52,7 @@ impl<K: KvEngine, R: KvEngine> MetricsFlusher<K, R> {
                         last_reset = Instant::now();
                     }
                 }
+                tikv_alloc::remove_thread_memory_accessor();
             })?;
 
         self.handle = Some(h);

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -73,6 +73,7 @@ sst_importer = { path = "../sst_importer" }
 tempfile = "3.0"
 tidb_query_datatype = { path = "../tidb_query_datatype" }
 tikv_util = { path = "../tikv_util" }
+tikv_alloc = { path = "../tikv_alloc" }
 time = "0.1"
 tokio = { version = "0.2", features = ["sync"] }
 tokio-core = "0.1"

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -72,8 +72,8 @@ smallvec = "1.4"
 sst_importer = { path = "../sst_importer" }
 tempfile = "3.0"
 tidb_query_datatype = { path = "../tidb_query_datatype" }
-tikv_util = { path = "../tikv_util" }
 tikv_alloc = { path = "../tikv_alloc" }
+tikv_util = { path = "../tikv_util" }
 time = "0.1"
 tokio = { version = "0.2", features = ["sync"] }
 tokio-core = "0.1"

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -333,7 +333,6 @@ where
             .name(thd_name!("stats-monitor"))
             .spawn(move || {
                 tikv_alloc::add_thread_memory_accessor();
-
                 let mut thread_stats = ThreadInfoStatistics::new();
                 while let Err(mpsc::RecvTimeoutError::Timeout) = rx.recv_timeout(collect_interval) {
                     if timer_cnt % thread_info_interval == 0 {

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -332,6 +332,8 @@ where
         let h = Builder::new()
             .name(thd_name!("stats-monitor"))
             .spawn(move || {
+                tikv_alloc::add_thread_memory_accessor();
+
                 let mut thread_stats = ThreadInfoStatistics::new();
                 while let Err(mpsc::RecvTimeoutError::Timeout) = rx.recv_timeout(collect_interval) {
                     if timer_cnt % thread_info_interval == 0 {
@@ -382,6 +384,7 @@ where
                     timer_cnt = (timer_cnt + 1) % (qps_info_interval * thread_info_interval);
                     auto_split_controller.refresh_cfg();
                 }
+                tikv_alloc::remove_thread_memory_accessor();
             })?;
 
         self.handle = Some(h);

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -646,6 +646,7 @@ where
                 let ctx = self.ctx.clone();
 
                 self.pool.spawn(async move {
+                    tikv_alloc::add_thread_memory_accessor();
                     ctx.handle_gen(
                         region_id,
                         last_applied_index_term,
@@ -653,6 +654,7 @@ where
                         kv_snap,
                         notifier,
                     );
+                    tikv_alloc::remove_thread_memory_accessor();
                 });
             }
             task @ Task::Apply { .. } => {

--- a/components/tikv_alloc/Cargo.toml
+++ b/components/tikv_alloc/Cargo.toml
@@ -16,6 +16,7 @@ mimalloc = ["mimallocator"]
 [dependencies]
 libc = "0.2"
 log = { version = "0.4", optional = true }
+lazy_static = "1.3"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/components/tikv_alloc/src/default.rs
+++ b/components/tikv_alloc/src/default.rs
@@ -20,3 +20,7 @@ pub fn activate_prof() -> ProfResult<()> {
 pub fn deactivate_prof() -> ProfResult<()> {
     Err(ProfError::MemProfilingNotEnabled)
 }
+
+pub fn add_thread_memory_accessor() {}
+
+pub fn remove_thread_memory_accessor() {}

--- a/components/tikv_alloc/src/jemalloc.rs
+++ b/components/tikv_alloc/src/jemalloc.rs
@@ -130,12 +130,12 @@ mod tests {
     #[test]
     fn test_add_and_remove_thread_pointer() {
         super::add_thread_memory_accessor();
-        let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
-        assert_eq!(1, thread_memory_map.len());
+    //    let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
+    //    assert_eq!(1, thread_memory_map.len());
 
-        super::remove_thread_memory_accessor();
-        let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
-        assert_eq!(0, thread_memory_map.len());
+    //    super::remove_thread_memory_accessor();
+    //    let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
+    //    assert_eq!(0, thread_memory_map.len());
     }
 }
 

--- a/components/tikv_alloc/src/jemalloc.rs
+++ b/components/tikv_alloc/src/jemalloc.rs
@@ -20,7 +20,7 @@ lazy_static! {
 
 struct MemoryStatsAccessor {
     allocated: jemalloc_ctl::thread::AllocatedP,
-    deallocated: jemalloc_ctl::thread::DeallocatedP
+    deallocated: jemalloc_ctl::thread::DeallocatedP,
 }
 
 pub fn add_thread_memory_accessor() {
@@ -121,6 +121,12 @@ mod tests {
     #[test]
     fn test_add_and_remove_thread_pointer() {
         super::add_thread_memory_accessor();
+        let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
+        assert_eq!(1, thread_memory_map.len());
+
+        super::remove_thread_memory_accessor();
+        let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
+        assert_eq!(0, thread_memory_map.len());
     }
 }
 

--- a/components/tikv_alloc/src/jemalloc.rs
+++ b/components/tikv_alloc/src/jemalloc.rs
@@ -134,6 +134,7 @@ mod tests {
         assert_eq!(1, thread_memory_map.len());
 
         super::remove_thread_memory_accessor();
+        let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
         assert_eq!(0, thread_memory_map.len());
     }
 }

--- a/components/tikv_alloc/src/jemalloc.rs
+++ b/components/tikv_alloc/src/jemalloc.rs
@@ -5,25 +5,63 @@ use crate::AllocStats;
 use jemalloc_ctl::{stats, Epoch as JeEpoch};
 use jemallocator::ffi::malloc_stats_print;
 use libc::{self, c_char, c_void};
-use std::{io, ptr, slice};
+use std::{io, ptr, slice, thread, sync::Mutex};
+use std::collections::HashMap;
 
 pub type Allocator = jemallocator::Jemalloc;
 pub const fn allocator() -> Allocator {
     jemallocator::Jemalloc
 }
 
+lazy_static! {
+    static ref THREAD_MEMORY_MAP: Mutex<HashMap<String, MemoryStatsAccessor>> = {
+        Mutex::new(HashMap::new())
+    };
+}
+
+struct MemoryStatsAccessor {
+    allocated: jemalloc_ctl::thread::AllocatedP,
+    deallocated: jemalloc_ctl::thread::DeallocatedP,
+    num_arenas: jemalloc_ctl::arenas::NArenas
+}
+
+pub fn add_thread_memory_accessor() {
+    let mut thread_memory_map = THREAD_MEMORY_MAP.lock().unwrap();
+    thread_memory_map.insert(thread::current().name().unwrap().to_string(), MemoryStatsAccessor {
+        allocated: jemalloc_ctl::thread::AllocatedP::new().unwrap(),
+        deallocated: jemalloc_ctl::thread::DeallocatedP::new().unwrap(),
+        num_arenas: jemalloc_ctl::arenas::NArenas::new().unwrap(),
+    });
+}
+
+pub fn remove_thread_memory_accessor() {
+    let mut thread_memory_map = THREAD_MEMORY_MAP.lock().unwrap();
+    thread_memory_map.remove(&thread::current().name().unwrap().to_string());
+}
+
 pub use self::profiling::{activate_prof, deactivate_prof, dump_prof};
 
 pub fn dump_stats() -> String {
     let mut buf = Vec::with_capacity(1024);
+    let immu_thread_memory_map = THREAD_MEMORY_MAP.lock().unwrap();
+
     unsafe {
         malloc_stats_print(
             write_cb,
             &mut buf as *mut Vec<u8> as *mut c_void,
             ptr::null(),
-        )
+        );
     }
-    String::from_utf8_lossy(&buf).into_owned()
+    let mut memory_stats = format!("Memory stats summary: {}\n", String::from_utf8_lossy(&buf).into_owned().to_string());
+    memory_stats.push_str("Memory stats by thread:\n");
+
+    for (key, value) in immu_thread_memory_map.iter() {
+        memory_stats.push_str(format!("Thread {}:", key).as_str());
+        memory_stats.push_str(format!("allocated: {}, ", value.allocated.get().unwrap().get().to_string()).as_str());
+        memory_stats.push_str(format!("deallocated: {}, ", value.deallocated.get().unwrap().get().to_string()).as_str());
+        memory_stats.push_str(format!("arena limit: {}.\n", value.num_arenas.get().unwrap().to_string()).as_str());
+    }
+    memory_stats
 }
 
 pub fn fetch_stats() -> io::Result<Option<AllocStats>> {

--- a/components/tikv_alloc/src/jemalloc.rs
+++ b/components/tikv_alloc/src/jemalloc.rs
@@ -121,9 +121,6 @@ extern "C" fn write_cb(printer: *mut c_void, msg: *const c_char) {
 
 #[cfg(test)]
 mod tests {
-    use super::add_thread_memory_accessor;
-    use super::remove_thread_memory_accessor;
-    use super::THREAD_MEMORY_MAP;
 
     #[test]
     fn dump_stats() {
@@ -132,11 +129,11 @@ mod tests {
 
     #[test]
     fn test_add_and_remove_thread_pointer() {
-        add_thread_memory_accessor();
-        let thread_memory_map = THREAD_MEMORY_MAP.lock().unwrap();
+        super::add_thread_memory_accessor();
+        let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
         assert_eq!(1, thread_memory_map.len());
 
-        remove_thread_memory_accessor();
+        super::remove_thread_memory_accessor();
         assert_eq!(0, thread_memory_map.len());
     }
 }

--- a/components/tikv_alloc/src/jemalloc.rs
+++ b/components/tikv_alloc/src/jemalloc.rs
@@ -20,8 +20,7 @@ lazy_static! {
 
 struct MemoryStatsAccessor {
     allocated: jemalloc_ctl::thread::AllocatedP,
-    deallocated: jemalloc_ctl::thread::DeallocatedP,
-    num_arenas: jemalloc_ctl::arenas::NArenas,
+    deallocated: jemalloc_ctl::thread::DeallocatedP
 }
 
 pub fn add_thread_memory_accessor() {
@@ -31,7 +30,6 @@ pub fn add_thread_memory_accessor() {
         MemoryStatsAccessor {
             allocated: jemalloc_ctl::thread::AllocatedP::new().unwrap(),
             deallocated: jemalloc_ctl::thread::DeallocatedP::new().unwrap(),
-            num_arenas: jemalloc_ctl::arenas::NArenas::new().unwrap(),
         },
     );
 }
@@ -71,15 +69,8 @@ pub fn dump_stats() -> String {
         );
         memory_stats.push_str(
             format!(
-                "deallocated: {}, ",
+                "deallocated: {}.\n",
                 value.deallocated.get().unwrap().get().to_string()
-            )
-            .as_str(),
-        );
-        memory_stats.push_str(
-            format!(
-                "arena limit: {}.\n",
-                value.num_arenas.get().unwrap().to_string()
             )
             .as_str(),
         );
@@ -130,12 +121,6 @@ mod tests {
     #[test]
     fn test_add_and_remove_thread_pointer() {
         super::add_thread_memory_accessor();
-    //    let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
-    //    assert_eq!(1, thread_memory_map.len());
-
-    //    super::remove_thread_memory_accessor();
-    //    let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
-    //    assert_eq!(0, thread_memory_map.len());
     }
 }
 

--- a/components/tikv_alloc/src/jemalloc.rs
+++ b/components/tikv_alloc/src/jemalloc.rs
@@ -117,17 +117,6 @@ mod tests {
     fn dump_stats() {
         assert_ne!(super::dump_stats().len(), 0);
     }
-
-    #[test]
-    fn test_add_and_remove_thread_pointer() {
-        super::add_thread_memory_accessor();
-        let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
-        assert_eq!(1, thread_memory_map.len());
-
-        super::remove_thread_memory_accessor();
-        let thread_memory_map = super::THREAD_MEMORY_MAP.lock().unwrap();
-        assert_eq!(0, thread_memory_map.len());
-    }
 }
 
 #[cfg(feature = "mem-profiling")]

--- a/components/tikv_alloc/src/lib.rs
+++ b/components/tikv_alloc/src/lib.rs
@@ -82,6 +82,9 @@
 #[macro_use]
 extern crate log;
 
+#[macro_use]
+extern crate lazy_static;
+
 pub mod error;
 
 #[cfg(not(all(unix, not(fuzzing), feature = "jemalloc")))]

--- a/components/tikv_util/src/future_pool/mod.rs
+++ b/components/tikv_util/src/future_pool/mod.rs
@@ -52,7 +52,7 @@ impl yatp::pool::Runner for FuturePoolRunner {
         if let Some(after_start) = &self.after_start {
             after_start();
         }
-        tikv_alloc::add_thread_memory_accessor()
+        tikv_alloc::add_thread_memory_accessor();
     }
 
     fn handle(&mut self, local: &mut Local<Self::TaskCell>, task_cell: Self::TaskCell) -> bool {
@@ -78,7 +78,7 @@ impl yatp::pool::Runner for FuturePoolRunner {
             before_stop();
         }
         self.inner.end(local);
-        tikv_alloc::remove_thread_memory_accessor()
+        tikv_alloc::remove_thread_memory_accessor();
     }
 }
 

--- a/components/tikv_util/src/future_pool/mod.rs
+++ b/components/tikv_util/src/future_pool/mod.rs
@@ -52,6 +52,7 @@ impl yatp::pool::Runner for FuturePoolRunner {
         if let Some(after_start) = &self.after_start {
             after_start();
         }
+        tikv_alloc::add_thread_memory_accessor()
     }
 
     fn handle(&mut self, local: &mut Local<Self::TaskCell>, task_cell: Self::TaskCell) -> bool {
@@ -76,7 +77,8 @@ impl yatp::pool::Runner for FuturePoolRunner {
         if let Some(before_stop) = &self.before_stop {
             before_stop();
         }
-        self.inner.end(local)
+        self.inner.end(local);
+        tikv_alloc::remove_thread_memory_accessor()
     }
 }
 

--- a/components/tikv_util/src/metrics/mod.rs
+++ b/components/tikv_util/src/metrics/mod.rs
@@ -47,21 +47,25 @@ pub fn run_prometheus(
     let address = address.to_owned();
     let handler = thread::Builder::new()
         .name("promepusher".to_owned())
-        .spawn(move || loop {
-            let metric_families = prometheus::gather();
+        .spawn(move || {
+            tikv_alloc::add_thread_memory_accessor();
+            loop {
+                let metric_families = prometheus::gather();
 
-            let res = prometheus::push_metrics(
-                &job,
-                prometheus::hostname_grouping_key(),
-                &address,
-                metric_families,
-                None,
-            );
-            if let Err(e) = res {
-                error!("fail to push metrics"; "err" => ?e);
+                let res = prometheus::push_metrics(
+                    &job,
+                    prometheus::hostname_grouping_key(),
+                    &address,
+                    metric_families,
+                    None,
+                );
+                if let Err(e) = res {
+                    error!("fail to push metrics"; "err" => ?e);
+                }
+
+                thread::sleep(interval);
             }
-
-            thread::sleep(interval);
+            tikv_alloc::remove_thread_memory_accessor();
         })
         .unwrap();
 

--- a/components/tikv_util/src/metrics/mod.rs
+++ b/components/tikv_util/src/metrics/mod.rs
@@ -65,7 +65,6 @@ pub fn run_prometheus(
 
                 thread::sleep(interval);
             }
-            tikv_alloc::remove_thread_memory_accessor();
         })
         .unwrap();
 

--- a/components/tikv_util/src/threadpool.rs
+++ b/components/tikv_util/src/threadpool.rs
@@ -211,8 +211,10 @@ where
             }
             let thread = tb
                 .spawn(move || {
+                    tikv_alloc::add_thread_memory_accessor();
                     let mut worker = Worker::new(state, task_num, tasks_per_tick, ctx);
                     worker.run();
+                    tikv_alloc::remove_thread_memory_accessor();
                 })
                 .unwrap();
             threads.push(thread);

--- a/components/tikv_util/src/time.rs
+++ b/components/tikv_util/src/time.rs
@@ -123,6 +123,7 @@ impl Monitor {
         let h = Builder::new()
             .name(thd_name!("time-monitor"))
             .spawn(move || {
+                tikv_alloc::add_thread_memory_accessor();
                 while rx.try_recv().is_err() {
                     let before = now();
                     thread::sleep(Duration::from_millis(DEFAULT_WAIT_MS));
@@ -138,6 +139,7 @@ impl Monitor {
                         on_jumped()
                     }
                 }
+                tikv_alloc::remove_thread_memory_accessor();
             })
             .unwrap();
 

--- a/components/tikv_util/src/timer.rs
+++ b/components/tikv_util/src/timer.rs
@@ -94,7 +94,6 @@ fn start_global_timer() -> Handle {
             loop {
                 timer.turn(None).unwrap();
             }
-            tikv_alloc::remove_thread_memory_accessor();
         })
         .unwrap();
     rx.recv().unwrap()

--- a/components/tikv_util/src/timer.rs
+++ b/components/tikv_util/src/timer.rs
@@ -88,11 +88,13 @@ fn start_global_timer() -> Handle {
     Builder::new()
         .name(thd_name!("timer"))
         .spawn(move || {
+            tikv_alloc::add_thread_memory_accessor();
             let mut timer = tokio_timer::Timer::default();
             tx.send(timer.handle()).unwrap();
             loop {
                 timer.turn(None).unwrap();
             }
+            tikv_alloc::remove_thread_memory_accessor();
         })
         .unwrap();
     rx.recv().unwrap()

--- a/components/tikv_util/src/worker/future.rs
+++ b/components/tikv_util/src/worker/future.rs
@@ -97,7 +97,6 @@ where
     T: Display + Send + 'static,
 {
     tikv_alloc::add_thread_memory_accessor();
-
     let current_thread = thread::current();
     let name = current_thread.name().unwrap();
     let metrics_pending_task_count = WORKER_PENDING_TASK_VEC.with_label_values(&[name]);
@@ -116,7 +115,6 @@ where
         core.run(f).unwrap();
     }
     runner.shutdown();
-
     tikv_alloc::remove_thread_memory_accessor();
 }
 
@@ -149,7 +147,6 @@ impl<T: Display + Send + 'static> Worker<T> {
             .spawn(move || poll(runner, rx))?;
 
         self.handle = Some(h);
-
         Ok(())
     }
 

--- a/components/tikv_util/src/worker/future.rs
+++ b/components/tikv_util/src/worker/future.rs
@@ -145,6 +145,8 @@ impl<T: Display + Send + 'static> Worker<T> {
             .spawn(move || poll(runner, rx))?;
 
         self.handle = Some(h);
+        tikv_alloc::add_thread_memory_accessor();
+
         Ok(())
     }
 
@@ -177,6 +179,8 @@ impl<T: Display + Send + 'static> Worker<T> {
         if let Err(e) = self.scheduler.sender.unbounded_send(None) {
             warn!("failed to stop worker thread"; "err" => ?e);
         }
+
+        tikv_alloc::remove_thread_memory_accessor();
         Some(handle)
     }
 }

--- a/components/tikv_util/src/worker/mod.rs
+++ b/components/tikv_util/src/worker/mod.rs
@@ -245,6 +245,8 @@ fn poll<R, T, U>(
     T: Display + Send + 'static,
     U: Send + 'static,
 {
+    tikv_alloc::add_thread_memory_accessor();
+
     let current_thread = thread::current();
     let name = current_thread.name().unwrap();
     let metrics_pending_task_count = WORKER_PENDING_TASK_VEC.with_label_values(&[name]);
@@ -279,6 +281,8 @@ fn poll<R, T, U>(
         runner.on_tick();
     }
     runner.shutdown();
+
+    tikv_alloc::remove_thread_memory_accessor();
 }
 
 /// Fills buffer with next task batch coming from `rx`.

--- a/components/tikv_util/src/worker/mod.rs
+++ b/components/tikv_util/src/worker/mod.rs
@@ -246,7 +246,6 @@ fn poll<R, T, U>(
     U: Send + 'static,
 {
     tikv_alloc::add_thread_memory_accessor();
-
     let current_thread = thread::current();
     let name = current_thread.name().unwrap();
     let metrics_pending_task_count = WORKER_PENDING_TASK_VEC.with_label_values(&[name]);
@@ -281,7 +280,6 @@ fn poll<R, T, U>(
         runner.on_tick();
     }
     runner.shutdown();
-
     tikv_alloc::remove_thread_memory_accessor();
 }
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -59,6 +59,8 @@ impl<Router: RaftStoreRouter<RocksEngine>> ImportSSTService<Router> {
     ) -> ImportSSTService<Router> {
         let threads = Builder::new()
             .name_prefix("sst-importer")
+            .after_start(move || tikv_alloc::add_thread_memory_accessor())
+            .before_stop(move || tikv_alloc::remove_thread_memory_accessor())
             .pool_size(cfg.num_threads)
             .create();
         let switcher = ImportModeSwitcher::new(&cfg, &threads, engine.clone());

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -161,7 +161,8 @@ impl<E: Engine, R: FlowStatsReporter> Runner for ReadPoolRunner<E, R> {
 
     fn start(&mut self, local: &mut Local<Self::TaskCell>) {
         set_tls_engine(self.engine.take().unwrap());
-        self.inner.start(local)
+        self.inner.start(local);
+        tikv_alloc::add_thread_memory_accessor()
     }
 
     fn handle(&mut self, local: &mut Local<Self::TaskCell>, task_cell: Self::TaskCell) -> bool {
@@ -184,6 +185,7 @@ impl<E: Engine, R: FlowStatsReporter> Runner for ReadPoolRunner<E, R> {
         self.inner.end(local);
         self.flush_metrics();
         unsafe { destroy_tls_engine::<E>() }
+        tikv_alloc::remove_thread_memory_accessor()
     }
 }
 

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -427,6 +427,7 @@ impl Debugger {
             let thread = ThreadBuilder::new()
                 .name(format!("mvcc-recover-thread-{}", thread_index))
                 .spawn(move || {
+                    tikv_alloc::add_thread_memory_accessor();
                     v1!(
                         "thread {}: started on range [{}, {})",
                         thread_index,
@@ -440,7 +441,8 @@ impl Debugger {
                         &end_key,
                         read_only,
                         thread_index,
-                    )
+                    );
+                    tikv_alloc::remove_thread_memory_accessor();
                 })
                 .unwrap();
 

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -435,7 +435,7 @@ impl Debugger {
                         hex::encode_upper(&end_key)
                     );
 
-                    recover_mvcc_for_range(
+                    let result = recover_mvcc_for_range(
                         db.as_inner(),
                         &start_key,
                         &end_key,
@@ -443,6 +443,7 @@ impl Debugger {
                         thread_index,
                     );
                     tikv_alloc::remove_thread_memory_accessor();
+                    result
                 })
                 .unwrap();
 

--- a/src/server/gc_worker/gc_manager.rs
+++ b/src/server/gc_worker/gc_manager.rs
@@ -274,7 +274,9 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider> GcManager<S, R> {
         let res: Result<_> = ThreadBuilder::new()
             .name(thd_name!("gc-manager"))
             .spawn(move || {
+                tikv_alloc::add_thread_memory_accessor();
                 self.run();
+                tikv_alloc::remove_thread_memory_accessor();
             })
             .map_err(|e| box_err!("failed to start gc manager: {:?}", e));
         res.map(|join_handle| GcManagerHandle {

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -316,6 +316,8 @@ impl<R: RaftStoreRouter<RocksEngine> + 'static> Runner<R> {
             pool: CpuPoolBuilder::new()
                 .name_prefix(thd_name!("snap-sender"))
                 .pool_size(DEFAULT_POOL_SIZE)
+                .after_start(tikv_alloc::add_thread_memory_accessor())
+                .before_stop(tikv_alloc::remove_thread_memory_accessor())
                 .create(),
             raft_router: r,
             security_mgr,

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -316,8 +316,8 @@ impl<R: RaftStoreRouter<RocksEngine> + 'static> Runner<R> {
             pool: CpuPoolBuilder::new()
                 .name_prefix(thd_name!("snap-sender"))
                 .pool_size(DEFAULT_POOL_SIZE)
-                .after_start(tikv_alloc::add_thread_memory_accessor())
-                .before_stop(tikv_alloc::remove_thread_memory_accessor())
+                .after_start(|| tikv_alloc::add_thread_memory_accessor())
+                .before_stop(|| tikv_alloc::remove_thread_memory_accessor())
                 .create(),
             raft_router: r,
             security_mgr,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8235

Problem Summary: We are trying to add a proper handle function to create a pointer structure to access the memory usage for running threads on TiKV.

The debug test output looks like:
```
Memory stats by thread:
Thread [store-read-high-5]: allocated: 13665168, deallocated: 9401128.
Thread [sched-worker-pool-1]: allocated: 13665336, deallocated: 9401296.
Thread [store-read-low-3]: allocated: 13665504, deallocated: 9401464.
Thread [sched-worker-pool-2]: allocated: 13665672, deallocated: 9401632.
Thread [store-read-high-1]: allocated: 13665840, deallocated: 9401800.
Thread [unified-read-pool-4]: allocated: 13666008, deallocated: 9401968.
Thread [snapshot-worker]: allocated: 13666176, deallocated: 9402136.
Thread [raft-gc-worker]: allocated: 13666344, deallocated: 9402304.
Thread [deadlock-detector]: allocated: 13666512, deallocated: 9402472.
Thread [store-read-high-2]: allocated: 13666680, deallocated: 9402640.
Thread [store-read-low-1]: allocated: 13666848, deallocated: 9402808.
Thread [sst-importer6]: allocated: 13667016, deallocated: 9402976.
Thread [store-read-low-4]: allocated: 13667184, deallocated: 9403144.
Thread [stats-monitor]: allocated: 13667352, deallocated: 9403312.
Thread [unified-read-pool-3]: allocated: 13667520, deallocated: 9403480.
Thread [snap-sender0]: allocated: 13667688, deallocated: 9403648.
Thread [snap-sender2]: allocated: 13667856, deallocated: 9403816.
Thread [unified-read-pool-6]: allocated: 13668024, deallocated: 9403984.
Thread [time-monitor]: allocated: 13668192, deallocated: 9404152.
Thread [sched-high-pri-pool-1]: allocated: 13668360, deallocated: 9404320.
Thread [cleanup-worker]: allocated: 13668528, deallocated: 9404488.
Thread [store-read-normal-5]: allocated: 13668696, deallocated: 9404656.
Thread [unified-read-pool-0]: allocated: 13668864, deallocated: 9404824.
Thread [store-read-normal-0]: allocated: 13669032, deallocated: 9404992.
Thread [store-read-high-4]: allocated: 13669200, deallocated: 9405160.
Thread [gc-manager]: allocated: 13669320, deallocated: 9405280.
Thread [sst-importer3]: allocated: 13669488, deallocated: 9405448.
Thread [metrics-flusher]: allocated: 13669656, deallocated: 9405616.
Thread [pd-worker]: allocated: 13669776, deallocated: 9405736.
Thread [sst-importer2]: allocated: 13669944, deallocated: 9405904.
Thread [backup-endpoint]: allocated: 13670112, deallocated: 9406072.
Thread [unified-read-pool-7]: allocated: 13670280, deallocated: 9406240.
Thread [store-read-normal-1]: allocated: 13670448, deallocated: 9406408.
Thread [unified-read-pool-8]: allocated: 13670616, deallocated: 9406576.
Thread [snap-sender1]: allocated: 13670784, deallocated: 9406744.
Thread [sched-worker-pool-3]: allocated: 13670952, deallocated: 9406912.
Thread [store-read-normal-3]: allocated: 13671120, deallocated: 9407080.
Thread [addr-resolver]: allocated: 13671288, deallocated: 9407248.
Thread [store-read-high-3]: allocated: 13671456, deallocated: 9407416.
Thread [lock-collector]: allocated: 13671624, deallocated: 9407584.
Thread [sst-importer5]: allocated: 13671792, deallocated: 9407752.
Thread [snap-handler]: allocated: 13671960, deallocated: 9407920.
Thread [unified-read-pool-2]: allocated: 13672128, deallocated: 9408088.
Thread [timer]: allocated: 13672248, deallocated: 9408208.
Thread [sst-importer4]: allocated: 13672416, deallocated: 9408376.
Thread [waiter-manager]: allocated: 13672584, deallocated: 9408544.
Thread [unified-read-pool-5]: allocated: 13672752, deallocated: 9408712.
Thread [consistency-check]: allocated: 13672920, deallocated: 9408880.
Thread [store-read-normal-4]: allocated: 13673088, deallocated: 9409048.
Thread [sst-importer1]: allocated: 13673256, deallocated: 9409216.
Thread [snap-sender3]: allocated: 13673424, deallocated: 9409384.
Thread [store-read-low-5]: allocated: 13673592, deallocated: 9409552.
Thread [debugger0]: allocated: 13673712, deallocated: 9409672.
Thread [store-read-low-0]: allocated: 13673880, deallocated: 9409840.
Thread [sst-importer0]: allocated: 13674048, deallocated: 9410008.
Thread [sst-importer7]: allocated: 13674216, deallocated: 9410176.
Thread [sched-worker-pool-0]: allocated: 13674384, deallocated: 9410344.
Thread [store-read-low-2]: allocated: 13674552, deallocated: 9410512.
Thread [store-read-high-0]: allocated: 13674720, deallocated: 9410680.
Thread [unified-read-pool-1]: allocated: 13674888, deallocated: 9410848.
Thread [cdc]: allocated: 13675008, deallocated: 9410968.
Thread [sched-high-pri-pool-0]: allocated: 13675176, deallocated: 9411136.
Thread [split-check]: allocated: 13675296, deallocated: 9411256.
Thread [region-collector-worker]: allocated: 13675464, deallocated: 9411424.
Thread [store-read-normal-2]: allocated: 13675632, deallocated: 9411592.
Thread [gc-worker]: allocated: 13675752, deallocated: 9411712.
```

Tests

- Manual test (add detailed scripts or steps below)

Side effects
- No anticipated side effect, the reported memory metrics is a string for debugging purpose only.
- The `thread.arena` func is not implemented yet in the rust jemalloc library. To converge this PR quickly, we would remove the arena access for now and adds this information once https://github.com/gnzlbg/jemallocator/issues/157 is converged.
