### PR TITLE
server: ignore channel error in tests

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -303,7 +303,7 @@ pub mod test_router {
 
     impl StoreRouter<RocksEngine> for TestRaftStoreRouter {
         fn send(&self, _: StoreMsg<RocksEngine>) -> RaftStoreResult<()> {
-            self.tx.send(1).unwrap();
+            let _ = self.tx.send(1);
             Ok(())
         }
     }
@@ -313,21 +313,21 @@ pub mod test_router {
             &self,
             _: RaftCommand<S>,
         ) -> std::result::Result<(), crossbeam::channel::TrySendError<RaftCommand<S>>> {
-            self.tx.send(1).unwrap();
+            let _ = self.tx.send(1);
             Ok(())
         }
     }
 
     impl<EK: KvEngine> CasualRouter<EK> for TestRaftStoreRouter {
         fn send(&self, _: u64, _: CasualMessage<EK>) -> RaftStoreResult<()> {
-            self.tx.send(1).unwrap();
+            let _ = self.tx.send(1);
             Ok(())
         }
     }
 
     impl RaftStoreRouter<RocksEngine> for TestRaftStoreRouter {
         fn send_raft_msg(&self, _: RaftMessage) -> RaftStoreResult<()> {
-            self.tx.send(1).unwrap();
+            let _ = self.tx.send(1);
             Ok(())
         }
 
@@ -336,12 +336,12 @@ pub mod test_router {
             _: u64,
             msg: SignificantMsg<RocksSnapshot>,
         ) -> RaftStoreResult<()> {
-            self.significant_msg_sender.send(msg).unwrap();
+            let _ = self.significant_msg_sender.send(msg);
             Ok(())
         }
 
         fn broadcast_normal(&self, _: impl FnMut() -> PeerMsg<RocksEngine>) {
-            self.tx.send(1).unwrap();
+            let _ = self.tx.send(1);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9221 <!-- REMOVE this line if no issue to close -->

What's Changed:

raft client will retry implicitly, so in tests, it's possible that the
test thread exits while raft client still tries to send messages, which
will result in panic. This PR solves the problem by just ignoring
the error.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- No release note.