### PR TITLE
kv: Remove unused impl of EngineIterator for DBIterator

### DIFF
--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -1,13 +1,12 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::borrow::Borrow;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use engine_rocks::raw::{ColumnFamilyOptions, DBIterator, SeekKey as DBSeekKey, DB};
+use engine_rocks::raw::ColumnFamilyOptions;
 use engine_rocks::raw_util::CFOptions;
 use engine_rocks::{RocksEngine as BaseRocksEngine, RocksEngineIterator};
 use engine_traits::{CfName, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
@@ -410,44 +409,6 @@ impl EngineIterator for RocksEngineIterator {
 
     fn value(&self) -> &[u8] {
         Iterator::value(self)
-    }
-}
-
-impl<D: Borrow<DB> + Send> EngineIterator for DBIterator<D> {
-    fn next(&mut self) -> Result<bool> {
-        DBIterator::next(self).map_err(|e| box_err!(e))
-    }
-
-    fn prev(&mut self) -> Result<bool> {
-        DBIterator::prev(self).map_err(|e| box_err!(e))
-    }
-
-    fn seek(&mut self, key: &Key) -> Result<bool> {
-        DBIterator::seek(self, key.as_encoded().as_slice().into()).map_err(|e| box_err!(e))
-    }
-
-    fn seek_for_prev(&mut self, key: &Key) -> Result<bool> {
-        DBIterator::seek_for_prev(self, key.as_encoded().as_slice().into()).map_err(|e| box_err!(e))
-    }
-
-    fn seek_to_first(&mut self) -> Result<bool> {
-        DBIterator::seek(self, DBSeekKey::Start).map_err(|e| box_err!(e))
-    }
-
-    fn seek_to_last(&mut self) -> Result<bool> {
-        DBIterator::seek(self, DBSeekKey::End).map_err(|e| box_err!(e))
-    }
-
-    fn valid(&self) -> Result<bool> {
-        DBIterator::valid(self).map_err(|e| box_err!(e))
-    }
-
-    fn key(&self) -> &[u8] {
-        DBIterator::key(self)
-    }
-
-    fn value(&self) -> &[u8] {
-        DBIterator::value(self)
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Brian Anderson <andersrb@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Cleaning up the tikv::storage::kv module to make it eventually generic over engine_traits

- cc https://github.com/tikv/tikv/issues/9480
- cc https://github.com/tikv/tikv/issues/6402

### What is changed and how it works?

This code is unused. Delete it.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->


### Release note <!-- bugfixes or new feature need a release note -->

- No release note.