### PR TITLE
*: remove setup configuration of jemalloc profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,9 @@ ENABLE_FEATURES += jemalloc
 # Only tested on Linux
 ifeq ($(shell uname -s),Linux)
 ENABLE_FEATURES += mem-profiling
-export JEMALLOC_SYS_WITH_MALLOC_CONF = prof:true,prof_active:false
+# According to jemalloc/jemalloc#585, enabling it on some platform or some
+# versions of glibc can cause deadlock.
+# export JEMALLOC_SYS_WITH_MALLOC_CONF = prof:true,prof_active:false
 endif
 endif
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

According to jemalloc/jemalloc#585, enabling memory profiling can cause
deadlock on some platform and with some version of glibc. So this pr
removes it by default for best safety.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- No release note