### PR TITLE
txn: return MinCommitTsPushed when lock.min_commit_ts > caller_start_ts

### DIFF
--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -597,7 +597,8 @@ pub mod tests {
         must_large_txn_locked(&engine, k, ts(5, 0), 100, ts(9, 1), false);
 
         // caller_start_ts < lock.min_commit_ts < current_ts
-        // When caller_start_ts < lock.min_commit_ts, no need to update it.
+        // When caller_start_ts < lock.min_commit_ts, no need to update it, but pushed should be
+        // true.
         must_success(
             &engine,
             k,
@@ -607,7 +608,7 @@ pub mod tests {
             r,
             false,
             false,
-            uncommitted(100, ts(9, 1), false),
+            uncommitted(100, ts(9, 1), true),
         );
         must_large_txn_locked(&engine, k, ts(5, 0), 100, ts(9, 1), false);
 
@@ -965,6 +966,12 @@ pub mod tests {
     }
 
     #[test]
+    fn test_check_txn_status() {
+        test_check_txn_status_impl(false);
+        test_check_txn_status_impl(true);
+    }
+
+    #[test]
     fn test_check_txn_status_resolving_pessimistic_lock() {
         let engine = TestEngineBuilder::new().build().unwrap();
         let k = b"k1";
@@ -1082,11 +1089,5 @@ pub mod tests {
         );
         must_unlocked(&engine, k);
         must_get_rollback_ts(&engine, k, ts(50, 0));
-    }
-
-    #[test]
-    fn test_check_txn_status() {
-        test_check_txn_status_impl(false);
-        test_check_txn_status_impl(true);
     }
 }


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/21658

Problem Summary:

TiDB decides whether a transaction can bypass other transactions' locks during reading by `MinCommitTsPushed` action. Now only when the min_commit_ts is updated, TiKV returns the action. It results in unexpected blocking.

### What is changed and how it works?

What's Changed:

Return `MinCommitTsPushed` when lock.min_commit_ts > caller_start_ts even if the min_commit_ts isn't updated.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

* Fix the issue that locks block reading even if their min_commit_ts is pushed forward.
