### PR TITLE
*: fix counter overflow

### DIFF
--- a/components/tikv_util/src/worker/pool.rs
+++ b/components/tikv_util/src/worker/pool.rs
@@ -379,7 +379,8 @@ impl Worker {
 
     /// Checks if underlying worker can't handle task immediately.
     pub fn is_busy(&self) -> bool {
-        self.stop.load(Ordering::Acquire) || self.counter.load(Ordering::Acquire) >= self.thread_count
+        self.stop.load(Ordering::Acquire)
+            || self.counter.load(Ordering::Acquire) >= self.thread_count
     }
 
     fn start_impl<R: Runnable + 'static>(

--- a/components/tikv_util/src/worker/pool.rs
+++ b/components/tikv_util/src/worker/pool.rs
@@ -113,19 +113,21 @@ impl<T: Display + Send> Scheduler<T> {
         if self.counter.load(Ordering::Acquire) >= self.pending_capacity {
             return Err(ScheduleError::Full(task));
         }
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        self.metrics_pending_task_count.inc();
         if let Err(e) = self.sender.unbounded_send(Msg::Task(task)) {
             if let Msg::Task(t) = e.into_inner() {
+                self.counter.fetch_sub(1, Ordering::SeqCst);
+                self.metrics_pending_task_count.dec();
                 return Err(ScheduleError::Stopped(t));
             }
         }
-        self.metrics_pending_task_count.inc();
-        self.counter.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 
     /// Checks if underlying worker can't handle task immediately.
     pub fn is_busy(&self) -> bool {
-        self.counter.load(Ordering::SeqCst) > 0
+        self.counter.load(Ordering::Acquire) > 0
     }
 
     pub fn stop(&self) {
@@ -285,6 +287,7 @@ impl<S: Into<String>> Builder<S> {
             pool,
             counter: Arc::new(AtomicUsize::new(0)),
             pending_capacity: self.pending_capacity,
+            thread_count: self.thread_count,
         }
     }
 }
@@ -297,6 +300,7 @@ pub struct Worker {
     pending_capacity: usize,
     counter: Arc<AtomicUsize>,
     stop: Arc<AtomicBool>,
+    thread_count: usize,
 }
 
 impl Worker {
@@ -368,14 +372,14 @@ impl Worker {
     /// Stops the worker thread.
     pub fn stop(&self) {
         if let Some(pool) = self.pool.lock().unwrap().take() {
-            pool.shutdown();
             self.stop.store(true, Ordering::Release);
+            pool.shutdown();
         }
     }
 
     /// Checks if underlying worker can't handle task immediately.
     pub fn is_busy(&self) -> bool {
-        self.stop.load(Ordering::SeqCst) || self.counter.load(Ordering::SeqCst) > 0
+        self.stop.load(Ordering::Acquire) || self.counter.load(Ordering::Acquire) >= self.thread_count
     }
 
     fn start_impl<R: Runnable + 'static>(
@@ -391,7 +395,7 @@ impl Worker {
                 match msg {
                     Msg::Task(task) => {
                         handle.inner.run(task);
-                        counter.fetch_sub(1, Ordering::Relaxed);
+                        counter.fetch_sub(1, Ordering::SeqCst);
                         metrics_pending_task_count.dec();
                     }
                     Msg::Timeout => (),
@@ -418,7 +422,7 @@ impl Worker {
                 match msg {
                     Msg::Task(task) => {
                         handle.inner.run(task);
-                        counter.fetch_sub(1, Ordering::Relaxed);
+                        counter.fetch_sub(1, Ordering::SeqCst);
                         metrics_pending_task_count.dec();
                     }
                     Msg::Timeout => {


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/8970

Problem Summary:
If the thread of `Worker` run too fast, the counter may call `sub` before scheduler call `add`,  so we will make the counter be `usize::MAX`.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note