### PR TITLE
test: fix test_pd_client_deadlock

### DIFF
--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -185,7 +185,7 @@ impl LeaderClient {
         };
 
         let (client, members) = future.await?;
-        fail_point!("leader_client_reconnect");
+        fail_point!("leader_client_reconnect", |_| Ok(()));
 
         {
             let start_refresh = Instant::now();

--- a/components/test_pd/src/mocker/service.rs
+++ b/components/test_pd/src/mocker/service.rs
@@ -283,4 +283,31 @@ impl PdMocker for Service {
         resp.set_header(header);
         Some(Ok(resp))
     }
+
+    fn put_store(&self, _: &PutStoreRequest) -> Option<Result<PutStoreResponse>> {
+        let mut resp = PutStoreResponse::default();
+        let header = Service::header();
+        resp.set_header(header);
+        Some(Ok(resp))
+    }
+
+    fn get_cluster_config(
+        &self,
+        _: &GetClusterConfigRequest,
+    ) -> Option<Result<GetClusterConfigResponse>> {
+        let mut resp = GetClusterConfigResponse::default();
+        let header = Service::header();
+        resp.set_header(header);
+        Some(Ok(resp))
+    }
+
+    fn get_gc_safe_point(
+        &self,
+        _: &GetGcSafePointRequest,
+    ) -> Option<Result<GetGcSafePointResponse>> {
+        let mut resp = GetGcSafePointResponse::default();
+        let header = Service::header();
+        resp.set_header(header);
+        Some(Ok(resp))
+    }
 }

--- a/components/test_pd/src/server.rs
+++ b/components/test_pd/src/server.rs
@@ -278,7 +278,7 @@ impl<C: PdMocker + Send + Sync + 'static> Pd for PdMock<C> {
                 }
             });
             let mut sink = sink.sink_map_err(PdError::from);
-            sink.send_all(&mut stream).await.unwrap();
+            let _ = sink.send_all(&mut stream).await;
             let _ = sink.close().await;
         });
     }

--- a/tests/failpoints/cases/test_pd_client.rs
+++ b/tests/failpoints/cases/test_pd_client.rs
@@ -84,14 +84,14 @@ fn test_pd_client_deadlock() {
             func();
             tx.send(()).unwrap();
         });
+        // Only allow to reconnect once for a func.
+        client.handle_reconnect(move || {
+            fail::cfg(leader_client_reconnect_fp, "return").unwrap();
+        });
         // Remove the fail point to let the PD client thread go on.
         fail::remove(leader_client_reconnect_fp);
 
-        let mut timeout = Duration::from_millis(500);
-        if name == "region_heartbeat" {
-            // region_heartbeat may need to retry a few times due to reconnection so increases its timeout.
-            timeout = Duration::from_secs(30);
-        }
+        let timeout = Duration::from_millis(500);
         if rx.recv_timeout(timeout).is_err() {
             panic!("PdClient::{}() hangs", name);
         }


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/9470

Problem Summary:

`region_heartbeat` in the `test_pd_client_deadlock` case sometimes hangs forever.

### What is changed and how it works?

What's Changed:

`region_heartbeat` interface in the PD client creates a stream when reconnecting to the PD leader which means `block_on`ing it can't return until reconnection. It results in the unstable test. It's changed to return a future instead of a stream which is more intuitive.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
* No release note