### PR TITLE
tests: allow changing cluster version in tests

### DIFF
--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -135,10 +135,6 @@ impl RpcClient {
         block_on(self.leader_client.reconnect())
     }
 
-    pub fn feature_gate(&self) -> &FeatureGate {
-        &self.leader_client.feature_gate
-    }
-
     /// Creates a new call option with default request timeout.
     #[inline]
     fn call_option() -> CallOption {
@@ -779,6 +775,10 @@ impl PdClient for RpcClient {
         self.leader_client
             .request(req, executor, LEADER_CHANGE_RETRY)
             .execute()
+    }
+
+    fn feature_gate(&self) -> &FeatureGate {
+        &self.leader_client.feature_gate
     }
 }
 

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -258,6 +258,11 @@ pub trait PdClient: Send + Sync {
     fn get_tso(&self) -> PdFuture<TimeStamp> {
         unimplemented!()
     }
+
+    /// Gets the internal `FeatureGate`.
+    fn feature_gate(&self) -> &FeatureGate {
+        todo!()
+    }
 }
 
 const REQUEST_TIMEOUT: u64 = 2; // 2s

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -24,7 +24,7 @@ use raft::eraftpb::ConfChangeType;
 use collections::{HashMap, HashMapEntry, HashSet};
 use fail::fail_point;
 use keys::{self, data_key, enc_end_key, enc_start_key};
-use pd_client::{Error, Key, PdClient, PdFuture, RegionInfo, RegionStat, Result};
+use pd_client::{Error, FeatureGate, Key, PdClient, PdFuture, RegionInfo, RegionStat, Result};
 use raftstore::store::util::{check_key_in_region, find_peer, is_learner};
 use raftstore::store::{INIT_EPOCH_CONF_VER, INIT_EPOCH_VER};
 use tikv_util::time::UnixSecs;
@@ -715,10 +715,14 @@ pub struct TestPdClient {
     is_incompatible: bool,
     tso: AtomicU64,
     trigger_tso_failure: AtomicBool,
+    feature_gate: FeatureGate,
 }
 
 impl TestPdClient {
     pub fn new(cluster_id: u64, is_incompatible: bool) -> TestPdClient {
+        let feature_gate = FeatureGate::default();
+        // For easy testing, most cases don't test upgrading.
+        feature_gate.set_version("999.0.0").unwrap();
         TestPdClient {
             cluster_id,
             cluster: Arc::new(RwLock::new(Cluster::new(cluster_id))),
@@ -726,6 +730,7 @@ impl TestPdClient {
             is_incompatible,
             tso: AtomicU64::new(1),
             trigger_tso_failure: AtomicBool::new(false),
+            feature_gate,
         }
     }
 
@@ -1208,6 +1213,10 @@ impl TestPdClient {
             );
         }
     }
+
+    pub fn reset_version(&self, version: &str) {
+        unsafe { self.feature_gate.reset_version(version).unwrap() }
+    }
 }
 
 impl PdClient for TestPdClient {
@@ -1525,5 +1534,9 @@ impl PdClient for TestPdClient {
         }
         let tso = self.tso.fetch_add(1, Ordering::SeqCst);
         Box::pin(ok(TimeStamp::new(tso)))
+    }
+
+    fn feature_gate(&self) -> &FeatureGate {
+        &self.feature_gate
     }
 }

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -32,7 +32,7 @@ const NEAR_SEEK_LIMIT: usize = 8;
 // The default version that can enable compaction filter for GC. This is necessary because after
 // compaction filter is enabled, it's impossible to fallback to ealier version which modifications
 // of GC are distributed to other replicas by Raft.
-const COMPACTION_FILTER_GC_FEATURE: Feature = Feature::acquire(5, 0, 0);
+const COMPACTION_FILTER_GC_FEATURE: Feature = Feature::require(5, 0, 0);
 
 // Global context to create a compaction filter for write CF. It's necessary as these fields are
 // not available when construcing `WriteCompactionFilterFactory`.

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -466,9 +466,9 @@ fn test_cluster_version() {
     let server = MockServer::<Service>::new(3);
     let eps = server.bind_addrs();
 
-    let feature_a = Feature::acquire(0, 0, 1);
-    let feature_b = Feature::acquire(5, 0, 0);
-    let feature_c = Feature::acquire(5, 0, 1);
+    let feature_a = Feature::require(0, 0, 1);
+    let feature_b = Feature::require(5, 0, 0);
+    let feature_c = Feature::require(5, 0, 1);
 
     let client = new_client(eps, None);
     let feature_gate = client.feature_gate();


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->


### What is changed and how it works?

What's Changed:
It's important to be able to adjust cluster version if we want to test
upgrading. This PR also moves feature gate into trait to make it
accessible in other module like raftstore.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- No release note.