### PR TITLE
cmd/src/server:mv gcworker cfg reg to initgcworker

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -448,6 +448,12 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             .start_observe_lock_apply(self.coprocessor_host.as_mut().unwrap())
             .unwrap_or_else(|e| fatal!("gc worker failed to observe lock apply: {}", e));
 
+        let cfg_controller = self.cfg_controller.as_mut().unwrap();
+        cfg_controller.register(
+            tikv::config::Module::Gc,
+            Box::new(gc_worker.get_config_manager()),
+        );
+
         gc_worker
     }
 
@@ -459,10 +465,6 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         >,
     ) -> Arc<ServerConfig> {
         let cfg_controller = self.cfg_controller.as_mut().unwrap();
-        cfg_controller.register(
-            tikv::config::Module::Gc,
-            Box::new(gc_worker.get_config_manager()),
-        );
 
         // Create cdc.
         let mut cdc_worker = Box::new(LazyWorker::new("cdc"));


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

### What's Changed:
move gc_worker config registration code to init_gc_worker in order to put related codes together

### Check List
Tests
- Unit test

### Release note
No release note.

Signed-off-by: Jinn rogue_king@hotmail.com