### PR TITLE
storage: add some top-level docs

### DIFF
--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -1,5 +1,9 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
+//! There are multiple [`Engine`](kv::Engine) implementations, [`RaftKv`](crate::server::raftkv::RaftKv)
+//! is used by the [`Server`](crate::server::Server). The [`BTreeEngine`](kv::BTreeEngine) and
+//! [`RocksEngine`](RocksEngine) are used for testing only.
+
 mod btree_engine;
 mod cursor;
 mod perf_context;


### PR DESCRIPTION
A few lines of docs are moved to the kv submodule, obviously the docs there need improvement later.

PTAL @youjiali1995 

### What problem does this PR solve?

Our horrible documentation situation (a baby step towards solving).

### What is changed and how it works?

Adds some docs to the storage module

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

* No release note