### PR TITLE
raftstore: destroy process must be asynchronous if peer is initialized

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3864,7 +3864,7 @@ mod tests {
             );
         });
 
-        router.schedule_task(2, Msg::destroy(2, true, false));
+        router.schedule_task(2, Msg::destroy(2, false));
         let (region_id, peer_id) = match rx.recv_timeout(Duration::from_secs(3)) {
             Ok(PeerMsg::ApplyRes { res, .. }) => match res {
                 TaskRes::Destroy {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -66,7 +66,6 @@ const REGION_SPLIT_SKIP_MAX_COUNT: usize = 3;
 
 pub struct DestroyPeerJob {
     pub initialized: bool,
-    pub async_remove: bool,
     pub region_id: u64,
     pub peer: metapb::Peer,
 }
@@ -1733,24 +1732,15 @@ where
     }
 
     fn handle_destroy_peer(&mut self, job: DestroyPeerJob) -> bool {
+        // The initialized flag implicitly means whether apply fsm exists or not.
         if job.initialized {
-            // When initialized is true and async_remove is false, apply fsm doesn't need to
-            // send destroy msg to peer fsm because peer fsm has already destroyed.
-            // In this case, if apply fsm sends destroy msg, peer fsm may be destroyed twice
-            // because there are some msgs in channel so peer fsm still need to handle them (e.g. callback)
-            self.ctx.apply_router.schedule_task(
-                job.region_id,
-                ApplyTask::destroy(job.region_id, job.async_remove, false),
-            );
-        }
-        if job.async_remove {
-            info!(
-                "peer is destroyed asynchronously";
-                "region_id" => job.region_id,
-                "peer_id" => job.peer.get_id(),
-            );
+            // Destroy the apply fsm first, wait for the reply msg from apply fsm
+            self.ctx
+                .apply_router
+                .schedule_task(job.region_id, ApplyTask::destroy(job.region_id, false));
             false
         } else {
+            // Destroy the peer fsm directly
             self.destroy_peer(false);
             true
         }
@@ -2724,7 +2714,7 @@ where
                 // Destroy apply fsm at first
                 self.ctx.apply_router.schedule_task(
                     self.fsm.region_id(),
-                    ApplyTask::destroy(self.fsm.region_id(), true, true),
+                    ApplyTask::destroy(self.fsm.region_id(), true),
                 );
             }
             MergeResultKind::FromTargetSnapshotStep2 => {

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -532,13 +532,8 @@ where
                 return None;
             }
         }
-        // If initialized is false, it implicitly means apply fsm does not exist now.
-        let initialized = self.get_store().is_initialized();
-        // If async_remove is true, it means peer fsm needs to be removed after its
-        // corresponding apply fsm was removed.
-        // If it is false, it means either apply fsm does not exist or there is no task
-        // in apply fsm so it's ok to remove peer fsm immediately.
-        let async_remove = if self.is_applying_snapshot() {
+
+        if self.is_applying_snapshot() {
             if !self.mut_store().cancel_applying_snap() {
                 info!(
                     "stale peer is applying snapshot, will destroy next time";
@@ -547,16 +542,12 @@ where
                 );
                 return None;
             }
-            // There is no tasks in apply/local read worker.
-            false
-        } else {
-            initialized
-        };
+        }
+
         self.pending_remove = true;
 
         Some(DestroyPeerJob {
-            async_remove,
-            initialized,
+            initialized: self.get_store().is_initialized(),
             region_id: self.region_id,
             peer: self.peer.clone(),
         })

--- a/tests/failpoints/cases/test_snap.rs
+++ b/tests/failpoints/cases/test_snap.rs
@@ -278,11 +278,11 @@ fn test_node_request_snapshot_on_split() {
 // A peer on store 3 is isolated and is applying snapshot. (add failpoint so it's always pending)
 // Then two conf change happens, this peer is removed and a new peer is added on store 3.
 // Then isolation clear, this peer will be destroyed because of a bigger peer id in msg.
-// Peerfsm can be destroyed synchronously because snapshot state is pending and can be canceled.
-// I.e. async_remove is false.
+// In previous implementation, peer fsm can be destroyed synchronously because snapshot state is
+// pending and can be canceled, but panic may happen if the applyfsm runs very slow.
 #[test]
 fn test_destroy_peer_on_pending_snapshot() {
-    let mut cluster = new_server_cluster(0, 4);
+    let mut cluster = new_server_cluster(0, 3);
     configure_for_snapshot(&mut cluster);
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
@@ -311,24 +311,28 @@ fn test_destroy_peer_on_pending_snapshot() {
     sleep_ms(100);
 
     cluster.add_send_filter(IsolationFilterFactory::new(3));
+    // Don't send check stale msg to PD
+    let peer_check_stale_state_fp = "peer_check_stale_state";
+    fail::cfg(peer_check_stale_state_fp, "return()").unwrap();
 
     pd_client.must_remove_peer(r1, new_peer(3, 3));
-    pd_client.must_add_peer(r1, new_peer(4, 4));
+    pd_client.must_add_peer(r1, new_peer(3, 4));
 
-    pd_client.must_remove_peer(r1, new_peer(4, 4));
-    pd_client.must_add_peer(r1, new_peer(3, 5));
+    let before_handle_normal_3_fp = "before_handle_normal_3";
+    fail::cfg(before_handle_normal_3_fp, "pause").unwrap();
 
-    let destroy_peer_fp = "destroy_peer";
-    fail::cfg(destroy_peer_fp, "pause").unwrap();
     cluster.clear_send_filters();
     // Wait for leader send msg to peer 3.
-    // Then destroy peer 3 and create peer 5.
+    // Then destroy peer 3 and create peer 4.
     sleep_ms(100);
-    fail::remove(destroy_peer_fp);
 
     fail::remove(apply_snapshot_fp);
-    // After peer 5 has applied snapshot, data should be got.
-    must_get_equal(&cluster.get_engine(3), b"k119", b"v1");
+
+    fail::remove(before_handle_normal_3_fp);
+
+    cluster.must_put(b"k120", b"v1");
+    // After peer 4 has applied snapshot, data should be got.
+    must_get_equal(&cluster.get_engine(3), b"k120", b"v1");
 }
 
 #[test]


### PR DESCRIPTION
Signed-off-by: Liqi Geng <gengliqiii@gmail.com>


### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/8433

Problem Summary:

Destroy process must be asynchronous if peer is initialized.
The details is in https://github.com/tikv/tikv/issues/8433.

### What is changed and how it works?

What's Changed:
described above

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

No

### Release note <!-- bugfixes or new feature need a release note -->
* Fix a panic issue if a TiKV runs very slow during conf change.