### PR TITLE
use bash from the PATH instead of the absolute path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@
 #
 # - `release` - create a release profile, optimized build
 
-SHELL := /bin/bash
+SHELL := bash
 ENABLE_FEATURES ?=
 
 # Pick an allocator


### PR DESCRIPTION
Signed-off-by: Akshat Agarwal <humancalico@disroot.org>

### What problem does this PR solve?

Fixes: #9015

Problem Summary: Some OS like NixOS don't follow the FHS so `make` fails because the Makefile sets the `SHELL` variable to `/bin/bash`.

What's Changed: This commit changes the variable used for `SHELL` in the Makefile to just `bash` so that it uses the `bash` present in the `PATH` instead of `/bin/bash`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
Tested on NixOS using `make build`


### Release note <!-- bugfixes or new feature need a release note -->
- Some OS like NixOS don't follow the FHS so `make` fails because the Makefile sets the `SHELL` variable to `/bin/bash`. This commit changes the variable used for `SHELL` in the Makefile to just `bash` so that it uses the `bash` present in the `PATH` instead of `/bin/bash`