### PR TITLE
rocksdb: Fix missing rocksdb update of #9029

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#6d8620d13c83b6388ac4d6fe629d43f94612372e"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#84369a7eee61422c476fe43835a53dae9490a39b"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#6d8620d13c83b6388ac4d6fe629d43f94612372e"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#84369a7eee61422c476fe43835a53dae9490a39b"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -3514,7 +3514,7 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#6d8620d13c83b6388ac4d6fe629d43f94612372e"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#84369a7eee61422c476fe43835a53dae9490a39b"
 dependencies = [
  "libc",
  "librocksdb_sys",


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
https://github.com/tikv/tikv/pull/9029 is intended to update rocksdb to include cache key collision fix and key order check. But the update is not included by mistake. So update rocksdb by this PR.

### What is changed and how it works?

What's Changed:
run `cargo update -p rocksdb`

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code


### Release note <!-- bugfixes or new feature need a release note -->
- None