### PR TITLE
storage: Optimize seek write for many tombstones (#8514)

### DIFF
--- a/components/engine/src/iterable.rs
+++ b/components/engine/src/iterable.rs
@@ -68,6 +68,7 @@ impl IterOptionsExt for IterOption {
     fn build_read_opts(self) -> ReadOptions {
         let mut opts = ReadOptions::new();
         opts.fill_cache(self.fill_cache());
+        opts.set_max_skippable_internal_keys(self.max_skippable_internal_keys());
         if self.key_only() {
             opts.set_titan_key_only(true);
         }

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -432,7 +432,12 @@ impl Snapshot for RegionSnapshot<RocksEngine> {
         fail_point!("raftkv_snapshot_iter", |_| Err(box_err!(
             "injected error for iter"
         )));
-        Ok(Cursor::new(RegionSnapshot::iter(self, iter_opt), mode))
+        let prefix_seek = iter_opt.prefix_seek_used();
+        Ok(Cursor::new(
+            RegionSnapshot::iter(self, iter_opt),
+            mode,
+            prefix_seek,
+        ))
     }
 
     fn iter_cf(
@@ -444,9 +449,11 @@ impl Snapshot for RegionSnapshot<RocksEngine> {
         fail_point!("raftkv_snapshot_iter_cf", |_| Err(box_err!(
             "injected error for iter_cf"
         )));
+        let prefix_seek = iter_opt.prefix_seek_used();
         Ok(Cursor::new(
             RegionSnapshot::iter_cf(self, cf, iter_opt)?,
             mode,
+            prefix_seek,
         ))
     }
 

--- a/src/storage/kv/btree_engine.rs
+++ b/src/storage/kv/btree_engine.rs
@@ -235,8 +235,12 @@ impl Snapshot for BTreeEngineSnapshot {
         mode: ScanMode,
     ) -> EngineResult<Cursor<Self::Iter>> {
         let tree = self.inner_engine.get_cf(cf);
-
-        Ok(Cursor::new(BTreeEngineIterator::new(tree, iter_opt), mode))
+        let prefix_seek = iter_opt.prefix_seek_used();
+        Ok(Cursor::new(
+            BTreeEngineIterator::new(tree, iter_opt),
+            mode,
+            prefix_seek,
+        ))
     }
 }
 

--- a/src/storage/kv/cursor.rs
+++ b/src/storage/kv/cursor.rs
@@ -17,6 +17,7 @@ use crate::storage::kv::{CfStatistics, Error, Iterator, Result, ScanMode, Snapsh
 pub struct Cursor<I: Iterator> {
     iter: I,
     scan_mode: ScanMode,
+    prefix_seek: bool,
     // the data cursor can be seen will be
     min_key: Option<Vec<u8>>,
     max_key: Option<Vec<u8>>,
@@ -41,12 +42,13 @@ macro_rules! near_loop {
 }
 
 impl<I: Iterator> Cursor<I> {
-    pub fn new(iter: I, mode: ScanMode) -> Self {
+    pub fn new(iter: I, mode: ScanMode, prefix_seek: bool) -> Self {
         Self {
             iter,
             scan_mode: mode,
             min_key: None,
             max_key: None,
+            prefix_seek,
 
             cur_key_has_read: Cell::new(false),
             cur_value_has_read: Cell::new(false),
@@ -95,7 +97,16 @@ impl<I: Iterator> Cursor<I> {
         }
 
         if !self.internal_seek(key, statistics)? {
-            self.max_key = Some(key.as_encoded().to_owned());
+            // Do not set `max_key` when prefix seek enabled.
+            // `max_key` is used to record the last key before the iter reaches
+            // the end, so later seek whose key is larger than `max_key` can be
+            // return not found directly instead of calling underlying iterator
+            // to seek the key.
+            // But when prefix seek enabled, !valid() doesn't mean reaching the
+            // end of iterator range. So the `max_key` shouldn't be updated.
+            if !self.prefix_seek {
+                self.max_key = Some(key.as_encoded().to_owned());
+            }
             return Ok(false);
         }
         Ok(true)
@@ -135,8 +146,14 @@ impl<I: Iterator> Cursor<I> {
                     self.next(statistics);
                 }
             } else {
-                assert!(self.seek_to_first(statistics));
-                return Ok(true);
+                if self.prefix_seek {
+                    // When prefixed seek and prefix_same_as_start enabled
+                    // seek_to_first may return false due to no key's prefix is same as iter lower bound's
+                    return self.seek(key, statistics);
+                } else {
+                    assert!(self.seek_to_first(statistics));
+                    return Ok(true);
+                }
             }
         } else {
             // ord == Less
@@ -147,7 +164,16 @@ impl<I: Iterator> Cursor<I> {
             );
         }
         if !self.valid()? {
-            self.max_key = Some(key.as_encoded().to_owned());
+            // Do not set `max_key` when prefix seek enabled.
+            // `max_key` is used to record the last key before the iter reaches
+            // the end, so later seek whose key is larger than `max_key` can be
+            // return not found directly instead of calling underlying iterator
+            // to seek the key.
+            // But when prefix seek enabled, !valid() doesn't mean reaching the
+            // end of iterator range. So the `max_key` shouldn't be updated.
+            if !self.prefix_seek {
+                self.max_key = Some(key.as_encoded().to_owned());
+            }
             return Ok(false);
         }
         Ok(true)
@@ -190,7 +216,9 @@ impl<I: Iterator> Cursor<I> {
         }
 
         if !self.internal_seek_for_prev(key, statistics)? {
-            self.min_key = Some(key.as_encoded().to_owned());
+            if !self.prefix_seek {
+                self.min_key = Some(key.as_encoded().to_owned());
+            }
             return Ok(false);
         }
         Ok(true)
@@ -228,8 +256,12 @@ impl<I: Iterator> Cursor<I> {
                     self.prev(statistics);
                 }
             } else {
-                assert!(self.seek_to_last(statistics));
-                return Ok(true);
+                if self.prefix_seek {
+                    return self.seek_for_prev(key, statistics);
+                } else {
+                    assert!(self.seek_to_last(statistics));
+                    return Ok(true);
+                }
             }
         } else {
             near_loop!(
@@ -240,7 +272,9 @@ impl<I: Iterator> Cursor<I> {
         }
 
         if !self.valid()? {
-            self.min_key = Some(key.as_encoded().to_owned());
+            if !self.prefix_seek {
+                self.min_key = Some(key.as_encoded().to_owned());
+            }
             return Ok(false);
         }
         Ok(true)
@@ -528,13 +562,15 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
 
 #[cfg(test)]
 mod tests {
-    use engine::rocks::Writable;
-    use engine::Engines;
+    use engine::rocks::util::{new_engine, CFOptions, FixedPrefixSliceTransform};
+    use engine::rocks::ColumnFamilyOptions;
     use engine::*;
+    use engine_traits::{IterOptions, SyncMutable, CF_DEFAULT};
 
     use engine_rocks::RocksEngine;
     use keys::data_key;
     use kvproto::metapb::{Peer, Region};
+    use std::sync::Arc;
     use tempfile::Builder;
     use txn_types::Key;
 
@@ -543,7 +579,7 @@ mod tests {
 
     type DataSet = Vec<(Vec<u8>, Vec<u8>)>;
 
-    fn load_default_dataset(engines: Engines) -> (Region, DataSet) {
+    fn load_default_dataset(engine: RocksEngine) -> (Region, DataSet) {
         let mut r = Region::default();
         r.mut_peers().push(Peer::default());
         r.set_id(10);
@@ -559,21 +595,70 @@ mod tests {
         ];
 
         for &(ref k, ref v) in &base_data {
-            engines.kv.put(&data_key(k), v).unwrap();
+            engine.put(&data_key(k), v).unwrap();
         }
         (r, base_data)
     }
 
     #[test]
+    fn test_seek_and_prev_with_prefix_seek() {
+        let path = Builder::new().prefix("test-cursor").tempdir().unwrap();
+        let mut cf_opts = ColumnFamilyOptions::new();
+        let e = Box::new(FixedPrefixSliceTransform::new(3));
+        cf_opts
+            .set_prefix_extractor("FixedPrefixSliceTransform", e)
+            .unwrap();
+        let engine = new_engine(
+            path.path().to_str().unwrap(),
+            None,
+            &[CF_DEFAULT],
+            Some(vec![CFOptions::new(CF_DEFAULT, cf_opts)]),
+        )
+        .unwrap();
+        let engine = Arc::new(engine);
+
+        let (region, _) = load_default_dataset(RocksEngine::from_db(engine.clone()));
+
+        let snap = RegionSnapshot::<RocksEngine>::from_raw(engine, region);
+        let mut statistics = CfStatistics::default();
+        let it = snap.iter(
+            IterOptions::default()
+                .use_prefix_seek()
+                .set_prefix_same_as_start(true),
+        );
+        let mut iter = Cursor::new(it, ScanMode::Mixed, true);
+
+        assert!(!iter
+            .seek(&Key::from_encoded_slice(b"a2"), &mut statistics)
+            .unwrap());
+        assert!(iter
+            .seek(&Key::from_encoded_slice(b"a3"), &mut statistics)
+            .unwrap());
+        assert!(iter
+            .seek(&Key::from_encoded_slice(b"a9"), &mut statistics)
+            .is_err());
+
+        assert!(!iter
+            .seek_for_prev(&Key::from_encoded_slice(b"a6"), &mut statistics)
+            .unwrap());
+        assert!(iter
+            .seek_for_prev(&Key::from_encoded_slice(b"a3"), &mut statistics)
+            .unwrap());
+        assert!(iter
+            .seek_for_prev(&Key::from_encoded_slice(b"a1"), &mut statistics)
+            .is_err());
+    }
+
+    #[test]
     fn test_reverse_iterate() {
-        let path = Builder::new().prefix("test-raftstore").tempdir().unwrap();
+        let path = Builder::new().prefix("test-cursor").tempdir().unwrap();
         let engines = new_temp_engine(&path);
-        let (region, test_data) = load_default_dataset(engines.clone());
+        let (region, test_data) = load_default_dataset(RocksEngine::from_db(engines.kv.clone()));
 
         let snap = RegionSnapshot::<RocksEngine>::from_raw(engines.kv.clone(), region);
         let mut statistics = CfStatistics::default();
         let it = snap.iter(IterOption::default());
-        let mut iter = Cursor::new(it, ScanMode::Mixed);
+        let mut iter = Cursor::new(it, ScanMode::Mixed, false);
         assert!(!iter
             .reverse_seek(&Key::from_encoded_slice(b"a2"), &mut statistics)
             .unwrap());
@@ -623,7 +708,7 @@ mod tests {
         region.mut_peers().push(Peer::default());
         let snap = RegionSnapshot::<RocksEngine>::from_raw(engines.kv, region);
         let it = snap.iter(IterOption::default());
-        let mut iter = Cursor::new(it, ScanMode::Mixed);
+        let mut iter = Cursor::new(it, ScanMode::Mixed, false);
         assert!(!iter
             .reverse_seek(&Key::from_encoded_slice(b"a1"), &mut statistics)
             .unwrap());

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -220,7 +220,7 @@ quick_error! {
     pub enum ErrorInner {
         Request(err: ErrorHeader) {
             from()
-            description("request to underhook engine failed")
+            description(err.get_message())
             display("{:?}", err)
         }
         Timeout(d: Duration) {

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -96,7 +96,7 @@ impl<S: Snapshot> PointGetterBuilder<S> {
         // If we only want to get single value, we can use prefix seek.
         let write_cursor = CursorBuilder::new(&self.snapshot, CF_WRITE)
             .fill_cache(self.fill_cache)
-            .prefix_seek(!self.multi)
+            .prefix_seek(true)
             .scan_mode(if self.multi {
                 ScanMode::Mixed
             } else {
@@ -243,8 +243,16 @@ impl<S: Snapshot> PointGetter<S> {
 
         seek_key = seek_key.append_ts(self.ts);
         let data_found = if use_near_seek {
-            self.write_cursor
-                .near_seek(&seek_key, &mut self.statistics.write)?
+            if self.write_cursor.key(&mut self.statistics.write) >= seek_key.as_encoded().as_slice()
+            {
+                // we call near_seek with ScanMode::Mixed set, if the key() > seek_key,
+                // it will call prev() several times, whereas we just want to seek forward here
+                // so cmp them in advance
+                true
+            } else {
+                self.write_cursor
+                    .near_seek(&seek_key, &mut self.statistics.write)?
+            }
         } else {
             self.write_cursor
                 .seek(&seek_key, &mut self.statistics.write)?
@@ -333,7 +341,9 @@ mod tests {
     use kvproto::kvrpcpb::Context;
     use txn_types::SHORT_VALUE_MAX_LEN;
 
-    use crate::storage::kv::{CfStatistics, Engine, RocksEngine, TestEngineBuilder};
+    use crate::storage::kv::{
+        CfStatistics, Engine, PerfStatisticsInstant, RocksEngine, TestEngineBuilder,
+    };
     use crate::storage::mvcc::tests::*;
 
     fn new_multi_point_getter<E: Engine>(engine: &E, ts: TimeStamp) -> PointGetter<E::Snap> {
@@ -569,6 +579,76 @@ mod tests {
         assert_seek_next_prev(&s.write, 1, 0, 0);
     }
 
+    #[test]
+    fn test_multi_tombstone() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+
+        must_prewrite_put(&engine, b"foo", b"bar", b"foo", 10);
+        must_prewrite_put(&engine, b"foo1", b"bar1", b"foo", 10);
+        must_prewrite_put(&engine, b"foo2", b"bar2", b"foo", 10);
+        must_prewrite_put(&engine, b"foo3", b"bar3", b"foo", 10);
+        must_commit(&engine, b"foo", 10, 20);
+        must_commit(&engine, b"foo1", 10, 20);
+        must_commit(&engine, b"foo2", 10, 20);
+        must_commit(&engine, b"foo3", 10, 20);
+        must_prewrite_delete(&engine, b"foo1", b"foo1", 30);
+        must_prewrite_delete(&engine, b"foo2", b"foo1", 30);
+        must_commit(&engine, b"foo1", 30, 40);
+        must_commit(&engine, b"foo2", 30, 40);
+
+        must_gc(&engine, b"foo", 50);
+        must_gc(&engine, b"foo1", 50);
+        must_gc(&engine, b"foo2", 50);
+        must_gc(&engine, b"foo3", 50);
+
+        let mut getter = new_multi_point_getter(&engine, TimeStamp::max());
+        let perf_statistics = PerfStatisticsInstant::new();
+        must_get_value(&mut getter, b"foo", b"bar");
+        assert_eq!(perf_statistics.delta().0.internal_delete_skipped_count, 0);
+
+        let perf_statistics = PerfStatisticsInstant::new();
+        must_get_none(&mut getter, b"foo1");
+        assert_eq!(perf_statistics.delta().0.internal_delete_skipped_count, 2);
+
+        let perf_statistics = PerfStatisticsInstant::new();
+        must_get_none(&mut getter, b"foo2");
+        assert_eq!(perf_statistics.delta().0.internal_delete_skipped_count, 2);
+
+        let perf_statistics = PerfStatisticsInstant::new();
+        must_get_value(&mut getter, b"foo3", b"bar3");
+        assert_eq!(perf_statistics.delta().0.internal_delete_skipped_count, 0);
+    }
+
+    #[test]
+    fn test_multi_with_iter_lower_bound() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        must_prewrite_put(&engine, b"foo", b"bar", b"foo", 10);
+        must_commit(&engine, b"foo", 10, 20);
+
+        let snapshot = engine.snapshot(&Context::default()).unwrap();
+        let write_cursor = CursorBuilder::new(&snapshot, CF_WRITE)
+            .prefix_seek(true)
+            .scan_mode(ScanMode::Mixed)
+            .range(Some(Key::from_raw(b"a")), None)
+            .build()
+            .unwrap();
+        let mut getter = PointGetter {
+            snapshot,
+            multi: true,
+            omit_value: false,
+            isolation_level: IsolationLevel::Si,
+            ts: TimeStamp::new(30),
+            bypass_locks: Default::default(),
+            met_newer_ts_data: NewerTsCheckState::NotMetYet,
+            statistics: Statistics::default(),
+            write_cursor,
+            drained: false,
+        };
+        must_get_value(&mut getter, b"foo", b"bar");
+        let s = getter.take_statistics();
+        assert_seek_next_prev(&s.write, 1, 0, 0);
+    }
+
     /// Some ts larger than get ts
     #[test]
     fn test_multi_basic_2() {
@@ -641,7 +721,7 @@ mod tests {
         must_get_none(&mut getter, b"foo1");
         must_get_none(&mut getter, b"foo2");
         let s = getter.take_statistics();
-        assert_seek_next_prev(&s.write, 3, 0, 0);
+        assert_seek_next_prev(&s.write, 4, 0, 0);
 
         let mut getter = new_multi_point_getter(&engine, 3.into());
         must_get_none(&mut getter, b"a");
@@ -652,7 +732,7 @@ mod tests {
         must_get_none(&mut getter, b"foo2");
         must_get_none(&mut getter, b"foo2");
         let s = getter.take_statistics();
-        assert_seek_next_prev(&s.write, 6, 0, 0);
+        assert_seek_next_prev(&s.write, 7, 0, 0);
 
         let mut getter = new_multi_point_getter(&engine, 4.into());
         must_get_none(&mut getter, b"a");

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -5,7 +5,9 @@ mod forward;
 
 use engine::IterOption;
 use engine_traits::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
+use keys::DATA_PREFIX_KEY;
 use kvproto::kvrpcpb::{ExtraOp, IsolationLevel};
+use tikv_util::keybuilder::KeyBuilder;
 use txn_types::{Key, TimeStamp, TsSet, Value, Write, WriteRef, WriteType};
 
 use self::backward::BackwardKvScanner;
@@ -354,11 +356,33 @@ pub fn has_data_in_range<S: Snapshot>(
     right: &Key,
     statistic: &mut CfStatistics,
 ) -> Result<bool> {
-    let iter_opt = IterOption::new(None, None, true);
+    let iter_opt = IterOption::new(
+        None,
+        Some(KeyBuilder::from_slice(
+            right.as_encoded(),
+            DATA_PREFIX_KEY.len(),
+            0,
+        )),
+        true,
+    )
+    .set_max_skippable_internal_keys(100);
     let mut iter = snapshot.iter_cf(cf, iter_opt, ScanMode::Forward)?;
-    if iter.seek(left, statistic)? {
-        if iter.key(statistic) < right.as_encoded().as_slice() {
+    match iter.seek(left, statistic) {
+        Ok(valid) => {
+            if valid {
+                if iter.key(statistic) < right.as_encoded().as_slice() {
+                    return Ok(true);
+                }
+            }
+        }
+        Err(e)
+            if e.to_string()
+                .contains("Result incomplete: Too many internal keys skipped") =>
+        {
             return Ok(true);
+        }
+        err @ Err(_) => {
+            err?;
         }
     }
     Ok(false)

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -405,7 +405,7 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
 
     /// Calls the callback with an error.
     fn finish_with_err(&self, cid: u64, err: Error) {
-        debug!("write command finished with error"; "cid" => cid);
+        debug!("write command finished with error"; "cid" => cid, "err" => ?err);
         let tctx = self.inner.dequeue_task_context(cid);
 
         SCHED_STAGE_COUNTER_VEC.get(tctx.tag).error.inc();

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -745,6 +745,7 @@ mod tests {
             Ok(Cursor::new(
                 MockRangeSnapshotIter::default(),
                 ScanMode::Forward,
+                false,
             ))
         }
         fn iter_cf(
@@ -756,6 +757,7 @@ mod tests {
             Ok(Cursor::new(
                 MockRangeSnapshotIter::default(),
                 ScanMode::Forward,
+                false,
             ))
         }
         fn lower_bound(&self) -> Option<&[u8]> {


### PR DESCRIPTION
Cherry-pick of #8514

### What problem does this PR solve?

optimize seek write when there are too many tombstones.
Fix https://github.com/tikv/tikv/issues/8486


### What is changed and how it works?

Three optimizations:
- for batch-get and coprocessor(point-get), use prefix_seek and prefix_same_as_start to get seek every key for write cf, so it can skip tombstones of other keys.
- for prewrite, when calculating `has_data_in_range` use `max-skippable-internals-keys` to avoid seek too many tombstones.
- check key order before calling `near_seek` for `ScanMode::Mixed` which save one seek() and several prev() calls

#### batch-get before and after
![image](https://user-images.githubusercontent.com/13497871/91380907-b33b5e80-e858-11ea-96ef-349b27dd69c7.png)
#### prewrite before and after
<img width="920" alt="截屏2020-08-27 上午11 38 23" src="https://user-images.githubusercontent.com/13497871/91381818-dbc45800-e85a-11ea-9afe-99e8fc1246b8.png">
(before has no tombstone statistics for seek, actually there are a lot) 

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- Optimize seek write for many tombstones