### PR TITLE
Revert "raftstore: make destroy overlapped regions and apply snapshot atomically"

### DIFF
--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -10,7 +10,7 @@ use kvproto::errorpb::Error as PbError;
 use kvproto::metapb::{self, Peer, RegionEpoch};
 use kvproto::pdpb;
 use kvproto::raft_cmdpb::*;
-use kvproto::raft_serverpb::{RaftApplyState, RaftMessage, RaftTruncatedState, RegionLocalState};
+use kvproto::raft_serverpb::{RaftApplyState, RaftMessage, RaftTruncatedState};
 use tempdir::TempDir;
 
 use engine::rocks;
@@ -800,13 +800,6 @@ impl<T: Simulator> Cluster<T> {
         let key = keys::apply_state_key(region_id);
         self.get_engine(store_id)
             .get_msg_cf::<RaftApplyState>(engine::CF_RAFT, &key)
-            .unwrap()
-            .unwrap()
-    }
-
-    pub fn region_local_state(&self, region_id: u64, store_id: u64) -> RegionLocalState {
-        self.get_engine(store_id)
-            .get_msg_cf::<RegionLocalState>(engine::CF_RAFT, &keys::region_state_key(region_id))
             .unwrap()
             .unwrap()
     }

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -2211,7 +2211,6 @@ impl RegionProposal {
 pub struct Destroy {
     region_id: u64,
     async_remove: bool,
-    merge_from_snapshot: bool,
 }
 
 /// A message that asks the delegate to apply to the given logs and then reply to
@@ -2290,11 +2289,10 @@ impl Msg {
         Msg::Registration(Registration::new(peer))
     }
 
-    pub fn destroy(region_id: u64, async_remove: bool, merge_from_snapshot: bool) -> Msg {
+    pub fn destroy(region_id: u64, async_remove: bool) -> Msg {
         Msg::Destroy(Destroy {
             region_id,
             async_remove,
-            merge_from_snapshot,
         })
     }
 }
@@ -2348,8 +2346,6 @@ pub enum TaskRes {
         region_id: u64,
         // ID of peer that has been destroyed.
         peer_id: u64,
-        // Whether destroy request is from its target region's snapshot
-        merge_from_snapshot: bool,
     },
 }
 
@@ -2469,9 +2465,6 @@ impl ApplyFsm {
     /// Handles peer destroy. When a peer is destroyed, the corresponding apply delegate should be removed too.
     fn handle_destroy(&mut self, ctx: &mut ApplyContext, d: Destroy) {
         assert_eq!(d.region_id, self.delegate.region_id());
-        if d.merge_from_snapshot {
-            assert_eq!(self.delegate.stopped, false);
-        }
         if !self.delegate.stopped {
             self.destroy(ctx);
             if d.async_remove {
@@ -2481,7 +2474,6 @@ impl ApplyFsm {
                         res: TaskRes::Destroy {
                             region_id: self.delegate.region_id(),
                             peer_id: self.delegate.id,
-                            merge_from_snapshot: d.merge_from_snapshot,
                         },
                     },
                 );
@@ -3163,12 +3155,10 @@ mod tests {
             assert_eq!(delegate.apply_state.get_applied_index(), 4);
         });
 
-        router.schedule_task(2, Msg::destroy(2, true, false));
+        router.schedule_task(2, Msg::destroy(2, true));
         let (region_id, peer_id) = match rx.recv_timeout(Duration::from_secs(3)) {
             Ok(PeerMsg::ApplyRes { res, .. }) => match res {
-                TaskRes::Destroy {
-                    region_id, peer_id, ..
-                } => (region_id, peer_id),
+                TaskRes::Destroy { region_id, peer_id } => (region_id, peer_id),
                 e => panic!("expected destroy result, but got {:?}", e),
             },
             e => panic!("expected destroy result, but got {:?}", e),

--- a/src/raftstore/store/fsm/peer.rs
+++ b/src/raftstore/store/fsm/peer.rs
@@ -52,8 +52,8 @@ use crate::raftstore::store::worker::{
     CleanupSSTTask, ConsistencyCheckTask, RaftlogGcTask, ReadDelegate, RegionTask, SplitCheckTask,
 };
 use crate::raftstore::store::{
-    util, CasualMessage, Config, MergeResultKind, PeerMsg, PeerTicks, RaftCommand, SignificantMsg,
-    SnapKey, SnapshotDeleter, StoreMsg,
+    util, CasualMessage, Config, PeerMsg, PeerTicks, RaftCommand, SignificantMsg, SnapKey,
+    SnapshotDeleter, StoreMsg,
 };
 use crate::raftstore::{Error, Result};
 
@@ -514,12 +514,8 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                     }
                 }
             }
-            SignificantMsg::MergeResult {
-                target_region_id,
-                target,
-                result,
-            } => {
-                self.on_merge_result(target_region_id, target, result);
+            SignificantMsg::MergeResult { target, stale } => {
+                self.on_merge_result(target, stale);
             }
             SignificantMsg::CatchUpLogs(catch_up_logs) => {
                 self.on_catch_up_logs_for_merge(catch_up_logs);
@@ -797,30 +793,9 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 // get fair schedule.
                 self.register_pd_heartbeat_tick();
             }
-            ApplyTaskRes::Destroy {
-                region_id,
-                peer_id,
-                merge_from_snapshot,
-            } => {
+            ApplyTaskRes::Destroy { peer_id, .. } => {
                 assert_eq!(peer_id, self.fsm.peer.peer_id());
-                if !merge_from_snapshot {
-                    self.destroy_peer(false);
-                } else {
-                    // Wait for its target peer to apply snapshot and then send `MergeResult` back
-                    // to destroy itself
-                    let mut meta = self.ctx.store_meta.lock().unwrap();
-                    // The `need_atomic` flag must be true
-                    assert!(*meta.destroyed_region_for_snap.get(&region_id).unwrap());
-
-                    let target_region_id = *meta.targets_map.get(&region_id).unwrap();
-                    let is_ready = meta
-                        .atomic_snap_regions
-                        .get_mut(&target_region_id)
-                        .unwrap()
-                        .get_mut(&region_id)
-                        .unwrap();
-                    *is_ready = true;
-                }
+                self.destroy_peer(false);
             }
         }
     }
@@ -851,7 +826,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         if msg.has_merge_target() {
             fail_point!("on_has_merge_target", |_| Ok(()));
             if self.need_gc_merge(&msg)? {
-                self.on_stale_merge(msg.get_merge_target().get_id());
+                self.on_stale_merge();
             }
             return Ok(());
         }
@@ -1074,18 +1049,14 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             .pending_merge_targets
             .entry(target_region_id)
             .or_default();
-        let mut no_range_merge_target = merge_target.clone();
-        no_range_merge_target.clear_start_key();
-        no_range_merge_target.clear_end_key();
-        if let Some(pre_merge_target) = v.insert(self.region_id(), no_range_merge_target) {
+        if let Some(epoch) = (*v).insert(self.region_id(), merge_target.get_region_epoch().clone())
+        {
             // Merge target epoch records the version of target region when source region is merged.
             // So it must be same no matter when receiving merge target.
-            if pre_merge_target.get_region_epoch().get_version()
-                != merge_target.get_region_epoch().get_version()
-            {
+            if epoch.get_version() != merge_target.get_region_epoch().get_version() {
                 panic!(
                     "conflict merge target epoch version {:?} {:?}",
-                    pre_merge_target.get_region_epoch().get_version(),
+                    epoch,
                     merge_target.get_region_epoch()
                 );
             }
@@ -1259,24 +1230,23 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 "exist" => ?exist_region,
                 "snap" => ?snap_region,
             );
-            let (can_destroy, merge_to_this_peer) = maybe_destroy_source(
-                &meta,
-                self.fsm.region_id(),
-                self.fsm.peer_id(),
-                exist_region.get_id(),
-                snap_region.get_region_epoch().to_owned(),
-            );
-            if ready && can_destroy {
+            if ready
+                && maybe_destroy_source(
+                    &meta,
+                    self.region_id(),
+                    exist_region.get_id(),
+                    snap_region.get_region_epoch().to_owned(),
+                )
+            {
                 // The snapshot that we decide to whether destroy peer based on must can be applied.
                 // So here not to destroy peer immediately, or the snapshot maybe dropped in later
                 // check but the peer is already destroyed.
-                regions_to_destroy.push((exist_region.get_id(), merge_to_this_peer));
+                regions_to_destroy.push(exist_region.get_id());
                 continue;
             }
             is_overlapped = true;
-            if !can_destroy
-                && snap_region.get_region_epoch().get_version()
-                    > exist_region.get_region_epoch().get_version()
+            if snap_region.get_region_epoch().get_version()
+                > exist_region.get_region_epoch().get_version()
             {
                 // If snapshot's epoch version is greater than exist region's, the exist region
                 // may has been merged already.
@@ -1295,39 +1265,15 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         self.ctx.snap_mgr.get_snapshot_for_applying(&key)?;
 
         meta.pending_snapshot_regions.push(snap_region);
-
-        assert!(!meta.atomic_snap_regions.contains_key(&region_id));
-        for (source_region_id, merge_to_this_peer) in regions_to_destroy {
-            info!(
-                "source region destroy due to target region's snapshot";
-                "region_id" => self.fsm.region_id(),
-                "peer_id" => self.fsm.peer_id(),
-                "source_region_id" => source_region_id,
-                "need_atomic" => merge_to_this_peer,
-            );
-            meta.atomic_snap_regions
-                .entry(region_id)
-                .or_default()
-                .insert(source_region_id, false);
-            meta.destroyed_region_for_snap
-                .insert(source_region_id, merge_to_this_peer);
-
-            let result = if merge_to_this_peer {
-                MergeResultKind::FromTargetSnapshotStep1
-            } else {
-                MergeResultKind::Stale
-            };
-            // Use `unwrap` is ok because the StoreMeta lock is held and these source peers still
-            // exist in regions and region_ranges map.
-            // It depends on the implementation of `destroy_peer`
+        self.ctx.queued_snapshot.insert(region_id);
+        for region_id in regions_to_destroy {
             self.ctx
                 .router
                 .force_send(
-                    source_region_id,
+                    region_id,
                     PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
-                        target_region_id: self.fsm.region_id(),
                         target: self.fsm.peer.peer.clone(),
-                        result,
+                        stale: true,
                     }),
                 )
                 .unwrap();
@@ -1344,7 +1290,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             // because there are some msgs in channel so peer fsm still need to handle them (e.g. callback)
             self.ctx.apply_router.schedule_task(
                 job.region_id,
-                ApplyTask::destroy(job.region_id, job.async_remove, false),
+                ApplyTask::destroy(job.region_id, job.async_remove),
             );
         }
         if job.async_remove {
@@ -1377,6 +1323,22 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
 
         // Clear merge related structures.
         let mut meta = self.ctx.store_meta.lock().unwrap();
+        meta.pending_merge_targets.remove(&region_id);
+        if let Some(target) = meta.targets_map.remove(&region_id) {
+            if meta.pending_merge_targets.contains_key(&target) {
+                meta.pending_merge_targets
+                    .get_mut(&target)
+                    .unwrap()
+                    .remove(&region_id);
+                // When the target doesn't exist(add peer but the store is isolated), source peer decide to destroy by itself.
+                // Without target, the `pending_merge_targets` for target won't be removed, so here source peer help target to clear.
+                if meta.regions.get(&target).is_none()
+                    && meta.pending_merge_targets.get(&target).unwrap().is_empty()
+                {
+                    meta.pending_merge_targets.remove(&target);
+                }
+            }
+        }
 
         // Destroy read delegates.
         if let Some(reader) = meta.readers.remove(&region_id) {
@@ -1406,8 +1368,6 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             // data too.
             panic!("{} destroy err {:?}", self.fsm.peer.tag, e);
         }
-        // Some places use `force_send().unwrap()` if the StoreMeta lock is held.
-        // So in here, it's necessary to held the StoreMeta lock when closing the router.
         self.ctx.router.close(region_id);
         self.fsm.stop();
 
@@ -1422,42 +1382,6 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         }
         if meta.regions.remove(&region_id).is_none() && !merged_by_target {
             panic!("{} meta corruption detected", self.fsm.peer.tag)
-        }
-
-        // Clear merge related structures.
-        if let Some(&need_atomic) = meta.destroyed_region_for_snap.get(&region_id) {
-            if need_atomic {
-                panic!(
-                    "{} should destroy with target region atomically",
-                    self.fsm.peer.tag
-                );
-            } else {
-                let target_region_id = *meta.targets_map.get(&region_id).unwrap();
-                let is_ready = meta
-                    .atomic_snap_regions
-                    .get_mut(&target_region_id)
-                    .unwrap()
-                    .get_mut(&region_id)
-                    .unwrap();
-                *is_ready = true;
-            }
-        }
-
-        meta.pending_merge_targets.remove(&region_id);
-        if let Some(target) = meta.targets_map.remove(&region_id) {
-            if meta.pending_merge_targets.contains_key(&target) {
-                meta.pending_merge_targets
-                    .get_mut(&target)
-                    .unwrap()
-                    .remove(&region_id);
-                // When the target doesn't exist(add peer but the store is isolated), source peer decide to destroy by itself.
-                // Without target, the `pending_merge_targets` for target won't be removed, so here source peer help target to clear.
-                if meta.regions.get(&target).is_none()
-                    && meta.pending_merge_targets.get(&target).unwrap().is_empty()
-                {
-                    meta.pending_merge_targets.remove(&target);
-                }
-            }
         }
     }
 
@@ -2092,7 +2016,6 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         reader.mark_invalid();
 
         drop(meta);
-
         // make approximate size and keys updated in time.
         // the reason why follower need to update is that there is a issue that after merge
         // and then transfer leader, the new leader may have stale size and keys.
@@ -2110,19 +2033,18 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         if let Err(e) = self.ctx.router.force_send(
             source.get_id(),
             PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
-                target_region_id: self.fsm.region_id(),
                 target: self.fsm.peer.peer.clone(),
-                result: MergeResultKind::FromTargetLog,
+                stale: false,
             }),
         ) {
-            if !self.ctx.router.is_shutdown() {
-                panic!(
-                    "{} failed to send merge result(FromTargetLog) to source region {}, err {}",
-                    self.fsm.peer.tag,
-                    source.get_id(),
-                    e
-                );
-            }
+            // TODO: need to remove "are we shutting down", it should panic
+            // if we are not in shut-down state
+            info!(
+                "failed to send merge result, are we shutting down?";
+                "region_id" => self.fsm.region_id(),
+                "peer_id" => self.fsm.peer_id(),
+                "err" => %e,
+            );
         }
     }
 
@@ -2164,12 +2086,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         }
     }
 
-    fn on_merge_result(
-        &mut self,
-        target_region_id: u64,
-        target: metapb::Peer,
-        result: MergeResultKind,
-    ) {
+    fn on_merge_result(&mut self, target: metapb::Peer, stale: bool) {
         let exists = self
             .fsm
             .peer
@@ -2178,74 +2095,36 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             .map_or(true, |s| s.get_target().get_peers().contains(&target));
         if !exists {
             panic!(
-                "{} unexpected merge result: {:?} {:?} {:?}",
-                self.fsm.peer.tag, self.fsm.peer.pending_merge_state, target, result
+                "{} unexpected merge result: {:?} {:?} {}",
+                self.fsm.peer.tag, self.fsm.peer.pending_merge_state, target, stale
             );
         }
-        // If the merge succeed, all source peers is impossible in apply snapshot state
-        // and must be initialized.
-        if self.fsm.peer.is_applying_snapshot() {
-            panic!(
-                "{} is applying snapshot on getting merge result, target region id {}, target peer {:?}, merge result type {:?}",
-                self.fsm.peer.tag, target_region_id, target, result
+        if !stale {
+            info!(
+                "merge finished";
+                "region_id" => self.fsm.region_id(),
+                "peer_id" => self.fsm.peer_id(),
+                "target_region" => ?self.fsm.peer.pending_merge_state.as_ref().unwrap().target,
             );
+            self.destroy_peer(true);
+        } else {
+            self.on_stale_merge();
         }
-        if !self.fsm.peer.is_initialized() {
-            panic!(
-                "{} is not initialized on getting merge result, target region id {}, target peer {:?}, merge result type {:?}",
-                self.fsm.peer.tag, target_region_id, target, result
-            );
-        }
-        match result {
-            MergeResultKind::FromTargetLog => {
-                info!(
-                    "merge finished";
-                    "region_id" => self.fsm.region_id(),
-                    "peer_id" => self.fsm.peer_id(),
-                    "target_region" => ?self.fsm.peer.pending_merge_state.as_ref().unwrap().target,
-                );
-                self.destroy_peer(true);
-            }
-            MergeResultKind::FromTargetSnapshotStep1 => {
-                info!(
-                    "merge finished with target snapshot";
-                    "region_id" => self.fsm.region_id(),
-                    "peer_id" => self.fsm.peer_id(),
-                    "target_region_id" => target_region_id,
-                );
-                self.fsm.peer.pending_remove = true;
-                // Destroy apply fsm at first
-                self.ctx.apply_router.schedule_task(
-                    self.fsm.region_id(),
-                    ApplyTask::destroy(self.fsm.region_id(), true, true),
-                );
-            }
-            MergeResultKind::FromTargetSnapshotStep2 => {
-                // `merge_by_target` is true because this region's range already belongs to
-                // its target region so we must not clear data otherwise its target region's
-                // data will corrupt.
-                self.destroy_peer(true);
-            }
-            MergeResultKind::Stale => {
-                self.on_stale_merge(target_region_id);
-            }
-        };
     }
 
-    fn on_stale_merge(&mut self, target_region_id: u64) {
-        if self.fsm.peer.pending_remove {
-            return;
-        }
+    fn on_stale_merge(&mut self) {
         info!(
-            "successful merge can't be continued, try to gc stale peer";
+            "successful merge can't be continued, try to gc stale peer.";
             "region_id" => self.fsm.region_id(),
             "peer_id" => self.fsm.peer_id(),
-            "target_region_id" => target_region_id,
             "merge_state" => ?self.fsm.peer.pending_merge_state,
         );
-        // It must succeed so here using `unwrap`
-        let job = self.fsm.peer.maybe_destroy().unwrap();
-        self.handle_destroy_peer(job);
+        match self.fsm.peer.maybe_destroy() {
+            None => self.ctx.raft_metrics.message_dropped.applying_snap += 1,
+            Some(job) => {
+                self.handle_destroy_peer(job);
+            }
+        }
     }
 
     fn on_ready_apply_snapshot(&mut self, apply_result: ApplySnapResult) {
@@ -2262,39 +2141,11 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         let mut meta = self.ctx.store_meta.lock().unwrap();
         debug!(
             "check snapshot range";
-            "region_id" => self.fsm.region_id(),
+            "region_id" => self.region_id(),
             "peer_id" => self.fsm.peer_id(),
             "ranges" => ?meta.region_ranges,
             "prev_region" => ?prev_region,
         );
-
-        // Remove this region's snapshot region from the `pending_snapshot_regions`
-        // The `pending_snapshot_regions` is only used to occupy the key range, so if this
-        // peer is added to `region_ranges`, it can be remove from `pending_snapshot_regions`
-        meta.pending_snapshot_regions
-            .retain(|r| self.fsm.region_id() != r.get_id());
-
-        // Remove its source peers' metadata
-        for r in &apply_result.destroyed_regions {
-            let prev = meta.region_ranges.remove(&enc_end_key(&r));
-            assert_eq!(prev, Some(r.get_id()));
-            assert!(meta.regions.remove(&r.get_id()).is_some());
-            let reader = meta.readers.remove(&r.get_id()).unwrap();
-            reader.mark_invalid();
-        }
-        // Remove the data from `atomic_snap_regions` and `destroyed_region_for_snap`
-        // which are added before applying snapshot
-        if let Some(wait_destroy_regions) = meta.atomic_snap_regions.remove(&self.fsm.region_id()) {
-            for (source_region_id, _) in wait_destroy_regions {
-                assert_eq!(
-                    meta.destroyed_region_for_snap
-                        .remove(&source_region_id)
-                        .is_some(),
-                    true
-                );
-            }
-        }
-
         let initialized = !prev_region.get_peers().is_empty();
         if initialized {
             info!(
@@ -2312,7 +2163,6 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 );
             }
         }
-
         if let Some(r) = meta
             .region_ranges
             .insert(enc_end_key(&region), region.get_id())
@@ -2321,23 +2171,6 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         }
         let prev = meta.regions.insert(region.get_id(), region);
         assert_eq!(prev, Some(prev_region));
-
-        drop(meta);
-
-        for r in &apply_result.destroyed_regions {
-            if let Err(e) = self.ctx.router.force_send(
-                r.get_id(),
-                PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
-                    target_region_id: self.fsm.region_id(),
-                    target: self.fsm.peer.peer.clone(),
-                    result: MergeResultKind::FromTargetSnapshotStep2,
-                }),
-            ) {
-                if !self.ctx.router.is_shutdown() {
-                    panic!("{} failed to send merge result(FromTargetSnapshotStep2) to source region {}, err {}", self.fsm.peer.tag, r.get_id(), e);
-                }
-            }
-        }
     }
 
     fn on_ready_result(&mut self, exec_results: &mut VecDeque<ExecResult>, metrics: &ApplyMetrics) {
@@ -3142,47 +2975,31 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
     }
 }
 
-/// Checks merge target, returns whether the source peer should be destroyed and whether the source peer is
-/// merged to this target peer.
-///
-/// It returns (`can_destroy`, `merge_to_this_peer`).
-///
-/// `can_destroy` is true when there is a network isolation which leads to a follower of a merge target
+/// Checks merge target, returns whether the source peer should be destroyed.
+/// It returns true when there is a network isolation which leads to a follower of a merge target
 /// Region's log falls behind and then receive a snapshot with epoch version after merge.
-///
-/// `merge_to_this_peer` is true when `can_destroy` is true and the source peer is merged to this target peer.
 pub fn maybe_destroy_source(
     meta: &StoreMeta,
     target_region_id: u64,
-    target_peer_id: u64,
     source_region_id: u64,
     region_epoch: RegionEpoch,
-) -> (bool, bool) {
+) -> bool {
     if let Some(merge_targets) = meta.pending_merge_targets.get(&target_region_id) {
-        if let Some(target_region) = merge_targets.get(&source_region_id) {
+        if let Some(target_epoch) = merge_targets.get(&source_region_id) {
             info!(
                 "[region {}] checking source {} epoch: {:?}, merge target epoch: {:?}",
-                target_region_id,
-                source_region_id,
-                region_epoch,
-                target_region.get_region_epoch(),
+                target_region_id, source_region_id, region_epoch, target_epoch,
             );
             // The target peer will move on, namely, it will apply a snapshot generated after merge,
             // so destroy source peer.
-            if region_epoch.get_version() > target_region.get_region_epoch().get_version() {
-                return (
-                    true,
-                    target_peer_id
-                        == util::find_peer(target_region, meta.store_id.unwrap())
-                            .unwrap()
-                            .get_id(),
-                );
+            if region_epoch.get_version() > target_epoch.get_version() {
+                return true;
             }
             // Wait till the target peer has caught up logs and source peer will be destroyed at that time.
-            return (false, false);
+            return false;
         }
     }
-    (false, false)
+    false
 }
 
 pub fn new_admin_request(region_id: u64, peer: metapb::Peer) -> RaftCmdRequest {

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -52,8 +52,8 @@ use crate::raftstore::store::worker::{
     SplitCheckRunner, SplitCheckTask,
 };
 use crate::raftstore::store::{
-    Callback, CasualMessage, MergeResultKind, PeerMsg, RaftCommand, SignificantMsg, SnapManager,
-    SnapshotDeleter, StoreMsg, StoreTick,
+    Callback, CasualMessage, PeerMsg, RaftCommand, SignificantMsg, SnapManager, SnapshotDeleter,
+    StoreMsg, StoreTick,
 };
 use crate::raftstore::Result;
 use crate::report_perf_context;
@@ -61,7 +61,7 @@ use crate::storage::kv::{CompactedEvent, CompactionListener};
 use engine::Engines;
 use engine::{Iterable, Mutable, Peekable};
 
-use tikv_util::collections::HashMap;
+use tikv_util::collections::{HashMap, HashSet};
 use tikv_util::mpsc::{self, LooseBoundedSender, Receiver};
 use tikv_util::time::{duration_to_sec, Instant as TiInstant, SlowTimer};
 use tikv_util::timer::SteadyTimer;
@@ -95,19 +95,11 @@ pub struct StoreMeta {
     /// The regions with pending snapshots.
     pub pending_snapshot_regions: Vec<Region>,
     /// A marker used to indicate the peer of a Region has received a merge target message and waits to be destroyed.
-    /// target_region_id -> (source_region_id -> merge_target_region)
-    pub pending_merge_targets: HashMap<u64, HashMap<u64, metapb::Region>>,
+    /// target_region_id -> (source_region_id -> merge_target_epoch)
+    pub pending_merge_targets: HashMap<u64, HashMap<u64, RegionEpoch>>,
     /// An inverse mapping of `pending_merge_targets` used to let source peer help target peer to clean up related entry.
     /// source_region_id -> target_region_id
     pub targets_map: HashMap<u64, u64>,
-    /// `atomic_snap_regions` and `destroyed_region_for_snap` are used for making destroy overlapped regions
-    /// and apply snapshot atomically.
-    /// region_id -> wait_destroy_regions_map(source_region_id -> is_ready)
-    /// A target peer must wait for all source peer to ready before applying snapshot.
-    pub atomic_snap_regions: HashMap<u64, HashMap<u64, bool>>,
-    /// source_region_id -> need_atomic
-    /// Used for reminding the source peer to switch to ready in `atomic_snap_regions`.
-    pub destroyed_region_for_snap: HashMap<u64, bool>,
 }
 
 impl StoreMeta {
@@ -121,8 +113,6 @@ impl StoreMeta {
             pending_snapshot_regions: Vec::default(),
             pending_merge_targets: HashMap::default(),
             targets_map: HashMap::default(),
-            atomic_snap_regions: HashMap::default(),
-            destroyed_region_for_snap: HashMap::default(),
         }
     }
 
@@ -238,6 +228,7 @@ pub struct PollContext<T, C: 'static> {
     pub has_ready: bool,
     pub ready_res: Vec<(Ready, InvokeContext)>,
     pub need_flush_trans: bool,
+    pub queued_snapshot: HashSet<u64>,
     pub current_time: Option<Timespec>,
     pub perf_context_statistics: PerfContextStatistics,
     pub node_start_time: Option<TiInstant>,
@@ -685,6 +676,12 @@ impl<T: Transport, C: PdClient> PollHandler<PeerFsm, StoreFsm> for RaftPoller<T,
             self.handle_raft_ready(peers);
         }
         self.poll_ctx.current_time = None;
+        if !self.poll_ctx.queued_snapshot.is_empty() {
+            let mut meta = self.poll_ctx.store_meta.lock().unwrap();
+            meta.pending_snapshot_regions
+                .retain(|r| !self.poll_ctx.queued_snapshot.contains(&r.get_id()));
+            self.poll_ctx.queued_snapshot.clear();
+        }
         self.poll_ctx
             .raft_metrics
             .process_ready
@@ -929,6 +926,7 @@ where
             has_ready: false,
             ready_res: Vec::new(),
             need_flush_trans: false,
+            queued_snapshot: HashSet::default(),
             current_time: None,
             perf_context_statistics: PerfContextStatistics::new(self.cfg.perf_level),
             node_start_time: Some(TiInstant::now_coarse()),
@@ -1437,27 +1435,14 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
             if util::is_first_vote_msg(msg.get_message()) {
                 meta.pending_votes.push(msg.to_owned());
             }
-            let (can_destroy, merge_to_this_peer) = maybe_destroy_source(
+
+            if maybe_destroy_source(
                 meta,
                 region_id,
-                target.get_id(),
                 exist_region.get_id(),
                 msg.get_region_epoch().to_owned(),
-            );
-            if can_destroy {
-                if !merge_to_this_peer {
-                    regions_to_destroy.push(exist_region.get_id());
-                } else {
-                    error!(
-                        "A new peer has a merge source peer";
-                        "region_id" => region_id,
-                        "peer_id" => target.get_id(),
-                        "source_region" => ?exist_region,
-                    );
-                    if self.ctx.cfg.dev_assert {
-                        panic!("something is wrong, maybe PD do not ensure all target peers exist before merging");
-                    }
-                }
+            ) {
+                regions_to_destroy.push(exist_region.get_id());
                 continue;
             }
             is_overlapped = true;
@@ -1482,13 +1467,13 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
                 .force_send(
                     id,
                     PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
-                        target_region_id: region_id,
                         target: target.clone(),
-                        result: MergeResultKind::Stale,
+                        stale: true,
                     }),
                 )
                 .unwrap();
         }
+
         // New created peers should know it's learner or not.
         let (tx, peer) = PeerFsm::replicate(
             self.ctx.store_id(),

--- a/src/raftstore/store/mod.rs
+++ b/src/raftstore/store/mod.rs
@@ -26,8 +26,8 @@ pub use self::bootstrap::{
 pub use self::config::Config;
 pub use self::fsm::{new_compaction_listener, DestroyPeerJob, RaftRouter, StoreInfo};
 pub use self::msg::{
-    Callback, CasualMessage, MergeResultKind, PeerMsg, PeerTicks, RaftCommand, ReadCallback,
-    ReadResponse, SignificantMsg, StoreMsg, StoreTick, WriteCallback, WriteResponse,
+    Callback, CasualMessage, PeerMsg, PeerTicks, RaftCommand, ReadCallback, ReadResponse,
+    SignificantMsg, StoreMsg, StoreTick, WriteCallback, WriteResponse,
 };
 pub use self::peer::{
     Peer, PeerStat, ProposalContext, ReadExecutor, RequestInspector, RequestPolicy,

--- a/src/raftstore/store/msg.rs
+++ b/src/raftstore/store/msg.rs
@@ -141,21 +141,6 @@ impl StoreTick {
     }
 }
 
-#[derive(Debug)]
-pub enum MergeResultKind {
-    /// Its target peer applys `CommitMerge` log.
-    FromTargetLog,
-    /// Its target peer receives snapshot.
-    /// In step 1, this peer should mark `pending_move` is true and destroy its apply fsm.
-    /// Then its target peer will remove this peer data and apply snapshot atomically.
-    FromTargetSnapshotStep1,
-    /// In step 2, this peer should destroy its peer fsm.
-    FromTargetSnapshotStep2,
-    /// This peer is no longer needed by its target peer so it can be destroyed by itself.
-    /// It happens if and only if its target peer has been removed by conf change.
-    Stale,
-}
-
 /// Some significant messages sent to raftstore. Raftstore will dispatch these messages to Raft
 /// groups to update some important internal status.
 #[derive(Debug)]
@@ -178,9 +163,10 @@ pub enum SignificantMsg {
     CatchUpLogs(CatchUpLogs),
     /// Result of the fact that the region is merged.
     MergeResult {
-        target_region_id: u64,
         target: metapb::Peer,
-        result: MergeResultKind,
+        // True means it's a stale merge source.
+        // False means it came from target region.
+        stale: bool,
     },
 }
 

--- a/src/raftstore/store/peer_storage.rs
+++ b/src/raftstore/store/peer_storage.rs
@@ -253,7 +253,6 @@ pub struct ApplySnapResult {
     // prev_region is the region before snapshot applied.
     pub prev_region: metapb::Region,
     pub region: metapb::Region,
-    pub destroyed_regions: Vec<metapb::Region>,
 }
 
 /// Returned by `PeerStorage::handle_raft_ready`, used for recording changed status of
@@ -267,8 +266,6 @@ pub struct InvokeContext {
     last_term: u64,
     /// The old region is stored here if there is a snapshot.
     pub snap_region: Option<Region>,
-    /// The regions whose range are overlapped with this region
-    pub destroyed_regions: Vec<metapb::Region>,
 }
 
 impl InvokeContext {
@@ -279,7 +276,6 @@ impl InvokeContext {
             apply_state: store.apply_state.clone(),
             last_term: store.last_term,
             snap_region: None,
-            destroyed_regions: vec![],
         }
     }
 
@@ -901,7 +897,6 @@ impl PeerStorage {
         snap: &Snapshot,
         kv_wb: &WriteBatch,
         raft_wb: &WriteBatch,
-        destroy_regions: &[metapb::Region],
     ) -> Result<()> {
         info!(
             "begin to apply snapshot";
@@ -927,10 +922,7 @@ impl PeerStorage {
             // we can only delete the old data when the peer is initialized.
             self.clear_meta(kv_wb, raft_wb)?;
         }
-        // Write its source peers' `RegionLocalState` together with itself for atomicity
-        for r in destroy_regions {
-            write_peer_state(&self.engines.kv, kv_wb, r, PeerState::Tombstone, None)?;
-        }
+
         write_peer_state(&self.engines.kv, kv_wb, &region, PeerState::Applying, None)?;
 
         let last_index = snap.get_metadata().get_index();
@@ -978,14 +970,11 @@ impl PeerStorage {
     }
 
     /// Delete all data that is not covered by `new_region`.
-    fn clear_extra_data(
-        &self,
-        region_id: u64,
-        old_region: &metapb::Region,
-        new_region: &metapb::Region,
-    ) -> Result<()> {
-        let (old_start_key, old_end_key) = (enc_start_key(old_region), enc_end_key(old_region));
+    fn clear_extra_data(&self, new_region: &metapb::Region) -> Result<()> {
+        let (old_start_key, old_end_key) =
+            (enc_start_key(self.region()), enc_end_key(self.region()));
         let (new_start_key, new_end_key) = (enc_start_key(new_region), enc_end_key(new_region));
+        let region_id = new_region.get_id();
         if old_start_key < new_start_key {
             box_try!(self.region_sched.schedule(RegionTask::destroy(
                 region_id,
@@ -1129,7 +1118,6 @@ impl PeerStorage {
         &mut self,
         ready_ctx: &mut H,
         ready: &Ready,
-        destroy_regions: Vec<metapb::Region>,
     ) -> Result<InvokeContext> {
         let mut ctx = InvokeContext::new(self);
         let snapshot_index = if raft::is_empty_snap(&ready.snapshot) {
@@ -1141,11 +1129,8 @@ impl PeerStorage {
                 &ready.snapshot,
                 &ready_ctx.kv_wb(),
                 &ready_ctx.raft_wb(),
-                &destroy_regions,
             )?;
             fail_point!("raft_after_apply_snap");
-
-            ctx.destroyed_regions = destroy_regions;
 
             last_index(&ctx.raft_state)
         };
@@ -1166,8 +1151,7 @@ impl PeerStorage {
             }
         }
 
-        // Save raft state if it has changed or peer has applied a snapshot.
-        if ctx.raft_state != self.raft_state || snapshot_index > 0 {
+        if ctx.raft_state != self.raft_state {
             ctx.save_raft_state_to(ready_ctx.raft_wb_mut())?;
             if snapshot_index > 0 {
                 // in case of restart happen when we just write region state to Applying,
@@ -1183,8 +1167,8 @@ impl PeerStorage {
         }
 
         // only when apply snapshot
-        if snapshot_index > 0 {
-            ctx.save_apply_state_to(&self.engines.kv, ready_ctx.kv_wb_mut())?;
+        if ctx.apply_state != self.apply_state {
+            ctx.save_apply_state_to(&self.engines.kv, &mut ready_ctx.kv_wb_mut())?;
         }
 
         Ok(ctx)
@@ -1202,34 +1186,15 @@ impl PeerStorage {
         };
         // cleanup data before scheduling apply task
         if self.is_initialized() {
-            if let Err(e) = self.clear_extra_data(self.get_region_id(), self.region(), &snap_region)
-            {
+            if let Err(e) = self.clear_extra_data(self.region()) {
                 // No need panic here, when applying snapshot, the deletion will be tried
                 // again. But if the region range changes, like [a, c) -> [a, b) and [b, c),
                 // [b, c) will be kept in rocksdb until a covered snapshot is applied or
                 // store is restarted.
                 error!(
                     "failed to cleanup data, may leave some dirty data";
-                    "region_id" => self.get_region_id(),
+                    "region_id" => self.region.get_id(),
                     "peer_id" => self.peer_id,
-                    "err" => ?e,
-                );
-            }
-        }
-
-        // Note that the correctness depends on the fact that these source regions MUST NOT
-        // serve read request otherwise a corrupt data may be returned.
-        // For now, it is ensured by
-        // 1. After `PrepareMerge` log is committed, the source region leader's lease will be
-        //    suspected immediately which makes local reader invalid to serve read request.
-        // 2. No read request can be responsed during merging.
-        // These conditions are used to prevent reading **stale** data in the past.
-        // At present, they are used to prevent reading **corrupt** data.
-        for r in &ctx.destroyed_regions {
-            if let Err(e) = self.clear_extra_data(r.get_id(), r, &snap_region) {
-                error!(
-                    "failed to cleanup data, may leave some dirty data";
-                    "region_id" => r.get_id(),
                     "err" => ?e,
                 );
             }
@@ -1242,7 +1207,6 @@ impl PeerStorage {
         Some(ApplySnapResult {
             prev_region,
             region: self.region().clone(),
-            destroyed_regions: ctx.destroyed_regions,
         })
     }
 }
@@ -2336,7 +2300,7 @@ mod tests {
         assert_ne!(ctx.last_term, snap1.get_metadata().get_term());
         let kv_wb = WriteBatch::new();
         let raft_wb = WriteBatch::new();
-        s2.apply_snapshot(&mut ctx, &snap1, &kv_wb, &raft_wb, &[])
+        s2.apply_snapshot(&mut ctx, &snap1, &kv_wb, &raft_wb)
             .unwrap();
         assert_eq!(ctx.last_term, snap1.get_metadata().get_term());
         assert_eq!(ctx.apply_state.get_applied_index(), 6);
@@ -2354,7 +2318,7 @@ mod tests {
         assert_ne!(ctx.last_term, snap1.get_metadata().get_term());
         let kv_wb = WriteBatch::new();
         let raft_wb = WriteBatch::new();
-        s3.apply_snapshot(&mut ctx, &snap1, &kv_wb, &raft_wb, &[])
+        s3.apply_snapshot(&mut ctx, &snap1, &kv_wb, &raft_wb)
             .unwrap();
         assert_eq!(ctx.last_term, snap1.get_metadata().get_term());
         assert_eq!(ctx.apply_state.get_applied_index(), 6);

--- a/src/raftstore/store/worker/region.rs
+++ b/src/raftstore/store/worker/region.rs
@@ -607,8 +607,7 @@ where
                     .execute(move |_| ctx.handle_gen(region_id, raft_snap, kv_snap, notifier))
             }
             task @ Task::Apply { .. } => {
-                fail_point!("on_region_worker_apply", true, |_| {});
-                // to makes sure applying snapshots in order.
+                // to makes sure appling snapshots in order.
                 self.pending_applies.push_back(task);
                 self.handle_pending_applies();
                 if !self.pending_applies.is_empty() {
@@ -623,7 +622,6 @@ where
                 start_key,
                 end_key,
             } => {
-                fail_point!("on_region_worker_destroy", true, |_| {});
                 // try to delay the range deletion because
                 // there might be a coprocessor request related to this range
                 if !self

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -1,13 +1,13 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::thread;
 use std::time::*;
 
 use fail;
 
-use kvproto::raft_serverpb::{PeerState, RaftMessage, RegionLocalState};
+use kvproto::raft_serverpb::{PeerState, RegionLocalState};
 use raft::eraftpb::MessageType;
 
 use engine::*;
@@ -933,8 +933,8 @@ fn test_node_merge_write_data_to_source_region_after_merging() {
         sleep_ms(10);
     }
     // Ignore this msg to make left region exist.
-    let on_has_merge_target_fp = "on_has_merge_target";
-    fail::cfg(on_has_merge_target_fp, "return").unwrap();
+    let on_need_gc_merge_fp = "on_need_gc_merge";
+    fail::cfg(on_need_gc_merge_fp, "return").unwrap();
 
     cluster.clear_send_filters();
     // On store 3, now the right region is updated by snapshot not applying logs
@@ -942,7 +942,7 @@ fn test_node_merge_write_data_to_source_region_after_merging() {
     // Wait for left region to rollback merge (in previous wrong implementation)
     sleep_ms(200);
     // Write data to left region
-    let mut new_left = left;
+    let mut new_left = left.clone();
     let mut epoch = new_left.take_region_epoch();
     // prepareMerge => conf_ver + 1, version + 1
     // rollbackMerge => version + 1
@@ -967,245 +967,4 @@ fn test_node_merge_write_data_to_source_region_after_merging() {
     }
 
     fail::remove(on_handle_apply_2_fp);
-}
-
-/// In previous implementation, destroying its source peer(s) and applying snapshot is not **atomic**.
-/// It may break the rule of our merging process.
-///
-/// A tikv crash after its source peers have destroyed but this target peer does not become to
-/// `Applying` state which means it will not apply snapshot after this tikv restarts.
-/// After this tikv restarts, a new leader may send logs to this target peer, then the panic may happen
-/// because it can not find its source peers when applying `CommitMerge` log.
-///
-/// This test is to reproduce above situation.
-#[test]
-fn test_node_merge_crash_before_snapshot_then_catch_up_logs() {
-    let _guard = crate::setup();
-    let mut cluster = new_node_cluster(0, 3);
-    cluster.cfg.raft_store.merge_max_log_gap = 10;
-    cluster.cfg.raft_store.raft_log_gc_count_limit = 11;
-    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(50);
-    // Make merge check resume quickly.
-    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(10);
-    cluster.cfg.raft_store.raft_election_timeout_ticks = 10;
-    // election timeout must be greater than lease
-    cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(99);
-    cluster.cfg.raft_store.merge_check_tick_interval = ReadableDuration::millis(100);
-    cluster.cfg.raft_store.peer_stale_state_check_interval = ReadableDuration::millis(500);
-
-    let pd_client = Arc::clone(&cluster.pd_client);
-    pd_client.disable_default_operator();
-
-    let on_raft_gc_log_tick_fp = "on_raft_gc_log_tick";
-    fail::cfg(on_raft_gc_log_tick_fp, "return()").unwrap();
-
-    cluster.run();
-
-    let mut region = pd_client.get_region(b"k1").unwrap();
-    cluster.must_split(&region, b"k2");
-
-    let left = pd_client.get_region(b"k1").unwrap();
-    let right = pd_client.get_region(b"k2").unwrap();
-
-    let left_on_store1 = find_peer(&left, 1).unwrap().to_owned();
-    cluster.must_transfer_leader(left.get_id(), left_on_store1);
-    let right_on_store1 = find_peer(&right, 1).unwrap().to_owned();
-    cluster.must_transfer_leader(right.get_id(), right_on_store1);
-
-    cluster.must_put(b"k1", b"v1");
-
-    cluster.add_send_filter(IsolationFilterFactory::new(3));
-
-    pd_client.must_merge(left.get_id(), right.get_id());
-
-    region = pd_client.get_region(b"k1").unwrap();
-    // Write some logs and the logs' number is greater than `raft_log_gc_count_limit`
-    // for latter log compaction
-    for i in 2..15 {
-        cluster.must_put(format!("k{}", i).as_bytes(), b"v");
-    }
-
-    // Aim at making peer 2 only know the compact log but do not know it is committed
-    let condition = Arc::new(AtomicBool::new(false));
-    let recv_filter = Box::new(
-        RegionPacketFilter::new(region.get_id(), 2)
-            .direction(Direction::Recv)
-            .when(condition.clone())
-            .set_msg_callback(Arc::new(move |msg: &RaftMessage| {
-                if !condition.load(Ordering::Acquire)
-                    && msg.get_message().get_msg_type() == MessageType::MsgAppend
-                    && !msg.get_message().get_entries().is_empty()
-                {
-                    condition.store(true, Ordering::Release);
-                }
-            })),
-    );
-    cluster.sim.wl().add_recv_filter(2, recv_filter);
-
-    let state1 = cluster.truncated_state(region.get_id(), 1);
-    // Remove log compaction failpoint
-    fail::remove(on_raft_gc_log_tick_fp);
-    // Wait to trigger compact raft log
-    let timer = Instant::now();
-    loop {
-        let state2 = cluster.truncated_state(region.get_id(), 1);
-        if state1.get_index() != state2.get_index() {
-            break;
-        }
-        if timer.elapsed() > Duration::from_secs(3) {
-            panic!("log compaction not finish after 3 seconds.");
-        }
-        sleep_ms(10);
-    }
-
-    let peer_on_store3 = find_peer(&region, 3).unwrap().to_owned();
-    assert_eq!(peer_on_store3.get_id(), 3);
-    // Make peer 3 do not handle snapshot ready
-    // In previous implementation, destroying its source peer and applying snapshot is not atomic.
-    // So making its source peer be destroyed and do not apply snapshot to reproduce the problem
-    let before_handle_snapshot_ready_3_fp = "before_handle_snapshot_ready_3";
-    fail::cfg(before_handle_snapshot_ready_3_fp, "return()").unwrap();
-
-    cluster.clear_send_filters();
-    // Peer 1 will send snapshot to peer 3
-    // Source peer sends msg to others to get target region info until the election timeout.
-    // The max election timeout is 2 * 10 * 10 = 200ms
-    let election_timeout = 2
-        * cluster.cfg.raft_store.raft_base_tick_interval.as_millis()
-        * cluster.cfg.raft_store.raft_election_timeout_ticks as u64;
-    sleep_ms(election_timeout + 100);
-
-    cluster.stop_node(1);
-    cluster.stop_node(3);
-
-    cluster.sim.wl().clear_recv_filters(2);
-    fail::remove(before_handle_snapshot_ready_3_fp);
-    cluster.run_node(3).unwrap();
-    // Peer 2 will become leader and it don't know the compact log is committed.
-    // So it will send logs not snapshot to peer 3
-    for i in 20..30 {
-        cluster.must_put(format!("k{}", i).as_bytes(), b"v");
-    }
-    must_get_equal(&cluster.get_engine(3), b"k29", b"v");
-}
-
-/// Test if snapshot is applying correctly when crash happens.
-#[test]
-fn test_node_merge_crash_when_snapshot() {
-    let _guard = crate::setup();
-    let mut cluster = new_node_cluster(0, 3);
-    cluster.cfg.raft_store.merge_max_log_gap = 10;
-    cluster.cfg.raft_store.raft_log_gc_count_limit = 11;
-    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(50);
-    // Make merge check resume quickly.
-    cluster.cfg.raft_store.raft_base_tick_interval = ReadableDuration::millis(10);
-    cluster.cfg.raft_store.raft_election_timeout_ticks = 10;
-    // election timeout must be greater than lease
-    cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration::millis(99);
-    cluster.cfg.raft_store.merge_check_tick_interval = ReadableDuration::millis(100);
-    cluster.cfg.raft_store.peer_stale_state_check_interval = ReadableDuration::millis(500);
-
-    let pd_client = Arc::clone(&cluster.pd_client);
-    pd_client.disable_default_operator();
-
-    let on_raft_gc_log_tick_fp = "on_raft_gc_log_tick";
-    fail::cfg(on_raft_gc_log_tick_fp, "return()").unwrap();
-
-    cluster.run();
-
-    let mut region = pd_client.get_region(b"k1").unwrap();
-    cluster.must_split(&region, b"k2");
-
-    region = pd_client.get_region(b"k2").unwrap();
-    cluster.must_split(&region, b"k3");
-
-    region = pd_client.get_region(b"k3").unwrap();
-    cluster.must_split(&region, b"k4");
-
-    region = pd_client.get_region(b"k4").unwrap();
-    cluster.must_split(&region, b"k5");
-
-    let r1 = pd_client.get_region(b"k1").unwrap();
-    let r1_on_store1 = find_peer(&r1, 1).unwrap().to_owned();
-    cluster.transfer_leader(r1.get_id(), r1_on_store1);
-    let r2 = pd_client.get_region(b"k2").unwrap();
-    let r2_on_store1 = find_peer(&r2, 1).unwrap().to_owned();
-    cluster.transfer_leader(r2.get_id(), r2_on_store1);
-    let r3 = pd_client.get_region(b"k3").unwrap();
-    let r3_on_store1 = find_peer(&r3, 1).unwrap().to_owned();
-    cluster.transfer_leader(r3.get_id(), r3_on_store1);
-    let r4 = pd_client.get_region(b"k4").unwrap();
-    let r4_on_store1 = find_peer(&r4, 1).unwrap().to_owned();
-    cluster.transfer_leader(r4.get_id(), r4_on_store1);
-    let r5 = pd_client.get_region(b"k5").unwrap();
-    let r5_on_store1 = find_peer(&r5, 1).unwrap().to_owned();
-    cluster.transfer_leader(r5.get_id(), r5_on_store1);
-
-    for i in 1..5 {
-        cluster.must_put(format!("k{}", i).as_bytes(), b"v");
-        must_get_equal(&cluster.get_engine(3), format!("k{}", i).as_bytes(), b"v");
-    }
-
-    cluster.add_send_filter(IsolationFilterFactory::new(3));
-
-    pd_client.must_merge(r2.get_id(), r3.get_id());
-    pd_client.must_merge(r4.get_id(), r3.get_id());
-    pd_client.must_merge(r1.get_id(), r3.get_id());
-    pd_client.must_merge(r5.get_id(), r3.get_id());
-
-    for i in 1..5 {
-        for j in 1..20 {
-            cluster.must_put(format!("k{}{}", i, j).as_bytes(), b"vvv");
-        }
-    }
-
-    region = pd_client.get_region(b"k1").unwrap();
-
-    let state1 = cluster.truncated_state(region.get_id(), 1);
-    // Remove log compaction failpoint
-    fail::remove(on_raft_gc_log_tick_fp);
-    // Wait to trigger compact raft log
-    let timer = Instant::now();
-    loop {
-        let state2 = cluster.truncated_state(region.get_id(), 1);
-        if state1.get_index() != state2.get_index() {
-            break;
-        }
-        if timer.elapsed() > Duration::from_secs(3) {
-            panic!("log compaction not finish after 3 seconds.");
-        }
-        sleep_ms(10);
-    }
-
-    let on_region_worker_apply_fp = "on_region_worker_apply";
-    fail::cfg(on_region_worker_apply_fp, "return()").unwrap();
-    let on_region_worker_destroy_fp = "on_region_worker_destroy";
-    fail::cfg(on_region_worker_destroy_fp, "return()").unwrap();
-
-    cluster.clear_send_filters();
-    let timer = Instant::now();
-    loop {
-        let local_state = cluster.region_local_state(region.get_id(), 3);
-        if local_state.get_state() == PeerState::Applying {
-            break;
-        }
-        if timer.elapsed() > Duration::from_secs(1) {
-            panic!("not become applying state after 1 seconds.");
-        }
-        sleep_ms(10);
-    }
-    cluster.stop_node(3);
-    fail::remove(on_region_worker_apply_fp);
-    fail::remove(on_region_worker_destroy_fp);
-    cluster.run_node(3).unwrap();
-
-    for i in 1..5 {
-        for j in 1..20 {
-            must_get_equal(
-                &cluster.get_engine(3),
-                format!("k{}{}", i, j).as_bytes(),
-                b"vvv",
-            );
-        }
-    }
 }

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -168,7 +168,7 @@ fn test_node_merge_with_slow_learner() {
     let state1 = cluster.truncated_state(right.get_id(), 1);
     (0..50).for_each(|i| cluster.must_put(b"k2", format!("v{}", i).as_bytes()));
 
-    // Wait to trigger compact raft log
+    // wait to trigger compact raft log
     let timer = Instant::now();
     loop {
         let state2 = cluster.truncated_state(right.get_id(), 1);


### PR DESCRIPTION
Due to https://github.com/tikv/tikv/issues/8373 is caused by #8301, this PR reverts it.


### Release note <!-- bugfixes or new feature need a release note -->
* No release note