### PR TITLE
copr: fix deadline detection test: `test_deadline_3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,6 +4551,7 @@ name = "tidb_query_vec_executors"
 version = "0.0.1"
 dependencies = [
  "codec",
+ "fail",
  "failure",
  "hex 0.3.2",
  "kvproto",

--- a/components/tidb_query_vec_executors/Cargo.toml
+++ b/components/tidb_query_vec_executors/Cargo.toml
@@ -20,6 +20,7 @@ tidb_query_vec_expr = { path = "../tidb_query_vec_expr" }
 tidb_query_vec_aggr = { path = "../tidb_query_vec_aggr" }
 tikv_util = { path = "../tikv_util" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
+fail = { git = "https://github.com/tikv/fail-rs.git", rev = "2cf1175a1a5cc2c70bd20ebd45313afd69b558fc" }
 
 [dependencies.yatp]
 git = "https://github.com/tikv/yatp.git"

--- a/components/tidb_query_vec_executors/Cargo.toml
+++ b/components/tidb_query_vec_executors/Cargo.toml
@@ -20,7 +20,7 @@ tidb_query_vec_expr = { path = "../tidb_query_vec_expr" }
 tidb_query_vec_aggr = { path = "../tidb_query_vec_aggr" }
 tikv_util = { path = "../tikv_util" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
-fail = { git = "https://github.com/tikv/fail-rs.git", rev = "2cf1175a1a5cc2c70bd20ebd45313afd69b558fc" }
+fail = "0.3"
 
 [dependencies.yatp]
 git = "https://github.com/tikv/yatp.git"

--- a/components/tidb_query_vec_executors/src/runner.rs
+++ b/components/tidb_query_vec_executors/src/runner.rs
@@ -363,14 +363,15 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         })
     }
 
-    fn batch_size() -> usize {
-        fail_point!("copr_batch_size", |r| r.map_or(1, |e| e.parse().unwrap()));
+    fn batch_initial_size() -> usize {
+        fail_point!("copr_batch_initial_size", |r| r
+            .map_or(1, |e| e.parse().unwrap()));
         BATCH_INITIAL_SIZE
     }
 
     pub async fn handle_request(&mut self) -> Result<SelectResponse> {
         let mut chunks = vec![];
-        let mut batch_size = Self::batch_size();
+        let mut batch_size = Self::batch_initial_size();
         let mut warnings = self.config.new_eval_warnings();
         let mut ctx = EvalContext::new(self.config.clone());
 

--- a/tests/failpoints/cases/test_coprocessor.rs
+++ b/tests/failpoints/cases/test_coprocessor.rs
@@ -49,14 +49,12 @@ fn test_deadline_3() {
         let engine = tikv::storage::TestEngineBuilder::new().build().unwrap();
         let mut cfg = tikv::server::Config::default();
         cfg.end_point_request_max_handle_duration = tikv_util::config::ReadableDuration::secs(1);
-        // Batch execution will check deadline after the first batch is executed, but our
-        // test data is not large enough for the second batch. So let's disable it.
-        cfg.end_point_enable_batch_if_possible = false;
         init_data_with_details(Context::default(), engine, &product, &data, true, &cfg)
     };
     let req = DAGSelect::from(&product).build();
 
     fail::cfg("kv_cursor_seek", "sleep(2000)").unwrap();
+    fail::cfg("copr_batch_size", "return(1)").unwrap();
     let cop_resp = handle_request(&endpoint, req);
     let mut resp = SelectResponse::default();
     resp.merge_from_bytes(cop_resp.get_data()).unwrap();

--- a/tests/failpoints/cases/test_coprocessor.rs
+++ b/tests/failpoints/cases/test_coprocessor.rs
@@ -54,7 +54,7 @@ fn test_deadline_3() {
     let req = DAGSelect::from(&product).build();
 
     fail::cfg("kv_cursor_seek", "sleep(2000)").unwrap();
-    fail::cfg("copr_batch_size", "return(1)").unwrap();
+    fail::cfg("copr_batch_initial_size", "return(1)").unwrap();
     let cop_resp = handle_request(&endpoint, req);
     let mut resp = SelectResponse::default();
     resp.merge_from_bytes(cop_resp.get_data()).unwrap();


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

This pull request fixes a fail test related to coprocessor request's deadline detection: https://github.com/tikv/tikv/blob/1ebd3e2178bcea0543bb356d80e521bc1bc44782/tests/failpoints/cases/test_coprocessor.rs#L39

### What is changed and how it works?

This pull request checks the deadline at 3 points to ensure that we could ensure the request stepping over the deadline confidently.

1. At the time that the request handler begins to execute.
2. At the time that the batch executor runner fetches a batch of data from the executors.
3. At the time that the batch executor finishes the response encoding.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Fix deadline detection of coprocessor's batch executor runner.