### PR TITLE
Remove sync-log config option (migrate #8631)

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -29,8 +29,6 @@ with_prefix!(prefix_store "store-");
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
-    // true for high reliability, prevent data loss when power failure.
-    pub sync_log: bool,
     // minimizes disruption when a partitioned node rejoins the cluster by using a two phase election.
     #[config(skip)]
     pub prevote: bool,
@@ -189,7 +187,6 @@ impl Default for Config {
     fn default() -> Config {
         let split_size = ReadableSize::mb(coprocessor::config::SPLIT_SIZE_MB);
         Config {
-            sync_log: true,
             prevote: true,
             raftdb_path: String::new(),
             capacity: ReadableSize(0),
@@ -477,9 +474,6 @@ impl Config {
     }
 
     pub fn write_into_metrics(&self) {
-        CONFIG_RAFTSTORE_GAUGE
-            .with_label_values(&["sync_log"])
-            .set((self.sync_log as i32).into());
         CONFIG_RAFTSTORE_GAUGE
             .with_label_values(&["prevote"])
             .set((self.prevote as i32).into());

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -307,8 +307,6 @@ struct ApplyContext<W: WriteBatch + WriteBatchVecExt<RocksEngine>> {
     last_applied_index: u64,
     committed_count: usize,
 
-    // Indicates that WAL can be synchronized when data is written to KV engine.
-    enable_sync_log: bool,
     // Whether synchronize WAL is preferred.
     sync_log_hint: bool,
     // Whether to use the delete range API instead of deleting one by one.
@@ -348,7 +346,6 @@ impl<W: WriteBatch + WriteBatchVecExt<RocksEngine>> ApplyContext<W> {
             kv_wb_last_keys: 0,
             last_applied_index: 0,
             committed_count: 0,
-            enable_sync_log: cfg.sync_log,
             sync_log_hint: false,
             exec_ctx: None,
             use_delete_range: cfg.use_delete_range,
@@ -419,7 +416,7 @@ impl<W: WriteBatch + WriteBatchVecExt<RocksEngine>> ApplyContext<W> {
     /// Writes all the changes into RocksDB.
     /// If it returns true, all pending writes are persisted in engines.
     pub fn write_to_db(&mut self) -> bool {
-        let need_sync = self.enable_sync_log && self.sync_log_hint;
+        let need_sync = self.sync_log_hint;
         if self.kv_wb.as_ref().map_or(false, |wb| !wb.is_empty()) {
             let mut write_opts = engine_traits::WriteOptions::new();
             write_opts.set_sync(need_sync);
@@ -2444,7 +2441,7 @@ pub enum Msg {
         cb: Callback<RocksEngine>,
     },
     #[cfg(any(test, feature = "testexport"))]
-    Validate(u64, Box<dyn FnOnce((&ApplyDelegate, bool)) + Send>),
+    Validate(u64, Box<dyn FnOnce(&ApplyDelegate) + Send>),
 }
 
 impl Msg {
@@ -2926,7 +2923,7 @@ impl ApplyFsm {
                     cb,
                 }) => self.handle_change(apply_ctx, cmd, region_epoch, cb),
                 #[cfg(any(test, feature = "testexport"))]
-                Some(Msg::Validate(_, f)) => f((&self.delegate, apply_ctx.enable_sync_log)),
+                Some(Msg::Validate(_, f)) => f(&self.delegate),
                 None => break,
             }
         }
@@ -3004,7 +3001,6 @@ impl<W: WriteBatch + WriteBatchVecExt<RocksEngine>> PollHandler<ApplyFsm, Contro
                 }
                 _ => {}
             }
-            self.apply_ctx.enable_sync_log = incoming.sync_log;
         }
         self.apply_ctx.perf_context_statistics.start();
     }
@@ -3367,7 +3363,7 @@ mod tests {
             region_id,
             Msg::Validate(
                 region_id,
-                Box::new(move |(delegate, _): (&ApplyDelegate, _)| {
+                Box::new(move |delegate: &ApplyDelegate                              | {
                     validate(delegate);
                     validate_tx.send(()).unwrap();
                 }),

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3363,7 +3363,7 @@ mod tests {
             region_id,
             Msg::Validate(
                 region_id,
-                Box::new(move |delegate: &ApplyDelegate                              | {
+                Box::new(move |delegate: &ApplyDelegate| {
                     validate(delegate);
                     validate_tx.send(()).unwrap();
                 }),

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -556,7 +556,7 @@ impl<T: Transport, C: PdClient> RaftPoller<T, C> {
                 |_| {}
             );
             let mut write_opts = WriteOptions::new();
-            write_opts.set_sync(self.poll_ctx.cfg.sync_log || self.poll_ctx.sync_log);
+            write_opts.set_sync(true);
             self.poll_ctx
                 .engines
                 .raft

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -481,7 +481,7 @@ impl Peer {
         )?;
         // write kv rocksdb first in case of restart happen between two write
         let mut write_opts = WriteOptions::new();
-        write_opts.set_sync(ctx.cfg.sync_log);
+        write_opts.set_sync(true);
         ctx.engines.kv.c().write_opt(&kv_wb, &write_opts)?;
         ctx.engines.raft.c().write_opt(&raft_wb, &write_opts)?;
 

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -231,11 +231,6 @@
 # retry-max-count = -1
 
 [raftstore]
-## Whether to force to flush logs.
-## Set to `true` (default) for best reliability, which prevents data loss when there is a power
-## failure. Set to `false` for higher performance (ensure that you run multiple TiKV nodes!).
-# sync-log = true
-
 ## Whether to enable Raft prevote.
 ## Prevote minimizes disruption when a partitioned node rejoins the cluster by using a two phase
 ## election.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2848,7 +2848,6 @@ mod tests {
         let mut incoming = TiKvConfig::default();
         incoming.coprocessor.region_split_keys = 10000;
         incoming.gc.max_write_bytes_per_sec = ReadableSize::mb(100);
-        incoming.raft_store.sync_log = false;
         incoming.rocksdb.defaultcf.block_cache_size = ReadableSize::mb(500);
         let diff = old.diff(&incoming);
         let mut change = HashMap::new();
@@ -2857,7 +2856,6 @@ mod tests {
             "10000".to_owned(),
         );
         change.insert("gc.max-write-bytes-per-sec".to_owned(), "100MB".to_owned());
-        change.insert("raftstore.sync-log".to_owned(), "false".to_owned());
         change.insert(
             "rocksdb.defaultcf.block-cache-size".to_owned(),
             "500MB".to_owned(),
@@ -2907,7 +2905,6 @@ mod tests {
             "10000".to_owned(),
         );
         change.insert("gc.max-write-bytes-per-sec".to_owned(), "100MB".to_owned());
-        change.insert("raftstore.sync-log".to_owned(), "false".to_owned());
         change.insert(
             "rocksdb.defaultcf.titan.blob-run-mode".to_owned(),
             "read-only".to_owned(),
@@ -2925,7 +2922,6 @@ mod tests {
             res.get("gc.max-write-bytes-per-sec"),
             Some(&"\"100MB\"".to_owned())
         );
-        assert_eq!(res.get("raftstore.sync-log"), Some(&"false".to_owned()));
         assert_eq!(
             res.get("rocksdb.defaultcf.titan.blob-run-mode"),
             Some(&"\"read-only\"".to_owned())

--- a/tests/integrations/config/dynamic/raftstore.rs
+++ b/tests/integrations/config/dynamic/raftstore.rs
@@ -121,24 +121,6 @@ where
     rx.recv_timeout(Duration::from_secs(3)).unwrap();
 }
 
-fn validate_apply<F>(router: &ApplyRouter, region_id: u64, validate: F)
-where
-    F: FnOnce(bool) + Send + 'static,
-{
-    let (tx, rx) = mpsc::channel();
-    router.schedule_task(
-        region_id,
-        ApplyTask::Validate(
-            region_id,
-            Box::new(move |(_, sync_log): (_, bool)| {
-                validate(sync_log);
-                tx.send(()).unwrap();
-            }),
-        ),
-    );
-    rx.recv_timeout(Duration::from_secs(3)).unwrap();
-}
-
 #[test]
 fn test_update_raftstore_config() {
     let (mut config, _dir) = TiKvConfig::with_tmp().unwrap();
@@ -163,43 +145,6 @@ fn test_update_raftstore_config() {
     raft_store.raft_log_gc_threshold = 54321;
     validate_store(&router, move |cfg: &Config| {
         assert_eq!(cfg, &raft_store);
-    });
-
-    system.shutdown();
-}
-
-#[test]
-fn test_update_apply_store_config() {
-    let (mut config, _dir) = TiKvConfig::with_tmp().unwrap();
-    config.raft_store.sync_log = true;
-    config.validate().unwrap();
-    let (cfg_controller, raft_router, apply_router, mut system) =
-        start_raftstore(config.clone(), &_dir);
-
-    // register region
-    let region_id = 1;
-    let mut reg = Registration::default();
-    reg.region.set_id(region_id);
-    apply_router.schedule_task(region_id, ApplyTask::Registration(reg));
-
-    validate_store(&raft_router, move |cfg: &Config| {
-        assert_eq!(cfg.sync_log, true);
-    });
-    validate_apply(&apply_router, region_id, |sync_log| {
-        assert_eq!(sync_log, true);
-    });
-
-    // dispatch updated config
-    cfg_controller
-        .update_config("raftstore.sync-log", "false")
-        .unwrap();
-
-    // both configs should be updated
-    validate_store(&raft_router, move |cfg: &Config| {
-        assert_eq!(cfg.sync_log, false);
-    });
-    validate_apply(&apply_router, region_id, |sync_log| {
-        assert_eq!(sync_log, false);
     });
 
     system.shutdown();

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -138,7 +138,6 @@ fn test_serde_custom_tikv_config() {
     store_batch_system.pool_size = 3;
     store_batch_system.reschedule_duration = ReadableDuration::secs(2);
     value.raft_store = RaftstoreConfig {
-        sync_log: false,
         prevote: false,
         raftdb_path: "/var".to_owned(),
         capacity: ReadableSize(123),

--- a/tests/integrations/config/test_config_client.rs
+++ b/tests/integrations/config/test_config_client.rs
@@ -92,10 +92,6 @@ fn test_write_update_to_file() {
 ## comment should be reserve
 [raftstore]
 
-## comment should be reserve
-# comment with one `#` should also be reserve
-sync-log = true
-
 # config that comment out by one `#` should be update in place
 ## pd-heartbeat-tick-interval = "30s"
 # pd-heartbeat-tick-interval = "30s"
@@ -131,7 +127,6 @@ blob-run-mode = "normal"
             "raftstore.pd-heartbeat-tick-interval".to_owned(),
             "1h".to_owned(),
         );
-        change.insert("raftstore.sync-log".to_owned(), "false".to_owned());
         change.insert(
             "coprocessor.region-split-keys".to_owned(),
             "10000".to_owned(),
@@ -158,10 +153,6 @@ blob-run-mode = "normal"
     let expect = r#"
 ## comment should be reserve
 [raftstore]
-
-## comment should be reserve
-# comment with one `#` should also be reserve
-sync-log = false
 
 # config that comment out by one `#` should be update in place
 ## pd-heartbeat-tick-interval = "30s"


### PR DESCRIPTION
Signed-off-by: Xintao <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Migrate #8631

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Release note <!-- bugfixes or new feature need a release note -->
- Set sync-log true always.