### PR TITLE
Makefile: do not gen error code before build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ dev: format clippy
 	@env FAIL_POINT=1 make test
 
 build: export TIKV_PROFILE=debug
-build: error-code
+build:
 	cargo build --no-default-features --features "${ENABLE_FEATURES}"
 
 ## Release builds (optimized dev builds)
@@ -140,7 +140,7 @@ build: error-code
 # sse2-level instruction set), but with sse4.2 and the PCLMUL instruction
 # enabled (the "sse" option)
 release: export TIKV_PROFILE=release
-release: error-code
+release:
 	cargo build --release --no-default-features --features "${ENABLE_FEATURES}"
 
 # An optimized build that builds an "unportable" RocksDB, which means it is
@@ -178,7 +178,7 @@ endif
 # Build with release flag as if it were for distribution, but without
 # additional sanity checks and file movement.
 build_dist_release: export TIKV_PROFILE=dist_release
-build_dist_release: error-code
+build_dist_release:
 	make x-build-dist
 ifeq ($(shell uname),Linux) # Macs don't have objcopy
 	# Reduce binary size by compressing binaries.


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
Previously we introduced an `error-code` pre-condition of every build command in Makefile, which makes the build process slower.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Remove the `error-code` pre-condition in Makefile.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->
* N/A