### PR TITLE
*: fix make build PROST=1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
+# See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md
+# Without resolver = 2, using `cargo build --features x` to build `cmd`
+# will _not_ propagate the feature `x` into `cmd`'s direct dependencies.
+cargo-features = ["resolver"]
+
 [package]
 name = "tikv"
 version = "4.1.0-alpha"
@@ -188,6 +193,7 @@ protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "65
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 
 [workspace]
+resolver = "2"
 members = [
   "fuzz",
   "fuzz/fuzzer-afl",

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -767,7 +767,7 @@ fn decode_write(key: Vec<u8>, value: &[u8], row: &mut EventRow) -> bool {
     row.start_ts = write.start_ts.into_inner();
     row.commit_ts = commit_ts;
     row.key = key.truncate_ts().unwrap().into_raw().unwrap();
-    row.op_type = op_type;
+    row.op_type = op_type as _;
     set_event_row_type(row, r_type);
     if let Some(value) = write.short_value {
         row.value = value;
@@ -792,7 +792,7 @@ fn decode_lock(key: Vec<u8>, lock: Lock, row: &mut EventRow) -> bool {
     let key = Key::from_encoded(key);
     row.start_ts = lock.ts.into_inner();
     row.key = key.into_raw().unwrap();
-    row.op_type = op_type;
+    row.op_type = op_type as _;
     set_event_row_type(row, EventLogType::Prewrite);
     if let Some(value) = lock.short_value {
         row.value = value;
@@ -1034,14 +1034,14 @@ mod tests {
         row1.start_ts = 1;
         row1.commit_ts = 0;
         row1.key = b"a".to_vec();
-        row1.op_type = EventRowOpType::Put;
+        row1.op_type = EventRowOpType::Put as _;
         set_event_row_type(&mut row1, EventLogType::Prewrite);
         row1.value = b"b".to_vec();
         let mut row2 = EventRow::default();
         row2.start_ts = 1;
         row2.commit_ts = 2;
         row2.key = b"a".to_vec();
-        row2.op_type = EventRowOpType::Put;
+        row2.op_type = EventRowOpType::Put as _;
         set_event_row_type(&mut row2, EventLogType::Committed);
         row2.value = b"b".to_vec();
         let mut row3 = EventRow::default();

--- a/components/cdc/tests/failpoints/test_resolve.rs
+++ b/components/cdc/tests/failpoints/test_resolve.rs
@@ -185,7 +185,7 @@ fn test_joint_confchange() {
     cluster.cfg.cdc.hibernate_regions_compatible = true;
     let mut suite = TestSuite::with_cluster(3, cluster);
 
-    let receive_resolved_ts = |receive_event: &Box<dyn Fn(bool) -> ChangeDataEvent + Send>| {
+    let receive_resolved_ts = |receive_event: &(dyn Fn(bool) -> ChangeDataEvent + Send)| {
         let mut last_resolved_ts = 0;
         let mut i = 0;
         loop {
@@ -218,7 +218,7 @@ fn test_joint_confchange() {
     let req = suite.new_changedata_request(region.get_id());
     let (mut req_tx, event_feed_wrap, receive_event) =
         new_event_feed(suite.get_region_cdc_client(region.get_id()));
-    block_on(req_tx.send((req.clone(), WriteFlags::default()))).unwrap();
+    block_on(req_tx.send((req, WriteFlags::default()))).unwrap();
     receive_resolved_ts(&receive_event);
 
     suite.cluster.stop_node(peers[1].get_store_id());

--- a/components/tidb_query_common/src/error.rs
+++ b/components/tidb_query_common/src/error.rs
@@ -1,5 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::convert::Infallible;
+
 use error_code::{self, ErrorCode, ErrorCodeExt};
 use failure::Fail;
 
@@ -44,6 +46,12 @@ impl From<tikv_util::deadline::DeadlineError> for EvaluateError {
     #[inline]
     fn from(_: tikv_util::deadline::DeadlineError) -> Self {
         EvaluateError::DeadlineExceeded
+    }
+}
+
+impl From<Infallible> for EvaluateError {
+    fn from(e: Infallible) -> Self {
+        match e {}
     }
 }
 

--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -109,7 +109,7 @@ fn get_cast_fn_rpn_meta(
 
         // any as string
         (EvalType::Int, EvalType::Bytes) => {
-            if from_field_type.tp() == FieldTypeTp::Year {
+            if FieldTypeAccessor::tp(from_field_type) == FieldTypeTp::Year {
                 cast_year_as_string_fn_meta()
             } else if from_field_type.is_unsigned() {
                 cast_uint_as_string_fn_meta()
@@ -118,7 +118,7 @@ fn get_cast_fn_rpn_meta(
             }
         }
         (EvalType::Real, EvalType::Bytes) => {
-            if from_field_type.tp() == FieldTypeTp::Float {
+            if FieldTypeAccessor::tp(from_field_type) == FieldTypeTp::Float {
                 cast_float_real_as_string_fn_meta()
             } else {
                 cast_any_as_string_fn_meta::<Real>()
@@ -169,7 +169,7 @@ fn get_cast_fn_rpn_meta(
         (EvalType::Json, EvalType::Duration) => cast_json_as_duration_fn_meta(),
 
         (EvalType::Int, EvalType::DateTime) => {
-            if from_field_type.tp() == FieldTypeTp::Year {
+            if FieldTypeAccessor::tp(from_field_type) == FieldTypeTp::Year {
                 cast_year_as_time_fn_meta()
             } else {
                 cast_int_as_time_fn_meta()
@@ -1092,7 +1092,7 @@ fn cast_year_as_time(
         ctx.handle_truncate_err(Error::truncated_wrong_val("YEAR", year))?;
         return Ok(None);
     }
-    let time_type = extra.ret_field_type.tp().try_into()?;
+    let time_type = FieldTypeAccessor::tp(extra.ret_field_type).try_into()?;
     let fsp = extra.ret_field_type.decimal() as i8;
     let time = Time::from_year(ctx, year as u32, fsp, time_type)?;
 

--- a/scripts/test
+++ b/scripts/test
@@ -27,6 +27,6 @@ export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${LOCAL_DIR}/lib"
 export LOG_LEVEL=DEBUG
 export RUST_BACKTRACE=1
 
-cargo -Zpackage-features test --workspace \
+cargo test --workspace \
     --exclude fuzzer-honggfuzz --exclude fuzzer-afl --exclude fuzzer-libfuzzer \
     --features "${TIKV_ENABLE_FEATURES}" ${EXTRA_CARGO_ARGS} "$@"

--- a/src/server/service/diagnostics/log.rs
+++ b/src/server/service/diagnostics/log.rs
@@ -763,7 +763,7 @@ Some invalid logs 2: Welcome to TiKV - test-filter"#
         let mut req = SearchLogRequest::default();
         req.set_start_time(timestamp("2019/08/23 18:09:54.387 +08:00"));
         req.set_end_time(std::i64::MAX);
-        req.set_levels(vec![LogLevel::Warn]);
+        req.set_levels(vec![LogLevel::Warn as _]);
         req.set_patterns(vec![".*test-filter.*".to_string()].into());
         let expected = vec![
             "2019/08/23 18:09:58.387 +08:00",


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9352

Problem Summary: `make build PROST=1` failed to compile.

### What is changed and how it works?

What's Changed:

* Changed TiKV's Cargo.toml to use "resolver = 2" so that `cmd` can recognize `feature = "prost-codec"`.
* In Prost, we have the `FieldType::tp()` inherent method which has name conflict with `FieldTypeAccessor::tp()` trait method. Use the FQN to disambiguate.
* Use `as _` to bridge enum-to-int conversion.
* Use `.into()` to bridge T-to-Box&lt;T&gt; conversion.

### Related changes

- Need to cherry-pick to the release branch
    * release-5.0-rc

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
   * make build PROST=1
   * make build

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

No release notes