### PR TITLE
test: stablize test_multi_early_apply test

### DIFF
--- a/tests/failpoints/cases/test_early_apply.rs
+++ b/tests/failpoints/cases/test_early_apply.rs
@@ -45,6 +45,10 @@ fn test_multi_early_apply() {
     must_get_equal(&cluster.get_engine(1), b"k0", b"v0");
     must_get_equal(&cluster.get_engine(1), b"k3", b"v3");
 
+    // Prevent gc_log_tick to propose a compact log
+    let raft_gc_log_tick_fp = "on_raft_gc_log_tick";
+    fail::cfg(raft_gc_log_tick_fp, "return()").unwrap();
+
     let store_1_fp = "raft_before_save_on_store_1";
 
     let executed = AtomicBool::new(false);


### PR DESCRIPTION
Signed-off-by: gengliqi <gengliqiii@gmail.com>

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/9252

Problem Summary:
The test_multi_early_apply is not stable because the compact log may be proposed after adding the send filter and the `"raft_before_save_on_store_1"` failpoint is triggered, which makes leader not send append msg for `cluster.async_put(b"k4", b"v4").unwrap();`.
We can easily reproduce this test failure by adding a `sleep_ms(500)` before `cluster.async_put(b"k4", b"v4").unwrap();`.

### What is changed and how it works?

What's Changed:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->
* No Release Note