### PR TITLE
server: report cpu cores quota to Prometheus

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -81,7 +81,7 @@ pub fn run_tikv(config: TiKvConfig) {
 
     // Print resource quota.
     SysQuota::new().log_quota();
-    CPU_CORES_QUOTA.set(SysQuota::new().cpu_cores_quota() as i64);
+    CPU_CORES_QUOTA.set(SysQuota::new().cpu_cores_quota());
 
     // Do some prepare works before start.
     pre_start();

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -53,8 +53,7 @@ use tikv::{
         resolve,
         service::{DebugService, DiagnosticsService},
         status_server::StatusServer,
-        Node, RaftKv, Server, DEFAULT_CLUSTER_ID,
-        CPU_CORES_QUOTA,
+        Node, RaftKv, Server, CPU_CORES_QUOTA, DEFAULT_CLUSTER_ID,
     },
     storage::{self, config::StorageConfigManger},
 };

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -55,7 +55,7 @@ use tikv::{
         resolve,
         service::{DebugService, DiagnosticsService},
         status_server::StatusServer,
-        Node, RaftKv, Server, CPU_CORES_QUOTA, DEFAULT_CLUSTER_ID,
+        Node, RaftKv, Server, CPU_CORES_QUOTA_GAUGE, DEFAULT_CLUSTER_ID,
     },
     storage::{self, concurrency_manager::ConcurrencyManager, config::StorageConfigManger},
 };
@@ -81,7 +81,7 @@ pub fn run_tikv(config: TiKvConfig) {
 
     // Print resource quota.
     SysQuota::new().log_quota();
-    CPU_CORES_QUOTA.set(SysQuota::new().cpu_cores_quota());
+    CPU_CORES_QUOTA_GAUGE.set(SysQuota::new().cpu_cores_quota());
 
     // Do some prepare works before start.
     pre_start();

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -54,6 +54,7 @@ use tikv::{
         service::{DebugService, DiagnosticsService},
         status_server::StatusServer,
         Node, RaftKv, Server, DEFAULT_CLUSTER_ID,
+        metrics::CPU_CORES_QUOTA,
     },
     storage::{self, config::StorageConfigManger},
 };
@@ -78,7 +79,9 @@ pub fn run_tikv(config: TiKvConfig) {
     tikv::log_tikv_info();
 
     // Print resource quota.
-    SysQuota::new().log_quota();
+    let sys_quota = SysQuota::new();
+    sys_quota.log_quota();
+    CPU_CORES_QUOTA.set(sys_quota.cpu_cores_quota());
 
     // Do some prepare works before start.
     pre_start();

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -54,7 +54,7 @@ use tikv::{
         service::{DebugService, DiagnosticsService},
         status_server::StatusServer,
         Node, RaftKv, Server, DEFAULT_CLUSTER_ID,
-        metrics::CPU_CORES_QUOTA,
+        CPU_CORES_QUOTA,
     },
     storage::{self, config::StorageConfigManger},
 };
@@ -79,9 +79,8 @@ pub fn run_tikv(config: TiKvConfig) {
     tikv::log_tikv_info();
 
     // Print resource quota.
-    let sys_quota = SysQuota::new();
-    sys_quota.log_quota();
-    CPU_CORES_QUOTA.set(sys_quota.cpu_cores_quota());
+    SysQuota::new().log_quota();
+    CPU_CORES_QUOTA.set(SysQuota::new().cpu_cores_quota() as i64);
 
     // Do some prepare works before start.
     pre_start();

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -332,7 +332,7 @@ lazy_static! {
             exponential_buckets(1f64, 5f64, 10).unwrap()
         )
         .unwrap();
-    pub static ref CPU_CORES_QUOTA: IntGauge = register_int_gauge!(
+    pub static ref CPU_CORES_QUOTA: Gauge = register_gauge!(
         "tikv_server_cpu_cores_quota",
         "Total CPU cores quota for TiKV server"
     )

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -332,6 +332,11 @@ lazy_static! {
             exponential_buckets(1f64, 5f64, 10).unwrap()
         )
         .unwrap();
+    pub static ref CPU_CORES_QUOTA: IntGauge = register_int_gauge!(
+        "tikv_server_cpu_cores_quota",
+        "Total CPU cores quota for TiKV server"
+    )
+    .unwrap();
 }
 
 make_auto_flush_static_metric! {

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -332,7 +332,7 @@ lazy_static! {
             exponential_buckets(1f64, 5f64, 10).unwrap()
         )
         .unwrap();
-    pub static ref CPU_CORES_QUOTA: Gauge = register_gauge!(
+    pub static ref CPU_CORES_QUOTA_GAUGE: Gauge = register_gauge!(
         "tikv_server_cpu_cores_quota",
         "Total CPU cores quota for TiKV server"
     )

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,6 +21,7 @@ pub mod transport;
 pub use self::config::{Config, DEFAULT_CLUSTER_ID, DEFAULT_LISTENING_ADDR};
 pub use self::errors::{Error, Result};
 pub use self::metrics::CONFIG_ROCKSDB_GAUGE;
+pub use self::metrics::CPU_CORES_QUOTA;
 pub use self::node::{create_raft_storage, Node};
 pub use self::raft_client::RaftClient;
 pub use self::raftkv::RaftKv;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,7 +21,7 @@ pub mod transport;
 pub use self::config::{Config, DEFAULT_CLUSTER_ID, DEFAULT_LISTENING_ADDR};
 pub use self::errors::{Error, Result};
 pub use self::metrics::CONFIG_ROCKSDB_GAUGE;
-pub use self::metrics::CPU_CORES_QUOTA;
+pub use self::metrics::CPU_CORES_QUOTA_GAUGE;
 pub use self::node::{create_raft_storage, Node};
 pub use self::raft_client::RaftClient;
 pub use self::raftkv::RaftKv;


### PR DESCRIPTION
Signed-off-by: Howard Lau <howardlau1999@hotmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

PD needs the CPU cores quota info of the TiKV server for auto-scaling.

### What is changed and how it works?

What's Changed:

The TiKV server will now report a new Gauge metric `tikv_server_cpu_cores_quota` to Prometheus. The metric value is set to `SysQuota::new().cpu_cores_quota()` on server startup.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

Reports CPU cores quota to Prometheus.