### PR TITLE
txn: Store rollback ts in the lock when the key is locked by another transaction

### DIFF
--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -75,7 +75,7 @@ pub struct Lock {
     pub secondaries: Vec<Vec<u8>>,
     // In some rare cases, a protected rollback may happen when there's already another
     // transaction's lock on the key. In this case, if the other transaction uses calculated
-    // timestamp as commit_ts, the protected rollback record may be overwritte. Checking Write CF
+    // timestamp as commit_ts, the protected rollback record may be overwritten. Checking Write CF
     // while committing is relatively expensive. So the solution is putting the ts of the rollback
     // to the lock.
     pub rollback_ts: Vec<TimeStamp>,

--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -26,6 +26,7 @@ const FOR_UPDATE_TS_PREFIX: u8 = b'f';
 const TXN_SIZE_PREFIX: u8 = b't';
 const MIN_COMMIT_TS_PREFIX: u8 = b'c';
 const ASYNC_COMMIT_PREFIX: u8 = b'a';
+const ROLLBACK_TS_PREFIX: u8 = b'r';
 
 impl LockType {
     pub fn from_mutation(mutation: &Mutation) -> Option<LockType> {
@@ -72,6 +73,12 @@ pub struct Lock {
     // Only valid when `use_async_commit` is true, and the lock is primary. Do not set
     // `secondaries` for secondaries.
     pub secondaries: Vec<Vec<u8>>,
+    // In some rare cases, a protected rollback may happen when there's already another
+    // transaction's lock on the key. In this case, if the other transaction uses calculated
+    // timestamp as commit_ts, the protected rollback record may be overwritte. Checking Write CF
+    // while committing is relatively expensive. So the solution is putting the ts of the rollback
+    // to the lock.
+    pub rollback_ts: Vec<TimeStamp>,
 }
 
 impl Lock {
@@ -96,12 +103,18 @@ impl Lock {
             min_commit_ts,
             use_async_commit: false,
             secondaries: Vec::default(),
+            rollback_ts: Vec::default(),
         }
     }
 
     pub fn use_async_commit(mut self, secondaries: Vec<Vec<u8>>) -> Self {
         self.use_async_commit = true;
         self.secondaries = secondaries;
+        self
+    }
+
+    pub fn with_rollback_ts(mut self, rollback_ts: Vec<TimeStamp>) -> Self {
+        self.rollback_ts = rollback_ts;
         self
     }
 
@@ -135,6 +148,13 @@ impl Lock {
                 b.encode_compact_bytes(k).unwrap();
             }
         }
+        if !self.rollback_ts.is_empty() {
+            b.push(ROLLBACK_TS_PREFIX);
+            b.encode_var_u64(self.rollback_ts.len() as _).unwrap();
+            for ts in &self.rollback_ts {
+                b.encode_u64(ts.into_inner()).unwrap();
+            }
+        }
         b
     }
 
@@ -160,6 +180,9 @@ impl Lock {
                     .iter()
                     .map(|k| MAX_VAR_I64_LEN + k.len())
                     .sum::<usize>();
+        }
+        if !self.rollback_ts.is_empty() {
+            size += 1 + MAX_VAR_U64_LEN + size_of::<u64>() * self.rollback_ts.len();
         }
         size
     }
@@ -196,6 +219,7 @@ impl Lock {
         let mut min_commit_ts = TimeStamp::zero();
         let mut use_async_commit = false;
         let mut secondaries = Vec::new();
+        let mut rollback_ts = Vec::new();
         while !b.is_empty() {
             match b.read_u8()? {
                 SHORT_VALUE_PREFIX => {
@@ -220,6 +244,15 @@ impl Lock {
                         .map(|_| bytes::decode_compact_bytes(&mut b).map_err(Into::into))
                         .collect::<Result<_>>()?;
                 }
+                ROLLBACK_TS_PREFIX => {
+                    let len = number::decode_var_u64(&mut b)? as usize;
+                    // Allocate one more place to avoid reallocation when pushing a new timestamp
+                    // to it.
+                    rollback_ts = Vec::with_capacity(len + 1);
+                    for _ in 0..len {
+                        rollback_ts.push(number::decode_u64(&mut b)?.into());
+                    }
+                }
                 flag => panic!("invalid flag [{}] in lock", flag),
             }
         }
@@ -236,6 +269,7 @@ impl Lock {
         if use_async_commit {
             lock = lock.use_async_commit(secondaries);
         }
+        lock.rollback_ts = rollback_ts;
         Ok(lock)
     }
 
@@ -296,6 +330,10 @@ impl Lock {
         Err(Error::from(ErrorInner::KeyIsLocked(
             lock.into_owned().into_lock_info(raw_key),
         )))
+    }
+
+    pub fn is_pessimistic_txn(&self) -> bool {
+        !self.for_update_ts.is_zero()
     }
 }
 
@@ -477,6 +515,34 @@ mod tests {
                 b"k3k3k3k3k3k3".to_vec(),
                 b"k".to_vec(),
             ]),
+            Lock::new(
+                LockType::Put,
+                b"pk".to_vec(),
+                111.into(),
+                222,
+                Some(b"short_value".to_vec()),
+                333.into(),
+                444,
+                555.into(),
+            )
+            .use_async_commit(vec![
+                b"k1".to_vec(),
+                b"kkkkk2".to_vec(),
+                b"k3k3k3k3k3k3".to_vec(),
+                b"k".to_vec(),
+            ])
+            .with_rollback_ts(vec![12.into(), 24.into(), 13.into()]),
+            Lock::new(
+                LockType::Put,
+                b"pk".to_vec(),
+                111.into(),
+                222,
+                Some(b"short_value".to_vec()),
+                333.into(),
+                444,
+                555.into(),
+            )
+            .with_rollback_ts(vec![12.into(), 24.into(), 13.into()]),
         ];
         for (i, lock) in locks.drain(..).enumerate() {
             let v = lock.to_bytes();

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -640,6 +640,34 @@ pub mod tests {
         );
     }
 
+    pub fn must_pessimistic_prewrite_put_async_commit<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        value: &[u8],
+        pk: &[u8],
+        secondary_keys: &Option<Vec<Vec<u8>>>,
+        ts: impl Into<TimeStamp>,
+        for_update_ts: impl Into<TimeStamp>,
+        is_pessimistic_lock: bool,
+        min_commit_ts: impl Into<TimeStamp>,
+    ) {
+        assert!(secondary_keys.is_some());
+        must_prewrite_put_impl(
+            engine,
+            key,
+            value,
+            pk,
+            secondary_keys,
+            ts.into(),
+            is_pessimistic_lock,
+            0,
+            for_update_ts.into(),
+            0,
+            min_commit_ts.into(),
+            false,
+        );
+    }
+
     fn must_prewrite_put_err_impl<E: Engine>(
         engine: &E,
         key: &[u8],

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -368,7 +368,7 @@ impl<S: Snapshot> MvccTxn<S> {
         }
 
         if self.start_ts < lock.ts || self.start_ts < lock.min_commit_ts {
-            // The rollback will surely note be overwritten by committing the lock. Do nothing.
+            // The rollback will surely not be overwritten by committing the lock. Do nothing.
             return;
         }
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -807,7 +807,6 @@ impl<S: Snapshot> MvccTxn<S> {
         )
         .into()));
 
-        // let (lock_type, short_value, is_pessimistic_txn)
         let mut lock = match self.reader.load_lock(&key)? {
             Some(mut lock) if lock.ts == self.start_ts => {
                 // A lock with larger min_commit_ts than current commit_ts can't be committed
@@ -843,11 +842,6 @@ impl<S: Snapshot> MvccTxn<S> {
                     // Commit with WriteType::Lock.
                     lock.lock_type = LockType::Lock;
                 }
-                // (
-                //     lock.lock_type,
-                //     lock.short_value.take(),
-                //     !lock.for_update_ts.is_zero(),
-                // )
                 lock
             }
             _ => {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

In some rare cases, a rollback may happen between another transaction's prewrite and commit on some key. In this case, the rollback have no chance to push the another transaction's commit_ts, so if the second transaction commits with a calculated commit ts (currently only possible in async commit), it may overwrite the rollback. We don't want to check write cf if there's a rollback when committing, since it harms performance greatly. But when doing rollback, we can let it record its ts in the second transaction's lock, so the second transaction can check it from the lock and needn't to read write cf.

Closes https://github.com/tikv/sig-transaction/issues/46 , I think.

### What is changed and how it works?

When (protected) rolling back a key, if the key is already locked by  another transaction, put the ts to the lock. When committing, check the rollback ts-es from the lock, and if there's a rollback ts equals to the current commit_ts, set `overlapped_rollback` flag of the write record that it will write.

By the way the logic of prewrite is a little bit changed.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

* No release note (part of async commit)