### PR TITLE
Implements Trim2Args (Vectorized)

### DIFF
--- a/components/tidb_query_shared_expr/src/string.rs
+++ b/components/tidb_query_shared_expr/src/string.rs
@@ -85,6 +85,8 @@ pub enum TrimDirection {
     Trailing,
 }
 
+// FIXME: We could use `TryInto` here but then we need to introduce some ad-hoc error type?
+//        Maybe once Rust have something like `MaybeInto`...
 impl TrimDirection {
     pub fn from_i64(i: i64) -> Option<Self> {
         match i {
@@ -92,6 +94,14 @@ impl TrimDirection {
             2 => Some(TrimDirection::Leading),
             3 => Some(TrimDirection::Trailing),
             _ => None,
+        }
+    }
+
+    pub fn into_i64(&self) -> i64 {
+        match self {
+            TrimDirection::Both => 1,
+            TrimDirection::Leading => 2,
+            TrimDirection::Trailing => 3
         }
     }
 }

--- a/components/tidb_query_vec_expr/src/impl_string.rs
+++ b/components/tidb_query_vec_expr/src/impl_string.rs
@@ -687,6 +687,12 @@ pub fn trim_1_arg(arg: Option<BytesRef>) -> Result<Option<Bytes>> {
 
 #[rpn_fn(nullable)]
 #[inline]
+pub fn trim_2_args(arg: Option<BytesRef>, pat: Option<BytesRef>) -> Result<Option<Bytes>> {
+    trim_3_args(arg, pat, Some(&TrimDirection::Both.into_i64()))
+}
+
+#[rpn_fn(nullable)]
+#[inline]
 pub fn trim_3_args(
     arg: Option<BytesRef>,
     pat: Option<BytesRef>,
@@ -2708,6 +2714,60 @@ mod tests {
             invalid_utf8_output,
             Some(b"\xF0 Hello \x90 World \x80".to_vec())
         );
+    }
+
+    #[test]
+    fn test_trim_2_args() {
+        let tests = vec![
+            (
+                Some("xxxbarxxx"),
+                Some("x"),
+                Some("bar"),
+            ),
+            (
+                Some("barxxyz"),
+                Some("xyz"),
+                Some("barx"),
+            ),
+            (
+                Some("xxxbarxxx"),
+                Some("x"),
+                Some("bar"),
+            ),
+        ];
+        for (arg, pat, exp) in tests {
+            let arg = arg.map(|s| s.as_bytes().to_vec());
+            let pat = pat.map(|s| s.as_bytes().to_vec());
+            let exp = exp.map(|s| s.as_bytes().to_vec());
+
+            let got = RpnFnScalarEvaluator::new()
+                .push_param(arg)
+                .push_param(pat)
+                .evaluate(ScalarFuncSig::Trim3Args)
+                .unwrap();
+            assert_eq!(got, exp);
+        }
+
+        let invalid_tests = vec![
+            (
+                None,
+                Some(b"x".to_vec()),
+                None as Option<Bytes>,
+            ),
+            (
+                Some(b"bar".to_vec()),
+                None,
+                None as Option<Bytes>,
+            ),
+        ];
+        for (arg, pat, exp) in invalid_tests {
+            let got = RpnFnScalarEvaluator::new()
+                .push_param(arg)
+                .push_param(pat)
+                .evaluate(ScalarFuncSig::Trim3Args)
+                .unwrap();
+            assert_eq!(got, exp);
+        }
     }
 
     #[test]

--- a/components/tidb_query_vec_expr/src/lib.rs
+++ b/components/tidb_query_vec_expr/src/lib.rs
@@ -544,6 +544,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::LpadUtf8 => lpad_utf8_fn_meta(),
         ScalarFuncSig::Rpad => rpad_fn_meta(),
         ScalarFuncSig::Trim1Arg => trim_1_arg_fn_meta(),
+        ScalarFuncSig::Trim2Args => trim_2_args_fn_meta(),
         ScalarFuncSig::Trim3Args => trim_3_args_fn_meta(),
         ScalarFuncSig::FromBase64 => from_base64_fn_meta(),
         ScalarFuncSig::Replace => replace_fn_meta(),


### PR DESCRIPTION
Part of the functions migration process from TiDB.
Related issue #5751.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: #5751  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->