### PR TITLE
raftstore: match ready by batch_offset

### DIFF
--- a/components/raftstore/src/store/fsm/mod.rs
+++ b/components/raftstore/src/store/fsm/mod.rs
@@ -15,7 +15,7 @@ pub use self::apply::{
     Msg as ApplyTask, Notifier as ApplyNotifier, ObserveID, Proposal, Registration,
     TaskRes as ApplyTaskRes,
 };
-pub use self::peer::{DestroyPeerJob, PeerFsm};
+pub use self::peer::{CollectedReady, DestroyPeerJob, PeerFsm};
 pub use self::store::{
     create_raft_batch_system, RaftBatchSystem, RaftPollerBuilder, RaftRouter, StoreInfo, StoreMeta,
 };

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -70,6 +70,23 @@ pub struct DestroyPeerJob {
     pub peer: metapb::Peer,
 }
 
+pub struct CollectedReady {
+    /// The offset of source peer in the batch system.
+    pub batch_offset: usize,
+    pub ctx: InvokeContext,
+    pub ready: Ready,
+}
+
+impl CollectedReady {
+    pub fn new(ctx: InvokeContext, ready: Ready) -> CollectedReady {
+        CollectedReady {
+            batch_offset: 0,
+            ctx,
+            ready,
+        }
+    }
+}
+
 pub struct PeerFsm<EK, ER>
 where
     EK: KvEngine,
@@ -888,9 +905,12 @@ where
         self.ctx.pending_count += 1;
         self.ctx.has_ready = true;
         let res = self.fsm.peer.handle_raft_ready_append(self.ctx);
-        if let Some(r) = res {
-            self.on_role_changed(&r.0);
-            if r.1.has_new_entries {
+        if let Some(mut r) = res {
+            // This bases on an assumption that fsm array passed in `end` method will have
+            // the same order of processing.
+            r.batch_offset = self.ctx.processed_fsm_count;
+            self.on_role_changed(&r.ready);
+            if r.ctx.has_new_entries {
                 self.register_raft_gc_log_tick();
                 self.register_split_region_check_tick();
             }
@@ -898,10 +918,20 @@ where
         }
     }
 
-    pub fn post_raft_ready_append(&mut self, ready: Ready, invoke_ctx: InvokeContext) {
+    pub fn post_raft_ready_append(&mut self, ready: CollectedReady) {
+        if ready.ctx.region_id != self.fsm.region_id() {
+            panic!(
+                "{} region id not matched: {} # {}",
+                self.fsm.peer.tag,
+                ready.ctx.region_id,
+                self.fsm.region_id()
+            );
+        }
         let is_merging = self.fsm.peer.pending_merge_state.is_some();
-        let res = self.fsm.peer.post_raft_ready_append(self.ctx, invoke_ctx);
-        self.fsm.peer.handle_raft_ready_advance(self.ctx, ready);
+        let res = self.fsm.peer.post_raft_ready_append(self.ctx, ready.ctx);
+        self.fsm
+            .peer
+            .handle_raft_ready_advance(self.ctx, ready.ready);
         if let Some(apply_res) = res {
             self.on_ready_apply_snapshot(apply_res);
             if is_merging {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2121,6 +2121,7 @@ where
         regions: Vec<metapb::Region>,
         new_split_regions: HashMap<u64, apply::NewSplitPeer>,
     ) {
+        fail_point!("on_split", self.ctx.store_id() == 3, |_| {});
         self.register_split_region_check_tick();
         let mut meta = self.ctx.store_meta.lock().unwrap();
         let region_id = derived.get_id();
@@ -2329,6 +2330,7 @@ where
                 }
             }
         }
+        fail_point!("after_split", self.ctx.store_id() == 3, |_| {});
     }
 
     fn register_merge_check_tick(&mut self) {

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -24,7 +24,7 @@ use kvproto::raft_cmdpb::{AdminCmdType, AdminRequest};
 use kvproto::raft_serverpb::{ExtraMessageType, PeerState, RaftMessage, RegionLocalState};
 use kvproto::replication_modepb::{ReplicationMode, ReplicationStatus};
 use protobuf::Message;
-use raft::{Ready, StateRole};
+use raft::StateRole;
 use time::{self, Timespec};
 
 use collections::HashMap;
@@ -53,10 +53,11 @@ use crate::store::fsm::ApplyNotifier;
 use crate::store::fsm::ApplyTaskRes;
 use crate::store::fsm::{
     create_apply_batch_system, ApplyBatchSystem, ApplyPollerBuilder, ApplyRes, ApplyRouter,
+    CollectedReady,
 };
 use crate::store::local_metrics::RaftMetrics;
 use crate::store::metrics::*;
-use crate::store::peer_storage::{self, HandleRaftReadyContext, InvokeContext};
+use crate::store::peer_storage::{self, HandleRaftReadyContext};
 use crate::store::transport::Transport;
 use crate::store::util::{is_initial_msg, PerfContextStatistics};
 use crate::store::worker::{
@@ -294,6 +295,8 @@ where
     EK: KvEngine,
     ER: RaftEngine,
 {
+    /// The count of processed normal Fsm.
+    pub processed_fsm_count: usize,
     pub cfg: Config,
     pub store: metapb::Store,
     pub pd_scheduler: FutureScheduler<PdTask<EK>>,
@@ -333,7 +336,7 @@ where
     pub pending_count: usize,
     pub sync_log: bool,
     pub has_ready: bool,
-    pub ready_res: Vec<(Ready, InvokeContext)>,
+    pub ready_res: Vec<CollectedReady>,
     pub current_time: Option<Timespec>,
     pub perf_context_statistics: PerfContextStatistics,
     pub tick_batch: Vec<PeerTickBatch>,
@@ -667,18 +670,10 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> RaftPoller<EK, ER, T> {
         );
         fail_point!("raft_after_save");
         if ready_cnt != 0 {
-            let mut batch_pos = 0;
             let mut ready_res = mem::take(&mut self.poll_ctx.ready_res);
-            for (ready, invoke_ctx) in ready_res.drain(..) {
-                let region_id = invoke_ctx.region_id;
-                if peers[batch_pos].region_id() == region_id {
-                } else {
-                    while peers[batch_pos].region_id() != region_id {
-                        batch_pos += 1;
-                    }
-                }
-                PeerFsmDelegate::new(&mut peers[batch_pos], &mut self.poll_ctx)
-                    .post_raft_ready_append(ready, invoke_ctx);
+            for ready in ready_res.drain(..) {
+                PeerFsmDelegate::new(&mut peers[ready.batch_offset], &mut self.poll_ctx)
+                    .post_raft_ready_append(ready);
             }
         }
         let dur = self.timer.elapsed();
@@ -737,6 +732,7 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
 {
     fn begin(&mut self, _batch_size: usize) {
         self.previous_metrics = self.poll_ctx.raft_metrics.clone();
+        self.poll_ctx.processed_fsm_count = 0;
         self.poll_ctx.pending_count = 0;
         self.poll_ctx.sync_log = false;
         self.poll_ctx.has_ready = false;
@@ -832,6 +828,7 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
         let mut delegate = PeerFsmDelegate::new(peer, &mut self.poll_ctx);
         delegate.handle_msgs(&mut self.peer_msg_buf);
         delegate.collect_ready();
+        self.poll_ctx.processed_fsm_count += 1;
         expected_msg_count
     }
 
@@ -1054,6 +1051,7 @@ where
 
     fn build(&mut self) -> RaftPoller<EK, ER, T> {
         let mut ctx = PollContext {
+            processed_fsm_count: 0,
             cfg: self.cfg.value().clone(),
             store: self.store.clone(),
             pd_scheduler: self.pd_scheduler.clone(),

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -37,7 +37,7 @@ use uuid::Uuid;
 use crate::coprocessor::{CoprocessorHost, RegionChangeEvent};
 use crate::store::fsm::apply::CatchUpLogs;
 use crate::store::fsm::store::PollContext;
-use crate::store::fsm::{apply, Apply, ApplyMetrics, ApplyTask, Proposal};
+use crate::store::fsm::{apply, Apply, ApplyMetrics, ApplyTask, CollectedReady, Proposal};
 use crate::store::hibernate_state::GroupState;
 use crate::store::worker::{HeartbeatTask, ReadDelegate, ReadExecutor, ReadProgress, RegionTask};
 use crate::store::{
@@ -1510,7 +1510,7 @@ where
     pub fn handle_raft_ready_append<T: Transport>(
         &mut self,
         ctx: &mut PollContext<EK, ER, T>,
-    ) -> Option<(Ready, InvokeContext)> {
+    ) -> Option<CollectedReady> {
         if self.pending_remove {
             return None;
         }
@@ -1663,7 +1663,7 @@ where
             }
         };
 
-        Some((ready, invoke_ctx))
+        Some(CollectedReady::new(invoke_ctx, ready))
     }
 
     pub fn post_raft_ready_append<T: Transport>(

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -384,7 +384,7 @@ fn test_split_not_to_split_exist_tombstone_region() {
 
 /// A filter that collects all snapshots.
 ///
-/// It's different from the one in simulate_transport in two aspects:
+/// It's different from the one in simulate_transport in three aspects:
 /// 1. It will not flush the collected snapshots.
 /// 2. It will not report error when collecting snapshots.
 /// 3. It callers can access the collected snapshots.
@@ -430,13 +430,14 @@ impl Filter for CollectSnapshotFilter {
             }
         }
         msgs.extend(to_send);
+        check_messages(msgs)?;
         Ok(())
     }
 }
 
-/// If the uninitialized peer and split peer are fetched into one batch, and the front
+/// If the uninitialized peer and split peer are fetched into one batch, and the first
 /// one doesn't generate ready, the second one does, ready should not be mapped to the
-/// front one.
+/// first one.
 #[test]
 fn test_split_duplicated_batch() {
     let mut cluster = new_node_cluster(0, 3);

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -1,6 +1,6 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 
@@ -13,6 +13,7 @@ use raftstore::store::util::is_vote_msg;
 use raftstore::Result;
 use tikv_util::HandyRwLock;
 
+use collections::HashMap;
 use test_raftstore::*;
 use tikv_util::config::{ReadableDuration, ReadableSize};
 
@@ -379,4 +380,157 @@ fn test_split_not_to_split_exist_tombstone_region() {
 
     fail::remove("on_raft_gc_log_tick");
     fail::remove(peer_check_stale_state_fp);
+}
+
+/// A filter that collects all snapshots. Once it has two snapshots, it will skip
+/// all messages except snapshot.
+pub struct CollectSnapshotFilter {
+    pending_msg: Arc<Mutex<HashMap<u64, RaftMessage>>>,
+    pending_count_sender: Mutex<mpsc::Sender<usize>>,
+}
+
+impl CollectSnapshotFilter {
+    pub fn new(sender: mpsc::Sender<usize>) -> CollectSnapshotFilter {
+        CollectSnapshotFilter {
+            pending_msg: Arc::default(),
+            pending_count_sender: Mutex::new(sender),
+        }
+    }
+}
+
+impl Filter for CollectSnapshotFilter {
+    fn before(&self, msgs: &mut Vec<RaftMessage>) -> Result<()> {
+        let mut to_send = vec![];
+        let mut pending_msg = self.pending_msg.lock().unwrap();
+        for msg in msgs.drain(..) {
+            let (is_pending, from_peer_id) = {
+                if msg.get_message().get_msg_type() == MessageType::MsgSnapshot {
+                    let from_peer_id = msg.get_from_peer().get_id();
+                    if pending_msg.contains_key(&from_peer_id) {
+                        // Drop this snapshot message directly since it's from a seen peer
+                        continue;
+                    } else {
+                        // Pile the snapshot from unseen peer
+                        (true, from_peer_id)
+                    }
+                } else {
+                    (false, 0)
+                }
+            };
+            if is_pending {
+                pending_msg.insert(from_peer_id, msg);
+                let sender = self.pending_count_sender.lock().unwrap();
+                sender.send(pending_msg.len()).unwrap();
+            } else {
+                to_send.push(msg);
+            }
+        }
+        msgs.extend(to_send);
+        Ok(())
+    }
+}
+
+/// If the uninitialized peer and split peer are fetched into one batch, and the front
+/// one doesn't generate ready, the second one does, ready should not be mapped to the
+/// front one.
+#[test]
+fn test_split_duplicated_batch() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_request_snapshot(&mut cluster);
+    // Disable raft log gc in this test case.
+    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::secs(60);
+    // Use one thread to make it more possible to be fetched into one batch.
+    cluster.cfg.raft_store.store_batch_system.pool_size = 1;
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    // Disable default max peer count check.
+    pd_client.disable_default_operator();
+
+    let r1 = cluster.run_conf_change();
+    cluster.must_put(b"k1", b"v1");
+    pd_client.must_add_peer(r1, new_peer(2, 2));
+    // Force peer 2 to be followers all the way.
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(r1, 2)
+            .msg_type(MessageType::MsgRequestVote)
+            .direction(Direction::Send),
+    ));
+    cluster.must_transfer_leader(r1, new_peer(1, 1));
+    cluster.must_put(b"k3", b"v3");
+
+    // Pile up snapshots of overlapped region ranges
+    let (tx, rx) = mpsc::channel();
+    let filter = CollectSnapshotFilter::new(tx);
+    let pending_msgs = filter.pending_msg.clone();
+    cluster.sim.wl().add_recv_filter(3, Box::new(filter));
+    pd_client.must_add_peer(r1, new_peer(3, 3));
+    let region = cluster.get_region(b"k1");
+    // Ensure the snapshot of range ("", "") is sent and piled in filter.
+    if let Err(e) = rx.recv_timeout(Duration::from_secs(1)) {
+        panic!("the snapshot is not sent before split, e: {:?}", e);
+    }
+    // Split the region range and then there should be another snapshot for the split ranges.
+    cluster.must_split(&region, b"k2");
+    // Ensure second is also sent and piled in filter.
+    if let Err(e) = rx.recv_timeout(Duration::from_secs(1)) {
+        panic!("the snapshot is not sent before split, e: {:?}", e);
+    }
+
+    let r2 = cluster.get_region(b"k0");
+    let filter_r2 = Arc::new(AtomicBool::new(true));
+    // So uninitialized peer will not generate ready for response.
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(r2.get_id(), 3)
+            .when(filter_r2.clone())
+            .direction(Direction::Recv),
+    ));
+    // So peer can catch up logs and execute split
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(r1, 3)
+            .msg_type(MessageType::MsgSnapshot)
+            .direction(Direction::Recv),
+    ));
+    cluster.sim.wl().clear_recv_filters(3);
+    // Start applying snapshot in source peer.
+    for (peer_id, msg) in pending_msgs.lock().unwrap().iter() {
+        if *peer_id < 1000 {
+            cluster.sim.wl().send_raft_msg(msg.clone()).unwrap();
+        }
+    }
+
+    let (tx1, rx1) = mpsc::sync_channel(0);
+    let (tx2, rx2) = mpsc::sync_channel(0);
+    let tx1 = Mutex::new(tx1);
+    fail::cfg_callback("on_split", move || {
+        // First is for notification, second is waiting for configuration.
+        let _ = tx1.lock().unwrap().send(());
+        let _ = tx1.lock().unwrap().send(());
+    })
+    .unwrap();
+    rx1.recv_timeout(Duration::from_secs(3)).unwrap();
+    // Notify uninitialized peer to be ready be fetched at next try.
+    for (peer_id, msg) in pending_msgs.lock().unwrap().iter() {
+        if *peer_id >= 1000 {
+            cluster.sim.wl().send_raft_msg(msg.clone()).unwrap();
+        }
+    }
+    let tx2 = Mutex::new(tx2);
+    fail::cfg_callback("after_split", move || {
+        // First is for notification, second is waiting for configuration.
+        let _ = tx2.lock().unwrap().send(());
+        let _ = tx2.lock().unwrap().send(());
+    })
+    .unwrap();
+    // Resume on_split hook.
+    rx1.recv_timeout(Duration::from_secs(3)).unwrap();
+    // Pause at the end of on_split.
+    rx2.recv_timeout(Duration::from_secs(3)).unwrap();
+    // New peer is generated, no need to filter any more.
+    filter_r2.store(false, Ordering::SeqCst);
+    // Force generating new messages so split peer will be notified and ready to
+    // be fetched at next try.
+    cluster.must_put(b"k11", b"v11");
+    // Exit on_split hook.
+    rx2.recv_timeout(Duration::from_secs(3)).unwrap();
+    must_get_equal(&cluster.get_engine(3), b"k11", b"v11");
 }

--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -382,8 +382,12 @@ fn test_split_not_to_split_exist_tombstone_region() {
     fail::remove(peer_check_stale_state_fp);
 }
 
-/// A filter that collects all snapshots. Once it has two snapshots, it will skip
-/// all messages except snapshot.
+/// A filter that collects all snapshots.
+///
+/// It's different from the one in simulate_transport in two aspects:
+/// 1. It will not flush the collected snapshots.
+/// 2. It will not report error when collecting snapshots.
+/// 3. It callers can access the collected snapshots.
 pub struct CollectSnapshotFilter {
     pending_msg: Arc<Mutex<HashMap<u64, RaftMessage>>>,
     pending_count_sender: Mutex<mpsc::Sender<usize>>,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9388 <!-- REMOVE this line if no issue to close -->

What's Changed:

This PR adds a new field batch_offset to ready collection, which
indicates the offset of origin peer in the batch.

Stores the ready inside Fsm is an alternative, but it can occupy
unnecessary memory.

Using memory address of Fsm is also an alternative, though seems a
little hacky.

Both of the alternatives require a loop, using offset only needs to
query once. It may have improvement in clusters that have a lot of
regions and ticking usually doesn't generate readiness.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- Fix wrong mapping between readies and peers by offset