### PR TITLE
batch-system: do not process too many messages in one poll

### DIFF
--- a/components/batch-system/src/config.rs
+++ b/components/batch-system/src/config.rs
@@ -14,7 +14,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            max_batch_size: 256,
+            max_batch_size: 1024,
             pool_size: 2,
             reschedule_duration: ReadableDuration::secs(5),
         }

--- a/components/batch-system/tests/cases/batch.rs
+++ b/components/batch-system/tests/cases/batch.rs
@@ -20,12 +20,14 @@ fn test_batch() {
     let tx_ = tx.clone();
     let r = router.clone();
     router
-        .send_control(Message::Callback(Box::new(move |_: &mut Runner| {
-            let (tx, runner) = Runner::new(10);
-            let mailbox = BasicMailbox::new(tx, runner);
-            r.register(1, mailbox);
-            tx_.send(1).unwrap();
-        })))
+        .send_control(Message::Callback(Box::new(
+            move |_: &mut Runner, _: &HandleMetrics| {
+                let (tx, runner) = Runner::new(10);
+                let mailbox = BasicMailbox::new(tx, runner);
+                r.register(1, mailbox);
+                tx_.send(1).unwrap();
+            },
+        )))
         .unwrap();
     assert_eq!(rx.recv_timeout(Duration::from_secs(3)), Ok(1));
     // sleep to wait Batch-System to finish calling end().
@@ -33,7 +35,7 @@ fn test_batch() {
     router
         .send(
             1,
-            Message::Callback(Box::new(move |_: &mut Runner| {
+            Message::Callback(Box::new(move |_: &mut Runner, _: &HandleMetrics| {
                 tx.send(2).unwrap();
             })),
         )
@@ -44,4 +46,95 @@ fn test_batch() {
     expected_metrics.normal = 1;
     expected_metrics.begin = 2;
     assert_eq!(*metrics.lock().unwrap(), expected_metrics);
+}
+
+#[test]
+fn test_process_count() {
+    let (control_tx, control_fsm) = Runner::new(10);
+    let mut cfg = Config::default();
+    cfg.max_batch_size = 10;
+    cfg.pool_size = 1;
+    let (router, mut system) = batch_system::create_system(&cfg, control_tx, control_fsm);
+    let builder = Builder::new();
+    let metrics = builder.metrics.clone();
+    system.spawn("test".to_owned(), builder);
+    let (tx, rx) = mpsc::unbounded();
+
+    for addr in 1..5 {
+        let r = router.clone();
+        let tx_ = tx.clone();
+        router
+            .send_control(Message::Callback(Box::new(
+                move |_: &mut Runner, _: &HandleMetrics| {
+                    let (tx, runner) = Runner::new(100);
+                    let mailbox = BasicMailbox::new(tx, runner);
+                    r.register(addr, mailbox);
+                    tx_.send(1).unwrap();
+                },
+            )))
+            .unwrap();
+        assert_eq!(rx.recv_timeout(Duration::from_secs(3)), Ok(1));
+    }
+
+    // Block batch-system to wait other msg reached.
+    let (tx1, rx1) = mpsc::unbounded();
+    router
+        .send(
+            1,
+            Message::Callback(Box::new(move |_: &mut Runner, _: &HandleMetrics| {
+                let _ = rx1.recv();
+            })),
+        )
+        .unwrap();
+    for _ in 0..cfg.max_batch_size {
+        router.send(1, Message::Loop(1)).unwrap();
+    }
+    let (tx2, rx2) = mpsc::unbounded();
+    let (tx3, rx3) = mpsc::unbounded();
+    router
+        .send(
+            1,
+            Message::Callback(Box::new(move |_, _| {
+                tx3.send(()).unwrap();
+                let _ = rx2.recv();
+            })),
+        )
+        .unwrap();
+    tx1.send(()).unwrap();
+    // block test thread until region-1 blocks by second callback again.
+    let _ = rx3.recv();
+
+    // The handler has not flush because the batch size does not exceed max_batch_size
+    assert_eq!(0, metrics.lock().unwrap().processed_count);
+
+    // The handler has not flush because heartbeat does not make difference
+    router.send(2, Message::HeartBeat).unwrap();
+    let max_batch_size = cfg.max_batch_size;
+    router
+        .send(
+            2,
+            Message::Callback(Box::new(move |_: &mut Runner, m: &HandleMetrics| {
+                assert_eq!(max_batch_size, m.processed_count)
+            })),
+        )
+        .unwrap();
+
+    router.send(3, Message::Loop(1)).unwrap();
+    let (tx4, rx4) = mpsc::unbounded();
+    // The 4th region will notify batch-system and make it aware that the processed count has exceed
+    // max_batch_size
+    router
+        .send(
+            4,
+            Message::Callback(Box::new(move |_, _| {
+                tx4.send(()).unwrap();
+            })),
+        )
+        .unwrap();
+    tx2.send(()).unwrap();
+    let _ = rx4.recv();
+    assert_eq!(
+        cfg.max_batch_size + 1,
+        metrics.lock().unwrap().processed_count
+    );
 }

--- a/components/engine_panic/src/raft_engine.rs
+++ b/components/engine_panic/src/raft_engine.rs
@@ -116,4 +116,8 @@ impl RaftLogBatch for PanicWriteBatch {
     fn is_empty(&self) -> bool {
         panic!()
     }
+
+    fn count(&self) -> usize {
+        panic!()
+    }
 }

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -189,7 +189,7 @@ impl RaftEngine for RocksEngine {
         for idx in from..to {
             let key = keys::raft_log_key(raft_group_id, idx);
             raft_wb.delete(&key)?;
-            if raft_wb.count() >= Self::WRITE_BATCH_MAX_KEYS {
+            if RaftLogBatch::count(&raft_wb) >= Self::WRITE_BATCH_MAX_KEYS {
                 self.write(&raft_wb)?;
                 raft_wb.clear();
             }
@@ -249,6 +249,10 @@ impl RaftLogBatch for RocksWriteBatch {
 
     fn is_empty(&self) -> bool {
         Mutable::is_empty(self)
+    }
+
+    fn count(&self) -> usize {
+        Mutable::count(self)
     }
 }
 

--- a/components/engine_traits/src/raft_engine.rs
+++ b/components/engine_traits/src/raft_engine.rs
@@ -100,6 +100,8 @@ pub trait RaftLogBatch: Send {
     fn put_raft_state(&mut self, raft_group_id: u64, state: &RaftLocalState) -> Result<()>;
 
     fn is_empty(&self) -> bool;
+
+    fn count(&self) -> usize;
 }
 
 #[derive(Clone, Copy, Default)]

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -38,13 +38,17 @@ impl RaftLogEngine {
 }
 
 #[derive(Default)]
-pub struct RaftLogBatch(LogBatch<Entry, EntryExtTyped>);
+pub struct RaftLogBatch {
+    inner: LogBatch<Entry, EntryExtTyped>,
+    count: usize,
+}
 
 const RAFT_LOG_STATE_KEY: &[u8] = b"R";
 
 impl RaftLogBatchTrait for RaftLogBatch {
     fn append(&mut self, raft_group_id: u64, entries: Vec<Entry>) -> Result<()> {
-        self.0.add_entries(raft_group_id, entries);
+        self.count += entries.len();
+        self.inner.add_entries(raft_group_id, entries);
         Ok(())
     }
 
@@ -54,13 +58,17 @@ impl RaftLogBatchTrait for RaftLogBatch {
 
     fn put_raft_state(&mut self, raft_group_id: u64, state: &RaftLocalState) -> Result<()> {
         box_try!(self
-            .0
+            .inner
             .put_msg(raft_group_id, RAFT_LOG_STATE_KEY.to_vec(), state));
         Ok(())
     }
 
     fn is_empty(&self) -> bool {
-        self.0.items.is_empty()
+        self.inner.items.is_empty()
+    }
+
+    fn count(&self) -> usize {
+        self.count
     }
 }
 
@@ -101,7 +109,7 @@ impl RaftEngine for RaftLogEngine {
     }
 
     fn consume(&self, batch: &mut Self::LogBatch, sync: bool) -> Result<usize> {
-        let ret = box_try!(self.0.write(&mut batch.0, sync));
+        let ret = box_try!(self.0.write(&mut batch.inner, sync));
         Ok(ret)
     }
 
@@ -112,7 +120,7 @@ impl RaftEngine for RaftLogEngine {
         _: usize,
         _: usize,
     ) -> Result<usize> {
-        let ret = box_try!(self.0.write(&mut batch.0, sync));
+        let ret = box_try!(self.0.write(&mut batch.inner, sync));
         Ok(ret)
     }
 
@@ -122,14 +130,14 @@ impl RaftEngine for RaftLogEngine {
         _: &RaftLocalState,
         batch: &mut RaftLogBatch,
     ) -> Result<()> {
-        batch.0.clean_region(raft_group_id);
+        batch.inner.clean_region(raft_group_id);
         Ok(())
     }
 
     fn append(&self, raft_group_id: u64, entries: Vec<Entry>) -> Result<usize> {
         let mut batch = Self::LogBatch::default();
-        batch.0.add_entries(raft_group_id, entries);
-        let ret = box_try!(self.0.write(&mut batch.0, false));
+        batch.inner.add_entries(raft_group_id, entries);
+        let ret = box_try!(self.0.write(&mut batch.inner, false));
         Ok(ret)
     }
 

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3244,7 +3244,7 @@ where
                 |_| unimplemented!()
             );
 
-            apply_ctx.flush();
+            apply_ctx.commit(&mut self.delegate);
             // For now, it's more like last_flush_apply_index.
             // TODO: Update it only when `flush()` returns true.
             self.delegate.last_sync_apply_index = applied_index;
@@ -3543,6 +3543,10 @@ where
                 fsm.delegate.last_sync_apply_index = fsm.delegate.apply_state.get_applied_index();
             }
         }
+    }
+
+    fn processed_messages(&self) -> usize {
+        self.apply_ctx.committed_count
     }
 }
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -855,6 +855,10 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
         self.poll_ctx.store_stat.flush();
     }
 
+    fn processed_messages(&self) -> usize {
+        self.poll_ctx.raft_wb.count()
+    }
+
     fn pause(&mut self) {
         if self.poll_ctx.need_flush_trans {
             self.poll_ctx.trans.flush();


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

To solve the problem mentioned by https://github.com/tikv/tikv/pull/9020

Problem Summary:

We have to solve the two problem in different case:
1. There are a lot of regions waiting to be processed, but each of them only receive  few messages because they just wake up by periodic heartbeat. If we limit `max-batch-size` of raftstore to a small value, raftstore-thread must write to `raftdb` every time for only few keys and this will have a bad impact on write performance because each write operations will call `fdatasync` at least once.
2. There are a lot of regions waiting to be processed, but each of them receive a lot of messages.  If we set `max-batch-size` of raftstore  a large value, the regions which are processed earlier will wait a long time for other region. A larger `max-batch-size` will also make one batch-system thread hold too many regions while other threads are idle.

### What is changed and how it works?

This PR will judge whether once poll shall break by the number of messages it has processed, instead of the number of fsm. Any message which would never be written into engine will not be count.

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- Refactor the batch-system. So the configuration `apply-max-batch-size` and `store-max-batch-size` could be set a larger value. The default value `1024` is recommend.
