### PR TITLE
copr: add fast path for ensure_decoded

### DIFF
--- a/components/tidb_query_datatype/src/codec/batch/lazy_column.rs
+++ b/components/tidb_query_datatype/src/codec/batch/lazy_column.rs
@@ -199,13 +199,8 @@ impl LazyBatchColumn {
         ctx: &mut EvalContext,
         field_type: &FieldType,
     ) -> Result<()> {
-        let logical_rows: Vec<_> = (0..self.len()).collect();
-        // let logical_rows = LogicalRows::Identical { size: self.len() };
-        self.ensure_decoded(
-            ctx,
-            field_type,
-            LogicalRows::from_slice(logical_rows.as_slice()),
-        )
+        let logical_rows = LogicalRows::Identical { size: self.len() };
+        self.ensure_decoded(ctx, field_type, logical_rows)
     }
 
     /// Returns maximum encoded size.

--- a/components/tidb_query_datatype/src/codec/data_type/logical_rows.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/logical_rows.rs
@@ -1,0 +1,85 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+// TODO: This value is chosen based on MonetDB/X100's research without our own benchmarks.
+pub const BATCH_MAX_SIZE: usize = 1024;
+
+/// Identical logical row is a special case in expression evaluation that
+/// the rows in physical_value are continuous and in order.
+static IDENTICAL_LOGICAL_ROWS: [usize; BATCH_MAX_SIZE] = {
+    let mut logical_rows = [0; BATCH_MAX_SIZE];
+    let mut row = 0;
+    while row < logical_rows.len() {
+        logical_rows[row] = row;
+        row += 1;
+    }
+    logical_rows
+};
+
+/// LogicalRows is a replacement for `logical_rows` parameter
+/// in many of the copr functions. By distinguishing identical
+/// and non-identical mapping with a enum, we can directly
+/// tell if a `logical_rows` contains all items in a vector,
+/// and we may optimiaze many cases by using direct copy and
+/// construction.
+///
+/// Note that `Identical` supports no more than `BATCH_MAX_SIZE`
+/// rows. In this way, it is always recommended to use `get_idx`
+/// instead of `as_slice` to avoid runtime error.
+#[derive(Clone, Copy, Debug)]
+pub enum LogicalRows<'a> {
+    Identical { size: usize },
+    Ref { logical_rows: &'a [usize] },
+}
+
+impl<'a> LogicalRows<'a> {
+    pub fn new_ident(size: usize) -> Self {
+        Self::Identical { size }
+    }
+
+    pub fn from_slice(logical_rows: &'a [usize]) -> Self {
+        Self::Ref { logical_rows }
+    }
+
+    /// Convert `LogicalRows` into legacy `&[usize]`.
+    /// This function should only be called if you are sure
+    /// that identical `logical_rows` doesn't exceed `BATCH_MAX_SIZE`.
+    /// This function will be phased out after all `logical_rows`
+    /// are refactored to use the new form.
+    pub fn as_slice(self) -> &'a [usize] {
+        match self {
+            LogicalRows::Identical { size } => {
+                if size >= BATCH_MAX_SIZE {
+                    panic!("construct identical logical_rows larger than batch size")
+                }
+                &IDENTICAL_LOGICAL_ROWS[0..size]
+            }
+            LogicalRows::Ref { logical_rows } => logical_rows,
+        }
+    }
+
+    #[inline]
+    pub fn get_idx(&self, idx: usize) -> usize {
+        match self {
+            LogicalRows::Identical { size: _ } => idx,
+            LogicalRows::Ref { logical_rows } => logical_rows[idx],
+        }
+    }
+
+    pub fn is_ident(&self) -> bool {
+        match self {
+            LogicalRows::Identical { size: _ } => true,
+            LogicalRows::Ref { logical_rows: _ } => false,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            LogicalRows::Identical { size } => *size,
+            LogicalRows::Ref { logical_rows } => logical_rows.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}

--- a/components/tidb_query_datatype/src/codec/data_type/logical_rows.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/logical_rows.rs
@@ -83,3 +83,35 @@ impl<'a> LogicalRows<'a> {
         self.len() == 0
     }
 }
+
+pub struct LogicalRowsIterator<'a> {
+    logical_rows: LogicalRows<'a>,
+    idx: usize,
+}
+
+impl<'a> Iterator for LogicalRowsIterator<'a> {
+    type Item = usize;
+    fn next(&mut self) -> Option<Self::Item> {
+        let result = if self.idx < self.logical_rows.len() {
+            Some(self.logical_rows.get_idx(self.idx))
+        } else {
+            None
+        };
+
+        self.idx += 1;
+
+        result
+    }
+}
+
+impl<'a> IntoIterator for LogicalRows<'a> {
+    type Item = usize;
+    type IntoIter = LogicalRowsIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        LogicalRowsIterator {
+            logical_rows: self,
+            idx: 0,
+        }
+    }
+}

--- a/components/tidb_query_datatype/src/codec/data_type/logical_rows.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/logical_rows.rs
@@ -5,7 +5,7 @@ pub const BATCH_MAX_SIZE: usize = 1024;
 
 /// Identical logical row is a special case in expression evaluation that
 /// the rows in physical_value are continuous and in order.
-static IDENTICAL_LOGICAL_ROWS: [usize; BATCH_MAX_SIZE] = {
+pub static IDENTICAL_LOGICAL_ROWS: [usize; BATCH_MAX_SIZE] = {
     let mut logical_rows = [0; BATCH_MAX_SIZE];
     let mut row = 0;
     while row < logical_rows.len() {

--- a/components/tidb_query_datatype/src/codec/data_type/mod.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/mod.rs
@@ -5,8 +5,10 @@ mod chunked_vec_bytes;
 mod chunked_vec_common;
 mod chunked_vec_json;
 mod chunked_vec_sized;
+mod logical_rows;
 mod scalar;
 mod vector;
+pub use logical_rows::{LogicalRows, BATCH_MAX_SIZE};
 
 // Concrete eval types without a nullable wrapper.
 pub type Int = i64;

--- a/components/tidb_query_datatype/src/codec/data_type/mod.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/mod.rs
@@ -8,7 +8,7 @@ mod chunked_vec_sized;
 mod logical_rows;
 mod scalar;
 mod vector;
-pub use logical_rows::{LogicalRows, BATCH_MAX_SIZE};
+pub use logical_rows::{LogicalRows, BATCH_MAX_SIZE, IDENTICAL_LOGICAL_ROWS};
 
 // Concrete eval types without a nullable wrapper.
 pub type Int = i64;

--- a/components/tidb_query_vec_executors/src/selection_executor.rs
+++ b/components/tidb_query_vec_executors/src/selection_executor.rs
@@ -94,7 +94,7 @@ impl<Src: BatchExecutor> BatchSelectionExecutor<Src> {
                     )?;
                 }
                 RpnStackNode::Vector { value, .. } => {
-                    let eval_result_logical_rows = value.logical_rows();
+                    let eval_result_logical_rows = value.logical_rows_struct();
                     match_template_evaluable! {
                         TT, match value.as_ref() {
                             VectorValue::TT(eval_result) => {
@@ -134,7 +134,7 @@ fn update_logical_rows_by_vector_value<'a, TT: EvaluableRef<'a>, T: 'a + ChunkRe
     logical_rows: &mut Vec<usize>,
     ctx: &mut EvalContext,
     eval_result: T,
-    eval_result_logical_rows: &[usize],
+    eval_result_logical_rows: LogicalRows,
 ) -> tidb_query_common::error::Result<()>
 where
     Option<TT>: AsMySQLBool,
@@ -146,7 +146,7 @@ where
         // does not affect the filtering. Instead, the eval result in corresponding logical index
         // matters.
 
-        let eval_result_physical_index = eval_result_logical_rows[logical_index];
+        let eval_result_physical_index = eval_result_logical_rows.get_idx(logical_index);
         logical_index += 1;
 
         match eval_result

--- a/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
+++ b/components/tidb_query_vec_executors/src/slow_hash_aggr_executor.rs
@@ -286,7 +286,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SlowHashAggregationImp
                 match group_by_result {
                     RpnStackNode::Vector { value, field_type } => {
                         value.as_ref().encode_sort_key(
-                            value.logical_rows()[logical_row_idx],
+                            value.logical_rows_struct().get_idx(logical_row_idx),
                             *field_type,
                             context,
                             &mut self.group_key_buffer,
@@ -327,7 +327,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SlowHashAggregationImp
                     RpnStackNode::Vector { value, field_type } => {
                         debug_assert!(value.as_ref().eval_type() == EvalType::Bytes);
                         value.as_ref().encode(
-                            value.logical_rows()[logical_row_idx],
+                            value.logical_rows_struct().get_idx(logical_row_idx),
                             *field_type,
                             context,
                             &mut self.group_key_buffer,

--- a/components/tidb_query_vec_executors/src/util/hash_aggr_helper.rs
+++ b/components/tidb_query_vec_executors/src/util/hash_aggr_helper.rs
@@ -49,7 +49,7 @@ impl HashAggregationHelper {
                 }
                 RpnStackNode::Vector { value, .. } => {
                     let physical_vec = value.as_ref();
-                    let logical_rows = value.logical_rows();
+                    let logical_rows = value.logical_rows_struct();
                     match_template_evaluable! {
                         TT, match physical_vec {
                             VectorValue::TT(vec) => {
@@ -58,7 +58,7 @@ impl HashAggregationHelper {
                                     .zip(logical_rows)
                                 {
                                     let aggr_fn_state = &mut states[*states_offset + idx];
-                                    update!(aggr_fn_state, &mut entities.context, vec.get_option_ref(*physical_idx))?;
+                                    update!(aggr_fn_state, &mut entities.context, vec.get_option_ref(physical_idx))?;
                                 }
                             }
                         }

--- a/components/tidb_query_vec_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_vec_expr/src/types/expr_eval.rs
@@ -6,53 +6,9 @@ use super::expr::{RpnExpression, RpnExpressionNode};
 use super::RpnFnCallExtra;
 use tidb_query_common::Result;
 use tidb_query_datatype::codec::batch::LazyBatchColumnVec;
+pub use tidb_query_datatype::codec::data_type::{LogicalRows, BATCH_MAX_SIZE};
 use tidb_query_datatype::codec::data_type::{ScalarValue, ScalarValueRef, VectorValue};
 use tidb_query_datatype::expr::EvalContext;
-
-// TODO: This value is chosen based on MonetDB/X100's research without our own benchmarks.
-pub const BATCH_MAX_SIZE: usize = 1024;
-
-/// Identical logical row is a special case in expression evaluation that
-/// the rows in physical_value are continuous and in order.
-static IDENTICAL_LOGICAL_ROWS: [usize; BATCH_MAX_SIZE] = {
-    let mut logical_rows = [0; BATCH_MAX_SIZE];
-    let mut row = 0;
-    while row < logical_rows.len() {
-        logical_rows[row] = row;
-        row += 1;
-    }
-    logical_rows
-};
-
-#[derive(Clone, Copy, Debug)]
-pub enum LogicalRows<'a> {
-    Identical { size: usize },
-    Ref { logical_rows: &'a [usize] },
-}
-
-impl<'a> LogicalRows<'a> {
-    pub fn as_slice(self) -> &'a [usize] {
-        match self {
-            LogicalRows::Identical { size } => &IDENTICAL_LOGICAL_ROWS[0..size],
-            LogicalRows::Ref { logical_rows } => logical_rows,
-        }
-    }
-
-    #[inline]
-    pub fn get_idx(self, idx: usize) -> usize {
-        match self {
-            LogicalRows::Identical { size: _ } => idx,
-            LogicalRows::Ref { logical_rows } => logical_rows[idx],
-        }
-    }
-
-    pub fn is_ident(self) -> bool {
-        match self {
-            LogicalRows::Identical { size: _ } => true,
-            LogicalRows::Ref { logical_rows: _ } => false,
-        }
-    }
-}
 
 /// Represents a vector value node in the RPN stack.
 ///

--- a/components/tidb_query_vec_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_vec_expr/src/types/expr_eval.rs
@@ -185,7 +185,7 @@ impl RpnExpression {
                 input_physical_columns[*offset].ensure_decoded(
                     ctx,
                     &schema[*offset],
-                    input_logical_rows,
+                    LogicalRows::from_slice(input_logical_rows),
                 )?;
             }
         }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

Previously in https://github.com/tikv/tikv/pull/8189 , we introduced a bitmap for decoding columns in sequence. And in https://github.com/tikv/tikv/pull/8345 , we introduced a enum type `LogicalRows`, which distinguishes identical row mapping and logical ones. Now, we add fast path for decoding identical logical rows.

### What is changed and how it works?

What's Changed:

* Add fast path for identical logical rows.

**A SIDE NOTE** When working on this feature, I found integration test constantly fails, though my code seems very reasonable. (Refer to first commit, I just moved LogicalRows from one module to another, and this simple change causes the test to fail.) In my opinion, there might be some `unsafe` part that caused this issue. This may need further investigation. https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tikv_ghpr_integration_common_test/detail/tikv_ghpr_integration_common_test/17791/pipeline

From the TiKV log, I observed `construct identical logical_rows larger than batch size`. This issue may have existed in TiKV before, but surfaced after I introduced `LogicalRows`.

This issue can be permanently solved after we phased out `as_slice()` interface on `LogicalRows`, or by increasing `BATCH_SIZE`.

**Next Step**

In executors, we find a lot of code like this:

```
let logical_rows = (0..logical_columns.rows_len()).collect();
```

Now we can just pass `LogicalRows::Identical`, which will significantly reduce overhead of constructing a `Vec`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note

- No release note
