### PR TITLE
txn: Move check_data_constraint to action module

### DIFF
--- a/src/storage/txn/actions/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/actions/acquire_pessimistic_lock.rs
@@ -2,6 +2,7 @@ use crate::storage::mvcc::{
     metrics::{MVCC_CONFLICT_COUNTER, MVCC_DUPLICATE_CMD_COUNTER_VEC},
     ErrorInner, MvccTxn, Result as MvccResult,
 };
+use crate::storage::txn::actions::check_data_constraint::check_data_constraint;
 use crate::storage::Snapshot;
 use txn_types::{Key, Lock, LockType, TimeStamp, Value, WriteType};
 
@@ -119,7 +120,7 @@ pub fn acquire_pessimistic_lock<S: Snapshot>(
         }
 
         // Check data constraint when acquiring pessimistic lock.
-        txn.check_data_constraint(should_not_exist, &write, commit_ts, &key)?;
+        check_data_constraint(txn, should_not_exist, &write, commit_ts, &key)?;
 
         if need_value {
             val = match write.write_type {

--- a/src/storage/txn/actions/check_data_constraint.rs
+++ b/src/storage/txn/actions/check_data_constraint.rs
@@ -23,3 +23,98 @@ pub(crate) fn check_data_constraint<S: Snapshot>(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::mvcc::tests::write;
+    use crate::storage::mvcc::{ErrorInner, MvccTxn, Result as MvccResult};
+    use crate::storage::txn::actions::check_data_constraint::check_data_constraint;
+    use crate::storage::{Engine, TestEngineBuilder};
+    use concurrency_manager::ConcurrencyManager;
+    use kvproto::kvrpcpb::Context;
+    use txn_types::{Key, TimeStamp, Write, WriteType};
+
+    #[test]
+    fn test_check_data_constraint() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let cm = ConcurrencyManager::new(42.into());
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut txn = MvccTxn::new(snapshot, TimeStamp::new(2), true, cm.clone());
+        txn.put_write(
+            Key::from_raw(b"a"),
+            TimeStamp::new(5),
+            Write::new(WriteType::Put, TimeStamp::new(2), None)
+                .as_ref()
+                .to_bytes(),
+        );
+        write(&engine, &Context::default(), txn.into_modifies());
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut txn = MvccTxn::new(snapshot, TimeStamp::new(3), true, cm);
+
+        struct Case {
+            expected: MvccResult<()>,
+
+            should_not_exist: bool,
+            write: Write,
+            write_commit_ts: TimeStamp,
+            key: Key,
+        }
+
+        let cases = vec![
+            // todo: add more cases
+            Case {
+                // should skip the check when `should_not_exist` is `false`
+                expected: Ok(()),
+                should_not_exist: false,
+                write: Write::new(WriteType::Put, TimeStamp::new(3), None),
+                write_commit_ts: Default::default(),
+                key: Key::from_raw(b"a"),
+            },
+            Case {
+                // should skip the check when `write_type` is `delete`
+                expected: Ok(()),
+                should_not_exist: true,
+                write: Write::new(WriteType::Delete, TimeStamp::new(3), None),
+                write_commit_ts: Default::default(),
+                key: Key::from_raw(b"a"),
+            },
+            Case {
+                // should detect conflict `Put`
+                expected: Err(ErrorInner::AlreadyExist { key: b"a".to_vec() }.into()),
+                should_not_exist: true,
+                write: Write::new(WriteType::Put, TimeStamp::new(3), None),
+                write_commit_ts: Default::default(),
+                key: Key::from_raw(b"a"),
+            },
+            Case {
+                // should detect an older version when the current write type is `Rollback`
+                expected: Err(ErrorInner::AlreadyExist { key: b"a".to_vec() }.into()),
+                should_not_exist: true,
+                write: Write::new(WriteType::Rollback, TimeStamp::new(3), None),
+                write_commit_ts: TimeStamp::new(6),
+                key: Key::from_raw(b"a"),
+            },
+            Case {
+                // should detect an older version when the current write type is `Lock`
+                expected: Err(ErrorInner::AlreadyExist { key: b"a".to_vec() }.into()),
+                should_not_exist: true,
+                write: Write::new(WriteType::Lock, TimeStamp::new(10), None),
+                write_commit_ts: TimeStamp::new(15),
+                key: Key::from_raw(b"a"),
+            },
+        ];
+
+        for Case {
+            expected,
+            should_not_exist,
+            write,
+            write_commit_ts,
+            key,
+        } in cases
+        {
+            let result =
+                check_data_constraint(&mut txn, should_not_exist, &write, write_commit_ts, &key);
+            assert_eq!(format!("{:?}", expected), format!("{:?}", result));
+        }
+    }
+}

--- a/src/storage/txn/actions/check_data_constraint.rs
+++ b/src/storage/txn/actions/check_data_constraint.rs
@@ -1,0 +1,25 @@
+use crate::storage::mvcc::{ErrorInner, MvccTxn, Result as MvccResult};
+use crate::storage::Snapshot;
+use txn_types::{Key, TimeStamp, Write, WriteType};
+
+/// Checks the existence of the key according to `should_not_exist`.
+/// If not, returns an `AlreadyExist` error.
+pub(crate) fn check_data_constraint<S: Snapshot>(
+    txn: &mut MvccTxn<S>,
+    should_not_exist: bool,
+    write: &Write,
+    write_commit_ts: TimeStamp,
+    key: &Key,
+) -> MvccResult<()> {
+    if !should_not_exist || write.write_type == WriteType::Delete {
+        return Ok(());
+    }
+
+    // The current key exists under any of the following conditions:
+    // 1.The current write type is `PUT`
+    // 2.The current write type is `Rollback` or `Lock`, and the key have an older version.
+    if write.write_type == WriteType::Put || txn.key_exist(&key, write_commit_ts.prev())? {
+        return Err(ErrorInner::AlreadyExist { key: key.to_raw()? }.into());
+    }
+    Ok(())
+}

--- a/src/storage/txn/actions/mod.rs
+++ b/src/storage/txn/actions/mod.rs
@@ -14,4 +14,5 @@ pub mod commit;
 pub mod pessimistic_prewrite;
 pub mod prewrite;
 
+pub mod check_data_constraint;
 pub mod tests;

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -4,6 +4,7 @@ use crate::storage::mvcc::{
     metrics::{MVCC_CONFLICT_COUNTER, MVCC_DUPLICATE_CMD_COUNTER_VEC},
     ErrorInner, LockType, MvccTxn, Result as MvccResult,
 };
+use crate::storage::txn::actions::check_data_constraint::check_data_constraint;
 use crate::storage::txn::actions::shared::prewrite_key_value;
 use crate::storage::Snapshot;
 use txn_types::{Key, Mutation, TimeStamp, WriteType};
@@ -94,7 +95,7 @@ pub fn prewrite<S: Snapshot>(
             }
             // Should check it when no lock exists, otherwise it can report error when there is
             // a lock belonging to a committed transaction which deletes the key.
-            txn.check_data_constraint(should_not_exist, &write, commit_ts, &key)?;
+            check_data_constraint(txn, should_not_exist, &write, commit_ts, &key)?;
             prev_write = Some(write);
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
As I proposed in #8513, we can move these "action" function and related tests to txn/actions.rs, and make the code cleaner.

Though `check_data_constraint` is not used by commands, its also a "high level" operation which is made up with multiple basic operations in MvccTxn, so it should be also an action

### What is changed and how it works?

What's Changed:
Move `MvccTxn::check_data_constraint` and related tests and test utils to `action` mod.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test (I added a real unit test for it)
- Integration test
Side effects