### PR TITLE
encryption: support multiple cloud providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,7 @@ dependencies = [
  "prometheus",
  "rand",
  "rusoto_core",
+ "rusoto_credential",
  "rusoto_mock",
  "rusoto_s3",
  "rusoto_util",

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -381,7 +381,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             &self.config.security.encryption,
             &self.config.storage.data_dir,
         )
-        .unwrap()
+        .expect("Encryption failed to initialize")
         .map(Arc::new);
     }
 

--- a/components/encryption/examples/ecli.rs
+++ b/components/encryption/examples/ecli.rs
@@ -69,17 +69,9 @@ fn create_kms_backend(cmd: &KmsCommand, credential_file: Option<&String>) -> Res
     if let Some(credential_file) = credential_file {
         let ini = Ini::load_from_file(credential_file)
             .map_err(|e| Error::Other(box_err!("Failed to parse credential file as ini: {}", e)))?;
-        let props = ini
+        let _props = ini
             .section(Some("default"))
             .ok_or_else(|| Error::Other(box_err!("fail to parse section")))?;
-        config.access_key = props
-            .get("aws_access_key_id")
-            .ok_or_else(|| Error::Other(box_err!("fail to parse credential")))?
-            .clone();
-        config.secret_access_key = props
-            .get("aws_secret_access_key")
-            .ok_or_else(|| Error::Other(box_err!("fail to parse credential")))?
-            .clone();
     }
     if let Some(ref region) = cmd.region {
         config.region = region.to_string();

--- a/components/encryption/src/config.rs
+++ b/components/encryption/src/config.rs
@@ -49,21 +49,6 @@ pub struct FileConfig {
 #[serde(rename_all = "kebab-case")]
 pub struct KmsConfig {
     pub key_id: String,
-
-    // It is preferable to use the cloud provider SDK to automatically rotate credentials
-    // Using access_key and secret_access_key creates a security risk.
-    // These fields are required by the macro new_client! that is currently in use
-    #[doc(hidden)]
-    // We don't want to write access_key and secret_access_key to config file
-    // accidentally.
-    #[serde(skip_serializing)]
-    #[config(skip)]
-    pub access_key: String,
-    #[doc(hidden)]
-    #[serde(skip_serializing)]
-    #[config(skip)]
-    pub secret_access_key: String,
-
     pub region: String,
     pub endpoint: String,
 }
@@ -167,8 +152,6 @@ mod tests {
             master_key: MasterKeyConfig::Kms {
                 config: KmsConfig {
                     key_id: "key_id".to_owned(),
-                    access_key: "access_key".to_owned(),
-                    secret_access_key: "secret_access_key".to_owned(),
                     region: "region".to_owned(),
                     endpoint: "endpoint".to_owned(),
                 },
@@ -187,8 +170,6 @@ mod tests {
         [master-key]
         type = "kms"
         key-id = "key_id"
-        access-key = "access_key"
-        secret-access-key = "secret_access_key"
         region = "region"
         endpoint = "endpoint"
         "#;

--- a/components/encryption/src/config.rs
+++ b/components/encryption/src/config.rs
@@ -3,11 +3,6 @@
 use kvproto::encryptionpb::EncryptionMethod;
 use tikv_util::config::ReadableDuration;
 
-#[cfg(test)]
-use crate::master_key::Backend;
-#[cfg(test)]
-use std::sync::Arc;
-
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Configuration)]
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
@@ -55,10 +50,11 @@ pub struct FileConfig {
 pub struct KmsConfig {
     pub key_id: String,
 
-    // Providing access_key and secret_access_key is recommended as it has
-    // security risk.
+    // It is preferable to use the cloud provider SDK to automatically rotate credentials
+    // Using access_key and secret_access_key creates a security risk.
+    // These fields are required by the macro new_client! that is currently in use
     #[doc(hidden)]
-    // We don's want to write access_key and secret_access_key to config file
+    // We don't want to write access_key and secret_access_key to config file
     // accidentally.
     #[serde(skip_serializing)]
     #[config(skip)]
@@ -71,18 +67,6 @@ pub struct KmsConfig {
     pub region: String,
     pub endpoint: String,
 }
-
-#[cfg(test)]
-#[derive(Clone, Debug)]
-pub struct Mock(pub Arc<dyn Backend>);
-#[cfg(test)]
-impl PartialEq for Mock {
-    fn eq(&self, _: &Self) -> bool {
-        false
-    }
-}
-#[cfg(test)]
-impl Eq for Mock {}
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", tag = "type")]
@@ -104,10 +88,6 @@ pub enum MasterKeyConfig {
         #[serde(flatten)]
         config: KmsConfig,
     },
-
-    #[cfg(test)]
-    #[serde(skip)]
-    Mock(Mock),
 }
 
 impl Default for MasterKeyConfig {

--- a/components/encryption/src/crypter.rs
+++ b/components/encryption/src/crypter.rs
@@ -141,14 +141,14 @@ impl AesGcmTag {
 /// An Aes256-GCM crypter.
 pub struct AesGcmCrypter<'k> {
     iv: Iv,
-    key: &'k [u8],
+    key: &'k PlainKey,
 }
 
 impl<'k> AesGcmCrypter<'k> {
     /// The key length of `AesGcmCrypter` is 32 bytes.
     pub const KEY_LEN: usize = 32;
 
-    pub fn new(key: &'k [u8], iv: Iv) -> AesGcmCrypter<'k> {
+    pub fn new(key: &'k PlainKey, iv: Iv) -> AesGcmCrypter<'k> {
         AesGcmCrypter { iv, key }
     }
 
@@ -157,7 +157,7 @@ impl<'k> AesGcmCrypter<'k> {
         let mut tag = AesGcmTag([0u8; GCM_TAG_LEN]);
         let ciphertext = symm::encrypt_aead(
             cipher,
-            self.key,
+            &self.key.0,
             Some(self.iv.as_slice()),
             &[], /* AAD */
             &pt,
@@ -170,7 +170,7 @@ impl<'k> AesGcmCrypter<'k> {
         let cipher = OCipher::aes_256_gcm();
         let plaintext = symm::decrypt_aead(
             cipher,
-            self.key,
+            &self.key.0,
             Some(self.iv.as_slice()),
             &[], /* AAD */
             &ct,
@@ -195,6 +195,46 @@ pub fn verify_encryption_config(method: EncryptionMethod, key: &[u8]) -> Result<
         }
     }
     Ok(())
+}
+
+// PlainKey is a newtype used to mark a vector a plaintext key.
+// It requires the vec to be a valid AesGcmCrypter key.
+pub struct PlainKey(Vec<u8>);
+
+impl PlainKey {
+    pub fn new(key: Vec<u8>) -> Result<Self> {
+        if key.len() != AesGcmCrypter::KEY_LEN {
+            return Err(box_err!(
+                "encryption method and key length mismatch, expect {} get {}",
+                AesGcmCrypter::KEY_LEN,
+                key.len()
+            ));
+        }
+        Ok(Self(key))
+    }
+}
+
+impl std::ops::Deref for PlainKey {
+    type Target = Vec<u8>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// Don't expose the key in a debug print
+impl std::fmt::Debug for PlainKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("PlainKey")
+            .field(&"REDACTED".to_string())
+            .finish()
+    }
+}
+
+// Don't expose the key in a display print
+impl std::fmt::Display for PlainKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 #[cfg(test)]
@@ -248,7 +288,7 @@ mod tests {
 
         let pt = Vec::from_hex(pt).unwrap();
         let ct = Vec::from_hex(ct).unwrap();
-        let key = Vec::from_hex(key).unwrap();
+        let key = PlainKey::new(Vec::from_hex(key).unwrap()).unwrap();
         let iv = Iv::from_slice(Vec::from_hex(iv).unwrap().as_slice()).unwrap();
         let tag = Vec::from_hex(tag).unwrap();
 

--- a/components/encryption/src/encrypted_file/mod.rs
+++ b/components/encryption/src/encrypted_file/mod.rs
@@ -70,7 +70,7 @@ impl<'a> EncryptedFile<'a> {
             .create(true)
             .write(true)
             .open(&tmp_path)
-            .unwrap();
+            .unwrap_or_else(|_| panic!("EncryptedFile::write {}", &tmp_path.to_str().unwrap()));
 
         // Encrypt the content.
         let encrypted_content = master_key

--- a/components/encryption/src/lib.rs
+++ b/components/encryption/src/lib.rs
@@ -29,5 +29,5 @@ pub use self::crypter::{
 pub use self::encrypted_file::EncryptedFile;
 pub use self::errors::{Error, Result};
 pub use self::io::{create_aes_ctr_crypter, DecrypterReader, EncrypterReader, EncrypterWriter};
-pub use self::manager::DataKeyManager;
-pub use self::master_key::{Backend, FileBackend, KmsBackend};
+pub use self::manager::{DataKeyManager, DataKeyManagerArgs};
+pub use self::master_key::{create_backend, AwsKms, Backend, FileBackend, KmsBackend};

--- a/components/encryption/src/manager/mod.rs
+++ b/components/encryption/src/manager/mod.rs
@@ -12,7 +12,10 @@ use engine_traits::{EncryptionKeyManager, FileEncryptionInfo};
 use kvproto::encryptionpb::{DataKey, EncryptionMethod, FileDictionary, FileInfo, KeyDictionary};
 use protobuf::Message;
 
-use crate::config::{EncryptionConfig, MasterKeyConfig};
+use crate::config::EncryptionConfig;
+#[cfg(test)]
+use crate::config::MasterKeyConfig;
+
 use crate::crypter::{self, compat, Iv};
 use crate::encrypted_file::EncryptedFile;
 use crate::file_dict_file::FileDictionaryFile;
@@ -169,18 +172,9 @@ impl Dicts {
         )
     }
 
-    fn get_file(&self, fname: &str) -> FileInfo {
+    fn get_file(&self, fname: &str) -> Option<FileInfo> {
         let dict = self.file_dict.lock().unwrap();
-        let file_info = dict.files.get(fname);
-        match file_info {
-            None => {
-                // Return Plaintext if file not found
-                let mut file = FileInfo::default();
-                file.method = compat(EncryptionMethod::Plaintext);
-                file
-            }
-            Some(info) => info.clone(),
-        }
+        dict.files.get(fname).cloned()
     }
 
     fn new_file(&self, fname: &str, method: EncryptionMethod) -> Result<FileInfo> {
@@ -210,6 +204,8 @@ impl Dicts {
         Ok(file)
     }
 
+    // If the file does not exist, return Ok(())
+    // In either case the intent that the file not exist is achieved.
     fn delete_file(&self, fname: &str) -> Result<()> {
         let mut file_dict_file = self.file_dict_file.lock().unwrap();
         let (file, file_num) = {
@@ -238,7 +234,7 @@ impl Dicts {
         Ok(())
     }
 
-    fn link_file(&self, src_fname: &str, dst_fname: &str) -> Result<()> {
+    fn link_file(&self, src_fname: &str, dst_fname: &str) -> Result<Option<()>> {
         let mut file_dict_file = self.file_dict_file.lock().unwrap();
         let (method, file, file_num) = {
             let mut file_dict = self.file_dict.lock().unwrap();
@@ -247,7 +243,7 @@ impl Dicts {
                 None => {
                     // Could be a plaintext file not tracked by file dictionary.
                     info!("link untracked plaintext file"; "src" => src_fname, "dst" => dst_fname);
-                    return Ok(());
+                    return Ok(None);
                 }
             };
             // When an encrypted file exists in the file system, the file_dict must have info about
@@ -267,7 +263,7 @@ impl Dicts {
         } else {
             info!("link plaintext file"; "src" => src_fname, "dst" => dst_fname);
         }
-        Ok(())
+        Ok(Some(()))
     }
 
     fn rotate_key(&self, key_id: u64, key: DataKey, master_key: &dyn Backend) -> Result<()> {
@@ -355,7 +351,7 @@ fn check_stale_file_exist(
 fn run_background_rotate_work(
     dict: Arc<Dicts>,
     method: EncryptionMethod,
-    master_key: Arc<dyn Backend>,
+    master_key: &dyn Backend,
     terminal_recv: channel::Receiver<()>,
 ) {
     let check_period = std::cmp::min(
@@ -367,7 +363,7 @@ fn run_background_rotate_work(
         select! {
             recv(tick(check_period)) -> _ => {
                 info!("Try to rotate data key, current method:{:?}", method);
-                dict.maybe_rotate_data_key(method, master_key.as_ref())
+                dict.maybe_rotate_data_key(method, master_key)
                     .expect("Rotating key operation encountered error in the background worker");
             },
             recv(terminal_recv) -> _ => {
@@ -395,128 +391,169 @@ pub struct DataKeyManager {
     background_worker: Option<JoinHandle<()>>,
 }
 
+#[derive(Debug)]
+pub struct DataKeyManagerArgs {
+    pub method: EncryptionMethod,
+    pub rotation_period: Duration,
+    pub enable_file_dictionary_log: bool,
+    pub file_dictionary_rewrite_threshold: u64,
+    pub dict_path: String,
+}
+
+#[allow(clippy::large_enum_variant)]
+enum LoadDicts {
+    EncryptionDisabled,
+    WrongMasterKey(Box<dyn std::error::Error + Send + Sync + 'static>),
+    Loaded(Dicts),
+}
+
 impl DataKeyManager {
+    pub fn new(
+        master_key: Box<dyn Backend>,
+        previous_master_key: &dyn Backend,
+        args: DataKeyManagerArgs,
+    ) -> Result<Option<DataKeyManager>> {
+        let dicts = match Self::load_dicts(&*master_key, &args)? {
+            LoadDicts::Loaded(dicts) => dicts,
+            LoadDicts::EncryptionDisabled => return Ok(None),
+            LoadDicts::WrongMasterKey(err) => {
+                Self::load_previous_dicts(&*master_key, &*previous_master_key, &args, err)?
+            }
+        };
+        Ok(Some(Self::from_dicts(dicts, args.method, master_key)?))
+    }
+
     pub fn from_config(
         config: &EncryptionConfig,
         dict_path: &str,
     ) -> Result<Option<DataKeyManager>> {
-        Self::new(
-            &config.master_key,
-            &config.previous_master_key,
-            config.data_encryption_method,
-            config.data_key_rotation_period.into(),
-            config.enable_file_dictionary_log,
-            config.file_dictionary_rewrite_threshold,
-            dict_path,
-        )
-    }
-
-    pub fn new(
-        master_key_config: &MasterKeyConfig,
-        previous_master_key_config: &MasterKeyConfig,
-        method: EncryptionMethod,
-        rotation_period: Duration,
-        enable_file_dictionary_log: bool,
-        file_dictionary_rewrite_threshold: u64,
-        dict_path: &str,
-    ) -> Result<Option<DataKeyManager>> {
-        let master_key = create_backend(master_key_config).map_err(|e| {
+        let master_key = create_backend(&config.master_key).map_err(|e| {
             error!("failed to access master key, {}", e);
             e
         })?;
-        if method != EncryptionMethod::Plaintext && !master_key.is_secure() {
+        let args = DataKeyManagerArgs {
+            dict_path: dict_path.to_string(),
+            method: config.data_encryption_method,
+            rotation_period: config.data_key_rotation_period.into(),
+            enable_file_dictionary_log: config.enable_file_dictionary_log,
+            file_dictionary_rewrite_threshold: config.file_dictionary_rewrite_threshold,
+        };
+        let dicts = match Self::load_dicts(&*master_key, &args)? {
+            LoadDicts::Loaded(dicts) => dicts,
+            LoadDicts::EncryptionDisabled => return Ok(None),
+            LoadDicts::WrongMasterKey(err) => {
+                let previous_master_key = create_backend(&config.previous_master_key)?;
+                Self::load_previous_dicts(&*master_key, &*previous_master_key, &args, err)?
+            }
+        };
+        Ok(Some(Self::from_dicts(dicts, args.method, master_key)?))
+    }
+
+    fn load_dicts(master_key: &dyn Backend, args: &DataKeyManagerArgs) -> Result<LoadDicts> {
+        if args.method != EncryptionMethod::Plaintext && !master_key.is_secure() {
             return Err(box_err!(
                 "encryption is to enable but master key is either absent or insecure."
             ));
         }
-        let dicts = match (
+        match (
             Dicts::open(
-                dict_path,
-                rotation_period,
-                master_key.as_ref(),
-                enable_file_dictionary_log,
-                file_dictionary_rewrite_threshold,
+                &args.dict_path,
+                args.rotation_period,
+                &*master_key,
+                args.enable_file_dictionary_log,
+                args.file_dictionary_rewrite_threshold,
             ),
-            method,
+            args.method,
         ) {
             // Encryption is disabled.
             (Ok(None), EncryptionMethod::Plaintext) => {
                 info!("encryption is disabled.");
-                return Ok(None);
+                Ok(LoadDicts::EncryptionDisabled)
             }
             // Encryption is being enabled.
             (Ok(None), _) => {
-                info!("encryption is being enabled. method = {:?}", method);
-                Dicts::new(
-                    dict_path,
-                    rotation_period,
-                    enable_file_dictionary_log,
-                    file_dictionary_rewrite_threshold,
-                )?
+                info!("encryption is being enabled. method = {:?}", args.method);
+                Ok(LoadDicts::Loaded(Dicts::new(
+                    &args.dict_path,
+                    args.rotation_period,
+                    args.enable_file_dictionary_log,
+                    args.file_dictionary_rewrite_threshold,
+                )?))
             }
             // Encryption was enabled and master key didn't change.
             (Ok(Some(dicts)), _) => {
-                info!("encryption is enabled. method = {:?}", method);
-                dicts
+                info!("encryption is enabled. method = {:?}", args.method);
+                Ok(LoadDicts::Loaded(dicts))
             }
             // Failed to decrypt the dictionaries using master key. Could be master key being
             // rotated. Try the previous master key.
-            (Err(Error::WrongMasterKey(e_current)), _) => {
-                warn!(
-                    "failed to open encryption metadata using master key. \
-                      could be master key being rotated. \
-                      current master key: {:?}, previous master key: {:?}",
-                    master_key_config, previous_master_key_config
-                );
-                let previous_master_key = create_backend(previous_master_key_config)?;
-                let dicts = Dicts::open(
-                    dict_path,
-                    rotation_period,
-                    previous_master_key.as_ref(),
-                    enable_file_dictionary_log,
-                    file_dictionary_rewrite_threshold,
-                )
-                .map_err(|e| {
-                    if let Error::WrongMasterKey(e_previous) = e {
-                        Error::BothMasterKeyFail(e_current, e_previous)
-                    } else {
-                        e
-                    }
-                })?
-                .ok_or_else(|| {
-                    Error::Other(box_err!(
-                        "Fallback to previous master key but find dictionaries to be empty."
-                    ))
-                })?;
-                // Rewrite key_dict after replace master key.
-                dicts.save_key_dict(master_key.as_ref())?;
-
-                info!("encryption: persisted result after replace master key.");
-
-                dicts
-            }
+            (Err(Error::WrongMasterKey(e_current)), _) => Ok(LoadDicts::WrongMasterKey(e_current)),
             // Error.
-            (Err(e), _) => return Err(e),
-        };
-        dicts.maybe_rotate_data_key(method, master_key.as_ref())?;
+            (Err(e), _) => Err(e),
+        }
+    }
 
+    fn load_previous_dicts(
+        master_key: &dyn Backend,
+        previous_master_key: &dyn Backend,
+        args: &DataKeyManagerArgs,
+        e_current: Box<dyn std::error::Error + Send + Sync + 'static>,
+    ) -> Result<Dicts> {
+        warn!(
+            "failed to open encryption metadata using master key. \
+                could be master key being rotated. \
+                current master key: {:?}, previous master key: {:?}",
+            master_key, previous_master_key
+        );
+        let dicts = Dicts::open(
+            &args.dict_path,
+            args.rotation_period,
+            previous_master_key,
+            args.enable_file_dictionary_log,
+            args.file_dictionary_rewrite_threshold,
+        )
+        .map_err(|e| {
+            if let Error::WrongMasterKey(e_previous) = e {
+                Error::BothMasterKeyFail(e_current, e_previous)
+            } else {
+                e
+            }
+        })?
+        .ok_or_else(|| {
+            Error::Other(box_err!(
+                "Fallback to previous master key but find dictionaries to be empty."
+            ))
+        })?;
+        // Rewrite key_dict after replace master key.
+        dicts.save_key_dict(&*master_key)?;
+
+        info!("encryption: persisted result after replace master key.");
+        Ok(dicts)
+    }
+
+    fn from_dicts(
+        dicts: Dicts,
+        method: EncryptionMethod,
+        master_key: Box<dyn Backend>,
+    ) -> Result<DataKeyManager> {
+        dicts.maybe_rotate_data_key(method, &*master_key)?;
         let dicts = Arc::new(dicts);
         let dict_clone = dicts.clone();
         let (rotate_terminal, rx) = channel::bounded(1);
         let background_worker = std::thread::Builder::new()
             .name(thd_name!("enc:key"))
             .spawn(move || {
-                run_background_rotate_work(dict_clone, method, master_key, rx);
+                run_background_rotate_work(dict_clone, method, &*master_key, rx);
             })?;
 
         ENCRYPTION_INITIALIZED_GAUGE.set(1);
 
-        Ok(Some(DataKeyManager {
+        Ok(DataKeyManager {
             dicts,
             method,
             rotate_terminal,
             background_worker: Some(background_worker),
-        }))
+        })
     }
 
     pub fn create_file<P: AsRef<Path>>(&self, path: P) -> Result<EncrypterWriter<File>> {
@@ -582,21 +619,13 @@ impl DataKeyManager {
         }
         Ok(())
     }
-}
 
-impl Drop for DataKeyManager {
-    fn drop(&mut self) {
-        self.rotate_terminal.send(()).unwrap();
-        self.background_worker.take().unwrap().join().unwrap();
-    }
-}
-
-impl EncryptionKeyManager for DataKeyManager {
-    // Get key to open existing file.
-    fn get_file(&self, fname: &str) -> IoResult<FileEncryptionInfo> {
+    fn get_file_exists(&self, fname: &str) -> IoResult<Option<FileEncryptionInfo>> {
         let (method, key_id, iv) = {
-            let file = self.dicts.get_file(fname);
-            (file.method, file.key_id, file.iv)
+            match self.dicts.get_file(fname) {
+                Some(file) => (file.method, file.key_id, file.iv),
+                None => return Ok(None),
+            }
         };
         // Fail if key is specified but not found.
         let key = if method as i32 == EncryptionMethod::Plaintext as i32 {
@@ -606,7 +635,7 @@ impl EncryptionKeyManager for DataKeyManager {
                 Some(k) => k.key.clone(),
                 None => {
                     return Err(IoError::new(
-                        ErrorKind::Other,
+                        ErrorKind::NotFound,
                         format!("key not found for id {}", key_id),
                     ));
                 }
@@ -617,7 +646,41 @@ impl EncryptionKeyManager for DataKeyManager {
             method: crypter::encryption_method_to_db_encryption_method(method),
             iv,
         };
-        Ok(encrypted_file)
+        Ok(Some(encrypted_file))
+    }
+}
+
+impl Drop for DataKeyManager {
+    fn drop(&mut self) {
+        self.rotate_terminal
+            .send(())
+            .expect("DataKeyManager drop send");
+        self.background_worker
+            .take()
+            .expect("DataKeyManager worker take")
+            .join()
+            .expect("DataKeyManager worker join");
+    }
+}
+
+impl EncryptionKeyManager for DataKeyManager {
+    // Get key to open existing file.
+    fn get_file(&self, fname: &str) -> IoResult<FileEncryptionInfo> {
+        match self.get_file_exists(fname) {
+            Ok(Some(result)) => Ok(result),
+            Ok(None) => {
+                // Return Plaintext if file is not found
+                // RocksDB requires this
+                let file = FileInfo::default();
+                let method = compat(EncryptionMethod::Plaintext);
+                Ok(FileEncryptionInfo {
+                    key: vec![],
+                    method: crypter::encryption_method_to_db_encryption_method(method),
+                    iv: file.iv,
+                })
+            }
+            Err(err) => Err(err),
+        }
     }
 
     fn new_file(&self, fname: &str) -> IoResult<FileEncryptionInfo> {
@@ -641,7 +704,9 @@ impl EncryptionKeyManager for DataKeyManager {
     }
 
     fn link_file(&self, src_fname: &str, dst_fname: &str) -> IoResult<()> {
-        self.dicts.link_file(src_fname, dst_fname)?;
+        let _ = self.dicts.link_file(src_fname, dst_fname)?;
+        // For now we ignore file not found.
+        // TODO: propagate it back up as an Option.
         Ok(())
     }
 }
@@ -649,8 +714,8 @@ impl EncryptionKeyManager for DataKeyManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{FileConfig, Mock};
-    use crate::master_key::tests::MockBackend;
+    use crate::config::FileConfig;
+    use crate::master_key::tests::{decrypt_called, encrypt_called, MockBackend};
     use crate::master_key::PlaintextBackend;
 
     use engine_traits::EncryptionMethod as DBEncryptionMethod;
@@ -658,31 +723,72 @@ mod tests {
     use std::{
         fs::{remove_file, File},
         io::Write,
-        sync::{Arc, Mutex},
     };
     use tempfile::TempDir;
 
-    // TODO(yiwu): use the similar method in test_util crate instead.
-    fn new_tmp_key_manager(
-        temp: Option<tempfile::TempDir>,
+    fn new_mock_backend() -> Box<MockBackend> {
+        Box::new(MockBackend::default())
+    }
+
+    fn new_key_manager_def(
+        tmp_dir: &tempfile::TempDir,
         method: Option<EncryptionMethod>,
-        master_key: Option<MasterKeyConfig>,
-        previous_master_key: Option<MasterKeyConfig>,
-    ) -> (tempfile::TempDir, Result<Option<DataKeyManager>>) {
-        let tmp = temp.unwrap_or_else(|| tempfile::TempDir::new().unwrap());
-        let mock_config = MasterKeyConfig::Mock(Mock(Arc::new(Mutex::new(MockBackend::default()))));
-        let master_key = master_key.unwrap_or_else(|| mock_config.clone());
-        let previous_master_key = previous_master_key.unwrap_or(mock_config);
-        let manager = DataKeyManager::new(
-            &master_key,
-            &previous_master_key,
-            method.unwrap_or(EncryptionMethod::Aes256Ctr),
-            Duration::from_secs(60),
-            true, /*enable_file_dictionary_log*/
-            2,
-            tmp.path().as_os_str().to_str().unwrap(),
-        );
-        (tmp, manager)
+    ) -> Result<DataKeyManager> {
+        let master_backend = new_mock_backend() as Box<dyn Backend>;
+        let mut args = def_data_key_args(tmp_dir);
+        if let Some(method) = method {
+            args.method = method;
+        }
+        match DataKeyManager::new(master_backend, &MockBackend::default(), args) {
+            Ok(None) => panic!("expected encryption"),
+            Ok(Some(dkm)) => Ok(dkm),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn def_data_key_args(tmp_dir: &tempfile::TempDir) -> DataKeyManagerArgs {
+        DataKeyManagerArgs {
+            method: EncryptionMethod::Aes256Ctr,
+            rotation_period: Duration::from_secs(60),
+            enable_file_dictionary_log: true,
+            file_dictionary_rewrite_threshold: 2,
+            dict_path: tmp_dir.path().as_os_str().to_str().unwrap().to_string(),
+        }
+    }
+
+    // TODO(yiwu): use the similar method in test_util crate instead.
+    fn new_mock_key_manager(
+        tmp_dir: &tempfile::TempDir,
+        method: Option<EncryptionMethod>,
+        master_backend: Box<MockBackend>,
+        previous_key: &MockBackend,
+    ) -> Result<DataKeyManager> {
+        let mut args = def_data_key_args(tmp_dir);
+        if let Some(method) = method {
+            args.method = method;
+        }
+        match DataKeyManager::new(master_backend, previous_key, args) {
+            Ok(None) => panic!("expected encryption"),
+            Ok(Some(dkm)) => Ok(dkm),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn new_key_manager(
+        tmp_dir: &tempfile::TempDir,
+        method: Option<EncryptionMethod>,
+        master_backend: Box<dyn Backend>,
+        previous_key: &dyn Backend,
+    ) -> Result<DataKeyManager> {
+        let mut args = def_data_key_args(tmp_dir);
+        if let Some(method) = method {
+            args.method = method;
+        }
+        match DataKeyManager::new(master_backend, previous_key, args) {
+            Ok(None) => panic!("expected encryption"),
+            Ok(Some(dkm)) => Ok(dkm),
+            Err(e) => Err(e),
+        }
     }
 
     // TODO(yiwu): use the similar method in test_util crate instead.
@@ -698,29 +804,25 @@ mod tests {
     #[test]
     fn test_key_manager_encryption_enable_disable() {
         // encryption not enabled.
-        let (tmp, manager) =
-            new_tmp_key_manager(None, Some(EncryptionMethod::Plaintext), None, None);
-        assert!(manager.unwrap().is_none());
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let mut args = def_data_key_args(&tmp_dir);
+        args.method = EncryptionMethod::Plaintext;
+        let dkm = DataKeyManager::new(new_mock_backend(), &*new_mock_backend(), args).unwrap();
+        assert!(dkm.is_none());
 
         // encryption being enabled.
-        let (tmp, manager) =
-            new_tmp_key_manager(Some(tmp), Some(EncryptionMethod::Aes256Ctr), None, None);
-        let manager = manager.unwrap().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, Some(EncryptionMethod::Aes256Ctr)).unwrap();
         let foo1 = manager.new_file("foo").unwrap();
         drop(manager);
 
         // encryption was enabled. reopen.
-        let (tmp, manager) =
-            new_tmp_key_manager(Some(tmp), Some(EncryptionMethod::Aes256Ctr), None, None);
-        let manager = manager.unwrap().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, Some(EncryptionMethod::Aes256Ctr)).unwrap();
         let foo2 = manager.get_file("foo").unwrap();
         assert_eq!(foo1, foo2);
         drop(manager);
 
         // disable encryption.
-        let (_tmp, manager) =
-            new_tmp_key_manager(Some(tmp), Some(EncryptionMethod::Plaintext), None, None);
-        let manager = manager.unwrap().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, Some(EncryptionMethod::Plaintext)).unwrap();
         let foo3 = manager.get_file("foo").unwrap();
         assert_eq!(foo1, foo3);
         let bar = manager.new_file("bar").unwrap();
@@ -730,11 +832,12 @@ mod tests {
     // When enabling encryption, using insecure master key is not allowed.
     #[test]
     fn test_key_manager_disallow_plaintext_metadata() {
-        let (_tmp, manager) = new_tmp_key_manager(
-            None,
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let manager = new_key_manager(
+            &tmp_dir,
             Some(EncryptionMethod::Aes256Ctr),
-            Some(MasterKeyConfig::Plaintext),
-            None,
+            create_backend(&MasterKeyConfig::Plaintext).unwrap(),
+            &*(new_mock_backend() as Box<dyn Backend>),
         );
         manager.err().unwrap();
     }
@@ -743,107 +846,109 @@ mod tests {
     #[test]
     fn test_key_manager_rotate_master_key() {
         // create initial dictionaries.
-        let (tmp, manager) = new_tmp_key_manager(None, None, None, None);
-        let manager = manager.unwrap().unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, None).unwrap();
         let info1 = manager.new_file("foo").unwrap();
         drop(manager);
 
-        let current_key = Arc::new(Mutex::new(MockBackend {
+        let mut current_key = Box::new(MockBackend {
             is_wrong_master_key: true,
             ..Default::default()
-        }));
-        let previous_key = Arc::new(Mutex::new(MockBackend::default()));
-        let (_tmp, manager) = new_tmp_key_manager(
-            Some(tmp),
-            None,
-            Some(MasterKeyConfig::Mock(Mock(current_key.clone()))),
-            Some(MasterKeyConfig::Mock(Mock(previous_key.clone()))),
-        );
-        let manager = manager.unwrap().unwrap();
-        let info2 = manager.get_file("foo").unwrap();
+        });
+        current_key.track("current".to_string());
+        let mut previous_key = new_mock_backend();
+        previous_key.track("previous".to_string());
+        assert_eq!(encrypt_called("current"), 0);
+        assert_eq!(encrypt_called("previous"), 0);
+        assert_eq!(decrypt_called("current"), 0);
+        assert_eq!(decrypt_called("previous"), 0);
+        let manager = new_mock_key_manager(&tmp_dir, None, current_key, &*previous_key).unwrap();
+        let info2 = manager.get_file("foo").expect("get file foo");
         assert_eq!(info1, info2);
-        assert_eq!(1, current_key.lock().unwrap().encrypt_called);
-        assert_eq!(1, current_key.lock().unwrap().decrypt_called);
-        assert_eq!(1, previous_key.lock().unwrap().decrypt_called);
+        assert_eq!(encrypt_called("current"), 1);
+        assert_eq!(encrypt_called("previous"), 0);
+        assert_eq!(decrypt_called("current"), 1);
+        assert_eq!(decrypt_called("previous"), 1);
+        assert_eq!(ENCRYPTION_INITIALIZED_GAUGE.get(), 1);
+        assert_eq!(ENCRYPTION_FILE_NUM_GAUGE.get(), 1);
     }
 
     #[test]
     fn test_key_manager_rotate_master_key_rewrite_failure() {
         // create initial dictionaries.
-        let (tmp, manager) = new_tmp_key_manager(None, None, None, None);
-        let manager = manager.unwrap().unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, None).unwrap();
         manager.new_file("foo").unwrap();
         drop(manager);
 
-        let current_key = Arc::new(Mutex::new(MockBackend {
+        let mut current_key = Box::new(MockBackend {
             is_wrong_master_key: true,
             encrypt_fail: true,
-            ..Default::default()
-        }));
-        let previous_key = Arc::new(Mutex::new(MockBackend::default()));
-        let (_tmp, manager) = new_tmp_key_manager(
-            Some(tmp),
-            None,
-            Some(MasterKeyConfig::Mock(Mock(current_key.clone()))),
-            Some(MasterKeyConfig::Mock(Mock(previous_key.clone()))),
-        );
+            ..MockBackend::default()
+        });
+        current_key.track("current".to_string());
+        let mut previous_key = new_mock_backend();
+        previous_key.track("previous".to_string());
+        let manager = new_mock_key_manager(&tmp_dir, None, current_key, &previous_key);
         assert!(manager.is_err());
-        assert_eq!(1, current_key.lock().unwrap().encrypt_called);
-        assert_eq!(1, current_key.lock().unwrap().decrypt_called);
-        assert_eq!(1, previous_key.lock().unwrap().decrypt_called);
+        assert_eq!(encrypt_called("current"), 1);
+        assert_eq!(encrypt_called("previous"), 0);
+        assert_eq!(decrypt_called("current"), 1);
+        assert_eq!(decrypt_called("previous"), 1);
+        assert_eq!(ENCRYPTION_INITIALIZED_GAUGE.get(), 1);
+        assert_eq!(ENCRYPTION_FILE_NUM_GAUGE.get(), 1);
     }
 
     #[test]
     fn test_key_manager_both_master_key_fail() {
         // create initial dictionaries.
-        let (tmp, manager) = new_tmp_key_manager(None, None, None, None);
-        let manager = manager.unwrap().unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, None).unwrap();
         manager.new_file("foo").unwrap();
         drop(manager);
 
-        let master_key = Arc::new(Mutex::new(MockBackend {
+        let master_key = Box::new(MockBackend {
             is_wrong_master_key: true,
             ..Default::default()
-        }));
-        let (_tmp, manager) = new_tmp_key_manager(
-            Some(tmp),
-            None,
-            Some(MasterKeyConfig::Mock(Mock(master_key.clone()))),
-            Some(MasterKeyConfig::Mock(Mock(master_key))),
-        );
+        });
+        let previous_master_key = Box::new(MockBackend {
+            is_wrong_master_key: true,
+            ..Default::default()
+        });
+        let manager = new_mock_key_manager(&tmp_dir, None, master_key, &*previous_master_key);
         assert_matches!(manager.err(), Some(Error::BothMasterKeyFail(_, _)));
     }
 
     #[test]
     fn test_key_manager_key_dict_missing() {
         // create initial dictionaries.
-        let (tmp, manager) = new_tmp_key_manager(None, None, None, None);
-        let manager = manager.unwrap().unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, None).unwrap();
         manager.new_file("foo").unwrap();
         drop(manager);
 
-        remove_file(tmp.path().join(KEY_DICT_NAME)).unwrap();
-        let (_tmp, manager) = new_tmp_key_manager(Some(tmp), None, None, None);
+        remove_file(tmp_dir.path().join(KEY_DICT_NAME)).unwrap();
+        let manager = new_key_manager_def(&tmp_dir, None);
         assert!(manager.is_err());
     }
 
     #[test]
     fn test_key_manager_file_dict_missing() {
         // create initial dictionaries.
-        let (tmp, manager) = new_tmp_key_manager(None, None, None, None);
-        let manager = manager.unwrap().unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, None).unwrap();
         manager.new_file("foo").unwrap();
         drop(manager);
 
-        remove_file(tmp.path().join(FILE_DICT_NAME)).unwrap();
-        let (_tmp, manager) = new_tmp_key_manager(Some(tmp), None, None, None);
+        remove_file(tmp_dir.path().join(FILE_DICT_NAME)).unwrap();
+        let manager = new_key_manager_def(&tmp_dir, None);
         assert!(manager.is_err());
     }
 
     #[test]
     fn test_key_manager_create_get_delete() {
-        let (_tmp, manager) = new_tmp_key_manager(None, None, None, None);
-        let mut manager = manager.unwrap().unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, None).unwrap();
 
         let new_file = manager.new_file("foo").unwrap();
         let get_file = manager.get_file("foo").unwrap();
@@ -853,12 +958,10 @@ mod tests {
         manager.delete_file("foo1").unwrap();
 
         // Must be plaintext if file not found.
-        let file = manager.get_file("foo").unwrap();
-        assert_eq!(file.method, DBEncryptionMethod::Plaintext);
+        assert_eq!(manager.get_file_exists("foo").unwrap(), None,);
 
-        manager.method = EncryptionMethod::Aes192Ctr;
-        let file1 = manager.new_file("foo").unwrap();
-        assert_ne!(file, file1);
+        let manager = new_key_manager_def(&tmp_dir, Some(EncryptionMethod::Aes192Ctr)).unwrap();
+        assert_eq!(manager.get_file_exists("foo").unwrap(), None,);
 
         // Must fail if key is specified but not found.
         let mut file = FileInfo::default();
@@ -871,18 +974,20 @@ mod tests {
             .unwrap()
             .files
             .insert("foo".to_owned(), file);
-        manager.get_file("foo").unwrap_err();
+        assert_eq!(
+            manager.get_file_exists("foo").unwrap_err().kind(),
+            ErrorKind::NotFound,
+        );
     }
 
     #[test]
     fn test_key_manager_link() {
-        let tmp_path = TempDir::new().unwrap();
-        let file_foo1 = tmp_path.path().join("foo1");
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let file_foo1 = tmp_dir.path().join("foo1");
         let _ = std::fs::File::create(&file_foo1).unwrap();
         let foo1_path = file_foo1.as_path().to_str().unwrap();
 
-        let (_tmp, manager) = new_tmp_key_manager(None, None, None, None);
-        let manager = manager.unwrap().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, None).unwrap();
 
         let file = manager.new_file("foo").unwrap();
         manager.link_file("foo", foo1_path).unwrap();
@@ -891,20 +996,20 @@ mod tests {
         let file1 = manager.get_file(foo1_path).unwrap();
         assert_eq!(file1, file);
 
-        // Source file not exists.
         manager.link_file("not exists", "not exists1").unwrap();
         // Target file already exists.
         manager.new_file("foo2").unwrap();
         // Here we create a temp file "foo1" to make the `link_file` return an error.
-        manager.link_file("foo2", foo1_path).unwrap_err();
+        assert_eq!(
+            manager.link_file("foo2", foo1_path).unwrap_err().kind(),
+            ErrorKind::AlreadyExists,
+        )
     }
 
     #[test]
     fn test_key_manager_rename() {
-        let (_tmp, manager) = new_tmp_key_manager(None, None, None, None);
-        let mut manager = manager.unwrap().unwrap();
-
-        manager.method = EncryptionMethod::Aes192Ctr;
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, Some(EncryptionMethod::Aes192Ctr)).unwrap();
         let file = manager.new_file("foo").unwrap();
 
         manager.link_file("foo", "foo1").unwrap();
@@ -914,33 +1019,27 @@ mod tests {
         let file1 = manager.get_file("foo1").unwrap();
         assert_eq!(file1, file);
 
-        // foo must not exist (should be plaintext)
         manager.link_file("foo", "foo2").unwrap();
         manager.delete_file("foo").unwrap();
 
-        let file_foo = manager.get_file("foo").unwrap();
-        assert_ne!(file_foo, file);
-        assert_eq!(file_foo.method, DBEncryptionMethod::Plaintext);
-        let file_foo2 = manager.get_file("foo2").unwrap();
-        assert_ne!(file_foo2, file);
-        assert_eq!(file_foo2.method, DBEncryptionMethod::Plaintext);
+        assert_eq!(manager.get_file_exists("foo").unwrap(), None);
+        assert_eq!(manager.get_file_exists("foo2").unwrap(), None);
     }
 
     #[test]
     fn test_key_manager_rotate() {
-        let (_tmp, manager) = new_tmp_key_manager(None, None, None, None);
-        let manager = manager.unwrap().unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, None).unwrap();
         let (key_id, key) = {
             let (id, k) = manager.dicts.current_data_key();
             (id, k)
         };
 
         // Do not rotate.
-        let mock_config = MasterKeyConfig::Mock(Mock(Arc::new(Mutex::new(MockBackend::default()))));
-        let master_key = create_backend(&mock_config).unwrap();
+        let master_key = MockBackend::default();
         manager
             .dicts
-            .maybe_rotate_data_key(manager.method, master_key.as_ref())
+            .maybe_rotate_data_key(manager.method, &master_key)
             .unwrap();
         let (current_key_id1, current_key1) = {
             let (id, k) = manager.dicts.current_data_key();
@@ -949,7 +1048,7 @@ mod tests {
         assert_eq!(current_key_id1, key_id);
         assert_eq!(current_key1, key);
 
-        // Change rotateion period to a smaller value, must rotate.
+        // Change rotation period to a smaller value, must rotate.
         unsafe {
             let ptr: *mut Dicts = manager.dicts.as_ref() as *const Dicts as *mut Dicts;
             let mut dict = Box::from_raw(ptr);
@@ -959,7 +1058,7 @@ mod tests {
         std::thread::sleep(Duration::from_secs(1));
         manager
             .dicts
-            .maybe_rotate_data_key(manager.method, master_key.as_ref())
+            .maybe_rotate_data_key(manager.method, &master_key)
             .unwrap();
         let (current_key_id2, current_key2) = {
             let (id, k) = manager.dicts.current_data_key();
@@ -971,8 +1070,8 @@ mod tests {
 
     #[test]
     fn test_key_manager_persistence() {
-        let (tmp, manager) = new_tmp_key_manager(None, None, None, None);
-        let manager = manager.unwrap().unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let manager = new_key_manager_def(&tmp_dir, None).unwrap();
 
         // Create a file and a datakey.
         manager.new_file("foo").unwrap();
@@ -982,8 +1081,7 @@ mod tests {
 
         // Close and re-open.
         drop(manager);
-        let (_tmp, manager1) = new_tmp_key_manager(Some(tmp), None, None, None);
-        let manager1 = manager1.unwrap().unwrap();
+        let manager1 = new_key_manager_def(&tmp_dir, None).unwrap();
 
         let files1 = manager1.dicts.file_dict.lock().unwrap().clone();
         let keys1 = manager1.dicts.key_dict.lock().unwrap().clone();
@@ -1000,17 +1098,19 @@ mod tests {
             },
         };
         let master_key_backend = create_backend(&master_key).unwrap();
-        let (_tmp_data_dir, manager) = new_tmp_key_manager(None, None, Some(master_key), None);
-        let manager = manager.unwrap().unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let previous = new_mock_backend() as Box<dyn Backend>;
+        let manager = new_key_manager(&tmp_dir, None, master_key_backend, &*previous).unwrap();
         let (key_id, key) = {
             let (id, k) = manager.dicts.current_data_key();
             (id, k)
         };
 
+        let master_key_backend = create_backend(&master_key).unwrap();
         // Do not rotate.
         manager
             .dicts
-            .maybe_rotate_data_key(manager.method, master_key_backend.as_ref())
+            .maybe_rotate_data_key(manager.method, &*master_key_backend)
             .unwrap();
         let (current_key_id1, current_key1) = {
             let (id, k) = manager.dicts.current_data_key();
@@ -1031,7 +1131,7 @@ mod tests {
             .was_exposed = true;
         manager
             .dicts
-            .maybe_rotate_data_key(manager.method, master_key_backend.as_ref())
+            .maybe_rotate_data_key(manager.method, &*master_key_backend)
             .unwrap();
         let (current_key_id2, current_key2) = {
             let (id, k) = manager.dicts.current_data_key();
@@ -1051,13 +1151,15 @@ mod tests {
         };
 
         let master_key_backend = create_backend(&master_key).unwrap();
-        let (_tmp_data_dir, manager) = new_tmp_key_manager(None, None, Some(master_key), None);
-        let manager = manager.unwrap().unwrap();
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let previous = new_mock_backend() as Box<dyn Backend>;
+        let manager = new_key_manager(&tmp_dir, None, master_key_backend, &*previous).unwrap();
 
+        let master_key_backend = create_backend(&master_key).unwrap();
         for i in 0..100 {
             manager
                 .dicts
-                .rotate_key(i, DataKey::default(), master_key_backend.as_ref())
+                .rotate_key(i, DataKey::default(), &*master_key_backend)
                 .unwrap();
         }
         for value in manager.dicts.key_dict.lock().unwrap().keys.values() {
@@ -1066,10 +1168,10 @@ mod tests {
 
         // Change it insecure backend and save dicts,
         // must set expose for all keys.
-        let insecure = Arc::new(PlaintextBackend::default());
+        let insecure = PlaintextBackend::default();
         manager
             .dicts
-            .rotate_key(100, DataKey::default(), insecure.as_ref())
+            .rotate_key(100, DataKey::default(), &insecure)
             .unwrap();
 
         let mut count = 0;

--- a/components/encryption/src/master_key/file.rs
+++ b/components/encryption/src/master_key/file.rs
@@ -10,6 +10,7 @@ use super::{Backend, MemAesGcmBackend};
 use crate::AesGcmCrypter;
 use crate::{Error, Iv, Result};
 
+#[derive(Debug)]
 pub struct FileBackend {
     backend: MemAesGcmBackend,
 }

--- a/components/encryption/src/master_key/kms.rs
+++ b/components/encryption/src/master_key/kms.rs
@@ -1,7 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::future::Future;
-use std::marker::PhantomData;
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -16,69 +15,109 @@ use tokio::runtime::{Builder, Runtime};
 
 use super::{metadata::MetadataKey, Backend, MemAesGcmBackend};
 use crate::config::KmsConfig;
-use crate::crypter::Iv;
+use crate::crypter::{Iv, PlainKey};
 use crate::{Error, Result};
 use rusoto_util::new_client;
 
 const AWS_KMS_DATA_KEY_SPEC: &str = "AES_256";
 const AWS_KMS_VENDOR_NAME: &[u8] = b"AWS";
 
-struct AwsKms {
+#[derive(PartialEq, Debug)]
+pub struct KeyId(String);
+
+// KeyID is a newtype to mark a String as an ID of a key
+// This ID exists in a foreign system such as AWS
+// The key id must be non-empty
+impl KeyId {
+    fn new(id: String) -> Result<KeyId> {
+        if id.is_empty() {
+            Err(box_err!("KMS key id can not be empty"))
+        } else {
+            Ok(KeyId(id))
+        }
+    }
+}
+
+pub struct AwsKms {
     client: KmsClient,
-    current_key_id: String,
-    runtime: Runtime,
-    // The current implementation (rosoto 0.43.0 + hyper 0.13.3) is not `Send`
-    // in practical. See more https://github.com/tikv/tikv/issues/7236.
-    // FIXME: remove it.
-    _not_send: PhantomData<*const ()>,
+    current_key_id: KeyId,
+    region: String,
+    endpoint: String,
+}
+
+struct KmsClientDebug {
+    region: String,
+    endpoint: String,
+}
+
+impl std::fmt::Debug for KmsClientDebug {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KmsClient")
+            .field("region", &self.region)
+            .field("endpoint", &self.endpoint)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for AwsKms {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let kms_client = KmsClientDebug {
+            region: self.region.clone(),
+            endpoint: self.endpoint.clone(),
+        };
+        f.debug_struct("AwsKms")
+            .field("client", &kms_client)
+            .field("current_key_id", &self.current_key_id)
+            .finish()
+    }
 }
 
 impl AwsKms {
-    fn with_request_dispatcher<D>(config: &KmsConfig, dispatcher: D) -> Result<AwsKms>
+    fn new_with_dispatcher<D>(config: KmsConfig, dispatcher: D) -> Result<AwsKms>
     where
         D: DispatchSignedRequest + Send + Sync + 'static,
     {
-        Self::check_config(config)?;
-
-        // Create and run the client in the same thread.
         let client = new_client!(KmsClient, config, dispatcher);
-        // Basic scheduler executes futures in the current thread.
-        let runtime = Builder::new()
-            .basic_scheduler()
-            .thread_name("kms-runtime")
-            .core_threads(1)
-            .enable_all()
-            .build()?;
-
         Ok(AwsKms {
             client,
-            current_key_id: config.key_id.clone(),
-            runtime,
-            _not_send: PhantomData::default(),
+            current_key_id: KeyId::new(config.key_id)?,
+            region: config.region,
+            endpoint: config.endpoint,
         })
     }
 
-    fn check_config(config: &KmsConfig) -> Result<()> {
-        if config.key_id.is_empty() {
-            return Err(box_err!("KMS key id can not be empty"));
-        }
-        Ok(())
+    pub fn new(config: KmsConfig) -> Result<AwsKms> {
+        // We must create our own dispatcher
+        // See https://github.com/tikv/tikv/issues/7236
+        let dispatcher = HttpClient::new()?;
+        Self::new_with_dispatcher(config, dispatcher)
+    }
+}
+
+impl std::convert::From<rusoto_core::request::TlsError> for Error {
+    fn from(err: rusoto_core::request::TlsError) -> Error {
+        box_err!(format!("{}", err))
+    }
+}
+
+impl KmsProvider for AwsKms {
+    fn name(&self) -> &[u8] {
+        AWS_KMS_VENDOR_NAME
     }
 
     // On decrypt failure, the rule is to return WrongMasterKey error in case it is possible that
     // a wrong master key has been used, or other error otherwise.
-    fn decrypt(&mut self, ciphertext: &[u8]) -> Result<Vec<u8>> {
+    fn decrypt_data_key(&self, runtime: &mut Runtime, data_key: &EncryptedKey) -> Result<Vec<u8>> {
         let decrypt_request = DecryptRequest {
-            ciphertext_blob: ciphertext.to_vec().into(),
+            ciphertext_blob: bytes::Bytes::copy_from_slice(&*data_key),
             // Use default algorithm SYMMETRIC_DEFAULT.
             encryption_algorithm: None,
             // Use key_id encoded in ciphertext.
-            key_id: Some(self.current_key_id.clone()),
+            key_id: Some(self.current_key_id.0.clone()),
             // Encryption context and grant tokens are not used.
             encryption_context: None,
             grant_tokens: None,
         };
-        let runtime = &mut self.runtime;
         let client = &self.client;
         let decrypt_response = retry(runtime, || {
             client.decrypt(decrypt_request.clone()).map_err(|e| {
@@ -91,19 +130,17 @@ impl AwsKms {
                 }
             })
         })?;
-        let plaintext = decrypt_response.plaintext.unwrap().as_ref().to_vec();
-        Ok(plaintext)
+        Ok(decrypt_response.plaintext.unwrap().as_ref().to_vec())
     }
 
-    fn generate_data_key(&mut self) -> Result<(Vec<u8>, Vec<u8>)> {
+    fn generate_data_key(&self, runtime: &mut Runtime) -> Result<DataKeyPair> {
         let generate_request = GenerateDataKeyRequest {
             encryption_context: None,
             grant_tokens: None,
-            key_id: self.current_key_id.clone(),
+            key_id: self.current_key_id.0.clone(),
             key_spec: Some(AWS_KMS_DATA_KEY_SPEC.to_owned()),
             number_of_bytes: None,
         };
-        let runtime = &mut self.runtime;
         let client = &self.client;
         let generate_response = retry(runtime, || {
             client
@@ -113,7 +150,10 @@ impl AwsKms {
         .unwrap();
         let ciphertext_key = generate_response.ciphertext_blob.unwrap().as_ref().to_vec();
         let plaintext_key = generate_response.plaintext.unwrap().as_ref().to_vec();
-        Ok((ciphertext_key, plaintext_key))
+        Ok(DataKeyPair {
+            encrypted: EncryptedKey::new(ciphertext_key)?,
+            plaintext: PlainKey::new(plaintext_key)?,
+        })
     }
 }
 
@@ -148,92 +188,107 @@ where
     Err(Error::Other(box_err!("{:?}", last_err)))
 }
 
-struct Inner {
-    config: KmsConfig,
-    backend: Option<MemAesGcmBackend>,
-    cached_ciphertext_key: Vec<u8>,
+#[derive(Debug)]
+struct State {
+    encryption_backend: MemAesGcmBackend,
+    cached_ciphertext_key: EncryptedKey,
 }
 
-impl Inner {
-    fn maybe_update_backend(&mut self, ciphertext_key: Option<&Vec<u8>>) -> Result<()> {
-        let http_dispatcher = HttpClient::new().unwrap();
-        self.maybe_update_backend_with(ciphertext_key, http_dispatcher)
+impl State {
+    fn new_from_datakey(datakey: DataKeyPair) -> Result<State> {
+        Ok(State {
+            cached_ciphertext_key: datakey.encrypted,
+            encryption_backend: MemAesGcmBackend {
+                key: datakey.plaintext,
+            },
+        })
     }
 
-    fn maybe_update_backend_with<D>(
-        &mut self,
-        ciphertext_key: Option<&Vec<u8>>,
-        dispatcher: D,
-    ) -> Result<()>
-    where
-        D: DispatchSignedRequest + Send + Sync + 'static,
-    {
-        if self.backend.is_some()
-            && ciphertext_key.map_or(true, |key| *key == self.cached_ciphertext_key)
-        {
-            return Ok(());
-        }
-
-        let mut kms = AwsKms::with_request_dispatcher(&self.config, dispatcher)?;
-        let key = if let Some(ciphertext_key) = ciphertext_key {
-            self.cached_ciphertext_key = ciphertext_key.to_owned();
-            kms.decrypt(ciphertext_key)?
-        } else {
-            let (ciphertext_key, plaintext_key) = kms.generate_data_key()?;
-            self.cached_ciphertext_key = ciphertext_key;
-            plaintext_key
-        };
-        if self.cached_ciphertext_key == key {
-            panic!(
-                "ciphertext key should not be the same as master key, \
-                otherwise it leaks master key!"
-            );
-        }
-
-        // Always use AES 256 for encrypting master key.
-        self.backend = Some(MemAesGcmBackend::new(key)?);
-        Ok(())
+    fn cached(&self, ciphertext_key: &EncryptedKey) -> bool {
+        *ciphertext_key == self.cached_ciphertext_key
     }
 }
 
+// EncryptedKey is a newtype used to mark data as an encrypted key
+// It requires the vec to be non-empty
+#[derive(PartialEq, Clone, Debug)]
+pub struct EncryptedKey(Vec<u8>);
+
+impl EncryptedKey {
+    fn new(key: Vec<u8>) -> Result<EncryptedKey> {
+        if key.is_empty() {
+            error!("Encrypted content is empty");
+        }
+        Ok(EncryptedKey(key))
+    }
+}
+
+impl std::ops::Deref for EncryptedKey {
+    type Target = Vec<u8>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+pub struct DataKeyPair {
+    pub encrypted: EncryptedKey,
+    pub plaintext: PlainKey,
+}
+
+pub trait KmsProvider: Sync + Send + 'static + std::fmt::Debug {
+    fn generate_data_key(&self, runtime: &mut Runtime) -> Result<DataKeyPair>;
+    fn decrypt_data_key(&self, runtime: &mut Runtime, data_key: &EncryptedKey) -> Result<Vec<u8>>;
+    fn name(&self) -> &[u8];
+}
+
+#[derive(Debug)]
 pub struct KmsBackend {
-    inner: Mutex<Inner>,
+    state: Mutex<Option<State>>,
+    kms_provider: Box<dyn KmsProvider>,
+    // This mutex allows the decrypt_content API to be reference based
+    runtime: Mutex<Runtime>,
 }
 
 impl KmsBackend {
-    pub fn new(config: KmsConfig) -> Result<KmsBackend> {
-        let inner = Inner {
-            backend: None,
-            config,
-            cached_ciphertext_key: Vec::new(),
-        };
+    pub fn new(kms_provider: Box<dyn KmsProvider>) -> Result<KmsBackend> {
+        // Basic scheduler executes futures in the current thread.
+        let runtime = Mutex::new(
+            Builder::new()
+                .basic_scheduler()
+                .thread_name("kms-runtime")
+                .core_threads(1)
+                .enable_all()
+                .build()?,
+        );
 
         Ok(KmsBackend {
-            inner: Mutex::new(inner),
+            state: Mutex::new(None),
+            runtime,
+            kms_provider,
         })
     }
 
     fn encrypt_content(&self, plaintext: &[u8], iv: Iv) -> Result<EncryptedContent> {
-        let mut inner = self.inner.lock().unwrap();
-        inner.maybe_update_backend(None)?;
-        let mut content = inner
-            .backend
-            .as_ref()
-            .unwrap()
-            .encrypt_content(plaintext, iv)?;
+        let mut opt_state = self.state.lock().unwrap();
+        if opt_state.is_none() {
+            let mut runtime = self.runtime.lock().unwrap();
+            let data_key = self.kms_provider.generate_data_key(&mut runtime)?;
+            *opt_state = Some(State::new_from_datakey(data_key)?);
+        }
+        let state = opt_state.as_ref().unwrap();
+
+        let mut content = state.encryption_backend.encrypt_content(plaintext, iv)?;
 
         // Set extra metadata for KmsBackend.
         // For now, we only support AWS.
         content.metadata.insert(
             MetadataKey::KmsVendor.as_str().to_owned(),
-            AWS_KMS_VENDOR_NAME.to_vec(),
+            self.kms_provider.name().to_vec(),
         );
-        if inner.cached_ciphertext_key.is_empty() {
-            return Err(box_err!("KMS ciphertext key not found"));
-        }
         content.metadata.insert(
             MetadataKey::KmsCiphertextKey.as_str().to_owned(),
-            inner.cached_ciphertext_key.clone(),
+            state.cached_ciphertext_key.to_vec(),
         );
 
         Ok(content)
@@ -242,9 +297,9 @@ impl KmsBackend {
     // On decrypt failure, the rule is to return WrongMasterKey error in case it is possible that
     // a wrong master key has been used, or other error otherwise.
     fn decrypt_content(&self, content: &EncryptedContent) -> Result<Vec<u8>> {
+        let vendor_name = self.kms_provider.name();
         match content.metadata.get(MetadataKey::KmsVendor.as_str()) {
-            // For now, we only support AWS.
-            Some(val) if val.as_slice() == AWS_KMS_VENDOR_NAME => (),
+            Some(val) if val.as_slice() == vendor_name => (),
             None => {
                 return Err(
                     // If vender is missing in metadata, it could be the encrypted content is invalid
@@ -256,19 +311,39 @@ impl KmsBackend {
             other => {
                 return Err(box_err!(
                     "KMS vendor mismatch expect {:?} got {:?}",
-                    AWS_KMS_VENDOR_NAME,
+                    vendor_name,
                     other
                 ))
             }
         }
 
-        let mut inner = self.inner.lock().unwrap();
-        let ciphertext_key = content.metadata.get(MetadataKey::KmsCiphertextKey.as_str());
-        if ciphertext_key.is_none() {
-            return Err(box_err!("KMS ciphertext key not found"));
+        let ciphertext_key = match content.metadata.get(MetadataKey::KmsCiphertextKey.as_str()) {
+            None => return Err(box_err!("KMS ciphertext key not found")),
+            Some(key) => EncryptedKey::new(key.to_vec())?,
+        };
+
+        {
+            let mut opt_state = self.state.lock().unwrap();
+            if let Some(state) = &*opt_state {
+                if state.cached(&ciphertext_key) {
+                    return state.encryption_backend.decrypt_content(content);
+                }
+            }
+            {
+                let mut runtime = self.runtime.lock().unwrap();
+                let plaintext = self
+                    .kms_provider
+                    .decrypt_data_key(&mut runtime, &ciphertext_key)?;
+                let data_key = DataKeyPair {
+                    encrypted: ciphertext_key,
+                    plaintext: PlainKey::new(plaintext)?,
+                };
+                let state = State::new_from_datakey(data_key)?;
+                let content = state.encryption_backend.decrypt_content(content)?;
+                *opt_state = Some(state);
+                Ok(content)
+            }
         }
-        inner.maybe_update_backend(ciphertext_key)?;
-        inner.backend.as_ref().unwrap().decrypt_content(content)
     }
 }
 
@@ -294,9 +369,76 @@ mod tests {
     use rusoto_kms::{DecryptResponse, GenerateDataKeyResponse};
     use rusoto_mock::MockRequestDispatcher;
 
+    const FAKE_VENDOR_NAME: &[u8] = b"FAKE";
+    const FAKE_DATA_KEY_ENCRYPTED: &[u8] = b"encrypted                       ";
+
+    #[derive(Debug)]
+    struct FakeKms {
+        plaintext_key: PlainKey,
+    }
+
+    impl FakeKms {
+        pub fn new(plaintext_key: PlainKey) -> Self {
+            Self { plaintext_key }
+        }
+    }
+
+    impl KmsProvider for FakeKms {
+        fn generate_data_key(&self, _runtime: &mut Runtime) -> Result<DataKeyPair> {
+            Ok(DataKeyPair {
+                encrypted: EncryptedKey::new(FAKE_DATA_KEY_ENCRYPTED.to_vec())?,
+                plaintext: PlainKey::new(self.plaintext_key.clone()).unwrap(),
+            })
+        }
+
+        fn decrypt_data_key(
+            &self,
+            _runtime: &mut Runtime,
+            _ciphertext: &EncryptedKey,
+        ) -> Result<Vec<u8>> {
+            Ok(vec![1u8, 32])
+        }
+
+        fn name(&self) -> &[u8] {
+            FAKE_VENDOR_NAME
+        }
+    }
+
+    fn runtime() -> Runtime {
+        Builder::new()
+            .basic_scheduler()
+            .thread_name("kms-runtime")
+            .core_threads(1)
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_state() {
+        let plaintext = PlainKey::new(vec![1u8; 32]).unwrap();
+        let encrypted = EncryptedKey::new(vec![2u8; 32]).unwrap();
+        let data_key = DataKeyPair {
+            plaintext: PlainKey::new(plaintext.clone()).unwrap(),
+            encrypted: encrypted.clone(),
+        };
+        let encrypted2 = EncryptedKey::new(vec![3u8; 32]).unwrap();
+        let state = State::new_from_datakey(data_key).unwrap();
+        // cached to the data key
+        assert_eq!(state.cached(&encrypted), true);
+        let state2 = State::new_from_datakey(DataKeyPair {
+            plaintext,
+            encrypted: encrypted2.clone(),
+        })
+        .unwrap();
+        // updated to the new data key
+        assert_eq!(state2.cached(&encrypted2), true);
+    }
+
     #[test]
     fn test_aws_kms() {
-        let magic_contents = b"5678";
+        let magic_contents = b"5678" as &[u8];
+        let key_contents = vec![1u8; 32];
         let config = KmsConfig {
             key_id: "test_key_id".to_string(),
             region: "ap-southeast-2".to_string(),
@@ -304,93 +446,32 @@ mod tests {
             secret_access_key: "xyz".to_string(),
             endpoint: String::new(),
         };
+        let mut runtime = runtime();
 
         let dispatcher =
             MockRequestDispatcher::with_status(200).with_json_body(GenerateDataKeyResponse {
                 ciphertext_blob: Some(magic_contents.as_ref().into()),
                 key_id: Some("test_key_id".to_string()),
-                plaintext: Some(magic_contents.as_ref().into()),
+                plaintext: Some(key_contents.clone().into()),
             });
-        let mut aws_kms = AwsKms::with_request_dispatcher(&config, dispatcher).unwrap();
-        let (ciphertext, plaintext) = aws_kms.generate_data_key().unwrap();
-        assert_eq!(ciphertext, magic_contents);
-        assert_eq!(plaintext, magic_contents);
+        let aws_kms = AwsKms::new_with_dispatcher(config.clone(), dispatcher).unwrap();
+        let data_key = aws_kms.generate_data_key(&mut runtime).unwrap();
+        assert_eq!(
+            data_key.encrypted,
+            EncryptedKey::new(magic_contents.to_vec()).unwrap()
+        );
+        assert_eq!(*data_key.plaintext, key_contents);
 
         let dispatcher = MockRequestDispatcher::with_status(200).with_json_body(DecryptResponse {
-            plaintext: Some(magic_contents.as_ref().into()),
+            plaintext: Some(key_contents.clone().into()),
             key_id: Some("test_key_id".to_string()),
             encryption_algorithm: None,
         });
-        let mut aws_kms = AwsKms::with_request_dispatcher(&config, dispatcher).unwrap();
-        let plaintext = aws_kms.decrypt(ciphertext.as_slice()).unwrap();
-        assert_eq!(plaintext, magic_contents);
-    }
-
-    #[test]
-    fn test_update_backend() {
-        let config = KmsConfig {
-            key_id: "test_key_id".to_string(),
-            region: "ap-southeast-2".to_string(),
-            access_key: "abc".to_string(),
-            secret_access_key: "xyz".to_string(),
-            endpoint: String::new(),
-        };
-
-        let plaintext_key = vec![5u8; 32]; // 32 * 8 = 256 bits
-        let ciphertext_key1 = vec![7u8; 32]; // 32 * 8 = 256 bits
-        let ciphertext_key2 = vec![8u8; 32]; // 32 * 8 = 256 bits
-
-        let mut inner = Inner {
-            config,
-            backend: None,
-            cached_ciphertext_key: vec![],
-        };
-
-        // Update mem backend
-        let dispatcher =
-            MockRequestDispatcher::with_status(200).with_json_body(GenerateDataKeyResponse {
-                ciphertext_blob: Some(ciphertext_key1.to_vec().into()),
-                key_id: Some("test_key_id".to_string()),
-                plaintext: Some(plaintext_key.to_vec().into()),
-            });
-        inner.maybe_update_backend_with(None, dispatcher).unwrap();
-        assert!(inner.backend.is_some());
-        assert_eq!(inner.cached_ciphertext_key, ciphertext_key1.to_vec());
-
-        // Do not update mem backend if ciphertext_key is None.
-        let dispatcher =
-            MockRequestDispatcher::with_status(200).with_json_body(GenerateDataKeyResponse {
-                ciphertext_blob: Some(plaintext_key.to_vec().into()),
-                key_id: Some("test_key_id".to_string()),
-                plaintext: Some(plaintext_key.to_vec().into()),
-            });
-        inner.maybe_update_backend_with(None, dispatcher).unwrap();
-        assert_eq!(inner.cached_ciphertext_key, ciphertext_key1.to_vec());
-
-        // Do not update mem backend if cached_ciphertext_key equals to ciphertext_key.
-        let dispatcher =
-            MockRequestDispatcher::with_status(200).with_json_body(GenerateDataKeyResponse {
-                ciphertext_blob: Some(ciphertext_key2.to_vec().into()),
-                key_id: Some("test_key_id".to_string()),
-                plaintext: Some(plaintext_key.to_vec().into()),
-            });
-        inner
-            .maybe_update_backend_with(Some(&ciphertext_key1.to_vec()), dispatcher)
+        let aws_kms = AwsKms::new_with_dispatcher(config, dispatcher).unwrap();
+        let plaintext = aws_kms
+            .decrypt_data_key(&mut runtime, &data_key.encrypted)
             .unwrap();
-        assert_eq!(inner.cached_ciphertext_key, ciphertext_key1.to_vec());
-
-        // Update mem backend if cached_ciphertext_key does not equal to ciphertext_key.
-        let dispatcher =
-            MockRequestDispatcher::with_status(200).with_json_body(GenerateDataKeyResponse {
-                ciphertext_blob: Some(ciphertext_key2.to_vec().into()),
-                key_id: Some("test_key_id".to_string()),
-                plaintext: Some(plaintext_key.to_vec().into()),
-            });
-        inner
-            .maybe_update_backend_with(Some(&ciphertext_key2.to_vec()), dispatcher)
-            .unwrap();
-        assert!(inner.backend.is_some());
-        assert_eq!(inner.cached_ciphertext_key, ciphertext_key2.to_vec());
+        assert_eq!(plaintext, key_contents);
     }
 
     #[test]
@@ -400,20 +481,14 @@ mod tests {
             .unwrap();
         let ct = Vec::from_hex("84e5f23f95648fa247cb28eef53abec947dbf05ac953734618111583840bd980")
             .unwrap();
-        let key = Vec::from_hex("c3d99825f2181f4808acd2068eac7441a65bd428f14d2aab43fefc0129091139")
-            .unwrap();
+        let key = PlainKey::new(
+            Vec::from_hex("c3d99825f2181f4808acd2068eac7441a65bd428f14d2aab43fefc0129091139")
+                .unwrap(),
+        )
+        .unwrap();
         let iv = Vec::from_hex("cafabd9672ca6c79a2fbdc22").unwrap();
 
-        let backend = MemAesGcmBackend::new(key.clone()).unwrap();
-
-        let inner = Inner {
-            config: KmsConfig::default(),
-            backend: Some(backend),
-            cached_ciphertext_key: key,
-        };
-        let backend = KmsBackend {
-            inner: Mutex::new(inner),
-        };
+        let backend = KmsBackend::new(Box::new(FakeKms::new(key))).unwrap();
         let iv = Iv::from_slice(iv.as_slice()).unwrap();
         let encrypted_content = backend.encrypt_content(&pt, iv).unwrap();
         assert_eq!(encrypted_content.get_content(), ct.as_slice());
@@ -476,8 +551,11 @@ mod tests {
                 "Message": "mock"
             }"#,
         );
-        let mut aws_kms = AwsKms::with_request_dispatcher(&config, dispatcher).unwrap();
-        match aws_kms.decrypt(b"invalid") {
+        let aws_kms = AwsKms::new_with_dispatcher(config, dispatcher).unwrap();
+        match aws_kms.decrypt_data_key(
+            &mut runtime(),
+            &EncryptedKey::new(b"invalid".to_vec()).unwrap(),
+        ) {
             Err(Error::WrongMasterKey(_)) => (),
             other => panic!("{:?}", other),
         }

--- a/components/encryption/src/master_key/mem.rs
+++ b/components/encryption/src/master_key/mem.rs
@@ -7,20 +7,16 @@ use crate::crypter::*;
 use crate::{AesGcmCrypter, Error, Iv, Result};
 
 /// An in-memory backend, it saves master key in memory.
+#[derive(Debug)]
 pub(crate) struct MemAesGcmBackend {
-    pub key: Vec<u8>,
+    pub key: PlainKey,
 }
 
 impl MemAesGcmBackend {
     pub fn new(key: Vec<u8>) -> Result<MemAesGcmBackend> {
-        if key.len() != AesGcmCrypter::KEY_LEN {
-            return Err(box_err!(
-                "encryption method and key length mismatch, expect {} get {}",
-                AesGcmCrypter::KEY_LEN,
-                key.len()
-            ));
-        }
-        Ok(MemAesGcmBackend { key })
+        Ok(MemAesGcmBackend {
+            key: PlainKey::new(key)?,
+        })
     }
 
     pub fn encrypt_content(&self, plaintext: &[u8], iv: Iv) -> Result<EncryptedContent> {

--- a/components/encryption/src/master_key/mod.rs
+++ b/components/encryption/src/master_key/mod.rs
@@ -2,19 +2,16 @@
 
 use kvproto::encryptionpb::EncryptedContent;
 
-#[cfg(test)]
-use crate::config::Mock;
 use crate::{Error, MasterKeyConfig, Result};
 
 use std::path::Path;
-use std::sync::Arc;
 
 /// Provide API to encrypt/decrypt key dictionary content.
 ///
 /// Can be back by KMS, or a key read from a file. If file is used, it will
 /// prefix the result with the IV (nonce + initial counter) on encrypt,
 /// and decode the IV on decrypt.
-pub trait Backend: Sync + Send + 'static {
+pub trait Backend: Sync + Send + std::fmt::Debug + 'static {
     fn encrypt(&self, plaintext: &[u8]) -> Result<EncryptedContent>;
     fn decrypt(&self, ciphertext: &EncryptedContent) -> Result<Vec<u8>>;
 
@@ -29,12 +26,12 @@ mod file;
 pub use self::file::FileBackend;
 
 mod kms;
-pub use self::kms::KmsBackend;
+pub use self::kms::{AwsKms, KmsBackend};
 
 mod metadata;
 use self::metadata::*;
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 pub(crate) struct PlaintextBackend {}
 
 impl Backend for PlaintextBackend {
@@ -72,70 +69,108 @@ impl Backend for PlaintextBackend {
     }
 }
 
-pub(crate) fn create_backend(config: &MasterKeyConfig) -> Result<Arc<dyn Backend>> {
-    Ok(match config {
-        MasterKeyConfig::Plaintext => Arc::new(PlaintextBackend {}) as _,
-        MasterKeyConfig::File { config } => {
-            Arc::new(FileBackend::new(Path::new(&config.path))?) as _
-        }
-        MasterKeyConfig::Kms { config } => Arc::new(KmsBackend::new(config.clone())?) as _,
-        #[cfg(test)]
-        MasterKeyConfig::Mock(Mock(mock)) => mock.clone() as _,
-    })
+pub fn create_backend(config: &MasterKeyConfig) -> Result<Box<dyn Backend>> {
+    let result = create_backend_inner(config);
+    if let Err(e) = result {
+        error!("failed to access master key, {}", e);
+        return Err(e);
+    };
+    result
 }
 
-// To make MasterKeyConfig able to compile.
-#[cfg(test)]
-impl std::fmt::Debug for dyn Backend {
-    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        Ok(())
-    }
+fn create_backend_inner(config: &MasterKeyConfig) -> Result<Box<dyn Backend>> {
+    Ok(match config {
+        MasterKeyConfig::Plaintext => Box::new(PlaintextBackend {}) as _,
+        MasterKeyConfig::File { config } => {
+            Box::new(FileBackend::new(Path::new(&config.path))?) as _
+        }
+        MasterKeyConfig::Kms { config } => {
+            let kms_provider = AwsKms::new(config.clone())?;
+            Box::new(KmsBackend::new(Box::new(kms_provider))?) as _
+        }
+    })
 }
 
 #[cfg(test)]
 pub mod tests {
     use super::*;
     use crate::*;
-
+    use lazy_static::lazy_static;
+    use std::collections::HashMap;
     use std::sync::Mutex;
 
-    pub(crate) struct MockBackend {
-        pub inner: Box<dyn Backend>,
+    #[derive(Debug)]
+    pub struct MockBackend {
         pub is_wrong_master_key: bool,
         pub encrypt_fail: bool,
-        pub encrypt_called: usize,
-        pub decrypt_called: usize,
+        pub track: String,
+    }
+
+    // Use a technique to use mutable state for a testing mock
+    // without having it infect the rest of the program.
+    lazy_static! {
+        pub static ref ENCRYPT_CALLED: Mutex<HashMap<String, usize>> = Mutex::new(HashMap::new());
+        pub static ref DECRYPT_CALLED: Mutex<HashMap<String, usize>> = Mutex::new(HashMap::new());
+    }
+
+    pub fn decrypt_called(name: &str) -> usize {
+        let track = make_track(name);
+        *DECRYPT_CALLED.lock().unwrap().get(&track).unwrap()
+    }
+
+    pub fn encrypt_called(name: &str) -> usize {
+        let track = make_track(name);
+        *ENCRYPT_CALLED.lock().unwrap().get(&track).unwrap()
+    }
+
+    fn make_track(name: &str) -> String {
+        format!("{} {:?}", name, std::thread::current().id())
+    }
+
+    impl MockBackend {
+        // Callers are responsible for enabling tracking on the MockBackend by calling this function
+        // This names the backend instance, allowiing later fine-grained recall
+        pub fn track(&mut self, name: String) {
+            let track = make_track(&name);
+            self.track = track.clone();
+            ENCRYPT_CALLED.lock().unwrap().insert(track.clone(), 0);
+            DECRYPT_CALLED.lock().unwrap().insert(track, 0);
+        }
     }
 
     impl Default for MockBackend {
         fn default() -> MockBackend {
             MockBackend {
-                inner: Box::new(PlaintextBackend {}),
                 is_wrong_master_key: false,
                 encrypt_fail: false,
-                encrypt_called: 0,
-                decrypt_called: 0,
+                track: "Not tracked".to_string(),
             }
         }
     }
 
-    impl Backend for Mutex<MockBackend> {
+    impl Backend for MockBackend {
         fn encrypt(&self, plaintext: &[u8]) -> Result<EncryptedContent> {
-            let mut mock = self.lock().unwrap();
-            mock.encrypt_called += 1;
-            if mock.encrypt_fail {
+            let mut map = ENCRYPT_CALLED.lock().unwrap();
+            if let Some(count) = map.get_mut(&self.track) {
+                *count += 1
+            }
+            if self.encrypt_fail {
                 return Err(box_err!("mock error"));
             }
-            mock.inner.encrypt(plaintext)
+            (PlaintextBackend {}).encrypt(plaintext)
         }
+
         fn decrypt(&self, ciphertext: &EncryptedContent) -> Result<Vec<u8>> {
-            let mut mock = self.lock().unwrap();
-            mock.decrypt_called += 1;
-            if mock.is_wrong_master_key {
+            let mut map = DECRYPT_CALLED.lock().unwrap();
+            if let Some(count) = map.get_mut(&self.track) {
+                *count += 1
+            }
+            if self.is_wrong_master_key {
                 return Err(Error::WrongMasterKey("".to_owned().into()));
             }
-            mock.inner.decrypt(ciphertext)
+            (PlaintextBackend {}).decrypt(ciphertext)
         }
+
         fn is_secure(&self) -> bool {
             true
         }

--- a/components/engine_traits/src/encryption.rs
+++ b/components/engine_traits/src/encryption.rs
@@ -38,6 +38,12 @@ impl Debug for FileEncryptionInfo {
     }
 }
 
+impl FileEncryptionInfo {
+    pub fn is_empty(&self) -> bool {
+        self.key.is_empty() && self.iv.is_empty()
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum EncryptionMethod {
     Unknown = 0,

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -27,6 +27,7 @@ lazy_static = "1.3"
 prometheus = { version = "0.10", default-features = false, features = ["nightly", "push"] }
 rand = "0.7"
 rusoto_core = "0.45.0"
+rusoto_credential = "0.45.0"
 rusoto_s3 = "0.45.0"
 rusoto_util = { path = "../rusoto_util" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/components/rusoto_util/src/lib.rs
+++ b/components/rusoto_util/src/lib.rs
@@ -8,29 +8,12 @@ use rusoto_core::{
 };
 use rusoto_credential::{
     AutoRefreshingProvider, AwsCredentials, ChainProvider, CredentialsError, ProvideAwsCredentials,
-    StaticProvider,
 };
 use rusoto_sts::WebIdentityProvider;
 
 use async_trait::async_trait;
 
 const READ_BUF_SIZE: usize = 1024 * 1024 * 2;
-
-#[macro_export]
-macro_rules! new_client {
-    ($client: ty, $config: ident) => {{
-        let http_client = $crate::new_http_client()?;
-        new_client!($client, $config, http_client)
-    }};
-    ($client: ty, $config: ident, $dispatcher: ident) => {{
-        let region = $crate::get_region($config.region.as_ref(), $config.endpoint.as_ref())?;
-        let cred_provider = $crate::CredentialsProvider::new(
-            $config.access_key.as_ref(),
-            $config.secret_access_key.as_ref(),
-        )?;
-        <$client>::new_with($dispatcher, cred_provider, region)
-    }};
-}
 
 pub fn new_http_client() -> io::Result<HttpClient> {
     let mut http_config = HttpConfig::new();
@@ -64,43 +47,25 @@ pub fn get_region(region: &str, endpoint: &str) -> io::Result<Region> {
     }
 }
 
-pub enum CredentialsProvider {
-    Default(Box<AutoRefreshingProvider<DefaultCredentialsProvider>>),
-    Static(StaticProvider),
-}
+pub struct CredentialsProvider(AutoRefreshingProvider<DefaultCredentialsProvider>);
 
 impl CredentialsProvider {
-    pub fn new(access_key: &str, secret_access_key: &str) -> io::Result<CredentialsProvider> {
-        let cred_provider = if !access_key.is_empty() && !secret_access_key.is_empty() {
-            CredentialsProvider::Static(StaticProvider::new(
-                access_key.to_owned(),
-                secret_access_key.to_owned(),
-                None, /* token */
-                None, /* valid_for*/
-            ))
-        } else {
-            CredentialsProvider::Default(Box::new(
-                AutoRefreshingProvider::new(DefaultCredentialsProvider::default()).map_err(
-                    |e| {
-                        Error::new(
-                            ErrorKind::Other,
-                            format!("create aws credentials provider error: {}", e),
-                        )
-                    },
-                )?,
-            ))
-        };
-        Ok(cred_provider)
+    pub fn new() -> io::Result<CredentialsProvider> {
+        Ok(CredentialsProvider(
+            AutoRefreshingProvider::new(DefaultCredentialsProvider::default()).map_err(|e| {
+                Error::new(
+                    ErrorKind::Other,
+                    format!("create aws credentials provider error: {}", e),
+                )
+            })?,
+        ))
     }
 }
 
 #[async_trait]
 impl ProvideAwsCredentials for CredentialsProvider {
     async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
-        match self {
-            CredentialsProvider::Default(default_provider) => default_provider.credentials().await,
-            CredentialsProvider::Static(static_provider) => static_provider.credentials().await,
-        }
+        self.0.credentials().await
     }
 }
 
@@ -125,13 +90,15 @@ impl Default for DefaultCredentialsProvider {
 #[async_trait]
 impl ProvideAwsCredentials for DefaultCredentialsProvider {
     async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
-        // Need to use web identity provider first to prevent default provider takes precedence in
-        // kubernetes environment.
-        let k8s_error = match self.web_identity_provider.credentials().await {
+        // Prefer the web identity provider first for the kubernetes environment.
+        // Search for both in parallel.
+        let web_creds = self.web_identity_provider.credentials();
+        let def_creds = self.default_provider.credentials();
+        let k8s_error = match web_creds.await {
             res @ Ok(_) => return res,
             Err(e) => e,
         };
-        let def_error = match self.default_provider.credentials().await {
+        let def_error = match def_creds.await {
             res @ Ok(_) => return res,
             Err(e) => e,
         };

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -789,10 +789,9 @@ impl ImportFile {
         }
         fs::rename(&self.path.temp, &self.path.save)?;
         if let Some(ref manager) = self.key_manager {
-            manager.link_file(
-                self.path.temp.to_str().unwrap(),
-                self.path.save.to_str().unwrap(),
-            )?;
+            let tmp_str = self.path.temp.to_str().unwrap();
+            let save_str = self.path.save.to_str().unwrap();
+            manager.link_file(tmp_str, save_str)?;
             manager.delete_file(self.path.temp.to_str().unwrap())?;
         }
         Ok(())
@@ -1059,9 +1058,8 @@ mod tests {
         assert!(!path.exists());
         if let Some(manager) = key_manager {
             let info = manager.get_file(path.to_str().unwrap()).unwrap();
-            // the returned encryption info must be the default value
+            assert!(info.is_empty());
             assert_eq!(info.method, EncryptionMethod::Plaintext);
-            assert!(info.key.is_empty() && info.iv.is_empty());
         }
     }
 
@@ -1077,7 +1075,8 @@ mod tests {
 
     fn new_key_manager_for_test() -> (tempfile::TempDir, Arc<DataKeyManager>) {
         // test with tde
-        let (tmp_dir, key_manager) = new_test_key_manager(None, None, None, None);
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let key_manager = new_test_key_manager(&tmp_dir, None, None, None);
         assert!(key_manager.is_ok());
         (tmp_dir, Arc::new(key_manager.unwrap().unwrap()))
     }

--- a/components/sst_importer/src/util.rs
+++ b/components/sst_importer/src/util.rs
@@ -231,14 +231,16 @@ mod tests {
 
     #[test]
     fn test_prepare_sst_for_ingestion_with_key_manager_plaintext() {
-        let (_tmp_dir, key_manager) = new_test_key_manager(None, None, None, None);
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let key_manager = new_test_key_manager(&tmp_dir, None, None, None);
         let manager = Arc::new(key_manager.unwrap().unwrap());
         check_prepare_sst_for_ingestion(None, None, Some(&manager), false /*was_encrypted*/);
     }
 
     #[test]
     fn test_prepare_sst_for_ingestion_with_key_manager_encrypted() {
-        let (_tmp_dir, key_manager) = new_test_key_manager(None, None, None, None);
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let key_manager = new_test_key_manager(&tmp_dir, None, None, None);
         let manager = Arc::new(key_manager.unwrap().unwrap());
         check_prepare_sst_for_ingestion(None, None, Some(&manager), true /*was_encrypted*/);
     }


### PR DESCRIPTION
Signed-off-by: Greg Weber <greg@pingcap.com>

### What problem does this PR solve?

Problem Summary:

TiKV needs to support different KMS encryption providers. For example, issue #8906 


### What is changed and how it works?

What's Changed:

The KMS backend now has a KmsProvider which defaults to AwsKms.
It is now straightforward to write a different backend.

Some associated refactorings were made:
* Simplify KmsBackend internal state management
* Creating a backend does not happen inside Arc::new()
* Reduce code pollution of testing where `#[cfg(test)]` was used
* Add a Debug trait to backends
* Add some newtypes for safety
* Make some error messages more detailed
* Fix KMS was marked as not send but can change how it uses the APIs instead


### Related changes

None, cherry-pick to a release branch may be needed in the future.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test (tested manually with file backend and KMS backend to see that encryption is enabled and that keys are rotated)

### Release note <!-- bugfixes or new feature need a release note -->

Support alternative KMS encryption backends