### PR TITLE
txn: test min commit ts properties

### DIFF
--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -227,7 +227,7 @@ pub mod tests {
             false,
             uncommitted(100, ts(20, 1)),
         );
-        // The the min_commit_ts should be ts(20, 1)
+        // The min_commit_ts should be ts(20, 1)
         must_err(&engine, k, ts(10, 0), ts(15, 0));
         must_err(&engine, k, ts(10, 0), ts(20, 0));
         must_succeed(&engine, k, ts(10, 0), ts(20, 1));


### PR DESCRIPTION
Adds a unit test to ensure that the min commit ts is properly computed.

PTAL @sticnarf @ekexium 

### Release note <!-- bugfixes or new feature need a release note -->

* No release note