### PR TITLE
metrics: use tidb_cluster label get variable values

### DIFF
--- a/metrics/grafana/performance_read.json
+++ b/metrics/grafana/performance_read.json
@@ -4131,7 +4131,7 @@
         "options": [
 
         ],
-        "query": "label_values(tikv_engine_block_cache_size_bytes, cluster)",
+        "query": "label_values(tikv_engine_block_cache_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/metrics/grafana/performance_write.json
+++ b/metrics/grafana/performance_write.json
@@ -4574,7 +4574,7 @@
         "options": [
 
         ],
-        "query": "label_values(tikv_engine_block_cache_size_bytes, cluster)",
+        "query": "label_values(tikv_engine_block_cache_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -27115,7 +27115,7 @@
         "options": [
 
         ],
-        "query": "label_values(tikv_engine_block_cache_size_bytes, cluster)",
+        "query": "label_values(tikv_engine_block_cache_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/metrics/grafana/tikv_fast_tune.json
+++ b/metrics/grafana/tikv_fast_tune.json
@@ -6985,7 +6985,7 @@
         "options": [
 
         ],
-        "query": "label_values(tikv_engine_block_cache_size_bytes, cluster)",
+        "query": "label_values(tikv_engine_block_cache_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/metrics/grafana/tikv_raw.json
+++ b/metrics/grafana/tikv_raw.json
@@ -304,7 +304,7 @@
         "options": [
 
         ],
-        "query": "label_values(tikv_engine_block_cache_size_bytes, cluster)",
+        "query": "label_values(tikv_engine_block_cache_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/metrics/grafana/tikv_summary.json
+++ b/metrics/grafana/tikv_summary.json
@@ -4793,7 +4793,7 @@
         "options": [
 
         ],
-        "query": "label_values(tikv_engine_block_cache_size_bytes, cluster)",
+        "query": "label_values(tikv_engine_block_cache_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/metrics/grafana/tikv_trouble_shooting.json
+++ b/metrics/grafana/tikv_trouble_shooting.json
@@ -7852,7 +7852,7 @@
         "options": [
 
         ],
-        "query": "label_values(tikv_engine_block_cache_size_bytes, cluster)",
+        "query": "label_values(tikv_engine_block_cache_size_bytes, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,


### PR DESCRIPTION
Signed-off-by: zhengjiajin <zhengjiajin@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

The latest version of tidb-operator will use the instance name as the cluster label. The previous expression uses the cluster label got the value of the tidb_cluster variable. It will cause Grafana can not to display the data.

https://github.com/tikv/pd/pull/3389#issuecomment-767977783

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- no change

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- No release note