### PR TITLE
fix: add invalid time check for `add_datetime_and_duration` & `sub_datetime_and_duration`

### DIFF
--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -28,7 +28,7 @@ pub fn date_format(
     let (t, layout) = (t.as_ref().unwrap(), layout.as_ref().unwrap());
     if t.invalid_zero() {
         return ctx
-            .handle_invalid_time_error(Error::incorrect_datetime_value(&format!("{}", t)))
+            .handle_invalid_time_error(Error::incorrect_datetime_value(t))
             .map(|_| Ok(None))?;
     }
 
@@ -53,7 +53,7 @@ pub fn week_with_mode(
     let (t, m) = (t.unwrap(), m.unwrap());
     if t.invalid_zero() {
         return ctx
-            .handle_invalid_time_error(Error::incorrect_datetime_value(&format!("{}", t)))
+            .handle_invalid_time_error(Error::incorrect_datetime_value(t))
             .map(|_| Ok(None))?;
     }
     let week = t.week(WeekMode::from_bits_truncate(*m as u32));
@@ -69,7 +69,7 @@ pub fn week_day(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<In
     let t = t.as_ref().unwrap();
     if t.invalid_zero() {
         return ctx
-            .handle_invalid_time_error(Error::incorrect_datetime_value(&format!("{}", t)))
+            .handle_invalid_time_error(Error::incorrect_datetime_value(t))
             .map(|_| Ok(None))?;
     }
     let day = t.weekday().num_days_from_monday();
@@ -187,7 +187,7 @@ pub fn sub_datetime_and_duration(
             return ctx
                 .handle_invalid_time_error(Error::overflow(
                     "DATETIME",
-                    format!("({} + {})", datetime, duration),
+                    format!("({} - {})", datetime, duration),
                 ))
                 .map(|_| Ok(None))?
         }
@@ -291,7 +291,7 @@ pub fn year(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Option<Int>> 
     if t.is_zero() {
         if ctx.cfg.sql_mode.contains(SqlMode::NO_ZERO_DATE) {
             return ctx
-                .handle_invalid_time_error(Error::incorrect_datetime_value(&format!("{}", t)))
+                .handle_invalid_time_error(Error::incorrect_datetime_value(t))
                 .map(|_| Ok(None))?;
         }
         return Ok(Some(0));
@@ -310,7 +310,7 @@ pub fn day_of_month(ctx: &mut EvalContext, t: Option<&DateTime>) -> Result<Optio
     if t.is_zero() {
         if ctx.cfg.sql_mode.contains(SqlMode::NO_ZERO_DATE) {
             return ctx
-                .handle_invalid_time_error(Error::incorrect_datetime_value(&format!("{}", t)))
+                .handle_invalid_time_error(Error::incorrect_datetime_value(t))
                 .map(|_| Ok(None))?;
         }
         return Ok(Some(0));
@@ -368,7 +368,7 @@ pub fn period_diff(p1: Option<&Int>, p2: Option<&Int>) -> Result<Option<Int>> {
 pub fn last_day(ctx: &mut EvalContext, t: &DateTime) -> Result<Option<DateTime>> {
     if t.month() == 0 {
         return ctx
-            .handle_invalid_time_error(Error::incorrect_datetime_value(&format!("{}", t)))
+            .handle_invalid_time_error(Error::incorrect_datetime_value(t))
             .map(|_| Ok(None))?;
     }
     if t.day() == 0 {
@@ -390,13 +390,17 @@ pub fn add_duration_and_duration(
     let res = match res {
         None => {
             return ctx
-                .handle_invalid_time_error(Error::overflow(duration1, duration2))
+                .handle_invalid_time_error(Error::overflow(
+                    "DURATION",
+                    format!("({} + {})", duration1, duration2),
+                ))
                 .map(|_| Ok(None))?
         }
         Some(res) => res,
     };
     Ok(Some(res))
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -157,14 +157,13 @@ pub fn add_datetime_and_duration(
     datetime: &DateTime,
     duration: &Duration,
 ) -> Result<Option<DateTime>> {
-    if datetime.invalid_zero() {
-        return ctx
-            .handle_invalid_time_error(Error::incorrect_datetime_value(datetime))
-            .map(|_| Ok(None))?;
-    }
     let mut res = match datetime.checked_add(ctx, *duration) {
         Some(res) => res,
-        None => return Ok(None),
+        None => {
+            return ctx
+                .handle_invalid_time_error(Error::incorrect_datetime_value(datetime))
+                .map(|_| Ok(None))?
+        }
     };
     if res.set_time_type(TimeType::DateTime).is_err() {
         return Ok(None);
@@ -179,14 +178,13 @@ pub fn sub_datetime_and_duration(
     datetime: &DateTime,
     duration: &Duration,
 ) -> Result<Option<DateTime>> {
-    if datetime.invalid_zero() {
-        return ctx
-            .handle_invalid_time_error(Error::incorrect_datetime_value(datetime))
-            .map(|_| Ok(None))?;
-    }
     let mut res = match datetime.checked_sub(ctx, *duration) {
         Some(res) => res,
-        None => return Ok(None),
+        None => {
+            return ctx
+                .handle_invalid_time_error(Error::incorrect_datetime_value(datetime))
+                .map(|_| Ok(None))?
+        }
     };
     if res.set_time_type(TimeType::DateTime).is_err() {
         return Ok(None);

--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -161,7 +161,10 @@ pub fn add_datetime_and_duration(
         Some(res) => res,
         None => {
             return ctx
-                .handle_invalid_time_error(Error::incorrect_datetime_value(datetime))
+                .handle_invalid_time_error(Error::overflow(
+                    "DATETIME",
+                    format!("({} + {})", datetime, duration),
+                ))
                 .map(|_| Ok(None))?
         }
     };
@@ -182,7 +185,10 @@ pub fn sub_datetime_and_duration(
         Some(res) => res,
         None => {
             return ctx
-                .handle_invalid_time_error(Error::incorrect_datetime_value(datetime))
+                .handle_invalid_time_error(Error::overflow(
+                    "DATETIME",
+                    format!("({} + {})", datetime, duration),
+                ))
                 .map(|_| Ok(None))?
         }
     };

--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -157,6 +157,11 @@ pub fn add_datetime_and_duration(
     datetime: &DateTime,
     duration: &Duration,
 ) -> Result<Option<DateTime>> {
+    if datetime.invalid_zero() {
+        return ctx
+            .handle_invalid_time_error(Error::incorrect_datetime_value(datetime))
+            .map(|_| Ok(None))?;
+    }
     let mut res = match datetime.checked_add(ctx, *duration) {
         Some(res) => res,
         None => return Ok(None),
@@ -174,6 +179,11 @@ pub fn sub_datetime_and_duration(
     datetime: &DateTime,
     duration: &Duration,
 ) -> Result<Option<DateTime>> {
+    if datetime.invalid_zero() {
+        return ctx
+            .handle_invalid_time_error(Error::incorrect_datetime_value(datetime))
+            .map(|_| Ok(None))?;
+    }
     let mut res = match datetime.checked_sub(ctx, *duration) {
         Some(res) => res,
         None => return Ok(None),


### PR DESCRIPTION
Signed-off-by: wangggong <793160615@qq.com>

### What problem does this PR solve?

Add check missed in https://github.com/tikv/tikv/pull/8999.

Problem Summary:

### What is changed and how it works?

What's Changed:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

No release note.