### PR TITLE
enable more logs for tikv-ctl

### DIFF
--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -1030,6 +1030,15 @@ fn warning_prompt(message: &str) -> bool {
 }
 
 fn main() {
+    // The config is only used to initialize the global logger.
+    let rocksdb_info_dir = tempfile::tempdir().unwrap();
+    let raftdb_info_dir = tempfile::tempdir().unwrap();
+    let mut cfg = TiKvConfig::default();
+    cfg.log_file = "./tikv-ctl.log".to_owned();
+    cfg.rocksdb.info_log_dir = rocksdb_info_dir.path().to_str().unwrap().to_owned();
+    cfg.raftdb.info_log_dir = raftdb_info_dir.path().to_str().unwrap().to_owned();
+    cmd::setup::initial_logger(&cfg);
+
     vlog::set_verbosity_level(1);
 
     let raw_key_hint: &'static str = "Raw key (generally starts with \"z\") in escaped form";

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -1838,8 +1838,8 @@ fn main() {
     if let Some(log) = matches.value_of("log") {
         let mut cfg = TiKvConfig::default();
         cfg.log_file = log.to_owned();
-        cfg.rocksdb.info_log_level = LogLevel::Fatal;
-        cfg.raftdb.info_log_level = LogLevel::Fatal;
+        cfg.rocksdb.info_log_level = LogLevel::Error;
+        cfg.raftdb.info_log_level = LogLevel::Error;
         cmd::setup::initial_logger(&cfg);
     }
 

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -1033,11 +1033,14 @@ fn main() {
     // The config is only used to initialize the global logger.
     let rocksdb_info_dir = tempfile::tempdir().unwrap();
     let raftdb_info_dir = tempfile::tempdir().unwrap();
-    let mut cfg = TiKvConfig::default();
-    cfg.log_file = "./tikv-ctl.log".to_owned();
-    cfg.rocksdb.info_log_dir = rocksdb_info_dir.path().to_str().unwrap().to_owned();
-    cfg.raftdb.info_log_dir = raftdb_info_dir.path().to_str().unwrap().to_owned();
-    cmd::setup::initial_logger(&cfg);
+    #[allow(clippy::field_reassign_with_default)]
+    {
+        let mut cfg = TiKvConfig::default();
+        cfg.log_file = "./tikv-ctl.log".to_owned();
+        cfg.rocksdb.info_log_dir = rocksdb_info_dir.path().to_str().unwrap().to_owned();
+        cfg.raftdb.info_log_dir = raftdb_info_dir.path().to_str().unwrap().to_owned();
+        cmd::setup::initial_logger(&cfg);
+    }
 
     vlog::set_verbosity_level(1);
 


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

tikv-ctl can't print logs in `src/*` because it doesn't call `initial_logger`.

### What is changed and how it works?

Make tikv-ctl print more detail logs in `tikv-ctl.log`, which is in the current directory.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

For example, `unsafe-recover remove-fail-stores` will record such a log:
```
[2021/02/20 14:18:03.439 +08:00] [INFO] [debug.rs:586] ["peers changed"] [new_peers="[id: 3 store_id: 1]"] [old_peers="[id: 3 store_id: 1]"] [region_id=2]
```

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.