### PR TITLE
diagnostics:add cpu arch

### DIFF
--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -305,6 +305,16 @@ fn cpu_hardware_info(collector: &mut Vec<ServerInfoItem>) {
         ("cpu-frequency", format!("{}MHz", processor.get_frequency())),
         ("cpu-vendor-id", processor.get_vendor_id().to_string()),
     ];
+    //Depend on Rust lib return CPU arch not matching
+    //Golang lib so need this match loop to conversion
+    //GOlang Doc:https://go.googlesource.com/go/+/go1.15.8/src/runtime/internal/sys/zgoarch_amd64.go#7
+    //Rust Doc:http://web.mit.edu/rust-lang_v1.26.0/arch/amd64_ubuntu1404/share/doc/rust/html/std/env/consts/constant.ARCH.html
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "x86" => "386",
+        _ => std::env::consts::ARCH,
+    };
+    infos.push(("cpu-arch", arch.to_string()));
     // cache
     let caches = vec![
         ("l1-cache-size", cache_size(1)),

--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -719,13 +719,13 @@ mod tests {
                     "cpu-physical-cores",
                     "cpu-frequency",
                     "cpu-vendor-id",
+                    "cpu-arch",
                     "l1-cache-size",
                     "l1-cache-line-size",
                     "l2-cache-size",
                     "l2-cache-line-size",
                     "l3-cache-size",
                     "l3-cache-line-size",
-                    "cpu-arch",
                 ]
             );
         }

--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -305,13 +305,16 @@ fn cpu_hardware_info(collector: &mut Vec<ServerInfoItem>) {
         ("cpu-frequency", format!("{}MHz", processor.get_frequency())),
         ("cpu-vendor-id", processor.get_vendor_id().to_string()),
     ];
-    //Depend on Rust lib return CPU arch not matching
-    //Golang lib so need this match loop to conversion
-    //GOlang Doc:https://go.googlesource.com/go/+/go1.15.8/src/runtime/internal/sys/zgoarch_amd64.go#7
-    //Rust Doc:http://web.mit.edu/rust-lang_v1.26.0/arch/amd64_ubuntu1404/share/doc/rust/html/std/env/consts/constant.ARCH.html
+    // Depend on Rust lib return CPU arch not matching
+    // Golang lib so need this match loop to conversion
+    // Golang Doc:https://go.googlesource.com/go/+/go1.15.8/src/runtime/internal/sys/zgoarch_amd64.go#7
+    // Rust Doc:http://web.mit.edu/rust-lang_v1.26.0/arch/amd64_ubuntu1404/share/doc/rust/html/std/env/consts/constant.ARCH.html
     let arch = match std::env::consts::ARCH {
         "x86_64" => "amd64",
         "x86" => "386",
+        "aarch64" => "arm64",
+        "powerpc" => "ppc",
+        "powerpc64" => "ppc64",
         _ => std::env::consts::ARCH,
     };
     infos.push(("cpu-arch", arch.to_string()));
@@ -722,6 +725,7 @@ mod tests {
                     "l2-cache-line-size",
                     "l3-cache-size",
                     "l3-cache-line-size",
+                    "cpu-arch",
                 ]
             );
         }


### PR DESCRIPTION
Signed-off-by: Max-Cheng <aaron9shire@gmail.com>

What's Changed:

This PR implements the Diagnostics service server information retrieving interface, which is used to retrieve server load / hardware / system wide information. And this PR includes the following information:

- Hardware
  - CPU 
    - Arch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- Support display CPU arch