### PR TITLE
engine_traits: Add delete_range (no cf) methods

### DIFF
--- a/components/engine_panic/src/engine.rs
+++ b/components/engine_panic/src/engine.rs
@@ -55,6 +55,9 @@ impl SyncMutable for PanicEngine {
     fn delete_cf(&self, cf: &str, key: &[u8]) -> Result<()> {
         panic!()
     }
+    fn delete_range(&self, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
+        panic!()
+    }
     fn delete_range_cf(&self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
         panic!()
     }

--- a/components/engine_panic/src/write_batch.rs
+++ b/components/engine_panic/src/write_batch.rs
@@ -72,6 +72,9 @@ impl Mutable for PanicWriteBatch {
     fn delete_cf(&mut self, cf: &str, key: &[u8]) -> Result<()> {
         panic!()
     }
+    fn delete_range(&mut self, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
+        panic!()
+    }
     fn delete_range_cf(&mut self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
         panic!()
     }

--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -174,6 +174,12 @@ impl SyncMutable for RocksEngine {
         self.db.delete_cf(handle, key).map_err(Error::Engine)
     }
 
+    fn delete_range(&self, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
+        self.db
+            .delete_range(begin_key, end_key)
+            .map_err(Error::Engine)
+    }
+
     fn delete_range_cf(&self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
         let handle = get_cf_handle(&self.db, cf)?;
         self.db

--- a/components/engine_rocks/src/write_batch.rs
+++ b/components/engine_rocks/src/write_batch.rs
@@ -130,6 +130,12 @@ impl Mutable for RocksWriteBatch {
         self.wb.delete_cf(handle, key).map_err(Error::Engine)
     }
 
+    fn delete_range(&mut self, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
+        self.wb
+            .delete_range(begin_key, end_key)
+            .map_err(Error::Engine)
+    }
+
     fn delete_range_cf(&mut self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
         let handle = get_cf_handle(self.db.as_ref(), cf)?;
         self.wb
@@ -283,6 +289,13 @@ impl Mutable for RocksWriteBatchVec {
         let handle = get_cf_handle(self.db.as_ref(), cf)?;
         self.wbs[self.index]
             .delete_cf(handle, key)
+            .map_err(Error::Engine)
+    }
+
+    fn delete_range(&mut self, begin_key: &[u8], end_key: &[u8]) -> Result<()> {
+        self.check_switch_batch();
+        self.wbs[self.index]
+            .delete_range(begin_key, end_key)
             .map_err(Error::Engine)
     }
 

--- a/components/engine_traits/src/mutable.rs
+++ b/components/engine_traits/src/mutable.rs
@@ -11,6 +11,8 @@ pub trait SyncMutable {
 
     fn delete_cf(&self, cf: &str, key: &[u8]) -> Result<()>;
 
+    fn delete_range(&self, begin_key: &[u8], end_key: &[u8]) -> Result<()>;
+
     fn delete_range_cf(&self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()>;
 
     fn put_msg<M: protobuf::Message>(&self, key: &[u8], m: &M) -> Result<()> {

--- a/components/engine_traits/src/write_batch.rs
+++ b/components/engine_traits/src/write_batch.rs
@@ -34,6 +34,7 @@ pub trait Mutable: Send {
     fn delete(&mut self, key: &[u8]) -> Result<()>;
     fn delete_cf(&mut self, cf: &str, key: &[u8]) -> Result<()>;
 
+    fn delete_range(&mut self, begin_key: &[u8], end_key: &[u8]) -> Result<()>;
     fn delete_range_cf(&mut self, cf: &str, begin_key: &[u8], end_key: &[u8]) -> Result<()>;
 
     fn put_msg<M: protobuf::Message>(&mut self, key: &[u8], m: &M) -> Result<()> {


### PR DESCRIPTION
Signed-off-by: Brian Anderson <andersrb@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

The other two mutation methods, put and delete, have two versions each: one that takes a CF, and one that doesn't (it mutates CF_DEFAULT). The `delete_range_cf` method though has no corresponding `delete_range` method.

This PR adds the method.

This is not _actually_ needed by tikv - the one place it calls `delete_range_cf(CF_DEFAULT...)` makes sense to continue using the "cf" version of the method.

As a matter of API design though, these methods should exist.

But furthermore, the engine test suite I'm developing will be more self-consistent if the non-cf version of this method is available - various tests are parameterized over both the "cf" and "non-cf" versions of these mutation methods.

I've included no unit tests, but the engine_traits_test suite will include tests for it, and I intend to submit a PR for that in the next week or so.

Part of https://github.com/tikv/tikv/issues/6402

### What is changed and how it works?

Add `delete_range` methods to `SyncMutable` and `Mutable` traits in engine_traits.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->


### Release note <!-- bugfixes or new feature need a release note -->

- No release note.