### PR TITLE
txn: remove extra_op related things from MvccTxn

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -105,7 +105,7 @@ pub(crate) type OldValueCallback =
     Box<dyn FnMut(Key, TimeStamp, &mut OldValueCache, &mut Statistics) -> Option<Vec<u8>> + Send>;
 
 pub struct OldValueCache {
-    pub cache: LruCache<Key, (Option<OldValue>, MutationType)>,
+    pub cache: LruCache<Key, (OldValue, MutationType)>,
     pub miss_count: usize,
     pub access_count: usize,
 }
@@ -1245,7 +1245,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> RunnableWithTimer for Endpoint<T
             .old_value_cache
             .cache
             .iter()
-            .map(|(k, v)| k.as_encoded().len() + v.0.as_ref().map_or(0, |v| v.size()))
+            .map(|(k, v)| k.as_encoded().len() + v.0.size())
             .sum();
         CDC_OLD_VALUE_CACHE_BYTES.set(cache_size as i64);
         CDC_OLD_VALUE_CACHE_ACCESS.add(self.old_value_cache.access_count as i64);

--- a/components/txn_types/src/lib.rs
+++ b/components/txn_types/src/lib.rs
@@ -19,8 +19,8 @@ use std::io;
 pub use lock::{Lock, LockType};
 pub use timestamp::{TimeStamp, TsSet};
 pub use types::{
-    is_short_value, Key, KvPair, Mutation, MutationType, OldValue, TxnExtra, TxnExtraScheduler,
-    Value, SHORT_VALUE_MAX_LEN,
+    is_short_value, Key, KvPair, Mutation, MutationType, OldValue, OldValues, TxnExtra,
+    TxnExtraScheduler, Value, SHORT_VALUE_MAX_LEN,
 };
 pub use write::{Write, WriteRef, WriteType};
 

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -244,6 +244,12 @@ pub enum MutationType {
     Other,
 }
 
+impl MutationType {
+    pub fn may_have_old_value(&self) -> bool {
+        matches!(self, MutationType::Put | MutationType::Delete)
+    }
+}
+
 /// A row mutation.
 #[derive(Debug, Clone)]
 pub enum Mutation {

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -1,4 +1,5 @@
 use super::timestamp::TimeStamp;
+use crate::Write;
 use byteorder::{ByteOrder, NativeEndian};
 use collections::HashMap;
 use kvproto::kvrpcpb;
@@ -322,17 +323,57 @@ impl From<kvrpcpb::Mutation> for Mutation {
     }
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct OldValue {
-    pub short_value: Option<Value>,
-    pub start_ts: TimeStamp,
+/// `OldValue` is used by cdc to read the previous value associated with some key during the prewrite process
+#[derive(Debug, Clone, PartialEq)]
+pub enum OldValue {
+    /// A real `OldValue`
+    Value {
+        short_value: Option<Value>,
+        start_ts: TimeStamp,
+    },
+    /// `None` means we don't found a previous value
+    None,
+    /// `Unspecified` means the user doesn't care about the previous value
+    Unspecified,
+}
+
+impl Default for OldValue {
+    fn default() -> Self {
+        OldValue::Unspecified
+    }
+}
+
+impl From<Option<Write>> for OldValue {
+    fn from(write: Option<Write>) -> Self {
+        match write {
+            Some(w) => OldValue::Value {
+                short_value: w.short_value,
+                start_ts: w.start_ts,
+            },
+            None => OldValue::None,
+        }
+    }
 }
 
 impl OldValue {
+    pub fn specified(&self) -> bool {
+        !matches!(self, OldValue::Unspecified)
+    }
+
+    pub fn exists(&self) -> bool {
+        matches!(
+            self,
+            OldValue::Value {..}
+        )
+    }
+
     pub fn size(&self) -> usize {
-        let value_size = match self.short_value {
-            Some(ref v) => v.len(),
-            None => 0,
+        let value_size = match self {
+            OldValue::Value {
+                short_value: Some(v),
+                ..
+            } => v.len(),
+            _ => 0,
         };
         value_size + std::mem::size_of::<TimeStamp>()
     }
@@ -342,7 +383,7 @@ impl OldValue {
 // key with current ts -> (short value of the prev txn, start ts of the prev txn).
 // The value of the map will be None when the mutation is `Insert`.
 // MutationType is the type of mutation of the current write.
-pub type OldValues = HashMap<Key, (Option<OldValue>, MutationType)>;
+pub type OldValues = HashMap<Key, (OldValue, MutationType)>;
 
 // Extra data fields filled by kvrpcpb::ExtraOp.
 #[derive(Default, Debug, Clone)]
@@ -354,22 +395,8 @@ pub struct TxnExtra {
 }
 
 impl TxnExtra {
-    pub fn add_old_value(
-        &mut self,
-        key: Key,
-        value: Option<OldValue>,
-        mutation_type: MutationType,
-    ) {
-        self.old_values.insert(key, (value, mutation_type));
-    }
-
     pub fn is_empty(&self) -> bool {
         self.old_values.is_empty()
-    }
-
-    pub fn extend(&mut self, other: &mut Self) {
-        self.old_values
-            .extend(std::mem::take(&mut other.old_values))
     }
 }
 

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -324,9 +324,12 @@ impl WriteRef<'_> {
         size
     }
 
-    /// Assume the current `Write` record is the latest version found by reading at `read_ts`, check
-    /// the GC fence to determine if the `Write` record is valid. The `read_ts` is assumed to be
-    /// safe, which means, it's not earlier than the current GC safepoint.
+    /// Prev Conditions:
+    ///   * The `Write` record `self` is referring to is the latest version found by reading at `read_ts`
+    ///   * The `read_ts` is safe, which means, it's not earlier than the current GC safepoint.
+    /// Return:
+    ///   Whether the `Write` record is valid, ie. there's no GC fence or GC fence doesn't points to any other
+    ///   version.
     pub fn check_gc_fence_as_latest_version(&self, read_ts: TimeStamp) -> bool {
         // It's a valid write record if there's no GC fence or GC fence doesn't points to any other
         // version.

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -218,6 +218,10 @@ impl Write {
             gc_fence: self.gc_fence,
         }
     }
+
+    pub fn may_has_old_value(&self) -> bool {
+        matches!(self.write_type, WriteType::Put | WriteType::Delete)
+    }
 }
 
 #[derive(PartialEq, Clone)]

--- a/components/txn_types/src/write.rs
+++ b/components/txn_types/src/write.rs
@@ -219,7 +219,7 @@ impl Write {
         }
     }
 
-    pub fn may_has_old_value(&self) -> bool {
+    pub fn may_have_old_value(&self) -> bool {
         matches!(self.write_type, WriteType::Put | WriteType::Delete)
     }
 }

--- a/src/storage/mvcc/mod.rs
+++ b/src/storage/mvcc/mod.rs
@@ -4,7 +4,7 @@
 
 mod consistency_check;
 pub(super) mod metrics;
-mod reader;
+pub(crate) mod reader;
 pub(super) mod txn;
 
 pub use self::consistency_check::{Mvcc as MvccConsistencyCheckObserver, MvccInfoIterator};

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -192,7 +192,6 @@ impl<S: Snapshot> MvccReader<S> {
     ///   leave the write_cursor at the first record which key is less or equal to the `ts` encoded version of `key`
     pub fn seek_write(&mut self, key: &Key, ts: TimeStamp) -> Result<Option<(TimeStamp, Write)>> {
         // Get the cursor for write record
-        // Get the cursor for write record
         //
         // When it switches to another key in prefix seek mode, creates a new cursor for it
         // because the current position of the cursor is seldom around `key`.
@@ -213,6 +212,7 @@ impl<S: Snapshot> MvccReader<S> {
         if !Key::is_user_key_eq(write_key, key.as_encoded()) {
             return Ok(None);
         }
+        // parse out the write record
         let write = WriteRef::parse(cursor.value(&mut self.statistics.write))?.to_owned();
         Ok(Some((commit_ts, write)))
     }

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -605,6 +605,7 @@ mod tests {
                 txn_size: 0,
                 lock_ttl: 0,
                 min_commit_ts: TimeStamp::default(),
+                need_old_value: false,
             }
         }
 

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -190,7 +190,8 @@ impl<S: Snapshot> MvccReader<S> {
     ///   (commit_ts, write_record) of the write record for `key` committed before or equal to`ts`
     /// Post Condition:
     ///   leave the write_cursor at the first record which key is less or equal to the `ts` encoded version of `key`
-    pub fn seek_write(&mut self, key: &Key, ts: TimeStamp) -> Result<Option<(TimeStamp, Write)>> {// Get the cursor for write record
+    pub fn seek_write(&mut self, key: &Key, ts: TimeStamp) -> Result<Option<(TimeStamp, Write)>> {
+        // Get the cursor for write record
         // Get the cursor for write record
         //
         // When it switches to another key in prefix seek mode, creates a new cursor for it

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -417,7 +417,7 @@ pub(crate) fn make_txn_error(
 pub(crate) mod tests {
     use super::*;
 
-    use crate::storage::kv::RocksEngine;
+    use crate::storage::kv::{RocksEngine, WriteData};
     use crate::storage::mvcc::tests::*;
     use crate::storage::mvcc::{Error, ErrorInner, Mutation, MvccReader};
     use crate::storage::txn::commands::*;

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -1,6 +1,6 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::storage::kv::{Modify, ScanMode, Snapshot, Statistics, WriteData};
+use crate::storage::kv::{Modify, ScanMode, Snapshot, Statistics};
 use crate::storage::mvcc::reader::{MvccReader, OverlappedWrite};
 use crate::storage::mvcc::Result;
 use concurrency_manager::{ConcurrencyManager, KeyHandleGuard};

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -7,9 +7,7 @@ use concurrency_manager::{ConcurrencyManager, KeyHandleGuard};
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::{ExtraOp, IsolationLevel};
 use std::fmt;
-use txn_types::{
-    Key, Lock, LockType, MutationType, OldValue, TimeStamp, TxnExtra, Value, Write, WriteType,
-};
+use txn_types::{Key, Lock, LockType, TimeStamp, TxnExtra, Value, Write, WriteType};
 
 pub const MAX_TXN_WRITE_SIZE: usize = 32 * 1024;
 
@@ -103,7 +101,7 @@ pub struct MvccTxn<S: Snapshot> {
     pub(crate) reader: MvccReader<S>,
     pub(crate) start_ts: TimeStamp,
     pub(crate) write_size: usize,
-    writes: WriteData,
+    pub(crate) writes: WriteData,
     // When 1PC is enabled, locks will be collected here instead of marshalled and put into `writes`,
     // so it can be further processed. The elements are tuples representing
     // (key, lock, remove_pessimistic_lock)
@@ -343,57 +341,6 @@ impl<S: Snapshot> MvccTxn<S> {
         }
         Ok(())
     }
-
-    // Check and execute the extra operation.
-    // Currently we use it only for reading the old value for CDC.
-    pub fn check_extra_op(
-        &mut self,
-        key: &Key,
-        mutation_type: MutationType,
-        prev_write: Option<Write>,
-    ) -> Result<()> {
-        use crate::storage::mvcc::reader::seek_for_valid_write;
-
-        if self.extra_op == ExtraOp::ReadOldValue
-            && (mutation_type == MutationType::Put || mutation_type == MutationType::Delete)
-        {
-            let old_value = if let Some(w) = prev_write {
-                // If write is Rollback or Lock, seek for valid write record.
-                if w.write_type == WriteType::Rollback || w.write_type == WriteType::Lock {
-                    let write_cursor = self.reader.write_cursor.as_mut().unwrap();
-                    // Skip the current write record.
-                    write_cursor.next(&mut self.reader.statistics.write);
-                    let write = seek_for_valid_write(
-                        write_cursor,
-                        key,
-                        self.start_ts,
-                        self.start_ts,
-                        &mut self.reader.statistics,
-                    )?;
-                    write.map(|w| OldValue {
-                        short_value: w.short_value,
-                        start_ts: w.start_ts,
-                    })
-                } else if w.as_ref().check_gc_fence_as_latest_version(self.start_ts) {
-                    Some(OldValue {
-                        short_value: w.short_value,
-                        start_ts: w.start_ts,
-                    })
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-            // If write is None or cannot find a previously valid write record.
-            self.writes.extra.add_old_value(
-                key.clone().append_ts(self.start_ts),
-                old_value,
-                mutation_type,
-            );
-        }
-        Ok(())
-    }
 }
 
 impl<S: Snapshot> fmt::Debug for MvccTxn<S> {
@@ -473,7 +420,7 @@ pub(crate) fn make_txn_error(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     use crate::storage::kv::RocksEngine;
@@ -482,8 +429,7 @@ mod tests {
     use crate::storage::txn::commands::*;
     use crate::storage::txn::tests::*;
     use crate::storage::txn::{
-        acquire_pessimistic_lock, commit, prewrite, CommitKind, TransactionKind,
-        TransactionProperties,
+        commit, prewrite, CommitKind, TransactionKind, TransactionProperties,
     };
     use crate::storage::SecondaryLocksStatus;
     use crate::storage::{
@@ -492,7 +438,6 @@ mod tests {
     };
     use kvproto::kvrpcpb::Context;
     use txn_types::{TimeStamp, SHORT_VALUE_MAX_LEN};
-
     fn test_mvcc_txn_read_imp(k1: &[u8], k2: &[u8], v: &[u8]) {
         let engine = TestEngineBuilder::new().build().unwrap();
 
@@ -919,7 +864,7 @@ mod tests {
         test_scan_keys_imp(vec![b"a", b"c", b"e", b"b", b"d", b"f"], vec![&v1, &v4]);
     }
 
-    fn txn_props(
+    pub fn txn_props(
         start_ts: TimeStamp,
         primary: &[u8],
         commit_kind: CommitKind,
@@ -1383,145 +1328,6 @@ mod tests {
         must_acquire_pessimistic_lock(&engine, k, k, 80, 80);
         must_cleanup(&engine, k, 80, TimeStamp::max());
         must_pessimistic_prewrite_put_err(&engine, k, &v, k, 80, 80, true);
-    }
-
-    #[test]
-    fn test_extra_op_old_value() {
-        let engine = TestEngineBuilder::new().build().unwrap();
-        let key = Key::from_raw(b"key");
-        let ctx = Context::default();
-
-        let new_old_value = |short_value, start_ts| OldValue {
-            short_value,
-            start_ts,
-        };
-
-        let cases = vec![
-            (
-                Mutation::Put((key.clone(), b"v0".to_vec())),
-                false,
-                5,
-                5,
-                None,
-                true,
-            ),
-            (
-                Mutation::Put((key.clone(), b"v1".to_vec())),
-                false,
-                6,
-                6,
-                Some(new_old_value(Some(b"v0".to_vec()), 5.into())),
-                true,
-            ),
-            (Mutation::Lock(key.clone()), false, 7, 7, None, false),
-            (
-                Mutation::Lock(key.clone()),
-                false,
-                8,
-                8,
-                Some(new_old_value(Some(b"v1".to_vec()), 6.into())),
-                false,
-            ),
-            (
-                Mutation::Put((key.clone(), vec![b'0'; 5120])),
-                false,
-                9,
-                9,
-                Some(new_old_value(Some(b"v1".to_vec()), 6.into())),
-                true,
-            ),
-            (
-                Mutation::Put((key.clone(), b"v3".to_vec())),
-                false,
-                10,
-                10,
-                Some(new_old_value(None, 9.into())),
-                true,
-            ),
-            (
-                Mutation::Put((key.clone(), b"v4".to_vec())),
-                true,
-                11,
-                11,
-                None,
-                true,
-            ),
-        ];
-
-        let write = |modifies| {
-            engine.write(&ctx, modifies).unwrap();
-        };
-
-        let new_txn = |start_ts, cm| {
-            let snapshot = engine.snapshot(Default::default()).unwrap();
-            MvccTxn::new(snapshot, start_ts, true, cm)
-        };
-
-        for case in cases {
-            let (mutation, is_pessimistic, start_ts, commit_ts, old_value, check_old_value) = case;
-            let mutation_type = mutation.mutation_type();
-            let cm = ConcurrencyManager::new(start_ts.into());
-            let mut txn = new_txn(start_ts.into(), cm.clone());
-
-            txn.extra_op = ExtraOp::ReadOldValue;
-            if is_pessimistic {
-                acquire_pessimistic_lock(
-                    &mut txn,
-                    key.clone(),
-                    b"key",
-                    false,
-                    0,
-                    start_ts.into(),
-                    false,
-                    TimeStamp::zero(),
-                )
-                .unwrap();
-                write(WriteData::from_modifies(txn.into_modifies()));
-                txn = new_txn(start_ts.into(), cm.clone());
-                txn.extra_op = ExtraOp::ReadOldValue;
-                prewrite(
-                    &mut txn,
-                    &txn_props(
-                        start_ts.into(),
-                        b"key",
-                        CommitKind::TwoPc,
-                        Some(TimeStamp::default()),
-                        0,
-                        false,
-                    ),
-                    mutation,
-                    &None,
-                    true,
-                )
-                .unwrap();
-            } else {
-                prewrite(
-                    &mut txn,
-                    &txn_props(start_ts.into(), b"key", CommitKind::TwoPc, None, 0, false),
-                    mutation,
-                    &None,
-                    false,
-                )
-                .unwrap();
-            }
-            if check_old_value {
-                let extra = txn.take_extra();
-                let ts_key = key.clone().append_ts(start_ts.into());
-                assert!(
-                    extra.old_values.get(&ts_key).is_some(),
-                    "{}@{}",
-                    ts_key,
-                    start_ts
-                );
-                assert_eq!(extra.old_values[&ts_key], (old_value, mutation_type));
-            }
-            write(WriteData::from_modifies(txn.into_modifies()));
-            let mut txn = new_txn(start_ts.into(), cm);
-            commit(&mut txn, key.clone(), commit_ts.into()).unwrap();
-            engine
-                .write(&ctx, WriteData::from_modifies(txn.into_modifies()))
-                .unwrap();
-        }
     }
 
     #[test]

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -5,7 +5,7 @@ use crate::storage::mvcc::reader::{MvccReader, OverlappedWrite};
 use crate::storage::mvcc::Result;
 use concurrency_manager::{ConcurrencyManager, KeyHandleGuard};
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE};
-use kvproto::kvrpcpb::{ExtraOp, IsolationLevel};
+use kvproto::kvrpcpb::IsolationLevel;
 use std::fmt;
 use txn_types::{Key, Lock, LockType, TimeStamp, TxnExtra, Value, Write, WriteType};
 
@@ -108,7 +108,6 @@ pub struct MvccTxn<S: Snapshot> {
     pub(crate) locks_for_1pc: Vec<(Key, Lock, bool)>,
     // collapse continuous rollbacks.
     pub(crate) collapse_rollback: bool,
-    pub extra_op: ExtraOp,
     // `concurrency_manager` is used to set memory locks for prewritten keys.
     // Prewritten locks of async commit transactions should be visible to
     // readers before they are written to the engine.
@@ -171,7 +170,6 @@ impl<S: Snapshot> MvccTxn<S> {
             writes: WriteData::default(),
             locks_for_1pc: Vec::new(),
             collapse_rollback: true,
-            extra_op: ExtraOp::Noop,
             concurrency_manager,
             guards: vec![],
         }
@@ -886,6 +884,7 @@ pub(crate) mod tests {
             txn_size,
             lock_ttl: 0,
             min_commit_ts: TimeStamp::default(),
+            need_old_value: false,
         }
     }
 

--- a/src/storage/txn/actions/check_extra_op.rs
+++ b/src/storage/txn/actions/check_extra_op.rs
@@ -39,6 +39,13 @@ fn get_old_value<S: Snapshot>(
 ) -> MvccResult<Option<OldValue>> {
     if prev_write.write_type == WriteType::Rollback || prev_write.write_type == WriteType::Lock {
         let write_cursor = txn.reader.write_cursor.as_mut().unwrap();
+        debug_assert_eq!(write_cursor.key(&mut txn.reader.statistics.write), key);
+        debug_assert_eq!(
+            txn_types::WriteRef::parse(cursor.value(&mut txn.reader.statistics.write))
+                .unwrap()
+                .to_owned(),
+            prev_write
+        );
         // Skip the current write record.
         write_cursor.next(&mut txn.reader.statistics.write);
         let write = seek_for_valid_write(

--- a/src/storage/txn/actions/check_extra_op.rs
+++ b/src/storage/txn/actions/check_extra_op.rs
@@ -13,9 +13,7 @@ pub fn check_extra_op<S: Snapshot>(
     mutation_type: MutationType,
     prev_write: Option<Write>,
 ) -> MvccResult<()> {
-    if txn.extra_op == ExtraOp::ReadOldValue
-        && (mutation_type == MutationType::Put || mutation_type == MutationType::Delete)
-    {
+    if txn.extra_op == ExtraOp::ReadOldValue && mutation_type.may_have_old_value() {
         let old_value = if let Some(w) = prev_write {
             // If write is Rollback or Lock, seek for valid write record.
             get_old_value(txn, key, w)?

--- a/src/storage/txn/actions/check_extra_op.rs
+++ b/src/storage/txn/actions/check_extra_op.rs
@@ -1,0 +1,207 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use crate::storage::mvcc::{MvccTxn, Result as MvccResult};
+use crate::storage::Snapshot;
+use kvproto::kvrpcpb::ExtraOp;
+use txn_types::{Key, MutationType, OldValue, Write, WriteType};
+
+// Check and execute the extra operation.
+// Currently we use it only for reading the old value for CDC.
+pub fn check_extra_op<S: Snapshot>(
+    txn: &mut MvccTxn<S>,
+    key: &Key,
+    mutation_type: MutationType,
+    prev_write: Option<Write>,
+) -> MvccResult<()> {
+    use crate::storage::mvcc::reader::seek_for_valid_write;
+
+    if txn.extra_op == ExtraOp::ReadOldValue
+        && (mutation_type == MutationType::Put || mutation_type == MutationType::Delete)
+    {
+        let old_value = if let Some(w) = prev_write {
+            // If write is Rollback or Lock, seek for valid write record.
+            if w.write_type == WriteType::Rollback || w.write_type == WriteType::Lock {
+                let write_cursor = txn.reader.write_cursor.as_mut().unwrap();
+                // Skip the current write record.
+                write_cursor.next(&mut txn.reader.statistics.write);
+                let write = seek_for_valid_write(
+                    write_cursor,
+                    key,
+                    txn.start_ts,
+                    txn.start_ts,
+                    &mut txn.reader.statistics,
+                )?;
+                write.map(|w| OldValue {
+                    short_value: w.short_value,
+                    start_ts: w.start_ts,
+                })
+            } else if w.as_ref().check_gc_fence_as_latest_version(txn.start_ts) {
+                Some(OldValue {
+                    short_value: w.short_value,
+                    start_ts: w.start_ts,
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        // If write is None or cannot find a previously valid write record.
+        txn.writes.extra.add_old_value(
+            key.clone().append_ts(txn.start_ts),
+            old_value,
+            mutation_type,
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::kv::WriteData;
+    use crate::storage::mvcc::txn::tests::txn_props;
+    use crate::storage::txn::{acquire_pessimistic_lock, commit, prewrite, CommitKind};
+    use crate::storage::{Engine, TestEngineBuilder};
+    use concurrency_manager::ConcurrencyManager;
+    use kvproto::kvrpcpb::Context;
+    use txn_types::{Mutation, TimeStamp};
+    #[test]
+    fn test_extra_op_old_value() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let key = Key::from_raw(b"key");
+        let ctx = Context::default();
+
+        let new_old_value = |short_value, start_ts| OldValue {
+            short_value,
+            start_ts,
+        };
+
+        let cases = vec![
+            (
+                Mutation::Put((key.clone(), b"v0".to_vec())),
+                false,
+                5,
+                5,
+                None,
+                true,
+            ),
+            (
+                Mutation::Put((key.clone(), b"v1".to_vec())),
+                false,
+                6,
+                6,
+                Some(new_old_value(Some(b"v0".to_vec()), 5.into())),
+                true,
+            ),
+            (Mutation::Lock(key.clone()), false, 7, 7, None, false),
+            (
+                Mutation::Lock(key.clone()),
+                false,
+                8,
+                8,
+                Some(new_old_value(Some(b"v1".to_vec()), 6.into())),
+                false,
+            ),
+            (
+                Mutation::Put((key.clone(), vec![b'0'; 5120])),
+                false,
+                9,
+                9,
+                Some(new_old_value(Some(b"v1".to_vec()), 6.into())),
+                true,
+            ),
+            (
+                Mutation::Put((key.clone(), b"v3".to_vec())),
+                false,
+                10,
+                10,
+                Some(new_old_value(None, 9.into())),
+                true,
+            ),
+            (
+                Mutation::Put((key.clone(), b"v4".to_vec())),
+                true,
+                11,
+                11,
+                None,
+                true,
+            ),
+        ];
+
+        let write = |modifies| {
+            engine.write(&ctx, modifies).unwrap();
+        };
+
+        let new_txn = |start_ts, cm| {
+            let snapshot = engine.snapshot(Default::default()).unwrap();
+            MvccTxn::new(snapshot, start_ts, true, cm)
+        };
+
+        for case in cases {
+            let (mutation, is_pessimistic, start_ts, commit_ts, old_value, check_old_value) = case;
+            let mutation_type = mutation.mutation_type();
+            let cm = ConcurrencyManager::new(start_ts.into());
+            let mut txn = new_txn(start_ts.into(), cm.clone());
+
+            txn.extra_op = ExtraOp::ReadOldValue;
+            if is_pessimistic {
+                acquire_pessimistic_lock(
+                    &mut txn,
+                    key.clone(),
+                    b"key",
+                    false,
+                    0,
+                    start_ts.into(),
+                    false,
+                    TimeStamp::zero(),
+                )
+                .unwrap();
+                write(WriteData::from_modifies(txn.into_modifies()));
+                txn = new_txn(start_ts.into(), cm.clone());
+                txn.extra_op = ExtraOp::ReadOldValue;
+                prewrite(
+                    &mut txn,
+                    &txn_props(
+                        start_ts.into(),
+                        b"key",
+                        CommitKind::TwoPc,
+                        Some(TimeStamp::default()),
+                        0,
+                        false,
+                    ),
+                    mutation,
+                    &None,
+                    true,
+                )
+                .unwrap();
+            } else {
+                prewrite(
+                    &mut txn,
+                    &txn_props(start_ts.into(), b"key", CommitKind::TwoPc, None, 0, false),
+                    mutation,
+                    &None,
+                    false,
+                )
+                .unwrap();
+            }
+            if check_old_value {
+                let extra = txn.take_extra();
+                let ts_key = key.clone().append_ts(start_ts.into());
+                assert!(
+                    extra.old_values.get(&ts_key).is_some(),
+                    "{}@{}",
+                    ts_key,
+                    start_ts
+                );
+                assert_eq!(extra.old_values[&ts_key], (old_value, mutation_type));
+            }
+            write(WriteData::from_modifies(txn.into_modifies()));
+            let mut txn = new_txn(start_ts.into(), cm);
+            commit(&mut txn, key.clone(), commit_ts.into()).unwrap();
+            engine
+                .write(&ctx, WriteData::from_modifies(txn.into_modifies()))
+                .unwrap();
+        }
+    }
+}

--- a/src/storage/txn/actions/check_extra_op.rs
+++ b/src/storage/txn/actions/check_extra_op.rs
@@ -37,15 +37,33 @@ fn get_old_value<S: Snapshot>(
     key: &Key,
     prev_write: Write,
 ) -> MvccResult<Option<OldValue>> {
+    debug_assert_eq!(
+        &Key::from_encoded(
+            txn.reader
+                .write_cursor
+                .as_ref()
+                .unwrap()
+                .key(&mut txn.reader.statistics.write)
+                .to_vec()
+        )
+        .truncate_ts()
+        .unwrap(),
+        key
+    );
+    debug_assert_eq!(
+        txn_types::WriteRef::parse(
+            txn.reader
+                .write_cursor
+                .as_ref()
+                .unwrap()
+                .value(&mut txn.reader.statistics.write)
+        )
+        .unwrap()
+        .to_owned(),
+        prev_write
+    );
     if prev_write.write_type == WriteType::Rollback || prev_write.write_type == WriteType::Lock {
         let write_cursor = txn.reader.write_cursor.as_mut().unwrap();
-        debug_assert_eq!(write_cursor.key(&mut txn.reader.statistics.write), key);
-        debug_assert_eq!(
-            txn_types::WriteRef::parse(cursor.value(&mut txn.reader.statistics.write))
-                .unwrap()
-                .to_owned(),
-            prev_write
-        );
         // Skip the current write record.
         write_cursor.next(&mut txn.reader.statistics.write);
         let write = seek_for_valid_write(
@@ -75,149 +93,123 @@ fn get_old_value<S: Snapshot>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::kv::WriteData;
-    use crate::storage::mvcc::txn::tests::txn_props;
-    use crate::storage::txn::{acquire_pessimistic_lock, commit, prewrite, CommitKind};
+    use crate::storage::mvcc::tests::write;
     use crate::storage::{Engine, TestEngineBuilder};
     use concurrency_manager::ConcurrencyManager;
     use kvproto::kvrpcpb::Context;
-    use txn_types::{Mutation, TimeStamp};
+    use txn_types::TimeStamp;
+
     #[test]
-    fn test_extra_op_old_value() {
-        let engine = TestEngineBuilder::new().build().unwrap();
-        let key = Key::from_raw(b"key");
-        let ctx = Context::default();
+    fn test_get_old_value() {
+        struct Case {
+            expected: Option<OldValue>,
 
-        let new_old_value = |short_value, start_ts| OldValue {
-            short_value,
-            start_ts,
-        };
-
+            // (write_record, put_ts)
+            // all data to write to the engine
+            // current write_cursor will be on the last record in `written`
+            // which also means prev_write is `Write` in the record
+            written: Vec<(Write, TimeStamp)>,
+        }
         let cases = vec![
-            (
-                Mutation::Put((key.clone(), b"v0".to_vec())),
-                false,
-                5,
-                5,
-                None,
-                true,
-            ),
-            (
-                Mutation::Put((key.clone(), b"v1".to_vec())),
-                false,
-                6,
-                6,
-                Some(new_old_value(Some(b"v0".to_vec()), 5.into())),
-                true,
-            ),
-            (Mutation::Lock(key.clone()), false, 7, 7, None, false),
-            (
-                Mutation::Lock(key.clone()),
-                false,
-                8,
-                8,
-                Some(new_old_value(Some(b"v1".to_vec()), 6.into())),
-                false,
-            ),
-            (
-                Mutation::Put((key.clone(), vec![b'0'; 5120])),
-                false,
-                9,
-                9,
-                Some(new_old_value(Some(b"v1".to_vec()), 6.into())),
-                true,
-            ),
-            (
-                Mutation::Put((key.clone(), b"v3".to_vec())),
-                false,
-                10,
-                10,
-                Some(new_old_value(None, 9.into())),
-                true,
-            ),
-            (
-                Mutation::Put((key.clone(), b"v4".to_vec())),
-                true,
-                11,
-                11,
-                None,
-                true,
-            ),
-        ];
+            // prev_write is Rollback, and there exists a more previous valid write
+            Case {
+                expected: Some(OldValue {
+                    short_value: None,
+                    start_ts: TimeStamp::new(4),
+                }),
 
-        let write = |modifies| {
-            engine.write(&ctx, modifies).unwrap();
-        };
-
-        let new_txn = |start_ts, cm| {
-            let snapshot = engine.snapshot(Default::default()).unwrap();
-            MvccTxn::new(snapshot, start_ts, true, cm)
-        };
-
-        for case in cases {
-            let (mutation, is_pessimistic, start_ts, commit_ts, old_value, check_old_value) = case;
-            let mutation_type = mutation.mutation_type();
-            let cm = ConcurrencyManager::new(start_ts.into());
-            let mut txn = new_txn(start_ts.into(), cm.clone());
-
-            txn.extra_op = ExtraOp::ReadOldValue;
-            if is_pessimistic {
-                acquire_pessimistic_lock(
-                    &mut txn,
-                    key.clone(),
-                    b"key",
-                    false,
-                    0,
-                    start_ts.into(),
-                    false,
-                    TimeStamp::zero(),
-                )
-                .unwrap();
-                write(WriteData::from_modifies(txn.into_modifies()));
-                txn = new_txn(start_ts.into(), cm.clone());
-                txn.extra_op = ExtraOp::ReadOldValue;
-                prewrite(
-                    &mut txn,
-                    &txn_props(
-                        start_ts.into(),
-                        b"key",
-                        CommitKind::TwoPc,
-                        Some(TimeStamp::default()),
-                        0,
-                        false,
+                written: vec![
+                    (
+                        Write::new(WriteType::Put, TimeStamp::new(4), None),
+                        TimeStamp::new(6),
                     ),
-                    mutation,
-                    &None,
-                    true,
-                )
-                .unwrap();
-            } else {
-                prewrite(
-                    &mut txn,
-                    &txn_props(start_ts.into(), b"key", CommitKind::TwoPc, None, 0, false),
-                    mutation,
-                    &None,
-                    false,
-                )
-                .unwrap();
-            }
-            if check_old_value {
-                let extra = txn.take_extra();
-                let ts_key = key.clone().append_ts(start_ts.into());
-                assert!(
-                    extra.old_values.get(&ts_key).is_some(),
-                    "{}@{}",
-                    ts_key,
-                    start_ts
+                    (
+                        Write::new(WriteType::Rollback, TimeStamp::new(5), None),
+                        TimeStamp::new(7),
+                    ),
+                ],
+            },
+            // prev_write is Rollback, and there isn't a more previous valid write
+            Case {
+                expected: None,
+
+                written: vec![(
+                    Write::new(WriteType::Rollback, TimeStamp::new(5), None),
+                    TimeStamp::new(6),
+                )],
+            },
+            // prev_write is Lock, and there exists a more previous valid write
+            Case {
+                expected: Some(OldValue {
+                    short_value: None,
+                    start_ts: TimeStamp::new(3),
+                }),
+
+                written: vec![
+                    (
+                        Write::new(WriteType::Put, TimeStamp::new(3), None),
+                        TimeStamp::new(6),
+                    ),
+                    (
+                        Write::new(WriteType::Lock, TimeStamp::new(5), None),
+                        TimeStamp::new(7),
+                    ),
+                ],
+            },
+            // prev_write is Lock, and there isn't a more previous valid write
+            Case {
+                expected: None,
+
+                written: vec![(
+                    Write::new(WriteType::Lock, TimeStamp::new(5), None),
+                    TimeStamp::new(6),
+                )],
+            },
+            // prev_write is not Rollback or Lock, check_gc_fence_as_latest_version is true
+            Case {
+                expected: Some(OldValue {
+                    short_value: None,
+                    start_ts: TimeStamp::new(7),
+                }),
+                written: vec![(
+                    Write::new(WriteType::Put, TimeStamp::new(7), None)
+                        .set_overlapped_rollback(true, Some(27.into())),
+                    TimeStamp::new(5),
+                )],
+            },
+            // prev_write is not Rollback or Lock, check_gc_fence_as_latest_version is false
+            Case {
+                expected: None,
+                written: vec![(
+                    Write::new(WriteType::Put, TimeStamp::new(4), None)
+                        .set_overlapped_rollback(true, Some(3.into())),
+                    TimeStamp::new(5),
+                )],
+            },
+        ];
+        for case in cases {
+            let engine = TestEngineBuilder::new().build().unwrap();
+            let cm = ConcurrencyManager::new(42.into());
+            let snapshot = engine.snapshot(Default::default()).unwrap();
+            let mut txn = MvccTxn::new(snapshot, TimeStamp::new(10), true, cm.clone());
+            for (write_record, put_ts) in case.written.iter() {
+                txn.put_write(
+                    Key::from_raw(b"a"),
+                    *put_ts,
+                    write_record.as_ref().to_bytes(),
                 );
-                assert_eq!(extra.old_values[&ts_key], (old_value, mutation_type));
             }
-            write(WriteData::from_modifies(txn.into_modifies()));
-            let mut txn = new_txn(start_ts.into(), cm);
-            commit(&mut txn, key.clone(), commit_ts.into()).unwrap();
-            engine
-                .write(&ctx, WriteData::from_modifies(txn.into_modifies()))
-                .unwrap();
+            write(&engine, &Context::default(), txn.into_modifies());
+            let snapshot = engine.snapshot(Default::default()).unwrap();
+            let mut txn = MvccTxn::new(snapshot, TimeStamp::new(25), true, cm);
+            let prev_write = txn
+                .reader
+                .seek_write(&Key::from_raw(b"a"), case.written.last().unwrap().1)
+                .unwrap()
+                .unwrap()
+                .1;
+            let result = get_old_value(&mut txn, &Key::from_raw(b"a"), prev_write).unwrap();
+            assert_eq!(result, case.expected);
         }
     }
 }

--- a/src/storage/txn/actions/get_old_value.rs
+++ b/src/storage/txn/actions/get_old_value.rs
@@ -28,7 +28,7 @@ pub fn get_old_value<S: Snapshot>(
         true
     });
     match prev_write {
-        Some(w) if !w.may_has_old_value() => {
+        Some(w) if !w.may_have_old_value() => {
             let write_cursor = txn.reader.write_cursor.as_mut().unwrap();
             // Skip the current write record.
             write_cursor.next(&mut txn.reader.statistics.write);

--- a/src/storage/txn/actions/mod.rs
+++ b/src/storage/txn/actions/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod acquire_pessimistic_lock;
 pub mod check_data_constraint;
+pub mod check_extra_op;
 pub mod check_txn_status;
 pub mod cleanup;
 pub mod commit;

--- a/src/storage/txn/actions/mod.rs
+++ b/src/storage/txn/actions/mod.rs
@@ -7,10 +7,10 @@
 
 pub mod acquire_pessimistic_lock;
 pub mod check_data_constraint;
-pub mod check_extra_op;
 pub mod check_txn_status;
 pub mod cleanup;
 pub mod commit;
 pub mod gc;
+pub mod get_old_value;
 pub mod prewrite;
 pub mod tests;

--- a/src/storage/txn/actions/mod.rs
+++ b/src/storage/txn/actions/mod.rs
@@ -11,6 +11,6 @@ pub mod check_txn_status;
 pub mod cleanup;
 pub mod commit;
 pub mod gc;
-pub mod get_old_value;
+pub(crate) mod get_old_value;
 pub mod prewrite;
 pub mod tests;

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use crate::storage::txn::actions::check_extra_op::check_extra_op;
 use crate::storage::{
     mvcc::{
         metrics::{
@@ -55,7 +56,7 @@ pub fn prewrite<S: Snapshot>(
         return Ok(TimeStamp::zero());
     }
 
-    txn.check_extra_op(&mutation.key, mutation.mutation_type, prev_write)?;
+    check_extra_op(txn, &mutation.key, mutation.mutation_type, prev_write)?;
 
     let final_min_commit_ts = mutation.write_lock(lock_status, txn)?;
 

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -58,12 +58,7 @@ pub fn prewrite<S: Snapshot>(
     }
 
     let old_value = if txn_props.need_old_value && mutation.mutation_type.may_have_old_value() {
-        if let Some(w) = prev_write {
-            // If write is Rollback or Lock, seek for valid write record.
-            get_old_value(txn, &mutation.key, w)?
-        } else {
-            OldValue::None
-        }
+        get_old_value(txn, &mutation.key, prev_write)?
     } else {
         OldValue::Unspecified
     };

--- a/src/storage/txn/actions/tests.rs
+++ b/src/storage/txn/actions/tests.rs
@@ -51,6 +51,7 @@ pub fn must_prewrite_put_impl<E: Engine>(
             txn_size,
             lock_ttl,
             min_commit_ts,
+            need_old_value: false,
         },
         mutation,
         &secondary_keys,
@@ -236,6 +237,7 @@ fn default_txn_props(
         txn_size: 0,
         lock_ttl: 0,
         min_commit_ts: TimeStamp::default(),
+        need_old_value: false,
     }
 }
 fn must_prewrite_put_err_impl<E: Engine>(

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -447,7 +447,7 @@ impl<K: PrewriteKind> Prewriter<K> {
                     if (secondaries.is_some() || self.try_one_pc) && final_min_commit_ts < ts {
                         final_min_commit_ts = ts;
                     }
-                    if let Some(old_value) = old_value {
+                    if old_value.specified() {
                         self.old_values.insert(key, (old_value, mutation_type));
                     }
                 }

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -21,6 +21,7 @@ use crate::storage::{
     Context, Error as StorageError, ProcessResult, Snapshot,
 };
 use engine_traits::CF_WRITE;
+use kvproto::kvrpcpb::ExtraOp;
 use std::mem;
 use txn_types::{Key, Mutation, TimeStamp, Write, WriteType};
 
@@ -361,10 +362,9 @@ impl<K: PrewriteKind> Prewriter<K> {
             context.concurrency_manager,
         );
         // Set extra op here for getting the write record when check write conflict in prewrite.
-        txn.extra_op = context.extra_op;
 
         let rows = self.mutations.len();
-        let (locks, final_min_commit_ts) = self.prewrite(&mut txn)?;
+        let (locks, final_min_commit_ts) = self.prewrite(&mut txn, context.extra_op)?;
 
         context.statistics.add(&txn.take_statistics());
 
@@ -399,6 +399,7 @@ impl<K: PrewriteKind> Prewriter<K> {
     fn prewrite(
         &mut self,
         txn: &mut MvccTxn<impl Snapshot>,
+        extra_op: ExtraOp,
     ) -> Result<(Vec<std::result::Result<(), StorageError>>, TimeStamp)> {
         let commit_kind = match (&self.secondary_keys, self.try_one_pc) {
             (_, true) => CommitKind::OnePc(self.max_commit_ts),
@@ -414,6 +415,7 @@ impl<K: PrewriteKind> Prewriter<K> {
             txn_size: self.txn_size,
             lock_ttl: self.lock_ttl,
             min_commit_ts: self.min_commit_ts,
+            need_old_value: extra_op == ExtraOp::ReadOldValue,
         };
 
         let async_commit_pk = self

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -650,6 +650,7 @@ mod tests {
                             txn_size: 0,
                             lock_ttl: 0,
                             min_commit_ts: TimeStamp::default(),
+                            need_old_value: false,
                         },
                         Mutation::Put((Key::from_raw(key), key.to_vec())),
                         &None,

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -43,6 +43,7 @@ where
             txn_size: 0,
             lock_ttl: 0,
             min_commit_ts: TimeStamp::default(),
+            need_old_value: false,
         };
         prewrite(
             &mut txn,
@@ -88,6 +89,7 @@ fn mvcc_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Bench
                     txn_size: 0,
                     lock_ttl: 0,
                     min_commit_ts: TimeStamp::default(),
+                    need_old_value: false,
                 };
                 prewrite(&mut txn, &txn_props, mutation, &None, false).unwrap();
             }

--- a/tests/benches/hierarchy/txn/mod.rs
+++ b/tests/benches/hierarchy/txn/mod.rs
@@ -39,6 +39,7 @@ where
             txn_size: 0,
             lock_ttl: 0,
             min_commit_ts: TimeStamp::default(),
+            need_old_value: false,
         };
         prewrite(
             &mut txn,
@@ -81,6 +82,7 @@ fn txn_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchC
                     txn_size: 0,
                     lock_ttl: 0,
                     min_commit_ts: TimeStamp::default(),
+                    need_old_value: false,
                 };
                 prewrite(&mut txn, &txn_props, mutation, &None, false).unwrap();
                 let write_data = WriteData::from_modifies(txn.into_modifies());


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:

`ExtraOp` is a very unatural thing to be handled in MvccTxn, in fact, the only situation we need it is for getting the old value for cdc during the prewrite process. So maybe we can move it to there.

### What is changed and how it works?

What's Changed:

Move `ExtraOp` and old_value getting staff to actions module, and change the prewrite part to adopt it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->
- No Release Note