### PR TITLE
gc : skip for flushing to the bottommost level

### DIFF
--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -663,7 +663,7 @@ fn check_need_gc(
     ratio_threshold: f64,
     context: &CompactionFilterContext,
 ) -> bool {
-    if ratio_threshold < 1.0 || context.is_bottommost_level() {
+    if ratio_threshold < 1.0 {
         // According to our tests, `split_ts` on keys and `parse_write` on values
         // won't utilize much CPU.
         return true;
@@ -672,6 +672,9 @@ fn check_need_gc(
     let check_props = |props: &MvccProperties| {
         if props.min_ts > safe_point {
             return false;
+        }
+        if context.is_bottommost_level() {
+            return true;
         }
         if props.num_versions as f64 > props.num_rows as f64 * ratio_threshold {
             // When comparing `num_versions` with `num_rows`, it's unnecessary to


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

When inserting data into a new constructed cluster, SST files will be flushed from memtables to L6(the bottommost level) directly. It's unnecessary to run GC for them because all data should be fresh instead of stale.

### What is changed and how it works?
Update `check_need_gc` function for GC in compaction filter:
For a given SST file if its min ts is larger than safe point, skip GC for it.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
* gc: skip SSTs flushed to the bottommost level