### PR TITLE
raftstore: fix lost request vote messages during split

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -1972,6 +1972,12 @@ where
         resp.mut_splits().set_regions(regions.clone().into());
         PEER_ADMIN_CMD_COUNTER.batch_split.success.inc();
 
+        fail_point!(
+            "apply_after_split_1_3",
+            self.id == 3 && self.region_id() == 1,
+            |_| { unreachable!() }
+        );
+
         Ok((
             resp,
             ApplyResult::Res(ExecResult::SplitRegion {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2179,7 +2179,7 @@ where
                         .router
                         .force_send(new_region_id, PeerMsg::RaftMessage(msg))
                     {
-                        warn!("handle first vote msg failed"; "region_id" => region_id, "error" => ?e);
+                        warn!("handle first requset vote failed"; "region_id" => region_id, "error" => ?e);
                     }
                 }
             }

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2174,10 +2174,13 @@ where
                     .pending_votes
                     .swap_remove_front(|m| m.get_to_peer() == &meta_peer)
                 {
-                    let _ = self
+                    if let Err(e) = self
                         .ctx
                         .router
-                        .send(new_region_id, PeerMsg::RaftMessage(msg));
+                        .force_send(new_region_id, PeerMsg::RaftMessage(msg))
+                    {
+                        warn!("handle first vote msg failed"; "region_id" => region_id, "error" => ?e);
+                    }
                 }
             }
         }

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -38,7 +38,8 @@ fn test_follower_slow_split() {
             .msg_type(MessageType::MsgRequestPreVote)
             .direction(Direction::Send)
             .allow(1),
-        tx: Mutex::new(range_tx),
+        before: Some(Mutex::new(range_tx)),
+        after: None,
     };
     cluster
         .sim
@@ -63,6 +64,94 @@ fn test_follower_slow_split() {
 
     // After the follower split success, it will response to the pending vote.
     fail::cfg("apply_before_split_1_3", "off").unwrap();
+    assert!(rx.recv_timeout(Duration::from_millis(100)).is_ok());
+}
+
+#[test]
+fn test_split_lost_request_vote() {
+    let mut cluster = new_node_cluster(0, 3);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+    cluster.run();
+    let region = cluster.get_region(b"");
+
+    // Only need peer 1 and 3. Stop node 2 to avoid extra vote messages.
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    pd_client.must_remove_peer(1, new_peer(2, 2));
+    cluster.stop_node(2);
+
+    // Use a channel to retrieve start_key and end_key in pre-vote messages.
+    let (range_tx, range_rx) = mpsc::channel();
+    let (after_sent_tx, after_sent_rx) = mpsc::channel();
+    let prevote_filter = PrevoteRangeFilter {
+        // Only send 1 pre-vote message to peer 3 so if peer 3 drops it,
+        // it needs to start a new election.
+        filter: RegionPacketFilter::new(1000, 1) // new region id is 1000
+            .msg_type(MessageType::MsgRequestPreVote)
+            .direction(Direction::Send)
+            .allow(1),
+        before: Some(Mutex::new(range_tx)),
+        after: Some(Mutex::new(after_sent_tx)),
+    };
+    cluster
+        .sim
+        .wl()
+        .add_send_filter(1, Box::new(prevote_filter));
+
+    // Ensure pre-vote response is really sent.
+    let (tx, rx) = mpsc::channel();
+    let prevote_resp_notifier = Box::new(MessageTypeNotifier::new(
+        MessageType::MsgRequestPreVoteResponse,
+        tx,
+        Arc::from(AtomicBool::new(true)),
+    ));
+    cluster.sim.wl().add_send_filter(3, prevote_resp_notifier);
+
+    // After split, pre-vote message should be sent to peer 3.
+    fail::cfg("apply_after_split_1_3", "pause").unwrap();
+    cluster.must_split(&region, b"k2");
+    let range = range_rx.recv_timeout(Duration::from_millis(100)).unwrap();
+    assert_eq!(range.0, b"");
+    assert_eq!(range.1, b"k2");
+
+    // Make sure the message has sent to peer 3.
+    let _sent = after_sent_rx
+        .recv_timeout(Duration::from_millis(100))
+        .unwrap();
+
+    // Make sure pre-vote is handled.
+    let new_region = cluster.pd_client.get_region(b"").unwrap();
+    let pending_create_peer = new_region
+        .get_peers()
+        .iter()
+        .find(|p| p.get_store_id() == 3)
+        .unwrap()
+        .to_owned();
+    let _ = read_on_peer(
+        &mut cluster,
+        pending_create_peer,
+        region,
+        b"k1",
+        false,
+        Duration::from_millis(100),
+    );
+
+    // Make sure pre-vote is cached in pending votes.
+    {
+        let store_meta = cluster.store_metas.get(&3).unwrap();
+        let meta = store_meta.lock().unwrap();
+        assert!(meta
+            .pending_votes
+            .iter()
+            .find(|m| {
+                m.region_id == new_region.id
+                    && raftstore::store::util::is_first_vote_msg(m.get_message())
+            })
+            .is_some());
+    }
+
+    // After the follower split success, it will response to the pending vote.
+    fail::cfg("apply_after_split_1_3", "off").unwrap();
     assert!(rx.recv_timeout(Duration::from_millis(100)).is_ok());
 }
 
@@ -130,7 +219,8 @@ fn test_pause_split_when_snap_gen_never_split() {
 // Filter prevote message and record the range.
 struct PrevoteRangeFilter {
     filter: RegionPacketFilter,
-    tx: Mutex<mpsc::Sender<(Vec<u8>, Vec<u8>)>>,
+    before: Option<Mutex<mpsc::Sender<(Vec<u8>, Vec<u8>)>>>,
+    after: Option<Mutex<mpsc::Sender<()>>>,
 }
 
 impl Filter for PrevoteRangeFilter {
@@ -139,8 +229,17 @@ impl Filter for PrevoteRangeFilter {
         if let Some(msg) = msgs.iter().filter(|m| is_vote_msg(m.get_message())).last() {
             let start_key = msg.get_start_key().to_owned();
             let end_key = msg.get_end_key().to_owned();
-            let tx = self.tx.lock().unwrap();
-            let _ = tx.send((start_key, end_key));
+            if let Some(before) = self.before.as_ref() {
+                let tx = before.lock().unwrap();
+                let _ = tx.send((start_key, end_key));
+            }
+        }
+        Ok(())
+    }
+    fn after(&self, _: Result<()>) -> Result<()> {
+        if let Some(after) = self.after.as_ref() {
+            let tx = after.lock().unwrap();
+            let _ = tx.send(());
         }
         Ok(())
     }


### PR DESCRIPTION
### What problem does this PR solve?

Fix #8456, request vote messages are lost during split.

This PR improve TiDB 99.999% Txn duration from 15s to 1s.

![image](https://user-images.githubusercontent.com/2150711/90218989-b174a280-de37-11ea-89b2-07ccdf770ead.png)

![image](https://user-images.githubusercontent.com/2150711/90219132-f7ca0180-de37-11ea-8cd4-fa850a85d188.png)

### What is changed and how it works?

Cache vote message into pending votes, so that new peer can response ASAP.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

* Fix lost request vote messages during split.