### PR TITLE
ci: stabilize case test_node_merge_crash_when_snapshot

### DIFF
--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -772,6 +772,16 @@ impl<T: Simulator> Cluster<T> {
                 sleep_ms(100);
                 continue;
             }
+            if resp
+                .get_header()
+                .get_error()
+                .get_message()
+                .contains("proposal dropped")
+            {
+                warn!("seems transferring leadership, let's retry");
+                sleep_ms(100);
+                continue;
+            }
             return resp;
         }
         panic!("request timeout");


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

The test case test_node_merge_crash_when_snapshot is not stable.

Here is a failure result: https://internal.pingcap.net/idc-jenkins/blue/rest/organizations/jenkins/pipelines/tikv_ghpr_test/runs/39212/nodes/98/steps/537/log/?start=0 . 

It shows that it's possible to meet `proposal dropped` in `Cluster::put_cf`.

### What is changed and how it works?

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.