### PR TITLE
Replace more uses of RocksEngine with generics in raftstore

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crossbeam::atomic::AtomicCell;
-use engine_rocks::{RocksEngine, RocksSnapshot};
+use engine_rocks::{RocksEngine};
 use futures::future::Future;
 use futures03::compat::Compat;
 use kvproto::cdcpb::*;
@@ -671,7 +671,7 @@ struct Initializer {
 }
 
 impl Initializer {
-    fn on_change_cmd(&self, mut resp: ReadResponse<RocksSnapshot>) {
+    fn on_change_cmd(&self, mut resp: ReadResponse<RocksEngine>) {
         if let Some(region_snapshot) = resp.snapshot {
             assert_eq!(self.region_id, region_snapshot.get_region().get_id());
             let region = region_snapshot.get_region().clone();

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crossbeam::atomic::AtomicCell;
-use engine_rocks::{RocksEngine};
+use engine_rocks::RocksEngine;
 use futures::future::Future;
 use futures03::compat::Compat;
 use kvproto::cdcpb::*;

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -124,7 +124,7 @@ impl<E: KvEngine> CmdObserver<E> for CdcObserver {
             region.mut_peers().push(Peer::default());
             // Create a snapshot here for preventing the old value was GC-ed.
             let snapshot =
-                RegionSnapshot::from_snapshot(Arc::new(engine.snapshot()), Arc::new(region));
+                RegionSnapshot::<E>::from_snapshot(Arc::new(engine.snapshot()), Arc::new(region));
             let mut reader = OldValueReader::new(snapshot);
             let get_old_value = move |key| {
                 if let Some((old_value, mutation_type)) = txn_extra.mut_old_values().remove(&key) {

--- a/components/raftstore/src/router.rs
+++ b/components/raftstore/src/router.rs
@@ -50,11 +50,7 @@ where
     fn release_snapshot_cache(&self) {}
 
     /// Sends a significant message. We should guarantee that the message can't be dropped.
-    fn significant_send(
-        &self,
-        region_id: u64,
-        msg: SignificantMsg<EK>,
-    ) -> RaftStoreResult<()>;
+    fn significant_send(&self, region_id: u64, msg: SignificantMsg<EK>) -> RaftStoreResult<()>;
 
     /// Reports the peer being unreachable to the Region.
     fn report_unreachable(&self, region_id: u64, to_peer_id: u64) -> RaftStoreResult<()> {
@@ -226,11 +222,7 @@ where
             .map_err(|e| handle_send_error(region_id, e))
     }
 
-    fn significant_send(
-        &self,
-        region_id: u64,
-        msg: SignificantMsg<EK>,
-    ) -> RaftStoreResult<()> {
+    fn significant_send(&self, region_id: u64, msg: SignificantMsg<EK>) -> RaftStoreResult<()> {
         if let Err(SendError(msg)) = self
             .router
             .force_send(region_id, PeerMsg::SignificantMsg(msg))

--- a/components/raftstore/src/router.rs
+++ b/components/raftstore/src/router.rs
@@ -53,7 +53,7 @@ where
     fn significant_send(
         &self,
         region_id: u64,
-        msg: SignificantMsg<EK::Snapshot>,
+        msg: SignificantMsg<EK>,
     ) -> RaftStoreResult<()>;
 
     /// Reports the peer being unreachable to the Region.
@@ -112,7 +112,7 @@ where
     }
 
     /// Sends a significant message. We should guarantee that the message can't be dropped.
-    fn significant_send(&self, _: u64, _: SignificantMsg<EK::Snapshot>) -> RaftStoreResult<()> {
+    fn significant_send(&self, _: u64, _: SignificantMsg<EK>) -> RaftStoreResult<()> {
         Ok(())
     }
 
@@ -229,7 +229,7 @@ where
     fn significant_send(
         &self,
         region_id: u64,
-        msg: SignificantMsg<EK::Snapshot>,
+        msg: SignificantMsg<EK>,
     ) -> RaftStoreResult<()> {
         if let Err(SendError(msg)) = self
             .router

--- a/components/raftstore/src/router.rs
+++ b/components/raftstore/src/router.rs
@@ -25,7 +25,7 @@ where
     fn send_raft_msg(&self, msg: RaftMessage) -> RaftStoreResult<()>;
 
     /// Sends RaftCmdRequest to local store.
-    fn send_command(&self, req: RaftCmdRequest, cb: Callback<EK::Snapshot>) -> RaftStoreResult<()> {
+    fn send_command(&self, req: RaftCmdRequest, cb: Callback<EK>) -> RaftStoreResult<()> {
         self.send_command_txn_extra(req, TxnExtra::default(), cb)
     }
 
@@ -34,7 +34,7 @@ where
         &self,
         req: RaftCmdRequest,
         txn_extra: TxnExtra,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
     ) -> RaftStoreResult<()>;
 
     /// Sends Snapshot to local store.
@@ -42,7 +42,7 @@ where
         &self,
         _read_id: Option<ThreadReadId>,
         req: RaftCmdRequest,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
     ) -> RaftStoreResult<()> {
         self.send_command(req, cb)
     }
@@ -106,7 +106,7 @@ where
         &self,
         _: RaftCmdRequest,
         _: TxnExtra,
-        _: Callback<EK::Snapshot>,
+        _: Callback<EK>,
     ) -> RaftStoreResult<()> {
         Ok(())
     }
@@ -189,7 +189,7 @@ where
             .map_err(|e| handle_send_error(region_id, e))
     }
 
-    fn send_command(&self, req: RaftCmdRequest, cb: Callback<EK::Snapshot>) -> RaftStoreResult<()> {
+    fn send_command(&self, req: RaftCmdRequest, cb: Callback<EK>) -> RaftStoreResult<()> {
         let cmd = RaftCommand::new(req, cb);
         let region_id = cmd.request.get_header().get_region_id();
         self.router
@@ -201,7 +201,7 @@ where
         &self,
         read_id: Option<ThreadReadId>,
         req: RaftCmdRequest,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
     ) -> RaftStoreResult<()> {
         let mut local_reader = self.local_reader.borrow_mut();
         local_reader.read(read_id, req, cb);
@@ -217,7 +217,7 @@ where
         &self,
         req: RaftCmdRequest,
         txn_extra: TxnExtra,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
     ) -> RaftStoreResult<()> {
         let cmd = RaftCommand::with_txn_extra(req, cb, txn_extra);
         let region_id = cmd.request.get_header().get_region_id();

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -4555,7 +4555,7 @@ mod tests {
                     region_id: 1,
                     enabled: enabled.clone(),
                 },
-                cb: Callback::Read(Box::new(|resp: ReadResponse<RocksSnapshot>| {
+                cb: Callback::Read(Box::new(|resp: ReadResponse<RocksEngine>| {
                     assert!(!resp.response.get_header().has_error());
                     assert!(resp.snapshot.is_some());
                     let snap = resp.snapshot.unwrap();

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2441,7 +2441,10 @@ where
     entries_count: i64,
 }
 
-impl<EK> Apply<EK> where EK: KvEngine {
+impl<EK> Apply<EK>
+where
+    EK: KvEngine,
+{
     pub(crate) fn new(
         peer_id: u64,
         region_id: u64,
@@ -2472,7 +2475,10 @@ impl<EK> Apply<EK> where EK: KvEngine {
     }
 }
 
-impl<EK> Drop for Apply<EK> where EK: KvEngine {
+impl<EK> Drop for Apply<EK>
+where
+    EK: KvEngine,
+{
     fn drop(&mut self) {
         APPLY_PENDING_BYTES_GAUGE.sub(self.entries_mem_size);
         APPLY_PENDING_ENTRIES_GAUGE.sub(self.entries_count);
@@ -3451,8 +3457,7 @@ where
                         "region_id" => region_id
                     );
                     for p in apply.cbs.drain(..) {
-                        let cmd =
-                            PendingCmd::<EK>::new(p.index, p.term, p.cb, p.txn_extra);
+                        let cmd = PendingCmd::<EK>::new(p.index, p.term, p.cb, p.txn_extra);
                         notify_region_removed(apply.region_id, apply.peer_id, cmd);
                     }
                     return;
@@ -3942,7 +3947,10 @@ mod tests {
         system.shutdown();
     }
 
-    fn cb<EK>(idx: u64, term: u64, tx: Sender<RaftCmdResponse>) -> Proposal<EK> where EK: KvEngine {
+    fn cb<EK>(idx: u64, term: u64, tx: Sender<RaftCmdResponse>) -> Proposal<EK>
+    where
+        EK: KvEngine,
+    {
         proposal(
             false,
             idx,

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -698,12 +698,7 @@ where
         self.register_split_region_check_tick();
     }
 
-    fn on_capture_change(
-        &mut self,
-        cmd: ChangeCmd,
-        region_epoch: RegionEpoch,
-        cb: Callback<EK>,
-    ) {
+    fn on_capture_change(&mut self, cmd: ChangeCmd, region_epoch: RegionEpoch, cb: Callback<EK>) {
         fail_point!("raft_on_capture_change");
         let region_id = self.region_id();
         let msg =

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -313,7 +313,7 @@ where
         true
     }
 
-    fn add(&mut self, cmd: RaftCommand<E::Snapshot>, req_size: u32) {
+    fn add(&mut self, cmd: RaftCommand<E>, req_size: u32) {
         let req_num = cmd.request.get_requests().len();
         let RaftCommand {
             mut request,
@@ -348,7 +348,7 @@ where
         false
     }
 
-    fn build(&mut self, metric: &mut RaftProposeMetrics) -> Option<RaftCommand<E::Snapshot>> {
+    fn build(&mut self, metric: &mut RaftProposeMetrics) -> Option<RaftCommand<E>> {
         if let Some(req) = self.request.take() {
             self.batch_req_size = 0;
             if self.callbacks.len() == 1 {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -122,7 +122,7 @@ where
     raft_entry_max_size: f64,
     batch_req_size: u32,
     request: Option<RaftCmdRequest>,
-    callbacks: Vec<(Callback<E::Snapshot>, usize)>,
+    callbacks: Vec<(Callback<E>, usize)>,
     txn_extra: TxnExtra,
 }
 
@@ -702,7 +702,7 @@ where
         &mut self,
         cmd: ChangeCmd,
         region_epoch: RegionEpoch,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
     ) {
         fail_point!("raft_on_capture_change");
         let region_id = self.region_id();
@@ -818,7 +818,7 @@ where
         self.fsm.peer.raft_group.report_snapshot(to_peer_id, status)
     }
 
-    fn on_leader_callback(&mut self, cb: Callback<EK::Snapshot>) {
+    fn on_leader_callback(&mut self, cb: Callback<EK>) {
         let msg = new_read_index_request(
             self.region_id(),
             self.region().get_region_epoch().clone(),
@@ -3068,7 +3068,7 @@ where
     fn propose_raft_command(
         &mut self,
         mut msg: RaftCmdRequest,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
         txn_extra: TxnExtra,
     ) {
         match self.pre_propose_raft_command(&msg) {
@@ -3329,7 +3329,7 @@ where
         &mut self,
         region_epoch: metapb::RegionEpoch,
         split_keys: Vec<Vec<u8>>,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
     ) {
         if let Err(e) = self.validate_split_region(&region_epoch, &split_keys) {
             cb.invoke_with_response(new_error(e));

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -730,7 +730,7 @@ where
         );
     }
 
-    fn on_significant_msg(&mut self, msg: SignificantMsg<EK::Snapshot>) {
+    fn on_significant_msg(&mut self, msg: SignificantMsg<EK>) {
         match msg {
             SignificantMsg::SnapshotStatus {
                 to_peer_id, status, ..

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -7,9 +7,8 @@ use std::time::{Duration, Instant};
 use std::{cmp, u64};
 
 use batch_system::{BasicMailbox, Fsm};
-use engine_rocks::RocksEngine;
 use engine_traits::CF_RAFT;
-use engine_traits::{Engines, KvEngine, Snapshot, WriteBatchExt};
+use engine_traits::{Engines, KvEngine, WriteBatchExt};
 use error_code::ErrorCodeExt;
 use futures::Future;
 use kvproto::errorpb;
@@ -113,17 +112,17 @@ where
     skip_split_count: usize,
 
     // Batch raft command which has the same header into an entry
-    batch_req_builder: BatchRaftCmdRequestBuilder<EK::Snapshot>,
+    batch_req_builder: BatchRaftCmdRequestBuilder<EK>,
 }
 
-pub struct BatchRaftCmdRequestBuilder<S>
+pub struct BatchRaftCmdRequestBuilder<E>
 where
-    S: Snapshot,
+    E: KvEngine,
 {
     raft_entry_max_size: f64,
     batch_req_size: u32,
     request: Option<RaftCmdRequest>,
-    callbacks: Vec<(Callback<S>, usize)>,
+    callbacks: Vec<(Callback<E::Snapshot>, usize)>,
     txn_extra: TxnExtra,
 }
 
@@ -276,11 +275,11 @@ where
     }
 }
 
-impl<S> BatchRaftCmdRequestBuilder<S>
+impl<E> BatchRaftCmdRequestBuilder<E>
 where
-    S: Snapshot,
+    E: KvEngine,
 {
-    fn new(raft_entry_max_size: f64) -> BatchRaftCmdRequestBuilder<S> {
+    fn new(raft_entry_max_size: f64) -> BatchRaftCmdRequestBuilder<E> {
         BatchRaftCmdRequestBuilder {
             raft_entry_max_size,
             request: None,
@@ -314,7 +313,7 @@ where
         true
     }
 
-    fn add(&mut self, cmd: RaftCommand<S>, req_size: u32) {
+    fn add(&mut self, cmd: RaftCommand<E::Snapshot>, req_size: u32) {
         let req_num = cmd.request.get_requests().len();
         let RaftCommand {
             mut request,
@@ -342,14 +341,14 @@ where
             if f64::from(self.batch_req_size) > self.raft_entry_max_size * 0.4 {
                 return true;
             }
-            if batch_req.get_requests().len() > RocksEngine::WRITE_BATCH_MAX_KEYS {
+            if batch_req.get_requests().len() > <E as WriteBatchExt>::WRITE_BATCH_MAX_KEYS {
                 return true;
             }
         }
         false
     }
 
-    fn build(&mut self, metric: &mut RaftProposeMetrics) -> Option<RaftCommand<S>> {
+    fn build(&mut self, metric: &mut RaftProposeMetrics) -> Option<RaftCommand<E::Snapshot>> {
         if let Some(req) = self.request.take() {
             self.batch_req_size = 0;
             if self.callbacks.len() == 1 {
@@ -3890,7 +3889,7 @@ mod tests {
     use crate::store::local_metrics::RaftProposeMetrics;
     use crate::store::msg::{Callback, RaftCommand};
 
-    use engine_rocks::RocksSnapshot;
+    use engine_rocks::RocksEngine;
     use kvproto::raft_cmdpb::{
         AdminRequest, CmdType, PutRequest, RaftCmdRequest, RaftCmdResponse, Request, Response,
         StatusRequest,
@@ -3902,7 +3901,7 @@ mod tests {
     #[test]
     fn test_batch_raft_cmd_request_builder() {
         let max_batch_size = 1000.0;
-        let mut builder = BatchRaftCmdRequestBuilder::<RocksSnapshot>::new(max_batch_size);
+        let mut builder = BatchRaftCmdRequestBuilder::<RocksEngine>::new(max_batch_size);
         let mut q = Request::default();
         let mut metric = RaftProposeMetrics::default();
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -215,8 +215,8 @@ where
     #[inline]
     pub fn send_raft_command(
         &self,
-        cmd: RaftCommand<EK::Snapshot>,
-    ) -> std::result::Result<(), TrySendError<RaftCommand<EK::Snapshot>>> {
+        cmd: RaftCommand<EK>,
+    ) -> std::result::Result<(), TrySendError<RaftCommand<EK>>> {
         let region_id = cmd.request.get_header().get_region_id();
         match self.send(region_id, PeerMsg::RaftCommand(cmd)) {
             Ok(()) => Ok(()),

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::time::Instant;
 
-use engine_traits::{KvEngine};
+use engine_traits::KvEngine;
 use kvproto::import_sstpb::SstMeta;
 use kvproto::kvrpcpb::ExtraOp as TxnExtraOp;
 use kvproto::metapb;
@@ -26,7 +26,10 @@ use tikv_util::escape;
 use super::{AbstractPeer, RegionSnapshot};
 
 #[derive(Debug)]
-pub struct ReadResponse<EK> where EK: KvEngine {
+pub struct ReadResponse<EK>
+where
+    EK: KvEngine,
+{
     pub response: RaftCmdResponse,
     pub snapshot: Option<RegionSnapshot<EK>>,
     pub txn_extra_op: TxnExtraOp,
@@ -42,7 +45,7 @@ pub struct WriteResponse {
 // be.
 impl<EK> Clone for ReadResponse<EK>
 where
-    EK: KvEngine
+    EK: KvEngine,
 {
     fn clone(&self) -> ReadResponse<EK> {
         ReadResponse {
@@ -61,7 +64,10 @@ pub type WriteCallback = Box<dyn FnOnce(WriteResponse) + Send>;
 ///         `GetRequest` and `SnapRequest`
 ///  - `Write`: a callback for write only requests including `AdminRequest`
 ///          `PutRequest`, `DeleteRequest` and `DeleteRangeRequest`.
-pub enum Callback<EK> where EK: KvEngine {
+pub enum Callback<EK>
+where
+    EK: KvEngine,
+{
     /// No callback.
     None,
     /// Read callback.
@@ -321,14 +327,20 @@ impl<EK: KvEngine> fmt::Debug for CasualMessage<EK> {
 /// Raft command is the command that is expected to be proposed by the
 /// leader of the target raft group.
 #[derive(Debug)]
-pub struct RaftCommand<EK> where EK: KvEngine {
+pub struct RaftCommand<EK>
+where
+    EK: KvEngine,
+{
     pub send_time: Instant,
     pub request: RaftCmdRequest,
     pub callback: Callback<EK>,
     pub txn_extra: TxnExtra,
 }
 
-impl<EK> RaftCommand<EK> where EK: KvEngine {
+impl<EK> RaftCommand<EK>
+where
+    EK: KvEngine,
+{
     #[inline]
     pub fn with_txn_extra(
         request: RaftCmdRequest,

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -321,20 +321,20 @@ impl<EK: KvEngine> fmt::Debug for CasualMessage<EK> {
 /// Raft command is the command that is expected to be proposed by the
 /// leader of the target raft group.
 #[derive(Debug)]
-pub struct RaftCommand<S: Snapshot> {
+pub struct RaftCommand<EK> where EK: KvEngine {
     pub send_time: Instant,
     pub request: RaftCmdRequest,
-    pub callback: Callback<S>,
+    pub callback: Callback<EK::Snapshot>,
     pub txn_extra: TxnExtra,
 }
 
-impl<S: Snapshot> RaftCommand<S> {
+impl<EK> RaftCommand<EK> where EK: KvEngine {
     #[inline]
     pub fn with_txn_extra(
         request: RaftCmdRequest,
-        callback: Callback<S>,
+        callback: Callback<EK::Snapshot>,
         txn_extra: TxnExtra,
-    ) -> RaftCommand<S> {
+    ) -> RaftCommand<EK> {
         RaftCommand {
             request,
             callback,
@@ -343,7 +343,7 @@ impl<S: Snapshot> RaftCommand<S> {
         }
     }
 
-    pub fn new(request: RaftCmdRequest, callback: Callback<S>) -> RaftCommand<S> {
+    pub fn new(request: RaftCmdRequest, callback: Callback<EK::Snapshot>) -> RaftCommand<EK> {
         Self::with_txn_extra(request, callback, TxnExtra::default())
     }
 }
@@ -357,7 +357,7 @@ pub enum PeerMsg<EK: KvEngine> {
     /// Raft command is the command that is expected to be proposed by the
     /// leader of the target raft group. If it's failed to be sent, callback
     /// usually needs to be called before dropping in case of resource leak.
-    RaftCommand(RaftCommand<EK::Snapshot>),
+    RaftCommand(RaftCommand<EK>),
     /// Tick is periodical task. If target peer doesn't exist there is a potential
     /// that the raft node will not work anymore.
     Tick(PeerTicks),

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -28,7 +28,7 @@ use super::{AbstractPeer, RegionSnapshot};
 #[derive(Debug)]
 pub struct ReadResponse<EK> where EK: KvEngine {
     pub response: RaftCmdResponse,
-    pub snapshot: Option<RegionSnapshot<EK::Snapshot>>,
+    pub snapshot: Option<RegionSnapshot<EK>>,
     pub txn_extra_op: TxnExtraOp,
 }
 

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -188,9 +188,9 @@ pub enum MergeResultKind {
 /// Some significant messages sent to raftstore. Raftstore will dispatch these messages to Raft
 /// groups to update some important internal status.
 #[derive(Debug)]
-pub enum SignificantMsg<SK>
+pub enum SignificantMsg<EK>
 where
-    SK: Snapshot,
+    EK: KvEngine,
 {
     /// Reports whether the snapshot sending is successful or not.
     SnapshotStatus {
@@ -222,9 +222,9 @@ where
     CaptureChange {
         cmd: ChangeCmd,
         region_epoch: RegionEpoch,
-        callback: Callback<SK>,
+        callback: Callback<EK::Snapshot>,
     },
-    LeaderCallback(Callback<SK>),
+    LeaderCallback(Callback<EK::Snapshot>),
 }
 
 /// Message that will be sent to a peer.
@@ -365,7 +365,7 @@ pub enum PeerMsg<EK: KvEngine> {
     ApplyRes { res: ApplyTaskRes<EK::Snapshot> },
     /// Message that can't be lost but rarely created. If they are lost, real bad
     /// things happen like some peers will be considered dead in the group.
-    SignificantMsg(SignificantMsg<EK::Snapshot>),
+    SignificantMsg(SignificantMsg<EK>),
     /// Start the FSM.
     Start,
     /// A message only used to notify a peer.

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -185,7 +185,7 @@ pub struct CheckTickResult {
 pub struct ProposedAdminCmd<EK> where EK: KvEngine {
     epoch_state: AdminCmdEpochState,
     index: u64,
-    cbs: Vec<Callback<EK::Snapshot>>,
+    cbs: Vec<Callback<EK>>,
 }
 
 impl<EK> ProposedAdminCmd<EK> where EK: KvEngine {
@@ -296,7 +296,7 @@ impl<EK> CmdEpochChecker<EK> where EK: KvEngine {
         }
     }
 
-    pub fn attach_to_conflict_cmd(&mut self, index: u64, cb: Callback<EK::Snapshot>) {
+    pub fn attach_to_conflict_cmd(&mut self, index: u64, cb: Callback<EK>) {
         if let Some(cmd) = self
             .proposed_admin_cmd
             .iter_mut()
@@ -2007,7 +2007,7 @@ where
     pub fn propose<T: Transport, C>(
         &mut self,
         ctx: &mut PollContext<EK, ER, T, C>,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
         req: RaftCmdRequest,
         mut err_resp: RaftCmdResponse,
         txn_extra: TxnExtra,
@@ -2275,7 +2275,7 @@ where
         &mut self,
         ctx: &mut PollContext<EK, ER, T, C>,
         req: RaftCmdRequest,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
     ) {
         ctx.raft_metrics.propose.local_read += 1;
         cb.invoke_read(self.handle_read(ctx, req, false, Some(self.get_store().committed_index())))
@@ -2339,7 +2339,7 @@ where
         poll_ctx: &mut PollContext<EK, ER, T, C>,
         req: RaftCmdRequest,
         mut err_resp: RaftCmdResponse,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
     ) -> bool {
         if let Err(e) = self.pre_read_index() {
             debug!(
@@ -2749,7 +2749,7 @@ where
         &mut self,
         ctx: &mut PollContext<EK, ER, T, C>,
         req: RaftCmdRequest,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
     ) -> bool {
         ctx.raft_metrics.propose.transfer_leader += 1;
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -79,7 +79,7 @@ struct ProposalQueue<EK>
 where
     EK: KvEngine,
 {
-    queue: VecDeque<Proposal<EK::Snapshot>>,
+    queue: VecDeque<Proposal<EK>>,
 }
 
 impl<EK> ProposalQueue<EK> where EK: KvEngine {
@@ -100,7 +100,7 @@ impl<EK> ProposalQueue<EK> where EK: KvEngine {
 
     // Return all proposals that before (and included) the proposal
     // at the given term and index
-    fn take(&mut self, index: u64, term: u64) -> Vec<Proposal<EK::Snapshot>> {
+    fn take(&mut self, index: u64, term: u64) -> Vec<Proposal<EK>> {
         let mut propos = Vec::new();
         while let Some(p) = self.queue.pop_front() {
             // Comparing the term first then the index, because the term is
@@ -117,7 +117,7 @@ impl<EK> ProposalQueue<EK> where EK: KvEngine {
         propos
     }
 
-    fn push(&mut self, p: Proposal<EK::Snapshot>) {
+    fn push(&mut self, p: Proposal<EK>) {
         self.queue.push_back(p);
     }
 
@@ -2081,7 +2081,7 @@ where
     fn post_propose<T, C>(
         &mut self,
         poll_ctx: &mut PollContext<EK, ER, T, C>,
-        mut p: Proposal<EK::Snapshot>,
+        mut p: Proposal<EK>,
     ) {
         // Try to renew leader lease on every consistent read/write request.
         if poll_ctx.current_time.is_none() {

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2854,7 +2854,7 @@ where
         req: RaftCmdRequest,
         check_epoch: bool,
         read_index: Option<u64>,
-    ) -> ReadResponse<EK::Snapshot> {
+    ) -> ReadResponse<EK> {
         let region = self.region().clone();
         if check_epoch {
             if let Err(e) = check_region_epoch(&req, &region, true) {

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -75,15 +75,15 @@ pub enum StaleState {
     LeaderMissing,
 }
 
-struct ProposalQueue<S>
+struct ProposalQueue<EK>
 where
-    S: Snapshot,
+    EK: KvEngine,
 {
-    queue: VecDeque<Proposal<S>>,
+    queue: VecDeque<Proposal<EK::Snapshot>>,
 }
 
-impl<S: Snapshot> ProposalQueue<S> {
-    fn new() -> ProposalQueue<S> {
+impl<EK> ProposalQueue<EK> where EK: KvEngine {
+    fn new() -> ProposalQueue<EK> {
         ProposalQueue {
             queue: VecDeque::new(),
         }
@@ -100,7 +100,7 @@ impl<S: Snapshot> ProposalQueue<S> {
 
     // Return all proposals that before (and included) the proposal
     // at the given term and index
-    fn take(&mut self, index: u64, term: u64) -> Vec<Proposal<S>> {
+    fn take(&mut self, index: u64, term: u64) -> Vec<Proposal<EK::Snapshot>> {
         let mut propos = Vec::new();
         while let Some(p) = self.queue.pop_front() {
             // Comparing the term first then the index, because the term is
@@ -117,7 +117,7 @@ impl<S: Snapshot> ProposalQueue<S> {
         propos
     }
 
-    fn push(&mut self, p: Proposal<S>) {
+    fn push(&mut self, p: Proposal<EK::Snapshot>) {
         self.queue.push_back(p);
     }
 
@@ -343,7 +343,7 @@ where
     /// Record the last instant of each peer's heartbeat response.
     pub peer_heartbeats: HashMap<u64, Instant>,
 
-    proposals: ProposalQueue<EK::Snapshot>,
+    proposals: ProposalQueue<EK>,
     leader_missing_time: Option<Instant>,
     leader_lease: Lease,
     pending_reads: ReadIndexQueue<EK::Snapshot>,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -82,7 +82,10 @@ where
     queue: VecDeque<Proposal<EK>>,
 }
 
-impl<EK> ProposalQueue<EK> where EK: KvEngine {
+impl<EK> ProposalQueue<EK>
+where
+    EK: KvEngine,
+{
     fn new() -> ProposalQueue<EK> {
         ProposalQueue {
             queue: VecDeque::new(),
@@ -182,13 +185,19 @@ pub struct CheckTickResult {
     up_to_date: bool,
 }
 
-pub struct ProposedAdminCmd<EK> where EK: KvEngine {
+pub struct ProposedAdminCmd<EK>
+where
+    EK: KvEngine,
+{
     epoch_state: AdminCmdEpochState,
     index: u64,
     cbs: Vec<Callback<EK>>,
 }
 
-impl<EK> ProposedAdminCmd<EK> where EK: KvEngine {
+impl<EK> ProposedAdminCmd<EK>
+where
+    EK: KvEngine,
+{
     fn new(epoch_state: AdminCmdEpochState, index: u64) -> ProposedAdminCmd<EK> {
         ProposedAdminCmd {
             epoch_state,
@@ -198,14 +207,20 @@ impl<EK> ProposedAdminCmd<EK> where EK: KvEngine {
     }
 }
 
-struct CmdEpochChecker<EK> where EK: KvEngine {
+struct CmdEpochChecker<EK>
+where
+    EK: KvEngine,
+{
     // Although it's a deque, because of the characteristics of the settings from `ADMIN_CMD_EPOCH_MAP`,
     // the max size of admin cmd is 2, i.e. split/merge and change peer.
     proposed_admin_cmd: VecDeque<ProposedAdminCmd<EK>>,
     term: u64,
 }
 
-impl<EK> Default for CmdEpochChecker<EK> where EK: KvEngine {
+impl<EK> Default for CmdEpochChecker<EK>
+where
+    EK: KvEngine,
+{
     fn default() -> CmdEpochChecker<EK> {
         CmdEpochChecker {
             proposed_admin_cmd: VecDeque::new(),
@@ -214,7 +229,10 @@ impl<EK> Default for CmdEpochChecker<EK> where EK: KvEngine {
     }
 }
 
-impl<EK> CmdEpochChecker<EK> where EK: KvEngine {
+impl<EK> CmdEpochChecker<EK>
+where
+    EK: KvEngine,
+{
     fn maybe_update_term(&mut self, term: u64) {
         assert!(term >= self.term);
         if term > self.term {
@@ -313,7 +331,10 @@ impl<EK> CmdEpochChecker<EK> where EK: KvEngine {
     }
 }
 
-impl<EK> Drop for CmdEpochChecker<EK> where EK: KvEngine {
+impl<EK> Drop for CmdEpochChecker<EK>
+where
+    EK: KvEngine,
+{
     fn drop(&mut self) {
         for state in self.proposed_admin_cmd.drain(..) {
             for cb in state.cbs {

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1764,7 +1764,7 @@ where
 
     fn response_read<T, C>(
         &self,
-        read: &mut ReadIndexRequest<EK::Snapshot>,
+        read: &mut ReadIndexRequest<EK>,
         ctx: &mut PollContext<EK, ER, T, C>,
         replica_read: bool,
     ) {

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -346,7 +346,7 @@ where
     proposals: ProposalQueue<EK>,
     leader_missing_time: Option<Instant>,
     leader_lease: Lease,
-    pending_reads: ReadIndexQueue<EK::Snapshot>,
+    pending_reads: ReadIndexQueue<EK>,
 
     /// If it fails to send messages to leader.
     pub leader_unreachable: bool,

--- a/components/raftstore/src/store/read_queue.rs
+++ b/components/raftstore/src/store/read_queue.rs
@@ -22,7 +22,7 @@ where
     EK: KvEngine,
 {
     pub id: Uuid,
-    pub cmds: MustConsumeVec<(RaftCmdRequest, Callback<EK::Snapshot>, Option<u64>)>,
+    pub cmds: MustConsumeVec<(RaftCmdRequest, Callback<EK>, Option<u64>)>,
     pub renew_lease_time: Timespec,
     pub read_index: Option<u64>,
     // `true` means it's in `ReadIndexQueue::reads`.
@@ -33,7 +33,7 @@ impl<EK> ReadIndexRequest<EK>
 where
     EK: KvEngine,
 {
-    pub fn push_command(&mut self, req: RaftCmdRequest, cb: Callback<EK::Snapshot>, read_index: u64) {
+    pub fn push_command(&mut self, req: RaftCmdRequest, cb: Callback<EK>, read_index: u64) {
         RAFT_READ_INDEX_PENDING_COUNT.inc();
         self.cmds.push((req, cb, Some(read_index)));
     }
@@ -41,7 +41,7 @@ where
     pub fn with_command(
         id: Uuid,
         req: RaftCmdRequest,
-        cb: Callback<EK::Snapshot>,
+        cb: Callback<EK>,
         renew_lease_time: Timespec,
     ) -> Self {
         RAFT_READ_INDEX_PENDING_COUNT.inc();

--- a/components/raftstore/src/store/region_snapshot.rs
+++ b/components/raftstore/src/store/region_snapshot.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use crate::store::{util, PeerStorage};
 use crate::{Error, Result};
-use engine_rocks::{RocksEngine};
+use engine_rocks::RocksEngine;
 use engine_traits::util::check_key_in_range;
 use engine_traits::CF_RAFT;
 use engine_traits::{Error as EngineError, Iterable, Iterator};
@@ -23,7 +23,10 @@ use tikv_util::{panic_when_unexpected_key_or_data, set_panic_mark};
 ///
 /// Only data within a region can be accessed.
 #[derive(Debug)]
-pub struct RegionSnapshot<EK> where EK: KvEngine {
+pub struct RegionSnapshot<EK>
+where
+    EK: KvEngine,
+{
     snap: Arc<EK::Snapshot>,
     region: Arc<Region>,
     apply_index: Arc<AtomicU64>,
@@ -128,7 +131,12 @@ where
         self.scan_impl(self.iter_cf(cf, iter_opt)?, start_key, f)
     }
 
-    fn scan_impl<F>(&self, mut it: RegionIterator<EK::Snapshot>, start_key: &[u8], mut f: F) -> Result<()>
+    fn scan_impl<F>(
+        &self,
+        mut it: RegionIterator<EK::Snapshot>,
+        start_key: &[u8],
+        mut f: F,
+    ) -> Result<()>
     where
         F: FnMut(&[u8], &[u8]) -> Result<bool>,
     {

--- a/components/raftstore/src/store/transport.rs
+++ b/components/raftstore/src/store/transport.rs
@@ -3,7 +3,7 @@
 use crate::store::{CasualMessage, PeerMsg, RaftCommand, RaftRouter, StoreMsg};
 use crate::{DiscardReason, Error, Result};
 use crossbeam::TrySendError;
-use engine_traits::{KvEngine};
+use engine_traits::KvEngine;
 use kvproto::raft_serverpb::RaftMessage;
 use raft_engine::RaftEngine;
 use std::sync::mpsc;
@@ -61,10 +61,7 @@ where
     ER: RaftEngine,
 {
     #[inline]
-    fn send(
-        &self,
-        cmd: RaftCommand<EK>,
-    ) -> std::result::Result<(), TrySendError<RaftCommand<EK>>> {
+    fn send(&self, cmd: RaftCommand<EK>) -> std::result::Result<(), TrySendError<RaftCommand<EK>>> {
         self.send_raft_command(cmd)
     }
 }
@@ -101,7 +98,10 @@ where
     }
 }
 
-impl<EK> ProposalRouter<EK> for mpsc::SyncSender<RaftCommand<EK>> where EK: KvEngine {
+impl<EK> ProposalRouter<EK> for mpsc::SyncSender<RaftCommand<EK>>
+where
+    EK: KvEngine,
+{
     fn send(&self, cmd: RaftCommand<EK>) -> std::result::Result<(), TrySendError<RaftCommand<EK>>> {
         match self.try_send(cmd) {
             Ok(()) => Ok(()),

--- a/components/raftstore/src/store/transport.rs
+++ b/components/raftstore/src/store/transport.rs
@@ -30,7 +30,7 @@ pub trait ProposalRouter<EK>
 where
     EK: KvEngine,
 {
-    fn send(&self, cmd: RaftCommand<EK::Snapshot>) -> std::result::Result<(), TrySendError<RaftCommand<EK::Snapshot>>>;
+    fn send(&self, cmd: RaftCommand<EK>) -> std::result::Result<(), TrySendError<RaftCommand<EK>>>;
 }
 
 /// Routes message to store FSM.
@@ -63,8 +63,8 @@ where
     #[inline]
     fn send(
         &self,
-        cmd: RaftCommand<EK::Snapshot>,
-    ) -> std::result::Result<(), TrySendError<RaftCommand<EK::Snapshot>>> {
+        cmd: RaftCommand<EK>,
+    ) -> std::result::Result<(), TrySendError<RaftCommand<EK>>> {
         self.send_raft_command(cmd)
     }
 }
@@ -101,8 +101,8 @@ where
     }
 }
 
-impl<EK> ProposalRouter<EK> for mpsc::SyncSender<RaftCommand<EK::Snapshot>> where EK: KvEngine {
-    fn send(&self, cmd: RaftCommand<EK::Snapshot>) -> std::result::Result<(), TrySendError<RaftCommand<EK::Snapshot>>> {
+impl<EK> ProposalRouter<EK> for mpsc::SyncSender<RaftCommand<EK>> where EK: KvEngine {
+    fn send(&self, cmd: RaftCommand<EK>) -> std::result::Result<(), TrySendError<RaftCommand<EK>>> {
         match self.try_send(cmd) {
             Ok(()) => Ok(()),
             Err(mpsc::TrySendError::Disconnected(cmd)) => Err(TrySendError::Disconnected(cmd)),

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -82,7 +82,7 @@ where
         peer: metapb::Peer,
         // If true, right Region derives origin region_id.
         right_derive: bool,
-        callback: Callback<E::Snapshot>,
+        callback: Callback<E>,
     },
     AskBatchSplit {
         region: metapb::Region,
@@ -90,7 +90,7 @@ where
         peer: metapb::Peer,
         // If true, right Region derives origin region_id.
         right_derive: bool,
-        callback: Callback<E::Snapshot>,
+        callback: Callback<E>,
     },
     AutoSplit {
         split_infos: Vec<SplitInfo>,
@@ -474,7 +474,7 @@ where
         split_key: Vec<u8>,
         peer: metapb::Peer,
         right_derive: bool,
-        callback: Callback<EK::Snapshot>,
+        callback: Callback<EK>,
         task: String,
     ) {
         let router = self.router.clone();
@@ -518,7 +518,7 @@ where
         mut split_keys: Vec<Vec<u8>>,
         peer: metapb::Peer,
         right_derive: bool,
-        callback: Callback<EK::Snapshot>,
+        callback: Callback<EK>,
         task: String,
     ) {
         if split_keys.is_empty() {
@@ -1145,7 +1145,7 @@ fn send_admin_request<EK, ER>(
     epoch: metapb::RegionEpoch,
     peer: metapb::Peer,
     request: AdminRequest,
-    callback: Callback<EK::Snapshot>,
+    callback: Callback<EK>,
 ) where
     EK: KvEngine,
     ER: RaftEngine,

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -258,7 +258,7 @@ impl Progress {
 
 pub struct LocalReader<C, E>
 where
-    C: ProposalRouter<E::Snapshot>,
+    C: ProposalRouter<E>,
     E: KvEngine,
 {
     store_id: Cell<Option<u64>>,
@@ -275,7 +275,7 @@ where
 
 impl<C, E> ReadExecutor<E> for LocalReader<C, E>
 where
-    C: ProposalRouter<E::Snapshot>,
+    C: ProposalRouter<E>,
     E: KvEngine,
 {
     fn get_engine(&self) -> &E {
@@ -302,7 +302,7 @@ where
 
 impl<C, E> LocalReader<C, E>
 where
-    C: ProposalRouter<E::Snapshot>,
+    C: ProposalRouter<E>,
     E: KvEngine,
 {
     pub fn new(kv_engine: E, store_meta: Arc<Mutex<StoreMeta>>, router: C) -> Self {
@@ -519,7 +519,7 @@ where
 
 impl<C, E> Clone for LocalReader<C, E>
 where
-    C: ProposalRouter<E::Snapshot> + Clone,
+    C: ProposalRouter<E> + Clone,
     E: KvEngine,
 {
     fn clone(&self) -> Self {

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -502,12 +502,7 @@ where
     /// the last RaftCommand which left a snapshot cached in LocalReader. ThreadReadId is composed
     /// by thread_id and a thread_local incremental sequence.
     #[inline]
-    pub fn read(
-        &mut self,
-        read_id: Option<ThreadReadId>,
-        req: RaftCmdRequest,
-        cb: Callback<E>,
-    ) {
+    pub fn read(&mut self, read_id: Option<ThreadReadId>, req: RaftCmdRequest, cb: Callback<E>) {
         self.propose_raft_command(read_id, req, cb);
         self.metrics.maybe_flush();
     }
@@ -694,7 +689,7 @@ mod tests {
 
     use crate::store::util::Lease;
     use crate::store::Callback;
-    use engine_rocks::{RocksEngine};
+    use engine_rocks::RocksEngine;
     use engine_traits::ALL_CFS;
     use tikv_util::time::monotonic_raw_now;
 

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -428,7 +428,7 @@ where
         &mut self,
         mut read_id: Option<ThreadReadId>,
         req: RaftCmdRequest,
-        cb: Callback<E::Snapshot>,
+        cb: Callback<E>,
     ) {
         let region_id = req.get_header().get_region_id();
         loop {
@@ -506,7 +506,7 @@ where
         &mut self,
         read_id: Option<ThreadReadId>,
         req: RaftCmdRequest,
-        cb: Callback<E::Snapshot>,
+        cb: Callback<E>,
     ) {
         self.propose_raft_command(read_id, req, cb);
         self.metrics.maybe_flush();

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -5,7 +5,6 @@ use std::collections::BinaryHeap;
 use std::fmt::{self, Display, Formatter};
 use std::mem;
 
-use engine_rocks::RocksEngine;
 use engine_traits::{CfName, IterOptions, Iterable, Iterator, KvEngine, CF_WRITE, LARGE_CFS};
 use error_code::ErrorCodeExt;
 use kvproto::metapb::Region;
@@ -163,20 +162,20 @@ impl Display for Task {
     }
 }
 
-pub struct Runner<S> {
-    engine: RocksEngine,
+pub struct Runner<E, S> where E: KvEngine {
+    engine: E,
     router: S,
-    coprocessor: CoprocessorHost<RocksEngine>,
+    coprocessor: CoprocessorHost<E>,
     cfg: Config,
 }
 
-impl<S: CasualRouter<RocksEngine>> Runner<S> {
+impl<E, S> Runner<E, S> where E: KvEngine, S: CasualRouter<E> {
     pub fn new(
-        engine: RocksEngine,
+        engine: E,
         router: S,
-        coprocessor: CoprocessorHost<RocksEngine>,
+        coprocessor: CoprocessorHost<E>,
         cfg: Config,
-    ) -> Runner<S> {
+    ) -> Runner<E, S> {
         Runner {
             engine,
             router,
@@ -266,13 +265,13 @@ impl<S: CasualRouter<RocksEngine>> Runner<S> {
     /// Gets the split keys by scanning the range.
     fn scan_split_keys(
         &self,
-        host: &mut SplitCheckerHost<'_, RocksEngine>,
+        host: &mut SplitCheckerHost<'_, E>,
         region: &Region,
         start_key: &[u8],
         end_key: &[u8],
     ) -> Result<Vec<Vec<u8>>> {
         let timer = CHECK_SPILT_HISTOGRAM.start_coarse_timer();
-        MergedIterator::<<RocksEngine as Iterable>::Iterator>::new(
+        MergedIterator::<<E as Iterable>::Iterator>::new(
             &self.engine,
             LARGE_CFS,
             start_key,
@@ -320,7 +319,7 @@ impl<S: CasualRouter<RocksEngine>> Runner<S> {
     }
 }
 
-impl<S: CasualRouter<RocksEngine>> Runnable<Task> for Runner<S> {
+impl<E, S> Runnable<Task> for Runner<E, S> where E: KvEngine, S: CasualRouter<E> {
     fn run(&mut self, task: Task) {
         match task {
             Task::SplitCheckTask {
@@ -335,10 +334,10 @@ impl<S: CasualRouter<RocksEngine>> Runnable<Task> for Runner<S> {
     }
 }
 
-fn new_split_region(
+fn new_split_region<E>(
     region_epoch: RegionEpoch,
     split_keys: Vec<Vec<u8>>,
-) -> CasualMessage<RocksEngine> {
+) -> CasualMessage<E> where E: KvEngine {
     CasualMessage::SplitRegion {
         region_epoch,
         split_keys,

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -162,20 +162,22 @@ impl Display for Task {
     }
 }
 
-pub struct Runner<E, S> where E: KvEngine {
+pub struct Runner<E, S>
+where
+    E: KvEngine,
+{
     engine: E,
     router: S,
     coprocessor: CoprocessorHost<E>,
     cfg: Config,
 }
 
-impl<E, S> Runner<E, S> where E: KvEngine, S: CasualRouter<E> {
-    pub fn new(
-        engine: E,
-        router: S,
-        coprocessor: CoprocessorHost<E>,
-        cfg: Config,
-    ) -> Runner<E, S> {
+impl<E, S> Runner<E, S>
+where
+    E: KvEngine,
+    S: CasualRouter<E>,
+{
+    pub fn new(engine: E, router: S, coprocessor: CoprocessorHost<E>, cfg: Config) -> Runner<E, S> {
         Runner {
             engine,
             router,
@@ -319,7 +321,11 @@ impl<E, S> Runner<E, S> where E: KvEngine, S: CasualRouter<E> {
     }
 }
 
-impl<E, S> Runnable<Task> for Runner<E, S> where E: KvEngine, S: CasualRouter<E> {
+impl<E, S> Runnable<Task> for Runner<E, S>
+where
+    E: KvEngine,
+    S: CasualRouter<E>,
+{
     fn run(&mut self, task: Task) {
         match task {
             Task::SplitCheckTask {
@@ -334,10 +340,10 @@ impl<E, S> Runnable<Task> for Runner<E, S> where E: KvEngine, S: CasualRouter<E>
     }
 }
 
-fn new_split_region<E>(
-    region_epoch: RegionEpoch,
-    split_keys: Vec<Vec<u8>>,
-) -> CasualMessage<E> where E: KvEngine {
+fn new_split_region<E>(region_epoch: RegionEpoch, split_keys: Vec<Vec<u8>>) -> CasualMessage<E>
+where
+    E: KvEngine,
+{
     CasualMessage::SplitRegion {
         region_epoch,
         split_keys,

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -63,7 +63,7 @@ pub trait Simulator {
         &self,
         node_id: u64,
         request: RaftCmdRequest,
-        cb: Callback<RocksSnapshot>,
+        cb: Callback<RocksEngine>,
     ) -> Result<()>;
     fn send_raft_msg(&mut self, msg: RaftMessage) -> Result<()>;
     fn get_snap_dir(&self, node_id: u64) -> String;
@@ -96,7 +96,7 @@ pub trait Simulator {
         node_id: u64,
         batch_id: Option<ThreadReadId>,
         request: RaftCmdRequest,
-        cb: Callback<RocksSnapshot>,
+        cb: Callback<RocksEngine>,
     );
 
     fn call_command_on_node(
@@ -1140,7 +1140,7 @@ impl<T: Simulator> Cluster<T> {
         &mut self,
         region: &metapb::Region,
         split_key: &[u8],
-        cb: Callback<RocksSnapshot>,
+        cb: Callback<RocksEngine>,
     ) {
         let leader = self.leader_of_region(region.get_id()).unwrap();
         let router = self.sim.rl().get_router(leader.get_store_id()).unwrap();

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -13,7 +13,7 @@ use raft::SnapshotStatus;
 
 use super::*;
 use encryption::DataKeyManager;
-use engine_rocks::{RocksEngine};
+use engine_rocks::RocksEngine;
 use engine_traits::{Engines, MiscExt, Peekable};
 use raftstore::coprocessor::config::SplitCheckConfigManager;
 use raftstore::coprocessor::CoprocessorHost;

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -13,7 +13,7 @@ use raft::SnapshotStatus;
 
 use super::*;
 use encryption::DataKeyManager;
-use engine_rocks::{RocksEngine, RocksSnapshot};
+use engine_rocks::{RocksEngine};
 use engine_traits::{Engines, MiscExt, Peekable};
 use raftstore::coprocessor::config::SplitCheckConfigManager;
 use raftstore::coprocessor::CoprocessorHost;
@@ -331,7 +331,7 @@ impl Simulator for NodeCluster {
         &self,
         node_id: u64,
         request: RaftCmdRequest,
-        cb: Callback<RocksSnapshot>,
+        cb: Callback<RocksEngine>,
     ) -> Result<()> {
         if !self
             .trans
@@ -361,7 +361,7 @@ impl Simulator for NodeCluster {
         node_id: u64,
         batch_id: Option<ThreadReadId>,
         request: RaftCmdRequest,
-        cb: Callback<RocksSnapshot>,
+        cb: Callback<RocksEngine>,
     ) {
         if !self
             .trans

--- a/components/test_raftstore/src/router.rs
+++ b/components/test_raftstore/src/router.rs
@@ -35,7 +35,7 @@ impl RaftStoreRouter<RocksEngine> for MockRaftStoreRouter {
     fn significant_send(
         &self,
         region_id: u64,
-        msg: SignificantMsg<RocksSnapshot>,
+        msg: SignificantMsg<RocksEngine>,
     ) -> RaftStoreResult<()> {
         let mut senders = self.senders.lock().unwrap();
         if let Some(tx) = senders.get_mut(&region_id) {

--- a/components/test_raftstore/src/router.rs
+++ b/components/test_raftstore/src/router.rs
@@ -2,7 +2,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use engine_rocks::{RocksEngine, RocksSnapshot};
+use engine_rocks::{RocksEngine};
 use kvproto::raft_cmdpb::RaftCmdRequest;
 use kvproto::raft_serverpb::RaftMessage;
 use raftstore::errors::{Error as RaftStoreError, Result as RaftStoreResult};
@@ -60,14 +60,14 @@ impl RaftStoreRouter<RocksEngine> for MockRaftStoreRouter {
     fn send_raft_msg(&self, _: RaftMessage) -> RaftStoreResult<()> {
         unimplemented!()
     }
-    fn send_command(&self, _: RaftCmdRequest, _: Callback<RocksSnapshot>) -> RaftStoreResult<()> {
+    fn send_command(&self, _: RaftCmdRequest, _: Callback<RocksEngine>) -> RaftStoreResult<()> {
         unimplemented!()
     }
     fn send_command_txn_extra(
         &self,
         _: RaftCmdRequest,
         _: TxnExtra,
-        _: Callback<RocksSnapshot>,
+        _: Callback<RocksEngine>,
     ) -> RaftStoreResult<()> {
         unimplemented!()
     }

--- a/components/test_raftstore/src/router.rs
+++ b/components/test_raftstore/src/router.rs
@@ -2,7 +2,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use engine_rocks::{RocksEngine};
+use engine_rocks::RocksEngine;
 use kvproto::raft_cmdpb::RaftCmdRequest;
 use kvproto::raft_serverpb::RaftMessage;
 use raftstore::errors::{Error as RaftStoreError, Result as RaftStoreResult};

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -19,7 +19,7 @@ use tempfile::{Builder, TempDir};
 
 use super::*;
 use encryption::DataKeyManager;
-use engine_rocks::{RocksEngine, RocksSnapshot};
+use engine_rocks::{RocksEngine};
 use engine_traits::{Engines, MiscExt};
 use pd_client::PdClient;
 use raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor};
@@ -399,7 +399,7 @@ impl Simulator for ServerCluster {
         &self,
         node_id: u64,
         request: RaftCmdRequest,
-        cb: Callback<RocksSnapshot>,
+        cb: Callback<RocksEngine>,
     ) -> Result<()> {
         let router = match self.metas.get(&node_id) {
             None => return Err(box_err!("missing sender for store {}", node_id)),
@@ -413,7 +413,7 @@ impl Simulator for ServerCluster {
         node_id: u64,
         batch_id: Option<ThreadReadId>,
         request: RaftCmdRequest,
-        cb: Callback<RocksSnapshot>,
+        cb: Callback<RocksEngine>,
     ) {
         match self.metas.get(&node_id) {
             None => {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -19,7 +19,7 @@ use tempfile::{Builder, TempDir};
 
 use super::*;
 use encryption::DataKeyManager;
-use engine_rocks::{RocksEngine};
+use engine_rocks::RocksEngine;
 use engine_traits::{Engines, MiscExt};
 use pd_client::PdClient;
 use raftstore::coprocessor::{CoprocessorHost, RegionInfoAccessor};

--- a/components/test_raftstore/src/transport_simulate.rs
+++ b/components/test_raftstore/src/transport_simulate.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 use std::{mem, thread, time, usize};
 
-use engine_rocks::{RocksEngine, RocksSnapshot};
+use engine_rocks::{RocksEngine};
 use kvproto::raft_cmdpb::RaftCmdRequest;
 use kvproto::raft_serverpb::RaftMessage;
 use raft::eraftpb::MessageType;
@@ -193,7 +193,7 @@ impl<C: RaftStoreRouter<RocksEngine>> RaftStoreRouter<RocksEngine> for SimulateT
         filter_send(&self.filters, msg, |m| self.ch.send_raft_msg(m))
     }
 
-    fn send_command(&self, req: RaftCmdRequest, cb: Callback<RocksSnapshot>) -> Result<()> {
+    fn send_command(&self, req: RaftCmdRequest, cb: Callback<RocksEngine>) -> Result<()> {
         self.ch.send_command(req, cb)
     }
 
@@ -201,7 +201,7 @@ impl<C: RaftStoreRouter<RocksEngine>> RaftStoreRouter<RocksEngine> for SimulateT
         &self,
         read_id: Option<ThreadReadId>,
         req: RaftCmdRequest,
-        cb: Callback<RocksSnapshot>,
+        cb: Callback<RocksEngine>,
     ) -> Result<()> {
         self.ch.read(read_id, req, cb)
     }
@@ -210,7 +210,7 @@ impl<C: RaftStoreRouter<RocksEngine>> RaftStoreRouter<RocksEngine> for SimulateT
         &self,
         req: RaftCmdRequest,
         txn_extra: TxnExtra,
-        cb: Callback<RocksSnapshot>,
+        cb: Callback<RocksEngine>,
     ) -> Result<()> {
         self.ch.send_command_txn_extra(req, txn_extra, cb)
     }

--- a/components/test_raftstore/src/transport_simulate.rs
+++ b/components/test_raftstore/src/transport_simulate.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 use std::{mem, thread, time, usize};
 
-use engine_rocks::{RocksEngine};
+use engine_rocks::RocksEngine;
 use kvproto::raft_cmdpb::RaftCmdRequest;
 use kvproto::raft_serverpb::RaftMessage;
 use raft::eraftpb::MessageType;

--- a/components/test_raftstore/src/transport_simulate.rs
+++ b/components/test_raftstore/src/transport_simulate.rs
@@ -223,7 +223,7 @@ impl<C: RaftStoreRouter<RocksEngine>> RaftStoreRouter<RocksEngine> for SimulateT
         self.ch.broadcast_unreachable(store_id)
     }
 
-    fn significant_send(&self, region_id: u64, msg: SignificantMsg<RocksSnapshot>) -> Result<()> {
+    fn significant_send(&self, region_id: u64, msg: SignificantMsg<RocksEngine>) -> Result<()> {
         self.ch.significant_send(region_id, msg)
     }
 }

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -328,7 +328,7 @@ pub fn new_pd_merge_region(target_region: metapb::Region) -> RegionHeartbeatResp
     resp
 }
 
-pub fn make_cb(cmd: &RaftCmdRequest) -> (Callback<RocksSnapshot>, mpsc::Receiver<RaftCmdResponse>) {
+pub fn make_cb(cmd: &RaftCmdRequest) -> (Callback<RocksEngine>, mpsc::Receiver<RaftCmdResponse>) {
     let mut is_read;
     let mut is_write;
     is_read = cmd.has_status_request();

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -25,7 +25,7 @@ use engine_rocks::config::BlobRunMode;
 use engine_rocks::encryption::get_env;
 use engine_rocks::raw::DB;
 use engine_rocks::{CompactionListener, RocksCompactionJobInfo};
-use engine_rocks::{Compat, RocksEngine, RocksSnapshot};
+use engine_rocks::{Compat, RocksEngine};
 use engine_traits::{Engines, Iterable, Peekable};
 use raftstore::store::fsm::RaftRouter;
 use raftstore::store::*;
@@ -346,7 +346,7 @@ pub fn make_cb(cmd: &RaftCmdRequest) -> (Callback<RocksEngine>, mpsc::Receiver<R
 
     let (tx, rx) = mpsc::channel();
     let cb = if is_read {
-        Callback::Read(Box::new(move |resp: ReadResponse<RocksSnapshot>| {
+        Callback::Read(Box::new(move |resp: ReadResponse<RocksEngine>| {
             // we don't care error actually.
             let _ = tx.send(resp.response);
         }))
@@ -404,7 +404,7 @@ pub fn async_read_on_peer<T: Simulator>(
 pub fn batch_read_on_peer<T: Simulator>(
     cluster: &mut Cluster<T>,
     requests: &[(metapb::Peer, metapb::Region)],
-) -> Vec<ReadResponse<RocksSnapshot>> {
+) -> Vec<ReadResponse<RocksEngine>> {
     let batch_id = Some(ThreadReadId::new());
     let (tx, rx) = mpsc::sync_channel(3);
     let mut results = vec![];

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -802,7 +802,6 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::mpsc::channel;
 
-    use engine_rocks::RocksSnapshot;
     use engine_traits::KvEngine;
     use futures::Future;
     use kvproto::{kvrpcpb::Op, metapb};
@@ -831,7 +830,7 @@ mod tests {
 
     impl Engine for PrefixedEngine {
         // Use RegionSnapshot which can remove the z prefix internally.
-        type Snap = RegionSnapshot<RocksSnapshot>;
+        type Snap = RegionSnapshot<RocksEngine>;
         type Local = RocksEngine;
 
         fn kv_engine(&self) -> RocksEngine {

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -146,7 +146,7 @@ fn on_write_result(mut write_resp: WriteResponse, req_cnt: usize) -> (CbContext,
 }
 
 fn on_read_result(
-    mut read_resp: ReadResponse<RocksSnapshot>,
+    mut read_resp: ReadResponse<RocksEngine>,
     req_cnt: usize,
 ) -> (CbContext, Result<CmdRes>) {
     let mut cb_ctx = new_ctx(&read_resp.response);

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -3,7 +3,7 @@
 use engine_rocks::{RocksEngine, RocksTablePropertiesCollection};
 use engine_traits::CfName;
 use engine_traits::CF_DEFAULT;
-use engine_traits::{IterOptions, Peekable, ReadOptions, Snapshot, TablePropertiesExt, KvEngine};
+use engine_traits::{IterOptions, KvEngine, Peekable, ReadOptions, Snapshot, TablePropertiesExt};
 use kvproto::kvrpcpb::Context;
 use kvproto::raft_cmdpb::{
     CmdType, DeleteRangeRequest, DeleteRequest, PutRequest, RaftCmdRequest, RaftCmdResponse,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -314,7 +314,7 @@ mod tests {
     #[derive(Clone)]
     struct TestRaftStoreRouter {
         tx: Sender<usize>,
-        significant_msg_sender: Sender<SignificantMsg<RocksSnapshot>>,
+        significant_msg_sender: Sender<SignificantMsg<RocksEngine>>,
     }
 
     impl RaftStoreRouter<RocksEngine> for TestRaftStoreRouter {
@@ -345,7 +345,7 @@ mod tests {
         fn significant_send(
             &self,
             _: u64,
-            msg: SignificantMsg<RocksSnapshot>,
+            msg: SignificantMsg<RocksEngine>,
         ) -> RaftStoreResult<()> {
             self.significant_msg_sender.send(msg).unwrap();
             Ok(())
@@ -362,7 +362,7 @@ mod tests {
     }
 
     fn is_unreachable_to(
-        msg: &SignificantMsg<RocksSnapshot>,
+        msg: &SignificantMsg<RocksEngine>,
         region_id: u64,
         to_peer_id: u64,
     ) -> bool {

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -322,11 +322,7 @@ mod tests {
             Ok(())
         }
 
-        fn send_command(
-            &self,
-            _: RaftCmdRequest,
-            _: Callback<RocksEngine>,
-        ) -> RaftStoreResult<()> {
+        fn send_command(&self, _: RaftCmdRequest, _: Callback<RocksEngine>) -> RaftStoreResult<()> {
             self.tx.send(1).unwrap();
             Ok(())
         }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -285,7 +285,6 @@ mod tests {
     use raftstore::Result as RaftStoreResult;
 
     use crate::storage::lock_manager::DummyLockManager;
-    use engine_rocks::RocksSnapshot;
     use kvproto::raft_cmdpb::RaftCmdRequest;
     use kvproto::raft_serverpb::RaftMessage;
     use security::SecurityConfig;
@@ -326,7 +325,7 @@ mod tests {
         fn send_command(
             &self,
             _: RaftCmdRequest,
-            _: Callback<RocksSnapshot>,
+            _: Callback<RocksEngine>,
         ) -> RaftStoreResult<()> {
             self.tx.send(1).unwrap();
             Ok(())
@@ -336,7 +335,7 @@ mod tests {
             &self,
             _: RaftCmdRequest,
             _: TxnExtra,
-            _: Callback<RocksSnapshot>,
+            _: Callback<RocksEngine>,
         ) -> RaftStoreResult<()> {
             self.tx.send(1).unwrap();
             Ok(())

--- a/src/storage/kv/cursor.rs
+++ b/src/storage/kv/cursor.rs
@@ -498,7 +498,7 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
 
 #[cfg(test)]
 mod tests {
-    use engine_rocks::{RocksEngine};
+    use engine_rocks::RocksEngine;
     use engine_traits::{Engines, IterOptions, SyncMutable};
     use keys::data_key;
     use kvproto::metapb::{Peer, Region};

--- a/src/storage/kv/cursor.rs
+++ b/src/storage/kv/cursor.rs
@@ -498,7 +498,7 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
 
 #[cfg(test)]
 mod tests {
-    use engine_rocks::{RocksEngine, RocksSnapshot};
+    use engine_rocks::{RocksEngine};
     use engine_traits::{Engines, IterOptions, SyncMutable};
     use keys::data_key;
     use kvproto::metapb::{Peer, Region};
@@ -537,7 +537,7 @@ mod tests {
         let engines = new_temp_engine(&path);
         let (region, test_data) = load_default_dataset(engines.clone());
 
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(engines.kv.clone(), region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(engines.kv.clone(), region);
         let mut statistics = CfStatistics::default();
         let it = snap.iter(IterOptions::default());
         let mut iter = Cursor::new(it, ScanMode::Mixed);
@@ -588,7 +588,7 @@ mod tests {
         // test last region
         let mut region = Region::default();
         region.mut_peers().push(Peer::default());
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(engines.kv, region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(engines.kv, region);
         let it = snap.iter(IterOptions::default());
         let mut iter = Cursor::new(it, ScanMode::Mixed);
         assert!(!iter

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -1493,8 +1493,7 @@ mod tests {
         // Creates a reader and scan locks,
         let check_scan_lock =
             |start_key: Option<Key>, limit, expect_res: &[_], expect_is_remain| {
-                let snap =
-                    RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
+                let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
                 let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
                 let res = reader
                     .scan_locks(start_key.as_ref(), |l| l.ts <= 10.into(), limit)

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -512,7 +512,7 @@ mod tests {
     use engine_rocks::raw::DB;
     use engine_rocks::raw::{ColumnFamilyOptions, DBOptions};
     use engine_rocks::raw_util::CFOptions;
-    use engine_rocks::{Compat, RocksSnapshot};
+    use engine_rocks::{Compat, RocksEngine};
     use engine_traits::{Mutable, TablePropertiesExt, WriteBatchExt};
     use engine_traits::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
     use kvproto::kvrpcpb::IsolationLevel;
@@ -574,7 +574,7 @@ mod tests {
 
         fn prewrite(&mut self, m: Mutation, pk: &[u8], start_ts: impl Into<TimeStamp>) {
             let snap =
-                RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
+                RegionSnapshot::<RocksEngine>::from_raw(self.db.c().clone(), self.region.clone());
             let start_ts = start_ts.into();
             let cm = ConcurrencyManager::new(start_ts);
             let mut txn = MvccTxn::new(snap, start_ts, true, cm);
@@ -591,7 +591,7 @@ mod tests {
             start_ts: impl Into<TimeStamp>,
         ) {
             let snap =
-                RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
+                RegionSnapshot::<RocksEngine>::from_raw(self.db.c().clone(), self.region.clone());
             let start_ts = start_ts.into();
             let cm = ConcurrencyManager::new(start_ts);
             let mut txn = MvccTxn::new(snap, start_ts, true, cm);
@@ -619,7 +619,7 @@ mod tests {
             for_update_ts: impl Into<TimeStamp>,
         ) {
             let snap =
-                RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
+                RegionSnapshot::<RocksEngine>::from_raw(self.db.c().clone(), self.region.clone());
             let for_update_ts = for_update_ts.into();
             let cm = ConcurrencyManager::new(for_update_ts);
             let mut txn = MvccTxn::new(snap, start_ts.into(), true, cm);
@@ -635,7 +635,7 @@ mod tests {
             commit_ts: impl Into<TimeStamp>,
         ) {
             let snap =
-                RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
+                RegionSnapshot::<RocksEngine>::from_raw(self.db.c().clone(), self.region.clone());
             let start_ts = start_ts.into();
             let cm = ConcurrencyManager::new(start_ts);
             let mut txn = MvccTxn::new(snap, start_ts, true, cm);
@@ -645,7 +645,7 @@ mod tests {
 
         fn rollback(&mut self, pk: &[u8], start_ts: impl Into<TimeStamp>) {
             let snap =
-                RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
+                RegionSnapshot::<RocksEngine>::from_raw(self.db.c().clone(), self.region.clone());
             let start_ts = start_ts.into();
             let cm = ConcurrencyManager::new(start_ts);
             let mut txn = MvccTxn::new(snap, start_ts, true, cm);
@@ -656,7 +656,7 @@ mod tests {
 
         fn rollback_protected(&mut self, pk: &[u8], start_ts: impl Into<TimeStamp>) {
             let snap =
-                RegionSnapshot::<RocksSnapshot>::from_raw(self.db.c().clone(), self.region.clone());
+                RegionSnapshot::<RocksEngine>::from_raw(self.db.c().clone(), self.region.clone());
             let start_ts = start_ts.into();
             let cm = ConcurrencyManager::new(start_ts);
             let mut txn = MvccTxn::new(snap, start_ts, true, cm);
@@ -669,7 +669,7 @@ mod tests {
         fn gc(&mut self, pk: &[u8], safe_point: impl Into<TimeStamp> + Copy) {
             let cm = ConcurrencyManager::new(safe_point.into());
             loop {
-                let snap = RegionSnapshot::<RocksSnapshot>::from_raw(
+                let snap = RegionSnapshot::<RocksEngine>::from_raw(
                     self.db.c().clone(),
                     self.region.clone(),
                 );
@@ -823,7 +823,7 @@ mod tests {
         engine.put(&[12], 11, 12);
         engine.flush();
 
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
 
         let tests = vec![
             // set nothing.
@@ -897,7 +897,7 @@ mod tests {
         iopt.set_hint_min_ts(Bound::Included(1));
         iopt.set_hint_max_ts(Bound::Included(6));
 
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
         let mut iter = snap.iter_cf(CF_WRITE, iopt).unwrap();
 
         // Must not omit the latest deletion of key1 to prevent seeing outdated record.
@@ -1028,7 +1028,7 @@ mod tests {
         engine.prewrite_pessimistic_lock(m, k, 45);
         engine.commit(k, 45, 50);
 
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
         // Let's assume `50_45 PUT` means a commit version with start ts is 45 and commit ts
@@ -1134,7 +1134,7 @@ mod tests {
         engine.prewrite_pessimistic_lock(m, k, 1);
         engine.commit(k, 1, 4);
 
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         let (commit_ts, write_type) = reader
             .get_txn_commit_record(&key, 2.into())
@@ -1184,7 +1184,7 @@ mod tests {
         // Let's assume `2_1 PUT` means a commit version with start ts is 1 and commit ts
         // is 2.
         // Commit versions: [25_23 PUT, 20_10 PUT, 17_15 PUT, 7_7 Rollback, 5_1 PUT, 3_3 Rollback].
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
         let k = Key::from_raw(k);
@@ -1236,7 +1236,7 @@ mod tests {
         engine.prewrite(m2, k2, 1);
         engine.commit(k2, 1, 2);
 
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
         let (commit_ts, write) = reader
@@ -1253,7 +1253,7 @@ mod tests {
 
         // Test seek_write touches region's end.
         let region1 = make_region(1, vec![], Key::from_raw(b"k1").into_encoded());
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region1);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region1);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
         assert!(reader.seek_write(&k, 2.into()).unwrap().is_none());
@@ -1303,7 +1303,7 @@ mod tests {
         let m = Mutation::Put((Key::from_raw(k), v.to_vec()));
         engine.prewrite(m, k, 24);
 
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
 
         // Let's assume `2_1 PUT` means a commit version with start ts is 1 and commit ts
@@ -1366,7 +1366,7 @@ mod tests {
         engine.prewrite(Mutation::Put((Key::from_raw(k2), v.to_vec())), k1, 5);
         engine.prewrite(Mutation::Lock(Key::from_raw(k3)), k1, 5);
 
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         // Ignore the lock if read ts is less than the lock version
         assert!(reader.check_lock(&Key::from_raw(k1), 4.into()).is_ok());
@@ -1387,7 +1387,7 @@ mod tests {
 
         // Commit the primary lock only
         engine.commit(k1, 5, 7);
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         // Then reading the primary key should succeed
         assert!(reader.check_lock(&Key::from_raw(k1), 6.into()).is_ok());
@@ -1399,7 +1399,7 @@ mod tests {
 
         // Pessimistic locks
         engine.acquire_pessimistic_lock(Key::from_raw(k4), k4, 9, 9);
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         // Pessimistic locks don't block any read operation
         assert!(reader.check_lock(&Key::from_raw(k4), 10.into()).is_ok());
@@ -1494,7 +1494,7 @@ mod tests {
         let check_scan_lock =
             |start_key: Option<Key>, limit, expect_res: &[_], expect_is_remain| {
                 let snap =
-                    RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
+                    RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
                 let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
                 let res = reader
                     .scan_locks(start_key.as_ref(), |l| l.ts <= 10.into(), limit)
@@ -1552,7 +1552,7 @@ mod tests {
         let m = Mutation::Put((Key::from_raw(k), long_value.to_vec()));
         engine.prewrite(m, k, 10);
 
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region.clone());
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region.clone());
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         let key = Key::from_raw(k);
 
@@ -1576,7 +1576,7 @@ mod tests {
 
         // Commit the long value
         engine.commit(k, 10, 11);
-        let snap = RegionSnapshot::<RocksSnapshot>::from_raw(db.c().clone(), region);
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(db.c().clone(), region);
         let mut reader = MvccReader::new(snap, None, false, IsolationLevel::Si);
         for &skip_lock_check in &[false, true] {
             assert_eq!(

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -39,7 +39,7 @@ impl SyncBenchRouter {
 }
 
 impl SyncBenchRouter {
-    fn invoke(&self, cmd: RaftCommand<RocksSnapshot>) {
+    fn invoke(&self, cmd: RaftCommand<RocksEngine>) {
         let mut response = RaftCmdResponse::default();
         cmd_resp::bind_term(&mut response, 1);
         match cmd.callback {

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -84,7 +84,7 @@ impl RaftStoreRouter<RocksEngine> for SyncBenchRouter {
         Ok(())
     }
 
-    fn significant_send(&self, _: u64, _: SignificantMsg<RocksSnapshot>) -> Result<()> {
+    fn significant_send(&self, _: u64, _: SignificantMsg<RocksEngine>) -> Result<()> {
         Ok(())
     }
 

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -129,7 +129,7 @@ fn bench_async_snapshots_noop(b: &mut test::Bencher) {
                 }
             });
         let cb: Callback<RocksEngine> =
-            Callback::Read(Box::new(move |resp: ReadResponse<RocksSnapshot>| {
+            Callback::Read(Box::new(move |resp: ReadResponse<RocksEngine>| {
                 let res = CmdRes::Snap(resp.snapshot.unwrap());
                 cb2((CbContext::new(), Ok(res)));
             }));

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -117,8 +117,8 @@ fn bench_async_snapshots_noop(b: &mut test::Bencher) {
     };
 
     b.iter(|| {
-        let cb1: EngineCallback<RegionSnapshot<RocksSnapshot>> = Box::new(
-            move |(_, res): (CbContext, EngineResult<RegionSnapshot<RocksSnapshot>>)| {
+        let cb1: EngineCallback<RegionSnapshot<RocksEngine>> = Box::new(
+            move |(_, res): (CbContext, EngineResult<RegionSnapshot<RocksEngine>>)| {
                 assert!(res.is_ok());
             },
         );
@@ -158,7 +158,7 @@ fn bench_async_snapshot(b: &mut test::Bencher) {
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(leader);
     b.iter(|| {
-        let on_finished: EngineCallback<RegionSnapshot<RocksSnapshot>> = Box::new(move |results| {
+        let on_finished: EngineCallback<RegionSnapshot<RocksEngine>> = Box::new(move |results| {
             let _ = test::black_box(results);
         });
         kv.async_snapshot(&ctx, None, on_finished).unwrap();

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -69,7 +69,7 @@ impl RaftStoreRouter<RocksEngine> for SyncBenchRouter {
         Ok(())
     }
 
-    fn send_command(&self, req: RaftCmdRequest, cb: Callback<RocksSnapshot>) -> Result<()> {
+    fn send_command(&self, req: RaftCmdRequest, cb: Callback<RocksEngine>) -> Result<()> {
         self.invoke(RaftCommand::new(req, cb));
         Ok(())
     }
@@ -78,7 +78,7 @@ impl RaftStoreRouter<RocksEngine> for SyncBenchRouter {
         &self,
         req: RaftCmdRequest,
         txn_extra: TxnExtra,
-        cb: Callback<RocksSnapshot>,
+        cb: Callback<RocksEngine>,
     ) -> Result<()> {
         self.invoke(RaftCommand::with_txn_extra(req, cb, txn_extra));
         Ok(())
@@ -128,7 +128,7 @@ fn bench_async_snapshots_noop(b: &mut test::Bencher) {
                     cb1((ctx, Ok(snap)));
                 }
             });
-        let cb: Callback<RocksSnapshot> =
+        let cb: Callback<RocksEngine> =
             Callback::Read(Box::new(move |resp: ReadResponse<RocksSnapshot>| {
                 let res = CmdRes::Snap(resp.snapshot.unwrap());
                 cb2((CbContext::new(), Ok(res)));

--- a/tests/integrations/raftstore/test_lease_read.rs
+++ b/tests/integrations/raftstore/test_lease_read.rs
@@ -11,7 +11,7 @@ use kvproto::metapb;
 use kvproto::raft_serverpb::RaftLocalState;
 use raft::eraftpb::{ConfChangeType, MessageType};
 
-use engine_rocks::{Compat, RocksSnapshot};
+use engine_rocks::{Compat, RocksEngine};
 use engine_traits::Peekable;
 use pd_client::PdClient;
 use raftstore::store::{Callback, RegionSnapshot};
@@ -337,7 +337,7 @@ fn test_batch_id_in_lease<T: Simulator>(cluster: &mut Cluster<T>) {
         .map(|(p, r)| (p.clone(), r))
         .collect();
     let responses = batch_read_on_peer(cluster, &requests);
-    let snaps: Vec<RegionSnapshot<RocksSnapshot>> = responses
+    let snaps: Vec<RegionSnapshot<RocksEngine>> = responses
         .into_iter()
         .map(|response| {
             assert!(!response.response.get_header().has_error());
@@ -358,7 +358,7 @@ fn test_batch_id_in_lease<T: Simulator>(cluster: &mut Cluster<T>) {
     // make sure that region 2 could renew lease.
     cluster.must_put(b"k55", b"v2");
     let responses = batch_read_on_peer(cluster, &requests);
-    let snaps2: Vec<RegionSnapshot<RocksSnapshot>> = responses
+    let snaps2: Vec<RegionSnapshot<RocksEngine>> = responses
         .into_iter()
         .map(|response| {
             assert!(!response.response.get_header().has_error());

--- a/tests/integrations/storage/test_titan.rs
+++ b/tests/integrations/storage/test_titan.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use engine_rocks::raw::{IngestExternalFileOptions, Writable};
 use engine_rocks::util::get_cf_handle;
 use engine_rocks::RocksEngine;
-use engine_rocks::{Compat, RocksSnapshot, RocksSstWriterBuilder};
+use engine_rocks::{Compat, RocksSstWriterBuilder};
 use engine_traits::{
     CompactExt, Engines, KvEngine, MiscExt, SstWriter, SstWriterBuilder, ALL_CFS, CF_DEFAULT,
     CF_WRITE,
@@ -390,7 +390,7 @@ fn test_delete_files_in_range_for_titan() {
     r.mut_peers().push(Peer::default());
     r.set_start_key(b"a".to_vec());
     r.set_end_key(b"z".to_vec());
-    let snapshot = RegionSnapshot::<RocksSnapshot>::from_raw(engines1.kv.clone(), r);
+    let snapshot = RegionSnapshot::<RocksEngine>::from_raw(engines1.kv.clone(), r);
     let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
         .range(Some(Key::from_raw(b"a")), None)
         .build()


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Making raftstore generic over storage engines.

Part of https://github.com/tikv/tikv/issues/6402


### What is changed and how it works?

More instances of RocksEngine replaced with type parameters. A big result of this is that many Snapshot typarams are now KvEngine typarams.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note