### PR TITLE
Bump version v4.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project are documented in this file.
 See also [TiDB Changelog](https://github.com/pingcap/tidb/blob/master/CHANGELOG.md) and [PD Changelog](https://github.com/pingcap/pd/blob/master/CHANGELOG.md).
 
+## [4.0.11] - 2021-02-26
+
++ New Features
+  + Support the `utf8mb4_unicode_ci` collation [#9577](https://github.com/tikv/tikv/pull/9577)
+  + Support the `cast_year_as_time` collation [#9299](https://github.com/tikv/tikv/pull/9299)
++ Improvements
+  + Add metrics of server information for DBaaS [#9591](https://github.com/tikv/tikv/pull/9591)
+  + Support multiple clusters in Grafana dashboards [#9572](https://github.com/tikv/tikv/pull/9572)
+  + Report RocksDB metrics to TiDB [#9316](https://github.com/tikv/tikv/pull/9316)
+  + Record the suspension time for Coprocessor tasks [#9277](https://github.com/tikv/tikv/pull/9277)
+  + Add thresholds of key counts and key size for Load Base Split [#9354](https://github.com/tikv/tikv/pull/9354)
+  + Check whether the file exists before data import [#9544](https://github.com/tikv/tikv/pull/9544)
+  + Improve Fast Tune panels [#9180](https://github.com/tikv/tikv/pull/9180)
++ Bug Fixes
+  + Fix the issue that TiKV is failed to build with `PROST=1` [#9604](https://github.com/tikv/tikv/pull/9604)
+  + Fix the unmatched memory diagnostics [#9589](https://github.com/tikv/tikv/pull/9589)
+  + Fix the issue that the end key of a partial RawKV-restore range is inclusive [#9583](https://github.com/tikv/tikv/pull/9583)
+  + Fix the issue that TiKV might panic when loading the old value of a key of a rolled-back transaction during TiCDC's incremental scan [#9569](https://github.com/tikv/tikv/pull/9569)
+  + Fix the configuration glitch of old values when changefeeds with different settings connect to one Region [#9565](https://github.com/tikv/tikv/pull/9565)
+  + Fix a crash issue that occurs when running a TiKV cluster on a machine with a network interface that lacks the MAC address (introduced in v4.0.9) [#9516](https://github.com/tikv/tikv/pull/9516)
+  + Fix the issue of TiKV OOM when backing up a huge Region [#9448](https://github.com/tikv/tikv/pull/9448)
+  + Fix the issue that `region-split-check-diff` cannot be customized [#9530](https://github.com/tikv/tikv/pull/9530)
+  + Fix the issue of TiKV panic when the system time goes back [#9542](https://github.com/tikv/tikv/pull/9542)
+
 ## [4.0.10] - 2021-01-15
 
 + Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "tikv"
-version = "4.0.10"
+version = "4.0.11"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv"
-version = "4.0.10"
+version = "4.0.11"
 authors = ["The TiKV Authors"]
 description = "A distributed transactional key-value database powered by Rust and Raft"
 license = "Apache-2.0"


### PR DESCRIPTION
This PR is used to bump TiKV version to v4.0.11
### Release note <!-- bugfixes or new feature need a release note -->
* No release note.