### PR TITLE
*: update and fix docs links and format

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -13,9 +13,9 @@ Thanks for using TiKV! Before asking a question, please take a look in the follo
 - Open and closed [GitHub issues](https://github.com/tikv/tikv/issues?utf8=%E2%9C%93&q=is%3Aissue)
 - Our documentation:
   - [TiKV Readme](https://github.com/tikv/tikv)
-  - [TiKV Documentation](https://github.com/tikv/tikv/wiki/TiKV-Documentation)
-  - [TiKV-Ctl Documentation](https://pingcap.github.io/docs/tools/tikv-control/)
-  - [TiDB & TiKV Documentation](https://pingcap.github.io/docs/)
+  - [TiKV Documentation](https://tikv.org/docs/4.0/concepts/overview/)
+  - [TiKV-Ctl Documentation](https://tikv.org/docs/4.0/reference/tools/tikv-ctl/)
+  - [TiDB & TiKV Documentation](http://docs.pingcap.com/)
 
 You might get a faster response in the TiKV [Discourse forum](https://forum.tikv.org/c/tikv) or [Slack](https://join.slack.com/t/tikv-wg/shared_invite/enQtNTUyODE4ODU2MzI0LTgzZDQ3NzZlNDkzMGIyYjU1MTA0NzIwMjFjODFiZjA0YjFmYmQyOTZiNzNkNzg1N2U1MDdlZTIxNTU5NWNhNjk).
 -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -17,5 +17,5 @@ Thanks for using TiKV! Before asking a question, please take a look in the follo
   - [TiKV-Ctl Documentation](https://tikv.org/docs/4.0/reference/tools/tikv-ctl/)
   - [TiDB & TiKV Documentation](http://docs.pingcap.com/)
 
-You might get a faster response in the TiKV [Discourse forum](https://forum.tikv.org/c/tikv) or [Slack](https://join.slack.com/t/tikv-wg/shared_invite/enQtNTUyODE4ODU2MzI0LTgzZDQ3NzZlNDkzMGIyYjU1MTA0NzIwMjFjODFiZjA0YjFmYmQyOTZiNzNkNzg1N2U1MDdlZTIxNTU5NWNhNjk).
+You might get a faster response in [Slack](https://join.slack.com/t/tikv-wg/shared_invite/enQtNTUyODE4ODU2MzI0LTgzZDQ3NzZlNDkzMGIyYjU1MTA0NzIwMjFjODFiZjA0YjFmYmQyOTZiNzNkNzg1N2U1MDdlZTIxNTU5NWNhNjk).
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,11 +109,11 @@ When building with make, cargo will automatically use [pipelined][p] compilation
 
 ## Running TiKV
 
-To run TiKV as an actual key-value store, you will need to run it as a cluster (a cluster can have just one node, which is useful for testing). You can do this on a single machine or on multiple machines. You need to use [PD](https://github.com/tikv/pd) to manage the cluster (even if there is just one node on a single machine). Instructions are in our [docs](https://tikv.org/docs/4.0/tasks/deploy/binary/) (if you build TiKV from source, then you don't need to download the binary).
+To run TiKV as an actual key-value store, you will need to run it as a cluster (a cluster can have just one node, which is useful for testing). You can do this on a single machine or on multiple machines. You need to use [PD](https://github.com/tikv/pd) to manage the cluster (even if there is just one node on a single machine). Instructions are in our [docs](https://tikv.org/docs/dev/tasks/deploy/binary/) (if you build TiKV from source, then you don't need to download the binary).
 
 ### Configuration
 
-Read our configuration guide to learn about various [configuration options](https://tikv.org/docs/4.0/tasks/configure/introduction/). There is also a [configuration template](./etc/config-template.toml).
+Read our configuration guide to learn about various [configuration options](https://tikv.org/docs/dev/tasks/configure/introduction/). There is also a [configuration template](./etc/config-template.toml).
 
 ## Contribution flow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ TiKV has many dependent repositories. If you need any help or mentoring getting 
 
 ## Building and setting up a development workspace
 
-TiKV is mostly written in Rust, but has components written in C++ (RocksDB) and Go (gRPC). We are currently using the Rust nightly toolchain. To provide consistency, we use linters and automated formatting tools. 
+TiKV is mostly written in Rust, but has components written in C++ (RocksDB) and Go (gRPC). We are currently using the Rust nightly toolchain. To provide consistency, we use linters and automated formatting tools.
 
 ### Prerequisites
 
@@ -94,7 +94,6 @@ See the [style doc](https://github.com/rust-lang/rfcs/blob/master/style-guide/RE
 
 Please follow this style to make TiKV easy to review, maintain, and develop.
 
-
 ### Build issues
 
 To reduce compilation time, TiKV builds do not include full debugging information by default &mdash; `release` and `bench` builds include no debuginfo; `dev` and `test` builds include line numbers only. The easiest way to enable debuginfo is to precede build commands with `RUSTFLAGS=-Cdebuginfo=1` (for line numbers), or `RUSTFLAGS=-Cdebuginfo=2` (for full debuginfo). For example,
@@ -108,16 +107,13 @@ When building with make, cargo will automatically use [pipelined][p] compilation
 
 [p]: https://internals.rust-lang.org/t/evaluating-pipelined-rustc-compilation/10199
 
-
 ## Running TiKV
 
-To run TiKV as an actual key-value store, you will need to run it as a cluster (a cluster can have just one node, which is useful for testing). You can do this on a single machine or on multiple machines. You need to use [PD](https://github.com/tikv/pd) to manage the cluster (even if there is just one node on a single machine). Instructions are in our [docs](docs/how-to/deploy/using-binary.md) (if you build TiKV from source, then you don't need to download the binary).
-
+To run TiKV as an actual key-value store, you will need to run it as a cluster (a cluster can have just one node, which is useful for testing). You can do this on a single machine or on multiple machines. You need to use [PD](https://github.com/tikv/pd) to manage the cluster (even if there is just one node on a single machine). Instructions are in our [docs](https://tikv.org/docs/4.0/tasks/deploy/binary/) (if you build TiKV from source, then you don't need to download the binary).
 
 ### Configuration
 
-Read our configuration guide to learn about various [configuration options](./docs/reference/configuration). There is also a [configuration template](./etc/config-template.toml).
-
+Read our configuration guide to learn about various [configuration options](https://tikv.org/docs/4.0/tasks/configure/introduction/). There is also a [configuration template](./etc/config-template.toml).
 
 ## Contribution flow
 
@@ -137,8 +133,7 @@ This is a rough outline of what a contributor's workflow looks like:
 
 Thanks for your contributions!
 
-
-### Finding something to work on.
+### Finding something to work on
 
 For beginners, we have prepared many suitable tasks for you. Checkout our [Help Wanted issues](https://github.com/tikv/tikv/issues?q=is%3Aopen+is%3Aissue+label%3Astatus%2Fhelp-wanted) for a list, in which we have also marked the difficulty level.
 
@@ -151,7 +146,6 @@ The TiKV team actively develops and maintains a bunch of dependencies used in Ti
 - [raft-rs](https://github.com/tikv/raft-rs): The Raft distributed consensus algorithm implemented in Rust
 - [grpc-rs](https://github.com/tikv/grpc-rs): The gRPC library for Rust built on the gRPC C Core library and Rust Futures
 - [fail-rs](https://github.com/tikv/fail-rs): Fail points for Rust
-
 
 ### Format of the commit message
 
@@ -187,4 +181,4 @@ The body of the commit message should describe why the change was made and at a 
 
 The project uses [DCO check](https://github.com/probot/dco#how-it-works) and the commit message must contain a `Signed-off-by` line for [Developer Certificate of Origin](https://developercertificate.org/).
 
-Use option `git commit -s` to sign off your commits. 
+Use option `git commit -s` to sign off your commits.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ TiKV has the following key features:
 
 - **Coprocessor support**
 
-    Similar to Hbase, TiKV implements a coprocessor framework to support distributed computing.
+    Similar to HBase, TiKV implements a coprocessor framework to support distributed computing.
 
 - **Cooperates with [TiDB](https://github.com/pingcap/tidb)**
 
@@ -54,11 +54,11 @@ For instructions on deployment, configuration, and maintenance of TiKV,see TiKV 
 >
 > We have migrated our documentation from the [TiKV's wiki page](https://github.com/tikv/tikv/wiki/) to the [official website](https://tikv.org/docs). The original Wiki page is discontinued. If you have any suggestions or issues regarding documentation, offer your feedback [here](https://github.com/tikv/website).
 
-## TiKV Adopters
+## TiKV adopters
 
 You can view the list of [TiKV Adopters](https://tikv.org/adopters/).
 
-## TiKV Roadmap
+## TiKV roadmap
 
 You can see the [TiKV Roadmap](docs/ROADMAP.md).
 
@@ -83,7 +83,7 @@ We provide multiple deployment methods, but it is recommended to use our Ansible
 
 - [Try TiKV and TiDB](https://tikv.org/docs/4.0/tasks/try/introduction/)
 
-    You can use [`tidb-docker-compose`](https://github.com/pingcap/tidb-docker-compose/) to quickly test TiKV and TiDB on a single machine. This is the easiest way. For other ways, see [TiDB documentation](https://pingcap.com/docs/).
+    You can use [`tidb-docker-compose`](https://github.com/pingcap/tidb-docker-compose/) to quickly test TiKV and TiDB on a single machine. This is the easiest way. For other ways, see [TiDB documentation](https://docs.pingcap.com/).
 
 - Try TiKV separately
     - [Deploy TiKV Using Docker Stack](https://tikv.org/docs/4.0/tasks/try/docker-stack/): To quickly test TiKV separately without TiDB on a single machine
@@ -92,9 +92,9 @@ We provide multiple deployment methods, but it is recommended to use our Ansible
 
 ### Production deployment
 
-For the production environment, use [Ansible](https://github.com/pingcap/tidb-ansible) to deploy the cluster.
+For the production environment, use [TiDB Ansible](https://github.com/pingcap/tidb-ansible) to deploy the cluster.
 
-- [Deploy TiDB Using Ansible](https://github.com/pingcap/docs/blob/master/how-to/deploy/orchestrated/ansible.md)
+- [Deploy TiDB Using Ansible](https://docs.pingcap.com/tidb/stable/online-deployment-using-ansible)
 - [Deploy TiKV separately Using Ansible](https://tikv.org/docs/4.0/tasks/deploy/ansible/)
 
 ## Client drivers
@@ -110,27 +110,27 @@ These are the clients for TiKV:
 
 If you want to try the Go client, see [Go Client](https://tikv.org/docs/4.0/reference/clients/go/).
 
-## Community Meeting
+## Community meeting
 
 The TiKV team meets on the 4th Wednesday of every month (unless otherwise specified) at 07.00 p.m. PST ([Time zone converter](https://www.google.com/search?sxsrf=ALeKk01UVqm3BLWjN2AJxMSG73KiUqUdDw%3A1589771998935&ei=3v7BXuDQOJSl-QaKq62ICQ&q=7pm+PST&oq=7pm+PST&gs_lcp=CgZwc3ktYWIQAzIECAAQQzIECAAQQzIECAAQQzIECAAQQzIECAAQQzIECAAQQzICCAAyAggAMgYIABAHEB4yAggAOgQIABBHOggIABAHEAoQHlDQWFicXGC-ZWgAcAF4AIABmwGIAa4CkgEDMC4ymAEAoAEBqgEHZ3dzLXdpeg&sclient=psy-ab&ved=0ahUKEwjgt5SaurzpAhWUUt4KHYpVC5EQ4dUDCAw&uact=5)).
 
 Quick links:
 
-*   [Meeting notes](https://docs.google.com/document/d/1CWUAkBrcm9KPclAu8fWHZzByZ0yhsQdRggnEdqtRMQ8/edit)
-*   [Zoom meeting link](https://zoom.us/my/cncftikvproject)
-*   [Recorded videos](https://www.youtube.com/playlist?list=PLR6NVnaTxyL2B2ZyKw5XDzkGN72YF7vuN)
+* [Meeting notes](https://docs.google.com/document/d/1CWUAkBrcm9KPclAu8fWHZzByZ0yhsQdRggnEdqtRMQ8/edit)
+* [Zoom meeting link](https://zoom.us/my/cncftikvproject)
+* [Recorded videos](https://www.youtube.com/playlist?list=PLR6NVnaTxyL2B2ZyKw5XDzkGN72YF7vuN)
 
 ## Security
 
-### Security Audit
+### Security audit
 
 A third-party security auditing was performed by Cure53. See the full report [here](./docs/Security-Audit.pdf).
 
 ### Reporting Security Vulnerabilities
 
-To report a security vulnerability, please send an email to [TiKV-security](tikv-security@lists.cncf.io) group.
+To report a security vulnerability, please send an email to [TiKV-security](mailto:tikv-security@lists.cncf.io) group.
 
-See [Security](./SECURITY.md) for the process and policy followed by the TiKV project. 
+See [Security](./SECURITY.md) for the process and policy followed by the TiKV project.
 
 ## Communication
 


### PR DESCRIPTION
Signed-off-by: lilin90 <lilin@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: N/A

Problem Summary: Outdated docs links and some poor format

### What is changed and how it works?

What's Changed:
- Update several outdated or broken doc links
- Update mail address format
- Make capitalization style consistent and standard
- Remove the deprecated link of TiKV forum

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: N/A
- PR to update `pingcap/tidb-ansible`: N/A
- Need to cherry-pick to the release branch: @dcalvin What do you think?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

N/A