### PR TITLE
Support parallel running for failpoint tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,12 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
+name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -212,7 +218,7 @@ dependencies = [
  "prometheus",
  "raft",
  "raftstore",
- "rand",
+ "rand 0.7.3",
  "security",
  "serde",
  "serde_derive",
@@ -254,6 +260,7 @@ dependencies = [
  "criterion",
  "crossbeam",
  "derive_more",
+ "fail 0.4.0",
  "serde",
  "serde_derive",
  "slog",
@@ -456,7 +463,7 @@ version = "0.0.1"
 dependencies = [
  "engine_rocks",
  "engine_traits",
- "fail",
+ "fail 0.4.0",
  "failure",
  "futures 0.1.29",
  "grpcio",
@@ -589,7 +596,7 @@ dependencies = [
  "protobuf",
  "raft",
  "raftstore",
- "rand",
+ "rand 0.7.3",
  "security",
  "serde_json",
  "signal",
@@ -623,7 +630,7 @@ dependencies = [
  "libc",
  "panic_hook",
  "protobuf",
- "rand",
+ "rand 0.7.3",
  "static_assertions",
  "tikv_alloc",
 ]
@@ -664,7 +671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c750ec12b83377637110d5a57f5ae08e895b06c4b16e2bdbf1a94ef717428c59"
 dependencies = [
  "proc-macro-hack",
- "rand",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -718,8 +725,8 @@ dependencies = [
  "itertools",
  "lazy_static",
  "num-traits",
- "rand_core",
- "rand_os",
+ "rand_core 0.5.1",
+ "rand_os 0.2.2",
  "rand_xoshiro",
  "rayon",
  "serde",
@@ -801,7 +808,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -826,7 +833,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "cfg-if",
  "lazy_static",
 ]
@@ -1014,7 +1021,7 @@ dependencies = [
  "openssl",
  "prometheus",
  "protobuf",
- "rand",
+ "rand 0.7.3",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_kms",
@@ -1057,7 +1064,7 @@ dependencies = [
  "num_cpus",
  "prometheus",
  "prometheus-static-metric",
- "rand",
+ "rand 0.7.3",
  "rocksdb",
  "serde",
  "serde_derive",
@@ -1120,7 +1127,7 @@ dependencies = [
  "hyper",
  "hyper-tls",
  "kvproto",
- "rand",
+ "rand 0.7.3",
  "rusoto_core",
  "rusoto_mock",
  "rusoto_s3",
@@ -1141,11 +1148,22 @@ dependencies = [
 [[package]]
 name = "fail"
 version = "0.3.0"
-source = "git+https://github.com/tikv/fail-rs.git?rev=2cf1175a1a5cc2c70bd20ebd45313afd69b558fc#2cf1175a1a5cc2c70bd20ebd45313afd69b558fc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63eec71a3013ee912a0ecb339ff0c5fa5ed9660df04bfefa10c250b885d018c"
 dependencies = [
  "lazy_static",
  "log",
- "rand",
+ "rand 0.6.5",
+]
+
+[[package]]
+name = "fail"
+version = "0.4.0"
+source = "git+https://github.com/hunterlxt/fail-rs?branch=XT/threads#0421da8aaf3b5ec1ba0266707ae484491b7e99a0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -1236,6 +1254,12 @@ name = "fs_extra"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -1473,8 +1497,7 @@ dependencies = [
 [[package]]
 name = "grpcio"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a60cc544face71ebbc053d821fdf880b809340b67d19f5d07d6b829e9e36e63"
+source = "git+https://github.com/hunterlxt/grpc-rs?branch=xt/pick-474#d103af121df412d7a628027de3f2eef15a1b5afc"
 dependencies = [
  "bytes 0.5.3",
  "futures 0.1.29",
@@ -1502,8 +1525,7 @@ dependencies = [
 [[package]]
 name = "grpcio-sys"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae317d29eb55297b760ca3641662f140e17b9dc36e3f23a3e7e7327e3c33c7e"
+source = "git+https://github.com/hunterlxt/grpc-rs?branch=xt/pick-474#d103af121df412d7a628027de3f2eef15a1b5afc"
 dependencies = [
  "bindgen",
  "cc",
@@ -2343,7 +2365,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-traits",
 ]
 
@@ -2374,7 +2396,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-traits",
 ]
 
@@ -2384,7 +2406,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-integer",
  "num-traits",
 ]
@@ -2395,7 +2417,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-integer",
  "num-traits",
 ]
@@ -2406,7 +2428,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -2466,7 +2488,7 @@ version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "cc",
  "libc",
  "openssl-src",
@@ -2956,7 +2978,7 @@ dependencies = [
  "protobuf",
  "quick-error",
  "raft-proto",
- "rand",
+ "rand 0.7.3",
  "slog",
 ]
 
@@ -2984,7 +3006,7 @@ dependencies = [
  "encryption",
  "engine_rocks",
  "engine_traits",
- "fail",
+ "fail 0.4.0",
  "fs2",
  "futures 0.1.29",
  "futures-executor",
@@ -3005,7 +3027,7 @@ dependencies = [
  "protobuf",
  "quick-error",
  "raft",
- "rand",
+ "rand 0.7.3",
  "serde",
  "serde_derive",
  "serde_with",
@@ -3029,15 +3051,44 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac 0.1.1",
+ "rand_jitter",
+ "rand_os 0.1.3",
+ "rand_pcg",
+ "rand_xorshift 0.1.1",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.1",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3047,8 +3098,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 dependencies = [
  "c2-chacha",
- "rand_core",
+ "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3061,11 +3127,29 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3074,7 +3158,32 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df6b0b3dc9991a10b2d91a86d1129314502169a1bf6afa67328945e02498b76"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3084,7 +3193,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a788ae3edb696cfcba1c19bfd388cc4b8c21f8a408432b199c072825084da58a"
 dependencies = [
  "getrandom",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3093,7 +3221,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3102,7 +3230,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e18c91676f670f6f0312764c759405f13afb98d5d73819840cf72a518487bff"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3138,6 +3266,15 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4081,7 +4218,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
@@ -4150,7 +4287,7 @@ dependencies = [
  "pd_client",
  "raft",
  "raftstore",
- "rand",
+ "rand 0.7.3",
  "security",
  "slog",
  "slog-global",
@@ -4193,11 +4330,11 @@ name = "test_util"
 version = "0.0.1"
 dependencies = [
  "encryption",
- "fail",
+ "fail 0.4.0",
  "grpcio",
  "kvproto",
- "rand",
- "rand_isaac",
+ "rand 0.7.3",
+ "rand_isaac 0.2.0",
  "security",
  "slog",
  "slog-global",
@@ -4224,7 +4361,7 @@ dependencies = [
  "engine_rocks",
  "engine_traits",
  "external_storage",
- "fail",
+ "fail 0.4.0",
  "futures 0.1.29",
  "futures 0.3.4",
  "futures-cpupool",
@@ -4239,8 +4376,8 @@ dependencies = [
  "protobuf",
  "raft",
  "raftstore",
- "rand",
- "rand_xorshift",
+ "rand 0.7.3",
+ "rand_xorshift 0.2.0",
  "security",
  "semver 0.10.0",
  "serde_json",
@@ -4419,7 +4556,7 @@ dependencies = [
 name = "tidb_query_shared_expr"
 version = "0.0.1"
 dependencies = [
- "rand",
+ "rand 0.7.3",
  "safemem",
  "tidb_query_datatype",
  "time 0.1.42",
@@ -4515,7 +4652,7 @@ dependencies = [
  "engine_panic",
  "engine_rocks",
  "engine_traits",
- "fail",
+ "fail 0.4.0",
  "failure",
  "fs2",
  "futures 0.1.29",
@@ -4559,7 +4696,7 @@ dependencies = [
  "quick-error",
  "raft",
  "raftstore",
- "rand",
+ "rand 0.7.3",
  "regex",
  "rev_lines",
  "security",
@@ -4633,7 +4770,7 @@ dependencies = [
  "crc32fast",
  "crossbeam",
  "derive_more",
- "fail",
+ "fail 0.4.0",
  "fs2",
  "futures 0.1.29",
  "futures 0.3.4",
@@ -4654,7 +4791,7 @@ dependencies = [
  "prometheus",
  "protobuf",
  "quick-error",
- "rand",
+ "rand 0.7.3",
  "regex",
  "serde",
  "serde_json",
@@ -5177,7 +5314,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
- "rand",
+ "rand 0.7.3",
  "serde",
 ]
 
@@ -5428,12 +5565,12 @@ source = "git+https://github.com/tikv/yatp.git#3894a861643b6ba384aaad352bbaed971
 dependencies = [
  "crossbeam-deque",
  "dashmap",
- "fail",
+ "fail 0.3.0",
  "lazy_static",
  "num_cpus",
  "parking_lot_core 0.7.0",
  "prometheus",
- "rand",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -5448,7 +5585,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e12b8667a4fff63d236f8363be54392f93dbb13616be64a83e761a9319ab589"
 dependencies = [
- "rand",
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ encryption = { path = "components/encryption" }
 engine_panic = { path = "components/engine_panic", optional = true }
 engine_rocks = { path = "components/engine_rocks" }
 engine_traits = { path = "components/engine_traits" }
-fail = "0.3"
+fail = "0.4"
 failure = "0.1"
 fs2 = "0.4"
 futures = "0.1"
@@ -182,8 +182,9 @@ raft = { git = "https://github.com/pingcap/raft-rs", branch = "master", default-
 raft-proto = { git = "https://github.com/pingcap/raft-rs", branch = "master", default-features = false }
 protobuf = { git = "https://github.com/pingcap/rust-protobuf", rev = "b67d432c1b74350b38a5d96ddf885ac6c3ff46f5" }
 protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "b67d432c1b74350b38a5d96ddf885ac6c3ff46f5" }
-fail = { git = "https://github.com/tikv/fail-rs.git", rev = "2cf1175a1a5cc2c70bd20ebd45313afd69b558fc" }
 prometheus = { git = "https://github.com/tikv/rust-prometheus.git", rev = "fd122caa03de8e7e5e4fae9372583aebf19e39f6" }
+fail = { git = "https://github.com/hunterlxt/fail-rs", branch = "XT/threads" }
+grpcio = { git = "https://github.com/hunterlxt/grpc-rs", branch = "xt/pick-474" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }

--- a/components/batch-system/Cargo.toml
+++ b/components/batch-system/Cargo.toml
@@ -15,6 +15,7 @@ serde_derive = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "0e23a5baff302a9d7bccd85f8f31e43339c2f2c1" }
 derive_more = { version = "0.99", optional = true }
+fail = "0.4"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/batch-system/src/batch.rs
+++ b/components/batch-system/src/batch.rs
@@ -10,6 +10,7 @@ use crate::fsm::{Fsm, FsmScheduler};
 use crate::mailbox::BasicMailbox;
 use crate::router::Router;
 use crossbeam::channel::{self, SendError};
+use fail::FailPointRegistry;
 use std::borrow::Cow;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -391,9 +392,13 @@ where
                 max_batch_size: self.max_batch_size,
                 reschedule_duration: self.reschedule_duration,
             };
+            let local_registry = FailPointRegistry::current_registry();
             let t = thread::Builder::new()
                 .name(thd_name!(format!("{}-{}", name_prefix, i)))
-                .spawn(move || poller.poll())
+                .spawn(move || {
+                    local_registry.register_current();
+                    poller.poll();
+                })
                 .unwrap();
             self.workers.push(t);
         }

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -51,7 +51,7 @@ tikv = { path = "../../", default-features = false }
 tikv_util = { path = "../tikv_util" }
 tokio-threadpool = "0.1"
 txn_types = { path = "../txn_types" }
-fail = "0.3"
+fail = "0.4"
 lazy_static = "1.3"
 prometheus = { version = "0.8", default-features = false, features = ["nightly", "push"] }
 

--- a/components/cdc/tests/failpoints/test_observe.rs
+++ b/components/cdc/tests/failpoints/test_observe.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 use crate::{new_event_feed, TestSuite};
+use fail::FailPointRegistry;
 use futures::sink::Sink;
 use futures::Future;
 use grpcio::WriteFlags;
@@ -24,6 +25,9 @@ use tikv_util::HandyRwLock;
 
 #[test]
 fn test_observe_duplicate_cmd() {
+    let local_registry = FailPointRegistry::new();
+    local_registry.register_current();
+
     let mut suite = TestSuite::new(3);
 
     let region = suite.cluster.get_region(&[]);

--- a/components/cdc/tests/failpoints/test_register.rs
+++ b/components/cdc/tests/failpoints/test_register.rs
@@ -22,6 +22,9 @@ use test_raftstore::sleep_ms;
 
 #[test]
 fn test_failed_pending_batch() {
+    let local_registry = fail::FailPointRegistry::new();
+    local_registry.register_current();
+
     // For test that a pending cmd batch contains a error like epoch not match.
     let mut suite = TestSuite::new(3);
 
@@ -81,6 +84,9 @@ fn test_failed_pending_batch() {
 
 #[test]
 fn test_region_ready_after_deregister() {
+    let local_registry = fail::FailPointRegistry::new();
+    local_registry.register_current();
+
     let mut suite = TestSuite::new(1);
 
     let fp = "cdc_incremental_scan_start";
@@ -114,6 +120,9 @@ fn test_region_ready_after_deregister() {
 
 #[test]
 fn test_connections_register() {
+    let local_registry = fail::FailPointRegistry::new();
+    local_registry.register_current();
+
     let mut suite = TestSuite::new(3);
 
     let fp = "cdc_incremental_scan_start";
@@ -196,6 +205,9 @@ fn test_connections_register() {
 
 #[test]
 fn test_merge() {
+    let local_registry = fail::FailPointRegistry::new();
+    local_registry.register_current();
+
     let mut suite = TestSuite::new(1);
     // Split region
     let region = suite.cluster.get_region(&[]);
@@ -305,6 +317,9 @@ fn test_merge() {
 
 #[test]
 fn test_deregister_pending_downstream() {
+    let local_registry = fail::FailPointRegistry::new();
+    local_registry.register_current();
+
     let mut suite = TestSuite::new(1);
 
     let build_resolver_fp = "before_schedule_resolver_ready";

--- a/components/cdc/tests/failpoints/test_resolve.rs
+++ b/components/cdc/tests/failpoints/test_resolve.rs
@@ -16,6 +16,9 @@ use test_raftstore::sleep_ms;
 
 #[test]
 fn test_stale_resolver() {
+    let local_registry = fail::FailPointRegistry::new();
+    local_registry.register_current();
+
     let mut suite = TestSuite::new(3);
 
     let fp = "before_schedule_resolver_ready";

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -43,7 +43,7 @@ crossbeam = "0.7.2"
 engine_rocks = { path = "../engine_rocks" }
 encryption = { path = "../encryption" }
 engine_traits = { path = "../engine_traits" }
-fail = "0.3"
+fail = "0.4"
 openssl = "0.10"
 fs2 = "0.4"
 futures = "0.1"

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1067,6 +1067,7 @@ impl RaftBatchSystem {
             .registry
             .register_admin_observer(100, BoxAdminObserver::new(SplitObserver));
 
+        let local_registry = fail::FailPointRegistry::current_registry();
         let workers = Workers {
             split_check_worker,
             region_worker: Worker::new("snapshot-worker"),
@@ -1078,6 +1079,7 @@ impl RaftBatchSystem {
             future_poller: tokio_threadpool::Builder::new()
                 .name_prefix("future-poller")
                 .pool_size(cfg.value().future_poll_size)
+                .after_start(move || local_registry.register_current())
                 .build(),
         };
         let mut builder = RaftPollerBuilder {

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -645,7 +645,9 @@ where
                 // but it may not when merge is implemented.
                 let ctx = self.ctx.clone();
 
+                let local_registry = fail::FailPointRegistry::current_registry();
                 self.pool.spawn(async move {
+                    local_registry.register_current();
                     ctx.handle_gen(
                         region_id,
                         last_applied_index_term,

--- a/components/test_util/Cargo.toml
+++ b/components/test_util/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 encryption = { path = "../encryption" }
-fail = "0.3"
+fail = "0.4"
 grpcio = { version = "0.5", default-features = false, features = ["openssl-vendored"] }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rand = "0.7"

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 crc32fast = "1.2"
 crossbeam = "0.7.2"
 derive_more = "0.99.3"
-fail = "0.3"
+fail = "0.4"
 fs2 = "0.4"
 futures = "0.1"
 futures03 = { package = "futures", version = "0.3" }

--- a/components/tikv_util/src/worker/future.rs
+++ b/components/tikv_util/src/worker/future.rs
@@ -140,9 +140,13 @@ impl<T: Display + Send + 'static> Worker<T> {
         }
 
         let rx = receiver.take().unwrap();
+        let local_registry = fail::FailPointRegistry::current_registry();
         let h = Builder::new()
             .name(thd_name!(self.scheduler.name.as_ref()))
-            .spawn(move || poll(runner, rx))?;
+            .spawn(move || {
+                local_registry.register_current();
+                poll(runner, rx);
+            })?;
 
         self.handle = Some(h);
         Ok(())

--- a/components/tikv_util/src/worker/mod.rs
+++ b/components/tikv_util/src/worker/mod.rs
@@ -338,9 +338,13 @@ impl<T: Display + Send + 'static> Worker<T> {
         let rx = receiver.take().unwrap();
         let counter = Arc::clone(&self.scheduler.counter);
         let batch_size = self.batch_size;
+        let local_registry = fail::FailPointRegistry::current_registry();
         let h = ThreadBuilder::new()
             .name(thd_name!(self.scheduler.name.as_ref()))
-            .spawn(move || poll(runner, rx, counter, batch_size, timer))?;
+            .spawn(move || {
+                local_registry.register_current();
+                poll(runner, rx, counter, batch_size, timer);
+            })?;
         self.handle = Some(h);
         Ok(())
     }

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -8303,7 +8303,7 @@
             "x": 12,
             "y": 38
           },
-          "id": 4375,
+          "id": 91991299,
           "legend": {
             "alignAsTable": true,
             "avg": false,

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -57,9 +57,11 @@ impl<Router: RaftStoreRouter<RocksSnapshot>> ImportSSTService<Router> {
         importer: Arc<SSTImporter>,
         security_mgr: Arc<SecurityManager>,
     ) -> ImportSSTService<Router> {
+        let local_registry = fail::FailPointRegistry::current_registry();
         let threads = Builder::new()
             .name_prefix("sst-importer")
             .pool_size(cfg.num_threads)
+            .after_start(move || local_registry.register_current())
             .create();
         let switcher = ImportModeSwitcher::new(&cfg, &threads, engine.clone());
         ImportSSTService {

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -88,10 +88,12 @@ impl<T: RaftStoreRouter<RocksSnapshot> + 'static, E: Engine, L: LockManager> Ser
         req_batch_wait_duration: Option<Duration>,
         security_mgr: Arc<SecurityManager>,
     ) -> Self {
+        let local_registry = fail::FailPointRegistry::current_registry();
         let timer_pool = Arc::new(Mutex::new(
             ThreadPoolBuilder::new()
                 .pool_size(1)
                 .name_prefix("req_batch_timer_guard")
+                .after_start(move || local_registry.register_current())
                 .build(),
         ));
         Service {

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -310,12 +310,14 @@ impl<R: RaftStoreRouter<RocksSnapshot> + 'static> Runner<R> {
         security_mgr: Arc<SecurityManager>,
         cfg: Arc<Config>,
     ) -> Runner<R> {
+        let local_registry = fail::FailPointRegistry::current_registry();
         Runner {
             env,
             snap_mgr,
             pool: CpuPoolBuilder::new()
                 .name_prefix(thd_name!("snap-sender"))
                 .pool_size(DEFAULT_POOL_SIZE)
+                .after_start(move || local_registry.register_current())
                 .create(),
             raft_router: r,
             security_mgr,

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -37,6 +37,7 @@ pub struct SchedPool {
 
 impl SchedPool {
     pub fn new<E: Engine>(engine: E, pool_size: usize, name_prefix: &str) -> Self {
+        let local_registry = fail::FailPointRegistry::current_registry();
         let engine = Arc::new(Mutex::new(engine));
         let pool = FuturePoolBuilder::new()
             .pool_size(pool_size)
@@ -44,7 +45,10 @@ impl SchedPool {
             .on_tick(tls_flush)
             // Safety: by setting `after_start` and `before_stop`, `FuturePool` ensures
             // the tls_engine invariants.
-            .after_start(move || set_tls_engine(engine.lock().unwrap().clone()))
+            .after_start(move || {
+                local_registry.register_current();
+                set_tls_engine(engine.lock().unwrap().clone());
+            })
             .before_stop(move || {
                 // Safety: we ensure the `set_` and `destroy_` calls use the same engine type.
                 unsafe {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -78,7 +78,7 @@ sse = ["tikv/sse"]
 portable = ["tikv/portable"]
 
 [dependencies]
-fail = { version = "0.3", optional = true }
+fail = { version = "0.4", optional = true }
 batch-system = { path = "../components/batch-system" }
 crc64fast = "0.1"
 crossbeam = "0.7.2"

--- a/tests/failpoints/cases/test_snap.rs
+++ b/tests/failpoints/cases/test_snap.rs
@@ -359,7 +359,9 @@ fn test_shutdown_when_snap_gc() {
     }
 
     fail::cfg("peer_2_handle_snap_mgr_gc", "pause").unwrap();
-    std::thread::spawn(|| {
+    let fail_registry = fail::FailPointRegistry::current_registry();
+    std::thread::spawn(move || {
+        fail_registry.register_current();
         // Sleep a while to wait snap_gc event to reach batch system.
         sleep_ms(500);
         fail::cfg("peer_2_handle_snap_mgr_gc", "off").unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #8259

Problem Summary: Support parallel running for failpoints test

### What is changed and how it works?

- patch grpcio and fail-rs
- modify the code of creating threads in TiKV and grpc to support registry which is a new concept of fail-rs 0.4

### Check List <!--REMOVE the items that are not applicable-->

- Manual test (add detailed scripts or steps below)
1. add `println!("list name {:?}", fail::list());` at `failpoint!`
2. `cargo test --package tests --test failpoints -- test_name --exact --nocapture`
3. check if failpoint has been configured correctly

Side effects

- Code Style
Modify some code used for release build

### Release note <!-- bugfixes or new feature need a release note -->
- Support parallel running for failpoint tests