### PR TITLE
copr: fix the different behavior between tidb and tikv in convert function.

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/duration.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/duration.rs
@@ -499,16 +499,7 @@ impl Duration {
                     return t.convert(ctx);
                 }
             }
-            ctx.handle_overflow_err(Error::overflow("Duration", n))?;
-            // Returns max duration if overflow occurred
-            return Self::new_from_parts(
-                n.is_negative(),
-                MAX_HOUR_PART,
-                MAX_MINUTE_PART,
-                MAX_SECOND_PART,
-                0,
-                fsp,
-            );
+            return Err(Error::overflow("Duration", n));
         }
 
         let abs = n.abs();
@@ -1104,50 +1095,50 @@ mod tests {
             (
                 8385960,
                 0,
-                Ok(Duration::parse(&mut EvalContext::default(), b"838:59:59", 0).unwrap()),
-                true,
+                Err(Error::overflow("Duration", 8385960)),
+                false,
             ),
             (
                 8385960,
                 1,
-                Ok(Duration::parse(&mut EvalContext::default(), b"838:59:59", 1).unwrap()),
-                true,
+                Err(Error::overflow("Duration", 8385960)),
+                false,
             ),
             (
                 8385960,
                 5,
-                Ok(Duration::parse(&mut EvalContext::default(), b"838:59:59", 5).unwrap()),
-                true,
+                Err(Error::overflow("Duration", 8385960)),
+                false,
             ),
             (
                 8385960,
                 6,
-                Ok(Duration::parse(&mut EvalContext::default(), b"838:59:59", 6).unwrap()),
-                true,
+                Err(Error::overflow("Duration", 8385960)),
+                false,
             ),
             (
                 -8385960,
                 0,
-                Ok(Duration::parse(&mut EvalContext::default(), b"-838:59:59", 0).unwrap()),
-                true,
+                Err(Error::overflow("Duration", 8385960)),
+                false,
             ),
             (
                 -8385960,
                 1,
-                Ok(Duration::parse(&mut EvalContext::default(), b"-838:59:59", 1).unwrap()),
-                true,
+                Err(Error::overflow("Duration", 8385960)),
+                false,
             ),
             (
                 -8385960,
                 5,
-                Ok(Duration::parse(&mut EvalContext::default(), b"-838:59:59", 5).unwrap()),
-                true,
+                Err(Error::overflow("Duration", 8385960)),
+                false,
             ),
             (
                 -8385960,
                 6,
-                Ok(Duration::parse(&mut EvalContext::default(), b"-838:59:59", 6).unwrap()),
-                true,
+                Err(Error::overflow("Duration", 8385960)),
+                false,
             ),
             // will truncated
             (8376049, 0, Err(Error::truncated_wrong_val("", "")), false),
@@ -1168,15 +1159,7 @@ mod tests {
             (
                 -10000235959,
                 0,
-                Ok(Duration::new_from_parts(
-                    true,
-                    MAX_HOUR_PART,
-                    MAX_MINUTE_PART,
-                    MAX_SECOND_PART,
-                    0,
-                    0,
-                )
-                .unwrap()),
+                Err(Error::overflow("Duration", "-10000235959")),
                 false,
             ),
         ];

--- a/components/tidb_query_datatype/src/codec/mysql/duration.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/duration.rs
@@ -1092,30 +1092,10 @@ mod tests {
                 false,
             ),
             // will overflow
-            (
-                8385960,
-                0,
-                Err(Error::overflow("Duration", 8385960)),
-                false,
-            ),
-            (
-                8385960,
-                1,
-                Err(Error::overflow("Duration", 8385960)),
-                false,
-            ),
-            (
-                8385960,
-                5,
-                Err(Error::overflow("Duration", 8385960)),
-                false,
-            ),
-            (
-                8385960,
-                6,
-                Err(Error::overflow("Duration", 8385960)),
-                false,
-            ),
+            (8385960, 0, Err(Error::overflow("Duration", 8385960)), false),
+            (8385960, 1, Err(Error::overflow("Duration", 8385960)), false),
+            (8385960, 5, Err(Error::overflow("Duration", 8385960)), false),
+            (8385960, 6, Err(Error::overflow("Duration", 8385960)), false),
             (
                 -8385960,
                 0,

--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -5326,18 +5326,8 @@ mod tests {
                 false,
             ),
             // overflow as warning
-            (
-                8385960,
-                0,
-                Ok(Some(Duration::parse(&mut ctx, b"838:59:59", 0).unwrap())),
-                true,
-            ),
-            (
-                -8385960,
-                0,
-                Ok(Some(Duration::parse(&mut ctx, b"-838:59:59", 0).unwrap())),
-                true,
-            ),
+            (8385960, 0, Ok(None), true),
+            (-8385960, 0, Ok(None), true),
             // will truncated
             (8376049, 0, Err(Error::truncated_wrong_val("", "")), false),
             (8375960, 0, Err(Error::truncated_wrong_val("", "")), false),
@@ -5354,12 +5344,7 @@ mod tests {
                 Ok(Some(Duration::parse(&mut ctx, b"23:59:59", 0).unwrap())),
                 false,
             ),
-            (
-                -10000235959,
-                0,
-                Ok(Some(Duration::parse(&mut ctx, b"-838:59:59", 0).unwrap())),
-                false,
-            ),
+            (-10000235959, 0, Ok(None), false),
         ];
 
         for (input, fsp, expected, overflow) in cs {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/21695 <!-- REMOVE this line if no issue to close -->

Problem Summary:
The condition value is NULL, but TiKV return the result.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
In the function Duration.from_i64, return a MaxDurationTime is meaningless.

When it throw an overflow error, the behavior should be the two situations:
1. If Flag::OVERFLOW_AS_WARNING is set, TiKV should handle the error, and return a NULL value.
2. If Flag::OVERFLOW_AS_WARNING is not set, TiKV should return the error. 

But now, the overflow number will be convert to MaxDurationTime, and make the condition ture. 
So I try to throw the error directly, can handle the error in `cast_int_as_duration`


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the wrong behavior for convert function.