### PR TITLE
storage: return memory locks as ScanResponse level error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#494a2fb764b7f4118094380d82e29e0440c9bee5"
+source = "git+https://github.com/sticnarf/kvproto.git?branch=async-commit-scan#1eacea5f033c326faa5e49c126bf68110b6dcfd2"
 dependencies = [
  "futures 0.3.7",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/sticnarf/kvproto.git?branch=async-commit-scan#1eacea5f033c326faa5e49c126bf68110b6dcfd2"
+source = "git+https://github.com/pingcap/kvproto.git#5dfa7b1325a3bfc07100eb2bcde655950122fa25"
 dependencies = [
  "futures 0.3.7",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,9 +183,6 @@ raft-proto = { git = "https://github.com/tikv/raft-rs", branch = "master", defau
 protobuf = { git = "https://github.com/pingcap/rust-protobuf", rev = "65e9df20fbcbcf2409d5ee86a2332ecd04c534f8" }
 protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "65e9df20fbcbcf2409d5ee86a2332ecd04c534f8" }
 
-[patch.'https://github.com/pingcap/kvproto.git']
-kvproto = { git = "https://github.com/sticnarf/kvproto.git", branch = "async-commit-scan" }
-
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,9 @@ raft-proto = { git = "https://github.com/tikv/raft-rs", branch = "master", defau
 protobuf = { git = "https://github.com/pingcap/rust-protobuf", rev = "65e9df20fbcbcf2409d5ee86a2332ecd04c534f8" }
 protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "65e9df20fbcbcf2409d5ee86a2332ecd04c534f8" }
 
+[patch.'https://github.com/pingcap/kvproto.git']
+kvproto = { git = "https://github.com/sticnarf/kvproto.git", branch = "async-commit-scan" }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/tests/failpoints/cases/test_kv_service.rs
+++ b/tests/failpoints/cases/test_kv_service.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use kvproto::kvrpcpb::BatchGetRequest;
+use kvproto::kvrpcpb::*;
 use test_raftstore::must_new_cluster_and_kv_client;
 
 #[test]
@@ -14,6 +14,23 @@ fn test_batch_get_memory_lock() {
 
     fail::cfg("raftkv_async_snapshot_err", "return").unwrap();
     let resp = client.kv_batch_get(&req).unwrap();
+    // the injected error should be returned at both places for backward compatibility.
+    assert!(!resp.pairs[0].get_error().get_abort().is_empty());
+    assert!(!resp.get_error().get_abort().is_empty());
+    fail::remove("raftkv_async_snapshot_err");
+}
+
+#[test]
+fn test_kv_scan_memory_lock() {
+    let (_cluster, client, ctx) = must_new_cluster_and_kv_client();
+
+    let mut req = ScanRequest::default();
+    req.set_context(ctx);
+    req.set_start_key(b"a".to_vec());
+    req.version = 50;
+
+    fail::cfg("raftkv_async_snapshot_err", "return").unwrap();
+    let resp = client.kv_scan(&req).unwrap();
     // the injected error should be returned at both places for backward compatibility.
     assert!(!resp.pairs[0].get_error().get_abort().is_empty());
     assert!(!resp.get_error().get_abort().is_empty());

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -1197,4 +1197,3 @@ fn test_kv_scan_memory_lock() {
         assert_eq!(resp.get_error().get_locked(), &lock_info);
     });
 }
- 


### PR DESCRIPTION
- [x] Depends on the unmerged https://github.com/pingcap/kvproto/pull/697

### What problem does this PR solve?

Problem Summary:

`KvScan` interface has a similar problem with https://github.com/tikv/tikv/pull/9077. TiDB requires all the KV pairs in the range to be returned (if the limit is not reached).

Although queries from TiDB users are transformed into coprocessor queries, the `KvScan` interface is still used in multiple cases like backfilling in DDLs.

### What is changed and how it works?

Set memory lock to the newly added KeyError field in `ScanResponse`. The client will skip using pairs if the error is used.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- Part of the async commit feature