### PR TITLE
engine_rocks: support change rate limit dynamically

### DIFF
--- a/components/engine_panic/src/db_options.rs
+++ b/components/engine_panic/src/db_options.rs
@@ -23,9 +23,19 @@ impl DBOptions for PanicDBOptions {
     fn new() -> Self {
         panic!()
     }
+
     fn get_max_background_jobs(&self) -> i32 {
         panic!()
     }
+
+    fn get_rate_bytes_per_sec(&self) -> Option<i64> {
+        panic!()
+    }
+
+    fn set_rate_bytes_per_sec(&mut self, rate_bytes_per_sec: i64) -> Result<()> {
+        panic!()
+    }
+
     fn set_titandb_options(&mut self, opts: &Self::TitanDBOptions) {
         panic!()
     }

--- a/components/engine_rocks/src/db_options.rs
+++ b/components/engine_rocks/src/db_options.rs
@@ -44,6 +44,16 @@ impl DBOptions for RocksDBOptions {
         self.0.get_max_background_jobs()
     }
 
+    fn get_rate_bytes_per_sec(&self) -> Option<i64> {
+        self.0.get_rate_bytes_per_sec()
+    }
+
+    fn set_rate_bytes_per_sec(&mut self, rate_bytes_per_sec: i64) -> Result<()> {
+        self.0
+            .set_rate_bytes_per_sec(rate_bytes_per_sec)
+            .map_err(|e| box_err!(e))
+    }
+
     fn set_titandb_options(&mut self, opts: &Self::TitanDBOptions) {
         self.0.set_titandb_options(opts.as_raw())
     }

--- a/components/engine_traits/src/db_options.rs
+++ b/components/engine_traits/src/db_options.rs
@@ -16,6 +16,8 @@ pub trait DBOptions {
 
     fn new() -> Self;
     fn get_max_background_jobs(&self) -> i32;
+    fn get_rate_bytes_per_sec(&self) -> Option<i64>;
+    fn set_rate_bytes_per_sec(&mut self, rate_bytes_per_sec: i64) -> Result<()>;
     fn set_titandb_options(&mut self, opts: &Self::TitanDBOptions);
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -769,7 +769,6 @@ pub struct DbConfig {
     pub info_log_keep_log_file_num: u64,
     #[config(skip)]
     pub info_log_dir: String,
-    #[config(skip)]
     pub rate_bytes_per_sec: ReadableSize,
     #[serde(with = "rocks_config::rate_limiter_mode_serde")]
     #[config(skip)]
@@ -1236,6 +1235,12 @@ impl DBConfigManger {
         Ok(())
     }
 
+    fn set_rate_bytes_per_sec(&self, rate_bytes_per_sec: i64) -> Result<(), Box<dyn Error>> {
+        let mut opt = self.db.as_inner().get_db_options();
+        opt.set_rate_bytes_per_sec(rate_bytes_per_sec)?;
+        Ok(())
+    }
+
     fn validate_cf(&self, cf: &str) -> Result<(), Box<dyn Error>> {
         match (self.db_type, cf) {
             (DBType::Kv, CF_DEFAULT)
@@ -1273,6 +1278,15 @@ impl ConfigManager for DBConfigManger {
                 }
             }
         }
+
+        if let Some(rate_bytes_config) = change
+            .drain_filter(|(name, _)| name == "rate_bytes_per_sec")
+            .next()
+        {
+            let rate_bytes_per_sec: ReadableSize = rate_bytes_config.1.into();
+            self.set_rate_bytes_per_sec(rate_bytes_per_sec.0 as i64)?;
+        }
+
         if !change.is_empty() {
             let change = config_value_to_string(change);
             let change_slice = config_to_slice(&change);
@@ -1286,7 +1300,6 @@ impl ConfigManager for DBConfigManger {
         Ok(())
     }
 }
-
 fn config_to_slice(config_change: &[(String, String)]) -> Vec<(&str, &str)> {
     config_change
         .iter()
@@ -2966,6 +2979,7 @@ mod tests {
         cfg.rocksdb.defaultcf.disable_auto_compactions = false;
         cfg.rocksdb.defaultcf.target_file_size_base = ReadableSize::mb(64);
         cfg.rocksdb.defaultcf.block_cache_size = ReadableSize::mb(8);
+        cfg.rocksdb.rate_bytes_per_sec = ReadableSize::mb(64);
         cfg.storage.block_cache.shared = false;
         cfg.validate().unwrap();
         let (db, cfg_controller) = new_engines(cfg);
@@ -2978,6 +2992,21 @@ mod tests {
             .update_config("rocksdb.max-background-jobs", "8")
             .unwrap();
         assert_eq!(db.get_db_options().get_max_background_jobs(), 8);
+
+        // update rate_bytes_per_sec
+        let db_opts = db.get_db_options();
+        assert_eq!(
+            db_opts.get_rate_bytes_per_sec().unwrap(),
+            ReadableSize::mb(64).0 as i64
+        );
+
+        cfg_controller
+            .update_config("rocksdb.rate-bytes-per-sec", "128MB")
+            .unwrap();
+        assert_eq!(
+            db.get_db_options().get_rate_bytes_per_sec().unwrap(),
+            ReadableSize::mb(128).0 as i64
+        );
 
         // update some configs on default cf
         let defaultcf = db.cf_handle(CF_DEFAULT).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1300,6 +1300,7 @@ impl ConfigManager for DBConfigManger {
         Ok(())
     }
 }
+
 fn config_to_slice(config_change: &[(String, String)]) -> Vec<(&str, &str)> {
     config_change
         .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1236,7 +1236,7 @@ impl DBConfigManger {
     }
 
     fn set_rate_bytes_per_sec(&self, rate_bytes_per_sec: i64) -> Result<(), Box<dyn Error>> {
-        let mut opt = self.db.as_inner().get_db_options();
+        let mut opt = self.db.get_db_options();
         opt.set_rate_bytes_per_sec(rate_bytes_per_sec)?;
         Ok(())
     }


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>
Signed-off-by: tabokie <xy.tao@outlook.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

cherry-pick #8124
This PR is trying to support changing `rate-bytes-per-sec` dynamically. Related to tikv/rust-rocksdb#515

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- Support changing `rate-bytes-per-sec` dynamically