### PR TITLE
copr: refine JSON conversion, throw err when object/array convert to integer/float/decimal

### DIFF
--- a/components/tidb_query_datatype/src/codec/convert.rs
+++ b/components/tidb_query_datatype/src/codec/convert.rs
@@ -497,7 +497,7 @@ impl<'a> ToInt for JsonRef<'a> {
         // MySQL: 4
         let val = match self.get_type() {
             JsonType::Object | JsonType::Array => Ok(ctx
-                .handle_truncate_err(Error::incorrect_datetime_value("Integer"))
+                .handle_truncate_err(Error::truncated_wrong_val("Integer", self.to_string()))
                 .map(|_| 0)?),
             JsonType::Literal => Ok(self.get_literal().map_or(0, |x| x as i64)),
             JsonType::I64 => Ok(self.get_i64()),
@@ -513,7 +513,7 @@ impl<'a> ToInt for JsonRef<'a> {
     fn to_uint(&self, ctx: &mut EvalContext, tp: FieldTypeTp) -> Result<u64> {
         let val = match self.get_type() {
             JsonType::Object | JsonType::Array => Ok(ctx
-                .handle_truncate_err(Error::incorrect_datetime_value("Integer"))
+                .handle_truncate_err(Error::truncated_wrong_val("Integer", self.to_string()))
                 .map(|_| 0)?),
             JsonType::Literal => Ok(self.get_literal().map_or(0, |x| x as u64)),
             JsonType::I64 => Ok(self.get_i64() as u64),

--- a/components/tidb_query_datatype/src/codec/convert.rs
+++ b/components/tidb_query_datatype/src/codec/convert.rs
@@ -496,7 +496,9 @@ impl<'a> ToInt for JsonRef<'a> {
         // TiDB:  5
         // MySQL: 4
         let val = match self.get_type() {
-            JsonType::Object | JsonType::Array => Ok(0),
+            JsonType::Object | JsonType::Array => Ok(ctx
+                .handle_truncate_err(Error::incorrect_datetime_value("Integer"))
+                .map(|_| 0)?),
             JsonType::Literal => Ok(self.get_literal().map_or(0, |x| x as i64)),
             JsonType::I64 => Ok(self.get_i64()),
             JsonType::U64 => Ok(self.get_u64() as i64),
@@ -510,7 +512,9 @@ impl<'a> ToInt for JsonRef<'a> {
     #[inline]
     fn to_uint(&self, ctx: &mut EvalContext, tp: FieldTypeTp) -> Result<u64> {
         let val = match self.get_type() {
-            JsonType::Object | JsonType::Array => Ok(0),
+            JsonType::Object | JsonType::Array => Ok(ctx
+                .handle_truncate_err(Error::incorrect_datetime_value("Integer"))
+                .map(|_| 0)?),
             JsonType::Literal => Ok(self.get_literal().map_or(0, |x| x as u64)),
             JsonType::I64 => Ok(self.get_i64() as u64),
             JsonType::U64 => Ok(self.get_u64()),
@@ -1473,7 +1477,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_to_int() {
+    fn test_json_to_int() {
         let test_cases = vec![
             ("{}", 0),
             ("[]", 0),
@@ -1493,6 +1497,28 @@ mod tests {
             let json: Json = jstr.parse().unwrap();
             let get = json.to_int(&mut ctx, FieldTypeTp::LongLong).unwrap();
             assert_eq!(get, exp, "json.as_i64 get: {}, exp: {}", get, exp);
+        }
+    }
+
+    #[test]
+    fn test_cast_err_when_json_array_or_object_to_int() {
+        let test_cases = vec![
+            ("{}", ERR_TRUNCATE_WRONG_VALUE),
+            ("[]", ERR_TRUNCATE_WRONG_VALUE),
+        ];
+        // avoid to use EvalConfig::default_for_test() that set Flag::IGNORE_TRUNCATE as true
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new()));
+        for (jstr, exp) in test_cases {
+            let json: Json = jstr.parse().unwrap();
+            let result: Result<i64> = json.to_int(&mut ctx, FieldTypeTp::LongLong);
+            let err = result.unwrap_err();
+            assert_eq!(
+                err.code(),
+                exp,
+                "json.as_f64 get: {}, exp: {}",
+                err.code(),
+                exp
+            );
         }
     }
 
@@ -1786,7 +1812,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_to_uint() {
+    fn test_json_to_uint() {
         let test_cases = vec![
             ("{}", 0u64),
             ("[]", 0u64),
@@ -1805,6 +1831,28 @@ mod tests {
             let json: Json = jstr.parse().unwrap();
             let get = json.to_uint(&mut ctx, FieldTypeTp::LongLong).unwrap();
             assert_eq!(get, exp, "json.as_u64 get: {}, exp: {}", get, exp);
+        }
+    }
+
+    #[test]
+    fn test_cast_err_when_json_array_or_object_to_uint() {
+        let test_cases = vec![
+            ("{}", ERR_TRUNCATE_WRONG_VALUE),
+            ("[]", ERR_TRUNCATE_WRONG_VALUE),
+        ];
+        // avoid to use EvalConfig::default_for_test() that set Flag::IGNORE_TRUNCATE as true
+        let mut ctx = EvalContext::new(Arc::new(EvalConfig::new()));
+        for (jstr, exp) in test_cases {
+            let json: Json = jstr.parse().unwrap();
+            let result: Result<u64> = json.to_uint(&mut ctx, FieldTypeTp::LongLong);
+            let err = result.unwrap_err();
+            assert_eq!(
+                err.code(),
+                exp,
+                "json.as_f64 get: {}, exp: {}",
+                err.code(),
+                exp
+            );
         }
     }
 

--- a/components/tidb_query_datatype/src/codec/mysql/json/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/mod.rs
@@ -400,7 +400,7 @@ impl<'a> ConvertTo<f64> for JsonRef<'a> {
     fn convert(&self, ctx: &mut EvalContext) -> Result<f64> {
         let d = match self.get_type() {
             JsonType::Array | JsonType::Object => ctx
-                .handle_truncate_err(Error::incorrect_datetime_value("Float"))
+                .handle_truncate_err(Error::truncated_wrong_val("Float", self.to_string()))
                 .map(|_| 0f64)?,
             JsonType::U64 => self.get_u64() as f64,
             JsonType::I64 => self.get_i64() as f64,

--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -1565,19 +1565,13 @@ mod tests {
 
     fn check_overflow(ctx: &EvalContext, overflow: bool, log: &str) {
         if overflow {
-            assert_eq!(
-                ctx.warnings.warning_cnt, 1,
-                "{}, {:?}",
-                log, ctx.warnings.warnings
-            );
-            assert_eq!(
-                ctx.warnings.warnings[0].get_code(),
-                ERR_DATA_OUT_OF_RANGE,
-                "{}",
-                log
-            );
-        } else {
-            assert_eq!(ctx.warnings.warning_cnt, 0, "{}", log);
+            check_warning(ctx, Some(ERR_DATA_OUT_OF_RANGE), log)
+        }
+    }
+
+    fn check_truncate(ctx: &EvalContext, truncate: bool, log: &str) {
+        if truncate {
+            check_warning(ctx, Some(ERR_TRUNCATE_WRONG_VALUE), log)
         }
     }
 
@@ -2493,53 +2487,79 @@ mod tests {
 
         // no overflow
         let cs = vec![
-            // (origin, expect, overflow)
-            (Json::from_object(BTreeMap::default()).unwrap(), 0, false),
-            (Json::from_array(vec![]).unwrap(), 0, false),
-            (Json::from_i64(10).unwrap(), 10i64, false),
-            (Json::from_i64(i64::MAX).unwrap(), i64::MAX, false),
-            (Json::from_i64(i64::MIN).unwrap(), i64::MIN, false),
-            (Json::from_u64(0).unwrap(), 0, false),
-            (Json::from_u64(u64::MAX).unwrap(), u64::MAX as i64, false),
+            // (origin, expect, overflow, truncate)
+            (
+                Json::from_object(BTreeMap::default()).unwrap(),
+                0,
+                false,
+                true,
+            ),
+            (Json::from_array(vec![]).unwrap(), 0, false, true),
+            (Json::from_i64(10).unwrap(), 10i64, false, false),
+            (Json::from_i64(i64::MAX).unwrap(), i64::MAX, false, false),
+            (Json::from_i64(i64::MIN).unwrap(), i64::MIN, false, false),
+            (Json::from_u64(0).unwrap(), 0, false, false),
+            (
+                Json::from_u64(u64::MAX).unwrap(),
+                u64::MAX as i64,
+                false,
+                false,
+            ),
             (
                 Json::from_f64(i64::MIN as u64 as f64).unwrap(),
                 i64::MAX,
+                false,
                 false,
             ),
             (
                 Json::from_f64(i64::MAX as u64 as f64).unwrap(),
                 i64::MAX,
                 false,
+                false,
             ),
             (
                 Json::from_f64(i64::MIN as u64 as f64).unwrap(),
                 i64::MAX,
                 false,
+                false,
             ),
-            (Json::from_f64(i64::MIN as f64).unwrap(), i64::MIN, false),
-            (Json::from_f64(10.5).unwrap(), 11, false),
-            (Json::from_f64(10.4).unwrap(), 10, false),
-            (Json::from_f64(-10.4).unwrap(), -10, false),
-            (Json::from_f64(-10.5).unwrap(), -11, false),
-            (Json::from_string(String::from("10.0")).unwrap(), 10, false),
-            (Json::from_bool(true).unwrap(), 1, false),
-            (Json::from_bool(false).unwrap(), 0, false),
-            (Json::none().unwrap(), 0, false),
+            (
+                Json::from_f64(i64::MIN as f64).unwrap(),
+                i64::MIN,
+                false,
+                false,
+            ),
+            (Json::from_f64(10.5).unwrap(), 11, false, false),
+            (Json::from_f64(10.4).unwrap(), 10, false, false),
+            (Json::from_f64(-10.4).unwrap(), -10, false, false),
+            (Json::from_f64(-10.5).unwrap(), -11, false, false),
+            (
+                Json::from_string(String::from("10.0")).unwrap(),
+                10,
+                false,
+                false,
+            ),
+            (Json::from_bool(true).unwrap(), 1, false, false),
+            (Json::from_bool(false).unwrap(), 0, false, false),
+            (Json::none().unwrap(), 0, false, false),
             (
                 Json::from_f64(((1u64 << 63) + (1u64 << 62)) as u64 as f64).unwrap(),
                 i64::MAX,
                 true,
+                false,
             ),
             (
                 Json::from_f64(-((1u64 << 63) as f64 + (1u64 << 62) as f64)).unwrap(),
                 i64::MIN,
                 true,
+                false,
             ),
         ];
 
-        for (input, expect, overflow) in cs {
+        for (input, expect, overflow, truncate) in cs {
             let mut ctx = CtxConfig {
                 overflow_as_warning: true,
+                truncate_as_warning: true,
                 ..CtxConfig::default()
             }
             .into();
@@ -2547,6 +2567,7 @@ mod tests {
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
             check_overflow(&ctx, overflow, log.as_str());
+            check_truncate(&ctx, truncate, log.as_str())
         }
     }
 
@@ -5249,19 +5270,6 @@ mod tests {
 
         // TODO: add test case that make Decimal::from_str failed
         let cs: Vec<(Json, bool, bool, Decimal)> = vec![
-            // (cast_func_input, in_union, is_res_unsigned, base_result)
-            (
-                Json::from_object(BTreeMap::default()).unwrap(),
-                false,
-                false,
-                Decimal::zero(),
-            ),
-            (
-                Json::from_array(vec![]).unwrap(),
-                false,
-                false,
-                Decimal::zero(),
-            ),
             (
                 Json::from_i64(10).unwrap(),
                 false,
@@ -5360,6 +5368,41 @@ mod tests {
             |x| x.to_string(),
             "cast_json_as_decimal",
         );
+    }
+
+    #[test]
+    fn test_truncate_when_cast_json_object_or_array_as_decimal() {
+        test_none_with_ctx(cast_any_as_any::<Real, Int>);
+
+        let cs = vec![
+            // (origin, result, errcode)
+            (
+                Json::from_object(BTreeMap::default()).unwrap(),
+                Decimal::zero(),
+                ERR_TRUNCATE_WRONG_VALUE,
+            ),
+            (
+                Json::from_array(vec![]).unwrap(),
+                Decimal::zero(),
+                ERR_TRUNCATE_WRONG_VALUE,
+            ),
+        ];
+
+        for (input, result, errcode) in cs {
+            let mut ctx = CtxConfig {
+                truncate_as_warning: true,
+                ..CtxConfig::default()
+            }
+            .into();
+
+            let rft = FieldTypeConfig::default().into();
+            let extra = make_extra(&rft);
+            let r = cast_json_as_decimal(&mut ctx, &extra, Some(input.as_ref()));
+
+            let log = make_log(&input, &result, &r);
+            check_result(Some(&result), &r, log.as_str());
+            check_warning(&ctx, Some(errcode), log.as_str());
+        }
     }
 
     #[test]


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: for https://github.com/pingcap/tidb/issues/21362

Problem Summary:
Migrate TiDB json conversion logic modification from https://github.com/pingcap/tidb/pull/21826.

### What is changed and how it works?
What's Changed:
Return data truncate error when convert object/array to integer/float/decimal.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- copr: refine JSON conversion, throw err when object/array convert to integer/float/decimal
