### PR TITLE
Fix wrong approximate keys for rawkv

### DIFF
--- a/components/engine_panic/src/range_properties.rs
+++ b/components/engine_panic/src/range_properties.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::engine::PanicEngine;
-use engine_traits::{Range, RangePropertiesExt, Result};
+use engine_traits::{Range, CfName, RangePropertiesExt, Result};
 
 impl RangePropertiesExt for PanicEngine {
     fn get_range_approximate_keys(
@@ -9,7 +9,7 @@ impl RangePropertiesExt for PanicEngine {
         range: Range,
         region_id: u64,
         large_threshold: u64,
-    ) -> Result<u64> {
+    ) -> Result<(CfName, u64)> {
         panic!()
     }
 

--- a/components/engine_rocks/src/range_properties.rs
+++ b/components/engine_rocks/src/range_properties.rs
@@ -3,7 +3,7 @@
 use crate::engine::RocksEngine;
 use crate::properties::{get_range_entries_and_versions, RangeProperties};
 use engine_traits::{
-    MiscExt, Range, RangePropertiesExt, Result, TableProperties, TablePropertiesCollection,
+    MiscExt, Range, RangePropertiesExt, CfName, Result, TableProperties, TablePropertiesCollection,
     TablePropertiesExt, CF_DEFAULT, CF_LOCK, CF_WRITE, LARGE_CFS,
 };
 use std::path::Path;
@@ -14,23 +14,32 @@ impl RangePropertiesExt for RocksEngine {
         range: Range,
         region_id: u64,
         large_threshold: u64,
-    ) -> Result<u64> {
-        // try to get from RangeProperties first.
-        match self.get_range_approximate_keys_cf(CF_WRITE, range, region_id, large_threshold) {
-            Ok(v) => {
-                return Ok(v);
+    ) -> Result<(CfName, u64)> {
+        // For Txn, Return result of CF_WRITE directly if it's not empty.
+        // For RawKV, return result of CF_DEFAULT.
+        let cfs = vec![CF_WRITE, CF_DEFAULT];
+        for cf in cfs {
+            // try to get from RangeProperties first.
+            let num_keys_cf = match self.get_range_approximate_keys_cf(cf, range, region_id, large_threshold) {
+                Ok(v) => v,
+                Err(e) => {
+                    debug!(
+                        "failed to get keys from RangeProperties";
+                        "err" => ?e,
+                    );
+                    let start = &range.start_key;
+                    let end = &range.end_key;
+                    let (_, keys) =
+                        get_range_entries_and_versions(self, CF_WRITE, &start, &end).unwrap_or_default();
+                    keys
+                }
+            };
+            if num_keys_cf > 0 {
+                return Ok((cf, num_keys_cf));
             }
-            Err(e) => debug!(
-                "failed to get keys from RangeProperties";
-                "err" => ?e,
-            ),
         }
 
-        let start = &range.start_key;
-        let end = &range.end_key;
-        let (_, keys) =
-            get_range_entries_and_versions(self, CF_WRITE, &start, &end).unwrap_or_default();
-        Ok(keys)
+        Ok((CF_DEFAULT, 0))
     }
 
     fn get_range_approximate_keys_cf(

--- a/components/engine_traits/src/range_properties.rs
+++ b/components/engine_traits/src/range_properties.rs
@@ -6,7 +6,7 @@
 //! which might require the database to be constructed with specific options.
 
 use crate::errors::Result;
-use crate::Range;
+use crate::{Range, CfName};
 
 pub trait RangePropertiesExt {
     /// Gets the number of keys in a range.
@@ -17,7 +17,7 @@ pub trait RangePropertiesExt {
         range: Range,
         region_id: u64,
         large_threshold: u64,
-    ) -> Result<u64>;
+    ) -> Result<(CfName, u64)>;
 
     fn get_range_approximate_keys_cf(
         &self,

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1112,7 +1112,7 @@ where
                     get_region_approximate_size(&self.db, &region, 0).unwrap_or_default()
                 });
                 let approximate_keys = approximate_keys.unwrap_or_else(|| {
-                    get_region_approximate_keys(&self.db, &region, 0).unwrap_or_default()
+                    get_region_approximate_keys(&self.db, &region, 0).unwrap_or_default().1
                 });
                 let (
                     read_bytes_delta,


### PR DESCRIPTION
Signed-off-by: Connor <zbk602423539@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/5319

Problem Summary: approximate keys always be zero for rawkv  

### What is changed and how it works?

What's Changed:
This PR calculates approximate keys on CF_WRITE first, if the result is 0, it checks CF_DEFAULT then.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
- Fix wrong approximate keys for rawkv