### PR TITLE
txn: fix min_commit_ts calculation in prewrite

### DIFF
--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -205,7 +205,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Prewrite {
                 self.min_commit_ts,
             ) {
                 Ok(ts) => {
-                    if secondaries.is_some() && async_commit_ts > ts {
+                    if secondaries.is_some() && async_commit_ts < ts {
                         async_commit_ts = ts;
                     }
                 }

--- a/src/storage/txn/commands/prewrite_pessimistic.rs
+++ b/src/storage/txn/commands/prewrite_pessimistic.rs
@@ -121,7 +121,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for PrewritePessimistic {
                 context.pipelined_pessimistic_lock,
             ) {
                 Ok(ts) => {
-                    if secondaries.is_some() && async_commit_ts > ts {
+                    if secondaries.is_some() && async_commit_ts < ts {
                         async_commit_ts = ts;
                     }
                 }


### PR DESCRIPTION

### What problem does this PR solve?

https://github.com/tikv/tikv/pull/8657 introduces a bug that the inequality is reversed... `min_commit_ts` always returns 0 after that PR.

### What is changed and how it works?

This bug exposed that some code is not covered by tests. This PR mainly adds a test covering it besides fixing the bug.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

Part of async commit.