### PR TITLE
gc: assertion on zero `self_store_id`

### DIFF
--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -651,6 +651,8 @@ where
         cfg: AutoGcConfig<S, R>,
         safe_point: Arc<AtomicU64>, // Store safe point here.
     ) -> Result<()> {
+        assert!(cfg.self_store_id > 0, "AutoGcConfig::self_store_id shouldn't be 0");
+
         let kvdb = self.engine.kv_engine();
         let cfg_mgr = self.config_manager.clone();
         let feature_gate = self.feature_gate.clone();

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -651,7 +651,10 @@ where
         cfg: AutoGcConfig<S, R>,
         safe_point: Arc<AtomicU64>, // Store safe point here.
     ) -> Result<()> {
-        assert!(cfg.self_store_id > 0, "AutoGcConfig::self_store_id shouldn't be 0");
+        assert!(
+            cfg.self_store_id > 0,
+            "AutoGcConfig::self_store_id shouldn't be 0"
+        );
 
         let kvdb = self.engine.kv_engine();
         let cfg_mgr = self.config_manager.clone();


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

Assertion on `self_store_id >  0` for GC worker. So that if component initialization order in `cmd/src/server.rs` is changed incorrectly, we can find that immediately.

### What is changed and how it works?

Assertion on `self_store_id > 0` for GC worker. And adjust test code if necessary.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* No release note