### PR TITLE
tikv_util: use singleton sysinfo::System

### DIFF
--- a/components/tikv_util/src/sys/mod.rs
+++ b/components/tikv_util/src/sys/mod.rs
@@ -5,10 +5,19 @@ pub mod cpu_time;
 #[cfg(target_os = "linux")]
 mod cgroup;
 
+// re-export some traits for ease of use
+pub use sysinfo::{DiskExt, NetworkExt, ProcessExt, ProcessorExt, SystemExt};
+
+use std::sync::Mutex;
+
+lazy_static! {
+    pub static ref SYS_INFO: Mutex<sysinfo::System> = Mutex::new(sysinfo::System::new());
+}
+
 #[cfg(target_os = "linux")]
 pub mod sys_quota {
     use super::super::config::KB;
-    use super::cgroup::CGroupSys;
+    use super::{cgroup::CGroupSys, SystemExt, SYS_INFO};
 
     pub struct SysQuota {
         cgroup: CGroupSys,
@@ -30,10 +39,11 @@ pub mod sys_quota {
         }
 
         pub fn memory_limit_in_bytes(&self) -> u64 {
-            use sysinfo::SystemExt;
-            let mut system = sysinfo::System::new();
-            system.refresh_all();
-            let total_mem = system.get_total_memory() * KB;
+            let total_mem = {
+                let mut system = SYS_INFO.lock().unwrap();
+                system.refresh_memory();
+                system.get_total_memory() * KB
+            };
             let cgroup_memory_limits = self.cgroup.memory_limit_in_bytes();
             if cgroup_memory_limits <= 0 {
                 total_mem
@@ -55,6 +65,7 @@ pub mod sys_quota {
 #[cfg(not(target_os = "linux"))]
 pub mod sys_quota {
     use super::super::config::KB;
+    use super::{SystemExt, SYS_INFO};
 
     pub struct SysQuota {}
 
@@ -68,9 +79,8 @@ pub mod sys_quota {
         }
 
         pub fn memory_limit_in_bytes(&self) -> u64 {
-            use sysinfo::SystemExt;
-            let mut system = sysinfo::System::new();
-            system.refresh_all();
+            let mut system = SYS_INFO.lock().unwrap();
+            system.refresh_memory();
             system.get_total_memory() * KB
         }
 

--- a/src/server/service/diagnostics/mod.rs
+++ b/src/server/service/diagnostics/mod.rs
@@ -24,8 +24,10 @@ use kvproto::diagnosticspb::search_log_request::Target as SearchLogRequestTarget
 use kvproto::diagnosticspb::SearchLogRequestTarget;
 
 use security::{check_common_name, SecurityManager};
-use sysinfo::SystemExt;
-use tikv_util::timer::GLOBAL_TIMER_HANDLE;
+use tikv_util::{
+    sys::{SystemExt, SYS_INFO},
+    timer::GLOBAL_TIMER_HANDLE,
+};
 
 mod ioload;
 mod log;
@@ -122,7 +124,7 @@ impl Diagnostics for Service {
         let collect = async move {
             let (load, when) = match tp {
                 ServerInfoType::LoadInfo | ServerInfoType::All => {
-                    let mut system = sysinfo::System::new();
+                    let mut system = SYS_INFO.lock().unwrap();
                     system.refresh_networks_list();
                     system.refresh_all();
                     let load = (

--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -5,10 +5,8 @@ use std::string::ToString;
 
 use crate::server::service::diagnostics::ioload;
 use kvproto::diagnosticspb::{ServerInfoItem, ServerInfoPair};
-use sysinfo::{DiskExt, NetworkExt, ProcessExt, ProcessorExt, SystemExt};
 use tikv_util::config::KB;
-use tikv_util::sys::cpu_time::LiunxStyleCpuTime;
-use tikv_util::sys::sys_quota::SysQuota;
+use tikv_util::sys::{cpu_time::LiunxStyleCpuTime, sys_quota::SysQuota, *};
 use walkdir::WalkDir;
 
 type CpuTimeSnapshot = Option<LiunxStyleCpuTime>;
@@ -59,14 +57,16 @@ impl NicSnapshot {
 fn cpu_load_info(prev_cpu: CpuTimeSnapshot, collector: &mut Vec<ServerInfoItem>) {
     // CPU load
     {
-        let mut system = sysinfo::System::new();
-        system.refresh_system();
-        let load = system.get_load_average();
-        let infos = vec![
-            ("load1", load.one),
-            ("load5", load.five),
-            ("load15", load.fifteen),
-        ];
+        let infos = {
+            let mut system = SYS_INFO.lock().unwrap();
+            system.refresh_system();
+            let load = system.get_load_average();
+            vec![
+                ("load1", load.one),
+                ("load5", load.five),
+                ("load15", load.fifteen),
+            ]
+        };
         let mut pairs = vec![];
         for info in infos.iter() {
             let mut pair = ServerInfoPair::default();
@@ -125,14 +125,15 @@ fn cpu_load_info(prev_cpu: CpuTimeSnapshot, collector: &mut Vec<ServerInfoItem>)
 }
 
 fn mem_load_info(collector: &mut Vec<ServerInfoItem>) {
-    let mut system = sysinfo::System::new();
+    let mut system = SYS_INFO.lock().unwrap();
     system.refresh_memory();
-    let total_memory = SysQuota::new().memory_limit_in_bytes();
     let used_memory = system.get_used_memory() * KB;
     let free_memory = system.get_free_memory() * KB;
     let total_swap = system.get_total_swap() * KB;
     let used_swap = system.get_used_swap() * KB;
     let free_swap = system.get_free_swap() * KB;
+    drop(system);
+    let total_memory = SysQuota::new().memory_limit_in_bytes();
     let used_memory_pct = (used_memory as f64) / (total_memory as f64);
     let free_memory_pct = (free_memory as f64) / (total_memory as f64);
     let used_swap_pct = (used_swap as f64) / (total_swap as f64);
@@ -176,7 +177,7 @@ fn mem_load_info(collector: &mut Vec<ServerInfoItem>) {
 }
 
 fn nic_load_info(prev_nic: HashMap<String, NicSnapshot>, collector: &mut Vec<ServerInfoItem>) {
-    let mut system = sysinfo::System::new();
+    let mut system = SYS_INFO.lock().unwrap();
     system.refresh_networks_list();
     system.refresh_networks();
     let current = system.get_networks();
@@ -289,7 +290,7 @@ pub fn load_info(
 }
 
 fn cpu_hardware_info(collector: &mut Vec<ServerInfoItem>) {
-    let mut system = sysinfo::System::new();
+    let mut system = SYS_INFO.lock().unwrap();
     system.refresh_cpu();
     let processor = match system.get_processors().iter().next() {
         Some(p) => p,
@@ -333,7 +334,7 @@ fn cpu_hardware_info(collector: &mut Vec<ServerInfoItem>) {
 }
 
 fn mem_hardware_info(collector: &mut Vec<ServerInfoItem>) {
-    let mut system = sysinfo::System::new();
+    let mut system = SYS_INFO.lock().unwrap();
     system.refresh_memory();
     let mut pair = ServerInfoPair::default();
     pair.set_key("capacity".to_string());
@@ -346,7 +347,7 @@ fn mem_hardware_info(collector: &mut Vec<ServerInfoItem>) {
 }
 
 fn disk_hardware_info(collector: &mut Vec<ServerInfoItem>) {
-    let mut system = sysinfo::System::new();
+    let mut system = SYS_INFO.lock().unwrap();
     system.refresh_disks_list();
     system.refresh_disks();
     let disks = system.get_disks();
@@ -487,7 +488,7 @@ fn get_sysctl_list() -> HashMap<String, String> {
 /// TODO: use different `ServerInfoType` to collect process list
 #[allow(dead_code)]
 pub fn process_info(collector: &mut Vec<ServerInfoItem>) {
-    let mut system = sysinfo::System::new();
+    let mut system = SYS_INFO.lock().unwrap();
     system.refresh_processes();
     let processes = system.get_processes();
     for (pid, p) in processes.iter() {
@@ -524,14 +525,16 @@ mod tests {
     #[test]
     fn test_load_info() {
         let prev_cpu = cpu_time_snapshot();
-        let mut system = sysinfo::System::new();
-        system.refresh_networks_list();
-        system.refresh_all();
-        let prev_nic = system
-            .get_networks()
-            .into_iter()
-            .map(|(n, d)| (n.to_owned(), NicSnapshot::from_network_data(d)))
-            .collect();
+        let prev_nic = {
+            let mut system = SYS_INFO.lock().unwrap();
+            system.refresh_networks_list();
+            system.refresh_all();
+            system
+                .get_networks()
+                .into_iter()
+                .map(|(n, d)| (n.to_owned(), NicSnapshot::from_network_data(d)))
+                .collect()
+        };
         let prev_io = ioload::IoLoad::snapshot();
         let mut collector = vec![];
         load_info((prev_cpu, prev_nic, prev_io), &mut collector);


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

`sysinfo::System` shouldn't be created multiple times. It should be created once and for all. See https://github.com/GuillaumeGomez/sysinfo/issues/345#issuecomment-658624786. 

BTW, `sysinfo` will create the same number of threads as the number of CPUs available due to `rayon`.

### What is changed and how it works?

What's Changed:

Use a singleton `sysinfo::System`. It's protected by a mutex which may affect performance, but I think it's acceptable because it's seldom used.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression

### Release note <!-- bugfixes or new feature need a release note -->
* No release note