### PR TITLE
[4.0] cdc: cherry pick bug fixes to release-4.0

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -605,6 +605,7 @@ impl TiKVServer {
         // Start CDC.
         let raft_router = self.engines.as_ref().unwrap().raft_router.clone();
         let cdc_endpoint = cdc::Endpoint::new(
+            &self.config.cdc,
             self.pd_client.clone(),
             cdc_worker.scheduler(),
             raft_router,

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -18,6 +18,7 @@ use raftstore::router::RaftStoreRouter;
 use raftstore::store::fsm::{ChangeCmd, ObserveID, StoreMeta};
 use raftstore::store::msg::{Callback, ReadResponse, SignificantMsg};
 use resolved_ts::Resolver;
+use tikv::config::CdcConfig;
 use tikv::storage::kv::Snapshot;
 use tikv::storage::mvcc::{DeltaScanner, ScannerBuilder};
 use tikv::storage::txn::TxnEntry;
@@ -228,6 +229,7 @@ pub struct Endpoint<T> {
 
 impl<T: 'static + RaftStoreRouter> Endpoint<T> {
     pub fn new(
+        cfg: &CdcConfig,
         pd_client: Arc<dyn PdClient>,
         scheduler: Scheduler<Task>,
         raft_router: T,
@@ -248,7 +250,7 @@ impl<T: 'static + RaftStoreRouter> Endpoint<T> {
             observer,
             store_meta,
             scan_batch_size: 1024,
-            min_ts_interval: Duration::from_secs(1),
+            min_ts_interval: cfg.min_ts_interval.0,
             min_resolved_ts: TimeStamp::max(),
             min_ts_region_id: 0,
         };
@@ -1055,6 +1057,7 @@ mod tests {
         let observer = CdcObserver::new(task_sched.clone());
         let pd_client = Arc::new(TestPdClient::new(0, true));
         let mut ep = Endpoint::new(
+            &CdcConfig::default(),
             pd_client,
             task_sched,
             raft_router.clone(),
@@ -1112,6 +1115,7 @@ mod tests {
         let observer = CdcObserver::new(task_sched.clone());
         let pd_client = Arc::new(TestPdClient::new(0, true));
         let mut ep = Endpoint::new(
+            &CdcConfig::default(),
             pd_client,
             task_sched,
             raft_router,

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -212,9 +212,7 @@ struct OldValueReader<S: EngineSnapshot> {
 
 impl<S: EngineSnapshot> OldValueReader<S> {
     fn new(snapshot: S) -> Self {
-        let mut iter_opts = IterOptions::default()
-            .use_prefix_seek()
-            .set_prefix_same_as_start(true);
+        let mut iter_opts = IterOptions::default();
         iter_opts.set_fill_cache(false);
         let write_cursor = snapshot
             .iter_cf(CF_WRITE, iter_opts, ScanMode::Mixed)

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -27,6 +27,7 @@ use kvproto::tikvpb::TikvClient;
 use raftstore::coprocessor::CoprocessorHost;
 use security::*;
 use test_raftstore::*;
+use tikv::config::CdcConfig;
 use tikv_util::collections::HashMap;
 use tikv_util::worker::Worker;
 use tikv_util::HandyRwLock;
@@ -128,6 +129,7 @@ impl TestSuite {
             let raft_router = sim.get_server_router(*id);
             let cdc_ob = obs.get(&id).unwrap().clone();
             let mut cdc_endpoint = cdc::Endpoint::new(
+                &CdcConfig::default(),
                 pd_cli.clone(),
                 worker.scheduler(),
                 raft_router,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1926,6 +1926,21 @@ impl Default for BackupConfig {
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Configuration)]
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
+pub struct CdcConfig {
+    pub min_ts_interval: ReadableDuration,
+}
+
+impl Default for CdcConfig {
+    fn default() -> Self {
+        Self {
+            min_ts_interval: ReadableDuration::secs(1),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Configuration)]
+#[serde(default)]
+#[serde(rename_all = "kebab-case")]
 pub struct TiKvConfig {
     #[doc(hidden)]
     #[serde(skip_serializing)]
@@ -1999,6 +2014,9 @@ pub struct TiKvConfig {
 
     #[config(submodule)]
     pub split: SplitConfig,
+
+    #[config(submodule)]
+    pub cdc: CdcConfig,
 }
 
 impl Default for TiKvConfig {
@@ -2027,6 +2045,7 @@ impl Default for TiKvConfig {
             pessimistic_txn: PessimisticTxnConfig::default(),
             gc: GcConfig::default(),
             split: SplitConfig::default(),
+            cdc: CdcConfig::default(),
         }
     }
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -601,6 +601,9 @@ fn test_serde_custom_tikv_config() {
         wake_up_delay_duration: ReadableDuration::millis(100),
         pipelined: true,
     };
+    value.cdc = CdcConfig {
+        min_ts_interval: ReadableDuration::secs(4),
+    };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");
     let load = toml::from_str(&custom).unwrap();

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -510,3 +510,5 @@ wait-for-lock-timeout = "10ms"
 wake-up-delay-duration = 100 # test backward compatible
 pipelined = true
 
+[cdc]
+min-ts-interval = "4s"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Several problems for CDC:
* the interval of advancing resolved ts is hard-coded
* panic caused by prefix checking of lower bound in `seek_to_first` when seeking for old value

### What is changed and how it works?

What's Changed:
* pick #8434 for supporting config file
* disable prefix checking for old value iterator

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* N/A