### PR TITLE
txn: move gc to action module

### DIFF
--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -31,6 +31,7 @@ use super::applied_lock_collector::{AppliedLockCollector, Callback as LockCollec
 use super::config::{GcConfig, GcWorkerConfigManager};
 use super::gc_manager::{AutoGcConfig, GcManager, GcManagerHandle};
 use super::{Callback, CompactionFilterInitializer, Error, ErrorInner, Result};
+use crate::storage::txn::gc;
 
 /// After the GC scan of a key, output a message to the log if there are at least this many
 /// versions of the key.
@@ -191,7 +192,7 @@ where
         gc_info: &mut GcInfo,
         txn: &mut MvccTxn<E::Snap>,
     ) -> Result<()> {
-        let next_gc_info = txn.gc(key.clone(), safe_point)?;
+        let next_gc_info = gc(txn, key.clone(), safe_point)?;
         gc_info.found_versions += next_gc_info.found_versions;
         gc_info.deleted_versions += next_gc_info.deleted_versions;
         gc_info.is_completed = next_gc_info.is_completed;

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -320,7 +320,6 @@ pub fn default_not_found_error(key: Vec<u8>, hint: &str) -> Error {
 pub mod tests {
     use super::*;
     use crate::storage::kv::{Engine, Modify, ScanMode, SnapContext, Snapshot, WriteData};
-    use concurrency_manager::ConcurrencyManager;
     use engine_traits::CF_WRITE;
     use kvproto::kvrpcpb::{Context, IsolationLevel};
     use txn_types::Key;
@@ -374,21 +373,6 @@ pub mod tests {
         let snapshot = engine.snapshot(ctx).unwrap();
         let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
         assert!(reader.get(&Key::from_raw(key), ts.into(), false).is_err());
-    }
-
-    pub fn must_gc<E: Engine>(engine: &E, key: &[u8], safe_point: impl Into<TimeStamp>) {
-        let ctx = SnapContext::default();
-        let snapshot = engine.snapshot(ctx).unwrap();
-        let cm = ConcurrencyManager::new(1.into());
-        let mut txn = MvccTxn::for_scan(
-            snapshot,
-            Some(ScanMode::Forward),
-            TimeStamp::zero(),
-            true,
-            cm,
-        );
-        txn.gc(Key::from_raw(key), safe_point.into()).unwrap();
-        write(engine, &Context::default(), txn.into_modifies());
     }
 
     pub fn must_locked<E: Engine>(engine: &E, key: &[u8], start_ts: impl Into<TimeStamp>) -> Lock {

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -345,9 +345,8 @@ mod tests {
     use crate::storage::kv::{
         CfStatistics, Engine, PerfStatisticsInstant, RocksEngine, TestEngineBuilder,
     };
-    use crate::storage::mvcc::tests::*;
     use crate::storage::txn::tests::{
-        must_acquire_pessimistic_lock, must_commit, must_pessimistic_prewrite_delete,
+        must_acquire_pessimistic_lock, must_commit, must_gc, must_pessimistic_prewrite_delete,
         must_prewrite_delete, must_prewrite_lock, must_prewrite_put, must_rollback,
     };
 

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -465,7 +465,7 @@ mod tests {
     use crate::storage::mvcc::{MvccReader, MvccTxn};
 
     use crate::storage::txn::{
-        acquire_pessimistic_lock, cleanup, commit, pessimistic_prewrite, prewrite,
+        acquire_pessimistic_lock, cleanup, commit, gc, pessimistic_prewrite, prewrite,
     };
     use concurrency_manager::ConcurrencyManager;
     use engine_rocks::properties::MvccPropertiesCollectorFactory;
@@ -655,7 +655,7 @@ mod tests {
                     self.region.clone(),
                 );
                 let mut txn = MvccTxn::new(snap, safe_point.into(), true, cm.clone());
-                txn.gc(Key::from_raw(pk), safe_point.into()).unwrap();
+                gc(&mut txn, Key::from_raw(pk), safe_point.into()).unwrap();
                 let modifies = txn.into_modifies();
                 if modifies.is_empty() {
                     return;

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -433,9 +433,8 @@ mod tests {
     use super::super::ScannerBuilder;
     use super::*;
     use crate::storage::kv::{Engine, TestEngineBuilder};
-    use crate::storage::mvcc::tests::*;
     use crate::storage::txn::tests::{
-        must_commit, must_prewrite_delete, must_prewrite_put, must_rollback,
+        must_commit, must_gc, must_prewrite_delete, must_prewrite_put, must_rollback,
     };
     use crate::storage::Scanner;
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -103,7 +103,7 @@ pub enum SecondaryLockStatus {
 pub struct MvccTxn<S: Snapshot> {
     pub(crate) reader: MvccReader<S>,
     pub(crate) start_ts: TimeStamp,
-    write_size: usize,
+    pub(crate) write_size: usize,
     writes: WriteData,
     // When 1PC is enabled, locks will be collected here instead of marshalled and put into `writes`,
     // so it can be further processed. The elements are tuples representing
@@ -235,7 +235,7 @@ impl<S: Snapshot> MvccTxn<S> {
         self.writes.modifies.push(write);
     }
 
-    fn delete_value(&mut self, key: Key, ts: TimeStamp) {
+    pub(crate) fn delete_value(&mut self, key: Key, ts: TimeStamp) {
         let write = Modify::Delete(CF_DEFAULT, key.append_ts(ts));
         self.write_size += write.size();
         self.writes.modifies.push(write);
@@ -247,7 +247,7 @@ impl<S: Snapshot> MvccTxn<S> {
         self.writes.modifies.push(write);
     }
 
-    fn delete_write(&mut self, key: Key, ts: TimeStamp) {
+    pub(crate) fn delete_write(&mut self, key: Key, ts: TimeStamp) {
         let write = Modify::Delete(CF_WRITE, key.append_ts(ts));
         self.write_size += write.size();
         self.writes.modifies.push(write);
@@ -393,73 +393,6 @@ impl<S: Snapshot> MvccTxn<S> {
         Ok(())
     }
 
-    pub fn gc(&mut self, key: Key, safe_point: TimeStamp) -> Result<GcInfo> {
-        let mut remove_older = false;
-        let mut ts = TimeStamp::max();
-        let mut found_versions = 0;
-        let mut deleted_versions = 0;
-        let mut latest_delete = None;
-        let mut is_completed = true;
-        while let Some((commit, write)) = self.reader.seek_write(&key, ts)? {
-            ts = commit.prev();
-            found_versions += 1;
-
-            if self.write_size >= MAX_TXN_WRITE_SIZE {
-                // Cannot remove latest delete when we haven't iterate all versions.
-                latest_delete = None;
-                is_completed = false;
-                break;
-            }
-
-            if remove_older {
-                self.delete_write(key.clone(), commit);
-                if write.write_type == WriteType::Put && write.short_value.is_none() {
-                    self.delete_value(key.clone(), write.start_ts);
-                }
-                deleted_versions += 1;
-                continue;
-            }
-
-            if commit > safe_point {
-                continue;
-            }
-
-            // Set `remove_older` after we find the latest value.
-            match write.write_type {
-                WriteType::Put | WriteType::Delete => {
-                    remove_older = true;
-                }
-                WriteType::Rollback | WriteType::Lock => {}
-            }
-
-            // Latest write before `safe_point` can be deleted if its type is Delete,
-            // Rollback or Lock.
-            match write.write_type {
-                WriteType::Delete => {
-                    latest_delete = Some(commit);
-                }
-                WriteType::Rollback | WriteType::Lock => {
-                    self.delete_write(key.clone(), commit);
-                    deleted_versions += 1;
-                }
-                WriteType::Put => {}
-            }
-        }
-        if let Some(commit) = latest_delete {
-            self.delete_write(key, commit);
-            deleted_versions += 1;
-        }
-        MVCC_VERSIONS_HISTOGRAM.observe(found_versions as f64);
-        if deleted_versions > 0 {
-            GC_DELETE_VERSIONS_HISTOGRAM.observe(deleted_versions as f64);
-        }
-        Ok(GcInfo {
-            found_versions,
-            deleted_versions,
-            is_completed,
-        })
-    }
-
     // Check and execute the extra operation.
     // Currently we use it only for reading the old value for CDC.
     pub fn check_extra_op(
@@ -591,7 +524,7 @@ mod tests {
     use crate::storage::txn::{acquire_pessimistic_lock, commit, pessimistic_prewrite, prewrite};
     use crate::storage::SecondaryLocksStatus;
     use crate::storage::{
-        kv::{Engine, RocksEngine, TestEngineBuilder},
+        kv::{Engine, TestEngineBuilder},
         TxnStatus,
     };
     use kvproto::kvrpcpb::Context;
@@ -963,89 +896,6 @@ mod tests {
         let key = b"key";
         must_rollback(&engine, key, 5);
         must_prewrite_lock_err(&engine, key, key, 5);
-    }
-
-    fn test_gc_imp<F>(k: &[u8], v1: &[u8], v2: &[u8], v3: &[u8], v4: &[u8], gc: F)
-    where
-        F: Fn(&RocksEngine, &[u8], u64),
-    {
-        let engine = TestEngineBuilder::new().build().unwrap();
-
-        must_prewrite_put(&engine, k, v1, k, 5);
-        must_commit(&engine, k, 5, 10);
-        must_prewrite_put(&engine, k, v2, k, 15);
-        must_commit(&engine, k, 15, 20);
-        must_prewrite_delete(&engine, k, k, 25);
-        must_commit(&engine, k, 25, 30);
-        must_prewrite_put(&engine, k, v3, k, 35);
-        must_commit(&engine, k, 35, 40);
-        must_prewrite_lock(&engine, k, k, 45);
-        must_commit(&engine, k, 45, 50);
-        must_prewrite_put(&engine, k, v4, k, 55);
-        must_rollback(&engine, k, 55);
-
-        // Transactions:
-        // startTS commitTS Command
-        // --
-        // 55      -        PUT "x55" (Rollback)
-        // 45      50       LOCK
-        // 35      40       PUT "x35"
-        // 25      30       DELETE
-        // 15      20       PUT "x15"
-        //  5      10       PUT "x5"
-
-        // CF data layout:
-        // ts CFDefault   CFWrite
-        // --
-        // 55             Rollback(PUT,50)
-        // 50             Commit(LOCK,45)
-        // 45
-        // 40             Commit(PUT,35)
-        // 35   x35
-        // 30             Commit(Delete,25)
-        // 25
-        // 20             Commit(PUT,15)
-        // 15   x15
-        // 10             Commit(PUT,5)
-        // 5    x5
-
-        gc(&engine, k, 12);
-        must_get(&engine, k, 12, v1);
-
-        gc(&engine, k, 22);
-        must_get(&engine, k, 22, v2);
-        must_get_none(&engine, k, 12);
-
-        gc(&engine, k, 32);
-        must_get_none(&engine, k, 22);
-        must_get_none(&engine, k, 35);
-
-        gc(&engine, k, 60);
-        must_get(&engine, k, 62, v3);
-    }
-
-    #[test]
-    fn test_gc() {
-        test_gc_imp(b"k1", b"v1", b"v2", b"v3", b"v4", must_gc);
-
-        let v1 = "x".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
-        let v2 = "y".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
-        let v3 = "z".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
-        let v4 = "v".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
-        test_gc_imp(b"k2", &v1, &v2, &v3, &v4, must_gc);
-    }
-
-    #[test]
-    fn test_gc_with_compaction_filter() {
-        use crate::server::gc_worker::gc_by_compact;
-
-        test_gc_imp(b"zk1", b"v1", b"v2", b"v3", b"v4", gc_by_compact);
-
-        let v1 = "x".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
-        let v2 = "y".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
-        let v3 = "z".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
-        let v4 = "v".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
-        test_gc_imp(b"zk2", &v1, &v2, &v3, &v4, gc_by_compact);
     }
 
     fn test_write_imp(k: &[u8], v: &[u8], k2: &[u8]) {

--- a/src/storage/txn/actions/gc.rs
+++ b/src/storage/txn/actions/gc.rs
@@ -1,0 +1,194 @@
+use crate::storage::mvcc::{
+    GcInfo, MvccTxn, Result as MvccResult, GC_DELETE_VERSIONS_HISTOGRAM, MAX_TXN_WRITE_SIZE,
+    MVCC_VERSIONS_HISTOGRAM,
+};
+use crate::storage::Snapshot;
+use txn_types::{Key, TimeStamp, WriteType};
+
+pub fn gc<S: Snapshot>(
+    txn: &mut MvccTxn<S>,
+    key: Key,
+    safe_point: TimeStamp,
+) -> MvccResult<GcInfo> {
+    let mut remove_older = false;
+    let mut ts = TimeStamp::max();
+    let mut found_versions = 0;
+    let mut deleted_versions = 0;
+    let mut latest_delete = None;
+    let mut is_completed = true;
+    while let Some((commit, write)) = txn.reader.seek_write(&key, ts)? {
+        ts = commit.prev();
+        found_versions += 1;
+
+        if txn.write_size >= MAX_TXN_WRITE_SIZE {
+            // Cannot remove latest delete when we haven't iterate all versions.
+            latest_delete = None;
+            is_completed = false;
+            break;
+        }
+
+        if remove_older {
+            txn.delete_write(key.clone(), commit);
+            if write.write_type == WriteType::Put && write.short_value.is_none() {
+                txn.delete_value(key.clone(), write.start_ts);
+            }
+            deleted_versions += 1;
+            continue;
+        }
+
+        if commit > safe_point {
+            continue;
+        }
+
+        // Set `remove_older` after we find the latest value.
+        match write.write_type {
+            WriteType::Put | WriteType::Delete => {
+                remove_older = true;
+            }
+            WriteType::Rollback | WriteType::Lock => {}
+        }
+
+        // Latest write before `safe_point` can be deleted if its type is Delete,
+        // Rollback or Lock.
+        match write.write_type {
+            WriteType::Delete => {
+                latest_delete = Some(commit);
+            }
+            WriteType::Rollback | WriteType::Lock => {
+                txn.delete_write(key.clone(), commit);
+                deleted_versions += 1;
+            }
+            WriteType::Put => {}
+        }
+    }
+    if let Some(commit) = latest_delete {
+        txn.delete_write(key, commit);
+        deleted_versions += 1;
+    }
+    MVCC_VERSIONS_HISTOGRAM.observe(found_versions as f64);
+    if deleted_versions > 0 {
+        GC_DELETE_VERSIONS_HISTOGRAM.observe(deleted_versions as f64);
+    }
+    Ok(GcInfo {
+        found_versions,
+        deleted_versions,
+        is_completed,
+    })
+}
+
+pub mod tests {
+    use super::*;
+    use crate::storage::kv::SnapContext;
+    use crate::storage::mvcc::tests::write;
+    use crate::storage::{Engine, ScanMode};
+    use concurrency_manager::ConcurrencyManager;
+    use kvproto::kvrpcpb::Context;
+
+    #[cfg(test)]
+    use crate::storage::{
+        mvcc::tests::{must_get, must_get_none},
+        txn::tests::*,
+        RocksEngine, TestEngineBuilder,
+    };
+    #[cfg(test)]
+    use txn_types::SHORT_VALUE_MAX_LEN;
+
+    pub fn must_succeed<E: Engine>(engine: &E, key: &[u8], safe_point: impl Into<TimeStamp>) {
+        let ctx = SnapContext::default();
+        let snapshot = engine.snapshot(ctx).unwrap();
+        let cm = ConcurrencyManager::new(1.into());
+        let mut txn = MvccTxn::for_scan(
+            snapshot,
+            Some(ScanMode::Forward),
+            TimeStamp::zero(),
+            true,
+            cm,
+        );
+        gc(&mut txn, Key::from_raw(key), safe_point.into()).unwrap();
+        write(engine, &Context::default(), txn.into_modifies());
+    }
+
+    #[cfg(test)]
+    fn test_gc_imp<F>(k: &[u8], v1: &[u8], v2: &[u8], v3: &[u8], v4: &[u8], gc: F)
+    where
+        F: Fn(&RocksEngine, &[u8], u64),
+    {
+        let engine = TestEngineBuilder::new().build().unwrap();
+
+        must_prewrite_put(&engine, k, v1, k, 5);
+        must_commit(&engine, k, 5, 10);
+        must_prewrite_put(&engine, k, v2, k, 15);
+        must_commit(&engine, k, 15, 20);
+        must_prewrite_delete(&engine, k, k, 25);
+        must_commit(&engine, k, 25, 30);
+        must_prewrite_put(&engine, k, v3, k, 35);
+        must_commit(&engine, k, 35, 40);
+        must_prewrite_lock(&engine, k, k, 45);
+        must_commit(&engine, k, 45, 50);
+        must_prewrite_put(&engine, k, v4, k, 55);
+        must_rollback(&engine, k, 55);
+
+        // Transactions:
+        // startTS commitTS Command
+        // --
+        // 55      -        PUT "x55" (Rollback)
+        // 45      50       LOCK
+        // 35      40       PUT "x35"
+        // 25      30       DELETE
+        // 15      20       PUT "x15"
+        //  5      10       PUT "x5"
+
+        // CF data layout:
+        // ts CFDefault   CFWrite
+        // --
+        // 55             Rollback(PUT,50)
+        // 50             Commit(LOCK,45)
+        // 45
+        // 40             Commit(PUT,35)
+        // 35   x35
+        // 30             Commit(Delete,25)
+        // 25
+        // 20             Commit(PUT,15)
+        // 15   x15
+        // 10             Commit(PUT,5)
+        // 5    x5
+
+        gc(&engine, k, 12);
+        must_get(&engine, k, 12, v1);
+
+        gc(&engine, k, 22);
+        must_get(&engine, k, 22, v2);
+        must_get_none(&engine, k, 12);
+
+        gc(&engine, k, 32);
+        must_get_none(&engine, k, 22);
+        must_get_none(&engine, k, 35);
+
+        gc(&engine, k, 60);
+        must_get(&engine, k, 62, v3);
+    }
+
+    #[test]
+    fn test_gc() {
+        test_gc_imp(b"k1", b"v1", b"v2", b"v3", b"v4", must_succeed);
+
+        let v1 = "x".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
+        let v2 = "y".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
+        let v3 = "z".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
+        let v4 = "v".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
+        test_gc_imp(b"k2", &v1, &v2, &v3, &v4, must_succeed);
+    }
+
+    #[test]
+    fn test_gc_with_compaction_filter() {
+        use crate::server::gc_worker::gc_by_compact;
+
+        test_gc_imp(b"zk1", b"v1", b"v2", b"v3", b"v4", gc_by_compact);
+
+        let v1 = "x".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
+        let v2 = "y".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
+        let v3 = "z".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
+        let v4 = "v".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
+        test_gc_imp(b"zk2", &v1, &v2, &v3, &v4, gc_by_compact);
+    }
+}

--- a/src/storage/txn/actions/mod.rs
+++ b/src/storage/txn/actions/mod.rs
@@ -8,11 +8,11 @@
 pub(crate) mod shared;
 
 pub mod acquire_pessimistic_lock;
+pub mod check_data_constraint;
 pub mod check_txn_status;
 pub mod cleanup;
 pub mod commit;
+pub mod gc;
 pub mod pessimistic_prewrite;
 pub mod prewrite;
-
-pub mod check_data_constraint;
 pub mod tests;

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -9,7 +9,7 @@ pub mod scheduler;
 mod actions;
 
 pub use actions::{
-    acquire_pessimistic_lock::acquire_pessimistic_lock, cleanup::cleanup, commit::commit,
+    acquire_pessimistic_lock::acquire_pessimistic_lock, cleanup::cleanup, commit::commit, gc::gc,
     pessimistic_prewrite::pessimistic_prewrite, prewrite::prewrite,
 };
 
@@ -247,6 +247,7 @@ pub mod tests {
     };
     pub use actions::cleanup::tests::{must_err as must_cleanup_err, must_succeed as must_cleanup};
     pub use actions::commit::tests::{must_err as must_commit_err, must_succeed as must_commit};
+    pub use actions::gc::tests::must_succeed as must_gc;
     pub use actions::pessimistic_prewrite::tests::try_pessimistic_prewrite_check_not_exists;
     pub use actions::prewrite::tests::{try_prewrite_check_not_exists, try_prewrite_insert};
     pub use actions::tests::*;


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
As I proposed in #8513, we can move these "action" function and related tests to txn/actions.rs, and make the code cleaner.

Though `gc` is not used by commands, its also a "high level" operation which is made up with multiple basic operations in MvccTxn, so it should be also an action

### What is changed and how it works?

What's Changed:
Move `MvccTxn::gc` and related tests and test utils to `action` mod.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
Side effects