### PR TITLE
fix: broken build on Mac

### DIFF
--- a/components/file_system/Cargo.toml
+++ b/components/file_system/Cargo.toml
@@ -10,6 +10,7 @@ bcc-iosnoop = ["bcc"]
 [dependencies]
 collections = { path = "../collections" }
 crc32fast = "1.2"
+crossbeam-utils = "0.8.0"
 fs2 = "0.4"
 lazy_static = "1.3"
 libc = "0.2"
@@ -21,7 +22,6 @@ tikv_alloc = { path = "../tikv_alloc" }
 tikv_util = { path = "../tikv_util" }
 variant_count = "1.0.0"
 
-
 [dev-dependencies]
 rand = "0.7"
 tempfile = "3.0"
@@ -29,4 +29,4 @@ maligned = "0.2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bcc = { version = "0.0.30", optional = true }
-crossbeam-utils = "0.8.0"
+


### PR DESCRIPTION
On Mac:

```
 --> components/file_system/src/rate_limiter.rs:5:5
5 | use crossbeam_utils::CachePadded;
  |     ^^^^^^^^^^^^^^^ use of undeclared crate or module `crossbeam_utils`
```

### Release note

* None
