### PR TITLE
metrics: Accurate duration tracing of storage/scheduler message handling

### DIFF
--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -816,6 +816,7 @@ mod tests {
         TestEngineBuilder, WriteData,
     };
     use crate::storage::lock_manager::DummyLockManager;
+    use crate::storage::metrics::CommandKind;
     use crate::storage::{txn::commands, Engine, Storage, TestStorageBuilder};
 
     use super::*;
@@ -880,6 +881,7 @@ mod tests {
             ctx: &Context,
             mut batch: WriteData,
             callback: EngineCallback<()>,
+            tag: Option<CommandKind>,
         ) -> EngineResult<()> {
             batch.modifies.iter_mut().for_each(|modify| match modify {
                 Modify::Delete(_, ref mut key) => {
@@ -893,7 +895,7 @@ mod tests {
                     *end_key = Key::from_encoded(keys::data_end_key(end_key.as_encoded()));
                 }
             });
-            self.0.async_write(ctx, batch, callback)
+            self.0.async_write(ctx, batch, callback, tag)
         }
 
         fn async_snapshot(

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -22,6 +22,7 @@ use crate::storage::kv::{
     ErrorInner as KvErrorInner, Iterator as EngineIterator, Modify, ScanMode,
     Snapshot as EngineSnapshot, WriteData,
 };
+
 use crate::storage::{self, kv};
 use raftstore::errors::Error as RaftServerError;
 use raftstore::router::RaftStoreRouter;
@@ -29,6 +30,10 @@ use raftstore::store::{Callback as StoreCallback, ReadResponse, WriteResponse};
 use raftstore::store::{RegionIterator, RegionSnapshot};
 use tikv_util::time::Instant;
 use tikv_util::time::ThreadReadId;
+
+use crate::storage::metrics::CommandKind;
+use crate::storage::metrics::ASYNC_WRITE_DURATIONS_VEC;
+use crate::storage::metrics::PRE_ASYNC_WRITE_DURATIONS_VEC;
 
 quick_error! {
     #[derive(Debug)]
@@ -313,7 +318,14 @@ impl<S: RaftStoreRouter<RocksEngine>> Engine for RaftKv<S> {
         write_modifies(&self.engine, modifies)
     }
 
-    fn async_write(&self, ctx: &Context, batch: WriteData, cb: Callback<()>) -> kv::Result<()> {
+    fn async_write(
+        &self,
+        ctx: &Context,
+        batch: WriteData,
+        cb: Callback<()>,
+        tag: Option<CommandKind>,
+    ) -> kv::Result<()> {
+        let pre_begin_instant = Instant::now_coarse();
         fail_point!("raftkv_async_write");
         if batch.modifies.is_empty() {
             return Err(KvError::from(KvErrorInner::EmptyRequest));
@@ -356,6 +368,12 @@ impl<S: RaftStoreRouter<RocksEngine>> Engine for RaftKv<S> {
         }
 
         ASYNC_REQUESTS_COUNTER_VEC.write.all.inc();
+
+        if let Some(tag) = tag {
+            PRE_ASYNC_WRITE_DURATIONS_VEC
+                .get(tag)
+                .observe(pre_begin_instant.elapsed_secs());
+        }
         let begin_instant = Instant::now_coarse();
 
         self.exec_write_requests(
@@ -368,6 +386,12 @@ impl<S: RaftStoreRouter<RocksEngine>> Engine for RaftKv<S> {
                     ASYNC_REQUESTS_DURATIONS_VEC
                         .write
                         .observe(begin_instant.elapsed_secs());
+                    if let Some(tag) = tag {
+                        ASYNC_WRITE_DURATIONS_VEC
+                            .get(tag)
+                            .observe(begin_instant.elapsed_secs());
+                    }
+
                     fail_point!("raftkv_async_write_finish");
                     cb((cb_ctx, Ok(())))
                 }

--- a/src/storage/kv/btree_engine.rs
+++ b/src/storage/kv/btree_engine.rs
@@ -17,6 +17,7 @@ use crate::storage::kv::{
     ErrorInner as EngineErrorInner, Iterator, Modify, Result as EngineResult, ScanMode, Snapshot,
     WriteData,
 };
+use crate::storage::metrics::CommandKind;
 use tikv_util::time::ThreadReadId;
 
 type RwLockTree = RwLock<BTreeMap<Key, Value>>;
@@ -90,6 +91,7 @@ impl Engine for BTreeEngine {
         _ctx: &Context,
         batch: WriteData,
         cb: EngineCallback<()>,
+        _tag: Option<CommandKind>,
     ) -> EngineResult<()> {
         if batch.modifies.is_empty() {
             return Err(EngineError::from(EngineErrorInner::EmptyRequest));

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use std::time::Duration;
 use std::{error, ptr, result};
 
+use crate::storage::metrics::CommandKind;
 use engine_rocks::RocksTablePropertiesCollection;
 use engine_traits::{CfName, CF_DEFAULT};
 use engine_traits::{IterOptions, KvEngine as LocalEngine, ReadOptions};
@@ -111,11 +112,17 @@ pub trait Engine: Send + Clone + 'static {
         cb: Callback<Self::Snap>,
     ) -> Result<()>;
 
-    fn async_write(&self, ctx: &Context, batch: WriteData, callback: Callback<()>) -> Result<()>;
+    fn async_write(
+        &self,
+        ctx: &Context,
+        batch: WriteData,
+        callback: Callback<()>,
+        tag: Option<CommandKind>,
+    ) -> Result<()>;
 
     fn write(&self, ctx: &Context, batch: WriteData) -> Result<()> {
         let timeout = Duration::from_secs(DEFAULT_TIMEOUT_SECS);
-        match wait_op!(|cb| self.async_write(ctx, batch, cb), timeout) {
+        match wait_op!(|cb| self.async_write(ctx, batch, cb, None), timeout) {
             Some((_, res)) => res,
             None => Err(Error::from(ErrorInner::Timeout(timeout))),
         }

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -20,6 +20,7 @@ use tempfile::{Builder, TempDir};
 use txn_types::{Key, Value};
 
 use crate::storage::config::BlockCacheConfig;
+use crate::storage::metrics::CommandKind;
 use tikv_util::escape;
 use tikv_util::time::ThreadReadId;
 use tikv_util::worker::{Runnable, Scheduler, Worker};
@@ -290,7 +291,13 @@ impl Engine for RocksEngine {
         write_modifies(&self.engines.kv, modifies)
     }
 
-    fn async_write(&self, _: &Context, batch: WriteData, cb: Callback<()>) -> Result<()> {
+    fn async_write(
+        &self,
+        _: &Context,
+        batch: WriteData,
+        cb: Callback<()>,
+        _tag: Option<CommandKind>,
+    ) -> Result<()> {
         fail_point!("rockskv_async_write", |_| Err(box_err!("write failed")));
 
         if batch.modifies.is_empty() {

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -213,6 +213,42 @@ make_auto_flush_static_metric! {
     pub struct SchedCommandPriCounterVec: LocalIntCounter {
         "priority" => CommandPriority,
     }
+
+    pub struct SchedWaitDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct AsyncWriteDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct PreAsyncWriteDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedAsyncSnapshotDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedWaitForThreadDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedProcessBeforeWriteDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedExecCallbackDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedPostHandleDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
+
+    pub struct SchedPostWriteDurationVec: LocalHistogram {
+        "type" => CommandKind,
+    }
 }
 
 impl Into<GcKeysCF> for ServerGcKeysCF {
@@ -349,4 +385,91 @@ lazy_static! {
         "Counter of request exceed bound"
     )
     .unwrap();
+    pub static ref SCHED_WAIT_HISTOGRAM: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_wait_for_process_duration_seconds",
+        "Bucketed histogram of duration of wait-for-process",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_WAIT_HISTOGRAM_VEC: SchedWaitDurationVec =
+        auto_flush_from!(SCHED_WAIT_HISTOGRAM, SchedWaitDurationVec);
+    pub static ref ASYNC_WRITE_DURATIONS_VEC: AsyncWriteDurationVec =
+        auto_flush_from!(ASYNC_WRITE_DURATIONS, AsyncWriteDurationVec);
+    pub static ref ASYNC_WRITE_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_storage_engine_async_write_duration_seconds",
+        "Bucketed histogram of successful async-write requests.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref PRE_ASYNC_WRITE_DURATIONS_VEC: PreAsyncWriteDurationVec =
+        auto_flush_from!(PRE_ASYNC_WRITE_DURATIONS, PreAsyncWriteDurationVec);
+    pub static ref PRE_ASYNC_WRITE_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_storage_engine_pre_async_write_duration_seconds",
+        "Bucketed histogram of duration of pre-async-write requests.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_ASYNC_SNAPSHOT_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_async_snapshot_duration_seconds",
+        "Bucketed histogram of scheduler before-process duration.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_ASYNC_SNAPSHOT_DURATIONS_VEC: SchedAsyncSnapshotDurationVec = auto_flush_from!(
+        SCHED_ASYNC_SNAPSHOT_DURATIONS,
+        SchedAsyncSnapshotDurationVec
+    );
+    pub static ref SCHED_WAIT_FOR_THREAD_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_wait_for_thread_duration_seconds",
+        "Bucketed histogram of scheduler wait-for-thread duration.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_WAIT_FOR_THREAD_DURATIONS_VEC: SchedWaitForThreadDurationVec = auto_flush_from!(
+        SCHED_WAIT_FOR_THREAD_DURATIONS,
+        SchedWaitForThreadDurationVec
+    );
+    pub static ref SCHED_PROCESS_BEFORE_WRITE_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_process_before_write_duration_seconds",
+        "Bucketed histogram of scheduler process-before-write duration.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_PROCESS_BEFORE_WRITE_DURATIONS_VEC: SchedProcessBeforeWriteDurationVec = auto_flush_from!(
+        SCHED_PROCESS_BEFORE_WRITE_DURATIONS,
+        SchedProcessBeforeWriteDurationVec
+    );
+    pub static ref SCHED_EXEC_CALLBACK_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_exec_callback_duration_seconds",
+        "Bucketed histogram of scheduler executing callback.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_EXEC_CALLBACK_DURATIONS_VEC: SchedExecCallbackDurationVec =
+        auto_flush_from!(SCHED_EXEC_CALLBACK_DURATIONS, SchedExecCallbackDurationVec);
+    pub static ref SCHED_POST_HANDLE_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_post_handle_duration_seconds",
+        "Bucketed histogram of scheduler post-handle processing requests.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_POST_HANDLE_DURATIONS_VEC: SchedPostHandleDurationVec =
+        auto_flush_from!(SCHED_POST_HANDLE_DURATIONS, SchedPostHandleDurationVec);
+    pub static ref SCHED_POST_WRITE_DURATIONS: HistogramVec = register_histogram_vec!(
+        "tikv_scheduler_post_write_duration_seconds",
+        "Bucketed histogram of scheduler post-write processing requests.",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+    pub static ref SCHED_POST_WRITE_DURATIONS_VEC: SchedPostWriteDurationVec =
+        auto_flush_from!(SCHED_POST_WRITE_DURATIONS, SchedPostWriteDurationVec);
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -32,7 +32,7 @@ pub use self::{
 };
 
 use crate::read_pool::{ReadPool, ReadPoolHandle};
-use crate::storage::metrics::CommandKind;
+pub use crate::storage::metrics::CommandKind;
 use crate::storage::{
     config::Config,
     kv::{with_tls_engine, Modify, WriteData},
@@ -716,6 +716,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
             &ctx,
             WriteData::from_modifies(modifies),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.delete_range.inc();
         Ok(())
@@ -940,6 +941,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                 value,
             )]),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_put.inc();
         Ok(())
@@ -969,6 +971,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
             &ctx,
             WriteData::from_modifies(modifies),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_batch_put.inc();
         Ok(())
@@ -991,6 +994,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                 Key::from_encoded(key),
             )]),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_delete.inc();
         Ok(())
@@ -1021,6 +1025,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
             &ctx,
             WriteData::from_modifies(vec![Modify::DeleteRange(cf, start_key, end_key, false)]),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_delete_range.inc();
         Ok(())
@@ -1045,6 +1050,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
             &ctx,
             WriteData::from_modifies(modifies),
             Box::new(|(_, res): (_, kv::Result<_>)| callback(res.map_err(Error::from))),
+            None,
         )?;
         KV_COMMAND_COUNTER_VEC_STATIC.raw_batch_delete.inc();
         Ok(())

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -44,7 +44,7 @@ where
         .unwrap();
     }
     let write_data = WriteData::from_modifies(txn.into_modifies());
-    let _ = engine.async_write(&ctx, write_data, Box::new(move |(_, _)| {}));
+    let _ = engine.async_write(&ctx, write_data, Box::new(move |(_, _)| {}), None);
     let keys: Vec<Key> = kvs.iter().map(|(k, _)| Key::from_raw(&k)).collect();
     let snapshot = engine.snapshot(&ctx).unwrap();
     (snapshot, keys)

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -196,6 +196,7 @@ fn bench_async_write(b: &mut test::Bencher) {
                 Key::from_encoded(b"fooo".to_vec()),
             )]),
             on_finished,
+            None,
         )
         .unwrap();
     });


### PR DESCRIPTION
Signed-off-by: Liu Cong <innerr@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

The inaccurate duration tracing of TiKV

Problem Summary:
1. The `tikv_raftstore_apply_wait_time_duration_secs` is not only the duration in queue
2. Lack of duration recording (separated by message type) of `async_write`
3. The `SCHED_LATCH_HISTOGRAM_VEC` include duration in queue and  latch time, which is not correct
4. For each storage message, the duration recording was not fully covered the whole executing progress now 

### What is changed and how it works?

1. Record only the in-queue duration
2. Add a metric to record it
3. Add a metric for in-queue duration
4. Add a group of metrics, to record the whole executing progress by parts

Tests <!-- At least one of them must be included. -->

- Manual test
- CI test

Side effects

- The related metrics' meaning will be different from before

### Release note <!-- bugfixes or new feature need a release note -->

- Add accurate duration tracing of TiKV

### Later works

About the `4`, there will be some new Grafana panels to trace the duration  of each message:
![WeChat Work Screenshot_20200804235913](https://user-images.githubusercontent.com/1285390/89316482-c40c1080-d6ae-11ea-80c4-e594dd802aee.png)
![WeChat Work Screenshot_20200804235936](https://user-images.githubusercontent.com/1285390/89316534-d1c19600-d6ae-11ea-9ffe-34445aabc2c0.png)

And, there will be a panel to show the accuracy of this trace:
(the red delta line should close to `0`, means the trace is accurate)
![WeChat Work Screenshot_20200804235848](https://user-images.githubusercontent.com/1285390/89316749-13ead780-d6af-11ea-90ba-9eee46532904.png)

