### PR TITLE
copr: add vectorize substring_2_args, substring_3_args

### DIFF
--- a/components/tidb_query_expr/src/impl_string.rs
+++ b/components/tidb_query_expr/src/impl_string.rs
@@ -3,6 +3,7 @@
 use std::str;
 use tidb_query_codegen::rpn_fn;
 
+use crate::impl_math::i64_to_usize;
 use tidb_query_common::Result;
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::*;
@@ -814,6 +815,40 @@ pub fn repeat(input: BytesRef, cnt: &Int, writer: BytesWriter) -> Result<BytesGu
         writer.partial_write(input);
     }
     Ok(writer.finish())
+}
+
+#[rpn_fn(writer)]
+#[inline]
+pub fn substring_2_args(input: BytesRef, pos: &Int, writer: BytesWriter) -> Result<BytesGuard> {
+    substring(input, *pos, input.len() as Int, writer)
+}
+
+#[rpn_fn(writer)]
+#[inline]
+pub fn substring_3_args(
+    input: BytesRef,
+    pos: &Int,
+    len: &Int,
+    writer: BytesWriter,
+) -> Result<BytesGuard> {
+    substring(input, *pos, *len, writer)
+}
+
+#[inline]
+fn substring(input: BytesRef, pos: Int, len: Int, writer: BytesWriter) -> Result<BytesGuard> {
+    let (len, len_positive) = i64_to_usize(len, len > 0);
+    let (pos, positive_search) = i64_to_usize(pos, pos > 0);
+    if pos == 0 || len == 0 || !len_positive {
+        return Ok(writer.write_ref(Some(b"")));
+    }
+
+    let start = if positive_search {
+        (pos - 1).min(input.len())
+    } else {
+        input.len().checked_sub(pos).unwrap_or_else(|| input.len())
+    };
+    let end = start.saturating_add(len).min(input.len());
+    Ok(writer.write_ref(Some(&input[start..end])))
 }
 
 #[cfg(test)]
@@ -3038,6 +3073,197 @@ mod tests {
             let got =
                 super::validate_target_len_for_pad(true, case.0 as i64, case.1, case.2, case.3);
             assert_eq!(got, case.4);
+        }
+    }
+
+    #[test]
+    fn test_substring_2_args() {
+        let cases = vec![
+            (
+                Some("中文a测试bb".as_bytes().to_vec()),
+                Some(1),
+                Some("中文a测试bb".as_bytes().to_vec()),
+            ),
+            (
+                Some("中文a测试".as_bytes().to_vec()),
+                Some(-3),
+                Some("试".as_bytes().to_vec()),
+            ),
+            (
+                Some("\x61\x76\x5e\x38\x2f\x35".as_bytes().to_vec()),
+                Some(-1),
+                Some("\x35".as_bytes().to_vec()),
+            ),
+            (
+                Some("\x61\x76\x5e\x38\x2f\x35".as_bytes().to_vec()),
+                Some(2),
+                Some("\x76\x5e\x38\x2f\x35".as_bytes().to_vec()),
+            ),
+            (
+                Some("Quadratically".as_bytes().to_vec()),
+                Some(5),
+                Some("ratically".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(1),
+                Some("Sakila".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(-3),
+                Some("ila".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(0),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(100),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(-100),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(i64::max_value()),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(i64::min_value()),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("".as_bytes().to_vec()),
+                Some(1),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("".as_bytes().to_vec()),
+                Some(-1),
+                Some("".as_bytes().to_vec()),
+            ),
+        ];
+
+        for (str, pos, exp) in cases {
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(str)
+                .push_param(pos)
+                .evaluate(ScalarFuncSig::Substring2Args)
+                .unwrap();
+            assert_eq!(output, exp);
+        }
+    }
+
+    #[test]
+    fn test_substring_3_args() {
+        let cases = vec![
+            (
+                Some("Quadratically".as_bytes().to_vec()),
+                Some(5),
+                Some(6),
+                Some("ratica".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(-5),
+                Some(3),
+                Some("aki".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(2),
+                Some(0),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(2),
+                Some(-1),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(2),
+                Some(100),
+                Some("akila".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(100),
+                Some(5),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("Sakila".as_bytes().to_vec()),
+                Some(-100),
+                Some(5),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("中文a测a试".as_bytes().to_vec()),
+                Some(4),
+                Some(3),
+                Some("文".as_bytes().to_vec()),
+            ),
+            (
+                Some("中文a测a试".as_bytes().to_vec()),
+                Some(4),
+                Some(4),
+                Some("文a".as_bytes().to_vec()),
+            ),
+            (
+                Some("中文a测a试".as_bytes().to_vec()),
+                Some(-3),
+                Some(3),
+                Some("试".as_bytes().to_vec()),
+            ),
+            (
+                Some("".as_bytes().to_vec()),
+                Some(1),
+                Some(1),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("\x61\x76\x5e\x38\x2f\x35".as_bytes().to_vec()),
+                Some(2),
+                Some(2),
+                Some("\x76\x5e".as_bytes().to_vec()),
+            ),
+            (
+                Some("\x61\x76\x5e\x38\x2f\x35".as_bytes().to_vec()),
+                Some(4),
+                Some(100),
+                Some("\x38\x2f\x35".as_bytes().to_vec()),
+            ),
+            (
+                Some("\x61\x76\x5e\x38\x2f\x35".as_bytes().to_vec()),
+                Some(-1),
+                Some(2),
+                Some("\x35".as_bytes().to_vec()),
+            ),
+            (
+                Some("\x61\x76\x5e\x38\x2f\x35".as_bytes().to_vec()),
+                Some(-2),
+                Some(2),
+                Some("\x2f\x35".as_bytes().to_vec()),
+            ),
+        ];
+
+        for (str, pos, len, exp) in cases {
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(str)
+                .push_param(pos)
+                .push_param(len)
+                .evaluate(ScalarFuncSig::Substring3Args)
+                .unwrap();
+            assert_eq!(output, exp);
         }
     }
 }

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -572,6 +572,8 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::CharLengthUtf8 => char_length_utf8_fn_meta(),
         ScalarFuncSig::ToBase64 => to_base64_fn_meta(),
         ScalarFuncSig::Repeat => repeat_fn_meta(),
+        ScalarFuncSig::Substring2Args => substring_2_args_fn_meta(),
+        ScalarFuncSig::Substring3Args => substring_3_args_fn_meta(),
         // impl_time
         ScalarFuncSig::DateFormatSig => date_format_fn_meta(),
         ScalarFuncSig::WeekOfYear => week_of_year_fn_meta(),


### PR DESCRIPTION
Signed-off-by: FateTHarlaown <623239185@qq.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
add vectorize substring_2_args, substring_3_args
Issue Number:  #9016

Problem Summary:
What's Changed:
 add push-down & test of substring_2_args, substring_3_args

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->