### PR TITLE
Fix build of all crates under default features, and prost-codec / test-engines-panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,7 +1160,6 @@ dependencies = [
  "slog-global",
  "structopt",
  "tempfile",
- "test_util",
  "tikv_alloc",
  "tikv_util",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
  "futures-executor",
  "futures-io",
  "futures-util",
+ "grpcio",
  "http",
  "hyper",
  "hyper-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,10 @@ protobuf-codec = [
 ]
 testexport = ["raftstore/testexport"]
 test-engines-rocksdb = [
-  "engine_test/test-engine-kv-rocksdb",
-  "engine_test/test-engine-raft-rocksdb",
+  "engine_test/test-engines-rocksdb",
 ]
 test-engines-panic = [
-  "engine_test/test-engine-kv-panic",
-  "engine_test/test-engine-raft-panic",
+  "engine_test/test-engines-panic",
 ]
 bcc-iosnoop = [
   "file_system/bcc-iosnoop",
@@ -98,7 +96,7 @@ derive_more = "0.99.3"
 encryption = { path = "components/encryption" }
 engine_panic = { path = "components/engine_panic", optional = true }
 engine_rocks = { path = "components/engine_rocks" }
-engine_test = { path = "components/engine_test" }
+engine_test = { path = "components/engine_test", default-features = false }
 engine_traits = { path = "components/engine_traits" }
 error_code = { path = "components/error_code" }
 fail = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,8 +206,8 @@ yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 
 [dev-dependencies]
 panic_hook = { path = "components/panic_hook" }
-test_sst_importer = { path = "components/test_sst_importer" }
-test_util = { path = "components/test_util" }
+test_sst_importer = { path = "components/test_sst_importer", default-features = false }
+test_util = { path = "components/test_util", default-features = false }
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 zipf = "6.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,35 +29,63 @@ failpoints = [
   "raftstore/failpoints",
   "engine_rocks/failpoints"
 ]
-prost-codec = [
-  "engine_rocks/prost-codec",
-  "grpcio/prost-codec",
-  "keys/prost-codec",
-  "kvproto/prost-codec",
-  "pd_client/prost-codec",
-  "raft/prost-codec",
-  "raftstore/prost-codec",
-  "sst_importer/prost-codec",
-  "tidb_query_datatype/prost-codec",
-  "tipb/prost-codec",
-  "txn_types/prost-codec",
-  "encryption/prost-codec",
-  "tikv_util/prost-codec",
-]
 protobuf-codec = [
+  "batch-system/protobuf-codec",
+  "codec/protobuf-codec",
+  "concurrency_manager/protobuf-codec",
+  "encryption/protobuf-codec",
+  "engine_panic/protobuf-codec",
   "engine_rocks/protobuf-codec",
+  "engine_test/protobuf-codec",
+  "engine_traits/protobuf-codec",
+  "error_code/protobuf-codec",
   "grpcio/protobuf-codec",
+  "into_other/protobuf-codec",
   "keys/protobuf-codec",
   "kvproto/protobuf-codec",
   "pd_client/protobuf-codec",
   "raft/protobuf-codec",
   "raftstore/protobuf-codec",
+  "raft_log_engine/protobuf-codec",
+  "security/protobuf-codec",
   "sst_importer/protobuf-codec",
+  "tidb_query_aggr/protobuf-codec",
+  "tidb_query_common/protobuf-codec",
   "tidb_query_datatype/protobuf-codec",
+  "tidb_query_executors/protobuf-codec",
+  "tidb_query_expr/protobuf-codec",
   "tipb/protobuf-codec",
-  "txn_types/protobuf-codec",
-  "encryption/protobuf-codec",
   "tikv_util/protobuf-codec",
+  "txn_types/protobuf-codec",
+]
+prost-codec = [
+  "batch-system/prost-codec",
+  "codec/prost-codec",
+  "concurrency_manager/prost-codec",
+  "encryption/prost-codec",
+  "engine_panic/prost-codec",
+  "engine_rocks/prost-codec",
+  "engine_test/prost-codec",
+  "engine_traits/prost-codec",
+  "error_code/prost-codec",
+  "grpcio/prost-codec",
+  "into_other/prost-codec",
+  "keys/prost-codec",
+  "kvproto/prost-codec",
+  "pd_client/prost-codec",
+  "raft/prost-codec",
+  "raftstore/prost-codec",
+  "raft_log_engine/prost-codec",
+  "security/prost-codec",
+  "sst_importer/prost-codec",
+  "tidb_query_aggr/prost-codec",
+  "tidb_query_common/prost-codec",
+  "tidb_query_datatype/prost-codec",
+  "tidb_query_executors/prost-codec",
+  "tidb_query_expr/prost-codec",
+  "tipb/prost-codec",
+  "tikv_util/prost-codec",
+  "txn_types/prost-codec",
 ]
 testexport = ["raftstore/testexport"]
 test-engines-rocksdb = [
@@ -86,19 +114,19 @@ bitflags = "1.0.1"
 byteorder = "1.2"
 cache-size = "0.5"
 chrono = "0.4"
-codec = { path = "components/codec" }
-concurrency_manager = { path = "components/concurrency_manager" }
+codec = { path = "components/codec", default-features = false }
+concurrency_manager = { path = "components/concurrency_manager", default-features = false }
 configuration = { path = "components/configuration" }
 crc32fast = "1.2"
 crc64fast = "0.1"
 crossbeam = "0.7.2"
 derive_more = "0.99.3"
-encryption = { path = "components/encryption" }
-engine_panic = { path = "components/engine_panic", optional = true }
-engine_rocks = { path = "components/engine_rocks" }
+encryption = { path = "components/encryption", default-features = false }
+engine_panic = { path = "components/engine_panic", default-features = false }
+engine_rocks = { path = "components/engine_rocks", default-features = false }
 engine_test = { path = "components/engine_test", default-features = false }
-engine_traits = { path = "components/engine_traits" }
-error_code = { path = "components/error_code" }
+engine_traits = { path = "components/engine_traits", default-features = false }
+error_code = { path = "components/error_code", default-features = false }
 fail = "0.4"
 failure = "0.1"
 file_system = { path = "components/file_system" }
@@ -114,8 +142,8 @@ openssl = "0.10"
 hyper = "0.13"
 hyper-openssl = "0.8"
 http = "0"
-into_other = { path = "components/into_other" }
-keys = { path = "components/keys" }
+into_other = { path = "components/into_other", default-features = false }
+keys = { path = "components/keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 libc = "0.2"
@@ -126,7 +154,7 @@ more-asserts = "0.2"
 murmur3 = "0.5.1"
 nom = { version = "5.1.0", default-features = false, features = ["std"] }
 num_cpus = "1"
-pd_client = { path = "components/pd_client" }
+pd_client = { path = "components/pd_client", default-features = false }
 pin-project = "0.4.8"
 pnet_datalink = "0.23"
 prost = "0.6"
@@ -134,12 +162,12 @@ pprof = { version = "^0.3.14", default-features = false, features = ["flamegraph
 protobuf = "2.8"
 quick-error = "1.2.3"
 raft = { version = "0.6.0-alpha", default-features = false }
-raftstore = { path = "components/raftstore" }
-raft_log_engine = { path = "components/raft_log_engine" }
+raftstore = { path = "components/raftstore", default-features = false }
+raft_log_engine = { path = "components/raft_log_engine", default-features = false }
 rand = "0.7.3"
 regex = "1.3"
 rev_lines = "0.2.1"
-security = { path = "components/security" }
+security = { path = "components/security", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_ignored = "0.1"
@@ -150,17 +178,17 @@ slog_derive = "0.2"
 parking_lot = "0.11"
 prometheus = { version = "0.10", features = ["nightly"] }
 prometheus-static-metric = "0.4"
-sst_importer = { path = "components/sst_importer" }
+sst_importer = { path = "components/sst_importer", default-features = false }
 sysinfo = "0.15"
 tempfile = "3.0"
 match_template = { path = "components/match_template" }
-tidb_query_datatype = { path = "components/tidb_query_datatype" }
-tidb_query_common = { path = "components/tidb_query_common" }
-tidb_query_expr = { path = "components/tidb_query_expr" }
-tidb_query_aggr = { path = "components/tidb_query_aggr" }
-tidb_query_executors = { path = "components/tidb_query_executors" }
+tidb_query_datatype = { path = "components/tidb_query_datatype", default-features = false }
+tidb_query_common = { path = "components/tidb_query_common", default-features = false }
+tidb_query_expr = { path = "components/tidb_query_expr", default-features = false }
+tidb_query_aggr = { path = "components/tidb_query_aggr", default-features = false }
+tidb_query_executors = { path = "components/tidb_query_executors", default-features = false }
 tikv_alloc = { path = "components/tikv_alloc" }
-tikv_util = { path = "components/tikv_util" }
+tikv_util = { path = "components/tikv_util", default-features = false }
 collections = { path = "components/collections" }
 time = "0.1"
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
@@ -168,7 +196,7 @@ tokio = { version = "0.2", features = ["full"] }
 tokio-timer = "0.2"
 tokio-openssl = "0.4"
 toml = "0.5"
-txn_types = { path = "components/txn_types" }
+txn_types = { path = "components/txn_types", default-features = false }
 url = "2"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 vlog = "0.1.4"

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 default-run = "tikv-server"
 
 [features]
-default = ["tikv/test-engines-rocksdb"]
+default = ["protobuf-codec", "test-engines-rocksdb"]
 tcmalloc = ["tikv/tcmalloc"]
 jemalloc = ["tikv/jemalloc"]
 mimalloc = ["tikv/mimalloc"]
@@ -17,29 +17,49 @@ mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
 protobuf-codec = [
   "backup/protobuf-codec",
+  "cdc/protobuf-codec",
+  "concurrency_manager/protobuf-codec",
+  "encryption/protobuf-codec",
+  "engine_rocks/protobuf-codec",
+  "engine_traits/protobuf-codec",
+  "error_code/protobuf-codec",
   "grpcio/protobuf-codec",
   "keys/protobuf-codec",
   "kvproto/protobuf-codec",
   "pd_client/protobuf-codec",
   "raft/protobuf-codec",
   "raftstore/protobuf-codec",
+  "raft_log_engine/protobuf-codec",
+  "security/protobuf-codec",
   "tikv/protobuf-codec",
+  "tikv_util/protobuf-codec",
   "txn_types/protobuf-codec",
-  "cdc/protobuf-codec",
-  "raft_log_engine/protobuf-codec"
 ]
 prost-codec = [
   "backup/prost-codec",
+  "cdc/prost-codec",
+  "concurrency_manager/prost-codec",
+  "encryption/prost-codec",
+  "engine_rocks/prost-codec",
+  "engine_traits/prost-codec",
+  "error_code/prost-codec",
   "grpcio/prost-codec",
   "keys/prost-codec",
   "kvproto/prost-codec",
   "pd_client/prost-codec",
   "raft/prost-codec",
   "raftstore/prost-codec",
+  "raft_log_engine/prost-codec",
+  "security/prost-codec",
   "tikv/prost-codec",
+  "tikv_util/prost-codec",
   "txn_types/prost-codec",
-  "cdc/prost-codec",
-  "raft_log_engine/prost-codec"
+]
+test-engines-rocksdb = [
+  "tikv/test-engines-rocksdb",
+]
+test-engines-panic = [
+  "tikv/test-engines-panic",
 ]
 
 [lib]
@@ -53,46 +73,46 @@ name = "tikv-ctl"
 
 [dependencies]
 backup = { path = "../components/backup", default-features = false }
-cdc = { path = "../components/cdc" }
+cdc = { path = "../components/cdc", default-features = false }
 chrono = "0.4"
 crossbeam = "0.7"
 tempfile = "3.0"
 clap = "2.32"
-concurrency_manager = { path = "../components/concurrency_manager" }
-encryption = { path = "../components/encryption" }
-engine_rocks = { path = "../components/engine_rocks" }
-engine_traits = { path = "../components/engine_traits" }
-error_code = { path = "../components/error_code" }
+concurrency_manager = { path = "../components/concurrency_manager", default-features = false }
+encryption = { path = "../components/encryption", default-features = false }
+engine_rocks = { path = "../components/engine_rocks", default-features = false }
+engine_traits = { path = "../components/engine_traits", default-features = false }
+error_code = { path = "../components/error_code", default-features = false }
 file_system = { path = "../components/file_system" }
 fs2 = "0.4"
 futures = "0.3"
 tokio = { version = "0.2", features = ["rt-threaded"] }
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
-keys = { path = "../components/keys" }
+keys = { path = "../components/keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../components/log_wrappers" }
 nix = "0.11"
-pd_client = { path = "../components/pd_client" }
+pd_client = { path = "../components/pd_client", default-features = false }
 prometheus = { version = "0.10", features = ["nightly"] }
 promptly = "0.3.0"
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }
-raft_log_engine = { path = "../components/raft_log_engine" }
-raftstore = { path = "../components/raftstore" }
+raft_log_engine = { path = "../components/raft_log_engine", default-features = false }
+raftstore = { path = "../components/raftstore", default-features = false }
 rand = "0.7"
-security = { path = "../components/security" }
+security = { path = "../components/security", default-features = false }
 serde_json = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tikv = { path = "../", default-features = false }
 tikv_alloc = { path = "../components/tikv_alloc" }
-tikv_util = { path = "../components/tikv_util" }
+tikv_util = { path = "../components/tikv_util", default-features = false }
 collections = { path = "../components/collections" }
 toml = "0.5"
-txn_types = { path = "../components/txn_types" }
+txn_types = { path = "../components/txn_types", default-features = false }
 vlog = "0.1.4"
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 default-run = "tikv-server"
 
 [features]
+default = ["tikv/test-engines-rocksdb"]
 tcmalloc = ["tikv/tcmalloc"]
 jemalloc = ["tikv/jemalloc"]
 mimalloc = ["tikv/mimalloc"]
@@ -40,8 +41,6 @@ prost-codec = [
   "cdc/prost-codec",
   "raft_log_engine/prost-codec"
 ]
-test-engines-rocksdb = ["tikv/test-engines-rocksdb"]
-test-engines-panic = ["tikv/test-engines-panic"]
 
 [lib]
 name = "cmd"

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -9,28 +9,48 @@ name = "integrations"
 path = "tests/integrations/mod.rs"
 
 [features]
-default = ["protobuf-codec", "tikv/test-engines-rocksdb"]
+default = ["protobuf-codec", "test-engines-rocksdb"]
 protobuf-codec = [
+  "concurrency_manager/protobuf-codec",
   "engine_rocks/protobuf-codec",
+  "engine_traits/protobuf-codec",
+  "error_code/protobuf-codec",
   "external_storage/protobuf-codec",
   "grpcio/protobuf-codec",
   "keys/protobuf-codec",
   "kvproto/protobuf-codec",
+  "pd_client/protobuf-codec",
   "raft/protobuf-codec",
   "raftstore/protobuf-codec",
+  "security/protobuf-codec",
+  "tidb_query_common/protobuf-codec",
   "tikv/protobuf-codec",
+  "tikv_util/protobuf-codec",
   "txn_types/protobuf-codec",
 ]
 prost-codec = [
+  "concurrency_manager/prost-codec",
   "engine_rocks/prost-codec",
+  "engine_traits/prost-codec",
+  "error_code/prost-codec",
   "external_storage/prost-codec",
   "grpcio/prost-codec",
   "keys/prost-codec",
   "kvproto/prost-codec",
+  "pd_client/prost-codec",
   "raft/prost-codec",
   "raftstore/prost-codec",
+  "security/prost-codec",
+  "tidb_query_common/prost-codec",
   "tikv/prost-codec",
+  "tikv_util/prost-codec",
   "txn_types/prost-codec",
+]
+test-engines-rocksdb = [
+  "tikv/test-engines-rocksdb",
+]
+test-engines-panic = [
+  "tikv/test-engines-panic",
 ]
 tcmalloc = ["tikv/tcmalloc"]
 jemalloc = ["tikv/jemalloc"]
@@ -41,39 +61,39 @@ mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
 
 [dependencies]
-concurrency_manager = { path = "../concurrency_manager" }
+concurrency_manager = { path = "../concurrency_manager", default-features = false }
 configuration = { path = "../configuration" }
 crc64fast = "0.1"
-engine_rocks = { path = "../engine_rocks" }
-engine_traits = { path = "../engine_traits" }
-error_code = { path = "../error_code" }
-external_storage = { path = "../external_storage" }
+engine_rocks = { path = "../engine_rocks", default-features = false }
+engine_traits = { path = "../engine_traits", default-features = false }
+error_code = { path = "../error_code", default-features = false }
+external_storage = { path = "../external_storage", default-features = false }
 failure = "0.1"
 file_system = { path = "../file_system" }
 futures = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
-keys = { path = "../keys" }
+keys = { path = "../keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
-pd_client = { path = "../pd_client" }
+pd_client = { path = "../pd_client", default-features = false }
 prometheus = { version = "0.10", default-features = false, features = ["nightly"] }
 raft = { version = "0.6.0-alpha", default-features = false }
-raftstore = { path = "../raftstore" }
-security = { path = "../security" }
+raftstore = { path = "../raftstore", default-features = false }
+security = { path = "../security", default-features = false }
 serde = "1.0"
 serde_derive = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 # better to not use slog-global, but pass in the logger
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
-tidb_query_common = { path = "../tidb_query_common" }
+tidb_query_common = { path = "../tidb_query_common", default-features = false }
 tikv = { path = "../../", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
-txn_types = { path = "../txn_types" }
+txn_types = { path = "../txn_types", default-features = false }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 
 [dev-dependencies]
@@ -81,5 +101,5 @@ futures-executor = "0.3"
 rand = "0.7"
 tempfile = "3.0"
 test_util = { path = "../test_util" }
-test_raftstore = { path = "../test_raftstore" }
+test_raftstore = { path = "../test_raftstore", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -9,7 +9,7 @@ name = "integrations"
 path = "tests/integrations/mod.rs"
 
 [features]
-default = ["protobuf-codec", "test-engines-rocksdb"]
+default = ["protobuf-codec", "tikv/test-engines-rocksdb"]
 protobuf-codec = [
   "engine_rocks/protobuf-codec",
   "external_storage/protobuf-codec",
@@ -39,8 +39,6 @@ portable = ["tikv/portable"]
 sse = ["tikv/sse"]
 mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
-test-engines-rocksdb = ["tikv/test-engines-rocksdb"]
-test-engines-panic = ["tikv/test-engines-panic"]
 
 [dependencies]
 concurrency_manager = { path = "../concurrency_manager" }

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -100,6 +100,6 @@ yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 futures-executor = "0.3"
 rand = "0.7"
 tempfile = "3.0"
-test_util = { path = "../test_util" }
+test_util = { path = "../test_util", default-features = false }
 test_raftstore = { path = "../test_raftstore", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }

--- a/components/batch-system/Cargo.toml
+++ b/components/batch-system/Cargo.toml
@@ -4,12 +4,18 @@ version = "0.1.0"
 edition = "2018"
 
 [features]
-default = ["test-runner"]
+default = ["test-runner", "protobuf-codec"]
 test-runner = ["derive_more"]
+prost-codec = [
+  "tikv_util/prost-codec",
+]
+protobuf-codec = [
+  "tikv_util/protobuf-codec",
+]
 
 [dependencies]
 crossbeam = "0.7"
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 file_system = { path = "../file_system" }
 collections = { path = "../collections" }
 serde = { version = "1.0", features = ["derive"] }

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["tikv/test-engines-rocksdb"]
 protobuf-codec = [
   "engine_rocks/protobuf-codec",
   "grpcio/protobuf-codec",
@@ -32,8 +33,6 @@ portable = ["tikv/portable"]
 sse = ["tikv/sse"]
 mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
-test-engines-rocksdb = ["tikv/test-engines-rocksdb"]
-test-engines-panic = ["tikv/test-engines-panic"]
 
 [dependencies]
 bitflags = "1.0"

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -5,26 +5,42 @@ edition = "2018"
 publish = false
 
 [features]
-default = ["tikv/test-engines-rocksdb"]
+default = ["protobuf-codec", "test-engines-rocksdb"]
 protobuf-codec = [
+  "concurrency_manager/protobuf-codec",
   "engine_rocks/protobuf-codec",
+  "engine_traits/protobuf-codec",
   "grpcio/protobuf-codec",
   "kvproto/protobuf-codec",
   "pd_client/protobuf-codec",
   "raft/protobuf-codec",
   "raftstore/protobuf-codec",
+  "resolved_ts/protobuf-codec",
+  "security/protobuf-codec",
   "tikv/protobuf-codec",
+  "tikv_util/protobuf-codec",
   "txn_types/protobuf-codec",
 ]
 prost-codec = [
+  "concurrency_manager/prost-codec",
   "engine_rocks/prost-codec",
+  "engine_traits/prost-codec",
   "grpcio/prost-codec",
   "kvproto/prost-codec",
   "pd_client/prost-codec",
   "raft/prost-codec",
   "raftstore/prost-codec",
+  "resolved_ts/prost-codec",
+  "security/prost-codec",
   "tikv/prost-codec",
+  "tikv_util/prost-codec",
   "txn_types/prost-codec",
+]
+test-engines-rocksdb = [
+  "tikv/test-engines-rocksdb",
+]
+test-engines-panic = [
+  "tikv/test-engines-panic",
 ]
 tcmalloc = ["tikv/tcmalloc"]
 jemalloc = ["tikv/jemalloc"]
@@ -37,26 +53,26 @@ failpoints = ["tikv/failpoints"]
 [dependencies]
 bitflags = "1.0"
 crossbeam = "0.7"
-engine_rocks = { path = "../engine_rocks" }
-engine_traits = { path = "../engine_traits" }
+engine_rocks = { path = "../engine_rocks", default-features = false }
+engine_traits = { path = "../engine_traits", default-features = false }
 failure = "0.1"
 futures = "0.3"
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
-pd_client = { path = "../pd_client" }
+pd_client = { path = "../pd_client", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
-raftstore = { path = "../raftstore" }
-resolved_ts = { path = "../resolved_ts" }
-security = { path = "../security" }
+raftstore = { path = "../raftstore", default-features = false }
+resolved_ts = { path = "../resolved_ts", default-features = false }
+security = { path = "../security", default-features = false }
 semver = "0.10"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tikv = { path = "../../", default-features = false }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
 tokio = { version = "0.2", features = ["rt-threaded"]}
-txn_types = { path = "../txn_types" }
-concurrency_manager = { path = "../concurrency_manager" }
+txn_types = { path = "../txn_types", default-features = false }
+concurrency_manager = { path = "../concurrency_manager", default-features = false }
 fail = "0.4"
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
@@ -67,7 +83,7 @@ prost = "0.6"
 [dev-dependencies]
 engine_traits = { path = "../engine_traits" }
 tempfile = "3.0"
-test_raftstore = { path = "../test_raftstore" }
+test_raftstore = { path = "../test_raftstore", default-features = false }
 test_util = { path = "../test_util" }
 panic_hook = { path = "../panic_hook" }
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -81,10 +81,10 @@ protobuf = "2.8"
 prost = "0.6"
 
 [dev-dependencies]
-engine_traits = { path = "../engine_traits" }
+engine_traits = { path = "../engine_traits", default-features = false }
 tempfile = "3.0"
 test_raftstore = { path = "../test_raftstore", default-features = false }
-test_util = { path = "../test_util" }
+test_util = { path = "../test_util", default-features = false }
 panic_hook = { path = "../panic_hook" }
 raft = { version = "0.6.0-alpha", default-features = false }
 

--- a/components/codec/Cargo.toml
+++ b/components/codec/Cargo.toml
@@ -4,9 +4,18 @@ version = "0.0.1"
 edition = "2018"
 publish = false
 
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "error_code/protobuf-codec",
+]
+prost-codec = [
+  "error_code/prost-codec",
+]
+
 [dependencies]
 byteorder = "1.2"
-error_code = { path = "../error_code" }
+error_code = { path = "../error_code", default-features = false }
 failure = "0.1"
 libc = "0.2"
 static_assertions = { version = "1.0", features = ["nightly"] }

--- a/components/concurrency_manager/Cargo.toml
+++ b/components/concurrency_manager/Cargo.toml
@@ -15,7 +15,7 @@ prost-codec = [
 
 [dependencies]
 parking_lot = "0.11"
-tokio = { version = "0.2", features = ["sync"] }
+tokio = { version = "0.2", features = ["macros", "sync", "time"] }
 txn_types = { path = "../txn_types", default-features = false }
 fail = "0.4"
 

--- a/components/concurrency_manager/Cargo.toml
+++ b/components/concurrency_manager/Cargo.toml
@@ -4,10 +4,19 @@ name = "concurrency_manager"
 publish = false
 version = "0.0.1"
 
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "txn_types/protobuf-codec",
+]
+prost-codec = [
+  "txn_types/prost-codec",
+]
+
 [dependencies]
 parking_lot = "0.11"
 tokio = { version = "0.2", features = ["sync"] }
-txn_types = { path = "../txn_types" }
+txn_types = { path = "../txn_types", default-features = false }
 fail = "0.4"
 
 [dependencies.crossbeam-skiplist]

--- a/components/configuration/Cargo.toml
+++ b/components/configuration/Cargo.toml
@@ -9,7 +9,7 @@ name = "configuration"
 
 [dependencies]
 configuration_derive = { path = "./configuration_derive" }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -5,8 +5,19 @@ edition = "2018"
 publish = false
 
 [features]
-protobuf-codec = ["kvproto/protobuf-codec"]
-prost-codec = ["kvproto/prost-codec"]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "engine_traits/protobuf-codec",
+  "error_code/protobuf-codec",
+  "kvproto/protobuf-codec",
+  "tikv_util/protobuf-codec",
+]
+prost-codec = [
+  "engine_traits/prost-codec",
+  "error_code/prost-codec",
+  "kvproto/prost-codec",
+  "tikv_util/prost-codec",
+]
 failpoints = ["fail/failpoints"]
 
 [dependencies]
@@ -15,8 +26,8 @@ bytes = "0.5"
 crossbeam = "0.7"
 configuration = { path = "../configuration" }
 crc32fast = "1.2"
-engine_traits = { path = "../engine_traits" }
-error_code = { path = "../error_code" }
+engine_traits = { path = "../engine_traits", default-features = false }
+error_code = { path = "../error_code", default-features = false }
 fail = "0.4"
 failure = "0.1"
 futures = "0.3"
@@ -38,7 +49,7 @@ slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debu
 # better to not use slog-global, but pass in the logger
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tikv_alloc = { path = "../tikv_alloc" }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 tokio = { version = "0.2", features = ["time", "rt-core"] }
 
 [dev-dependencies]

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -59,4 +59,3 @@ toml = "0.5"
 rusoto_mock = "0.45.0"
 rust-ini = "0.14.0"
 structopt = "0.3"
-test_util = { path = "../test_util" }

--- a/components/engine_panic/Cargo.toml
+++ b/components/engine_panic/Cargo.toml
@@ -6,20 +6,27 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = [
-  "raft/protobuf-codec",
+  "engine_traits/protobuf-codec",
   "kvproto/protobuf-codec",
+  "raft/protobuf-codec",
+  "tikv_util/protobuf-codec",
+  "txn_types/protobuf-codec",
 ]
 prost-codec = [
-  "raft/prost-codec",
+  "engine_traits/prost-codec",
   "kvproto/prost-codec",
+  "raft/prost-codec",
+  "tikv_util/prost-codec",
+  "txn_types/prost-codec",
 ]
 
 [dependencies]
-engine_traits = { path = "../engine_traits" }
+engine_traits = { path = "../engine_traits", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
 # FIXME: Remove this dep from the engine_traits interface
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
-txn_types = { path = "../txn_types" }
+txn_types = { path = "../txn_types", default-features = false }

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -5,17 +5,24 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = [
+  "encryption/protobuf-codec",
+  "engine_traits/protobuf-codec",
   "keys/protobuf-codec",
-  "txn_types/protobuf-codec",
-  "raft/protobuf-codec",
   "kvproto/protobuf-codec",
+  "raft/protobuf-codec",
+  "tikv_util/protobuf-codec",
+  "txn_types/protobuf-codec",
 ]
 prost-codec = [
+  "encryption/prost-codec",
+  "engine_traits/prost-codec",
   "keys/prost-codec",
-  "txn_types/prost-codec",
-  "raft/prost-codec",
   "kvproto/prost-codec",
+  "raft/prost-codec",
+  "tikv_util/prost-codec",
+  "txn_types/prost-codec",
 ]
 jemalloc = ["rocksdb/jemalloc"]
 portable = ["rocksdb/portable"]
@@ -23,18 +30,18 @@ sse = ["rocksdb/sse"]
 failpoints = ["fail/failpoints"]
 
 [dependencies]
-encryption = { path = "../encryption" }
-engine_traits = { path = "../engine_traits" }
-keys = { path = "../keys" }
+encryption = { path = "../encryption", default-features = false }
+engine_traits = { path = "../engine_traits", default-features = false }
+keys = { path = "../keys", default-features = false }
 num_cpus = "1"
 prometheus = { version = "0.10", features = ["nightly"] }
 prometheus-static-metric = "0.4"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tikv_alloc = { path = "../tikv_alloc" }
-tikv_util = { path = "../tikv_util" }
-collections = { path = "../collections" }
-txn_types = { path = "../txn_types"}
+tikv_util = { path = "../tikv_util", default-features = false }
+collections = { path = "../collections", default-features = false }
+txn_types = { path = "../txn_types", default-features = false}
 lazy_static = "1.4.0"
 log_wrappers = { path = "../log_wrappers" }
 time = "0.1"

--- a/components/engine_test/Cargo.toml
+++ b/components/engine_test/Cargo.toml
@@ -6,18 +6,42 @@ edition = "2018"
 publish = false
 
 [features]
-default = []
+default = ["protobuf-codec", "test-engines-rocksdb"]
+
+protobuf-codec = [
+  "engine_panic/protobuf-codec",
+  "engine_rocks/protobuf-codec",
+  "engine_traits/protobuf-codec",
+  "tikv_util/protobuf-codec",
+]
+
+prost-codec = [
+  "engine_panic/prost-codec",
+  "engine_rocks/prost-codec",
+  "engine_traits/prost-codec",
+  "tikv_util/prost-codec",
+]
+
 test-engine-kv-panic = []
 test-engine-kv-rocksdb = []
 test-engine-raft-panic = []
 test-engine-raft-rocksdb = []
 
+test-engines-rocksdb = [
+  "test-engine-kv-rocksdb",
+  "test-engine-raft-rocksdb",
+]
+test-engines-panic = [
+  "test-engine-kv-panic",
+  "test-engine-raft-panic",
+]
+
 
 [dependencies]
-engine_traits = { path = "../engine_traits" }
-engine_rocks = { path = "../engine_rocks" }
-engine_panic = { path = "../engine_panic" }
+engine_panic = { path = "../engine_panic", default-features = false }
+engine_rocks = { path = "../engine_rocks", default-features = false }
+engine_traits = { path = "../engine_traits", default-features = false }
 tempfile = "3.0"
 tikv_alloc = { path = "../tikv_alloc" }
 # FIXME: Remove this dep from the engine_traits interface
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }

--- a/components/engine_traits/Cargo.toml
+++ b/components/engine_traits/Cargo.toml
@@ -5,24 +5,31 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = [
+  "error_code/protobuf-codec",
   "raft/protobuf-codec",
   "kvproto/protobuf-codec",
+  "tikv_util/protobuf-codec",
+  "txn_types/protobuf-codec",
 ]
 prost-codec = [
+  "error_code/prost-codec",
   "raft/prost-codec",
   "kvproto/prost-codec",
+  "tikv_util/prost-codec",
+  "txn_types/prost-codec",
 ]
 
 [dependencies]
-error_code = { path = "../error_code" }
+error_code = { path = "../error_code", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 protobuf = "2"
 quick-error = "1.2.3"
 tikv_alloc = { path = "../tikv_alloc" }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 file_system = { path = "../file_system" }
-txn_types = { path = "../txn_types" }
+txn_types = { path = "../txn_types", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }

--- a/components/error_code/Cargo.toml
+++ b/components/error_code/Cargo.toml
@@ -5,13 +5,14 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 prost-codec = [
-  "kvproto/prost-codec",
   "grpcio/prost-codec",
+  "kvproto/prost-codec",
 ]
 protobuf-codec = [
-  "kvproto/protobuf-codec",
   "grpcio/protobuf-codec",
+  "kvproto/protobuf-codec",
 ]
 
 [lib]

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = ["kvproto/protobuf-codec"]
 prost-codec = ["kvproto/prost-codec"]
 

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -15,6 +15,10 @@ futures = "0.3"
 futures-executor = "0.3"
 futures-io = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
+# This is only a dependency to vendor openssl for rusoto. It's not clear exactly
+# how openssl is built for tikv, but it seems to be controlled by grpcio. This
+# makes `cargo test -p external_storage` link correctly.
+grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 http = "0.2.0"
 hyper = "0.13.3"
 hyper-tls = "0.4.1"

--- a/components/into_other/Cargo.toml
+++ b/components/into_other/Cargo.toml
@@ -5,10 +5,19 @@ edition = "2018"
 publish = false
 
 [features]
-protobuf-codec = ["kvproto/protobuf-codec", "raft/protobuf-codec"]
-prost-codec = ["kvproto/prost-codec", "raft/prost-codec"]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "engine_traits/protobuf-codec",
+  "kvproto/protobuf-codec",
+  "raft/protobuf-codec"
+]
+prost-codec = [
+  "engine_traits/prost-codec",
+  "kvproto/prost-codec",
+  "raft/prost-codec"
+]
 
 [dependencies]
-engine_traits = { path = "../engine_traits" }
+engine_traits = { path = "../engine_traits", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -5,8 +5,15 @@ edition = "2018"
 publish = false
 
 [features]
-protobuf-codec = ["kvproto/protobuf-codec"]
-prost-codec = ["kvproto/prost-codec"]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "kvproto/protobuf-codec",
+  "tikv_util/protobuf-codec",
+]
+prost-codec = [
+  "kvproto/prost-codec",
+  "tikv_util/prost-codec",
+]
 
 [dependencies]
 byteorder = "1.2"
@@ -15,7 +22,7 @@ failure = "0.1"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 tikv_alloc = { path = "../tikv_alloc" }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 
 [dev-dependencies]
 panic_hook = { path = "../panic_hook" }

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -5,20 +5,27 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = [
+  "error_code/protobuf-codec",
   "grpcio/protobuf-codec",
   "kvproto/protobuf-codec",
+  "security/protobuf-codec",
+  "tikv_util/protobuf-codec",
   "txn_types/protobuf-codec",
 ]
 prost-codec = [
+  "error_code/prost-codec",
   "grpcio/prost-codec",
   "kvproto/prost-codec",
+  "security/prost-codec",
+  "tikv_util/prost-codec",
   "txn_types/prost-codec",
 ]
 failpoints = ["fail/failpoints"]
 
 [dependencies]
-error_code = { path = "../error_code" }
+error_code = { path = "../error_code", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
@@ -27,15 +34,15 @@ log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug
 log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.10", features = ["nightly"] }
 quick-error = "1.2.3"
-security = { path = "../security" }
+security = { path = "../security", default-features = false }
 serde = "1.0"
 serde_derive = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tikv_alloc = { path = "../tikv_alloc" }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
 tokio-timer = "0.2"
-txn_types = { path = "../txn_types" }
+txn_types = { path = "../txn_types", default-features = false }
 semver = "0.10"
 fail = "0.4"

--- a/components/raft_log_engine/Cargo.toml
+++ b/components/raft_log_engine/Cargo.toml
@@ -5,19 +5,24 @@ publish = false
 edition = "2018"
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = [
+  "engine_traits/protobuf-codec",
   "raft/protobuf-codec",
   "kvproto/protobuf-codec",
+  "tikv_util/protobuf-codec",
 ]
 
 prost-codec = [
+  "engine_traits/prost-codec",
   "raft/prost-codec",
   "kvproto/prost-codec",
+  "tikv_util/prost-codec",
 ]
 
 [dependencies]
-engine_traits = { path = "../engine_traits" }
-tikv_util = { path = "../tikv_util" }
+engine_traits = { path = "../engine_traits", default-features = false }
+tikv_util = { path = "../tikv_util", default-features = false }
 num_cpus = "1"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["test-engines-rocksdb"]
 failpoints = ["fail/failpoints"]
 prost-codec = [
   "prost",
@@ -32,6 +33,12 @@ protobuf-codec = [
   "txn_types/protobuf-codec",
 ]
 testexport = []
+test-engines-rocksdb = [
+  "engine_test/test-engines-rocksdb",
+]
+test-engines-panic = [
+  "engine_test/test-engines-panic",
+]
 
 [dependencies]
 batch-system = { path = "../batch-system" }
@@ -41,8 +48,9 @@ concurrency_manager = { path = "../concurrency_manager" }
 configuration = { path = "../configuration" }
 crc32fast = "1.2"
 crossbeam = "0.7.2"
-engine_rocks = { path = "../engine_rocks" }
 encryption = { path = "../encryption" }
+engine_rocks = { path = "../engine_rocks" }
+engine_test = { path = "../engine_test", default-features = false }
 engine_traits = { path = "../engine_traits" }
 error_code = { path = "../error_code" }
 fail = "0.4"
@@ -85,7 +93,6 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 
 [dev-dependencies]
-engine_test = { path = "../engine_test" }
 panic_hook = { path = "../panic_hook" }
 test_sst_importer = { path = "../test_sst_importer" }
 engine_panic = { path = "../engine_panic" }

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -7,22 +7,15 @@ edition = "2018"
 publish = false
 
 [features]
-default = ["test-engines-rocksdb"]
+default = ["protobuf-codec", "test-engines-rocksdb"]
 failpoints = ["fail/failpoints"]
-prost-codec = [
-  "prost",
-  "engine_rocks/prost-codec",
-  "into_other/prost-codec",
-  "keys/prost-codec",
-  "kvproto/prost-codec",
-  "raft/prost-codec",
-  "pd_client/prost-codec",
-  "sst_importer/prost-codec",
-  "tidb_query_datatype/prost-codec",
-  "txn_types/prost-codec",
-]
 protobuf-codec = [
+  "batch-system/protobuf-codec",
+  "concurrency_manager/protobuf-codec",
   "engine_rocks/protobuf-codec",
+  "engine_test/protobuf-codec",
+  "engine_traits/protobuf-codec",
+  "error_code/protobuf-codec",
   "into_other/protobuf-codec",
   "keys/protobuf-codec",
   "kvproto/protobuf-codec",
@@ -30,7 +23,26 @@ protobuf-codec = [
   "pd_client/protobuf-codec",
   "sst_importer/protobuf-codec",
   "tidb_query_datatype/protobuf-codec",
+  "tikv_util/protobuf-codec",
   "txn_types/protobuf-codec",
+]
+prost-codec = [
+  "prost",
+  "batch-system/prost-codec",
+  "concurrency_manager/prost-codec",
+  "engine_rocks/prost-codec",
+  "engine_test/prost-codec",
+  "engine_traits/prost-codec",
+  "error_code/prost-codec",
+  "into_other/prost-codec",
+  "keys/prost-codec",
+  "kvproto/prost-codec",
+  "raft/prost-codec",
+  "pd_client/prost-codec",
+  "sst_importer/prost-codec",
+  "tidb_query_datatype/prost-codec",
+  "tikv_util/prost-codec",
+  "txn_types/prost-codec",
 ]
 testexport = []
 test-engines-rocksdb = [
@@ -41,31 +53,30 @@ test-engines-panic = [
 ]
 
 [dependencies]
-batch-system = { path = "../batch-system" }
+batch-system = { path = "../batch-system", default-features = false }
 bitflags = "1.0.1"
 byteorder = "1.2"
-concurrency_manager = { path = "../concurrency_manager" }
+concurrency_manager = { path = "../concurrency_manager", default-features = false }
 configuration = { path = "../configuration" }
 crc32fast = "1.2"
 crossbeam = "0.7.2"
-encryption = { path = "../encryption" }
-engine_rocks = { path = "../engine_rocks" }
-engine_test = { path = "../engine_test", default-features = false }
-engine_traits = { path = "../engine_traits" }
-error_code = { path = "../error_code" }
+encryption = { path = "../encryption", default-features = false }
+engine_rocks = { path = "../engine_rocks", default-features = false }
+engine_traits = { path = "../engine_traits", default-features = false }
+error_code = { path = "../error_code", default-features = false }
 fail = "0.4"
 openssl = "0.10"
 file_system = { path = "../file_system" }
 fs2 = "0.4"
 futures = "0.3"
 futures-util = { version = "0.3.1", default-features = false, features = ["io"] }
-into_other = { path = "../into_other" }
-keys = { path = "../keys" }
+into_other = { path = "../into_other",  default-features = false }
+keys = { path = "../keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }
-pd_client = { path = "../pd_client" }
+pd_client = { path = "../pd_client", default-features = false }
 prometheus = { version = "0.10", features = ["nightly"] }
 prometheus-static-metric = "0.4"
 prost = { version = "0.6", optional = true }
@@ -80,17 +91,21 @@ serde_with = "1.4"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 smallvec = "1.4"
-sst_importer = { path = "../sst_importer" }
+sst_importer = { path = "../sst_importer", default-features = false }
 tempfile = "3.0"
-tidb_query_datatype = { path = "../tidb_query_datatype" }
+tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
 time = "0.1"
 tokio = { version = "0.2", features = ["sync", "rt-threaded"] }
-txn_types = { path = "../txn_types" }
+txn_types = { path = "../txn_types", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
+
+# should be dev-dependencies but the feature interaction
+# doesn't work unless it's a regular dependency
+engine_test = { path = "../engine_test", default-features = false }
 
 [dev-dependencies]
 panic_hook = { path = "../panic_hook" }

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -103,11 +103,11 @@ txn_types = { path = "../txn_types", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 
-# should be dev-dependencies but the feature interaction
-# doesn't work unless it's a regular dependency
+# Should be [dev-dependencies] but we need to control the features
+# https://github.com/rust-lang/cargo/issues/6915
 engine_test = { path = "../engine_test", default-features = false }
 
 [dev-dependencies]
 panic_hook = { path = "../panic_hook" }
-test_sst_importer = { path = "../test_sst_importer" }
-engine_panic = { path = "../engine_panic" }
+test_sst_importer = { path = "../test_sst_importer", default-features = false }
+engine_panic = { path = "../engine_panic", default-features = false }

--- a/components/resolved_ts/Cargo.toml
+++ b/components/resolved_ts/Cargo.toml
@@ -5,13 +5,20 @@ edition = "2018"
 publish = false
 
 [features]
-protobuf-codec = ["txn_types/protobuf-codec"]
-prost-codec = ["txn_types/prost-codec"]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "txn_types/protobuf-codec",
+  "tikv_util/protobuf-codec",
+]
+prost-codec = [
+  "txn_types/prost-codec",
+  "tikv_util/prost-codec",
+]
 
 [dependencies]
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
-txn_types = { path = "../txn_types" }
+txn_types = { path = "../txn_types", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/security/Cargo.toml
+++ b/components/security/Cargo.toml
@@ -4,13 +4,26 @@ version = "0.0.1"
 edition = "2018"
 publish = false
 
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "encryption/protobuf-codec",
+  "grpcio/protobuf-codec",
+  "tikv_util/protobuf-codec",
+]
+prost-codec = [
+  "encryption/prost-codec",
+  "grpcio/prost-codec",
+  "tikv_util/prost-codec",
+]
+
 [dependencies]
-encryption = { path = "../encryption" }
+encryption = { path = "../encryption", default-features = false }
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
 
 [dev-dependencies]

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -60,5 +60,5 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 
 [dev-dependencies]
 tempfile = "3.0"
-test_util = { path = "../test_util" }
-test_sst_importer = { path = "../test_sst_importer" }
+test_sst_importer = { path = "../test_sst_importer", default-features = false }
+test_util = { path = "../test_util", default-features = false }

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -5,33 +5,44 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = [
+  "encryption/protobuf-codec",
+  "engine_rocks/protobuf-codec",
+  "engine_traits/protobuf-codec",
+  "error_code/protobuf-codec",
   "external_storage/protobuf-codec",
   "grpcio/protobuf-codec",
   "keys/protobuf-codec",
   "kvproto/protobuf-codec",
+  "tikv_util/protobuf-codec",
   "txn_types/protobuf-codec",
 ]
 prost-codec = [
+  "encryption/prost-codec",
+  "engine_rocks/prost-codec",
+  "engine_traits/prost-codec",
+  "error_code/prost-codec",
   "external_storage/prost-codec",
   "grpcio/prost-codec",
   "keys/prost-codec",
   "kvproto/prost-codec",
+  "tikv_util/prost-codec",
   "txn_types/prost-codec",
 ]
 
 [dependencies]
 crc32fast = "1.2"
-encryption = { path = "../encryption" }
-engine_rocks = { path = "../engine_rocks" }
-engine_traits = { path = "../engine_traits" }
-error_code = { path = "../error_code" }
-external_storage = { path = "../external_storage" }
+encryption = { path = "../encryption", default-features = false }
+engine_rocks = { path = "../engine_rocks", default-features = false }
+engine_traits = { path = "../engine_traits", default-features = false }
+error_code = { path = "../error_code", default-features = false }
+external_storage = { path = "../external_storage", default-features = false }
 file_system = { path = "../file_system" }
-futures = "0.3"
+futures = { version = "0.3", features = ["thread-pool"] }
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
-keys = { path = "../keys" }
+keys = { path = "../keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
@@ -42,13 +53,12 @@ serde_derive = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tikv_alloc = { path = "../tikv_alloc" }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 tokio = { version = "0.2.13", features = ["time", "rt-threaded", "macros"] }
-txn_types = { path = "../txn_types" }
+txn_types = { path = "../txn_types", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 
 [dev-dependencies]
-engine_rocks = { path = "../engine_rocks" }
 tempfile = "3.0"
 test_util = { path = "../test_util" }
 test_sst_importer = { path = "../test_sst_importer" }

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -5,20 +5,28 @@ edition = "2018"
 publish = false
 
 [features]
-default = ["test-engines-rocksdb"]
+default = ["protobuf-codec", "test-engines-rocksdb"]
 protobuf-codec = [
+  "concurrency_manager/protobuf-codec",
+  "engine_rocks/protobuf-codec",
   "kvproto/protobuf-codec",
   "test_storage/protobuf-codec",
+  "tidb_query_common/protobuf-codec",
   "tidb_query_datatype/protobuf-codec",
   "tikv/protobuf-codec",
+  "tikv_util/protobuf-codec",
   "tipb/protobuf-codec",
   "txn_types/protobuf-codec",
 ]
 prost-codec = [
+  "concurrency_manager/prost-codec",
+  "engine_rocks/prost-codec",
   "kvproto/prost-codec",
   "test_storage/prost-codec",
+  "tidb_query_common/prost-codec",
   "tidb_query_datatype/prost-codec",
   "tikv/prost-codec",
+  "tikv_util/prost-codec",
   "tipb/prost-codec",
   "txn_types/prost-codec",
 ]
@@ -30,16 +38,16 @@ test-engines-panic = [
 ]
 
 [dependencies]
-engine_rocks = { path = "../engine_rocks" }
+engine_rocks = { path = "../engine_rocks", default-features = false }
 futures = "0.3"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 protobuf = "2"
-test_storage = { path = "../test_storage" }
-tidb_query_datatype = { path = "../tidb_query_datatype" }
-tidb_query_common = { path = "../tidb_query_common" }
+test_storage = { path = "../test_storage", default-features = false }
+tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }
+tidb_query_common = { path = "../tidb_query_common", default-features = false }
 tikv = { path = "../../", default-features = false }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
-txn_types = { path = "../txn_types" }
-concurrency_manager = { path = "../concurrency_manager" }
+txn_types = { path = "../txn_types", default-features = false }
+concurrency_manager = { path = "../concurrency_manager", default-features = false }

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["test-engines-rocksdb"]
 protobuf-codec = [
   "kvproto/protobuf-codec",
   "test_storage/protobuf-codec",
@@ -20,6 +21,12 @@ prost-codec = [
   "tikv/prost-codec",
   "tipb/prost-codec",
   "txn_types/prost-codec",
+]
+test-engines-rocksdb = [
+  "test_storage/test-engines-rocksdb",
+]
+test-engines-panic = [
+  "test_storage/test-engines-panic",
 ]
 
 [dependencies]

--- a/components/test_pd/Cargo.toml
+++ b/components/test_pd/Cargo.toml
@@ -5,15 +5,20 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = [
   "grpcio/protobuf-codec",
   "kvproto/protobuf-codec",
   "pd_client/protobuf-codec",
+  "security/protobuf-codec",
+  "tikv_util/protobuf-codec",
 ]
 prost-codec = [
   "grpcio/prost-codec",
   "kvproto/prost-codec",
   "pd_client/prost-codec",
+  "security/prost-codec",
+  "tikv_util/prost-codec",
 ]
 
 [dependencies]
@@ -23,7 +28,7 @@ grpcio = { version = "0.7", default-features = false, features = ["openssl-vendo
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
-pd_client = { path = "../pd_client" }
-security = { path = "../security" }
-tikv_util = { path = "../tikv_util" }
+pd_client = { path = "../pd_client", default-features = false }
+security = { path = "../security",  default-features = false }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -5,26 +5,40 @@ edition = "2018"
 publish = false
 
 [features]
-default = ["test-engines-rocksdb"]
+default = ["protobuf-codec", "test-engines-rocksdb"]
 protobuf-codec = [
+  "concurrency_manager/protobuf-codec",
+  "encryption/protobuf-codec",
   "engine_rocks/protobuf-codec",
+  "engine_traits/protobuf-codec",
   "grpcio/protobuf-codec",
   "keys/protobuf-codec",
   "kvproto/protobuf-codec",
   "pd_client/protobuf-codec",
   "raft/protobuf-codec",
   "raftstore/protobuf-codec",
+  "security/protobuf-codec",
+  "test_util/protobuf-codec",
   "tikv/protobuf-codec",
+  "tikv_util/protobuf-codec",
+  "txn_types/protobuf-codec",
 ]
 prost-codec = [
+  "concurrency_manager/prost-codec",
+  "encryption/prost-codec",
   "engine_rocks/prost-codec",
+  "engine_traits/prost-codec",
   "grpcio/prost-codec",
   "keys/prost-codec",
   "kvproto/prost-codec",
   "pd_client/prost-codec",
   "raft/prost-codec",
   "raftstore/prost-codec",
+  "security/prost-codec",
+  "test_util/prost-codec",
   "tikv/prost-codec",
+  "tikv_util/prost-codec",
+  "txn_types/prost-codec",
 ]
 test-engines-rocksdb = [
   "raftstore/test-engines-rocksdb",
@@ -35,30 +49,30 @@ test-engines-panic = [
 
 [dependencies]
 crossbeam = "0.7.2"
-engine_traits = { path = "../engine_traits" }
-engine_rocks = { path = "../engine_rocks" }
+engine_traits = { path = "../engine_traits", default-features = false }
+engine_rocks = { path = "../engine_rocks", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
-keys = { path = "../keys" }
+keys = { path = "../keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
-pd_client = { path = "../pd_client" }
+pd_client = { path = "../pd_client", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
-raftstore = { path = "../raftstore" }
+raftstore = { path = "../raftstore", default-features = false }
 rand = "0.7"
-security = { path = "../security" }
+security = { path = "../security", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 # better to not use slog-global, but pass in the logger
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tempfile = "3.0"
-test_util = { path = "../test_util" }
+test_util = { path = "../test_util", default-features = false }
 tikv = { path = "../../", default-features = false }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
 tokio-timer = "0.2"
-txn_types = { path = "../txn_types" }
-encryption = { path = "../encryption" }
+txn_types = { path = "../txn_types", default-features = false }
+encryption = { path = "../encryption", default-features = false }
 tokio = { version = "0.2", features = ["rt-threaded"]}
-concurrency_manager = { path = "../concurrency_manager" }
+concurrency_manager = { path = "../concurrency_manager", default-features = false }
 fail = "0.4"

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["test-engines-rocksdb"]
 protobuf-codec = [
   "engine_rocks/protobuf-codec",
   "grpcio/protobuf-codec",
@@ -24,6 +25,12 @@ prost-codec = [
   "raft/prost-codec",
   "raftstore/prost-codec",
   "tikv/prost-codec",
+]
+test-engines-rocksdb = [
+  "raftstore/test-engines-rocksdb",
+]
+test-engines-panic = [
+  "raftstore/test-engines-panic",
 ]
 
 [dependencies]

--- a/components/test_sst_importer/Cargo.toml
+++ b/components/test_sst_importer/Cargo.toml
@@ -9,21 +9,24 @@ description = "test helpers for sst_importer"
 test = false
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = [
   "engine_rocks/protobuf-codec",
+  "engine_traits/protobuf-codec",
   "keys/protobuf-codec",
   "kvproto/protobuf-codec",
 ]
 prost-codec = [
   "engine_rocks/prost-codec",
+  "engine_traits/prost-codec",
   "keys/prost-codec",
   "kvproto/prost-codec",
 ]
 
 [dependencies]
 crc32fast = "1.2"
-engine_rocks = { path = "../engine_rocks" }
-engine_traits = { path = "../engine_traits" }
-keys = { path = "../keys" }
+engine_rocks = { path = "../engine_rocks", default-features = false }
+engine_traits = { path = "../engine_traits", default-features = false }
+keys = { path = "../keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["test-engines-rocksdb"]
 protobuf-codec = [
   "kvproto/protobuf-codec",
   "raftstore/protobuf-codec",
@@ -18,6 +19,12 @@ prost-codec = [
   "test_raftstore/prost-codec",
   "tikv/prost-codec",
   "txn_types/prost-codec",
+]
+test-engines-rocksdb = [
+  "test_raftstore/test-engines-rocksdb",
+]
+test-engines-panic = [
+  "test_raftstore/test-engines-panic",
 ]
 
 [dependencies]

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -5,19 +5,23 @@ edition = "2018"
 publish = false
 
 [features]
-default = ["test-engines-rocksdb"]
+default = ["protobuf-codec", "test-engines-rocksdb"]
 protobuf-codec = [
   "kvproto/protobuf-codec",
   "raftstore/protobuf-codec",
+  "pd_client/protobuf-codec",
   "test_raftstore/protobuf-codec",
   "tikv/protobuf-codec",
+  "tikv_util/protobuf-codec",
   "txn_types/protobuf-codec",
 ]
 prost-codec = [
   "kvproto/prost-codec",
   "raftstore/prost-codec",
+  "pd_client/prost-codec",
   "test_raftstore/prost-codec",
   "tikv/prost-codec",
+  "tikv_util/prost-codec",
   "txn_types/prost-codec",
 ]
 test-engines-rocksdb = [
@@ -30,10 +34,10 @@ test-engines-panic = [
 [dependencies]
 futures = "0.3"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
-raftstore = { path = "../raftstore" }
-pd_client = { path = "../pd_client" }
-test_raftstore = { path = "../test_raftstore" }
+raftstore = { path = "../raftstore", default-features = false }
+pd_client = { path = "../pd_client", default-features = false }
+test_raftstore = { path = "../test_raftstore", default-features = false }
 tikv = { path = "../../", default-features = false }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
-txn_types = { path = "../txn_types" }
+txn_types = { path = "../txn_types", default-features = false }

--- a/components/test_util/Cargo.toml
+++ b/components/test_util/Cargo.toml
@@ -4,17 +4,34 @@ version = "0.0.1"
 edition = "2018"
 publish = false
 
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "encryption/protobuf-codec",
+  "grpcio/protobuf-codec",
+  "kvproto/protobuf-codec",
+  "security/protobuf-codec",
+  "tikv_util/protobuf-codec",
+]
+prost-codec = [
+  "encryption/prost-codec",
+  "grpcio/prost-codec",
+  "kvproto/prost-codec",
+  "security/prost-codec",
+  "tikv_util/prost-codec",
+]
+
 [dependencies]
-encryption = { path = "../encryption" }
+encryption = { path = "../encryption", default-features = false }
 fail = "0.4"
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rand = "0.7"
 rand_isaac = "0.2"
-security = { path = "../security" }
+security = { path = "../security", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tempfile = "3.0"
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
 time = "0.1"

--- a/components/tidb_query_aggr/Cargo.toml
+++ b/components/tidb_query_aggr/Cargo.toml
@@ -5,15 +5,30 @@ edition = "2018"
 publish = false
 description = "Vector aggr functions of query engine to run TiDB pushed down executors"
 
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "tidb_query_common/protobuf-codec",
+  "tidb_query_datatype/protobuf-codec",
+  "tidb_query_expr/protobuf-codec",
+  "tikv_util/protobuf-codec",
+]
+prost-codec = [
+  "tidb_query_common/prost-codec",
+  "tidb_query_datatype/prost-codec",
+  "tidb_query_expr/prost-codec",
+  "tikv_util/prost-codec",
+]
+
 [dependencies]
 match_template = { path = "../match_template" }
 tidb_query_codegen = { path = "../tidb_query_codegen" }
-tidb_query_datatype = { path = "../tidb_query_datatype" }
-tidb_query_common = { path = "../tidb_query_common" }
-tidb_query_expr = { path = "../tidb_query_expr" }
-tikv_util = { path = "../tikv_util" }
+tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }
+tidb_query_common = { path = "../tidb_query_common", default-features = false }
+tidb_query_expr = { path = "../tidb_query_expr", default-features = false }
+tikv_util = { path = "../tikv_util", default-features = false }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
 
 [dev-dependencies]
 panic_hook = { path = "../panic_hook" }
-tipb_helper = { path = "../tipb_helper" }
+tipb_helper = { path = "../tipb_helper", default-features = false }

--- a/components/tidb_query_common/Cargo.toml
+++ b/components/tidb_query_common/Cargo.toml
@@ -5,12 +5,23 @@ edition = "2018"
 publish = false
 description = "Common utility of a query engine to run TiDB pushed down executors"
 
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "error_code/protobuf-codec",
+  "tikv_util/protobuf-codec",
+]
+prost-codec = [
+  "error_code/prost-codec",
+  "tikv_util/prost-codec",
+]
+
 [dependencies]
 time = "0.1"
 failure = "0.1"
 derive_more = "0.99.3"
-error_code = { path = "../error_code" }
-tikv_util = { path = "../tikv_util" }
+error_code = { path = "../error_code", default-features = false }
+tikv_util = { path = "../tikv_util", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 prometheus = { version = "0.10", features = ["nightly"] }
 prometheus-static-metric = "0.4"

--- a/components/tidb_query_datatype/Cargo.toml
+++ b/components/tidb_query_datatype/Cargo.toml
@@ -6,12 +6,21 @@ publish = false
 description = "Data type of a query engine to run TiDB pushed down executors"
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = [
+  "codec/protobuf-codec",
+  "error_code/protobuf-codec",
   "kvproto/protobuf-codec",
+  "tidb_query_common/protobuf-codec",
+  "tikv_util/protobuf-codec",
   "tipb/protobuf-codec",
 ]
 prost-codec = [
+  "codec/prost-codec",
+  "error_code/prost-codec",
   "kvproto/prost-codec",
+  "tidb_query_common/prost-codec",
+  "tikv_util/prost-codec",
   "tipb/prost-codec",
 ]
 
@@ -21,8 +30,8 @@ bitflags = "1.0.1"
 boolinator = "2.4.0"
 chrono = "0.4"
 chrono-tz = "0.5.1"
-codec = { path = "../codec" }
-error_code = { path = "../error_code" }
+codec = { path = "../codec", default-features = false }
+error_code = { path = "../error_code", default-features = false }
 failure = "0.1"
 hex = "0.4"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
@@ -40,11 +49,11 @@ serde = "1.0"
 serde_json = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
 static_assertions = { version = "1.0", features = ["nightly"] }
-tidb_query_common = { path = "../tidb_query_common" }
+tidb_query_common = { path = "../tidb_query_common", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
 bstr = "0.2.8"
 log_wrappers = { path = "../log_wrappers" }

--- a/components/tidb_query_executors/Cargo.toml
+++ b/components/tidb_query_executors/Cargo.toml
@@ -49,5 +49,5 @@ yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 
 [dev-dependencies]
 failure = "0.1"
-tipb_helper = { path = "../tipb_helper" }
-tidb_query_codegen = { path = "../tidb_query_codegen" }
+tipb_helper = { path = "../tipb_helper", default-features = false }
+tidb_query_codegen = { path = "../tidb_query_codegen", default-features = false }

--- a/components/tidb_query_executors/Cargo.toml
+++ b/components/tidb_query_executors/Cargo.toml
@@ -5,20 +5,43 @@ edition = "2018"
 publish = false
 description = "A vector query engine to run TiDB pushed down executors"
 
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "codec/protobuf-codec",
+  "kvproto/protobuf-codec",
+  "tidb_query_aggr/protobuf-codec",
+  "tidb_query_common/protobuf-codec",
+  "tidb_query_datatype/protobuf-codec",
+  "tidb_query_expr/protobuf-codec",
+  "tikv_util/protobuf-codec",
+  "tipb/protobuf-codec",
+]
+prost-codec = [
+  "codec/prost-codec",
+  "kvproto/prost-codec",
+  "tidb_query_aggr/prost-codec",
+  "tidb_query_common/prost-codec",
+  "tidb_query_datatype/prost-codec",
+  "tidb_query_expr/prost-codec",
+  "tikv_util/prost-codec",
+  "tipb/prost-codec",
+]
+
 [dependencies]
 protobuf = "2.8"
-codec = { path = "../codec" }
+codec = { path = "../codec", default-features = false }
 fail = "0.4"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 match_template = { path = "../match_template" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 smallvec = "1.4"
-tidb_query_datatype = { path = "../tidb_query_datatype" }
-tidb_query_common = { path = "../tidb_query_common" }
-tidb_query_expr = { path = "../tidb_query_expr" }
-tidb_query_aggr = { path = "../tidb_query_aggr" }
-tikv_util = { path = "../tikv_util" }
+tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }
+tidb_query_common = { path = "../tidb_query_common", default-features = false }
+tidb_query_expr = { path = "../tidb_query_expr", default-features = false }
+tidb_query_aggr = { path = "../tidb_query_aggr", default-features = false }
+tikv_util = { path = "../tikv_util", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 collections = { path = "../collections" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }

--- a/components/tidb_query_expr/Cargo.toml
+++ b/components/tidb_query_expr/Cargo.toml
@@ -5,6 +5,21 @@ edition = "2018"
 publish = false
 description = "Vector expressions of query engine to run TiDB pushed down executors"
 
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "codec/protobuf-codec",
+  "tidb_query_common/protobuf-codec",
+  "tidb_query_datatype/protobuf-codec",
+  "tikv_util/protobuf-codec",
+]
+prost-codec = [
+  "codec/prost-codec",
+  "tidb_query_common/prost-codec",
+  "tidb_query_datatype/prost-codec",
+  "tikv_util/prost-codec",
+]
+
 [dependencies]
 rand = "0.7.3"
 safemem = { version = "0.3", default-features = false }
@@ -12,7 +27,7 @@ time = "0.1"
 base64 = "0.12"
 bstr = "0.2.8"
 byteorder = "1.2"
-codec = { path = "../codec" }
+codec = { path = "../codec", default-features = false }
 flate2 = { version = "=1.0.11", default-features = false, features = ["zlib"] }
 file_system = { path = "../file_system" }
 hex = "0.4"
@@ -23,9 +38,9 @@ num-traits = "0.2"
 openssl = { version = "0.10" }
 protobuf = "2"
 tidb_query_codegen = { path = "../tidb_query_codegen" }
-tidb_query_datatype = { path = "../tidb_query_datatype" }
-tidb_query_common = { path = "../tidb_query_common" }
-tikv_util = { path = "../tikv_util" }
+tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }
+tidb_query_common = { path = "../tidb_query_common", default-features = false }
+tikv_util = { path = "../tikv_util", default-features = false }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
 twoway = "0.2.0"
 uuid = { version = "0.8.1", features = ["v4"] }
@@ -36,4 +51,4 @@ bstr = "0.2.8"
 chrono = "0.4"
 profiler = { path = "../profiler" }
 panic_hook = { path = "../panic_hook" }
-tipb_helper = { path = "../tipb_helper" }
+tipb_helper = { path = "../tipb_helper", default-features = false }

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -5,25 +5,34 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 failpoints = ["fail/failpoints"]
-protobuf-codec = ["kvproto/protobuf-codec"]
-prost-codec = ["kvproto/prost-codec"]
+protobuf-codec = [
+  "error_code/protobuf-codec",
+  "grpcio/protobuf-codec",
+  "kvproto/protobuf-codec",
+]
+prost-codec = [
+  "error_code/prost-codec",
+  "grpcio/prost-codec",
+  "kvproto/prost-codec",
+]
 
 [dependencies]
 async-speed-limit = "0.3"
 backtrace = "0.3.9"
 byteorder = "1.2"
-codec = { path = "../codec" }
+codec = { path = "../codec", default-features = false }
 configuration = { path = "../configuration" }
 chrono = "0.4"
 crc32fast = "1.2"
 crossbeam = "0.7.2"
-error_code = { path = "../error_code" }
+error_code = { path = "../error_code", default-features = false }
 derive_more = "0.99.3"
 fail = "0.4"
 file_system = { path = "../file_system" }
 fs2 = "0.4"
-futures = "0.3"
+futures = { version = "0.3", features = ["compat"] }
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 lazy_static = "1.3"
 libc = "0.2"
@@ -45,7 +54,7 @@ sysinfo = "0.15"
 tikv_alloc = { path = "../tikv_alloc" }
 collections = { path = "../collections" }
 time = "0.1"
-tokio = { version = "0.2", features = ["rt-util"] }
+tokio = { version = "0.2", features = ["rt-util", "rt-threaded"] }
 tokio-executor = "0.1"
 tokio-timer = "0.2"
 url = "2"

--- a/components/tipb_helper/Cargo.toml
+++ b/components/tipb_helper/Cargo.toml
@@ -5,16 +5,19 @@ edition = "2018"
 publish = false
 
 [features]
+default = ["protobuf-codec"]
 protobuf-codec = [
+  "codec/protobuf-codec",
   "tidb_query_datatype/protobuf-codec",
-  "tipb/protobuf-codec"
+  "tipb/protobuf-codec",
 ]
 prost-codec = [
+  "codec/prost-codec",
   "tidb_query_datatype/prost-codec",
-  "tipb/prost-codec"
+  "tipb/prost-codec",
 ]
 
 [dependencies]
-codec = { path = "../codec" }
-tidb_query_datatype = { path = "../tidb_query_datatype" }
+codec = { path = "../codec", default-features = false }
+tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }

--- a/components/txn_types/Cargo.toml
+++ b/components/txn_types/Cargo.toml
@@ -5,18 +5,29 @@ edition = "2018"
 publish = false
 
 [features]
-protobuf-codec = ["kvproto/protobuf-codec"]
-prost-codec = ["kvproto/prost-codec"]
+default = ["protobuf-codec"]
+protobuf-codec = [
+  "codec/protobuf-codec",
+  "error_code/protobuf-codec",
+  "kvproto/protobuf-codec",
+  "tikv_util/protobuf-codec",
+]
+prost-codec = [
+  "codec/prost-codec",
+  "error_code/prost-codec",
+  "kvproto/prost-codec",
+  "tikv_util/prost-codec",
+]
 
 [dependencies]
 byteorder = "1.2"
 farmhash = "1.1.5"
-error_code = { path = "../error_code" }
-codec = { path = "../codec" }
+error_code = { path = "../error_code", default-features = false }
+codec = { path = "../codec", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = "2.3"
 quick-error = "1.2.3"
 tikv_alloc = { path = "../tikv_alloc" }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 collections = { path = "../collections" }
 log_wrappers = { path = "../log_wrappers" }

--- a/scripts/check-build-opts.py
+++ b/scripts/check-build-opts.py
@@ -1,0 +1,135 @@
+# Verify that individual crates build with various feature combinations
+#
+# re: https://github.com/tikv/tikv/issues/9406
+#
+# TiKV has several compile time features that are threaded through the
+# dependency tree. It is common that the features are not configured correctly,
+# causing individual crates to not build on their own. This script goes through
+# each individual crate and runs `cargo check -p` and `cargo test -p --no-run`
+# on them, with multiple feature combinations.
+#
+# In particular it verifies that these configurations work:
+#
+# - The default
+# - With `prost-codec`
+# - With `test-engines-panic`
+#
+# Requires Python 3.6+
+
+import os
+import subprocess
+import sys
+
+components = [f for f in os.listdir("components") if os.path.isdir(f"components/{f}")]
+
+other_crates = [
+    ("cmd", "cmd"),
+    ("tests", "tests"),
+    ("tikv", "./"),
+]
+
+components_with_dirs = [(x, f"components/{x}") for x in components]
+crates = components_with_dirs + other_crates
+
+errors = []
+
+def cargo_check_default():
+    cargo_run_default("check", [])
+
+def cargo_test_default():
+    cargo_run_default("test", ["--no-run"])
+
+def cargo_check_codec(codec):
+    cargo_run_codec("check", [], codec)
+
+def cargo_test_codec(codec):
+    cargo_run_codec("test", ["--no-run"], codec)
+
+def cargo_check_test_engines(test_engine):
+    cargo_run_test_engines("check", [], test_engine)
+
+def cargo_test_test_engines(test_engine):
+    cargo_run_test_engines("test", ["--no-run"], test_engine)
+
+def cargo_run_default(cmd, extra_args):
+    for (crate, _) in crates:
+        args = ["cargo", cmd, "-p", crate]
+        args += extra_args
+        run_and_collect_errors(args)
+
+def cargo_run_codec(cmd, extra_args, codec):
+    for (crate, path) in crates:
+        (has_protobuf_features, has_test_engine_features) = get_features(path)
+
+        if not has_protobuf_features:
+            continue
+
+        args = ["cargo", cmd, "-p", crate, "--no-default-features"]
+        args += extra_args
+        if has_protobuf_features:
+            args += ["--features", f"{codec}-codec"]
+        if has_test_engine_features:
+            args += ["--features", "test-engines-rocksdb"]
+
+        run_and_collect_errors(args)
+
+def cargo_run_test_engines(cmd, extra_args, test_engine):
+    for (crate, path) in crates:
+        (has_protobuf_features, has_test_engine_features) = get_features(path)
+
+        if not has_test_engine_features:
+            continue
+
+        args = ["cargo", cmd, "-p", crate, "--no-default-features"]
+        args += extra_args
+        if has_protobuf_features:
+            args += ["--features", "protobuf-codec"]
+        if has_test_engine_features:
+            args += ["--features", f"test-engines-{test_engine}"]
+
+        run_and_collect_errors(args)
+
+def run_and_collect_errors(args):
+    global errors
+    joined_args = " ".join(args)
+    print(f"running `{joined_args}`")
+    res = subprocess.run(args)
+    if res.returncode != 0:
+        errors += [joined_args]
+
+def get_features(path):
+    path = f"{path}/Cargo.toml"
+    f = open(path)
+    s = f.read()
+    f.close()
+
+    has_protobuf_features = "protobuf-codec" in s
+    has_test_engine_features = "test-engines-rocksdb" in s
+
+    return (has_protobuf_features, has_test_engine_features)
+
+print()
+
+cargo_check_default()
+cargo_check_codec("prost")
+cargo_check_codec("protobuf")
+cargo_check_test_engines("panic")
+cargo_check_test_engines("rocksdb")
+cargo_test_default()
+cargo_test_codec("prost")
+cargo_test_codec("protobuf")
+cargo_test_test_engines("panic")
+cargo_test_test_engines("rocksdb")
+
+if len(errors) == 0:
+    sys.exit(0)
+
+print()
+print("errors:")
+    
+for error in errors:
+    print(f"    {error}")
+
+print()
+
+sys.exit(1)

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -50,25 +50,45 @@ failpoints = ["fail/failpoints", "tikv/failpoints"]
 testexport = ["raftstore/testexport", "tikv/testexport"]
 profiling = ["profiler/profiling"]
 protobuf-codec = [
+  "batch-system/protobuf-codec",
+  "error_code/protobuf-codec",
   "grpcio/protobuf-codec",
   "kvproto/protobuf-codec",
   "pd_client/protobuf-codec",
   "raft/protobuf-codec",
   "raftstore/protobuf-codec",
+  "sst_importer/protobuf-codec",
+  "test_coprocessor/protobuf-codec",
+  "test_raftstore/protobuf-codec",
+  "test_storage/protobuf-codec",
   "tikv/protobuf-codec",
+  "tidb_query_aggr/protobuf-codec",
+  "tidb_query_common/protobuf-codec",
   "tidb_query_datatype/protobuf-codec",
+  "tidb_query_expr/protobuf-codec",
+  "tikv_util/protobuf-codec",
   "tipb/protobuf-codec",
   "txn_types/protobuf-codec",
   "cdc/protobuf-codec",
 ]
 prost-codec = [
+  "batch-system/prost-codec",
+  "error_code/prost-codec",
   "grpcio/prost-codec",
   "kvproto/prost-codec",
   "pd_client/prost-codec",
   "raft/prost-codec",
   "raftstore/prost-codec",
+  "sst_importer/prost-codec",
+  "test_coprocessor/prost-codec",
+  "test_raftstore/prost-codec",
+  "test_storage/prost-codec",
   "tikv/prost-codec",
+  "tidb_query_aggr/prost-codec",
+  "tidb_query_common/prost-codec",
   "tidb_query_datatype/prost-codec",
+  "tidb_query_expr/prost-codec",
+  "tikv_util/prost-codec",
   "tipb/prost-codec",
   "txn_types/prost-codec",
   "cdc/prost-codec",
@@ -80,33 +100,33 @@ portable = ["tikv/portable"]
 
 [dependencies]
 fail = "0.4"
-batch-system = { path = "../components/batch-system" }
+batch-system = { path = "../components/batch-system", default-features = false }
 crc64fast = "0.1"
 crossbeam = "0.7.2"
-configuration = { path = "../components/configuration" }
+configuration = { path = "../components/configuration", default-features = false }
 encryption = { path = "../components/encryption" }
 cdc = { path = "../components/cdc" }
 futures = "0.3"
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 log_wrappers = { path = "../components/log_wrappers" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
-pd_client = { path = "../components/pd_client" }
+pd_client = { path = "../components/pd_client", default-features = false }
 protobuf = "2.8"
 more-asserts = "0.2"
 raft = { version = "0.6.0-alpha", default-features = false }
-raftstore = { path = "../components/raftstore" }
+raftstore = { path = "../components/raftstore", default-features = false }
 rand = "0.7.3"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tempfile = "3.0"
-tidb_query_datatype = { path = "../components/tidb_query_datatype" }
-tidb_query_common = { path = "../components/tidb_query_common" }
-tidb_query_aggr = { path = "../components/tidb_query_aggr" }
+tidb_query_datatype = { path = "../components/tidb_query_datatype", default-features = false }
+tidb_query_common = { path = "../components/tidb_query_common", default-features = false }
+tidb_query_aggr = { path = "../components/tidb_query_aggr", default-features = false }
 tidb_query_executors = { path = "../components/tidb_query_executors" }
-tidb_query_expr = { path = "../components/tidb_query_expr" }
+tidb_query_expr = { path = "../components/tidb_query_expr", default-features = false }
 tikv = { path = "../", default-features = false }
-tikv_util = { path = "../components/tikv_util" }
-error_code = { path = "../components/error_code" }
+tikv_util = { path = "../components/tikv_util", default-features = false }
+error_code = { path = "../components/error_code", default-features = false }
 collections = { path = "../components/collections" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
 toml = "0.5"
@@ -129,14 +149,14 @@ keys = { path = "../components/keys" }
 profiler = { path = "../components/profiler" }
 panic_hook = { path = "../components/panic_hook" }
 security = { path = "../components/security" }
-sst_importer = {path = "../components/sst_importer" }
-tipb_helper = { path = "../components/tipb_helper" }
-tidb_query_datatype = { path = "../components/tidb_query_datatype" }
+sst_importer = {path = "../components/sst_importer", default-features = false }
+tipb_helper = { path = "../components/tipb_helper", default-features = false }
+tidb_query_datatype = { path = "../components/tidb_query_datatype", default-features = false }
 test_util = { path = "../components/test_util" }
-test_storage = { path = "../components/test_storage" }
-test_coprocessor = { path = "../components/test_coprocessor" }
+test_storage = { path = "../components/test_storage", default-features = false }
+test_coprocessor = { path = "../components/test_coprocessor", default-features = false }
 test_sst_importer = { path = "../components/test_sst_importer" }
-test_raftstore = { path = "../components/test_raftstore" }
+test_raftstore = { path = "../components/test_raftstore", default-features = false }
 test_pd = { path = "../components/test_pd" }
 byteorder = "1.2"
 serde_json = "1.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -45,12 +45,14 @@ path = "benches/channel/mod.rs"
 test = true
 
 [features]
-default = ["failpoints", "testexport", "protobuf-codec"]
+default = ["failpoints", "testexport", "protobuf-codec", "test-engines-rocksdb"]
 failpoints = ["fail/failpoints", "tikv/failpoints"]
 testexport = ["raftstore/testexport", "tikv/testexport"]
 profiling = ["profiler/profiling"]
 protobuf-codec = [
   "batch-system/protobuf-codec",
+  "cdc/protobuf-codec",
+  "encryption/protobuf-codec",
   "error_code/protobuf-codec",
   "grpcio/protobuf-codec",
   "kvproto/protobuf-codec",
@@ -65,14 +67,16 @@ protobuf-codec = [
   "tidb_query_aggr/protobuf-codec",
   "tidb_query_common/protobuf-codec",
   "tidb_query_datatype/protobuf-codec",
+  "tidb_query_executors/protobuf-codec",
   "tidb_query_expr/protobuf-codec",
   "tikv_util/protobuf-codec",
   "tipb/protobuf-codec",
   "txn_types/protobuf-codec",
-  "cdc/protobuf-codec",
 ]
 prost-codec = [
   "batch-system/prost-codec",
+  "cdc/prost-codec",
+  "encryption/prost-codec",
   "error_code/prost-codec",
   "grpcio/prost-codec",
   "kvproto/prost-codec",
@@ -87,11 +91,17 @@ prost-codec = [
   "tidb_query_aggr/prost-codec",
   "tidb_query_common/prost-codec",
   "tidb_query_datatype/prost-codec",
+  "tidb_query_executors/prost-codec",
   "tidb_query_expr/prost-codec",
   "tikv_util/prost-codec",
   "tipb/prost-codec",
   "txn_types/prost-codec",
-  "cdc/prost-codec",
+]
+test-engines-rocksdb = [
+  "raftstore/test-engines-rocksdb",
+]
+test-engines-panic = [
+  "raftstore/test-engines-panic",
 ]
 jemalloc = ["tikv/jemalloc"]
 mem-profiling = ["tikv/mem-profiling"]
@@ -104,8 +114,8 @@ batch-system = { path = "../components/batch-system", default-features = false }
 crc64fast = "0.1"
 crossbeam = "0.7.2"
 configuration = { path = "../components/configuration", default-features = false }
-encryption = { path = "../components/encryption" }
-cdc = { path = "../components/cdc" }
+encryption = { path = "../components/encryption", default-features = false }
+cdc = { path = "../components/cdc", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 log_wrappers = { path = "../components/log_wrappers" }
@@ -122,7 +132,7 @@ tempfile = "3.0"
 tidb_query_datatype = { path = "../components/tidb_query_datatype", default-features = false }
 tidb_query_common = { path = "../components/tidb_query_common", default-features = false }
 tidb_query_aggr = { path = "../components/tidb_query_aggr", default-features = false }
-tidb_query_executors = { path = "../components/tidb_query_executors" }
+tidb_query_executors = { path = "../components/tidb_query_executors", default-features = false }
 tidb_query_expr = { path = "../components/tidb_query_expr", default-features = false }
 tikv = { path = "../", default-features = false }
 tikv_util = { path = "../components/tikv_util", default-features = false }
@@ -130,7 +140,7 @@ error_code = { path = "../components/error_code", default-features = false }
 collections = { path = "../components/collections" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
 toml = "0.5"
-txn_types = { path = "../components/txn_types" }
+txn_types = { path = "../components/txn_types", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 time = "0.1"
 
@@ -141,27 +151,27 @@ criterion = "0.3"
 criterion-cpu-time = "0.1"
 arrow = "0.10"
 rand_xorshift = "0.2"
-engine_rocks = { path = "../components/engine_rocks" }
-engine_traits = { path = "../components/engine_traits" }
-external_storage = { path = "../components/external_storage" }
+engine_rocks = { path = "../components/engine_rocks", default-features = false }
+engine_traits = { path = "../components/engine_traits", default-features = false }
+external_storage = { path = "../components/external_storage", default-features = false }
 hyper = { version = "0.13", default-features = false, features = ["runtime"] }
-keys = { path = "../components/keys" }
+keys = { path = "../components/keys", default-features = false }
 profiler = { path = "../components/profiler" }
 panic_hook = { path = "../components/panic_hook" }
-security = { path = "../components/security" }
+security = { path = "../components/security", default-features = false }
 sst_importer = {path = "../components/sst_importer", default-features = false }
 tipb_helper = { path = "../components/tipb_helper", default-features = false }
 tidb_query_datatype = { path = "../components/tidb_query_datatype", default-features = false }
-test_util = { path = "../components/test_util" }
+test_util = { path = "../components/test_util", default-features = false }
 test_storage = { path = "../components/test_storage", default-features = false }
 test_coprocessor = { path = "../components/test_coprocessor", default-features = false }
-test_sst_importer = { path = "../components/test_sst_importer" }
+test_sst_importer = { path = "../components/test_sst_importer", default-features = false }
 test_raftstore = { path = "../components/test_raftstore", default-features = false }
-test_pd = { path = "../components/test_pd" }
+test_pd = { path = "../components/test_pd", default-features = false }
 byteorder = "1.2"
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["rt-threaded"] }
-concurrency_manager = { path = "../components/concurrency_manager" }
+concurrency_manager = { path = "../components/concurrency_manager", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 criterion-papi = "0.1"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -45,7 +45,7 @@ path = "benches/channel/mod.rs"
 test = true
 
 [features]
-default = ["failpoints", "testexport", "protobuf-codec", "test-engines-rocksdb"]
+default = ["failpoints", "testexport", "protobuf-codec"]
 failpoints = ["fail/failpoints", "tikv/failpoints"]
 testexport = ["raftstore/testexport", "tikv/testexport"]
 profiling = ["profiler/profiling"]
@@ -77,8 +77,6 @@ jemalloc = ["tikv/jemalloc"]
 mem-profiling = ["tikv/mem-profiling"]
 sse = ["tikv/sse"]
 portable = ["tikv/portable"]
-test-engines-rocksdb = ["tikv/test-engines-rocksdb"]
-test-engines-panic = ["tikv/test-engines-panic"]
 
 [dependencies]
 fail = "0.4"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9406

Problem Summary:

Building many individual crates with `-p` fails, particularly after https://github.com/tikv/tikv/pull/9358 changed cargo to use the v2 resolver.

In some cases the default configuration is unbuildable for not specifying the `protobuf-codec` feature, in some cases `prost-codec` is broken, in some cases `test-engines-panic` is broken, and there are a few other broken cases.

### What is changed and how it works?

What's Changed:

This patch makes sure every crate that needs `protobuf-codec` to build specifies it as a default feature, and that every crate that depends on a crate with a `protobuf-codec` default feature turns _off_ the default feature, and instead uses its own `protobuf-codec` / `prost-codec` feature to turn on the correct codec. This creates a connected tree of crates with `protobuf-codec / `prost-codec` features.

It does the same for `test-engines-rocksdb` / `test-engines-panic`.

It further fixes up some other cases where crates don't build on their own.

Note that the "external_storage: make sure openssl is vendored" commit contains a hack, where I use the grpcio crate to correctly include the openssl dependency. I could not otherwise figure out how to vendor the correct openssl directly (other means either had missing or duplicate symbols).

Note that this approach assumes that we _want_ all crates in the workspace to build by default. IMO we do - at least I do a lot of development on a single crate at a time, and I think it makes the contributor experience better. On the other hand, not having a default feature set simplifies some of the manifest maintenance, while making the cargo invocation for building any given crate require extra work.

In the final commit I add the script I used to verify that all crates build correctly. I am not sure what to do with this script as it takes 100m to run locally, so it is neither suitable as part of the test suite, nor as part of CI. But _some kind_ of automation is needed to keep the build working in all its configurations - the feature setup is so complex it is sure to break again. At least this script can be used to help fix it later.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note