### PR TITLE
error_code: remove default implementation

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -428,7 +428,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
                 let ch = ch.lock().unwrap();
                 let event = StoreMsg::CompactedEvent(compacted_event);
                 if let Err(e) = ch.send_control(event) {
-                    error!(?e; "send compaction finished event to raftstore failed");
+                    error_unknown!(?e; "send compaction finished event to raftstore failed");
                 }
             });
         engine_rocks::CompactionListener::new(compacted_handler, Some(size_change_filter))
@@ -845,7 +845,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
     fn init_io_utility(&mut self) -> BytesFetcher {
         let io_snooper_on = self.config.enable_io_snoop
             && file_system::init_io_snooper()
-                .map_err(|e| error!(%e; "failed to init io snooper"))
+                .map_err(|e| error_unknown!(%e; "failed to init io snooper"))
                 .is_ok();
         let (fetcher, limiter) = if io_snooper_on {
             (BytesFetcher::FromIOSnooper(), IORateLimiter::new(0, false))
@@ -899,7 +899,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             ) {
                 Ok(status_server) => Box::new(status_server),
                 Err(e) => {
-                    error!(%e; "failed to start runtime for status service");
+                    error_unknown!(%e; "failed to start runtime for status service");
                     return;
                 }
             };
@@ -908,7 +908,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
                 self.config.server.status_addr.clone(),
                 self.config.server.advertise_status_addr.clone(),
             ) {
-                error!(%e; "failed to bind addr for status service");
+                error_unknown!(%e; "failed to bind addr for status service");
             } else {
                 self.to_stop.push(status_server);
             }

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -266,7 +266,7 @@ impl BackupRange {
                         files.append(&mut split_files);
                     }
                     Err(e) => {
-                        error!(?e; "backup save file failed");
+                        error_unknown!(?e; "backup save file failed");
                         return Err(e);
                     }
                 }
@@ -275,7 +275,7 @@ impl BackupRange {
                         writer = w;
                     }
                     Err(e) => {
-                        error!(?e; "backup writer failed");
+                        error_unknown!(?e; "backup writer failed");
                         return Err(e);
                     }
                 }
@@ -283,7 +283,7 @@ impl BackupRange {
 
             // Build sst files.
             if let Err(e) = writer.write(entries, true) {
-                error!(?e; "backup build sst failed");
+                error_unknown!(?e; "backup build sst failed");
                 return Err(e);
             }
         }
@@ -305,7 +305,7 @@ impl BackupRange {
                     files.append(&mut split_files);
                 }
                 Err(e) => {
-                    error!(?e; "backup save file failed");
+                    error_unknown!(?e; "backup save file failed");
                     return Err(e);
                 }
             }
@@ -367,7 +367,7 @@ impl BackupRange {
             debug!("backup scan raw kv entries"; "len" => batch.len());
             // Build sst files.
             if let Err(e) = writer.write(batch.drain(..), false) {
-                error!(?e; "backup raw kv build sst failed");
+                error_unknown!(?e; "backup raw kv build sst failed");
                 return Err(e);
             }
         }
@@ -397,7 +397,7 @@ impl BackupRange {
         ) {
             Ok(w) => w,
             Err(e) => {
-                error!(?e; "backup writer failed");
+                error_unknown!(?e; "backup writer failed");
                 return Err(e);
             }
         };
@@ -409,7 +409,7 @@ impl BackupRange {
         match writer.save(&storage.storage) {
             Ok(files) => Ok((files, stat)),
             Err(e) => {
-                error!(?e; "backup save file failed");
+                error_unknown!(?e; "backup save file failed");
                 Err(e)
             }
         }
@@ -673,11 +673,11 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
             let backend = match create_storage(&request.backend) {
                 Ok(backend) => backend,
                 Err(err) => {
-                    error!(?err; "backup create storage failed");
+                    error_unknown!(?err; "backup create storage failed");
                     let mut response = BackupResponse::default();
                     response.set_error(crate::Error::Io(err).into());
                     if let Err(err) = tx.unbounded_send(response) {
-                        error!(?err; "backup failed to send response");
+                        error_unknown!(?err; "backup failed to send response");
                     }
                     return;
                 }
@@ -764,7 +764,7 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
                     let mut response = BackupResponse::default();
                     match res {
                         Err(e) => {
-                            error!(?e; "backup region failed";
+                            error_unknown!(?e; "backup region failed";
                                 "region" => ?brange.region,
                                 "start_key" => &log_wrappers::Value::key(&start_key),
                                 "end_key" => &log_wrappers::Value::key(&end_key),
@@ -793,7 +793,7 @@ impl<E: Engine, R: RegionInfoProvider> Endpoint<E, R> {
                     response.set_end_key(end_key);
 
                     if let Err(e) = tx.unbounded_send(response) {
-                        error!(?e; "backup failed to send response");
+                        error_unknown!(?e; "backup failed to send response");
                         return;
                     }
                 }

--- a/components/encryption/src/lib.rs
+++ b/components/encryption/src/lib.rs
@@ -1,5 +1,4 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
-#![feature(min_specialization)]
 
 #[macro_use(fail_point)]
 extern crate fail;

--- a/components/error_code/src/lib.rs
+++ b/components/error_code/src/lib.rs
@@ -57,12 +57,6 @@ pub trait ErrorCodeExt {
     fn error_code(&self) -> ErrorCode;
 }
 
-impl<T> ErrorCodeExt for T {
-    default fn error_code(&self) -> ErrorCode {
-        UNKNOWN
-    }
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -1,5 +1,4 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
-#![feature(min_specialization)]
 
 mod client;
 mod feature_gate;

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -281,7 +281,7 @@ where
             // Error::Incompatible is returned by response header from PD, no need to retry
             Err(Error::Incompatible) => true,
             Err(err) => {
-                error!(?err; "request failed, retry");
+                error!(?*err; "request failed, retry");
                 false
             }
         }

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![cfg_attr(test, feature(test))]
 #![feature(thread_id_value)]
-#![feature(min_specialization)]
 #![feature(box_patterns)]
 #![feature(str_split_once)]
 

--- a/components/tikv_util/src/log.rs
+++ b/components/tikv_util/src/log.rs
@@ -33,6 +33,10 @@ macro_rules! error {
     };
 }
 
+// error_unknown is used the same as the above error macro
+// However, it will always use an error code of UNKNOWN
+// This is for errors that do not implement ErrorCodeExt
+// It is recommended to implement ErrorCodeExt instead of using this macro
 #[macro_export]
 macro_rules! error_unknown {
     (?$e:expr; $l:literal) => {

--- a/components/tikv_util/src/log.rs
+++ b/components/tikv_util/src/log.rs
@@ -33,6 +33,25 @@ macro_rules! error {
     };
 }
 
+#[macro_export]
+macro_rules! error_unknown {
+    (?$e:expr; $l:literal) => {
+        ::slog_global::error!($l; "err" => ?$e,"err_code" => %error_code::UNKNOWN)
+    };
+
+    (%$e:expr; $l:literal) => {
+        ::slog_global::error!($l; "err" => ?$e,"err_code" => %error_code::UNKNOWN)
+    };
+
+    (?$e:expr; $($args:tt)+) => {
+        ::slog_global::error!($($args)+ "err" => ?$e,"err_code" => %error_code::UNKNOWN)
+    };
+
+    (%$e:expr; $($args:tt)+) => {
+        ::slog_global::error!($($args)+ "err" => %$e,"err_code" => %error_code::UNKNOWN)
+    };
+}
+
 /// Logs a warning level message using the slog global logger.
 #[macro_export]
 macro_rules! warn(($($args:tt)+) => {

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -126,7 +126,7 @@ where
         };
         match res {
             Ok(_) => info!("switch mode"; "mode" => ?req.get_mode()),
-            Err(ref e) => error!(%e; "switch mode failed"; "mode" => ?req.get_mode(),),
+            Err(ref e) => error!(%*e; "switch mode failed"; "mode" => ?req.get_mode(),),
         }
 
         let task = async move {
@@ -389,7 +389,7 @@ where
                     "end" => end.map(log_wrappers::Value::key),
                     "output_level" => ?output_level, "takes" => ?timer.elapsed()
                 ),
-                Err(ref e) => error!(%e;
+                Err(ref e) => error!(%*e;
                     "compact files in range failed";
                     "start" => start.map(log_wrappers::Value::key),
                     "end" => end.map(log_wrappers::Value::key),

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -653,7 +653,7 @@ async fn maybe_backoff(cfg: &Config, last_wake_time: &mut Instant, retry_times: 
         return;
     }
     if let Err(e) = GLOBAL_TIMER_HANDLE.delay(now + timeout).compat().await {
-        error!(?e; "failed to backoff");
+        error_unknown!(?e; "failed to backoff");
     }
     *last_wake_time = Instant::now();
 }
@@ -691,7 +691,7 @@ async fn start<S, R>(
             Err(e) => {
                 RESOLVE_STORE_COUNTER.with_label_values(&["failed"]).inc();
                 back_end.clear_pending_message();
-                error!(?e; "resolve store address failed"; "store_id" => back_end.store_id,);
+                error_unknown!(?e; "resolve store address failed"; "store_id" => back_end.store_id,);
                 // TOMBSTONE
                 if format!("{}", e).contains("has been removed") {
                     let mut pool = pool.lock().unwrap();

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -333,7 +333,7 @@ pub fn extract_key_error(err: &Error) -> kvrpcpb::KeyError {
             key_error.set_commit_ts_too_large(commit_ts_too_large);
         }
         _ => {
-            error!(?err; "txn aborts");
+            error!(?*err; "txn aborts");
             key_error.set_abort(format!("{:?}", err));
         }
     }


### PR DESCRIPTION


### What problem does this PR solve?

default <T> to unknown means the compiler cannot tell us if error codes
are working. It is easy to accidentally end up with the unknown code.
It also requires all implemntations to use specialization.

### What is changed and how it works?

Remove defaulting to unknown
use an error_unknown macro if there is no error code to set it to
unknown.




### Related changes

None

### Check List

Tests

Tested a case where the error code shows up after these changes. Previously wrappers were getting defaulted to unknown but are now properly dereferenced.

Side effects

Code may change from Unknown to a more specific code.


### Release note

Fix error code propagation