### PR TITLE
Components/concurrency-manager: Remove stale comments

### DIFF
--- a/components/concurrency_manager/src/lib.rs
+++ b/components/concurrency_manager/src/lib.rs
@@ -25,8 +25,6 @@ use std::{
 };
 use txn_types::{Key, Lock, TimeStamp};
 
-// TODO: Currently we are using a Mutex<BTreeMap> to implement the handle table.
-// In the future we should replace it with a concurrent ordered map.
 // Pay attention that the async functions of ConcurrencyManager should not hold
 // the mutex.
 #[derive(Clone)]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?

Remove stale comments. Since after #8608, `LockTable` is already a concurrency ordered structure. And it's no longer a `BtreeMap`.


### Related changes

#8608

### Check List <!--REMOVE the items that are not applicable-->

No code

Side effects

None

### Release note <!-- bugfixes or new feature need a release note -->

* No release note

