### PR TITLE
Optimize scheduler latches to avoid latch-wait (#6094)

### DIFF
--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -15,7 +15,8 @@ pub const DEFAULT_ROCKSDB_SUB_DIR: &str = "db";
 const DEFAULT_GC_RATIO_THRESHOLD: f64 = 1.1;
 const DEFAULT_MAX_KEY_SIZE: usize = 4 * 1024;
 const DEFAULT_SCHED_CAPACITY: usize = 10240;
-const DEFAULT_SCHED_CONCURRENCY: usize = 2048000;
+const DEFAULT_SCHED_CONCURRENCY: usize = 1024 * 512;
+const MAX_SCHED_CONCURRENCY: usize = 2 * 1024 * 1024;
 
 // According to "Little's law", assuming you can write 100MB per
 // second, and it takes about 100ms to process the write requests
@@ -58,6 +59,12 @@ impl Config {
     pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
         if self.data_dir != DEFAULT_DATA_DIR {
             self.data_dir = config::canonicalize_path(&self.data_dir)?
+        }
+        if self.scheduler_concurrency > MAX_SCHED_CONCURRENCY {
+            warn!("TiKV has optimized latch since v3.0.20, so it is not necessary to set large schedule \
+                concurrency. To save memory, change it from {:?} to {:?}",
+                  self.scheduler_concurrency, MAX_SCHED_CONCURRENCY);
+            self.scheduler_concurrency = MAX_SCHED_CONCURRENCY;
         }
         Ok(())
     }

--- a/src/storage/txn/latch.rs
+++ b/src/storage/txn/latch.rs
@@ -3,20 +3,23 @@
 use std::collections::hash_map::DefaultHasher;
 use std::collections::VecDeque;
 use std::hash::{Hash, Hasher};
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 use std::usize;
+
+const WAITING_LIST_SHRINK_SIZE: usize = 8;
+const WAITING_LIST_MAX_CAPACITY: usize = 16;
 
 /// Latch which is used to serialize accesses to resources hashed to the same slot.
 ///
-/// Latches are indexed by slot IDs. The keys of a command are hashed to slot IDs, then the command
-/// is added to the waiting queues of the latches.
+/// Latches are indexed by slot IDs. The keys of a command are hashed into unsigned numbers,
+/// then the command is added to the waiting queues of the latches.
 ///
 /// If command A is ahead of command B in one latch, it must be ahead of command B in all the
 /// overlapping latches. This is an invariant ensured by the `gen_lock`, `acquire` and `release`.
 #[derive(Clone)]
 struct Latch {
-    // store waiting commands
-    pub waiting: VecDeque<u64>,
+    // store hash value of the key and command ID which requires this key.
+    pub waiting: VecDeque<Option<(u64, u64)>>,
 }
 
 impl Latch {
@@ -26,13 +29,70 @@ impl Latch {
             waiting: VecDeque::new(),
         }
     }
+
+    /// Find the first command ID in the queue whose hash value is equal to hash.
+    pub fn get_first_req_by_hash(&self, hash: u64) -> Option<u64> {
+        for item in self.waiting.iter() {
+            if let Some((h, cid)) = item {
+                if *h == hash {
+                    return Some(*cid);
+                }
+            }
+        }
+        None
+    }
+
+    /// Remove the first command ID in the queue whose hash value is equal to hash_key.
+    /// If the element which would be removed does not appear at the front of the queue, it will leave
+    /// a hole in the queue. So we must remove consecutive hole when remove the head of the
+    /// queue to make the queue not too long.
+    pub fn pop_front(&mut self, key_hash: u64) -> Option<(u64, u64)> {
+        if let Some(item) = self.waiting.pop_front() {
+            if let Some((k, _)) = item.as_ref() {
+                if *k == key_hash {
+                    self.maybe_shrink();
+                    return item;
+                }
+                self.waiting.push_front(item);
+            }
+            for it in self.waiting.iter_mut() {
+                if let Some((v, _)) = it {
+                    if *v == key_hash {
+                        return it.take();
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    pub fn wait_for_wake(&mut self, key_hash: u64, cid: u64) {
+        self.waiting.push_back(Some((key_hash, cid)));
+    }
+
+    /// For some hot keys, the waiting list maybe very long, so we should shrink the waiting
+    /// VecDeque after pop.
+    fn maybe_shrink(&mut self) {
+        // Pop item which is none to make queue not too long.
+        while let Some(item) = self.waiting.front() {
+            if item.is_some() {
+                break;
+            }
+            self.waiting.pop_front().unwrap();
+        }
+        if self.waiting.capacity() > WAITING_LIST_MAX_CAPACITY
+            && self.waiting.len() < WAITING_LIST_SHRINK_SIZE
+        {
+            self.waiting.shrink_to_fit();
+        }
+    }
 }
 
 /// Lock required for a command.
 #[derive(Clone)]
 pub struct Lock {
-    /// The slot IDs of the latches that a command must acquire before being able to be processed.
-    pub required_slots: Vec<usize>,
+    /// The hash value of the keys that a command must acquire before being able to be processed.
+    pub required_hashes: Vec<u64>,
 
     /// The number of latches that the command has acquired.
     pub owned_count: usize,
@@ -40,20 +100,20 @@ pub struct Lock {
 
 impl Lock {
     /// Creates a lock.
-    pub fn new(required_slots: Vec<usize>) -> Lock {
+    pub fn new(required_hashes: Vec<u64>) -> Lock {
         Lock {
-            required_slots,
+            required_hashes,
             owned_count: 0,
         }
     }
 
     /// Returns true if all the required latches have be acquired, false otherwise.
     pub fn acquired(&self) -> bool {
-        self.required_slots.len() == self.owned_count
+        self.required_hashes.len() == self.owned_count
     }
 
     pub fn is_write_lock(&self) -> bool {
-        !self.required_slots.is_empty()
+        !self.required_hashes.is_empty()
     }
 }
 
@@ -83,33 +143,32 @@ impl Latches {
         H: Hash,
     {
         // prevent from deadlock, so we sort and deduplicate the index
-        let mut slots: Vec<usize> = keys.iter().map(|x| self.calc_slot(x)).collect();
-        slots.sort();
-        slots.dedup();
-        Lock::new(slots)
+        let mut hashes: Vec<u64> = keys.iter().map(|x| self.calc_slot(x)).collect();
+        hashes.sort();
+        hashes.dedup();
+        Lock::new(hashes)
     }
 
     /// Tries to acquire the latches specified by the `lock` for command with ID `who`.
     ///
     /// This method will enqueue the command ID into the waiting queues of the latches. A latch is
-    /// considered acquired if the command ID is at the front of the queue. Returns true if all the
-    /// Latches are acquired, false otherwise.
+    /// considered acquired if the command ID is the first one of elements in the queue which have
+    /// the same hash value. Returns true if all the Latches are acquired, false otherwise.
     pub fn acquire(&self, lock: &mut Lock, who: u64) -> bool {
         let mut acquired_count: usize = 0;
-        for i in &lock.required_slots[lock.owned_count..] {
-            let mut latch = self.slots[*i].lock().unwrap();
-            let front = latch.waiting.front().cloned();
-            match front {
+        for &key_hash in &lock.required_hashes[lock.owned_count..] {
+            let mut latch = self.lock_latch(key_hash);
+            match latch.get_first_req_by_hash(key_hash) {
                 Some(cid) => {
                     if cid == who {
                         acquired_count += 1;
                     } else {
-                        latch.waiting.push_back(who);
+                        latch.wait_for_wake(key_hash, who);
                         break;
                     }
                 }
                 None => {
-                    latch.waiting.push_back(who);
+                    latch.wait_for_wake(key_hash, who);
                     acquired_count += 1;
                 }
             }
@@ -123,25 +182,34 @@ impl Latches {
     /// Preconditions: the caller must ensure the command is at the front of the latches.
     pub fn release(&self, lock: &Lock, who: u64) -> Vec<u64> {
         let mut wakeup_list: Vec<u64> = vec![];
-        for i in &lock.required_slots[..lock.owned_count] {
-            let mut latch = self.slots[*i].lock().unwrap();
-            let front = latch.waiting.pop_front().unwrap();
+        for &key_hash in &lock.required_hashes[..lock.owned_count] {
+            let mut latch = self.lock_latch(key_hash);
+            let (v, front) = latch.pop_front(key_hash).unwrap();
             assert_eq!(front, who);
-            if let Some(wakeup) = latch.waiting.front() {
-                wakeup_list.push(*wakeup);
+            assert_eq!(v, key_hash);
+            if let Some(wakeup) = latch.get_first_req_by_hash(key_hash) {
+                wakeup_list.push(wakeup);
             }
         }
         wakeup_list
     }
 
-    /// Calculates the slot ID by hashing the `key`.
-    fn calc_slot<H>(&self, key: &H) -> usize
+    /// Calculates the hash value of the `key`.
+    fn calc_slot<H>(&self, key: &H) -> u64
     where
         H: Hash,
     {
         let mut s = DefaultHasher::new();
         key.hash(&mut s);
-        (s.finish() as usize) & (self.size - 1)
+
+        s.finish()
+    }
+
+    #[inline]
+    fn lock_latch(&self, hash: u64) -> MutexGuard<'_, Latch> {
+        self.slots[(hash as usize) & (self.size - 1)]
+            .lock()
+            .unwrap()
     }
 }
 
@@ -153,9 +221,9 @@ mod tests {
     fn test_wakeup() {
         let latches = Latches::new(256);
 
-        let slots_a: Vec<usize> = vec![1, 3, 5];
+        let slots_a: Vec<u64> = vec![1, 3, 5];
         let mut lock_a = Lock::new(slots_a);
-        let slots_b: Vec<usize> = vec![4, 5, 6];
+        let slots_b: Vec<u64> = vec![4, 5, 6];
         let mut lock_b = Lock::new(slots_b);
         let cid_a: u64 = 1;
         let cid_b: u64 = 2;
@@ -181,9 +249,9 @@ mod tests {
     fn test_wakeup_by_multi_cmds() {
         let latches = Latches::new(256);
 
-        let slots_a: Vec<usize> = vec![1, 2, 3];
-        let slots_b: Vec<usize> = vec![4, 5, 6];
-        let slots_c: Vec<usize> = vec![3, 4];
+        let slots_a: Vec<u64> = vec![1, 2, 3];
+        let slots_b: Vec<u64> = vec![4, 5, 6];
+        let slots_c: Vec<u64> = vec![3, 4];
         let mut lock_a = Lock::new(slots_a);
         let mut lock_b = Lock::new(slots_b);
         let mut lock_c = Lock::new(slots_c);
@@ -218,5 +286,54 @@ mod tests {
         // finally c acquire lock success
         acquired_c = latches.acquire(&mut lock_c, cid_c);
         assert_eq!(acquired_c, true);
+    }
+
+    #[test]
+    fn test_wakeup_by_small_latch_slot() {
+        let latches = Latches::new(5);
+
+        let slots_a: Vec<u64> = vec![1, 2, 3];
+        let slots_b: Vec<u64> = vec![6, 7, 8];
+        let slots_c: Vec<u64> = vec![3, 4];
+        let slots_d: Vec<u64> = vec![7, 10];
+        let mut lock_a = Lock::new(slots_a);
+        let mut lock_b = Lock::new(slots_b);
+        let mut lock_c = Lock::new(slots_c);
+        let mut lock_d = Lock::new(slots_d);
+        let cid_a: u64 = 1;
+        let cid_b: u64 = 2;
+        let cid_c: u64 = 3;
+        let cid_d: u64 = 4;
+
+        let acquired_a = latches.acquire(&mut lock_a, cid_a);
+        assert_eq!(acquired_a, true);
+
+        // c acquire lock failed, cause a occupied slot 3
+        let mut acquired_c = latches.acquire(&mut lock_c, cid_c);
+        assert_eq!(acquired_c, false);
+
+        // b acquire lock success
+        let acquired_b = latches.acquire(&mut lock_b, cid_b);
+        assert_eq!(acquired_b, true);
+
+        // d acquire lock failed, cause a occupied slot 7
+        let mut acquired_d = latches.acquire(&mut lock_d, cid_d);
+        assert_eq!(acquired_d, false);
+
+        // a release lock, and get wakeup list
+        let wakeup = latches.release(&lock_a, cid_a);
+        assert_eq!(wakeup[0], cid_c);
+
+        // c acquire lock success
+        acquired_c = latches.acquire(&mut lock_c, cid_c);
+        assert_eq!(acquired_c, true);
+
+        // b release lock, and get wakeup list
+        let wakeup = latches.release(&lock_b, cid_b);
+        assert_eq!(wakeup[0], cid_d);
+
+        // finally d acquire lock success
+        acquired_d = latches.acquire(&mut lock_d, cid_d);
+        assert_eq!(acquired_d, true);
     }
 }


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
The latches scheduler would prevent key writing ,if there has been one key in waiting queue. I changed this behavior to check the waiting if there has been a hash value repeat with it .

I set scheduler-concurrency to 512 * 1024 by default. If there are 1000K keys written at the same time, every key would be compared in the deque only twice. I think it is efficient enough.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.