### PR TITLE
misc: Update KvProto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#9616d46d226248544d942aa79ee3948e7e7f7ac2"
+source = "git+https://github.com/pingcap/kvproto.git#2f1a3bc78fc900dc5f9d0914828cf8cc8c25a63d"
 dependencies = [
  "futures 0.3.7",
  "grpcio",

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -432,7 +432,7 @@ impl<E: Engine> Endpoint<E> {
         let mut storage_stats = Statistics::default();
         handler.collect_scan_statistics(&mut storage_stats);
         tracker.collect_storage_statistics(storage_stats);
-        let exec_details = tracker.get_exec_details();
+        let (exec_details, exec_details_v2) = tracker.get_exec_details();
         tracker.on_finish_all_items();
 
         let mut resp = match result {
@@ -443,6 +443,7 @@ impl<E: Engine> Endpoint<E> {
             Err(e) => make_error_response(e),
         };
         resp.set_exec_details(exec_details);
+        resp.set_exec_details_v2(exec_details_v2);
         Ok(resp)
     }
 
@@ -554,12 +555,13 @@ impl<E: Engine> Endpoint<E> {
                     result
                 };
 
-                let exec_details = tracker.get_item_exec_details();
+                let (exec_details, exec_details_v2) = tracker.get_item_exec_details();
 
                 match result {
                     Err(e) => {
                         let mut resp = make_error_response(e);
                         resp.set_exec_details(exec_details);
+                        resp.set_exec_details_v2(exec_details_v2);
                         yield resp;
                         break;
                     },
@@ -567,6 +569,7 @@ impl<E: Engine> Endpoint<E> {
                     Ok((Some(mut resp), finished)) => {
                         COPR_RESP_SIZE.inc_by(resp.data.len() as i64);
                         resp.set_exec_details(exec_details);
+                        resp.set_exec_details_v2(exec_details_v2);
                         yield resp;
                         if finished {
                             break;
@@ -1305,7 +1308,7 @@ mod tests {
 
         // A request that requests execution details.
         let mut req_with_exec_detail = ReqContext::default_for_test();
-        req_with_exec_detail.context.set_handle_time(true);
+        req_with_exec_detail.context.set_record_time_stat(true);
 
         {
             let mut wait_time: i64 = 0;
@@ -1342,19 +1345,27 @@ mod tests {
             let resp = &rx.recv().unwrap()[0];
             assert!(resp.get_other_error().is_empty());
             assert_ge!(
-                resp.get_exec_details().get_handle_time().get_process_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_SMALL - COARSE_ERROR_MS
             );
             assert_lt!(
-                resp.get_exec_details().get_handle_time().get_process_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_SMALL + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
             assert_ge!(
-                resp.get_exec_details().get_handle_time().get_wait_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_wait_wall_time_ms(),
                 wait_time - HANDLE_ERROR_MS - COARSE_ERROR_MS
             );
             assert_lt!(
-                resp.get_exec_details().get_handle_time().get_wait_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_wait_wall_time_ms(),
                 wait_time + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
             wait_time += PAYLOAD_SMALL - SNAPSHOT_DURATION_MS;
@@ -1363,19 +1374,27 @@ mod tests {
             let resp = &rx.recv().unwrap()[0];
             assert!(!resp.get_other_error().is_empty());
             assert_ge!(
-                resp.get_exec_details().get_handle_time().get_process_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_LARGE - COARSE_ERROR_MS
             );
             assert_lt!(
-                resp.get_exec_details().get_handle_time().get_process_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_LARGE + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
             assert_ge!(
-                resp.get_exec_details().get_handle_time().get_wait_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_wait_wall_time_ms(),
                 wait_time - HANDLE_ERROR_MS - COARSE_ERROR_MS
             );
             assert_lt!(
-                resp.get_exec_details().get_handle_time().get_wait_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_wait_wall_time_ms(),
                 wait_time + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
         }
@@ -1415,11 +1434,15 @@ mod tests {
             let resp = &rx.recv().unwrap()[0];
             assert!(resp.get_other_error().is_empty());
             assert_ge!(
-                resp.get_exec_details().get_handle_time().get_process_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_SMALL - COARSE_ERROR_MS
             );
             assert_lt!(
-                resp.get_exec_details().get_handle_time().get_process_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_SMALL + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
 
@@ -1427,11 +1450,15 @@ mod tests {
             let resp = &rx.recv().unwrap()[0];
             assert!(!resp.get_other_error().is_empty());
             assert_ge!(
-                resp.get_exec_details().get_handle_time().get_process_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_LARGE - COARSE_ERROR_MS
             );
             assert_lt!(
-                resp.get_exec_details().get_handle_time().get_process_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_LARGE + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
         }
@@ -1486,19 +1513,27 @@ mod tests {
             let resp = &rx.recv().unwrap()[0];
             assert!(resp.get_other_error().is_empty());
             assert_ge!(
-                resp.get_exec_details().get_handle_time().get_process_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_LARGE - COARSE_ERROR_MS
             );
             assert_lt!(
-                resp.get_exec_details().get_handle_time().get_process_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_LARGE + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
             assert_ge!(
-                resp.get_exec_details().get_handle_time().get_wait_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_wait_wall_time_ms(),
                 wait_time - HANDLE_ERROR_MS - COARSE_ERROR_MS
             );
             assert_lt!(
-                resp.get_exec_details().get_handle_time().get_wait_ms(),
+                resp.get_exec_details()
+                    .get_time_detail()
+                    .get_wait_wall_time_ms(),
                 wait_time + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
             wait_time += PAYLOAD_LARGE - SNAPSHOT_DURATION_MS;
@@ -1510,23 +1545,29 @@ mod tests {
             assert_ge!(
                 resp[0]
                     .get_exec_details()
-                    .get_handle_time()
-                    .get_process_ms(),
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_SMALL - COARSE_ERROR_MS
             );
             assert_lt!(
                 resp[0]
                     .get_exec_details()
-                    .get_handle_time()
-                    .get_process_ms(),
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_SMALL + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
             assert_ge!(
-                resp[0].get_exec_details().get_handle_time().get_wait_ms(),
+                resp[0]
+                    .get_exec_details()
+                    .get_time_detail()
+                    .get_wait_wall_time_ms(),
                 wait_time - HANDLE_ERROR_MS - COARSE_ERROR_MS
             );
             assert_lt!(
-                resp[0].get_exec_details().get_handle_time().get_wait_ms(),
+                resp[0]
+                    .get_exec_details()
+                    .get_time_detail()
+                    .get_wait_wall_time_ms(),
                 wait_time + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
 
@@ -1534,23 +1575,29 @@ mod tests {
             assert_ge!(
                 resp[1]
                     .get_exec_details()
-                    .get_handle_time()
-                    .get_process_ms(),
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_LARGE - COARSE_ERROR_MS
             );
             assert_lt!(
                 resp[1]
                     .get_exec_details()
-                    .get_handle_time()
-                    .get_process_ms(),
+                    .get_time_detail()
+                    .get_process_wall_time_ms(),
                 PAYLOAD_LARGE + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
             assert_ge!(
-                resp[1].get_exec_details().get_handle_time().get_wait_ms(),
+                resp[1]
+                    .get_exec_details()
+                    .get_time_detail()
+                    .get_wait_wall_time_ms(),
                 wait_time - HANDLE_ERROR_MS - COARSE_ERROR_MS
             );
             assert_lt!(
-                resp[1].get_exec_details().get_handle_time().get_wait_ms(),
+                resp[1]
+                    .get_exec_details()
+                    .get_time_detail()
+                    .get_wait_wall_time_ms(),
                 wait_time + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
         }

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -150,27 +150,32 @@ impl Tracker {
     /// Get current item's ExecDetail according to previous collected metrics.
     /// TiDB asks for ExecDetail to be printed in its log.
     /// WARN: TRY BEST NOT TO USE THIS FUNCTION.
-    pub fn get_item_exec_details(&self) -> kvrpcpb::ExecDetails {
+    pub fn get_item_exec_details(&self) -> (kvrpcpb::ExecDetails, kvrpcpb::ExecDetailsV2) {
         assert_eq!(self.current_stage, TrackerState::ItemFinished);
         self.exec_details(self.item_process_time)
     }
 
     /// Get ExecDetail according to previous collected metrics.
     /// TiDB asks for ExecDetail to be printed in its log.
-    pub fn get_exec_details(&self) -> kvrpcpb::ExecDetails {
+    pub fn get_exec_details(&self) -> (kvrpcpb::ExecDetails, kvrpcpb::ExecDetailsV2) {
         assert_eq!(self.current_stage, TrackerState::ItemFinished);
         self.exec_details(self.total_process_time)
     }
 
-    fn exec_details(&self, measure: Duration) -> kvrpcpb::ExecDetails {
+    fn exec_details(&self, measure: Duration) -> (kvrpcpb::ExecDetails, kvrpcpb::ExecDetailsV2) {
+        // For compatibility, ExecDetails field is still filled.
         let mut exec_details = kvrpcpb::ExecDetails::default();
 
-        let mut handle = kvrpcpb::HandleTime::default();
-        handle.set_process_ms((time::duration_to_sec(measure) * 1000.0) as i64);
-        handle.set_wait_ms((time::duration_to_sec(self.wait_time) * 1000.0) as i64);
-        exec_details.set_handle_time(handle);
+        let mut td = kvrpcpb::TimeDetail::default();
+        td.set_process_wall_time_ms(time::duration_to_ms(measure) as i64);
+        td.set_wait_wall_time_ms(time::duration_to_ms(self.wait_time) as i64);
+        exec_details.set_time_detail(td.clone());
 
         let detail = self.total_storage_stats.scan_detail();
+        exec_details.set_scan_detail(detail);
+
+        let mut exec_details_v2 = kvrpcpb::ExecDetailsV2::default();
+        exec_details_v2.set_time_detail(td);
 
         let mut detail_v2 = ScanDetailV2::default();
         detail_v2.set_processed_versions(self.total_storage_stats.write.processed_keys as u64);
@@ -186,11 +191,9 @@ impl Tracker {
         );
         detail_v2.set_rocksdb_block_read_count(self.total_perf_stats.0.block_read_count as u64);
         detail_v2.set_rocksdb_block_read_byte(self.total_perf_stats.0.block_read_byte as u64);
+        exec_details_v2.set_scan_detail_v2(detail_v2);
 
-        exec_details.set_use_scan_detail_v2(true);
-        exec_details.set_scan_detail(detail);
-        exec_details.set_scan_detail_v2(detail_v2);
-        exec_details
+        (exec_details, exec_details_v2)
     }
 
     pub fn on_finish_all_items(&mut self) {

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -101,8 +101,10 @@ fn future_batch_get_command<E: Engine, L: LockManager>(
                     } else {
                         match v {
                             Ok((val, statistics, perf_statistics_delta)) => {
-                                statistics.write_scan_detail(resp.mut_scan_detail_v2());
-                                perf_statistics_delta.write_scan_detail(resp.mut_scan_detail_v2());
+                                let scan_detail_v2 =
+                                    resp.mut_exec_details_v2().mut_scan_detail_v2();
+                                statistics.write_scan_detail(scan_detail_v2);
+                                perf_statistics_delta.write_scan_detail(scan_detail_v2);
                                 match val {
                                     Some(val) => resp.set_value(val),
                                     None => resp.set_not_found(true),

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -994,27 +994,27 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
 
     fn dispatch_mpp_task(
         &mut self,
-        _: RpcContext<'_>,
-        _: DispatchTaskRequest,
-        _: UnarySink<DispatchTaskResponse>,
+        _ctx: RpcContext<'_>,
+        _req: DispatchTaskRequest,
+        _sink: UnarySink<DispatchTaskResponse>,
     ) {
         unimplemented!()
     }
 
     fn cancel_mpp_task(
         &mut self,
-        _: RpcContext<'_>,
-        _: CancelTaskRequest,
-        _: UnarySink<CancelTaskResponse>,
+        _ctx: RpcContext<'_>,
+        _req: CancelTaskRequest,
+        _sink: UnarySink<CancelTaskResponse>,
     ) {
         unimplemented!()
     }
 
     fn establish_mpp_connection(
         &mut self,
-        _: RpcContext<'_>,
-        _: EstablishMppConnectionRequest,
-        _: ServerStreamingSink<MppDataPacket>,
+        _ctx: RpcContext<'_>,
+        _req: EstablishMppConnectionRequest,
+        _sink: ServerStreamingSink<MppDataPacket>,
     ) {
         unimplemented!()
     }
@@ -1185,8 +1185,9 @@ fn future_get<E: Engine, L: LockManager>(
         } else {
             match v {
                 Ok((val, statistics, perf_statistics_delta)) => {
-                    statistics.write_scan_detail(resp.mut_scan_detail_v2());
-                    perf_statistics_delta.write_scan_detail(resp.mut_scan_detail_v2());
+                    let scan_detail_v2 = resp.mut_exec_details_v2().mut_scan_detail_v2();
+                    statistics.write_scan_detail(scan_detail_v2);
+                    perf_statistics_delta.write_scan_detail(scan_detail_v2);
                     match val {
                         Some(val) => resp.set_value(val),
                         None => resp.set_not_found(true),
@@ -1241,8 +1242,9 @@ fn future_batch_get<E: Engine, L: LockManager>(
             resp.set_region_error(err);
         } else {
             let (val, statistics, perf_statistics_delta) = extract_kv_pairs_and_statistics(v);
-            statistics.write_scan_detail(resp.mut_scan_detail_v2());
-            perf_statistics_delta.write_scan_detail(resp.mut_scan_detail_v2());
+            let scan_detail_v2 = resp.mut_exec_details_v2().mut_scan_detail_v2();
+            statistics.write_scan_detail(scan_detail_v2);
+            perf_statistics_delta.write_scan_detail(scan_detail_v2);
             resp.set_pairs(val.into());
         }
         Ok(resp)

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -7,7 +7,7 @@ use std::thread;
 use kvproto::coprocessor::Response;
 use kvproto::kvrpcpb::Context;
 use protobuf::Message;
-use tipb::{Chunk, Expr, ExprType, ScalarFuncSig};
+use tipb::{Chunk, Expr, ExprType, ScalarFuncSig, SelectResponse};
 
 use test_coprocessor::*;
 use test_storage::*;
@@ -231,17 +231,21 @@ fn test_scan_detail() {
     ];
 
     for mut req in reqs {
-        req.mut_context().set_scan_detail(true);
-        req.mut_context().set_handle_time(true);
+        req.mut_context().set_record_scan_stat(true);
+        req.mut_context().set_record_time_stat(true);
 
         let resp = handle_request(&endpoint, req);
-        assert!(resp.get_exec_details().has_handle_time());
-
+        assert!(resp.get_exec_details().has_time_detail());
         let scan_detail = resp.get_exec_details().get_scan_detail();
         // Values would occur in data cf are inlined in write cf.
         assert_eq!(scan_detail.get_write().get_total(), 5);
         assert_eq!(scan_detail.get_write().get_processed(), 4);
         assert_eq!(scan_detail.get_lock().get_total(), 1);
+
+        assert!(resp.get_exec_details_v2().has_time_detail());
+        let scan_detail_v2 = resp.get_exec_details_v2().get_scan_detail_v2();
+        assert_eq!(scan_detail_v2.get_total_versions(), 5);
+        assert_eq!(scan_detail_v2.get_processed_versions(), 4);
     }
 }
 
@@ -938,14 +942,23 @@ fn test_del_select() {
     store.commit();
 
     // for dag
-    let req = DAGSelect::from_index(&product, &product["id"]).build();
-    let mut resp = handle_select(&endpoint, req);
-    let spliter = DAGChunkSpliter::new(resp.take_chunks().into(), 1);
+    let mut req = DAGSelect::from_index(&product, &product["id"]).build();
+    req.mut_context().set_record_scan_stat(true);
+
+    let resp = handle_request(&endpoint, req);
+    let mut sel_resp = SelectResponse::default();
+    sel_resp.merge_from_bytes(resp.get_data()).unwrap();
+    let spliter = DAGChunkSpliter::new(sel_resp.take_chunks().into(), 1);
     let mut row_count = 0;
     for _ in spliter {
         row_count += 1;
     }
     assert_eq!(row_count, 5);
+
+    assert!(resp.get_exec_details_v2().has_time_detail());
+    let scan_detail_v2 = resp.get_exec_details_v2().get_scan_detail_v2();
+    assert_eq!(scan_detail_v2.get_total_versions(), 8);
+    assert_eq!(scan_detail_v2.get_processed_versions(), 5);
 }
 
 #[test]
@@ -1642,8 +1655,12 @@ fn test_exec_details() {
     let resp = handle_request(&endpoint, req);
     assert!(resp.has_exec_details());
     let exec_details = resp.get_exec_details();
-    assert!(exec_details.has_handle_time());
+    assert!(exec_details.has_time_detail());
     assert!(exec_details.has_scan_detail());
+    assert!(resp.has_exec_details_v2());
+    let exec_details = resp.get_exec_details_v2();
+    assert!(exec_details.has_time_detail());
+    assert!(exec_details.has_scan_detail_v2());
 }
 
 #[test]

--- a/tests/integrations/server/mod.rs
+++ b/tests/integrations/server/mod.rs
@@ -234,6 +234,13 @@ trait MockKvService {
     unary_call!(split_region, SplitRegionRequest, SplitRegionResponse);
     unary_call!(read_index, ReadIndexRequest, ReadIndexResponse);
     bstream_call!(batch_commands, BatchCommandsRequest, BatchCommandsResponse);
+    unary_call!(dispatch_mpp_task, DispatchTaskRequest, DispatchTaskResponse);
+    unary_call!(cancel_mpp_task, CancelTaskRequest, CancelTaskResponse);
+    sstream_call!(
+        establish_mpp_connection,
+        EstablishMppConnectionRequest,
+        MppDataPacket
+    );
 }
 
 impl<T: MockKvService + Clone + Send + 'static> Tikv for MockKv<T> {
@@ -348,6 +355,13 @@ impl<T: MockKvService + Clone + Send + 'static> Tikv for MockKv<T> {
     unary_call_dispatch!(split_region, SplitRegionRequest, SplitRegionResponse);
     unary_call_dispatch!(read_index, ReadIndexRequest, ReadIndexResponse);
     bstream_call_dispatch!(batch_commands, BatchCommandsRequest, BatchCommandsResponse);
+    unary_call_dispatch!(dispatch_mpp_task, DispatchTaskRequest, DispatchTaskResponse);
+    unary_call_dispatch!(cancel_mpp_task, CancelTaskRequest, CancelTaskResponse);
+    sstream_call_dispatch!(
+        establish_mpp_connection,
+        EstablishMppConnectionRequest,
+        MppDataPacket
+    );
 }
 
 fn mock_kv_service<T>(kv: MockKv<T>, ip: &str, port: u16) -> Result<Server>

--- a/tests/integrations/server/mod.rs
+++ b/tests/integrations/server/mod.rs
@@ -234,13 +234,6 @@ trait MockKvService {
     unary_call!(split_region, SplitRegionRequest, SplitRegionResponse);
     unary_call!(read_index, ReadIndexRequest, ReadIndexResponse);
     bstream_call!(batch_commands, BatchCommandsRequest, BatchCommandsResponse);
-    unary_call!(dispatch_mpp_task, DispatchTaskRequest, DispatchTaskResponse);
-    unary_call!(cancel_mpp_task, CancelTaskRequest, CancelTaskResponse);
-    sstream_call!(
-        establish_mpp_connection,
-        EstablishMppConnectionRequest,
-        MppDataPacket
-    );
 }
 
 impl<T: MockKvService + Clone + Send + 'static> Tikv for MockKv<T> {
@@ -355,13 +348,6 @@ impl<T: MockKvService + Clone + Send + 'static> Tikv for MockKv<T> {
     unary_call_dispatch!(split_region, SplitRegionRequest, SplitRegionResponse);
     unary_call_dispatch!(read_index, ReadIndexRequest, ReadIndexResponse);
     bstream_call_dispatch!(batch_commands, BatchCommandsRequest, BatchCommandsResponse);
-    unary_call_dispatch!(dispatch_mpp_task, DispatchTaskRequest, DispatchTaskResponse);
-    unary_call_dispatch!(cancel_mpp_task, CancelTaskRequest, CancelTaskResponse);
-    sstream_call_dispatch!(
-        establish_mpp_connection,
-        EstablishMppConnectionRequest,
-        MppDataPacket
-    );
 }
 
 fn mock_kv_service<T>(kv: MockKv<T>, ip: &str, port: u16) -> Result<Server>


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

KvProto update https://github.com/pingcap/kvproto/pull/689 introduced some code changes, so that this PR adapts to it.

### What is changed and how it works?

Update code to be compatible with latest KvProto https://github.com/pingcap/kvproto/pull/689

What's Changed:

1. Renames are performed accordingly.
2. Use `ExecDetailsV2` instead of `ScanDetailV2` in Coprocessor response, KvGet response and KvBatchGet response.

   ExecDetailsV2 = ScanDetailV2 + TimeDetail. This makes it possible to return TiKV side process time in future, as proposed in https://github.com/pingcap/kvproto/pull/689

### Related changes

- [ ] Need to cherry-pick to the release branch
- [x] Wait https://github.com/pingcap/kvproto/pull/689 to be merged.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
