### PR TITLE
metrics: Accurate duration tracing of scheduler message handling (prewrite, commit, acquire_pessimistic_lock)

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3124,6 +3124,10 @@ where
                     if channel_timer.is_none() {
                         channel_timer = Some(start);
                     }
+                    if let Some(timer) = channel_timer {
+                        let elapsed = duration_to_sec(timer.elapsed());
+                        APPLY_TASK_WAIT_TIME_HISTOGRAM.observe(elapsed);
+                    }
                     self.handle_apply(apply_ctx, apply);
                     if let Some(ref mut state) = self.delegate.yield_state {
                         state.pending_msgs = drainer.collect();
@@ -3144,10 +3148,6 @@ where
                 Some(Msg::Validate(_, f)) => f((&self.delegate, apply_ctx.enable_sync_log)),
                 None => break,
             }
-        }
-        if let Some(timer) = channel_timer {
-            let elapsed = duration_to_sec(timer.elapsed());
-            APPLY_TASK_WAIT_TIME_HISTOGRAM.observe(elapsed);
         }
     }
 }

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -896,7 +896,7 @@ mod tests {
                     *end_key = Key::from_encoded(keys::data_end_key(end_key.as_encoded()));
                 }
             });
-            self.0.async_write(ctx, batch, callback)
+            self.0.async_write(ctx, batch, callback, None)
         }
 
         fn async_snapshot(

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -820,6 +820,7 @@ mod tests {
         TestEngineBuilder, WriteData,
     };
     use crate::storage::lock_manager::DummyLockManager;
+    use crate::storage::metrics::CommandKind;
     use crate::storage::{txn::commands, Engine, Storage, TestStorageBuilder};
 
     use super::*;
@@ -883,6 +884,7 @@ mod tests {
             ctx: &Context,
             mut batch: WriteData,
             callback: EngineCallback<()>,
+            tag: Option<CommandKind>,
         ) -> EngineResult<()> {
             batch.modifies.iter_mut().for_each(|modify| match modify {
                 Modify::Delete(_, ref mut key) => {
@@ -896,7 +898,7 @@ mod tests {
                     *end_key = Key::from_encoded(keys::data_end_key(end_key.as_encoded()));
                 }
             });
-            self.0.async_write(ctx, batch, callback, None)
+            self.0.async_write(ctx, batch, callback, tag)
         }
 
         fn async_snapshot(

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -317,7 +317,13 @@ impl<S: RaftStoreRouter<RocksEngine>> Engine for RaftKv<S> {
         write_modifies(&self.engine, modifies)
     }
 
-    fn async_write(&self, ctx: &Context, batch: WriteData, cb: Callback<()>, tag: Option<CommandKind>) -> kv::Result<()> {
+    fn async_write(
+        &self,
+        ctx: &Context,
+        batch: WriteData,
+        cb: Callback<()>,
+        tag: Option<CommandKind>,
+    ) -> kv::Result<()> {
         let pre_begin_instant = Instant::now_coarse();
         fail_point!("raftkv_async_write");
         if batch.modifies.is_empty() {

--- a/src/storage/kv/btree_engine.rs
+++ b/src/storage/kv/btree_engine.rs
@@ -17,6 +17,7 @@ use crate::storage::kv::{
     ErrorInner as EngineErrorInner, Iterator, Modify, Result as EngineResult, ScanMode, Snapshot,
     WriteData,
 };
+use crate::storage::metrics::CommandKind;
 use tikv_util::time::ThreadReadId;
 
 type RwLockTree = RwLock<BTreeMap<Key, Value>>;
@@ -89,6 +90,7 @@ impl Engine for BTreeEngine {
         _ctx: &Context,
         batch: WriteData,
         cb: EngineCallback<()>,
+        _tag: Option<CommandKind>,
     ) -> EngineResult<()> {
         if batch.modifies.is_empty() {
             return Err(EngineError::from(EngineErrorInner::EmptyRequest));

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use std::time::Duration;
 use std::{error, ptr, result};
 
+use crate::storage::metrics::CommandKind;
 use engine_rocks::{RocksEngine as BaseRocksEngine, RocksTablePropertiesCollection};
 use engine_traits::{CfName, CF_DEFAULT};
 use engine_traits::{IterOptions, ReadOptions};
@@ -18,7 +19,6 @@ use futures03::prelude::*;
 use kvproto::errorpb::Error as ErrorHeader;
 use kvproto::kvrpcpb::{Context, ExtraOp as TxnExtraOp};
 use txn_types::{Key, TxnExtra, Value};
-use crate::storage::metrics::CommandKind;
 
 pub use self::btree_engine::{BTreeEngine, BTreeEngineIterator, BTreeEngineSnapshot};
 pub use self::cursor::{Cursor, CursorBuilder};
@@ -110,7 +110,13 @@ pub trait Engine: Send + Clone + 'static {
         cb: Callback<Self::Snap>,
     ) -> Result<()>;
 
-    fn async_write(&self, ctx: &Context, batch: WriteData, callback: Callback<()>, tag: Option<CommandKind>) -> Result<()>;
+    fn async_write(
+        &self,
+        ctx: &Context,
+        batch: WriteData,
+        callback: Callback<()>,
+        tag: Option<CommandKind>,
+    ) -> Result<()>;
 
     fn write(&self, ctx: &Context, batch: WriteData) -> Result<()> {
         let timeout = Duration::from_secs(DEFAULT_TIMEOUT_SECS);

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -20,6 +20,7 @@ use tempfile::{Builder, TempDir};
 use txn_types::{Key, Value};
 
 use crate::storage::config::BlockCacheConfig;
+use crate::storage::metrics::CommandKind;
 use tikv_util::escape;
 use tikv_util::time::ThreadReadId;
 use tikv_util::worker::{Runnable, Scheduler, Worker};
@@ -285,7 +286,7 @@ impl Engine for RocksEngine {
         write_modifies(&self.engines.kv, modifies)
     }
 
-    fn async_write(&self, _: &Context, batch: WriteData, cb: Callback<()>) -> Result<()> {
+    fn async_write(&self, _: &Context, batch: WriteData, cb: Callback<()>, _tag: Option<CommandKind>) -> Result<()> {
         fail_point!("rockskv_async_write", |_| Err(box_err!("write failed")));
 
         if batch.modifies.is_empty() {

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -286,7 +286,13 @@ impl Engine for RocksEngine {
         write_modifies(&self.engines.kv, modifies)
     }
 
-    fn async_write(&self, _: &Context, batch: WriteData, cb: Callback<()>, _tag: Option<CommandKind>) -> Result<()> {
+    fn async_write(
+        &self,
+        _: &Context,
+        batch: WriteData,
+        cb: Callback<()>,
+        _tag: Option<CommandKind>,
+    ) -> Result<()> {
         fail_point!("rockskv_async_write", |_| Err(box_err!("write failed")));
 
         if batch.modifies.is_empty() {

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -213,6 +213,50 @@ make_auto_flush_static_metric! {
     pub struct SchedCommandPriCounterVec: LocalIntCounter {
         "priority" => CommandPriority,
     }
+
+    pub struct SchedWaitDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct AsyncWriteDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct PreAsyncWriteDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedPreHandle1DurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedPreHandle2DurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedPreHandle3DurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedBeforeWrite1DurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedBeforeWrite2DurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedExecCallbackDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedPostHandleDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedPostWriteDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
 }
 
 impl Into<GcKeysCF> for ServerGcKeysCF {
@@ -350,4 +394,114 @@ lazy_static! {
         "Counter of request exceed bound"
     )
     .unwrap();
+
+    pub static ref SCHED_WAIT_HISTOGRAM: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_wait_for_process_duration_seconds",
+        "Bucketed histogram of duration of wait-for-process",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_WAIT_HISTOGRAM_VEC: SchedWaitDurationVec =
+        auto_flush_from!(SCHED_WAIT_HISTOGRAM, SchedWaitDurationVec);
+
+    pub static ref ASYNC_WRITE_DURATIONS_VEC: AsyncWriteDurationVec =
+        auto_flush_from!(ASYNC_WRITE_DURATIONS, AsyncWriteDurationVec);
+    pub static ref ASYNC_WRITE_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_storage_engine_async_write_duration_seconds",
+        "Bucketed histogram of successful async-write requests.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+
+    pub static ref PRE_ASYNC_WRITE_DURATIONS_VEC: PreAsyncWriteDurationVec =
+        auto_flush_from!(PRE_ASYNC_WRITE_DURATIONS, PreAsyncWriteDurationVec);
+    pub static ref PRE_ASYNC_WRITE_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_storage_engine_pre_async_write_duration_seconds",
+        "Bucketed histogram of duration of pre-async-write requests.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+
+    pub static ref SCHED_PRE_HANDLE_1_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_pre_handle_1_duration_seconds",
+        "Bucketed histogram of scheduler pre_handle_1 duration.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_PRE_HANDLE_1_DURATIONS_VEC: SchedPreHandle1DurationVec =
+        auto_flush_from!(SCHED_PRE_HANDLE_1_DURATIONS, SchedPreHandle1DurationVec);
+
+    pub static ref SCHED_PRE_HANDLE_2_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_pre_handle_2_duration_seconds",
+        "Bucketed histogram of scheduler pre_handle_2 duration.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_PRE_HANDLE_2_DURATIONS_VEC: SchedPreHandle2DurationVec =
+        auto_flush_from!(SCHED_PRE_HANDLE_2_DURATIONS, SchedPreHandle2DurationVec);
+
+    pub static ref SCHED_PRE_HANDLE_3_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_pre_handle_3_duration_seconds",
+        "Bucketed histogram of scheduler pre_handle_3 duration.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_PRE_HANDLE_3_DURATIONS_VEC: SchedPreHandle3DurationVec =
+        auto_flush_from!(SCHED_PRE_HANDLE_3_DURATIONS, SchedPreHandle3DurationVec);
+
+    pub static ref SCHED_BEFORE_WRITE_1_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_before_write_1_duration_seconds",
+        "Bucketed histogram of scheduler before_write_1 duration.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_BEFORE_WRITE_1_DURATIONS_VEC: SchedBeforeWrite1DurationVec =
+        auto_flush_from!(SCHED_BEFORE_WRITE_1_DURATIONS, SchedBeforeWrite1DurationVec);
+
+    pub static ref SCHED_BEFORE_WRITE_2_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_before_write_2_duration_seconds",
+        "Bucketed histogram of scheduler before_write_2 duration.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_BEFORE_WRITE_2_DURATIONS_VEC: SchedBeforeWrite2DurationVec =
+        auto_flush_from!(SCHED_BEFORE_WRITE_2_DURATIONS, SchedBeforeWrite2DurationVec);
+
+    pub static ref SCHED_EXEC_CALLBACK_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_exec_callback_duration_seconds",
+        "Bucketed histogram of scheduler executing callback.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_EXEC_CALLBACK_DURATIONS_VEC: SchedExecCallbackDurationVec =
+        auto_flush_from!(SCHED_EXEC_CALLBACK_DURATIONS, SchedExecCallbackDurationVec);
+
+    pub static ref SCHED_POST_HANDLE_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_post_handle_duration_seconds",
+        "Bucketed histogram of scheduler post-handle processing requests.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_POST_HANDLE_DURATIONS_VEC: SchedPostHandleDurationVec =
+        auto_flush_from!(SCHED_POST_HANDLE_DURATIONS, SchedPostHandleDurationVec);
+
+    pub static ref SCHED_POST_WRITE_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_post_write_duration_seconds",
+        "Bucketed histogram of scheduler post-write processing requests.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_POST_WRITE_DURATIONS_VEC: SchedPostWriteDurationVec =
+        auto_flush_from!(SCHED_POST_WRITE_DURATIONS, SchedPostWriteDurationVec);
 }

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -394,7 +394,6 @@ lazy_static! {
         "Counter of request exceed bound"
     )
     .unwrap();
-
     pub static ref SCHED_WAIT_HISTOGRAM: HistogramVec = register_histogram_vec!(
         "tikv_scheduler_wait_for_process_duration_seconds",
         "Bucketed histogram of duration of wait-for-process",
@@ -404,7 +403,6 @@ lazy_static! {
     .unwrap();
     pub static ref SCHED_WAIT_HISTOGRAM_VEC: SchedWaitDurationVec =
         auto_flush_from!(SCHED_WAIT_HISTOGRAM, SchedWaitDurationVec);
-
     pub static ref ASYNC_WRITE_DURATIONS_VEC: AsyncWriteDurationVec =
         auto_flush_from!(ASYNC_WRITE_DURATIONS, AsyncWriteDurationVec);
     pub static ref ASYNC_WRITE_DURATIONS: HistogramVec = register_histogram_vec!(
@@ -414,7 +412,6 @@ lazy_static! {
         exponential_buckets(0.0005, 2.0, 20).unwrap()
     )
     .unwrap();
-
     pub static ref PRE_ASYNC_WRITE_DURATIONS_VEC: PreAsyncWriteDurationVec =
         auto_flush_from!(PRE_ASYNC_WRITE_DURATIONS, PreAsyncWriteDurationVec);
     pub static ref PRE_ASYNC_WRITE_DURATIONS: HistogramVec = register_histogram_vec!(
@@ -424,7 +421,6 @@ lazy_static! {
         exponential_buckets(0.0005, 2.0, 20).unwrap()
     )
     .unwrap();
-
     pub static ref SCHED_PRE_HANDLE_1_DURATIONS: HistogramVec = register_histogram_vec!(
         "tikv_scheduler_pre_handle_1_duration_seconds",
         "Bucketed histogram of scheduler pre_handle_1 duration.",
@@ -434,7 +430,6 @@ lazy_static! {
     .unwrap();
     pub static ref SCHED_PRE_HANDLE_1_DURATIONS_VEC: SchedPreHandle1DurationVec =
         auto_flush_from!(SCHED_PRE_HANDLE_1_DURATIONS, SchedPreHandle1DurationVec);
-
     pub static ref SCHED_PRE_HANDLE_2_DURATIONS: HistogramVec = register_histogram_vec!(
         "tikv_scheduler_pre_handle_2_duration_seconds",
         "Bucketed histogram of scheduler pre_handle_2 duration.",
@@ -444,7 +439,6 @@ lazy_static! {
     .unwrap();
     pub static ref SCHED_PRE_HANDLE_2_DURATIONS_VEC: SchedPreHandle2DurationVec =
         auto_flush_from!(SCHED_PRE_HANDLE_2_DURATIONS, SchedPreHandle2DurationVec);
-
     pub static ref SCHED_PRE_HANDLE_3_DURATIONS: HistogramVec = register_histogram_vec!(
         "tikv_scheduler_pre_handle_3_duration_seconds",
         "Bucketed histogram of scheduler pre_handle_3 duration.",
@@ -454,7 +448,6 @@ lazy_static! {
     .unwrap();
     pub static ref SCHED_PRE_HANDLE_3_DURATIONS_VEC: SchedPreHandle3DurationVec =
         auto_flush_from!(SCHED_PRE_HANDLE_3_DURATIONS, SchedPreHandle3DurationVec);
-
     pub static ref SCHED_BEFORE_WRITE_1_DURATIONS: HistogramVec = register_histogram_vec!(
         "tikv_scheduler_before_write_1_duration_seconds",
         "Bucketed histogram of scheduler before_write_1 duration.",
@@ -464,7 +457,6 @@ lazy_static! {
     .unwrap();
     pub static ref SCHED_BEFORE_WRITE_1_DURATIONS_VEC: SchedBeforeWrite1DurationVec =
         auto_flush_from!(SCHED_BEFORE_WRITE_1_DURATIONS, SchedBeforeWrite1DurationVec);
-
     pub static ref SCHED_BEFORE_WRITE_2_DURATIONS: HistogramVec = register_histogram_vec!(
         "tikv_scheduler_before_write_2_duration_seconds",
         "Bucketed histogram of scheduler before_write_2 duration.",
@@ -474,7 +466,6 @@ lazy_static! {
     .unwrap();
     pub static ref SCHED_BEFORE_WRITE_2_DURATIONS_VEC: SchedBeforeWrite2DurationVec =
         auto_flush_from!(SCHED_BEFORE_WRITE_2_DURATIONS, SchedBeforeWrite2DurationVec);
-
     pub static ref SCHED_EXEC_CALLBACK_DURATIONS: HistogramVec = register_histogram_vec!(
         "tikv_scheduler_exec_callback_duration_seconds",
         "Bucketed histogram of scheduler executing callback.",
@@ -484,7 +475,6 @@ lazy_static! {
     .unwrap();
     pub static ref SCHED_EXEC_CALLBACK_DURATIONS_VEC: SchedExecCallbackDurationVec =
         auto_flush_from!(SCHED_EXEC_CALLBACK_DURATIONS, SchedExecCallbackDurationVec);
-
     pub static ref SCHED_POST_HANDLE_DURATIONS: HistogramVec = register_histogram_vec!(
         "tikv_scheduler_post_handle_duration_seconds",
         "Bucketed histogram of scheduler post-handle processing requests.",
@@ -494,7 +484,6 @@ lazy_static! {
     .unwrap();
     pub static ref SCHED_POST_HANDLE_DURATIONS_VEC: SchedPostHandleDurationVec =
         auto_flush_from!(SCHED_POST_HANDLE_DURATIONS, SchedPostHandleDurationVec);
-
     pub static ref SCHED_POST_WRITE_DURATIONS: HistogramVec = register_histogram_vec!(
         "tikv_scheduler_post_write_duration_seconds",
         "Bucketed histogram of scheduler post-write processing requests.",

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -32,7 +32,7 @@ pub use self::{
 };
 
 use crate::read_pool::{ReadPool, ReadPoolHandle};
-use crate::storage::metrics::CommandKind;
+pub use crate::storage::metrics::CommandKind;
 use crate::storage::{
     config::Config,
     kv::{with_tls_engine, Modify, WriteData},
@@ -606,6 +606,7 @@ impl<E: Engine, L: LockManager, P: PdClient + 'static> Storage<E, L, P> {
             &ctx,
             WriteData::from_modifies(modifies),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.delete_range.inc();
         Ok(())
@@ -830,6 +831,7 @@ impl<E: Engine, L: LockManager, P: PdClient + 'static> Storage<E, L, P> {
                 value,
             )]),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_put.inc();
         Ok(())
@@ -859,6 +861,7 @@ impl<E: Engine, L: LockManager, P: PdClient + 'static> Storage<E, L, P> {
             &ctx,
             WriteData::from_modifies(modifies),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_batch_put.inc();
         Ok(())
@@ -881,6 +884,7 @@ impl<E: Engine, L: LockManager, P: PdClient + 'static> Storage<E, L, P> {
                 Key::from_encoded(key),
             )]),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_delete.inc();
         Ok(())
@@ -911,6 +915,7 @@ impl<E: Engine, L: LockManager, P: PdClient + 'static> Storage<E, L, P> {
             &ctx,
             WriteData::from_modifies(vec![Modify::DeleteRange(cf, start_key, end_key, false)]),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_delete_range.inc();
         Ok(())
@@ -935,6 +940,7 @@ impl<E: Engine, L: LockManager, P: PdClient + 'static> Storage<E, L, P> {
             &ctx,
             WriteData::from_modifies(modifies),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_batch_delete.inc();
         Ok(())

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -58,13 +58,13 @@ use crate::storage::metrics::SCHED_POST_WRITE_DURATIONS_VEC;
 // Scheduler command duration == ASYNC_WRITE_DURATIONS_VEC +
 //   ASYNC_WRITE_DURATIONS_VEC +
 //   sum duration of below:
-use crate::storage::metrics::SCHED_WAIT_HISTOGRAM_VEC;
-use crate::storage::metrics::SCHED_PRE_HANDLE_1_DURATIONS_VEC;
-use crate::storage::metrics::SCHED_PRE_HANDLE_2_DURATIONS_VEC;
-use crate::storage::metrics::SCHED_PRE_HANDLE_3_DURATIONS_VEC;
 use crate::storage::metrics::SCHED_BEFORE_WRITE_1_DURATIONS_VEC;
 use crate::storage::metrics::SCHED_BEFORE_WRITE_2_DURATIONS_VEC;
 use crate::storage::metrics::SCHED_EXEC_CALLBACK_DURATIONS_VEC;
+use crate::storage::metrics::SCHED_PRE_HANDLE_1_DURATIONS_VEC;
+use crate::storage::metrics::SCHED_PRE_HANDLE_2_DURATIONS_VEC;
+use crate::storage::metrics::SCHED_PRE_HANDLE_3_DURATIONS_VEC;
+use crate::storage::metrics::SCHED_WAIT_HISTOGRAM_VEC;
 
 const TASKS_SLOTS_NUM: usize = 1 << 12; // 4096 slots.
 
@@ -396,7 +396,6 @@ impl<E: Engine, L: LockManager, P: PdClient + 'static> Scheduler<E, L, P> {
                             .get(tag)
                             .observe(timer.elapsed_secs());
                         sched.process_by_worker(snapshot, task);
-
                     }
                     Err(err) => {
                         SCHED_STAGE_COUNTER_VEC.get(tag).snapshot_err.inc();

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -196,6 +196,7 @@ fn bench_async_write(b: &mut test::Bencher) {
                 Key::from_encoded(b"fooo".to_vec()),
             )]),
             on_finished,
+            None,
         )
         .unwrap();
     });


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

The inaccurate duration tracing of TiKV

Problem Summary:
1. The `tikv_raftstore_apply_wait_time_duration_secs` is not only the duration in queue
2. Lack of duration recording (separated by message type) of `async_write`
3. The `SCHED_LATCH_HISTOGRAM_VEC` include duration in queue and  latch time, which is not correct
4. For each storage message, the duration recording was not fully covered the whole executing progress now 

### What is changed and how it works?

1. Record only the in-queue duration
2. Add a metric to record it
3. Add a metric for in-queue duration
4. Add a group of metrics, to record the whole executing progress by parts

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- The related metrics' meaning will be different from before

### Release note <!-- bugfixes or new feature need a release note -->

- Add accurate duration tracing of TiKV
