### PR TITLE
remove unused import

### DIFF
--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -1,7 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::storage::kv::{Modify, ScanMode, Snapshot, Statistics, WriteData};
-use crate::storage::mvcc::{reader::MvccReader, ErrorInner, Result};
+use crate::storage::mvcc::{reader::MvccReader, Result};
 use concurrency_manager::{ConcurrencyManager, KeyHandleGuard};
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::{ExtraOp, IsolationLevel};


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

current master branch will produce this warning when compiling:

```console
root@kv:~/tikv# make
cargo build --release --no-default-features --features " jemalloc mem-profiling portable sse protobuf-codec test-engines-rocksdb"
   Compiling tikv v4.1.0-alpha (/root/tikv)
warning: unused import: `ErrorInner`
 --> src/storage/mvcc/txn.rs:4:48
  |
4 | use crate::storage::mvcc::{reader::MvccReader, ErrorInner, Result};
  |                                                ^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```

this PR Is just to remove unused import.

Problem Summary:

### What is changed and how it works?

N/A

What's Changed:

### Related changes

N/A


Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

just run `make` to check the warning is disappeared

Side effects

N/A
