### PR TITLE
mark read-index API deprecated

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -33,7 +33,6 @@ use kvproto::coprocessor::*;
 use kvproto::errorpb::{Error as RegionError, *};
 use kvproto::kvrpcpb::*;
 use kvproto::mpp::*;
-use kvproto::raft_cmdpb::{CmdType, RaftCmdRequest, RaftRequestHeader, Request as RaftRequest};
 use kvproto::raft_serverpb::*;
 use kvproto::tikvpb::*;
 use raftstore::router::RaftStoreRouter;
@@ -723,7 +722,7 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
     fn read_index(
         &mut self,
         ctx: RpcContext<'_>,
-        req: ReadIndexRequest,
+        _req: ReadIndexRequest,
         sink: UnarySink<ReadIndexResponse>,
     ) {
         ctx.spawn(


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

Deprecated the read-index API. Close https://github.com/tikv/tikv/issues/9351.

Code about `CmdType::ReadIndex` is not removed from `components/raftstore` for backforward compatibility.

### What is changed and how it works?

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- No code

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.