### PR TITLE
storage: fix that extract_key_error fails to extract memory locks

### DIFF
--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -233,7 +233,8 @@ pub fn extract_key_error(err: &Error) -> kvrpcpb::KeyError {
     match err {
         Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
             box MvccErrorInner::KeyIsLocked(info),
-        ))))) => {
+        )))))
+        | Error(box ErrorInner::Mvcc(MvccError(box MvccErrorInner::KeyIsLocked(info)))) => {
             key_error.set_locked(info.clone());
         }
         // failed in prewrite or pessimistic lock


### PR DESCRIPTION
### What is changed and how it works?

Locks in the storage module should be in the form of `Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
box MvccErrorInner::KeyIsLocked(info))))))`. However, previously memory locks are transformed to `Error(box ErrorInner::Mvcc(MvccError(box MvccErrorInner::KeyIsLocked(info))))`, which makes `extract_key_error` fail to extract key error from it. This PR lets `extract_key_error` support the other form.

_Another solution is to change the error type, but it will lead to an extra box. The solution in this PR also prevents similar mistakes in the future._
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

Part of async commit