### PR TITLE
tests: transfer leader to node 1 first to make sync max ts tests stable

### DIFF
--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -1195,6 +1195,9 @@ fn test_sync_max_ts_after_region_merge() {
     configure_for_merge(&mut cluster);
     cluster.run();
 
+    // Transfer leader to node 1 first to ensure all operations happen on node 1
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+
     cluster.must_put(b"k1", b"v1");
     cluster.must_put(b"k3", b"v3");
 

--- a/tests/integrations/raftstore/test_transfer_leader.rs
+++ b/tests/integrations/raftstore/test_transfer_leader.rs
@@ -201,6 +201,7 @@ fn test_sync_max_ts_after_leader_transfer() {
         assert!(snapshot.is_max_ts_synced());
     };
 
+    cluster.must_transfer_leader(1, new_peer(1, 1));
     wait_for_synced(&mut cluster);
     let max_ts = cm.max_read_ts();
 


### PR DESCRIPTION
### What problem does this PR solve?

Closes #8516 and closes #8505 

### What is changed and how it works?

`test_sync_max_ts_after_region_merge` and `test_sync_max_ts_after_leader_transfer` assumed the region 1 leader is on node 1. However it's not true. So this PR transfer the leader to region 1 first.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

This PR is to stablize tests.

### Release note <!-- bugfixes or new feature need a release note -->

No release note.