### PR TITLE
copr: support writer-guard pattern for Bytes

### DIFF
--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -551,7 +551,7 @@ struct RpnFnSignatureReturnGuardType {
 }
 
 impl RpnFnSignatureReturnGuardType {
-    fn to_return_type(self) -> Result<RpnFnSignatureReturnType> {
+    fn into_return_type(self) -> Result<RpnFnSignatureReturnType> {
         match self.eval_type.path.get_ident() {
             Some(x) => {
                 if *x == "BytesGuard" {
@@ -1242,7 +1242,7 @@ impl NormalRpnFn {
                         "Expect return type to be like `Result<SomeGuard>`",
                     )
                 })?
-                .to_return_type()?
+                .into_return_type()?
         } else {
             parse2::<RpnFnSignatureReturnType>((&item_fn.sig.output).into_token_stream()).map_err(
                 |_| {

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -1220,8 +1220,7 @@ impl NormalRpnFn {
         let mut arg_types = Vec::new();
         let mut arg_types_anonymous = Vec::new();
         let mut arg_types_no_ref = Vec::new();
-        let take_cnt =
-            item_fn.sig.inputs.len() - attr.captures.len() - if attr.writer { 1 } else { 0 };
+        let take_cnt = item_fn.sig.inputs.len() - attr.captures.len() - attr.writer as usize;
         let fn_args = item_fn
             .sig
             .inputs

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -1399,8 +1399,8 @@ impl NormalRpnFn {
         let vec_type = &self.ret_type;
 
         let chunked_push = if self.writer {
-            quote! { 
-                let writer = result.into_writer(); 
+            quote! {
+                let writer = result.into_writer();
                 let guard = #fn_ident #ty_generics_turbofish ( #(#captures,)* #(#call_arg),* , writer)?;
                 result = guard.into_inner();
             }

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -209,14 +209,6 @@ pub fn transform(attr: TokenStream, item_fn: TokenStream) -> Result<TokenStream>
     } else if attr.is_raw_varg {
         Ok(RawVargsRpnFn::new(attr, item_fn)?.generate())
     } else {
-        /*
-        let writer = attr.writer;
-        let x = Ok(NormalRpnFn::new(attr, item_fn)?.generate());
-        if writer {
-             println!("{}", x.clone().unwrap());
-        }
-        x
-        */
         Ok(NormalRpnFn::new(attr, item_fn)?.generate())
     }
 }

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -1885,6 +1885,7 @@ mod tests_normal {
                 metadata_type: None,
                 captures: vec![parse_str("ctx").unwrap()],
                 nullable: true,
+                writer: false,
             },
             item_fn,
         )

--- a/components/tidb_query_codegen/src/rpn_function.rs
+++ b/components/tidb_query_codegen/src/rpn_function.rs
@@ -209,6 +209,14 @@ pub fn transform(attr: TokenStream, item_fn: TokenStream) -> Result<TokenStream>
     } else if attr.is_raw_varg {
         Ok(RawVargsRpnFn::new(attr, item_fn)?.generate())
     } else {
+        /*
+        let writer = attr.writer;
+        let x = Ok(NormalRpnFn::new(attr, item_fn)?.generate());
+        if writer {
+             println!("{}", x.clone().unwrap());
+        }
+        x
+        */
         Ok(NormalRpnFn::new(attr, item_fn)?.generate())
     }
 }
@@ -230,6 +238,9 @@ struct RpnFnAttr {
 
     /// Whether or not the function needs extra logic on `None` value.
     nullable: bool,
+
+    /// Whether or not to use writer / guard pattern.
+    writer: bool,
 
     /// The maximum accepted arguments, which will be checked by the validator.
     ///
@@ -259,6 +270,7 @@ impl Default for RpnFnAttr {
             is_varg: false,
             is_raw_varg: false,
             nullable: true,
+            writer: false,
             max_args: None,
             min_args: None,
             extra_validator: None,
@@ -274,6 +286,7 @@ impl parse::Parse for RpnFnAttr {
         let mut is_varg = false;
         let mut is_raw_varg = false;
         let mut nullable = false;
+        let mut writer = false;
         let mut max_args = None;
         let mut min_args = None;
         let mut extra_validator = None;
@@ -338,6 +351,9 @@ impl parse::Parse for RpnFnAttr {
                         "nullable" => {
                             nullable = true;
                         }
+                        "writer" => {
+                            writer = true;
+                        }
                         _ => {
                             return Err(Error::new_spanned(
                                 path,
@@ -354,32 +370,58 @@ impl parse::Parse for RpnFnAttr {
                 }
             }
         }
+
         if is_varg && is_raw_varg {
             return Err(Error::new_spanned(
                 config_items,
                 "`varg` and `raw_varg` conflicts to each other",
             ));
         }
+
         if !is_varg && !is_raw_varg && (min_args != None || max_args != None) {
             return Err(Error::new_spanned(
                 config_items,
                 "`min_args` or `max_args` is only available when `varg` or `raw_varg` presents",
             ));
         }
+
         if !nullable && is_raw_varg {
             return Err(Error::new_spanned(
                 config_items,
                 "`raw_varg` function must be nullable",
             ));
         }
+
         if !nullable && is_varg {
             return Err(Error::new_spanned(config_items, "`varg` must be nullable"));
+        }
+
+        if writer && is_varg {
+            return Err(Error::new_spanned(
+                config_items,
+                "`varg` doesn't support writer",
+            ));
+        }
+
+        if writer && is_raw_varg {
+            return Err(Error::new_spanned(
+                config_items,
+                "`raw_varg` doesn't support writer",
+            ));
+        }
+
+        if writer && (metadata_type.is_some() || metadata_mapper.is_some()) {
+            return Err(Error::new_spanned(
+                config_items,
+                "writer cannot be used with metadata",
+            ));
         }
 
         Ok(Self {
             is_varg,
             is_raw_varg,
             nullable,
+            writer,
             max_args,
             min_args,
             extra_validator,
@@ -508,6 +550,62 @@ impl parse::Parse for VargsRpnFnSignatureParam {
             _pat: pat,
             eval_type: et,
         })
+    }
+}
+
+/// Parses a function signature return type like `Result<SomeGuard>`.
+struct RpnFnSignatureReturnGuardType {
+    eval_type: TypePath,
+}
+
+impl RpnFnSignatureReturnGuardType {
+    fn to_return_type(self) -> Result<RpnFnSignatureReturnType> {
+        match self.eval_type.path.get_ident() {
+            Some(x) => {
+                if *x == "BytesGuard" {
+                    Ok(RpnFnSignatureReturnType {
+                        eval_type: parse_quote! { Bytes },
+                    })
+                } else {
+                    Err(Error::new_spanned(
+                        self.eval_type.to_token_stream(),
+                        format!("Unknown writer type `{:?}`", self.eval_type),
+                    ))
+                }
+            }
+            None => Err(Error::new_spanned(
+                self.eval_type.to_token_stream(),
+                format!("Unknown type `{:?}`", self.eval_type),
+            )),
+        }
+    }
+}
+
+impl parse::Parse for RpnFnSignatureReturnGuardType {
+    fn parse(input: parse::ParseStream<'_>) -> Result<Self> {
+        input.parse::<Token![->]>()?;
+        let tp = input.parse::<Type>()?;
+        if let Type::Path(TypePath {
+            path: Path { segments, .. },
+            ..
+        }) = &tp
+        {
+            let result_type = segments.last().unwrap().clone();
+            if let PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) =
+                result_type.arguments
+            {
+                Ok(Self {
+                    eval_type: parse2::<TypePath>(args.into_token_stream())?,
+                })
+            } else {
+                Err(Error::new_spanned(
+                    tp,
+                    "expect angle bracketed path arguments",
+                ))
+            }
+        } else {
+            Err(Error::new_spanned(tp, "expect path"))
+        }
     }
 }
 
@@ -1086,6 +1184,7 @@ struct NormalRpnFn {
     metadata_type: Option<TokenStream>,
     metadata_mapper: Option<TokenStream>,
     nullable: bool,
+    writer: bool,
     item_fn: ItemFn,
     fn_trait_ident: Ident,
     evaluator_ident: Ident,
@@ -1129,21 +1228,39 @@ impl NormalRpnFn {
         let mut arg_types = Vec::new();
         let mut arg_types_anonymous = Vec::new();
         let mut arg_types_no_ref = Vec::new();
-        for fn_arg in item_fn.sig.inputs.iter().skip(attr.captures.len()) {
+        let take_cnt =
+            item_fn.sig.inputs.len() - attr.captures.len() - if attr.writer { 1 } else { 0 };
+        let fn_args = item_fn
+            .sig
+            .inputs
+            .iter()
+            .skip(attr.captures.len())
+            .take(take_cnt);
+        for fn_arg in fn_args {
             let arg_type = Self::get_arg_type(&attr, &fn_arg)?;
             arg_types.push(arg_type.eval_type.get_type_with_lifetime(quote! { 'arg_ }));
             arg_types_anonymous.push(arg_type.eval_type.get_type_with_lifetime(quote! { '_ }));
             arg_types_no_ref.push(arg_type.eval_type.get_type_with_lifetime(quote! {}));
         }
-        let ret_type = parse2::<RpnFnSignatureReturnType>(
-            (&item_fn.sig.output).into_token_stream(),
-        )
-        .map_err(|_| {
-            Error::new_spanned(
-                &item_fn.sig.output,
-                "Expect return type to be like `Result<Option<T>>`",
-            )
-        })?;
+        let ret_type = if attr.writer {
+            parse2::<RpnFnSignatureReturnGuardType>((&item_fn.sig.output).into_token_stream())
+                .map_err(|_| {
+                    Error::new_spanned(
+                        &item_fn.sig.output,
+                        "Expect return type to be like `Result<SomeGuard>`",
+                    )
+                })?
+                .to_return_type()?
+        } else {
+            parse2::<RpnFnSignatureReturnType>((&item_fn.sig.output).into_token_stream()).map_err(
+                |_| {
+                    Error::new_spanned(
+                        &item_fn.sig.output,
+                        "Expect return type to be like `Result<Option<T>>`",
+                    )
+                },
+            )?
+        };
         let camel_name = item_fn.sig.ident.to_string().to_camel_case();
         let fn_trait_ident = Ident::new(&format!("{}_Fn", camel_name), Span::call_site());
         let evaluator_ident = Ident::new(&format!("{}_Evaluator", camel_name), Span::call_site());
@@ -1153,6 +1270,7 @@ impl NormalRpnFn {
             metadata_type: attr.metadata_type,
             metadata_mapper: attr.metadata_mapper,
             nullable: attr.nullable,
+            writer: attr.writer,
             item_fn,
             fn_trait_ident,
             evaluator_ident,
@@ -1280,6 +1398,18 @@ impl NormalRpnFn {
 
         let vec_type = &self.ret_type;
 
+        let chunked_push = if self.writer {
+            quote! { 
+                let writer = result.into_writer(); 
+                let guard = #fn_ident #ty_generics_turbofish ( #(#captures,)* #(#call_arg),* , writer)?;
+                result = guard.into_inner();
+            }
+        } else {
+            quote! {
+                result.chunked_push( #fn_ident #ty_generics_turbofish ( #(#captures,)* #(#call_arg),* )?);
+            }
+        };
+
         quote! {
             impl #impl_generics #fn_trait_ident #ty_generics for #tp #where_clause {
                 default fn eval(
@@ -1296,7 +1426,7 @@ impl NormalRpnFn {
                     for row_index in 0..output_rows {
                         #(let (#extract, arg) = arg.extract(row_index));*;
                         #nonnull_unwrap
-                        result.chunked_push( #fn_ident #ty_generics_turbofish ( #(#captures,)* #(#call_arg),* )?);
+                        #chunked_push
                     }
                     Ok(#vec_type::into_vector_value(result))
                 }

--- a/components/tidb_query_datatype/src/codec/data_type/chunked_vec_bytes.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/chunked_vec_bytes.rs
@@ -359,11 +359,14 @@ mod test {
         }
         assert_eq!(
             chunked_vec.to_vec(),
-            test_bytes.iter().map(|x| if let Some(x) = x {
-                Some(repeat(x.to_vec(), 3))
-            } else {
-                None
-            }).collect::<Vec<Option<Bytes>>>()
+            test_bytes
+                .iter()
+                .map(|x| if let Some(x) = x {
+                    Some(repeat(x.to_vec(), 3))
+                } else {
+                    None
+                })
+                .collect::<Vec<Option<Bytes>>>()
         );
     }
 }

--- a/components/tidb_query_datatype/src/codec/data_type/chunked_vec_bytes.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/chunked_vec_bytes.rs
@@ -318,12 +318,20 @@ mod test {
         let test_bytes: &[Option<Bytes>] = &[
             None,
             None,
-            Some("我好菜啊".as_bytes().to_vec()),
+            Some(
+                "TiDB 是PingCAP 公司自主设计、研发的开源分布式关系型数据库，"
+                    .as_bytes()
+                    .to_vec(),
+            ),
             None,
-            Some("我菜爆了".as_bytes().to_vec()),
-            Some("我失败了".as_bytes().to_vec()),
+            Some(
+                "是一款同时支持在线事务处理与在线分析处理(HTAP)的融合型分布式数据库产品。"
+                    .as_bytes()
+                    .to_vec(),
+            ),
+            Some("🐮🐮🐮🐮🐮".as_bytes().to_vec()),
             None,
-            Some("💩".as_bytes().to_vec()),
+            Some("💩💩💩".as_bytes().to_vec()),
             None,
         ];
         let mut chunked_vec = ChunkedVecBytes::with_capacity(0);

--- a/components/tidb_query_datatype/src/codec/data_type/chunked_vec_bytes.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/chunked_vec_bytes.rs
@@ -330,6 +330,7 @@ mod test {
                     .to_vec(),
             ),
             Some("🐮🐮🐮🐮🐮".as_bytes().to_vec()),
+            Some("我成功了".as_bytes().to_vec()),
             None,
             Some("💩💩💩".as_bytes().to_vec()),
             None,

--- a/components/tidb_query_datatype/src/codec/data_type/mod.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/mod.rs
@@ -14,7 +14,7 @@ pub type Real = ordered_float::NotNan<f64>;
 pub type Bytes = Vec<u8>;
 pub type BytesRef<'a> = &'a [u8];
 pub use crate::codec::mysql::{json::JsonRef, Decimal, Duration, Json, JsonType, Time as DateTime};
-pub use chunked_vec_bytes::ChunkedVecBytes;
+pub use chunked_vec_bytes::{BytesGuard, BytesWriter, ChunkedVecBytes, PartialBytesWriter};
 pub use chunked_vec_json::ChunkedVecJson;
 pub use chunked_vec_sized::ChunkedVecSized;
 

--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -805,7 +805,7 @@ pub fn repeat(input: BytesRef, cnt: &Int, writer: BytesWriter) -> Result<BytesGu
     } else {
         *cnt
     };
-    let mut writer = writer.to_partial_writer();
+    let mut writer = writer.begin();
     for _i in 0..cnt {
         writer.partial_write(input);
     }

--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -3002,14 +3002,14 @@ mod tests {
 
         let output = RpnFnScalarEvaluator::new()
             .push_param(Some(b"hi".to_vec()))
-            .push_param(null_cnt.clone())
+            .push_param(null_cnt)
             .evaluate::<Bytes>(ScalarFuncSig::Repeat)
             .unwrap();
         assert_eq!(output, None);
 
         let output = RpnFnScalarEvaluator::new()
-            .push_param(null_string.clone())
-            .push_param(null_cnt.clone())
+            .push_param(null_string)
+            .push_param(null_cnt)
             .evaluate::<Bytes>(ScalarFuncSig::Repeat)
             .unwrap();
         assert_eq!(output, None);

--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -797,9 +797,6 @@ pub fn quote(input: Option<BytesRef>) -> Result<Option<Bytes>> {
     }
 }
 
-
-/*
-
 #[rpn_fn(writer)]
 #[inline]
 pub fn repeat(input: BytesRef, cnt: &Int, writer: BytesWriter) -> Result<BytesGuard> {
@@ -808,27 +805,11 @@ pub fn repeat(input: BytesRef, cnt: &Int, writer: BytesWriter) -> Result<BytesGu
     } else {
         *cnt
     };
-    let mut result = vec![];
+    let mut writer = writer.to_partial_writer();
     for _i in 0..cnt {
-        result.append(&mut input.to_owned_value())
+        writer.partial_write(input);
     }
-    Ok(Some(result))
-}
-*/
-
-#[rpn_fn]
-#[inline]
-pub fn repeat(input: BytesRef, cnt: &Int) -> Result<Option<Bytes>> {
-    let cnt = if *cnt > std::i32::MAX.into() {
-        std::i32::MAX.into()
-    } else {
-        *cnt
-    };
-    let mut result = vec![];
-    for i in 0..cnt {
-        result.append(&mut input.to_owned_value())
-    }
-    Ok(Some(result))
+    Ok(writer.finish())
 }
 
 #[cfg(test)]

--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -798,6 +798,24 @@ pub fn quote(input: Option<BytesRef>) -> Result<Option<Bytes>> {
 }
 
 
+/*
+
+#[rpn_fn(writer)]
+#[inline]
+pub fn repeat(input: BytesRef, cnt: &Int, writer: BytesWriter) -> Result<BytesGuard> {
+    let cnt = if *cnt > std::i32::MAX.into() {
+        std::i32::MAX.into()
+    } else {
+        *cnt
+    };
+    let mut result = vec![];
+    for _i in 0..cnt {
+        result.append(&mut input.to_owned_value())
+    }
+    Ok(Some(result))
+}
+*/
+
 #[rpn_fn]
 #[inline]
 pub fn repeat(input: BytesRef, cnt: &Int) -> Result<Option<Bytes>> {
@@ -807,7 +825,7 @@ pub fn repeat(input: BytesRef, cnt: &Int) -> Result<Option<Bytes>> {
         *cnt
     };
     let mut result = vec![];
-    for _i in 0..cnt {
+    for i in 0..cnt {
         result.append(&mut input.to_owned_value())
     }
     Ok(Some(result))

--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -797,6 +797,22 @@ pub fn quote(input: Option<BytesRef>) -> Result<Option<Bytes>> {
     }
 }
 
+
+#[rpn_fn]
+#[inline]
+pub fn repeat(input: BytesRef, cnt: &Int) -> Result<Option<Bytes>> {
+    let cnt = if *cnt > std::i32::MAX.into() {
+        std::i32::MAX.into()
+    } else {
+        *cnt
+    };
+    let mut result = vec![];
+    for _i in 0..cnt {
+        result.append(&mut input.to_owned_value())
+    }
+    Ok(Some(result))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2945,5 +2961,58 @@ mod tests {
         // check for null
         let got = quote(None).unwrap();
         assert_eq!(got, Some(Bytes::from("NULL")))
+    }
+
+    #[test]
+    fn test_repeat() {
+        let cases = vec![
+            ("hello, world!", -1, ""),
+            ("hello, world!", 0, ""),
+            ("hello, world!", 1, "hello, world!"),
+            (
+                "hello, world!",
+                3,
+                "hello, world!hello, world!hello, world!",
+            ),
+            ("你好世界", 3, "你好世界你好世界你好世界"),
+            ("こんにちは", 2, "こんにちはこんにちは"),
+            ("\x2f\x35", 5, "\x2f\x35\x2f\x35\x2f\x35\x2f\x35\x2f\x35"),
+        ];
+
+        for (input, cnt, expect) in cases {
+            let input = Bytes::from(input);
+            let expected_output = Bytes::from(expect);
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(Some(input))
+                .push_param(Some(cnt))
+                .evaluate::<Bytes>(ScalarFuncSig::Repeat)
+                .unwrap();
+            assert_eq!(output, Some(expected_output));
+        }
+
+        let null_string: Option<Bytes> = None;
+        let null_cnt: Option<Int> = None;
+
+        // test NULL case
+        let output = RpnFnScalarEvaluator::new()
+            .push_param(null_string.clone())
+            .push_param(Some(42))
+            .evaluate::<Bytes>(ScalarFuncSig::Repeat)
+            .unwrap();
+        assert_eq!(output, None);
+
+        let output = RpnFnScalarEvaluator::new()
+            .push_param(Some(b"hi".to_vec()))
+            .push_param(null_cnt.clone())
+            .evaluate::<Bytes>(ScalarFuncSig::Repeat)
+            .unwrap();
+        assert_eq!(output, None);
+
+        let output = RpnFnScalarEvaluator::new()
+            .push_param(null_string.clone())
+            .push_param(null_cnt.clone())
+            .evaluate::<Bytes>(ScalarFuncSig::Repeat)
+            .unwrap();
+        assert_eq!(output, None);
     }
 }

--- a/components/tidb_query_vec_expr/src/lib.rs
+++ b/components/tidb_query_vec_expr/src/lib.rs
@@ -561,6 +561,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::CharLength => char_length_fn_meta(),
         ScalarFuncSig::CharLengthUtf8 => char_length_utf8_fn_meta(),
         ScalarFuncSig::ToBase64 => to_base64_fn_meta(),
+        ScalarFuncSig::Repeat => repeat_fn_meta(),
         // impl_time
         ScalarFuncSig::DateFormatSig => date_format_fn_meta(),
         ScalarFuncSig::WeekOfYear => week_of_year_fn_meta(),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

**Problem Summary**

Now we can use writer / guard for efficient writing `Bytes` to `ChunkedVec` in vectorized functions.


### What is changed and how it works?

Proposal: [RFC: Using chunk format in coprocessor framework](https://github.com/tikv/rfcs/pull/43/)

Related Issue: close #7724

What's Changed:

* add a new vectorized function `repeat`
* add `BytesWriter`, `BytesGuard`, `PartialBytesWriter` for `ChunkedVecBytes`
* add `writer` support for `rpn_fn`

Now all of the items listed in RFC has been implemented. Later I'll update documentation.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test