### PR TITLE
gc: check configuration changes in a round

### DIFF
--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -663,7 +663,7 @@ fn check_need_gc(
     ratio_threshold: f64,
     context: &CompactionFilterContext,
 ) -> bool {
-    if ratio_threshold < 1.0 || context.is_bottommost_level() {
+    if ratio_threshold < 1.0 {
         // According to our tests, `split_ts` on keys and `parse_write` on values
         // won't utilize much CPU.
         return true;
@@ -672,6 +672,9 @@ fn check_need_gc(
     let check_props = |props: &MvccProperties| {
         if props.min_ts > safe_point {
             return false;
+        }
+        if context.is_bottommost_level() {
+            return true;
         }
         if props.num_versions as f64 > props.num_rows as f64 * ratio_threshold {
             // When comparing `num_versions` with `num_rows`, it's unnecessary to

--- a/src/server/gc_worker/gc_manager.rs
+++ b/src/server/gc_worker/gc_manager.rs
@@ -432,6 +432,10 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider> GcManager<S, R> {
         // rewinding will happen.
         loop {
             self.gc_manager_ctx.check_stopped()?;
+            if self.cfg_tracker.value().enable_compaction_filter {
+                // `enable_compaction_filter` is switched on by dynamic configuration change.
+                return Ok(());
+            }
 
             // Check the current GC progress and determine if we are going to rewind or we have
             // finished the round of GC.

--- a/src/server/gc_worker/gc_manager.rs
+++ b/src/server/gc_worker/gc_manager.rs
@@ -432,8 +432,7 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider> GcManager<S, R> {
         // rewinding will happen.
         loop {
             self.gc_manager_ctx.check_stopped()?;
-            if self.cfg_tracker.value().enable_compaction_filter {
-                // `enable_compaction_filter` is switched on by dynamic configuration change.
+            if is_compaction_filter_allowed(&*self.cfg_tracker.value(), &self.feature_gate) {
                 return Ok(());
             }
 


### PR DESCRIPTION
### What problem does this PR solve?

It's possible that users switch GC in Compaction Filter one during TiKV in a GC round. To save resource, the GC round can be broken.

### What is changed and how it works?

Checking configuration changes in GC round. If GC manager finds that it's unnecessary to continue, return from the round.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->
* gc: check configuration changes in a round