### PR TITLE
storage: Fix incorrect processed / total keys counter (#7563)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-4.0#0e3ce33f29b8be60d24610eb1c4695114de367ca"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-4.0#6c93789"
 dependencies = [
  "futures 0.1.29",
  "grpcio",
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#84369a7eee61422c476fe43835a53dae9490a39b"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#53453446f16a25784ada946db6f35cd876131b2b"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#84369a7eee61422c476fe43835a53dae9490a39b"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#53453446f16a25784ada946db6f35cd876131b2b"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -2066,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.0.25"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
  "libc",
@@ -3513,7 +3513,7 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#84369a7eee61422c476fe43835a53dae9490a39b"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#53453446f16a25784ada946db6f35cd876131b2b"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-4.0#6c93789"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-4.0#dfe1b7b9d0dfea83fa357ac6cb2cc6ff43599712"
 dependencies = [
  "futures 0.1.29",
  "grpcio",

--- a/src/coprocessor/metrics.rs
+++ b/src/coprocessor/metrics.rs
@@ -51,7 +51,7 @@ lazy_static! {
     pub static ref COPR_SCAN_KEYS: HistogramVec = register_histogram_vec!(
         "tikv_coprocessor_scan_keys",
         "Bucketed histogram of coprocessor per request scan keys",
-        &["req"],
+        &["req", "kind"],
         exponential_buckets(1.0, 2.0, 20).unwrap()
     )
     .unwrap();

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -1,6 +1,7 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
 use kvproto::kvrpcpb;
+use kvproto::kvrpcpb::ScanDetailV2;
 
 use crate::storage::kv::{PerfStatisticsDelta, PerfStatisticsInstant};
 
@@ -146,31 +147,50 @@ impl Tracker {
 
     /// Get current item's ExecDetail according to previous collected metrics.
     /// TiDB asks for ExecDetail to be printed in its log.
-    pub fn get_item_exec_details(&self) -> kvrpcpb::ExecDetails {
+    pub fn get_item_exec_details(&self) -> (kvrpcpb::ExecDetails, kvrpcpb::ExecDetailsV2) {
         assert_eq!(self.current_stage, TrackerState::ItemFinished);
         self.exec_details(self.item_process_time)
     }
 
     /// Get ExecDetail according to previous collected metrics.
     /// TiDB asks for ExecDetail to be printed in its log.
-    pub fn get_exec_details(&self) -> kvrpcpb::ExecDetails {
+    pub fn get_exec_details(&self) -> (kvrpcpb::ExecDetails, kvrpcpb::ExecDetailsV2) {
         assert_eq!(self.current_stage, TrackerState::ItemFinished);
         self.exec_details(self.total_process_time)
     }
 
-    fn exec_details(&self, measure: Duration) -> kvrpcpb::ExecDetails {
+    fn exec_details(&self, measure: Duration) -> (kvrpcpb::ExecDetails, kvrpcpb::ExecDetailsV2) {
+        // For compatibility, ExecDetails field is still filled.
         let mut exec_details = kvrpcpb::ExecDetails::default();
-        if self.req_ctx.context.get_handle_time() {
-            let mut handle = kvrpcpb::HandleTime::default();
-            handle.set_process_ms((time::duration_to_sec(measure) * 1000.0) as i64);
-            handle.set_wait_ms((time::duration_to_sec(self.wait_time) * 1000.0) as i64);
-            exec_details.set_handle_time(handle);
-        }
-        if self.req_ctx.context.get_scan_detail() {
-            let detail = self.total_storage_stats.scan_detail();
-            exec_details.set_scan_detail(detail);
-        }
-        exec_details
+
+        let mut td = kvrpcpb::TimeDetail::default();
+        td.set_process_wall_time_ms(time::duration_to_ms(measure) as i64);
+        td.set_wait_wall_time_ms(time::duration_to_ms(self.wait_time) as i64);
+        exec_details.set_time_detail(td.clone());
+
+        let detail = self.total_storage_stats.scan_detail();
+        exec_details.set_scan_detail(detail);
+
+        let mut exec_details_v2 = kvrpcpb::ExecDetailsV2::default();
+        exec_details_v2.set_time_detail(td);
+
+        let mut detail_v2 = ScanDetailV2::default();
+        detail_v2.set_processed_versions(self.total_storage_stats.write.processed_keys as u64);
+        detail_v2.set_total_versions(self.total_storage_stats.write.total_op_count() as u64);
+        detail_v2.set_rocksdb_delete_skipped_count(
+            self.total_perf_stats.0.internal_delete_skipped_count as u64,
+        );
+        detail_v2.set_rocksdb_key_skipped_count(
+            self.total_perf_stats.0.internal_key_skipped_count as u64,
+        );
+        detail_v2.set_rocksdb_block_cache_hit_count(
+            self.total_perf_stats.0.block_cache_hit_count as u64,
+        );
+        detail_v2.set_rocksdb_block_read_count(self.total_perf_stats.0.block_read_count as u64);
+        detail_v2.set_rocksdb_block_read_byte(self.total_perf_stats.0.block_read_byte as u64);
+        exec_details_v2.set_scan_detail_v2(detail_v2);
+
+        (exec_details, exec_details_v2)
     }
 
     pub fn on_finish_all_items(&mut self) {

--- a/src/storage/kv/stats.rs
+++ b/src/storage/kv/stats.rs
@@ -5,8 +5,7 @@ use kvproto::kvrpcpb::{ScanDetail, ScanInfo};
 
 pub use raftstore::store::{FlowStatistics, FlowStatsReporter};
 
-const STAT_TOTAL: &str = "total";
-const STAT_PROCESSED: &str = "processed";
+const STAT_PROCESSED_KEYS: &str = "processed_keys";
 const STAT_GET: &str = "get";
 const STAT_NEXT: &str = "next";
 const STAT_PREV: &str = "prev";
@@ -21,15 +20,16 @@ const STAT_SEEK_FOR_PREV_TOMBSTONE: &str = "seek_for_prev_tombstone";
 /// Statistics collects the ops taken when fetching data.
 #[derive(Default, Clone, Debug)]
 pub struct CfStatistics {
-    // How many keys that's effective to user. This counter should be increased
-    // by the caller.
-    pub processed: usize,
+    // How many keys that's visible to user
+    pub processed_keys: usize,
+
     pub get: usize,
     pub next: usize,
     pub prev: usize,
     pub seek: usize,
     pub seek_for_prev: usize,
     pub over_seek_bound: usize,
+
     pub flow_stats: FlowStatistics,
 
     pub next_tombstone: usize,
@@ -44,10 +44,9 @@ impl CfStatistics {
         self.get + self.next + self.prev + self.seek + self.seek_for_prev
     }
 
-    pub fn details(&self) -> [(&'static str, usize); 12] {
+    pub fn details(&self) -> [(&'static str, usize); 11] {
         [
-            (STAT_TOTAL, self.total_op_count()),
-            (STAT_PROCESSED, self.processed),
+            (STAT_PROCESSED_KEYS, self.processed_keys),
             (STAT_GET, self.get),
             (STAT_NEXT, self.next),
             (STAT_PREV, self.prev),
@@ -62,7 +61,7 @@ impl CfStatistics {
     }
 
     pub fn add(&mut self, other: &Self) {
-        self.processed = self.processed.saturating_add(other.processed);
+        self.processed_keys = self.processed_keys.saturating_add(other.processed_keys);
         self.get = self.get.saturating_add(other.get);
         self.next = self.next.saturating_add(other.next);
         self.prev = self.prev.saturating_add(other.prev);
@@ -78,9 +77,10 @@ impl CfStatistics {
             .saturating_add(other.seek_for_prev_tombstone);
     }
 
+    /// Deprecated
     pub fn scan_info(&self) -> ScanInfo {
         let mut info = ScanInfo::default();
-        info.set_processed(self.processed as i64);
+        info.set_processed(self.processed_keys as i64);
         info.set_total(self.total_op_count() as i64);
         info
     }
@@ -94,15 +94,7 @@ pub struct Statistics {
 }
 
 impl Statistics {
-    pub fn total_op_count(&self) -> usize {
-        self.lock.total_op_count() + self.write.total_op_count() + self.data.total_op_count()
-    }
-
-    pub fn total_processed(&self) -> usize {
-        self.lock.processed + self.write.processed + self.data.processed
-    }
-
-    pub fn details(&self) -> [(&'static str, [(&'static str, usize); 12]); 3] {
+    pub fn details(&self) -> [(&'static str, [(&'static str, usize); 11]); 3] {
         [
             (CF_DEFAULT, self.data.details()),
             (CF_LOCK, self.lock.details()),
@@ -116,6 +108,7 @@ impl Statistics {
         self.data.add(&other.data);
     }
 
+    /// Deprecated
     pub fn scan_detail(&self) -> ScanDetail {
         let mut detail = ScanDetail::default();
         detail.set_data(self.data.scan_info());

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -274,6 +274,7 @@ impl<S: Snapshot, P: ScanPolicy<S>> ForwardScanner<S, P> {
                         &mut self.cursors,
                         &mut self.statistics,
                     )? {
+                        self.statistics.write.processed_keys += 1;
                         return Ok(Some(output));
                     }
                 }
@@ -364,7 +365,6 @@ impl<S: Snapshot> ScanPolicy<S> for LatestKvPolicy {
     ) -> Result<HandleRes<Self::Output>> {
         let value: Option<Value> = loop {
             let write = WriteRef::parse(cursors.write.value(&mut statistics.write))?;
-            statistics.write.processed += 1;
 
             match write.write_type {
                 WriteType::Put => {
@@ -465,7 +465,6 @@ impl<S: Snapshot> ScanPolicy<S> for LatestEntryPolicy {
             }
             let write_value = cursors.write.value(&mut statistics.write);
             let write = WriteRef::parse(write_value)?;
-            statistics.write.processed += 1;
 
             match write.write_type {
                 WriteType::Put => {
@@ -547,6 +546,7 @@ fn scan_latest_handle_lock<S: Snapshot, T>(
     // Even if there is a lock error, we still need to step the cursor for future
     // calls.
     if result.is_err() {
+        statistics.lock.processed_keys += 1;
         cursors.move_write_cursor_to_next_user_key(&current_user_key, statistics)?;
     }
     result

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -318,7 +318,7 @@ where
             "near_load_data_by_write",
         ));
     }
-    statistics.data.processed += 1;
+    statistics.data.processed_keys += 1;
     Ok(default_cursor.value(&mut statistics.data).to_vec())
 }
 
@@ -343,7 +343,7 @@ where
             "near_reverse_load_data_by_write",
         ));
     }
-    statistics.data.processed += 1;
+    statistics.data.processed_keys += 1;
     Ok(default_cursor.value(&mut statistics.data).to_vec())
 }
 

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -7,7 +7,7 @@ use std::thread;
 use kvproto::coprocessor::Response;
 use kvproto::kvrpcpb::Context;
 use protobuf::Message;
-use tipb::{Chunk, Expr, ExprType, ScalarFuncSig};
+use tipb::{Chunk, Expr, ExprType, ScalarFuncSig, SelectResponse};
 
 use test_coprocessor::*;
 use test_storage::*;
@@ -225,17 +225,22 @@ fn test_scan_detail() {
     ];
 
     for mut req in reqs {
-        req.mut_context().set_scan_detail(true);
-        req.mut_context().set_handle_time(true);
+        req.mut_context().set_record_scan_stat(true);
+        req.mut_context().set_record_time_stat(true);
 
         let resp = handle_request(&endpoint, req);
-        assert!(resp.get_exec_details().has_handle_time());
+        assert!(resp.get_exec_details().has_time_detail());
 
         let scan_detail = resp.get_exec_details().get_scan_detail();
         // Values would occur in data cf are inlined in write cf.
         assert_eq!(scan_detail.get_write().get_total(), 5);
         assert_eq!(scan_detail.get_write().get_processed(), 4);
         assert_eq!(scan_detail.get_lock().get_total(), 1);
+
+        assert!(resp.get_exec_details_v2().has_time_detail());
+        let scan_detail_v2 = resp.get_exec_details_v2().get_scan_detail_v2();
+        assert_eq!(scan_detail_v2.get_total_versions(), 5);
+        assert_eq!(scan_detail_v2.get_processed_versions(), 4);
     }
 }
 
@@ -932,14 +937,23 @@ fn test_del_select() {
     store.commit();
 
     // for dag
-    let req = DAGSelect::from_index(&product, &product["id"]).build();
-    let mut resp = handle_select(&endpoint, req);
-    let spliter = DAGChunkSpliter::new(resp.take_chunks().into(), 1);
+    let mut req = DAGSelect::from_index(&product, &product["id"]).build();
+    req.mut_context().set_record_scan_stat(true);
+
+    let resp = handle_request(&endpoint, req);
+    let mut sel_resp = SelectResponse::default();
+    sel_resp.merge_from_bytes(resp.get_data()).unwrap();
+    let spliter = DAGChunkSpliter::new(sel_resp.take_chunks().into(), 1);
     let mut row_count = 0;
     for _ in spliter {
         row_count += 1;
     }
     assert_eq!(row_count, 5);
+
+    assert!(resp.get_exec_details_v2().has_time_detail());
+    let scan_detail_v2 = resp.get_exec_details_v2().get_scan_detail_v2();
+    assert_eq!(scan_detail_v2.get_total_versions(), 8);
+    assert_eq!(scan_detail_v2.get_processed_versions(), 5);
 }
 
 #[test]
@@ -1629,46 +1643,19 @@ fn test_exec_details() {
     let product = ProductTable::new();
     let (_, endpoint) = init_with_data(&product, &data);
 
-    // get none
-    let req = DAGSelect::from(&product).build();
-    let resp = handle_request(&endpoint, req);
-    assert!(resp.has_exec_details());
-    let exec_details = resp.get_exec_details();
-    assert!(!exec_details.has_handle_time());
-    assert!(!exec_details.has_scan_detail());
-
     let flags = &[0];
 
-    // get handle_time
-    let mut ctx = Context::default();
-    ctx.set_handle_time(true);
+    let ctx = Context::default();
     let req = DAGSelect::from(&product).build_with(ctx, flags);
     let resp = handle_request(&endpoint, req);
     assert!(resp.has_exec_details());
     let exec_details = resp.get_exec_details();
-    assert!(exec_details.has_handle_time());
-    assert!(!exec_details.has_scan_detail());
-
-    // get scan detail
-    let mut ctx = Context::default();
-    ctx.set_scan_detail(true);
-    let req = DAGSelect::from(&product).build_with(ctx, flags);
-    let resp = handle_request(&endpoint, req);
-    assert!(resp.has_exec_details());
-    let exec_details = resp.get_exec_details();
-    assert!(!exec_details.has_handle_time());
+    assert!(exec_details.has_time_detail());
     assert!(exec_details.has_scan_detail());
-
-    // get both
-    let mut ctx = Context::default();
-    ctx.set_scan_detail(true);
-    ctx.set_handle_time(true);
-    let req = DAGSelect::from(&product).build_with(ctx, flags);
-    let resp = handle_request(&endpoint, req);
-    assert!(resp.has_exec_details());
-    let exec_details = resp.get_exec_details();
-    assert!(exec_details.has_handle_time());
-    assert!(exec_details.has_scan_detail());
+    assert!(resp.has_exec_details_v2());
+    let exec_details = resp.get_exec_details_v2();
+    assert!(exec_details.has_time_detail());
+    assert!(exec_details.has_scan_detail_v2());
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

This PR cherry picks https://github.com/tikv/tikv/pull/7563

What's more, some code in #7563 is refined later in https://github.com/tikv/tikv/pull/9008, so that this PR includes it as well.

This PR should be merged together with https://github.com/pingcap/kvproto/pull/699. Roadmaps:

- [x] Get two approvals from this PR
- [x] Merge https://github.com/pingcap/kvproto/pull/699
- [x] Update this PR to use the new kvproto ref
- [ ] Merge this PR

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test:

Insert 300000 rows, randomly delete 111 rows, then query `select count(*)`:

```
[2021/01/26 15:52:23.754 +08:00] [INFO] [tracker.rs:241] [slow-query] [perf_stats.internal_delete_skipped_count=47424] [perf_stats.internal_key_skipped_count=347565] [perf_stats.block_read_byte=0] [perf_stats.block_read_count=0] [perf_stats.block_cache_hit_count=98] [scan.range.first="Some(start: 7480000000000000315F69800000000000000100 end: 7480000000000000315F698000000000000001FB)"] [scan.ranges=1] [scan.total=300112] [scan.processed=299889] [scan.is_desc=false] [tag=index] [table_id=49] [txn_start_ts=422483732800995329] [total_suspend_time=6ms] [total_process_time=3.446s] [handler_build_time=1ms] [wait_time.snapshot=0ns] [wait_time.schedule=0ns] [wait_time=0ns] [total_lifetime=3.453s] [remote_host=ipv4:127.0.0.1:61640] [region_id=2]
```

### Release note <!-- bugfixes or new feature need a release note -->

- Report RocksDB metrics to TiDB
- Fix incorrect process_keys and total_keys