### PR TITLE
scanner: Fix the panic on loading old value when there's a rollback record with large ts

### DIFF
--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -2239,6 +2239,12 @@ mod delta_entry_tests {
         must_acquire_pessimistic_lock(&engine, b"b", b"b", 9, 15);
         must_pessimistic_prewrite_put(&engine, b"b", b"b_15", b"b", 9, 15, true);
 
+        must_prewrite_put(&engine, b"c", b"c_4", b"c", 4);
+        must_commit(&engine, b"c", 4, 6);
+        must_acquire_pessimistic_lock(&engine, b"c", b"c", 5, 15);
+        must_pessimistic_prewrite_put(&engine, b"c", b"c_5", b"c", 5, 15, true);
+        must_cleanup(&engine, b"c", 20, 0);
+
         let entry_a_1 = EntryBuilder::default()
             .key(b"a")
             .value(b"a_1")
@@ -2277,6 +2283,20 @@ mod delta_entry_tests {
             .start_ts(9.into())
             .for_update_ts(15.into())
             .build_prewrite(LockType::Put, true);
+        let entry_c_4 = EntryBuilder::default()
+            .key(b"c")
+            .value(b"c_4")
+            .start_ts(4.into())
+            .commit_ts(6.into())
+            .build_commit(WriteType::Put, true);
+        let entry_c_5 = EntryBuilder::default()
+            .key(b"c")
+            .value(b"c_5")
+            .primary(b"c")
+            .start_ts(5.into())
+            .for_update_ts(15.into())
+            .old_value(b"c_4")
+            .build_prewrite(LockType::Put, true);
 
         let check = |after_ts: u64, expected: Vec<&TxnEntry>| {
             let snapshot = engine.snapshot(Default::default()).unwrap();
@@ -2292,9 +2312,9 @@ mod delta_entry_tests {
         };
 
         // Scanning entries in (10, max] should get all prewrites
-        check(10, vec![&entry_a_5, &entry_b_15]);
-        // Scanning entries include delete in (7, max] should get a_5, b_10 and b_15
-        check(7, vec![&entry_a_5, &entry_b_15, &entry_b_10]);
+        check(10, vec![&entry_a_5, &entry_b_15, &entry_c_5]);
+        // Scanning entries include delete in (7, max] should get a_5, b_10, b_15 and c_5
+        check(7, vec![&entry_a_5, &entry_b_15, &entry_b_10, &entry_c_5]);
         // Scanning entries in (0, max] should get a_1, a_3, a_5, b_2, b_10, and b_15
         check(
             0,
@@ -2305,6 +2325,8 @@ mod delta_entry_tests {
                 &entry_b_15,
                 &entry_b_10,
                 &entry_b_2,
+                &entry_c_5,
+                &entry_c_4,
             ],
         );
     }

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -411,16 +411,16 @@ where
             user_key.as_encoded(),
         )
     {
-        assert_ge!(
-            after_ts,
-            Key::decode_ts_from(write_cursor.key(&mut statistics.write))?
-        );
         let write_ref = WriteRef::parse(write_cursor.value(&mut statistics.write))?;
         if !write_ref.check_gc_fence_as_latest_version(gc_fence_limit) {
             break;
         }
         match write_ref.write_type {
             WriteType::Put | WriteType::Delete => {
+                assert_ge!(
+                    after_ts,
+                    Key::decode_ts_from(write_cursor.key(&mut statistics.write))?
+                );
                 ret = Some(write_ref.to_owned());
                 break;
             }


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9551 

Problem Summary: When the DeltaScanner loads old value for a lock, it asserts all other write records has less `commit_ts` than the lock's `max(start_ts, for_update_ts)`. However there's a special case: a rollback record can be written at any time even the key is locked by a smaller ts.

### What is changed and how it works?

What's Changed: Moves the panicking assertion statement so that rollback records will not be asserted.

### Related changes

- Need to cherry-pick to the release branch
  - 4.0, 5.0-rc

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

-

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that when loading old value for CDC's incremental scan on a key where there's a rolled back transaction, in some cases TiKV may panic.