### PR TITLE
raftstore: add more checks before proposing joint confchange

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3107,6 +3107,22 @@ where
         self.ctx.store_stat.engine_total_keys_written += metrics.written_keys;
     }
 
+    fn check_joint_state(&self, msg: &RaftCmdRequest) -> Result<()> {
+        if !self.fsm.peer.in_joint_state() {
+            return Ok(());
+        }
+        let cmd = msg.get_admin_request();
+        if cmd.has_prepare_merge() || cmd.has_commit_merge() || cmd.has_split() || cmd.has_splits()
+        {
+            return Err(box_err!(
+                "{} region in joint state, can not propose split or merge command, command: {:?}",
+                self.fsm.peer.tag,
+                cmd
+            ));
+        }
+        Ok(())
+    }
+
     /// Check if a request is valid if it has valid prepare_merge/commit_merge proposal.
     fn check_merge_proposal(&self, msg: &mut RaftCmdRequest) -> Result<()> {
         if !msg.get_admin_request().has_prepare_merge()
@@ -3283,17 +3299,32 @@ where
             return;
         }
 
-        if let Err(e) = self.check_merge_proposal(&mut msg) {
-            warn!(
-                "failed to propose merge";
-                "region_id" => self.region_id(),
-                "peer_id" => self.fsm.peer_id(),
-                "message" => ?msg,
-                "err" => %e,
-                "error_code" => %e.error_code(),
-            );
-            cb.invoke_with_response(new_error(e));
-            return;
+        if msg.has_admin_request() {
+            if let Err(e) = self.check_joint_state(&msg) {
+                warn!(
+                    "failed to propose merge or split while region in joint state";
+                    "region_id" => self.region_id(),
+                    "peer_id" => self.fsm.peer_id(),
+                    "message" => ?msg,
+                    "err" => %e,
+                    "error_code" => %e.error_code(),
+                );
+                cb.invoke_with_response(new_error(e));
+                return;
+            }
+
+            if let Err(e) = self.check_merge_proposal(&mut msg) {
+                warn!(
+                    "failed to propose merge";
+                    "region_id" => self.region_id(),
+                    "peer_id" => self.fsm.peer_id(),
+                    "message" => ?msg,
+                    "err" => %e,
+                    "error_code" => %e.error_code(),
+                );
+                cb.invoke_with_response(new_error(e));
+                return;
+            }
         }
 
         // Note:

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3115,16 +3115,15 @@ where
             return Ok(());
         }
 
-        if self.fsm.peer.in_joint_state() {
-            return Err(box_err!(
-                "{} region in joint state, can not propose merge command, command: {:?}",
-                self.fsm.peer.tag,
-                msg.get_admin_request()
-            ));
-        }
-
         let region = self.fsm.peer.region();
         if msg.get_admin_request().has_prepare_merge() {
+            if self.fsm.peer.in_joint_state() {
+                return Err(box_err!(
+                    "{} region in joint state, can not propose merge command, command: {:?}",
+                    self.fsm.peer.tag,
+                    msg.get_admin_request()
+                ));
+            }
             let target_region = msg.get_admin_request().get_prepare_merge().get_target();
             {
                 let meta = self.ctx.store_meta.lock().unwrap();

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3117,6 +3117,7 @@ where
 
         let region = self.fsm.peer.region();
         if msg.get_admin_request().has_prepare_merge() {
+            // Just for simplicity, do not start region merge while in joint state
             if self.fsm.peer.in_joint_state() {
                 return Err(box_err!(
                     "{} region in joint state, can not propose merge command, command: {:?}",


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9445 #9332 #8789 #8775

Problem Summary:

Currently, TiKV doesn't check leave joint command. If the leader is `DemotingVoter`, it will step down after applying the leave joint command and lead to region unavailable until a new leader elect. Normally, this should not happened, because PD (with its acknowledge about the region) won't send such command to the leader,  and as such command can send to the leader with the right `RegionEpoch` meaning PD has up-to-date acknowledge. But we should add such check for robustness.

### What is changed and how it works?

What's Changed:

This PRs add checks to prevent leave joint while the leader is `DemotingVoter`, and also add checks to prevent split or merge region while the region is in joint state, again this also should not happen because of the epoch check.

This PRs also fix some unstable tests,  which cause by checking `must_get_none` on peers that were added as learner with joint confchange. This PRs fix them by checking the roles of these peers.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
- raftstore: add more checks before proposing joint confchange