### PR TITLE
coprocessor/expression: push down builtin method NullTimeDiff

### DIFF
--- a/components/tidb_query_normal_expr/src/builtin_time.rs
+++ b/components/tidb_query_normal_expr/src/builtin_time.rs
@@ -351,6 +351,15 @@ impl ScalarFunc {
     }
 
     #[inline]
+    pub fn null_time_diff(
+        &self,
+        _ctx: &mut EvalContext,
+        _row: &[Datum],
+    ) -> Result<Option<MyDuration>> {
+        Ok(None)
+    }
+
+    #[inline]
     pub fn add_datetime_and_duration<'a, 'b: 'a>(
         &'b self,
         ctx: &mut EvalContext,
@@ -1504,6 +1513,12 @@ mod tests {
             .set_sql_mode(SqlMode::ERROR_FOR_DIVISION_BY_ZERO | SqlMode::STRICT_ALL_TABLES);
 
         test_err_case_two_arg(&mut ctx, ScalarFuncSig::DateDiff, Datum::Null, Datum::Null);
+    }
+
+    #[test]
+    fn test_null_time_diff() {
+        let mut ctx = EvalContext::default();
+        test_ok_case_zero_arg(&mut ctx, ScalarFuncSig::NullTimeDiff, Datum::Null);
     }
 
     #[test]

--- a/components/tidb_query_normal_expr/src/scalar_function.rs
+++ b/components/tidb_query_normal_expr/src/scalar_function.rs
@@ -408,6 +408,7 @@ impl ScalarFunc {
             | ScalarFuncSig::JsonReplaceSig => (3, usize::MAX),
 
             ScalarFuncSig::AddTimeDateTimeNull
+            | ScalarFuncSig::NullTimeDiff
             | ScalarFuncSig::AddTimeDurationNull
             | ScalarFuncSig::AddTimeStringNull
             | ScalarFuncSig::SubTimeDateTimeNull
@@ -988,6 +989,8 @@ dispatch_call! {
 
         CoalesceDuration => coalesce_duration,
         CaseWhenDuration => case_when_duration,
+
+        NullTimeDiff => null_time_diff,
 
         AddDurationAndDuration => add_duration_and_duration,
         AddDurationAndString => add_duration_and_string,


### PR DESCRIPTION
part of #3275

One of the tests is consistently failing on my system- `store::util::tests::test_lease`. I am on Ubuntu 20.04

Signed-off-by: Kunal Mohan <kunalmohan99@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

Problem Summary:

### What is changed and how it works?

What's Changed: push down builtin method NullTimeDiff

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
No release notes