### PR TITLE
Remove sync-log config option

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -27,8 +27,6 @@ with_prefix!(prefix_store "store-");
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
-    // true for high reliability, prevent data loss when power failure.
-    pub sync_log: bool,
     // minimizes disruption when a partitioned node rejoins the cluster by using a two phase election.
     #[config(skip)]
     pub prevote: bool,
@@ -196,7 +194,6 @@ impl Default for Config {
     fn default() -> Config {
         let split_size = ReadableSize::mb(coprocessor::config::SPLIT_SIZE_MB);
         Config {
-            sync_log: true,
             prevote: true,
             raftdb_path: String::new(),
             capacity: ReadableSize(0),
@@ -416,9 +413,6 @@ impl Config {
     }
 
     pub fn write_into_metrics(&self) {
-        CONFIG_RAFTSTORE_GAUGE
-            .with_label_values(&["sync_log"])
-            .set((self.sync_log as i32).into());
         CONFIG_RAFTSTORE_GAUGE
             .with_label_values(&["prevote"])
             .set((self.prevote as i32).into());

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3601,7 +3601,7 @@ mod tests {
             region_id,
             Msg::Validate(
                 region_id,
-                Box::new(move |(delegate, _): (*const u8, _)| {
+                Box::new(move |delegate: *const u8| {
                     let delegate = unsafe { &*(delegate as *const ApplyDelegate<RocksEngine>) };
                     validate(delegate);
                     validate_tx.send(()).unwrap();

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -649,13 +649,12 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport, C: PdClient> RaftPoller<EK, ER,
                 |_| {}
             );
 
-            let need_sync = self.poll_ctx.cfg.sync_log || self.poll_ctx.sync_log;
             self.poll_ctx
                 .engines
                 .raft
                 .consume_and_shrink(
                     &mut self.poll_ctx.raft_wb,
-                    need_sync,
+                    true,
                     RAFT_WB_SHRINK_SIZE,
                     4 * 1024,
                 )

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -751,9 +751,9 @@ where
         )?;
         // write kv rocksdb first in case of restart happen between two write
         let mut write_opts = WriteOptions::new();
-        write_opts.set_sync(ctx.cfg.sync_log);
+        write_opts.set_sync(true);
         ctx.engines.kv.write_opt(&kv_wb, &write_opts)?;
-        ctx.engines.raft.consume(&mut raft_wb, ctx.cfg.sync_log)?;
+        ctx.engines.raft.consume(&mut raft_wb, true)?;
 
         if self.get_store().is_initialized() && !keep_data {
             // If we meet panic when deleting data and raft log, the dirty data

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -243,11 +243,6 @@
 # retry-max-count = -1
 
 [raftstore]
-## Whether to force to flush logs.
-## Set to `true` (default) for best reliability, which prevents data loss when there is a power
-## failure. Set to `false` for higher performance (ensure that you run multiple TiKV nodes!).
-# sync-log = true
-
 ## Whether to enable Raft prevote.
 ## Prevote minimizes disruption when a partitioned node rejoins the cluster by using a two phase
 ## election.

--- a/src/config.rs
+++ b/src/config.rs
@@ -3018,7 +3018,6 @@ mod tests {
             "10000".to_owned(),
         );
         change.insert("gc.max-write-bytes-per-sec".to_owned(), "100MB".to_owned());
-        change.insert("raftstore.sync-log".to_owned(), "false".to_owned());
         change.insert(
             "rocksdb.defaultcf.block-cache-size".to_owned(),
             "500MB".to_owned(),
@@ -3068,7 +3067,6 @@ mod tests {
             "10000".to_owned(),
         );
         change.insert("gc.max-write-bytes-per-sec".to_owned(), "100MB".to_owned());
-        change.insert("raftstore.sync-log".to_owned(), "false".to_owned());
         change.insert(
             "rocksdb.defaultcf.titan.blob-run-mode".to_owned(),
             "read-only".to_owned(),
@@ -3086,7 +3084,6 @@ mod tests {
             res.get("gc.max-write-bytes-per-sec"),
             Some(&"\"100MB\"".to_owned())
         );
-        assert_eq!(res.get("raftstore.sync-log"), Some(&"false".to_owned()));
         assert_eq!(
             res.get("rocksdb.defaultcf.titan.blob-run-mode"),
             Some(&"\"read-only\"".to_owned())

--- a/src/config.rs
+++ b/src/config.rs
@@ -3010,7 +3010,6 @@ mod tests {
         let mut incoming = TiKvConfig::default();
         incoming.coprocessor.region_split_keys = 10000;
         incoming.gc.max_write_bytes_per_sec = ReadableSize::mb(100);
-        incoming.raft_store.sync_log = false;
         incoming.rocksdb.defaultcf.block_cache_size = ReadableSize::mb(500);
         let diff = old.diff(&incoming);
         let mut change = HashMap::new();

--- a/tests/integrations/config/dynamic/raftstore.rs
+++ b/tests/integrations/config/dynamic/raftstore.rs
@@ -128,24 +128,6 @@ where
     rx.recv_timeout(Duration::from_secs(3)).unwrap();
 }
 
-fn validate_apply<F>(router: &ApplyRouter<RocksEngine>, region_id: u64, validate: F)
-where
-    F: FnOnce(bool) + Send + 'static,
-{
-    let (tx, rx) = mpsc::channel();
-    router.schedule_task(
-        region_id,
-        ApplyTask::Validate(
-            region_id,
-            Box::new(move |(_, sync_log): (_, bool)| {
-                validate(sync_log);
-                tx.send(()).unwrap();
-            }),
-        ),
-    );
-    rx.recv_timeout(Duration::from_secs(3)).unwrap();
-}
-
 #[test]
 fn test_update_raftstore_config() {
     let (mut config, _dir) = TiKvConfig::with_tmp().unwrap();
@@ -170,43 +152,6 @@ fn test_update_raftstore_config() {
     raft_store.raft_log_gc_threshold = 54321;
     validate_store(&router, move |cfg: &Config| {
         assert_eq!(cfg, &raft_store);
-    });
-
-    system.shutdown();
-}
-
-#[test]
-fn test_update_apply_store_config() {
-    let (mut config, _dir) = TiKvConfig::with_tmp().unwrap();
-    config.raft_store.sync_log = true;
-    config.validate().unwrap();
-    let (cfg_controller, raft_router, apply_router, mut system) =
-        start_raftstore(config.clone(), &_dir);
-
-    // register region
-    let region_id = 1;
-    let mut reg = Registration::default();
-    reg.region.set_id(region_id);
-    apply_router.schedule_task(region_id, ApplyTask::Registration(reg));
-
-    validate_store(&raft_router, move |cfg: &Config| {
-        assert_eq!(cfg.sync_log, true);
-    });
-    validate_apply(&apply_router, region_id, |sync_log| {
-        assert_eq!(sync_log, true);
-    });
-
-    // dispatch updated config
-    cfg_controller
-        .update_config("raftstore.sync-log", "false")
-        .unwrap();
-
-    // both configs should be updated
-    validate_store(&raft_router, move |cfg: &Config| {
-        assert_eq!(cfg.sync_log, false);
-    });
-    validate_apply(&apply_router, region_id, |sync_log| {
-        assert_eq!(sync_log, false);
     });
 
     system.shutdown();

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -137,7 +137,6 @@ fn test_serde_custom_tikv_config() {
     store_batch_system.pool_size = 3;
     store_batch_system.reschedule_duration = ReadableDuration::secs(2);
     value.raft_store = RaftstoreConfig {
-        sync_log: false,
         prevote: false,
         raftdb_path: "/var".to_owned(),
         capacity: ReadableSize(123),

--- a/tests/integrations/config/test_config_client.rs
+++ b/tests/integrations/config/test_config_client.rs
@@ -92,10 +92,6 @@ fn test_write_update_to_file() {
 ## comment should be reserve
 [raftstore]
 
-## comment should be reserve
-# comment with one `#` should also be reserve
-sync-log = true
-
 # config that comment out by one `#` should be update in place
 ## pd-heartbeat-tick-interval = "30s"
 # pd-heartbeat-tick-interval = "30s"
@@ -131,7 +127,6 @@ blob-run-mode = "normal"
             "raftstore.pd-heartbeat-tick-interval".to_owned(),
             "1h".to_owned(),
         );
-        change.insert("raftstore.sync-log".to_owned(), "false".to_owned());
         change.insert(
             "coprocessor.region-split-keys".to_owned(),
             "10000".to_owned(),
@@ -158,10 +153,6 @@ blob-run-mode = "normal"
     let expect = r#"
 ## comment should be reserve
 [raftstore]
-
-## comment should be reserve
-# comment with one `#` should also be reserve
-sync-log = false
 
 # config that comment out by one `#` should be update in place
 ## pd-heartbeat-tick-interval = "30s"


### PR DESCRIPTION
Signed-off-by: Xintao <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

If `sync-log` is set to `false`, there is chance that data will be loss.

### What is changed and how it works?

Make this option true always.

### Related changes

- Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->
- Set sync-log true always.