### PR TITLE
importer: fix test_ingest_sst

### DIFF
--- a/tests/integrations/import/test_sst_service.rs
+++ b/tests/integrations/import/test_sst_service.rs
@@ -11,6 +11,7 @@ use super::util::*;
 use pd_client::PdClient;
 
 use test_sst_importer::*;
+use tikv::config::TiKvConfig;
 
 macro_rules! assert_to_string_contains {
     ($e:expr, $substr:expr) => {{
@@ -87,7 +88,9 @@ fn test_write_and_ingest_with_tde() {
 
 #[test]
 fn test_ingest_sst() {
-    let (_cluster, ctx, _tikv, import) = new_cluster_and_tikv_import_client();
+    let mut cfg = TiKvConfig::default();
+    cfg.server.grpc_concurrency = 1;
+    let (_cluster, ctx, _tikv, import) = open_cluster_and_tikv_import_client(Some(cfg));
 
     let temp_dir = Builder::new().prefix("test_ingest_sst").tempdir().unwrap();
 


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/9472

Problem Summary:
TiKV may cleanup sst which has been upload just, so the ingest-job will success because it can not found file in path before it starts proposing, and the error is checked only when applied this entries.


### What is changed and how it works?

We do not need to check and cleanup sst very quickly in this tests, so I remove the configuration for `cleanup_import_sst_interval`.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
