### PR TITLE
server: fix panic when a NIC doesn't have a mac address again

### DIFF
--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -378,11 +378,18 @@ fn disk_hardware_info(collector: &mut Vec<ServerInfoItem>) {
     }
 }
 
+fn mac_address(mac: Option<pnet_datalink::MacAddr>) -> String {
+    match mac {
+        Some(mac) => mac.to_string(),
+        None => "none".to_string(),
+    }
+}
+
 fn nic_hardware_info(collector: &mut Vec<ServerInfoItem>) {
     let nics = pnet_datalink::interfaces();
     for nic in nics.into_iter() {
         let mut infos = vec![
-            ("mac", nic.mac_address().to_string()),
+            ("mac", mac_address(nic.mac)),
             ("flag", nic.flags.to_string()),
             ("index", nic.index.to_string()),
             ("is-up", nic.is_up().to_string()),


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:

TiKV panics when the `server_info` gRPC method of the Diagnostic service is invoked, when there exists a NIC with no MAC address (e.g. PTP interfaces).

### What is changed and how it works?

What's Changed:

This PR reapplies #7942, which when the cherry-pick PR #8939 refactored this part of code causes the change to be lost.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
   * See #7942.

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

* Fixes a crash problem when running a TiKV on a machine with a network interface lacking MAC address since v4.0.9.