### PR TITLE
copr: remove nullable arithmetic_with_ctx 

### DIFF
--- a/components/tidb_query_vec_expr/src/impl_arithmetic.rs
+++ b/components/tidb_query_vec_expr/src/impl_arithmetic.rs
@@ -445,11 +445,7 @@ impl ArithmeticOp for UintDivideInt {
 
 #[rpn_fn(capture = [ctx])]
 #[inline]
-fn int_divide_decimal(
-    ctx: &mut EvalContext,
-    lhs: &Decimal,
-    rhs: &Decimal,
-) -> Result<Option<Int>> {
+fn int_divide_decimal(ctx: &mut EvalContext, lhs: &Decimal, rhs: &Decimal) -> Result<Option<Int>> {
     let result = arithmetic_with_ctx::<DecimalDivide>(ctx, lhs, rhs)?;
     if let Some(result) = result {
         let result = result.as_i64();
@@ -459,10 +455,7 @@ fn int_divide_decimal(
             result
                 .into_result_with_overflow_err(
                     ctx,
-                    Error::overflow(
-                        "BIGINT",
-                        format!("({} / {})", lhs, rhs),
-                    ),
+                    Error::overflow("BIGINT", format!("({} / {})", lhs, rhs)),
                 )
                 .map(Some)?
         })

--- a/components/tidb_query_vec_expr/src/impl_arithmetic.rs
+++ b/components/tidb_query_vec_expr/src/impl_arithmetic.rs
@@ -14,23 +14,9 @@ pub fn arithmetic<A: ArithmeticOp>(lhs: &A::T, rhs: &A::T) -> Result<Option<A::T
     A::calc(lhs, rhs)
 }
 
-#[rpn_fn(nullable, capture = [ctx])]
-#[inline]
-pub fn arithmetic_with_ctx<A: ArithmeticOpWithCtx>(
-    ctx: &mut EvalContext,
-    arg0: Option<&A::T>,
-    arg1: Option<&A::T>,
-) -> Result<Option<A::T>> {
-    if let (Some(lhs), Some(rhs)) = (arg0, arg1) {
-        A::calc(ctx, lhs, rhs)
-    } else {
-        Ok(None)
-    }
-}
-
 #[rpn_fn(capture = [ctx])]
 #[inline]
-pub fn arithmetic_with_ctx_nonnull<A: ArithmeticOpWithCtx>(
+pub fn arithmetic_with_ctx<A: ArithmeticOpWithCtx>(
     ctx: &mut EvalContext,
     lhs: &A::T,
     rhs: &A::T,
@@ -457,28 +443,32 @@ impl ArithmeticOp for UintDivideInt {
     }
 }
 
-#[rpn_fn(nullable, capture = [ctx])]
+#[rpn_fn(capture = [ctx])]
 #[inline]
 fn int_divide_decimal(
     ctx: &mut EvalContext,
-    lhs: Option<&Decimal>,
-    rhs: Option<&Decimal>,
+    lhs: &Decimal,
+    rhs: &Decimal,
 ) -> Result<Option<Int>> {
-    let result = try_opt!(arithmetic_with_ctx::<DecimalDivide>(ctx, lhs, rhs)).as_i64();
-
-    Ok(if result.is_truncated() {
-        Some(result.unwrap())
+    let result = arithmetic_with_ctx::<DecimalDivide>(ctx, lhs, rhs)?;
+    if let Some(result) = result {
+        let result = result.as_i64();
+        Ok(if result.is_truncated() {
+            Some(result.unwrap())
+        } else {
+            result
+                .into_result_with_overflow_err(
+                    ctx,
+                    Error::overflow(
+                        "BIGINT",
+                        format!("({} / {})", lhs, rhs),
+                    ),
+                )
+                .map(Some)?
+        })
     } else {
-        result
-            .into_result_with_overflow_err(
-                ctx,
-                Error::overflow(
-                    "BIGINT",
-                    format!("({} / {})", lhs.as_ref().unwrap(), rhs.as_ref().unwrap()),
-                ),
-            )
-            .map(Some)?
-    })
+        Ok(None)
+    }
 }
 
 pub struct DecimalDivide;

--- a/components/tidb_query_vec_expr/src/lib.rs
+++ b/components/tidb_query_vec_expr/src/lib.rs
@@ -245,12 +245,12 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::MultiplyInt => map_int_sig(value, children, multiply_mapper)?,
         ScalarFuncSig::MultiplyIntUnsigned => arithmetic_fn_meta::<UintUintMultiply>(),
         ScalarFuncSig::MultiplyReal => arithmetic_fn_meta::<RealMultiply>(),
-        ScalarFuncSig::DivideDecimal => arithmetic_with_ctx_nonnull_fn_meta::<DecimalDivide>(),
-        ScalarFuncSig::DivideReal => arithmetic_with_ctx_nonnull_fn_meta::<RealDivide>(),
+        ScalarFuncSig::DivideDecimal => arithmetic_with_ctx_fn_meta::<DecimalDivide>(),
+        ScalarFuncSig::DivideReal => arithmetic_with_ctx_fn_meta::<RealDivide>(),
         ScalarFuncSig::IntDivideInt => map_int_sig(value, children, divide_mapper)?,
         ScalarFuncSig::IntDivideDecimal => int_divide_decimal_fn_meta(),
         ScalarFuncSig::ModReal => arithmetic_fn_meta::<RealMod>(),
-        ScalarFuncSig::ModDecimal => arithmetic_with_ctx_nonnull_fn_meta::<DecimalMod>(),
+        ScalarFuncSig::ModDecimal => arithmetic_with_ctx_fn_meta::<DecimalMod>(),
         ScalarFuncSig::ModInt => map_int_sig(value, children, mod_mapper)?,
         // impl_cast
         ScalarFuncSig::CastIntAsInt |


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

copr: remove nullable `arithmetic_with_ctx`

Problem Summary:

### What is changed and how it works?

What's Changed:

* Replace `arithmetic_with_ctx` with `arithmetic_with_ctx_nonnull`
* Rewrite `int_divide_decimal`


### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
