### PR TITLE
copr: allow checksum request to be rescheduled

### DIFF
--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -7,8 +7,8 @@ use kvproto::coprocessor::{KeyRange, Response};
 use protobuf::Message;
 use tidb_query_common::storage::scanner::{RangesScanner, RangesScannerOptions};
 use tidb_query_common::storage::Range;
-use tidb_query_vec_executors::runner::MAX_TIME_SLICE;
-use tidb_query_vec_expr::BATCH_MAX_SIZE;
+use tidb_query_expr::BATCH_MAX_SIZE;
+use tidb_query_executors::runner::MAX_TIME_SLICE;
 use tipb::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse};
 use yatp::task::future::reschedule;
 

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -7,8 +7,8 @@ use kvproto::coprocessor::{KeyRange, Response};
 use protobuf::Message;
 use tidb_query_common::storage::scanner::{RangesScanner, RangesScannerOptions};
 use tidb_query_common::storage::Range;
-use tidb_query_expr::BATCH_MAX_SIZE;
 use tidb_query_executors::runner::MAX_TIME_SLICE;
+use tidb_query_expr::BATCH_MAX_SIZE;
 use tipb::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse};
 use yatp::task::future::reschedule;
 

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -1,11 +1,16 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::time::Instant;
+
 use async_trait::async_trait;
 use kvproto::coprocessor::{KeyRange, Response};
 use protobuf::Message;
 use tidb_query_common::storage::scanner::{RangesScanner, RangesScannerOptions};
 use tidb_query_common::storage::Range;
+use tidb_query_vec_executors::runner::MAX_TIME_SLICE;
+use tidb_query_vec_expr::BATCH_MAX_SIZE;
 use tipb::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse};
+use yatp::task::future::reschedule;
 
 use crate::coprocessor::dag::TiKVStorage;
 use crate::coprocessor::*;
@@ -68,7 +73,18 @@ impl<S: Snapshot> RequestHandler for ChecksumContext<S> {
         let mut prefix_digest = crc64fast::Digest::new();
         prefix_digest.write(&old_prefix);
 
+        let mut row_count = 0;
+        let mut time_slice_start = Instant::now();
         while let Some((k, v)) = self.scanner.next()? {
+            row_count += 1;
+            if row_count >= BATCH_MAX_SIZE {
+                if time_slice_start.elapsed() > MAX_TIME_SLICE {
+                    reschedule().await;
+                    time_slice_start = Instant::now();
+                }
+                row_count = 0;
+            }
+
             if !k.starts_with(&new_prefix) {
                 return Err(box_err!("Wrong prefix expect: {:?}", new_prefix));
             }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close pingcap/br#611

Problem Summary:

Running the checksum coprocessor, even with concurrency = 1, affects the cluster performance since it never yields control.

### What is changed and how it works?

What's Changed:

Copied the "reschedule" mechanism from the "analyze" coprocessor to the checksum coprocessor.

### Related changes

- Need to cherry-pick to the release branch 
   * 3.0, 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
   * Execute BR backup while a SELECT is running in background. The following shows the TiDB QPS measurement before and after applying this PR:
     ![](https://user-images.githubusercontent.com/103023/100057753-08403e00-2e63-11eb-9f31-21df21302496.png)
      * Green = (Negation of) number of keys processed by the "checksum" coprocessor, non-zero means a checksum is running
      * Yellow = QPS, higher means the background SELECT is less affected
      * Left 3 = before this PR was applied, QPS is dropped to 30% of original
      * Right 1 = after this PR is applied, QPS is almost unaffected.

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

* Running checksum in BR and Lightning should have less influence on the cluster performance.