### PR TITLE
raftstore: make destroy overlapped regions and apply snapshot atomically

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2349,6 +2349,7 @@ impl RegionProposal {
 
 pub struct Destroy {
     region_id: u64,
+    merge_from_snapshot: bool,
 }
 
 /// A message that asks the delegate to apply to the given logs and then reply to
@@ -2489,8 +2490,11 @@ impl Msg {
         Msg::Registration(Registration::new(peer))
     }
 
-    pub fn destroy(region_id: u64) -> Msg {
-        Msg::Destroy(Destroy { region_id })
+    pub fn destroy(region_id: u64, merge_from_snapshot: bool) -> Msg {
+        Msg::Destroy(Destroy {
+            region_id,
+            merge_from_snapshot,
+        })
     }
 }
 
@@ -2551,6 +2555,8 @@ pub enum TaskRes {
         region_id: u64,
         // ID of peer that has been destroyed.
         peer_id: u64,
+        // Whether destroy request is from its target region's snapshot
+        merge_from_snapshot: bool,
     },
 }
 
@@ -2703,6 +2709,9 @@ impl ApplyFsm {
         d: Destroy,
     ) {
         assert_eq!(d.region_id, self.delegate.region_id());
+        if d.merge_from_snapshot {
+            assert_eq!(self.delegate.stopped, false);
+        }
         if !self.delegate.stopped {
             self.destroy(ctx);
             ctx.notifier.notify(
@@ -2711,6 +2720,7 @@ impl ApplyFsm {
                     res: TaskRes::Destroy {
                         region_id: self.delegate.region_id(),
                         peer_id: self.delegate.id,
+                        merge_from_snapshot: d.merge_from_snapshot,
                     },
                 },
             );
@@ -3598,10 +3608,12 @@ mod tests {
             );
         });
 
-        router.schedule_task(2, Msg::destroy(2));
+        router.schedule_task(2, Msg::destroy(2, false));
         let (region_id, peer_id) = match rx.recv_timeout(Duration::from_secs(3)) {
             Ok(PeerMsg::ApplyRes { res, .. }) => match res {
-                TaskRes::Destroy { region_id, peer_id } => (region_id, peer_id),
+                TaskRes::Destroy {
+                    region_id, peer_id, ..
+                } => (region_id, peer_id),
                 e => panic!("expected destroy result, but got {:?}", e),
             },
             e => panic!("expected destroy result, but got {:?}", e),

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -56,7 +56,8 @@ use crate::store::worker::{
 };
 use crate::store::PdTask;
 use crate::store::{
-    util, CasualMessage, Config, PeerMsg, PeerTicks, RaftCommand, SignificantMsg, SnapKey, StoreMsg,
+    util, CasualMessage, Config, MergeResultKind, PeerMsg, PeerTicks, RaftCommand, SignificantMsg,
+    SnapKey, StoreMsg,
 };
 use crate::{Error, Result};
 use keys::{self, enc_end_key, enc_start_key};
@@ -742,8 +743,12 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                     }
                 }
             }
-            SignificantMsg::MergeResult { target, stale } => {
-                self.on_merge_result(target, stale);
+            SignificantMsg::MergeResult {
+                target_region_id,
+                target,
+                result,
+            } => {
+                self.on_merge_result(target_region_id, target, result);
             }
             SignificantMsg::CatchUpLogs(catch_up_logs) => {
                 self.on_catch_up_logs_for_merge(catch_up_logs);
@@ -1046,9 +1051,30 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 // get fair schedule.
                 self.register_pd_heartbeat_tick();
             }
-            ApplyTaskRes::Destroy { peer_id, .. } => {
+            ApplyTaskRes::Destroy {
+                region_id,
+                peer_id,
+                merge_from_snapshot,
+            } => {
                 assert_eq!(peer_id, self.fsm.peer.peer_id());
-                self.destroy_peer(false);
+                if !merge_from_snapshot {
+                    self.destroy_peer(false);
+                } else {
+                    // Wait for its target peer to apply snapshot and then send `MergeResult` back
+                    // to destroy itself
+                    let mut meta = self.ctx.store_meta.lock().unwrap();
+                    // The `need_atomic` flag must be true
+                    assert!(*meta.destroyed_region_for_snap.get(&region_id).unwrap());
+
+                    let target_region_id = *meta.targets_map.get(&region_id).unwrap();
+                    let is_ready = meta
+                        .atomic_snap_regions
+                        .get_mut(&target_region_id)
+                        .unwrap()
+                        .get_mut(&region_id)
+                        .unwrap();
+                    *is_ready = true;
+                }
             }
         }
     }
@@ -1079,7 +1105,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         if msg.has_merge_target() {
             fail_point!("on_has_merge_target", |_| Ok(()));
             if self.need_gc_merge(&msg)? {
-                self.on_stale_merge();
+                self.on_stale_merge(msg.get_merge_target().get_id());
             }
             return Ok(());
         }
@@ -1313,14 +1339,18 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             .pending_merge_targets
             .entry(target_region_id)
             .or_default();
-        if let Some(epoch) = (*v).insert(self.region_id(), merge_target.get_region_epoch().clone())
-        {
+        let mut no_range_merge_target = merge_target.clone();
+        no_range_merge_target.clear_start_key();
+        no_range_merge_target.clear_end_key();
+        if let Some(pre_merge_target) = v.insert(self.region_id(), no_range_merge_target) {
             // Merge target epoch records the version of target region when source region is merged.
             // So it must be same no matter when receiving merge target.
-            if epoch.get_version() != merge_target.get_region_epoch().get_version() {
+            if pre_merge_target.get_region_epoch().get_version()
+                != merge_target.get_region_epoch().get_version()
+            {
                 panic!(
                     "conflict merge target epoch version {:?} {:?}",
-                    epoch,
+                    pre_merge_target.get_region_epoch().get_version(),
                     merge_target.get_region_epoch()
                 );
             }
@@ -1494,23 +1524,24 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 "exist" => ?exist_region,
                 "snap" => ?snap_region,
             );
-            if ready
-                && maybe_destroy_source(
-                    &meta,
-                    self.region_id(),
-                    exist_region.get_id(),
-                    snap_region.get_region_epoch().to_owned(),
-                )
-            {
+            let (can_destroy, merge_to_this_peer) = maybe_destroy_source(
+                &meta,
+                self.fsm.region_id(),
+                self.fsm.peer_id(),
+                exist_region.get_id(),
+                snap_region.get_region_epoch().to_owned(),
+            );
+            if ready && can_destroy {
                 // The snapshot that we decide to whether destroy peer based on must can be applied.
                 // So here not to destroy peer immediately, or the snapshot maybe dropped in later
                 // check but the peer is already destroyed.
-                regions_to_destroy.push(exist_region.get_id());
+                regions_to_destroy.push((exist_region.get_id(), merge_to_this_peer));
                 continue;
             }
             is_overlapped = true;
-            if snap_region.get_region_epoch().get_version()
-                > exist_region.get_region_epoch().get_version()
+            if !can_destroy
+                && snap_region.get_region_epoch().get_version()
+                    > exist_region.get_region_epoch().get_version()
             {
                 // If snapshot's epoch version is greater than exist region's, the exist region
                 // may has been merged already.
@@ -1529,15 +1560,39 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         self.ctx.snap_mgr.get_snapshot_for_applying(&key)?;
 
         meta.pending_snapshot_regions.push(snap_region);
-        self.ctx.queued_snapshot.insert(region_id);
-        for region_id in regions_to_destroy {
+
+        assert!(!meta.atomic_snap_regions.contains_key(&region_id));
+        for (source_region_id, merge_to_this_peer) in regions_to_destroy {
+            info!(
+                "source region destroy due to target region's snapshot";
+                "region_id" => self.fsm.region_id(),
+                "peer_id" => self.fsm.peer_id(),
+                "source_region_id" => source_region_id,
+                "need_atomic" => merge_to_this_peer,
+            );
+            meta.atomic_snap_regions
+                .entry(region_id)
+                .or_default()
+                .insert(source_region_id, false);
+            meta.destroyed_region_for_snap
+                .insert(source_region_id, merge_to_this_peer);
+
+            let result = if merge_to_this_peer {
+                MergeResultKind::FromTargetSnapshotStep1
+            } else {
+                MergeResultKind::Stale
+            };
+            // Use `unwrap` is ok because the StoreMeta lock is held and these source peers still
+            // exist in regions and region_ranges map.
+            // It depends on the implementation of `destroy_peer`
             self.ctx
                 .router
                 .force_send(
-                    region_id,
+                    source_region_id,
                     PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
+                        target_region_id: self.fsm.region_id(),
                         target: self.fsm.peer.peer.clone(),
-                        stale: true,
+                        result,
                     }),
                 )
                 .unwrap();
@@ -1565,7 +1620,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             // Destroy the apply fsm first, wait for the reply msg from apply fsm
             self.ctx
                 .apply_router
-                .schedule_task(job.region_id, ApplyTask::destroy(job.region_id));
+                .schedule_task(job.region_id, ApplyTask::destroy(job.region_id, false));
             false
         } else {
             // Destroy the peer fsm directly
@@ -1589,24 +1644,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         // Mark itself as pending_remove
         self.fsm.peer.pending_remove = true;
 
-        // Clear merge related structures.
         let mut meta = self.ctx.store_meta.lock().unwrap();
-        meta.pending_merge_targets.remove(&region_id);
-        if let Some(target) = meta.targets_map.remove(&region_id) {
-            if meta.pending_merge_targets.contains_key(&target) {
-                meta.pending_merge_targets
-                    .get_mut(&target)
-                    .unwrap()
-                    .remove(&region_id);
-                // When the target doesn't exist(add peer but the store is isolated), source peer decide to destroy by itself.
-                // Without target, the `pending_merge_targets` for target won't be removed, so here source peer help target to clear.
-                if meta.regions.get(&target).is_none()
-                    && meta.pending_merge_targets.get(&target).unwrap().is_empty()
-                {
-                    meta.pending_merge_targets.remove(&target);
-                }
-            }
-        }
 
         // Destroy read delegates.
         if let Some(reader) = meta.readers.remove(&region_id) {
@@ -1636,6 +1674,8 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             // data too.
             panic!("{} destroy err {:?}", self.fsm.peer.tag, e);
         }
+        // Some places use `force_send().unwrap()` if the StoreMeta lock is held.
+        // So in here, it's necessary to held the StoreMeta lock when closing the router.
         self.ctx.router.close(region_id);
         self.fsm.stop();
 
@@ -1650,6 +1690,42 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         }
         if meta.regions.remove(&region_id).is_none() && !merged_by_target {
             panic!("{} meta corruption detected", self.fsm.peer.tag)
+        }
+
+        // Clear merge related structures.
+        if let Some(&need_atomic) = meta.destroyed_region_for_snap.get(&region_id) {
+            if need_atomic {
+                panic!(
+                    "{} should destroy with target region atomically",
+                    self.fsm.peer.tag
+                );
+            } else {
+                let target_region_id = *meta.targets_map.get(&region_id).unwrap();
+                let is_ready = meta
+                    .atomic_snap_regions
+                    .get_mut(&target_region_id)
+                    .unwrap()
+                    .get_mut(&region_id)
+                    .unwrap();
+                *is_ready = true;
+            }
+        }
+
+        meta.pending_merge_targets.remove(&region_id);
+        if let Some(target) = meta.targets_map.remove(&region_id) {
+            if meta.pending_merge_targets.contains_key(&target) {
+                meta.pending_merge_targets
+                    .get_mut(&target)
+                    .unwrap()
+                    .remove(&region_id);
+                // When the target doesn't exist(add peer but the store is isolated), source peer decide to destroy by itself.
+                // Without target, the `pending_merge_targets` for target won't be removed, so here source peer help target to clear.
+                if meta.regions.get(&target).is_none()
+                    && meta.pending_merge_targets.get(&target).unwrap().is_empty()
+                {
+                    meta.pending_merge_targets.remove(&target);
+                }
+            }
         }
     }
 
@@ -2306,6 +2382,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         reader.mark_invalid();
 
         drop(meta);
+
         // make approximate size and keys updated in time.
         // the reason why follower need to update is that there is a issue that after merge
         // and then transfer leader, the new leader may have stale size and keys.
@@ -2323,18 +2400,19 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         if let Err(e) = self.ctx.router.force_send(
             source.get_id(),
             PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
+                target_region_id: self.fsm.region_id(),
                 target: self.fsm.peer.peer.clone(),
-                stale: false,
+                result: MergeResultKind::FromTargetLog,
             }),
         ) {
-            // TODO: need to remove "are we shutting down", it should panic
-            // if we are not in shut-down state
-            info!(
-                "failed to send merge result, are we shutting down?";
-                "region_id" => self.fsm.region_id(),
-                "peer_id" => self.fsm.peer_id(),
-                "err" => %e,
-            );
+            if !self.ctx.router.is_shutdown() {
+                panic!(
+                    "{} failed to send merge result(FromTargetLog) to source region {}, err {}",
+                    self.fsm.peer.tag,
+                    source.get_id(),
+                    e
+                );
+            }
         }
     }
 
@@ -2376,7 +2454,12 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         }
     }
 
-    fn on_merge_result(&mut self, target: metapb::Peer, stale: bool) {
+    fn on_merge_result(
+        &mut self,
+        target_region_id: u64,
+        target: metapb::Peer,
+        result: MergeResultKind,
+    ) {
         let exists = self
             .fsm
             .peer
@@ -2385,36 +2468,74 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
             .map_or(true, |s| s.get_target().get_peers().contains(&target));
         if !exists {
             panic!(
-                "{} unexpected merge result: {:?} {:?} {}",
-                self.fsm.peer.tag, self.fsm.peer.pending_merge_state, target, stale
+                "{} unexpected merge result: {:?} {:?} {:?}",
+                self.fsm.peer.tag, self.fsm.peer.pending_merge_state, target, result
             );
         }
-        if !stale {
-            info!(
-                "merge finished";
-                "region_id" => self.fsm.region_id(),
-                "peer_id" => self.fsm.peer_id(),
-                "target_region" => ?self.fsm.peer.pending_merge_state.as_ref().unwrap().target,
+        // If the merge succeed, all source peers is impossible in apply snapshot state
+        // and must be initialized.
+        if self.fsm.peer.is_applying_snapshot() {
+            panic!(
+                "{} is applying snapshot on getting merge result, target region id {}, target peer {:?}, merge result type {:?}",
+                self.fsm.peer.tag, target_region_id, target, result
             );
-            self.destroy_peer(true);
-        } else {
-            self.on_stale_merge();
         }
+        if !self.fsm.peer.is_initialized() {
+            panic!(
+                "{} is not initialized on getting merge result, target region id {}, target peer {:?}, merge result type {:?}",
+                self.fsm.peer.tag, target_region_id, target, result
+            );
+        }
+        match result {
+            MergeResultKind::FromTargetLog => {
+                info!(
+                    "merge finished";
+                    "region_id" => self.fsm.region_id(),
+                    "peer_id" => self.fsm.peer_id(),
+                    "target_region" => ?self.fsm.peer.pending_merge_state.as_ref().unwrap().target,
+                );
+                self.destroy_peer(true);
+            }
+            MergeResultKind::FromTargetSnapshotStep1 => {
+                info!(
+                    "merge finished with target snapshot";
+                    "region_id" => self.fsm.region_id(),
+                    "peer_id" => self.fsm.peer_id(),
+                    "target_region_id" => target_region_id,
+                );
+                self.fsm.peer.pending_remove = true;
+                // Destroy apply fsm at first
+                self.ctx.apply_router.schedule_task(
+                    self.fsm.region_id(),
+                    ApplyTask::destroy(self.fsm.region_id(), true, true),
+                );
+            }
+            MergeResultKind::FromTargetSnapshotStep2 => {
+                // `merge_by_target` is true because this region's range already belongs to
+                // its target region so we must not clear data otherwise its target region's
+                // data will corrupt.
+                self.destroy_peer(true);
+            }
+            MergeResultKind::Stale => {
+                self.on_stale_merge(target_region_id);
+            }
+        };
     }
 
-    fn on_stale_merge(&mut self) {
+    fn on_stale_merge(&mut self, target_region_id: u64) {
+        if self.fsm.peer.pending_remove {
+            return;
+        }
         info!(
-            "successful merge can't be continued, try to gc stale peer.";
+            "successful merge can't be continued, try to gc stale peer";
             "region_id" => self.fsm.region_id(),
             "peer_id" => self.fsm.peer_id(),
+            "target_region_id" => target_region_id,
             "merge_state" => ?self.fsm.peer.pending_merge_state,
         );
-        match self.fsm.peer.maybe_destroy() {
-            None => self.ctx.raft_metrics.message_dropped.applying_snap += 1,
-            Some(job) => {
-                self.handle_destroy_peer(job);
-            }
-        }
+        // It must succeed so here using `unwrap`
+        let job = self.fsm.peer.maybe_destroy().unwrap();
+        self.handle_destroy_peer(job);
     }
 
     fn on_ready_apply_snapshot(&mut self, apply_result: ApplySnapResult) {
@@ -2431,10 +2552,38 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         let mut meta = self.ctx.store_meta.lock().unwrap();
         debug!(
             "check snapshot range";
-            "region_id" => self.region_id(),
+            "region_id" => self.fsm.region_id(),
             "peer_id" => self.fsm.peer_id(),
             "prev_region" => ?prev_region,
         );
+
+        // Remove this region's snapshot region from the `pending_snapshot_regions`
+        // The `pending_snapshot_regions` is only used to occupy the key range, so if this
+        // peer is added to `region_ranges`, it can be remove from `pending_snapshot_regions`
+        meta.pending_snapshot_regions
+            .retain(|r| self.fsm.region_id() != r.get_id());
+
+        // Remove its source peers' metadata
+        for r in &apply_result.destroyed_regions {
+            let prev = meta.region_ranges.remove(&enc_end_key(&r));
+            assert_eq!(prev, Some(r.get_id()));
+            assert!(meta.regions.remove(&r.get_id()).is_some());
+            let reader = meta.readers.remove(&r.get_id()).unwrap();
+            reader.mark_invalid();
+        }
+        // Remove the data from `atomic_snap_regions` and `destroyed_region_for_snap`
+        // which are added before applying snapshot
+        if let Some(wait_destroy_regions) = meta.atomic_snap_regions.remove(&self.fsm.region_id()) {
+            for (source_region_id, _) in wait_destroy_regions {
+                assert_eq!(
+                    meta.destroyed_region_for_snap
+                        .remove(&source_region_id)
+                        .is_some(),
+                    true
+                );
+            }
+        }
+
         let initialized = !prev_region.get_peers().is_empty();
         if initialized {
             info!(
@@ -2452,6 +2601,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 );
             }
         }
+
         if let Some(r) = meta
             .region_ranges
             .insert(enc_end_key(&region), region.get_id())
@@ -2460,6 +2610,23 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
         }
         let prev = meta.regions.insert(region.get_id(), region);
         assert_eq!(prev, Some(prev_region));
+
+        drop(meta);
+
+        for r in &apply_result.destroyed_regions {
+            if let Err(e) = self.ctx.router.force_send(
+                r.get_id(),
+                PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
+                    target_region_id: self.fsm.region_id(),
+                    target: self.fsm.peer.peer.clone(),
+                    result: MergeResultKind::FromTargetSnapshotStep2,
+                }),
+            ) {
+                if !self.ctx.router.is_shutdown() {
+                    panic!("{} failed to send merge result(FromTargetSnapshotStep2) to source region {}, err {}", self.fsm.peer.tag, r.get_id(), e);
+                }
+            }
+        }
     }
 
     fn on_ready_result(&mut self, exec_results: &mut VecDeque<ExecResult>, metrics: &ApplyMetrics) {
@@ -3306,31 +3473,47 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
     }
 }
 
-/// Checks merge target, returns whether the source peer should be destroyed.
-/// It returns true when there is a network isolation which leads to a follower of a merge target
+/// Checks merge target, returns whether the source peer should be destroyed and whether the source peer is
+/// merged to this target peer.
+///
+/// It returns (`can_destroy`, `merge_to_this_peer`).
+///
+/// `can_destroy` is true when there is a network isolation which leads to a follower of a merge target
 /// Region's log falls behind and then receive a snapshot with epoch version after merge.
+///
+/// `merge_to_this_peer` is true when `can_destroy` is true and the source peer is merged to this target peer.
 pub fn maybe_destroy_source(
     meta: &StoreMeta,
     target_region_id: u64,
+    target_peer_id: u64,
     source_region_id: u64,
     region_epoch: RegionEpoch,
-) -> bool {
+) -> (bool, bool) {
     if let Some(merge_targets) = meta.pending_merge_targets.get(&target_region_id) {
-        if let Some(target_epoch) = merge_targets.get(&source_region_id) {
+        if let Some(target_region) = merge_targets.get(&source_region_id) {
             info!(
                 "[region {}] checking source {} epoch: {:?}, merge target epoch: {:?}",
-                target_region_id, source_region_id, region_epoch, target_epoch,
+                target_region_id,
+                source_region_id,
+                region_epoch,
+                target_region.get_region_epoch(),
             );
             // The target peer will move on, namely, it will apply a snapshot generated after merge,
             // so destroy source peer.
-            if region_epoch.get_version() > target_epoch.get_version() {
-                return true;
+            if region_epoch.get_version() > target_region.get_region_epoch().get_version() {
+                return (
+                    true,
+                    target_peer_id
+                        == util::find_peer(target_region, meta.store_id.unwrap())
+                            .unwrap()
+                            .get_id(),
+                );
             }
             // Wait till the target peer has caught up logs and source peer will be destroyed at that time.
-            return false;
+            return (false, false);
         }
     }
-    false
+    (false, false)
 }
 
 pub fn new_read_index_request(

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2586,7 +2586,7 @@ impl<'a, T: Transport, C: PdClient> PeerFsmDelegate<'a, T, C> {
                 // Destroy apply fsm at first
                 self.ctx.apply_router.schedule_task(
                     self.fsm.region_id(),
-                    ApplyTask::destroy(self.fsm.region_id(), true, true),
+                    ApplyTask::destroy(self.fsm.region_id(), true),
                 );
             }
             MergeResultKind::FromTargetSnapshotStep2 => {

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -59,8 +59,8 @@ use crate::store::worker::{
 use crate::store::PdTask;
 use crate::store::PeerTicks;
 use crate::store::{
-    util, Callback, CasualMessage, MergeResultKind, PeerMsg, RaftCommand, SignificantMsg, SnapManager, StoreMsg,
-    StoreTick,
+    util, Callback, CasualMessage, MergeResultKind, PeerMsg, RaftCommand, SignificantMsg,
+    SnapManager, StoreMsg, StoreTick,
 };
 
 use crate::Result;

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -59,7 +59,7 @@ use crate::store::worker::{
 use crate::store::PdTask;
 use crate::store::PeerTicks;
 use crate::store::{
-    util, Callback, CasualMessage, PeerMsg, RaftCommand, SignificantMsg, SnapManager, StoreMsg,
+    util, Callback, CasualMessage, MergeResultKind, PeerMsg, RaftCommand, SignificantMsg, SnapManager, StoreMsg,
     StoreTick,
 };
 
@@ -69,7 +69,7 @@ use engine_rocks::{CompactedEvent, CompactionListener};
 use keys::{self, data_end_key, data_key, enc_end_key, enc_start_key};
 use pd_client::PdClient;
 use sst_importer::SSTImporter;
-use tikv_util::collections::{HashMap, HashSet};
+use tikv_util::collections::HashMap;
 use tikv_util::config::{Tracker, VersionTrack};
 use tikv_util::future::poll_future_notify;
 use tikv_util::mpsc::{self, LooseBoundedSender, Receiver};
@@ -106,11 +106,19 @@ pub struct StoreMeta {
     /// The regions with pending snapshots.
     pub pending_snapshot_regions: Vec<Region>,
     /// A marker used to indicate the peer of a Region has received a merge target message and waits to be destroyed.
-    /// target_region_id -> (source_region_id -> merge_target_epoch)
-    pub pending_merge_targets: HashMap<u64, HashMap<u64, RegionEpoch>>,
+    /// target_region_id -> (source_region_id -> merge_target_region)
+    pub pending_merge_targets: HashMap<u64, HashMap<u64, metapb::Region>>,
     /// An inverse mapping of `pending_merge_targets` used to let source peer help target peer to clean up related entry.
     /// source_region_id -> target_region_id
     pub targets_map: HashMap<u64, u64>,
+    /// `atomic_snap_regions` and `destroyed_region_for_snap` are used for making destroy overlapped regions
+    /// and apply snapshot atomically.
+    /// region_id -> wait_destroy_regions_map(source_region_id -> is_ready)
+    /// A target peer must wait for all source peer to ready before applying snapshot.
+    pub atomic_snap_regions: HashMap<u64, HashMap<u64, bool>>,
+    /// source_region_id -> need_atomic
+    /// Used for reminding the source peer to switch to ready in `atomic_snap_regions`.
+    pub destroyed_region_for_snap: HashMap<u64, bool>,
 }
 
 impl StoreMeta {
@@ -124,6 +132,8 @@ impl StoreMeta {
             pending_snapshot_regions: Vec::default(),
             pending_merge_targets: HashMap::default(),
             targets_map: HashMap::default(),
+            atomic_snap_regions: HashMap::default(),
+            destroyed_region_for_snap: HashMap::default(),
         }
     }
 
@@ -253,7 +263,6 @@ pub struct PollContext<T, C: 'static> {
     pub has_ready: bool,
     pub ready_res: Vec<(Ready, InvokeContext)>,
     pub need_flush_trans: bool,
-    pub queued_snapshot: HashSet<u64>,
     pub current_time: Option<Timespec>,
     pub perf_context_statistics: PerfContextStatistics,
     pub tick_batch: Vec<PeerTickBatch>,
@@ -790,12 +799,6 @@ impl<T: Transport, C: PdClient> PollHandler<PeerFsm<RocksEngine>, StoreFsm> for 
             self.handle_raft_ready(peers);
         }
         self.poll_ctx.current_time = None;
-        if !self.poll_ctx.queued_snapshot.is_empty() {
-            let mut meta = self.poll_ctx.store_meta.lock().unwrap();
-            meta.pending_snapshot_regions
-                .retain(|r| !self.poll_ctx.queued_snapshot.contains(&r.get_id()));
-            self.poll_ctx.queued_snapshot.clear();
-        }
         self.poll_ctx
             .raft_metrics
             .process_ready
@@ -1039,7 +1042,6 @@ where
             has_ready: false,
             ready_res: Vec::new(),
             need_flush_trans: false,
-            queued_snapshot: HashSet::default(),
             current_time: None,
             perf_context_statistics: PerfContextStatistics::new(self.cfg.value().perf_level),
             tick_batch: vec![PeerTickBatch::default(); 256],
@@ -1580,14 +1582,27 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
                 "msg" => ?msg,
                 "exist_region" => ?exist_region,
             );
-
-            if maybe_destroy_source(
+            let (can_destroy, merge_to_this_peer) = maybe_destroy_source(
                 meta,
                 region_id,
+                target.get_id(),
                 exist_region.get_id(),
                 msg.get_region_epoch().to_owned(),
-            ) {
-                regions_to_destroy.push(exist_region.get_id());
+            );
+            if can_destroy {
+                if !merge_to_this_peer {
+                    regions_to_destroy.push(exist_region.get_id());
+                } else {
+                    error!(
+                        "A new peer has a merge source peer";
+                        "region_id" => region_id,
+                        "peer_id" => target.get_id(),
+                        "source_region" => ?exist_region,
+                    );
+                    if self.ctx.cfg.dev_assert {
+                        panic!("something is wrong, maybe PD do not ensure all target peers exist before merging");
+                    }
+                }
                 continue;
             }
             is_overlapped = true;
@@ -1612,13 +1627,13 @@ impl<'a, T: Transport, C: PdClient> StoreFsmDelegate<'a, T, C> {
                 .force_send(
                     id,
                     PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
+                        target_region_id: region_id,
                         target: target.clone(),
-                        stale: true,
+                        result: MergeResultKind::Stale,
                     }),
                 )
                 .unwrap();
         }
-
         // New created peers should know it's learner or not.
         let (tx, peer) = PeerFsm::replicate(
             self.ctx.store_id(),

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -26,7 +26,7 @@ pub use self::bootstrap::{
 pub use self::config::Config;
 pub use self::fsm::{new_compaction_listener, DestroyPeerJob, RaftRouter, StoreInfo};
 pub use self::msg::{
-    Callback, CasualMessage, ExtCallback, PeerMsg, PeerTicks, RaftCommand, ReadCallback,
+    Callback, CasualMessage, ExtCallback, MergeResultKind, PeerMsg, PeerTicks, RaftCommand, ReadCallback,
     ReadResponse, SignificantMsg, StoreMsg, StoreTick, WriteCallback, WriteResponse,
 };
 pub use self::peer::{

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -26,8 +26,8 @@ pub use self::bootstrap::{
 pub use self::config::Config;
 pub use self::fsm::{new_compaction_listener, DestroyPeerJob, RaftRouter, StoreInfo};
 pub use self::msg::{
-    Callback, CasualMessage, ExtCallback, MergeResultKind, PeerMsg, PeerTicks, RaftCommand, ReadCallback,
-    ReadResponse, SignificantMsg, StoreMsg, StoreTick, WriteCallback, WriteResponse,
+    Callback, CasualMessage, ExtCallback, MergeResultKind, PeerMsg, PeerTicks, RaftCommand,
+    ReadCallback, ReadResponse, SignificantMsg, StoreMsg, StoreTick, WriteCallback, WriteResponse,
 };
 pub use self::peer::{
     Peer, PeerStat, ProposalContext, ReadExecutor, RequestInspector, RequestPolicy,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -571,7 +571,10 @@ impl Peer {
     }
 
     /// Tries to destroy itself. Returns a job (if needed) to do more cleaning tasks.
-    pub fn maybe_destroy(&mut self) -> Option<DestroyPeerJob> {
+    pub fn maybe_destroy<T, C>(
+        &mut self,
+        ctx: &PollContext<EK, ER, T, C>,
+    ) -> Option<DestroyPeerJob> {
         if self.pending_remove {
             info!(
                 "is being destroyed, skip";
@@ -580,16 +583,25 @@ impl Peer {
             );
             return None;
         }
-
-        if self.is_applying_snapshot() {
-            if !self.mut_store().cancel_applying_snap() {
+        {
+            let meta = ctx.store_meta.lock().unwrap();
+            if meta.atomic_snap_regions.contains_key(&self.region_id) {
                 info!(
-                    "stale peer is applying snapshot, will destroy next time";
+                    "stale peer is applying atomic snapshot, will destroy next time";
                     "region_id" => self.region_id,
                     "peer_id" => self.peer.get_id(),
                 );
                 return None;
             }
+        }
+
+        if self.is_applying_snapshot() && !self.mut_store().cancel_applying_snap() {
+            info!(
+                "stale peer is applying snapshot, will destroy next time";
+                "region_id" => self.region_id,
+                "peer_id" => self.peer.get_id(),
+            );
+            return None;
         }
 
         self.pending_remove = true;
@@ -1287,7 +1299,7 @@ impl Peer {
             self.send(&mut ctx.trans, messages, &mut ctx.raft_metrics.message);
         }
         let mut destroy_regions = vec![];
-        if self.get_pending_snapshot().is_some() {
+        if self.has_pending_snapshot() {
             if !self.ready_to_handle_pending_snap() {
                 let count = self.pending_request_snapshot_count.load(Ordering::SeqCst);
                 debug!(

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1,7 +1,6 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::cell::RefCell;
-use std::collections::Bound::{Excluded, Unbounded};
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{atomic, Arc};
@@ -23,7 +22,6 @@ use kvproto::raft_cmdpb::{
 };
 use kvproto::raft_serverpb::{
     ExtraMessage, ExtraMessageType, MergeState, PeerState, RaftApplyState, RaftMessage,
-    RaftSnapshotData,
 };
 use protobuf::Message;
 use raft::eraftpb::{self, ConfChangeType, EntryType, MessageType};
@@ -44,7 +42,6 @@ use crate::store::fsm::{
 use crate::store::worker::{ReadDelegate, ReadProgress, RegionTask};
 use crate::store::{Callback, Config, PdTask, ReadResponse, RegionSnapshot};
 use crate::{Error, Result};
-use keys::{enc_end_key, enc_start_key};
 use pd_client::INVALID_ID;
 use tikv_util::collections::{HashMap, HashSet};
 use tikv_util::time::Instant as UtilInstant;
@@ -340,7 +337,9 @@ pub struct Peer {
     /// Indicates whether the peer should be woken up.
     pub should_wake_up: bool,
     /// Whether this peer is destroyed asynchronously.
-    /// If it's true when merging, its data in storeMeta will be removed early by the target peer
+    /// If it's true,
+    /// 1. when merging, its data in storeMeta will be removed early by the target peer.
+    /// 2. all read requests must be rejected.
     pub pending_remove: bool,
     /// If a snapshot is being applied asynchronously, messages should not be sent.
     pending_messages: Vec<eraftpb::Message>,
@@ -1287,8 +1286,8 @@ impl Peer {
             ctx.need_flush_trans = true;
             self.send(&mut ctx.trans, messages, &mut ctx.raft_metrics.message);
         }
-
-        if let Some(snap) = self.get_pending_snapshot() {
+        let mut destroy_regions = vec![];
+        if self.get_pending_snapshot().is_some() {
             if !self.ready_to_handle_pending_snap() {
                 let count = self.pending_request_snapshot_count.load(Ordering::SeqCst);
                 debug!(
@@ -1302,46 +1301,24 @@ impl Peer {
                 return None;
             }
 
-            let mut snap_data = RaftSnapshotData::default();
-            snap_data
-                .merge_from_bytes(snap.get_data())
-                .unwrap_or_else(|e| {
-                    warn!(
-                        "failed to parse snap data";
-                        "region_id" => self.region_id,
-                        "peer_id" => self.peer.get_id(),
-                        "err" => ?e,
-                    );
-                });
-            let region = snap_data.take_region();
-
             let meta = ctx.store_meta.lock().unwrap();
-            // Region's range changes if and only if epoch version change. So if the snapshot's
-            // version is not larger than now, we can make sure there is no overlap.
-            if region.get_region_epoch().get_version()
-                > meta.regions[&region.get_id()]
-                    .get_region_epoch()
-                    .get_version()
-            {
-                // For merge process, when applying snapshot or create new peer the stale source
-                // peer is destroyed asynchronously. So here checks whether there is any overlap, if
-                // so, wait and do not handle raft ready.
-                if let Some(r) = meta
-                    .region_ranges
-                    .range((Excluded(enc_start_key(&region)), Unbounded::<Vec<u8>>))
-                    .map(|(_, &region_id)| &meta.regions[&region_id])
-                    .take_while(|r| enc_start_key(r) < enc_end_key(&region))
-                    .find(|r| r.get_id() != region.get_id())
-                {
-                    info!(
-                        "snapshot range overlaps, wait source destroy finish";
-                        "region_id" => self.region_id,
-                        "peer_id" => self.peer.get_id(),
-                        "apply_index" => self.get_store().applied_index(),
-                        "last_applying_index" => self.last_applying_idx,
-                        "overlap_region" => ?r,
-                    );
-                    return None;
+            // For merge process, the stale source peer is destroyed asynchronously when applying
+            // snapshot or creating new peer. So here checks whether there is any overlap, if so,
+            // wait and do not handle raft ready.
+            if let Some(wait_destroy_regions) = meta.atomic_snap_regions.get(&self.region_id) {
+                for (source_region_id, is_ready) in wait_destroy_regions {
+                    if !is_ready {
+                        info!(
+                            "snapshot range overlaps, wait source destroy finish";
+                            "region_id" => self.region_id,
+                            "peer_id" => self.peer.get_id(),
+                            "apply_index" => self.get_store().applied_index(),
+                            "last_applying_index" => self.last_applying_idx,
+                            "overlap_region_id" => source_region_id,
+                        );
+                        return None;
+                    }
+                    destroy_regions.push(meta.regions[source_region_id].clone());
                 }
             }
         }
@@ -1360,12 +1337,6 @@ impl Peer {
             return None;
         }
 
-        debug!(
-            "handle raft ready";
-            "region_id" => self.region_id,
-            "peer_id" => self.peer.get_id(),
-        );
-
         let before_handle_raft_ready_1003 = || {
             fail_point!(
                 "before_handle_raft_ready_1003",
@@ -1374,6 +1345,18 @@ impl Peer {
             );
         };
         before_handle_raft_ready_1003();
+
+        fail_point!(
+            "before_handle_snapshot_ready_3",
+            self.peer.get_id() == 3 && self.get_pending_snapshot().is_some(),
+            |_| None
+        );
+
+        debug!(
+            "handle raft ready";
+            "region_id" => self.region_id,
+            "peer_id" => self.peer.get_id(),
+        );
 
         let mut ready = self.raft_group.ready_since(self.last_applying_idx);
 
@@ -1450,7 +1433,10 @@ impl Peer {
             self.send(&mut ctx.trans, msgs, &mut ctx.raft_metrics.message);
         }
 
-        let invoke_ctx = match self.mut_store().handle_raft_ready(ctx, &ready) {
+        let invoke_ctx = match self
+            .mut_store()
+            .handle_raft_ready(ctx, &ready, destroy_regions)
+        {
             Ok(r) => r,
             Err(e) => {
                 // We may have written something to writebatch and it can't be reverted, so has

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -571,10 +571,7 @@ impl Peer {
     }
 
     /// Tries to destroy itself. Returns a job (if needed) to do more cleaning tasks.
-    pub fn maybe_destroy<T, C>(
-        &mut self,
-        ctx: &PollContext<T, C>,
-    ) -> Option<DestroyPeerJob> {
+    pub fn maybe_destroy<T, C>(&mut self, ctx: &PollContext<T, C>) -> Option<DestroyPeerJob> {
         if self.pending_remove {
             info!(
                 "is being destroyed, skip";

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -573,7 +573,7 @@ impl Peer {
     /// Tries to destroy itself. Returns a job (if needed) to do more cleaning tasks.
     pub fn maybe_destroy<T, C>(
         &mut self,
-        ctx: &PollContext<EK, ER, T, C>,
+        ctx: &PollContext<T, C>,
     ) -> Option<DestroyPeerJob> {
         if self.pending_remove {
             info!(

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -263,6 +263,7 @@ pub struct ApplySnapResult {
     // prev_region is the region before snapshot applied.
     pub prev_region: metapb::Region,
     pub region: metapb::Region,
+    pub destroyed_regions: Vec<metapb::Region>,
 }
 
 /// Returned by `PeerStorage::handle_raft_ready`, used for recording changed status of
@@ -276,6 +277,8 @@ pub struct InvokeContext {
     last_term: u64,
     /// The old region is stored here if there is a snapshot.
     pub snap_region: Option<Region>,
+    /// The regions whose range are overlapped with this region
+    pub destroyed_regions: Vec<metapb::Region>,
 }
 
 impl InvokeContext {
@@ -286,6 +289,7 @@ impl InvokeContext {
             apply_state: store.apply_state.clone(),
             last_term: store.last_term,
             snap_region: None,
+            destroyed_regions: vec![],
         }
     }
 
@@ -981,6 +985,7 @@ impl PeerStorage {
         snap: &Snapshot,
         kv_wb: &mut RocksWriteBatch,
         raft_wb: &mut RocksWriteBatch,
+        destroy_regions: &[metapb::Region],
     ) -> Result<()> {
         info!(
             "begin to apply snapshot";
@@ -1006,7 +1011,10 @@ impl PeerStorage {
             // we can only delete the old data when the peer is initialized.
             self.clear_meta(kv_wb, raft_wb)?;
         }
-
+        // Write its source peers' `RegionLocalState` together with itself for atomicity
+        for r in destroy_regions {
+            write_peer_state(kv_wb, r, PeerState::Tombstone, None)?;
+        }
         write_peer_state(kv_wb, &region, PeerState::Applying, None)?;
 
         let last_index = snap.get_metadata().get_index();
@@ -1060,11 +1068,14 @@ impl PeerStorage {
     }
 
     /// Delete all data that is not covered by `new_region`.
-    fn clear_extra_data(&self, new_region: &metapb::Region) -> Result<()> {
-        let (old_start_key, old_end_key) =
-            (enc_start_key(self.region()), enc_end_key(self.region()));
+    fn clear_extra_data(
+        &self,
+        region_id: u64,
+        old_region: &metapb::Region,
+        new_region: &metapb::Region,
+    ) -> Result<()> {
+        let (old_start_key, old_end_key) = (enc_start_key(old_region), enc_end_key(old_region));
         let (new_start_key, new_end_key) = (enc_start_key(new_region), enc_end_key(new_region));
-        let region_id = new_region.get_id();
         if old_start_key < new_start_key {
             box_try!(self.region_sched.schedule(RegionTask::destroy(
                 region_id,
@@ -1210,6 +1221,7 @@ impl PeerStorage {
         &mut self,
         ready_ctx: &mut H,
         ready: &Ready,
+        destroy_regions: Vec<metapb::Region>,
     ) -> Result<InvokeContext> {
         let mut ctx = InvokeContext::new(self);
         let snapshot_index = if raft::is_empty_snap(ready.snapshot()) {
@@ -1217,8 +1229,10 @@ impl PeerStorage {
         } else {
             fail_point!("raft_before_apply_snap");
             let (kv_wb, raft_wb) = ready_ctx.wb_mut();
-            self.apply_snapshot(&mut ctx, ready.snapshot(), kv_wb, raft_wb)?;
+            self.apply_snapshot(&mut ctx, ready.snapshot(), kv_wb, raft_wb, &destroy_regions)?;
             fail_point!("raft_after_apply_snap");
+
+            ctx.destroyed_regions = destroy_regions;
 
             last_index(&ctx.raft_state)
         };
@@ -1240,7 +1254,7 @@ impl PeerStorage {
         }
 
         // Save raft state if it has changed or peer has applied a snapshot.
-        if ctx.raft_state != self.raft_state || snapshot_index != 0 {
+        if ctx.raft_state != self.raft_state || snapshot_index > 0 {
             ctx.save_raft_state_to(ready_ctx.raft_wb_mut())?;
             if snapshot_index > 0 {
                 // in case of restart happen when we just write region state to Applying,
@@ -1252,7 +1266,7 @@ impl PeerStorage {
         }
 
         // only when apply snapshot
-        if snapshot_index != 0 {
+        if snapshot_index > 0 0 {
             ctx.save_apply_state_to(&mut ready_ctx.kv_wb_mut())?;
         }
 
@@ -1271,15 +1285,34 @@ impl PeerStorage {
         };
         // cleanup data before scheduling apply task
         if self.is_initialized() {
-            if let Err(e) = self.clear_extra_data(self.region()) {
+            if let Err(e) = self.clear_extra_data(self.get_region_id(), self.region(), &snap_region)
+            {
                 // No need panic here, when applying snapshot, the deletion will be tried
                 // again. But if the region range changes, like [a, c) -> [a, b) and [b, c),
                 // [b, c) will be kept in rocksdb until a covered snapshot is applied or
                 // store is restarted.
                 error!(?e;
                     "failed to cleanup data, may leave some dirty data";
-                    "region_id" => self.region.get_id(),
+                    "region_id" => self.get_region_id(),
                     "peer_id" => self.peer_id,
+                );
+            }
+        }
+
+        // Note that the correctness depends on the fact that these source regions MUST NOT
+        // serve read request otherwise a corrupt data may be returned.
+        // For now, it is ensured by
+        // 1. After `PrepareMerge` log is committed, the source region leader's lease will be
+        //    suspected immediately which makes local reader invalid to serve read request.
+        // 2. No read request can be responsed during merging.
+        // These conditions are used to prevent reading **stale** data in the past.
+        // At present, they are used to prevent reading **corrupt** data.
+        for r in &ctx.destroyed_regions {
+            if let Err(e) = self.clear_extra_data(r.get_id(), r, &snap_region) {
+                error!(
+                    "failed to cleanup data, may leave some dirty data";
+                    "region_id" => r.get_id(),
+                    "err" => ?e,
                 );
             }
         }
@@ -1291,6 +1324,7 @@ impl PeerStorage {
         Some(ApplySnapResult {
             prev_region,
             region: self.region().clone(),
+            destroyed_regions: ctx.destroyed_regions,
         })
     }
 }
@@ -2259,7 +2293,7 @@ mod tests {
         assert_ne!(ctx.last_term, snap1.get_metadata().get_term());
         let mut kv_wb = s2.engines.kv.c().write_batch();
         let mut raft_wb = s2.engines.raft.c().write_batch();
-        s2.apply_snapshot(&mut ctx, &snap1, &mut kv_wb, &mut raft_wb)
+        s2.apply_snapshot(&mut ctx, &snap1, &mut kv_wb, &mut raft_wb, &[])
             .unwrap();
         assert_eq!(ctx.last_term, snap1.get_metadata().get_term());
         assert_eq!(ctx.apply_state.get_applied_index(), 6);
@@ -2277,7 +2311,7 @@ mod tests {
         assert_ne!(ctx.last_term, snap1.get_metadata().get_term());
         let mut kv_wb = s3.engines.kv.c().write_batch();
         let mut raft_wb = s3.engines.raft.c().write_batch();
-        s3.apply_snapshot(&mut ctx, &snap1, &mut kv_wb, &mut raft_wb)
+        s3.apply_snapshot(&mut ctx, &snap1, &mut kv_wb, &mut raft_wb, &[])
             .unwrap();
         assert_eq!(ctx.last_term, snap1.get_metadata().get_term());
         assert_eq!(ctx.apply_state.get_applied_index(), 6);

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1266,7 +1266,7 @@ impl PeerStorage {
         }
 
         // only when apply snapshot
-        if snapshot_index > 0 0 {
+        if snapshot_index > 0 {
             ctx.save_apply_state_to(&mut ready_ctx.kv_wb_mut())?;
         }
 

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -638,7 +638,8 @@ where
                 });
             }
             task @ Task::Apply { .. } => {
-                // to makes sure appling snapshots in order.
+                fail_point!("on_region_worker_apply", true, |_| {});
+                // to makes sure applying snapshots in order.
                 self.pending_applies.push_back(task);
                 self.handle_pending_applies();
                 if !self.pending_applies.is_empty() {
@@ -653,6 +654,7 @@ where
                 start_key,
                 end_key,
             } => {
+                fail_point!("on_region_worker_destroy", true, |_| {});
                 // try to delay the range deletion because
                 // there might be a coprocessor request related to this range
                 self.ctx

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -10,7 +10,9 @@ use kvproto::errorpb::Error as PbError;
 use kvproto::metapb::{self, Peer, RegionEpoch};
 use kvproto::pdpb;
 use kvproto::raft_cmdpb::*;
-use kvproto::raft_serverpb::{self, RaftApplyState, RaftMessage, RaftTruncatedState};
+use kvproto::raft_serverpb::{
+    self, RaftApplyState, RaftLocalState, RaftMessage, RaftTruncatedState, RegionLocalState,
+};
 use raft::eraftpb::ConfChangeType;
 use tempfile::TempDir;
 
@@ -927,11 +929,22 @@ impl<T: Simulator> Cluster<T> {
             .unwrap()
     }
 
-    pub fn raft_local_state(&self, region_id: u64, store_id: u64) -> raft_serverpb::RaftLocalState {
+    pub fn raft_local_state(&self, region_id: u64, store_id: u64) -> RaftLocalState {
         let key = keys::raft_state_key(region_id);
         self.get_raft_engine(store_id)
             .c()
             .get_msg::<raft_serverpb::RaftLocalState>(&key)
+            .unwrap()
+            .unwrap()
+    }
+
+    pub fn region_local_state(&self, region_id: u64, store_id: u64) -> RegionLocalState {
+        self.get_engine(store_id)
+            .c()
+            .get_msg_cf::<RegionLocalState>(
+                engine_traits::CF_RAFT,
+                &keys::region_state_key(region_id),
+            )
             .unwrap()
             .unwrap()
     }

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -62,7 +62,7 @@ impl Transport for ChannelTransport {
         let region_id = msg.get_region_id();
         let is_snapshot = msg.get_message().get_msg_type() == MessageType::MsgSnapshot;
 
-        if msg.get_message().get_msg_type() == MessageType::MsgSnapshot {
+        if is_snapshot {
             let snap = msg.get_message().get_snapshot();
             let key = SnapKey::from_snap(snap).unwrap();
             let from = match self.core.lock().unwrap().snap_paths.get(&from_store) {

--- a/tests/failpoints/cases/test_snap.rs
+++ b/tests/failpoints/cases/test_snap.rs
@@ -3,7 +3,7 @@
 use std::sync::atomic::Ordering;
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::*;
-use std::{fs, io, thread};
+use std::{fs, io, mem, thread};
 
 use fail;
 use raft::eraftpb::MessageType;
@@ -376,4 +376,96 @@ fn test_shutdown_when_snap_gc() {
     if dir.count() == 0 {
         panic!("store 2 snap dir must not be empty");
     }
+}
+
+// Test if a peer handle the old snapshot properly.
+#[test]
+fn test_receive_old_snapshot() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_snapshot(&mut cluster);
+    cluster.cfg.raft_store.right_derive_when_split = true;
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+    let r1 = cluster.run_conf_change();
+
+    // Bypass the snapshot gc because the snapshot may be used twice.
+    let peer_2_handle_snap_mgr_gc_fp = "peer_2_handle_snap_mgr_gc";
+    fail::cfg(peer_2_handle_snap_mgr_gc_fp, "return()").unwrap();
+
+    pd_client.must_add_peer(r1, new_peer(2, 2));
+    pd_client.must_add_peer(r1, new_peer(3, 3));
+
+    cluster.must_transfer_leader(r1, new_peer(1, 1));
+
+    cluster.must_put(b"k00", b"v1");
+    // Ensure peer 2 is initialized.
+    must_get_equal(&cluster.get_engine(2), b"k00", b"v1");
+
+    cluster.add_send_filter(IsolationFilterFactory::new(2));
+
+    for i in 0..20 {
+        cluster.must_put(format!("k{}", i).as_bytes(), b"v1");
+    }
+
+    let dropped_msgs = Arc::new(Mutex::new(Vec::new()));
+    let recv_filter = Box::new(
+        RegionPacketFilter::new(r1, 2)
+            .direction(Direction::Recv)
+            .msg_type(MessageType::MsgSnapshot)
+            .reserve_dropped(Arc::clone(&dropped_msgs)),
+    );
+    cluster.sim.wl().add_recv_filter(2, recv_filter);
+
+    cluster.clear_send_filters();
+
+    for _ in 0..20 {
+        let guard = dropped_msgs.lock().unwrap();
+        if !guard.is_empty() {
+            break;
+        }
+        drop(guard);
+        sleep_ms(10);
+    }
+    let msgs = {
+        let mut guard = dropped_msgs.lock().unwrap();
+        if guard.is_empty() {
+            drop(guard);
+            panic!("do not receive snapshot msg in 200ms");
+        }
+        mem::replace(guard.as_mut(), vec![])
+    };
+
+    cluster.sim.wl().clear_recv_filters(2);
+
+    for i in 20..40 {
+        cluster.must_put(format!("k{}", i).as_bytes(), b"v1");
+    }
+    must_get_equal(&cluster.get_engine(2), b"k39", b"v1");
+
+    let router = cluster.sim.wl().get_router(2).unwrap();
+    // Send the old snapshot
+    for raft_msg in msgs {
+        router.send_raft_message(raft_msg).unwrap();
+    }
+
+    cluster.must_put(b"k40", b"v1");
+    must_get_equal(&cluster.get_engine(2), b"k40", b"v1");
+
+    pd_client.must_remove_peer(r1, new_peer(2, 2));
+
+    must_get_none(&cluster.get_engine(2), b"k40");
+
+    let region = cluster.get_region(b"k1");
+    cluster.must_split(&region, b"k5");
+
+    let left = cluster.get_region(b"k1");
+    pd_client.must_add_peer(left.get_id(), new_peer(2, 4));
+
+    cluster.must_put(b"k11", b"v1");
+    // If peer 2 handles previous old snapshot properly and does not leave over metadata
+    // in `pending_snapshot_regions`, peer 4 should be created normally.
+    must_get_equal(&cluster.get_engine(2), b"k11", b"v1");
+
+    fail::remove(peer_2_handle_snap_mgr_gc_fp);
 }

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -174,7 +174,7 @@ fn test_node_merge_with_slow_learner() {
     let state1 = cluster.truncated_state(right.get_id(), 1);
     (0..50).for_each(|i| cluster.must_put(b"k2", format!("v{}", i).as_bytes()));
 
-    // wait to trigger compact raft log
+    // Wait to trigger compact raft log
     let timer = Instant::now();
     loop {
         let state2 = cluster.truncated_state(right.get_id(), 1);


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:
Cherry-pick https://github.com/tikv/tikv/pull/7027, https://github.com/tikv/tikv/pull/8408


### Release note <!-- bugfixes or new feature need a release note -->
* Fix an issue that region merge may cause data loss during network partition.
* Fix a panic issue that may happen in region merge when TiKV crashes.