### PR TITLE
remove shared_block_cache from engines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,9 +1896,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "libflate"
@@ -2330,6 +2330,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "void",
+]
+
+[[package]]
+name = "nix"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -3031,10 +3043,11 @@ dependencies = [
 [[package]]
 name = "raft-engine"
 version = "0.1.0"
-source = "git+https://github.com/tikv/raft-engine#8d45f51381ebf9941f9857474602cab2a5e9a0a2"
+source = "git+https://github.com/tikv/raft-engine#16f8a37c88d758131740f492a1626f6016dfaafd"
 dependencies = [
  "byteorder",
  "crc32fast",
+ "crossbeam",
  "errno",
  "fxhash",
  "kvproto",
@@ -3042,6 +3055,7 @@ dependencies = [
  "libc",
  "log",
  "lz4-sys",
+ "nix 0.18.0",
  "prometheus",
  "protobuf",
  "quick-error",
@@ -3049,6 +3063,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -104,10 +104,9 @@ fn new_debug_executor(
 
             let mut kv_db = RocksEngine::from_db(Arc::new(kv_db));
             let mut raft_db = RocksEngine::from_db(Arc::new(raft_db));
-            if cache.is_some() {
-                kv_db.set_shared_block_cache();
-                raft_db.set_shared_block_cache();
-            }
+            let shared_block_cache = cache.is_some();
+            kv_db.set_shared_block_cache(shared_block_cache);
+            raft_db.set_shared_block_cache(shared_block_cache);
 
             Box::new(Debugger::new(
                 Engines::new(kv_db, raft_db),

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -102,12 +102,15 @@ fn new_debug_executor(
                 engine_rocks::raw_util::new_engine_opt(&raft_path, raft_db_opts, raft_db_cf_opts)
                     .unwrap();
 
+            let mut kv_db = RocksEngine::from_db(Arc::new(kv_db));
+            let mut raft_db = RocksEngine::from_db(Arc::new(raft_db));
+            if cache.is_some() {
+                kv_db.set_shared_block_cache();
+                raft_db.set_shared_block_cache();
+            }
+
             Box::new(Debugger::new(
-                Engines::new(
-                    RocksEngine::from_db(Arc::new(kv_db)),
-                    RocksEngine::from_db(Arc::new(raft_db)),
-                    cache.is_some(),
-                ),
+                Engines::new(kv_db, raft_db),
                 ConfigController::default(),
             )) as Box<dyn DebugExecutor>
         }

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -427,10 +427,9 @@ impl TiKVServer {
 
         let mut kv_engine = RocksEngine::from_db(Arc::new(kv_engine));
         let mut raft_engine = RocksEngine::from_db(Arc::new(raft_engine));
-        if block_cache.is_some() {
-            kv_engine.set_shared_block_cache();
-            raft_engine.set_shared_block_cache();
-        }
+        let shared_block_cache = block_cache.is_some();
+        kv_engine.set_shared_block_cache(shared_block_cache);
+        raft_engine.set_shared_block_cache(shared_block_cache);
         let engines = Engines::new(kv_engine, raft_engine);
 
         let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_VOTES_CAP)));

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -425,11 +425,14 @@ impl TiKVServer {
         )
         .unwrap_or_else(|s| fatal!("failed to create kv engine: {}", s));
 
-        let engines = Engines::new(
-            RocksEngine::from_db(Arc::new(kv_engine)),
-            RocksEngine::from_db(Arc::new(raft_engine)),
-            block_cache.is_some(),
-        );
+        let mut kv_engine = RocksEngine::from_db(Arc::new(kv_engine));
+        let mut raft_engine = RocksEngine::from_db(Arc::new(raft_engine));
+        if block_cache.is_some() {
+            kv_engine.set_shared_block_cache();
+            raft_engine.set_shared_block_cache();
+        }
+        let engines = Engines::new(kv_engine, raft_engine);
+
         let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_VOTES_CAP)));
         let local_reader =
             LocalReader::new(engines.kv.clone(), store_meta.clone(), self.router.clone());
@@ -822,11 +825,9 @@ impl TiKVServer {
     }
 
     fn init_metrics_flusher(&mut self) {
-        let mut metrics_flusher = Box::new(MetricsFlusher::new(Engines::new(
-            self.engines.as_ref().unwrap().engines.kv.clone(),
-            self.engines.as_ref().unwrap().engines.raft.clone(),
-            self.engines.as_ref().unwrap().engines.shared_block_cache,
-        )));
+        let mut metrics_flusher = Box::new(MetricsFlusher::new(
+            self.engines.as_ref().unwrap().engines.clone(),
+        ));
 
         // Start metrics flusher
         if let Err(e) = metrics_flusher.start() {

--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -60,8 +60,8 @@ impl RocksEngine {
         fs::read_dir(&path).unwrap().next().is_some()
     }
 
-    pub fn set_shared_block_cache(&mut self) {
-        self.shared_block_cache = true;
+    pub fn set_shared_block_cache(&mut self, enable: bool) {
+        self.shared_block_cache = enable;
     }
 }
 

--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -23,12 +23,17 @@ use crate::util::get_cf_handle;
 use crate::{RocksEngineIterator, RocksSnapshot};
 
 #[derive(Clone, Debug)]
-#[repr(transparent)]
-pub struct RocksEngine(Arc<DB>);
+pub struct RocksEngine {
+    db: Arc<DB>,
+    shared_block_cache: bool,
+}
 
 impl RocksEngine {
     pub fn from_db(db: Arc<DB>) -> Self {
-        RocksEngine(db)
+        RocksEngine {
+            db,
+            shared_block_cache: false,
+        }
     }
 
     pub fn from_ref(db: &Arc<DB>) -> &Self {
@@ -36,11 +41,11 @@ impl RocksEngine {
     }
 
     pub fn as_inner(&self) -> &Arc<DB> {
-        &self.0
+        &self.db
     }
 
     pub fn get_sync_db(&self) -> Arc<DB> {
-        self.0.clone()
+        self.db.clone()
     }
 
     pub fn exists(path: &str) -> bool {
@@ -54,50 +59,54 @@ impl RocksEngine {
         // the directory by this indication.
         fs::read_dir(&path).unwrap().next().is_some()
     }
+
+    pub fn set_shared_block_cache(&mut self) {
+        self.shared_block_cache = true;
+    }
 }
 
 impl KvEngine for RocksEngine {
     type Snapshot = RocksSnapshot;
 
     fn snapshot(&self) -> RocksSnapshot {
-        RocksSnapshot::new(self.0.clone())
+        RocksSnapshot::new(self.db.clone())
     }
 
     fn sync(&self) -> Result<()> {
-        self.0.sync_wal().map_err(Error::Engine)
+        self.db.sync_wal().map_err(Error::Engine)
     }
 
-    fn flush_metrics(&self, instance: &str, shared_block_cache: bool) {
+    fn flush_metrics(&self, instance: &str) {
         for t in ENGINE_TICKER_TYPES {
-            let v = self.0.get_and_reset_statistics_ticker_count(*t);
+            let v = self.db.get_and_reset_statistics_ticker_count(*t);
             flush_engine_ticker_metrics(*t, v, instance);
         }
         for t in ENGINE_HIST_TYPES {
-            if let Some(v) = self.0.get_statistics_histogram(*t) {
+            if let Some(v) = self.db.get_statistics_histogram(*t) {
                 flush_engine_histogram_metrics(*t, v, instance);
             }
         }
-        if self.0.is_titan() {
+        if self.db.is_titan() {
             for t in TITAN_ENGINE_TICKER_TYPES {
-                let v = self.0.get_and_reset_statistics_ticker_count(*t);
+                let v = self.db.get_and_reset_statistics_ticker_count(*t);
                 flush_engine_ticker_metrics(*t, v, instance);
             }
             for t in TITAN_ENGINE_HIST_TYPES {
-                if let Some(v) = self.0.get_statistics_histogram(*t) {
+                if let Some(v) = self.db.get_statistics_histogram(*t) {
                     flush_engine_histogram_metrics(*t, v, instance);
                 }
             }
         }
-        flush_engine_properties(&self.0, instance, shared_block_cache);
-        flush_engine_iostall_properties(&self.0, instance);
+        flush_engine_properties(&self.db, instance, self.shared_block_cache);
+        flush_engine_iostall_properties(&self.db, instance);
     }
 
     fn reset_statistics(&self) {
-        self.0.reset_statistics();
+        self.db.reset_statistics();
     }
 
     fn bad_downcast<T: 'static>(&self) -> &T {
-        let e: &dyn Any = &self.0;
+        let e: &dyn Any = &self.db;
         e.downcast_ref().expect("bad engine downcast")
     }
 }
@@ -108,16 +117,16 @@ impl Iterable for RocksEngine {
     fn iterator_opt(&self, opts: IterOptions) -> Result<Self::Iterator> {
         let opt: RocksReadOptions = opts.into();
         Ok(RocksEngineIterator::from_raw(DBIterator::new(
-            self.0.clone(),
+            self.db.clone(),
             opt.into_raw(),
         )))
     }
 
     fn iterator_cf_opt(&self, cf: &str, opts: IterOptions) -> Result<Self::Iterator> {
-        let handle = get_cf_handle(&self.0, cf)?;
+        let handle = get_cf_handle(&self.db, cf)?;
         let opt: RocksReadOptions = opts.into();
         Ok(RocksEngineIterator::from_raw(DBIterator::new_cf(
-            self.0.clone(),
+            self.db.clone(),
             handle,
             opt.into_raw(),
         )))
@@ -129,7 +138,7 @@ impl Peekable for RocksEngine {
 
     fn get_value_opt(&self, opts: &ReadOptions, key: &[u8]) -> Result<Option<RocksDBVector>> {
         let opt: RocksReadOptions = opts.into();
-        let v = self.0.get_opt(key, &opt.into_raw())?;
+        let v = self.db.get_opt(key, &opt.into_raw())?;
         Ok(v.map(RocksDBVector::from_raw))
     }
 
@@ -140,34 +149,34 @@ impl Peekable for RocksEngine {
         key: &[u8],
     ) -> Result<Option<RocksDBVector>> {
         let opt: RocksReadOptions = opts.into();
-        let handle = get_cf_handle(&self.0, cf)?;
-        let v = self.0.get_cf_opt(handle, key, &opt.into_raw())?;
+        let handle = get_cf_handle(&self.db, cf)?;
+        let v = self.db.get_cf_opt(handle, key, &opt.into_raw())?;
         Ok(v.map(RocksDBVector::from_raw))
     }
 }
 
 impl SyncMutable for RocksEngine {
     fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
-        self.0.put(key, value).map_err(Error::Engine)
+        self.db.put(key, value).map_err(Error::Engine)
     }
 
     fn put_cf(&self, cf: &str, key: &[u8], value: &[u8]) -> Result<()> {
-        let handle = get_cf_handle(&self.0, cf)?;
-        self.0.put_cf(handle, key, value).map_err(Error::Engine)
+        let handle = get_cf_handle(&self.db, cf)?;
+        self.db.put_cf(handle, key, value).map_err(Error::Engine)
     }
 
     fn delete(&self, key: &[u8]) -> Result<()> {
-        self.0.delete(key).map_err(Error::Engine)
+        self.db.delete(key).map_err(Error::Engine)
     }
 
     fn delete_cf(&self, cf: &str, key: &[u8]) -> Result<()> {
-        let handle = get_cf_handle(&self.0, cf)?;
-        self.0.delete_cf(handle, key).map_err(Error::Engine)
+        let handle = get_cf_handle(&self.db, cf)?;
+        self.db.delete_cf(handle, key).map_err(Error::Engine)
     }
 
     fn delete_range_cf(&self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
-        let handle = get_cf_handle(&self.0, cf)?;
-        self.0
+        let handle = get_cf_handle(&self.db, cf)?;
+        self.db
             .delete_range_cf(handle, begin_key, end_key)
             .map_err(Error::Engine)
     }

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -1,8 +1,8 @@
 use crate::{RocksEngine, RocksWriteBatch};
 
 use engine_traits::{
-    Iterable, MiscExt, Mutable, Peekable, SyncMutable, WriteBatchExt, WriteOptions, CF_DEFAULT,
-    MAX_DELETE_BATCH_SIZE,
+    Iterable, KvEngine, MiscExt, Mutable, Peekable, SyncMutable, WriteBatchExt, WriteOptions,
+    CF_DEFAULT, MAX_DELETE_BATCH_SIZE,
 };
 use kvproto::raft_serverpb::RaftLocalState;
 use protobuf::Message;
@@ -204,12 +204,23 @@ impl RaftEngine for RocksEngine {
         Ok((to - from) as usize)
     }
 
+    fn purge_expired_files(&self) -> Result<Vec<u64>> {
+        Ok(vec![])
+    }
+
     fn has_builtin_entry_cache(&self) -> bool {
         false
     }
 
     fn flush_stats(&self) -> CacheStats {
         CacheStats::default()
+    }
+
+    fn flush_metrics(&self, instance: &str) {
+        KvEngine::flush_metrics(self, instance)
+    }
+    fn reset_statistics(&self) {
+        KvEngine::reset_statistics(self)
     }
 }
 

--- a/components/engine_rocks/src/util.rs
+++ b/components/engine_rocks/src/util.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 pub fn new_temp_engine(path: &tempfile::TempDir) -> Engines<RocksEngine, RocksEngine> {
     let raft_path = path.path().join(std::path::Path::new("raft"));
-    let shared_block_cache = false;
     Engines::new(
         new_engine(
             path.path().to_str().unwrap(),
@@ -34,7 +33,6 @@ pub fn new_temp_engine(path: &tempfile::TempDir) -> Engines<RocksEngine, RocksEn
             None,
         )
         .unwrap(),
-        shared_block_cache,
     )
 }
 

--- a/components/engine_traits/src/engine.rs
+++ b/components/engine_traits/src/engine.rs
@@ -42,9 +42,7 @@ pub trait KvEngine:
     /// Flush metrics to prometheus
     ///
     /// `instance` is the label of the metric to flush.
-    ///
-    /// TODO: remove `shared_block_cache`.
-    fn flush_metrics(&self, _instance: &str, _shared_block_cache: bool) {}
+    fn flush_metrics(&self, _instance: &str) {}
 
     /// Reset internal statistics
     fn reset_statistics(&self) {}

--- a/components/engine_traits/src/engines.rs
+++ b/components/engine_traits/src/engines.rs
@@ -10,15 +10,13 @@ use crate::options::WriteOptions;
 pub struct Engines<K, R> {
     pub kv: K,
     pub raft: R,
-    pub shared_block_cache: bool,
 }
 
 impl<K: KvEngine, R: RaftEngine> Engines<K, R> {
-    pub fn new(kv_engine: K, raft_engine: R, shared_block_cache: bool) -> Self {
+    pub fn new(kv_engine: K, raft_engine: R) -> Self {
         Engines {
             kv: kv_engine,
             raft: raft_engine,
-            shared_block_cache,
         }
     }
 

--- a/components/engine_traits/src/metrics_flusher.rs
+++ b/components/engine_traits/src/metrics_flusher.rs
@@ -6,19 +6,21 @@ use std::sync::mpsc::{self, Sender};
 use std::thread::{Builder as ThreadBuilder, JoinHandle};
 use std::time::{Duration, Instant};
 
+use raft_engine::RaftEngine;
+
 use crate::*;
 
 const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_millis(10_000);
 const FLUSHER_RESET_INTERVAL: Duration = Duration::from_millis(60_000);
 
-pub struct MetricsFlusher<K: KvEngine, R: KvEngine> {
+pub struct MetricsFlusher<K: KvEngine, R: RaftEngine> {
     pub engines: Engines<K, R>,
     interval: Duration,
     handle: Option<JoinHandle<()>>,
     sender: Option<Sender<bool>>,
 }
 
-impl<K: KvEngine, R: KvEngine> MetricsFlusher<K, R> {
+impl<K: KvEngine, R: RaftEngine> MetricsFlusher<K, R> {
     pub fn new(engines: Engines<K, R>) -> Self {
         MetricsFlusher {
             engines,
@@ -34,7 +36,6 @@ impl<K: KvEngine, R: KvEngine> MetricsFlusher<K, R> {
 
     pub fn start(&mut self) -> Result<(), io::Error> {
         let (kv_db, raft_db) = (self.engines.kv.clone(), self.engines.raft.clone());
-        let shared_block_cache = self.engines.shared_block_cache;
         let interval = self.interval;
         let (tx, rx) = mpsc::channel();
         self.sender = Some(tx);
@@ -44,8 +45,8 @@ impl<K: KvEngine, R: KvEngine> MetricsFlusher<K, R> {
                 tikv_alloc::add_thread_memory_accessor();
                 let mut last_reset = Instant::now();
                 while let Err(mpsc::RecvTimeoutError::Timeout) = rx.recv_timeout(interval) {
-                    kv_db.flush_metrics("kv", shared_block_cache);
-                    raft_db.flush_metrics("raft", shared_block_cache);
+                    kv_db.flush_metrics("kv");
+                    raft_db.flush_metrics("raft");
                     if last_reset.elapsed() >= FLUSHER_RESET_INTERVAL {
                         kv_db.reset_statistics();
                         raft_db.reset_statistics();

--- a/components/engine_traits/tests/src/test_metrics_fluster.rs
+++ b/components/engine_traits/tests/src/test_metrics_fluster.rs
@@ -45,8 +45,7 @@ fn test_metrics_flusher() {
     .unwrap();
     assert!(!raft_engine.is_titan());
 
-    let shared_block_cache = false;
-    let engines = Engines::new(engine, raft_engine, shared_block_cache);
+    let engines = Engines::new(engine, raft_engine);
     let mut metrics_flusher = MetricsFlusher::new(engines);
     metrics_flusher.set_flush_interval(Duration::from_millis(100));
 

--- a/components/raftstore/src/store/bootstrap.rs
+++ b/components/raftstore/src/store/bootstrap.rs
@@ -146,8 +146,7 @@ mod tests {
         let raft_engine =
             engine_rocks::util::new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None)
                 .unwrap();
-        let shared_block_cache = false;
-        let engines = Engines::new(kv_engine.clone(), raft_engine.clone(), shared_block_cache);
+        let engines = Engines::new(kv_engine.clone(), raft_engine.clone());
         let region = initial_region(1, 1, 1);
 
         assert!(bootstrap_store(&engines, 1, 1).is_ok());

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1081,7 +1081,7 @@ where
             return;
         }
         let stats = self.engines.raft.flush_stats();
-        RAFT_ENTRIES_CACHES_GAUGE.add(stats.mem_size_change as i64);
+        RAFT_ENTRIES_CACHES_GAUGE.set(stats.cache_size as i64);
         RAFT_ENTRY_FETCHES.hit.inc_by(stats.hit as i64);
         RAFT_ENTRY_FETCHES.miss.inc_by(stats.miss as i64);
     }
@@ -1670,8 +1670,7 @@ mod tests {
         let kv_db = new_engine(path.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
         let raft_path = path.path().join(Path::new("raft"));
         let raft_db = new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None).unwrap();
-        let shared_block_cache = false;
-        let engines = Engines::new(kv_db, raft_db, shared_block_cache);
+        let engines = Engines::new(kv_db, raft_db);
         bootstrap_store(&engines, 1, 1).unwrap();
 
         let region = initial_region(1, 1, 1);
@@ -2497,8 +2496,7 @@ mod tests {
         let kv_db = new_engine(td.path().to_str().unwrap(), None, ALL_CFS, None).unwrap();
         let raft_path = td.path().join(Path::new("raft"));
         let raft_db = new_engine(raft_path.to_str().unwrap(), None, &[CF_DEFAULT], None).unwrap();
-        let shared_block_cache = false;
-        let engines = Engines::new(kv_db, raft_db, shared_block_cache);
+        let engines = Engines::new(kv_db, raft_db);
         bootstrap_store(&engines, 1, 1).unwrap();
 
         let region = initial_region(1, 1, 1);

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1625,11 +1625,9 @@ pub mod tests {
             kv.c()
                 .put_msg_cf(CF_RAFT, &keys::region_state_key(region_id), &region_state)?;
         }
-        let shared_block_cache = false;
         Ok(Engines {
             kv: kv.c().clone(),
             raft: raft.c().clone(),
-            shared_block_cache,
         })
     }
 

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -844,8 +844,7 @@ mod tests {
         let mgr = SnapManager::new(snap_dir.path().to_str().unwrap());
         let mut worker = Worker::new("region-worker");
         let sched = worker.scheduler();
-        let shared_block_cache = false;
-        let engines = Engines::new(engine.kv.clone(), engine.raft.clone(), shared_block_cache);
+        let engines = Engines::new(engine.kv.clone(), engine.raft.clone());
         let (router, _) = mpsc::sync_channel(1);
         let runner = RegionRunner::new(
             engines,
@@ -922,8 +921,7 @@ mod tests {
             }
         }
 
-        let shared_block_cache = false;
-        let engines = Engines::new(engine.kv.clone(), engine.raft.clone(), shared_block_cache);
+        let engines = Engines::new(engine.kv.clone(), engine.raft.clone());
         let snap_dir = Builder::new().prefix("snap_dir").tempdir().unwrap();
         let mgr = SnapManager::new(snap_dir.path().to_str().unwrap());
         let mut worker = Worker::new("snap-manager");

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -560,11 +560,13 @@ pub fn create_test_engine(
         engine_rocks::raw_util::new_engine_opt(raft_path_str, raft_db_opt, raft_cfs_opt).unwrap(),
     );
 
-    let engines = Engines::new(
-        RocksEngine::from_db(engine),
-        RocksEngine::from_db(raft_engine),
-        cache.is_some(),
-    );
+    let mut engine = RocksEngine::from_db(engine);
+    let mut raft_engine = RocksEngine::from_db(raft_engine);
+    if cache.is_some() {
+        engine.set_shared_block_cache();
+        raft_engine.set_shared_block_cache();
+    }
+    let engines = Engines::new(engine, raft_engine);
     (engines, key_manager, dir)
 }
 

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -562,10 +562,9 @@ pub fn create_test_engine(
 
     let mut engine = RocksEngine::from_db(engine);
     let mut raft_engine = RocksEngine::from_db(raft_engine);
-    if cache.is_some() {
-        engine.set_shared_block_cache();
-        raft_engine.set_shared_block_cache();
-    }
+    let shared_block_cache = cache.is_some();
+    engine.set_shared_block_cache(shared_block_cache);
+    raft_engine.set_shared_block_cache(shared_block_cache);
     let engines = Engines::new(engine, raft_engine);
     (engines, key_manager, dir)
 }

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -1518,11 +1518,9 @@ mod tests {
             .unwrap(),
         );
 
-        let shared_block_cache = false;
         let engines = Engines::new(
             RocksEngine::from_db(Arc::clone(&engine)),
             RocksEngine::from_db(engine),
-            shared_block_cache,
         );
         Debugger::new(engines, ConfigController::default())
     }

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -113,10 +113,8 @@ impl RocksEngine {
         // rocksdb.
         let mut kv_engine = BaseRocksEngine::from_db(db.clone());
         let mut raft_engine = BaseRocksEngine::from_db(db);
-        if shared_block_cache {
-            kv_engine.set_shared_block_cache();
-            raft_engine.set_shared_block_cache();
-        }
+        kv_engine.set_shared_block_cache(shared_block_cache);
+        raft_engine.set_shared_block_cache(shared_block_cache);
         let engines = Engines::new(kv_engine, raft_engine);
         box_try!(worker.start(Runner(engines.clone())));
         Ok(RocksEngine {

--- a/tests/integrations/config/dynamic/raftstore.rs
+++ b/tests/integrations/config/dynamic/raftstore.rs
@@ -51,12 +51,7 @@ fn create_tmp_engine(dir: &TempDir) -> Engines<RocksEngine, RocksEngine> {
         )
         .unwrap(),
     );
-    let shared_block_cache = false;
-    Engines::new(
-        RocksEngine::from_db(db),
-        RocksEngine::from_db(raft_db),
-        shared_block_cache,
-    )
+    Engines::new(RocksEngine::from_db(db), RocksEngine::from_db(raft_db))
 }
 
 fn start_raftstore(

--- a/tests/integrations/raftstore/test_bootstrap.rs
+++ b/tests/integrations/raftstore/test_bootstrap.rs
@@ -52,11 +52,9 @@ fn test_node_bootstrap_with_prepared_data() {
         engine_rocks::raw_util::new_engine(tmp_path_raft.to_str().unwrap(), None, &[], None)
             .unwrap(),
     );
-    let shared_block_cache = false;
     let engines = Engines::new(
         RocksEngine::from_db(Arc::clone(&engine)),
         RocksEngine::from_db(Arc::clone(&raft_engine)),
-        shared_block_cache,
     );
     let tmp_mgr = Builder::new().prefix("test_cluster").tempdir().unwrap();
 

--- a/tests/integrations/storage/test_titan.rs
+++ b/tests/integrations/storage/test_titan.rs
@@ -163,7 +163,6 @@ fn test_delete_files_in_range_for_titan() {
     let kv_cfs_opts = cfg.rocksdb.build_cf_opts(&cache);
 
     let raft_path = path.path().join(Path::new("titan"));
-    let shared_block_cache = false;
     let engines = Engines::new(
         RocksEngine::from_db(Arc::new(
             engine_rocks::raw_util::new_engine(
@@ -183,7 +182,6 @@ fn test_delete_files_in_range_for_titan() {
             )
             .unwrap(),
         )),
-        shared_block_cache,
     );
 
     // Write some mvcc keys and values into db


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?
Use `RaftEngine` instead of `KvEngine` in `MetricsFlusher`.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* No release note