### PR TITLE
txn: fix returned action in check async commit txn status

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1618,7 +1618,8 @@ txn_command_future!(future_check_txn_status, CheckTxnStatusRequest, CheckTxnStat
                     // If the caller_start_ts is max, it's a point get in the autocommit transaction.
                     // Even though the min_commit_ts is not pushed, the point get can ingore the lock
                     // next time because it's not committed. So we pretend it has been pushed.
-                    if lock.min_commit_ts > caller_start_ts || caller_start_ts.is_max() {
+                    // Also note that min_commit_ts of async commit locks are never pushed.
+                    if !lock.use_async_commit && (lock.min_commit_ts > caller_start_ts || caller_start_ts.is_max()) {
                         resp.set_action(Action::MinCommitTsPushed);
                     }
                     resp.set_lock_ttl(lock.ttl);

--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -6,7 +6,7 @@ use crate::storage::kv::WriteData;
 use crate::storage::lock_manager::LockManager;
 use crate::storage::mvcc::metrics::MVCC_CHECK_TXN_STATUS_COUNTER_VEC;
 use crate::storage::mvcc::txn::MissingLockAction;
-use crate::storage::mvcc::{Error as MvccError, MvccTxn};
+use crate::storage::mvcc::MvccTxn;
 use crate::storage::txn::commands::{
     Command, CommandExt, ReleasedLocks, TypedCommand, WriteCommand, WriteContext, WriteResult,
 };
@@ -67,10 +67,14 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckTxnStatus {
 
         let mut released_locks = ReleasedLocks::new(self.lock_ts, TimeStamp::zero());
         let ctx = mem::take(&mut self.ctx);
-        fail_point!("check_txn_status", |err| Err(MvccError::from(
-            crate::storage::mvcc::txn::make_txn_error(err, &self.primary_key, self.lock_ts)
-        )
-        .into()));
+        fail_point!("check_txn_status", |err| Err(
+            crate::storage::mvcc::Error::from(crate::storage::mvcc::txn::make_txn_error(
+                err,
+                &self.primary_key,
+                self.lock_ts
+            ))
+            .into()
+        ));
 
         let result = match txn.reader.load_lock(&self.primary_key)? {
             Some(mut lock) if lock.ts == self.lock_ts => {

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -1,9 +1,12 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use futures::{Future, Sink, Stream};
+use futures03::executor::block_on;
 use grpcio::*;
+use kvproto::kvrpcpb::*;
 use kvproto::tikvpb::TikvClient;
 use kvproto::tikvpb::*;
+use pd_client::PdClient;
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
@@ -99,4 +102,45 @@ fn test_empty_commands() {
         }
     });
     rx.recv_timeout(Duration::from_secs(1)).unwrap();
+}
+
+#[test]
+fn test_async_commit_check_txn_status() {
+    let mut cluster = new_server_cluster(0, 1);
+    cluster.run();
+
+    let region = cluster.get_region(b"");
+    let leader = region.get_peers()[0].clone();
+    let addr = cluster.sim.rl().get_addr(leader.get_store_id()).to_owned();
+
+    let env = Arc::new(Environment::new(1));
+    let channel = ChannelBuilder::new(env).connect(&addr);
+    let client = TikvClient::new(channel);
+
+    let mut ctx = Context::default();
+    ctx.set_region_id(leader.get_id());
+    ctx.set_region_epoch(region.get_region_epoch().clone());
+    ctx.set_peer(leader);
+
+    let start_ts = block_on(cluster.pd_client.get_tso()).unwrap();
+    let mut req = PrewriteRequest::default();
+    req.set_context(ctx.clone());
+    req.set_primary_lock(b"key".to_vec());
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.set_key(b"key".to_vec());
+    mutation.set_value(b"value".to_vec());
+    req.mut_mutations().push(mutation);
+    req.set_start_version(start_ts.into_inner());
+    req.set_lock_ttl(20000);
+    req.set_use_async_commit(true);
+    client.kv_prewrite(&req).unwrap();
+
+    let mut req = CheckTxnStatusRequest::default();
+    req.set_context(ctx.clone());
+    req.set_primary_key(b"key".to_vec());
+    req.set_lock_ts(start_ts.into_inner());
+    req.set_rollback_if_not_exist(true);
+    let resp = client.kv_check_txn_status(&req).unwrap();
+    assert_ne!(resp.get_action(), Action::MinCommitTsPushed);
 }


### PR DESCRIPTION

### What problem does this PR solve?

The `min_commit_ts` of an async commit lock is never pushed. Previously we could return `MinCommitTsPushed` action even if the lock is an async commit lock. Then, the client would think the lock was pushed and ignore the lock by mistake.

### What is changed and how it works?

Never return `MinCommitTsPushed` when the lock is an async commit lock.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
 
* Part of async commit.