### PR TITLE
txn: Documentation for TypedCommand and command macro

### DIFF
--- a/src/storage/txn/commands/macros.rs
+++ b/src/storage/txn/commands/macros.rs
@@ -37,8 +37,8 @@ macro_rules! command {
         }
 
         impl $cmd {
-            /// Return a `TypedCommand` encapsulating the result of executing this command.
-            /// The result is of type `StorageCallbackType`
+            /// Return a `TypedCommand` that encapsulates the result of executing this command.
+            /// The actual result of the command implements the `StorageCallbackType` trait.
             pub fn new(
                 $($arg: $arg_ty,)*
                 ctx: crate::storage::Context,

--- a/src/storage/txn/commands/macros.rs
+++ b/src/storage/txn/commands/macros.rs
@@ -11,7 +11,7 @@ macro_rules! ctx {
     };
 }
 
-/// Generate the struct definition and Debug, Display methods for a passed in
+/// Generate the struct definition and Debug, Display methods for a passed-in
 /// storage command. An instance of this type is created from the `From`
 /// trait implementations of `TypedCommand`, when processing incoming storage
 /// requests of different types.

--- a/src/storage/txn/commands/macros.rs
+++ b/src/storage/txn/commands/macros.rs
@@ -12,9 +12,7 @@ macro_rules! ctx {
 }
 
 /// Generate the struct definition and Debug, Display methods for a passed-in
-/// storage command. An instance of this type is created from the `From`
-/// trait implementations of `TypedCommand`, when processing incoming storage
-/// requests of different types.
+/// storage command.
 /// Parameters:
 /// cmd -> Used as the type name for the generated struct. A variant of the
 /// enum `storage::txns::commands::Command` must exist whose name matches the

--- a/src/storage/txn/commands/macros.rs
+++ b/src/storage/txn/commands/macros.rs
@@ -19,9 +19,6 @@ macro_rules! ctx {
 /// value of `cmd` and which accepts one parameter whose type name matches
 /// the value of `cmd`.
 /// cmd_ty -> The type of the result of executing this command.
-/// A `From` conversion should exist in txn/commands/mod.rs from a `Command` enum
-/// variant corresponding to the value of `cmd` to a `TypedCommand`
-/// parameterized with the value of `cmd_ty`.
 /// display -> Information needed to implement the `Display` trait for the command.
 /// content -> The fields of the struct definition for the command.
 macro_rules! command {

--- a/src/storage/txn/commands/macros.rs
+++ b/src/storage/txn/commands/macros.rs
@@ -11,6 +11,15 @@ macro_rules! ctx {
     };
 }
 
+/// Generate the struct definition and Debug, Display methods for a passed in
+/// storage command.
+/// Parameters:
+/// cmd -> Used as the type name for the struct. It must match one of the variants of the enum
+/// `storage::txns::commands::Command`.
+/// cmd_ty -> The type that encapsulates the result of executing this command. It is passed as
+/// a generic parameter to `TypedCommand`.
+/// display -? Information needed to implement the `Display` trait for the command.
+/// content -> The contents of the struct definition for the command.
 macro_rules! command {
     (
         $(#[$outer_doc: meta])*
@@ -28,6 +37,8 @@ macro_rules! command {
         }
 
         impl $cmd {
+            /// Return a `TypedCommand` encapsulating the result of executing this command.
+            /// The result is of type `StorageCallbackType`
             pub fn new(
                 $($arg: $arg_ty,)*
                 ctx: crate::storage::Context,

--- a/src/storage/txn/commands/macros.rs
+++ b/src/storage/txn/commands/macros.rs
@@ -12,13 +12,19 @@ macro_rules! ctx {
 }
 
 /// Generate the struct definition and Debug, Display methods for a passed in
-/// storage command.
+/// storage command. An instance of this type is created from the `From`
+/// trait implementations of `TypedCommand`, when processing incoming storage
+/// requests of different types.
 /// Parameters:
-/// cmd -> Used as the type name for the struct. It must match one of the variants of the enum
-/// `storage::txns::commands::Command`.
-/// cmd_ty -> The type that encapsulates the result of executing this command. It is passed as
-/// a generic parameter to `TypedCommand`.
-/// display -? Information needed to implement the `Display` trait for the command.
+/// cmd -> Used as the type name for the generated struct. A variant of the
+/// enum `storage::txns::commands::Command` must exist whose name matches the
+/// value of `cmd` and which accepts one parameter whose type name matches
+/// the value of `cmd`.
+/// cmd_ty -> The type that encapsulates the result of executing this command.
+/// A `From` conversion should exist in txn/commands/mod.rs from a `Command` enum
+/// variant corresponding to the value of `cmd` to a `TypedCommand`
+/// parameterized with the value of `cmd_ty`.
+/// display -> Information needed to implement the `Display` trait for the command.
 /// content -> The contents of the struct definition for the command.
 macro_rules! command {
     (

--- a/src/storage/txn/commands/macros.rs
+++ b/src/storage/txn/commands/macros.rs
@@ -44,7 +44,6 @@ macro_rules! command {
 
         impl $cmd {
             /// Return a `TypedCommand` that encapsulates the result of executing this command.
-            /// The actual result of the command implements the `StorageCallbackType` trait.
             pub fn new(
                 $($arg: $arg_ty,)*
                 ctx: crate::storage::Context,

--- a/src/storage/txn/commands/macros.rs
+++ b/src/storage/txn/commands/macros.rs
@@ -20,12 +20,12 @@ macro_rules! ctx {
 /// enum `storage::txns::commands::Command` must exist whose name matches the
 /// value of `cmd` and which accepts one parameter whose type name matches
 /// the value of `cmd`.
-/// cmd_ty -> The type that encapsulates the result of executing this command.
+/// cmd_ty -> The type of the result of executing this command.
 /// A `From` conversion should exist in txn/commands/mod.rs from a `Command` enum
 /// variant corresponding to the value of `cmd` to a `TypedCommand`
 /// parameterized with the value of `cmd_ty`.
 /// display -> Information needed to implement the `Display` trait for the command.
-/// content -> The contents of the struct definition for the command.
+/// content -> The fields of the struct definition for the command.
 macro_rules! command {
     (
         $(#[$outer_doc: meta])*

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -624,15 +624,11 @@ impl Debug for Command {
 }
 
 /// Commands that do not need to modify the database during execution will implement this trait.
-/// Currently, this refers to the following variants of `storage::txn::commands::Command`:
-/// `ScanLock`, `ResolveLockReadPhase`, `MvccByKey` and `MvccByStartTs`.
 pub trait ReadCommand<S: Snapshot>: CommandExt {
     fn process_read(self, snapshot: S, statistics: &mut Statistics) -> Result<ProcessResult>;
 }
 
 /// Commands that need to modify the database during execution will implement this trait.
-/// Currently, that refers to all variants of `storage::txn::commands::Command` except for
-/// `ScanLock`, `ResolveLockReadPhase`, `MvccByKey` and `MvccByStartTs`.
 pub trait WriteCommand<S: Snapshot, L: LockManager>: CommandExt {
     fn process_write(self, snapshot: S, context: WriteContext<'_, L>) -> Result<WriteResult>;
 }

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -95,15 +95,16 @@ pub enum Command {
 /// needs to be transformed to a `TypedCommand` before being passed to the
 /// `storage.sched_txn_command` method.
 /// 2. The `From<CommitRequest>` impl for `TypedCommand` gets chosen, and its generic
-/// parameters indicates that the result type for this instance of `TypedCommand` is
+/// parameter indicates that the result type for this instance of `TypedCommand` is
 /// going to be `TxnStatus` - one of the variants of the `StorageCallback` enum.
 /// 3. In the above `from` method, the details of the commit request are captured by
-/// instantiating an instance of the struct `storage::txn::commands::commit::Command`
+/// creating an instance of the struct `storage::txn::commands::commit::Command`
 /// via its `new` method.
 /// 4. This struct is wrapped in a variant of the enum `storage::txn::commands::Command`.
 /// This enum exists to facilitate generic operations over different commands.
 /// 5. Finally, the `Command` enum variant for `Commit` is converted to the `TypedCommand`
 /// using the `From<Command>` impl for `TypedCommand`.
+///
 /// For other requests, see the corresponding `future_` method, the `From` trait
 /// implementation and so on.
 pub struct TypedCommand<T> {

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -104,6 +104,8 @@ pub enum Command {
 /// This enum exists to facilitate generic operations over different commands.
 /// 5. Finally, the `Command` enum variant for `Commit` is converted to the `TypedCommand`
 /// using the `From<Command>` impl for `TypedCommand`.
+/// For other requests, see the corresponding `future_` method, the `From` trait
+/// implementation and so on.
 pub struct TypedCommand<T> {
     pub cmd: Command,
 

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -86,9 +86,9 @@ pub enum Command {
     MvccByStartTs(MvccByStartTs),
 }
 
-/// Stores the `Command` along with its return type, stored as generic parameter `T`.
+/// A `Command` with its return type, reified as the generic parameter `T`.
 ///
-/// Incoming protobuf requests (like `CommitRequest`, `PrewriteRequest`) are converted to
+/// Incoming grpc requests (like `CommitRequest`, `PrewriteRequest`) are converted to
 /// this type via a series of transformations. That process is described below using
 /// `CommitRequest` as an example:
 /// 1. A `CommitRequest` is handled by the `future_commit` method in kv.rs, where it


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:  Addresses the need for code level documentation in transactions, as per https://github.com/tikv/sig-transaction/issues/25

### What is changed and how it works?

What's Changed:
Documentation added for `TypedCommand`, the `command` macro and a couple of other traits.

I found it hard to follow the flow of the Request -> Command handling and thought these comments might help others in future. My difficulty lay in putting 3-4 pieces together: the macros (and their enums), the `From` traits invoked via .into() and the usage of PhantomData. There's also the StorageCallback and some async code there that I haven't dug into much.

Let me know whether the documentation I have added is correct, and whether it is worth keeping around in the code. If not in the code, I'll keep it around somewhere at least for my own reference. Also, if my docs show a lack of use of the right Rust terminology, please point out that as well.

Tests:
- No code

Side effects:
- None

/cc @andylokandy  and @nrc 