### PR TITLE
pd_client: introduce async versions of methods to avoid block_on

### DIFF
--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -2,13 +2,12 @@
 
 use std::fmt;
 use std::sync::Arc;
-use std::thread;
 use std::time::{Duration, Instant};
 
 use futures::channel::mpsc;
 use futures::compat::Future01CompatExt;
 use futures::executor::block_on;
-use futures::future::{self, FutureExt};
+use futures::future::{self, BoxFuture, FutureExt, TryFutureExt};
 use futures::sink::SinkExt;
 use futures::stream::{StreamExt, TryStreamExt};
 
@@ -41,6 +40,14 @@ impl RpcClient {
         shared_env: Option<Arc<Environment>>,
         security_mgr: Arc<SecurityManager>,
     ) -> Result<RpcClient> {
+        block_on(Self::new_async(cfg, shared_env, security_mgr))
+    }
+
+    pub async fn new_async(
+        cfg: &Config,
+        shared_env: Option<Arc<Environment>>,
+        security_mgr: Arc<SecurityManager>,
+    ) -> Result<RpcClient> {
         let env = shared_env.unwrap_or_else(|| {
             Arc::new(
                 EnvBuilder::new()
@@ -56,7 +63,7 @@ impl RpcClient {
             v => v.checked_add(1).unwrap_or(std::isize::MAX),
         };
         for i in 0..retries {
-            match validate_endpoints(Arc::clone(&env), cfg, security_mgr.clone()) {
+            match validate_endpoints(Arc::clone(&env), cfg, security_mgr.clone()).await {
                 Ok((client, members)) => {
                     let rpc_client = RpcClient {
                         cluster_id: members.get_header().get_cluster_id(),
@@ -98,6 +105,7 @@ impl RpcClient {
                         }
                     };
 
+                    // FIXME: RwLock may block the async executor.
                     rpc_client
                         .leader_client
                         .inner
@@ -111,7 +119,10 @@ impl RpcClient {
                     if i as usize % cfg.retry_log_every == 0 {
                         warn!("validate PD endpoints failed"; "err" => ?e);
                     }
-                    thread::sleep(cfg.retry_interval.0);
+                    let _ = GLOBAL_TIMER_HANDLE
+                        .delay(Instant::now() + cfg.retry_interval.0)
+                        .compat()
+                        .await;
                 }
             }
         }
@@ -142,7 +153,10 @@ impl RpcClient {
     }
 
     /// Gets given key's Region and Region's leader from PD.
-    fn get_region_and_leader(&self, key: &[u8]) -> Result<(metapb::Region, Option<metapb::Peer>)> {
+    fn get_region_and_leader(
+        &self,
+        key: &[u8],
+    ) -> PdFuture<(metapb::Region, Option<metapb::Peer>)> {
         let _timer = PD_REQUEST_HISTOGRAM_VEC
             .with_label_values(&["get_region"])
             .start_coarse_timer();
@@ -151,22 +165,71 @@ impl RpcClient {
         req.set_header(self.header());
         req.set_region_key(key.to_vec());
 
-        let mut resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
-            client.get_region_opt(&req, Self::call_option())
-        })?;
-        check_resp_header(resp.get_header())?;
+        let executor = move |client: &LeaderClient, req: pdpb::GetRegionRequest| {
+            let handler = client
+                .inner
+                .rl()
+                .client_stub
+                .get_region_async_opt(&req, Self::call_option())
+                .unwrap_or_else(|e| {
+                    panic!("fail to request PD {} err {:?}", "get_region_async_opt", e)
+                });
 
-        let region = if resp.has_region() {
-            resp.take_region()
-        } else {
-            return Err(Error::RegionNotFound(key.to_owned()));
+            Box::pin(async move {
+                let mut resp = handler.await?;
+                check_resp_header(resp.get_header())?;
+                let region = if resp.has_region() {
+                    resp.take_region()
+                } else {
+                    return Err(Error::RegionNotFound(req.region_key));
+                };
+                let leader = if resp.has_leader() {
+                    Some(resp.take_leader())
+                } else {
+                    None
+                };
+                Ok((region, leader))
+            }) as PdFuture<_>
         };
-        let leader = if resp.has_leader() {
-            Some(resp.take_leader())
-        } else {
-            None
+
+        self.leader_client
+            .request(req, executor, LEADER_CHANGE_RETRY)
+            .execute()
+    }
+
+    fn get_store_and_stats(&self, store_id: u64) -> PdFuture<(metapb::Store, pdpb::StoreStats)> {
+        let timer = Instant::now();
+
+        let mut req = pdpb::GetStoreRequest::default();
+        req.set_header(self.header());
+        req.set_store_id(store_id);
+
+        let executor = move |client: &LeaderClient, req: pdpb::GetStoreRequest| {
+            let handler = client
+                .inner
+                .rl()
+                .client_stub
+                .get_store_async_opt(&req, Self::call_option())
+                .unwrap_or_else(|e| panic!("fail to request PD {} err {:?}", "get_store_async", e));
+
+            Box::pin(async move {
+                let mut resp = handler.await?;
+                PD_REQUEST_HISTOGRAM_VEC
+                    .with_label_values(&["get_store_async"])
+                    .observe(duration_to_sec(timer.elapsed()));
+                check_resp_header(resp.get_header())?;
+                let store = resp.take_store();
+                if store.get_state() != metapb::StoreState::Tombstone {
+                    Ok((store, resp.take_stats()))
+                } else {
+                    Err(Error::StoreTombstone(format!("{:?}", store)))
+                }
+            }) as PdFuture<_>
         };
-        Ok((region, leader))
+
+        self.leader_client
+            .request(req, executor, LEADER_CHANGE_RETRY)
+            .execute()
     }
 }
 
@@ -279,38 +342,7 @@ impl PdClient for RpcClient {
     }
 
     fn get_store_async(&self, store_id: u64) -> PdFuture<metapb::Store> {
-        let timer = Instant::now();
-
-        let mut req = pdpb::GetStoreRequest::default();
-        req.set_header(self.header());
-        req.set_store_id(store_id);
-
-        let executor = move |client: &LeaderClient, req: pdpb::GetStoreRequest| {
-            let handler = client
-                .inner
-                .rl()
-                .client_stub
-                .get_store_async_opt(&req, Self::call_option())
-                .unwrap_or_else(|e| panic!("fail to request PD {} err {:?}", "get_store_async", e));
-
-            Box::pin(async move {
-                let mut resp = handler.await?;
-                PD_REQUEST_HISTOGRAM_VEC
-                    .with_label_values(&["get_store_async"])
-                    .observe(duration_to_sec(timer.elapsed()));
-                check_resp_header(resp.get_header())?;
-                let store = resp.take_store();
-                if store.get_state() != metapb::StoreState::Tombstone {
-                    Ok(store)
-                } else {
-                    Err(Error::StoreTombstone(format!("{:?}", store)))
-                }
-            }) as PdFuture<_>
-        };
-
-        self.leader_client
-            .request(req, executor, LEADER_CHANGE_RETRY)
-            .execute()
+        self.get_store_and_stats(store_id).map_ok(|x| x.0).boxed()
     }
 
     fn get_all_stores(&self, exclude_tombstone: bool) -> Result<Vec<metapb::Store>> {
@@ -347,12 +379,21 @@ impl PdClient for RpcClient {
     }
 
     fn get_region(&self, key: &[u8]) -> Result<metapb::Region> {
-        self.get_region_and_leader(key).map(|x| x.0)
+        block_on(self.get_region_and_leader(key)).map(|x| x.0)
     }
 
     fn get_region_info(&self, key: &[u8]) -> Result<RegionInfo> {
+        block_on(self.get_region_and_leader(key)).map(|x| RegionInfo::new(x.0, x.1))
+    }
+
+    fn get_region_async<'k>(&'k self, key: &'k [u8]) -> BoxFuture<'k, Result<metapb::Region>> {
+        self.get_region_and_leader(key).map_ok(|x| x.0).boxed()
+    }
+
+    fn get_region_info_async<'k>(&'k self, key: &'k [u8]) -> BoxFuture<'k, Result<RegionInfo>> {
         self.get_region_and_leader(key)
-            .map(|x| RegionInfo::new(x.0, x.1))
+            .map_ok(|x| RegionInfo::new(x.0, x.1))
+            .boxed()
     }
 
     fn get_region_by_id(&self, region_id: u64) -> PdFuture<Option<metapb::Region>> {
@@ -696,26 +737,8 @@ impl PdClient for RpcClient {
             .execute()
     }
 
-    fn get_store_stats(&self, store_id: u64) -> Result<pdpb::StoreStats> {
-        let _timer = PD_REQUEST_HISTOGRAM_VEC
-            .with_label_values(&["get_store"])
-            .start_coarse_timer();
-
-        let mut req = pdpb::GetStoreRequest::default();
-        req.set_header(self.header());
-        req.set_store_id(store_id);
-
-        let mut resp = sync_request(&self.leader_client, LEADER_CHANGE_RETRY, |client| {
-            client.get_store_opt(&req, Self::call_option())
-        })?;
-        check_resp_header(resp.get_header())?;
-
-        let store = resp.get_store();
-        if store.get_state() != metapb::StoreState::Tombstone {
-            Ok(resp.take_stats())
-        } else {
-            Err(Error::StoreTombstone(format!("{:?}", store)))
-        }
+    fn get_store_stats_async(&self, store_id: u64) -> BoxFuture<'_, Result<pdpb::StoreStats>> {
+        self.get_store_and_stats(store_id).map_ok(|x| x.1).boxed()
     }
 
     fn get_operator(&self, region_id: u64) -> Result<pdpb::GetOperatorResponse> {

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -160,8 +160,18 @@ pub trait PdClient: Send + Sync {
         unimplemented!();
     }
 
+    /// Gets Region which the key belongs to asynchronously.
+    fn get_region_async<'k>(&'k self, _key: &'k [u8]) -> BoxFuture<'k, Result<metapb::Region>> {
+        unimplemented!();
+    }
+
     /// Gets Region info which the key belongs to.
     fn get_region_info(&self, _key: &[u8]) -> Result<RegionInfo> {
+        unimplemented!();
+    }
+
+    /// Gets Region info which the key belongs to asynchronously.
+    fn get_region_info_async<'k>(&'k self, _key: &'k [u8]) -> BoxFuture<'k, Result<RegionInfo>> {
         unimplemented!();
     }
 
@@ -243,8 +253,8 @@ pub trait PdClient: Send + Sync {
         unimplemented!();
     }
 
-    /// Gets store state if it is not a tombstone store.
-    fn get_store_stats(&self, _store_id: u64) -> Result<pdpb::StoreStats> {
+    /// Gets store state if it is not a tombstone store asynchronously.
+    fn get_store_stats_async(&self, _store_id: u64) -> BoxFuture<'_, Result<pdpb::StoreStats>> {
         unimplemented!();
     }
 

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -10,7 +10,7 @@ use std::{cmp, thread};
 use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use futures::compat::Future01CompatExt;
 use futures::executor::block_on;
-use futures::future::{err, ok, FutureExt};
+use futures::future::{err, ok, ready, BoxFuture, FutureExt};
 use futures::{stream, stream::StreamExt};
 use tokio_timer::timer::Handle;
 
@@ -1495,13 +1495,14 @@ impl PdClient for TestPdClient {
         Box::pin(ok(safe_point))
     }
 
-    fn get_store_stats(&self, store_id: u64) -> Result<pdpb::StoreStats> {
+    fn get_store_stats_async(&self, store_id: u64) -> BoxFuture<'_, Result<pdpb::StoreStats>> {
         let cluster = self.cluster.rl();
         let stats = cluster.store_stats.get(&store_id);
-        match stats {
+        ready(match stats {
             Some(s) => Ok(s.clone()),
             None => Err(Error::StoreTombstone(format!("store_id:{}", store_id))),
-        }
+        })
+        .boxed()
     }
 
     fn get_operator(&self, region_id: u64) -> Result<pdpb::GetOperatorResponse> {

--- a/tests/failpoints/cases/test_pd_client.rs
+++ b/tests/failpoints/cases/test_pd_client.rs
@@ -56,6 +56,8 @@ fn test_pd_client_deadlock() {
         request!(client => get_cluster_config()),
         request!(client => get_region(b"")),
         request!(client => get_region_info(b"")),
+        request!(client => block_on(get_region_async(b""))),
+        request!(client => block_on(get_region_info_async(b""))),
         request!(client => block_on(get_region_by_id(0))),
         request!(client => block_on(region_heartbeat(0, Region::default(), Peer::default(), RegionStat::default(), None))),
         request!(client => block_on(ask_split(Region::default()))),
@@ -64,7 +66,7 @@ fn test_pd_client_deadlock() {
         request!(client => block_on(report_batch_split(vec![]))),
         request!(client => scatter_region(RegionInfo::new(Region::default(), None))),
         request!(client => block_on(get_gc_safe_point())),
-        request!(client => get_store_stats(0)),
+        request!(client => block_on(get_store_stats_async(0))),
         request!(client => get_operator(0)),
         request!(client => block_on(get_tso())),
     ];

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -215,7 +215,7 @@ fn test_validate_endpoints() {
     let eps = server.bind_addrs();
 
     let mgr = Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap());
-    assert!(validate_endpoints(env, &new_config(eps), mgr).is_err());
+    assert!(block_on(validate_endpoints(env, &new_config(eps), mgr)).is_err());
 }
 
 fn test_retry<F: Fn(&RpcClient)>(func: F) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:

Prerequisite of tikv/importer#89. TiKV Importer relies on TiKV as a library, and uses various pd_client methods when processing the gRPC call. However, many pd_client methods are made synchronous using `block_on`. Since gRPC calls are async, this leads to [`EnterError`](https://docs.rs/futures-executor/0.3.8/futures_executor/struct.EnterError.html) panic due to recursive use of executors.

### What is changed and how it works?

Added async methods for the following to avoid `block_on`:

* RpcClient::new_async
* PdClient::get_region_async
* PdClient::get_region_info_async
* PdClient::get_store_stats_async (the sync version is removed since it is not used anywhere else)

What's Changed:

### Related changes

- Need to cherry-pick to the release branch (release-5.0-rc)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

No release note