### PR TITLE
tests: try to stabilize test_server_auto_adjust_replica

### DIFF
--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -562,7 +562,7 @@ impl Cluster {
                         .all(|x| x.get_store_id() != *store_id)
                     {
                         let peer = Either::Left(new_peer(*store_id, self.alloc_id().unwrap()));
-                        let policy = SchedulePolicy::Repeat(1);
+                        let policy = SchedulePolicy::TillSuccess;
                         return Some(Operator::AddPeer { peer, policy });
                     }
                 }

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -562,7 +562,7 @@ impl Cluster {
                         .all(|x| x.get_store_id() != *store_id)
                     {
                         let peer = Either::Left(new_peer(*store_id, self.alloc_id().unwrap()));
-                        let policy = SchedulePolicy::TillSuccess;
+                        let policy = SchedulePolicy::Repeat(1);
                         return Some(Operator::AddPeer { peer, policy });
                     }
                 }

--- a/tests/integrations/raftstore/test_conf_change.rs
+++ b/tests/integrations/raftstore/test_conf_change.rs
@@ -259,7 +259,7 @@ fn wait_till_reach_count(pd_client: Arc<TestPdClient>, region_id: u64, c: usize)
             None => continue,
         };
         replica_count = region.get_peers().len();
-        if replica_count == c {
+        if replica_count >= c {
             return;
         }
         thread::sleep(Duration::from_millis(10));


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #3162 <!-- REMOVE this line if no issue to close -->

Problem Summary:
`test_server_auto_adjust_replica` is not stable because of the replica count check.

### What is changed and how it works?

What's Changed:
Relax the check condition.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* N/A