### PR TITLE
raftstore: improve the coverage for half_split_bucket_size

### DIFF
--- a/components/raftstore/src/coprocessor/split_check/half.rs
+++ b/components/raftstore/src/coprocessor/split_check/half.rs
@@ -252,4 +252,21 @@ mod tests {
             .unwrap();
         assert_eq!(escape(&middle_key), "key_049");
     }
+
+    #[test]
+    fn test_half_split_bucket_size() {
+        assert!(half_split_bucket_size(1023), 1);
+        assert!(
+            half_split_bucket_size(ReadableSize::kb(2048).0),
+            ReadableSize::kb(2)
+        );
+        assert!(
+            half_split_bucket_size(ReadableSize::gb(1).0),
+            ReadableSize::mb(1)
+        );
+        assert!(
+            half_split_bucket_size(ReadableSize::gb(512).0),
+            ReadableSize::mb(BUCKET_SIZE_LIMIT_MB).0
+        );
+    }
 }


### PR DESCRIPTION
…nts/raftstore/coprocessor/split_check

Signed-off-by: FateTHarlaown <623239185@qq.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: ##7191

Problem Summary:
### What is changed and how it works?
add unit test for half_split_bucket_size

What's Changed:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->