### PR TITLE
Fix histogram name for unsafe_destroy_range

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -546,16 +546,16 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
             }
             sink.success(resp).await?;
             GRPC_MSG_HISTOGRAM_STATIC
-                .physical_scan_lock
+                .unsafe_destroy_range
                 .observe(duration_to_sec(begin_instant.elapsed()));
             ServerResult::Ok(())
         }
         .map_err(|e| {
             debug!("kv rpc failed";
-                "request" => "physical_scan_lock",
+                "request" => "unsafe_destroy_range",
                 "err" => ?e
             );
-            GRPC_MSG_FAIL_COUNTER.physical_scan_lock.inc();
+            GRPC_MSG_FAIL_COUNTER.unsafe_destroy_range.inc();
         })
         .map(|_| ());
 


### PR DESCRIPTION
Signed-off-by: Xintao <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

In #8494 the histogram statistic name is modified to a wrong name.

### Release note <!-- bugfixes or new feature need a release note -->
- None