### PR TITLE
util: support float cgroup cpu quota

### DIFF
--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -253,20 +253,18 @@ impl CGroupSys {
         Self { cgroups }
     }
 
-    pub fn cpu_cores_quota(&self) -> i64 {
+    pub fn cpu_cores_quota(&self) -> Option<f64> {
         if let Some(sub_cpu) = self.cgroups.get(CPU_SUBSYS) {
             if let Ok(quota) = sub_cpu.read_num(CPU_QUOTA) {
                 if quota < 0 {
-                    return -1;
+                    return None;
                 }
                 if let Ok(period) = sub_cpu.read_num(CPU_PERIOD) {
-                    return quota / period;
+                    return Some(quota as f64 / period as f64);
                 }
             }
         }
-
-        // -1 means no limit.
-        -1
+        None
     }
 
     pub fn memory_limit_in_bytes(&self) -> i64 {

--- a/components/tikv_util/src/sys/mod.rs
+++ b/components/tikv_util/src/sys/mod.rs
@@ -21,13 +21,11 @@ pub mod sys_quota {
             }
         }
 
-        pub fn cpu_cores_quota(&self) -> usize {
-            let cpu_num = num_cpus::get();
-            let cgroup_quota = self.cgroup.cpu_cores_quota();
-            if cgroup_quota < 0 {
-                cpu_num
-            } else {
-                std::cmp::min(cpu_num, cgroup_quota as usize)
+        pub fn cpu_cores_quota(&self) -> f64 {
+            let cpu_num = num_cpus::get() as f64;
+            match self.cgroup.cpu_cores_quota() {
+                Some(cgroup_quota) if cgroup_quota > 0.0 && cgroup_quota < cpu_num => cgroup_quota,
+                _ => cpu_num,
             }
         }
 
@@ -65,8 +63,8 @@ pub mod sys_quota {
             Self {}
         }
 
-        pub fn cpu_cores_quota(&self) -> usize {
-            num_cpus::get()
+        pub fn cpu_cores_quota(&self) -> f64 {
+            num_cpus::get() as f64
         }
 
         pub fn memory_limit_in_bytes(&self) -> u64 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,7 +164,7 @@ fn get_background_job_limit(
     // By default, rocksdb assign (max_background_jobs / 4) threads dedicated for flush, and
     // the rest shared by flush and compaction.
     let max_background_jobs: i32 =
-        cmp::max(2, cmp::min(default_background_jobs, (cpu_num - 1) as i32));
+        cmp::max(2, cmp::min(default_background_jobs, (cpu_num - 1.0) as i32));
     // Cap max_sub_compactions to allow at least two compactions.
     let max_compactions = max_background_jobs - max_background_jobs / 4;
     let max_sub_compactions: u32 = cmp::max(
@@ -1493,7 +1493,7 @@ const UNIFIED_READPOOL_MIN_CONCURRENCY: usize = 4;
 impl Default for UnifiedReadPoolConfig {
     fn default() -> UnifiedReadPoolConfig {
         let cpu_num = SysQuota::new().cpu_cores_quota();
-        let mut concurrency = (cpu_num as f64 * 0.8) as usize;
+        let mut concurrency = (cpu_num * 0.8) as usize;
         concurrency = cmp::max(UNIFIED_READPOOL_MIN_CONCURRENCY, concurrency);
         Self {
             min_thread_count: 1,
@@ -1729,7 +1729,7 @@ readpool_config!(StorageReadPoolConfig, storage_read_pool_test, "storage");
 impl Default for StorageReadPoolConfig {
     fn default() -> Self {
         let cpu_num = SysQuota::new().cpu_cores_quota();
-        let mut concurrency = (cpu_num as f64 * 0.5) as usize;
+        let mut concurrency = (cpu_num * 0.5) as usize;
         concurrency = cmp::max(DEFAULT_STORAGE_READPOOL_MIN_CONCURRENCY, concurrency);
         concurrency = cmp::min(DEFAULT_STORAGE_READPOOL_MAX_CONCURRENCY, concurrency);
         Self {
@@ -1771,7 +1771,7 @@ readpool_config!(
 impl Default for CoprReadPoolConfig {
     fn default() -> Self {
         let cpu_num = SysQuota::new().cpu_cores_quota();
-        let mut concurrency = (cpu_num as f64 * 0.8) as usize;
+        let mut concurrency = (cpu_num * 0.8) as usize;
         concurrency = cmp::max(DEFAULT_COPROCESSOR_READPOOL_MIN_CONCURRENCY, concurrency);
         Self {
             use_unified_pool: None,
@@ -2001,7 +2001,7 @@ impl Default for BackupConfig {
         let cpu_num = SysQuota::new().cpu_cores_quota();
         Self {
             // use at most 75% of vCPU by default
-            num_threads: (cpu_num - cpu_num / 4).clamp(1, 32),
+            num_threads: (cpu_num * 0.75).clamp(1.0, 32.0) as usize,
         }
     }
 }

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -1,6 +1,6 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{i32, isize};
+use std::{cmp, i32, isize};
 
 use super::Result;
 use grpcio::CompressionAlgorithms;
@@ -31,6 +31,9 @@ const DEFAULT_ENDPOINT_REQUEST_MAX_HANDLE_SECS: u64 = 60;
 
 // Number of rows in each chunk for streaming coprocessor.
 const DEFAULT_ENDPOINT_STREAM_BATCH_ROW_LIMIT: usize = 128;
+
+// At least 4 long coprocessor requests are allowed to run concurrently.
+const MIN_ENDPOINT_MAX_CONCURRENCY: usize = 4;
 
 const DEFAULT_SNAP_MAX_BYTES_PER_SEC: u64 = 100 * 1024 * 1024;
 
@@ -152,7 +155,7 @@ impl Default for Config {
             end_point_request_max_handle_duration: ReadableDuration::secs(
                 DEFAULT_ENDPOINT_REQUEST_MAX_HANDLE_SECS,
             ),
-            end_point_max_concurrency: cpu_num,
+            end_point_max_concurrency: cmp::max(cpu_num as usize, MIN_ENDPOINT_MAX_CONCURRENCY),
             snap_max_write_bytes_per_sec: ReadableSize(DEFAULT_SNAP_MAX_BYTES_PER_SEC),
             snap_max_total_size: ReadableSize(0),
             stats_concurrency: 1,

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -57,7 +57,7 @@ impl Default for Config {
             gc_ratio_threshold: DEFAULT_GC_RATIO_THRESHOLD,
             max_key_size: DEFAULT_MAX_KEY_SIZE,
             scheduler_concurrency: DEFAULT_SCHED_CONCURRENCY,
-            scheduler_worker_pool_size: if cpu_num >= 16 { 8 } else { 4 },
+            scheduler_worker_pool_size: if cpu_num >= 16.0 { 8 } else { 4 },
             scheduler_pending_write_threshold: ReadableSize::mb(DEFAULT_SCHED_PENDING_WRITE_MB),
             reserve_space: ReadableSize::gb(DEFAULT_RESERVER_SPACE_SIZE),
             block_cache: BlockCacheConfig::default(),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8423 

Problem Summary:

The CPU quota set in cgroup can be an arbitrary float but we don't handle it. TiKV considers the CPU quota is 0 if the quota is less than 1.

### What is changed and how it works?

What's Changed:

Let `cpu_cores_quota` just return an `f64` and change calculations just use the float cpu quota.

Coprocessor max_concurrency is also set to not less than 4. Such a number should not cause OOM.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

  - Set cgroup cpu quota to a float and see the calculated thread number. For example, set cgroup cpu quota to 6.5 cores, then the default coprocessor pool should have 5 threads (previously 4).
  - Set cgroup cpu quota to a very small number, `end_point_max_concurrency` will be at least 4.

### Release note <!-- bugfixes or new feature need a release note -->

Support float CPU quota in cgroup.