### PR TITLE
*: remove io from gRPC threads (#8886)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,6 +1166,8 @@ dependencies = [
  "hyper",
  "hyper-tls",
  "kvproto",
+ "lazy_static",
+ "prometheus",
  "rand 0.7.3",
  "rusoto_core",
  "rusoto_mock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
  "encryption",
  "engine",
  "engine_traits",
+ "fail",
  "kvproto",
  "lazy_static",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,11 @@ mimalloc = ["tikv_alloc/mimalloc"]
 portable = ["engine/portable"]
 sse = ["engine/sse"]
 mem-profiling = ["tikv_alloc/mem-profiling"]
-failpoints = ["fail/failpoints", "raftstore/failpoints"]
+failpoints = [
+  "fail/failpoints",
+  "raftstore/failpoints",
+  "engine_rocks/failpoints"
+]
 prost-codec = [
   "engine/prost-codec",
   "engine_rocks/prost-codec",

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -1128,8 +1128,6 @@ pub mod tests {
             req.set_start_version(0);
             req.set_end_version(ts.into_inner());
             let (tx, rx) = unbounded();
-            // Empty path should return an error.
-            Task::new(req.clone(), tx.clone()).unwrap_err();
 
             // Set an unique path to avoid AlreadyExists error.
             req.set_storage_backend(make_local_backend(&tmp.path().join(ts.to_string())));

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -100,9 +100,6 @@ impl Task {
             cf: req.get_cf().to_owned(),
         })?;
 
-        // Check storage backend eagerly.
-        create_storage(req.get_storage_backend())?;
-
         let task = Task {
             request: Request {
                 start_key: req.get_start_key().to_owned(),

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -10,6 +10,7 @@ prost-codec = ["engine/prost-codec"]
 jemalloc = ["rocksdb/jemalloc"]
 portable = ["rocksdb/portable"]
 sse = ["rocksdb/sse"]
+failpoints = ["fail/failpoints"]
 
 [dependencies]
 encryption = { path = "../encryption" }
@@ -26,6 +27,7 @@ configuration = { path = "../configuration" }
 serde = "1.0"
 serde_derive = "1.0"
 coarsetime = "0.1"
+fail = "0.3"
 
 [dependencies.rocksdb]
 git = "https://github.com/tikv/rust-rocksdb.git"

--- a/components/engine_rocks/src/lib.rs
+++ b/components/engine_rocks/src/lib.rs
@@ -18,9 +18,10 @@
 extern crate tikv_alloc;
 #[macro_use]
 extern crate tikv_util;
-
 #[macro_use]
 extern crate serde_derive;
+#[macro_use(fail_point)]
+extern crate fail;
 
 mod cf_handle;
 pub use crate::cf_handle::*;

--- a/components/engine_rocks/src/sst.rs
+++ b/components/engine_rocks/src/sst.rs
@@ -209,6 +209,7 @@ impl SstWriterBuilder<RocksEngine> for RocksSstWriterBuilder {
         io_options.compression_per_level(&[]);
         io_options.bottommost_compression(DBCompressionType::Disable);
         let mut writer = SstFileWriter::new(EnvOptions::new(), io_options);
+        fail_point!("on_open_sst_writer");
         writer.open(path)?;
         Ok(RocksSstWriter { writer, env })
     }

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -31,6 +31,8 @@ tame-oauth = "0.4.2"
 tikv_alloc = { path = "../tikv_alloc" }
 tokio = { version = "0.2.13", features = ["time"] }
 url = "2.0"
+lazy_static = "1.3"
+prometheus = { version = "0.8", default-features = false, features = ["nightly", "push"] }
 
 [dev-dependencies]
 structopt = "0.3"

--- a/components/external_storage/src/metrics.rs
+++ b/components/external_storage/src/metrics.rs
@@ -1,0 +1,14 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use lazy_static::*;
+use prometheus::*;
+
+lazy_static! {
+    pub static ref EXT_STORAGE_CREATE_HISTOGRAM: HistogramVec = register_histogram_vec!(
+        "tikv_external_storage_create_seconds",
+        "Bucketed histogram of creating external storage duration",
+        &["type"],
+        exponential_buckets(0.0005, 2.0, 20).unwrap()
+    )
+    .unwrap();
+}

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -186,13 +186,14 @@ impl<Router: RaftStoreRouter> ImportSst for ImportSSTService<Router> {
         let importer = Arc::clone(&self.importer);
         let limiter = self.limiter.clone();
         let engine = Arc::clone(&self.engine);
-        let sst_writer = <RocksEngine as SstExt>::SstWriterBuilder::new()
-            .set_db(RocksEngine::from_ref(&engine))
-            .set_cf(name_to_cf(req.get_sst().get_cf_name()).unwrap())
-            .build(self.importer.get_path(req.get_sst()).to_str().unwrap())
-            .unwrap();
 
         ctx.spawn(self.threads.spawn_fn(move || {
+            let sst_writer = <RocksEngine as SstExt>::SstWriterBuilder::new()
+                .set_db(RocksEngine::from_ref(&engine))
+                .set_cf(name_to_cf(req.get_sst().get_cf_name()).unwrap())
+                .build(importer.get_path(req.get_sst()).to_str().unwrap())
+                .unwrap();
+
             // FIXME: download() should be an async fn, to allow BR to cancel
             // a download task.
             // Unfortunately, this currently can't happen because the S3Storage

--- a/tests/failpoints/cases/mod.rs
+++ b/tests/failpoints/cases/mod.rs
@@ -5,6 +5,7 @@ mod test_conf_change;
 mod test_coprocessor;
 mod test_early_apply;
 mod test_gc_worker;
+mod test_import_service;
 mod test_merge;
 mod test_pd_client;
 mod test_pending_peers;

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -1,0 +1,59 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use kvproto::import_sstpb::*;
+use tempfile::Builder;
+use test_sst_importer::*;
+
+#[allow(dead_code)]
+#[path = "../../integrations/import/util.rs"]
+mod util;
+use self::util::{check_ingested_kvs, new_cluster_and_tikv_import_client};
+
+// Opening sst writer involves IO operation, it may block threads for a while.
+// Test if download sst works when opening sst writer is blocked.
+#[test]
+fn test_download_sst_blocking_sst_writer() {
+    let (_cluster, ctx, tikv, import) = new_cluster_and_tikv_import_client();
+    let temp_dir = Builder::new()
+        .prefix("test_download_sst_blocking_sst_writer")
+        .tempdir()
+        .unwrap();
+
+    let sst_path = temp_dir.path().join("test.sst");
+    let sst_range = (0, 100);
+    let (mut meta, _) = gen_sst_file(sst_path, sst_range);
+    meta.set_region_id(ctx.get_region_id());
+    meta.set_region_epoch(ctx.get_region_epoch().clone());
+
+    // Sleep 20s, make sure it is large than grpc_keepalive_timeout (3s).
+    let sst_writer_open_fp = "on_open_sst_writer";
+    fail::cfg(sst_writer_open_fp, "sleep(20000)").unwrap();
+
+    // Now perform a proper download.
+    let mut download = DownloadRequest::default();
+    download.set_sst(meta.clone());
+    download.set_storage_backend(external_storage::make_local_backend(temp_dir.path()));
+    download.set_name("test.sst".to_owned());
+    download.mut_sst().mut_range().set_start(vec![sst_range.1]);
+    download
+        .mut_sst()
+        .mut_range()
+        .set_end(vec![sst_range.1 + 1]);
+    download.mut_sst().mut_range().set_start(Vec::new());
+    download.mut_sst().mut_range().set_end(Vec::new());
+    let result = import.download(&download).unwrap();
+    assert!(!result.get_is_empty());
+    assert_eq!(result.get_range().get_start(), &[sst_range.0]);
+    assert_eq!(result.get_range().get_end(), &[sst_range.1 - 1]);
+
+    fail::remove(sst_writer_open_fp);
+
+    // Do an ingest and verify the result is correct.
+    let mut ingest = IngestRequest::default();
+    ingest.set_context(ctx.clone());
+    ingest.set_sst(meta);
+    let resp = import.ingest(&ingest).unwrap();
+    assert!(!resp.has_error());
+
+    check_ingested_kvs(&tikv, &ctx, sst_range);
+}

--- a/tests/integrations/import/mod.rs
+++ b/tests/integrations/import/mod.rs
@@ -1,3 +1,4 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-mod sst_service;
+mod test_sst_service;
+mod util;

--- a/tests/integrations/import/test_sst_service.rs
+++ b/tests/integrations/import/test_sst_service.rs
@@ -6,51 +6,24 @@ use std::time::Duration;
 
 use futures::{stream, Future, Stream};
 use tempfile::Builder;
-use uuid::Uuid;
 
-use grpcio::{ChannelBuilder, Environment, Result, WriteFlags};
 use kvproto::import_sstpb::*;
-use kvproto::kvrpcpb::*;
-use kvproto::tikvpb::*;
 
 use pd_client::PdClient;
-use test_raftstore::*;
 use test_sst_importer::*;
-use tikv_util::HandyRwLock;
 
-const CLEANUP_SST_MILLIS: u64 = 10;
+use super::util::*;
 
-fn new_cluster() -> (Cluster<ServerCluster>, Context) {
-    let count = 1;
-    let mut cluster = new_server_cluster(0, count);
-    let cleanup_interval = Duration::from_millis(CLEANUP_SST_MILLIS);
-    cluster.cfg.raft_store.cleanup_import_sst_interval.0 = cleanup_interval;
-    cluster.run();
-
-    let region_id = 1;
-    let leader = cluster.leader_of_region(region_id).unwrap();
-    let epoch = cluster.get_region_epoch(region_id);
-    let mut ctx = Context::default();
-    ctx.set_region_id(region_id);
-    ctx.set_peer(leader);
-    ctx.set_region_epoch(epoch);
-
-    (cluster, ctx)
-}
-
-fn new_cluster_and_tikv_import_client(
-) -> (Cluster<ServerCluster>, Context, TikvClient, ImportSstClient) {
-    let (cluster, ctx) = new_cluster();
-
-    let ch = {
-        let env = Arc::new(Environment::new(1));
-        let node = ctx.get_peer().get_store_id();
-        ChannelBuilder::new(env).connect(cluster.sim.rl().get_addr(node))
-    };
-    let tikv = TikvClient::new(ch.clone());
-    let import = ImportSstClient::new(ch);
-
-    (cluster, ctx, tikv, import)
+macro_rules! assert_to_string_contains {
+    ($e:expr, $substr:expr) => {{
+        let msg = $e.to_string();
+        assert!(
+            msg.contains($substr),
+            "msg: {}; expr: {}",
+            msg,
+            stringify!($e)
+        );
+    }};
 }
 
 #[test]
@@ -271,99 +244,4 @@ fn test_ingest_sst_region_not_found() {
     ingest.set_sst(meta);
     let resp = import.ingest(&ingest).unwrap();
     assert!(resp.get_error().has_region_not_found());
-}
-
-fn new_sst_meta(crc32: u32, length: u64) -> SstMeta {
-    let mut m = SstMeta::default();
-    m.set_uuid(Uuid::new_v4().as_bytes().to_vec());
-    m.set_crc32(crc32);
-    m.set_length(length);
-    m
-}
-
-fn send_upload_sst(
-    client: &ImportSstClient,
-    meta: &SstMeta,
-    data: &[u8],
-) -> Result<UploadResponse> {
-    let mut r1 = UploadRequest::default();
-    r1.set_meta(meta.clone());
-    let mut r2 = UploadRequest::default();
-    r2.set_data(data.to_vec());
-    let reqs: Vec<_> = vec![r1, r2]
-        .into_iter()
-        .map(|r| (r, WriteFlags::default()))
-        .collect();
-    let (tx, rx) = client.upload().unwrap();
-    let stream = stream::iter_ok(reqs);
-    stream.forward(tx).and_then(|_| rx).wait()
-}
-
-fn send_write_sst(
-    client: &ImportSstClient,
-    meta: &SstMeta,
-    keys: Vec<Vec<u8>>,
-    values: Vec<Vec<u8>>,
-    commit_ts: u64,
-) -> Result<WriteResponse> {
-    let mut r1 = WriteRequest::default();
-    r1.set_meta(meta.clone());
-    let mut r2 = WriteRequest::default();
-
-    let mut batch = WriteBatch::default();
-    let mut pairs = vec![];
-
-    for (i, key) in keys.iter().enumerate() {
-        let mut pair = Pair::default();
-        pair.set_key(key.to_vec());
-        pair.set_value(values[i].to_vec());
-        pairs.push(pair);
-    }
-    batch.set_commit_ts(commit_ts);
-    batch.set_pairs(pairs.into());
-    r2.set_batch(batch);
-
-    let reqs: Vec<_> = vec![r1, r2]
-        .into_iter()
-        .map(|r| (r, WriteFlags::default()))
-        .collect();
-
-    let (tx, rx) = client.write().unwrap();
-    let stream = stream::iter_ok(reqs);
-    stream.forward(tx).and_then(|_| rx).wait()
-}
-
-fn check_ingested_kvs(tikv: &TikvClient, ctx: &Context, sst_range: (u8, u8)) {
-    for i in sst_range.0..sst_range.1 {
-        let mut m = RawGetRequest::default();
-        m.set_context(ctx.clone());
-        m.set_key(vec![i]);
-        let resp = tikv.raw_get(&m).unwrap();
-        assert!(resp.get_error().is_empty());
-        assert!(!resp.has_region_error());
-        assert_eq!(resp.get_value(), &[i]);
-    }
-}
-
-fn check_ingested_txn_kvs(tikv: &TikvClient, ctx: &Context, sst_range: (u8, u8), start_ts: u64) {
-    for i in sst_range.0..sst_range.1 {
-        let mut m = GetRequest::default();
-        m.set_context(ctx.clone());
-        m.set_key(vec![i]);
-        m.set_version(start_ts);
-        let resp = tikv.kv_get(&m).unwrap();
-        assert!(!resp.has_region_error());
-        assert_eq!(resp.get_value(), &[i]);
-    }
-}
-
-fn check_sst_deleted(client: &ImportSstClient, meta: &SstMeta, data: &[u8]) {
-    for _ in 0..10 {
-        if send_upload_sst(client, meta, data).is_ok() {
-            // If we can upload the file, it means the previous file has been deleted.
-            return;
-        }
-        thread::sleep(Duration::from_millis(CLEANUP_SST_MILLIS));
-    }
-    send_upload_sst(client, meta, data).unwrap();
 }

--- a/tests/integrations/import/test_sst_service.rs
+++ b/tests/integrations/import/test_sst_service.rs
@@ -1,10 +1,6 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
-
-use futures::{stream, Future, Stream};
+use futures::Future;
 use tempfile::Builder;
 
 use kvproto::import_sstpb::*;

--- a/tests/integrations/import/util.rs
+++ b/tests/integrations/import/util.rs
@@ -91,7 +91,7 @@ pub fn send_write_sst(
     // TODO rewrite following code blocks with cfg-if.
     #[cfg(feature = "prost-codec")]
     {
-        r1.meta = meta.clone();
+        r2.chunk = Some(write_request::Chunk::Meta(meta.clone()));
     }
     #[cfg(not(feature = "prost-codec"))]
     {
@@ -112,7 +112,7 @@ pub fn send_write_sst(
     batch.set_pairs(pairs.into());
     #[cfg(feature = "prost-codec")]
     {
-        r2.batch = batch;
+        r2.chunk = Some(write_request::Chunk::Batch(batch));
     }
     #[cfg(not(feature = "prost-codec"))]
     {

--- a/tests/integrations/import/util.rs
+++ b/tests/integrations/import/util.rs
@@ -91,7 +91,7 @@ pub fn send_write_sst(
     // TODO rewrite following code blocks with cfg-if.
     #[cfg(feature = "prost-codec")]
     {
-        r2.chunk = Some(write_request::Chunk::Meta(meta.clone()));
+        r1.chunk = Some(write_request::Chunk::Meta(meta.clone()));
     }
     #[cfg(not(feature = "prost-codec"))]
     {

--- a/tests/integrations/import/util.rs
+++ b/tests/integrations/import/util.rs
@@ -93,7 +93,7 @@ pub fn send_write_sst(
     commit_ts: u64,
 ) -> Result<WriteResponse> {
     let mut r1 = WriteRequest::default();
-    r1.set_meta(meta.clone());
+    r1.meta = meta.clone();
     let mut r2 = WriteRequest::default();
 
     let mut batch = WriteBatch::default();
@@ -107,7 +107,7 @@ pub fn send_write_sst(
     }
     batch.set_commit_ts(commit_ts);
     batch.set_pairs(pairs.into());
-    r2.set_batch(batch);
+    r2.batch = batch;
 
     let reqs: Vec<_> = vec![r1, r2]
         .into_iter()

--- a/tests/integrations/import/util.rs
+++ b/tests/integrations/import/util.rs
@@ -1,0 +1,164 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use futures::executor::block_on;
+use futures::{stream, SinkExt};
+use grpcio::{ChannelBuilder, Environment, Result, WriteFlags};
+use kvproto::import_sstpb::*;
+use kvproto::kvrpcpb::*;
+use kvproto::tikvpb::*;
+use uuid::Uuid;
+
+use test_raftstore::*;
+use tikv_util::HandyRwLock;
+
+const CLEANUP_SST_MILLIS: u64 = 10;
+
+pub fn new_cluster() -> (Cluster<ServerCluster>, Context) {
+    let count = 1;
+    let mut cluster = new_server_cluster(0, count);
+    let cleanup_interval = Duration::from_millis(CLEANUP_SST_MILLIS);
+    cluster.cfg.raft_store.cleanup_import_sst_interval.0 = cleanup_interval;
+    cluster.cfg.server.grpc_concurrency = 1;
+    cluster.run();
+
+    let region_id = 1;
+    let leader = cluster.leader_of_region(region_id).unwrap();
+    let epoch = cluster.get_region_epoch(region_id);
+    let mut ctx = Context::default();
+    ctx.set_region_id(region_id);
+    ctx.set_peer(leader);
+    ctx.set_region_epoch(epoch);
+
+    (cluster, ctx)
+}
+
+pub fn new_cluster_and_tikv_import_client(
+) -> (Cluster<ServerCluster>, Context, TikvClient, ImportSstClient) {
+    let (cluster, ctx) = new_cluster();
+
+    let ch = {
+        let env = Arc::new(Environment::new(1));
+        let node = ctx.get_peer().get_store_id();
+        ChannelBuilder::new(env)
+            .http2_max_ping_strikes(i32::MAX) // For pings without data from clients.
+            .keepalive_time(cluster.cfg.server.grpc_keepalive_time.into())
+            .keepalive_timeout(cluster.cfg.server.grpc_keepalive_timeout.into())
+            .connect(&cluster.sim.rl().get_addr(node))
+    };
+    let tikv = TikvClient::new(ch.clone());
+    let import = ImportSstClient::new(ch);
+
+    (cluster, ctx, tikv, import)
+}
+
+pub fn new_sst_meta(crc32: u32, length: u64) -> SstMeta {
+    let mut m = SstMeta::default();
+    m.set_uuid(Uuid::new_v4().as_bytes().to_vec());
+    m.set_crc32(crc32);
+    m.set_length(length);
+    m
+}
+
+pub fn send_upload_sst(
+    client: &ImportSstClient,
+    meta: &SstMeta,
+    data: &[u8],
+) -> Result<UploadResponse> {
+    let mut r1 = UploadRequest::default();
+    r1.set_meta(meta.clone());
+    let mut r2 = UploadRequest::default();
+    r2.set_data(data.to_vec());
+    let reqs: Vec<_> = vec![r1, r2]
+        .into_iter()
+        .map(|r| Result::Ok((r, WriteFlags::default())))
+        .collect();
+    let (mut tx, rx) = client.upload().unwrap();
+    let mut stream = stream::iter(reqs);
+    block_on(async move {
+        tx.send_all(&mut stream).await?;
+        tx.close().await?;
+        rx.await
+    })
+}
+
+pub fn send_write_sst(
+    client: &ImportSstClient,
+    meta: &SstMeta,
+    keys: Vec<Vec<u8>>,
+    values: Vec<Vec<u8>>,
+    commit_ts: u64,
+) -> Result<WriteResponse> {
+    let mut r1 = WriteRequest::default();
+    r1.set_meta(meta.clone());
+    let mut r2 = WriteRequest::default();
+
+    let mut batch = WriteBatch::default();
+    let mut pairs = vec![];
+
+    for (i, key) in keys.iter().enumerate() {
+        let mut pair = Pair::default();
+        pair.set_key(key.to_vec());
+        pair.set_value(values[i].to_vec());
+        pairs.push(pair);
+    }
+    batch.set_commit_ts(commit_ts);
+    batch.set_pairs(pairs.into());
+    r2.set_batch(batch);
+
+    let reqs: Vec<_> = vec![r1, r2]
+        .into_iter()
+        .map(|r| Result::Ok((r, WriteFlags::default())))
+        .collect();
+
+    let (mut tx, rx) = client.write().unwrap();
+    let mut stream = stream::iter(reqs);
+    block_on(async move {
+        tx.send_all(&mut stream).await?;
+        tx.close().await?;
+        rx.await
+    })
+}
+
+pub fn check_ingested_kvs(tikv: &TikvClient, ctx: &Context, sst_range: (u8, u8)) {
+    for i in sst_range.0..sst_range.1 {
+        let mut m = RawGetRequest::default();
+        m.set_context(ctx.clone());
+        m.set_key(vec![i]);
+        let resp = tikv.raw_get(&m).unwrap();
+        assert!(resp.get_error().is_empty());
+        assert!(!resp.has_region_error());
+        assert_eq!(resp.get_value(), &[i]);
+    }
+}
+
+pub fn check_ingested_txn_kvs(
+    tikv: &TikvClient,
+    ctx: &Context,
+    sst_range: (u8, u8),
+    start_ts: u64,
+) {
+    for i in sst_range.0..sst_range.1 {
+        let mut m = GetRequest::default();
+        m.set_context(ctx.clone());
+        m.set_key(vec![i]);
+        m.set_version(start_ts);
+        let resp = tikv.kv_get(&m).unwrap();
+        assert!(!resp.has_region_error());
+        assert_eq!(resp.get_value(), &[i]);
+    }
+}
+
+pub fn check_sst_deleted(client: &ImportSstClient, meta: &SstMeta, data: &[u8]) {
+    for _ in 0..10 {
+        if send_upload_sst(client, meta, data).is_ok() {
+            // If we can upload the file, it means the previous file has been deleted.
+            return;
+        }
+        thread::sleep(Duration::from_millis(CLEANUP_SST_MILLIS));
+    }
+    send_upload_sst(client, meta, data).unwrap();
+}

--- a/tests/integrations/import/util.rs
+++ b/tests/integrations/import/util.rs
@@ -93,7 +93,15 @@ pub fn send_write_sst(
     commit_ts: u64,
 ) -> Result<WriteResponse> {
     let mut r1 = WriteRequest::default();
-    r1.meta = meta.clone();
+    // TODO rewrite following code blocks with cfg-if.
+    #[cfg(feature = "prost-codec")]
+    {
+        r1.meta = meta.clone();
+    }
+    #[cfg(not(feature = "prost-codec"))]
+    {
+        r1.set_meta(meta.clone());
+    }
     let mut r2 = WriteRequest::default();
 
     let mut batch = WriteBatch::default();
@@ -107,7 +115,14 @@ pub fn send_write_sst(
     }
     batch.set_commit_ts(commit_ts);
     batch.set_pairs(pairs.into());
-    r2.batch = batch;
+    #[cfg(feature = "prost-codec")]
+    {
+        r2.batch = batch;
+    }
+    #[cfg(not(feature = "prost-codec"))]
+    {
+        r2.set_batch(batch);
+    }
 
     let reqs: Vec<_> = vec![r1, r2]
         .into_iter()


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Backup and restore involves some IO in gRPC threads. They should be moved to worker threads.

### What is changed and how it works?

Remove io from grpc threads

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- Stabilize backup and restore by removing IO operations from gRPC threads.