### PR TITLE
server: register consistency checker correctly

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -14,7 +14,7 @@ use std::{
     fs::{self, File},
     net::SocketAddr,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::{atomic::AtomicU64, Arc, Mutex},
 };
 
 use concurrency_manager::ConcurrencyManager;
@@ -628,6 +628,21 @@ impl<ER: RaftEngine> TiKVServer<ER> {
 
         let auto_split_controller = AutoSplitController::new(split_config_manager);
 
+        let safe_point = Arc::new(AtomicU64::new(0));
+        let observer = match self.config.coprocessor.consistency_check_method {
+            ConsistencyCheckMethod::Mvcc => BoxConsistencyCheckObserver::new(
+                MvccConsistencyCheckObserver::new(safe_point.clone()),
+            ),
+            ConsistencyCheckMethod::Raw => {
+                BoxConsistencyCheckObserver::new(RawConsistencyCheckObserver::default())
+            }
+        };
+        self.coprocessor_host
+            .as_mut()
+            .unwrap()
+            .registry
+            .register_consistency_check_observer(100, observer);
+
         let mut node = Node::new(
             self.system.take().unwrap(),
             &server_config,
@@ -636,6 +651,16 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             self.state.clone(),
             self.background_worker.clone(),
         );
+
+        // Start auto gc
+        let auto_gc_config = AutoGcConfig::new(
+            self.pd_client.clone(),
+            self.region_info_accessor.clone(),
+            node.id(),
+        );
+        if let Err(e) = gc_worker.start_auto_gc(auto_gc_config, safe_point) {
+            fatal!("failed to start auto_gc on storage, error: {}", e);
+        }
 
         node.start(
             engines.engines.clone(),
@@ -652,31 +677,6 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         .unwrap_or_else(|e| fatal!("failed to start node: {}", e));
 
         initial_metric(&self.config.metric);
-
-        // Start auto gc
-        let auto_gc_config = AutoGcConfig::new(
-            self.pd_client.clone(),
-            self.region_info_accessor.clone(),
-            node.id(),
-        );
-
-        let safe_point = match gc_worker.start_auto_gc(auto_gc_config) {
-            Err(e) => fatal!("failed to start auto_gc on storage, error: {}", e),
-            Ok(safe_point) => safe_point,
-        };
-        let observer = match self.config.coprocessor.consistency_check_method {
-            ConsistencyCheckMethod::Mvcc => {
-                BoxConsistencyCheckObserver::new(MvccConsistencyCheckObserver::new(safe_point))
-            }
-            ConsistencyCheckMethod::Raw => {
-                BoxConsistencyCheckObserver::new(RawConsistencyCheckObserver::default())
-            }
-        };
-        self.coprocessor_host
-            .as_mut()
-            .unwrap()
-            .registry
-            .register_consistency_check_observer(100, observer);
 
         // Start CDC.
         let cdc_endpoint = cdc::Endpoint::new(

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -5,6 +5,7 @@ use futures::executor::block_on;
 use kvproto::kvrpcpb::{Context, GetRequest, LockInfo};
 use raftstore::coprocessor::RegionInfoProvider;
 use raftstore::router::RaftStoreBlackHole;
+use std::sync::{atomic::AtomicU64, Arc};
 use tikv::server::gc_worker::{AutoGcConfig, GcConfig, GcSafePointProvider, GcWorker};
 use tikv::storage::config::Config;
 use tikv::storage::kv::RocksEngine;
@@ -88,7 +89,9 @@ impl<E: Engine> SyncTestStorage<E> {
         &mut self,
         cfg: AutoGcConfig<S, R>,
     ) {
-        self.gc_worker.start_auto_gc(cfg).unwrap();
+        self.gc_worker
+            .start_auto_gc(cfg, Arc::new(AtomicU64::new(0)))
+            .unwrap();
     }
 
     pub fn get_storage(&self) -> Storage<E, DummyLockManager> {

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -649,9 +649,8 @@ where
     pub fn start_auto_gc<S: GcSafePointProvider, R: RegionInfoProvider>(
         &self,
         cfg: AutoGcConfig<S, R>,
-    ) -> Result<Arc<AtomicU64>> {
-        let safe_point = Arc::new(AtomicU64::new(0));
-
+        safe_point: Arc<AtomicU64>, // Store safe point here.
+    ) -> Result<()> {
         let kvdb = self.engine.kv_engine();
         let cfg_mgr = self.config_manager.clone();
         let feature_gate = self.feature_gate.clone();
@@ -661,14 +660,14 @@ where
         assert!(handle.is_none());
         let new_handle = GcManager::new(
             cfg,
-            safe_point.clone(),
+            safe_point,
             self.worker_scheduler.clone(),
             self.config_manager.clone(),
             self.feature_gate.clone(),
         )
         .start()?;
         *handle = Some(new_handle);
-        Ok(safe_point)
+        Ok(())
     }
 
     pub fn start(&mut self) -> Result<()> {


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?
Currently there is a bug that consistency checker can't be registered correctly, so that users can't enable consistency check at all.

### What is changed and how it works?

In the PR we register consistency checker before starting batch system, so that it can work as expected.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)
  1. Start a tikv server with configuration `raftstore.consistency-check-interval = '5s'`
  2. Wait 5 seconds, and then check the TiKV's log
  3. Grep "consistency check pass", if we can see something it says the patch works

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* server: register consistency checker correctly