### PR TITLE
ci: stabilize case test_auto_gc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4546,6 +4546,7 @@ dependencies = [
  "encryption",
  "engine_rocks",
  "engine_traits",
+ "error_code",
  "external_storage",
  "fail",
  "futures 0.3.7",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -108,6 +108,7 @@ tidb_query_executors = { path = "../components/tidb_query_executors" }
 tidb_query_expr = { path = "../components/tidb_query_expr" }
 tikv = { path = "../", default-features = false }
 tikv_util = { path = "../components/tikv_util" }
+error_code = { path = "../components/error_code" }
 collections = { path = "../components/collections" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
 toml = "0.5"

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -4,6 +4,7 @@ use std::thread;
 use std::time::Duration;
 
 use collections::HashMap;
+use error_code::{raftstore::STALE_COMMAND, ErrorCodeExt};
 use kvproto::kvrpcpb::Context;
 use std::sync::mpsc::channel;
 use std::sync::Arc;
@@ -226,18 +227,28 @@ fn check_data<E: Engine>(
 ) {
     let ts = ts.into();
     for (k, v) in test_data {
-        let mut region = cluster.get_region(k);
-        let leader = cluster.leader_of_region(region.get_id()).unwrap();
-        let leader_id = leader.get_store_id();
-        let mut ctx = Context::default();
-        ctx.set_region_id(region.get_id());
-        ctx.set_region_epoch(region.take_region_epoch());
-        ctx.set_peer(leader);
+        let mut retry_times = 0;
+        let value = loop {
+            let mut region = cluster.get_region(k);
+            let leader = cluster.leader_of_region(region.get_id()).unwrap();
+            let leader_id = leader.get_store_id();
+            let mut ctx = Context::default();
+            ctx.set_region_id(region.get_id());
+            ctx.set_region_epoch(region.take_region_epoch());
+            ctx.set_peer(leader);
 
-        let value = storages[&leader_id]
-            .get(ctx, &Key::from_raw(k), ts)
-            .unwrap()
-            .0;
+            match storages[&leader_id].get(ctx, &Key::from_raw(k), ts) {
+                Ok(v) => break v.0,
+                // Retry if meeting `StaleCommand` error.
+                Err(e) if e.error_code() == STALE_COMMAND => {}
+                Err(e) => panic!("storage get meets error: {:?}", e),
+            }
+            if retry_times > 50 {
+                panic!("storage get fails after 50 retry");
+            }
+            thread::sleep(Duration::from_millis(20));
+            retry_times += 1;
+        };
         if expect_success {
             assert_eq!(value.unwrap().as_slice(), v.as_slice());
         } else {


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

The test case test_auto_gc is not stable.
It fails at `Storage::get(...).unwrap()`, which expects an `Ok` but `Err(StaleCommand)` is got. So retry the request can stabilize the case.

Issue Number: close https://github.com/tikv/tikv/issues/6400 .

### What is changed and how it works?

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.