### PR TITLE
Encryption: reduce lock range of file_dict and background the key rotation (#8805)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ dependencies = [
  "bytes 0.4.12",
  "configuration",
  "crc32fast",
+ "crossbeam",
  "engine_traits",
  "error_code",
  "failure",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
 dependencies = [
  "backtrace-sys",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rustc-demangle",
 ]
@@ -277,7 +277,7 @@ checksum = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if",
+ "cfg-if 0.1.10",
  "clang-sys",
  "clap",
  "env_logger",
@@ -509,6 +509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "chrono"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,7 +722,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -777,25 +789,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d818a4990769aac0c7ff1360e233ef3a41adcb009ebb2036bf6915eb0f6b23c"
+checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-deque 0.8.0",
+ "crossbeam-epoch 0.9.0",
+ "crossbeam-queue 0.3.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.3.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
- "crossbeam-utils",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -804,8 +817,19 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-epoch 0.7.2",
+ "crossbeam-utils 0.6.6",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch 0.9.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -815,8 +839,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 dependencies = [
  "arrayvec 0.4.11",
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.6.6",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "const_fn",
+ "crossbeam-utils 0.8.0",
  "lazy_static",
  "memoffset",
  "scopeguard",
@@ -828,7 +866,17 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.6.6",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2a58563f049aa3bae172bc4120f093b5901161c629f280a1f40ba55317d774"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -837,7 +885,19 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+dependencies = [
+ "autocfg 1.0.0",
+ "cfg-if 1.0.0",
+ "const_fn",
  "lazy_static",
 ]
 
@@ -915,7 +975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "010ef3f25ed5bb93505a3238d19957622190268640526aab07174c66ccf5d611"
 dependencies = [
  "ahash",
- "cfg-if",
+ "cfg-if 0.1.10",
  "num_cpus",
 ]
 
@@ -956,7 +1016,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -966,7 +1026,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_users",
  "winapi 0.3.8",
@@ -1002,7 +1062,7 @@ version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1493,7 +1553,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -2020,7 +2080,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -2084,11 +2144,11 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.1"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "rustc_version",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -2141,7 +2201,7 @@ version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -2244,7 +2304,7 @@ version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.8",
 ]
@@ -2257,7 +2317,7 @@ checksum = "becb657d662f1cd2ef38c7ad480ec6b8cf9e96b27adb543e594f9cf0f2e6065c"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "void",
 ]
@@ -2270,7 +2330,7 @@ checksum = "dd0eaf8df8bab402257e0a5c17a254e4cc1f72a93588a1ddfb5d356c801aa7cb"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "void",
 ]
@@ -2283,7 +2343,7 @@ checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "void",
 ]
@@ -2434,7 +2494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -2510,7 +2570,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi",
  "libc",
  "redox_syscall",
@@ -2525,7 +2585,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi",
  "libc",
  "redox_syscall",
@@ -2799,7 +2859,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0575e258dab62268e7236d7307caa38848acbda7ec7ab87bd9093791e999d20"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fnv",
  "lazy_static",
  "libc",
@@ -3220,7 +3280,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 dependencies = [
- "crossbeam-deque",
+ "crossbeam-deque 0.7.1",
  "either",
  "rayon-core",
 ]
@@ -3231,9 +3291,9 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 dependencies = [
- "crossbeam-deque",
- "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-deque 0.7.1",
+ "crossbeam-queue 0.1.2",
+ "crossbeam-utils 0.6.6",
  "lazy_static",
  "num_cpus",
 ]
@@ -3539,7 +3599,7 @@ dependencies = [
  "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.6.6",
 ]
 
 [[package]]
@@ -3592,7 +3652,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a7384a84da856bd163ef2c22982c816b0bcedaf17978ec13d8e0e277ddc332"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs",
  "libc",
  "log",
@@ -3643,9 +3703,9 @@ checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security"
@@ -3903,7 +3963,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.8",
@@ -4099,7 +4159,7 @@ version = "0.9.6"
 source = "git+https://github.com/tikv/sysinfo.git?branch=tikv#762badf918f1e0b36fce032f9f81274d79fdff7d"
 dependencies = [
  "cache-size",
- "cfg-if",
+ "cfg-if 0.1.10",
  "doc-comment",
  "libc",
  "num_cpus",
@@ -4174,7 +4234,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand 0.7.3",
  "redox_syscall",
@@ -4704,7 +4764,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6329a7835505d46f5f3a9a2c237f8d6bf5ca6f0015decb3698ba57fcdbb609ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rustversion",
  "standback",
@@ -4860,7 +4920,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.6.6",
  "futures 0.1.29",
 ]
 
@@ -4913,7 +4973,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c56391be9805bc80163151c0b9e5164ee64f4b0200962c346fea12773158f22d"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.6.6",
  "futures 0.1.29",
  "lazy_static",
  "log",
@@ -4956,9 +5016,9 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"
 dependencies = [
- "crossbeam-deque",
- "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-deque 0.7.1",
+ "crossbeam-queue 0.1.2",
+ "crossbeam-utils 0.6.6",
  "futures 0.1.29",
  "lazy_static",
  "log",
@@ -4973,7 +5033,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.6.6",
  "futures 0.1.29",
  "slab",
  "tokio-executor",
@@ -5266,7 +5326,7 @@ version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -5293,7 +5353,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "457414a91863c0ec00090dba537f88ab955d93ca6555862c29b6d860990b8a8a"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -5436,7 +5496,7 @@ name = "yatp"
 version = "0.0.1"
 source = "git+https://github.com/tikv/yatp.git#3894a861643b6ba384aaad352bbaed9717f66838"
 dependencies = [
- "crossbeam-deque",
+ "crossbeam-deque 0.7.1",
  "dashmap",
  "fail",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ codec = { path = "components/codec" }
 configuration = { path = "components/configuration" }
 crc32fast = "1.2"
 crc64fast = "0.1"
-crossbeam = "0.7.2"
+crossbeam = "0.8"
 derive_more = "0.99.3"
 encryption = { path = "components/encryption" }
 engine = { path = "components/engine" }

--- a/components/batch-system/Cargo.toml
+++ b/components/batch-system/Cargo.toml
@@ -8,7 +8,7 @@ default = ["test-runner"]
 test-runner = ["derive_more"]
 
 [dependencies]
-crossbeam = "0.7"
+crossbeam = "0.8"
 tikv_util = { path = "../tikv_util" }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -34,7 +34,7 @@ mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
 
 [dependencies]
-crossbeam = "0.7.2"
+crossbeam = "0.8"
 hex = "0.4"
 engine_rocks = { path = "../engine_rocks" }
 engine_traits = { path = "../engine_traits" }

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -10,6 +10,7 @@ prost-codec = ["kvproto/prost-codec"]
 
 [dependencies]
 byteorder = "1.2"
+crossbeam = "0.7"
 configuration = { path = "../configuration" }
 crc32fast = "1.2"
 engine_traits = { path = "../engine_traits" }

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -10,7 +10,7 @@ prost-codec = ["kvproto/prost-codec"]
 
 [dependencies]
 byteorder = "1.2"
-crossbeam = "0.7"
+crossbeam = "0.8"
 configuration = { path = "../configuration" }
 crc32fast = "1.2"
 engine_traits = { path = "../engine_traits" }

--- a/components/encryption/src/manager/mod.rs
+++ b/components/encryption/src/manager/mod.rs
@@ -1,12 +1,12 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::collections::hash_map::Entry;
 use std::fs::File;
 use std::io::{Error as IoError, ErrorKind, Result as IoResult};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::sync::{atomic::AtomicU64, atomic::Ordering, Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use crossbeam::channel::{self, select, tick};
 use engine_traits::{EncryptionKeyManager, FileEncryptionInfo};
 use kvproto::encryptionpb::{DataKey, EncryptionMethod, FileDictionary, FileInfo, KeyDictionary};
 use protobuf::Message;
@@ -21,10 +21,21 @@ use crate::{Error, Result};
 
 const KEY_DICT_NAME: &str = "key.dict";
 const FILE_DICT_NAME: &str = "file.dict";
+const ROTATE_CHECK_PERIOD: u64 = 600; // 10min
 
 struct Dicts {
-    file_dict: FileDictionary,
-    key_dict: KeyDictionary,
+    // Maps data file paths to key id and metadata. This file is stored as plaintext.
+    file_dict: Mutex<FileDictionary>,
+    // Lock to make sure there's no concurrent update operations to file dictionary.
+    file_lock: Mutex<()>,
+    // Maps data key id to data keys, together with metadata. Also stores the data
+    // key id used to encrypt the encryption file dictionary. The content is encrypted
+    // using master key.
+    key_dict: Mutex<KeyDictionary>,
+    // Thread-safe version of current_key_id. Only when writing back to key_dict,
+    // write it back to `key_dict`. Reader should always use this atomic, instead of
+    // key_dict.current_key_id, since the latter can reflect an update-in-progress key.
+    current_key_id: AtomicU64,
     rotation_period: Duration,
     base: PathBuf,
 }
@@ -32,11 +43,13 @@ struct Dicts {
 impl Dicts {
     fn new(path: &str, rotation_period: Duration) -> Dicts {
         Dicts {
-            file_dict: FileDictionary::default(),
-            key_dict: KeyDictionary {
+            file_dict: Mutex::new(FileDictionary::default()),
+            key_dict: Mutex::new(KeyDictionary {
                 current_key_id: 0,
                 ..Default::default()
-            },
+            }),
+            current_key_id: AtomicU64::new(0),
+            file_lock: Mutex::new(()),
             rotation_period,
             base: Path::new(path).to_owned(),
         }
@@ -66,13 +79,16 @@ impl Dicts {
                 file_dict.merge_from_bytes(&file_bytes)?;
                 let mut key_dict = KeyDictionary::default();
                 key_dict.merge_from_bytes(&key_bytes)?;
+                let current_key_id = AtomicU64::new(key_dict.current_key_id);
 
                 ENCRYPTION_DATA_KEY_GAUGE.set(key_dict.keys.len() as _);
                 ENCRYPTION_FILE_NUM_GAUGE.set(file_dict.files.len() as _);
 
                 Ok(Some(Dicts {
-                    file_dict,
-                    key_dict,
+                    file_dict: Mutex::new(file_dict),
+                    key_dict: Mutex::new(key_dict),
+                    current_key_id,
+                    file_lock: Mutex::new(()),
                     rotation_period,
                     base: base.to_owned(),
                 }))
@@ -98,75 +114,93 @@ impl Dicts {
         }
     }
 
-    fn save_key_dict(&mut self, master_key: &dyn Backend) -> Result<()> {
+    fn save_key_dict(&self, master_key: &dyn Backend) -> Result<()> {
         let file = EncryptedFile::new(&self.base, KEY_DICT_NAME);
-        if !master_key.is_secure() {
-            for value in self.key_dict.keys.values_mut() {
-                value.was_exposed = true
+        let (keys_len, key_bytes) = {
+            let mut key_dict = self.key_dict.lock().unwrap();
+            if !master_key.is_secure() {
+                for value in key_dict.keys.values_mut() {
+                    value.was_exposed = true
+                }
             }
-        }
-        let key_bytes = self.key_dict.write_to_bytes()?;
+            let keys_len = key_dict.keys.len() as _;
+            let key_bytes = key_dict.write_to_bytes()?;
+            (keys_len, key_bytes)
+        };
         file.write(&key_bytes, master_key)?;
 
         ENCRYPTION_FILE_SIZE_GAUGE
             .with_label_values(&["key_dictionary"])
             .set(key_bytes.len() as _);
-        ENCRYPTION_DATA_KEY_GAUGE.set(self.key_dict.keys.len() as _);
+        ENCRYPTION_DATA_KEY_GAUGE.set(keys_len);
 
         Ok(())
     }
 
     fn save_file_dict(&self) -> Result<()> {
         let file = EncryptedFile::new(&self.base, FILE_DICT_NAME);
-        let file_bytes = self.file_dict.write_to_bytes()?;
+        let (file_bytes, file_num) = {
+            let file_dict = self.file_dict.lock().unwrap();
+            let file_bytes = file_dict.write_to_bytes()?;
+            let file_num = file_dict.files.len() as _;
+            (file_bytes, file_num)
+        };
         // File dict is saved in plaintext.
         file.write(&file_bytes, &PlaintextBackend::default())?;
 
         ENCRYPTION_FILE_SIZE_GAUGE
             .with_label_values(&["file_dictionary"])
             .set(file_bytes.len() as _);
-        ENCRYPTION_FILE_NUM_GAUGE.set(self.file_dict.files.len() as _);
+        ENCRYPTION_FILE_NUM_GAUGE.set(file_num);
 
         Ok(())
     }
 
-    fn get_key(&self, key_id: u64) -> Option<&DataKey> {
-        self.key_dict.keys.get(&key_id)
-    }
-
-    fn current_data_key(&self) -> (u64, &DataKey) {
+    fn current_data_key(&self) -> (u64, DataKey) {
+        let key_dict = self.key_dict.lock().unwrap();
+        let current_key_id = self.current_key_id.load(Ordering::SeqCst);
         (
-            self.key_dict.current_key_id,
-            self.key_dict
+            current_key_id,
+            key_dict
                 .keys
-                .get(&self.key_dict.current_key_id)
+                .get(&current_key_id)
+                .cloned()
                 .unwrap_or_else(|| {
                     panic!(
                         "current data key not found! Number of keys {}",
-                        self.key_dict.keys.len()
+                        key_dict.keys.len()
                     );
                 }),
         )
     }
 
-    fn get_file(&mut self, fname: &str) -> &FileInfo {
-        if self.file_dict.files.get(fname).is_none() {
-            // Return Plaintext if file not found
-            let mut file = FileInfo::default();
-            file.method = compat(EncryptionMethod::Plaintext);
-            self.file_dict.files.insert(fname.to_owned(), file);
+    fn get_file(&self, fname: &str) -> FileInfo {
+        let dict = self.file_dict.lock().unwrap();
+        let file_info = dict.files.get(fname);
+        match file_info {
+            None => {
+                // Return Plaintext if file not found
+                let mut file = FileInfo::default();
+                file.method = compat(EncryptionMethod::Plaintext);
+                file
+            }
+            Some(info) => info.clone(),
         }
-        self.file_dict.files.get(fname).unwrap()
     }
 
-    fn new_file(&mut self, fname: &str, method: EncryptionMethod) -> Result<&FileInfo> {
+    fn new_file(&self, fname: &str, method: EncryptionMethod) -> Result<FileInfo> {
+        let _lock = self.file_lock.lock().unwrap();
         let iv = Iv::new_ctr();
         let mut file = FileInfo::default();
         file.iv = iv.as_slice().to_vec();
-        file.key_id = self.key_dict.current_key_id;
+        file.key_id = self.current_key_id.load(Ordering::SeqCst);
         file.method = compat(method);
-        self.file_dict.files.insert(fname.to_owned(), file);
+        {
+            let mut file_dict = self.file_dict.lock().unwrap();
+            file_dict.files.insert(fname.to_owned(), file.clone());
+        }
         self.save_file_dict()?;
+
         if method != EncryptionMethod::Plaintext {
             info!("new encrypted file"; 
                   "fname" => fname, 
@@ -175,16 +209,20 @@ impl Dicts {
         } else {
             info!("new plaintext file"; "fname" => fname);
         }
-        Ok(self.file_dict.files.get(fname).unwrap())
+        Ok(file)
     }
 
-    fn delete_file(&mut self, fname: &str) -> Result<()> {
-        let file = match self.file_dict.files.remove(fname) {
-            Some(file_info) => file_info,
-            None => {
-                // Could be a plaintext file not tracked by file dictionary.
-                info!("delete untracked plaintext file"; "fname" => fname);
-                return Ok(());
+    fn delete_file(&self, fname: &str) -> Result<()> {
+        let _lock = self.file_lock.lock().unwrap();
+        let file = {
+            let mut file_dict = self.file_dict.lock().unwrap();
+            match file_dict.files.remove(fname) {
+                Some(file_info) => file_info,
+                None => {
+                    // Could be a plaintext file not tracked by file dictionary.
+                    info!("delete untracked plaintext file"; "fname" => fname);
+                    return Ok(());
+                }
             }
         };
 
@@ -198,24 +236,31 @@ impl Dicts {
         Ok(())
     }
 
-    fn link_file(&mut self, src_fname: &str, dst_fname: &str) -> Result<()> {
-        let file = match self.file_dict.files.get(src_fname) {
-            Some(file_info) => file_info.clone(),
-            None => {
-                // Could be a plaintext file not tracked by file dictionary.
-                info!("link untracked plaintext file"; "src" => src_fname, "dst" => dst_fname);
-                return Ok(());
+    fn link_file(&self, src_fname: &str, dst_fname: &str) -> Result<()> {
+        let _lock = self.file_lock.lock().unwrap();
+
+        let method = {
+            let mut file_dict = self.file_dict.lock().unwrap();
+            let file = match file_dict.files.get(src_fname) {
+                Some(file_info) => file_info.clone(),
+                None => {
+                    // Could be a plaintext file not tracked by file dictionary.
+                    info!("link untracked plaintext file"; "src" => src_fname, "dst" => dst_fname);
+                    return Ok(());
+                }
+            };
+            if file_dict.files.get(dst_fname).is_some() {
+                return Err(Error::Io(IoError::new(
+                    ErrorKind::AlreadyExists,
+                    format!("file already exists, {}", dst_fname),
+                )));
             }
+            let method = file.method;
+            file_dict.files.insert(dst_fname.to_owned(), file);
+            method
         };
-        if self.file_dict.files.get(dst_fname).is_some() {
-            return Err(Error::Io(IoError::new(
-                ErrorKind::AlreadyExists,
-                format!("file already exists, {}", dst_fname),
-            )));
-        }
-        let method = file.method;
-        self.file_dict.files.insert(dst_fname.to_owned(), file);
         self.save_file_dict()?;
+
         if method != compat(EncryptionMethod::Plaintext) {
             info!("link encrypted file"; "src" => src_fname, "dst" => dst_fname);
         } else {
@@ -224,18 +269,24 @@ impl Dicts {
         Ok(())
     }
 
-    fn rename_file(&mut self, src_fname: &str, dst_fname: &str) -> Result<()> {
-        let file = match self.file_dict.files.remove(src_fname) {
-            Some(file_info) => file_info,
-            None => {
-                // Could be a plaintext file not tracked by file dictionary.
-                info!("rename untracked plaintext file"; "src" => src_fname, "dst" => dst_fname);
-                return Ok(());
-            }
+    fn rename_file(&self, src_fname: &str, dst_fname: &str) -> Result<()> {
+        let _lock = self.file_lock.lock().unwrap();
+        let method = {
+            let mut file_dict = self.file_dict.lock().unwrap();
+            let file = match file_dict.files.remove(src_fname) {
+                Some(file_info) => file_info,
+                None => {
+                    // Could be a plaintext file not tracked by file dictionary.
+                    info!("rename untracked plaintext file"; "src" => src_fname, "dst" => dst_fname);
+                    return Ok(());
+                }
+            };
+            let method = file.method;
+            file_dict.files.insert(dst_fname.to_owned(), file);
+            method
         };
-        let method = file.method;
-        self.file_dict.files.insert(dst_fname.to_owned(), file);
         self.save_file_dict()?;
+
         if method != compat(EncryptionMethod::Plaintext) {
             info!("rename encrypted file"; "src" => src_fname, "dst" => dst_fname);
         } else {
@@ -244,31 +295,32 @@ impl Dicts {
         Ok(())
     }
 
-    fn rotate_key(&mut self, key_id: u64, key: DataKey, master_key: &dyn Backend) -> Result<bool> {
+    fn rotate_key(&self, key_id: u64, key: DataKey, master_key: &dyn Backend) -> Result<()> {
         info!("encryption: rotate data key."; "key_id" => key_id);
-        match self.key_dict.keys.entry(key_id) {
-            // key id collides
-            Entry::Occupied(_) => return Ok(false),
-            Entry::Vacant(e) => e.insert(key),
+        {
+            let mut key_dict = self.key_dict.lock().unwrap();
+            key_dict.keys.insert(key_id, key);
+            key_dict.current_key_id = key_id;
         };
-        // Update current data key id.
-        self.key_dict.current_key_id = key_id;
+
         // re-encrypt key dict file.
-        self.save_key_dict(master_key).map(|()| true)
+        self.save_key_dict(master_key)?;
+        // Update current data key id.
+        self.current_key_id.store(key_id, Ordering::SeqCst);
+        Ok(())
     }
 
     fn maybe_rotate_data_key(
-        &mut self,
+        &self,
         method: EncryptionMethod,
         master_key: &dyn Backend,
     ) -> Result<()> {
         let now = SystemTime::now();
         // 0 means it's a new key dict
-        if self.key_dict.current_key_id != 0 {
+        if self.current_key_id.load(Ordering::SeqCst) != 0 {
             // It's not a new dict, then check current data key
             // creation time.
             let (_, key) = self.current_data_key();
-
             // Generate a new data key if
             //   1. encryption method is not the same, or
             //   2. the current data key was exposed and the new master key is secure.
@@ -293,28 +345,39 @@ impl Dicts {
         let duration = now.duration_since(UNIX_EPOCH).unwrap();
         let creation_time = duration.as_secs();
 
-        // Generate new data key.
-        let generate_limit = 10;
-        for _ in 0..generate_limit {
-            let (key_id, key) = generate_data_key(method);
-            if key_id == 0 {
-                // 0 is invalid
-                continue;
-            }
-            let mut data_key = DataKey::default();
-            data_key.key = key;
-            data_key.method = compat(method);
-            data_key.creation_time = creation_time;
-            data_key.was_exposed = false;
+        let (key_id, key) = generate_data_key(method);
+        let mut data_key = DataKey::default();
+        data_key.key = key;
+        data_key.method = compat(method);
+        data_key.creation_time = creation_time;
+        data_key.was_exposed = false;
+        self.rotate_key(key_id, data_key, master_key)
+    }
+}
 
-            let ok = self.rotate_key(key_id, data_key, master_key)?;
-            if !ok {
-                // key id collides, retry
-                continue;
-            }
-            return Ok(());
+fn run_background_rotate_work(
+    dict: Arc<Dicts>,
+    method: EncryptionMethod,
+    master_key: Arc<dyn Backend>,
+    terminal_recv: channel::Receiver<()>,
+) {
+    let check_period = std::cmp::min(
+        Duration::from_secs(ROTATE_CHECK_PERIOD),
+        dict.rotation_period,
+    );
+
+    loop {
+        select! {
+            recv(tick(check_period)) -> _ => {
+                info!("Try to rotate data key, current method:{:?}", method);
+                dict.maybe_rotate_data_key(method, master_key.as_ref())
+                    .expect("Rotating key operation encountered error in the background worker");
+            },
+            recv(terminal_recv) -> _ => {
+                info!("Key rotate worker has been cancelled.");
+                break
+            },
         }
-        Err(box_err!("key id collides {} times!", generate_limit))
     }
 }
 
@@ -328,11 +391,10 @@ fn generate_data_key(method: EncryptionMethod) -> (u64, Vec<u8>) {
     (key_id, key)
 }
 
-#[derive(Clone)]
 pub struct DataKeyManager {
-    master_key: Arc<dyn Backend>,
-    dicts: Arc<RwLock<Dicts>>,
+    dicts: Arc<Dicts>,
     method: EncryptionMethod,
+    rotate_terminal: channel::Sender<()>,
 }
 
 impl DataKeyManager {
@@ -365,7 +427,7 @@ impl DataKeyManager {
                 "encryption is to enable but master key is either absent or insecure."
             ));
         }
-        let mut dicts = match (
+        let dicts = match (
             Dicts::open(dict_path, rotation_period, master_key.as_ref()),
             method,
         ) {
@@ -394,21 +456,22 @@ impl DataKeyManager {
                     master_key_config, previous_master_key_config
                 );
                 let previous_master_key = create_backend(previous_master_key_config)?;
-                let mut dicts =
-                    Dicts::open(dict_path, rotation_period, previous_master_key.as_ref())
-                        .map_err(|e| {
-                            if let Error::WrongMasterKey(e_previous) = e {
-                                Error::BothMasterKeyFail(e_current, e_previous)
-                            } else {
-                                e
-                            }
-                        })?
-                        .ok_or_else(|| {
-                            Error::Other(box_err!(
-                            "Fallback to previous master key but find dictionaries to be empty."))
-                        })?;
+                let dicts = Dicts::open(dict_path, rotation_period, previous_master_key.as_ref())
+                    .map_err(|e| {
+                        if let Error::WrongMasterKey(e_previous) = e {
+                            Error::BothMasterKeyFail(e_current, e_previous)
+                        } else {
+                            e
+                        }
+                    })?
+                    .ok_or_else(|| {
+                        Error::Other(box_err!(
+                            "Fallback to previous master key but find dictionaries to be empty."
+                        ))
+                    })?;
                 // Rewrite key_dict after replace master key.
                 dicts.save_key_dict(master_key.as_ref())?;
+
                 info!("encryption: persisted result after replace master key.");
 
                 dicts
@@ -418,12 +481,21 @@ impl DataKeyManager {
         };
         dicts.maybe_rotate_data_key(method, master_key.as_ref())?;
 
+        let dicts = Arc::new(dicts);
+        let dict_clone = dicts.clone();
+        let (rotate_terminal, rx) = channel::bounded(1);
+        std::thread::Builder::new()
+            .name(thd_name!("encryption-rotate-key"))
+            .spawn(move || {
+                run_background_rotate_work(dict_clone, method, master_key, rx);
+            })?;
+
         ENCRYPTION_INITIALIZED_GAUGE.set(1);
 
         Ok(Some(DataKeyManager {
-            dicts: Arc::new(RwLock::new(dicts)),
-            master_key,
+            dicts,
             method,
+            rotate_terminal,
         }))
     }
 
@@ -491,19 +563,24 @@ impl DataKeyManager {
     }
 }
 
+impl Drop for DataKeyManager {
+    fn drop(&mut self) {
+        self.rotate_terminal.send(()).unwrap();
+    }
+}
+
 impl EncryptionKeyManager for DataKeyManager {
     // Get key to open existing file.
     fn get_file(&self, fname: &str) -> IoResult<FileEncryptionInfo> {
-        let mut dicts = self.dicts.write().unwrap();
         let (method, key_id, iv) = {
-            let file = dicts.get_file(fname);
-            (file.method, file.key_id, file.iv.to_owned())
+            let file = self.dicts.get_file(fname);
+            (file.method, file.key_id, file.iv)
         };
         // Fail if key is specified but not found.
         let key = if method as i32 == EncryptionMethod::Plaintext as i32 {
             vec![]
         } else {
-            match dicts.get_key(key_id) {
+            match self.dicts.key_dict.lock().unwrap().keys.get(&key_id) {
                 Some(k) => k.key.clone(),
                 None => {
                     return Err(IoError::new(
@@ -522,12 +599,9 @@ impl EncryptionKeyManager for DataKeyManager {
     }
 
     fn new_file(&self, fname: &str) -> IoResult<FileEncryptionInfo> {
-        let mut dicts = self.dicts.write().unwrap();
-        // Rotate data key if necessary.
-        dicts.maybe_rotate_data_key(self.method, self.master_key.as_ref())?;
-        let (_, data_key) = dicts.current_data_key();
+        let (_, data_key) = self.dicts.current_data_key();
         let key = data_key.get_key().to_owned();
-        let file = dicts.new_file(fname, self.method)?;
+        let file = self.dicts.new_file(fname, self.method)?;
         let encrypted_file = FileEncryptionInfo {
             key,
             method: crypter::encryption_method_to_db_encryption_method(file.method),
@@ -537,23 +611,17 @@ impl EncryptionKeyManager for DataKeyManager {
     }
 
     fn delete_file(&self, fname: &str) -> IoResult<()> {
-        self.dicts.write().unwrap().delete_file(fname)?;
+        self.dicts.delete_file(fname)?;
         Ok(())
     }
 
     fn link_file(&self, src_fname: &str, dst_fname: &str) -> IoResult<()> {
-        self.dicts
-            .write()
-            .unwrap()
-            .link_file(src_fname, dst_fname)?;
+        self.dicts.link_file(src_fname, dst_fname)?;
         Ok(())
     }
 
     fn rename_file(&self, src_fname: &str, dst_fname: &str) -> IoResult<()> {
-        self.dicts
-            .write()
-            .unwrap()
-            .rename_file(src_fname, dst_fname)?;
+        self.dicts.rename_file(src_fname, dst_fname)?;
         Ok(())
     }
 }
@@ -570,7 +638,6 @@ mod tests {
         fs::{remove_file, File},
         io::Write,
         sync::{Arc, Mutex},
-        thread::sleep,
     };
     use tempfile::TempDir;
 
@@ -776,9 +843,9 @@ mod tests {
         file.key_id = 7; // Not exists.
         manager
             .dicts
-            .write()
-            .unwrap()
             .file_dict
+            .lock()
+            .unwrap()
             .files
             .insert("foo".to_owned(), file);
         manager.get_file("foo").unwrap_err();
@@ -830,55 +897,43 @@ mod tests {
     fn test_key_manager_rotate() {
         let (_tmp, manager) = new_tmp_key_manager(None, None, None, None);
         let manager = manager.unwrap().unwrap();
-
         let (key_id, key) = {
-            let dicts = manager.dicts.read().unwrap();
-            let (id, k) = dicts.current_data_key();
-            (id, k.clone())
+            let (id, k) = manager.dicts.current_data_key();
+            (id, k)
         };
 
         // Do not rotate.
+        let mock_config = MasterKeyConfig::Mock(Mock(Arc::new(Mutex::new(MockBackend::default()))));
+        let master_key = create_backend(&mock_config).unwrap();
         manager
             .dicts
-            .write()
-            .unwrap()
-            .maybe_rotate_data_key(manager.method, manager.master_key.as_ref())
+            .maybe_rotate_data_key(manager.method, master_key.as_ref())
             .unwrap();
         let (current_key_id1, current_key1) = {
-            let dicts = manager.dicts.read().unwrap();
-            let (id, k) = dicts.current_data_key();
-            (id, k.clone())
+            let (id, k) = manager.dicts.current_data_key();
+            (id, k)
         };
         assert_eq!(current_key_id1, key_id);
         assert_eq!(current_key1, key);
 
         // Change rotateion period to a smaller value, must rotate.
-        manager.dicts.write().unwrap().rotation_period = Duration::from_millis(1);
-        sleep(Duration::from_secs(1));
+        unsafe {
+            let ptr: *mut Dicts = manager.dicts.as_ref() as *const Dicts as *mut Dicts;
+            let mut dict = Box::from_raw(ptr);
+            dict.rotation_period = Duration::from_millis(1);
+            Box::leak(dict);
+        }
+        std::thread::sleep(Duration::from_secs(1));
         manager
             .dicts
-            .write()
-            .unwrap()
-            .maybe_rotate_data_key(manager.method, manager.master_key.as_ref())
+            .maybe_rotate_data_key(manager.method, master_key.as_ref())
             .unwrap();
         let (current_key_id2, current_key2) = {
-            let dicts = manager.dicts.read().unwrap();
-            let (id, k) = dicts.current_data_key();
-            (id, k.clone())
+            let (id, k) = manager.dicts.current_data_key();
+            (id, k)
         };
         assert_ne!(current_key_id2, key_id);
         assert_ne!(current_key2, key);
-
-        // Sleep and must rotate when new a file.
-        sleep(Duration::from_secs(1));
-        manager.new_file("foo").unwrap();
-        let (current_key_id3, current_key3) = {
-            let dicts = manager.dicts.read().unwrap();
-            let (id, k) = dicts.current_data_key();
-            (id, k.clone())
-        };
-        assert_ne!(current_key_id3, current_key_id2);
-        assert_ne!(current_key3, current_key2);
     }
 
     #[test]
@@ -889,36 +944,18 @@ mod tests {
         // Create a file and a datakey.
         manager.new_file("foo").unwrap();
 
-        let (files, keys) = {
-            let dicts = manager.dicts.read().unwrap();
-            (dicts.file_dict.clone(), dicts.key_dict.clone())
-        };
+        let files = manager.dicts.file_dict.lock().unwrap().clone();
+        let keys = manager.dicts.key_dict.lock().unwrap().clone();
 
         // Close and re-open.
         drop(manager);
         let (_tmp, manager1) = new_tmp_key_manager(Some(tmp), None, None, None);
         let manager1 = manager1.unwrap().unwrap();
 
-        let dicts = manager1.dicts.read().unwrap();
-        assert_eq!(files, dicts.file_dict);
-        assert_eq!(keys, dicts.key_dict);
-    }
-
-    #[test]
-    fn test_dcit_rotate_key_collides() {
-        let (_tmp, manager) = new_tmp_key_manager(None, None, None, None);
-        let manager = manager.unwrap().unwrap();
-        let mut dict = manager.dicts.write().unwrap();
-
-        let ok = dict
-            .rotate_key(1, DataKey::default(), manager.master_key.as_ref())
-            .unwrap();
-        assert!(ok);
-
-        let ok = dict
-            .rotate_key(1, DataKey::default(), manager.master_key.as_ref())
-            .unwrap();
-        assert!(!ok);
+        let files1 = manager1.dicts.file_dict.lock().unwrap().clone();
+        let keys1 = manager1.dicts.key_dict.lock().unwrap().clone();
+        assert_eq!(files, files1);
+        assert_eq!(keys, keys1);
     }
 
     #[test]
@@ -929,39 +966,43 @@ mod tests {
                 path: key_path.to_str().unwrap().to_owned(),
             },
         };
+        let master_key_backend = create_backend(&master_key).unwrap();
         let (_tmp_data_dir, manager) = new_tmp_key_manager(None, None, Some(master_key), None);
         let manager = manager.unwrap().unwrap();
-        let mut dicts = manager.dicts.write().unwrap();
-
         let (key_id, key) = {
-            let (id, k) = dicts.current_data_key();
-            (id, k.clone())
+            let (id, k) = manager.dicts.current_data_key();
+            (id, k)
         };
 
         // Do not rotate.
-        dicts
-            .maybe_rotate_data_key(manager.method, manager.master_key.as_ref())
+        manager
+            .dicts
+            .maybe_rotate_data_key(manager.method, master_key_backend.as_ref())
             .unwrap();
         let (current_key_id1, current_key1) = {
-            let (id, k) = dicts.current_data_key();
-            (id, k.clone())
+            let (id, k) = manager.dicts.current_data_key();
+            (id, k)
         };
         assert_eq!(current_key_id1, key_id);
         assert_eq!(current_key1, key);
 
         // Expose the current data key and must rotate.
-        dicts
+        manager
+            .dicts
             .key_dict
+            .lock()
+            .unwrap()
             .keys
             .get_mut(&current_key_id1)
             .unwrap()
             .was_exposed = true;
-        dicts
-            .maybe_rotate_data_key(manager.method, manager.master_key.as_ref())
+        manager
+            .dicts
+            .maybe_rotate_data_key(manager.method, master_key_backend.as_ref())
             .unwrap();
         let (current_key_id2, current_key2) = {
-            let (id, k) = dicts.current_data_key();
-            (id, k.clone())
+            let (id, k) = manager.dicts.current_data_key();
+            (id, k)
         };
         assert_ne!(current_key_id2, key_id);
         assert_ne!(current_key2, key);
@@ -976,30 +1017,30 @@ mod tests {
             },
         };
 
+        let master_key_backend = create_backend(&master_key).unwrap();
         let (_tmp_data_dir, manager) = new_tmp_key_manager(None, None, Some(master_key), None);
         let manager = manager.unwrap().unwrap();
-        let mut dicts = manager.dicts.write().unwrap();
 
         for i in 0..100 {
-            let ok = dicts
-                .rotate_key(i, DataKey::default(), manager.master_key.as_ref())
+            manager
+                .dicts
+                .rotate_key(i, DataKey::default(), master_key_backend.as_ref())
                 .unwrap();
-            assert!(ok);
         }
-        for value in dicts.key_dict.keys.values() {
+        for value in manager.dicts.key_dict.lock().unwrap().keys.values() {
             assert!(!value.was_exposed);
         }
 
         // Change it insecure backend and save dicts,
         // must set expose for all keys.
         let insecure = Arc::new(PlaintextBackend::default());
-        let ok = dicts
+        manager
+            .dicts
             .rotate_key(100, DataKey::default(), insecure.as_ref())
             .unwrap();
-        assert!(ok);
 
         let mut count = 0;
-        for value in dicts.key_dict.keys.values() {
+        for value in manager.dicts.key_dict.lock().unwrap().keys.values() {
             count += 1;
             assert!(value.was_exposed);
         }

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -41,7 +41,7 @@ bitflags = "1.0.1"
 byteorder = "1.2"
 configuration = { path = "../configuration" }
 crc32fast = "1.2"
-crossbeam = "0.7.2"
+crossbeam = "0.8"
 engine = { path = "../engine" }
 engine_rocks = { path = "../engine_rocks" }
 encryption = { path = "../encryption" }

--- a/components/raftstore/src/errors.rs
+++ b/components/raftstore/src/errors.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::net;
 use std::result;
 
-use crossbeam::TrySendError;
+use crossbeam::channel::TrySendError;
 #[cfg(feature = "prost-codec")]
 use prost::{DecodeError, EncodeError};
 use protobuf::ProtobufError;

--- a/components/raftstore/src/router.rs
+++ b/components/raftstore/src/router.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crossbeam::{SendError, TrySendError};
+use crossbeam::channel::{SendError, TrySendError};
 use kvproto::raft_cmdpb::RaftCmdRequest;
 use kvproto::raft_serverpb::RaftMessage;
 

--- a/components/raftstore/src/store/transport.rs
+++ b/components/raftstore/src/store/transport.rs
@@ -2,7 +2,7 @@
 
 use crate::store::{CasualMessage, PeerMsg, RaftCommand, RaftRouter, StoreMsg};
 use crate::{DiscardReason, Error, Result};
-use crossbeam::TrySendError;
+use crossbeam::channel::TrySendError;
 use engine_rocks::RocksEngine;
 use engine_traits::KvEngine;
 use kvproto::raft_serverpb::RaftMessage;

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crossbeam::atomic::AtomicCell;
-use crossbeam::TrySendError;
+use crossbeam::channel::TrySendError;
 use kvproto::errorpb;
 use kvproto::kvrpcpb::ExtraOp as TxnExtraOp;
 use kvproto::metapb;

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -16,7 +16,7 @@ codec = { path = "../codec" }
 configuration = { path = "../configuration" }
 chrono = "0.4"
 crc32fast = "1.2"
-crossbeam = "0.7.2"
+crossbeam = "0.8"
 error_code = { path = "../error_code" }
 derive_more = "0.99.3"
 fail = "0.3"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -83,7 +83,7 @@ portable = ["tikv/portable"]
 fail = { version = "0.3", optional = true }
 batch-system = { path = "../components/batch-system" }
 crc64fast = "0.1"
-crossbeam = "0.7.2"
+crossbeam = "0.8"
 configuration = { path = "../components/configuration" }
 encryption = { path = "../components/encryption" }
 engine = { path = "../components/engine" }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

cherry-pick #8805 to release-4.0

Issue Number: close #8761

Problem Summary: Mutex conflict of encryption makes pd-worker deal with heartbeat slow

### What is changed and how it works?

- Remove the IO operation from the file_dict mutex.
- Create background thread to do rotation of key.

### Release note <!-- bugfixes or new feature need a release note -->
- Fix the bug that mutex conflict of encryption makes pd-worker deal with heartbeat slow