### PR TITLE
copr: remove nullable signature for expression `compare`

### DIFF
--- a/components/tidb_query_vec_expr/src/impl_compare.rs
+++ b/components/tidb_query_vec_expr/src/impl_compare.rs
@@ -20,30 +20,17 @@ where
     C::compare(lhs, rhs)
 }
 
-#[rpn_fn(nullable)]
+#[rpn_fn]
 #[inline]
-pub fn compare_json<F: CmpOp>(lhs: Option<JsonRef>, rhs: Option<JsonRef>) -> Result<Option<i64>> {
-    Ok(match (lhs, rhs) {
-        (None, None) => F::compare_null(),
-        (None, _) | (_, None) => F::compare_partial_null(),
-        (Some(lhs), Some(rhs)) => Some(F::compare_order(lhs.cmp(&rhs)) as i64),
-    })
+pub fn compare_json<F: CmpOp>(lhs: JsonRef, rhs: JsonRef) -> Result<Option<i64>> {
+    Ok(Some(F::compare_order(lhs.cmp(&rhs)) as i64))
 }
 
-#[rpn_fn(nullable)]
+#[rpn_fn]
 #[inline]
-pub fn compare_bytes<C: Collator, F: CmpOp>(
-    lhs: Option<BytesRef>,
-    rhs: Option<BytesRef>,
-) -> Result<Option<i64>> {
-    Ok(match (lhs, rhs) {
-        (None, None) => F::compare_null(),
-        (None, _) | (_, None) => F::compare_partial_null(),
-        (Some(lhs), Some(rhs)) => {
-            let ord = C::sort_compare(lhs, rhs)?;
-            Some(F::compare_order(ord) as i64)
-        }
-    })
+pub fn compare_bytes<C: Collator, F: CmpOp>(lhs: BytesRef, rhs: BytesRef) -> Result<Option<i64>> {
+    let ord = C::sort_compare(lhs, rhs)?;
+    Ok(Some(F::compare_order(ord) as i64))
 }
 
 pub trait Comparer {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Remove Option from `compare` signature.

### Related changes

- #8331 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
