### PR TITLE
cdc: fix unstable old value test

### DIFF
--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -762,48 +762,60 @@ fn test_old_value_basic() {
     m1.set_op(Op::Put);
     m1.key = k1.clone();
     m1.value = b"v1".to_vec();
-    suite.must_kv_prewrite(1, vec![m1], k1.clone(), 1.into());
-    suite.must_kv_commit(1, vec![k1.clone()], 1.into(), 2.into());
+    let ts1 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_prewrite(1, vec![m1], k1.clone(), ts1);
+    let ts2 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_commit(1, vec![k1.clone()], ts1, ts2);
     // Rollback
     let mut m2 = Mutation::default();
     m2.set_op(Op::Put);
     m2.key = k1.clone();
     m2.value = b"v2".to_vec();
-    suite.must_kv_prewrite(1, vec![m2], k1.clone(), 3.into());
-    suite.must_kv_rollback(1, vec![k1.clone()], 3.into());
+    let ts3 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_prewrite(1, vec![m2], k1.clone(), ts3);
+    suite.must_kv_rollback(1, vec![k1.clone()], ts3);
     // Update value
     let mut m3 = Mutation::default();
     m3.set_op(Op::Put);
     m3.key = k1.clone();
     m3.value = vec![b'3'; 5120];
-    suite.must_kv_prewrite(1, vec![m3], k1.clone(), 4.into());
-    suite.must_kv_commit(1, vec![k1.clone()], 4.into(), 5.into());
+    let ts4 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_prewrite(1, vec![m3], k1.clone(), ts4);
+    let ts5 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_commit(1, vec![k1.clone()], ts4, ts5);
     // Lock
     let mut m4 = Mutation::default();
     m4.set_op(Op::Lock);
     m4.key = k1.clone();
-    suite.must_kv_prewrite(1, vec![m4], k1.clone(), 6.into());
-    suite.must_kv_commit(1, vec![k1.clone()], 6.into(), 7.into());
+    let ts6 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_prewrite(1, vec![m4], k1.clone(), ts6);
+    let ts7 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_commit(1, vec![k1.clone()], ts6, ts7);
     // Delete value and rollback
     let mut m5 = Mutation::default();
     m5.set_op(Op::Del);
     m5.key = k1.clone();
-    suite.must_kv_prewrite(1, vec![m5], k1.clone(), 8.into());
-    suite.must_kv_rollback(1, vec![k1.clone()], 8.into());
+    let ts8 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_prewrite(1, vec![m5], k1.clone(), ts8);
+    suite.must_kv_rollback(1, vec![k1.clone()], ts8);
     // Update value
     let mut m6 = Mutation::default();
     m6.set_op(Op::Put);
     m6.key = k1.clone();
     m6.value = b"v6".to_vec();
-    suite.must_kv_prewrite(1, vec![m6], k1.clone(), 10.into());
-    suite.must_kv_commit(1, vec![k1.clone()], 10.into(), 11.into());
+    let ts9 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let ts10 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_prewrite(1, vec![m6], k1.clone(), ts10);
+    let ts11 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_commit(1, vec![k1.clone()], ts10, ts11);
     // Delete value
     let mut m7 = Mutation::default();
     m7.set_op(Op::PessimisticLock);
     m7.key = k1.clone();
-    suite.must_acquire_pessimistic_lock(1, vec![m7.clone()], k1.clone(), 9.into(), 12.into());
+    let ts12 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_acquire_pessimistic_lock(1, vec![m7.clone()], k1.clone(), ts9, ts12);
     m7.set_op(Op::Del);
-    suite.must_kv_pessimistic_prewrite(1, vec![m7], k1, 9.into(), 12.into());
+    suite.must_kv_pessimistic_prewrite(1, vec![m7], k1, ts9, ts12);
 
     let mut event_count = 0;
     loop {
@@ -813,13 +825,15 @@ fn test_old_value_basic() {
                 Event_oneof_event::Entries(mut es) => {
                     for row in es.take_entries().to_vec() {
                         if row.get_type() == EventLogType::Prewrite {
-                            if row.get_start_ts() == 3 || row.get_start_ts() == 4 {
+                            if row.get_start_ts() == ts3.into_inner()
+                                || row.get_start_ts() == ts4.into_inner()
+                            {
                                 assert_eq!(row.get_old_value(), b"v1");
                                 event_count += 1;
-                            } else if row.get_start_ts() == 8 {
+                            } else if row.get_start_ts() == ts8.into_inner() {
                                 assert_eq!(row.get_old_value(), vec![b'3'; 5120].as_slice());
                                 event_count += 1;
-                            } else if row.get_start_ts() == 9 {
+                            } else if row.get_start_ts() == ts9.into_inner() {
                                 assert_eq!(row.get_old_value(), b"v6");
                                 event_count += 1;
                             }
@@ -844,16 +858,18 @@ fn test_old_value_basic() {
             match e.event.unwrap() {
                 Event_oneof_event::Entries(mut es) => {
                     for row in es.take_entries().to_vec() {
-                        if row.get_type() == EventLogType::Committed && row.get_start_ts() == 1 {
+                        if row.get_type() == EventLogType::Committed
+                            && row.get_start_ts() == ts1.into_inner()
+                        {
                             assert_eq!(row.get_old_value(), b"");
                             event_count += 1;
                         } else if row.get_type() == EventLogType::Committed
-                            && row.get_start_ts() == 4
+                            && row.get_start_ts() == ts4.into_inner()
                         {
                             assert_eq!(row.get_old_value(), b"v1");
                             event_count += 1;
                         } else if row.get_type() == EventLogType::Prewrite
-                            && row.get_start_ts() == 9
+                            && row.get_start_ts() == ts9.into_inner()
                         {
                             assert_eq!(row.get_old_value(), b"v6");
                             event_count += 1;


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
Fix unstable test.

### What is changed and how it works?

What's Changed:
Get ts from pd client instead of hardcode ts.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* N/A