### PR TITLE
Fix test_raft_client_reconnect by shutdown mockserver before restart

### DIFF
--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -139,7 +139,7 @@ fn test_raft_client_reconnect() {
     let msg_count = Arc::new(AtomicUsize::new(0));
     let batch_msg_count = Arc::new(AtomicUsize::new(0));
     let service = MockKvForRaft::new(Arc::clone(&msg_count), Arc::clone(&batch_msg_count), true);
-    let (mock_server, port) = create_mock_server(service, 60100, 60200).unwrap();
+    let (mut mock_server, port) = create_mock_server(service, 60100, 60200).unwrap();
 
     // `send` should success.
     let addr = format!("localhost:{}", port);
@@ -149,6 +149,7 @@ fn test_raft_client_reconnect() {
     check_msg_count(500, &msg_count, 50);
 
     // `send` should fail after the mock server stopped.
+    mock_server.shutdown();
     drop(mock_server);
 
     let send = |_| {


### PR DESCRIPTION
Signed-off-by: Xintao <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/8666

This PR make sure that original server is shutdown. Otherwise, subsequent request may not be sent because the raft client use same `Conn`.

### Release note <!-- bugfixes or new feature need a release note -->
- None