### PR TITLE
copr: add vectorized Trim2Args

### DIFF
--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -593,6 +593,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::AddStringAndDuration => add_string_and_duration_fn_meta(),
         ScalarFuncSig::SubStringAndDuration => sub_string_and_duration_fn_meta(),
         ScalarFuncSig::Trim1Arg => trim_1_arg_fn_meta(),
+        ScalarFuncSig::Trim2Args => trim_2_args_fn_meta(),
         ScalarFuncSig::Trim3Args => trim_3_args_fn_meta(),
         ScalarFuncSig::FromBase64 => from_base64_fn_meta(),
         ScalarFuncSig::Replace => replace_fn_meta(),


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

Hi! I am dipping my toes slowly into contributing to TiKV by this small PR

### What problem does this PR solve?

Issue Number: part of https://github.com/tikv/tikv/issues/9016

Problem Summary: implement vectorized `Trim2Args`

I have just reused the implementation for `Trim3Args` to reduce chances of subtle differences in their behaviour in the future. My question is - do you want to go forward with a specialized implementation for `Trim1Arg`? All three could share the same implementation, but a specialized implementation  for `Trim1Arg` that does not bother with conversions to strings also makes sense.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test: migrated from old non-vec implementation


### Release note <!-- bugfixes or new feature need a release note -->
- No release note