### PR TITLE
cdc: Filter out apply events with GC Fence 

### DIFF
--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -1241,3 +1241,95 @@ fn test_cdc_scan_not_filter_gc_fence() {
         other => panic!("unknown event {:?}", other),
     }
 }
+
+#[test]
+fn test_cdc_filtering_gc_fence() {
+    let mut suite = TestSuite::new(1);
+
+    let req = suite.new_changedata_request(1);
+    let (mut req_tx, _, receive_event) = new_event_feed(suite.get_region_cdc_client(1));
+    block_on(req_tx.send((req, WriteFlags::default()))).unwrap();
+    let event = receive_event(false);
+    event
+        .events
+        .into_iter()
+        .for_each(|e| match e.event.unwrap() {
+            Event_oneof_event::Entries(es) => {
+                assert!(es.entries.len() == 1, "{:?}", es);
+                let e = &es.entries[0];
+                assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+            }
+            other => panic!("unknown event {:?}", other),
+        });
+
+    sleep_ms(1000);
+
+    // Write two versions of a key
+    let (key, v1, v2) = (b"key", b"value1", b"value2");
+    let start_ts1 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = key.to_vec();
+    mutation.value = v1.to_vec();
+    suite.must_kv_prewrite(1, vec![mutation], key.to_vec(), start_ts1);
+
+    let commit_ts1 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_commit(1, vec![key.to_vec()], start_ts1, commit_ts1);
+
+    let start_ts2 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = key.to_vec();
+    mutation.value = v2.to_vec();
+    suite.must_kv_prewrite(1, vec![mutation], key.to_vec(), start_ts2);
+
+    let commit_ts2 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_commit(1, vec![key.to_vec()], start_ts2, commit_ts2);
+
+    // We don't care about the events caused by the previous writings in this test case, and it's
+    // too complicated to check them. Just skip them here, and wait for resolved_ts to be pushed to
+    // a greater value than the two versions' commit_ts-es.
+    let skip_to_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    loop {
+        let e = receive_event(true);
+        if let Some(r) = e.resolved_ts.as_ref() {
+            if r.ts > skip_to_ts.into_inner() {
+                break;
+            }
+        }
+    }
+
+    // Assume the two versions of the key are written by async commit transactions, and their
+    // commit_ts-es are also other transaction's start_ts-es. Run check_txn_status on the
+    // commit_ts-es of the two versions to cause overlapping rollback.
+    let caller_start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_check_txn_status(
+        1,
+        key.to_vec(),
+        commit_ts1,
+        caller_start_ts,
+        caller_start_ts,
+        true,
+    );
+    suite.must_check_txn_status(
+        1,
+        key.to_vec(),
+        commit_ts2,
+        caller_start_ts,
+        caller_start_ts,
+        true,
+    );
+
+    // Then nothing should be received by CDC.
+    let latest_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    loop {
+        let event = receive_event(true);
+
+        if let Some(r) = event.resolved_ts.as_ref() {
+            assert_ne!(r.ts, 0);
+            if r.ts > latest_ts.into_inner() {
+                break;
+            }
+        }
+    }
+}

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -1164,3 +1164,80 @@ fn test_region_created_replicate() {
     event_feed_wrap.replace(None);
     suite.stop();
 }
+
+#[test]
+fn test_cdc_scan_not_filter_gc_fence() {
+    // This case is similar to `test_cdc_scan` but constructs a case with GC Fence.
+    let mut suite = TestSuite::new(1);
+
+    let (key, v1, v2) = (b"key", b"value1", b"value2");
+
+    // Write two versions to the key.
+    let start_ts1 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = key.to_vec();
+    mutation.value = v1.to_vec();
+    suite.must_kv_prewrite(1, vec![mutation], key.to_vec(), start_ts1);
+
+    let commit_ts1 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_commit(1, vec![key.to_vec()], start_ts1, commit_ts1);
+
+    let start_ts2 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let mut mutation = Mutation::default();
+    mutation.key = key.to_vec();
+    mutation.value = v2.to_vec();
+    suite.must_kv_prewrite(1, vec![mutation], key.to_vec(), start_ts2);
+
+    let commit_ts2 = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    suite.must_kv_commit(1, vec![key.to_vec()], start_ts2, commit_ts2);
+
+    // Assume the first version above is written by async commit and it's commit_ts is not unique.
+    // Use it's commit_ts as another transaction's start_ts.
+    // Run check_txn_status on commit_ts1 so that gc_fence will be set on the first version.
+    let caller_start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
+    let action = suite.must_check_txn_status(
+        1,
+        key.to_vec(),
+        commit_ts1,
+        caller_start_ts,
+        caller_start_ts,
+        true,
+    );
+    assert_eq!(action, Action::LockNotExistRollback);
+
+    let req = suite.new_changedata_request(1);
+    let (mut req_tx, _, receive_event) = new_event_feed(suite.get_region_cdc_client(1));
+    block_on(req_tx.send((req, WriteFlags::default()))).unwrap();
+    let mut events = receive_event(false).events.to_vec();
+    if events.len() == 1 {
+        events.extend(receive_event(false).events.into_iter());
+    }
+    assert_eq!(events.len(), 2, "{:?}", events);
+    match events.remove(0).event.unwrap() {
+        Event_oneof_event::Entries(es) => {
+            assert!(es.entries.len() == 2, "{:?}", es);
+            let e = &es.entries[0];
+            assert_eq!(e.get_type(), EventLogType::Committed, "{:?}", es);
+            assert_eq!(e.start_ts, start_ts2.into_inner(), "{:?}", es);
+            assert_eq!(e.commit_ts, commit_ts2.into_inner(), "{:?}", es);
+            assert_eq!(e.key, key.to_vec(), "{:?}", es);
+            assert_eq!(e.value, v2.to_vec(), "{:?}", es);
+            let e = &es.entries[1];
+            assert_eq!(e.get_type(), EventLogType::Committed, "{:?}", es);
+            assert_eq!(e.start_ts, start_ts1.into_inner(), "{:?}", es);
+            assert_eq!(e.commit_ts, commit_ts1.into_inner(), "{:?}", es);
+            assert_eq!(e.key, key.to_vec(), "{:?}", es);
+            assert_eq!(e.value, v1.to_vec(), "{:?}", es);
+        }
+        other => panic!("unknown event {:?}", other),
+    }
+    match events.pop().unwrap().event.unwrap() {
+        Event_oneof_event::Entries(es) => {
+            assert!(es.entries.len() == 1, "{:?}", es);
+            let e = &es.entries[0];
+            assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
+        }
+        other => panic!("unknown event {:?}", other),
+    }
+}

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -264,6 +264,31 @@ impl TestSuite {
         );
     }
 
+    pub fn must_check_txn_status(
+        &mut self,
+        region_id: u64,
+        primary_key: Vec<u8>,
+        lock_ts: TimeStamp,
+        caller_start_ts: TimeStamp,
+        current_ts: TimeStamp,
+        rollback_if_not_exist: bool,
+    ) -> Action {
+        let mut req = CheckTxnStatusRequest::default();
+        req.set_context(self.get_context(region_id));
+        req.set_primary_key(primary_key);
+        req.set_lock_ts(lock_ts.into_inner());
+        req.set_caller_start_ts(caller_start_ts.into_inner());
+        req.set_current_ts(current_ts.into_inner());
+        req.set_rollback_if_not_exist(rollback_if_not_exist);
+        let resp = self
+            .get_tikv_client(region_id)
+            .kv_check_txn_status(&req)
+            .unwrap();
+        assert!(!resp.has_region_error(), "{:?}", resp.get_region_error());
+        assert!(!resp.has_error(), "{:?}", resp.get_error());
+        resp.get_action()
+    }
+
     pub fn must_acquire_pessimistic_lock(
         &mut self,
         region_id: u64,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary: This PR filters out write cf's apply events that has the `gc_fence` field set, which means the applying is caused by rewriting while adding overlapped rollback flag.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: Filter out apply events with gc fence set.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- bugfixes or new feature need a release note -->

- No release note.