### PR TITLE
cdc: use bounded queue in cdc server

### DIFF
--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -287,7 +287,6 @@ impl ChangeData for Service {
         if !check_common_name(self.security_mgr.cert_allowed_cn(), &ctx) {
             return;
         }
-        // TODO: make it a bounded channel.
         let (tx, rx) = batch::bounded(CDC_MSG_QUEUE_BOUND, CDC_MSG_NOTIFY_COUNT);
         let peer = ctx.peer();
         let conn = Conn::new(tx, peer);

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -32,6 +32,7 @@ const CDC_MSG_MAX_BATCH_SIZE: usize = 128;
 // Assume the average size of event is 1KB.
 // 2 = (CDC_MSG_MAX_BATCH_SIZE * 1KB / CDC_EVENT_MAX_BATCH_SIZE).ceil() + 1 /* reserve for ResolvedTs */;
 const CDC_EVENT_MAX_BATCH_SIZE: usize = 2;
+const CDC_MSG_QUEUE_BOUND: usize = 1024 * 1024;
 
 /// A unique identifier of a Connection.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -287,7 +288,7 @@ impl ChangeData for Service {
             return;
         }
         // TODO: make it a bounded channel.
-        let (tx, rx) = batch::unbounded(CDC_MSG_NOTIFY_COUNT);
+        let (tx, rx) = batch::bounded(CDC_MSG_QUEUE_BOUND, CDC_MSG_NOTIFY_COUNT);
         let peer = ctx.peer();
         let conn = Conn::new(tx, peer);
         let conn_id = conn.get_id();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #8168  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

### Related changes

- Changed the event queue to bounded in CDC server.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- bugfixes or new feature need a release note -->
- Use a bounded queue in cdc component to reduce possibility of OOM when there is a large amount of data pending.