### PR TITLE
txn: Forbit pushing min_commit_ts of async commit transaction

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4424,7 +4424,7 @@ mod tests {
                 commands::CheckTxnStatus::new(
                     k.clone(),
                     ts(10, 0),
-                    ts(12, 0),
+                    ts(0, 0),
                     ts(15, 0),
                     true,
                     Context::default(),

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -3591,6 +3591,11 @@ mod tests {
         };
         do_check_txn_status(true);
         do_check_txn_status(false);
+
+        // Disallow calling check_txn_status on async commit transactions with caller_start_ts or
+        // current_ts set.
+        must_check_txn_status_err(&engine, b"key", 2, 1, 0, true);
+        must_check_txn_status_err(&engine, b"key", 2, 0, 1, true);
     }
 
     #[test]

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -1000,7 +1000,8 @@ impl<S: Snapshot, P: PdClient + 'static> MvccTxn<S, P> {
                 if !caller_start_ts.is_zero() && lock.use_async_commit {
                     return Err(ErrorInner::Other(box_err!(
                         "cannot push min_commit_ts of an async commit transaction"
-                    )));
+                    ))
+                    .into());
                 }
 
                 // If lock.min_commit_ts is 0, it's not a large transaction and we can't push forward


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This  PR adds a check to check_txn_status that prevents it from misusing that may push `min_commit_ts` of async commit transactions.

### Related changes

- No

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- **Unit test will be added after merging https://github.com/tikv/tikv/pull/8349 , which added some test utility for async commit.**


### Release note <!-- bugfixes or new feature need a release note -->

* No release note