### PR TITLE
*: Tag io type for foreground and snpashot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/Connor1996/kvproto?branch=snap#ef1f63da0910b1b3200d73290cb217a60612ab4a"
+source = "git+https://github.com/pingcap/kvproto.git#1df45810a26df001620f9508b06588640847965e"
 dependencies = [
  "futures 0.3.7",
  "grpcio",
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "raft-proto"
 version = "0.6.0-alpha"
-source = "git+https://github.com/tikv/raft-rs#c7c230f63c59d408176e9288966da00c579ef4ba"
+source = "git+https://github.com/tikv/raft-rs?branch=master#c7c230f63c59d408176e9288966da00c579ef4ba"
 dependencies = [
  "lazy_static",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#fc36d7869035ffd96810efdb9c1f053c6081a773"
+source = "git+https://github.com/Connor1996/kvproto?branch=snap#ef1f63da0910b1b3200d73290cb217a60612ab4a"
 dependencies = [
  "futures 0.3.7",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,6 +4580,7 @@ dependencies = [
  "error_code",
  "external_storage",
  "fail",
+ "file_system",
  "futures 0.3.7",
  "grpcio",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,9 +192,6 @@ raft-proto = { git = "https://github.com/tikv/raft-rs", branch = "master", defau
 protobuf = { git = "https://github.com/pingcap/rust-protobuf", rev = "65e9df20fbcbcf2409d5ee86a2332ecd04c534f8" }
 protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "65e9df20fbcbcf2409d5ee86a2332ecd04c534f8" }
 
-[patch."https://github.com/pingcap/kvproto.git"]
-kvproto = { git = "https://github.com/Connor1996/kvproto", branch = "snap", default-features = false }
-
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,9 @@ raft-proto = { git = "https://github.com/tikv/raft-rs", branch = "master", defau
 protobuf = { git = "https://github.com/pingcap/rust-protobuf", rev = "65e9df20fbcbcf2409d5ee86a2332ecd04c534f8" }
 protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "65e9df20fbcbcf2409d5ee86a2332ecd04c534f8" }
 
+[patch."https://github.com/pingcap/kvproto.git"]
+kvproto = { git = "https://github.com/Connor1996/kvproto", branch = "snap", default-features = false }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/components/batch-system/src/batch.rs
+++ b/components/batch-system/src/batch.rs
@@ -395,7 +395,7 @@ where
             let t = thread::Builder::new()
                 .name(thd_name!(format!("{}-{}", name_prefix, i)))
                 .spawn(move || {
-                    set_io_type(IOType::Write);
+                    set_io_type(IOType::ForegroundWrite);
                     poller.poll()
                 })
                 .unwrap();

--- a/components/file_system/src/file.rs
+++ b/components/file_system/src/file.rs
@@ -216,21 +216,21 @@ mod tests {
         let tmp_file = tmp_dir.path().join("instrumented.txt");
         let content = String::from("magic words");
         {
-            let _guard = WithIOType::new(IOType::Write);
+            let _guard = WithIOType::new(IOType::ForegroundWrite);
             let mut f = File::create(&tmp_file).unwrap();
             f.write_all(content.as_bytes()).unwrap();
             f.sync_all().unwrap();
-            assert_eq!(recorder.fetch(IOType::Write, IOOp::Write), content.len());
+            assert_eq!(recorder.fetch(IOType::ForegroundWrite, IOOp::Write), content.len());
         }
         {
-            let _guard = WithIOType::new(IOType::Read);
+            let _guard = WithIOType::new(IOType::ForegroundRead);
             let mut buffer = String::new();
             let mut f = File::open(&tmp_file).unwrap();
             assert_eq!(f.read_to_string(&mut buffer).unwrap(), content.len());
             assert_eq!(buffer, content);
             // read_to_string only exit when file.read() returns zero, which means
             // it requires two EOF reads to finish the call.
-            assert_eq!(recorder.fetch(IOType::Read, IOOp::Read), content.len() + 2);
+            assert_eq!(recorder.fetch(IOType::ForegroundRead, IOOp::Read), content.len() + 2);
         }
     }
 }

--- a/components/file_system/src/file.rs
+++ b/components/file_system/src/file.rs
@@ -215,13 +215,13 @@ mod tests {
         let tmp_file = tmp_dir.path().join("instrumented.txt");
         let content = String::from("magic words");
         {
-            WithIOType::new(IOType::Write);
+            WithIOType::new(IOType::ForegroundWrite);
             let mut f = File::create(&tmp_file).unwrap();
             f.write_all(content.as_bytes()).unwrap();
             f.sync_all().unwrap();
         }
         {
-            WithIOType::new(IOType::Read);
+            WithIOType::new(IOType::ForegroundRead);
             let mut buffer = String::new();
             let mut f = File::open(&tmp_file).unwrap();
             assert_eq!(f.read_to_string(&mut buffer).unwrap(), content.len());

--- a/components/file_system/src/file.rs
+++ b/components/file_system/src/file.rs
@@ -220,7 +220,10 @@ mod tests {
             let mut f = File::create(&tmp_file).unwrap();
             f.write_all(content.as_bytes()).unwrap();
             f.sync_all().unwrap();
-            assert_eq!(recorder.fetch(IOType::ForegroundWrite, IOOp::Write), content.len());
+            assert_eq!(
+                recorder.fetch(IOType::ForegroundWrite, IOOp::Write),
+                content.len()
+            );
         }
         {
             let _guard = WithIOType::new(IOType::ForegroundRead);
@@ -230,7 +233,10 @@ mod tests {
             assert_eq!(buffer, content);
             // read_to_string only exit when file.read() returns zero, which means
             // it requires two EOF reads to finish the call.
-            assert_eq!(recorder.fetch(IOType::ForegroundRead, IOOp::Read), content.len() + 2);
+            assert_eq!(
+                recorder.fetch(IOType::ForegroundRead, IOOp::Read),
+                content.len() + 2
+            );
         }
     }
 }

--- a/components/file_system/src/iosnoop/biosnoop.c
+++ b/components/file_system/src/iosnoop/biosnoop.c
@@ -79,7 +79,7 @@ int trace_req_start(struct pt_regs *ctx, struct request *req) {
                                             // otherwise verifier will complain.
   io_type **type_ptr = type_by_pid.lookup(&pid);
   if (type_ptr == 0) {
-    info.type = Other 
+    info.type = Other;
   } else {
     int err = bpf_probe_read(&info.type, sizeof(io_type), (void *)*type_ptr);
     if (err != 0) {

--- a/components/file_system/src/iosnoop/metrics.rs
+++ b/components/file_system/src/iosnoop/metrics.rs
@@ -6,9 +6,8 @@ use prometheus_static_metric::*;
 make_static_metric! {
     pub label_enum IOType {
         other,
-        read,
-        write,
-        coprocessor,
+        foreground_read,
+        foreground_write,
         flush,
         compaction,
         replication,

--- a/components/file_system/src/lib.rs
+++ b/components/file_system/src/lib.rs
@@ -40,9 +40,12 @@ pub enum IOOp {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum IOType {
     Other,
-    Read,
-    Write,
-    Coprocessor,
+    // Including coprocessor and storage read.
+    ForegroundRead,
+    // Including scheduler worker, raftstore and apply. Scheduler worker only
+    // does read related works, but it's on the path of foreground write, so
+    // account it as foreground-write instead of foreground-read.
+    ForegroundWrite,
     Flush,
     Compaction,
     Replication,

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2769,7 +2769,7 @@ impl GenSnapTask {
         }
     }
 
-    pub fn mark_for_balance(&mut self) {
+    pub fn set_for_balance(&mut self) {
         self.for_balance = true;
     }
 

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -2756,6 +2756,8 @@ pub struct CatchUpLogs {
 pub struct GenSnapTask {
     pub(crate) region_id: u64,
     snap_notifier: SyncSender<RaftSnapshot>,
+    // indicates whether the snapshot is triggered due to load balance
+    for_balance: bool,
 }
 
 impl GenSnapTask {
@@ -2763,7 +2765,12 @@ impl GenSnapTask {
         GenSnapTask {
             region_id,
             snap_notifier,
+            for_balance: false,
         }
+    }
+
+    pub fn mark_for_balance(&mut self) {
+        self.for_balance = true;
     }
 
     pub fn generate_and_schedule_snapshot<EK>(
@@ -2779,6 +2786,7 @@ impl GenSnapTask {
         let snapshot = RegionTask::Gen {
             region_id: self.region_id,
             notifier: self.snap_notifier,
+            for_balance: self.for_balance,
             last_applied_index_term,
             last_applied_state,
             // This snapshot may be held for a long time, which may cause too many

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1116,7 +1116,7 @@ where
 
         let mut for_balance = false;
         if !has_snap_task && self.get_store().has_gen_snap_task() {
-           if let Some(progress) = self.raft_group.status().progress {
+            if let Some(progress) = self.raft_group.status().progress {
                 if let Some(pr) = progress.get(from_id) {
                     // When a peer is uninitialized (e.g. created by load balance),
                     // the last index of the peer is 0 which makes the matched index to be 0.

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1002,6 +1002,14 @@ where
         ))
     }
 
+    pub fn has_gen_snap_task(&self) -> bool {
+        self.gen_snap_task.borrow().is_some()
+    }
+
+    pub fn mut_gen_snap_task(&mut self) -> &mut Option<GenSnapTask> {
+        self.gen_snap_task.get_mut()
+    }
+
     pub fn take_gen_snap_task(&mut self) -> Option<GenSnapTask> {
         self.gen_snap_task.get_mut().take()
     }

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1518,6 +1518,7 @@ pub fn do_snapshot<E>(
     region_id: u64,
     last_applied_index_term: u64,
     last_applied_state: RaftApplyState,
+    for_balance: bool,
 ) -> raft::Result<Snapshot>
 where
     E: KvEngine,
@@ -1586,6 +1587,7 @@ where
         &mut snap_data,
         &mut stat,
     )?;
+    snap_data.mut_meta().set_for_balance(for_balance);
     let v = snap_data.write_to_bytes()?;
     snapshot.set_data(v);
 

--- a/components/raftstore/src/store/worker/raftlog_gc.rs
+++ b/components/raftstore/src/store/worker/raftlog_gc.rs
@@ -7,6 +7,7 @@ use std::sync::mpsc::Sender;
 use crate::store::{CasualMessage, CasualRouter};
 
 use engine_traits::{Engines, KvEngine, RaftEngine};
+use file_system::{IOType, WithIOType};
 use tikv_util::time::Duration;
 use tikv_util::worker::{Runnable, RunnableWithTimer};
 
@@ -145,6 +146,7 @@ where
     type Task = Task;
 
     fn run(&mut self, task: Task) {
+        let _io_type_guard = WithIOType::new(IOType::ForegroundWrite);
         self.tasks.push(task);
         if self.tasks.len() < MAX_GC_REGION_BATCH {
             return;

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -285,7 +285,7 @@ where
     ) {
         SNAP_COUNTER.generate.all.inc();
         let start = tikv_util::time::Instant::now();
-        let _ = WithIOType::new(if for_balance {
+        let _io_type_guard = WithIOType::new(if for_balance {
             IOType::LoadBalance
         } else {
             IOType::Replication

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -19,6 +19,7 @@ use crate::coprocessor::{get_region_approximate_keys, get_region_approximate_siz
 use crate::store::{Callback, CasualMessage, CasualRouter};
 use crate::Result;
 use configuration::{ConfigChange, Configuration};
+use file_system::{IOType, WithIOType};
 use tikv_util::keybuilder::KeyBuilder;
 use tikv_util::worker::Runnable;
 
@@ -337,8 +338,8 @@ where
     S: CasualRouter<E>,
 {
     type Task = Task;
-
     fn run(&mut self, task: Task) {
+        let _io_type_guard = WithIOType::new(IOType::LoadBalance);
         match task {
             Task::SplitCheckTask {
                 region,

--- a/src/coprocessor/readpool_impl.rs
+++ b/src/coprocessor/readpool_impl.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use crate::config::CoprReadPoolConfig;
 use crate::storage::kv::{destroy_tls_engine, set_tls_engine};
 use crate::storage::{Engine, FlowStatsReporter};
+use file_system::{set_io_type, IOType};
 use tikv_util::yatp_pool::{Config, DefaultTicker, FuturePool, PoolTicker, YatpPoolBuilder};
 
 use super::metrics::*;
@@ -38,7 +39,10 @@ pub fn build_read_pool<E: Engine, R: FlowStatsReporter>(
             YatpPoolBuilder::new(FuturePoolTicker { reporter })
                 .config(config)
                 .name_prefix(name)
-                .after_start(move || set_tls_engine(engine.lock().unwrap().clone()))
+                .after_start(move || {
+                    set_tls_engine(engine.lock().unwrap().clone());
+                    set_io_type(IOType::ForegroundRead);
+                })
                 .before_stop(move || unsafe {
                     // Safety: we call `set_` and `destroy_` with the same engine type.
                     destroy_tls_engine::<E>();
@@ -61,7 +65,10 @@ pub fn build_read_pool_for_test<E: Engine>(
             let engine = Arc::new(Mutex::new(engine.clone()));
             YatpPoolBuilder::new(DefaultTicker::default())
                 .config(config)
-                .after_start(move || set_tls_engine(engine.lock().unwrap().clone()))
+                .after_start(move || {
+                    set_tls_engine(engine.lock().unwrap().clone());
+                    set_io_type(IOType::ForegroundRead);
+                })
                 // Safety: we call `set_` and `destroy_` with the same engine type.
                 .before_stop(|| unsafe { destroy_tls_engine::<E>() })
                 .build_future_pool()

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -3,6 +3,7 @@
 use self::metrics::*;
 use crate::config::UnifiedReadPoolConfig;
 use crate::storage::kv::{destroy_tls_engine, set_tls_engine, Engine, FlowStatsReporter};
+use file_system::{set_io_type, IOType};
 use futures::channel::oneshot;
 use futures::future::TryFutureExt;
 use kvproto::kvrpcpb::CommandPri;
@@ -194,6 +195,7 @@ pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(
         .after_start(move || {
             let engine = raftkv.lock().unwrap().clone();
             set_tls_engine(engine);
+            set_io_type(IOType::ForegroundRead);
         })
         .before_stop(|| unsafe {
             destroy_tls_engine::<E>();

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -110,6 +110,7 @@ tikv = { path = "../", default-features = false }
 tikv_util = { path = "../components/tikv_util" }
 error_code = { path = "../components/error_code" }
 collections = { path = "../components/collections" }
+file_system = { path = "../components/file_system" }
 tipb = { git = "https://github.com/pingcap/tipb.git", default-features = false }
 toml = "0.5"
 txn_types = { path = "../components/txn_types" }

--- a/tests/integrations/raftstore/test_snap.rs
+++ b/tests/integrations/raftstore/test_snap.rs
@@ -11,13 +11,12 @@ use raft::eraftpb::{Message, MessageType};
 
 use engine_rocks::Compat;
 use engine_traits::Peekable;
+use file_system::{set_io_rate_limiter, BytesRecorder, IOOp, IORateLimiter, IOType};
 use raftstore::store::*;
 use raftstore::Result;
 use test_raftstore::*;
 use tikv_util::config::*;
 use tikv_util::HandyRwLock;
-use file_system::{set_io_rate_limiter, BytesRecorder, IOOp, IORateLimiter, IOType};
-
 
 fn test_huge_snapshot<T: Simulator>(cluster: &mut Cluster<T>) {
     cluster.cfg.raft_store.raft_log_gc_count_limit = 1000;
@@ -510,7 +509,7 @@ fn test_inspected_snapshot() {
     must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
     assert_ne!(recorder.fetch(IOType::Replication, IOOp::Read), 0);
     assert_ne!(recorder.fetch(IOType::Replication, IOOp::Write), 0);
-    
+
     pd_client.must_remove_peer(1, new_peer(2, 2));
     assert_eq!(recorder.fetch(IOType::LoadBalance, IOOp::Read), 0);
     assert_eq!(recorder.fetch(IOType::LoadBalance, IOOp::Write), 0);


### PR DESCRIPTION
Signed-off-by: Connor <zbk602423539@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: part of #9156 
Problem Summary: 
Tag io type for foreground read/write and snapshot of replication/loadbalance, so io rate limiter can use it to throttle different tasks

### What is changed and how it works?

What's Changed:
- tag `ForegroundRead` for storage/coprocessor readpool
- tag `ForegroundWrite` for scheduler worker and batch system of raftstore/apply
- Add a field `for_balance` for snapshot meta https://github.com/pingcap/kvproto/pull/707, so the receiver can know whether the snapshot is triggered by balance.
- use `matched_index==0` to decide whether the snapshot is triggered by balance or not, and tag `LoadBalance` or `Replication` on the generation and receiving of snapshots. 

### Related changes

https://github.com/pingcap/kvproto/pull/707

### Check List <!--REMOVE the items that are not applicable-->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

- None