### PR TITLE
Makefile: disable memory profile feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,13 @@ else ifeq ($(SYSTEM_ALLOC),1)
 else
 ENABLE_FEATURES += jemalloc
 
-# Only tested on Linux
-ifeq ($(shell uname -s),Linux)
-ENABLE_FEATURES += mem-profiling
 # According to jemalloc/jemalloc#585, enabling it on some platform or some
 # versions of glibc can cause deadlock.
+# Only tested on Linux
+# ifeq ($(shell uname -s),Linux)
+# ENABLE_FEATURES += mem-profiling
 # export JEMALLOC_SYS_WITH_MALLOC_CONF = prof:true,prof_active:false
-endif
+# endif
 endif
 
 # Disable portable on MacOS to sidestep the compiler bug in clang 4.9
@@ -247,11 +247,12 @@ run-test:
 	export RUST_BACKTRACE=1 && \
 	cargo -Zpackage-features test --workspace \
 		--exclude fuzzer-honggfuzz --exclude fuzzer-afl --exclude fuzzer-libfuzzer \
-		--features "${ENABLE_FEATURES}" ${EXTRA_CARGO_ARGS} -- --nocapture && \
+		--features "${ENABLE_FEATURES} mem-profiling" ${EXTRA_CARGO_ARGS} -- --nocapture && \
 	if [[ "`uname`" == "Linux" ]]; then \
+		export MALLOC_CONF=prof:true,prof_active:false && \
 		cargo -Zpackage-features test --workspace \
 			--exclude fuzzer-honggfuzz --exclude fuzzer-afl --exclude fuzzer-libfuzzer \
-			--features "${ENABLE_FEATURES}" ${EXTRA_CARGO_ARGS} -p tikv -p tikv_alloc --lib -- --nocapture --ignored; \
+			--features "${ENABLE_FEATURES} mem-profiling" ${EXTRA_CARGO_ARGS} -p tikv -p tikv_alloc --lib -- --nocapture --ignored; \
 	fi
 
 .PHONY: test


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Turn out even compiling profiling can still lead to deadlock.

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- No release note