### PR TITLE
raftstore: force voter initialized

### DIFF
--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2324,8 +2324,22 @@ where
                         cp
                     ));
                 }
+                (ConfChangeType::AddNode, PeerRole::Voter) => {
+                    let pr = match current_progress.get(peer.get_id()) {
+                        Some(pr) => pr,
+                        None => {
+                            return Err(box_err!("{} invalid conf change request: {:?}, voter should be added as learner first.", self.tag, cp));
+                        }
+                    };
+                    if pr.matched == 0 {
+                        return Err(box_err!(
+                            "{} reject adding uninitialized peer {:?}",
+                            self.tag,
+                            cp
+                        ));
+                    }
+                }
                 (ConfChangeType::RemoveNode, _)
-                | (ConfChangeType::AddNode, PeerRole::Voter)
                 | (ConfChangeType::AddLearnerNode, PeerRole::Learner) => {}
                 _ => {
                     return Err(box_err!(

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1010,6 +1010,23 @@ impl<T: Simulator> Cluster<T> {
         self.apply_state(region_id, store_id).take_truncated_state()
     }
 
+    pub fn wait_log_truncated(&self, region_id: u64, store_id: u64, index: u64) {
+        let timer = Instant::now();
+        loop {
+            let truncated_state = self.truncated_state(region_id, store_id);
+            if truncated_state.get_index() >= index {
+                return;
+            }
+            if timer.elapsed() >= Duration::from_secs(5) {
+                panic!(
+                    "[region {}] log is still not truncated to {}: {:?} on store {}",
+                    region_id, index, truncated_state, store_id,
+                );
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
     pub fn apply_state(&self, region_id: u64, store_id: u64) -> RaftApplyState {
         let key = keys::apply_state_key(region_id);
         self.get_engine(store_id)

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -1017,6 +1017,12 @@ impl TestPdClient {
     }
 
     pub fn must_add_peer(&self, region_id: u64, peer: metapb::Peer) {
+        if peer.get_role() == PeerRole::Voter {
+            let mut learner = peer.clone();
+            learner.set_role(PeerRole::Learner);
+            self.add_peer(region_id, learner.clone());
+            self.must_have_peer(region_id, learner);
+        }
         self.add_peer(region_id, peer.clone());
         self.must_have_peer(region_id, peer);
     }

--- a/tests/integrations/raftstore/test_snap.rs
+++ b/tests/integrations/raftstore/test_snap.rs
@@ -425,7 +425,7 @@ fn test_snapshot_with_append<T: Simulator>(cluster: &mut Cluster<T>) {
         .sim
         .wl()
         .add_recv_filter(4, Box::new(SnapshotAppendFilter::new(tx)));
-    pd_client.add_peer(1, new_peer(4, 5));
+    pd_client.add_peer(1, new_learner_peer(4, 5));
     rx.recv_timeout(Duration::from_secs(3)).unwrap();
     cluster.must_put(b"k1", b"v1");
     cluster.must_put(b"k2", b"v2");


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #3572 

Problem Summary:

Not saving hardstate of uninitialized peer can cause two leader at a term. This PR adds a check to deny promoting uninitialized learner to voter. So every voting peer should be initialized.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
- require voter be initialized to fix potential violation of election safety