### PR TITLE
ci: allow to not truncate log file

### DIFF
--- a/components/test_util/src/logging.rs
+++ b/components/test_util/src/logging.rs
@@ -1,6 +1,6 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io::prelude::*;
 use std::sync::{Mutex, Once};
 use std::{env, fmt, io};
@@ -100,7 +100,19 @@ pub fn init_log_for_test() {
             &env::var("LOG_LEVEL").unwrap_or_else(|_| "debug".to_owned()),
         )
         .unwrap();
-        let writer = output.map(|f| Mutex::new(File::create(f).unwrap()));
+        let writer = if env::var("LOG_APPEND").is_ok() {
+            output.map(|f| {
+                Mutex::new(
+                    OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(f)
+                        .unwrap(),
+                )
+            })
+        } else {
+            output.map(|f| Mutex::new(File::create(f).unwrap()))
+        };
         // We don't mind set it multiple times.
         // We hardly ever read rocksdb log in tests.
         let drainer = CaseTraceLogger {

--- a/components/test_util/src/logging.rs
+++ b/components/test_util/src/logging.rs
@@ -105,6 +105,7 @@ pub fn init_log_for_test() {
             Mutex::new(
                 OpenOptions::new()
                     .create(true)
+                    .write(!append_instead_truncate)
                     .truncate(!append_instead_truncate)
                     .append(append_instead_truncate)
                     .open(f)


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

When running one test case, for example:
```bash
cargo test --all test_node_merge_transfer_leader
```
Both `integrations-*` and `failpoints-` will be runned, which will open and truncate the target log file twice.

### What is changed and how it works?

Add a new environment variable `LOG_APPEND`.
Setting it to any value will use append instead of truncate when opening log file.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.