### PR TITLE
raftstore: add epoch checker to eliminate the proposals' failure due to epoch not match during applying

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1204,7 +1204,7 @@ where
         if let Some(epoch) = origin_epoch {
             let cmd_type = req.get_admin_request().get_cmd_type();
             let epoch_state = *ADMIN_CMD_EPOCH_MAP.get(&cmd_type).unwrap();
-            // The chenge-epoch behavior **MUST BE** equal to the data in `ADMIN_CMD_EPOCH_MAP`
+            // The chenge-epoch behavior **MUST BE** equal to the settings in `ADMIN_CMD_EPOCH_MAP`
             if (epoch_state.change_ver
                 && epoch.get_version() == self.region.get_region_epoch().get_version())
                 || (epoch_state.change_conf_ver

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2617,7 +2617,7 @@ where
             }
         } else if req.has_admin_request() {
             // The admin request is rejected because it may need to update epoch checker which
-            // introduces a uncertainty and may breaks the correctness of epoch checker.
+            // introduces an uncertainty and may breaks the correctness of epoch checker.
             return Err(box_err!(
                 "{} peer is not applied to current term, applied_term {}, current_term {}",
                 self.tag,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2030,9 +2030,9 @@ where
             Ok(RequestPolicy::ProposeTransferLeader) => {
                 return self.propose_transfer_leader(ctx, req, cb);
             }
-            Ok(RequestPolicy::ProposeConfChange) => self
-                .propose_conf_change(ctx, &req)
-                .map(|x| Either::Right(x)),
+            Ok(RequestPolicy::ProposeConfChange) => {
+                self.propose_conf_change(ctx, &req).map(|x| Either::Left(x))
+            }
             Err(e) => Err(e),
         };
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -303,7 +303,7 @@ impl<S: Snapshot> CmdEpochChecker<S> {
         }
     }
 
-    pub fn add_to_conflict_index(&mut self, index: u64, cb: Callback<S>) {
+    pub fn add_to_conflict_cmd(&mut self, index: u64, cb: Callback<S>) {
         for state in self.proposed_admin_cmd.iter_mut().rev() {
             if state.index == index {
                 state.cbs.push(cb);
@@ -2043,7 +2043,7 @@ where
                 false
             }
             Ok(Either::Right(idx)) => {
-                self.cmd_epoch_checker.add_to_conflict_index(idx, cb);
+                self.cmd_epoch_checker.add_to_conflict_cmd(idx, cb);
                 false
             }
             Ok(Either::Left(idx)) => {

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -172,7 +172,7 @@ impl AdminCmdEpochState {
 
 lazy_static! {
     /// WARNING: the existing settings in `ADMIN_CMD_EPOCH_MAP` **MUST NOT** be changed!!!
-    /// Changing any admin cmd's `AdminCmdEpochState` or the epoch-change behavior during executing
+    /// Changing any admin cmd's `AdminCmdEpochState` or the epoch-change behavior during applying
     /// will break upgrade compatibility and correctness dependency of `CmdEpochChecker`.
     /// Please remember it is very difficult to fix the issues arising from not following this rule.
     ///

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1287,6 +1287,7 @@ mod tests {
 
     #[test]
     fn test_admin_cmd_epoch_map_include_all_cmd_type() {
+        #[cfg(feature = "protobuf-codec")]
         use protobuf::ProtobufEnum;
         for cmd_type in AdminCmdType::values() {
             assert!(ADMIN_CMD_EPOCH_MAP.contains_key(cmd_type));

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -171,10 +171,10 @@ impl AdminCmdEpochState {
 }
 
 lazy_static! {
-    /// WARNING: the existing data in `ADMIN_CMD_EPOCH_MAP` **MUST NOT** be changed!!!
+    /// WARNING: the existing settings in `ADMIN_CMD_EPOCH_MAP` **MUST NOT** be changed!!!
     /// Changing any admin cmd's `AdminCmdEpochState` or the epoch-change behavior during executing
     /// will break upgrade compatibility and correctness dependency of `CmdEpochChecker`.
-    /// Please remember it is very difficult to fix the issues arising from not following the rule.
+    /// Please remember it is very difficult to fix the issues arising from not following this rule.
     ///
     /// If you really want to change an admin cmd behavior, please add a new admin cmd and **do not**
     /// delete the old one.

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1182,6 +1182,9 @@ impl<T: Simulator> Cluster<T> {
                         if error.has_epoch_not_match()
                             || error.has_not_leader()
                             || error.has_stale_command()
+                            || error
+                                .get_message()
+                                .contains("peer is not applied to current term")
                         {
                             warn!("fail to split: {:?}, ignore.", error);
                             return;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Add a cmd epoch checker that is used for checking each proposal's epoch before really proposing it. In other words, this PR moves the epoch check before applying to before proposing, which reduces the extra overhead.
If the normal proposal is rejected by the epoch checker, the epoch checker will save it and callback until the last admin command that conflicts with it has applied. The behavior is almost the same as the previous implementation. The only slight difference is that its callback is called in apply fsm and now it is called in peer fsm.

Also, this work is part of #7980.

### What is changed and how it works?

What's Changed:
Add a cmd epoch checker to eliminate the proposals' failure due to epoch not match during applying.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

No.

### Release note <!-- bugfixes or new feature need a release note -->
* No release note