### PR TITLE
using rocksdb range-deletion to instead of scan-and-delete

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -237,7 +237,7 @@ impl Default for Config {
             allow_remove_leader: false,
             merge_max_log_gap: 10,
             merge_check_tick_interval: ReadableDuration::secs(10),
-            use_delete_range: false,
+            use_delete_range: true,
             cleanup_import_sst_interval: ReadableDuration::minutes(10),
             local_read_batch_size: 1024,
             apply_batch_system: BatchSystemConfig::default(),

--- a/src/server/gc_worker/config.rs
+++ b/src/server/gc_worker/config.rs
@@ -21,6 +21,7 @@ pub struct GcConfig {
     /// By default compaction_filter can only works if `cluster_version` is greater than 5.0.0.
     /// Change `compaction_filter_skip_version_check` can enable it by force.
     pub compaction_filter_skip_version_check: bool,
+    pub use_delete_range: bool,
 }
 
 impl Default for GcConfig {
@@ -31,6 +32,7 @@ impl Default for GcConfig {
             max_write_bytes_per_sec: ReadableSize(DEFAULT_GC_MAX_WRITE_BYTES_PER_SEC),
             enable_compaction_filter: false,
             compaction_filter_skip_version_check: false,
+            use_delete_range: true,
         }
     }
 }

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -326,7 +326,12 @@ impl<E: Engine> GcRunner<E> {
         let cleanup_all_start_time = Instant::now();
         for cf in cfs {
             local_storage
-                .delete_all_in_range_cf(cf, &start_data_key, &end_data_key, self.cfg.use_delete_range)
+                .delete_all_in_range_cf(
+                    cf,
+                    &start_data_key,
+                    &end_data_key,
+                    self.cfg.use_delete_range,
+                )
                 .map_err(|e| {
                     let e: Error = box_err!(e);
                     warn!(

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -325,9 +325,8 @@ impl<E: Engine> GcRunner<E> {
         // Then, delete all remaining keys in the range.
         let cleanup_all_start_time = Instant::now();
         for cf in cfs {
-            // TODO: set use_delete_range with config here.
             local_storage
-                .delete_all_in_range_cf(cf, &start_data_key, &end_data_key, false)
+                .delete_all_in_range_cf(cf, &start_data_key, &end_data_key, self.cfg.use_delete_range)
                 .map_err(|e| {
                     let e: Error = box_err!(e);
                     warn!(

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -644,6 +644,7 @@ fn test_serde_custom_tikv_config() {
         max_write_bytes_per_sec: ReadableSize::mb(10),
         enable_compaction_filter: true,
         compaction_filter_skip_version_check: true,
+        use_delete_range: false,
     };
     value.pessimistic_txn = PessimisticTxnConfig {
         wait_for_lock_timeout: ReadableDuration::millis(10),

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -566,6 +566,7 @@ batch-keys = 256
 max-write-bytes-per-sec = "10MB"
 enable-compaction-filter = true
 compaction-filter-skip-version-check = true
+use-delete-range = false
 
 [pessimistic-txn]
 enabled = false # test backward compatibility


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/8410

Eliminate the impact of removing a continuous range of data.

### What is changed and how it works?

Using RocksDB's range-deletion feature to clean up a continuous range of data:
- remove a region replica
- clean up the data after TiDB's table/index/partition has been dropped/truncated

### Related changes

- No

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- Change use-delete-range to true by default, use RocksDB's range-deletion to clean up a continuous range of data