### PR TITLE
reserve space with a better strategy

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -70,7 +70,7 @@ use tikv::{
     },
     storage::{
         self,
-        config::{StorageConfigManger, MAX_RESERVED_SPACE_SIZE},
+        config::{StorageConfigManger, MAX_RESERVED_SPACE_GB},
         mvcc::MvccConsistencyCheckObserver,
     },
 };
@@ -376,10 +376,10 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         file_system::reserve_space_for_recover(
             &self.config.storage.data_dir,
             cmp::min(
-                ReadableSize::gb(MAX_RESERVED_SPACE_SIZE).0,
+                ReadableSize::gb(MAX_RESERVED_SPACE_GB).0,
                 // Max one of configured `reserve_space` and `storage.capacity * 5%`.
                 cmp::max(
-                    (capacity as f64 / 20f64) as u64,
+                    (capacity as f64 * 0.05) as u64,
                     self.config.storage.reserve_space.0,
                 ),
             ),

--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -9,6 +9,7 @@
 //! We keep these components in the `TiKVServer` struct.
 
 use std::{
+    cmp,
     convert::TryFrom,
     env, fmt,
     fs::{self, File},
@@ -67,9 +68,13 @@ use tikv::{
         status_server::StatusServer,
         Node, RaftKv, Server, CPU_CORES_QUOTA_GAUGE, DEFAULT_CLUSTER_ID, GRPC_THREAD_PREFIX,
     },
-    storage::{self, config::StorageConfigManger, mvcc::MvccConsistencyCheckObserver},
+    storage::{
+        self,
+        config::{StorageConfigManger, MAX_RESERVED_SPACE_SIZE},
+        mvcc::MvccConsistencyCheckObserver,
+    },
 };
-use tikv_util::config::VersionTrack;
+use tikv_util::config::{ReadableSize, VersionTrack};
 use tikv_util::{
     check_environment_variables,
     config::ensure_dir_exist,
@@ -361,11 +366,23 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         }
 
         // We truncate a big file to make sure that both raftdb and kvdb of TiKV have enough space
-        // to compaction when TiKV recover. This file is created in data_dir rather than db_path,
-        // because we must not increase store size of db_path.
+        // to do compaction and region migration when TiKV recover. This file is created in
+        // data_dir rather than db_path, because we must not increase store size of db_path.
+        let disk_stats = fs2::statvfs(&self.config.storage.data_dir).unwrap();
+        let mut capacity = disk_stats.total_space();
+        if self.config.raft_store.capacity.0 > 0 {
+            capacity = cmp::min(capacity, self.config.raft_store.capacity.0);
+        }
         file_system::reserve_space_for_recover(
             &self.config.storage.data_dir,
-            self.config.storage.reserve_space.0,
+            cmp::min(
+                ReadableSize::gb(MAX_RESERVED_SPACE_SIZE).0,
+                // Max one of configured `reserve_space` and `storage.capacity * 5%`.
+                cmp::max(
+                    (capacity as f64 / 20f64) as u64,
+                    self.config.storage.reserve_space.0,
+                ),
+            ),
         )
         .unwrap();
     }

--- a/components/file_system/src/lib.rs
+++ b/components/file_system/src/lib.rs
@@ -268,13 +268,11 @@ const SPACE_PLACEHOLDER_FILE: &str = "space_placeholder_file";
 pub fn reserve_space_for_recover<P: AsRef<Path>>(data_dir: P, file_size: u64) -> io::Result<()> {
     let path = data_dir.as_ref().join(SPACE_PLACEHOLDER_FILE);
     let f = OpenOptions::new().create(true).write(true).open(&path)?;
-    let len = f.metadata()?.len();
-    if len >= file_size {
-        return Ok(());
+    if f.metadata()?.len() < file_size {
+        f.allocate(file_size)?;
+        f.sync_all()?;
+        sync_dir(data_dir)?;
     }
-    f.allocate(file_size - len)?;
-    f.sync_all()?;
-    sync_dir(data_dir)?;
     Ok(())
 }
 

--- a/components/file_system/src/lib.rs
+++ b/components/file_system/src/lib.rs
@@ -264,21 +264,17 @@ impl<R: Read> Read for Sha256Reader<R> {
 
 const SPACE_PLACEHOLDER_FILE: &str = "space_placeholder_file";
 
-// create a file with hole, to reserve space for TiKV.
+// Create a file with hole, to reserve space for TiKV.
 pub fn reserve_space_for_recover<P: AsRef<Path>>(data_dir: P, file_size: u64) -> io::Result<()> {
     let path = data_dir.as_ref().join(SPACE_PLACEHOLDER_FILE);
-    if file_exists(path.clone()) {
-        if get_file_size(path.clone())? == file_size {
-            return Ok(());
-        }
-        delete_file_if_exist(path.clone())?;
+    let f = OpenOptions::new().create(true).write(true).open(&path)?;
+    let len = f.metadata()?.len();
+    if len >= file_size {
+        return Ok(());
     }
-    if file_size > 0 {
-        let f = File::create(path)?;
-        f.allocate(file_size)?;
-        f.sync_all()?;
-        sync_dir(data_dir)?;
-    }
+    f.allocate(file_size - len)?;
+    f.sync_all()?;
+    sync_dir(data_dir)?;
     Ok(())
 }
 

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -674,16 +674,11 @@ where
             stats.get_used_size() + store_info.engine.get_engine_used_size().expect("cf");
         stats.set_used_size(used_size);
 
-        let mut available = if capacity > used_size {
-            capacity - used_size
-        } else {
-            warn!("no available space");
-            0
-        };
-
+        let mut available = capacity.checked_sub(used_size).unwrap_or_default();
         // We only care about rocksdb SST file size, so we should check disk available here.
-        if available > disk_stats.available_space() {
-            available = disk_stats.available_space();
+        available = cmp::min(available, disk_stats.available_space());
+        if available == 0 {
+            warn!("no available space");
         }
 
         stats.set_available(available);

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -682,8 +682,8 @@ where
         };
 
         // We only care about rocksdb SST file size, so we should check disk available here.
-        if available > disk_stats.free_space() {
-            available = disk_stats.free_space();
+        if available > disk_stats.available_space() {
+            available = disk_stats.available_space();
         }
 
         stats.set_available(available);

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -209,6 +209,13 @@
 ## latency jittering when apply duration is not stable.
 # enable-async-apply-prewrite = false
 
+## Reserve some space to ensure recovering the store from `no space left` must success. The
+## configured value only indicates the lower limit, and 20GB is the upper limit. In this range,
+## `max(reserve-space, capacity * 5%)` will be reserved exactly.
+##
+## Generally it's not necessary to change it. This configuration could be deprecated in future.
+# reserve-space = "5GB"
+
 [storage.block-cache]
 ## Whether to create a shared block cache for all RocksDB column families.
 ##

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -630,6 +630,8 @@
 # target-file-size-base = "8MB"
 
 ## Max bytes for `compaction.max_compaction_bytes`.
+## If it's necessary to enlarge value of this entry, it's better to also enlarge `reserve-space`
+## in `storage` to ensure that a restarted TiKV instance can perform compactions successfully.
 # max-compaction-bytes = "2GB"
 
 ## There are four different compaction priorities.

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -637,7 +637,7 @@ fn test_serde_custom_tikv_config() {
         scheduler_concurrency: 123,
         scheduler_worker_pool_size: 1,
         scheduler_pending_write_threshold: ReadableSize::kb(123),
-        reserve_space: ReadableSize::gb(5),
+        reserve_space: ReadableSize::gb(10),
         enable_async_apply_prewrite: true,
         block_cache: BlockCacheConfig {
             shared: true,

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -636,7 +636,7 @@ fn test_serde_custom_tikv_config() {
         scheduler_concurrency: 123,
         scheduler_worker_pool_size: 1,
         scheduler_pending_write_threshold: ReadableSize::kb(123),
-        reserve_space: ReadableSize::gb(2),
+        reserve_space: ReadableSize::gb(5),
         enable_async_apply_prewrite: true,
         block_cache: BlockCacheConfig {
             shared: true,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -77,6 +77,7 @@ scheduler-concurrency = 123
 scheduler-worker-pool-size = 1
 scheduler-pending-write-threshold = "123KB"
 enable-async-apply-prewrite = true
+reserve-space = "10GB"
 
 [storage.block-cache]
 shared = true


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

Currently TiKV reserves 2GB disk space to ensure recovering from `no space left` error must success. It's not enough exactly.

And, `available_space` reported to PD is wrong.

Issue Number: close https://github.com/tikv/tikv/issues/9395.

### What is changed and how it works?

TiKV reserve 5GB space at least and 20GB at most. The lower limit can be adjusted in config file.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  a. Start a TiKV instance without the patch
  b. Stop it and switch to the branch, restart it
  c. size of file `space_placeholder_file` increases larger

### Release note <!-- bugfixes or new feature need a release note -->
* server: reserve space with a better strategy