### PR TITLE
*: update rust-rocksdb's version to fix compiling error on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_cloud_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#ee6c08ad9fe9634301d1ac2bbfe64194ed4167db"
+source = "git+https://github.com/tikv/rust-rocksdb.git#0876316d4b0b585be0ca3ea3b9bc913c4aac9403"
 dependencies = [
  "cc",
  "cmake",
@@ -2024,7 +2024,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#ee6c08ad9fe9634301d1ac2bbfe64194ed4167db"
+source = "git+https://github.com/tikv/rust-rocksdb.git#0876316d4b0b585be0ca3ea3b9bc913c4aac9403"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2044,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#ee6c08ad9fe9634301d1ac2bbfe64194ed4167db"
+source = "git+https://github.com/tikv/rust-rocksdb.git#0876316d4b0b585be0ca3ea3b9bc913c4aac9403"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -2058,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.0.25"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
  "libc",
@@ -3558,7 +3558,7 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#ee6c08ad9fe9634301d1ac2bbfe64194ed4167db"
+source = "git+https://github.com/tikv/rust-rocksdb.git#0876316d4b0b585be0ca3ea3b9bc913c4aac9403"
 dependencies = [
  "libc",
  "librocksdb_sys",


### PR DESCRIPTION
Signed-off-by: gentcys <iamchencong@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #8659 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed: update rust-rocksdb and its dependencies in Cargo.lock

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.