### PR TITLE
build: disable fuzzer honggfuzz & afl on Windows

### DIFF
--- a/fuzz/fuzzer-afl/Cargo.toml
+++ b/fuzz/fuzzer-afl/Cargo.toml
@@ -12,5 +12,5 @@ prost-codec = ["fuzz-targets/prost-codec"]
 fuzz-targets = { path = "../targets", default-features = false }
 
 # AFL only works for x86 targets
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(all(not(target_os = "windows"), target_arch = "x86_64"))'.dependencies]
 afl = "0.6"

--- a/fuzz/fuzzer-honggfuzz/Cargo.toml
+++ b/fuzz/fuzzer-honggfuzz/Cargo.toml
@@ -10,4 +10,6 @@ prost-codec = ["fuzz-targets/prost-codec"]
 
 [dependencies]
 fuzz-targets = { path = "../targets", default-features = false }
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
 honggfuzz = "0.5.47"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: Supports #9103 

Problem Summary:

### What is changed and how it works?

Disable fuzzer honggfuzz & afl on Windows because they do not support Windows.

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
