### PR TITLE
*: Bump version v3.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project are documented in this file.
 See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.md) and [PD Changelog](https://github.com/pingcap/pd/blob/master/CHANGELOG.md).
 
+## [3.0.20] - 2020-12-25
+### Bug Fixes
+- Fix the issue that an error is returned indicating that a key exists when this key is locked and deleted in a committed transaction [#8931](https://github.com/tikv/tikv/pull/8931)
+
+### Improvements
+- Add the `end_point_slow_log_threshold` configuration item [#9145](https://github.com/tikv/tikv/pull/9145)
+
 ## [3.0.19]
 ### Bugfixes
 - Fix the bug that TiKV panics when parsing responses with missing reason phrases [#8540](https://github.com/tikv/tikv/pull/8540)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "tikv"
-version = "3.0.19"
+version = "3.0.20"
 dependencies = [
  "arrow 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv"
-version = "3.0.19"
+version = "3.0.20"
 authors = ["The TiKV Authors"]
 description = "A distributed transactional key-value database powered by Rust and Raft"
 license = "Apache-2.0"


### PR DESCRIPTION
As is stated, release note: https://github.com/pingcap/docs/pull/4421

### Release note <!-- bugfixes or new feature need a release note -->
- No release note