### PR TITLE
build: reduce generated layers in gen-dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,14 +356,13 @@ error-code:
 .PHONY: docker
 docker:
 	bash ./scripts/gen-dockerfile.sh > Dockerfile
-	@pwd
-	@ls -l .
 	docker build \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
 		. \
 		--build-arg GIT_HASH=${TIKV_BUILD_GIT_HASH} \
 		--build-arg GIT_TAG=${TIKV_BUILD_GIT_TAG} \
-		--build-arg GIT_BRANCH=${TIKV_BUILD_GIT_BRANCH}
+		--build-arg GIT_BRANCH=${TIKV_BUILD_GIT_BRANCH} || true
+	@rm -f Dockerfile cargo.tar code.tar
 
 ## The driver for script/run-cargo.sh
 ## ----------------------------------

--- a/Makefile
+++ b/Makefile
@@ -355,9 +355,12 @@ error-code:
 # A special target for building TiKV docker image.
 .PHONY: docker
 docker:
-	bash ./scripts/gen-dockerfile.sh | docker build \
+	bash ./scripts/gen-dockerfile.sh > Dockerfile
+	@pwd
+	@ls -l .
+	docker build \
 		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-		-f - . \
+		. \
 		--build-arg GIT_HASH=${TIKV_BUILD_GIT_HASH} \
 		--build-arg GIT_TAG=${TIKV_BUILD_GIT_TAG} \
 		--build-arg GIT_BRANCH=${TIKV_BUILD_GIT_BRANCH}

--- a/scripts/gen-dockerfile.sh
+++ b/scripts/gen-dockerfile.sh
@@ -15,7 +15,7 @@
 # Install the system dependencies
 # Attempt to clean and rebuild the cache to avoid 404s
 cat <<EOT
-FROM centos:centos7 as builder
+FROM centos:7.6.1810 as builder
 RUN yum install -y epel-release && \
     yum clean all && \
     yum makecache


### PR DESCRIPTION
Signed-off-by: lysu <sulifx@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

build dev image failed with 

```
[2020-10-12T09:07:16.886Z] Step 129/144 : COPY ./fuzz/targets ./fuzz/targets 
[2020-10-12T09:07:17.144Z] max depth exceeded 
[2020-10-12T09:07:17.144Z] make: *** [Makefile:356: docker] Error 1
```

https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/build_image_hash/detail/build_image_hash/7774/pipeline

### What is changed and how it works?

What's Changed:

use one COPY to copy multi files to reduce image layers

but docker's `COPY` cannot copy multiple files and keep old struct, so it's trick to using `tar` + `ADD`

it also land Dockfile instead of using pipe to avoid temp docker build context

### Related changes

- n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- no release note.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tikv/tikv/8810)
<!-- Reviewable:end -->
