### PR TITLE
copr: fix missing space in json format

### DIFF
--- a/components/tidb_query_expr/src/impl_json.rs
+++ b/components/tidb_query_expr/src/impl_json.rs
@@ -537,7 +537,7 @@ mod tests {
             (Some(r#""3""#), false, Some(r#""3""#)),
             (Some(r#""3""#), true, Some(r#"3"#)),
             (Some(r#"{"a":  "b"}"#), false, Some(r#"{"a":  "b"}"#)),
-            (Some(r#"{"a":  "b"}"#), true, Some(r#"{"a":"b"}"#)),
+            (Some(r#"{"a":  "b"}"#), true, Some(r#"{"a": "b"}"#)),
             (
                 Some(r#"hello,\"quoted string\",world"#),
                 false,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/22744 <!-- REMOVE this line if no issue to close -->

Problem Summary:

Rust `serde_json` will yield JSON string as `{"population":100}`, while MySQL yields `{"population": 100}`. Note the missing space.

### What is changed and how it works?

What's Changed:

This PR adds the missing space after `:` and `,`.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

* Fix missing space when casting json to string in TiKV coprocessor