### PR TITLE
statistics: support sample analyze index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4798,7 +4798,7 @@ dependencies = [
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#dcfcea0b59654004a89d5c25d6d22c113a13b848"
+source = "git+https://github.com/pingcap/tipb.git#57da1e63f73e7522afd92381d9b6219f8efc0a1d"
 dependencies = [
  "lazy_static",
  "prost",

--- a/components/tidb_query_vec_executors/src/runner.rs
+++ b/components/tidb_query_vec_executors/src/runner.rs
@@ -114,6 +114,7 @@ impl BatchExecutorsRunner<()> {
                     BatchTopNExecutor::check_supported(&descriptor)
                         .map_err(|e| other_err!("BatchTopNExecutor: {}", e))?;
                 }
+                ExecType::TypeJoin => unimplemented!("TypeJoin only supported in TiFlash"),
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tidb/issues/18551

Problem Summary:

we want to collect partition tables's stats as a single table.

but our index's histogram is collected rely on the order for index's data, and it's not true when we want to collect non-unique local index's stats( both partition p1 and p2 have chance to contains same value)

so we need use sample just as column histogram does to sample index then sort & build histogram in tidb server.

### What is changed and how it works?

What's Changed:

support SampleIndex

### Related changes

- TiDB PR: https://github.com/pingcap/tidb/pull/18717
- TiPB PR: https://github.com/pingcap/tipb/pull/192

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)

Side effects

- n/a
### Release note <!-- bugfixes or new feature need a release note -->

- no release note (target 5.0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tikv/tikv/8443)
<!-- Reviewable:end -->
