### PR TITLE
Merge lightning worker into one thread.

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -595,6 +595,7 @@ impl TiKVServer {
             self.pd_client.clone(),
             self.region_info_accessor.clone(),
             node.id(),
+            self.config.gc.ratio_threshold,
         );
         if let Err(e) = gc_worker.start_auto_gc(auto_gc_config) {
             fatal!("failed to start auto_gc on storage, error: {}", e);

--- a/components/engine_traits/src/lib.rs
+++ b/components/engine_traits/src/lib.rs
@@ -258,8 +258,6 @@
 extern crate quick_error;
 #[allow(unused_extern_crates)]
 extern crate tikv_alloc;
-#[macro_use]
-extern crate slog_global;
 
 // These modules contain traits that need to be implemented by engines, either
 // they are required by KvEngine or are an associated type of KvEngine. It is

--- a/components/engine_traits/src/metrics_flusher.rs
+++ b/components/engine_traits/src/metrics_flusher.rs
@@ -1,10 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::io;
-use std::result::Result;
-use std::sync::mpsc::{self, Sender};
-use std::thread::{Builder as ThreadBuilder, JoinHandle};
 use std::time::{Duration, Instant};
+use tikv_util::worker::{Runnable, Scheduler};
 
 use crate::*;
 
@@ -14,8 +11,23 @@ const FLUSHER_RESET_INTERVAL: Duration = Duration::from_millis(60_000);
 pub struct MetricsFlusher<K: KvEngine, R: KvEngine> {
     pub engines: KvEngines<K, R>,
     interval: Duration,
-    handle: Option<JoinHandle<()>>,
-    sender: Option<Sender<bool>>,
+    last_reset: Instant,
+    scheduler: Option<Scheduler<usize>>,
+}
+
+impl<K: KvEngine, R: KvEngine> Runnable<usize> for MetricsFlusher<K, R> {
+    fn register_scheduler(&mut self, scheduler: Scheduler<usize>) {
+        scheduler.register_timeout(0, self.interval);
+        self.scheduler = Some(scheduler);
+    }
+
+    fn run(&mut self, _: usize) {
+        self.flush();
+        self.scheduler
+            .as_ref()
+            .unwrap()
+            .register_timeout(0, self.interval);
+    }
 }
 
 impl<K: KvEngine, R: KvEngine> MetricsFlusher<K, R> {
@@ -23,8 +35,8 @@ impl<K: KvEngine, R: KvEngine> MetricsFlusher<K, R> {
         MetricsFlusher {
             engines,
             interval: DEFAULT_FLUSH_INTERVAL,
-            handle: None,
-            sender: None,
+            last_reset: Instant::now(),
+            scheduler: None,
         }
     }
 
@@ -32,40 +44,17 @@ impl<K: KvEngine, R: KvEngine> MetricsFlusher<K, R> {
         self.interval = interval;
     }
 
-    pub fn start(&mut self) -> Result<(), io::Error> {
-        let (kv_db, raft_db) = (self.engines.kv.clone(), self.engines.raft.clone());
-        let shared_block_cache = self.engines.shared_block_cache;
-        let interval = self.interval;
-        let (tx, rx) = mpsc::channel();
-        self.sender = Some(tx);
-        let h = ThreadBuilder::new()
-            .name("metrics-flusher".to_owned())
-            .spawn(move || {
-                let mut last_reset = Instant::now();
-                while let Err(mpsc::RecvTimeoutError::Timeout) = rx.recv_timeout(interval) {
-                    kv_db.flush_metrics("kv", shared_block_cache);
-                    raft_db.flush_metrics("raft", shared_block_cache);
-                    if last_reset.elapsed() >= FLUSHER_RESET_INTERVAL {
-                        kv_db.reset_statistics();
-                        raft_db.reset_statistics();
-                        last_reset = Instant::now();
-                    }
-                }
-            })?;
-
-        self.handle = Some(h);
-        Ok(())
-    }
-
-    pub fn stop(&mut self) {
-        let h = self.handle.take();
-        if h.is_none() {
-            return;
-        }
-        drop(self.sender.take().unwrap());
-        if let Err(e) = h.unwrap().join() {
-            error!("join metrics flusher failed"; "err" => ?e);
-            return;
+    fn flush(&mut self) {
+        self.engines
+            .kv
+            .flush_metrics("kv", self.engines.shared_block_cache);
+        self.engines
+            .raft
+            .flush_metrics("raft", self.engines.shared_block_cache);
+        if self.last_reset.elapsed() >= FLUSHER_RESET_INTERVAL {
+            self.engines.kv.reset_statistics();
+            self.engines.raft.reset_statistics();
+            self.last_reset = Instant::now();
         }
     }
 }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3420,7 +3420,6 @@ mod tests {
     use crate::store::{Config, RegionTask};
     use test_sst_importer::*;
     use tikv_util::config::VersionTrack;
-    use tikv_util::worker::dummy_scheduler;
 
     use super::*;
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1131,6 +1131,7 @@ impl RaftBatchSystem {
         pd_client: Arc<C>,
         mgr: SnapManager<RocksEngine>,
         pd_worker: FutureWorker<PdTask<RocksEngine>>,
+        worker: Option<Worker>,
         store_meta: Arc<Mutex<StoreMeta>>,
         mut coprocessor_host: CoprocessorHost<RocksEngine>,
         importer: Arc<SSTImporter>,
@@ -1146,8 +1147,10 @@ impl RaftBatchSystem {
             .registry
             .register_admin_observer(100, BoxAdminObserver::new(SplitObserver));
 
+        let common_worker = worker.unwrap_or_else(|| Worker::new("store-worker"));
+
         let workers = Workers {
-            common_worker: Worker::new("store-worker"),
+            common_worker,
             pd_worker,
             coprocessor_host,
         };

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1047,12 +1047,12 @@ where
 
 struct Workers {
     pd_worker: FutureWorker<PdTask<RocksEngine>>,
-    consistency_check_worker: Worker<ConsistencyCheckTask<RocksSnapshot>>,
-    split_check_worker: Worker<SplitCheckTask>,
-    // handle Compact, CleanupSST task
-    cleanup_worker: Worker<CleanupTask>,
-    raftlog_gc_worker: Worker<RaftlogGcTask<RocksEngine>>,
-    region_worker: Worker<RegionTask<RocksSnapshot>>,
+    // consistency_check_worker: Worker<ConsistencyCheckTask<RocksSnapshot>>,
+    // // handle Compact, CleanupSST task
+    // cleanup_worker: Worker<CleanupTask>,
+    // raftlog_gc_worker: Worker<RaftlogGcTask<RocksEngine>>,
+    // region_worker: Worker<RegionTask<RocksSnapshot>>,
+    common_worker: Worker,
     coprocessor_host: CoprocessorHost<RocksEngine>,
     future_poller: ThreadPool,
 }
@@ -1087,7 +1087,7 @@ impl RaftBatchSystem {
         store_meta: Arc<Mutex<StoreMeta>>,
         mut coprocessor_host: CoprocessorHost<RocksEngine>,
         importer: Arc<SSTImporter>,
-        split_check_worker: Worker<SplitCheckTask>,
+        split_check_scheduler: Scheduler<SplitCheckTask>,
         auto_split_controller: AutoSplitController,
         global_replication_state: Arc<Mutex<GlobalReplicationState>>,
     ) -> Result<()> {
@@ -1100,29 +1100,51 @@ impl RaftBatchSystem {
             .register_admin_observer(100, BoxAdminObserver::new(SplitObserver));
 
         let workers = Workers {
-            split_check_worker,
-            region_worker: Worker::new("snapshot-worker"),
+            common_worker: Worker::new("store-worker"),
             pd_worker,
-            consistency_check_worker: Worker::new("consistency-check"),
-            cleanup_worker: Worker::new("cleanup-worker"),
-            raftlog_gc_worker: Worker::new("raft-gc-worker"),
             coprocessor_host,
             future_poller: tokio_threadpool::Builder::new()
                 .name_prefix("future-poller")
                 .pool_size(cfg.value().future_poll_size)
                 .build(),
         };
+        let region_runner = RegionRunner::new(
+            engines.clone(),
+            mgr.clone(),
+            cfg.value().snap_apply_batch_size.0 as usize,
+            cfg.value().use_delete_range,
+            workers.coprocessor_host.clone(),
+            self.router(),
+        );
+        let region_scheduler = workers.common_worker.start(region_runner);
+
+        let raftlog_gc_runner = RaftlogGcRunner::new(None);
+        let raftlog_gc_scheduler = workers.common_worker.start(raftlog_gc_runner);
+
+        let compact_runner = CompactRunner::new(engines.kv.clone());
+        let cleanup_sst_runner = CleanupSSTRunner::new(
+            meta.get_id(),
+            self.router.clone(),
+            Arc::clone(&importer),
+            Arc::clone(&pd_client),
+        );
+        let cleanup_runner = CleanupRunner::new(compact_runner, cleanup_sst_runner);
+        let cleanup_scheduler = workers.common_worker.start(cleanup_runner);
+        let consistency_check_runner =
+            ConsistencyCheckRunner::<RocksEngine, _>::new(self.router.clone());
+        let consistency_check_scheduler = workers.common_worker.start(consistency_check_runner);
+
         let mut builder = RaftPollerBuilder {
             cfg,
             store: meta,
             engines,
             router: self.router.clone(),
-            split_check_scheduler: workers.split_check_worker.scheduler(),
-            region_scheduler: workers.region_worker.scheduler(),
+            split_check_scheduler,
+            region_scheduler,
             pd_scheduler: workers.pd_worker.scheduler(),
-            consistency_check_scheduler: workers.consistency_check_worker.scheduler(),
-            cleanup_scheduler: workers.cleanup_worker.scheduler(),
-            raftlog_gc_scheduler: workers.raftlog_gc_worker.scheduler(),
+            consistency_check_scheduler,
+            cleanup_scheduler,
+            raftlog_gc_scheduler,
             apply_router: self.apply_router.clone(),
             trans,
             pd_client,
@@ -1169,11 +1191,9 @@ impl RaftBatchSystem {
         builder.snap_mgr.init()?;
 
         let engines = builder.engines.clone();
-        let snap_mgr = builder.snap_mgr.clone();
         let cfg = builder.cfg.value().clone();
         let store = builder.store.clone();
         let pd_client = builder.pd_client.clone();
-        let importer = builder.importer.clone();
 
         let apply_poller_builder = ApplyPollerBuilder::<W>::new(
             &builder,
@@ -1223,30 +1243,6 @@ impl RaftBatchSystem {
         self.apply_system
             .spawn("apply".to_owned(), apply_poller_builder);
 
-        let region_runner = RegionRunner::new(
-            engines.clone(),
-            snap_mgr,
-            cfg.snap_apply_batch_size.0 as usize,
-            cfg.use_delete_range,
-            workers.coprocessor_host.clone(),
-            self.router(),
-        );
-        let timer = region_runner.new_timer();
-        box_try!(workers.region_worker.start_with_timer(region_runner, timer));
-
-        let raftlog_gc_runner = RaftlogGcRunner::new(None);
-        box_try!(workers.raftlog_gc_worker.start(raftlog_gc_runner));
-
-        let compact_runner = CompactRunner::new(engines.kv.clone());
-        let cleanup_sst_runner = CleanupSSTRunner::new(
-            store.get_id(),
-            self.router.clone(),
-            Arc::clone(&importer),
-            Arc::clone(&pd_client),
-        );
-        let cleanup_runner = CleanupRunner::new(compact_runner, cleanup_sst_runner);
-        box_try!(workers.cleanup_worker.start(cleanup_runner));
-
         let pd_runner = PdRunner::new(
             store.get_id(),
             Arc::clone(&pd_client),
@@ -1257,13 +1253,6 @@ impl RaftBatchSystem {
             auto_split_controller,
         );
         box_try!(workers.pd_worker.start(pd_runner));
-
-        let consistency_check_runner =
-            ConsistencyCheckRunner::<RocksEngine, _>::new(self.router.clone());
-        box_try!(workers
-            .consistency_check_worker
-            .start(consistency_check_runner));
-
         if let Err(e) = sys_util::thread::set_priority(sys_util::HIGH_PRI) {
             warn!("set thread priority for raftstore failed"; "error" => ?e);
         }
@@ -1278,12 +1267,8 @@ impl RaftBatchSystem {
         let mut workers = self.workers.take().unwrap();
         // Wait all workers finish.
         let mut handles: Vec<Option<thread::JoinHandle<()>>> = vec![];
-        handles.push(workers.split_check_worker.stop());
-        handles.push(workers.region_worker.stop());
         handles.push(workers.pd_worker.stop());
-        handles.push(workers.consistency_check_worker.stop());
-        handles.push(workers.cleanup_worker.stop());
-        handles.push(workers.raftlog_gc_worker.stop());
+        handles.push(workers.common_worker.stop());
         self.apply_system.shutdown();
         self.system.shutdown();
         for h in handles {

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -258,7 +258,7 @@ impl Clone for PeerTickBatch {
     fn clone(&self) -> PeerTickBatch {
         PeerTickBatch {
             ticks: vec![],
-            wait_duration: self.wait_duration
+            wait_duration: self.wait_duration,
         }
     }
 }
@@ -1042,7 +1042,7 @@ where
     type Handler = RaftPoller<T, C>;
 
     fn build(&mut self) -> RaftPoller<T, C> {
-        let tick_batch = vec![PeerTickBatch::default();256];
+        let tick_batch = vec![PeerTickBatch::default(); 256];
         let ctx = PollContext {
             cfg: self.cfg.value().clone(),
             store: self.store.clone(),
@@ -1293,6 +1293,7 @@ impl RaftBatchSystem {
             workers.pd_worker.scheduler(),
             cfg.pd_store_heartbeat_tick_interval.0,
             auto_split_controller,
+            workers.common_worker.clone(),
         );
         box_try!(workers.pd_worker.start(pd_runner));
         if let Err(e) = sys_util::thread::set_priority(sys_util::HIGH_PRI) {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -100,7 +100,6 @@ impl ServerCluster {
             security_mgr,
             RaftStoreBlackHole,
             Arc::new(ThreadLoad::with_threshold(usize::MAX)),
-            None,
         );
         ServerCluster {
             metas: HashMap::default(),

--- a/components/tikv_util/src/worker/mod.rs
+++ b/components/tikv_util/src/worker/mod.rs
@@ -251,7 +251,7 @@ impl Worker {
         scheduler
     }
 
-    pub fn stop(&mut self) -> Option<JoinHandle<()>> {
+    pub fn stop(&self) -> Option<JoinHandle<()>> {
         self.sender.send(WorkerMsg::Stop).unwrap();
         self.handle.lock().unwrap().take()
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -927,6 +927,7 @@ impl DbConfig {
         opts.set_wal_size_limit_mb(self.wal_size_limit.as_mb());
         opts.set_max_total_wal_size(self.max_total_wal_size.0);
         opts.set_max_background_jobs(self.max_background_jobs);
+        info!("DbConfig";"max_background_jobs" => self.max_background_jobs);
         opts.set_max_manifest_file_size(self.max_manifest_file_size.0);
         opts.create_if_missing(self.create_if_missing);
         opts.set_max_open_files(self.max_open_files);
@@ -1183,6 +1184,7 @@ impl RaftDbConfig {
         opts.set_wal_ttl_seconds(self.wal_ttl_seconds);
         opts.set_wal_size_limit_mb(self.wal_size_limit.as_mb());
         opts.set_max_background_jobs(self.max_background_jobs);
+        info!("RaftDbConfig";"max_background_jobs" => self.max_background_jobs);
         opts.set_max_total_wal_size(self.max_total_wal_size.0);
         opts.set_max_manifest_file_size(self.max_manifest_file_size.0);
         opts.create_if_missing(self.create_if_missing);

--- a/src/server/gc_worker/gc_manager.rs
+++ b/src/server/gc_worker/gc_manager.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};
-use tikv_util::worker::{FutureScheduler, Runnable, Scheduler};
+use tikv_util::worker::{Runnable, Scheduler};
 use txn_types::{Key, TimeStamp};
 
 use crate::server::metrics::*;
@@ -159,7 +159,7 @@ pub(super) struct GcManager<S: GcSafePointProvider, R: RegionInfoProvider> {
     safe_point_last_check_time: Instant,
 
     /// Used to schedule `GcTask`s.
-    worker_scheduler: FutureScheduler<GcTask>,
+    worker_scheduler: Scheduler<GcTask>,
     engine: RocksEngine,
     scheduler: Option<Scheduler<GcMsg>>,
 
@@ -234,7 +234,7 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider> GcManager<S, R> {
         cfg: AutoGcConfig<S, R>,
         safe_point: Arc<AtomicU64>,
         engine: RocksEngine,
-        worker_scheduler: FutureScheduler<GcTask>,
+        worker_scheduler: Scheduler<GcTask>,
         cfg_tracker: GcWorkerConfigManager,
         cluster_version: ClusterVersion,
     ) -> GcManager<S, R> {

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -163,8 +163,6 @@ impl<E: Engine> GcRunner<E> {
         }
     }
 
-
-
     /// Cleans up outdated data.
     fn gc_key(
         &mut self,

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -18,7 +18,7 @@ use raftstore::store::msg::StoreMsg;
 use tikv_util::config::{Tracker, VersionTrack};
 use tikv_util::time::{duration_to_sec, Limiter, SlowTimer};
 use tikv_util::worker::{
-    FutureRunnable, FutureScheduler, FutureWorker, Stopped as FutureWorkerStopped,
+    FutureRunnable, FutureScheduler, FutureWorker, Stopped as FutureWorkerStopped, Worker,
 };
 use tokio_core::reactor::Handle;
 use txn_types::{Key, TimeStamp};
@@ -656,10 +656,11 @@ impl<E: Engine> GcWorker<E> {
 
     pub fn start_observe_lock_apply(
         &mut self,
+        worker: &mut Worker,
         coprocessor_host: &mut CoprocessorHost<RocksEngine>,
     ) -> Result<()> {
         assert!(self.applied_lock_collector.is_none());
-        let collector = Arc::new(AppliedLockCollector::new(coprocessor_host)?);
+        let collector = Arc::new(AppliedLockCollector::new(worker, coprocessor_host));
         self.applied_lock_collector = Some(collector);
         Ok(())
     }

--- a/src/server/gc_worker/mod.rs
+++ b/src/server/gc_worker/mod.rs
@@ -12,7 +12,7 @@ pub use compaction_filter::WriteCompactionFilterFactory;
 use compaction_filter::{init_compaction_filter, is_compaction_filter_allowd};
 pub use config::{GcConfig, GcWorkerConfigManager, DEFAULT_GC_BATCH_KEYS};
 pub use gc_manager::AutoGcConfig;
-pub use gc_worker::{sync_gc, GcSafePointProvider, GcTask, GcWorker, GC_MAX_EXECUTING_TASKS};
+pub use gc_worker::{GcSafePointProvider, GcTask, GcWorker, GC_MAX_EXECUTING_TASKS};
 
 #[cfg(test)]
 pub use compaction_filter::tests::gc_by_compact;

--- a/src/server/lock_manager/client.rs
+++ b/src/server/lock_manager/client.rs
@@ -3,7 +3,7 @@
 use super::{Error, Result};
 use futures::unsync::mpsc::{self, UnboundedSender};
 use futures::{Future, Sink, Stream};
-use grpcio::{ChannelBuilder, EnvBuilder, Environment, WriteFlags};
+use grpcio::{ChannelBuilder, Environment, WriteFlags};
 use kvproto::deadlock::*;
 use security::SecurityManager;
 use std::sync::Arc;
@@ -12,19 +12,6 @@ use std::time::Duration;
 type DeadlockFuture<T> = Box<dyn Future<Item = T, Error = Error>>;
 
 pub type Callback = Box<dyn Fn(DeadlockResponse)>;
-
-const CQ_COUNT: usize = 1;
-const CLIENT_PREFIX: &str = "deadlock";
-
-/// Builds the `Environment` of deadlock clients. All clients should use the same instance.
-pub fn env() -> Arc<Environment> {
-    Arc::new(
-        EnvBuilder::new()
-            .cq_count(CQ_COUNT)
-            .name_prefix(thd_name!(CLIENT_PREFIX))
-            .build(),
-    )
-}
 
 #[derive(Clone)]
 pub struct Client {

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::client::{self, Client};
+use super::client::Client;
 use super::config::Config;
 use super::metrics::*;
 use super::waiter_manager::Scheduler as WaiterMgrScheduler;
@@ -507,12 +507,13 @@ where
         resolver: S,
         security_mgr: Arc<SecurityManager>,
         waiter_mgr_scheduler: WaiterMgrScheduler,
+        env: Arc<Environment>,
         cfg: &Config,
     ) -> Self {
         assert!(store_id != INVALID_ID);
         Self {
             store_id,
-            env: client::env(),
+            env,
             leader_info: None,
             leader_client: None,
             pd_client,

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -27,6 +27,7 @@ use crate::storage::{
 use raftstore::coprocessor::CoprocessorHost;
 
 use engine_rocks::RocksEngine;
+use grpcio::Environment;
 use parking_lot::Mutex;
 use pd_client::PdClient;
 use security::SecurityManager;
@@ -96,6 +97,7 @@ impl LockManager {
         pd_client: Arc<P>,
         resolver: S,
         security_mgr: Arc<SecurityManager>,
+        env: Arc<Environment>,
         cfg: &Config,
     ) -> Result<()>
     where
@@ -103,7 +105,7 @@ impl LockManager {
         P: PdClient + 'static,
     {
         self.start_waiter_manager(cfg)?;
-        self.start_deadlock_detector(store_id, pd_client, resolver, security_mgr, cfg)?;
+        self.start_deadlock_detector(store_id, pd_client, resolver, security_mgr, env, cfg)?;
         Ok(())
     }
 
@@ -146,6 +148,7 @@ impl LockManager {
         pd_client: Arc<P>,
         resolver: S,
         security_mgr: Arc<SecurityManager>,
+        env: Arc<Environment>,
         cfg: &Config,
     ) -> Result<()>
     where
@@ -158,6 +161,7 @@ impl LockManager {
             resolver,
             security_mgr,
             self.waiter_mgr_scheduler.clone(),
+            env,
             cfg,
         );
         self.detector_worker

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -25,5 +25,5 @@ pub use self::node::{create_raft_storage, Node};
 pub use self::raft_client::RaftClient;
 pub use self::raftkv::RaftKv;
 pub use self::resolve::{PdStoreAddrResolver, StoreAddrResolver};
-pub use self::server::Server;
+pub use self::server::{Server, GRPC_THREAD_PREFIX};
 pub use self::transport::ServerTransport;

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -27,7 +27,7 @@ use raftstore::store::AutoSplitController;
 use raftstore::store::{self, initial_region, Config as StoreConfig, SnapManager, Transport};
 use raftstore::store::{GlobalReplicationState, PdTask, SplitCheckTask};
 use tikv_util::config::VersionTrack;
-use tikv_util::worker::{FutureWorker, Scheduler};
+use tikv_util::worker::{FutureWorker, Scheduler, Worker};
 
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
 const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
@@ -139,6 +139,7 @@ where
         trans: T,
         snap_mgr: SnapManager<RocksEngine>,
         pd_worker: FutureWorker<PdTask<RocksEngine>>,
+        worker: Option<Worker>,
         store_meta: Arc<Mutex<StoreMeta>>,
         coprocessor_host: CoprocessorHost<RocksEngine>,
         importer: Arc<SSTImporter>,
@@ -180,6 +181,7 @@ where
             trans,
             snap_mgr,
             pd_worker,
+            worker,
             store_meta,
             coprocessor_host,
             importer,
@@ -374,6 +376,7 @@ where
         trans: T,
         snap_mgr: SnapManager<RocksEngine>,
         pd_worker: FutureWorker<PdTask<RocksEngine>>,
+        worker: Option<Worker>,
         store_meta: Arc<Mutex<StoreMeta>>,
         coprocessor_host: CoprocessorHost<RocksEngine>,
         importer: Arc<SSTImporter>,
@@ -400,6 +403,7 @@ where
             pd_client,
             snap_mgr,
             pd_worker,
+            worker,
             store_meta,
             coprocessor_host,
             importer,

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -25,8 +25,7 @@ use raftstore::store::AutoSplitController;
 use raftstore::store::{self, initial_region, Config as StoreConfig, SnapManager, Transport};
 use raftstore::store::{GlobalReplicationState, PdTask, SplitCheckTask};
 use tikv_util::config::VersionTrack;
-use tikv_util::worker::FutureWorker;
-use tikv_util::worker::Worker;
+use tikv_util::worker::{FutureWorker, Scheduler};
 
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
 const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
@@ -140,7 +139,7 @@ where
         store_meta: Arc<Mutex<StoreMeta>>,
         coprocessor_host: CoprocessorHost<RocksEngine>,
         importer: Arc<SSTImporter>,
-        split_check_worker: Worker<SplitCheckTask>,
+        split_check_scheduler: Scheduler<SplitCheckTask>,
         auto_split_controller: AutoSplitController,
     ) -> Result<()>
     where
@@ -181,7 +180,7 @@ where
             store_meta,
             coprocessor_host,
             importer,
-            split_check_worker,
+            split_check_scheduler,
             auto_split_controller,
         )?;
 
@@ -375,7 +374,7 @@ where
         store_meta: Arc<Mutex<StoreMeta>>,
         coprocessor_host: CoprocessorHost<RocksEngine>,
         importer: Arc<SSTImporter>,
-        split_check_worker: Worker<SplitCheckTask>,
+        split_check_scheduler: Scheduler<SplitCheckTask>,
         auto_split_controller: AutoSplitController,
     ) -> Result<()>
     where
@@ -401,7 +400,7 @@ where
             store_meta,
             coprocessor_host,
             importer,
-            split_check_worker,
+            split_check_scheduler,
             auto_split_controller,
             self.state.clone(),
         )?;

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -32,7 +32,7 @@ use super::service::*;
 use super::snap::Runner as SnapHandler;
 use super::transport::ServerTransport;
 use super::{Config, Result};
-use crate::read_pool::ReadPool;
+use crate::read_pool::YatpReadPool;
 
 const LOAD_STATISTICS_SLOTS: usize = 4;
 const LOAD_STATISTICS_INTERVAL: Duration = Duration::from_millis(1000);
@@ -54,7 +54,7 @@ pub struct Server<T: RaftStoreRouter<RocksEngine> + 'static, S: StoreAddrResolve
     trans: ServerTransport<T, S>,
     // Currently load statistics is done in the thread.
     grpc_thread_load: Arc<ThreadLoad>,
-    yatp_read_pool: Option<ReadPool>,
+    yatp_read_pool: Option<YatpReadPool>,
     readpool_normal_thread_load: Arc<ThreadLoad>,
     timer: Handle,
 }
@@ -70,7 +70,7 @@ impl<T: RaftStoreRouter<RocksEngine>, S: StoreAddrResolver + 'static> Server<T, 
         resolver: S,
         snap_mgr: SnapManager<RocksEngine>,
         gc_worker: GcWorker<E>,
-        yatp_read_pool: Option<ReadPool>,
+        yatp_read_pool: Option<YatpReadPool>,
         common_worker: Worker,
     ) -> Result<Self> {
         let grpc_thread_load = Arc::new(ThreadLoad::with_threshold(cfg.heavy_load_threshold));

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -1,7 +1,7 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::server::metrics::GRPC_MSG_HISTOGRAM_STATIC;
-use crate::server::service::kv::{batch_commands_response, poll_future_notify};
+use crate::server::service::kv::batch_commands_response;
 use crate::storage::{
     errors::{extract_key_error, extract_region_error},
     kv::Engine,
@@ -11,6 +11,7 @@ use crate::storage::{
 use futures::Future;
 use kvproto::kvrpcpb::*;
 use pd_client::PdClient;
+use tikv_util::future::poll_future_notify;
 use tikv_util::mpsc::batch::Sender;
 use tikv_util::time::{duration_to_sec, Instant};
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -20,9 +20,8 @@ use crate::storage::{
     Storage, TxnStatus,
 };
 use engine_rocks::RocksEngine;
-use futures::executor::{self, Notify, Spawn};
 use futures::future::Either;
-use futures::{future, Async, Future, Sink, Stream};
+use futures::{future, Future, Sink, Stream};
 use grpcio::{
     ClientStreamingSink, DuplexSink, Error as GrpcError, RequestStream, RpcContext, RpcStatus,
     RpcStatusCode, ServerStreamingSink, UnarySink, WriteFlags,
@@ -36,7 +35,7 @@ use pd_client::PdClient;
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::{Callback, CasualMessage};
 use security::{check_common_name, SecurityManager};
-use tikv_util::future::{paired_future_callback, AndThenWith};
+use tikv_util::future::{paired_future_callback, poll_future_notify, AndThenWith};
 use tikv_util::mpsc::batch::{unbounded, BatchCollector, BatchReceiver, Sender};
 use tikv_util::worker::Scheduler;
 use tokio_threadpool::{Builder as ThreadPoolBuilder, ThreadPool};
@@ -979,33 +978,6 @@ fn response_batch_commands_request<F>(
         Ok(())
     });
     poll_future_notify(f);
-}
-
-// BatchCommandsNotify is used to make business pool notifiy completion queues directly.
-struct BatchCommandsNotify<F>(Arc<Mutex<Option<Spawn<F>>>>);
-impl<F> Clone for BatchCommandsNotify<F> {
-    fn clone(&self) -> BatchCommandsNotify<F> {
-        BatchCommandsNotify(Arc::clone(&self.0))
-    }
-}
-impl<F> Notify for BatchCommandsNotify<F>
-where
-    F: Future<Item = (), Error = ()> + Send + 'static,
-{
-    fn notify(&self, id: usize) {
-        let n = Arc::new(self.clone());
-        let mut s = self.0.lock().unwrap();
-        match s.as_mut().map(|spawn| spawn.poll_future_notify(&n, id)) {
-            Some(Ok(Async::NotReady)) | None => {}
-            _ => *s = None,
-        };
-    }
-}
-
-pub fn poll_future_notify<F: Future<Item = (), Error = ()> + Send + 'static>(f: F) {
-    let spawn = Arc::new(Mutex::new(Some(executor::spawn(f))));
-    let notify = BatchCommandsNotify(spawn);
-    notify.notify(0);
 }
 
 fn handle_batch_commands_request<E: Engine, L: LockManager, P: PdClient + 'static>(

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -27,7 +27,7 @@ use super::{Config, Error, Result};
 
 pub type Callback = Box<dyn FnOnce(Result<()>) + Send>;
 
-const DEFAULT_POOL_SIZE: usize = 4;
+const DEFAULT_POOL_SIZE: usize = 1;
 
 /// A task for either receiving Snapshot or sending Snapshot
 pub enum Task {

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -141,7 +141,7 @@ impl RocksEngine {
     }
 
     pub fn stop(&self) {
-        let mut core = self.core.lock().unwrap();
+        let core = self.core.lock().unwrap();
         if let Some(h) = core.worker.stop() {
             h.join().unwrap();
         }

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -17,19 +17,12 @@ use tikv::server::{load_statistics::ThreadLoad, Config, RaftClient};
 
 use super::{mock_kv_service, MockKv, MockKvService};
 
-pub fn get_raft_client(pool: &tokio_threadpool::ThreadPool) -> RaftClient<RaftStoreBlackHole> {
+pub fn get_raft_client() -> RaftClient<RaftStoreBlackHole> {
     let env = Arc::new(Environment::new(2));
     let cfg = Arc::new(Config::default());
     let security_mgr = Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap());
     let grpc_thread_load = Arc::new(ThreadLoad::with_threshold(1000));
-    RaftClient::new(
-        env,
-        cfg,
-        security_mgr,
-        RaftStoreBlackHole,
-        grpc_thread_load,
-        Some(pool.sender().clone()),
-    )
+    RaftClient::new(env, cfg, security_mgr, RaftStoreBlackHole, grpc_thread_load)
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/18025

Problem Summary:
There are a lot of threads in TiKV. But most of them are only working a while and then suspend themself and wait for waking up. If there are a log of threads waiting for waking up, system will cost much time to schedule.



### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

This PR is to merged most of worker into one or two threads so that they can run without suspend and schedule.
- I refactor `Worker` in `components/tikv_util/src/worker/mod.rs` so that it could run multiple `Runner` in one threads.
- I use  `GLOBAL_TIMER_HANDLE` for some timed task.
- Use unified read pool for `SchedPool`, which is used to deal with transaction-write.


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->
- Reduce cost of thread scheduler so that TiKV could run in machine with fewer CPU cores.