### PR TITLE
raftstore: use lru cache store local read delegate

### DIFF
--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -425,7 +425,7 @@ where
                 let (meta_len, meta_reader) = {
                     let meta = self.store_meta.lock().unwrap();
                     (
-                        meta.len(),
+                        meta.readers.len(),
                         meta.readers.get(&region_id).cloned().map(Arc::new),
                     )
                 };

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -32,8 +32,6 @@ use tikv_util::time::{Instant, ThreadReadId};
 use super::metrics::*;
 use crate::store::fsm::store::StoreMeta;
 
-const DELEGATE_LRU_CACHE_CAPACITY: usize = 10 * 1024;
-
 pub trait ReadExecutor<E: KvEngine> {
     fn get_engine(&self) -> &E;
     fn get_snapshot(&mut self, ts: Option<ThreadReadId>) -> Arc<E::Snapshot>;
@@ -375,7 +373,7 @@ where
             cache_read_id,
             store_id: Cell::new(None),
             metrics: Default::default(),
-            delegates: LruCache::with_capacity(DELEGATE_LRU_CACHE_CAPACITY),
+            delegates: LruCache::with_capacity_and_sample(0, 7),
         }
     }
 
@@ -601,7 +599,7 @@ where
             router: self.router.clone(),
             store_id: self.store_id.clone(),
             metrics: Default::default(),
-            delegates: LruCache::with_capacity(DELEGATE_LRU_CACHE_CAPACITY),
+            delegates: LruCache::with_capacity_and_sample(0, 7),
             snap_cache: self.snap_cache.clone(),
             cache_read_id: self.cache_read_id.clone(),
         }


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9469 


### What is changed and how it works?

What's Changed:

Using `LruCache` instead of `HashMap` to store local `ReadDelegate`

### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->
- raftstore: use lru cache store local read delegate