### PR TITLE
copr: add vectorize sub_duration_and_duration

### DIFF
--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -180,6 +180,27 @@ pub fn add_datetime_and_duration(
     Ok(Some(res))
 }
 
+#[rpn_fn(capture=[ctx])]
+#[inline]
+pub fn sub_duration_and_duration(
+    ctx: &mut EvalContext,
+    duration1: &Duration,
+    duration2: &Duration,
+) -> Result<Option<Duration>> {
+    let result = match duration1.checked_sub(*duration2) {
+        Some(result) => result,
+        None => {
+            return ctx
+                .handle_invalid_time_error(Error::overflow(
+                    "Duration",
+                    format!("({} - {})", duration1, duration2),
+                ))
+                .map(|_| Ok(None))?
+        }
+    };
+    Ok(Some(result))
+}
+
 #[rpn_fn(capture = [ctx])]
 #[inline]
 pub fn sub_datetime_and_duration(
@@ -481,6 +502,31 @@ mod tests {
             (Some("11:59:59"), Some("00:00:01"), Some("12:00:00")),
             (Some("23:59:59"), Some("00:00:01"), Some("24:00:00")),
             (Some("23:59:59"), Some("00:00:02"), Some("24:00:01")),
+            (None, None, None),
+        ];
+        let mut ctx = EvalContext::default();
+        for (duration1, duration2, exp) in cases {
+            let expected =
+                exp.map(|exp| Duration::parse(&mut ctx, exp.as_bytes(), MAX_FSP).unwrap());
+            let duration1 =
+                duration1.map(|arg1| Duration::parse(&mut ctx, arg1.as_bytes(), MAX_FSP).unwrap());
+            let duration2 =
+                duration2.map(|arg2| Duration::parse(&mut ctx, arg2.as_bytes(), MAX_FSP).unwrap());
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(duration1)
+                .push_param(duration2)
+                .evaluate(ScalarFuncSig::AddDurationAndDuration)
+                .unwrap();
+            assert_eq!(output, expected);
+        }
+    }
+    #[test]
+    fn test_sub_duration_and_duration() {
+        let cases = vec![
+            (Some("00:02:02"), Some("00:01:01"), Some("00:01:01")),
+            (Some("12:00:00"), Some("00:00:01"), Some("11:59:59")),
+            (Some("24:00:00"), Some("00:00:01"), Some("23:59:59")),
+            (Some("24:00:01"), Some("00:00:02"), Some("23:59:59")),
             (None, None, None),
         ];
         let mut ctx = EvalContext::default();

--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -540,7 +540,7 @@ mod tests {
             let output = RpnFnScalarEvaluator::new()
                 .push_param(duration1)
                 .push_param(duration2)
-                .evaluate(ScalarFuncSig::AddDurationAndDuration)
+                .evaluate(ScalarFuncSig::SubDurationAndDuration)
                 .unwrap();
             assert_eq!(output, expected);
         }

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -601,6 +601,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::PeriodDiff => period_diff_fn_meta(),
         ScalarFuncSig::LastDay => last_day_fn_meta(),
         ScalarFuncSig::AddDurationAndDuration => add_duration_and_duration_fn_meta(),
+        ScalarFuncSig::SubDurationAndDuration => sub_duration_and_duration_fn_meta(),
         ScalarFuncSig::MakeTime => make_time_fn_meta(),
         _ => return Err(other_err!(
             "ScalarFunction {:?} is not supported in batch mode",


### PR DESCRIPTION
Signed-off-by: jyz0309 <45495947@qq.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
Issue Number: related to #9016
Problem Summary:
add vectorize sub_duration_and_duration
### What is changed and how it works?
What's Changed:
add vectorize sub_duration_and_duration
### Related changes
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->
- pr: add vectorize sub_duration_and_duration