### PR TITLE
copr: impl `JsonRef::is_zero` to support cast JSON as bool

### DIFF
--- a/components/tidb_query_datatype/src/codec/datum.rs
+++ b/components/tidb_query_datatype/src/codec/datum.rs
@@ -374,7 +374,7 @@ impl Datum {
             Datum::Time(t) => Some(!t.is_zero()),
             Datum::Dur(d) => Some(!d.is_zero()),
             Datum::Dec(d) => Some(ConvertTo::<f64>::convert(&d, ctx)?.round() != 0f64),
-            Datum::Json(j) => Some(j.as_ref().is_zero()),
+            Datum::Json(j) => Some(!j.as_ref().is_zero()),
             Datum::Null => None,
             _ => return Err(invalid_type!("can't convert {} to bool", self)),
         };
@@ -1790,6 +1790,7 @@ mod tests {
             (Datum::F64(0.5), Some(true)),
             (Datum::F64(-0.5), Some(true)),
             (Datum::F64(-0.4), Some(false)),
+            (Datum::Json(Json::from_i64(0).unwrap()), Some(false)),
             (Datum::Null, None),
             (b"".as_ref().into(), Some(false)),
             (b"0.5".as_ref().into(), Some(true)),

--- a/components/tidb_query_datatype/src/codec/datum.rs
+++ b/components/tidb_query_datatype/src/codec/datum.rs
@@ -372,6 +372,7 @@ impl Datum {
             Datum::Time(t) => Some(!t.is_zero()),
             Datum::Dur(d) => Some(!d.is_zero()),
             Datum::Dec(d) => Some(ConvertTo::<f64>::convert(&d, ctx)?.round() != 0f64),
+            Datum::Json(j) => Some(j.as_ref().is_zero()),
             Datum::Null => None,
             _ => return Err(invalid_type!("can't convert {} to bool", self)),
         };

--- a/components/tidb_query_datatype/src/codec/mysql/json/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/mod.rs
@@ -80,6 +80,7 @@ pub use self::jcodec::{JsonDatumPayloadChunkEncoder, JsonDecoder, JsonEncoder};
 pub use self::json_modify::ModifyType;
 pub use self::path_expr::{parse_json_path_expr, PathExpression};
 
+use num_traits::Zero;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::str;
@@ -146,6 +147,16 @@ impl<'a> JsonRef<'a> {
     /// Returns the underlying value slice
     pub fn value(&self) -> &'a [u8] {
         &self.value
+    }
+
+    /// Return a boolean indicate whether `self`'s value is zero
+    pub fn is_zero(&self) -> bool {
+        match self.type_code {
+            JsonType::I64 => self.get_i64() == 0,
+            JsonType::U64 => self.get_u64() == 0,
+            JsonType::Float => self.get_double().is_zero(),
+            _ => false,
+        }
     }
 
     // Returns the JSON value as u64

--- a/components/tidb_query_datatype/src/codec/mysql/json/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/mod.rs
@@ -154,7 +154,7 @@ impl<'a> JsonRef<'a> {
         match self.type_code {
             JsonType::I64 => self.get_i64() == 0,
             JsonType::U64 => self.get_u64() == 0,
-            JsonType::Float => self.get_double().is_zero(),
+            JsonType::Double => self.get_double().is_zero(),
             _ => false,
         }
     }


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/12233 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?
This pull request support cast JSON value as a numeric value and compare it to zero to implement `JsonRef::is_zero`


What's Changed:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- copr: impl JsonRef::is_zero to support cast JSON as bool