### PR TITLE
WIP implement check secondary locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#1e0910aabe6cffc721689606d88c8117d837d3cb"
+source = "git+https://github.com/pingcap/kvproto.git#5f564ec8820e3b4002930f6f3dd1fcd710d4ecd0"
 dependencies = [
  "futures 0.1.29",
  "grpcio",

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -21,6 +21,7 @@ make_auto_flush_static_metric! {
         kv_batch_rollback,
         kv_txn_heart_beat,
         kv_check_txn_status,
+        kv_check_secondary_locks,
         kv_scan_lock,
         kv_resolve_lock,
         kv_gc,

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -225,6 +225,12 @@ impl<
         CheckTxnStatusResponse
     );
     handle_request!(
+        kv_check_secondary_locks,
+        future_kv_check_secondary_locks,
+        CheckSecondaryLocksRequest,
+        CheckSecondaryLocksResponse
+    );
+    handle_request!(
         kv_scan_lock,
         future_scan_lock,
         ScanLockRequest,
@@ -1086,6 +1092,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, P: PdClient + 'stati
         BatchRollback, future_batch_rollback(storage), kv_batch_rollback;
         TxnHeartBeat, future_txn_heart_beat(storage), kv_txn_heart_beat;
         CheckTxnStatus, future_check_txn_status(storage), kv_check_txn_status;
+        CheckSecondaryLocks, future_kv_check_secondary_locks(storage), kv_check_secondary_locks;
         ScanLock, future_scan_lock(storage), kv_scan_lock;
         ResolveLock, future_resolve_lock(storage), kv_resolve_lock;
         Gc, future_gc(), kv_gc;
@@ -1615,6 +1622,16 @@ txn_command_future!(future_check_txn_status, CheckTxnStatusRequest, CheckTxnStat
                 }
             },
             Err(e) => resp.set_error(extract_key_error(&e)),
+        }
+});
+txn_command_future!(future_kv_check_secondary_locks, CheckSecondaryLocksRequest, CheckSecondaryLocksResponse,
+    (v, resp) {
+        match v {
+            Ok((locks, commit_ts)) => {
+                resp.set_locks(locks.into_iter().map(|l| l.unwrap_or_else(|| LockInfo::default())).collect());
+                resp.set_commit_ts(commit_ts.into_inner());
+            },
+            Err(e) => {} // TODO resp.set_error(extract_key_error(&e)),
         }
 });
 txn_command_future!(future_scan_lock, ScanLockRequest, ScanLockResponse, (v, resp) {

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -111,6 +111,7 @@ make_auto_flush_static_metric! {
         pessimistic_rollback,
         txn_heart_beat,
         check_txn_status,
+        check_secondary_locks,
         scan_lock,
         resolve_lock,
         resolve_lock_lite,

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -8,7 +8,7 @@ mod txn;
 
 pub use self::metrics::{GC_DELETE_VERSIONS_HISTOGRAM, MVCC_VERSIONS_HISTOGRAM};
 pub use self::reader::*;
-pub use self::txn::{GcInfo, MvccTxn, ReleasedLock, MAX_TXN_WRITE_SIZE};
+pub use self::txn::{AsyncLockInfo, GcInfo, MvccTxn, ReleasedLock, MAX_TXN_WRITE_SIZE};
 pub use crate::new_txn;
 pub use txn_types::{
     Key, Lock, LockType, Mutation, TimeStamp, Value, Write, WriteRef, WriteType,

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -177,6 +177,7 @@ storage_callback! {
     Booleans(Vec<Result<()>>) ProcessResult::MultiRes { results } => results,
     MvccInfoByKey(MvccInfo) ProcessResult::MvccKey { mvcc } => mvcc,
     MvccInfoByStartTs(Option<(Key, MvccInfo)>) ProcessResult::MvccStartTs { mvcc } => mvcc,
+    AsyncLocks((Vec<Option<kvrpcpb::LockInfo>>, TimeStamp)) ProcessResult::AsyncLocks { locks, commit_ts } => (locks, commit_ts),
     Locks(Vec<kvrpcpb::LockInfo>) ProcessResult::Locks { locks } => locks,
     TxnStatus(TxnStatus) ProcessResult::TxnStatus { txn_status } => txn_status,
     Prewrite(PrewriteResult) ProcessResult::PrewriteResult { result } => result,


### PR DESCRIPTION
Signed-off-by: Nick Cameron <nrc@ncameron.org>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
WIP - blocked on https://github.com/pingcap/kvproto/pull/657 and implementing a test

Issue Number: cc #8316 

Problem Summary: Implements a command for checking the status of async commit locks

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: Adds command boilerplate, plus implementation in process.rs/txn.rs for `CheckSecondaryLocks`.

Tests <!-- At least one of them must be included. -->

- Unit test - TODO

### Release note <!-- bugfixes or new feature need a release note -->

No release note (partial implementation only)