### PR TITLE
txn: allow async commit by default

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -157,7 +157,7 @@
 ## Whether to check memory locks before handling coprocessor requests.
 ## This option must be enabled if async commit is enable.
 ## DO NOT use it in production. This option may be removed in the future.
-# end-point-check-memory-locks = false
+# end-point-check-memory-locks = true
 
 ## Max bytes that snapshot can be written to disk in one second.
 ## It should be set based on your disk performance.
@@ -198,7 +198,7 @@
 
 ## Whether to enable the async commit feature.
 ## DO NOT use it in production. This option may be removed in the future.
-# enable-async-commit = false
+# enable-async-commit = true
 
 [storage.block-cache]
 ## Whether to create a shared block cache for all RocksDB column families.

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -160,7 +160,7 @@ impl Default for Config {
                 DEFAULT_ENDPOINT_REQUEST_MAX_HANDLE_SECS,
             ),
             end_point_max_concurrency: cmp::max(cpu_num as usize, MIN_ENDPOINT_MAX_CONCURRENCY),
-            end_point_check_memory_locks: false,
+            end_point_check_memory_locks: true,
             snap_max_write_bytes_per_sec: ReadableSize(DEFAULT_SNAP_MAX_BYTES_PER_SEC),
             snap_max_total_size: ReadableSize(0),
             stats_concurrency: 1,

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -66,7 +66,7 @@ impl Default for Config {
             scheduler_worker_pool_size: if cpu_num >= 16.0 { 8 } else { 4 },
             scheduler_pending_write_threshold: ReadableSize::mb(DEFAULT_SCHED_PENDING_WRITE_MB),
             reserve_space: ReadableSize::gb(DEFAULT_RESERVER_SPACE_SIZE),
-            enable_async_commit: false,
+            enable_async_commit: true,
             block_cache: BlockCacheConfig::default(),
         }
     }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -86,7 +86,7 @@ fn test_serde_custom_tikv_config() {
         end_point_stream_batch_row_limit: 4096,
         end_point_enable_batch_if_possible: true,
         end_point_request_max_handle_duration: ReadableDuration::secs(12),
-        end_point_check_memory_locks: true,
+        end_point_check_memory_locks: false,
         end_point_max_concurrency: 10,
         snap_max_write_bytes_per_sec: ReadableSize::mb(10),
         snap_max_total_size: ReadableSize::gb(10),
@@ -599,7 +599,7 @@ fn test_serde_custom_tikv_config() {
         scheduler_worker_pool_size: 1,
         scheduler_pending_write_threshold: ReadableSize::kb(123),
         reserve_space: ReadableSize::gb(2),
-        enable_async_commit: true,
+        enable_async_commit: false,
         block_cache: BlockCacheConfig {
             shared: true,
             capacity: OptionReadableSize(Some(ReadableSize::gb(40))),

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -56,7 +56,7 @@ end-point-stream-batch-row-limit = 4096
 end-point-enable-batch-if-possible = true
 end-point-request-max-handle-duration = "12s"
 end-point-max-concurrency = 10
-end-point-check-memory-locks = true
+end-point-check-memory-locks = false
 snap-max-write-bytes-per-sec = "10MB"
 snap-max-total-size = "10GB"
 stats-concurrency = 10
@@ -74,7 +74,7 @@ max-key-size = 8192
 scheduler-concurrency = 123
 scheduler-worker-pool-size = 1
 scheduler-pending-write-threshold = "123KB"
-enable-async-commit = true
+enable-async-commit = false
 
 [storage.block-cache]
 shared = true


### PR DESCRIPTION

### What is changed and how it works?

We have switched the implementation of the lock table to a lock-free skip list. Therefore, it shouldn't add much latency if the memory lock is always checked. 

I think we can allow async commit and check the memory locks by default.

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

Part of the async commit feature