### PR TITLE
txn: fix the wrong min_commit_ts returned by prewrite

### DIFF
--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -26,7 +26,7 @@ use crate::endpoint::{Deregister, Task};
 static CONNECTION_ID_ALLOC: AtomicUsize = AtomicUsize::new(0);
 
 const CDC_MSG_NOTIFY_COUNT: usize = 8;
-const CDC_MAX_RESP_SIZE: usize = 6 * 1024 * 1024; // 6MB
+const CDC_MAX_RESP_SIZE: u32 = 6 * 1024 * 1024; // 6MB
 const CDC_MSG_MAX_BATCH_SIZE: usize = 128;
 
 /// A unique identifier of a Connection.
@@ -39,18 +39,77 @@ impl ConnID {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum CdcEvent {
     ResolvedTs(ResolvedTs),
     Event(Event),
 }
 
 impl CdcEvent {
-    pub fn size(&self) -> usize {
+    pub fn size(&self) -> u32 {
         match self {
-            CdcEvent::ResolvedTs(r) => r.compute_size() as usize,
-            CdcEvent::Event(ref e) => e.compute_size() as usize,
+            CdcEvent::ResolvedTs(_) => 0,
+            CdcEvent::Event(ref e) => e.compute_size(),
         }
+    }
+
+    pub fn event(&self) -> &Event {
+        match self {
+            CdcEvent::ResolvedTs(_) => unreachable!(),
+            CdcEvent::Event(ref e) => e,
+        }
+    }
+
+    pub fn resolved_ts(&self) -> &ResolvedTs {
+        match self {
+            CdcEvent::ResolvedTs(ref r) => r,
+            CdcEvent::Event(_) => unreachable!(),
+        }
+    }
+}
+
+struct EventBatcher {
+    events: Vec<ChangeDataEvent>,
+    last_size: u32,
+}
+
+impl EventBatcher {
+    pub fn with_capacity(cap: usize) -> EventBatcher {
+        EventBatcher {
+            events: Vec::with_capacity(cap),
+            last_size: 0,
+        }
+    }
+
+    // The size of the response should not exceed CDC_MAX_RESP_SIZE.
+    // Split the events into multiple responses by CDC_MAX_RESP_SIZE here.
+    pub fn push(&mut self, event: CdcEvent) {
+        let size = event.size();
+        if self.events.is_empty() || self.last_size + size >= CDC_MAX_RESP_SIZE {
+            self.last_size = 0;
+            self.events.push(ChangeDataEvent::default());
+        }
+        match event {
+            CdcEvent::Event(e) => {
+                self.last_size += size;
+                self.events.last_mut().unwrap().mut_events().push(e);
+            }
+            CdcEvent::ResolvedTs(r) => {
+                let mut change_data_event = ChangeDataEvent::default();
+                change_data_event.set_resolved_ts(r);
+                self.events.push(change_data_event);
+                // Set last_size to MAX-1 for sending resolved ts as an individual event.
+                // '-1' is to avoid empty event when the next event is still resolved ts.
+                self.last_size = CDC_MAX_RESP_SIZE - 1;
+            }
+        }
+    }
+
+    pub fn build(self) -> Vec<ChangeDataEvent> {
+        self.events
+            .into_iter()
+            .filter(|e| e.has_resolved_ts() || !e.events.is_empty())
+            .collect()
     }
 }
 
@@ -244,38 +303,12 @@ impl ChangeData for Service {
         let rx = BatchReceiver::new(rx, CDC_MSG_MAX_BATCH_SIZE, Vec::new, VecCollector);
         let rx = rx
             .map(|events| {
-                // The size of the response should not exceed CDC_MAX_RESP_SIZE.
-                // Split the events into multiple responses by CDC_MAX_RESP_SIZE here.
-                let events_len = events.len();
-                let mut resp_vecs = Vec::with_capacity(events_len);
-                resp_vecs.push(ChangeDataEvent::default());
-                let mut current_events_size = 0;
-                for event in events {
-                    let event_size = event.size();
-                    if current_events_size + event_size >= CDC_MAX_RESP_SIZE {
-                        resp_vecs.push(ChangeDataEvent::default());
-                        current_events_size = 0;
-                    }
-                    match event {
-                        CdcEvent::Event(e) => {
-                            resp_vecs.last_mut().unwrap().mut_events().push(e);
-                            current_events_size += event_size;
-                        }
-                        CdcEvent::ResolvedTs(r) => {
-                            // Set resolved ts as an individual event.
-                            let events = resp_vecs.last_mut().unwrap().take_events();
-                            let mut change_data_event = ChangeDataEvent::default();
-                            change_data_event.set_events(events);
-
-                            resp_vecs.last_mut().unwrap().set_resolved_ts(r);
-                            resp_vecs.push(change_data_event);
-                        }
-                    }
-                }
-                let resps = resp_vecs
+                let mut batcher = EventBatcher::with_capacity(events.len());
+                events.into_iter().for_each(|e| batcher.push(e));
+                let resps = batcher
+                    .build()
                     .into_iter()
-                    .filter(|e| e.has_resolved_ts() || !e.events.is_empty())
-                    .map(|resp| (resp, WriteFlags::default()));
+                    .map(|e| (e, WriteFlags::default()));
                 stream::iter(resps)
             })
             .flatten()
@@ -319,5 +352,72 @@ impl ChangeData for Service {
             }
             Ok(())
         }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "prost-codec")]
+    use kvproto::cdcpb::event::{
+        Entries as EventEntries, Event as Event_oneof_event, Row as EventRow,
+    };
+    use kvproto::cdcpb::{ChangeDataEvent, Event, ResolvedTs};
+    #[cfg(not(feature = "prost-codec"))]
+    use kvproto::cdcpb::{EventEntries, EventRow, Event_oneof_event};
+
+    use crate::service::{CdcEvent, EventBatcher, CDC_MAX_RESP_SIZE};
+
+    #[test]
+    fn test_event_batcher() {
+        let mut batcher = EventBatcher::with_capacity(1024);
+
+        let check_events = |result: Vec<ChangeDataEvent>, expected: Vec<Vec<CdcEvent>>| {
+            assert_eq!(result.len(), expected.len());
+
+            for i in 0..expected.len() {
+                if !result[i].has_resolved_ts() {
+                    assert_eq!(result[i].events.len(), expected[i].len());
+                    for j in 0..expected[i].len() {
+                        assert_eq!(&result[i].events[j], expected[i][j].event());
+                    }
+                } else {
+                    assert_eq!(expected[i].len(), 1);
+                    assert_eq!(result[i].get_resolved_ts(), expected[i][0].resolved_ts());
+                }
+            }
+        };
+
+        let mut event_small = Event::default();
+        let row_small = EventRow::default();
+        let mut event_entries = EventEntries::default();
+        event_entries.entries = vec![row_small].into();
+        event_small.event = Some(Event_oneof_event::Entries(event_entries));
+
+        let mut event_big = Event::default();
+        let mut row_big = EventRow::default();
+        row_big.set_key(vec![0 as u8; CDC_MAX_RESP_SIZE as usize]);
+        let mut event_entries = EventEntries::default();
+        event_entries.entries = vec![row_big].into();
+        event_big.event = Some(Event_oneof_event::Entries(event_entries));
+
+        batcher.push(CdcEvent::Event(event_small.clone()));
+        batcher.push(CdcEvent::ResolvedTs(ResolvedTs::default()));
+        batcher.push(CdcEvent::ResolvedTs(ResolvedTs::default()));
+        batcher.push(CdcEvent::Event(event_big.clone()));
+        batcher.push(CdcEvent::Event(event_small.clone()));
+        batcher.push(CdcEvent::Event(event_small.clone()));
+        batcher.push(CdcEvent::Event(event_big.clone()));
+
+        check_events(
+            batcher.build(),
+            vec![
+                vec![CdcEvent::Event(event_small.clone())],
+                vec![CdcEvent::ResolvedTs(ResolvedTs::default())],
+                vec![CdcEvent::ResolvedTs(ResolvedTs::default())],
+                vec![CdcEvent::Event(event_big.clone())],
+                vec![CdcEvent::Event(event_small); 2],
+                vec![CdcEvent::Event(event_big)],
+            ],
+        );
     }
 }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -301,7 +301,7 @@ impl<S: Snapshot> MvccTxn<S> {
                     cmp::max(cmp::max(max_read_ts, self.start_ts), for_update_ts).next();
                 lock.min_commit_ts = cmp::max(lock.min_commit_ts, min_commit_ts);
                 *l = Some(lock.clone());
-                min_commit_ts
+                lock.min_commit_ts
             });
 
             self.guards.push(key_guard);
@@ -2905,6 +2905,34 @@ mod tests {
 
         // A duplicate prewrite request should return the min_commit_ts in the primary key
         assert_eq!(do_pessimistic_prewrite(), 43.into());
+    }
+
+    #[test]
+    fn test_async_commit_pushed_min_commit_ts() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let ctx = Context::default();
+        let cm = ConcurrencyManager::new(42.into());
+
+        // Simulate that min_commit_ts is pushed forward larger than latest_ts
+        must_acquire_pessimistic_lock_impl(&engine, b"key", b"key", 2, 20000, 2, false, 100);
+
+        let snapshot = engine.snapshot(&ctx).unwrap();
+        let mut txn = MvccTxn::new(snapshot, TimeStamp::new(2), true, cm.clone());
+        let mutation = Mutation::Put((Key::from_raw(b"key"), b"value".to_vec()));
+        let min_commit_ts = txn
+            .pessimistic_prewrite(
+                mutation,
+                b"key",
+                &Some(vec![b"key1".to_vec(), b"key2".to_vec(), b"key3".to_vec()]),
+                true,
+                0,
+                4.into(),
+                4,
+                TimeStamp::zero(),
+                false,
+            )
+            .unwrap();
+        assert_eq!(min_commit_ts.into_inner(), 100);
     }
 
     #[test]

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -2917,7 +2917,7 @@ mod tests {
         must_acquire_pessimistic_lock_impl(&engine, b"key", b"key", 2, 20000, 2, false, 100);
 
         let snapshot = engine.snapshot(&ctx).unwrap();
-        let mut txn = MvccTxn::new(snapshot, TimeStamp::new(2), true, cm.clone());
+        let mut txn = MvccTxn::new(snapshot, TimeStamp::new(2), true, cm);
         let mutation = Mutation::Put((Key::from_raw(b"key"), b"value".to_vec()));
         let min_commit_ts = txn
             .pessimistic_prewrite(

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -205,7 +205,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Prewrite {
                 self.min_commit_ts,
             ) {
                 Ok(ts) => {
-                    if secondaries.is_some() {
+                    if secondaries.is_some() && async_commit_ts > ts {
                         async_commit_ts = ts;
                     }
                 }

--- a/src/storage/txn/commands/prewrite_pessimistic.rs
+++ b/src/storage/txn/commands/prewrite_pessimistic.rs
@@ -121,7 +121,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for PrewritePessimistic {
                 context.pipelined_pessimistic_lock,
             ) {
                 Ok(ts) => {
-                    if secondaries.is_some() {
+                    if secondaries.is_some() && async_commit_ts > ts {
                         async_commit_ts = ts;
                     }
                 }


### PR DESCRIPTION
### What problem does this PR solve?

The `min_commit_ts` returned by prewrite was incorrect. This may make the client commit with a commit_ts smaller than expected.

It can happen when the `min_commit_ts` of a pessimistic lock is pushed forward and the new `min_commit_ts` is even larger `max_read_ts`.

### What is changed and how it works?

Correct the `min_commit_ts` returned by prewrite.

This PR also ensures `min_commit_ts` does not regress in prewriting multiple keys.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

* Part of async commit