### PR TITLE
start gc after node to fetch node id

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -636,6 +636,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
 
         let auto_split_controller = AutoSplitController::new(split_config_manager);
 
+        // `ConsistencyCheckObserver` must be registered before `Node::start`.
         let safe_point = Arc::new(AtomicU64::new(0));
         let observer = match self.config.coprocessor.consistency_check_method {
             ConsistencyCheckMethod::Mvcc => BoxConsistencyCheckObserver::new(
@@ -660,16 +661,6 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             self.background_worker.clone(),
         );
 
-        // Start auto gc
-        let auto_gc_config = AutoGcConfig::new(
-            self.pd_client.clone(),
-            self.region_info_accessor.clone(),
-            node.id(),
-        );
-        if let Err(e) = gc_worker.start_auto_gc(auto_gc_config, safe_point) {
-            fatal!("failed to start auto_gc on storage, error: {}", e);
-        }
-
         node.start(
             engines.engines.clone(),
             server.transport(),
@@ -683,6 +674,17 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             self.concurrency_manager.clone(),
         )
         .unwrap_or_else(|e| fatal!("failed to start node: {}", e));
+
+        // Start auto gc. Must after `Node::start` because `node_id` is initialized there.
+        assert!(node.id() > 0); // Node id should never be 0.
+        let auto_gc_config = AutoGcConfig::new(
+            self.pd_client.clone(),
+            self.region_info_accessor.clone(),
+            node.id(),
+        );
+        if let Err(e) = gc_worker.start_auto_gc(auto_gc_config, safe_point) {
+            fatal!("failed to start auto_gc on storage, error: {}", e);
+        }
 
         initial_metric(&self.config.metric);
 


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

There is a bug in the master branch that GC can't work at all. The reason is `0` is passed into the GC worker as `store_id`, which will cause all regions get skiped when doing GC.

Close https://github.com/tikv/tikv/issues/9466.

The bug is introduced in https://github.com/tikv/tikv/pull/9350.

### What is changed and how it works?

Start gc worker after node. So that `node_id` passed into the GC worker will must be valid.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)
a) starting a new tikv cluster
b) run a sysbench update_index workload, then check the gc worker cpu panel
c) check the result:
  
![图片](https://user-images.githubusercontent.com/8407317/104173318-8b801800-5440-11eb-8a8c-8093b0168153.png)
<img width="932" alt="图片" src="https://user-images.githubusercontent.com/8407317/104173382-a6eb2300-5440-11eb-87a4-63c9f0ab7880.png">

### Release note <!-- bugfixes or new feature need a release note -->
* No release note