### PR TITLE
batch_system: fix build when building the crate alone

### DIFF
--- a/components/batch-system/Cargo.toml
+++ b/components/batch-system/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 [features]
 default = ["test-runner"]
 test-runner = ["derive_more"]
+prost-codec = ["tikv_util/prost-codec"]
+protobuf-codec = ["tikv_util/protobuf-codec"]
 
 [dependencies]
 crossbeam = "0.7"

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 failpoints = ["fail/failpoints"]
 prost-codec = [
   "prost",
+  "batch-system/prost-codec",
   "engine_rocks/prost-codec",
   "into_other/prost-codec",
   "keys/prost-codec",
@@ -21,6 +22,7 @@ prost-codec = [
   "txn_types/prost-codec",
 ]
 protobuf-codec = [
+  "batch-system/protobuf-codec",
   "engine_rocks/protobuf-codec",
   "into_other/protobuf-codec",
   "keys/protobuf-codec",

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -23,7 +23,7 @@ derive_more = "0.99.3"
 fail = "0.4"
 file_system = { path = "../file_system" }
 fs2 = "0.4"
-futures = "0.3"
+futures = { version = "0.3", features = ["compat"] }
 grpcio = { version = "0.7", default-features = false, features = ["openssl-vendored"] }
 lazy_static = "1.3"
 libc = "0.2"
@@ -45,7 +45,7 @@ sysinfo = "0.15"
 tikv_alloc = { path = "../tikv_alloc" }
 collections = { path = "../collections" }
 time = "0.1"
-tokio = { version = "0.2", features = ["rt-util"] }
+tokio = { version = "0.2", features = ["rt-util", "rt-core"] }
 tokio-executor = "0.1"
 tokio-timer = "0.2"
 url = "2"


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

### What problem does this PR solve?

Issue Number: close #5209

Problem Summary:

Fixing build error when building `batch_system` crate alone, i.e. want to run the bench under the crate by:
```
cargo bench -p batch-system --feature protobuf-codec
```

### What is changed and how it works?

What's Changed: updating features flag in Cargo.toml.

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests

- Manually run `cargo bench -p batch-system --feature protobuf-codec`

### Release note <!-- bugfixes or new feature need a release note -->

- No release notes.