### PR TITLE
tests: add test for replica read with split isolation

### DIFF
--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -370,7 +370,7 @@ fn test_split_isolation() {
         if !resp.get_header().has_error() {
             return;
         }
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(200));
     }
     panic!("test failed");
 }

--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -334,7 +334,7 @@ fn test_split_isolation() {
     cluster.must_split(&r1, b"k2");
     let idx = cluster.truncated_state(1, 1).get_index();
     // Trigger a log compaction, so the left region ['', 'k2'] cannot created through split cmd.
-    for i in 0..cluster.cfg.raft_store.raft_log_gc_count_limit * 2 {
+    for i in 2..cluster.cfg.raft_store.raft_log_gc_count_limit * 2 {
         cluster.must_put(format!("k{}", i).as_bytes(), format!("v{}", i).as_bytes());
     }
     let timer = Instant::now();


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #6667  <!-- REMOVE this line if no issue to close -->

Problem Summary:
Previously tiflash gets read-index through `read_index` RPC, now it has changed to use follower read.
With #9068, a region that has pending peers will not go to sleep, and with #6648 and #6348, the failed follower read will be retried.
So for now we can consider that #6667 has been addressed.

### What is changed and how it works?

What's Changed:
Add a test for covering the case.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* N/A