### PR TITLE
file_system: cleanup eBPF on server shutdown instead of on thread exit

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -927,6 +927,8 @@ impl<ER: RaftEngine> TiKVServer<ER> {
 
         servers.lock_mgr.stop();
 
+        file_system::stop_io_snooper();
+
         self.to_stop.into_iter().for_each(|s| s.stop());
     }
 }

--- a/components/file_system/src/iosnoop/mod.rs
+++ b/components/file_system/src/iosnoop/mod.rs
@@ -9,4 +9,4 @@ mod imp;
 mod imp;
 
 pub(crate) use imp::{fetch_io_bytes, flush_io_latency_metrics};
-pub use imp::{get_io_type, init_io_snooper, set_io_type};
+pub use imp::{get_io_type, init_io_snooper, set_io_type, stop_io_snooper};

--- a/components/file_system/src/iosnoop/null.rs
+++ b/components/file_system/src/iosnoop/null.rs
@@ -8,6 +8,8 @@ pub fn init_io_snooper() -> Result<(), String> {
     Err("IO snooper is not started due to not compiling with BCC".to_string())
 }
 
+pub fn stop_io_snooper() {}
+
 thread_local! {
     static IO_TYPE: Cell<IOType> = Cell::new(IOType::Other)
 }

--- a/components/file_system/src/lib.rs
+++ b/components/file_system/src/lib.rs
@@ -15,7 +15,7 @@ mod metrics_manager;
 mod rate_limiter;
 
 pub use file::{File, OpenOptions};
-pub use iosnoop::{get_io_type, init_io_snooper, set_io_type};
+pub use iosnoop::{get_io_type, init_io_snooper, set_io_type, stop_io_snooper};
 pub use metrics_manager::{BytesFetcher, MetricsManager};
 pub use rate_limiter::{
     get_io_rate_limiter, set_io_rate_limiter, IORateLimiter, IORateLimiterStatistics,


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

### What problem does this PR solve?

Previously we count the threads using biosnoop and cleanup the eBPF when the count drops to 0. This fails to take into account the main thread may also need to access biosnoop and the thread `IdxWrapper` does not get `drop` after program exit. This patch change to let TiKV server cleanup eBPF on shutdown. This change also fixes the broken biosnoop unit test.

It is still a problem if TiKV gets killed and the eBPF won't be cleaned up, though. 

Problem Summary:

### What is changed and how it works?

What's Changed: This patch change to let TiKV server cleanup the eBPF for biosnoop on shutdown.

### Related changes

No

### Check List <!--REMOVE the items that are not applicable-->

Tests 

build and run test in environment with bcc support and see the test pass. https://gist.github.com/yiwu-arbug/35f52102defe25a7257f1a5082b54e0f

### Release note <!-- bugfixes or new feature need a release note -->

- No release note