### PR TITLE
components/tidb_query_expr: migrate Substring() for utf8.

### DIFF
--- a/components/tidb_query_expr/src/impl_string.rs
+++ b/components/tidb_query_expr/src/impl_string.rs
@@ -932,6 +932,27 @@ pub fn substring_3_args(
     substring(input, *pos, *len, writer)
 }
 
+#[rpn_fn(writer)]
+#[inline]
+pub fn substring_2_args_utf8(
+    input: BytesRef,
+    pos: &Int,
+    writer: BytesWriter,
+) -> Result<BytesGuard> {
+    substring_utf8(input, *pos, input.len() as Int, writer)
+}
+
+#[rpn_fn(writer)]
+#[inline]
+pub fn substring_3_args_utf8(
+    input: BytesRef,
+    pos: &Int,
+    len: &Int,
+    writer: BytesWriter,
+) -> Result<BytesGuard> {
+    substring_utf8(input, *pos, *len, writer)
+}
+
 #[inline]
 fn substring(input: BytesRef, pos: Int, len: Int, writer: BytesWriter) -> Result<BytesGuard> {
     let (len, len_positive) = i64_to_usize(len, len > 0);
@@ -947,6 +968,31 @@ fn substring(input: BytesRef, pos: Int, len: Int, writer: BytesWriter) -> Result
     };
     let end = start.saturating_add(len).min(input.len());
     Ok(writer.write_ref(Some(&input[start..end])))
+}
+
+#[inline]
+fn substring_utf8(input: BytesRef, pos: Int, len: Int, writer: BytesWriter) -> Result<BytesGuard> {
+    let (len, len_positive) = i64_to_usize(len, len > 0);
+    let (pos, positive_search) = i64_to_usize(pos, pos > 0);
+    if pos == 0 || len == 0 || !len_positive {
+        return Ok(writer.write_ref(Some(b"")));
+    }
+
+    match str::from_utf8(input) {
+        Ok(s) => {
+            let s_len = s.chars().count();
+
+            let start = if positive_search {
+                (pos - 1).min(s_len)
+            } else {
+                s_len.checked_sub(pos).unwrap_or_else(|| s_len)
+            };
+            let end = start.saturating_add(len).min(s_len);
+
+            Ok(writer.write_ref(Some(s[start..end].as_bytes())))
+        }
+        Err(err) => Err(box_err!("invalid input value: {:?}", err)),
+    }
 }
 
 #[cfg(test)]
@@ -3800,6 +3846,174 @@ mod tests {
                 .push_param(pos)
                 .push_param(len)
                 .evaluate(ScalarFuncSig::Substring3Args)
+                .unwrap();
+            assert_eq!(output, exp);
+        }
+    }
+
+    #[test]
+    fn test_substring_2_args_utf8() {
+        let cases = vec![
+            (
+                Some("中文a测试bb".as_bytes().to_vec()),
+                Some(1),
+                Some("中文a测试bb".as_bytes().to_vec()),
+            ),
+            (
+                Some("中文a测试bb".as_bytes().to_vec()),
+                Some(-5),
+                Some("a测试bb".as_bytes().to_vec()),
+            ),
+            (
+                Some("数据库测试".as_bytes().to_vec()),
+                Some(3),
+                Some("库测试".as_bytes().to_vec()),
+            ),
+            (
+                Some("数据库测试".as_bytes().to_vec()),
+                Some(-2),
+                Some("测试".as_bytes().to_vec()),
+            ),
+            (
+                Some("hello world".as_bytes().to_vec()),
+                Some(7),
+                Some("world".as_bytes().to_vec()),
+            ),
+            (
+                Some("hello world".as_bytes().to_vec()),
+                Some(-6),
+                Some(" world".as_bytes().to_vec()),
+            ),
+            (
+                Some("长度为8的字符串".as_bytes().to_vec()),
+                Some(0),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("长度为8的字符串".as_bytes().to_vec()),
+                Some(100),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("长度为8的字符串".as_bytes().to_vec()),
+                Some(-100),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("长度为8的字符串".as_bytes().to_vec()),
+                Some(i64::max_value()),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("长度为8的字符串".as_bytes().to_vec()),
+                Some(i64::min_value()),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("".as_bytes().to_vec()),
+                Some(1),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("".as_bytes().to_vec()),
+                Some(-1),
+                Some("".as_bytes().to_vec()),
+            ),
+        ];
+
+        for (str, pos, exp) in cases {
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(str)
+                .push_param(pos)
+                .evaluate(ScalarFuncSig::Substring2ArgUtf8)
+                .unwrap();
+            assert_eq!(output, exp);
+        }
+    }
+
+    #[test]
+    fn test_substring_3_args_utf8() {
+        let cases = vec![
+            (
+                Some("中文a测试bb".as_bytes().to_vec()),
+                Some(2),
+                Some(3),
+                Some("文a测".as_bytes().to_vec()),
+            ),
+            (
+                Some("中文a测试bb".as_bytes().to_vec()),
+                Some(-5),
+                Some(3),
+                Some("a测试".as_bytes().to_vec()),
+            ),
+            (
+                Some("中文a测试bb".as_bytes().to_vec()),
+                Some(2),
+                Some(0),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("中文a测试bb".as_bytes().to_vec()),
+                Some(2),
+                Some(-1),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("中文a测试bb".as_bytes().to_vec()),
+                Some(2),
+                Some(100),
+                Some("文a测试bb".as_bytes().to_vec()),
+            ),
+            (
+                Some("中文a测试bb".as_bytes().to_vec()),
+                Some(100),
+                Some(5),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("中文a测试bb".as_bytes().to_vec()),
+                Some(-100),
+                Some(5),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("".as_bytes().to_vec()),
+                Some(1),
+                Some(1),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("数据库测试".as_bytes().to_vec()),
+                Some(0),
+                Some(5),
+                Some("".as_bytes().to_vec()),
+            ),
+            (
+                Some("数据库测试".as_bytes().to_vec()),
+                Some(4),
+                Some(100),
+                Some("测试".as_bytes().to_vec()),
+            ),
+            (
+                Some("数据库测试".as_bytes().to_vec()),
+                Some(-1),
+                Some(2),
+                Some("试".as_bytes().to_vec()),
+            ),
+            (
+                Some("数据库测试".as_bytes().to_vec()),
+                Some(-2),
+                Some(2),
+                Some("测试".as_bytes().to_vec()),
+            ),
+        ];
+
+        for (str, pos, len, exp) in cases {
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(str)
+                .push_param(pos)
+                .push_param(len)
+                .evaluate(ScalarFuncSig::Substring3ArgsUtf8)
                 .unwrap();
             assert_eq!(output, exp);
         }


### PR DESCRIPTION
Migrate functions from TiDB to TiKV.

Signed-off-by: yah01 <kagaminehuan@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
Migrate `Substring2ArgUtf8` and `Substring3ArgUtf8` functions to TiKV

### What is changed and how it works?

What's Changed:
implement `Substring2ArgUtf8`
implement `Substring3ArgUtf8`

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
Add builtin substring functions:
`Substring2ArgUtf8`
`Substring3ArgUtf8`