### PR TITLE
txn: allow rollback a lock with an existing rollback

### DIFF
--- a/src/storage/txn/commands/rollback.rs
+++ b/src/storage/txn/commands/rollback.rs
@@ -65,3 +65,23 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Rollback {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::txn::tests::*;
+    use crate::storage::TestEngineBuilder;
+
+    #[test]
+    fn rollback_lock_with_existing_rollback() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let (k1, k2) = (b"k1", b"k2");
+        let v = b"v";
+
+        must_acquire_pessimistic_lock(&engine, k1, k1, 10, 10);
+        must_rollback(&engine, k1, 10);
+        must_rollback(&engine, k2, 10);
+
+        must_pessimistic_prewrite_put(&engine, k2, v, k1, 10, 10, false);
+        must_rollback(&engine, k2, 10);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9654

### What is changed and how it works?

This PR is to fix an incorrect assertion. See the unit test of this PR, the secondary lock of a pessimistic transaction may bypass rollback checks (e.g. an index key in TiDB). So the original assertion is not always true.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- Fix a false assertion when rolling back locks with existing rollbacks.