### PR TITLE
copr: use criterion-perf-events to get instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "398bc55d60097e7b7e9be67d1cb03cb41e5bf4901381607ba0fca8b1328584d6"
 dependencies = [
  "bytes 0.4.12",
- "libc",
+ "libc 0.2.80",
  "serde_json",
 ]
 
@@ -152,7 +152,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
- "libc",
+ "libc 0.2.80",
  "winapi 0.3.8",
 ]
 
@@ -176,7 +176,7 @@ checksum = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
 dependencies = [
  "backtrace-sys",
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.80",
  "rustc-demangle",
 ]
 
@@ -187,7 +187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -216,7 +216,7 @@ dependencies = [
  "prometheus",
  "raft",
  "raftstore",
- "rand",
+ "rand 0.7.3",
  "security",
  "serde",
  "serde_derive",
@@ -274,7 +274,7 @@ dependencies = [
  "bcc-sys",
  "bitflags",
  "byteorder",
- "libc",
+ "libc 0.2.80",
  "regex",
  "thiserror",
 ]
@@ -295,18 +295,20 @@ dependencies = [
  "cexpr",
  "cfg-if 0.1.10",
  "clang-sys",
- "clap",
- "env_logger",
  "lazy_static",
- "log",
  "peeking_take_while",
  "proc-macro2 1.0.24",
  "quote 1.0.3",
  "regex",
  "rustc-hash",
  "shlex",
- "which",
 ]
+
+[[package]]
+name = "bit_field"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
 
 [[package]]
 name = "bitfield"
@@ -405,7 +407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05305b41c5034ff0e93937ac64133d109b5a2660114ec45e9760bc6816d83038"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -424,7 +426,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7f788eaf239475a3c1e1acf89951255a46c4b9b46cf3e866fc4d0707b4b9e36"
 dependencies = [
- "libc",
+ "libc 0.2.80",
  "valgrind_request",
 ]
 
@@ -543,7 +545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 dependencies = [
  "glob",
- "libc",
+ "libc 0.2.80",
  "libloading",
 ]
 
@@ -611,7 +613,7 @@ dependencies = [
  "hex 0.4.2",
  "keys",
  "kvproto",
- "libc",
+ "libc 0.2.80",
  "log",
  "log_wrappers",
  "nix 0.11.1",
@@ -622,7 +624,7 @@ dependencies = [
  "raft",
  "raft_log_engine",
  "raftstore",
- "rand",
+ "rand 0.7.3",
  "security",
  "serde_json",
  "signal",
@@ -648,10 +650,10 @@ dependencies = [
  "bytes 0.5.3",
  "error_code",
  "failure",
- "libc",
+ "libc 0.2.80",
  "panic_hook",
  "protobuf",
- "rand",
+ "rand 0.7.3",
  "static_assertions",
  "tikv_alloc",
 ]
@@ -673,7 +675,7 @@ dependencies = [
  "fail",
  "futures 0.3.7",
  "parking_lot 0.11.0",
- "rand",
+ "rand 0.7.3",
  "tikv_alloc",
  "tokio",
  "txn_types",
@@ -715,7 +717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c750ec12b83377637110d5a57f5ae08e895b06c4b16e2bdbf1a94ef717428c59"
 dependencies = [
  "proc-macro-hack",
- "rand",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -737,7 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 dependencies = [
  "core-foundation-sys",
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -769,23 +771,24 @@ checksum = "0a82510de0a7cadd51dc68ff17da70aea0c80157f902230f9b157cecc2566318"
 
 [[package]]
 name = "criterion"
-version = "0.3.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938703e165481c8d612ea3479ac8342e5615185db37765162e762ec3523e2fc6"
+checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
 dependencies = [
  "atty",
  "cast",
  "clap",
  "criterion-plot",
  "csv",
- "itertools 0.8.2",
+ "itertools 0.10.0",
  "lazy_static",
  "num-traits",
- "rand_core",
- "rand_os",
- "rand_xoshiro",
+ "oorandom",
+ "plotters",
  "rayon",
+ "regex",
  "serde",
+ "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -799,28 +802,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63aaaf47e457badbcb376c65a49d0f182c317ebd97dc6d1ced94c8e1d09c0f3a"
 dependencies = [
  "criterion",
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
-name = "criterion-papi"
-version = "0.1.0"
+name = "criterion-perf-events"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd402c80822a64e66751efaca958ac1047a301c9455dce110c8ef1e9b8ecb931"
+checksum = "f0bbc73e81648d6a207b4727b24a3a111b905b24fe3ef582426c5348973e95b1"
 dependencies = [
  "criterion",
- "libc",
- "libpapi_sys",
+ "perfcnt",
 ]
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
+checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
 dependencies = [
  "cast",
- "itertools 0.8.2",
+ "itertools 0.9.0",
 ]
 
 [[package]]
@@ -1074,7 +1076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.80",
  "redox_users",
  "winapi 0.3.8",
 ]
@@ -1135,7 +1137,7 @@ dependencies = [
  "openssl",
  "prometheus",
  "protobuf",
- "rand",
+ "rand 0.7.3",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_kms",
@@ -1185,7 +1187,7 @@ dependencies = [
  "prometheus-static-metric",
  "protobuf",
  "raft",
- "rand",
+ "rand 0.7.3",
  "rocksdb",
  "serde",
  "serde_derive",
@@ -1233,19 +1235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "error-chain"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,7 +1274,7 @@ dependencies = [
  "lazy_static",
  "matches",
  "prometheus",
- "rand",
+ "rand 0.7.3",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_mock",
@@ -1312,7 +1301,7 @@ checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
 dependencies = [
  "lazy_static",
  "log",
- "rand",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -1353,13 +1342,13 @@ dependencies = [
  "crossbeam-utils 0.8.1",
  "fs2",
  "lazy_static",
- "libc",
+ "libc 0.2.80",
  "maligned",
  "nix 0.19.0",
  "openssl",
  "prometheus",
  "prometheus-static-metric",
- "rand",
+ "rand 0.7.3",
  "tempfile",
  "tikv_alloc",
  "tikv_util",
@@ -1379,7 +1368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2adaffba6388640136149e18ed080b77a78611c1e1d6de75aedcdf78df5d4682"
 dependencies = [
  "crc32fast",
- "libc",
+ "libc 0.2.80",
  "libz-sys",
  "miniz_oxide",
 ]
@@ -1411,7 +1400,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
- "libc",
+ "libc 0.2.80",
  "winapi 0.3.8",
 ]
 
@@ -1420,6 +1409,12 @@ name = "fs_extra"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -1617,7 +1612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.80",
  "wasi",
 ]
 
@@ -1658,7 +1653,7 @@ dependencies = [
  "bytes 0.5.3",
  "futures 0.3.7",
  "grpcio-sys",
- "libc",
+ "libc 0.2.80",
  "log",
  "parking_lot 0.11.0",
  "prost",
@@ -1689,7 +1684,7 @@ dependencies = [
  "boringssl-src",
  "cc",
  "cmake",
- "libc",
+ "libc 0.2.80",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -1716,6 +1711,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,7 +1731,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 dependencies = [
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -1792,15 +1793,6 @@ name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
 
 [[package]]
 name = "hyper"
@@ -1921,7 +1913,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -1958,6 +1950,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,15 +1971,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 dependencies = [
  "getrandom",
- "libc",
+ "libc 0.2.80",
  "log",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.36"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
+checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2030,6 +2031,12 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
+
+[[package]]
+name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
@@ -2073,16 +2080,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libpapi_sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c687368f5a574f3aaf97cad438fb572a87aa224051e1cd01ad926b1d592886b"
-dependencies = [
- "bindgen",
- "num_cpus",
-]
-
-[[package]]
 name = "librocksdb_cloud_sys"
 version = "0.1.0"
 source = "git+https://github.com/tikv/rust-rocksdb.git#fc904a5242539c8bf10699e6c82cfdfd47d26958"
@@ -2100,7 +2097,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc",
+ "libc 0.2.80",
  "librocksdb_cloud_sys",
  "libtitan_sys",
  "libz-sys",
@@ -2119,7 +2116,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc",
+ "libc 0.2.80",
  "libz-sys",
  "lz4-sys",
  "snappy-sys",
@@ -2133,7 +2130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.80",
  "pkg-config",
  "vcpkg",
 ]
@@ -2198,7 +2195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca79aa95d8b3226213ad454d328369853be3a1382d89532a854f4d69640acae"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -2240,7 +2237,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 dependencies = [
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -2249,7 +2246,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
- "libc",
+ "libc 0.2.80",
  "winapi 0.3.8",
 ]
 
@@ -2269,7 +2266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa3cefb626f6ae3d0b2f71c5378c89d2b1d4d7bc246b0ca9a7ee61a4daad291"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -2340,7 +2337,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc",
+ "libc 0.2.80",
  "log",
  "miow 0.2.2",
  "net2",
@@ -2367,7 +2364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 dependencies = [
  "iovec",
- "libc",
+ "libc 0.2.80",
  "mio",
 ]
 
@@ -2391,6 +2388,16 @@ checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "mmap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bc85448a6006dd2ba26a385a564a8a0f1f2c7e78c70f1a70b2e0f4af286b823"
+dependencies = [
+ "libc 0.1.12",
+ "tempdir",
 ]
 
 [[package]]
@@ -2421,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 dependencies = [
  "lazy_static",
- "libc",
+ "libc 0.2.80",
  "log",
  "openssl",
  "openssl-probe",
@@ -2439,7 +2446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.80",
  "winapi 0.3.8",
 ]
 
@@ -2452,7 +2459,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.80",
  "void",
 ]
 
@@ -2465,7 +2472,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.80",
  "void",
 ]
 
@@ -2478,7 +2485,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -2490,7 +2497,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -2625,7 +2632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -2633,6 +2640,12 @@ name = "once_cell"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -2650,7 +2663,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
- "libc",
+ "libc 0.2.80",
  "openssl-sys",
 ]
 
@@ -2677,7 +2690,7 @@ checksum = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
 dependencies = [
  "autocfg 1.0.0",
  "cc",
- "libc",
+ "libc 0.2.80",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -2725,7 +2738,7 @@ checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
- "libc",
+ "libc 0.2.80",
  "redox_syscall",
  "smallvec",
  "winapi 0.3.8",
@@ -2740,7 +2753,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.1.0",
  "instant",
- "libc",
+ "libc 0.2.80",
  "redox_syscall",
  "smallvec",
  "winapi 0.3.8",
@@ -2815,6 +2828,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "perfcnt"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f89cc4b06e712f0adddb96c818526f0dec372b88376ae829171bc2059ac7ac"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "libc 0.2.80",
+ "mmap",
+ "nom 4.2.3",
+ "phf 0.8.0",
+ "x86",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,6 +2850,62 @@ checksum = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
+dependencies = [
+ "phf_shared 0.7.24",
+]
+
+[[package]]
+name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.7.24",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
+dependencies = [
+ "phf_shared 0.7.24",
+ "rand 0.6.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
+dependencies = [
+ "siphasher 0.2.3",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher 0.3.3",
 ]
 
 [[package]]
@@ -2889,6 +2973,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 
 [[package]]
+name = "plotters"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "pnet_base"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,7 +3013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27361d7578b410d0eb5fe815c2b2105b01ab770a7c738cb9a231457a809fcc7"
 dependencies = [
  "ipnetwork",
- "libc",
+ "libc 0.2.80",
  "pnet_base",
  "pnet_sys",
  "winapi 0.2.8",
@@ -2913,7 +3025,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f881a6d75ac98c5541db6144682d1773bb14c6fc50c6ebac7086c8f7f23c29"
 dependencies = [
- "libc",
+ "libc 0.2.80",
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
@@ -2927,7 +3039,7 @@ dependencies = [
  "backtrace",
  "inferno",
  "lazy_static",
- "libc",
+ "libc 0.2.80",
  "log",
  "nix 0.17.0",
  "parking_lot 0.11.0",
@@ -3017,7 +3129,7 @@ dependencies = [
  "chrono",
  "hex 0.4.2",
  "lazy_static",
- "libc",
+ "libc 0.2.80",
  "libflate",
 ]
 
@@ -3027,7 +3139,7 @@ version = "0.4.2"
 source = "git+https://github.com/tikv/procinfo-rs?rev=5125fc1a69496b73b26b3c08b6e8afc3c665a56e#5125fc1a69496b73b26b3c08b6e8afc3c665a56e"
 dependencies = [
  "byteorder",
- "libc",
+ "libc 0.2.80",
  "nom 2.2.1",
  "rustc_version",
 ]
@@ -3052,7 +3164,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "fnv",
  "lazy_static",
- "libc",
+ "libc 0.2.80",
  "parking_lot 0.11.0",
  "protobuf",
  "regex",
@@ -3210,7 +3322,7 @@ dependencies = [
  "protobuf",
  "quick-error",
  "raft-proto",
- "rand",
+ "rand 0.7.3",
  "slog",
 ]
 
@@ -3302,7 +3414,7 @@ dependencies = [
  "quick-error",
  "raft",
  "raft-proto",
- "rand",
+ "rand 0.7.3",
  "serde",
  "serde_derive",
  "serde_with",
@@ -3324,15 +3436,57 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc 0.2.80",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc 0.2.80",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac 0.1.1",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift 0.1.1",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "libc 0.2.80",
+ "rand_chacha 0.2.1",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3342,8 +3496,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 dependencies = [
  "c2-chacha",
- "rand_core",
+ "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3356,11 +3525,29 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3369,17 +3556,51 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df6b0b3dc9991a10b2d91a86d1129314502169a1bf6afa67328945e02498b76"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc 0.2.80",
+ "rand_core 0.4.2",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "rand_os"
-version = "0.2.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a788ae3edb696cfcba1c19bfd388cc4b8c21f8a408432b199c072825084da58a"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "getrandom",
- "rand_core",
+ "cloudabi 0.0.3",
+ "fuchsia-cprng",
+ "libc 0.2.80",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3388,16 +3609,18 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.3.1"
+name = "raw-cpuid"
+version = "8.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e18c91676f670f6f0312764c759405f13afb98d5d73819840cf72a518487bff"
+checksum = "1fdf7d9dbd43f3d81d94a49c1c3df73cc2b3827995147e6cf7f89d4ec5483e73"
 dependencies = [
- "rand_core",
+ "bitflags",
+ "cc",
+ "rustc_version",
 ]
 
 [[package]]
@@ -3422,6 +3645,15 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3561,7 +3793,7 @@ checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
 dependencies = [
  "cc",
  "lazy_static",
- "libc",
+ "libc 0.2.80",
  "spin",
  "untrusted",
  "web-sys",
@@ -3579,7 +3811,7 @@ name = "rocksdb"
 version = "0.3.0"
 source = "git+https://github.com/tikv/rust-rocksdb.git#fc904a5242539c8bf10699e6c82cfdfd47d26958"
 dependencies = [
- "libc",
+ "libc 0.2.80",
  "librocksdb_sys",
 ]
 
@@ -3777,7 +4009,7 @@ checksum = "61a7384a84da856bd163ef2c22982c816b0bcedaf17978ec13d8e0e277ddc332"
 dependencies = [
  "cfg-if 0.1.10",
  "dirs",
- "libc",
+ "libc 0.2.80",
  "log",
  "memchr",
  "nix 0.17.0",
@@ -3852,7 +4084,7 @@ checksum = "eee63d0f4a9ec776eeb30e220f0bc1e092c3ad744b2a379e3993070364d3adc2"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
- "libc",
+ "libc 0.2.80",
  "security-framework-sys",
 ]
 
@@ -3897,6 +4129,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -3994,7 +4236,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106428d9d96840ecdec5208c13ab8a4e28c38da1e0ccf2909fb44e41b992f897"
 dependencies = [
- "libc",
+ "libc 0.2.80",
  "nix 0.11.1",
 ]
 
@@ -4004,8 +4246,20 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
- "libc",
+ "libc 0.2.80",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+
+[[package]]
+name = "siphasher"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 
 [[package]]
 name = "slab"
@@ -4089,7 +4343,7 @@ version = "0.1.0"
 source = "git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44"
 dependencies = [
  "cmake",
- "libc",
+ "libc 0.2.80",
  "pkg-config",
 ]
 
@@ -4100,7 +4354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 dependencies = [
  "cfg-if 1.0.0",
- "libc",
+ "libc 0.2.80",
  "redox_syscall",
  "winapi 0.3.8",
 ]
@@ -4335,7 +4589,7 @@ checksum = "67330cbee3b2a819e3365a773f05e884a136603687f812bf24db5b6c3d76b696"
 dependencies = [
  "cfg-if 0.1.10",
  "doc-comment",
- "libc",
+ "libc 0.2.80",
  "ntapi",
  "once_cell",
  "rayon",
@@ -4402,14 +4656,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b7ad73e635dd232c2c2106d59269f59a61de421cc6b95252d2d932094ff1f40"
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
- "rand",
+ "libc 0.2.80",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
@@ -4423,15 +4687,6 @@ checksum = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 dependencies = [
  "byteorder",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
-dependencies = [
- "wincolor",
 ]
 
 [[package]]
@@ -4450,7 +4705,7 @@ dependencies = [
  "futures-util",
  "grpcio",
  "kvproto",
- "rand",
+ "rand 0.7.3",
  "tempfile",
  "test_raftstore",
  "tidb_query_common",
@@ -4514,7 +4769,7 @@ dependencies = [
  "pd_client",
  "raft",
  "raftstore",
- "rand",
+ "rand 0.7.3",
  "security",
  "slog",
  "slog-global",
@@ -4563,8 +4818,8 @@ dependencies = [
  "fail",
  "grpcio",
  "kvproto",
- "rand",
- "rand_isaac",
+ "rand 0.7.3",
+ "rand_isaac 0.2.0",
  "security",
  "slog",
  "slog-global",
@@ -4587,7 +4842,7 @@ dependencies = [
  "crc64fast",
  "criterion",
  "criterion-cpu-time",
- "criterion-papi",
+ "criterion-perf-events",
  "crossbeam",
  "encryption",
  "engine_rocks",
@@ -4605,12 +4860,13 @@ dependencies = [
  "more-asserts",
  "panic_hook",
  "pd_client",
+ "perfcnt",
  "profiler",
  "protobuf",
  "raft",
  "raftstore",
- "rand",
- "rand_xorshift",
+ "rand 0.7.3",
+ "rand_xorshift 0.2.0",
  "security",
  "serde_json",
  "slog",
@@ -4814,7 +5070,7 @@ dependencies = [
  "panic_hook",
  "profiler",
  "protobuf",
- "rand",
+ "rand 0.7.3",
  "regex",
  "safemem",
  "static_assertions",
@@ -4872,7 +5128,7 @@ dependencies = [
  "keys",
  "kvproto",
  "lazy_static",
- "libc",
+ "libc 0.2.80",
  "log",
  "log_wrappers",
  "match_template",
@@ -4898,7 +5154,7 @@ dependencies = [
  "raft",
  "raft_log_engine",
  "raftstore",
- "rand",
+ "rand 0.7.3",
  "regex",
  "rev_lines",
  "security",
@@ -4942,7 +5198,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28c80e4338857639f443169a601fafe49866aed8d7a8d565c2f5bfb1a021adf"
 dependencies = [
- "libc",
+ "libc 0.2.80",
  "paste",
  "tikv-jemalloc-sys",
 ]
@@ -4955,7 +5211,7 @@ checksum = "8a26331b05179d4cb505c8d6814a7e18d298972f0a551b0e3cefccff927f86d3"
 dependencies = [
  "cc",
  "fs_extra",
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -4964,7 +5220,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
 dependencies = [
- "libc",
+ "libc 0.2.80",
  "tikv-jemalloc-sys",
 ]
 
@@ -4973,7 +5229,7 @@ name = "tikv_alloc"
 version = "0.1.0"
 dependencies = [
  "lazy_static",
- "libc",
+ "libc 0.2.80",
  "log",
  "mimallocator",
  "tcmalloc",
@@ -5006,7 +5262,7 @@ dependencies = [
  "grpcio",
  "kvproto",
  "lazy_static",
- "libc",
+ "libc 0.2.80",
  "log",
  "log_wrappers",
  "minitrace",
@@ -5018,7 +5274,7 @@ dependencies = [
  "prometheus",
  "protobuf",
  "quick-error",
- "rand",
+ "rand 0.7.3",
  "regex",
  "rusoto_core",
  "serde",
@@ -5047,7 +5303,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 dependencies = [
- "libc",
+ "libc 0.2.80",
  "redox_syscall",
  "winapi 0.3.8",
 ]
@@ -5059,7 +5315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcdaeea317915d59b2b4cd3b5efcd156c309108664277793f5351700c02ce98b"
 dependencies = [
  "const_fn",
- "libc",
+ "libc 0.2.80",
  "standback",
  "stdweb",
  "time-macros",
@@ -5091,9 +5347,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.0.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
+checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
 dependencies = [
  "serde",
  "serde_json",
@@ -5131,7 +5387,7 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static",
- "libc",
+ "libc 0.2.80",
  "memchr",
  "mio",
  "mio-named-pipes",
@@ -5358,7 +5614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "055058552ca15c566082fc61da433ae678f78986a6f16957e33162d1b218792a"
 dependencies = [
  "kernel32-sys",
- "libc",
+ "libc 0.2.80",
  "winapi 0.2.8",
 ]
 
@@ -5368,7 +5624,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
- "rand",
+ "rand 0.7.3",
  "serde",
 ]
 
@@ -5426,9 +5682,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
-version = "2.2.9"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
  "winapi 0.3.8",
@@ -5453,11 +5709,11 @@ checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.59"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -5465,9 +5721,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.59"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0da9c9a19850d3af6df1cb9574970b566d617ecfaf36eb0b706b6f3ef9bd2f8"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -5492,9 +5748,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.59"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6fde1d36e75a714b5fe0cffbb78978f222ea6baebb726af13c78869fdb4205"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
 dependencies = [
  "quote 1.0.3",
  "wasm-bindgen-macro-support",
@@ -5502,9 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.59"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bda4168030a6412ea8a047e27238cadf56f0e53516e1e83fec0a8b7c786f6d"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.3",
@@ -5515,15 +5771,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.59"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9f36ad51f25b0219a3d4d13b90eb44cd075dff8b6280cca015775d7acaddd8"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
 
 [[package]]
 name = "web-sys"
-version = "0.3.36"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721c6263e2c66fd44501cc5efbfa2b7dfa775d13e4ea38c46299646ed1f9c70a"
+checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5535,7 +5791,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
 dependencies = [
- "libc",
+ "libc 0.2.80",
 ]
 
 [[package]]
@@ -5582,16 +5838,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "wincolor"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
-dependencies = [
- "winapi 0.3.8",
- "winapi-util",
-]
-
-[[package]]
 name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5608,6 +5854,21 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "x86"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c146cbc47471e076987378c159a7aa8fa434680c6fbddca59fe6f40f1591c819"
+dependencies = [
+ "bit_field",
+ "bitflags",
+ "csv",
+ "phf 0.7.24",
+ "phf_codegen",
+ "raw-cpuid",
+ "serde_json",
 ]
 
 [[package]]
@@ -5634,7 +5895,7 @@ dependencies = [
  "num_cpus",
  "parking_lot_core 0.8.0",
  "prometheus",
- "rand",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -5649,7 +5910,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e12b8667a4fff63d236f8363be54392f93dbb13616be64a83e761a9319ab589"
 dependencies = [
- "rand",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -5661,5 +5922,5 @@ dependencies = [
  "cc",
  "glob",
  "itertools 0.9.0",
- "libc",
+ "libc 0.2.80",
 ]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -177,4 +177,5 @@ concurrency_manager = { path = "../components/concurrency_manager", default-feat
 file_system = { path = "../components/file_system" }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-criterion-papi = "0.1"
+criterion-perf-events = "0.1"
+perfcnt = "0.6"

--- a/tests/benches/coprocessor_executors/mod.rs
+++ b/tests/benches/coprocessor_executors/mod.rs
@@ -28,10 +28,15 @@ fn execute<M: criterion::measurement::Measurement + 'static>(c: &mut criterion::
 
 #[cfg(target_os = "linux")]
 fn run_bench(measurement: &str) {
+    use criterion_perf_events::Perf;
+    use perfcnt::linux::HardwareEventType as Hardware;
+    use perfcnt::linux::PerfCounterBuilderLinux as Builder;
+
     match measurement {
         "TOT_INS" => {
+            let perf_event_builder = Builder::from_hardware_event(Hardware::Instructions);
             let mut c = criterion::Criterion::default()
-                .with_measurement(criterion_papi::PapiMeasurement::new("PAPI_TOT_INS"))
+                .with_measurement(Perf::new(perf_event_builder))
                 .configure_from_args();
             execute(&mut c);
         }

--- a/tests/benches/deadlock_detector/mod.rs
+++ b/tests/benches/deadlock_detector/mod.rs
@@ -69,6 +69,8 @@ fn bench_detect(b: &mut Bencher, cfg: &Config) {
 }
 
 fn bench_dense_detect_without_cleanup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bench_dense_detect_without_cleanup");
+
     let ranges = vec![
         10,
         100,
@@ -80,28 +82,29 @@ fn bench_dense_detect_without_cleanup(c: &mut Criterion) {
         10_000_000,
         100_000_000,
     ];
-    let mut cfgs = vec![];
     for range in ranges {
-        cfgs.push(Config {
+        let config = Config {
             n: 10,
             range,
             ttl: Duration::from_secs(100000000),
-        });
+        };
+        group.bench_with_input(format!("{:?}", &config), &config, bench_detect);
     }
-    c.bench_function_over_inputs("bench_dense_detect_without_cleanup", bench_detect, cfgs);
 }
 
 fn bench_dense_detect_with_cleanup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bench_dense_detect_with_cleanup");
+
     let ttls = vec![1, 3, 5, 10, 100, 500, 1_000, 3_000];
-    let mut cfgs = vec![];
     for ttl in &ttls {
-        cfgs.push(Config {
+        let config = Config {
             n: 10,
             range: 1000,
             ttl: Duration::from_millis(*ttl),
-        })
+        };
+        group.bench_with_input(format!("{:?}", &config), &config, bench_detect);
     }
-    c.bench_function_over_inputs("bench_dense_detect_with_cleanup", bench_detect, cfgs);
+    group.finish();
 }
 
 fn main() {

--- a/tests/benches/deadlock_detector/mod.rs
+++ b/tests/benches/deadlock_detector/mod.rs
@@ -76,7 +76,6 @@ fn bench_dense_detect_without_cleanup(c: &mut Criterion) {
         100,
         1_000,
         10_000,
-        10_000,
         100_000,
         1_000_000,
         10_000_000,

--- a/tests/benches/hierarchy/engine/mod.rs
+++ b/tests/benches/hierarchy/engine/mod.rs
@@ -79,11 +79,19 @@ fn bench_engine_get<E: Engine, F: EngineFactory<E>>(
 }
 
 pub fn bench_engine<E: Engine, F: EngineFactory<E>>(c: &mut Criterion, configs: &[BenchConfig<F>]) {
-    c.bench_function_over_inputs(
-        "engine_get(exclude snapshot)",
-        bench_engine_get,
-        configs.to_vec(),
-    );
-    c.bench_function_over_inputs("engine_put", bench_engine_put, configs.to_owned());
-    c.bench_function_over_inputs("engine_snapshot", bench_engine_snapshot, configs.to_owned());
+    let mut group = c.benchmark_group("engine");
+    for config in configs {
+        group.bench_with_input(
+            format!("get(exclude snapshot)/{:?}", config),
+            config,
+            bench_engine_get,
+        );
+        group.bench_with_input(format!("put/{:?}", config), config, bench_engine_put);
+        group.bench_with_input(
+            format!("snapshot/{:?}", config),
+            config,
+            bench_engine_snapshot,
+        );
+    }
+    group.finish();
 }

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -238,27 +238,35 @@ fn mvcc_reader_seek_write<E: Engine, F: EngineFactory<E>>(
 }
 
 pub fn bench_mvcc<E: Engine, F: EngineFactory<E>>(c: &mut Criterion, configs: &[BenchConfig<F>]) {
-    c.bench_function_over_inputs("mvcc_prewrite", mvcc_prewrite, configs.to_owned());
-    c.bench_function_over_inputs("mvcc_commit", mvcc_commit, configs.to_owned());
-    c.bench_function_over_inputs(
-        "mvcc_rollback_prewrote",
-        mvcc_rollback_prewrote,
-        configs.to_owned(),
-    );
-    c.bench_function_over_inputs(
-        "mvcc_rollback_conflict",
-        mvcc_rollback_conflict,
-        configs.to_owned(),
-    );
-    c.bench_function_over_inputs(
-        "mvcc_rollback_non_prewrote",
-        mvcc_rollback_non_prewrote,
-        configs.to_owned(),
-    );
-    c.bench_function_over_inputs("mvcc_load_lock", mvcc_reader_load_lock, configs.to_owned());
-    c.bench_function_over_inputs(
-        "mvcc_seek_write",
-        mvcc_reader_seek_write,
-        configs.to_owned(),
-    );
+    let mut group = c.benchmark_group("mvcc");
+    for config in configs {
+        group.bench_with_input(format!("prewrite/{:?}", config), config, mvcc_prewrite);
+        group.bench_with_input(format!("commit/{:?}", config), config, mvcc_commit);
+        group.bench_with_input(
+            format!("rollback_prewrote/{:?}", config),
+            config,
+            mvcc_rollback_prewrote,
+        );
+        group.bench_with_input(
+            format!("rollback_conflict/{:?}", config),
+            config,
+            mvcc_rollback_conflict,
+        );
+        group.bench_with_input(
+            format!("rollback_non_prewrote/{:?}", config),
+            config,
+            mvcc_rollback_non_prewrote,
+        );
+        group.bench_with_input(
+            format!("load_lock/{:?}", config),
+            config,
+            mvcc_reader_load_lock,
+        );
+        group.bench_with_input(
+            format!("seek_write/{:?}", config),
+            config,
+            mvcc_reader_seek_write,
+        );
+    }
+    group.finish();
 }

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -36,7 +36,7 @@ where
     .generate(DEFAULT_ITERATIONS);
     for (k, v) in &kvs {
         let txn_props = TransactionProperties {
-            start_ts: TimeStamp::default(),
+            start_ts,
             kind: TransactionKind::Optimistic(false),
             commit_kind: CommitKind::TwoPc,
             primary: &k.clone(),

--- a/tests/benches/hierarchy/storage/mod.rs
+++ b/tests/benches/hierarchy/storage/mod.rs
@@ -95,11 +95,19 @@ pub fn bench_storage<E: Engine, F: EngineFactory<E>>(
     c: &mut Criterion,
     configs: &[BenchConfig<F>],
 ) {
-    c.bench_function_over_inputs(
-        "storage_async_prewrite",
-        storage_prewrite,
-        configs.to_owned(),
-    );
-    c.bench_function_over_inputs("storage_async_commit", storage_commit, configs.to_owned());
-    c.bench_function_over_inputs("storage_async_raw_get", storage_raw_get, configs.to_owned());
+    let mut group = c.benchmark_group("storage");
+    for config in configs {
+        group.bench_with_input(
+            format!("async_prewrite/{:?}", config),
+            config,
+            storage_prewrite,
+        );
+        group.bench_with_input(format!("async_commit/{:?}", config), config, storage_commit);
+        group.bench_with_input(
+            format!("async_raw_get/{:?}", config),
+            config,
+            storage_raw_get,
+        );
+    }
+    group.finish();
 }

--- a/tests/benches/hierarchy/txn/mod.rs
+++ b/tests/benches/hierarchy/txn/mod.rs
@@ -178,21 +178,25 @@ fn txn_rollback_non_prewrote<E: Engine, F: EngineFactory<E>>(
 }
 
 pub fn bench_txn<E: Engine, F: EngineFactory<E>>(c: &mut Criterion, configs: &[BenchConfig<F>]) {
-    c.bench_function_over_inputs("txn_prewrite", txn_prewrite, configs.to_owned());
-    c.bench_function_over_inputs("txn_commit", txn_commit, configs.to_owned());
-    c.bench_function_over_inputs(
-        "txn_rollback_prewrote",
-        txn_rollback_prewrote,
-        configs.to_owned(),
-    );
-    c.bench_function_over_inputs(
-        "txn_rollback_conflict",
-        txn_rollback_conflict,
-        configs.to_owned(),
-    );
-    c.bench_function_over_inputs(
-        "txn_rollback_non_prewrote",
-        txn_rollback_non_prewrote,
-        configs.to_owned(),
-    );
+    let mut group = c.benchmark_group("txn");
+    for config in configs {
+        group.bench_with_input(format!("prewrite/{:?}", config), config, txn_prewrite);
+        group.bench_with_input(format!("commit/{:?}", config), config, txn_commit);
+        group.bench_with_input(
+            format!("rollback_prewrote/{:?}", config),
+            config,
+            txn_rollback_prewrote,
+        );
+        group.bench_with_input(
+            format!("rollback_conflict/{:?}", config),
+            config,
+            txn_rollback_conflict,
+        );
+        group.bench_with_input(
+            format!("rollback_non_prewrote/{:?}", config),
+            config,
+            txn_rollback_non_prewrote,
+        );
+    }
+    group.finish();
 }

--- a/tests/benches/hierarchy/txn/mod.rs
+++ b/tests/benches/hierarchy/txn/mod.rs
@@ -32,7 +32,7 @@ where
     let kvs = KvGenerator::new(config.key_length, config.value_length).generate(DEFAULT_ITERATIONS);
     for (k, v) in &kvs {
         let txn_props = TransactionProperties {
-            start_ts: TimeStamp::default(),
+            start_ts,
             kind: TransactionKind::Optimistic(false),
             commit_kind: CommitKind::TwoPc,
             primary: &k.clone(),

--- a/tests/benches/raftstore/mod.rs
+++ b/tests/benches/raftstore/mod.rs
@@ -113,33 +113,29 @@ where
     let nodes_coll = vec![1, 3, 5];
     let value_size_coll = vec![8, 128, 1024, 4096];
 
-    let mut set_inputs = vec![];
-    let mut get_inputs = vec![];
-    let mut delete_inputs = vec![];
+    let mut group = c.benchmark_group(&format!("{}", label));
+
     for nodes in nodes_coll {
         for &value_size in &value_size_coll {
-            set_inputs.push(SetConfig {
+            let config = SetConfig {
                 factory: factory.clone(),
                 nodes,
                 value_size,
-            });
+            };
+            group.bench_with_input(format!("bench_set/{:?}", &config), &config, bench_set);
         }
-        get_inputs.push(GetConfig {
+        let config = GetConfig {
             factory: factory.clone(),
             nodes,
-        });
-        delete_inputs.push(DeleteConfig {
+        };
+        group.bench_with_input(format!("bench_get/{:?}", &config), &config, bench_get);
+        let config = DeleteConfig {
             factory: factory.clone(),
             nodes,
-        });
+        };
+        group.bench_with_input(format!("bench_delete/{:?}", &config), &config, bench_delete);
     }
-    c.bench_function_over_inputs(&format!("{}/bench_set", label), bench_set, set_inputs);
-    c.bench_function_over_inputs(&format!("{}/bench_get", label), bench_get, get_inputs);
-    c.bench_function_over_inputs(
-        &format!("{}/bench_delete", label),
-        bench_delete,
-        delete_inputs,
-    );
+    group.finish();
 }
 
 trait ClusterFactory<T: Simulator>: Clone + fmt::Debug + 'static {

--- a/tests/benches/raftstore/mod.rs
+++ b/tests/benches/raftstore/mod.rs
@@ -113,7 +113,7 @@ where
     let nodes_coll = vec![1, 3, 5];
     let value_size_coll = vec![8, 128, 1024, 4096];
 
-    let mut group = c.benchmark_group(&format!("{}", label));
+    let mut group = c.benchmark_group(label);
 
     for nodes in nodes_coll {
         for &value_size in &value_size_coll {


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

### What problem does this PR solve?

Remove `PAPI` dependency, which is really out of fashion now :face_with_head_bandage: , as the perf event document gets richer.

### What is changed and how it works?

Use `criterion-perf-events` rather than `criterion-papi` to get instructions counts during the benchmark.

The only degradation is that the unit is displayed as `cycles`, which is hard coded in `criterion-perf-events` :crying_cat_face: . Don't mind it because it doesn't effect the correctness of the result.

```
table_scan_datum_absent_large_row/RocksDB/batch/with_dag/rows=5000                                                                            
                        time:   [117543777.9983 cycles 117816414.1483 cycles 118078450.0667 cycles]

table_scan_long_datum_all/Memory/batch/next=1024                                                                            
                        time:   [1839019.2600 cycles 1839588.7667 cycles 1840377.1964 cycles]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
table_scan_long_datum_all/RocksDB/normal/with_dag/rows=5000                                                                             
                        time:   [20458704.2422 cycles 20462095.8382 cycles 20466490.3271 cycles]
Found 17 outliers among 100 measurements (17.00%)
  13 (13.00%) low severe
  4 (4.00%) high severe
table_scan_long_datum_all/RocksDB/batch/with_dag/rows=5000                                                                             
                        time:   [20461674.2794 cycles 20463698.1418 cycles 20466326.1559 cycles]
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low severe
  4 (4.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe
```

Besides this change, this PR also:

1. upgrade criterion to 0.3.4 and remove deprecated function calls
2. fix #9671

### Release note <!-- bugfixes or new feature need a release note -->

* No release note