### PR TITLE
fix doc tests

### DIFF
--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -662,10 +662,10 @@ async fn maybe_backoff(cfg: &Config, last_wake_time: &mut Instant, retry_times: 
 ///
 /// The general progress of connection is:
 ///
-///     1. resolve address
-///     2. connect
-///     3. make batch call
-///     4. fallback to legacy API if incompatible
+/// 1. resolve address
+/// 2. connect
+/// 3. make batch call
+/// 4. fallback to legacy API if incompatible
 ///
 /// Every failure during the process should trigger retry automatically.
 async fn start<S, R>(


### PR DESCRIPTION
When I ran `make test` I would get a failure because indentation is assumed to be a doc test. This fixes it. Common Mark does not require indentation of lists although I didn't verify the actual doc output of this.

### Release note

* No release note