### PR TITLE
raftstore: reduce merge check tick interval

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -239,7 +239,7 @@ impl Default for Config {
             right_derive_when_split: true,
             allow_remove_leader: false,
             merge_max_log_gap: 10,
-            merge_check_tick_interval: ReadableDuration::secs(10),
+            merge_check_tick_interval: ReadableDuration::secs(2),
             use_delete_range: false,
             cleanup_import_sst_interval: ReadableDuration::minutes(10),
             local_read_batch_size: 1024,


### PR DESCRIPTION
Signed-off-by: gengliqi <gengliqiii@gmail.com>


### What problem does this PR solve?

Change default merge-check-tick-interval from 10 to 2.

Problem Summary:
The admin cmd may be dropped when the leader has not applied to current term which is introduced by https://github.com/tikv/tikv/pull/8441.
If the `CommitMerge` is dropped, the merge process will get stuck and the data in source region can not be read or written until the later retry. The default of merge-check-tick-interval is 10(s) which is obviously too long so this PR change it to 2(s). 

### What is changed and how it works?

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->
* Change the default merge-check-tick-interval to 2 to speed up the retry of merge process