### PR TITLE
txn: Move functions from MvccTxn to their own Command

### DIFF
--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -2,9 +2,9 @@
 
 //! Multi-version concurrency control functionality.
 
-mod metrics;
+pub(super) mod metrics;
 mod reader;
-mod txn;
+pub(super) mod txn;
 
 pub use self::metrics::{GC_DELETE_VERSIONS_HISTOGRAM, MVCC_VERSIONS_HISTOGRAM};
 pub use self::reader::*;
@@ -833,7 +833,7 @@ pub mod tests {
                 false,
                 0,
                 0,
-                TimeStamp::default()
+                TimeStamp::default(),
             )
             .is_err());
     }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -355,7 +355,7 @@ impl<S: Snapshot, P: PdClient + 'static> MvccTxn<S, P> {
     // It's possible that lock conflict occours on them, but the isolation is
     // guaranteed by pessimistic locks on row keys, so let TiDB resolves these
     // locks immediately.
-    fn handle_non_pessimistic_lock_conflict(&self, key: Key, lock: Lock) -> Result<()> {
+    pub(crate) fn handle_non_pessimistic_lock_conflict(&self, key: Key, lock: Lock) -> Result<()> {
         // The previous pessimistic transaction has been committed or aborted.
         // Resolve it immediately.
         //
@@ -592,7 +592,7 @@ impl<S: Snapshot, P: PdClient + 'static> MvccTxn<S, P> {
 
     // TiKV may fails to write pessimistic locks due to pipelined process.
     // If the data is not changed after acquiring the lock, we can still prewrite the key.
-    fn amend_pessimistic_lock(
+    pub(crate) fn amend_pessimistic_lock(
         &mut self,
         pipelined_pessimistic_lock: bool,
         key: &Key,

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -53,7 +53,7 @@ pub enum MissingLockAction {
 }
 
 impl MissingLockAction {
-    fn rollback_protect(protect_rollback: bool) -> MissingLockAction {
+    pub(crate) fn rollback_protect(protect_rollback: bool) -> MissingLockAction {
         if protect_rollback {
             MissingLockAction::ProtectedRollback
         } else {
@@ -61,7 +61,7 @@ impl MissingLockAction {
         }
     }
 
-    fn rollback(rollback_if_not_exist: bool) -> MissingLockAction {
+    pub(crate) fn rollback(rollback_if_not_exist: bool) -> MissingLockAction {
         if rollback_if_not_exist {
             MissingLockAction::ProtectedRollback
         } else {
@@ -291,7 +291,7 @@ impl<S: Snapshot, P: PdClient + 'static> MvccTxn<S, P> {
 
     // Check whether there's an overlapped write record, and then perform rollback. The actual behavior
     // to do the rollback differs according to whether there's an overlapped write record.
-    fn check_write_and_rollback_lock(
+    pub(crate) fn check_write_and_rollback_lock(
         &mut self,
         key: Key,
         lock: &Lock,
@@ -848,7 +848,7 @@ impl<S: Snapshot, P: PdClient + 'static> MvccTxn<S, P> {
         self.cleanup(key, TimeStamp::zero(), false)
     }
 
-    fn check_txn_status_missing_lock(
+    pub(crate) fn check_txn_status_missing_lock(
         &mut self,
         primary_key: Key,
         action: MissingLockAction,

--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -67,7 +67,7 @@ impl CheckTxnStatus {
     /// is committed, get the commit_ts; otherwise, if the transaction is rolled back or there's
     /// no information about the transaction, results will be both 0.
     pub fn check_txn_status<S: Snapshot, P: PdClient + 'static>(
-        mut self,
+        self,
         txn: &mut MvccTxn<S, P>,
     ) -> MvccResult<(TxnStatus, Option<ReleasedLock>)> {
         fail_point!("check_txn_status", |err| Err(make_txn_error(

--- a/src/storage/txn/commands/cleanup.rs
+++ b/src/storage/txn/commands/cleanup.rs
@@ -5,12 +5,18 @@ use txn_types::{Key, TimeStamp};
 
 use crate::storage::kv::WriteData;
 use crate::storage::lock_manager::LockManager;
-use crate::storage::mvcc::MvccTxn;
+use crate::storage::mvcc::metrics::{MVCC_CONFLICT_COUNTER, MVCC_DUPLICATE_CMD_COUNTER_VEC};
+use crate::storage::mvcc::txn::make_txn_error;
+use crate::storage::mvcc::txn::MissingLockAction;
+use crate::storage::mvcc::{
+    ErrorInner as MvccErrorInner, MvccTxn, ReleasedLock, Result as MvccResult,
+};
 use crate::storage::txn::commands::{
     Command, CommandExt, ReleasedLocks, TypedCommand, WriteCommand, WriteContext, WriteResult,
 };
 use crate::storage::txn::Result;
-use crate::storage::{ProcessResult, Snapshot};
+use crate::storage::{ProcessResult, Snapshot, TxnStatus};
+use std::mem;
 
 command! {
     /// Rollback mutations on a single key.
@@ -37,8 +43,67 @@ impl CommandExt for Cleanup {
     gen_lock!(key);
 }
 
+impl Cleanup {
+    /// Cleanup the lock if it's TTL has expired, comparing with `current_ts`. If `current_ts` is 0,
+    /// cleanup the lock without checking TTL. If the lock is the primary lock of a pessimistic
+    /// transaction, the rollback record is protected from being collapsed.
+    ///
+    /// Returns the released lock. Returns error if the key is locked or has already been
+    /// committed.
+    pub fn cleanup<S: Snapshot, P: PdClient + 'static>(
+        mut self,
+        txn: &mut MvccTxn<S, P>,
+        protect_rollback: bool,
+    ) -> MvccResult<Option<ReleasedLock>> {
+        fail_point!("cleanup", |err| Err(make_txn_error(
+            err,
+            &self.key,
+            txn.start_ts,
+        )
+        .into()));
+
+        match txn.reader.load_lock(&self.key)? {
+            Some(ref lock) if lock.ts == txn.start_ts => {
+                // If current_ts is not 0, check the Lock's TTL.
+                // If the lock is not expired, do not rollback it but report key is locked.
+                if !self.current_ts.is_zero()
+                    && lock.ts.physical() + lock.ttl >= self.current_ts.physical()
+                {
+                    return Err(MvccErrorInner::KeyIsLocked(
+                        lock.clone().into_lock_info(self.key.into_raw()?),
+                    )
+                        .into());
+                }
+
+                let is_pessimistic_txn = !lock.for_update_ts.is_zero();
+                txn.check_write_and_rollback_lock(self.key, lock, is_pessimistic_txn)
+            }
+            _ => match txn.check_txn_status_missing_lock(
+                self.key,
+                MissingLockAction::rollback_protect(protect_rollback),
+            )? {
+                TxnStatus::Committed { commit_ts } => {
+                    MVCC_CONFLICT_COUNTER.rollback_committed.inc();
+                    Err(MvccErrorInner::Committed { commit_ts }.into())
+                }
+                TxnStatus::RolledBack => {
+                    // Return Ok on Rollback already exist.
+                    MVCC_DUPLICATE_CMD_COUNTER_VEC.rollback.inc();
+                    Ok(None)
+                }
+                TxnStatus::LockNotExist => Ok(None),
+                _ => unreachable!(),
+            },
+        }
+    }
+}
+
 impl<S: Snapshot, L: LockManager, P: PdClient + 'static> WriteCommand<S, L, P> for Cleanup {
-    fn process_write(self, snapshot: S, context: WriteContext<'_, L, P>) -> Result<WriteResult> {
+    fn process_write(
+        mut self,
+        snapshot: S,
+        context: WriteContext<'_, L, P>,
+    ) -> Result<WriteResult> {
         let mut txn = MvccTxn::new(
             snapshot,
             self.start_ts,
@@ -47,15 +112,16 @@ impl<S: Snapshot, L: LockManager, P: PdClient + 'static> WriteCommand<S, L, P> f
         );
 
         let mut released_locks = ReleasedLocks::new(self.start_ts, TimeStamp::zero());
+        let ctx = mem::take(&mut self.ctx);
         // The rollback must be protected, see more on
         // [issue #7364](https://github.com/tikv/tikv/issues/7364)
-        released_locks.push(txn.cleanup(self.key, self.current_ts, true)?);
+        released_locks.push(self.cleanup(&mut txn, true)?);
         released_locks.wake_up(context.lock_mgr);
 
         context.statistics.add(&txn.take_statistics());
         let write_data = WriteData::from_modifies(txn.into_modifies());
         Ok(WriteResult {
-            ctx: self.ctx,
+            ctx,
             to_be_write: write_data,
             rows: 1,
             pr: ProcessResult::Res,

--- a/src/storage/txn/commands/cleanup.rs
+++ b/src/storage/txn/commands/cleanup.rs
@@ -51,7 +51,7 @@ impl Cleanup {
     /// Returns the released lock. Returns error if the key is locked or has already been
     /// committed.
     pub fn cleanup<S: Snapshot, P: PdClient + 'static>(
-        mut self,
+        self,
         txn: &mut MvccTxn<S, P>,
         protect_rollback: bool,
     ) -> MvccResult<Option<ReleasedLock>> {

--- a/src/storage/txn/commands/cleanup.rs
+++ b/src/storage/txn/commands/cleanup.rs
@@ -72,7 +72,7 @@ impl Cleanup {
                     return Err(MvccErrorInner::KeyIsLocked(
                         lock.clone().into_lock_info(self.key.into_raw()?),
                     )
-                        .into());
+                    .into());
                 }
 
                 let is_pessimistic_txn = !lock.for_update_ts.is_zero();

--- a/src/storage/txn/commands/commit.rs
+++ b/src/storage/txn/commands/commit.rs
@@ -1,14 +1,13 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use pd_client::PdClient;
-use txn_types::{Key, LockType, TimeStamp, Write, WriteType};
+use txn_types::{Key, LockType, Write, WriteType};
 
 use crate::storage::kv::WriteData;
 use crate::storage::lock_manager::LockManager;
 use crate::storage::mvcc::metrics::{MVCC_CONFLICT_COUNTER, MVCC_DUPLICATE_CMD_COUNTER_VEC};
 use crate::storage::mvcc::{
-    has_data_in_range, txn::make_txn_error, Error as MvccError, ErrorInner as MvccErrorInner,
-    Result as MvccResult,
+    txn::make_txn_error, ErrorInner as MvccErrorInner, Result as MvccResult,
 };
 use crate::storage::mvcc::{MvccTxn, ReleasedLock};
 use crate::storage::txn::commands::{

--- a/src/storage/txn/commands/commit.rs
+++ b/src/storage/txn/commands/commit.rs
@@ -1,16 +1,22 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use pd_client::PdClient;
-use txn_types::Key;
+use txn_types::{Key, LockType, TimeStamp, Write, WriteType};
 
 use crate::storage::kv::WriteData;
 use crate::storage::lock_manager::LockManager;
-use crate::storage::mvcc::MvccTxn;
+use crate::storage::mvcc::metrics::{MVCC_CONFLICT_COUNTER, MVCC_DUPLICATE_CMD_COUNTER_VEC};
+use crate::storage::mvcc::{
+    has_data_in_range, txn::make_txn_error, Error as MvccError, ErrorInner as MvccErrorInner,
+    Result as MvccResult,
+};
+use crate::storage::mvcc::{MvccTxn, ReleasedLock};
 use crate::storage::txn::commands::{
     Command, CommandExt, ReleasedLocks, TypedCommand, WriteCommand, WriteContext, WriteResult,
 };
 use crate::storage::txn::{Error, ErrorInner, Result};
 use crate::storage::{ProcessResult, Snapshot, TxnStatus};
+use std::mem;
 
 command! {
     /// Commit the transaction that started at `lock_ts`.
@@ -37,8 +43,102 @@ impl CommandExt for Commit {
     gen_lock!(keys: multiple);
 }
 
+impl Commit {
+    pub fn commit<S: Snapshot, P: PdClient + 'static>(
+        &mut self,
+        txn: &mut MvccTxn<S, P>,
+        key: Key,
+    ) -> MvccResult<Option<ReleasedLock>> {
+        fail_point!("commit", |err| Err(
+            make_txn_error(err, &key, txn.start_ts,).into()
+        ));
+
+        let (lock_type, short_value, is_pessimistic_txn) = match txn.reader.load_lock(&key)? {
+            Some(ref mut lock) if lock.ts == txn.start_ts => {
+                // A lock with larger min_commit_ts than current commit_ts can't be committed
+                if self.commit_ts < lock.min_commit_ts {
+                    info!(
+                        "trying to commit with smaller commit_ts than min_commit_ts";
+                        "key" => %key,
+                        "start_ts" => txn.start_ts,
+                        "commit_ts" => self.commit_ts,
+                        "min_commit_ts" => lock.min_commit_ts,
+                    );
+                    return Err(MvccErrorInner::CommitTsExpired {
+                        start_ts: txn.start_ts,
+                        commit_ts: self.commit_ts,
+                        key: key.into_raw()?,
+                        min_commit_ts: lock.min_commit_ts,
+                    }
+                    .into());
+                }
+
+                // It's an abnormal routine since pessimistic locks shouldn't be committed in our
+                // transaction model. But a pessimistic lock will be left if the pessimistic
+                // rollback request fails to send and the transaction need not to acquire
+                // this lock again(due to WriteConflict). If the transaction is committed, we
+                // should commit this pessimistic lock too.
+                if lock.lock_type == LockType::Pessimistic {
+                    warn!(
+                        "commit a pessimistic lock with Lock type";
+                        "key" => %key,
+                        "start_ts" => txn.start_ts,
+                        "commit_ts" => self.commit_ts,
+                    );
+                    // Commit with WriteType::Lock.
+                    lock.lock_type = LockType::Lock;
+                }
+                (
+                    lock.lock_type,
+                    lock.short_value.take(),
+                    !lock.for_update_ts.is_zero(),
+                )
+            }
+            _ => {
+                return match txn.reader.get_txn_commit_record(&key, txn.start_ts)?.info() {
+                    Some((_, WriteType::Rollback)) | None => {
+                        MVCC_CONFLICT_COUNTER.commit_lock_not_found.inc();
+                        // None: related Rollback has been collapsed.
+                        // Rollback: rollback by concurrent transaction.
+                        info!(
+                            "txn conflict (lock not found)";
+                            "key" => %key,
+                            "start_ts" => txn.start_ts,
+                            "commit_ts" => self.commit_ts,
+                        );
+                        Err(MvccErrorInner::TxnLockNotFound {
+                            start_ts: txn.start_ts,
+                            commit_ts: self.commit_ts,
+                            key: key.into_raw()?,
+                        }
+                        .into())
+                    }
+                    // Committed by concurrent transaction.
+                    Some((_, WriteType::Put))
+                    | Some((_, WriteType::Delete))
+                    | Some((_, WriteType::Lock)) => {
+                        MVCC_DUPLICATE_CMD_COUNTER_VEC.commit.inc();
+                        Ok(None)
+                    }
+                };
+            }
+        };
+        let write = Write::new(
+            WriteType::from_lock_type(lock_type).unwrap(),
+            txn.start_ts,
+            short_value,
+        );
+        txn.put_write(key.clone(), self.commit_ts, write.as_ref().to_bytes());
+        Ok(txn.unlock_key(key, is_pessimistic_txn))
+    }
+}
+
 impl<S: Snapshot, L: LockManager, P: PdClient + 'static> WriteCommand<S, L, P> for Commit {
-    fn process_write(self, snapshot: S, context: WriteContext<'_, L, P>) -> Result<WriteResult> {
+    fn process_write(
+        mut self,
+        snapshot: S,
+        context: WriteContext<'_, L, P>,
+    ) -> Result<WriteResult> {
         if self.commit_ts <= self.lock_ts {
             return Err(Error::from(ErrorInner::InvalidTxnTso {
                 start_ts: self.lock_ts,
@@ -52,11 +152,12 @@ impl<S: Snapshot, L: LockManager, P: PdClient + 'static> WriteCommand<S, L, P> f
             context.pd_client,
         );
 
-        let rows = self.keys.len();
+        let keys = mem::take(&mut self.keys);
+        let rows = keys.len();
         // Pessimistic txn needs key_hashes to wake up waiters
         let mut released_locks = ReleasedLocks::new(self.lock_ts, self.commit_ts);
-        for k in self.keys {
-            released_locks.push(txn.commit(k, self.commit_ts)?);
+        for k in keys {
+            released_locks.push(self.commit(&mut txn, k)?);
         }
         released_locks.wake_up(context.lock_mgr);
 

--- a/src/storage/txn/commands/pessimistic_rollback.rs
+++ b/src/storage/txn/commands/pessimistic_rollback.rs
@@ -2,14 +2,16 @@
 
 use crate::storage::kv::WriteData;
 use crate::storage::lock_manager::LockManager;
-use crate::storage::mvcc::MvccTxn;
+use crate::storage::mvcc::txn::make_txn_error;
+use crate::storage::mvcc::{MvccTxn, ReleasedLock, Result as MvccResult};
 use crate::storage::txn::commands::{
     Command, CommandExt, ReleasedLocks, TypedCommand, WriteCommand, WriteContext, WriteResult,
 };
 use crate::storage::txn::Result;
 use crate::storage::{ProcessResult, Result as StorageResult, Snapshot};
 use pd_client::PdClient;
-use txn_types::{Key, TimeStamp};
+use std::mem;
+use txn_types::{Key, LockType, TimeStamp};
 
 command! {
     /// Rollback pessimistic locks identified by `start_ts` and `for_update_ts`.
@@ -35,10 +37,43 @@ impl CommandExt for PessimisticRollback {
     gen_lock!(keys: multiple);
 }
 
+impl PessimisticRollback {
+    /// Delete any pessimistic lock with small for_update_ts belongs to this transaction.
+    pub fn pessimistic_rollback<S: Snapshot, P: PdClient + 'static>(
+        &mut self,
+        txn: &mut MvccTxn<S, P>,
+        key: Key,
+    ) -> MvccResult<Option<ReleasedLock>> {
+        fail_point!("pessimistic_rollback", |err| Err(make_txn_error(
+            err,
+            &key,
+            txn.start_ts,
+        )
+        .into()));
+
+        if let Some(lock) = txn.reader.load_lock(&key)? {
+            if lock.lock_type == LockType::Pessimistic
+                && lock.ts == txn.start_ts
+                && lock.for_update_ts <= self.for_update_ts
+            {
+                return Ok(txn.unlock_key(key, true));
+            }
+        }
+        Ok(None)
+    }
+}
+
 impl<S: Snapshot, L: LockManager, P: PdClient + 'static> WriteCommand<S, L, P>
     for PessimisticRollback
 {
-    fn process_write(self, snapshot: S, context: WriteContext<'_, L, P>) -> Result<WriteResult> {
+    fn process_write(
+        mut self,
+        snapshot: S,
+        context: WriteContext<'_, L, P>,
+    ) -> Result<WriteResult> {
+        let ctx = mem::take(&mut self.ctx);
+        let keys = mem::take(&mut self.keys);
+
         let mut txn = MvccTxn::new(
             snapshot,
             self.start_ts,
@@ -46,17 +81,17 @@ impl<S: Snapshot, L: LockManager, P: PdClient + 'static> WriteCommand<S, L, P>
             context.pd_client,
         );
 
-        let rows = self.keys.len();
+        let rows = keys.len();
         let mut released_locks = ReleasedLocks::new(self.start_ts, TimeStamp::zero());
-        for k in self.keys {
-            released_locks.push(txn.pessimistic_rollback(k, self.for_update_ts)?);
+        for k in keys {
+            released_locks.push(self.pessimistic_rollback(&mut txn, k)?);
         }
         released_locks.wake_up(context.lock_mgr);
 
         context.statistics.add(&txn.take_statistics());
         let write_data = WriteData::from_modifies(txn.into_modifies());
         Ok(WriteResult {
-            ctx: self.ctx,
+            ctx,
             to_be_write: write_data,
             rows,
             pr: ProcessResult::MultiRes { results: vec![] },

--- a/src/storage/txn/commands/prewrite_pessimistic.rs
+++ b/src/storage/txn/commands/prewrite_pessimistic.rs
@@ -139,10 +139,10 @@ impl PrewritePessimistic {
             &self.primary,
             secondary_keys,
             value,
-            self.lock_ttl,
+            lock_ttl,
             self.for_update_ts,
             self.txn_size,
-            self.min_commit_ts,
+            min_commit_ts,
         )
     }
 }

--- a/src/storage/txn/commands/rollback.rs
+++ b/src/storage/txn/commands/rollback.rs
@@ -2,13 +2,16 @@
 
 use crate::storage::kv::WriteData;
 use crate::storage::lock_manager::LockManager;
-use crate::storage::mvcc::MvccTxn;
+use crate::storage::mvcc::txn::make_txn_error;
+use crate::storage::mvcc::{MvccTxn, ReleasedLock, Result as MvccResult};
+use crate::storage::txn::commands::cleanup::Cleanup;
 use crate::storage::txn::commands::{
     Command, CommandExt, ReleasedLocks, TypedCommand, WriteCommand, WriteContext, WriteResult,
 };
 use crate::storage::txn::Result;
 use crate::storage::{ProcessResult, Snapshot};
 use pd_client::PdClient;
+use std::mem;
 use txn_types::{Key, TimeStamp};
 
 command! {
@@ -33,8 +36,37 @@ impl CommandExt for Rollback {
     gen_lock!(keys: multiple);
 }
 
+impl Rollback {
+    pub fn rollback<S: Snapshot, P: PdClient + 'static>(
+        &mut self,
+        txn: &mut MvccTxn<S, P>,
+        key: Key,
+    ) -> MvccResult<Option<ReleasedLock>> {
+        fail_point!("rollback", |err| Err(make_txn_error(
+            err,
+            &key,
+            self.start_ts,
+        )
+        .into()));
+        let cleanup_command = Cleanup {
+            key,
+            start_ts: self.start_ts,
+            current_ts: TimeStamp::zero(),
+            ctx: self.ctx.clone(),
+        };
+
+        // Rollback is called only if the transaction is known to fail. Under the circumstances,
+        // the rollback record needn't be protected.
+        cleanup_command.cleanup(txn, false)
+    }
+}
+
 impl<S: Snapshot, L: LockManager, P: PdClient + 'static> WriteCommand<S, L, P> for Rollback {
-    fn process_write(self, snapshot: S, context: WriteContext<'_, L, P>) -> Result<WriteResult> {
+    fn process_write(
+        mut self,
+        snapshot: S,
+        context: WriteContext<'_, L, P>,
+    ) -> Result<WriteResult> {
         let mut txn = MvccTxn::new(
             snapshot,
             self.start_ts,
@@ -44,8 +76,9 @@ impl<S: Snapshot, L: LockManager, P: PdClient + 'static> WriteCommand<S, L, P> f
 
         let rows = self.keys.len();
         let mut released_locks = ReleasedLocks::new(self.start_ts, TimeStamp::zero());
-        for k in self.keys {
-            released_locks.push(txn.rollback(k)?);
+        let keys = mem::take(&mut self.keys);
+        for k in keys {
+            released_locks.push(self.rollback(&mut txn, k)?);
         }
         released_locks.wake_up(context.lock_mgr);
 

--- a/src/storage/txn/commands/txn_heart_beat.rs
+++ b/src/storage/txn/commands/txn_heart_beat.rs
@@ -2,7 +2,8 @@
 
 use crate::storage::kv::WriteData;
 use crate::storage::lock_manager::LockManager;
-use crate::storage::mvcc::MvccTxn;
+use crate::storage::mvcc::txn::make_txn_error;
+use crate::storage::mvcc::{ErrorInner as MvccErrorInner, MvccTxn, Result as MvccResult};
 use crate::storage::txn::commands::{
     Command, CommandExt, TypedCommand, WriteCommand, WriteContext, WriteResult,
 };
@@ -39,8 +40,60 @@ impl CommandExt for TxnHeartBeat {
     gen_lock!(primary_key);
 }
 
+impl TxnHeartBeat {
+    /// Update a primary key's TTL if `advise_ttl > lock.ttl`.
+    ///
+    /// Returns the new TTL.
+    pub fn txn_heart_beat<S: Snapshot, P: PdClient + 'static>(
+        &mut self,
+        txn: &mut MvccTxn<S, P>,
+    ) -> MvccResult<u64> {
+        fail_point!("txn_heart_beat", |err| Err(make_txn_error(
+            err,
+            &self.primary_key,
+            txn.start_ts,
+        )
+        .into()));
+
+        if let Some(mut lock) = txn.reader.load_lock(&self.primary_key)? {
+            if lock.ts == txn.start_ts {
+                if lock.ttl < self.advise_ttl {
+                    lock.ttl = self.advise_ttl;
+                    txn.put_lock(self.primary_key.clone(), &lock);
+                } else {
+                    debug!(
+                        "txn_heart_beat with advise_ttl not large than current ttl";
+                        "primary_key" => %self.primary_key,
+                        "start_ts" => txn.start_ts,
+                        "advise_ttl" => self.advise_ttl,
+                        "current_ttl" => lock.ttl,
+                    );
+                }
+                return Ok(lock.ttl);
+            }
+        }
+
+        debug!(
+            "txn_heart_beat invoked but lock is absent";
+            "primary_key" => %self.primary_key,
+            "start_ts" => txn.start_ts,
+            "advise_ttl" => self.advise_ttl,
+        );
+        Err(MvccErrorInner::TxnLockNotFound {
+            start_ts: txn.start_ts,
+            commit_ts: TimeStamp::zero(),
+            key: self.primary_key.clone().into_raw()?,
+        }
+        .into())
+    }
+}
+
 impl<S: Snapshot, L: LockManager, P: PdClient + 'static> WriteCommand<S, L, P> for TxnHeartBeat {
-    fn process_write(self, snapshot: S, context: WriteContext<'_, L, P>) -> Result<WriteResult> {
+    fn process_write(
+        mut self,
+        snapshot: S,
+        context: WriteContext<'_, L, P>,
+    ) -> Result<WriteResult> {
         // TxnHeartBeat never remove locks. No need to wake up waiters.
         let mut txn = MvccTxn::new(
             snapshot,
@@ -48,7 +101,7 @@ impl<S: Snapshot, L: LockManager, P: PdClient + 'static> WriteCommand<S, L, P> f
             !self.ctx.get_not_fill_cache(),
             context.pd_client,
         );
-        let lock_ttl = txn.txn_heart_beat(self.primary_key, self.advise_ttl)?;
+        let lock_ttl = self.txn_heart_beat(&mut txn)?;
 
         context.statistics.add(&txn.take_statistics());
         let pr = ProcessResult::TxnStatus {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

Currently `MvccTxn` contains several functions highly connected with certain `Command`, this breaks the SRP of `MvccTxn` and made the struct's code very long and hard to read.

### What is changed and how it works?

Move functions from MvccTxn to their own Command


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

