### PR TITLE
scripts: add scripts/clippy

### DIFF
--- a/scripts/clippy
+++ b/scripts/clippy
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# This script runs clippy with the most common configurations.
+# Arguments given will be passed through to "cargo clippy"
+# This runs in the Makefile environment via "make run"
+
+set -euo pipefail
+
+# Run from the Makefile environment
+MAKEFILE_RUN=${MAKEFILE_RUN:-""}
+if [[ -z $MAKEFILE_RUN ]] ; then
+	COMMAND="$0 $*" exec make run
+fi
+SHELL_DEBUG=${SHELL_DEBUG:-""}
+if [[ -n "$SHELL_DEBUG" ]] ; then
+  set -x
+fi
+
+ALLOWED_CLIPPY_LINTS=(-A clippy::module_inception  \
+	-A clippy::should_implement_trait \
+	-A clippy::new_without_default \
+	-A clippy::too_many_arguments \
+	-A clippy::blacklisted_name \
+	-A clippy::needless_range_loop \
+	-A clippy::new_ret_no_self \
+	-A clippy::unnecessary_sort_by \
+	-A clippy::unnecessary_wraps)
+
+cargo clippy --workspace --no-default-features \
+	--exclude fuzz-targets --exclude fuzzer-honggfuzz --exclude fuzzer-afl --exclude fuzzer-libfuzzer \
+	--features "${TIKV_ENABLE_FEATURES}" "$@" -- "${ALLOWED_CLIPPY_LINTS[@]}"

--- a/scripts/clippy-all
+++ b/scripts/clippy-all
@@ -10,20 +10,13 @@ MAKEFILE_RUN=${MAKEFILE_RUN:-""}
 if [[ -z $MAKEFILE_RUN ]] ; then
 	COMMAND="$0 $*" exec make run
 fi
+SHELL_DEBUG=${SHELL_DEBUG:-""}
+if [[ -n "$SHELL_DEBUG" ]] ; then
+  set -x
+fi
 
-ALLOWED_CLIPPY_LINTS=(-A clippy::module_inception  \
-	-A clippy::should_implement_trait \
-	-A clippy::new_without_default \
-	-A clippy::too_many_arguments \
-	-A clippy::blacklisted_name \
-	-A clippy::needless_range_loop \
-	-A clippy::new_ret_no_self \
-	-A clippy::unnecessary_sort_by \
-	-A clippy::unnecessary_wraps)
+./scripts/clippy --all-targets
 
-cargo clippy --workspace --all-targets --no-default-features \
-	--exclude fuzz-targets --exclude fuzzer-honggfuzz --exclude fuzzer-afl --exclude fuzzer-libfuzzer \
-	--features "${TIKV_ENABLE_FEATURES}" -- "${ALLOWED_CLIPPY_LINTS[@]}"
 # for pkg in "components/cdc" "components/backup" "cmd" "tests"; do
 # 	cd $pkg
 # 	cargo clippy --all-targets --no-default-features \

--- a/scripts/env
+++ b/scripts/env
@@ -2,4 +2,5 @@
 # This script runs the arguments given in the environment setup by the Makefile
 
 set -euo pipefail
-COMMAND="$*" exec make run
+
+COMMAND="$*" exec make -f "$(dirname "$0")/../Makefile" run


### PR DESCRIPTION
### What problem does this PR solve?

The official clippy configuration is in a shell script that runs against all targets.

### What is changed and how it works?

Add a helper ./scripts/clippy to run clippy against individual targets. 

### Check List

Tests

- Manual test `./scripts/clippy -p PACKAGE`

### Release note

None