### PR TITLE
test: try to make test `import::sst_service` more robust

### DIFF
--- a/components/sst_importer/src/errors.rs
+++ b/components/sst_importer/src/errors.rs
@@ -75,8 +75,8 @@ quick_error! {
             cause(err)
             display("{}", err)
         }
-        FileExists(path: PathBuf) {
-            display("File {:?} exists", path)
+        FileExists(path: PathBuf, action: &'static str) {
+            display("File {:?} exists, cannot {}", path, action)
         }
         FileCorrupted(path: PathBuf, reason: String) {
             display("File {:?} corrupted: {}", path, reason)
@@ -137,7 +137,7 @@ impl ErrorCodeExt for Error {
             Error::RocksDB(_) => error_code::sst_importer::ROCKSDB,
             Error::EngineTraits(e) => e.error_code(),
             Error::ParseIntError(_) => error_code::sst_importer::PARSE_INT_ERROR,
-            Error::FileExists(_) => error_code::sst_importer::FILE_EXISTS,
+            Error::FileExists(..) => error_code::sst_importer::FILE_EXISTS,
             Error::FileCorrupted(_, _) => error_code::sst_importer::FILE_CORRUPTED,
             Error::InvalidSSTPath(_) => error_code::sst_importer::INVALID_SST_PATH,
             Error::InvalidChunk => error_code::sst_importer::INVALID_CHUNK,

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -709,7 +709,10 @@ impl ImportFile {
         self.validate()?;
         self.file.take().unwrap().sync_all()?;
         if self.path.save.exists() {
-            return Err(Error::FileExists(self.path.save.clone(), "finalize SST write cache"));
+            return Err(Error::FileExists(
+                self.path.save.clone(),
+                "finalize SST write cache",
+            ));
         }
         fs::rename(&self.path.temp, &self.path.save)?;
         Ok(())

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -588,7 +588,7 @@ impl ImportDir {
     fn create(&self, meta: &SstMeta) -> Result<ImportFile> {
         let path = self.join(meta)?;
         if path.save.exists() {
-            return Err(Error::FileExists(path.save));
+            return Err(Error::FileExists(path.save, "create SST upload cache"));
         }
         ImportFile::create(meta.clone(), path)
     }
@@ -709,7 +709,7 @@ impl ImportFile {
         self.validate()?;
         self.file.take().unwrap().sync_all()?;
         if self.path.save.exists() {
-            return Err(Error::FileExists(self.path.save.clone()));
+            return Err(Error::FileExists(self.path.save.clone(), "finalize SST write cache"));
         }
         fs::rename(&self.path.temp, &self.path.save)?;
         Ok(())

--- a/etc/error_code.toml
+++ b/etc/error_code.toml
@@ -233,6 +233,11 @@ error = 'KV-Raft-RequestSnapshotDropped'
 description = ''
 workaround = ''
 
+[error.KV-Raft-ConfChangeError]
+error = 'KV-Raft-ConfChangeError'
+description = ''
+workaround = ''
+
 [error.KV-Raftstore-EntryTooLarge]
 error = 'KV-Raftstore-EntryTooLarge'
 description = ''

--- a/tests/integrations/import/sst_service.rs
+++ b/tests/integrations/import/sst_service.rs
@@ -21,6 +21,13 @@ use tikv_util::HandyRwLock;
 
 const CLEANUP_SST_MILLIS: u64 = 10;
 
+macro_rules! assert_to_string_contains {
+    ($e:expr, $substr:expr) => {{
+        let msg = $e.to_string();
+        assert!(msg.contains($substr), "msg: {}; expr: {}", msg, stringify!($e));
+    }}
+}
+
 fn new_cluster() -> (Cluster<ServerCluster>, Context) {
     let count = 1;
     let mut cluster = new_server_cluster(0, count);
@@ -64,11 +71,11 @@ fn test_upload_sst() {
 
     // Mismatch crc32
     let meta = new_sst_meta(0, length);
-    assert!(send_upload_sst(&import, &meta, &data).is_err());
+    assert_to_string_contains!(send_upload_sst(&import, &meta, &data).unwrap_err(), "crc32");
 
     // Mismatch length
     let meta = new_sst_meta(crc32, 0);
-    assert!(send_upload_sst(&import, &meta, &data).is_err());
+    assert_to_string_contains!(send_upload_sst(&import, &meta, &data).unwrap_err(), "length");
 
     let mut meta = new_sst_meta(crc32, length);
     meta.set_region_id(ctx.get_region_id());
@@ -76,7 +83,7 @@ fn test_upload_sst() {
     send_upload_sst(&import, &meta, &data).unwrap();
 
     // Can't upload the same uuid file again.
-    assert!(send_upload_sst(&import, &meta, &data).is_err());
+    assert_to_string_contains!(send_upload_sst(&import, &meta, &data).unwrap_err(), "FileExists");
 }
 
 #[test]
@@ -130,11 +137,11 @@ fn test_ingest_sst() {
     meta.set_region_epoch(ctx.get_region_epoch().clone());
     send_upload_sst(&import, &meta, &data).unwrap();
     // Can't upload the same file again.
-    assert!(send_upload_sst(&import, &meta, &data).is_err());
+    assert_to_string_contains!(send_upload_sst(&import, &meta, &data).unwrap_err(), "FileExists");
 
     ingest.set_sst(meta.clone());
     let resp = import.ingest(&ingest).unwrap();
-    assert!(!resp.has_error());
+    assert!(!resp.has_error(), "{:?}", resp.get_error());
 }
 
 #[test]
@@ -237,7 +244,7 @@ fn test_cleanup_sst() {
     send_upload_sst(&import, &meta, &data).unwrap();
 
     // Can not upload the same file when it exists.
-    assert!(send_upload_sst(&import, &meta, &data).is_err());
+    assert_to_string_contains!(send_upload_sst(&import, &meta, &data).unwrap_err(), "FileExists");
 
     // The uploaded SST should be deleted if the region split.
     let region = cluster.get_region(&[]);
@@ -259,7 +266,7 @@ fn test_cleanup_sst() {
     // The uploaded SST should be deleted if the region merged.
     cluster.pd_client.must_merge(left.get_id(), right.get_id());
     let res = block_on(cluster.pd_client.get_region_by_id(left.get_id()));
-    assert!(res.unwrap().is_none());
+    assert_eq!(res.unwrap(), None);
 
     check_sst_deleted(&import, &meta, &data);
 }
@@ -310,9 +317,11 @@ fn send_upload_sst(
         .collect();
     let (mut tx, rx) = client.upload().unwrap();
     let mut stream = stream::iter(reqs);
-    block_on(tx.send_all(&mut stream)).unwrap();
-    block_on(tx.close()).unwrap();
-    block_on(rx)
+    block_on(async move {
+        tx.send_all(&mut stream).await?;
+        tx.close().await?;
+        rx.await
+    })
 }
 
 fn send_write_sst(

--- a/tests/integrations/import/sst_service.rs
+++ b/tests/integrations/import/sst_service.rs
@@ -24,8 +24,13 @@ const CLEANUP_SST_MILLIS: u64 = 10;
 macro_rules! assert_to_string_contains {
     ($e:expr, $substr:expr) => {{
         let msg = $e.to_string();
-        assert!(msg.contains($substr), "msg: {}; expr: {}", msg, stringify!($e));
-    }}
+        assert!(
+            msg.contains($substr),
+            "msg: {}; expr: {}",
+            msg,
+            stringify!($e)
+        );
+    }};
 }
 
 fn new_cluster() -> (Cluster<ServerCluster>, Context) {
@@ -75,7 +80,10 @@ fn test_upload_sst() {
 
     // Mismatch length
     let meta = new_sst_meta(crc32, 0);
-    assert_to_string_contains!(send_upload_sst(&import, &meta, &data).unwrap_err(), "length");
+    assert_to_string_contains!(
+        send_upload_sst(&import, &meta, &data).unwrap_err(),
+        "length"
+    );
 
     let mut meta = new_sst_meta(crc32, length);
     meta.set_region_id(ctx.get_region_id());
@@ -83,7 +91,10 @@ fn test_upload_sst() {
     send_upload_sst(&import, &meta, &data).unwrap();
 
     // Can't upload the same uuid file again.
-    assert_to_string_contains!(send_upload_sst(&import, &meta, &data).unwrap_err(), "FileExists");
+    assert_to_string_contains!(
+        send_upload_sst(&import, &meta, &data).unwrap_err(),
+        "FileExists"
+    );
 }
 
 #[test]
@@ -137,7 +148,10 @@ fn test_ingest_sst() {
     meta.set_region_epoch(ctx.get_region_epoch().clone());
     send_upload_sst(&import, &meta, &data).unwrap();
     // Can't upload the same file again.
-    assert_to_string_contains!(send_upload_sst(&import, &meta, &data).unwrap_err(), "FileExists");
+    assert_to_string_contains!(
+        send_upload_sst(&import, &meta, &data).unwrap_err(),
+        "FileExists"
+    );
 
     ingest.set_sst(meta.clone());
     let resp = import.ingest(&ingest).unwrap();
@@ -244,7 +258,10 @@ fn test_cleanup_sst() {
     send_upload_sst(&import, &meta, &data).unwrap();
 
     // Can not upload the same file when it exists.
-    assert_to_string_contains!(send_upload_sst(&import, &meta, &data).unwrap_err(), "FileExists");
+    assert_to_string_contains!(
+        send_upload_sst(&import, &meta, &data).unwrap_err(),
+        "FileExists"
+    );
 
     // The uploaded SST should be deleted if the region split.
     let region = cluster.get_region(&[]);

--- a/tests/integrations/import/sst_service.rs
+++ b/tests/integrations/import/sst_service.rs
@@ -372,9 +372,11 @@ fn send_write_sst(
 
     let (mut tx, rx) = client.write().unwrap();
     let mut stream = stream::iter(reqs);
-    block_on(tx.send_all(&mut stream)).unwrap();
-    block_on(tx.close()).unwrap();
-    block_on(rx)
+    block_on(async move {
+        tx.send_all(&mut stream).await?;
+        tx.close().await?;
+        rx.await
+    })
 }
 
 fn check_ingested_kvs(tikv: &TikvClient, ctx: &Context, sst_range: (u8, u8)) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #7266

Problem Summary:

Recently #7266 happens again, with call stack involving these blocks:

https://github.com/tikv/tikv/blob/ed93f82480798d3badca3b324e40fab4c36fa84d/tests/integrations/import/sst_service.rs#L313-L315

https://github.com/tikv/tikv/blob/ed93f82480798d3badca3b324e40fab4c36fa84d/tests/integrations/import/sst_service.rs#L132-L133

Here, the call to `send_upload_sst()` is expected to error with FileExists, but previously it should only happen on line 315. Likely due to the async/await refactoring in #8550, the same error sometimes is emitted on line 313 instead, which caused the panic.

### What is changed and how it works?

What's Changed:

1. Merged the 3 `block_on` calls into a single `async` block and allow every future to propagate the error.
2. Tightened the `assert!(send_upload_sst().is_err())` check to also check the error message, to reduce chance of catching a wrong error due to relaxation at 1.
3. Since there are 2 places the `FileExists` error is thrown, we also encoded where the `FileExists` is generated into the Error.

### Related changes

- Need to cherry-pick to the release branch (release-4.0)
   * Perhaps combine into #8394 if accepted.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
   * run `cargo test -p tests --test integrations sst` several times and nothing happens (ok, not reliably reproducible before neither)

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

* No release note.