### PR TITLE
raftstore: fix the stale read index after transferring leader

### DIFF
--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -813,8 +813,8 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
         );
 
         fail_point!(
-            "on_peer_collect_message_1003",
-            peer.peer_id() == 1003,
+            "on_peer_collect_message_2",
+            peer.peer_id() == 2,
             |_| unreachable!()
         );
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -812,6 +812,12 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
             |_| unreachable!()
         );
 
+        fail_point!(
+            "on_peer_collect_message_1003",
+            peer.peer_id() == 1003,
+            |_| unreachable!()
+        );
+
         while self.peer_msg_buf.len() < self.messages_per_tick {
             match peer.receiver.try_recv() {
                 // TODO: we may need a way to optimize the message copy.

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1041,22 +1041,24 @@ where
         let msg_type = m.get_msg_type();
         if msg_type == MessageType::MsgReadIndex {
             ctx.coprocessor_host.on_step_read_index(&mut m);
-
-            // Here we hold up MsgReadIndex. If current peer has valid lease, then we could handle the
-            // request directly, rather than send a heartbeat to check quorum.
-            if self.raft_group.raft.commit_to_current_term() {
-                // If the leader hasn't committed any entries in its term, it can't response read only
-                // requests. Please also take a look at raft-rs.
+            // Must use the commit index of `PeerStorage` instead of the commit index
+            // in raft-rs which may be greater than the former one.
+            // For more details, see the annotations above `on_leader_commit_idx_changed`.
+            let index = self.get_store().commit_index();
+            // Check if the log term of this index is equal to current term, if so,
+            // this index can be used to reply the read index request if the leader holds
+            // the lease. Please also take a look at raft-rs.
+            if self.get_store().term(index).unwrap() == self.term() {
                 let state = self.inspect_lease();
                 if let LeaseState::Valid = state {
+                    // If current peer has valid lease, then we could handle the
+                    // request directly, rather than send a heartbeat to check quorum.
                     let mut resp = eraftpb::Message::default();
                     resp.set_msg_type(MessageType::MsgReadIndexResp);
                     resp.term = self.term();
                     resp.to = m.from;
-                    // Must use the commit index of `PeerStorage` instead of the commit index
-                    // in raft-rs which may be greater than the former one.
-                    // For more details, see the annotations above `on_leader_commit_idx_changed`.
-                    resp.index = self.get_store().commit_index();
+
+                    resp.index = index;
                     resp.set_entries(m.take_entries());
 
                     self.raft_group.raft.msgs.push(resp);

--- a/tests/failpoints/cases/test_replica_read.rs
+++ b/tests/failpoints/cases/test_replica_read.rs
@@ -415,3 +415,77 @@ fn must_truncated_to(engine: Arc<DB>, region_id: u64, index: u64) {
     }
     panic!("raft log is not truncated to {}", index);
 }
+
+/// Test if the read index request can get a correct response when the commit index of leader
+/// if not up-to-date after transferring leader.
+#[test]
+fn test_replica_read_after_transfer_leader() {
+    let mut cluster = new_node_cluster(0, 3);
+
+    configure_for_lease_read(&mut cluster, Some(50), Some(100));
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+
+    let r = cluster.run_conf_change();
+    assert_eq!(r, 1);
+    pd_client.must_add_peer(1, new_peer(2, 2));
+    pd_client.must_add_peer(1, new_peer(3, 1003));
+
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+
+    cluster.add_send_filter(IsolationFilterFactory::new(2));
+
+    // peer 1003 does not know the latest commit index if it cann't receive hearbeat.
+    // It's because the mechanism of notifying commit index in raft-rs is lazy.
+    let recv_filter_3 = Box::new(
+        RegionPacketFilter::new(1, 3)
+            .direction(Direction::Recv)
+            .msg_type(MessageType::MsgHeartbeat),
+    );
+    cluster.sim.wl().add_recv_filter(3, recv_filter_3);
+
+    cluster.must_put(b"k1", b"v2");
+
+    // Delay the response raft messages to peer 1003.
+    let dropped_msgs = Arc::new(Mutex::new(Vec::new()));
+    let response_recv_filter_3 = Box::new(
+        RegionPacketFilter::new(1, 3)
+            .direction(Direction::Recv)
+            .reserve_dropped(Arc::clone(&dropped_msgs))
+            .msg_type(MessageType::MsgAppendResponse)
+            .msg_type(MessageType::MsgHeartbeatResponse),
+    );
+    cluster.sim.wl().add_recv_filter(3, response_recv_filter_3);
+
+    cluster.must_transfer_leader(1, new_peer(3, 1003));
+
+    cluster.clear_send_filters();
+
+    // Wait peer 1 and 2 to send heartbeat response to peer 1003
+    sleep_ms(100);
+
+    let on_peer_collect_message_1003 = "on_peer_collect_message_1003";
+    fail::cfg(on_peer_collect_message_1003, "pause").unwrap();
+
+    cluster.sim.wl().clear_recv_filters(3);
+
+    let router = cluster.sim.wl().get_router(3).unwrap();
+    for raft_msg in mem::replace(dropped_msgs.lock().unwrap().as_mut(), vec![]) {
+        router.send_raft_message(raft_msg).unwrap();
+    }
+
+    let new_region = cluster.get_region(b"k1");
+    let resp_ch = async_read_on_peer(&mut cluster, new_peer(2, 2), new_region, b"k1", true, true);
+    // Wait peer 2 to send read index to peer 1003
+    sleep_ms(100);
+
+    fail::remove(on_peer_collect_message_1003);
+
+    let resp = resp_ch.recv_timeout(Duration::from_secs(3)).unwrap();
+    let exp_value = resp.get_responses()[0].get_get().get_value();
+    assert_eq!(exp_value, b"v2");
+}


### PR DESCRIPTION
Signed-off-by: gengliqi <gengliqiii@gmail.com>


### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/9208

Problem Summary:
The fast path of handling read index request in TiKV may give a stale index because we check the latest commit index, not the index which is used to reply to the response.
In most case, there is no problem. However, if this leader is a new one and the commit index of `PeerStorage` is too small and the log term of the latest commit index is equal to current term, this problem arises.

### What is changed and how it works?

What's Changed:
Check whether the log term of the commit index of `PeerStorage` is equal to current term.
Add a test to reproduce this bug.
At the end of this test, the read request gets a stale value in the previous implementation.

### Related changes

- Need to cherry-pick to the release branch

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

- Fix a bug that follower read may get a stale data after transferring leader