### PR TITLE
cdc: use for_update_ts to get old value

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -102,7 +102,7 @@ impl fmt::Debug for Deregister {
 
 type InitCallback = Box<dyn FnOnce() + Send>;
 pub(crate) type OldValueCallback =
-    Box<dyn FnMut(Key, &mut OldValueCache, &mut Statistics) -> Option<Vec<u8>> + Send>;
+    Box<dyn FnMut(Key, TimeStamp, &mut OldValueCache, &mut Statistics) -> Option<Vec<u8>> + Send>;
 
 pub struct OldValueCache {
     pub cache: LruCache<Key, (Option<OldValue>, MutationType)>,

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -127,6 +127,7 @@ impl<E: KvEngine> CmdObserver<E> for CdcObserver {
                 RegionSnapshot::from_snapshot(Arc::new(engine.snapshot()), Arc::new(region));
             let mut reader = OldValueReader::new(snapshot);
             let get_old_value = move |key,
+                                      query_ts,
                                       old_value_cache: &mut OldValueCache,
                                       statistics: &mut Statistics| {
                 old_value_cache.access_count += 1;
@@ -158,6 +159,7 @@ impl<E: KvEngine> CmdObserver<E> for CdcObserver {
                 // Cannot get old value from cache, seek for it in engine.
                 old_value_cache.miss_count += 1;
                 let start = Instant::now();
+                let key = key.truncate_ts().unwrap().append_ts(query_ts);
                 let value = reader
                     .near_seek_old_value(&key, statistics)
                     .unwrap_or_default();

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -803,7 +803,7 @@ fn test_old_value_basic() {
     m7.key = k1.clone();
     suite.must_acquire_pessimistic_lock(1, vec![m7.clone()], k1.clone(), 9.into(), 12.into());
     m7.set_op(Op::Del);
-    suite.must_kv_pessimistic_prewrite(1, vec![m7], k1.clone(), 9.into(), 12.into());
+    suite.must_kv_pessimistic_prewrite(1, vec![m7], k1, 9.into(), 12.into());
 
     let mut event_count = 0;
     loop {

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -762,41 +762,48 @@ fn test_old_value_basic() {
     m1.set_op(Op::Put);
     m1.key = k1.clone();
     m1.value = b"v1".to_vec();
-    let m1_start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
-    suite.must_kv_prewrite(1, vec![m1], k1.clone(), m1_start_ts);
-    let m1_commit_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
-    suite.must_kv_commit(1, vec![k1.clone()], m1_start_ts, m1_commit_ts);
+    suite.must_kv_prewrite(1, vec![m1], k1.clone(), 1.into());
+    suite.must_kv_commit(1, vec![k1.clone()], 1.into(), 2.into());
     // Rollback
     let mut m2 = Mutation::default();
     m2.set_op(Op::Put);
     m2.key = k1.clone();
     m2.value = b"v2".to_vec();
-    let m2_start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
-    suite.must_kv_prewrite(1, vec![m2], k1.clone(), m2_start_ts);
-    suite.must_kv_rollback(1, vec![k1.clone()], m2_start_ts);
+    suite.must_kv_prewrite(1, vec![m2], k1.clone(), 3.into());
+    suite.must_kv_rollback(1, vec![k1.clone()], 3.into());
     // Update value
     let mut m3 = Mutation::default();
     m3.set_op(Op::Put);
     m3.key = k1.clone();
     m3.value = vec![b'3'; 5120];
-    let m3_start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
-    suite.must_kv_prewrite(1, vec![m3], k1.clone(), m3_start_ts);
-    let m3_commit_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
-    suite.must_kv_commit(1, vec![k1.clone()], m3_start_ts, m3_commit_ts);
+    suite.must_kv_prewrite(1, vec![m3], k1.clone(), 4.into());
+    suite.must_kv_commit(1, vec![k1.clone()], 4.into(), 5.into());
     // Lock
     let mut m4 = Mutation::default();
     m4.set_op(Op::Lock);
     m4.key = k1.clone();
-    let m4_start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
-    suite.must_kv_prewrite(1, vec![m4], k1.clone(), m4_start_ts);
-    let m4_commit_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
-    suite.must_kv_commit(1, vec![k1.clone()], m4_start_ts, m4_commit_ts);
-    // Delete value
+    suite.must_kv_prewrite(1, vec![m4], k1.clone(), 6.into());
+    suite.must_kv_commit(1, vec![k1.clone()], 6.into(), 7.into());
+    // Delete value and rollback
     let mut m5 = Mutation::default();
     m5.set_op(Op::Del);
     m5.key = k1.clone();
-    let m5_start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
-    suite.must_kv_prewrite(1, vec![m5], k1, m5_start_ts);
+    suite.must_kv_prewrite(1, vec![m5], k1.clone(), 8.into());
+    suite.must_kv_rollback(1, vec![k1.clone()], 8.into());
+    // Update value
+    let mut m6 = Mutation::default();
+    m6.set_op(Op::Put);
+    m6.key = k1.clone();
+    m6.value = b"v6".to_vec();
+    suite.must_kv_prewrite(1, vec![m6], k1.clone(), 10.into());
+    suite.must_kv_commit(1, vec![k1.clone()], 10.into(), 11.into());
+    // Delete value
+    let mut m7 = Mutation::default();
+    m7.set_op(Op::PessimisticLock);
+    m7.key = k1.clone();
+    suite.must_acquire_pessimistic_lock(1, vec![m7.clone()], k1.clone(), 9.into(), 12.into());
+    m7.set_op(Op::Del);
+    suite.must_kv_pessimistic_prewrite(1, vec![m7], k1.clone(), 9.into(), 12.into());
 
     let mut event_count = 0;
     loop {
@@ -806,13 +813,14 @@ fn test_old_value_basic() {
                 Event_oneof_event::Entries(mut es) => {
                     for row in es.take_entries().to_vec() {
                         if row.get_type() == EventLogType::Prewrite {
-                            if row.get_start_ts() == m2_start_ts.into_inner()
-                                || row.get_start_ts() == m3_start_ts.into_inner()
-                            {
+                            if row.get_start_ts() == 3 || row.get_start_ts() == 4 {
                                 assert_eq!(row.get_old_value(), b"v1");
                                 event_count += 1;
-                            } else if row.get_start_ts() == m5_start_ts.into_inner() {
+                            } else if row.get_start_ts() == 8 {
                                 assert_eq!(row.get_old_value(), vec![b'3'; 5120].as_slice());
+                                event_count += 1;
+                            } else if row.get_start_ts() == 9 {
+                                assert_eq!(row.get_old_value(), b"v6");
                                 event_count += 1;
                             }
                         }
@@ -821,7 +829,7 @@ fn test_old_value_basic() {
                 other => panic!("unknown event {:?}", other),
             }
         }
-        if event_count >= 3 {
+        if event_count >= 4 {
             break;
         }
     }
@@ -836,20 +844,18 @@ fn test_old_value_basic() {
             match e.event.unwrap() {
                 Event_oneof_event::Entries(mut es) => {
                     for row in es.take_entries().to_vec() {
-                        if row.get_type() == EventLogType::Committed
-                            && row.get_start_ts() == m1_start_ts.into_inner()
-                        {
+                        if row.get_type() == EventLogType::Committed && row.get_start_ts() == 1 {
                             assert_eq!(row.get_old_value(), b"");
                             event_count += 1;
                         } else if row.get_type() == EventLogType::Committed
-                            && row.get_start_ts() == m3_start_ts.into_inner()
+                            && row.get_start_ts() == 4
                         {
                             assert_eq!(row.get_old_value(), b"v1");
                             event_count += 1;
                         } else if row.get_type() == EventLogType::Prewrite
-                            && row.get_start_ts() == m5_start_ts.into_inner()
+                            && row.get_start_ts() == 9
                         {
-                            assert_eq!(row.get_old_value(), vec![b'3'; 5120]);
+                            assert_eq!(row.get_old_value(), b"v6");
                             event_count += 1;
                         }
                     }

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -266,6 +266,68 @@ impl TestSuite {
         );
     }
 
+    pub fn must_acquire_pessimistic_lock(
+        &mut self,
+        region_id: u64,
+        muts: Vec<Mutation>,
+        pk: Vec<u8>,
+        start_ts: TimeStamp,
+        for_update_ts: TimeStamp,
+    ) {
+        let mut lock_req = PessimisticLockRequest::default();
+        lock_req.set_context(self.get_context(region_id));
+        lock_req.set_mutations(muts.into_iter().collect());
+        lock_req.start_version = start_ts.into_inner();
+        lock_req.for_update_ts = for_update_ts.into_inner();
+        lock_req.primary_lock = pk;
+        let lock_resp = self
+            .get_tikv_client(region_id)
+            .kv_pessimistic_lock(&lock_req)
+            .unwrap();
+        assert!(
+            !lock_resp.has_region_error(),
+            "{:?}",
+            lock_resp.get_region_error()
+        );
+        assert!(
+            lock_resp.get_errors().len() == 0,
+            "{:?}",
+            lock_resp.get_errors()
+        );
+    }
+
+    pub fn must_kv_pessimistic_prewrite(
+        &mut self,
+        region_id: u64,
+        muts: Vec<Mutation>,
+        pk: Vec<u8>,
+        ts: TimeStamp,
+        for_update_ts: TimeStamp,
+    ) {
+        let mut prewrite_req = PrewriteRequest::default();
+        prewrite_req.set_context(self.get_context(region_id));
+        prewrite_req.set_mutations(muts.into_iter().collect());
+        prewrite_req.primary_lock = pk;
+        prewrite_req.start_version = ts.into_inner();
+        prewrite_req.lock_ttl = prewrite_req.start_version + 1;
+        prewrite_req.for_update_ts = for_update_ts.into_inner();
+        prewrite_req.mut_is_pessimistic_lock().push(true);
+        let prewrite_resp = self
+            .get_tikv_client(region_id)
+            .kv_prewrite(&prewrite_req)
+            .unwrap();
+        assert!(
+            !prewrite_resp.has_region_error(),
+            "{:?}",
+            prewrite_resp.get_region_error()
+        );
+        assert!(
+            prewrite_resp.errors.is_empty(),
+            "{:?}",
+            prewrite_resp.get_errors()
+        );
+    }
+
     pub fn async_kv_commit(
         &mut self,
         region_id: u64,

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -290,7 +290,7 @@ impl TestSuite {
             lock_resp.get_region_error()
         );
         assert!(
-            lock_resp.get_errors().len() == 0,
+            lock_resp.get_errors().is_empty(),
             "{:?}",
             lock_resp.get_errors()
         );

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -386,7 +386,7 @@ pub fn has_data_in_range<S: Snapshot>(
 }
 
 /// Seek for the next valid (write type == Put or Delete) write record.
-/// The write cursor must indicate a data key of the user key of which ts >= after_ts.
+/// The write cursor must indicate a data key of the user key of which ts <= after_ts.
 /// Return None if cannot find any valid write record.
 pub fn seek_for_valid_write<I>(
     write_cursor: &mut Cursor<I>,
@@ -424,7 +424,7 @@ where
 }
 
 /// Seek for the last written value.
-/// The write cursor must indicate a data key of the user key of which ts >= after_ts.
+/// The write cursor must indicate a data key of the user key of which ts <= after_ts.
 /// Return None if cannot find any valid write record or found a delete record.
 pub fn seek_for_valid_value<I>(
     write_cursor: &mut Cursor<I>,

--- a/tests/integrations/raftstore/test_conf_change.rs
+++ b/tests/integrations/raftstore/test_conf_change.rs
@@ -259,7 +259,7 @@ fn wait_till_reach_count(pd_client: Arc<TestPdClient>, region_id: u64, c: usize)
             None => continue,
         };
         replica_count = region.get_peers().len();
-        if replica_count == c {
+        if replica_count >= c {
             return;
         }
         thread::sleep(Duration::from_millis(10));


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
Use `start_ts` to get old value maybe return a stale old value.

### What is changed and how it works?

What's Changed:

Replace with `max(for_update_ts, start_ts)`

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* cdc: fix stale old value with pessimistic lock.