### PR TITLE
metrics: update title of some raft IO metrics

### DIFF
--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -6126,7 +6126,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Apply log duration per server",
+          "title": "99% Apply log duration per server",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -6288,7 +6288,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Append log duration per server",
+          "title": "99% Append log duration per server",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -6442,7 +6442,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Commit log duration per server",
+          "title": "99% Commit log duration per server",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
Append log/Apply log/Commit log duration metrics are actually showing p99 latency of each raft IO stage. 

### What is changed and how it works?

What's Changed: update the metrics titles.

### Related changes

no

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
eyeball

### Release note <!-- bugfixes or new feature need a release note -->

* No release notes.