### PR TITLE
pd_client: prevent RPC being blocked by PD client update leader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,6 +2805,7 @@ dependencies = [
  "tikv_util",
  "tokio-timer",
  "txn_types",
+ "yatp",
 ]
 
 [[package]]

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -46,3 +46,4 @@ tokio-timer = "0.2"
 txn_types = { path = "../txn_types", default-features = false }
 semver = "0.10"
 fail = "0.4"
+yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -95,7 +95,6 @@ impl RpcClient {
                                 .await
                                 .is_ok();
 
-                            fail_point!("on_pd_client_update");
                             if !ok {
                                 warn!("failed to delay with global timer");
                                 continue;

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -17,14 +17,16 @@ use kvproto::pdpb::{self, Member};
 use kvproto::replication_modepb::{RegionReplicationStatus, ReplicationStatus};
 use security::SecurityManager;
 use tikv_util::time::duration_to_sec;
+use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 use tikv_util::{Either, HandyRwLock};
 use txn_types::TimeStamp;
+use yatp::task::future::TaskCell;
+use yatp::ThreadPool;
 
 use super::metrics::*;
 use super::util::{check_resp_header, sync_request, validate_endpoints, LeaderClient};
 use super::{Config, FeatureGate, PdFuture, UnixSecs};
 use super::{Error, PdClient, RegionInfo, RegionStat, Result, REQUEST_TIMEOUT};
-use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 
 const CQ_COUNT: usize = 1;
 const CLIENT_PREFIX: &str = "pd";
@@ -32,6 +34,7 @@ const CLIENT_PREFIX: &str = "pd";
 pub struct RpcClient {
     cluster_id: u64,
     leader_client: Arc<LeaderClient>,
+    monitor: ThreadPool<TaskCell>,
 }
 
 impl RpcClient {
@@ -73,6 +76,9 @@ impl RpcClient {
                             client,
                             members,
                         )),
+                        monitor: yatp::Builder::new(thd_name!("pdmonitor"))
+                            .max_thread_count(1)
+                            .build_future_pool(),
                     };
 
                     // spawn a background future to update PD information periodically
@@ -86,6 +92,7 @@ impl RpcClient {
                                 .await
                                 .is_ok();
 
+                            fail_point!("on_pd_client_update");
                             if !ok {
                                 warn!("failed to delay with global timer");
                                 continue;
@@ -105,13 +112,10 @@ impl RpcClient {
                         }
                     };
 
-                    // FIXME: RwLock may block the async executor.
-                    rpc_client
-                        .leader_client
-                        .inner
-                        .rl()
-                        .client_stub
-                        .spawn(update_loop);
+                    // `update_loop` contains RwLock that may block the monitor.
+                    // Since the monitor does not have other critical task, it
+                    // is not a major issue.
+                    rpc_client.monitor.spawn(update_loop);
 
                     return Ok(rpc_client);
                 }

--- a/tests/failpoints/cases/test_pd_client.rs
+++ b/tests/failpoints/cases/test_pd_client.rs
@@ -90,7 +90,7 @@ fn test_pd_client_deadlock() {
         let mut timeout = Duration::from_millis(500);
         if name == "region_heartbeat" {
             // region_heartbeat may need to retry a few times due to reconnection so increases its timeout.
-            timeout = Duration::from_secs(3);
+            timeout = Duration::from_secs(30);
         }
         if rx.recv_timeout(timeout).is_err() {
             panic!("PdClient::{}() hangs", name);

--- a/tests/failpoints/cases/test_pd_client.rs
+++ b/tests/failpoints/cases/test_pd_client.rs
@@ -107,7 +107,7 @@ fn test_slow_periodical_update() {
     let server = MockServer::new(1);
     let eps = server.bind_addrs();
 
-    let mut cfg = new_config(eps.clone());
+    let mut cfg = new_config(eps);
     let env = Arc::new(EnvBuilder::new().cq_count(1).build());
     let mgr = Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap());
 
@@ -117,7 +117,7 @@ fn test_slow_periodical_update() {
 
     // client2 never updates leader in the test.
     cfg.update_interval = ReadableDuration(Duration::from_secs(100));
-    let client2 = RpcClient::new(&cfg, Some(env.clone()), mgr.clone()).unwrap();
+    let client2 = RpcClient::new(&cfg, Some(env), mgr).unwrap();
 
     fail::cfg(leader_client_update, "pause").unwrap();
     // Wait for the PD client thread blocking on the fail point.

--- a/tests/failpoints/cases/test_pd_client.rs
+++ b/tests/failpoints/cases/test_pd_client.rs
@@ -1,7 +1,9 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use grpcio::EnvBuilder;
 use kvproto::metapb::*;
 use pd_client::{PdClient, RegionInfo, RegionStat, RpcClient};
+use security::{SecurityConfig, SecurityManager};
 use test_pd::{mocker::*, util::*, Server as MockServer};
 use tikv_util::config::ReadableDuration;
 
@@ -95,4 +97,44 @@ fn test_pd_client_deadlock() {
         }
         handle.join().unwrap();
     }
+}
+
+// Updating pd leader may be slow, we need to make sure it does not block other
+// RPC in the same gRPC Environment.
+#[test]
+fn test_slow_periodical_update() {
+    let leader_client_update = "on_pd_client_update";
+    let server = MockServer::new(1);
+    let eps = server.bind_addrs();
+
+    let mut cfg = new_config(eps.clone());
+    let env = Arc::new(EnvBuilder::new().cq_count(1).build());
+    let mgr = Arc::new(SecurityManager::new(&SecurityConfig::default()).unwrap());
+
+    // client1 updates leader frequently (100ms).
+    cfg.update_interval = ReadableDuration(Duration::from_millis(100));
+    let _client1 = RpcClient::new(&cfg, Some(env.clone()), mgr.clone()).unwrap();
+
+    // client2 never updates leader in the test.
+    cfg.update_interval = ReadableDuration(Duration::from_secs(100));
+    let client2 = RpcClient::new(&cfg, Some(env.clone()), mgr.clone()).unwrap();
+
+    fail::cfg(leader_client_update, "pause").unwrap();
+    // Wait for the PD client thread blocking on the fail point.
+    thread::sleep(Duration::from_secs(2));
+
+    let (tx, rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        client2.alloc_id().unwrap();
+        tx.send(()).unwrap();
+    });
+
+    let timeout = Duration::from_millis(500);
+    if rx.recv_timeout(timeout).is_err() {
+        panic!("pd client2 is blocked");
+    }
+
+    // Clean up the fail point.
+    fail::remove(leader_client_update);
+    handle.join().unwrap();
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9463 

Problem Summary: the `update_loop` may take 10s or more, it may block gRPC threads.

### What is changed and how it works?

What's Changed: move `update_loop` to anther thread.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

- Fix gRPC keepalive issue caused by PD client.