### PR TITLE
copr: disable fast-path on logical_rows

### DIFF
--- a/components/tidb_query_vec_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_vec_expr/src/types/expr_eval.rs
@@ -86,7 +86,9 @@ impl<'a> RpnStackNodeVectorValue<'a> {
     /// Gets a reference to the logical rows.
     pub fn logical_rows_struct(&self) -> LogicalRows {
         match self {
-            RpnStackNodeVectorValue::Generated { physical_value } => LogicalRows::Ref { logical_rows: &IDENTICAL_LOGICAL_ROWS[0..physical_value.len()] },
+            RpnStackNodeVectorValue::Generated { physical_value } => LogicalRows::Ref {
+                logical_rows: &IDENTICAL_LOGICAL_ROWS[0..physical_value.len()],
+            },
 
             RpnStackNodeVectorValue::Ref { logical_rows, .. } => LogicalRows::Ref { logical_rows },
         }

--- a/components/tidb_query_vec_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_vec_expr/src/types/expr_eval.rs
@@ -86,9 +86,7 @@ impl<'a> RpnStackNodeVectorValue<'a> {
     /// Gets a reference to the logical rows.
     pub fn logical_rows_struct(&self) -> LogicalRows {
         match self {
-            RpnStackNodeVectorValue::Generated { physical_value } => LogicalRows::Identical {
-                size: physical_value.len(),
-            },
+            RpnStackNodeVectorValue::Generated { physical_value } => LogicalRows::Ref { logical_rows: &IDENTICAL_LOGICAL_ROWS[0..physical_value.len()] },
 
             RpnStackNodeVectorValue::Ref { logical_rows, .. } => LogicalRows::Ref { logical_rows },
         }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #8481 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

Now all `LogicalRows` in TiKV won't be `Identical`. They are all treated as slice.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note
* No release note