### PR TITLE
server: support modifying endpoint-slow-log-threshold dynamically 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2224,7 +2224,7 @@ pub struct TiKvConfig {
     #[config(skip)]
     pub readpool: ReadPoolConfig,
 
-    #[config(skip)]
+    #[config(submodule)]
     pub server: ServerConfig,
 
     #[config(submodule)]

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -74,45 +74,89 @@ pub struct Config {
 
     // Status server's advertise listening address for outer communication.
     // If not set, the status server's listening address will be used.
+    #[config(skip)]
     pub advertise_status_addr: String,
 
+    #[config(skip)]
     pub status_thread_pool_size: usize,
 
+    #[config(skip)]
     pub max_grpc_send_msg_len: i32,
 
     // TODO: use CompressionAlgorithms instead once it supports traits like Clone etc.
     #[config(skip)]
     pub grpc_compression_type: GrpcCompressionType,
+
+    #[config(skip)]
     pub grpc_concurrency: usize,
+
+    #[config(skip)]
     pub grpc_concurrent_stream: i32,
+
+    #[config(skip)]
     pub grpc_raft_conn_num: usize,
+
     #[config(skip)]
     pub grpc_memory_pool_quota: ReadableSize,
+
     #[config(skip)]
     pub grpc_stream_initial_window_size: ReadableSize,
+
+    #[config(skip)]
     pub grpc_keepalive_time: ReadableDuration,
+
+    #[config(skip)]
     pub grpc_keepalive_timeout: ReadableDuration,
+
     /// How many snapshots can be sent concurrently.
     #[config(skip)]
     pub concurrent_send_snap_limit: usize,
+
     /// How many snapshots can be recv concurrently.
+    #[config(skip)]
     pub concurrent_recv_snap_limit: usize,
+
+    #[config(skip)]
     pub end_point_recursion_limit: u32,
+
+    #[config(skip)]
     pub end_point_stream_channel_size: usize,
+
+    #[config(skip)]
     pub end_point_batch_row_limit: usize,
+
+    #[config(skip)]
     pub end_point_stream_batch_row_limit: usize,
+
+    #[config(skip)]
     pub end_point_enable_batch_if_possible: bool,
+
+    #[config(skip)]
     pub end_point_request_max_handle_duration: ReadableDuration,
+
+    #[config(skip)]
     pub end_point_max_concurrency: usize,
+
     #[config(skip)]
     pub snap_max_write_bytes_per_sec: ReadableSize,
     #[config(skip)]
     pub snap_max_total_size: ReadableSize,
+
+    #[config(skip)]
     pub stats_concurrency: usize,
+
+    #[config(skip)]
     pub heavy_load_threshold: usize,
+
+    #[config(skip)]
     pub heavy_load_wait_duration: ReadableDuration,
+
+    #[config(skip)]
     pub enable_request_batch: bool,
+
+    #[config(skip)]
     pub background_thread_count: usize,
+
     // If handle time is larger than the threshold, it will print slow log in end point.
     pub end_point_slow_log_threshold: ReadableDuration,
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -57,6 +57,7 @@ pub enum GrpcCompressionType {
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     #[serde(skip)]
+    #[config(skip)]
     pub cluster_id: u64,
 
     // Server listening address.
@@ -139,6 +140,7 @@ pub struct Config {
 
     #[config(skip)]
     pub snap_max_write_bytes_per_sec: ReadableSize,
+
     #[config(skip)]
     pub snap_max_total_size: ReadableSize,
 
@@ -163,6 +165,7 @@ pub struct Config {
     // Test only.
     #[doc(hidden)]
     #[serde(skip_serializing)]
+    #[config(skip)]
     pub raft_client_backoff_step: ReadableDuration,
 
     // Server labels to specify some attributes about this server.

--- a/tests/integrations/config/dynamic/mod.rs
+++ b/tests/integrations/config/dynamic/mod.rs
@@ -3,4 +3,5 @@
 mod gc_worker;
 mod pessimistic_txn;
 mod raftstore;
+mod server;
 mod split_check;

--- a/tests/integrations/config/dynamic/server.rs
+++ b/tests/integrations/config/dynamic/server.rs
@@ -1,0 +1,40 @@
+use std::sync::{Arc, RwLock};
+use tikv::config::{ConfigController, Module, TiKvConfig};
+use tikv::server::config::ServerConfigManager;
+use tikv_util::config::ReadableDuration;
+
+#[test]
+fn test_update_server_config() {
+    let (mut cfg, _dir) = TiKvConfig::with_tmp().unwrap();
+    cfg.validate().unwrap();
+    let cfg_track = Arc::new(RwLock::new(cfg.server.clone()));
+    let cfg_controller = ConfigController::new(cfg);
+    cfg_controller.register(Module::Server, Box::new(ServerConfigManager(cfg_track)));
+
+    // skipped config should not be changed
+    let change = {
+        let mut m = std::collections::HashMap::new();
+        m.insert("server.addr".to_owned(), "localhost:3000".to_owned());
+        m
+    };
+    let res = cfg_controller.update(change);
+    assert!(res.is_err());
+
+    // supported configs should be changeable.
+    let change = {
+        let mut m = std::collections::HashMap::new();
+        m.insert(
+            "server.end-point-slow-log-threshold".to_owned(),
+            "15s".to_owned(),
+        );
+        m
+    };
+    cfg_controller.update(change).unwrap();
+    assert_eq!(
+        cfg_controller
+            .get_current()
+            .server
+            .end_point_slow_log_threshold,
+        ReadableDuration::secs(15)
+    );
+}


### PR DESCRIPTION
Signed-off-by: Michael Okoko <okokomichaels@outlook.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9132 

Problem Summary:
We would love to be able to dynamically adjust the `slow-log` config item added in #9061 (using the `modify-tikv-config`) command. But the config item belongs to the `server` module which is currently marked as skip.

### What is changed and how it works?
What's Changed:

Mark the server module as a submodule, and extend it to derive the `Configuration trait`.
Also, set up a `ServerConfigManager` to dispatch config changes.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Integration test

Side effects
- None

### Release note <!-- bugfixes or new feature need a release note -->
- support modifying endpoint-slow-log-threshold dynamically 