### PR TITLE
cdc: reduce raftstore msg for advancing resolved ts

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -633,7 +633,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                 let scheduler_clone = scheduler.clone();
                 if let Err(e) = raft_router.significant_send(
                     region_id,
-                    SignificantMsg::LeaderCallback(Callback::Read(Box::new(move |resp| {
+                    SignificantMsg::CheckLeader(Callback::Read(Box::new(move |resp| {
                         if !resp.response.get_header().has_error() {
                             match scheduler_clone.schedule(Task::MinTS { region_id, min_ts }) {
                                 Ok(_) | Err(ScheduleError::Stopped(_)) => (),

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3059,11 +3059,14 @@ where
             }
             Err(e) => {
                 // Return error if epoch not match
-                cb.invoke_read(ReadResponse {
-                    response: cmd_resp::new_error(e),
-                    snapshot: None,
-                    txn_extra_op: TxnExtraOp::Noop,
-                });
+                cb.invoke_read(
+                    ReadResponse {
+                        response: cmd_resp::new_error(e),
+                        snapshot: None,
+                        txn_extra_op: TxnExtraOp::Noop,
+                    },
+                    None,
+                );
                 return;
             }
         };
@@ -3086,7 +3089,7 @@ where
             });
         }
 
-        cb.invoke_read(resp);
+        cb.invoke_read(resp, None);
     }
 
     fn handle_tasks<W: WriteBatch<EK>>(
@@ -3440,7 +3443,7 @@ where
                         snapshot: None,
                         txn_extra_op: TxnExtraOp::Noop,
                     };
-                    cb.invoke_read(resp);
+                    cb.invoke_read(resp, None);
                     return;
                 }
                 #[cfg(any(test, feature = "testexport"))]

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -514,6 +514,11 @@ impl Lease {
         self.remote = Some(remote);
         Some(remote_clone)
     }
+
+    /// Return current `RemoteLease`.
+    pub fn remote(&self) -> Option<RemoteLease> {
+        self.remote.clone()
+    }
 }
 
 impl fmt::Debug for Lease {

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -430,7 +430,7 @@ impl Cluster {
             region.get_region_epoch().clone(),
         );
         assert!(end_key > start_key);
-        let overlaps = self.get_overlap(start_key.clone(), end_key.clone());
+        let overlaps = self.get_overlap(start_key, end_key);
         for r in overlaps.iter() {
             if incoming_epoch.get_version() < r.get_region_epoch().get_version() {
                 return Err(box_err!("epoch {:?} is stale.", incoming_epoch));

--- a/components/tidb_query_vec_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_vec_executors/src/table_scan_executor.rs
@@ -1263,7 +1263,7 @@ mod tests {
             Arc::new(EvalConfig::default()),
             columns_info.clone(),
             vec![key_range],
-            primary_column_ids.clone(),
+            primary_column_ids,
             false,
             false,
         )

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -158,7 +158,7 @@ fn bench_async_snapshots_noop(b: &mut test::Bencher) {
                 let res = CmdRes::Snap(resp.snapshot.unwrap());
                 cb2((CbContext::new(), Ok(res)));
             }));
-        cb.invoke_read(resp.clone());
+        cb.invoke_read(resp.clone(), None);
     });
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
Resolved TS should only be advanced by the region leader.
Then before advancing the resolved ts, we must check the leadership of the current peer. Currently we did this by a read request through raftstore.

### What is changed and how it works?

What's Changed:

Reduce the overhead of advancing resolved ts by checking read lease directly in cdc.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* N/A