### PR TITLE
txn: Unit test to check scheduler handle response_policy correctly

### DIFF
--- a/src/storage/kv/mock_engine.rs
+++ b/src/storage/kv/mock_engine.rs
@@ -118,12 +118,14 @@ impl Engine for MockEngine {
         let mut expected_writes = self.expected_modifies.0.lock().unwrap();
         for modify in batch.modifies.iter() {
             if let Some(expected_write) = expected_writes.pop_front() {
+                // check whether the modify is expected
                 if let Some(expected_modify) = expected_write.modify {
                     assert_eq!(
                         modify, &expected_modify,
                         "modify writing to Engine not match with expected"
                     )
                 }
+                // check whether use right callback
                 match expected_write.use_proposed_cb {
                     Some(true) => assert!(
                         proposed_cb.is_some(),

--- a/src/storage/kv/mock_engine.rs
+++ b/src/storage/kv/mock_engine.rs
@@ -18,7 +18,7 @@ pub struct MockEngine {
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ExpectedWrite {
-    // the following `Option`s means we just don't care
+    // if the following `Option`s are None, it means we just don't care
     modify: Option<Modify>,
     use_proposed_cb: Option<bool>,
     use_committed_cb: Option<bool>,

--- a/src/storage/kv/mock_engine.rs
+++ b/src/storage/kv/mock_engine.rs
@@ -1,0 +1,183 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use super::Result;
+use crate::storage::kv::{Callback, ExtCallback, Modify, SnapContext, WriteData};
+use crate::storage::{Engine, RocksEngine};
+use kvproto::kvrpcpb::Context;
+use std::collections::LinkedList;
+use std::sync::{Arc, Mutex};
+
+/// A mock engine is a simple wrapper around RocksEngine
+/// but with the ability to assert the modifies,
+/// the callback used, and other aspects during interaction with the engine
+#[derive(Clone)]
+pub struct MockEngine {
+    base: RocksEngine,
+    expected_modifies: Arc<ExpectedWriteList>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ExpectedWrite {
+    // the following `Option`s means we just don't care
+    modify: Option<Modify>,
+    use_proposed_cb: Option<bool>,
+    use_committed_cb: Option<bool>,
+}
+
+impl ExpectedWrite {
+    pub fn new() -> Self {
+        Default::default()
+    }
+    pub fn expect_modify(self, modify: Modify) -> Self {
+        Self {
+            modify: Some(modify),
+            use_proposed_cb: self.use_proposed_cb,
+            use_committed_cb: self.use_committed_cb,
+        }
+    }
+    pub fn expect_proposed_cb(self) -> Self {
+        Self {
+            modify: self.modify,
+            use_proposed_cb: Some(true),
+            use_committed_cb: self.use_committed_cb,
+        }
+    }
+    pub fn expect_no_proposed_cb(self) -> Self {
+        Self {
+            modify: self.modify,
+            use_proposed_cb: Some(false),
+            use_committed_cb: self.use_committed_cb,
+        }
+    }
+    pub fn expect_committed_cb(self) -> Self {
+        Self {
+            modify: self.modify,
+            use_proposed_cb: self.use_proposed_cb,
+            use_committed_cb: Some(true),
+        }
+    }
+    pub fn expect_no_committed_cb(self) -> Self {
+        Self {
+            modify: self.modify,
+            use_proposed_cb: self.use_proposed_cb,
+            use_committed_cb: Some(false),
+        }
+    }
+}
+
+/// `ExpectedWriteList` represents a list of writes expected to write to the engine
+struct ExpectedWriteList(Mutex<LinkedList<ExpectedWrite>>);
+
+// We implement drop here instead of on MockEngine
+// because `MockEngine` can be cloned and dropped everywhere
+// and we just want to assert every write
+impl Drop for ExpectedWriteList {
+    fn drop(&mut self) {
+        let expected_modifies = &mut *self.0.lock().unwrap();
+        assert_eq!(
+            expected_modifies.len(),
+            0,
+            "not all expected modifies have been written to the engine, {} rest",
+            expected_modifies.len()
+        )
+    }
+}
+
+impl Engine for MockEngine {
+    type Snap = <RocksEngine as Engine>::Snap;
+    type Local = <RocksEngine as Engine>::Local;
+
+    fn kv_engine(&self) -> Self::Local {
+        self.base.kv_engine()
+    }
+
+    fn snapshot_on_kv_engine(&self, start_key: &[u8], end_key: &[u8]) -> Result<Self::Snap> {
+        self.base.snapshot_on_kv_engine(start_key, end_key)
+    }
+
+    fn modify_on_kv_engine(&self, modifies: Vec<Modify>) -> Result<()> {
+        self.base.modify_on_kv_engine(modifies)
+    }
+
+    fn async_snapshot(&self, ctx: SnapContext<'_>, cb: Callback<Self::Snap>) -> Result<()> {
+        self.base.async_snapshot(ctx, cb)
+    }
+
+    fn async_write(&self, ctx: &Context, batch: WriteData, write_cb: Callback<()>) -> Result<()> {
+        self.async_write_ext(ctx, batch, write_cb, None, None)
+    }
+
+    fn async_write_ext(
+        &self,
+        ctx: &Context,
+        batch: WriteData,
+        write_cb: Callback<()>,
+        proposed_cb: Option<ExtCallback>,
+        committed_cb: Option<ExtCallback>,
+    ) -> Result<()> {
+        let mut expected_writes = self.expected_modifies.0.lock().unwrap();
+        for modify in batch.modifies.iter() {
+            if let Some(expected_write) = expected_writes.pop_front() {
+                if let Some(expected_modify) = expected_write.modify {
+                    assert_eq!(
+                        modify, &expected_modify,
+                        "modify writing to Engine not match with expected"
+                    )
+                }
+                match expected_write.use_proposed_cb {
+                    Some(true) => assert!(
+                        proposed_cb.is_some(),
+                        "this write is supposed to return during the propose stage"
+                    ),
+                    Some(false) => assert!(
+                        proposed_cb.is_none(),
+                        "this write is not supposed to return during the propose stage"
+                    ),
+                    None => {}
+                }
+                match expected_write.use_committed_cb {
+                    Some(true) => assert!(
+                        committed_cb.is_some(),
+                        "this write is supposed to return during the commit stage"
+                    ),
+                    Some(false) => assert!(
+                        committed_cb.is_none(),
+                        "this write is not supposed to return during the commit stage"
+                    ),
+                    None => {}
+                }
+            } else {
+                panic!("unexpected modify {:?} wrote to the Engine", modify)
+            }
+        }
+        drop(expected_writes);
+        self.base
+            .async_write_ext(ctx, batch, write_cb, proposed_cb, committed_cb)
+    }
+}
+
+pub struct MockEngineBuilder {
+    base: RocksEngine,
+    expected_modifies: LinkedList<ExpectedWrite>,
+}
+
+impl MockEngineBuilder {
+    pub fn from_rocks_engine(rocks_engine: RocksEngine) -> Self {
+        Self {
+            base: rocks_engine,
+            expected_modifies: LinkedList::new(),
+        }
+    }
+
+    pub fn add_expected_write(mut self, write: ExpectedWrite) -> Self {
+        self.expected_modifies.push_back(write);
+        self
+    }
+
+    pub fn build(self) -> MockEngine {
+        MockEngine {
+            base: self.base,
+            expected_modifies: Arc::new(ExpectedWriteList(Mutex::new(self.expected_modifies))),
+        }
+    }
+}

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -6,6 +6,7 @@
 
 mod btree_engine;
 mod cursor;
+mod mock_engine;
 mod perf_context;
 mod rocksdb_engine;
 mod stats;
@@ -25,6 +26,7 @@ use txn_types::{Key, TimeStamp, TxnExtra, Value};
 
 pub use self::btree_engine::{BTreeEngine, BTreeEngineIterator, BTreeEngineSnapshot};
 pub use self::cursor::{Cursor, CursorBuilder};
+pub use self::mock_engine::{ExpectedWrite, MockEngineBuilder};
 pub use self::perf_context::{PerfStatisticsDelta, PerfStatisticsInstant};
 pub use self::rocksdb_engine::{write_modifies, RocksEngine, RocksSnapshot, TestEngineBuilder};
 pub use self::stats::{
@@ -57,7 +59,7 @@ impl CbContext {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Modify {
     Delete(CfName, Key),
     Put(CfName, Key, Value),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1718,7 +1718,7 @@ mod tests {
     use crate::config::TitanDBConfig;
     use crate::storage::kv::{ExpectedWrite, MockEngineBuilder};
     use crate::storage::mvcc::LockType;
-    use crate::storage::txn::commands::Prewrite;
+    use crate::storage::txn::commands::{AcquirePessimisticLock, Prewrite};
     use crate::storage::{
         config::BlockCacheConfig,
         kv::{Error as EngineError, ErrorInner as EngineErrorInner},
@@ -5701,43 +5701,153 @@ mod tests {
         assert_eq!(res.min_commit_ts, 1001.into());
     }
 
+    // this test shows that the scheduler take `response_policy` in `WriteResult` serious,
+    // ie. call the callback at expected stage when writing to the engine
     #[test]
     fn test_scheduler_response_policy() {
-        let engine =
-            MockEngineBuilder::from_rocks_engine(TestEngineBuilder::new().build().unwrap())
-                .add_expected_write(ExpectedWrite::new().expect_committed_cb())
-                .add_expected_write(ExpectedWrite::new().expect_committed_cb())
-                .build();
-        let mut builder = TestStorageBuilder::from_engine_and_lock_mgr(engine, DummyLockManager {});
-        builder.config.enable_async_apply_prewrite = true;
-        let storage = builder.build().unwrap();
-        let (tx, rx) = channel();
+        struct Case<T: 'static + StorageCallbackType + Send> {
+            expected_writes: Vec<ExpectedWrite>,
+
+            command: TypedCommand<T>,
+            pipelined_pessimistic_lock: bool,
+        }
+
+        fn run_case<T: 'static + StorageCallbackType + Send>(case: Case<T>) {
+            let mut builder =
+                MockEngineBuilder::from_rocks_engine(TestEngineBuilder::new().build().unwrap());
+            for expected_write in case.expected_writes {
+                builder = builder.add_expected_write(expected_write)
+            }
+            let engine = builder.build();
+            let mut builder =
+                TestStorageBuilder::from_engine_and_lock_mgr(engine, DummyLockManager {});
+            builder.config.enable_async_apply_prewrite = true;
+            if case.pipelined_pessimistic_lock {
+                builder
+                    .pipelined_pessimistic_lock
+                    .store(true, Ordering::Relaxed);
+            }
+            let storage = builder.build().unwrap();
+            let (tx, rx) = channel();
+            storage
+                .sched_txn_command(
+                    case.command,
+                    Box::new(move |res| {
+                        tx.send(res).unwrap();
+                    }),
+                )
+                .unwrap();
+            rx.recv().unwrap().unwrap();
+        }
+
         let keys = [b"k1", b"k2"];
         let values = [b"v1", b"v2"];
         let mutations = vec![
             Mutation::Put((Key::from_raw(keys[0]), keys[0].to_vec())),
             Mutation::Put((Key::from_raw(keys[1]), values[1].to_vec())),
         ];
-        storage
-            .sched_txn_command(
-                Prewrite::new(
-                    mutations.clone(),
-                    keys[0].to_vec(),
-                    TimeStamp::new(10),
-                    0,
-                    false,
-                    1,
-                    TimeStamp::default(),
-                    TimeStamp::default(),
-                    Some(vec![]),
-                    false,
-                    Context::default(),
-                ),
-                Box::new(move |res| {
-                    tx.send(res).unwrap();
-                }),
-            )
-            .unwrap();
-        rx.recv().unwrap().unwrap();
+
+        let on_applied_case = Case {
+            // this case's command return ResponsePolicy::OnApplied
+            // tested by `test_response_stage` in command::prewrite
+            expected_writes: vec![
+                ExpectedWrite::new()
+                    .expect_no_committed_cb()
+                    .expect_no_proposed_cb(),
+                ExpectedWrite::new()
+                    .expect_no_committed_cb()
+                    .expect_no_proposed_cb(),
+            ],
+
+            command: Prewrite::new(
+                mutations.clone(),
+                keys[0].to_vec(),
+                TimeStamp::new(10),
+                0,
+                false,
+                1,
+                TimeStamp::default(),
+                TimeStamp::default(),
+                None,
+                false,
+                Context::default(),
+            ),
+            pipelined_pessimistic_lock: false,
+        };
+        let on_commited_case = Case {
+            // this case's command return ResponsePolicy::OnCommitted
+            // tested by `test_response_stage` in command::prewrite
+            expected_writes: vec![
+                ExpectedWrite::new().expect_committed_cb(),
+                ExpectedWrite::new().expect_committed_cb(),
+            ],
+
+            command: Prewrite::new(
+                mutations,
+                keys[0].to_vec(),
+                TimeStamp::new(10),
+                0,
+                false,
+                1,
+                TimeStamp::default(),
+                TimeStamp::default(),
+                Some(vec![]),
+                false,
+                Context::default(),
+            ),
+            pipelined_pessimistic_lock: false,
+        };
+        let on_proposed_case = Case {
+            // this case's command return ResponsePolicy::OnProposed
+            // untested, but all AcquirePessimisticLock should return ResponsePolicy::OnProposed now
+            // and the scheduler expected to take OnProposed serious when
+            // enable pipelined pessimistic lock
+            expected_writes: vec![
+                ExpectedWrite::new().expect_proposed_cb(),
+                ExpectedWrite::new().expect_proposed_cb(),
+            ],
+
+            command: AcquirePessimisticLock::new(
+                keys.iter().map(|&it| (Key::from_raw(it), true)).collect(),
+                keys[0].to_vec(),
+                TimeStamp::new(10),
+                0,
+                false,
+                TimeStamp::new(11),
+                None,
+                false,
+                TimeStamp::new(12),
+                Context::default(),
+            ),
+            pipelined_pessimistic_lock: true,
+        };
+        let on_proposed_fallback_case = Case {
+            // this case's command return ResponsePolicy::OnProposed
+            // but with pipelined pessimistic lock is off,
+            // the scheduler should fallback to use OnApplied
+            expected_writes: vec![
+                ExpectedWrite::new().expect_no_proposed_cb(),
+                ExpectedWrite::new().expect_no_proposed_cb(),
+            ],
+
+            command: AcquirePessimisticLock::new(
+                keys.iter().map(|&it| (Key::from_raw(it), true)).collect(),
+                keys[0].to_vec(),
+                TimeStamp::new(10),
+                0,
+                false,
+                TimeStamp::new(11),
+                None,
+                false,
+                TimeStamp::new(12),
+                Context::default(),
+            ),
+            pipelined_pessimistic_lock: false,
+        };
+
+        run_case(on_applied_case);
+        run_case(on_commited_case);
+        run_case(on_proposed_case);
+        run_case(on_proposed_fallback_case);
     }
 }

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -339,13 +339,13 @@ pub(super) struct ReleasedLocks {
 ///
 /// Note that this doesn't affect latch releasing. The latch and the memory lock (if any) are always
 /// released after applying, regardless of when the response is sent.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ResponsePolicy {
     /// Return the response to the client when the command has finished applying.
     OnApplied,
     /// Return the response after finishing Raft committing.
     OnCommitted,
-    /// Return the response after finishing raft porposing.
+    /// Return the response after finishing raft proposing.
     OnProposed,
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Currently we don't have a test to check whether the scheduler handle `response_policy` correctly.

### What is changed and how it works?

What's Changed:

Write tests for checking whether the correct stage the callback is called  according to `response_policy`. This is done by introducing a `MockEngine` which is a wrapper around `RocksEngine` but with the ability to assert the in comming writes, which should be also useful in other tests.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
