### PR TITLE
copr: remove nullable signature for expression `like`

### DIFF
--- a/components/tidb_query_vec_expr/src/impl_like.rs
+++ b/components/tidb_query_vec_expr/src/impl_like.rs
@@ -7,21 +7,12 @@ use tidb_query_datatype::codec::collation::*;
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_shared_expr::*;
 
-#[rpn_fn(nullable)]
+#[rpn_fn]
 #[inline]
-pub fn like<C: Collator>(
-    target: Option<BytesRef>,
-    pattern: Option<BytesRef>,
-    escape: Option<&i64>,
-) -> Result<Option<i64>> {
-    match (target, pattern, escape) {
-        (Some(target), Some(pattern), Some(escape)) => {
-            Ok(Some(
-                like::like::<C>(target, pattern, *escape as u32)? as i64
-            ))
-        }
-        _ => Ok(None),
-    }
+pub fn like<C: Collator>(target: BytesRef, pattern: BytesRef, escape: &i64) -> Result<Option<i64>> {
+    Ok(Some(
+        like::like::<C>(target, pattern, *escape as u32)? as i64
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?



### What is changed and how it works?


What's Changed:

Remove Option from `like` signature.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Note

This can be a template PR for community to paticipate.