### PR TITLE
raftstore: check valid leader before sleeping 

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -2121,6 +2121,9 @@ where
                 // Don't ping to speed up leader election
                 need_ping = false;
             }
+        } else if !self.fsm.peer.has_valid_leader() {
+            self.fsm.hibernate_state.reset(GroupState::Chaos);
+            self.register_raft_base_tick();
         }
         if need_ping {
             // Speed up snapshot instead of waiting another heartbeat.

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -733,7 +733,8 @@ impl<T: Simulator> Cluster<T> {
     ) -> RaftCmdResponse {
         let timer = Instant::now();
         let mut tried_times = 0;
-        while tried_times < 10 || timer.elapsed() < timeout {
+        // At least retry once.
+        while tried_times < 2 || timer.elapsed() < timeout {
             tried_times += 1;
             let mut region = self.get_region(key);
             let region_id = region.get_id();
@@ -851,6 +852,18 @@ impl<T: Simulator> Cluster<T> {
             .rl()
             .async_command_on_node(leader.get_store_id(), req, cb)?;
         Ok(rx)
+    }
+
+    pub fn async_exit_joint(&mut self, region_id: u64) -> Result<mpsc::Receiver<RaftCmdResponse>> {
+        let region = block_on(self.pd_client.get_region_by_id(region_id))
+            .unwrap()
+            .unwrap();
+        let exit_joint = new_admin_request(
+            region_id,
+            region.get_region_epoch(),
+            new_change_peer_v2_request(vec![]),
+        );
+        self.async_request(exit_joint)
     }
 
     pub fn async_put(

--- a/tests/integrations/raftstore/test_hibernate.rs
+++ b/tests/integrations/raftstore/test_hibernate.rs
@@ -410,3 +410,89 @@ fn test_hibernate_feature_gate() {
     // Leader can go to sleep as version requirement is met.
     assert!(!awakened.load(Ordering::SeqCst));
 }
+
+/// Tests when leader is demoted in a hibernated region, the region can recover automatically.
+#[test]
+fn test_leader_demoted_when_hibernated() {
+    let mut cluster = new_node_cluster(0, 4);
+    configure_for_hibernate(&mut cluster);
+    cluster.pd_client.disable_default_operator();
+    let r = cluster.run_conf_change();
+    cluster.pd_client.must_add_peer(r, new_peer(2, 2));
+    cluster.pd_client.must_add_peer(r, new_peer(3, 3));
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+
+    cluster.must_transfer_leader(r, new_peer(1, 1));
+    // Demote a follower to learner.
+    cluster.pd_client.must_joint_confchange(
+        r,
+        vec![
+            (ConfChangeType::AddLearnerNode, new_learner_peer(3, 3)),
+            (ConfChangeType::AddLearnerNode, new_learner_peer(4, 4)),
+        ],
+    );
+    // So leader will not commit the demote request.
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(r, 1)
+            .msg_type(MessageType::MsgAppendResponse)
+            .direction(Direction::Recv),
+    ));
+
+    // So only peer 3 can become leader.
+    for id in 1..=2 {
+        cluster.add_send_filter(CloneFilterFactory(
+            RegionPacketFilter::new(r, id)
+                .msg_type(MessageType::MsgRequestPreVote)
+                .direction(Direction::Send),
+        ));
+    }
+    // Leave joint.
+    cluster.async_exit_joint(r).unwrap();
+    // Ensure peer 3 can campaign.
+    cluster.wait_last_index(r, 3, 11, Duration::from_secs(5));
+    cluster.add_send_filter(CloneFilterFactory(
+        RegionPacketFilter::new(r, 1)
+            .msg_type(MessageType::MsgHeartbeat)
+            .direction(Direction::Send),
+    ));
+    // Wait some time to ensure the request has been delivered.
+    thread::sleep(Duration::from_millis(100));
+    // Peer 4 should start campaign.
+    let timer = Instant::now();
+    loop {
+        cluster.reset_leader_of_region(r);
+        let cur_leader = cluster.leader_of_region(r);
+        if let Some(ref cur_leader) = cur_leader {
+            if cur_leader.get_id() == 3 && cur_leader.get_store_id() == 3 {
+                break;
+            }
+        }
+        if timer.elapsed() > Duration::from_secs(5) {
+            panic!("peer 4 is still not leader after 5 seconds.");
+        }
+        let region = cluster.get_region(b"k1");
+        let mut request = new_request(
+            region.get_id(),
+            region.get_region_epoch().clone(),
+            vec![new_put_cf_cmd("default", b"k1", b"v1")],
+            false,
+        );
+        request.mut_header().set_peer(new_peer(3, 3));
+        // In case peer 4 is hibernated.
+        let (cb, _rx) = make_cb(&request);
+        cluster
+            .sim
+            .rl()
+            .async_command_on_node(3, request, cb)
+            .unwrap();
+    }
+
+    cluster.clear_send_filters();
+    // If there is no leader in the region, the cluster can't write two kvs successfully.
+    // The first one is possible to succeed if it's committed with the conf change at the
+    // same time, but the second one can't be committed or accepted because conf change
+    // should be applied and the leader should be demoted as learner.
+    cluster.must_put(b"k1", b"v1");
+    cluster.must_put(b"k2", b"v2");
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9505

What's Changed:

If leader is demoted and the region is hibernated, there can be no
leader for quite a long time. It's by design that client should try
other peer when leader is not available, but currently ticlient can't
handle the issue well. On the other hand, PD can still keep sending
scheduling command to the demoted leader, which will also timeout.

So this PR adds an additional check before sleeping to get around it.
This should fix the pd scheduling issue, but ticlient can still timeout
if demoted peer is restarted, client should still retry other peers when
necessary.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note.