### PR TITLE
ci: stabilize several test cases about merge

### DIFF
--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -554,17 +554,31 @@ fn prepare_request_snapshot_cluster() -> (Cluster<NodeCluster>, Region, Region) 
 fn test_node_merge_reject_request_snapshot() {
     let (mut cluster, region, target_region) = prepare_request_snapshot_cluster();
 
+    let k = b"k3_for_apply_to_current_term";
+    cluster.must_put(k, b"value");
+    must_get_equal(&cluster.get_engine(1), k, b"value");
+
     let apply_prepare_merge_fp = "apply_before_prepare_merge";
     fail::cfg(apply_prepare_merge_fp, "pause").unwrap();
     let prepare_merge = new_prepare_merge(target_region);
     let mut req = new_admin_request(region.get_id(), region.get_region_epoch(), prepare_merge);
     req.mut_header().set_peer(new_peer(1, 1));
+    let (tx, rx) = mpsc::sync_channel(1);
     cluster
         .sim
         .rl()
-        .async_command_on_node(1, req, Callback::None)
+        .async_command_on_node(
+            1,
+            req,
+            Callback::Write {
+                cb: Box::new(|_: WriteResponse| {}),
+                proposed_cb: None,
+                committed_cb: Some(Box::new(move || tx.send(()).unwrap())),
+            },
+        )
         .unwrap();
-    sleep_ms(200);
+    // Proposing merge shouldn't fail.
+    assert!(rx.recv_timeout(Duration::from_millis(1000)).is_ok());
 
     // Install snapshot filter before requesting snapshot.
     let (tx, rx) = mpsc::channel();
@@ -805,7 +819,15 @@ fn test_node_merge_transfer_leader() {
 
     cluster.run();
 
+    // To ensure the region has applied to its current term, to ensure later `split` can success
+    // without any retries, so that `left_peer_3` will must be `1003`.
     let region = pd_client.get_region(b"k1").unwrap();
+    let peer_1 = find_peer(&region, 1).unwrap().to_owned();
+    cluster.must_transfer_leader(region.get_id(), peer_1);
+    let k = b"k3_for_apply_to_current_term";
+    cluster.must_put(k, b"value");
+    must_get_equal(&cluster.get_engine(1), k, b"value");
+
     cluster.must_split(&region, b"k2");
 
     cluster.must_put(b"k1", b"v1");
@@ -817,13 +839,14 @@ fn test_node_merge_transfer_leader() {
     let left_peer_1 = find_peer(&left, 1).unwrap().to_owned();
     cluster.must_transfer_leader(left.get_id(), left_peer_1.clone());
 
+    let left_peer_3 = find_peer(&left, 3).unwrap().to_owned();
+    assert_eq!(left_peer_3.get_id(), 1003);
+
     let schedule_merge_fp = "on_schedule_merge";
     fail::cfg(schedule_merge_fp, "return()").unwrap();
 
     cluster.must_try_merge(left.get_id(), right.get_id());
 
-    let left_peer_3 = find_peer(&left, 3).unwrap().to_owned();
-    assert_eq!(left_peer_3.get_id(), 1003);
     // Prevent peer 1003 to handle ready when it's leader
     let before_handle_raft_ready_1003 = "before_handle_raft_ready_1003";
     fail::cfg(before_handle_raft_ready_1003, "pause").unwrap();

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -819,8 +819,8 @@ fn test_node_merge_transfer_leader() {
 
     cluster.run();
 
-    // To ensure the region has applied to its current term, to ensure later `split` can success
-    // without any retries, so that `left_peer_3` will must be `1003`.
+    // To ensure the region has applied to its current term so that later `split` can success
+    // without any retries. Then, `left_peer_3` will must be `1003`.
     let region = pd_client.get_region(b"k1").unwrap();
     let peer_1 = find_peer(&region, 1).unwrap().to_owned();
     cluster.must_transfer_leader(region.get_id(), peer_1);

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -574,8 +574,8 @@ fn test_node_merge_reject_request_snapshot() {
             req,
             Callback::Write {
                 cb: Box::new(|_: WriteResponse| {}),
-                proposed_cb: None,
-                committed_cb: Some(Box::new(move || tx.send(()).unwrap())),
+                proposed_cb: Some(Box::new(move || tx.send(()).unwrap())),
+                committed_cb: None,
             },
         )
         .unwrap();

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -556,7 +556,9 @@ fn test_node_merge_reject_request_snapshot() {
 
     let k = b"k3_for_apply_to_current_term";
     cluster.must_put(k, b"value");
-    must_get_equal(&cluster.get_engine(1), k, b"value");
+    for i in 1..=3 {
+        must_get_equal(&cluster.get_engine(i), k, b"value");
+    }
 
     let apply_prepare_merge_fp = "apply_before_prepare_merge";
     fail::cfg(apply_prepare_merge_fp, "pause").unwrap();
@@ -578,7 +580,7 @@ fn test_node_merge_reject_request_snapshot() {
         )
         .unwrap();
     // Proposing merge shouldn't fail.
-    assert!(rx.recv_timeout(Duration::from_millis(1000)).is_ok());
+    assert!(rx.recv_timeout(Duration::from_millis(200)).is_ok());
 
     // Install snapshot filter before requesting snapshot.
     let (tx, rx) = mpsc::channel();
@@ -824,7 +826,7 @@ fn test_node_merge_transfer_leader() {
     let region = pd_client.get_region(b"k1").unwrap();
     let peer_1 = find_peer(&region, 1).unwrap().to_owned();
     cluster.must_transfer_leader(region.get_id(), peer_1);
-    let k = b"k3_for_apply_to_current_term";
+    let k = b"k1_for_apply_to_current_term";
     cluster.must_put(k, b"value");
     must_get_equal(&cluster.get_engine(1), k, b"value");
 

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -863,9 +863,11 @@ fn test_request_snapshot_after_propose_merge() {
         .filter(|p| p.id != leader.id)
         .collect();
 
-    let k = b"k3_for_apply_to_current_term";
+    let k = b"k1_for_apply_to_current_term";
     cluster.must_put(k, b"value");
-    must_get_equal(&cluster.get_engine(leader.store_id), k, b"value");
+    for i in 1..=3 {
+        must_get_equal(&cluster.get_engine(i), k, b"value");
+    }
 
     // Drop append messages, so prepare merge can not be committed.
     cluster.add_send_filter(CloneFilterFactory(DropMessageFilter::new(

--- a/tests/integrations/raftstore/test_merge.rs
+++ b/tests/integrations/raftstore/test_merge.rs
@@ -863,6 +863,10 @@ fn test_request_snapshot_after_propose_merge() {
         .filter(|p| p.id != leader.id)
         .collect();
 
+    let k = b"k3_for_apply_to_current_term";
+    cluster.must_put(k, b"value");
+    must_get_equal(&cluster.get_engine(leader.store_id), k, b"value");
+
     // Drop append messages, so prepare merge can not be committed.
     cluster.add_send_filter(CloneFilterFactory(DropMessageFilter::new(
         MessageType::MsgAppend,


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?
Some test cases about merge are not stable:
* test_node_merge_transfer_leader
* test_node_merge_reject_request_snapshot
* test_request_snapshot_after_propose_merge

Old failures:
* https://internal.pingcap.net/idc-jenkins/blue/rest/organizations/jenkins/pipelines/tikv_ghpr_test/runs/39263/nodes/98/steps/589/log/?start=0
* https://internal.pingcap.net/idc-jenkins/blue/rest/organizations/jenkins/pipelines/tikv_ghpr_test/runs/39287/nodes/203/steps/615/log/?start=0
* https://internal.pingcap.net/idc-jenkins/blue/rest/organizations/jenkins/pipelines/tikv_ghpr_test/runs/39091/nodes/120/steps/924/log/?start=0

### What is changed and how it works?
These cases fail because `merge` or `split` commands are rejected for "not applied to current term".
So this PR add some code to ensure it.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.