### PR TITLE
gc_worker: Change log about gc failure to warn level

### DIFF
--- a/src/server/gc_worker/gc_manager.rs
+++ b/src/server/gc_worker/gc_manager.rs
@@ -546,7 +546,7 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider> GcManager<S, R> {
         ) {
             // Ignore the error and continue, since it's useless to retry this.
             // TODO: Find a better way to handle errors. Maybe we should retry.
-            error!("failed gc"; "start_key" => &hex_start, "end_key" => &hex_end, "err" => ?e);
+            warn!("failed gc"; "start_key" => &hex_start, "end_key" => &hex_end, "err" => ?e);
         }
 
         *processed_regions += 1;


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: Fixes #8294 

Problem Summary:

Distributed GC may print some annoying error logs about GC failures, but in most cases these are not errors. This PR changes the log level to warn.

### Related changes

- Need to cherry-pick to the release branch
  - release-4.0, release-3.1, release-3.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

* No release note