### PR TITLE
Remove sync-log config option (migrate #8631)

### DIFF
--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -113,7 +113,6 @@ pub fn must_region_cleared(engine: &Engines, region: &metapb::Region) {
 
 pub fn new_store_cfg() -> Config {
     Config {
-        sync_log: false,
         raft_base_tick_interval: ReadableDuration::millis(10),
         raft_heartbeat_ticks: 2,
         raft_election_timeout_ticks: 25,

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -182,11 +182,6 @@
 # retry-max-count = -1
 
 [raftstore]
-## Whether to force to flush logs.
-## Set to `true` (default) for best reliability, which prevents data loss when there is a power
-## failure. Set to `false` for higher performance (ensure that you run multiple TiKV nodes!).
-# sync-log = true
-
 ## Whether to enable Raft prevote.
 ## Prevote minimizes disruption when a partitioned node rejoins the cluster by using a two phase
 ## election.

--- a/src/raftstore/store/config.rs
+++ b/src/raftstore/store/config.rs
@@ -13,8 +13,6 @@ use engine::rocks::{util::config as rocks_config, PerfLevel};
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
-    // true for high reliability, prevent data loss when power failure.
-    pub sync_log: bool,
     // minimizes disruption when a partitioned node rejoins the cluster by using a two phase election.
     pub prevote: bool,
     pub raftdb_path: String,
@@ -143,7 +141,6 @@ impl Default for Config {
     fn default() -> Config {
         let split_size = ReadableSize::mb(coprocessor::config::SPLIT_SIZE_MB);
         Config {
-            sync_log: true,
             prevote: true,
             raftdb_path: String::new(),
             capacity: ReadableSize(0),
@@ -367,9 +364,6 @@ impl Config {
             &["name"]
         )
         .unwrap();
-        metrics
-            .with_label_values(&["sync_log"])
-            .set((self.sync_log as i32).into());
         metrics
             .with_label_values(&["prevote"])
             .set((self.prevote as i32).into());

--- a/src/raftstore/store/fsm/apply.rs
+++ b/src/raftstore/store/fsm/apply.rs
@@ -298,8 +298,6 @@ struct ApplyContext {
     last_applied_index: u64,
     committed_count: usize,
 
-    // Indicates that WAL can be synchronized when data is written to KV engine.
-    enable_sync_log: bool,
     // Whether synchronize WAL is preferred.
     sync_log_hint: bool,
     // Whether to use the delete range API instead of deleting one by one.
@@ -335,7 +333,6 @@ impl ApplyContext {
             kv_wb_last_keys: 0,
             last_applied_index: 0,
             committed_count: 0,
-            enable_sync_log: cfg.sync_log,
             sync_log_hint: false,
             exec_ctx: None,
             use_delete_range: cfg.use_delete_range,
@@ -385,7 +382,7 @@ impl ApplyContext {
     pub fn write_to_db(&mut self) {
         if self.kv_wb.as_ref().map_or(false, |wb| !wb.is_empty()) {
             let mut write_opts = WriteOptions::new();
-            write_opts.set_sync(self.enable_sync_log && self.sync_log_hint);
+            write_opts.set_sync(self.sync_log_hint);
             self.engines
                 .kv
                 .write_opt(self.kv_wb(), &write_opts)

--- a/src/raftstore/store/fsm/store.rs
+++ b/src/raftstore/store/fsm/store.rs
@@ -525,7 +525,7 @@ impl<T: Transport, C: PdClient> RaftPoller<T, C> {
         fail_point!("raft_between_save");
         if !self.poll_ctx.raft_wb.is_empty() {
             let mut write_opts = WriteOptions::new();
-            write_opts.set_sync(self.poll_ctx.cfg.sync_log || self.poll_ctx.sync_log);
+            write_opts.set_sync(true);
             self.poll_ctx
                 .engines
                 .raft

--- a/src/raftstore/store/peer.rs
+++ b/src/raftstore/store/peer.rs
@@ -558,7 +558,7 @@ impl Peer {
         )?;
         // write kv rocksdb first in case of restart happen between two write
         let mut write_opts = WriteOptions::new();
-        write_opts.set_sync(ctx.cfg.sync_log);
+        write_opts.set_sync(true);
         ctx.engines.write_kv_opt(&kv_wb, &write_opts)?;
         ctx.engines.write_raft_opt(&raft_wb, &write_opts)?;
 

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -107,7 +107,6 @@ fn test_serde_custom_tikv_config() {
         job: "tikv_1".to_owned(),
     };
     value.raft_store = RaftstoreConfig {
-        sync_log: false,
         prevote: false,
         raftdb_path: "/var".to_owned(),
         capacity: ReadableSize(123),


### PR DESCRIPTION
Signed-off-by: Xintao <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Migrate #8631

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Release note <!-- bugfixes or new feature need a release note -->
- Set sync-log true always.