### PR TITLE
raftstore: remove PendingCmdQueue from apply thread

### DIFF
--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1742,17 +1742,17 @@ where
                 let current_term = self.term();
                 let cbs = committed_entries
                     .iter()
-                    .filter_map(|e| {
+                    .map(|e| {
                         self.proposals
-                            .find_proposal(e.get_term(), e.get_index(), current_term)
-                    })
-                    .map(|mut p| {
-                        if p.must_pass_epoch_check {
-                            // In this case the apply can be guaranteed to be successful. Invoke the
-                            // on_committed callback if necessary.
-                            p.cb.invoke_committed();
-                        }
-                        p
+                            .find_proposal(e.get_index(), e.get_term(), current_term)
+                            .map(|mut p| {
+                                if p.must_pass_epoch_check {
+                                    // In this case the apply can be guaranteed to be successful. Invoke the
+                                    // on_committed callback if necessary.
+                                    p.cb.invoke_committed();
+                                }
+                                p.cb
+                            })
                     })
                     .collect();
                 let committed_index = self.raft_group.raft.raft_log.committed;
@@ -1762,10 +1762,10 @@ where
                     self.region_id,
                     self.term(),
                     committed_entries,
+                    cbs,
                     self.get_store().committed_index(),
                     committed_index,
                     committed_term,
-                    cbs,
                 );
                 ctx.apply_router
                     .schedule_task(self.region_id, ApplyTask::apply(apply));


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:

https://github.com/tikv/tikv/pull/9136 notify stale callbacks before send to the apply thread, so the `PendingCmdQueue` in apply thread is redundant

This should merged after https://github.com/tikv/tikv/pull/9136

### What is changed and how it works?

Remove the `PendingCmdQueue` from apply thread

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note