### PR TITLE
storage: yield in kv scan to avoid occupying cpu resource for too long

### DIFF
--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -183,40 +183,6 @@ impl ReqContext {
     }
 
     pub fn build_task_id(&self) -> u64 {
-        const ID_SHIFT: u32 = 16;
-        const MASK: u64 = u64::max_value() >> ID_SHIFT;
-        const MAX_TS: u64 = u64::max_value();
-        let base = match self.txn_start_ts.into_inner() {
-            0 | MAX_TS => thread_rng().next_u64(),
-            start_ts => start_ts,
-        };
-        let task_id: u64 = self.context.get_task_id();
-        if task_id > 0 {
-            // It is assumed that the lower bits of task IDs in a single transaction
-            // tend to be different. So if task_id is provided, we concatenate the
-            // low 16 bits of the task_id and the low 48 bits of the start_ts to build
-            // the final task id.
-            (task_id << (64 - ID_SHIFT)) | (base & MASK)
-        } else {
-            // Otherwise we use the start_ts as the task_id.
-            base
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_build_task_id() {
-        let mut ctx = ReqContext::default_for_test();
-        let start_ts: u64 = 0x05C6_1BFA_2648_324A;
-        ctx.txn_start_ts = start_ts.into();
-        ctx.context.set_task_id(1);
-        assert_eq!(ctx.build_task_id(), 0x0001_1BFA_2648_324A);
-
-        ctx.context.set_task_id(0);
-        assert_eq!(ctx.build_task_id(), start_ts);
+        super::read_pool::build_task_id(self.txn_start_ts, &self.context)
     }
 }

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -450,6 +450,7 @@ mod tests {
     };
     use crate::storage::Scanner;
     use engine_traits::{CF_LOCK, CF_WRITE};
+    use futures_executor::block_on;
     use kvproto::kvrpcpb::Context;
 
     #[test]
@@ -1366,8 +1367,7 @@ mod tests {
             .range(None, None)
             .build()
             .unwrap();
-        let result: Vec<_> = scanner
-            .scan(100, 0)
+        let result: Vec<_> = block_on(scanner.scan(100, 0))
             .unwrap()
             .into_iter()
             .map(|result| result.unwrap())

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -1013,6 +1013,7 @@ mod latest_kv_tests {
     use crate::storage::txn::tests::*;
     use crate::storage::Scanner;
     use engine_traits::{CF_LOCK, CF_WRITE};
+    use futures_executor::block_on;
     use kvproto::kvrpcpb::Context;
 
     /// Check whether everything works as usual when `ForwardKvScanner::get()` goes out of bound.
@@ -1387,8 +1388,7 @@ mod latest_kv_tests {
             .range(None, None)
             .build()
             .unwrap();
-        let result: Vec<_> = scanner
-            .scan(100, 0)
+        let result: Vec<_> = block_on(scanner.scan(100, 0))
             .unwrap()
             .into_iter()
             .map(|result| result.unwrap())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9188

### What is changed and how it works?

This PR makes scan interface asynchronous. Then, we can reschedule a long scan task during its execution. It should help yatp schedule these tasks better. So these long scan tasks will not affect normal requests greatly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```
Schedule long scan requests better when using the unified thread pool for the storage module.
```