### PR TITLE
copr: optimize Bytes and Json decode

### DIFF
--- a/components/tidb_query_datatype/src/codec/data_type/chunked_vec_bytes.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/chunked_vec_bytes.rs
@@ -51,10 +51,25 @@ impl ChunkedVecBytes {
         self.length += 1;
     }
 
+    pub fn push_data_ref(&mut self, value: BytesRef) {
+        self.bitmap.push(true);
+        self.data.extend_from_slice(value);
+        self.var_offset.push(self.data.len());
+        self.length += 1;
+    }
+
     pub fn push_null(&mut self) {
         self.bitmap.push(false);
         self.var_offset.push(self.data.len());
         self.length += 1;
+    }
+
+    pub fn push_ref(&mut self, value: Option<BytesRef>) {
+        if let Some(x) = value {
+            self.push_data_ref(x);
+        } else {
+            self.push_null();
+        }
     }
 
     pub fn truncate(&mut self, len: usize) {

--- a/components/tidb_query_datatype/src/codec/data_type/chunked_vec_json.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/chunked_vec_json.rs
@@ -53,10 +53,26 @@ impl ChunkedVecJson {
         self.length += 1;
     }
 
+    pub fn push_data_ref(&mut self, value: JsonRef) {
+        self.bitmap.push(true);
+        self.data.push(value.get_type() as u8);
+        self.data.extend_from_slice(value.value());
+        self.var_offset.push(self.data.len());
+        self.length += 1;
+    }
+
     pub fn push_null(&mut self) {
         self.bitmap.push(false);
         self.var_offset.push(self.data.len());
         self.length += 1;
+    }
+
+    pub fn push_ref(&mut self, value: Option<JsonRef>) {
+        if let Some(x) = value {
+            self.push_data_ref(x);
+        } else {
+            self.push_null();
+        }
     }
 
     pub fn truncate(&mut self, len: usize) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

When constructing decoded column, we can reduce overhead by directly pushing `BytesRef` and `JsonRef` into `ChunkedVec`.

UPDATE: It seems that the decode procedure is quite complex, and we could not get a reference directly. In this way, I'll close this PR for now.

### What is changed and how it works?

Proposal: [RFC: Using chunk format in coprocessor framework](https://github.com/tikv/rfcs/pull/43/)

Related Issue: #7724

What's Changed:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test