### PR TITLE
implement VerKv types and get rpc endpoints

### DIFF
--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -19,7 +19,7 @@ use std::io;
 pub use lock::{Lock, LockType};
 pub use timestamp::{TimeStamp, TsSet};
 pub use types::{
-    is_short_value, Key, KvPair, Mutation, MutationType, OldValue, TxnExtra, Value,
+    is_short_value, Key, KvPair, VerKvPair, Mutation, MutationType, OldValue, TxnExtra, Value,
     SHORT_VALUE_MAX_LEN,
 };
 pub use write::{Write, WriteRef, WriteType};

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -25,6 +25,12 @@ pub type Value = Vec<u8>;
 /// encoded bytes.
 pub type KvPair = (Vec<u8>, Value);
 
+/// Versioned Key-value pair type.
+///
+/// The value is not simply raw bytes; the key is a little bit tricky, which is
+/// encoded bytes.
+pub type VerKvPair = (Vec<u8>, Value);
+
 /// Key type.
 ///
 /// Keys have 2 types of binary representation - raw and encoded. The raw


### PR DESCRIPTION
### What problem does this PR solve?

WIP: it solves

 Add the Put/BatchPut RPC interface, and implement tikv-server side logic from #7259

Problem Summary:

Proposal: [VerKV ](https://github.com/tikv/tikv/issues/7295)

What's Changed:

### Related changes

- implement `future_ver_get`
- implement `future_ver_batch_get`
- implement `future_ver_delete_range`
- implement `future_ver_scan`

