### PR TITLE
raftstore: stop background worker

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -634,7 +634,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             raft_store,
             self.pd_client.clone(),
             self.state.clone(),
-            Some(self.background_worker.clone()),
+            self.background_worker.clone(),
         );
 
         node.start(

--- a/components/batch-system/src/router.rs
+++ b/components/batch-system/src/router.rs
@@ -220,7 +220,13 @@ where
                     .unwrap()
                     .force_send(m, &self.normal_scheduler)
             }
-            Err(TrySendError::Disconnected(m)) => Err(SendError(m)),
+            Err(TrySendError::Disconnected(m)) => {
+                if self.is_shutdown() {
+                    Ok(())
+                } else {
+                    Err(SendError(m))
+                }
+            }
         }
     }
 

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1725,18 +1725,17 @@ where
             // Use `unwrap` is ok because the StoreMeta lock is held and these source peers still
             // exist in regions and region_ranges map.
             // It depends on the implementation of `destroy_peer`.
-            if let Err(e) = self.ctx.router.force_send(
-                source_region_id,
-                PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
-                    target_region_id: self.fsm.region_id(),
-                    target: self.fsm.peer.peer.clone(),
-                    result,
-                }),
-            ) {
-                if !self.ctx.router.is_shutdown() {
-                    panic!("{} failed to send merge result(destroy_regions_for_snapshot) to source region {}, err {}", self.fsm.peer.tag, source_region_id, e);
-                }
-            }
+            self.ctx
+                .router
+                .force_send(
+                    source_region_id,
+                    PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
+                        target_region_id: self.fsm.region_id(),
+                        target: self.fsm.peer.peer.clone(),
+                        result,
+                    }),
+                )
+                .unwrap();
         }
     }
 
@@ -2239,14 +2238,10 @@ where
             }
             let mailbox = BasicMailbox::new(sender, new_peer);
             self.ctx.router.register(new_region_id, mailbox);
-            if let Err(e) = self.ctx.router.force_send(new_region_id, PeerMsg::Start) {
-                if !self.ctx.router.is_shutdown() {
-                    panic!(
-                        "{} failed to send PeerMsg::Start to region {}, err {}",
-                        self.fsm.peer.tag, new_region_id, e
-                    );
-                }
-            }
+            self.ctx
+                .router
+                .force_send(new_region_id, PeerMsg::Start)
+                .unwrap();
 
             if !campaigned {
                 if let Some(msg) = meta
@@ -2701,23 +2696,17 @@ where
             );
             self.fsm.peer.heartbeat_pd(self.ctx);
         }
-        if let Err(e) = self.ctx.router.force_send(
-            source.get_id(),
-            PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
-                target_region_id: self.fsm.region_id(),
-                target: self.fsm.peer.peer.clone(),
-                result: MergeResultKind::FromTargetLog,
-            }),
-        ) {
-            if !self.ctx.router.is_shutdown() {
-                panic!(
-                    "{} failed to send merge result(FromTargetLog) to source region {}, err {}",
-                    self.fsm.peer.tag,
-                    source.get_id(),
-                    e
-                );
-            }
-        }
+        self.ctx
+            .router
+            .force_send(
+                source.get_id(),
+                PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
+                    target_region_id: self.fsm.region_id(),
+                    target: self.fsm.peer.peer.clone(),
+                    result: MergeResultKind::FromTargetLog,
+                }),
+            )
+            .unwrap();
     }
 
     /// Handle rollbacking Merge result.
@@ -2948,18 +2937,17 @@ where
         drop(meta);
 
         for r in &apply_result.destroyed_regions {
-            if let Err(e) = self.ctx.router.force_send(
-                r.get_id(),
-                PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
-                    target_region_id: self.fsm.region_id(),
-                    target: self.fsm.peer.peer.clone(),
-                    result: MergeResultKind::FromTargetSnapshotStep2,
-                }),
-            ) {
-                if !self.ctx.router.is_shutdown() {
-                    panic!("{} failed to send merge result(FromTargetSnapshotStep2) to source region {}, err {}", self.fsm.peer.tag, r.get_id(), e);
-                }
-            }
+            self.ctx
+                .router
+                .force_send(
+                    r.get_id(),
+                    PeerMsg::SignificantMsg(SignificantMsg::MergeResult {
+                        target_region_id: self.fsm.region_id(),
+                        target: self.fsm.peer.peer.clone(),
+                        result: MergeResultKind::FromTargetSnapshotStep2,
+                    }),
+                )
+                .unwrap();
         }
     }
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1341,7 +1341,9 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
         let handle = workers.pd_worker.stop();
         self.apply_system.shutdown();
         self.system.shutdown();
-        handle.map(|h| h.join().unwrap());
+        if let Some(h) = handle {
+            h.join().unwrap();
+        }
         workers.coprocessor_host.shutdown();
         workers.cleanup_worker.stop();
         workers.background_worker.stop();

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -201,7 +201,7 @@ impl Simulator for NodeCluster {
             Arc::new(VersionTrack::new(raft_store)),
             Arc::clone(&self.pd_client),
             Arc::default(),
-            Some(bg_worker.clone()),
+            bg_worker.clone(),
         );
 
         let (snap_mgr, snap_mgr_path) = if node_id == 0

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -380,7 +380,7 @@ impl Simulator for ServerCluster {
             Arc::new(VersionTrack::new(raft_store)),
             Arc::clone(&self.pd_client),
             state,
-            Some(bg_worker.clone()),
+            bg_worker.clone(),
         );
 
         // Register the role change observer of the lock manager.

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -427,9 +427,9 @@ where
     /// Stops the Node.
     pub fn stop(&mut self) {
         let store_id = self.store.get_id();
+        self.stop_store(store_id);
         if let Some(worker) = self.bg_worker.take() {
             worker.stop();
         }
-        self.stop_store(store_id)
     }
 }

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -26,7 +26,7 @@ use raftstore::store::AutoSplitController;
 use raftstore::store::{self, initial_region, Config as StoreConfig, SnapManager, Transport};
 use raftstore::store::{GlobalReplicationState, PdTask, SplitCheckTask};
 use tikv_util::config::VersionTrack;
-use tikv_util::worker::{Builder as WorkerBuilder, FutureWorker, Scheduler, Worker};
+use tikv_util::worker::{FutureWorker, Scheduler, Worker};
 
 const MAX_CHECK_CLUSTER_BOOTSTRAPPED_RETRY_COUNT: u64 = 60;
 const CHECK_CLUSTER_BOOTSTRAPPED_RETRY_SECONDS: u64 = 3;
@@ -66,7 +66,7 @@ pub struct Node<C: PdClient + 'static, ER: RaftEngine> {
 
     pd_client: Arc<C>,
     state: Arc<Mutex<GlobalReplicationState>>,
-    bg_worker: Option<Worker>,
+    bg_worker: Worker,
 }
 
 impl<C, ER> Node<C, ER>
@@ -81,7 +81,7 @@ where
         store_cfg: Arc<VersionTrack<StoreConfig>>,
         pd_client: Arc<C>,
         state: Arc<Mutex<GlobalReplicationState>>,
-        bg_worker: Option<Worker>,
+        bg_worker: Worker,
     ) -> Node<C, ER> {
         let mut store = metapb::Store::default();
         store.set_id(INVALID_ID);
@@ -393,12 +393,7 @@ where
         let cfg = self.store_cfg.clone();
         let pd_client = Arc::clone(&self.pd_client);
         let store = self.store.clone();
-        let background_worker = if let Some(worker) = self.bg_worker.as_ref() {
-            worker.clone()
-        } else {
-            // only for test
-            WorkerBuilder::new("background").create()
-        };
+
         self.system.spawn(
             store,
             cfg,
@@ -411,7 +406,7 @@ where
             coprocessor_host,
             importer,
             split_check_scheduler,
-            background_worker,
+            self.bg_worker.clone(),
             auto_split_controller,
             self.state.clone(),
             concurrency_manager,
@@ -428,8 +423,6 @@ where
     pub fn stop(&mut self) {
         let store_id = self.store.get_id();
         self.stop_store(store_id);
-        if let Some(worker) = self.bg_worker.take() {
-            worker.stop();
-        }
+        self.bg_worker.stop();
     }
 }


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/9151 <!-- REMOVE this line if no issue to close -->

Problem Summary:
TiKV may crash if background worker stop before raftstore pool shutdown.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
