### PR TITLE
Fix test `test_node_snapshot_encryption`

### DIFF
--- a/tests/integrations/server_encryption.rs
+++ b/tests/integrations/server_encryption.rs
@@ -14,6 +14,8 @@ fn test_snapshot_encryption<T: Simulator>(cluster: &mut Cluster<T>) {
 
     cluster.pd_client.must_add_peer(r1, new_learner_peer(2, 2));
     cluster.pd_client.must_add_peer(r1, new_peer(2, 2));
+    // ensure that peer 2 has all previous logs.
+    cluster.must_put(b"00", b"00");
     must_get_equal(&cluster.get_engine(2), b"key-00", b"value");
     must_get_cf_equal(&cluster.get_engine(2), "lock", b"key-50", b"value");
     must_get_cf_equal(&cluster.get_engine(2), "write", b"key-99", b"value");

--- a/tests/integrations/server_encryption.rs
+++ b/tests/integrations/server_encryption.rs
@@ -13,6 +13,7 @@ fn test_snapshot_encryption<T: Simulator>(cluster: &mut Cluster<T>) {
     }
 
     cluster.pd_client.must_add_peer(r1, new_learner_peer(2, 2));
+    cluster.pd_client.must_add_peer(r1, new_peer(2, 2));
     must_get_equal(&cluster.get_engine(2), b"key-00", b"value");
     must_get_cf_equal(&cluster.get_engine(2), "lock", b"key-50", b"value");
     must_get_cf_equal(&cluster.get_engine(2), "write", b"key-99", b"value");


### PR DESCRIPTION
Signed-off-by: Xintao <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/8569

Problem Summary:

If the learner peer is added successfully, but learner has not got all data from leader, `must_get_equal` may fail.

### What is changed and how it works?

promote the peer from learner to voter.

### Release note <!-- bugfixes or new feature need a release note -->
- N/A