### PR TITLE
txn: Move MvccTxn::cleanup & MvccTxn::rollback to command

### DIFF
--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -472,7 +472,9 @@ mod tests {
     use crate::storage::kv::Modify;
     use crate::storage::mvcc::{MvccReader, MvccTxn};
 
-    use crate::storage::txn::{acquire_pessimistic_lock, commit, pessimistic_prewrite, prewrite};
+    use crate::storage::txn::{
+        acquire_pessimistic_lock, cleanup, commit, pessimistic_prewrite, prewrite,
+    };
     use concurrency_manager::ConcurrencyManager;
     use engine_rocks::properties::MvccPropertiesCollectorFactory;
     use engine_rocks::raw::DB;
@@ -648,8 +650,7 @@ mod tests {
             let cm = ConcurrencyManager::new(start_ts);
             let mut txn = MvccTxn::new(snap, start_ts, true, cm);
             txn.collapse_rollback(false);
-            txn.cleanup(Key::from_raw(pk), TimeStamp::zero(), true)
-                .unwrap();
+            cleanup(&mut txn, Key::from_raw(pk), TimeStamp::zero(), true).unwrap();
             self.write(txn.into_modifies());
         }
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -974,52 +974,6 @@ mod tests {
     }
 
     #[test]
-    fn test_cleanup() {
-        // Cleanup's logic is mostly similar to rollback, except the TTL check. Tests that not
-        // related to TTL check should be covered by other test cases.
-        let engine = TestEngineBuilder::new().build().unwrap();
-
-        // Shorthand for composing ts.
-        let ts = TimeStamp::compose;
-
-        let (k, v) = (b"k", b"v");
-
-        must_prewrite_put(&engine, k, v, k, ts(10, 0));
-        must_locked(&engine, k, ts(10, 0));
-        txn_heart_beat::tests::must_success(&engine, k, ts(10, 0), 100, 100);
-        // Check the last txn_heart_beat has set the lock's TTL to 100.
-        txn_heart_beat::tests::must_success(&engine, k, ts(10, 0), 90, 100);
-
-        // TTL not expired. Do nothing but returns an error.
-        must_cleanup_err(&engine, k, ts(10, 0), ts(20, 0));
-        must_locked(&engine, k, ts(10, 0));
-
-        // Try to cleanup another transaction's lock. Does nothing.
-        must_cleanup(&engine, k, ts(10, 1), ts(120, 0));
-        // If there is no exisiting lock when cleanup, it may be a pessimistic transaction,
-        // so the rollback should be protected.
-        must_get_rollback_protected(&engine, k, ts(10, 1), true);
-        must_locked(&engine, k, ts(10, 0));
-
-        // TTL expired. The lock should be removed.
-        must_cleanup(&engine, k, ts(10, 0), ts(120, 0));
-        must_unlocked(&engine, k);
-        // Rollbacks of optimistic transactions needn't be protected
-        must_get_rollback_protected(&engine, k, ts(10, 0), false);
-        must_get_rollback_ts(&engine, k, ts(10, 0));
-
-        // Rollbacks of primary keys in pessimistic transactions should be protected
-        must_acquire_pessimistic_lock(&engine, k, k, ts(11, 1), ts(12, 1));
-        must_cleanup(&engine, k, ts(11, 1), ts(120, 0));
-        must_get_rollback_protected(&engine, k, ts(11, 1), true);
-
-        must_acquire_pessimistic_lock(&engine, k, k, ts(13, 1), ts(14, 1));
-        must_pessimistic_prewrite_put(&engine, k, v, k, ts(13, 1), ts(14, 1), true);
-        must_cleanup(&engine, k, ts(13, 1), ts(120, 0));
-        must_get_rollback_protected(&engine, k, ts(13, 1), true);
-    }
-
-    #[test]
     fn test_mvcc_txn_prewrite() {
         test_mvcc_txn_prewrite_imp(b"k1", b"v1");
 

--- a/src/storage/txn/actions/cleanup.rs
+++ b/src/storage/txn/actions/cleanup.rs
@@ -1,0 +1,55 @@
+use crate::storage::mvcc::txn::MissingLockAction;
+use crate::storage::mvcc::{
+    metrics::{MVCC_CONFLICT_COUNTER, MVCC_DUPLICATE_CMD_COUNTER_VEC},
+    ErrorInner, Key, MvccTxn, ReleasedLock, Result as MvccResult, TimeStamp,
+};
+use crate::storage::{Snapshot, TxnStatus};
+
+/// Cleanup the lock if it's TTL has expired, comparing with `current_ts`. If `current_ts` is 0,
+/// cleanup the lock without checking TTL. If the lock is the primary lock of a pessimistic
+/// transaction, the rollback record is protected from being collapsed.
+///
+/// Returns the released lock. Returns error if the key is locked or has already been
+/// committed.
+pub fn cleanup<S: Snapshot>(
+    txn: &mut MvccTxn<S>,
+    key: Key,
+    current_ts: TimeStamp,
+    protect_rollback: bool,
+) -> MvccResult<Option<ReleasedLock>> {
+    fail_point!("cleanup", |err| Err(
+        crate::storage::mvcc::txn::make_txn_error(err, &key, txn.start_ts,).into()
+    ));
+
+    match txn.reader.load_lock(&key)? {
+        Some(ref lock) if lock.ts == txn.start_ts => {
+            // If current_ts is not 0, check the Lock's TTL.
+            // If the lock is not expired, do not rollback it but report key is locked.
+            if !current_ts.is_zero() && lock.ts.physical() + lock.ttl >= current_ts.physical() {
+                return Err(
+                    ErrorInner::KeyIsLocked(lock.clone().into_lock_info(key.into_raw()?)).into(),
+                );
+            }
+
+            let is_pessimistic_txn = !lock.for_update_ts.is_zero();
+            txn.check_write_and_rollback_lock(key, lock, is_pessimistic_txn)
+        }
+        l => match txn.check_txn_status_missing_lock(
+            key,
+            l,
+            MissingLockAction::rollback_protect(protect_rollback),
+        )? {
+            TxnStatus::Committed { commit_ts } => {
+                MVCC_CONFLICT_COUNTER.rollback_committed.inc();
+                Err(ErrorInner::Committed { commit_ts }.into())
+            }
+            TxnStatus::RolledBack => {
+                // Return Ok on Rollback already exist.
+                MVCC_DUPLICATE_CMD_COUNTER_VEC.rollback.inc();
+                Ok(None)
+            }
+            TxnStatus::LockNotExist => Ok(None),
+            _ => unreachable!(),
+        },
+    }
+}

--- a/src/storage/txn/actions/cleanup.rs
+++ b/src/storage/txn/actions/cleanup.rs
@@ -53,3 +53,100 @@ pub fn cleanup<S: Snapshot>(
         },
     }
 }
+
+pub mod tests {
+    use super::*;
+    use crate::storage::mvcc::{Error as MvccError, MvccTxn};
+    use crate::storage::Engine;
+    use concurrency_manager::ConcurrencyManager;
+    use kvproto::kvrpcpb::Context;
+    use txn_types::TimeStamp;
+
+    use crate::storage::mvcc::tests::write;
+    #[cfg(test)]
+    use crate::storage::{
+        mvcc::tests::{
+            must_get_rollback_protected, must_get_rollback_ts, must_locked, must_unlocked,
+        },
+        txn::commands::txn_heart_beat,
+        txn::tests::{
+            must_acquire_pessimistic_lock, must_pessimistic_prewrite_put, must_prewrite_put,
+        },
+        TestEngineBuilder,
+    };
+
+    pub fn must_succeed<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        current_ts: impl Into<TimeStamp>,
+    ) {
+        let ctx = Context::default();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let current_ts = current_ts.into();
+        let cm = ConcurrencyManager::new(current_ts);
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true, cm);
+        cleanup(&mut txn, Key::from_raw(key), current_ts, true).unwrap();
+        write(engine, &ctx, txn.into_modifies());
+    }
+
+    pub fn must_err<E: Engine>(
+        engine: &E,
+        key: &[u8],
+        start_ts: impl Into<TimeStamp>,
+        current_ts: impl Into<TimeStamp>,
+    ) -> MvccError {
+        let ctx = Context::default();
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let current_ts = current_ts.into();
+        let cm = ConcurrencyManager::new(current_ts);
+        let mut txn = MvccTxn::new(snapshot, start_ts.into(), true, cm);
+        cleanup(&mut txn, Key::from_raw(key), current_ts, true).unwrap_err()
+    }
+
+    #[test]
+    fn test_cleanup() {
+        // Cleanup's logic is mostly similar to rollback, except the TTL check. Tests that not
+        // related to TTL check should be covered by other test cases.
+        let engine = TestEngineBuilder::new().build().unwrap();
+
+        // Shorthand for composing ts.
+        let ts = TimeStamp::compose;
+
+        let (k, v) = (b"k", b"v");
+
+        must_prewrite_put(&engine, k, v, k, ts(10, 0));
+        must_locked(&engine, k, ts(10, 0));
+        txn_heart_beat::tests::must_success(&engine, k, ts(10, 0), 100, 100);
+        // Check the last txn_heart_beat has set the lock's TTL to 100.
+        txn_heart_beat::tests::must_success(&engine, k, ts(10, 0), 90, 100);
+
+        // TTL not expired. Do nothing but returns an error.
+        must_err(&engine, k, ts(10, 0), ts(20, 0));
+        must_locked(&engine, k, ts(10, 0));
+
+        // Try to cleanup another transaction's lock. Does nothing.
+        must_succeed(&engine, k, ts(10, 1), ts(120, 0));
+        // If there is no exisiting lock when cleanup, it may be a pessimistic transaction,
+        // so the rollback should be protected.
+        must_get_rollback_protected(&engine, k, ts(10, 1), true);
+        must_locked(&engine, k, ts(10, 0));
+
+        // TTL expired. The lock should be removed.
+        must_succeed(&engine, k, ts(10, 0), ts(120, 0));
+        must_unlocked(&engine, k);
+        // Rollbacks of optimistic transactions needn't be protected
+        must_get_rollback_protected(&engine, k, ts(10, 0), false);
+        must_get_rollback_ts(&engine, k, ts(10, 0));
+
+        // Rollbacks of primary keys in pessimistic transactions should be protected
+        must_acquire_pessimistic_lock(&engine, k, k, ts(11, 1), ts(12, 1));
+        must_succeed(&engine, k, ts(11, 1), ts(120, 0));
+        must_get_rollback_protected(&engine, k, ts(11, 1), true);
+
+        must_acquire_pessimistic_lock(&engine, k, k, ts(13, 1), ts(14, 1));
+        must_pessimistic_prewrite_put(&engine, k, v, k, ts(13, 1), ts(14, 1), true);
+        must_succeed(&engine, k, ts(13, 1), ts(120, 0));
+        must_get_rollback_protected(&engine, k, ts(13, 1), true);
+    }
+}

--- a/src/storage/txn/actions/mod.rs
+++ b/src/storage/txn/actions/mod.rs
@@ -11,4 +11,5 @@ pub mod pessimistic_prewrite;
 pub mod prewrite;
 pub(crate) mod shared;
 
+pub mod cleanup;
 pub mod tests;

--- a/src/storage/txn/commands/cleanup.rs
+++ b/src/storage/txn/commands/cleanup.rs
@@ -8,7 +8,7 @@ use crate::storage::mvcc::MvccTxn;
 use crate::storage::txn::commands::{
     Command, CommandExt, ReleasedLocks, TypedCommand, WriteCommand, WriteContext, WriteResult,
 };
-use crate::storage::txn::Result;
+use crate::storage::txn::{cleanup, Result};
 use crate::storage::{ProcessResult, Snapshot};
 
 command! {
@@ -52,7 +52,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Cleanup {
         let mut released_locks = ReleasedLocks::new(self.start_ts, TimeStamp::zero());
         // The rollback must be protected, see more on
         // [issue #7364](https://github.com/tikv/tikv/issues/7364)
-        released_locks.push(txn.cleanup(self.key, self.current_ts, true)?);
+        released_locks.push(cleanup(&mut txn, self.key, self.current_ts, true)?);
         released_locks.wake_up(context.lock_mgr);
 
         context.statistics.add(&txn.take_statistics());

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -9,7 +9,7 @@ pub mod scheduler;
 mod actions;
 
 pub use actions::{
-    acquire_pessimistic_lock::acquire_pessimistic_lock, commit::commit,
+    acquire_pessimistic_lock::acquire_pessimistic_lock, cleanup::cleanup, commit::commit,
     pessimistic_prewrite::pessimistic_prewrite, prewrite::prewrite,
 };
 

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -245,6 +245,7 @@ pub mod tests {
         must_succeed_return_value as must_acquire_pessimistic_lock_return_value,
         must_succeed_with_ttl as must_acquire_pessimistic_lock_with_ttl,
     };
+    pub use actions::cleanup::tests::{must_err as must_cleanup_err, must_succeed as must_cleanup};
     pub use actions::commit::tests::{must_err as must_commit_err, must_succeed as must_commit};
     pub use actions::pessimistic_prewrite::tests::try_pessimistic_prewrite_check_not_exists;
     pub use actions::prewrite::tests::{try_prewrite_check_not_exists, try_prewrite_insert};


### PR DESCRIPTION
Signed-off-by: longfangsong <longfangsong@icloud.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: 

Currently MvccTxn contains several functions highly related with certain Command, this breaks the SRP of `MvccTxn` and made the struct's code very long and hard to read.

(This is part of #8432.)

### What is changed and how it works?

What's Changed:

Move `cleanup` and `rollback` from `MvccTxn` to its own Command, and also move the tests.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
