### PR TITLE
test: stablize test_applied_lock_collector

### DIFF
--- a/tests/integrations/server/gc_worker.rs
+++ b/tests/integrations/server/gc_worker.rs
@@ -70,6 +70,7 @@ fn test_physical_scan_lock() {
 #[test]
 fn test_applied_lock_collector() {
     let mut cluster = new_server_cluster(0, 3);
+    cluster.pd_client.disable_default_operator();
     cluster.run();
 
     // Create all stores' clients.


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/8261 <!-- REMOVE this line if no issue to close -->

Problem Summary:

The test fails frequently when adds a new peer. The reason is PD's default operator already adds a new peer to the newly added store.

### What is changed and how it works?

What's Changed:

Disable the default operator.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

No release note