### PR TITLE
change error for split_region and read_index

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1744,8 +1744,8 @@ impl BatchCollector<BatchCommandsResponse, (u64, batch_commands_response::Respon
 fn raftstore_error_to_region_error(e: RaftStoreError, region_id: u64) -> RegionError {
     if let RaftStoreError::Transport(DiscardReason::Disconnected) = e {
         // `From::from(RaftStoreError) -> RegionError` treats `Disconnected` as `Other`.
-        let mut region_error = RegionError::new();
-        let mut region_not_found = RegionNotFound::new();
+        let mut region_error = RegionError::default();
+        let mut region_not_found = RegionNotFound::default();
         region_not_found.region_id = region_id;
         region_error.set_region_not_found(region_not_found);
         return region_error;


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

Previously `split_region` and `read_index` RPC calls return a grpc error when re-directing the request to backend raft regions, which will make TiDBs retry the request on the same store. So the `split-region` command could never success.

This PR changes to return `RegionNotFound`, which will make TiDB try other stores if necessary.

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* No release note