### PR TITLE
storage: make Engine::kv_engine generic

### DIFF
--- a/src/server/gc_worker/mod.rs
+++ b/src/server/gc_worker/mod.rs
@@ -9,7 +9,7 @@ mod gc_worker;
 // TODO: Use separated error type for GCWorker instead.
 pub use crate::storage::{Callback, Error, ErrorInner, Result};
 pub use compaction_filter::WriteCompactionFilterFactory;
-use compaction_filter::{init_compaction_filter, is_compaction_filter_allowd};
+use compaction_filter::{is_compaction_filter_allowd, CompactionFilterInitializer};
 pub use config::{GcConfig, GcWorkerConfigManager, DEFAULT_GC_BATCH_KEYS};
 pub use gc_manager::AutoGcConfig;
 pub use gc_worker::{sync_gc, GcSafePointProvider, GcTask, GcWorker, GC_MAX_EXECUTING_TASKS};

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -273,6 +273,7 @@ impl<S: RaftStoreRouter<RocksEngine>> Debug for RaftKv<S> {
 
 impl<S: RaftStoreRouter<RocksEngine>> Engine for RaftKv<S> {
     type Snap = RegionSnapshot<RocksSnapshot>;
+    type Local = RocksEngine;
 
     fn kv_engine(&self) -> RocksEngine {
         self.engine.clone()

--- a/src/storage/kv/btree_engine.rs
+++ b/src/storage/kv/btree_engine.rs
@@ -71,6 +71,7 @@ impl Default for BTreeEngine {
 
 impl Engine for BTreeEngine {
     type Snap = BTreeEngineSnapshot;
+    type Local = RocksEngine;
 
     fn kv_engine(&self) -> RocksEngine {
         unimplemented!();

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -11,9 +11,9 @@ use std::fmt;
 use std::time::Duration;
 use std::{error, ptr, result};
 
-use engine_rocks::{RocksEngine as BaseRocksEngine, RocksTablePropertiesCollection};
+use engine_rocks::RocksTablePropertiesCollection;
 use engine_traits::{CfName, CF_DEFAULT};
-use engine_traits::{IterOptions, ReadOptions};
+use engine_traits::{IterOptions, KvEngine as LocalEngine, ReadOptions};
 use futures03::prelude::*;
 use kvproto::errorpb::Error as ErrorHeader;
 use kvproto::kvrpcpb::{Context, ExtraOp as TxnExtraOp};
@@ -94,13 +94,14 @@ impl WriteData {
 
 pub trait Engine: Send + Clone + 'static {
     type Snap: Snapshot;
+    type Local: LocalEngine;
 
-    /// Key/value storage engine.
-    fn kv_engine(&self) -> BaseRocksEngine;
+    /// Local storage engine.
+    fn kv_engine(&self) -> Self::Local;
 
     fn snapshot_on_kv_engine(&self, start_key: &[u8], end_key: &[u8]) -> Result<Self::Snap>;
 
-    /// Write modifications into internal kv engine directly.
+    /// Write modifications into internal local engine directly.
     fn modify_on_kv_engine(&self, modifies: Vec<Modify>) -> Result<()>;
 
     fn async_snapshot(

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -276,6 +276,7 @@ pub fn write_modifies(kv_engine: &BaseRocksEngine, modifies: Vec<Modify>) -> Res
 
 impl Engine for RocksEngine {
     type Snap = Arc<RocksSnapshot>;
+    type Local = BaseRocksEngine;
 
     fn kv_engine(&self) -> BaseRocksEngine {
         self.engines.kv.clone()


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
Previous commits introduce `Engine::kv_engine` for return a `RocksEngine` with concrete type.

### What is changed and how it works?

What's Changed:
Make the return type of `Engine::kv_engine` generic.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* N/A