### PR TITLE
scripts: update check-bins to make it python3.8 compatible

### DIFF
--- a/scripts/check-bins.py
+++ b/scripts/check-bins.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# 
+#
 # This script makes sure tests binary are linked to jemalloc and release binaries
 # utilize sse4.2 extensions.
 #
@@ -75,7 +75,7 @@ def check_tests(features):
         return
     else:
         print("Checking bins for jemalloc")
-    start = time.clock()
+    start = time.time()
     for line in sys.stdin.readlines():
         if not line.startswith('{'):
             continue
@@ -83,7 +83,7 @@ def check_tests(features):
         data = json.loads(line)
         if not data.get("executable"):
             continue
-        
+
         executable = data["executable"]
         name = executable.rsplit("/", 1)[1]
         if name.split('-')[0] in WHITE_LIST:
@@ -93,7 +93,7 @@ def check_tests(features):
         pr("Checking binary %s" % name)
         check_jemalloc(executable)
     pr("")
-    print("Done, takes %.2fs." % (time.clock() - start))
+    print("Done, takes %.2fs." % (time.time() - start))
 
 def check_release(enabled_features, args):
     checked_features = []


### PR DESCRIPTION
Signed-off-by: ichn-hu <zfhu16@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:

check-bins.py uses `time.clock` to estimate the running time, but it is deprecated since python 3.3 and is removed since python 3.8. Users with python 3.8+ can't run this script.

See https://docs.python.org/3.7/library/time.html?highlight=time%20clock#time.clock for details.

### What is changed and how it works?

What's Changed: use time.time instead of `time.clock`

### Related changes

- N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- no release note.