### PR TITLE
*: fix skip tags

### DIFF
--- a/components/test_util/src/logging.rs
+++ b/components/test_util/src/logging.rs
@@ -21,7 +21,7 @@ impl<'a> slog::Serializer for Serializer<'a> {
 /// A logger that add a test case tag before each line of log.
 struct CaseTraceLogger {
     f: Option<Mutex<File>>,
-    skip_tags: Vec<String>,
+    skip_tags: Vec<&'static str>,
 }
 
 // FIXME: Remove this type when slog::Never implements Display.
@@ -39,10 +39,10 @@ impl CaseTraceLogger {
         w: &mut dyn std::io::Write,
         record: &Record<'_>,
         values: &OwnedKVList,
-        skip_tags: &[String],
+        skip_tags: &[&str],
     ) -> Result<(), std::io::Error> {
         use slog::KV;
-        if skip_tags.iter().any(|t| t.starts_with(record.tag())) {
+        if skip_tags.contains(&record.tag()) {
             return Ok(());
         }
 
@@ -105,7 +105,7 @@ pub fn init_log_for_test() {
     // We hardly ever read rocksdb log in tests.
     let drainer = CaseTraceLogger {
         f: writer,
-        skip_tags: vec!["rocksdb_log".to_owned(), "raftdb_log".to_owned()],
+        skip_tags: vec!["rocksdb_log", "raftdb_log", "rocksdb_log_header", "raftdb_log_header"],
     };
 
     // Default disabled log targets for test.


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?


Problem Summary:

If there is no tags, it become empty. And any string is started with
empty string, so most logs are skipped.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- No release log