### PR TITLE
collation: fix incorrect utf8_unicode_ci collation id

### DIFF
--- a/components/tidb_query_datatype/src/def/field_type.rs
+++ b/components/tidb_query_datatype/src/def/field_type.rs
@@ -482,8 +482,8 @@ mod tests {
             (-255, None),
             (i32::MAX, Some(Collation::Utf8Mb4BinNoPadding)),
             (i32::MIN, None),
-            (-192, Some(Collation::Utf8Mb4UnicodeCi))
-            (-224, Some(Collation::Utf8Mb4UnicodeCi))
+            (-192, Some(Collation::Utf8Mb4UnicodeCi)),
+            (-224, Some(Collation::Utf8Mb4UnicodeCi)),
         ];
 
         for (collate, expected) in cases {

--- a/components/tidb_query_datatype/src/def/field_type.rs
+++ b/components/tidb_query_datatype/src/def/field_type.rs
@@ -125,7 +125,7 @@ impl Collation {
             -46 | -83 | -65 => Ok(Collation::Utf8Mb4Bin),
             -47 => Ok(Collation::Latin1Bin),
             -63 | 63 | 47 => Ok(Collation::Binary),
-            -224 | -182 => Ok(Collation::Utf8Mb4UnicodeCi),
+            -224 | -192 => Ok(Collation::Utf8Mb4UnicodeCi),
             n if n >= 0 => Ok(Collation::Utf8Mb4BinNoPadding),
             n => Err(DataTypeError::UnsupportedCollation { code: n }),
         }

--- a/components/tidb_query_datatype/src/def/field_type.rs
+++ b/components/tidb_query_datatype/src/def/field_type.rs
@@ -482,6 +482,8 @@ mod tests {
             (-255, None),
             (i32::MAX, Some(Collation::Utf8Mb4BinNoPadding)),
             (i32::MIN, None),
+            (-192, Some(Collation::Utf8Mb4UnicodeCi))
+            (-224, Some(Collation::Utf8Mb4UnicodeCi))
         ];
 
         for (collate, expected) in cases {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

`utf8_unicode_ci` collation id is 192.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->
- no