### PR TITLE
doc: Fix a few stale links in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TiKV is hosted by the [Cloud Native Computing Foundation](https://cncf.io/) (CNC
 
 ---
 
-With the implementation of the Raft consensus algorithm in Rust and consensus state stored in RocksDB, TiKV guarantees data consistency. [Placement Driver (PD)](https://github.com/pingcap/pd/), which is introduced to implement auto-sharding, enables automatic data migration. The transaction model is similar to Google's Percolator with some performance improvements. TiKV also provides snapshot isolation (SI), snapshot isolation with lock (SQL: `SELECT ... FOR UPDATE`), and externally consistent reads and writes in distributed transactions.
+With the implementation of the Raft consensus algorithm in Rust and consensus state stored in RocksDB, TiKV guarantees data consistency. [Placement Driver (PD)](https://github.com/tikv/pd/), which is introduced to implement auto-sharding, enables automatic data migration. The transaction model is similar to Google's Percolator with some performance improvements. TiKV also provides snapshot isolation (SI), snapshot isolation with lock (SQL: `SELECT ... FOR UPDATE`), and externally consistent reads and writes in distributed transactions.
 
 TiKV has the following key features:
 
@@ -62,7 +62,7 @@ When a node starts, the metadata of the Node, Store and Region are recorded into
 
 TiKV was originally a component of [TiDB](https://github.com/pingcap/tidb). To run TiKV you must build and run it with PD, which is used to manage a TiKV cluster. You can use TiKV together with TiDB or separately on its own.
 
-We provide multiple deployment methods, but it is recommended to use our Ansible deployment for production environment. The TiKV documentation is available on [TiKV's wiki page](https://github.com/tikv/tikv/wiki/TiKV-Documentation).
+We provide multiple deployment methods, but it is recommended to use our Ansible deployment for production environment. The TiKV documentation is available on our official website [TiKV's wiki page](https://tikv.org/docs/4.0/concepts/overview/).
 
 ### Testing deployment
 
@@ -178,7 +178,7 @@ To get other components ([TiDB](https://github.com/pingcap/tidb) and [PD](https:
 
 ### Configuration
 
-Read our configuration guide to learn about various [configuration options](https://github.com/pingcap/docs/blob/master/op-guide/configuration.md).
+Read our configuration guide to learn about various [configuration options](https://github.com/pingcap/docs/blob/master/tikv-configuration-file.md).
 
 ## Contributing
 
@@ -236,4 +236,4 @@ TiKV is under the Apache 2.0 license. See the [LICENSE](./LICENSE) file for deta
 
 - Thanks [etcd](https://github.com/coreos/etcd) for providing some great open source tools.
 - Thanks [RocksDB](https://github.com/facebook/rocksdb) for their powerful storage engines.
-- Thanks [rust-clippy](https://github.com/Manishearth/rust-clippy). We do love the great project.
+- Thanks [rust-clippy](https://github.com/rust-lang/rust-clippy). We do love the great project.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

I found that the [configuration options](https://github.com/pingcap/docs/blob/master/op-guide/configuration.md) url is 404 now.

And a few other links can be updated (`pingcap/pd` -> `tikv/pd`, etc).

### What is changed and how it works?

What's Changed: Change the urls to the right ones

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

