### PR TITLE
test: stablize test_applied_lock_collector

### DIFF
--- a/tests/integrations/server/gc_worker.rs
+++ b/tests/integrations/server/gc_worker.rs
@@ -99,10 +99,21 @@ fn test_applied_lock_collector() {
     let wait_for_apply = |cluster: &mut Cluster<_>, region: &metapb::Region| {
         let cluster = &mut *cluster;
         region.get_peers().iter().for_each(|p| {
-            let resp = async_read_on_peer(cluster, p.clone(), region.clone(), b"key", true, true)
-                .recv()
-                .unwrap();
-            assert!(!resp.get_header().has_error(), "{:?}", resp);
+            let mut retry_times = 1;
+            loop {
+                let resp =
+                    async_read_on_peer(cluster, p.clone(), region.clone(), b"key", true, true)
+                        .recv()
+                        .unwrap();
+                if !resp.get_header().has_error() {
+                    return;
+                }
+                if retry_times >= 50 {
+                    panic!("failed to read on {:?}: {:?}", p, resp);
+                }
+                retry_times += 1;
+                sleep_ms(20);
+            }
         });
     };
 


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/9451

Problem Summary:

Fix an unstable test:
```
[2021-01-14T07:58:07.094Z] test server::gc_worker::test_applied_lock_collector ... thread 'main' panicked at 'header { error { message: "stale command" } current_term: 6 }', tests/integrations/server/gc_worker.rs:103:13
```

### What is changed and how it works?

What's Changed:

Add retry mechanism.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
* No release note