### PR TITLE
copr: non-null rpn_fn by default

### DIFF
--- a/components/tidb_query_vec_executors/src/selection_executor.rs
+++ b/components/tidb_query_vec_executors/src/selection_executor.rs
@@ -400,7 +400,7 @@ mod tests {
     }
 
     /// This function returns 1 when the value is even, 0 otherwise.
-    #[rpn_fn]
+    #[rpn_fn(nullable)]
     fn is_even(v: Option<&i64>) -> Result<Option<i64>> {
         let r = match v.cloned() {
             None => Some(0),
@@ -595,7 +595,7 @@ mod tests {
     #[test]
     fn test_predicate_error() {
         /// This function returns error when value is None.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v: Option<&i64>) -> Result<Option<i64>> {
             match v.cloned() {
                 None => Err(other_err!("foo")),

--- a/components/tidb_query_vec_expr/src/impl_arithmetic.rs
+++ b/components/tidb_query_vec_expr/src/impl_arithmetic.rs
@@ -8,13 +8,13 @@ use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::codec::{self, div_i64, div_i64_with_u64, div_u64_with_i64, Error};
 use tidb_query_datatype::expr::EvalContext;
 
-#[rpn_fn(nonnull)]
+#[rpn_fn]
 #[inline]
 pub fn arithmetic<A: ArithmeticOp>(lhs: &A::T, rhs: &A::T) -> Result<Option<A::T>> {
     A::calc(lhs, rhs)
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn arithmetic_with_ctx<A: ArithmeticOpWithCtx>(
     ctx: &mut EvalContext,
@@ -28,7 +28,7 @@ pub fn arithmetic_with_ctx<A: ArithmeticOpWithCtx>(
     }
 }
 
-#[rpn_fn(nonnull, capture = [ctx])]
+#[rpn_fn(capture = [ctx])]
 #[inline]
 pub fn arithmetic_with_ctx_nonnull<A: ArithmeticOpWithCtx>(
     ctx: &mut EvalContext,
@@ -457,7 +457,7 @@ impl ArithmeticOp for UintDivideInt {
     }
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 fn int_divide_decimal(
     ctx: &mut EvalContext,

--- a/components/tidb_query_vec_expr/src/impl_cast.rs
+++ b/components/tidb_query_vec_expr/src/impl_cast.rs
@@ -245,7 +245,7 @@ pub fn map_cast_func(expr: &Expr) -> Result<RpnFnMeta> {
 // - cast_duration_as_int_or_uint -> cast_any_as_any<Duration, Int>
 // - cast_json_as_int -> cast_any_as_any<Json, Int>
 
-#[rpn_fn(capture = [metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_signed_int_as_unsigned_int(
     metadata: &tipb::InUnionMetadata,
@@ -264,7 +264,7 @@ fn cast_signed_int_as_unsigned_int(
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn cast_int_as_int_others(val: Option<&Int>) -> Result<Option<Int>> {
     match val {
@@ -273,7 +273,7 @@ fn cast_int_as_int_others(val: Option<&Int>) -> Result<Option<Int>> {
     }
 }
 
-#[rpn_fn(capture = [ctx, metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [ctx, metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_real_as_uint(
     ctx: &mut EvalContext,
@@ -299,7 +299,7 @@ fn cast_real_as_uint(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_string_as_int(
     ctx: &mut EvalContext,
@@ -372,7 +372,7 @@ fn cast_string_as_int(
     }
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 fn cast_binary_string_as_int(ctx: &mut EvalContext, val: Option<BytesRef>) -> Result<Option<Int>> {
     match val {
         None => Ok(None),
@@ -383,7 +383,7 @@ fn cast_binary_string_as_int(ctx: &mut EvalContext, val: Option<BytesRef>) -> Re
     }
 }
 
-#[rpn_fn(capture = [ctx, metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [ctx, metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_decimal_as_uint(
     ctx: &mut EvalContext,
@@ -404,7 +404,7 @@ fn cast_decimal_as_uint(
     }
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 fn cast_json_as_uint(ctx: &mut EvalContext, val: Option<JsonRef>) -> Result<Option<Int>> {
     match val {
@@ -423,7 +423,7 @@ fn cast_json_as_uint(ctx: &mut EvalContext, val: Option<JsonRef>) -> Result<Opti
 // cast_duration_as_real -> cast_any_as_any<Duration, Real>
 // cast_json_as_real -> by cast_any_as_any<Json, Real>
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn cast_signed_int_as_signed_real(val: Option<&Int>) -> Result<Option<Real>> {
     match val {
@@ -432,7 +432,7 @@ fn cast_signed_int_as_signed_real(val: Option<&Int>) -> Result<Option<Real>> {
     }
 }
 
-#[rpn_fn(capture = [metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_signed_int_as_unsigned_real(
     metadata: &tipb::InUnionMetadata,
@@ -453,7 +453,7 @@ fn cast_signed_int_as_unsigned_real(
 
 // because we needn't to consider if uint overflow upper boundary of signed real,
 // so we can merge uint to signed/unsigned real in one function
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn cast_unsigned_int_as_signed_or_unsigned_real(val: Option<&Int>) -> Result<Option<Real>> {
     match val {
@@ -462,13 +462,13 @@ fn cast_unsigned_int_as_signed_or_unsigned_real(val: Option<&Int>) -> Result<Opt
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn cast_real_as_signed_real(val: Option<&Real>) -> Result<Option<Real>> {
     Ok(val.cloned())
 }
 
-#[rpn_fn(capture = [metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_real_as_unsigned_real(
     metadata: &tipb::InUnionMetadata,
@@ -487,7 +487,7 @@ fn cast_real_as_unsigned_real(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_string_as_signed_real(
     ctx: &mut EvalContext,
@@ -504,7 +504,7 @@ fn cast_string_as_signed_real(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_binary_string_as_signed_real(
     ctx: &mut EvalContext,
@@ -521,7 +521,7 @@ fn cast_binary_string_as_signed_real(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_string_as_unsigned_real(
     ctx: &mut EvalContext,
@@ -542,7 +542,7 @@ fn cast_string_as_unsigned_real(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_binary_string_as_unsigned_real(
     ctx: &mut EvalContext,
@@ -559,7 +559,7 @@ fn cast_binary_string_as_unsigned_real(
     }
 }
 
-#[rpn_fn(capture = [ctx, metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [ctx, metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_decimal_as_unsigned_real(
     ctx: &mut EvalContext,
@@ -588,7 +588,7 @@ fn cast_decimal_as_unsigned_real(
 // cast_duration_as_string -> cast_any_as_string_fn_meta::<Duration>
 // cast_json_as_string -> by cast_any_as_any<Json, String>
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_any_as_string<T: ConvertTo<Bytes> + Evaluable + EvaluableRet>(
     ctx: &mut EvalContext,
@@ -604,7 +604,7 @@ fn cast_any_as_string<T: ConvertTo<Bytes> + Evaluable + EvaluableRet>(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_uint_as_string(
     ctx: &mut EvalContext,
@@ -620,7 +620,7 @@ fn cast_uint_as_string(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_float_real_as_string(
     ctx: &mut EvalContext,
@@ -640,7 +640,7 @@ fn cast_float_real_as_string(
 // FIXME: We cannot use specialization in current Rust version, so impl ConvertTo<Bytes> for Bytes cannot
 //  pass compile because of we have impl Convert<Bytes> for T where T: ToString + Evaluable
 //  Refactor this part after https://github.com/rust-lang/rust/issues/31844 closed
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_string_as_string(
     ctx: &mut EvalContext,
@@ -684,7 +684,7 @@ fn cast_as_string_helper(
 // - cast_duration_as_decimal -> cast_any_as_decimal<Duration>
 // - cast_json_as_decimal -> cast_any_as_decimal<Json>
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_unsigned_int_as_signed_or_unsigned_decimal(
     ctx: &mut EvalContext,
@@ -706,7 +706,7 @@ fn cast_unsigned_int_as_signed_or_unsigned_decimal(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_signed_int_as_unsigned_decimal(
     ctx: &mut EvalContext,
@@ -731,7 +731,7 @@ fn cast_signed_int_as_unsigned_decimal(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_real_as_decimal(
     ctx: &mut EvalContext,
@@ -757,7 +757,7 @@ fn cast_real_as_decimal(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_string_as_unsigned_decimal(
     ctx: &mut EvalContext,
@@ -784,7 +784,7 @@ fn cast_string_as_unsigned_decimal(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_decimal_as_signed_decimal(
     ctx: &mut EvalContext,
@@ -801,7 +801,7 @@ fn cast_decimal_as_signed_decimal(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
+#[rpn_fn(nullable, capture = [ctx, extra, metadata], metadata_type = tipb::InUnionMetadata)]
 #[inline]
 fn cast_decimal_as_unsigned_decimal(
     ctx: &mut EvalContext,
@@ -826,7 +826,7 @@ fn cast_decimal_as_unsigned_decimal(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_any_as_decimal<From: Evaluable + EvaluableRet + ConvertTo<Decimal>>(
     ctx: &mut EvalContext,
@@ -846,7 +846,7 @@ fn cast_any_as_decimal<From: Evaluable + EvaluableRet + ConvertTo<Decimal>>(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_json_as_decimal(
     ctx: &mut EvalContext,
@@ -866,7 +866,7 @@ fn cast_json_as_decimal(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_bytes_as_decimal(
     ctx: &mut EvalContext,
@@ -888,7 +888,7 @@ fn cast_bytes_as_decimal(
 
 // cast any as duration, no cast functions reuse `cast_any_as_any`
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_int_as_duration(
     ctx: &mut EvalContext,
@@ -911,7 +911,7 @@ fn cast_int_as_duration(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
 fn cast_time_as_duration(
     ctx: &mut EvalContext,
@@ -927,7 +927,7 @@ fn cast_time_as_duration(
     }
 }
 
-#[rpn_fn(capture = [extra])]
+#[rpn_fn(nullable, capture = [extra])]
 #[inline]
 fn cast_duration_as_duration(
     extra: &RpnFnCallExtra,
@@ -941,7 +941,7 @@ fn cast_duration_as_duration(
 
 macro_rules! cast_as_duration {
     ($ty:ty, $as_uint_fn:ident, $extra:expr) => {
-        #[rpn_fn(capture = [ctx, extra])]
+        #[rpn_fn(nullable, capture = [ctx, extra])]
         #[inline]
         fn $as_uint_fn(
             ctx: &mut EvalContext,
@@ -986,7 +986,7 @@ cast_as_duration!(
 );
 cast_as_duration!(JsonRef, cast_json_as_duration, val.unquote()?.as_bytes());
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 fn cast_int_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
@@ -1013,7 +1013,7 @@ fn cast_int_as_time(
 
 // NOTE: in MySQL, casting `Real` to `Time` should cast `Real` to `Int` first,
 // However, TiDB cast `Real` to `String` and then parse it into a `Time`
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 fn cast_real_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
@@ -1036,7 +1036,7 @@ fn cast_real_as_time(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 fn cast_string_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
@@ -1059,7 +1059,7 @@ fn cast_string_as_time(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 fn cast_decimal_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
@@ -1082,7 +1082,7 @@ fn cast_decimal_as_time(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 fn cast_time_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
@@ -1099,7 +1099,7 @@ fn cast_time_as_time(
     }
 }
 
-#[rpn_fn(capture = [ctx, extra])]
+#[rpn_fn(nullable, capture = [ctx, extra])]
 fn cast_duration_as_time(
     ctx: &mut EvalContext,
     extra: &RpnFnCallExtra,
@@ -1127,7 +1127,7 @@ fn cast_duration_as_time(
 // - cast_time_as_json -> cast_any_as_any<Time, Json>
 // - cast_duration_as_json -> cast_any_as_any<Duration, Json>
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn cast_bool_as_json(val: Option<&Int>) -> Result<Option<Json>> {
     match val {
@@ -1136,7 +1136,7 @@ fn cast_bool_as_json(val: Option<&Int>) -> Result<Option<Json>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn cast_uint_as_json(val: Option<&Int>) -> Result<Option<Json>> {
     match val {
@@ -1145,7 +1145,7 @@ fn cast_uint_as_json(val: Option<&Int>) -> Result<Option<Json>> {
     }
 }
 
-#[rpn_fn(capture = [extra])]
+#[rpn_fn(nullable, capture = [extra])]
 #[inline]
 fn cast_string_as_json(extra: &RpnFnCallExtra<'_>, val: Option<BytesRef>) -> Result<Option<Json>> {
     match val {
@@ -1170,7 +1170,7 @@ fn cast_string_as_json(extra: &RpnFnCallExtra<'_>, val: Option<BytesRef>) -> Res
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn cast_json_as_json(val: Option<JsonRef>) -> Result<Option<Json>> {
     match val {
@@ -1179,7 +1179,7 @@ fn cast_json_as_json(val: Option<JsonRef>) -> Result<Option<Json>> {
     }
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 fn cast_any_as_any<From: ConvertTo<To> + Evaluable + EvaluableRet, To: Evaluable + EvaluableRet>(
     ctx: &mut EvalContext,
@@ -1194,7 +1194,7 @@ fn cast_any_as_any<From: ConvertTo<To> + Evaluable + EvaluableRet, To: Evaluable
     }
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 fn cast_json_as_any<To: Evaluable + EvaluableRet + ConvertFrom<Json>>(
     ctx: &mut EvalContext,
@@ -1209,7 +1209,7 @@ fn cast_json_as_any<To: Evaluable + EvaluableRet + ConvertFrom<Json>>(
     }
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 fn cast_any_as_json<From: ConvertTo<Json> + Evaluable + EvaluableRet>(
     ctx: &mut EvalContext,
@@ -1224,7 +1224,7 @@ fn cast_any_as_json<From: ConvertTo<Json> + Evaluable + EvaluableRet>(
     }
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 fn cast_any_as_bytes<From: ConvertTo<Bytes> + Evaluable + EvaluableRet>(
     ctx: &mut EvalContext,
@@ -1239,7 +1239,7 @@ fn cast_any_as_bytes<From: ConvertTo<Bytes> + Evaluable + EvaluableRet>(
     }
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 fn cast_json_as_bytes(ctx: &mut EvalContext, val: Option<JsonRef>) -> Result<Option<Bytes>> {
     match val {

--- a/components/tidb_query_vec_expr/src/impl_compare.rs
+++ b/components/tidb_query_vec_expr/src/impl_compare.rs
@@ -11,7 +11,7 @@ use tidb_query_datatype::codec::mysql::Time;
 use tidb_query_datatype::codec::Error;
 use tidb_query_datatype::expr::EvalContext;
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn compare<C: Comparer>(lhs: Option<&C::T>, rhs: Option<&C::T>) -> Result<Option<i64>>
 where
@@ -20,7 +20,7 @@ where
     C::compare(lhs, rhs)
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn compare_json<F: CmpOp>(lhs: Option<JsonRef>, rhs: Option<JsonRef>) -> Result<Option<i64>> {
     Ok(match (lhs, rhs) {
@@ -30,7 +30,7 @@ pub fn compare_json<F: CmpOp>(lhs: Option<JsonRef>, rhs: Option<JsonRef>) -> Res
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn compare_bytes<C: Collator, F: CmpOp>(
     lhs: Option<BytesRef>,
@@ -225,7 +225,7 @@ impl CmpOp for CmpOpNullEQ {
     }
 }
 
-#[rpn_fn(varg)]
+#[rpn_fn(nullable, varg)]
 #[inline]
 pub fn coalesce<T: Evaluable + EvaluableRet>(args: &[Option<&T>]) -> Result<Option<T>> {
     for arg in args {
@@ -236,7 +236,7 @@ pub fn coalesce<T: Evaluable + EvaluableRet>(args: &[Option<&T>]) -> Result<Opti
     Ok(None)
 }
 
-#[rpn_fn(varg)]
+#[rpn_fn(nullable, varg)]
 #[inline]
 pub fn coalesce_bytes(args: &[Option<BytesRef>]) -> Result<Option<Bytes>> {
     for arg in args {
@@ -247,7 +247,7 @@ pub fn coalesce_bytes(args: &[Option<BytesRef>]) -> Result<Option<Bytes>> {
     Ok(None)
 }
 
-#[rpn_fn(varg)]
+#[rpn_fn(nullable, varg)]
 #[inline]
 pub fn coalesce_json(args: &[Option<JsonRef>]) -> Result<Option<Json>> {
     for arg in args {
@@ -258,19 +258,19 @@ pub fn coalesce_json(args: &[Option<JsonRef>]) -> Result<Option<Json>> {
     Ok(None)
 }
 
-#[rpn_fn(varg, min_args = 2)]
+#[rpn_fn(nullable, varg, min_args = 2)]
 #[inline]
 pub fn greatest_int(args: &[Option<&Int>]) -> Result<Option<Int>> {
     do_get_extremum(args, max)
 }
 
-#[rpn_fn(varg, min_args = 2)]
+#[rpn_fn(nullable, varg, min_args = 2)]
 #[inline]
 pub fn greatest_real(args: &[Option<&Real>]) -> Result<Option<Real>> {
     do_get_extremum(args, |x, y| x.max(y))
 }
 
-#[rpn_fn(varg, min_args = 2, capture = [ctx])]
+#[rpn_fn(nullable, varg, min_args = 2, capture = [ctx])]
 #[inline]
 pub fn greatest_time(ctx: &mut EvalContext, args: &[Option<BytesRef>]) -> Result<Option<Bytes>> {
     let mut greatest = None;

--- a/components/tidb_query_vec_expr/src/impl_compare_in.rs
+++ b/components/tidb_query_vec_expr/src/impl_compare_in.rs
@@ -159,7 +159,7 @@ pub struct CompareInMeta<T: Eq + Hash> {
     has_null: bool,
 }
 
-#[rpn_fn(varg, capture = [metadata], min_args = 1, metadata_mapper = init_compare_in_data::<T>)]
+#[rpn_fn(nullable, varg, capture = [metadata], min_args = 1, metadata_mapper = init_compare_in_data::<T>)]
 #[inline]
 pub fn compare_in_by_hash<T: InByHash>(
     metadata: &CompareInMeta<T::StoreKey>,
@@ -196,7 +196,7 @@ where
     }
 }
 
-#[rpn_fn(varg, capture = [metadata], min_args = 1, metadata_mapper = init_compare_in_data::<CollationAwareBytesInByHash::<C>>)]
+#[rpn_fn(nullable, varg, capture = [metadata], min_args = 1, metadata_mapper = init_compare_in_data::<CollationAwareBytesInByHash::<C>>)]
 #[inline]
 pub fn compare_in_by_hash_bytes<C: Collator>(
     metadata: &CompareInMeta<SortKey<Bytes, C>>,
@@ -268,7 +268,7 @@ fn init_compare_in_data<T: InByHash>(expr: &mut Expr) -> Result<CompareInMeta<T:
     })
 }
 
-#[rpn_fn(varg, min_args = 1)]
+#[rpn_fn(nullable, varg, min_args = 1)]
 #[inline]
 pub fn compare_in_by_compare<T: InByCompare>(args: &[Option<&T>]) -> Result<Option<Int>> {
     assert!(!args.is_empty());
@@ -294,7 +294,7 @@ pub fn compare_in_by_compare<T: InByCompare>(args: &[Option<&T>]) -> Result<Opti
     }
 }
 
-#[rpn_fn(varg, min_args = 1)]
+#[rpn_fn(nullable, varg, min_args = 1)]
 #[inline]
 pub fn compare_in_by_compare_json(args: &[Option<JsonRef>]) -> Result<Option<Int>> {
     assert!(!args.is_empty());

--- a/components/tidb_query_vec_expr/src/impl_control.rs
+++ b/components/tidb_query_vec_expr/src/impl_control.rs
@@ -5,7 +5,7 @@ use tidb_query_codegen::rpn_fn;
 use tidb_query_common::Result;
 use tidb_query_datatype::codec::data_type::*;
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn if_null<T: Evaluable + EvaluableRet>(lhs: Option<&T>, rhs: Option<&T>) -> Result<Option<T>> {
     if lhs.is_some() {
@@ -14,7 +14,7 @@ fn if_null<T: Evaluable + EvaluableRet>(lhs: Option<&T>, rhs: Option<&T>) -> Res
     Ok(rhs.cloned())
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn if_null_json(lhs: Option<JsonRef>, rhs: Option<JsonRef>) -> Result<Option<Json>> {
     if lhs.is_some() {
@@ -23,7 +23,7 @@ fn if_null_json(lhs: Option<JsonRef>, rhs: Option<JsonRef>) -> Result<Option<Jso
     Ok(rhs.map(|x| x.to_owned()))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn if_null_bytes(lhs: Option<BytesRef>, rhs: Option<BytesRef>) -> Result<Option<Bytes>> {
     if lhs.is_some() {
@@ -32,7 +32,7 @@ fn if_null_bytes(lhs: Option<BytesRef>, rhs: Option<BytesRef>) -> Result<Option<
     Ok(rhs.map(|x| x.to_vec()))
 }
 
-#[rpn_fn(raw_varg, extra_validator = case_when_validator::<T>)]
+#[rpn_fn(nullable, raw_varg, extra_validator = case_when_validator::<T>)]
 #[inline]
 pub fn case_when<T: Evaluable + EvaluableRet>(args: &[ScalarValueRef<'_>]) -> Result<Option<T>> {
     for chunk in args.chunks(2) {
@@ -50,7 +50,7 @@ pub fn case_when<T: Evaluable + EvaluableRet>(args: &[ScalarValueRef<'_>]) -> Re
     Ok(None)
 }
 
-#[rpn_fn(raw_varg, extra_validator = case_when_validator::<Bytes>)]
+#[rpn_fn(nullable, raw_varg, extra_validator = case_when_validator::<Bytes>)]
 #[inline]
 pub fn case_when_bytes(args: &[ScalarValueRef<'_>]) -> Result<Option<Bytes>> {
     for chunk in args.chunks(2) {
@@ -68,7 +68,7 @@ pub fn case_when_bytes(args: &[ScalarValueRef<'_>]) -> Result<Option<Bytes>> {
     Ok(None)
 }
 
-#[rpn_fn(raw_varg, extra_validator = case_when_validator::<Json>)]
+#[rpn_fn(nullable, raw_varg, extra_validator = case_when_validator::<Json>)]
 #[inline]
 pub fn case_when_json(args: &[ScalarValueRef<'_>]) -> Result<Option<Json>> {
     for chunk in args.chunks(2) {
@@ -86,7 +86,7 @@ pub fn case_when_json(args: &[ScalarValueRef<'_>]) -> Result<Option<Json>> {
     Ok(None)
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn if_condition<T: Evaluable + EvaluableRet>(
     condition: Option<&Int>,
@@ -100,7 +100,7 @@ fn if_condition<T: Evaluable + EvaluableRet>(
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn if_condition_json(
     condition: Option<&Int>,
@@ -114,7 +114,7 @@ fn if_condition_json(
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn if_condition_bytes(
     condition: Option<&Int>,

--- a/components/tidb_query_vec_expr/src/impl_encryption.rs
+++ b/components/tidb_query_vec_expr/src/impl_encryption.rs
@@ -15,7 +15,7 @@ const SHA256: i64 = 256;
 const SHA384: i64 = 384;
 const SHA512: i64 = 512;
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn md5(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     match arg {
@@ -24,7 +24,7 @@ pub fn md5(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn sha1(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     match arg {
@@ -33,7 +33,7 @@ pub fn sha1(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     }
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn sha2(
     ctx: &mut EvalContext,
@@ -60,7 +60,7 @@ pub fn sha2(
 }
 
 // https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn password(ctx: &mut EvalContext, input: Option<BytesRef>) -> Result<Option<Bytes>> {
     ctx.warnings.append_warning(Error::Other(box_err!(
@@ -88,7 +88,7 @@ fn hex_digest(hashtype: MessageDigest, input: &[u8]) -> Result<Bytes> {
         .map_err(|e| box_err!("OpenSSL error: {:?}", e))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn uncompressed_length(ctx: &mut EvalContext, arg: Option<BytesRef>) -> Result<Option<Int>> {
     use byteorder::{ByteOrder, LittleEndian};
@@ -104,7 +104,7 @@ pub fn uncompressed_length(ctx: &mut EvalContext, arg: Option<BytesRef>) -> Resu
     }))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn random_bytes(_ctx: &mut EvalContext, arg: Option<&Int>) -> Result<Option<Bytes>> {
     match arg {

--- a/components/tidb_query_vec_expr/src/impl_json.rs
+++ b/components/tidb_query_vec_expr/src/impl_json.rs
@@ -9,7 +9,7 @@ use tidb_query_common::Result;
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::codec::mysql::json::*;
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn json_depth(arg: Option<JsonRef>) -> Result<Option<i64>> {
     match arg {
@@ -18,7 +18,7 @@ fn json_depth(arg: Option<JsonRef>) -> Result<Option<i64>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn json_type(arg: Option<JsonRef>) -> Result<Option<Bytes>> {
     Ok(arg
@@ -26,19 +26,19 @@ fn json_type(arg: Option<JsonRef>) -> Result<Option<Bytes>> {
         .map(|json_arg| Bytes::from(json_arg.json_type())))
 }
 
-#[rpn_fn(raw_varg, min_args = 2, extra_validator = json_modify_validator)]
+#[rpn_fn(nullable, raw_varg, min_args = 2, extra_validator = json_modify_validator)]
 #[inline]
 fn json_set(args: &[ScalarValueRef]) -> Result<Option<Json>> {
     json_modify(args, ModifyType::Set)
 }
 
-#[rpn_fn(raw_varg, min_args = 2, extra_validator = json_modify_validator)]
+#[rpn_fn(nullable, raw_varg, min_args = 2, extra_validator = json_modify_validator)]
 #[inline]
 fn json_insert(args: &[ScalarValueRef]) -> Result<Option<Json>> {
     json_modify(args, ModifyType::Insert)
 }
 
-#[rpn_fn(raw_varg, min_args = 2, extra_validator = json_modify_validator)]
+#[rpn_fn(nullable, raw_varg, min_args = 2, extra_validator = json_modify_validator)]
 #[inline]
 fn json_replace(args: &[ScalarValueRef]) -> Result<Option<Json>> {
     json_modify(args, ModifyType::Replace)
@@ -87,7 +87,7 @@ fn json_modify_validator(expr: &tipb::Expr) -> Result<()> {
     Ok(())
 }
 
-#[rpn_fn(varg)]
+#[rpn_fn(nullable, varg)]
 #[inline]
 fn json_array(args: &[Option<JsonRef>]) -> Result<Option<Json>> {
     let mut jsons = vec![];
@@ -115,7 +115,7 @@ fn json_object_validator(expr: &tipb::Expr) -> Result<()> {
 }
 
 /// Required args like `&[(Option<&Byte>, Option<JsonRef>)]`.
-#[rpn_fn(raw_varg, extra_validator = json_object_validator)]
+#[rpn_fn(nullable, raw_varg, extra_validator = json_object_validator)]
 #[inline]
 fn json_object(raw_args: &[ScalarValueRef]) -> Result<Option<Json>> {
     let mut pairs = BTreeMap::new();
@@ -143,7 +143,7 @@ fn json_object(raw_args: &[ScalarValueRef]) -> Result<Option<Json>> {
 
 // According to mysql 5.7,
 // arguments of json_merge should not be less than 2.
-#[rpn_fn(varg, min_args = 2)]
+#[rpn_fn(nullable, varg, min_args = 2)]
 #[inline]
 pub fn json_merge(args: &[Option<JsonRef>]) -> Result<Option<Json>> {
     // min_args = 2, so it's ok to call args[0]
@@ -161,7 +161,7 @@ pub fn json_merge(args: &[Option<JsonRef>]) -> Result<Option<Json>> {
     Ok(Some(Json::merge(jsons)?))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn json_unquote(arg: Option<JsonRef>) -> Result<Option<Bytes>> {
     arg.as_ref().map_or(Ok(None), |json_arg| {
@@ -185,7 +185,7 @@ fn valid_paths(expr: &tipb::Expr) -> Result<()> {
     Ok(())
 }
 
-#[rpn_fn(raw_varg, min_args = 2, extra_validator = json_with_paths_validator)]
+#[rpn_fn(nullable, raw_varg, min_args = 2, extra_validator = json_with_paths_validator)]
 #[inline]
 fn json_extract(args: &[ScalarValueRef]) -> Result<Option<Json>> {
     assert!(args.len() >= 2);
@@ -206,7 +206,7 @@ fn json_with_path_validator(expr: &tipb::Expr) -> Result<()> {
     valid_paths(expr)
 }
 
-#[rpn_fn(raw_varg,min_args= 1, max_args = 2, extra_validator = json_with_path_validator)]
+#[rpn_fn(nullable, raw_varg,min_args= 1, max_args = 2, extra_validator = json_with_path_validator)]
 #[inline]
 fn json_keys(args: &[ScalarValueRef]) -> Result<Option<Json>> {
     assert!(!args.is_empty() && args.len() <= 2);
@@ -218,7 +218,7 @@ fn json_keys(args: &[ScalarValueRef]) -> Result<Option<Json>> {
     Ok(None)
 }
 
-#[rpn_fn(raw_varg,min_args= 1, max_args = 2, extra_validator = json_with_path_validator)]
+#[rpn_fn(nullable, raw_varg,min_args= 1, max_args = 2, extra_validator = json_with_path_validator)]
 #[inline]
 fn json_length(args: &[ScalarValueRef]) -> Result<Option<Int>> {
     assert!(!args.is_empty() && args.len() <= 2);
@@ -233,7 +233,7 @@ fn json_length(args: &[ScalarValueRef]) -> Result<Option<Int>> {
     })
 }
 
-#[rpn_fn(raw_varg, min_args = 2, extra_validator = json_with_paths_validator)]
+#[rpn_fn(nullable, raw_varg, min_args = 2, extra_validator = json_with_paths_validator)]
 #[inline]
 fn json_remove(args: &[ScalarValueRef]) -> Result<Option<Json>> {
     assert!(args.len() >= 2);

--- a/components/tidb_query_vec_expr/src/impl_like.rs
+++ b/components/tidb_query_vec_expr/src/impl_like.rs
@@ -7,7 +7,7 @@ use tidb_query_datatype::codec::collation::*;
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_shared_expr::*;
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn like<C: Collator>(
     target: Option<BytesRef>,

--- a/components/tidb_query_vec_expr/src/impl_math.rs
+++ b/components/tidb_query_vec_expr/src/impl_math.rs
@@ -32,13 +32,13 @@ const I64_TEN_POWS: [i64; 19] = [
     1_000_000_000_000_000_000,
 ];
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn pi() -> Result<Option<Real>> {
     Ok(Some(Real::from(std::f64::consts::PI)))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn crc32(arg: Option<BytesRef>) -> Result<Option<Int>> {
     Ok(arg
@@ -47,13 +47,13 @@ pub fn crc32(arg: Option<BytesRef>) -> Result<Option<Int>> {
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn log_1_arg(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| f64_to_real(n.ln())))
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[allow(clippy::float_cmp)]
 pub fn log_2_arg(arg0: Option<&Real>, arg1: Option<&Real>) -> Result<Option<Real>> {
     Ok(match (arg0, arg1) {
@@ -69,13 +69,13 @@ pub fn log_2_arg(arg0: Option<&Real>, arg1: Option<&Real>) -> Result<Option<Real
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn log2(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| f64_to_real(n.log2())))
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn log10(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| f64_to_real(n.log10())))
 }
@@ -90,7 +90,7 @@ fn f64_to_real(n: f64) -> Option<Real> {
 }
 
 #[inline]
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 pub fn ceil<C: Ceil>(ctx: &mut EvalContext, arg: Option<&C::Input>) -> Result<Option<C::Output>> {
     if let Some(arg) = arg {
         C::ceil(ctx, arg)
@@ -170,7 +170,7 @@ impl Ceil for CeilIntToInt {
     }
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 pub fn floor<T: Floor>(ctx: &mut EvalContext, arg: Option<&T::Input>) -> Result<Option<T::Output>> {
     if let Some(arg) = arg {
         T::floor(ctx, arg)
@@ -248,7 +248,7 @@ impl Floor for FloorIntToInt {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn abs_int(arg: Option<&Int>) -> Result<Option<Int>> {
     match arg {
@@ -260,13 +260,13 @@ fn abs_int(arg: Option<&Int>) -> Result<Option<Int>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn abs_uint(arg: Option<&Int>) -> Result<Option<Int>> {
     Ok(arg.cloned())
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn abs_real(arg: Option<&Real>) -> Result<Option<Real>> {
     match arg {
@@ -275,7 +275,7 @@ fn abs_real(arg: Option<&Real>) -> Result<Option<Real>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn abs_decimal(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
     match arg {
@@ -288,7 +288,7 @@ fn abs_decimal(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 fn sign(arg: Option<&Real>) -> Result<Option<Int>> {
     Ok(arg.map(|n| {
         if **n > 0f64 {
@@ -302,7 +302,7 @@ fn sign(arg: Option<&Real>) -> Result<Option<Int>> {
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 fn sqrt(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| {
         if **n < 0f64 {
@@ -319,13 +319,13 @@ fn sqrt(arg: Option<&Real>) -> Result<Option<Real>> {
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 fn radians(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| Real::new(**n * std::f64::consts::PI / 180_f64).ok()))
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn exp(arg: Option<&Real>) -> Result<Option<Real>> {
     match arg {
         Some(x) => {
@@ -341,25 +341,25 @@ pub fn exp(arg: Option<&Real>) -> Result<Option<Real>> {
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 fn sin(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|arg| Real::new(arg.sin()).ok()))
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 fn cos(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|arg| Real::new(arg.cos()).ok()))
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 fn tan(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|arg| Real::new(arg.tan()).ok()))
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 fn cot(arg: Option<&Real>) -> Result<Option<Real>> {
     match arg {
         Some(arg) => {
@@ -376,7 +376,7 @@ fn cot(arg: Option<&Real>) -> Result<Option<Real>> {
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 fn pow(lhs: Option<&Real>, rhs: Option<&Real>) -> Result<Option<Real>> {
     match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => {
@@ -392,14 +392,14 @@ fn pow(lhs: Option<&Real>, rhs: Option<&Real>) -> Result<Option<Real>> {
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 fn rand() -> Result<Option<Real>> {
     let res = MYSQL_RNG.with(|mysql_rng| mysql_rng.borrow_mut().gen());
     Ok(Real::new(res).ok())
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 fn rand_with_seed_first_gen(seed: Option<&i64>) -> Result<Option<Real>> {
     let mut rng = MySQLRng::new_with_seed(seed.cloned().unwrap_or(0));
     let res = rng.gen();
@@ -407,31 +407,31 @@ fn rand_with_seed_first_gen(seed: Option<&i64>) -> Result<Option<Real>> {
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 fn degrees(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|n| Real::new(n.to_degrees()).ok()))
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn asin(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|arg| Real::new(arg.asin()).ok()))
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn acos(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|arg| Real::new(arg.acos()).ok()))
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn atan_1_arg(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.and_then(|arg| Real::new(arg.atan()).ok()))
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn atan_2_args(arg0: Option<&Real>, arg1: Option<&Real>) -> Result<Option<Real>> {
     Ok(match (arg0, arg1) {
         (Some(arg0), Some(arg1)) => Real::new(arg0.atan2(arg1.into_inner())).ok(),
@@ -440,7 +440,7 @@ pub fn atan_2_args(arg0: Option<&Real>, arg1: Option<&Real>) -> Result<Option<Re
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn conv(
     n: Option<BytesRef>,
     from_base: Option<&Int>,
@@ -456,7 +456,7 @@ pub fn conv(
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn round_real(arg: Option<&Real>) -> Result<Option<Real>> {
     match arg {
         Some(arg) => Ok(Real::new(arg.round()).ok()),
@@ -465,13 +465,13 @@ pub fn round_real(arg: Option<&Real>) -> Result<Option<Real>> {
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn round_int(arg: Option<&Int>) -> Result<Option<Int>> {
     Ok(arg.cloned())
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn round_dec(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
     match arg {
         Some(arg) => {
@@ -486,7 +486,7 @@ pub fn round_dec(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn truncate_int_with_int(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<Option<Int>> {
     match (arg0, arg1) {
         (Some(x), Some(d)) => {
@@ -505,7 +505,7 @@ pub fn truncate_int_with_int(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<O
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn truncate_int_with_uint(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<Option<Int>> {
     match (arg0, arg1) {
         (Some(x), Some(_)) => Ok(Some(*x)),
@@ -514,7 +514,7 @@ pub fn truncate_int_with_uint(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn truncate_real_with_int(arg0: Option<&Real>, arg1: Option<&Int>) -> Result<Option<Real>> {
     match (arg0, arg1) {
         (Some(x), Some(d)) => {
@@ -530,7 +530,7 @@ pub fn truncate_real_with_int(arg0: Option<&Real>, arg1: Option<&Int>) -> Result
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn truncate_real_with_uint(arg0: Option<&Real>, arg1: Option<&Int>) -> Result<Option<Real>> {
     match (arg0, arg1) {
         (Some(x), Some(d)) => {
@@ -554,7 +554,7 @@ pub fn truncate_real(x: Real, d: i32) -> Real {
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn round_with_frac_int(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<Option<Int>> {
     match (arg0, arg1) {
         (Some(number), Some(digits)) => {
@@ -570,7 +570,7 @@ pub fn round_with_frac_int(arg0: Option<&Int>, arg1: Option<&Int>) -> Result<Opt
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn round_with_frac_dec(arg0: Option<&Decimal>, arg1: Option<&Int>) -> Result<Option<Decimal>> {
     match (arg0, arg1) {
@@ -586,7 +586,7 @@ fn round_with_frac_dec(arg0: Option<&Decimal>, arg1: Option<&Int>) -> Result<Opt
 }
 
 #[inline]
-#[rpn_fn]
+#[rpn_fn(nullable)]
 pub fn round_with_frac_real(arg0: Option<&Real>, arg1: Option<&Int>) -> Result<Option<Real>> {
     match (arg0, arg1) {
         (Some(number), Some(digits)) => {

--- a/components/tidb_query_vec_expr/src/impl_miscellaneous.rs
+++ b/components/tidb_query_vec_expr/src/impl_miscellaneous.rs
@@ -18,7 +18,7 @@ const PREFIX_MAPPED: [u8; 12] = [
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff,
 ];
 
-#[rpn_fn(varg)]
+#[rpn_fn(nullable, varg)]
 #[inline]
 pub fn any_value<T: Evaluable + EvaluableRet>(args: &[Option<&T>]) -> Result<Option<T>> {
     if let Some(arg) = args.first() {
@@ -28,7 +28,7 @@ pub fn any_value<T: Evaluable + EvaluableRet>(args: &[Option<&T>]) -> Result<Opt
     }
 }
 
-#[rpn_fn(varg)]
+#[rpn_fn(nullable, varg)]
 #[inline]
 pub fn any_value_json(args: &[Option<JsonRef>]) -> Result<Option<Json>> {
     if let Some(arg) = args.first() {
@@ -38,7 +38,7 @@ pub fn any_value_json(args: &[Option<JsonRef>]) -> Result<Option<Json>> {
     }
 }
 
-#[rpn_fn(varg)]
+#[rpn_fn(nullable, varg)]
 #[inline]
 pub fn any_value_bytes(args: &[Option<BytesRef>]) -> Result<Option<Bytes>> {
     if let Some(arg) = args.first() {
@@ -48,7 +48,7 @@ pub fn any_value_bytes(args: &[Option<BytesRef>]) -> Result<Option<Bytes>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn inet_aton(addr: Option<BytesRef>) -> Result<Option<Int>> {
     Ok(addr
@@ -57,7 +57,7 @@ pub fn inet_aton(addr: Option<BytesRef>) -> Result<Option<Int>> {
         .and_then(miscellaneous::inet_aton))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn inet_ntoa(arg: Option<&Int>) -> Result<Option<Bytes>> {
     Ok(arg
@@ -66,7 +66,7 @@ pub fn inet_ntoa(arg: Option<&Int>) -> Result<Option<Bytes>> {
         .map(|arg| format!("{}", Ipv4Addr::from(arg)).into_bytes()))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn inet6_aton(input: Option<BytesRef>) -> Result<Option<Bytes>> {
     let input = match input {
@@ -82,7 +82,7 @@ pub fn inet6_aton(input: Option<BytesRef>) -> Result<Option<Bytes>> {
         .or(Ok(None))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn inet6_ntoa(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     Ok(arg.and_then(|s| {
@@ -98,7 +98,7 @@ pub fn inet6_ntoa(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     }))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn is_ipv4(addr: Option<BytesRef>) -> Result<Option<Int>> {
     Ok(match addr {
@@ -116,7 +116,7 @@ pub fn is_ipv4(addr: Option<BytesRef>) -> Result<Option<Int>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn is_ipv4_compat(addr: Option<BytesRef>) -> Result<Option<i64>> {
     Ok(addr.as_ref().map_or(Some(0), |addr| {
@@ -128,7 +128,7 @@ pub fn is_ipv4_compat(addr: Option<BytesRef>) -> Result<Option<i64>> {
     }))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn is_ipv4_mapped(addr: Option<BytesRef>) -> Result<Option<i64>> {
     Ok(addr.as_ref().map_or(Some(0), |addr| {
@@ -140,7 +140,7 @@ pub fn is_ipv4_mapped(addr: Option<BytesRef>) -> Result<Option<i64>> {
     }))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn is_ipv6(addr: Option<BytesRef>) -> Result<Option<Int>> {
     Ok(match addr {
@@ -158,7 +158,7 @@ pub fn is_ipv6(addr: Option<BytesRef>) -> Result<Option<Int>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn uuid() -> Result<Option<Bytes>> {
     let result = Uuid::new_v4();

--- a/components/tidb_query_vec_expr/src/impl_op.rs
+++ b/components/tidb_query_vec_expr/src/impl_op.rs
@@ -6,7 +6,7 @@ use tidb_query_common::Result;
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::codec::Error;
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn logical_and(lhs: Option<&i64>, rhs: Option<&i64>) -> Result<Option<i64>> {
     Ok(match (lhs, rhs) {
@@ -16,7 +16,7 @@ pub fn logical_and(lhs: Option<&i64>, rhs: Option<&i64>) -> Result<Option<i64>> 
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn logical_or(arg0: Option<&i64>, arg1: Option<&i64>) -> Result<Option<i64>> {
     // This is a standard Kleene OR used in SQL where
@@ -28,7 +28,7 @@ pub fn logical_or(arg0: Option<&i64>, arg1: Option<&i64>) -> Result<Option<i64>>
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn logical_xor(arg0: Option<&i64>, arg1: Option<&i64>) -> Result<Option<i64>> {
     // evaluates to 1 if an odd number of operands is nonzero, otherwise 0 is returned.
@@ -38,25 +38,25 @@ pub fn logical_xor(arg0: Option<&i64>, arg1: Option<&i64>) -> Result<Option<i64>
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn unary_not_int(arg: Option<&Int>) -> Result<Option<i64>> {
     Ok(arg.map(|v| (*v == 0) as i64))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn unary_not_real(arg: Option<&Real>) -> Result<Option<i64>> {
     Ok(arg.map(|v| (v.into_inner() == 0f64) as i64))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn unary_not_decimal(arg: Option<&Decimal>) -> Result<Option<i64>> {
     Ok(arg.as_ref().map(|v| v.is_zero() as i64))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn unary_minus_uint(arg: Option<&Int>) -> Result<Option<Int>> {
     use std::cmp::Ordering::*;
@@ -74,7 +74,7 @@ pub fn unary_minus_uint(arg: Option<&Int>) -> Result<Option<Int>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn unary_minus_int(arg: Option<&Int>) -> Result<Option<Int>> {
     match arg {
@@ -89,13 +89,13 @@ pub fn unary_minus_int(arg: Option<&Int>) -> Result<Option<Int>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn unary_minus_real(arg: Option<&Real>) -> Result<Option<Real>> {
     Ok(arg.map(|val| -*val))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn unary_minus_decimal(arg: Option<&Decimal>) -> Result<Option<Decimal>> {
     Ok(arg.map(|val| -*val))
@@ -106,25 +106,25 @@ pub fn is_null_ref<'a, T: EvaluableRef<'a>>(arg: Option<T>) -> Result<Option<i64
     Ok(Some(arg.is_none() as i64))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn is_null<T: Evaluable + EvaluableRet>(arg: Option<&T>) -> Result<Option<i64>> {
     is_null_ref(arg)
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn is_null_bytes(arg: Option<BytesRef>) -> Result<Option<i64>> {
     is_null_ref(arg)
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn is_null_json(arg: Option<JsonRef>) -> Result<Option<i64>> {
     is_null_ref(arg)
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn bit_and(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (lhs, rhs) {
@@ -133,7 +133,7 @@ pub fn bit_and(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn bit_or(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (lhs, rhs) {
@@ -142,7 +142,7 @@ pub fn bit_or(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn bit_xor(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (lhs, rhs) {
@@ -151,7 +151,7 @@ pub fn bit_xor(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn bit_neg(arg: Option<&Int>) -> Result<Option<Int>> {
     Ok(arg.map(|arg| !arg))
@@ -171,7 +171,7 @@ impl KeepNull for KeepNullOff {
     const VALUE: bool = false;
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn int_is_true<K: KeepNull>(arg: Option<&Int>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
@@ -181,7 +181,7 @@ pub fn int_is_true<K: KeepNull>(arg: Option<&Int>) -> Result<Option<i64>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn real_is_true<K: KeepNull>(arg: Option<&Real>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
@@ -191,7 +191,7 @@ pub fn real_is_true<K: KeepNull>(arg: Option<&Real>) -> Result<Option<i64>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn decimal_is_true<K: KeepNull>(arg: Option<&Decimal>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
@@ -201,7 +201,7 @@ pub fn decimal_is_true<K: KeepNull>(arg: Option<&Decimal>) -> Result<Option<i64>
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn int_is_false<K: KeepNull>(arg: Option<&Int>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
@@ -211,7 +211,7 @@ pub fn int_is_false<K: KeepNull>(arg: Option<&Int>) -> Result<Option<i64>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn real_is_false<K: KeepNull>(arg: Option<&Real>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
@@ -221,7 +221,7 @@ pub fn real_is_false<K: KeepNull>(arg: Option<&Real>) -> Result<Option<i64>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn decimal_is_false<K: KeepNull>(arg: Option<&Decimal>) -> Result<Option<i64>> {
     Ok(if K::VALUE {
@@ -231,7 +231,7 @@ fn decimal_is_false<K: KeepNull>(arg: Option<&Decimal>) -> Result<Option<i64>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn left_shift(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (lhs, rhs) {
@@ -246,7 +246,7 @@ fn left_shift(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 fn right_shift(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (lhs, rhs) {

--- a/components/tidb_query_vec_expr/src/impl_other.rs
+++ b/components/tidb_query_vec_expr/src/impl_other.rs
@@ -4,7 +4,7 @@ use tidb_query_codegen::rpn_fn;
 use tidb_query_common::Result;
 use tidb_query_datatype::codec::data_type::*;
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn bit_count(arg: Option<&Int>) -> Result<Option<Int>> {
     Ok(arg.map(|v| Int::from(v.count_ones())))

--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -13,25 +13,25 @@ use tidb_query_shared_expr::string::{
 
 const SPACE: u8 = 0o40u8;
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn bin(num: Option<&Int>) -> Result<Option<Bytes>> {
     Ok(num.map(|i| Bytes::from(format!("{:b}", i))))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn oct_int(num: Option<&Int>) -> Result<Option<Bytes>> {
     Ok(num.map(|i| Bytes::from(format!("{:o}", i))))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn length(arg: Option<BytesRef>) -> Result<Option<i64>> {
     Ok(arg.map(|bytes| bytes.len() as i64))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn unhex(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     if let Some(content) = arg {
@@ -49,13 +49,13 @@ pub fn unhex(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn bit_length(arg: Option<BytesRef>) -> Result<Option<i64>> {
     Ok(arg.map(|bytes| bytes.len() as i64 * 8))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn ord(arg: Option<BytesRef>) -> Result<Option<i64>> {
     let mut result = 0;
@@ -72,7 +72,7 @@ pub fn ord(arg: Option<BytesRef>) -> Result<Option<i64>> {
     Ok(Some(result))
 }
 
-#[rpn_fn(varg, min_args = 1)]
+#[rpn_fn(nullable, varg, min_args = 1)]
 #[inline]
 pub fn concat(args: &[Option<BytesRef>]) -> Result<Option<Bytes>> {
     let mut output = Bytes::new();
@@ -86,7 +86,7 @@ pub fn concat(args: &[Option<BytesRef>]) -> Result<Option<Bytes>> {
     Ok(Some(output))
 }
 
-#[rpn_fn(varg, min_args = 2)]
+#[rpn_fn(nullable, varg, min_args = 2)]
 #[inline]
 pub fn concat_ws(args: &[Option<BytesRef>]) -> Result<Option<Bytes>> {
     if let Some(sep) = args[0] {
@@ -102,7 +102,7 @@ pub fn concat_ws(args: &[Option<BytesRef>]) -> Result<Option<Bytes>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn ascii(arg: Option<BytesRef>) -> Result<Option<i64>> {
     Ok(arg.map(|bytes| {
@@ -114,7 +114,7 @@ pub fn ascii(arg: Option<BytesRef>) -> Result<Option<i64>> {
     }))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn reverse_utf8(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     Ok(arg.map(|bytes| {
@@ -123,13 +123,13 @@ pub fn reverse_utf8(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     }))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn hex_int_arg(arg: Option<&Int>) -> Result<Option<Bytes>> {
     Ok(arg.map(|i| format!("{:X}", i).into_bytes()))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn ltrim(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     Ok(arg.map(|bytes| {
@@ -142,7 +142,7 @@ pub fn ltrim(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     }))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn rtrim(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     Ok(arg.map(|bytes| {
@@ -155,7 +155,7 @@ pub fn rtrim(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     }))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn lpad(
     arg: Option<BytesRef>,
@@ -186,7 +186,7 @@ pub fn lpad(
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn lpad_utf8(
     arg: Option<BytesRef>,
@@ -225,7 +225,7 @@ pub fn lpad_utf8(
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn rpad(
     arg: Option<BytesRef>,
@@ -252,7 +252,7 @@ pub fn rpad(
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn replace(
     s: Option<BytesRef>,
@@ -279,7 +279,7 @@ pub fn replace(
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn left(lhs: Option<BytesRef>, rhs: Option<&Int>) -> Result<Option<Bytes>> {
     match (lhs, rhs) {
@@ -298,7 +298,7 @@ pub fn left(lhs: Option<BytesRef>, rhs: Option<&Int>) -> Result<Option<Bytes>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn left_utf8(lhs: Option<BytesRef>, rhs: Option<&Int>) -> Result<Option<Bytes>> {
     match (lhs, rhs) {
@@ -322,7 +322,7 @@ pub fn left_utf8(lhs: Option<BytesRef>, rhs: Option<&Int>) -> Result<Option<Byte
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn right(lhs: Option<BytesRef>, rhs: Option<&Int>) -> Result<Option<Bytes>> {
     match (lhs, rhs) {
@@ -341,7 +341,7 @@ pub fn right(lhs: Option<BytesRef>, rhs: Option<&Int>) -> Result<Option<Bytes>> 
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn insert(
     s: Option<BytesRef>,
@@ -371,7 +371,7 @@ pub fn insert(
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn right_utf8(lhs: Option<BytesRef>, rhs: Option<&Int>) -> Result<Option<Bytes>> {
     match (lhs, rhs) {
@@ -401,7 +401,7 @@ pub fn right_utf8(lhs: Option<BytesRef>, rhs: Option<&Int>) -> Result<Option<Byt
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn upper_utf8(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     match arg {
@@ -413,19 +413,19 @@ pub fn upper_utf8(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn upper(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     Ok(arg.map(|b| b.to_vec()))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn hex_str_arg(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     Ok(arg.map(|b| hex::encode_upper(b).into_bytes()))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn locate_2_args(substr: Option<BytesRef>, s: Option<BytesRef>) -> Result<Option<i64>> {
     let (substr, s) = match (substr, s) {
@@ -438,7 +438,7 @@ pub fn locate_2_args(substr: Option<BytesRef>, s: Option<BytesRef>) -> Result<Op
         .or(Some(0)))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn reverse(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     Ok(arg.map(|bytes| {
@@ -448,7 +448,7 @@ pub fn reverse(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     }))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn locate_3_args(
     substr: Option<BytesRef>,
@@ -467,7 +467,7 @@ pub fn locate_3_args(
     }
 }
 
-#[rpn_fn(varg, min_args = 1)]
+#[rpn_fn(nullable, varg, min_args = 1)]
 #[inline]
 fn field<T: Evaluable + EvaluableRet + PartialEq>(args: &[Option<&T>]) -> Result<Option<Int>> {
     Ok(Some(match args[0] {
@@ -481,7 +481,7 @@ fn field<T: Evaluable + EvaluableRet + PartialEq>(args: &[Option<&T>]) -> Result
     }))
 }
 
-#[rpn_fn(varg, min_args = 1)]
+#[rpn_fn(nullable, varg, min_args = 1)]
 #[inline]
 fn field_bytes(args: &[Option<BytesRef>]) -> Result<Option<Int>> {
     Ok(Some(match args[0] {
@@ -495,7 +495,7 @@ fn field_bytes(args: &[Option<BytesRef>]) -> Result<Option<Int>> {
     }))
 }
 
-#[rpn_fn(raw_varg, min_args = 2, extra_validator = elt_validator)]
+#[rpn_fn(nullable, raw_varg, min_args = 2, extra_validator = elt_validator)]
 #[inline]
 pub fn make_set(raw_args: &[ScalarValueRef]) -> Result<Option<Bytes>> {
     assert!(raw_args.len() >= 2);
@@ -530,7 +530,7 @@ pub fn make_set(raw_args: &[ScalarValueRef]) -> Result<Option<Bytes>> {
     Ok(Some(output))
 }
 
-#[rpn_fn(raw_varg, min_args = 2, extra_validator = elt_validator)]
+#[rpn_fn(nullable, raw_varg, min_args = 2, extra_validator = elt_validator)]
 #[inline]
 pub fn elt(raw_args: &[ScalarValueRef]) -> Result<Option<Bytes>> {
     assert!(raw_args.len() >= 2);
@@ -558,7 +558,7 @@ fn elt_validator(expr: &tipb::Expr) -> Result<()> {
     Ok(())
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn space(len: Option<&Int>) -> Result<Option<Bytes>> {
     Ok(match len.cloned() {
@@ -575,7 +575,7 @@ pub fn space(len: Option<&Int>) -> Result<Option<Bytes>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn substring_index(
     s: Option<BytesRef>,
@@ -621,7 +621,7 @@ pub fn substring_index(
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn strcmp(left: Option<BytesRef>, right: Option<BytesRef>) -> Result<Option<i64>> {
     use std::cmp::Ordering::*;
@@ -635,7 +635,7 @@ pub fn strcmp(left: Option<BytesRef>, right: Option<BytesRef>) -> Result<Option<
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn instr_utf8(s: Option<BytesRef>, substr: Option<BytesRef>) -> Result<Option<Int>> {
     if let (Some(s), Some(substr)) = (s, substr) {
@@ -651,7 +651,7 @@ pub fn instr_utf8(s: Option<BytesRef>, substr: Option<BytesRef>) -> Result<Optio
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn find_in_set(s: Option<BytesRef>, str_list: Option<BytesRef>) -> Result<Option<Int>> {
     Ok(match (s, str_list) {
@@ -671,7 +671,7 @@ pub fn find_in_set(s: Option<BytesRef>, str_list: Option<BytesRef>) -> Result<Op
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn trim_1_arg(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     Ok(arg.map(|bytes| {
@@ -685,7 +685,7 @@ pub fn trim_1_arg(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
     }))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn trim_3_args(
     arg: Option<BytesRef>,
@@ -706,13 +706,13 @@ pub fn trim_3_args(
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn char_length(bs: Option<BytesRef>) -> Result<Option<Int>> {
     Ok(bs.map(|b| b.len() as i64))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn char_length_utf8(bs: Option<BytesRef>) -> Result<Option<Int>> {
     match bs {
@@ -724,7 +724,7 @@ pub fn char_length_utf8(bs: Option<BytesRef>) -> Result<Option<Int>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn to_base64(bs: Option<BytesRef>) -> Result<Option<Bytes>> {
     match bs {
@@ -747,7 +747,7 @@ pub fn to_base64(bs: Option<BytesRef>) -> Result<Option<Bytes>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn from_base64(bs: Option<BytesRef>) -> Result<Option<Bytes>> {
     match bs {
@@ -769,7 +769,7 @@ pub fn from_base64(bs: Option<BytesRef>) -> Result<Option<Bytes>> {
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn quote(input: Option<BytesRef>) -> Result<Option<Bytes>> {
     match input {

--- a/components/tidb_query_vec_expr/src/impl_time.rs
+++ b/components/tidb_query_vec_expr/src/impl_time.rs
@@ -13,7 +13,7 @@ use tidb_query_datatype::codec::mysql::Time;
 use tidb_query_datatype::codec::Error;
 use tidb_query_datatype::expr::SqlMode;
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn date_format(
     ctx: &mut EvalContext,
@@ -40,7 +40,7 @@ pub fn date_format(
     Ok(Some(t.unwrap().into_bytes()))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn week_with_mode(
     ctx: &mut EvalContext,
@@ -60,7 +60,7 @@ pub fn week_with_mode(
     Ok(Some(i64::from(week)))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn week_day(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     if t.is_none() {
@@ -76,7 +76,7 @@ pub fn week_day(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<In
     Ok(Some(i64::from(day)))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn day_of_week(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     if t.is_none() {
@@ -92,7 +92,7 @@ pub fn day_of_week(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option
     Ok(Some(Int::from(day)))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn day_of_year(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     if t.is_none() {
@@ -108,7 +108,7 @@ pub fn day_of_year(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option
     Ok(Some(Int::from(day)))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn week_of_year(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     if t.is_none() {
@@ -124,7 +124,7 @@ pub fn week_of_year(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Optio
     Ok(Some(Int::from(week)))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn to_days(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     let t = match t {
@@ -139,7 +139,7 @@ pub fn to_days(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int
     Ok(Some(Int::from(t.day_number())))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn from_days(ctx: &mut EvalContext, arg: Option<&Int>) -> Result<Option<Time>> {
     arg.cloned().map_or(Ok(None), |daynr: Int| {
@@ -148,7 +148,7 @@ pub fn from_days(ctx: &mut EvalContext, arg: Option<&Int>) -> Result<Option<Time
     })
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn make_date(
     ctx: &mut EvalContext,
@@ -185,43 +185,43 @@ pub fn make_date(
     Ok(Some(ret))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn month(t: Option<&DateTime>) -> Result<Option<Int>> {
     t.map_or(Ok(None), |time| Ok(Some(Int::from(time.month()))))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn hour(t: Option<&Duration>) -> Result<Option<Int>> {
     Ok(t.as_ref().map(|t| i64::from(t.hours())))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn minute(t: Option<&Duration>) -> Result<Option<Int>> {
     Ok(t.as_ref().map(|t| i64::from(t.minutes())))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn second(t: Option<&Duration>) -> Result<Option<Int>> {
     Ok(t.as_ref().map(|t| i64::from(t.secs())))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn time_to_sec(t: Option<&Duration>) -> Result<Option<Int>> {
     Ok(t.as_ref().map(|t| t.to_secs()))
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn micro_second(t: Option<&Duration>) -> Result<Option<Int>> {
     Ok(t.as_ref().map(|t| i64::from(t.subsec_micros())))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn year(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     let t = match t {
@@ -240,7 +240,7 @@ pub fn year(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> 
     Ok(Some(Int::from(t.year())))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn day_of_month(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> {
     let t = match t {
@@ -259,7 +259,7 @@ pub fn day_of_month(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Optio
     Ok(Some(Int::from(t.day())))
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn day_name(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Bytes>> {
     match t {
@@ -275,7 +275,7 @@ pub fn day_name(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<By
     }
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn period_add(p: Option<&Int>, n: Option<&Int>) -> Result<Option<Int>> {
     Ok(match (p, n) {
@@ -292,7 +292,7 @@ pub fn period_add(p: Option<&Int>, n: Option<&Int>) -> Result<Option<Int>> {
     })
 }
 
-#[rpn_fn]
+#[rpn_fn(nullable)]
 #[inline]
 pub fn period_diff(p1: Option<&Int>, p2: Option<&Int>) -> Result<Option<Int>> {
     match (p1, p2) {
@@ -304,7 +304,7 @@ pub fn period_diff(p1: Option<&Int>, p2: Option<&Int>) -> Result<Option<Int>> {
     }
 }
 
-#[rpn_fn(capture = [ctx])]
+#[rpn_fn(nullable, capture = [ctx])]
 #[inline]
 pub fn last_day(ctx: &mut EvalContext, t: Option<&Time>) -> Result<Option<Time>> {
     if t.is_none() {

--- a/components/tidb_query_vec_expr/src/types/expr_builder.rs
+++ b/components/tidb_query_vec_expr/src/types/expr_builder.rs
@@ -467,49 +467,49 @@ mod tests {
     use tidb_query_common::Result;
 
     /// An RPN function for test. It accepts 1 int argument, returns float.
-    #[rpn_fn]
+    #[rpn_fn(nullable)]
     fn fn_a(_v: Option<&i64>) -> Result<Option<Real>> {
         unreachable!()
     }
 
     /// An RPN function for test. It accepts 2 float arguments, returns int.
-    #[rpn_fn]
+    #[rpn_fn(nullable)]
     fn fn_b(_v1: Option<&Real>, _v2: Option<&Real>) -> Result<Option<i64>> {
         unreachable!()
     }
 
     /// An RPN function for test. It accepts 3 int arguments, returns int.
-    #[rpn_fn]
+    #[rpn_fn(nullable)]
     fn fn_c(_v1: Option<&i64>, _v2: Option<&i64>, _v3: Option<&i64>) -> Result<Option<i64>> {
         unreachable!()
     }
 
     /// An RPN function for test. It accepts 3 float arguments, returns float.
-    #[rpn_fn]
+    #[rpn_fn(nullable)]
     fn fn_d(_v1: Option<&Real>, _v2: Option<&Real>, _v3: Option<&Real>) -> Result<Option<Real>> {
         unreachable!()
     }
 
     /// This function is only used when testing with the validator.
-    #[rpn_fn]
+    #[rpn_fn(nullable)]
     fn fn_e(_v1: Option<&Int>, _v2: Option<&Real>) -> Result<Option<Bytes>> {
         unreachable!()
     }
 
     /// This function is only used when testing with the validator.
-    #[rpn_fn(varg)]
+    #[rpn_fn(nullable, varg)]
     fn fn_f(_v: &[Option<&Int>]) -> Result<Option<Real>> {
         unreachable!()
     }
 
     /// This function is only used when testing with the validator.
-    #[rpn_fn(varg, min_args = 2)]
+    #[rpn_fn(nullable, varg, min_args = 2)]
     fn fn_g(_v: &[Option<&Real>]) -> Result<Option<Int>> {
         unreachable!()
     }
 
     /// This function is only used when testing with the validator.
-    #[rpn_fn(raw_varg, min_args = 1)]
+    #[rpn_fn(nullable, raw_varg, min_args = 1)]
     fn fn_h(_v: &[ScalarValueRef<'_>]) -> Result<Option<Real>> {
         unreachable!()
     }

--- a/components/tidb_query_vec_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_vec_expr/src/types/expr_eval.rs
@@ -435,7 +435,7 @@ mod tests {
     /// Single function call node (i.e. nullary function)
     #[test]
     fn test_eval_single_fn_call_node() {
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo() -> Result<Option<i64>> {
             Ok(Some(42))
         }
@@ -460,7 +460,7 @@ mod tests {
     #[test]
     fn test_eval_unary_function_scalar() {
         /// foo(v) performs v * 2.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v: Option<&Real>) -> Result<Option<Real>> {
             Ok(v.map(|v| *v * 2.0))
         }
@@ -490,7 +490,7 @@ mod tests {
     #[test]
     fn test_eval_unary_function_vector() {
         /// foo(v) performs v + 5.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v: Option<&i64>) -> Result<Option<i64>> {
             Ok(v.map(|v| v + 5))
         }
@@ -524,7 +524,7 @@ mod tests {
     #[test]
     fn test_eval_unary_function_raw_column() {
         /// foo(v) performs v + 5.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v: Option<&i64>) -> Result<Option<i64>> {
             Ok(Some(v.unwrap() + 5))
         }
@@ -575,7 +575,7 @@ mod tests {
     #[test]
     fn test_eval_binary_function_scalar_scalar() {
         /// foo(v) performs v1 + float(v2) - 1.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v1: Option<&Real>, v2: Option<&i64>) -> Result<Option<Real>> {
             Ok(Some(*v1.unwrap() + *v2.unwrap() as f64 - 1.0))
         }
@@ -606,7 +606,7 @@ mod tests {
     #[test]
     fn test_eval_binary_function_vector_scalar() {
         /// foo(v) performs v1 - v2.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v1: Option<&Real>, v2: Option<&Real>) -> Result<Option<Real>> {
             Ok(Some(*v1.unwrap() - *v2.unwrap()))
         }
@@ -644,7 +644,7 @@ mod tests {
     #[test]
     fn test_eval_binary_function_scalar_vector() {
         /// foo(v) performs v1 - float(v2).
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v1: Option<&Real>, v2: Option<&i64>) -> Result<Option<Real>> {
             Ok(Some(*v1.unwrap() - *v2.unwrap() as f64))
         }
@@ -682,7 +682,7 @@ mod tests {
     #[test]
     fn test_eval_binary_function_vector_vector() {
         /// foo(v) performs int(v1*2.5 - float(v2)*3.5).
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v1: Option<&Real>, v2: Option<&i64>) -> Result<Option<i64>> {
             Ok(Some(
                 (v1.unwrap().into_inner() * 2.5 - (*v2.unwrap() as f64) * 3.5) as i64,
@@ -734,7 +734,7 @@ mod tests {
     #[test]
     fn test_eval_binary_function_raw_column() {
         /// foo(v1, v2) performs v1 * v2.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v1: Option<&i64>, v2: Option<&i64>) -> Result<Option<i64>> {
             Ok(Some(v1.unwrap() * v2.unwrap()))
         }
@@ -786,7 +786,7 @@ mod tests {
     #[test]
     fn test_eval_ternary_function() {
         /// foo(v) performs v1 - v2 * v3.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v1: Option<&i64>, v2: Option<&i64>, v3: Option<&i64>) -> Result<Option<i64>> {
             Ok(Some(v1.unwrap() - v2.unwrap() * v3.unwrap()))
         }
@@ -832,25 +832,25 @@ mod tests {
     #[test]
     fn test_eval_comprehensive() {
         /// fn_a(v1, v2, v3) performs v1 * v2 - v3.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn fn_a(v1: Option<&Real>, v2: Option<&Real>, v3: Option<&Real>) -> Result<Option<Real>> {
             Ok(Some(*v1.unwrap() * *v2.unwrap() - *v3.unwrap()))
         }
 
         /// fn_b() returns 42.0.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn fn_b() -> Result<Option<Real>> {
             Ok(Real::new(42.0).ok())
         }
 
         /// fn_c(v1, v2) performs float(v2 - v1).
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn fn_c(v1: Option<&i64>, v2: Option<&i64>) -> Result<Option<Real>> {
             Ok(Real::new((v2.unwrap() - v1.unwrap()) as f64).ok())
         }
 
         /// fn_d(v1, v2) performs v1 + v2 * 2.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn fn_d(v1: Option<&i64>, v2: Option<&i64>) -> Result<Option<i64>> {
             Ok(Some(v1.unwrap() + v2.unwrap() * 2))
         }
@@ -910,7 +910,7 @@ mod tests {
     /// Unary function, but supplied zero arguments. Should panic.
     #[test]
     fn test_eval_fail_1() {
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(_v: Option<&i64>) -> Result<Option<i64>> {
             unreachable!()
         }
@@ -930,7 +930,7 @@ mod tests {
     #[test]
     fn test_eval_fail_2() {
         /// foo(v) performs v * 2.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v: Option<&Real>) -> Result<Option<Real>> {
             Ok(v.map(|v| *v * 2.0))
         }
@@ -955,7 +955,7 @@ mod tests {
     #[test]
     fn test_eval_fail_3() {
         /// Expects real argument, receives int argument.
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn foo(v: Option<&Real>) -> Result<Option<Real>> {
             Ok(v.map(|v| *v * 2.5))
         }
@@ -987,25 +987,25 @@ mod tests {
         //      )
 
         /// fn_a(a: int, b: float, c: int) performs: float(a) - b * float(c)
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn fn_a(a: Option<&i64>, b: Option<&Real>, c: Option<&i64>) -> Result<Option<Real>> {
             Ok(Real::new(*a.unwrap() as f64 - b.unwrap().into_inner() * *c.unwrap() as f64).ok())
         }
 
         /// fn_b(a: float, b: int) performs: a * (float(b) - 1.5)
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn fn_b(a: Option<&Real>, b: Option<&i64>) -> Result<Option<Real>> {
             Ok(Real::new(a.unwrap().into_inner() * (*b.unwrap() as f64 - 1.5)).ok())
         }
 
         /// fn_c() returns: int(42)
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn fn_c() -> Result<Option<i64>> {
             Ok(Some(42))
         }
 
         /// fn_d(a: float) performs: int(a)
-        #[rpn_fn]
+        #[rpn_fn(nullable)]
         fn fn_d(a: Option<&Real>) -> Result<Option<i64>> {
             Ok(Some(a.unwrap().into_inner() as i64))
         }
@@ -1084,7 +1084,7 @@ mod tests {
         use tipb::{Expr, ScalarFuncSig};
 
         #[allow(clippy::trivially_copy_pass_by_ref)]
-        #[rpn_fn(capture = [metadata], metadata_mapper = prepare_a::<T>)]
+        #[rpn_fn(nullable, capture = [metadata], metadata_mapper = prepare_a::<T>)]
         fn fn_a<T: Evaluable + EvaluableRet>(
             metadata: &i64,
             v: Option<&Int>,
@@ -1098,7 +1098,7 @@ mod tests {
         }
 
         #[allow(clippy::trivially_copy_pass_by_ref, clippy::ptr_arg)]
-        #[rpn_fn(varg, capture = [metadata], metadata_mapper = prepare_b::<T>)]
+        #[rpn_fn(nullable, varg, capture = [metadata], metadata_mapper = prepare_b::<T>)]
         fn fn_b<T: Evaluable + EvaluableRet>(
             metadata: &String,
             v: &[Option<&T>],
@@ -1112,7 +1112,7 @@ mod tests {
         }
 
         #[allow(clippy::trivially_copy_pass_by_ref)]
-        #[rpn_fn(raw_varg, capture = [metadata], metadata_mapper = prepare_c::<T>)]
+        #[rpn_fn(nullable, raw_varg, capture = [metadata], metadata_mapper = prepare_c::<T>)]
         fn fn_c<T: Evaluable>(
             _data: &std::marker::PhantomData<T>,
             args: &[ScalarValueRef<'_>],

--- a/components/tidb_query_vec_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_vec_expr/src/types/expr_eval.rs
@@ -1084,13 +1084,13 @@ mod tests {
         use tipb::{Expr, ScalarFuncSig};
 
         #[allow(clippy::trivially_copy_pass_by_ref)]
-        #[rpn_fn(nullable, capture = [metadata], metadata_mapper = prepare_a::<T>)]
-        fn fn_a<T: Evaluable + EvaluableRet>(
+        #[rpn_fn(capture = [metadata], metadata_mapper = prepare_a::<T>)]
+        fn fn_a_nonnull<T: Evaluable + EvaluableRet>(
             metadata: &i64,
-            v: Option<&Int>,
+            v: &Int,
         ) -> Result<Option<Int>> {
             assert_eq!(*metadata, 42);
-            Ok(v.map(|v| v + *metadata))
+            Ok(Some(v + *metadata))
         }
 
         fn prepare_a<T: Evaluable>(_expr: &mut Expr) -> Result<i64> {
@@ -1129,7 +1129,7 @@ mod tests {
             // fn_b: CastIntAsReal
             // fn_c: CastIntAsString
             Ok(match expr.get_sig() {
-                ScalarFuncSig::CastIntAsInt => fn_a_fn_meta::<Real>(),
+                ScalarFuncSig::CastIntAsInt => fn_a_nonnull_fn_meta::<Real>(),
                 ScalarFuncSig::CastIntAsReal => fn_b_fn_meta::<Real>(),
                 ScalarFuncSig::CastIntAsString => fn_c_fn_meta::<Int>(),
                 _ => unreachable!(),

--- a/components/tidb_query_vec_expr/src/types/function.rs
+++ b/components/tidb_query_vec_expr/src/types/function.rs
@@ -7,7 +7,7 @@
 //! ```ignore
 //! use tidb_query_codegen::rpn_fn;
 //!
-//! #[rpn_fn]
+//! #[rpn_fn(nullable)]
 //! fn foo(lhs: &Option<Int>, rhs: &Option<Int>) -> Result<Option<Int>> {
 //!     // Your RPN function logic
 //! }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

`non-null` is now by default for `rpn_fn` macro. If needs manually handle None case, we should add `nullable` in attributes.

### What is changed and how it works?

Proposal: [RFC: Using chunk format in coprocessor framework](https://github.com/tikv/rfcs/pull/43/)

Related Issue: #7724

What's Changed:

* `non-null` by default, add `nullable` attribute in `rpn_fn`
* All functions are refactored to be `nullable`, except for some arithmetic ones.
* In `expr_eval.rs` tests, we modified a cast function to be non-nullable.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test