### PR TITLE
raftstore: keep wake on isolation

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1092,6 +1092,8 @@ where
             (self.fsm.peer.is_leader() && !self.ctx.is_hibernate_timeout())
         {
             self.register_raft_base_tick();
+            // We need pd heartbeat tick to collect down peers and pending peers.
+            self.register_pd_heartbeat_tick();
             return;
         }
 

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -819,12 +819,12 @@ where
         let status = self.raft_group.status();
         let last_index = self.raft_group.raft.raft_log.last_index();
         for (id, pr) in status.progress.unwrap().iter() {
-            // Only recent active peer is considered, so that an isolated follower
-            // won't waste leader's resource.
-            if *id == self.peer.get_id() || !pr.recent_active {
+            // Even a recent inactive node is also considered. If we put leader into sleep,
+            // followers or learners may not sync its logs for a long time and become unavailable.
+            // We choose availability instead of performance in this case.
+            if *id == self.peer.get_id() {
                 continue;
             }
-            // Keep replicating data to active followers.
             if pr.matched != last_index {
                 return res;
             }

--- a/tests/integrations/raftstore/test_hibernate.rs
+++ b/tests/integrations/raftstore/test_hibernate.rs
@@ -228,3 +228,50 @@ fn test_transfer_leader_delay() {
     }
     panic!("failed to request after 3 seconds");
 }
+
+/// If a learner is isolated before split and then catch up logs by snapshot, then the
+/// range for split learner will be missing on the node until leader is waken.
+#[test]
+fn test_split_delay() {
+    let mut cluster = new_server_cluster(0, 4);
+    configure_for_hibernate(&mut cluster);
+    cluster.cfg.raft_store.raft_log_gc_count_limit = 20;
+    cluster.pd_client.disable_default_operator();
+    cluster.run_conf_change();
+    cluster.pd_client.must_add_peer(1, new_peer(2, 2));
+    cluster.pd_client.must_add_peer(1, new_peer(3, 3));
+
+    cluster.pd_client.must_add_peer(1, new_learner_peer(4, 4));
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(4), b"k1", b"v1");
+
+    // Suppose there is only one way partition.
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(1, 4).direction(Direction::Recv),
+    ));
+    let idx = cluster.truncated_state(1, 1).get_index();
+    // Trigger a log compaction.
+    for i in 0..cluster.cfg.raft_store.raft_log_gc_count_limit * 2 {
+        cluster.must_put(format!("k{}", i).as_bytes(), format!("v{}", i).as_bytes());
+    }
+    let region = cluster.get_region(b"k1");
+    cluster.must_split(&region, b"k3");
+    let timer = Instant::now();
+    loop {
+        if cluster.truncated_state(1, 1).get_index() > idx {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+        if timer.elapsed() > Duration::from_secs(3) {
+            panic!("log is not compact after 3 seconds");
+        }
+    }
+    // Wait till leader peer goes to sleep again.
+    thread::sleep(
+        cluster.cfg.raft_store.raft_base_tick_interval.0
+            * 2
+            * cluster.cfg.raft_store.raft_election_timeout_ticks as u32,
+    );
+    cluster.clear_send_filters();
+    must_get_equal(&cluster.get_engine(4), b"k2", b"v2");
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9022  <!-- REMOVE this line if no issue to close -->

### What is changed and how it works?

What's Changed:

Prevent leader going to sleep when there are still peer catching up for logs to reduce corner cases.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- Prevent hibernation when there are still peers catching up logs