### PR TITLE
txn: Unit test for response stage of prewrite

### DIFF
--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -1250,17 +1250,20 @@ mod tests {
             Mutation::Put((Key::from_raw(keys[1]), values[1].to_vec())),
         ];
         let mut statistics = Statistics::default();
+
         #[derive(Clone)]
         struct Case {
             expected: ResponsePolicy,
+
             // inputs
-            pessimistic: bool,
             // optimistic/pessimistic prewrite
-            async_commit: bool,
+            pessimistic: bool,
             // async commit on/off
-            one_pc: bool,
+            async_commit: bool,
             // 1pc on/off
-            async_apply_prewrite: bool, // async_apply_prewrite enabled
+            one_pc: bool,
+            // async_apply_prewrite enabled in config
+            async_apply_prewrite: bool,
         }
 
         let cases = vec![
@@ -1283,15 +1286,6 @@ mod tests {
                 async_apply_prewrite: true,
             },
             Case {
-                // early return can be turned on/off by async_apply_prewrite in context
-                expected: ResponsePolicy::OnApplied,
-
-                pessimistic: false,
-                async_commit: false,
-                one_pc: false,
-                async_apply_prewrite: false,
-            },
-            Case {
                 // works on async prewrite
                 expected: ResponsePolicy::OnCommitted,
 
@@ -1299,6 +1293,15 @@ mod tests {
                 async_commit: true,
                 one_pc: false,
                 async_apply_prewrite: true,
+            },
+            Case {
+                // early return can be turned on/off by async_apply_prewrite in context
+                expected: ResponsePolicy::OnApplied,
+
+                pessimistic: false,
+                async_commit: true,
+                one_pc: false,
+                async_apply_prewrite: false,
             },
             Case {
                 // works on 1pc

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -707,6 +707,7 @@ mod tests {
         },
         Engine, Snapshot, Statistics, TestEngineBuilder,
     };
+    use concurrency_manager::ConcurrencyManager;
     use engine_traits::CF_WRITE;
     use kvproto::kvrpcpb::Context;
     use txn_types::{Key, Mutation, TimeStamp};
@@ -1233,5 +1234,136 @@ mod tests {
             p.secondary_keys = Some(vec![]);
         }
         assert_max_ts_err!(cmd.cmd.process_write(MockSnapshot, context!()));
+    }
+
+    // this test shows which stage in raft can we return the response
+    #[test]
+    fn test_response_stage() {
+        use crate::storage::DummyLockManager;
+        use kvproto::kvrpcpb::ExtraOp;
+        let cm = ConcurrencyManager::new(42.into());
+        let start_ts = TimeStamp::new(10);
+        let keys = [b"k1", b"k2"];
+        let values = [b"v1", b"v2"];
+        let mutations = vec![
+            Mutation::Put((Key::from_raw(keys[0]), keys[0].to_vec())),
+            Mutation::Put((Key::from_raw(keys[1]), values[1].to_vec())),
+        ];
+        let mut statistics = Statistics::default();
+        #[derive(Clone)]
+        struct Case {
+            expected: ResponsePolicy,
+            // inputs
+            pessimistic: bool,
+            // optimistic/pessimistic prewrite
+            async_commit: bool,
+            // async commit on/off
+            one_pc: bool,
+            // 1pc on/off
+            async_apply_prewrite: bool, // async_apply_prewrite enabled
+        }
+
+        let cases = vec![
+            Case {
+                // basic case
+                expected: ResponsePolicy::OnApplied,
+
+                pessimistic: false,
+                async_commit: false,
+                one_pc: false,
+                async_apply_prewrite: false,
+            },
+            Case {
+                // async_apply_prewrite does not affect non-async/1pc prewrite
+                expected: ResponsePolicy::OnApplied,
+
+                pessimistic: false,
+                async_commit: false,
+                one_pc: false,
+                async_apply_prewrite: true,
+            },
+            Case {
+                // early return can be turned on/off by async_apply_prewrite in context
+                expected: ResponsePolicy::OnApplied,
+
+                pessimistic: false,
+                async_commit: false,
+                one_pc: false,
+                async_apply_prewrite: false,
+            },
+            Case {
+                // works on async prewrite, when no keys are previously locked
+                expected: ResponsePolicy::OnCommitted,
+
+                pessimistic: false,
+                async_commit: true,
+                one_pc: false,
+                async_apply_prewrite: true,
+            },
+            Case {
+                // works on 1pc, when no keys are previously locked
+                expected: ResponsePolicy::OnCommitted,
+
+                pessimistic: false,
+                async_commit: false,
+                one_pc: true,
+                async_apply_prewrite: true,
+            },
+        ];
+        let cases = cases
+            .iter()
+            .cloned()
+            .chain(cases.iter().cloned().map(|mut it| {
+                it.pessimistic = true;
+                it
+            }));
+
+        for case in cases {
+            let secondary_keys = if case.async_commit {
+                Some(vec![])
+            } else {
+                None
+            };
+            let cmd = if case.pessimistic {
+                PrewritePessimistic::new(
+                    mutations.iter().map(|it| (it.clone(), false)).collect(),
+                    keys[0].to_vec(),
+                    start_ts,
+                    0,
+                    11.into(),
+                    1,
+                    TimeStamp::default(),
+                    TimeStamp::default(),
+                    secondary_keys,
+                    case.one_pc,
+                    Context::default(),
+                )
+            } else {
+                Prewrite::new(
+                    mutations.clone(),
+                    keys[0].to_vec(),
+                    start_ts,
+                    0,
+                    false,
+                    1,
+                    TimeStamp::default(),
+                    TimeStamp::default(),
+                    secondary_keys,
+                    case.one_pc,
+                    Context::default(),
+                )
+            };
+            let context = WriteContext {
+                lock_mgr: &DummyLockManager {},
+                concurrency_manager: cm.clone(),
+                extra_op: ExtraOp::Noop,
+                statistics: &mut statistics,
+                async_apply_prewrite: case.async_apply_prewrite,
+            };
+            let engine = TestEngineBuilder::new().build().unwrap();
+            let snap = engine.snapshot(Default::default()).unwrap();
+            let result = cmd.cmd.process_write(snap, context).unwrap();
+            assert_eq!(result.response_policy, case.expected);
+        }
     }
 }

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -1292,7 +1292,7 @@ mod tests {
                 async_apply_prewrite: false,
             },
             Case {
-                // works on async prewrite, when no keys are previously locked
+                // works on async prewrite
                 expected: ResponsePolicy::OnCommitted,
 
                 pessimistic: false,
@@ -1301,7 +1301,7 @@ mod tests {
                 async_apply_prewrite: true,
             },
             Case {
-                // works on 1pc, when no keys are previously locked
+                // works on 1pc
                 expected: ResponsePolicy::OnCommitted,
 
                 pessimistic: false,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary: We don't have unit tests for which stage in raft can we response to the user.

### What is changed and how it works?

What's Changed:
Write unit tests to check `response_policy` field on the result `Prewrite` and `PrewritePessimistic` command match the expected result.

Related prs waiting for reviewing: 

(Also PTAL) #9245 test whether the scheduler handle `response_policy` correctly

#9136 by NingLin-P has a test for stale callbacks (I'm also tring to add an integration test for this)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test