### PR TITLE
engine: do memtable-insert tasks during compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_cloud_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#c6b58a4e99bb7fcc088cf856493d5f80907658ea"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=yield-compaction#09a438696bb8d5ff3553063cbe639dbff3e16afb"
 dependencies = [
  "cc",
  "cmake",
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#c6b58a4e99bb7fcc088cf856493d5f80907658ea"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=yield-compaction#09a438696bb8d5ff3553063cbe639dbff3e16afb"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#c6b58a4e99bb7fcc088cf856493d5f80907658ea"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=yield-compaction#09a438696bb8d5ff3553063cbe639dbff3e16afb"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -3419,7 +3419,7 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#c6b58a4e99bb7fcc088cf856493d5f80907658ea"
+source = "git+https://github.com/Little-Wallace/rust-rocksdb.git?branch=yield-compaction#09a438696bb8d5ff3553063cbe639dbff3e16afb"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -47,8 +47,9 @@ protobuf = "2"
 fail = "0.4"
 
 [dependencies.rocksdb]
-git = "https://github.com/tikv/rust-rocksdb.git"
+git = "https://github.com/Little-Wallace/rust-rocksdb.git"
 package = "rocksdb"
+branch = "yield-compaction"
 features = ["encryption", "static_libcpp"]
 
 [dev-dependencies]

--- a/components/engine_rocks/src/sst.rs
+++ b/components/engine_rocks/src/sst.rs
@@ -199,7 +199,7 @@ impl SstWriterBuilder<RocksEngine> for RocksSstWriterBuilder {
         if self.compression_level != 0 {
             // other three fields are default value.
             // see: https://github.com/facebook/rocksdb/blob/8cb278d11a43773a3ac22e523f4d183b06d37d88/include/rocksdb/advanced_options.h#L146-L153
-            io_options.set_compression_options(-14, self.compression_level, 0, 0);
+            io_options.set_compression_options(-14, self.compression_level, 0, 0, 0);
         }
         io_options.compression(compress_type);
         // in rocksdb 5.5.1, SstFileWriter will try to use bottommost_compression and


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Raft algorithm only allows TiKV to apply entry one by one.  if some region are hot or there is one big write request, this request will be slow because of the bottleneck of single-thread.
But as we know: not every entry depends on the result of previous. Most of write entries only require that they must be applied in order. So we can split them into multiple `WriteBatch` and let background thread to help apply-thread to insert these `WriteBatch` into memtable.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

This PR will make background thread could steal task from memtable-queue. All of `WriteBatch` will be pushed to `memtable-queue` to wait for inserting.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- No release note.