### PR TITLE
encryption: Turn file dictionary into log style (#8865)

### DIFF
--- a/components/encryption/src/config.rs
+++ b/components/encryption/src/config.rs
@@ -19,6 +19,8 @@ pub struct EncryptionConfig {
     #[config(skip)]
     pub data_key_rotation_period: ReadableDuration,
     #[config(skip)]
+    pub file_rewrite_threshold: u64,
+    #[config(skip)]
     pub master_key: MasterKeyConfig,
     #[config(skip)]
     pub previous_master_key: MasterKeyConfig,
@@ -31,6 +33,7 @@ impl Default for EncryptionConfig {
             data_key_rotation_period: ReadableDuration::days(7),
             master_key: MasterKeyConfig::default(),
             previous_master_key: MasterKeyConfig::default(),
+            file_rewrite_threshold: 1000000,
         }
     }
 }
@@ -187,6 +190,7 @@ mod tests {
                 },
             },
             previous_master_key: MasterKeyConfig::Plaintext,
+            file_rewrite_threshold: 1000000,
         };
         let kms_str = r#"
         data-encryption-method = "aes128-ctr"

--- a/components/encryption/src/encrypted_file/header.rs
+++ b/components/encryption/src/encrypted_file/header.rs
@@ -7,15 +7,18 @@ use byteorder::{BigEndian, ByteOrder};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Version {
+    // The content only contains the encrypted part.
     V1 = 1,
+    // The end contains a variable number of unencrypted log records.
+    V2 = 2,
 }
 
 impl Version {
     fn from(input: u8) -> Result<Version> {
-        if input == 1 {
-            Ok(Version::V1)
-        } else {
-            Err(box_err!("unknown version {:x}", input))
+        match input {
+            1 => Ok(Version::V1),
+            2 => Ok(Version::V2),
+            _ => Err(box_err!("unknown version {:x}", input)),
         }
     }
 }
@@ -47,18 +50,20 @@ impl Header {
     // Content size (8 bytes)
     const SIZE: usize = 1 + 3 + 4 + 8;
 
-    pub fn new(content: &[u8]) -> Header {
+    pub fn new(content: &[u8], version: Version) -> Header {
         let size = content.len() as u64;
         let mut digest = crc32fast::Hasher::new();
         digest.update(content);
         let crc32 = digest.finalize();
         Header {
-            version: Version::V1,
+            version,
             crc32,
             size,
         }
     }
-    pub fn parse(buf: &[u8]) -> Result<(Header, &[u8])> {
+
+    /// Parse bytes into header, content and remained bytes.
+    pub fn parse(buf: &[u8]) -> Result<(Header, &[u8], &[u8])> {
         if buf.len() < Header::SIZE {
             return Err(box_err!(
                 "file corrupted! header size mismatch {} != {}",
@@ -74,14 +79,30 @@ impl Header {
         // Content size (8 bytes)
         let size = BigEndian::read_u64(&buf[8..Header::SIZE]);
 
-        let content = &buf[Header::SIZE..];
-        if content.len() as u64 != size {
-            return Err(box_err!(
-                "file corrupted! content size mismatch {} != {}",
-                size,
-                content.len()
-            ));
+        let remained_size = buf.len() - Header::SIZE;
+        match version {
+            Version::V1 => {
+                if remained_size != size as usize {
+                    return Err(box_err!(
+                        "file corrupted! content size isn't expected: {}, expected: {}",
+                        remained_size,
+                        size
+                    ));
+                }
+            }
+            Version::V2 => {
+                if remained_size < size as usize {
+                    return Err(box_err!(
+                        "file corrupted! content size is too small: {}, expected: {}",
+                        remained_size,
+                        size
+                    ));
+                }
+            }
         }
+
+        let content = &buf[Header::SIZE..Header::SIZE + size as usize];
+        let remained = &buf[Header::SIZE + size as usize..];
 
         let mut digest = crc32fast::Hasher::new();
         digest.update(content);
@@ -99,7 +120,7 @@ impl Header {
             crc32,
             size,
         };
-        Ok((header, content))
+        Ok((header, content, remained))
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
@@ -116,6 +137,10 @@ impl Header {
 
         buf.to_vec()
     }
+
+    pub fn version(&self) -> Version {
+        self.version
+    }
 }
 
 #[cfg(test)]
@@ -131,7 +156,7 @@ mod tests {
         };
 
         let bytes = empty_header.to_bytes();
-        let (header1, content1) = Header::parse(&bytes).unwrap();
+        let (header1, content1, _) = Header::parse(&bytes).unwrap();
         assert_eq!(empty_header, header1);
         let empty: Vec<u8> = vec![];
         assert_eq!(content1, empty.as_slice())
@@ -141,13 +166,13 @@ mod tests {
     #[test]
     fn test_crc32_size() {
         let content = [5; 32];
-        let header = Header::new(&content);
+        let header = Header::new(&content, Version::V1);
 
         {
             let mut bytes = header.to_bytes();
             bytes.extend_from_slice(&content);
 
-            let (header1, content1) = Header::parse(&bytes).unwrap();
+            let (header1, content1, _) = Header::parse(&bytes).unwrap();
             assert_eq!(header, header1);
             assert_eq!(content, content1)
         }

--- a/components/encryption/src/encrypted_file/mod.rs
+++ b/components/encryption/src/encrypted_file/mod.rs
@@ -14,9 +14,9 @@ use crate::metrics::*;
 use crate::Result;
 
 mod header;
-use header::*;
+pub use header::*;
 
-const TMP_FILE_SUFFIX: &str = ".tmp";
+pub const TMP_FILE_SUFFIX: &str = ".tmp";
 
 /// An file encrypted by master key.
 pub struct EncryptedFile<'a> {
@@ -44,7 +44,7 @@ impl<'a> EncryptedFile<'a> {
             Ok(mut f) => {
                 let mut buf = Vec::new();
                 f.read_to_end(&mut buf)?;
-                let (_, content) = Header::parse(&buf)?;
+                let (_, content, _) = Header::parse(&buf)?;
                 let mut encrypted_content = EncryptedContent::default();
                 encrypted_content.merge_from_bytes(content)?;
                 let plaintext = master_key.decrypt(&encrypted_content)?;
@@ -77,7 +77,7 @@ impl<'a> EncryptedFile<'a> {
             .encrypt(&plaintext_content)?
             .write_to_bytes()
             .unwrap();
-        let header = Header::new(&encrypted_content);
+        let header = Header::new(&encrypted_content, Version::V1);
         tmp_file.write_all(&header.to_bytes())?;
         tmp_file.write_all(&encrypted_content)?;
         tmp_file.sync_all()?;

--- a/components/encryption/src/lib.rs
+++ b/components/encryption/src/lib.rs
@@ -15,6 +15,7 @@ mod crypter;
 mod encrypted_file;
 mod errors;
 mod io;
+mod log_file;
 mod manager;
 mod master_key;
 mod metrics;

--- a/components/encryption/src/log_file.rs
+++ b/components/encryption/src/log_file.rs
@@ -1,0 +1,406 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use byteorder::{BigEndian, ByteOrder};
+use kvproto::encryptionpb::{EncryptedContent, FileDictionary, FileInfo};
+use protobuf::Message;
+use rand::{thread_rng, RngCore};
+
+use crate::encrypted_file::{Header, Version, TMP_FILE_SUFFIX};
+use crate::master_key::{Backend, PlaintextBackend};
+use crate::Result;
+
+use std::fs::{rename, File, OpenOptions};
+use std::io::BufRead;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+enum LogRecord {
+    INSERT(FileInfo),
+    REMOVE,
+}
+
+/// LogFile is used to store log style file dictionary.
+///
+/// Layout:
+/// ```text
+/// Encrypted File Header + FileDictionary Content | Record Header + Record Content | etc
+/// ```
+#[derive(Debug)]
+pub struct LogFile {
+    base: PathBuf,
+    name: String,
+    // Avoid reopening the file every time when append.
+    append_file: Option<File>,
+    // Internal file dictionary to avoid recovery before rewrite and to check if compaction
+    // is needed.
+    file_dict: FileDictionary,
+    // Determine whether compact the log.
+    file_rewrite_threshold: u64,
+    // Record the number of `REMOVE` to determine whether compact the log.
+    removed: u64,
+}
+
+impl LogFile {
+    /// Header of record.
+    ///
+    /// ```text
+    /// +----+--+--+-+----+----
+    /// |    |  |  | |    |
+    /// ++---++-++-++++---++---
+    ///  ^    ^  ^  ^ ^    ^
+    ///  |    |  |  | |    + FileInfo content (variable bytes)
+    ///  |    |  |  | + File name content (variable bytes)
+    ///  |    |  |  + Log type (1 bytes)
+    ///  |    |  + FileInfo length (2 bytes)
+    ///  |    + File name length (2 bytes)
+    ///  + Crc32 (4 bytes)
+    /// ```
+    const RECORD_HEADER_SIZE: usize = 4 + 2 + 2 + 1;
+
+    pub fn new<P: AsRef<Path>>(
+        base: P,
+        name: &str,
+        file_rewrite_threshold: u64,
+    ) -> Result<LogFile> {
+        let mut log_file = LogFile {
+            base: base.as_ref().to_path_buf(),
+            name: name.to_owned(),
+            append_file: None,
+            file_dict: FileDictionary::default(),
+            file_rewrite_threshold,
+            removed: 0,
+        };
+        log_file.rewrite()?;
+        Ok(log_file)
+    }
+
+    pub fn open<P: AsRef<Path>>(
+        base: P,
+        name: &str,
+        file_rewrite_threshold: u64,
+        skip_rewrite: bool,
+    ) -> Result<(LogFile, FileDictionary)> {
+        let mut log_file = LogFile {
+            base: base.as_ref().to_path_buf(),
+            name: name.to_owned(),
+            append_file: None,
+            file_dict: FileDictionary::default(),
+            file_rewrite_threshold,
+            removed: 0,
+        };
+
+        let file_dict = log_file.recovery()?;
+        if !skip_rewrite {
+            log_file.rewrite()?;
+        }
+        Ok((log_file, file_dict))
+    }
+
+    /// Rewrite the log file to reduce file size and reduce the time of next recovery.
+    pub fn rewrite(&mut self) -> Result<()> {
+        let origin_path = self.base.join(&self.name);
+        let mut tmp_path = origin_path.clone();
+        tmp_path.set_extension(format!("{}.{}", thread_rng().next_u64(), TMP_FILE_SUFFIX));
+        let mut tmp_file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&tmp_path)
+            .unwrap();
+
+        let file_dict_bytes = self.file_dict.write_to_bytes()?;
+        let header = Header::new(&file_dict_bytes, Version::V2);
+        tmp_file.write_all(&header.to_bytes())?;
+        tmp_file.write_all(&file_dict_bytes)?;
+        tmp_file.sync_all()?;
+
+        // Replace old file with the tmp file aomticlly.
+        rename(&tmp_path, &origin_path)?;
+        let base_dir = File::open(&self.base)?;
+        base_dir.sync_all()?;
+        let file = std::fs::OpenOptions::new().append(true).open(origin_path)?;
+        self.append_file.replace(file);
+
+        Ok(())
+    }
+
+    /// Recovery from the log file and return `FileDictionary`.
+    pub fn recovery(&mut self) -> Result<FileDictionary> {
+        let mut f = OpenOptions::new()
+            .read(true)
+            .open(self.base.join(&self.name))?;
+        let mut buf = Vec::new();
+        f.read_to_end(&mut buf)?;
+        let remained = buf.as_slice();
+
+        // parse the file dictionary
+        let (header, content, mut remained) = Header::parse(remained)?;
+        let mut file_dict = FileDictionary::default();
+        match header.version() {
+            Version::V1 => {
+                let mut encrypted_content = EncryptedContent::default();
+                encrypted_content.merge_from_bytes(content)?;
+                let content = PlaintextBackend::default().decrypt(&encrypted_content)?;
+                file_dict.merge_from_bytes(&content)?;
+            }
+            Version::V2 => {
+                file_dict.merge_from_bytes(content)?;
+                // parse the remained records
+                while !remained.is_empty() {
+                    // If the parsing get errors, manual intervention is required to recover.
+                    let (used_size, file_name, mode) = Self::parse_next_record(remained)?;
+                    remained.consume(used_size);
+                    match mode {
+                        LogRecord::INSERT(info) => {
+                            file_dict.files.insert(file_name, info);
+                        }
+                        LogRecord::REMOVE => {
+                            let original = file_dict.files.remove(&file_name);
+                            if original.is_none() {
+                                return Err(box_err!(
+                                    "Try to recovery from log file but remove a null entry, file name: {}",
+                                    file_name
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.file_dict = file_dict.clone();
+        Ok(file_dict)
+    }
+
+    /// Append an insert operation to the log file.
+    ///
+    /// Warning: `self.write(file_dict)` must be called before.
+    pub fn insert(&mut self, name: &str, info: &FileInfo) -> Result<()> {
+        let file = self.append_file.as_mut().unwrap();
+        let bytes = Self::convert_record_to_bytes(name, LogRecord::INSERT(info.clone()))?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+
+        self.file_dict.files.insert(name.to_owned(), info.clone());
+        self.check_compact()?;
+
+        Ok(())
+    }
+
+    /// Append a remove operation to the log file.
+    ///
+    /// Warning: `self.write(file_dict)` must be called before.
+    pub fn remove(&mut self, name: &str) -> Result<()> {
+        let file = self.append_file.as_mut().unwrap();
+        let bytes = Self::convert_record_to_bytes(name, LogRecord::REMOVE)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+
+        self.file_dict.files.remove(name);
+        self.removed += 1;
+        self.check_compact()?;
+
+        Ok(())
+    }
+
+    /// Replace existed file entry with new file information.
+    ///
+    /// Warning: `self.write(file_dict)` must be called before.
+    pub fn replace(&mut self, src_name: &str, dst_name: &str, info: FileInfo) -> Result<()> {
+        assert_ne!(src_name, dst_name);
+        let file = self.append_file.as_mut().unwrap();
+        let mut bytes1 = Self::convert_record_to_bytes(dst_name, LogRecord::INSERT(info.clone()))?;
+        let bytes2 = Self::convert_record_to_bytes(src_name, LogRecord::REMOVE)?;
+        bytes1.extend_from_slice(&bytes2);
+        file.write_all(&bytes1)?;
+        file.sync_all()?;
+
+        self.file_dict.files.remove(src_name);
+        self.file_dict.files.insert(dst_name.to_owned(), info);
+        self.removed += 1;
+        self.check_compact()?;
+
+        Ok(())
+    }
+
+    /// This function needs to be called after each append operation to check
+    /// if compact is needed.
+    fn check_compact(&mut self) -> Result<()> {
+        if self.removed > self.file_rewrite_threshold {
+            self.removed = 0;
+            self.rewrite()?;
+        }
+        Ok(())
+    }
+
+    fn convert_record_to_bytes(fname: &str, record_type: LogRecord) -> Result<Vec<u8>> {
+        let name_len = fname.len() as u16;
+        let mut content = vec![];
+        content.extend_from_slice(fname.as_bytes());
+
+        let mut header_buf = [0; Self::RECORD_HEADER_SIZE];
+        let info_len = match record_type {
+            LogRecord::INSERT(info) => {
+                header_buf[Self::RECORD_HEADER_SIZE - 1] = 1;
+                let info_bytes = info.write_to_bytes()?;
+                content.extend_from_slice(&info_bytes);
+                info_bytes.len() as u16
+            }
+            LogRecord::REMOVE => {
+                header_buf[Self::RECORD_HEADER_SIZE - 1] = 2;
+                0
+            }
+        };
+
+        let mut digest = crc32fast::Hasher::new();
+        digest.update(&content);
+        let crc32 = digest.finalize();
+
+        BigEndian::write_u32(&mut header_buf[0..4], crc32);
+        BigEndian::write_u16(&mut header_buf[4..6], name_len);
+        BigEndian::write_u16(&mut header_buf[6..8], info_len);
+        let mut ret = header_buf.to_vec();
+        ret.extend_from_slice(&content);
+        Ok(ret)
+    }
+
+    fn parse_next_record(mut remained: &[u8]) -> Result<(usize, String, LogRecord)> {
+        if remained.len() < Self::RECORD_HEADER_SIZE {
+            return Err(box_err!(
+                "file corrupted! record header size is too small: {}",
+                remained.len()
+            ));
+        }
+
+        // parse header
+        let crc32 = BigEndian::read_u32(&remained[0..4]);
+        let name_len = BigEndian::read_u16(&remained[4..6]) as usize;
+        let info_len = BigEndian::read_u16(&remained[6..8]) as usize;
+        let mode = remained[Self::RECORD_HEADER_SIZE - 1];
+        remained.consume(Self::RECORD_HEADER_SIZE);
+        if remained.len() < name_len + info_len {
+            return Err(box_err!(
+                "file corrupted! record content size is too small: {}, expect: {}",
+                remained.len(),
+                name_len + info_len
+            ));
+        }
+
+        // checksum crc32
+        let mut digest = crc32fast::Hasher::new();
+        digest.update(&remained[0..name_len + info_len]);
+        let crc32_checksum = digest.finalize();
+        if crc32_checksum != crc32 {
+            return Err(box_err!(
+                "file corrupted! crc32 mismatch {} != {}",
+                crc32,
+                crc32_checksum
+            ));
+        }
+
+        // read file name
+        let ret: Result<String> = String::from_utf8(remained[0..name_len].to_owned())
+            .map_err(|e| box_err!("parse file name failed: {:?}", e));
+        let file_name = ret?;
+        remained.consume(name_len);
+
+        // return result
+        let used_size = Self::RECORD_HEADER_SIZE + name_len + info_len;
+        let record = match mode {
+            2 => LogRecord::REMOVE,
+            1 => {
+                let mut file_info = FileInfo::default();
+                file_info.merge_from_bytes(&remained[0..info_len])?;
+                LogRecord::INSERT(file_info)
+            }
+            _ => return Err(box_err!("file corrupted! record type is unknown: {}", mode)),
+        };
+        Ok((used_size, file_name, record))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypter::compat;
+    use crate::encrypted_file::EncryptedFile;
+    use crate::Error;
+    use kvproto::encryptionpb::EncryptionMethod;
+
+    #[test]
+    fn test_log_file_normal() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let mut log_file = LogFile::new(tempdir.path(), "test_log_file", 2).unwrap();
+        let info1 = create_file_info(1, EncryptionMethod::Aes256Ctr);
+        let info2 = create_file_info(2, EncryptionMethod::Unknown);
+        let info3 = create_file_info(3, EncryptionMethod::Aes128Ctr);
+        let info4 = create_file_info(4, EncryptionMethod::Aes128Ctr);
+
+        log_file.insert("info1", &info1).unwrap();
+        log_file.insert("info2", &info2).unwrap();
+        log_file.insert("info3", &info3).unwrap();
+
+        let file_dict = log_file.recovery().unwrap();
+
+        assert_eq!(*file_dict.files.get("info1").unwrap(), info1);
+        assert_eq!(*file_dict.files.get("info2").unwrap(), info2);
+        assert_eq!(*file_dict.files.get("info3").unwrap(), info3);
+        assert_eq!(file_dict.files.len(), 3);
+
+        log_file.remove("info2").unwrap();
+        log_file.remove("info1").unwrap();
+        log_file.insert("info2", &info4).unwrap();
+
+        let file_dict = log_file.recovery().unwrap();
+        assert_eq!(file_dict.files.get("info1"), None);
+        assert_eq!(*file_dict.files.get("info2").unwrap(), info4);
+        assert_eq!(*file_dict.files.get("info3").unwrap(), info3);
+        assert_eq!(file_dict.files.len(), 2);
+    }
+
+    #[test]
+    fn test_log_file_existed() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let mut log_file = LogFile::new(tempdir.path(), "test_log_file", 2).unwrap();
+
+        let info = create_file_info(1, EncryptionMethod::Aes256Ctr);
+        log_file.insert("info", &info).unwrap();
+
+        let (_, file_dict) = LogFile::open(tempdir.path(), "test_log_file", 2, false).unwrap();
+        assert_eq!(*file_dict.files.get("info").unwrap(), info);
+    }
+
+    #[test]
+    fn test_log_file_not_existed() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let ret = LogFile::open(tempdir.path(), "test_log_file", 2, false);
+        assert!(matches!(ret, Err(Error::Io(_))));
+    }
+
+    #[test]
+    fn test_log_file_update_from_v1() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let mut file_dict = FileDictionary::default();
+
+        let info1 = create_file_info(1, EncryptionMethod::Aes256Ctr);
+        let info2 = create_file_info(2, EncryptionMethod::Aes256Ctr);
+        file_dict.files.insert("f1".to_owned(), info1);
+        file_dict.files.insert("f2".to_owned(), info2);
+
+        let file = EncryptedFile::new(tempdir.path(), "test_log_file");
+        file.write(
+            &file_dict.write_to_bytes().unwrap(),
+            &PlaintextBackend::default(),
+        )
+        .unwrap();
+
+        let (_, file_dict_read) = LogFile::open(tempdir.path(), "test_log_file", 2, false).unwrap();
+        assert_eq!(file_dict, file_dict_read);
+    }
+
+    fn create_file_info(id: u64, method: EncryptionMethod) -> FileInfo {
+        let mut info = FileInfo::default();
+        info.key_id = id;
+        info.method = compat(method);
+        info
+    }
+}

--- a/components/encryption/src/log_file.rs
+++ b/components/encryption/src/log_file.rs
@@ -373,7 +373,10 @@ mod tests {
     fn test_log_file_not_existed() {
         let tempdir = tempfile::tempdir().unwrap();
         let ret = LogFile::open(tempdir.path(), "test_log_file", 2, false);
-        assert!(matches!(ret, Err(Error::Io(_))));
+        match ret {
+            Err(Error::Io(_)) => {}
+            _ => unreachable!(),
+        }
     }
 
     #[test]

--- a/components/encryption/src/manager/mod.rs
+++ b/components/encryption/src/manager/mod.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::{Error as IoError, ErrorKind, Result as IoResult};
 use std::path::{Path, PathBuf};
 use std::sync::{atomic::AtomicU64, atomic::Ordering, Arc, Mutex};
+use std::thread::JoinHandle;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crossbeam::channel::{self, select, tick};
@@ -15,7 +16,8 @@ use crate::config::{EncryptionConfig, MasterKeyConfig};
 use crate::crypter::{self, compat, Iv};
 use crate::encrypted_file::EncryptedFile;
 use crate::io::EncrypterWriter;
-use crate::master_key::{create_backend, Backend, PlaintextBackend};
+use crate::log_file::LogFile;
+use crate::master_key::{create_backend, Backend};
 use crate::metrics::*;
 use crate::{Error, Result};
 
@@ -26,8 +28,7 @@ const ROTATE_CHECK_PERIOD: u64 = 600; // 10min
 struct Dicts {
     // Maps data file paths to key id and metadata. This file is stored as plaintext.
     file_dict: Mutex<FileDictionary>,
-    // Lock to make sure there's no concurrent update operations to file dictionary.
-    file_lock: Mutex<()>,
+    log_file: Mutex<LogFile>,
     // Maps data key id to data keys, together with metadata. Also stores the data
     // key id used to encrypt the encryption file dictionary. The content is encrypted
     // using master key.
@@ -41,42 +42,42 @@ struct Dicts {
 }
 
 impl Dicts {
-    fn new(path: &str, rotation_period: Duration) -> Dicts {
-        Dicts {
+    fn new(path: &str, rotation_period: Duration, file_rewrite_threshold: u64) -> Result<Dicts> {
+        Ok(Dicts {
             file_dict: Mutex::new(FileDictionary::default()),
+            log_file: Mutex::new(LogFile::new(
+                Path::new(path).to_owned(),
+                FILE_DICT_NAME,
+                file_rewrite_threshold,
+            )?),
             key_dict: Mutex::new(KeyDictionary {
                 current_key_id: 0,
                 ..Default::default()
             }),
             current_key_id: AtomicU64::new(0),
-            file_lock: Mutex::new(()),
             rotation_period,
             base: Path::new(path).to_owned(),
-        }
+        })
     }
 
     fn open(
         path: &str,
         rotation_period: Duration,
         master_key: &dyn Backend,
+        file_rewrite_threshold: u64,
     ) -> Result<Option<Dicts>> {
         let base = Path::new(path);
 
         // File dict is saved in plaintext.
-        let file_file = EncryptedFile::new(base, FILE_DICT_NAME);
-        let plaintext_config = MasterKeyConfig::Plaintext;
-        let plaintext = create_backend(&plaintext_config)?;
-        let file_bytes = file_file.read(plaintext.as_ref());
+        let log_content = LogFile::open(base, FILE_DICT_NAME, file_rewrite_threshold, false);
 
         let key_file = EncryptedFile::new(base, KEY_DICT_NAME);
         let key_bytes = key_file.read(master_key);
 
-        match (file_bytes, key_bytes) {
+        match (log_content, key_bytes) {
             // Both files are found.
-            (Ok(file_bytes), Ok(key_bytes)) => {
+            (Ok((log_file, file_dict)), Ok(key_bytes)) => {
                 info!("encryption: found both of key dictionary and file dictionary.");
-                let mut file_dict = FileDictionary::default();
-                file_dict.merge_from_bytes(&file_bytes)?;
                 let mut key_dict = KeyDictionary::default();
                 key_dict.merge_from_bytes(&key_bytes)?;
                 let current_key_id = AtomicU64::new(key_dict.current_key_id);
@@ -86,9 +87,9 @@ impl Dicts {
 
                 Ok(Some(Dicts {
                     file_dict: Mutex::new(file_dict),
+                    log_file: Mutex::new(log_file),
                     key_dict: Mutex::new(key_dict),
                     current_key_id,
-                    file_lock: Mutex::new(()),
                     rotation_period,
                     base: base.to_owned(),
                 }))
@@ -102,13 +103,13 @@ impl Dicts {
                 Ok(None)
             }
             // ...else, return either error.
-            (file_bytes, key_bytes) => {
+            (log_file, key_bytes) => {
                 if let Err(key_err) = key_bytes {
                     error!("encryption: failed to load key dictionary.");
                     Err(key_err)
                 } else {
                     error!("encryption: failed to load file dictionary.");
-                    Err(file_bytes.unwrap_err())
+                    Err(log_file.unwrap_err())
                 }
             }
         }
@@ -133,25 +134,6 @@ impl Dicts {
             .with_label_values(&["key_dictionary"])
             .set(key_bytes.len() as _);
         ENCRYPTION_DATA_KEY_GAUGE.set(keys_len);
-
-        Ok(())
-    }
-
-    fn save_file_dict(&self) -> Result<()> {
-        let file = EncryptedFile::new(&self.base, FILE_DICT_NAME);
-        let (file_bytes, file_num) = {
-            let file_dict = self.file_dict.lock().unwrap();
-            let file_bytes = file_dict.write_to_bytes()?;
-            let file_num = file_dict.files.len() as _;
-            (file_bytes, file_num)
-        };
-        // File dict is saved in plaintext.
-        file.write(&file_bytes, &PlaintextBackend::default())?;
-
-        ENCRYPTION_FILE_SIZE_GAUGE
-            .with_label_values(&["file_dictionary"])
-            .set(file_bytes.len() as _);
-        ENCRYPTION_FILE_NUM_GAUGE.set(file_num);
 
         Ok(())
     }
@@ -189,17 +171,20 @@ impl Dicts {
     }
 
     fn new_file(&self, fname: &str, method: EncryptionMethod) -> Result<FileInfo> {
-        let _lock = self.file_lock.lock().unwrap();
+        let mut log_file = self.log_file.lock().unwrap();
         let iv = Iv::new_ctr();
         let mut file = FileInfo::default();
         file.iv = iv.as_slice().to_vec();
         file.key_id = self.current_key_id.load(Ordering::SeqCst);
         file.method = compat(method);
-        {
+        let file_num = {
             let mut file_dict = self.file_dict.lock().unwrap();
             file_dict.files.insert(fname.to_owned(), file.clone());
-        }
-        self.save_file_dict()?;
+            file_dict.files.len() as _
+        };
+
+        log_file.insert(fname, &file)?;
+        ENCRYPTION_FILE_NUM_GAUGE.set(file_num);
 
         if method != EncryptionMethod::Plaintext {
             info!("new encrypted file"; 
@@ -213,11 +198,15 @@ impl Dicts {
     }
 
     fn delete_file(&self, fname: &str) -> Result<()> {
-        let _lock = self.file_lock.lock().unwrap();
-        let file = {
+        let mut log_file = self.log_file.lock().unwrap();
+        let (file, file_num) = {
             let mut file_dict = self.file_dict.lock().unwrap();
+
             match file_dict.files.remove(fname) {
-                Some(file_info) => file_info,
+                Some(file_info) => {
+                    let file_num = file_dict.files.len() as _;
+                    (file_info, file_num)
+                }
                 None => {
                     // Could be a plaintext file not tracked by file dictionary.
                     info!("delete untracked plaintext file"; "fname" => fname);
@@ -226,8 +215,8 @@ impl Dicts {
             }
         };
 
-        // TOOD GC unused data keys.
-        self.save_file_dict()?;
+        log_file.remove(fname)?;
+        ENCRYPTION_FILE_NUM_GAUGE.set(file_num);
         if file.method != compat(EncryptionMethod::Plaintext) {
             info!("delete encrypted file"; "fname" => fname);
         } else {
@@ -237,9 +226,8 @@ impl Dicts {
     }
 
     fn link_file(&self, src_fname: &str, dst_fname: &str) -> Result<()> {
-        let _lock = self.file_lock.lock().unwrap();
-
-        let method = {
+        let mut log_file = self.log_file.lock().unwrap();
+        let (method, file, file_num) = {
             let mut file_dict = self.file_dict.lock().unwrap();
             let file = match file_dict.files.get(src_fname) {
                 Some(file_info) => file_info.clone(),
@@ -256,10 +244,12 @@ impl Dicts {
                 )));
             }
             let method = file.method;
-            file_dict.files.insert(dst_fname.to_owned(), file);
-            method
+            file_dict.files.insert(dst_fname.to_owned(), file.clone());
+            let file_num = file_dict.files.len() as _;
+            (method, file, file_num)
         };
-        self.save_file_dict()?;
+        log_file.insert(dst_fname, &file)?;
+        ENCRYPTION_FILE_NUM_GAUGE.set(file_num);
 
         if method != compat(EncryptionMethod::Plaintext) {
             info!("link encrypted file"; "src" => src_fname, "dst" => dst_fname);
@@ -270,8 +260,8 @@ impl Dicts {
     }
 
     fn rename_file(&self, src_fname: &str, dst_fname: &str) -> Result<()> {
-        let _lock = self.file_lock.lock().unwrap();
-        let method = {
+        let mut log_file = self.log_file.lock().unwrap();
+        let (method, file, file_num) = {
             let mut file_dict = self.file_dict.lock().unwrap();
             let file = match file_dict.files.remove(src_fname) {
                 Some(file_info) => file_info,
@@ -282,10 +272,13 @@ impl Dicts {
                 }
             };
             let method = file.method;
-            file_dict.files.insert(dst_fname.to_owned(), file);
-            method
+            file_dict.files.insert(dst_fname.to_owned(), file.clone());
+            let file_num = file_dict.files.len() as _;
+            (method, file, file_num)
         };
-        self.save_file_dict()?;
+        log_file.replace(src_fname, dst_fname, file)?;
+
+        ENCRYPTION_FILE_NUM_GAUGE.set(file_num);
 
         if method != compat(EncryptionMethod::Plaintext) {
             info!("rename encrypted file"; "src" => src_fname, "dst" => dst_fname);
@@ -395,6 +388,7 @@ pub struct DataKeyManager {
     dicts: Arc<Dicts>,
     method: EncryptionMethod,
     rotate_terminal: channel::Sender<()>,
+    background_worker: Option<JoinHandle<()>>,
 }
 
 impl DataKeyManager {
@@ -407,6 +401,7 @@ impl DataKeyManager {
             &config.previous_master_key,
             config.data_encryption_method,
             config.data_key_rotation_period.into(),
+            config.file_rewrite_threshold,
             dict_path,
         )
     }
@@ -416,6 +411,7 @@ impl DataKeyManager {
         previous_master_key_config: &MasterKeyConfig,
         method: EncryptionMethod,
         rotation_period: Duration,
+        file_rewrite_threshold: u64,
         dict_path: &str,
     ) -> Result<Option<DataKeyManager>> {
         let master_key = create_backend(master_key_config).map_err(|e| {
@@ -428,7 +424,12 @@ impl DataKeyManager {
             ));
         }
         let dicts = match (
-            Dicts::open(dict_path, rotation_period, master_key.as_ref()),
+            Dicts::open(
+                dict_path,
+                rotation_period,
+                master_key.as_ref(),
+                file_rewrite_threshold,
+            ),
             method,
         ) {
             // Encryption is disabled.
@@ -439,7 +440,7 @@ impl DataKeyManager {
             // Encryption is being enabled.
             (Ok(None), _) => {
                 info!("encryption is being enabled. method = {:?}", method);
-                Dicts::new(dict_path, rotation_period)
+                Dicts::new(dict_path, rotation_period, file_rewrite_threshold)?
             }
             // Encryption was enabled and master key didn't change.
             (Ok(Some(dicts)), _) => {
@@ -456,19 +457,24 @@ impl DataKeyManager {
                     master_key_config, previous_master_key_config
                 );
                 let previous_master_key = create_backend(previous_master_key_config)?;
-                let dicts = Dicts::open(dict_path, rotation_period, previous_master_key.as_ref())
-                    .map_err(|e| {
-                        if let Error::WrongMasterKey(e_previous) = e {
-                            Error::BothMasterKeyFail(e_current, e_previous)
-                        } else {
-                            e
-                        }
-                    })?
-                    .ok_or_else(|| {
-                        Error::Other(box_err!(
-                            "Fallback to previous master key but find dictionaries to be empty."
-                        ))
-                    })?;
+                let dicts = Dicts::open(
+                    dict_path,
+                    rotation_period,
+                    previous_master_key.as_ref(),
+                    file_rewrite_threshold,
+                )
+                .map_err(|e| {
+                    if let Error::WrongMasterKey(e_previous) = e {
+                        Error::BothMasterKeyFail(e_current, e_previous)
+                    } else {
+                        e
+                    }
+                })?
+                .ok_or_else(|| {
+                    Error::Other(box_err!(
+                        "Fallback to previous master key but find dictionaries to be empty."
+                    ))
+                })?;
                 // Rewrite key_dict after replace master key.
                 dicts.save_key_dict(master_key.as_ref())?;
 
@@ -484,8 +490,8 @@ impl DataKeyManager {
         let dicts = Arc::new(dicts);
         let dict_clone = dicts.clone();
         let (rotate_terminal, rx) = channel::bounded(1);
-        std::thread::Builder::new()
-            .name(thd_name!("encryption-rotate-key"))
+        let background_worker = std::thread::Builder::new()
+            .name(thd_name!("enc:key"))
             .spawn(move || {
                 run_background_rotate_work(dict_clone, method, master_key, rx);
             })?;
@@ -496,6 +502,7 @@ impl DataKeyManager {
             dicts,
             method,
             rotate_terminal,
+            background_worker: Some(background_worker),
         }))
     }
 
@@ -544,18 +551,13 @@ impl DataKeyManager {
     }
 
     pub fn dump_file_dict(dict_path: &str, file_path: Option<&str>) -> Result<()> {
-        let dict_file = EncryptedFile::new(Path::new(dict_path), FILE_DICT_NAME);
-        let config = MasterKeyConfig::Plaintext;
-        let backend = create_backend(&config)?;
-        let dict_bytes = dict_file.read(backend.as_ref())?;
-        let mut dict = FileDictionary::default();
-        dict.merge_from_bytes(&dict_bytes)?;
+        let (_, file_dict) = LogFile::open(dict_path, FILE_DICT_NAME, 1, true)?;
         if let Some(file_path) = file_path {
-            if let Some(info) = dict.files.get(file_path) {
+            if let Some(info) = file_dict.files.get(file_path) {
                 println!("{}: {:?}", file_path, info);
             }
         } else {
-            for (path, info) in dict.files.iter() {
+            for (path, info) in file_dict.files.iter() {
                 println!("{}: {:?}", path, info);
             }
         }
@@ -566,6 +568,7 @@ impl DataKeyManager {
 impl Drop for DataKeyManager {
     fn drop(&mut self) {
         self.rotate_terminal.send(()).unwrap();
+        self.background_worker.take().unwrap().join().unwrap();
     }
 }
 
@@ -631,6 +634,7 @@ mod tests {
     use super::*;
     use crate::config::{FileConfig, Mock};
     use crate::master_key::tests::MockBackend;
+    use crate::master_key::PlaintextBackend;
 
     use engine_traits::EncryptionMethod as DBEncryptionMethod;
     use matches::assert_matches;
@@ -657,6 +661,7 @@ mod tests {
             &previous_master_key,
             method.unwrap_or(EncryptionMethod::Aes256Ctr),
             Duration::from_secs(60),
+            2,
             tmp.path().as_os_str().to_str().unwrap(),
         );
         (tmp, manager)

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -136,6 +136,11 @@ impl<T: Simulator> Cluster<T> {
         }
     }
 
+    // To destroy temp dir later.
+    pub fn take_path(&mut self) -> Vec<TempDir> {
+        std::mem::replace(&mut self.paths, vec![])
+    }
+
     pub fn id(&self) -> u64 {
         self.cfg.server.cluster_id
     }

--- a/components/test_util/src/encryption.rs
+++ b/components/test_util/src/encryption.rs
@@ -30,6 +30,7 @@ pub fn new_test_key_manager(
         &previous_master_key,
         method.unwrap_or(EncryptionMethod::Aes256Ctr),
         Duration::from_secs(60),
+        2,
         tmp.path().as_os_str().to_str().unwrap(),
     );
     (tmp, manager)

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -587,6 +587,7 @@ fn test_serde_custom_tikv_config() {
                 },
             },
             previous_master_key: MasterKeyConfig::Plaintext,
+            file_rewrite_threshold: 1000000,
         },
     };
     value.backup = BackupConfig { num_threads: 456 };

--- a/tests/integrations/server_encryption.rs
+++ b/tests/integrations/server_encryption.rs
@@ -22,10 +22,12 @@ fn test_snapshot_encryption<T: Simulator>(cluster: &mut Cluster<T>) {
 fn test_node_snapshot_encryption() {
     let mut cluster = new_node_cluster(0, 2);
     test_snapshot_encryption(&mut cluster);
+    std::mem::forget(cluster.take_path());
 }
 
 #[test]
 fn test_server_snapshot_encryption() {
     let mut cluster = new_server_cluster(0, 2);
     test_snapshot_encryption(&mut cluster);
+    std::mem::forget(cluster.take_path());
 }


### PR DESCRIPTION
cherry-pick #8865 to release-4.0

## What problem does this PR solve?
Issue Number: close #8212

## Problem Summary:
When file number is large, file dictionary size is large too, so TiKV needs more time to rewrite the file dictionary.

## What is changed and how it works?
Add a new file format LogFile, it supports append writing.

## Release note
- Turn file dictionary into log style.