### PR TITLE
stabilize test_new_split_learner_can_not_find_leader

### DIFF
--- a/tests/failpoints/cases/test_replica_read.rs
+++ b/tests/failpoints/cases/test_replica_read.rs
@@ -355,7 +355,9 @@ fn test_read_after_cleanup_range_for_snap() {
 }
 
 /// Tests the learner of new split region will know its leader without waiting for the leader heartbeat timeout.
-/// The learner of a new split region may not know its leader if it applies log slowly and drops the no-op
+///
+/// Before https://github.com/tikv/tikv/pull/8820,
+/// the learner of a new split region may not know its leader if it applies log slowly and drops the no-op
 /// entry from the new leader, and it had to wait for a heartbeat timeout to know its leader before that it
 /// can't handle any read request.
 #[test]
@@ -389,8 +391,8 @@ fn test_new_split_learner_can_not_find_leader() {
 
     fail::remove("apply_before_split_1_3");
 
-    // Wait learner split
-    thread::sleep(Duration::from_millis(500));
+    // Wait the learner split. Then it can receive a `MsgAppend`.
+    must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
 
     let new_region = cluster.get_region(b"k2");
     let learner_peer = find_peer(&new_region, 3).unwrap().clone();


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?
Stabilize the test case test_new_split_learner_can_not_find_leader.

Fix https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tikv_ghpr_test/detail/tikv_ghpr_test/38960/pipeline/ .

### What is changed and how it works?
Stabilize the test case test_new_split_learner_can_not_find_leader.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.