### PR TITLE
importer: rename sst file with key manager to fix ingest sst failure

### DIFF
--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -443,6 +443,7 @@ impl SSTImporter {
             write_path,
             default_meta,
             write_meta,
+            self.key_manager.clone(),
         ))
     }
 }
@@ -456,6 +457,7 @@ pub struct SSTWriter<E: KvEngine> {
     write_entries: u64,
     write_path: ImportPath,
     write_meta: SstMeta,
+    key_manager: Option<Arc<DataKeyManager>>,
 }
 
 impl<E: KvEngine> SSTWriter<E> {
@@ -466,6 +468,7 @@ impl<E: KvEngine> SSTWriter<E> {
         write_path: ImportPath,
         default_meta: SstMeta,
         write_meta: SstMeta,
+        key_manager: Option<Arc<DataKeyManager>>,
     ) -> Self {
         SSTWriter {
             default,
@@ -476,6 +479,7 @@ impl<E: KvEngine> SSTWriter<E> {
             write_path,
             write_entries: 0,
             write_meta,
+            key_manager,
         }
     }
 
@@ -511,15 +515,15 @@ impl<E: KvEngine> SSTWriter<E> {
         let mut metas = Vec::with_capacity(2);
         let (default_entries, write_entries) = (self.default_entries, self.write_entries);
         let (p1, p2) = (self.default_path.clone(), self.write_path.clone());
-        let (w1, w2) = (self.default, self.write);
+        let (w1, w2, key_manager) = (self.default, self.write, self.key_manager);
         if default_entries > 0 {
             w1.finish()?;
-            Self::save(p1)?;
+            Self::save(p1, key_manager.as_ref())?;
             metas.push(default_meta);
         }
         if write_entries > 0 {
             w2.finish()?;
-            Self::save(p2)?;
+            Self::save(p2, key_manager.as_ref())?;
             metas.push(write_meta);
         }
         info!("finish write to sst";
@@ -530,8 +534,19 @@ impl<E: KvEngine> SSTWriter<E> {
     }
 
     // move file from temp to save.
-    fn save(mut import_path: ImportPath) -> Result<()> {
+    fn save(mut import_path: ImportPath, key_manager: Option<&Arc<DataKeyManager>>) -> Result<()> {
         fs::rename(&import_path.temp, &import_path.save)?;
+        if let Some(ref key_manager) = key_manager {
+            let temp_str = import_path
+                .temp
+                .to_str()
+                .ok_or_else(|| Error::InvalidSSTPath(import_path.temp.clone()))?;
+            let save_str = import_path
+                .save
+                .to_str()
+                .ok_or_else(|| Error::InvalidSSTPath(import_path.save.clone()))?;
+            key_manager.rename_file(temp_str, save_str)?;
+        }
         // sync the directory after rename
         import_path.save.pop();
         sync_dir(&import_path.save)?;

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -536,7 +536,7 @@ impl<E: KvEngine> SSTWriter<E> {
     // move file from temp to save.
     fn save(mut import_path: ImportPath, key_manager: Option<&DataKeyManager>) -> Result<()> {
         fs::rename(&import_path.temp, &import_path.save)?;
-        if let Some(ref key_manager) = key_manager {
+        if let Some(key_manager) = key_manager {
             let temp_str = import_path
                 .temp
                 .to_str()

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -518,12 +518,12 @@ impl<E: KvEngine> SSTWriter<E> {
         let (w1, w2, key_manager) = (self.default, self.write, self.key_manager);
         if default_entries > 0 {
             w1.finish()?;
-            Self::save(p1, key_manager.as_ref())?;
+            Self::save(p1, key_manager.as_deref())?;
             metas.push(default_meta);
         }
         if write_entries > 0 {
             w2.finish()?;
-            Self::save(p2, key_manager.as_ref())?;
+            Self::save(p2, key_manager.as_deref())?;
             metas.push(write_meta);
         }
         info!("finish write to sst";
@@ -534,7 +534,7 @@ impl<E: KvEngine> SSTWriter<E> {
     }
 
     // move file from temp to save.
-    fn save(mut import_path: ImportPath, key_manager: Option<&Arc<DataKeyManager>>) -> Result<()> {
+    fn save(mut import_path: ImportPath, key_manager: Option<&DataKeyManager>) -> Result<()> {
         fs::rename(&import_path.temp, &import_path.save)?;
         if let Some(ref key_manager) = key_manager {
             let temp_str = import_path

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -266,7 +266,7 @@ impl Simulator for ServerCluster {
         // Create import service.
         let importer = {
             let dir = Path::new(engines.kv.path()).join("import-sst");
-            Arc::new(SSTImporter::new(dir, None).unwrap())
+            Arc::new(SSTImporter::new(dir, key_manager.clone()).unwrap())
         };
         let import_service = ImportSSTService::new(
             cfg.import.clone(),

--- a/components/test_util/src/encryption.rs
+++ b/components/test_util/src/encryption.rs
@@ -15,20 +15,20 @@ pub fn create_test_key_file(path: &str) {
 fn new_test_file_master_key(tmp: &tempfile::TempDir) -> MasterKeyConfig {
     let key_path = tmp.path().join("test_key").to_str().unwrap().to_owned();
     create_test_key_file(&key_path);
-    return MasterKeyConfig::File {
+    MasterKeyConfig::File {
         config: FileConfig { path: key_path },
-    };
+    }
 }
 
 pub fn new_file_security_config(dir: &tempfile::TempDir) -> EncryptionConfig {
     let master_key_cfg = new_test_file_master_key(dir);
-    return EncryptionConfig {
+    EncryptionConfig {
         data_encryption_method: EncryptionMethod::Aes256Ctr,
         data_key_rotation_period: ReadableDuration::days(7),
         file_rewrite_threshold: 100000,
         master_key: master_key_cfg.clone(),
         previous_master_key: master_key_cfg,
-    };
+    }
 }
 
 pub fn new_test_key_manager(

--- a/components/test_util/src/encryption.rs
+++ b/components/test_util/src/encryption.rs
@@ -2,13 +2,33 @@
 
 use std::{fs::File, io::Write, time::Duration};
 
-use encryption::{DataKeyManager, FileConfig, MasterKeyConfig, Result};
+use encryption::{DataKeyManager, EncryptionConfig, FileConfig, MasterKeyConfig, Result};
 use kvproto::encryptionpb::EncryptionMethod;
+use tikv_util::config::ReadableDuration;
 
 pub fn create_test_key_file(path: &str) {
     let mut file = File::create(path).unwrap();
     file.write_all(b"603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4\n")
         .unwrap();
+}
+
+fn new_test_file_master_key(tmp: &tempfile::TempDir) -> MasterKeyConfig {
+    let key_path = tmp.path().join("test_key").to_str().unwrap().to_owned();
+    create_test_key_file(&key_path);
+    return MasterKeyConfig::File {
+        config: FileConfig { path: key_path },
+    };
+}
+
+pub fn new_file_security_config(dir: &tempfile::TempDir) -> EncryptionConfig {
+    let master_key_cfg = new_test_file_master_key(dir);
+    return EncryptionConfig {
+        data_encryption_method: EncryptionMethod::Aes256Ctr,
+        data_key_rotation_period: ReadableDuration::days(7),
+        file_rewrite_threshold: 100000,
+        master_key: master_key_cfg.clone(),
+        previous_master_key: master_key_cfg,
+    };
 }
 
 pub fn new_test_key_manager(
@@ -18,11 +38,7 @@ pub fn new_test_key_manager(
     previous_master_key: Option<MasterKeyConfig>,
 ) -> (tempfile::TempDir, Result<Option<DataKeyManager>>) {
     let tmp = temp.unwrap_or_else(|| tempfile::TempDir::new().unwrap());
-    let key_path = tmp.path().join("test_key").to_str().unwrap().to_owned();
-    create_test_key_file(&key_path);
-    let default_config = MasterKeyConfig::File {
-        config: FileConfig { path: key_path },
-    };
+    let default_config = new_test_file_master_key(&tmp);
     let master_key = master_key.unwrap_or_else(|| default_config.clone());
     let previous_master_key = previous_master_key.unwrap_or(default_config);
     let manager = DataKeyManager::new(

--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -15,6 +15,7 @@ mod security;
 
 use std::env;
 
+pub use crate::encryption::*;
 pub use crate::kv_generator::*;
 pub use crate::logging::*;
 pub use crate::macros::*;

--- a/tests/integrations/import/util.rs
+++ b/tests/integrations/import/util.rs
@@ -10,6 +10,7 @@ use grpcio::{ChannelBuilder, Environment, Result, WriteFlags};
 use kvproto::import_sstpb::*;
 use kvproto::kvrpcpb::*;
 use kvproto::tikvpb::*;
+use security::SecurityConfig;
 use uuid::Uuid;
 
 use test_raftstore::*;
@@ -17,12 +18,15 @@ use tikv_util::HandyRwLock;
 
 const CLEANUP_SST_MILLIS: u64 = 10;
 
-pub fn new_cluster() -> (Cluster<ServerCluster>, Context) {
+pub fn new_cluster(security_conf: Option<SecurityConfig>) -> (Cluster<ServerCluster>, Context) {
     let count = 1;
     let mut cluster = new_server_cluster(0, count);
     let cleanup_interval = Duration::from_millis(CLEANUP_SST_MILLIS);
     cluster.cfg.raft_store.cleanup_import_sst_interval.0 = cleanup_interval;
     cluster.cfg.server.grpc_concurrency = 1;
+    if let Some(cfg) = security_conf {
+        cluster.cfg.security = cfg;
+    }
     cluster.run();
 
     let region_id = 1;
@@ -36,23 +40,51 @@ pub fn new_cluster() -> (Cluster<ServerCluster>, Context) {
     (cluster, ctx)
 }
 
-pub fn new_cluster_and_tikv_import_client(
+fn open_cluster_and_tikv_import_client(
+    security_cfg: Option<SecurityConfig>,
 ) -> (Cluster<ServerCluster>, Context, TikvClient, ImportSstClient) {
-    let (cluster, ctx) = new_cluster();
+    let (cluster, ctx) = new_cluster(security_cfg.clone());
 
     let ch = {
         let env = Arc::new(Environment::new(1));
         let node = ctx.get_peer().get_store_id();
-        ChannelBuilder::new(env)
+        let builder = ChannelBuilder::new(env)
             .http2_max_ping_strikes(i32::MAX) // For pings without data from clients.
             .keepalive_time(cluster.cfg.server.grpc_keepalive_time.into())
-            .keepalive_timeout(cluster.cfg.server.grpc_keepalive_timeout.into())
-            .connect(&cluster.sim.rl().get_addr(node))
+            .keepalive_timeout(cluster.cfg.server.grpc_keepalive_timeout.into());
+
+        if security_cfg.is_some() {
+            let creds = test_util::new_channel_cred();
+            builder.secure_connect(&cluster.sim.rl().get_addr(node), creds)
+        } else {
+            builder.connect(&cluster.sim.rl().get_addr(node))
+        }
     };
     let tikv = TikvClient::new(ch.clone());
     let import = ImportSstClient::new(ch);
 
     (cluster, ctx, tikv, import)
+}
+
+pub fn new_cluster_and_tikv_import_client(
+) -> (Cluster<ServerCluster>, Context, TikvClient, ImportSstClient) {
+    return open_cluster_and_tikv_import_client(None);
+}
+
+pub fn new_cluster_and_tikv_import_client_tde() -> (
+    tempfile::TempDir,
+    Cluster<ServerCluster>,
+    Context,
+    TikvClient,
+    ImportSstClient,
+) {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let encryption_cfg = test_util::new_file_security_config(&tmp_dir);
+    let mut security = test_util::new_security_cfg(None);
+    security.encryption = encryption_cfg;
+
+    let (cluster, ctx, tikv, import) = open_cluster_and_tikv_import_client(Some(security));
+    return (tmp_dir, cluster, ctx, tikv, import);
 }
 
 pub fn new_sst_meta(crc32: u32, length: u64) -> SstMeta {


### PR DESCRIPTION
Signed-off-by: glorv <glorvs@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Fix ingest lightning written sst files failure with TDE enabled. 

### What is changed and how it works?
In #8852, if tikv TDE is enabled, the sst file written by lightning will be encrypted, but the save action renames the encrypt file but not register this action in the key manager, thus, when ingesting this sst file, rocksdb will treat it as unencrypted and fail.

So this pr add an extra `DataKeyManager::rename_files` to the original file rename action and add an integration test to test write and ingest sst with TDE enabled.

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
- Fix the bug that lightning fails to ingest sst files to tikv with importer/local backend when TDE is enabled