### PR TITLE
encryption: pipeline save file dict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "configuration",
  "crc32fast",
  "crossbeam",
+ "dashmap",
  "engine_traits",
  "error_code",
  "fail 0.4.0",

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -14,6 +14,7 @@ byteorder = "1.2"
 crossbeam = "0.8"
 configuration = { path = "../configuration" }
 crc32fast = "1.2"
+dashmap = "3.11.10"
 engine_traits = { path = "../engine_traits" }
 error_code = { path = "../error_code" }
 fail = "0.4"


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
Encryption manager has to save the file dict on disk every time when there is a new file created or updated. It will cost too much time to do this operation. https://github.com/tikv/tikv/pull/8865 has solved thie problem but it is hard to pick this change to release-4.0 because it also changes the file format, if user upgrade one cluster from release-4.0 to https://github.com/tikv/tikv/pull/8865, he can not go back to release-4.0 again. 

### What is changed and how it works?

This PR will make all of thread which want to change file dict in a pipeline queue. In origin implement, if there is  4 thread trying to call `save_file_dict`,  it may wait 3 * IO round and cost one IO round to sync the file dict again. But it is not necessary, because the second thread can sync the result of the 3rd and the 4th thread together, the 3rd and the 4th only need to wait 2 * IO round and cost no time to sync itself changes.
In this PR, no matter how many threads there are trying to call `save_file_dict`,  every of them only need to wait 2 IO round and do nothing at most.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
