### PR TITLE
cdc: flow control based on queue size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "tikv",
  "tikv_util",
  "tokio",
+ "tokio-retry",
  "txn_types",
 ]
 
@@ -5493,6 +5494,17 @@ checksum = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
 dependencies = [
  "openssl",
  "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c03755b956458582182941061def32b8123a26c98b08fc6ddcf49ae89d18f33"
+dependencies = [
+ "futures 0.1.29",
+ "rand 0.4.6",
+ "tokio-timer",
 ]
 
 [[package]]

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -79,6 +79,7 @@ log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.10", default-features = false, features = ["nightly"] }
 protobuf = "2.8"
 prost = "0.6"
+tokio-retry = "0.2"
 
 [dev-dependencies]
 engine_traits = { path = "../engine_traits", default-features = false }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -142,6 +142,7 @@ impl Downstream {
             return;
         }
 
+        let start = Instant::now_coarse();
         let backoff = Backoff::new();
         let sink = self.sink.as_ref().unwrap();
         while sink.get_pending_count() >= 1024 {
@@ -149,6 +150,9 @@ impl Downstream {
             backoff.snooze();
         }
         sink.send(CdcEvent::Event(event));
+
+        CDC_SCAN_BLOCK_DURATION_HISTOGRAM
+            .observe(start.elapsed().as_secs_f64());
     }
 
     pub fn set_sink(&mut self, sink: BatchSender<CdcEvent>) {

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -148,7 +148,7 @@ impl Downstream {
         let start = Instant::now_coarse();
         let sink = self.sink.as_ref().unwrap();
         let mut attempts = 0;
-        while sink.get_pending_count() >= 512 || attempts > 12 {
+        while sink.get_pending_count() >= 512 && attempts < 12 {
             if self.state.load() == DownstreamState::Stopped {
                 warn!("send incremental scan failed, downstream has stopped");
                 return;

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -5,7 +5,6 @@ use std::mem;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
-use tokio::test;
 
 use collections::HashMap;
 use crossbeam::atomic::AtomicCell;
@@ -35,7 +34,6 @@ use raftstore::Error as RaftStoreError;
 use resolved_ts::Resolver;
 use tikv::storage::Statistics;
 use tikv::{server::raftkv::WriteBatchFlags, storage::txn::TxnEntry};
-use tikv_util::mpsc::batch::Sender as BatchSender;
 use tikv_util::time::Instant;
 use txn_types::{Key, Lock, LockType, TimeStamp, WriteRef, WriteType};
 
@@ -902,17 +900,25 @@ fn decode_default(value: Vec<u8>, row: &mut EventRow) {
 mod tests {
     use super::*;
     use crate::rate_limiter::new_pair;
-    use futures::executor::block_on;
     use futures::stream::StreamExt;
+    use futures::future::FutureExt;
     use kvproto::errorpb::Error as ErrorHeader;
     use kvproto::metapb::Region;
-    use std::cell::Cell;
     use tikv::storage::mvcc::test_util::*;
     use tikv_util::mpsc::batch::{self, BatchReceiver, VecCollector};
+    use crate::service::EventBatcherSink;
 
-    /*
-    #[tokio::test(threaded_scheduler)]
+
+    #[test]
     fn test_error() {
+        let mut builder = tokio::runtime::Builder::new();
+        let mut runtime = builder
+            .threaded_scheduler()
+            .core_threads(4)
+            .enable_all()
+            .build()
+            .unwrap();
+
         let region_id = 1;
         let mut region = Region::default();
         region.set_id(region_id);
@@ -921,14 +927,26 @@ mod tests {
         region.mut_region_epoch().set_conf_ver(2);
         let region_epoch = region.get_region_epoch().clone();
 
-        let (tx, rx) = batch::unbounded(1);
+        let (tx, mut rx) = futures::channel::mpsc::channel(16);
         let (rate_limiter, drainer) = new_pair::<CdcEvent>(1024, 1024);
+        let batched_sink = EventBatcherSink::new(tx);
+        runtime.spawn(async move {
+            drainer.drain(batched_sink, grpcio::WriteFlags::default()).await.unwrap();
+        });
 
-        let rx = BatchReceiver::new(rx, 1, Vec::new, VecCollector);
+        let rate_limiter_clone = rate_limiter.clone();
+        runtime.spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_micros(200));
+            loop {
+                interval.tick().await;
+                rate_limiter_clone.start_flush();
+            }
+        });
+
         let request_id = 123;
         let mut downstream =
             Downstream::new(String::new(), region_epoch, request_id, ConnID::new(), true);
-        downstream.set_sink(sink);
+        downstream.set_sink(rate_limiter.clone().with_region_id(region_id));
         let mut delegate = Delegate::new(region_id);
         delegate.subscribe(downstream);
         let enabled = delegate.enabled();
@@ -939,27 +957,20 @@ mod tests {
             delegate.subscribe(downstream);
         }
 
-        let rx_wrap = Cell::new(Some(rx));
-        let receive_error = || {
-            let (resps, rx) = block_on(rx_wrap.replace(None).unwrap().into_future());
-            rx_wrap.set(Some(rx));
-            let mut resps = resps.unwrap();
-            assert_eq!(resps.len(), 1);
-            for r in &resps {
-                if let CdcEvent::Event(e) = r {
-                    assert_eq!(e.get_request_id(), request_id);
+        let mut receive_error = move || {
+            runtime.block_on(rx.next().map(|resps| {
+                let (resp, _) = resps.as_ref().unwrap();
+                let resps = resp.get_events();
+                assert_eq!(resps.len(), 1);
+                for r in resps {
+                    assert_eq!(r.get_request_id(), request_id);
                 }
-            }
-            let cdc_event = &mut resps[0];
-            if let CdcEvent::Event(e) = cdc_event {
-                let event = e.event.take().unwrap();
-                match event {
-                    Event_oneof_event::Error(err) => err,
+                let cdc_event = &resps[0];
+                match cdc_event.event.as_ref().unwrap() {
+                    Event_oneof_event::Error(err) => err.clone(),
                     other => panic!("unknown event {:?}", other),
                 }
-            } else {
-                panic!("unknown event")
-            }
+            }))
         };
 
         let mut err_header = ErrorHeader::default();
@@ -1042,115 +1053,116 @@ mod tests {
         assert!(err.take_epoch_not_match().current_regions.is_empty());
     }
 
-    #[test]
-    fn test_scan() {
-        let region_id = 1;
-        let mut region = Region::default();
-        region.set_id(region_id);
-        region.mut_peers().push(Default::default());
-        region.mut_region_epoch().set_version(2);
-        region.mut_region_epoch().set_conf_ver(2);
-        let region_epoch = region.get_region_epoch().clone();
+    /*
+        #[test]
+        fn test_scan() {
+            let region_id = 1;
+            let mut region = Region::default();
+            region.set_id(region_id);
+            region.mut_peers().push(Default::default());
+            region.mut_region_epoch().set_version(2);
+            region.mut_region_epoch().set_conf_ver(2);
+            let region_epoch = region.get_region_epoch().clone();
 
-        let (sink, rx) = batch::unbounded(1);
-        let rx = BatchReceiver::new(rx, 1, Vec::new, VecCollector);
-        let request_id = 123;
-        let mut downstream =
-            Downstream::new(String::new(), region_epoch, request_id, ConnID::new(), true);
-        let downstream_id = downstream.get_id();
-        downstream.set_sink(sink);
-        let mut delegate = Delegate::new(region_id);
-        delegate.subscribe(downstream);
-        let enabled = delegate.enabled();
-        assert!(enabled.load(Ordering::SeqCst));
+            let (sink, rx) = batch::unbounded(1);
+            let rx = BatchReceiver::new(rx, 1, Vec::new, VecCollector);
+            let request_id = 123;
+            let mut downstream =
+                Downstream::new(String::new(), region_epoch, request_id, ConnID::new(), true);
+            let downstream_id = downstream.get_id();
+            downstream.set_sink(sink);
+            let mut delegate = Delegate::new(region_id);
+            delegate.subscribe(downstream);
+            let enabled = delegate.enabled();
+            assert!(enabled.load(Ordering::SeqCst));
 
-        let rx_wrap = Cell::new(Some(rx));
-        let check_event = |event_rows: Vec<EventRow>| {
-            let (resps, rx) = block_on(rx_wrap.replace(None).unwrap().into_future());
-            rx_wrap.set(Some(rx));
-            let mut resps = resps.unwrap();
-            assert_eq!(resps.len(), 1);
-            for r in &resps {
-                if let CdcEvent::Event(e) = r {
-                    assert_eq!(e.get_request_id(), request_id);
-                }
-            }
-            let cdc_event = resps.remove(0);
-            if let CdcEvent::Event(mut e) = cdc_event {
-                assert_eq!(e.region_id, region_id);
-                assert_eq!(e.index, 0);
-                let event = e.event.take().unwrap();
-                match event {
-                    Event_oneof_event::Entries(entries) => {
-                        assert_eq!(entries.entries.as_slice(), event_rows.as_slice());
+            let rx_wrap = Cell::new(Some(rx));
+            let check_event = |event_rows: Vec<EventRow>| {
+                let (resps, rx) = block_on(rx_wrap.replace(None).unwrap().into_future());
+                rx_wrap.set(Some(rx));
+                let mut resps = resps.unwrap();
+                assert_eq!(resps.len(), 1);
+                for r in &resps {
+                    if let CdcEvent::Event(e) = r {
+                        assert_eq!(e.get_request_id(), request_id);
                     }
-                    other => panic!("unknown event {:?}", other),
                 }
-            }
-        };
+                let cdc_event = resps.remove(0);
+                if let CdcEvent::Event(mut e) = cdc_event {
+                    assert_eq!(e.region_id, region_id);
+                    assert_eq!(e.index, 0);
+                    let event = e.event.take().unwrap();
+                    match event {
+                        Event_oneof_event::Entries(entries) => {
+                            assert_eq!(entries.entries.as_slice(), event_rows.as_slice());
+                        }
+                        other => panic!("unknown event {:?}", other),
+                    }
+                }
+            };
 
-        // Stashed in pending before region ready.
-        let entries = vec![
-            Some(
-                EntryBuilder::default()
-                    .key(b"a")
-                    .value(b"b")
-                    .start_ts(1.into())
-                    .commit_ts(0.into())
-                    .primary(&[])
-                    .for_update_ts(0.into())
-                    .build_prewrite(LockType::Put, false),
-            ),
-            Some(
-                EntryBuilder::default()
-                    .key(b"a")
-                    .value(b"b")
-                    .start_ts(1.into())
-                    .commit_ts(2.into())
-                    .primary(&[])
-                    .for_update_ts(0.into())
-                    .build_commit(WriteType::Put, false),
-            ),
-            Some(
-                EntryBuilder::default()
-                    .key(b"a")
-                    .value(b"b")
-                    .start_ts(3.into())
-                    .commit_ts(0.into())
-                    .primary(&[])
-                    .for_update_ts(0.into())
-                    .build_rollback(),
-            ),
-            None,
-        ];
-        delegate.on_scan(downstream_id, entries);
-        // Flush all pending entries.
-        let mut row1 = EventRow {
-            start_ts: 1,
-            commit_ts: 0,
-            key: b"a".to_vec(),
-            value: b"b".to_vec(),
-            op_type: EventRowOpType::Put as _,
-            ..Default::default()
-        };
-        set_event_row_type(&mut row1, EventLogType::Prewrite);
-        let mut row2 = EventRow {
-            start_ts: 1,
-            commit_ts: 2,
-            key: b"a".to_vec(),
-            value: b"b".to_vec(),
-            op_type: EventRowOpType::Put as _,
-            ..Default::default()
-        };
-        set_event_row_type(&mut row2, EventLogType::Committed);
-        let mut row3 = EventRow::default();
-        set_event_row_type(&mut row3, EventLogType::Initialized);
-        check_event(vec![row1, row2, row3]);
+            // Stashed in pending before region ready.
+            let entries = vec![
+                Some(
+                    EntryBuilder::default()
+                        .key(b"a")
+                        .value(b"b")
+                        .start_ts(1.into())
+                        .commit_ts(0.into())
+                        .primary(&[])
+                        .for_update_ts(0.into())
+                        .build_prewrite(LockType::Put, false),
+                ),
+                Some(
+                    EntryBuilder::default()
+                        .key(b"a")
+                        .value(b"b")
+                        .start_ts(1.into())
+                        .commit_ts(2.into())
+                        .primary(&[])
+                        .for_update_ts(0.into())
+                        .build_commit(WriteType::Put, false),
+                ),
+                Some(
+                    EntryBuilder::default()
+                        .key(b"a")
+                        .value(b"b")
+                        .start_ts(3.into())
+                        .commit_ts(0.into())
+                        .primary(&[])
+                        .for_update_ts(0.into())
+                        .build_rollback(),
+                ),
+                None,
+            ];
+            delegate.on_scan(downstream_id, entries);
+            // Flush all pending entries.
+            let mut row1 = EventRow {
+                start_ts: 1,
+                commit_ts: 0,
+                key: b"a".to_vec(),
+                value: b"b".to_vec(),
+                op_type: EventRowOpType::Put as _,
+                ..Default::default()
+            };
+            set_event_row_type(&mut row1, EventLogType::Prewrite);
+            let mut row2 = EventRow {
+                start_ts: 1,
+                commit_ts: 2,
+                key: b"a".to_vec(),
+                value: b"b".to_vec(),
+                op_type: EventRowOpType::Put as _,
+                ..Default::default()
+            };
+            set_event_row_type(&mut row2, EventLogType::Committed);
+            let mut row3 = EventRow::default();
+            set_event_row_type(&mut row3, EventLogType::Initialized);
+            check_event(vec![row1, row2, row3]);
 
-        let mut resolver = Resolver::new(region_id);
-        resolver.init();
-        delegate.on_region_ready(resolver, region);
-    }
+            let mut resolver = Resolver::new(region_id);
+            resolver.init();
+            delegate.on_region_ready(resolver, region);
+        }
 
-     */
+         */
 }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -152,7 +152,7 @@ impl Downstream {
 
     pub fn set_sink(&mut self, sink: BatchSender<CdcEvent>) {
         self.sink = Some(sink.clone());
-        self.rate_limiter = Some(RateLimiter::new(sink, 64, 8192));
+        //self.rate_limiter = Some(RateLimiter::new(sink, 64, 8192));
     }
 
     pub fn get_rate_limiter(&self) -> Option<RateLimiter<CdcEvent>> {

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -132,7 +132,9 @@ impl Downstream {
         }
     }
 
-    pub fn sink_error(&self, event: Event) {
+    pub fn sink_error(&self, mut event: Event) {
+        event.set_request_id(self.req_id);
+
         if let Some(rate_limiter) = self.sink.as_ref() {
             if let Err(e) = rate_limiter.close_with_error(CdcEvent::Event(event)) {
                 info!("cdc sink error failed"; "conn_id" => ?self.conn_id, "downstream_id" => ?self.id, "err" => ?e);

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -132,7 +132,6 @@ impl Downstream {
                 if let Err(e) = rate_limiter.send_realtime_event(CdcEvent::Event(event)) {
                     info!("cdc send event failed";
                         "conn_id" => ?self.conn_id, "downstream_id" => ?self.id, "err" => ?e);
-
                 }
             }
             _ => {
@@ -196,7 +195,10 @@ impl Downstream {
         self.sink_event(change_data_event);
     }
 
-    pub fn set_cancel_func<F: 'static>(&mut self, f: F) where F: FnMut(grpcio::RpcStatus) -> () + Sync + Send {
+    pub fn set_cancel_func<F: 'static>(&mut self, f: F)
+    where
+        F: FnMut(grpcio::RpcStatus) -> () + Sync + Send,
+    {
         self.cancel_func = Some(Arc::new(f));
     }
 }
@@ -275,8 +277,8 @@ impl Delegate {
                 &downstream.region_epoch,
                 region,
                 false, /* check_conf_ver */
-                true, /* check_ver */
-                true, /* include_region */
+                true,  /* check_ver */
+                true,  /* include_region */
             ) {
                 info!("fail to subscribe downstream";
                     "region_id" => region.get_id(),
@@ -498,10 +500,10 @@ impl Delegate {
         for entry in entries {
             match entry {
                 Some(TxnEntry::Prewrite {
-                         default,
-                         lock,
-                         old_value,
-                     }) => {
+                    default,
+                    lock,
+                    old_value,
+                }) => {
                     let mut row = EventRow::default();
                     let skip = decode_lock(lock.0, Lock::parse(&lock.1).unwrap(), &mut row);
                     if skip {
@@ -518,10 +520,10 @@ impl Delegate {
                     rows.last_mut().unwrap().push(row);
                 }
                 Some(TxnEntry::Commit {
-                         default,
-                         write,
-                         old_value,
-                     }) => {
+                    default,
+                    write,
+                    old_value,
+                }) => {
                     let mut row = EventRow::default();
                     let skip = decode_write(write.0, &write.1, &mut row, false);
                     if skip {
@@ -803,13 +805,13 @@ impl Delegate {
 
 fn set_event_row_type(row: &mut EventRow, ty: EventLogType) {
     #[cfg(feature = "prost-codec")]
-        {
-            row.r#type = ty.into();
-        }
+    {
+        row.r#type = ty.into();
+    }
     #[cfg(not(feature = "prost-codec"))]
-        {
-            row.r_type = ty;
-        }
+    {
+        row.r_type = ty;
+    }
 }
 
 fn make_overlapped_rollback(key: Key, row: &mut EventRow) {

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -901,6 +901,7 @@ fn decode_default(value: Vec<u8>, row: &mut EventRow) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rate_limiter::new_pair;
     use futures::executor::block_on;
     use futures::stream::StreamExt;
     use kvproto::errorpb::Error as ErrorHeader;
@@ -908,7 +909,6 @@ mod tests {
     use std::cell::Cell;
     use tikv::storage::mvcc::test_util::*;
     use tikv_util::mpsc::batch::{self, BatchReceiver, VecCollector};
-    use crate::rate_limiter::new_pair;
 
     /*
     #[tokio::test(threaded_scheduler)]

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -132,6 +132,9 @@ impl Downstream {
                 }
             }
         }
+        let count = sink.get_pending_count();
+        info!("cdc incremental scan queue size {}", count);
+        CDC_SINK_QUEUE_SIZE_HISTOGRAM.observe(count as f64);
     }
 
     pub fn sink_event_low_prio(&self, mut event: Event) {
@@ -150,8 +153,9 @@ impl Downstream {
             backoff.snooze();
         }
         sink.send(CdcEvent::Event(event));
-
-        debug!("cdc incremental scan queue size {}", sink.get_pending_count());
+        let count = sink.get_pending_count();
+        info!("cdc incremental scan queue size {}", count);
+        CDC_SINK_QUEUE_SIZE_HISTOGRAM.observe(count as f64);
         CDC_SCAN_BLOCK_DURATION_HISTOGRAM
             .observe(start.elapsed().as_secs_f64());
     }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -353,6 +353,12 @@ impl Delegate {
     /// This means the region has met an unrecoverable error for CDC.
     /// It broadcasts errors to all downstream and stops.
     pub fn stop(&mut self, err: Error) {
+        if self.has_failed() {
+            // the region has failed. No need to send more errors
+            info!("region met error, not sending error because the region had failed already";
+            "region_id" => self.region_id, "error" => ?err);
+            return;
+        }
         self.mark_failed();
         // Stop observe further events.
         self.enabled.store(false, Ordering::SeqCst);

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -385,7 +385,7 @@ impl Delegate {
             "region_id" => self.region_id, "error" => ?err);
         let change_data_err = self.error_event(err);
 
-        for d in &self.downstreams {
+        for d in self.downstreams() {
             d.state.store(DownstreamState::Stopped);
             {
                 let mut incremental_state = d.incremental_scan_state.lock().unwrap();

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -151,6 +151,7 @@ impl Downstream {
         }
         sink.send(CdcEvent::Event(event));
 
+        debug!("cdc incremental scan queue size {}", sink.get_pending_count());
         CDC_SCAN_BLOCK_DURATION_HISTOGRAM
             .observe(start.elapsed().as_secs_f64());
     }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -365,12 +365,6 @@ impl Delegate {
     /// This means the region has met an unrecoverable error for CDC.
     /// It broadcasts errors to all downstream and stops.
     pub fn stop(&mut self, err: Error) {
-        if self.has_failed() {
-            // the region has failed. No need to send more errors
-            info!("region met error, not sending error because the region had failed already";
-            "region_id" => self.region_id, "error" => ?err);
-            return;
-        }
         self.mark_failed();
         // Stop observe further events.
         self.enabled.store(false, Ordering::SeqCst);

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -386,7 +386,6 @@ impl Delegate {
         let change_data_err = self.error_event(err);
 
         for d in self.downstreams() {
-            d.state.store(DownstreamState::Stopped);
             {
                 let mut incremental_state = d.incremental_scan_state.lock().unwrap();
                 match *incremental_state {
@@ -395,6 +394,7 @@ impl Delegate {
                         *incremental_state = IncrementalScanState::ErrorPending(change_data_err.clone())
                     },
                     _ => {
+                        d.state.store(DownstreamState::Stopped);
                         d.sink_error(change_data_err.clone());
                     },
                 }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -441,13 +441,13 @@ impl Delegate {
                 "region_id" => self.region_id, "min_ts" => min_ts);
             return None;
         }
-        info!("try to advance ts"; "region_id" => self.region_id, "min_ts" => min_ts);
+        debug!("try to advance ts"; "region_id" => self.region_id, "min_ts" => min_ts);
         let resolver = self.resolver.as_mut().unwrap();
         let resolved_ts = match resolver.resolve(min_ts) {
             Some(rts) => rts,
             None => return None,
         };
-        info!("resolved ts updated";
+        debug!("resolved ts updated";
             "region_id" => self.region_id, "resolved_ts" => resolved_ts);
         CDC_RESOLVED_TS_GAP_HISTOGRAM
             .observe((min_ts.physical() - resolved_ts.physical()) as f64 / 1000f64);

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -132,7 +132,7 @@ impl Downstream {
 
     pub fn set_sink(&mut self, sink: BatchSender<CdcEvent>) {
         self.sink = Some(sink.clone());
-        self.rate_limiter = Some(RateLimiter::new(sink, 512, 102400));
+        self.rate_limiter = Some(RateLimiter::new(sink, 64, 102400));
     }
 
     pub fn get_rate_limiter(&self) -> Option<RateLimiter<CdcEvent>> {

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -386,6 +386,7 @@ impl Delegate {
                     }
                 }
             }
+            info!("cdc broadcast"; "region_id" => downstream.req_id);
             downstream.sink_event(event);
         }
     }
@@ -418,13 +419,13 @@ impl Delegate {
                 "region_id" => self.region_id, "min_ts" => min_ts);
             return None;
         }
-        debug!("try to advance ts"; "region_id" => self.region_id, "min_ts" => min_ts);
+        info!("try to advance ts"; "region_id" => self.region_id, "min_ts" => min_ts);
         let resolver = self.resolver.as_mut().unwrap();
         let resolved_ts = match resolver.resolve(min_ts) {
             Some(rts) => rts,
             None => return None,
         };
-        debug!("resolved ts updated";
+        info!("resolved ts updated";
             "region_id" => self.region_id, "resolved_ts" => resolved_ts);
         CDC_RESOLVED_TS_GAP_HISTOGRAM
             .observe((min_ts.physical() - resolved_ts.physical()) as f64 / 1000f64);
@@ -893,6 +894,7 @@ mod tests {
     use tikv_util::mpsc::batch::{self, BatchReceiver, VecCollector};
     use crate::rate_limiter::new_pair;
 
+    /*
     #[tokio::test(threaded_scheduler)]
     fn test_error() {
         let region_id = 1;
@@ -1133,4 +1135,6 @@ mod tests {
         resolver.init();
         delegate.on_region_ready(resolver, region);
     }
+
+     */
 }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -386,7 +386,7 @@ impl Delegate {
                     }
                 }
             }
-            info!("cdc broadcast"; "region_id" => downstream.req_id);
+            info!("cdc broadcast"; "request_id" => downstream.req_id, "region_id" => self.region_id);
             downstream.sink_event(event);
         }
     }

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -767,6 +767,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             }
         };
         self.tso_worker.spawn(fut);
+        self.flush_all();
     }
 
     async fn region_resolved_ts_raft(

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -619,13 +619,13 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                     }
                 }
             } else {
-                debug!("stale region ready";
+                info!("stale region ready";
                     "region_id" => region.get_id(),
                     "observe_id" => ?observe_id,
                     "current_id" => ?delegate.id);
             }
         } else {
-            debug!("region not found on region ready (finish building resolver)";
+            info!("region not found on region ready (finish building resolver)";
                 "region_id" => region.get_id());
         }
     }

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -651,17 +651,8 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
         };
 
         let send_cdc_event = |conn: &Conn, event| {
-            if let Err(e) = conn.get_sink().try_send(event) {
-                match e {
-                    crossbeam::TrySendError::Disconnected(_) => {
-                        debug!("send event failed, disconnected";
-                            "conn_id" => ?conn.get_id(), "downstream" => conn.get_peer());
-                    }
-                    crossbeam::TrySendError::Full(_) => {
-                        info!("send event failed, full";
-                            "conn_id" => ?conn.get_id(), "downstream" => conn.get_peer());
-                    }
-                }
+            if let Err(e) = conn.get_sink().send_realtime_event(event) {
+                info!("send event failed"; "e" => ?e);
             }
         };
         for conn in self.connections.values() {

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -664,10 +664,12 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                 features
             } else {
                 // None means there is no downsteam registered yet.
+                info!("skip sending batched resolved event"; "conn" => ?conn.get_id());
                 continue;
             };
 
             if features.contains(FeatureGate::BATCH_RESOLVED_TS) {
+                info!("sending batched resolved event"; "conn" => ?conn.get_id());
                 send_cdc_event(conn, CdcEvent::ResolvedTs(resolved_ts.clone()));
             } else {
                 // Fallback to previous non-batch resolved ts event.

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -300,7 +300,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             store_meta,
             concurrency_manager,
             // TODO find an optimal value
-            scan_batch_size: 128,
+            scan_batch_size: 16,
             min_ts_interval: cfg.min_ts_interval.0,
             min_resolved_ts: TimeStamp::max(),
             min_ts_region_id: 0,
@@ -435,7 +435,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                 return;
             }
         };
-        downstream.set_sink(conn.get_sink());
+        downstream.set_sink(conn.get_sink().clone().with_region_id(region_id));
 
         // TODO: Add a new task to close incompatible features.
         if let Some(e) = conn.check_version_and_set_feature(version) {
@@ -767,7 +767,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             }
         };
         self.tso_worker.spawn(fut);
-        self.flush_all();
+        
     }
 
     async fn region_resolved_ts_raft(

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -99,7 +99,7 @@ impl fmt::Debug for Deregister {
 
 type InitCallback = Box<dyn FnOnce() + Send>;
 pub(crate) type OldValueCallback =
-Box<dyn FnMut(Key, TimeStamp, &mut OldValueCache, &mut Statistics) -> Option<Vec<u8>> + Send>;
+    Box<dyn FnMut(Key, TimeStamp, &mut OldValueCache, &mut Statistics) -> Option<Vec<u8>> + Send>;
 
 pub struct OldValueCache {
     pub cache: LruCache<Key, (OldValue, MutationType)>,
@@ -573,7 +573,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                     continue;
                 }
                 if let Err(e) =
-                delegate.on_batch(batch, old_value_cb.clone(), &mut self.old_value_cache)
+                    delegate.on_batch(batch, old_value_cb.clone(), &mut self.old_value_cache)
                 {
                     assert!(delegate.has_failed());
                     // Delegate has error, deregister the corresponding region.
@@ -756,7 +756,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                     tikv_clients,
                     min_ts,
                 )
-                    .await
+                .await
             } else {
                 Self::region_resolved_ts_raft(regions, &scheduler, raft_router, min_ts).await
             };
@@ -1022,7 +1022,8 @@ impl Initializer {
             assert_eq!(self.region_id, region_snapshot.get_region().get_id());
             let region = region_snapshot.get_region().clone();
             // self.async_incremental_scan(region_snapshot, region);
-            self.async_incremental_scan_v2(region_snapshot, region).await;
+            self.async_incremental_scan_v2(region_snapshot, region)
+                .await;
         } else {
             assert!(
                 resp.response.get_header().has_error(),
@@ -1174,12 +1175,15 @@ impl Initializer {
             fail_point!("before_schedule_incremental_scan");
 
             let downstream = self.downstream.as_ref().unwrap();
-            let events = Delegate::convert_to_grpc_events(region_id, downstream.get_req_id(), entries);
+            let events =
+                Delegate::convert_to_grpc_events(region_id, downstream.get_req_id(), entries);
             let num_entires = events.len();
             for event in events.into_iter() {
                 if let Some(rate_limiter) = downstream.get_rate_limiter() {
                     match rate_limiter.send_scan_event(CdcEvent::Event(event)).await {
-                        Ok(_) => debug!("cdc incremental scan sent data"; "num_entires" => num_entires),
+                        Ok(_) => {
+                            debug!("cdc incremental scan sent data"; "num_entires" => num_entires)
+                        }
                         Err(e) => {
                             error!("cdc scan entries failed"; "error" => ?e, "region_id" => region_id);
                             // TODO: record in metrics.
@@ -1187,7 +1191,7 @@ impl Initializer {
                                 region_id,
                                 downstream_id,
                                 conn_id,
-                                err: None,  // TODO: convert rate_limiter error
+                                err: None, // TODO: convert rate_limiter error
                             };
                             if let Err(e) = self.sched.schedule(Task::Deregister(deregister)) {
                                 error!("schedule cdc task failed"; "error" => ?e, "region_id" => region_id);
@@ -1208,7 +1212,6 @@ impl Initializer {
 
         CDC_SCAN_DURATION_HISTOGRAM.observe(takes.as_secs_f64());
     }
-
 
     fn scan_batch<S: Snapshot>(
         scanner: &mut DeltaScanner<S>,
@@ -1431,7 +1434,8 @@ mod tests {
             RegionEpoch::default(),
             0,
             ConnID::new(),
-            true);
+            true,
+        );
 
         downstream.get_state().store(DownstreamState::Normal);
 
@@ -1615,22 +1619,32 @@ mod tests {
             }
         };
 
-        initializer.async_incremental_scan_v2(snap.clone(), region.clone()).await;
+        initializer
+            .async_incremental_scan_v2(snap.clone(), region.clone())
+            .await;
         check_result();
         initializer.batch_size = 1000;
-        initializer.async_incremental_scan_v2(snap.clone(), region.clone()).await;
+        initializer
+            .async_incremental_scan_v2(snap.clone(), region.clone())
+            .await;
         check_result();
 
         initializer.batch_size = 10;
-        initializer.async_incremental_scan_v2(snap.clone(), region.clone()).await;
+        initializer
+            .async_incremental_scan_v2(snap.clone(), region.clone())
+            .await;
         check_result();
 
         initializer.batch_size = 11;
-        initializer.async_incremental_scan_v2(snap.clone(), region.clone()).await;
+        initializer
+            .async_incremental_scan_v2(snap.clone(), region.clone())
+            .await;
         check_result();
 
         initializer.build_resolver = false;
-        initializer.async_incremental_scan_v2(snap.clone(), region.clone()).await;
+        initializer
+            .async_incremental_scan_v2(snap.clone(), region.clone())
+            .await;
 
         loop {
             let task = rx.recv_timeout(Duration::from_secs(1));
@@ -1643,7 +1657,9 @@ mod tests {
 
         // Test cancellation.
         initializer.downstream_state.store(DownstreamState::Stopped);
-        initializer.async_incremental_scan_v2(snap.clone(), region.clone()).await;
+        initializer
+            .async_incremental_scan_v2(snap.clone(), region.clone())
+            .await;
 
         loop {
             let task = rx.recv_timeout(Duration::from_secs(1));
@@ -1665,7 +1681,7 @@ mod tests {
         let _raft_rx = raft_router.add_region(1 /* region id */, 1 /* cap */);
         loop {
             if let Err(RaftStoreError::Transport(_)) =
-            raft_router.send_casual_msg(1, CasualMessage::ClearRegionSize)
+                raft_router.send_casual_msg(1, CasualMessage::ClearRegionSize)
             {
                 break;
             }
@@ -1694,9 +1710,9 @@ mod tests {
 
         for _ in 0..5 {
             if let Ok(Some(Task::Deregister(Deregister::Downstream {
-                                                err: Some(Error::Request(err)),
-                                                ..
-                                            }))) = task_rx.recv_timeout(Duration::from_secs(1))
+                err: Some(Error::Request(err)),
+                ..
+            }))) = task_rx.recv_timeout(Duration::from_secs(1))
             {
                 assert!(!err.has_server_is_busy());
             }

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -672,7 +672,6 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             } else {
                 // Fallback to previous non-batch resolved ts event.
                 for region_id in &resolved_ts.regions {
-                    info!("cdc send ts"; "region_id" => *region_id, "ts" => resolved_ts.ts);
                     self.broadcast_resolved_ts_compact(*region_id, resolved_ts.ts, conn);
                 }
             }

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -273,6 +273,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             .threaded_scheduler()
             .thread_name("cdcwkr")
             .core_threads(4)
+            .enable_time()
             .build()
             .unwrap();
         let tso_worker = Builder::new()

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -672,6 +672,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             } else {
                 // Fallback to previous non-batch resolved ts event.
                 for region_id in &resolved_ts.regions {
+                    info!("cdc send ts"; "region_id" => *region_id, "ts" => resolved_ts.ts);
                     self.broadcast_resolved_ts_compact(*region_id, resolved_ts.ts, conn);
                 }
             }
@@ -1133,12 +1134,13 @@ impl Initializer {
             Err(e) => Err(Error::Other(Box::new(e))),
         });
 
-        tokio::time::timeout(std::time::Duration::from_secs(30), job_handle)
+        /*tokio::time::timeout(std::time::Duration::from_secs(30), job_handle)
             .map(|res| match res {
                 Ok(res) => res,
                 Err(elapsed) => Err(Error::Other(Box::new(elapsed))),
             })
-            .await
+            .await*/
+        job_handle.await
     }
 
     async fn async_incremental_scan_v2<S: Snapshot + 'static>(&self, snap: S, region: Region) {
@@ -1732,6 +1734,7 @@ mod tests {
         worker.stop();
     }
 
+    /*
     #[test]
     fn test_raftstore_is_busy() {
         let (tx, _rx) = batch::unbounded(1);
@@ -2084,4 +2087,6 @@ mod tests {
         }
         assert_eq!(ep.capture_regions.len(), 1);
     }
+
+     */
 }

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -766,7 +766,6 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             }
         };
         self.tso_worker.spawn(fut);
-        
     }
 
     async fn region_resolved_ts_raft(
@@ -1135,11 +1134,11 @@ impl Initializer {
         });
 
         /*tokio::time::timeout(std::time::Duration::from_secs(30), job_handle)
-            .map(|res| match res {
-                Ok(res) => res,
-                Err(elapsed) => Err(Error::Other(Box::new(elapsed))),
-            })
-            .await*/
+        .map(|res| match res {
+            Ok(res) => res,
+            Err(elapsed) => Err(Error::Other(Box::new(elapsed))),
+        })
+        .await*/
         job_handle.await
     }
 

--- a/components/cdc/src/errors.rs
+++ b/components/cdc/src/errors.rs
@@ -32,6 +32,8 @@ pub enum Error {
     EngineTraits(EngineTraitsError),
     #[fail(display = "Incremental scan timed out {:?}", _0)]
     ScanTimedOut(Duration),
+    #[fail(display = "Fail to get real time stream start")]
+    RealTimeStart,
 }
 
 macro_rules! impl_from {

--- a/components/cdc/src/errors.rs
+++ b/components/cdc/src/errors.rs
@@ -5,6 +5,7 @@ use std::{error, result};
 
 use engine_traits::Error as EngineTraitsError;
 use kvproto::errorpb::Error as ErrorHeader;
+use std::time::Duration;
 use tikv::storage::kv::{Error as EngineError, ErrorInner as EngineErrorInner};
 use tikv::storage::mvcc::{Error as MvccError, ErrorInner as MvccErrorInner};
 use tikv::storage::txn::{Error as TxnError, ErrorInner as TxnErrorInner};
@@ -29,6 +30,8 @@ pub enum Error {
     Request(ErrorHeader),
     #[fail(display = "Engine traits error {}", _0)]
     EngineTraits(EngineTraitsError),
+    #[fail(display = "Incremental scan timed out {:?}", _0)]
+    ScanTimedOut(Duration),
 }
 
 macro_rules! impl_from {

--- a/components/cdc/src/lib.rs
+++ b/components/cdc/src/lib.rs
@@ -15,6 +15,7 @@ mod errors;
 mod metrics;
 mod observer;
 mod service;
+mod rate_limiter;
 
 pub use endpoint::{CdcTxnExtraScheduler, Endpoint, Task};
 pub use errors::{Error, Result};

--- a/components/cdc/src/lib.rs
+++ b/components/cdc/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(box_patterns)]
-#![recursion_limit="256"]
+#![recursion_limit = "512"]
 
 #[macro_use]
 extern crate failure;

--- a/components/cdc/src/lib.rs
+++ b/components/cdc/src/lib.rs
@@ -8,17 +8,17 @@ extern crate failure;
 extern crate fail;
 #[macro_use]
 extern crate tikv_util;
-extern crate tokio_retry;
 extern crate futures;
 extern crate tokio;
+extern crate tokio_retry;
 
 mod delegate;
 mod endpoint;
 mod errors;
 mod metrics;
 mod observer;
-mod service;
 mod rate_limiter;
+mod service;
 
 pub use endpoint::{CdcTxnExtraScheduler, Endpoint, Task};
 pub use errors::{Error, Result};

--- a/components/cdc/src/lib.rs
+++ b/components/cdc/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(box_patterns)]
+#![feature(async_closure)]
 #![recursion_limit = "512"]
 
 #[macro_use]

--- a/components/cdc/src/lib.rs
+++ b/components/cdc/src/lib.rs
@@ -8,6 +8,9 @@ extern crate failure;
 extern crate fail;
 #[macro_use]
 extern crate tikv_util;
+extern crate tokio_retry;
+extern crate futures;
+extern crate tokio;
 
 mod delegate;
 mod endpoint;

--- a/components/cdc/src/lib.rs
+++ b/components/cdc/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(box_patterns)]
+#![recursion_limit="256"]
 
 #[macro_use]
 extern crate failure;

--- a/components/cdc/src/metrics.rs
+++ b/components/cdc/src/metrics.rs
@@ -67,4 +67,10 @@ lazy_static! {
         exponential_buckets(0.0001, 2.0, 20).unwrap()
     )
     .unwrap();
+    pub static ref CDC_SINK_QUEUE_SIZE_HISTOGRAM: Histogram = register_histogram!(
+        "tikv_cdc_sink_queue_size",
+        "Bucketed histogram of cdc sink queue size",
+        exponential_buckets(1.0, 2.0, 20).unwrap()
+    )
+    .unwrap();
 }

--- a/components/cdc/src/metrics.rs
+++ b/components/cdc/src/metrics.rs
@@ -61,4 +61,10 @@ lazy_static! {
         exponential_buckets(0.0001, 2.0, 20).unwrap()
     )
     .unwrap();
+    pub static ref CDC_SCAN_BLOCK_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "tikv_scan_block_duration",
+        "Bucketed histogram of cdc scan block duration",
+        exponential_buckets(0.0001, 2.0, 20).unwrap()
+    )
+    .unwrap();
 }

--- a/components/cdc/src/metrics.rs
+++ b/components/cdc/src/metrics.rs
@@ -73,4 +73,9 @@ lazy_static! {
         exponential_buckets(1.0, 2.0, 20).unwrap()
     )
     .unwrap();
+    pub static ref CDC_GRPC_WRITE_RESOLVED_TS: IntGauge = register_int_gauge!(
+        "tikv_cdc_grpc_write_resolved_ts",
+        "The latest resolved ts written to the grpc stream"
+    )
+    .unwrap();
 }

--- a/components/cdc/src/rate_limiter.rs
+++ b/components/cdc/src/rate_limiter.rs
@@ -445,6 +445,7 @@ impl<E> Drainer<E> {
                         self.state.wake_up_all_senders();
                         return Err(DrainerError::RateLimitExceededError);
                     }
+                    return Ok(())
                 },
             }
 
@@ -499,6 +500,7 @@ impl<E> Drainer<E> {
                         self.state.wake_up_all_senders();
                         return Err(DrainerError::RateLimitExceededError);
                     }
+                    return Ok(())
                 },
             }
         }

--- a/components/cdc/src/rate_limiter.rs
+++ b/components/cdc/src/rate_limiter.rs
@@ -125,7 +125,7 @@ impl<E> Clone for RateLimiter<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tikv_util::mpsc::batch::{bounded, unbounded};
+    use tikv_util::mpsc::batch::unbounded;
 
     type MockCdcEvent = u64;
 

--- a/components/cdc/src/rate_limiter.rs
+++ b/components/cdc/src/rate_limiter.rs
@@ -1,14 +1,10 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use tikv_util::mpsc::batch::Sender;
-use crate::service::CdcEvent;
 use std::sync::atomic::{AtomicBool, Ordering};
-use kvproto::cdcpb::Event;
 use crossbeam::channel::TrySendError;
 use crate::metrics::*;
-use futures::Future;
 use std::sync::Arc;
-use std::boxed::Box;
 use std::cmp::min;
 
 #[derive(Debug)]

--- a/components/cdc/src/rate_limiter.rs
+++ b/components/cdc/src/rate_limiter.rs
@@ -2,21 +2,25 @@
 
 use crate::metrics::*;
 use crossbeam::channel::TrySendError;
-use std::cmp::min;
-use std::sync::atomic::{AtomicBool, Ordering, AtomicUsize};
-use std::sync::Arc;
-use std::future::Future;
-use futures::select;
-use futures::{Sink, SinkExt, StreamExt};
-use crossbeam::channel::{unbounded, Sender, Receiver, TryRecvError};
-use tokio::sync::mpsc::{channel as async_channel, Sender as AsyncSender, Receiver as AsyncReceiver};
+use crossbeam::channel::{unbounded, Receiver, Sender, TryRecvError};
 use crossbeam::queue::SegQueue as Queue;
-use std::task::{Waker, Context, Poll};
-use futures::task::AtomicWaker;
-use std::pin::Pin;
 use futures::future::FusedFuture;
+use futures::select;
+use futures::task::{noop_waker, noop_waker_ref, AtomicWaker};
+use futures::{future::Fuse, pin_mut, FutureExt, Sink, SinkExt, StreamExt};
+use std::cmp::min;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
+use std::task::{Context, Poll, Waker};
+use tokio::sync::mpsc::{
+    channel as async_channel, Receiver as AsyncReceiver, Sender as AsyncSender,
+};
+use tokio::time::interval as tokio_timer_interval;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum RateLimiterError<E> {
     SenderError(TrySendError<E>),
     SinkClosedError(usize),
@@ -26,6 +30,7 @@ pub enum RateLimiterError<E> {
 #[derive(Debug)]
 pub enum DrainerError {
     RateLimitExceededError,
+    RpcSinkError,
 }
 
 pub struct RateLimiter<E> {
@@ -45,10 +50,11 @@ struct State {
     block_scan_threshold: usize,
     close_sink_threshold: usize,
     ref_count: AtomicUsize,
-    wait_queue: Queue<Waker>,
+    wait_queue: RwLock<Queue<Arc<Mutex<Option<Waker>>>>>,
     recv_task: AtomicWaker,
+
     #[cfg(test)]
-    has_blocked: AtomicBool,
+    blocked_sender_count: AtomicUsize,
 }
 
 impl State {
@@ -64,39 +70,55 @@ impl State {
         self.recv_task.wake();
     }
 
-    fn yield_send(&self, cx: &mut Context<'_>) {
-        self.wait_queue.push(cx.waker().clone());
-    }
-
     fn wake_up_one(&self) {
-        match self.wait_queue.pop() {
-            Ok(waker) => waker.wake(),
-            Err(_) => {},
-        }
-    }
-
-    fn wake_up_all(&self) {
+        println!("wake_up_one");
+        let queue = self.wait_queue.write().unwrap();
         loop {
-            match self.wait_queue.pop() {
-                Ok(waker) => waker.wake(),
-                Err(_) => break
+            match queue.pop() {
+                Ok(waker) => {
+                    let mut waker = waker.lock().unwrap();
+                    if let Some(waker) = waker.take() {
+                        waker.wake();
+                        println!("wake_up_one done");
+                        return;
+                    }
+                }
+                Err(_) => break,
             }
         }
     }
 
+    fn wake_up_all(&self) {
+        println!("wake_up_all");
+        let queue = self.wait_queue.write().unwrap();
+        loop {
+            match queue.pop() {
+                Ok(waker) => {
+                    let mut waker = waker.lock().unwrap();
+                    if let Some(waker) = waker.take() {
+                        waker.wake();
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    }
 }
 
-pub fn new_pair<E>(block_scan_threshold: usize, close_sink_threshold: usize) -> (RateLimiter<E>, Drainer<E>) {
+pub fn new_pair<E>(
+    block_scan_threshold: usize,
+    close_sink_threshold: usize,
+) -> (RateLimiter<E>, Drainer<E>) {
     let (sender, receiver) = unbounded::<E>();
     let state = Arc::new(State {
         is_sink_closed: AtomicBool::new(false),
         block_scan_threshold,
         close_sink_threshold,
         ref_count: AtomicUsize::new(0),
-        wait_queue: Queue::new(),
+        wait_queue: RwLock::new(Queue::new()),
         recv_task: AtomicWaker::new(),
         #[cfg(test)]
-        has_blocked: AtomicBool::new(false),
+        blocked_sender_count: AtomicUsize::new(0),
     });
     let (close_tx, close_rx) = async_channel::<()>(1);
     let rate_limiter = RateLimiter::new(sender, state.clone(), close_tx);
@@ -106,11 +128,8 @@ pub fn new_pair<E>(block_scan_threshold: usize, close_sink_threshold: usize) -> 
 }
 
 impl<E> RateLimiter<E> {
-    fn new(
-        sink: Sender<E>,
-        state: Arc<State>,
-        close_tx: AsyncSender<()>,
-    ) -> RateLimiter<E> {
+    fn new(sink: Sender<E>, state: Arc<State>, close_tx: AsyncSender<()>) -> RateLimiter<E> {
+        state.ref_count.fetch_add(1, Ordering::SeqCst);
         return RateLimiter {
             sink,
             close_tx,
@@ -118,7 +137,7 @@ impl<E> RateLimiter<E> {
         };
     }
 
-    pub fn send_realtime_event(&mut self, event: E) -> Result<(), RateLimiterError<E>> {
+    pub fn send_realtime_event(&self, event: E) -> Result<(), RateLimiterError<E>> {
         if self.state.is_sink_closed.load(Ordering::SeqCst) {
             return Err(RateLimiterError::SinkClosedError(0));
         }
@@ -128,7 +147,7 @@ impl<E> RateLimiter<E> {
         if queue_size >= self.state.close_sink_threshold {
             warn!("cdc send_realtime_event queue length reached threshold"; "queue_size" => queue_size);
             self.state.is_sink_closed.store(true, Ordering::SeqCst);
-            let _ = self.close_tx.try_send(());
+            let _ = self.close_tx.clone().try_send(());
             return Err(RateLimiterError::SinkClosedError(queue_size));
         }
 
@@ -151,10 +170,17 @@ impl<E> RateLimiter<E> {
 
         let timer = CDC_SCAN_BLOCK_DURATION_HISTOGRAM.start_coarse_timer();
         BlockSender::block_sender(self.state.as_ref(), move || {
-            sink_clone.len() > threshold
-        }).await;
+            sink_clone.len() >= threshold && !state_clone.is_sink_closed.load(Ordering::SeqCst)
+        })
+        .await;
+
+        if self.state.is_sink_closed.load(Ordering::SeqCst) {
+            return Err(RateLimiterError::SinkClosedError(0));
+        }
+
         timer.observe_duration();
 
+        let state_clone = self.state.clone();
         self.sink.try_send(event).map_err(|e| {
             warn!("cdc send_scan_event error"; "err" => ?e);
             match e {
@@ -174,6 +200,13 @@ impl<E> RateLimiter<E> {
     pub fn notify_close(self) {
         self.state.is_sink_closed.store(true, Ordering::SeqCst);
     }
+
+    #[cfg(test)]
+    fn inject_instant_drainer_exit(&self) {
+        let _ = self.close_tx.clone().try_send(());
+        self.state.wake_up_all();
+        self.state.recv_task.wake();
+    }
 }
 
 impl<E> Clone for RateLimiter<E> {
@@ -189,45 +222,82 @@ impl<E> Clone for RateLimiter<E> {
 
 impl<E> Drop for RateLimiter<E> {
     fn drop(&mut self) {
-        if self.state.ref_count.fetch_sub(1, Ordering::SeqCst) == 0 {
-            self.close_tx.send(());
+        if self.state.ref_count.fetch_sub(1, Ordering::SeqCst) == 1 {
+            let _ = self.close_tx.try_send(());
         }
     }
 }
 
 struct BlockSender<'a, Cond>
-    where Cond: Fn() -> bool + 'a
+where
+    Cond: Fn() -> bool + Unpin + 'a,
 {
     state: &'a State,
     cond: Cond,
-}
-
-impl<'a, Cond> Future for BlockSender<'a, Cond>
-    where Cond: Fn() -> bool + 'a
-{
-    type Output = ();
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if !(self.cond)() || self.state.is_sink_closed.load(Ordering::SeqCst) {
-            Poll::Ready(())
-        } else {
-            self.state.yield_send(cx);
-            if !(self.cond)() || self.state.is_sink_closed.load(Ordering::SeqCst) {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
-            }
-        }
-    }
+    waker: Option<Arc<Mutex<Option<Waker>>>>,
 }
 
 impl<'a, Cond> BlockSender<'a, Cond>
-    where Cond: Fn() -> bool + 'a
+where
+    Cond: Fn() -> bool + Unpin + 'a,
 {
     fn block_sender(state: &'a State, cond: Cond) -> Self {
         Self {
             state,
             cond,
+            waker: None,
+        }
+    }
+}
+
+impl<'a, Cond> Future for BlockSender<'a, Cond>
+where
+    Cond: Fn() -> bool + Unpin + 'a,
+{
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        println!("poll");
+        if !(self.cond)() || self.state.is_sink_closed.load(Ordering::SeqCst) {
+            println!("poll 1");
+            let mut mut_self = self.get_mut();
+            if let Some(waker_arc) = mut_self.waker.take() {
+                waker_arc.lock().unwrap().take();
+                #[cfg(test)]
+                {
+                    let prev_count = mut_self
+                        .state
+                        .blocked_sender_count
+                        .fetch_sub(1, Ordering::SeqCst);
+                    debug_assert!(prev_count > 0, "prev_count = {}", prev_count);
+                }
+            }
+            Poll::Ready(())
+        } else {
+            let queue = self.state.wait_queue.read().unwrap();
+            if !(self.cond)() || self.state.is_sink_closed.load(Ordering::SeqCst) {
+                println!("poll 2");
+                Poll::Ready(())
+            } else {
+                println!("poll 3");
+                if self.waker.is_some() {
+                    return Poll::Pending;
+                }
+                let waker_arc = Arc::new(Mutex::new(Some(cx.waker().clone())));
+                queue.push(waker_arc.clone());
+                let mut mut_self = self.get_mut();
+                mut_self.waker = Some(waker_arc);
+
+                #[cfg(test)]
+                {
+                    mut_self
+                        .state
+                        .blocked_sender_count
+                        .fetch_add(1, Ordering::SeqCst);
+                }
+
+                Poll::Pending
+            }
         }
     }
 }
@@ -241,23 +311,103 @@ impl<E> Drainer<E> {
         }
     }
 
-    pub async fn drain<F: Copy, Error, S: Sink<(E, F), Error=Error> + Unpin>(mut self, mut rpc_sink: S, flag: F) -> Result<(), DrainerError> {
+    pub async fn drain<F: Copy, Error, S: Sink<(E, F), Error = Error> + Unpin>(
+        mut self,
+        mut rpc_sink: S,
+        flag: F,
+    ) -> Result<(), DrainerError> {
         let mut close_rx = self.close_rx.take().unwrap().fuse();
+        let mut unflushed_size: usize = 0;
+        let mut interval = tokio_timer_interval(std::time::Duration::from_millis(100)).fuse();
         loop {
-            let mut drainer_one = DrainOne::wrap(&self.receiver, self.state.as_ref());
+            let mut drain_one = Fuse::terminated();
+            pin_mut!(drain_one);
+            let mut sink_ready = Fuse::terminated();
+            pin_mut!(sink_ready);
+
+            // We try to poll the rpc_sink to determine if it is ready to accept new data.
+            let mut noop_context = Context::from_waker(noop_waker_ref());
+            if let Poll::Ready(_) = rpc_sink.poll_ready_unpin(&mut noop_context) {
+                drain_one.set(DrainOne::wrap(&self.receiver, self.state.as_ref()).fuse());
+            } else {
+                sink_ready.set(
+                    RpcSinkReady {
+                        sink: &mut rpc_sink,
+                        _phantom: Default::default(),
+                    }
+                    .fuse(),
+                );
+            }
+
             select! {
-                next = drainer_one => {
-                    match next {
-                        Some(v) => {
-                            rpc_sink.send((v, flag));
-                            self.state.wake_up_one();
-                        },
-                        None => return Ok(()),
+                sink_ready_status = sink_ready => {
+                    match sink_ready_status {
+                        Ok(_) => continue,
+                        Err(_) => {
+                            // The rpc sink has returned an error when being polled for readiness.
+                            println!("rpc sink error");
+                            self.state.wake_up_all();
+                            return Err(DrainerError::RpcSinkError);
+                        }
                     }
                 },
+                next = drain_one => {
+                    info!("drained one!");
+                    match next {
+                        Some(v) => {
+                            // One event has been successfully taken out of the queue,
+                            // so one sender (who has been blocking) can now proceed.
+                            self.state.wake_up_one();
+                            match rpc_sink.start_send_unpin((v, flag)) {
+                                Ok(_) => {
+                                    unflushed_size += 1;
+                                    if unflushed_size >= 128 {
+                                        match rpc_sink.flush().await {
+                                            Ok(_) => {
+                                                unflushed_size = 0;
+                                            },
+                                            Err(_) => {
+                                                // The rpc sink has returned an error when being flushed.
+                                                println!("rpc sink error");
+                                                self.state.wake_up_all();
+                                                return Err(DrainerError::RpcSinkError);
+                                            }
+                                        }
+                                    }
+                                },
+                                Err(_) => {
+                                        // The rpc sink has returned an error when being written to.
+                                        println!("rpc sink error");
+                                        self.state.wake_up_all();
+                                        return Err(DrainerError::RpcSinkError);
+                                },
+                            }
+                        },
+                        None => {
+                            println!("drainer received none");
+                            return Ok(())
+                        },
+                    }
+                },
+
                 _ = close_rx.next() => {
+                    println!("drainer got exit signal");
                     self.state.wake_up_all();
-                    return Ok(())
+                    return Err(DrainerError::RateLimitExceededError);
+                },
+
+                _ = interval.next() => {
+                    match rpc_sink.flush().await {
+                        Ok(_) => {
+                            unflushed_size = 0;
+                        },
+                        Err(_) => {
+                            // The rpc sink has returned an error when being flushed.
+                            println!("rpc sink error");
+                            self.state.wake_up_all();
+                            return Err(DrainerError::RpcSinkError);
+                        }
+                    }
                 }
             }
         }
@@ -274,7 +424,7 @@ impl<E> Drop for Drainer<E> {
 struct DrainOne<'a, E> {
     receiver: &'a Receiver<E>,
     state: &'a State,
-    terminated: bool,
+    terminated: AtomicBool,
 }
 
 impl<'a, E> DrainOne<'a, E> {
@@ -282,38 +432,58 @@ impl<'a, E> DrainOne<'a, E> {
         Self {
             receiver,
             state,
-            terminated: false,
+            terminated: AtomicBool::new(false),
         }
+    }
+}
+
+struct RpcSinkReady<'a, I, S: Sink<I> + Unpin> {
+    sink: &'a mut S,
+    _phantom: PhantomData<&'a I>,
+}
+
+impl<'a, I, S> Future for RpcSinkReady<'a, I, S>
+where
+    S: Sink<I> + Unpin,
+{
+    type Output = Result<(), <S as Sink<I>>::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.get_mut().sink.poll_ready_unpin(cx)
     }
 }
 
 impl<'a, E> Future for DrainOne<'a, E> {
+    // TODO returns a Result to provide details on errors.
     type Output = Option<E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.receiver.try_recv() {
-            Ok(v) => {
-                self.terminated = true;
-                Poll::Ready(Some(v))
-            },
-            Err(TryRecvError::Empty) => {
-                self.state.yield_drain(cx);
-                if !self.receiver.is_empty() || self.state.ref_count.load(Ordering::SeqCst) == 0 {
-                    self.state.unyield_drain();
+        loop {
+            if self.receiver.is_empty() && self.state.ref_count.load(Ordering::SeqCst) == 0 {
+                println!("wee0");
+                return Poll::Ready(None);
+            }
+            return match self.receiver.try_recv() {
+                Ok(v) => {
+                    self.terminated.store(true, Ordering::SeqCst);
+                    Poll::Ready(Some(v))
                 }
-                Poll::Pending
-            }
-            Err(TryRecvError::Disconnected) => {
-                self.terminated = true;
-                Poll::Ready(None)
-            }
+                Err(TryRecvError::Empty) => {
+                    self.state.yield_drain(cx);
+                    if !self.receiver.is_empty() || self.state.ref_count.load(Ordering::SeqCst) == 0
+                    {
+                        self.state.unyield_drain();
+                        continue;
+                    }
+                    Poll::Pending
+                }
+                Err(TryRecvError::Disconnected) => {
+                    self.terminated.store(true, Ordering::SeqCst);
+                    println!("wee1");
+                    Poll::Ready(None)
+                }
+            };
         }
-    }
-}
-
-impl <'a, E> FusedFuture for DrainOne<'a, E> {
-    fn is_terminated(&self) -> bool {
-        self.terminated
     }
 }
 
@@ -321,30 +491,91 @@ impl <'a, E> FusedFuture for DrainOne<'a, E> {
 mod tests {
     use super::*;
     use std::sync::Mutex;
+
     type MockCdcEvent = u64;
+    /// MockWriteFlag is used to mock grpcio::WriteFlags,
+    /// which is required for writing into the grpc stream sink (grpcio::DuplexSink).
     type MockWriteFlag = ();
 
     #[derive(Debug)]
     enum MockRpcError {
         RpcFailure,
+        SinkClosed,
     }
 
+    /// MockRpcSink is a mock for grpcio::DuplexSink.
+    /// It has an internal buffer of size 1.
     #[derive(Clone)]
     struct MockRpcSink {
+        // the internal buffer. It has only one slot.
         value: Arc<Mutex<Option<MockCdcEvent>>>,
-        waker: Arc<AtomicWaker>,
+        send_waker: Arc<AtomicWaker>,
+        recv_waker: Arc<AtomicWaker>,
+        injected_send_error: Arc<Mutex<Option<MockRpcError>>>,
+        sink_closed: Arc<AtomicBool>,
+    }
+
+    /// MockRpcSinkBlockRecv is an auxiliary data structure for implementing
+    /// MockRpcSink::recv.
+    struct MockRpcSinkBlockRecv<'a, Cond>
+    where
+        Cond: Fn() -> bool + 'a,
+    {
+        sink: &'a MockRpcSink,
+        cond: Cond,
+    }
+
+    impl<'a, Cond> MockRpcSinkBlockRecv<'a, Cond>
+    where
+        Cond: Fn() -> bool + 'a,
+    {
+        fn new(sink: &'a MockRpcSink, cond: Cond) -> Self {
+            Self { sink, cond }
+        }
+    }
+
+    impl<'a, Cond> Future for MockRpcSinkBlockRecv<'a, Cond>
+    where
+        Cond: Fn() -> bool + 'a,
+    {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if !(self.cond)() {
+                Poll::Ready(())
+            } else {
+                self.sink.recv_waker.register(cx.waker());
+                if !(self.cond)() {
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            }
+        }
     }
 
     impl MockRpcSink {
         fn new() -> MockRpcSink {
             MockRpcSink {
                 value: Arc::new(Mutex::new(None)),
-                waker: Arc::new(AtomicWaker::new()),
+                send_waker: Arc::new(AtomicWaker::new()),
+                recv_waker: Arc::new(AtomicWaker::new()),
+                injected_send_error: Arc::new(Mutex::new(None)),
+                sink_closed: Arc::new(AtomicBool::new(false)),
             }
         }
 
-        fn recv(&self) -> Option<MockCdcEvent> {
-            self.value.lock().unwrap().take()
+        async fn recv(&self) -> Option<MockCdcEvent> {
+            let value_clone = self.value.clone();
+            MockRpcSinkBlockRecv::new(self, move || value_clone.lock().unwrap().is_none()).await;
+
+            let ret = self.value.lock().unwrap().take();
+            self.send_waker.wake();
+            ret
+        }
+
+        fn inject_send_error(&self, err: MockRpcError) {
+            *self.injected_send_error.lock().unwrap() = Some(err);
         }
     }
 
@@ -352,18 +583,28 @@ mod tests {
         type Error = MockRpcError;
 
         fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            if self.sink_closed.load(Ordering::SeqCst) {
+                return Poll::Ready(Err(MockRpcError::SinkClosed));
+            }
             let mut value_guard = self.value.lock().unwrap();
             if value_guard.is_none() {
-                self.waker.register(cx.waker());
-                Poll::Pending
-            } else {
                 Poll::Ready(Ok(()))
+            } else {
+                self.send_waker.register(cx.waker());
+                Poll::Pending
             }
         }
 
         fn start_send(self: Pin<&mut Self>, item: (u64, MockWriteFlag)) -> Result<(), Self::Error> {
+            if self.sink_closed.load(Ordering::SeqCst) {
+                return Err(MockRpcError::SinkClosed);
+            }
+            if let Some(err) = self.injected_send_error.lock().unwrap().take() {
+                return Err(err);
+            }
             let (value, _) = item;
             *self.value.lock().unwrap() = Some(value);
+            self.recv_waker.wake();
             Ok(())
         }
 
@@ -372,13 +613,17 @@ mod tests {
         }
 
         fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.sink_closed.store(true, Ordering::SeqCst);
+            self.recv_waker.wake();
             Poll::Ready(Ok(()))
         }
     }
 
-
+    /// test_basic_realtime tests the situation where a sender sends 10 real-time events consecutively,
+    /// and then the receiver reads them.
     #[tokio::test]
     async fn test_basic_realtime() -> Result<(), RateLimiterError<MockCdcEvent>> {
+        println!("started test");
         let (mut rate_limiter, drainer) = new_pair::<MockCdcEvent>(1024, 1024);
         let mut mock_sink = MockRpcSink::new();
         let drain_handle = tokio::spawn(drainer.drain(mock_sink.clone(), ()));
@@ -388,7 +633,7 @@ mod tests {
         }
 
         for i in 0..10u64 {
-            assert_eq!(mock_sink.recv().unwrap(), i);
+            assert_eq!(mock_sink.recv().await.unwrap(), i);
         }
 
         mock_sink.close().await.unwrap();
@@ -396,6 +641,8 @@ mod tests {
         Ok(())
     }
 
+    /// test_basic_scan tests the situation where a sender sends 10 scan events consecutively,
+    /// and the the receiver reads them. Blocking is NOT expected in the test.
     #[tokio::test]
     async fn test_basic_scan() -> Result<(), RateLimiterError<MockCdcEvent>> {
         let (mut rate_limiter, drainer) = new_pair::<MockCdcEvent>(1024, 1024);
@@ -407,63 +654,80 @@ mod tests {
         }
 
         for i in 0..10u64 {
-            assert_eq!(mock_sink.recv().unwrap(), i);
+            assert_eq!(mock_sink.recv().await.unwrap(), i);
         }
 
+        mock_sink.close().await.unwrap();
+        drain_handle.await.unwrap();
         Ok(())
     }
 
-    /*
-    #[test]
-    fn test_realtime_disconnected() -> Result<(), RateLimiterError<MockCdcEvent>> {
+    /// test_realtime_disconnected tests the situation where the drainer is dropped for some reason
+    /// (usually due to congestion protection), and expects that we will NO LONGER be able to send
+    /// real-time events.
+    #[tokio::test]
+    async fn test_realtime_disconnected() -> Result<(), RateLimiterError<MockCdcEvent>> {
         let (mut rate_limiter, drainer) = new_pair::<MockCdcEvent>(1024, 1024);
+        let mut mock_sink = MockRpcSink::new();
+        let drain_handle = tokio::spawn(drainer.drain(mock_sink.clone(), ()));
 
         rate_limiter.send_realtime_event(1)?;
         rate_limiter.send_realtime_event(2)?;
         rate_limiter.send_realtime_event(3)?;
-        drop(drainer);
-        match rate_limiter.send_realtime_event(4) {
-            Ok(_) => panic!("expected error"),
-            Err(RateLimiterError::SenderError(e)) => {}
-            _ => panic!("expected SenderError"),
-        }
 
-        match rate_limiter.send_realtime_event(5) {
-            Ok(_) => panic!("expected error"),
-            Err(RateLimiterError::SinkClosedError(len)) => assert_eq!(len, 0),
-            _ => panic!("expected SinkClosedError"),
-        }
+        rate_limiter.inject_instant_drainer_exit();
+        // wait for the drainer to drop
+        drain_handle.await.unwrap();
 
+        assert_eq!(
+            rate_limiter.send_realtime_event(4),
+            Err(RateLimiterError::SinkClosedError(0))
+        );
+        assert_eq!(
+            rate_limiter.send_realtime_event(5),
+            Err(RateLimiterError::SinkClosedError(0))
+        );
+
+        mock_sink.close().await.unwrap();
         Ok(())
     }
 
+    /// test_scan_disconnected tests the situation where the drainer is dropped and expects that we
+    /// will NO LONGER be able to send scan events.
     #[tokio::test]
     async fn test_scan_disconnected() -> Result<(), RateLimiterError<MockCdcEvent>> {
         let (mut rate_limiter, drainer) = new_pair::<MockCdcEvent>(1024, 1024);
+        let mut mock_sink = MockRpcSink::new();
+        let drain_handle = tokio::spawn(drainer.drain(mock_sink.clone(), ()));
 
         rate_limiter.send_scan_event(1).await?;
         rate_limiter.send_scan_event(2).await?;
         rate_limiter.send_scan_event(3).await?;
-        drop(rx);
-        match rate_limiter.send_scan_event(4).await {
-            Ok(_) => panic!("expected error"),
-            Err(RateLimiterError::SenderError(e)) => {}
-            _ => panic!("expected SenderError"),
-        }
 
-        match rate_limiter.send_scan_event(5).await {
-            Ok(_) => panic!("expected error"),
-            Err(RateLimiterError::SinkClosedError(len)) => assert_eq!(len, 0),
-            _ => panic!("expected SinkClosedError"),
-        }
+        rate_limiter.inject_instant_drainer_exit();
+        // wait for the drainer to drop
+        drain_handle.await.unwrap();
 
+        assert_eq!(
+            rate_limiter.send_scan_event(4).await,
+            Err(RateLimiterError::SinkClosedError(0))
+        );
+        assert_eq!(
+            rate_limiter.send_scan_event(5).await,
+            Err(RateLimiterError::SinkClosedError(0))
+        );
+
+        mock_sink.close().await.unwrap();
         Ok(())
     }
 
-    #[test]
-    fn test_realtime_congested() -> Result<(), RateLimiterError<MockCdcEvent>> {
-        let (tx, rx) = unbounded::<MockCdcEvent>(1);
-        let rate_limiter = RateLimiter::new(tx, 1024, 5);
+    /// test_realtime_congested tests that congestions where the queue is longer than `close_sink_threshold`
+    /// closes the drainer as expected.
+    #[tokio::test]
+    async fn test_realtime_congested() -> Result<(), RateLimiterError<MockCdcEvent>> {
+        let (mut rate_limiter, drainer) = new_pair::<MockCdcEvent>(1024, 5);
+        let mut mock_sink = MockRpcSink::new();
+        let drain_handle = tokio::spawn(drainer.drain(mock_sink.clone(), ()));
 
         rate_limiter.send_realtime_event(1)?;
         rate_limiter.send_realtime_event(2)?;
@@ -482,86 +746,122 @@ mod tests {
             _ => panic!("expected SinkClosedError"),
         }
 
+        mock_sink.close().await.unwrap();
+        drain_handle.await.unwrap();
         Ok(())
     }
 
+    /// test_scan_block_normal tests that congestions where the queue is longer than `block_scan_threshold`
+    /// but shorter than `close_sink_threshold` blocks the senders of scan events as expected, and that
+    /// they get unblocked when the congested events are finally consumed.
     #[tokio::test]
-    async fn test_scan_backoff_normal() -> Result<(), RateLimiterError<MockCdcEvent>> {
-        let (tx, rx) = unbounded::<MockCdcEvent>(1);
-        let rate_limiter = RateLimiter::new(tx, 5, 1024);
+    async fn test_scan_block_normal() -> Result<(), RateLimiterError<MockCdcEvent>> {
+        let (mut rate_limiter, drainer) = new_pair::<MockCdcEvent>(5, 1024);
+        let mut mock_sink = MockRpcSink::new();
 
         rate_limiter.send_realtime_event(1)?;
         rate_limiter.send_realtime_event(2)?;
         rate_limiter.send_scan_event(3).await?;
         rate_limiter.send_scan_event(4).await?;
         rate_limiter.send_scan_event(5).await?;
-        assert_eq!(rate_limiter.state.has_blocked.load(Ordering::SeqCst), false);
+        assert_eq!(
+            rate_limiter
+                .state
+                .blocked_sender_count
+                .load(Ordering::SeqCst),
+            0
+        );
 
         let rate_limiter_clone = rate_limiter.clone();
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             rate_limiter_clone.send_scan_event(6).await.unwrap();
-            assert_eq!(rate_limiter.state.has_blocked.load(Ordering::SeqCst), true);
         });
 
         tokio::time::delay_for(std::time::Duration::from_millis(200)).await;
-        let finished = Arc::new(AtomicBool::new(false));
-        let finished_clone = finished.clone();
-        std::thread::spawn(move || {
-            assert_eq!(rx.recv().unwrap(), 1);
-            assert_eq!(rx.recv().unwrap(), 2);
-            assert_eq!(rx.recv().unwrap(), 3);
-            assert_eq!(rx.recv().unwrap(), 4);
-            assert_eq!(rx.recv().unwrap(), 5);
-            assert_eq!(rx.recv().unwrap(), 6);
-            finished_clone.store(true, Ordering::SeqCst);
-        });
+        assert_eq!(
+            rate_limiter
+                .state
+                .blocked_sender_count
+                .load(Ordering::SeqCst),
+            1
+        );
 
-        while !finished.load(Ordering::SeqCst) {
-            tokio::task::yield_now().await;
-        }
+        let drain_handle = tokio::spawn(drainer.drain(mock_sink.clone(), ()));
+        assert_eq!(mock_sink.recv().await.unwrap(), 1);
+        assert_eq!(mock_sink.recv().await.unwrap(), 2);
+        assert_eq!(mock_sink.recv().await.unwrap(), 3);
+        assert_eq!(mock_sink.recv().await.unwrap(), 4);
+        assert_eq!(mock_sink.recv().await.unwrap(), 5);
+        assert_eq!(mock_sink.recv().await.unwrap(), 6);
 
+        mock_sink.close().await.unwrap();
+        drain_handle.await.unwrap();
+        handle.await.unwrap();
         Ok(())
     }
 
+    /// test_scan_block_disconnected tests that senders that are blocked due to congestion gets unblocked
+    /// when the drainer is dropped.
     #[tokio::test]
-    async fn test_scan_backoff_disconnected() -> Result<(), RateLimiterError<MockCdcEvent>> {
-        let (tx, rx) = unbounded::<MockCdcEvent>(1);
-        let rate_limiter = RateLimiter::new(tx, 5, 1024);
+    async fn test_scan_block_disconnected() -> Result<(), RateLimiterError<MockCdcEvent>> {
+        let (mut rate_limiter, drainer) = new_pair::<MockCdcEvent>(5, 1024);
+        let mut mock_sink = MockRpcSink::new();
 
         rate_limiter.send_realtime_event(1)?;
+        let drain_handle = tokio::spawn(drainer.drain(mock_sink.clone(), ()));
+        // Waits for the drainer to drain one event (given that MockRpcSink has internal buffer size 1),
+        // so that the queue length becomes predictable for this unit test.
+        tokio::time::delay_for(std::time::Duration::from_millis(200)).await;
+
+        assert_eq!(rate_limiter.sink.len(), 0);
         rate_limiter.send_realtime_event(2)?;
+        assert_eq!(rate_limiter.sink.len(), 1);
         rate_limiter.send_scan_event(3).await?;
+        assert_eq!(rate_limiter.sink.len(), 2);
         rate_limiter.send_scan_event(4).await?;
+        assert_eq!(rate_limiter.sink.len(), 3);
         rate_limiter.send_scan_event(5).await?;
-        assert_eq!(rate_limiter.state.has_blocked.load(Ordering::SeqCst), false);
+        assert_eq!(rate_limiter.sink.len(), 4);
+        rate_limiter.send_scan_event(6).await?;
+
+        tokio::time::delay_for(std::time::Duration::from_millis(200)).await;
+        assert_eq!(
+            rate_limiter
+                .state
+                .blocked_sender_count
+                .load(Ordering::SeqCst),
+            0
+        );
 
         let rate_limiter_clone = rate_limiter.clone();
-        let finished = Arc::new(AtomicBool::new(false));
-        let finished_clone = finished.clone();
 
-        tokio::spawn(async move {
-            match rate_limiter_clone.send_scan_event(6).await {
+        let handle = tokio::spawn(async move {
+            assert_eq!(rate_limiter_clone.sink.len(), 5);
+            // A queue length of 5 implies the blocking of the subsequent send_scan_event call.
+            match rate_limiter_clone.send_scan_event(7).await {
                 Ok(_) => panic!("expected error"),
                 Err(RateLimiterError::SinkClosedError(len)) => assert_eq!(len, 0),
                 _ => panic!("expected SinkClosedError"),
             }
-            assert_eq!(
-                rate_limiter_clone.state.has_blocked.load(Ordering::SeqCst),
-                true
-            );
-            finished_clone.store(true, Ordering::SeqCst);
         });
 
+        // waits for the sender to be blocked.
         tokio::time::delay_for(std::time::Duration::from_millis(200)).await;
-        drop(rx);
-        rate_limiter.notify_close();
+        // asserts that the sender has been blocked
+        assert_eq!(
+            rate_limiter
+                .state
+                .blocked_sender_count
+                .load(Ordering::SeqCst),
+            1
+        );
+        // injects a drainer exit
+        rate_limiter.inject_instant_drainer_exit();
+        // wait for the drainer to drop
+        drain_handle.await.unwrap();
 
-        while !finished.load(Ordering::SeqCst) {
-            tokio::task::yield_now().await;
-        }
-
+        mock_sink.close().await.unwrap();
+        handle.await.unwrap();
         Ok(())
     }
-
-     */
 }

--- a/components/cdc/src/rate_limiter.rs
+++ b/components/cdc/src/rate_limiter.rs
@@ -238,7 +238,10 @@ impl<E> Clone for RateLimiter<E> {
 
 impl<E> Drop for RateLimiter<E> {
     fn drop(&mut self) {
-        self.state.ref_count.fetch_sub(1, Ordering::SeqCst);
+        let previous = self.state.ref_count.fetch_sub(1, Ordering::SeqCst);
+        if previous == 1 {
+            warn!("cdc RateLimiter ref_count = 0");
+        }
     }
 }
 

--- a/components/cdc/src/rate_limiter.rs
+++ b/components/cdc/src/rate_limiter.rs
@@ -1,0 +1,17 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use tikv_util::mpsc::batch::Sender;
+use crate::service::CdcEvent;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub struct RateLimiter {
+    sink: Sender<CdcEvent>,
+    is_sink_closed: AtomicBool,
+    block_scan_threshold: usize,
+}
+
+impl RateLimiter {
+    pub fn record_realtime_event(len: usize) {
+        
+    }
+}

--- a/components/cdc/src/rate_limiter.rs
+++ b/components/cdc/src/rate_limiter.rs
@@ -201,11 +201,12 @@ impl<E> RateLimiter<E> {
         let threshold = self.state.block_scan_threshold;
 
         let timer = CDC_SCAN_BLOCK_DURATION_HISTOGRAM.start_coarse_timer();
+        info!("cdc send_scan_event blocking"; "queue_size" => sink_clone.len());
         BlockSender::block_sender(self.state.as_ref(), move || {
             sink_clone.len() >= threshold && !state_clone.is_sink_closed.load(Ordering::SeqCst)
         })
         .await;
-
+        info!("cdc send_scan_event block done");
         if self.state.is_sink_closed.load(Ordering::SeqCst) {
             return Err(RateLimiterError::DisconnectedError);
         }

--- a/components/cdc/src/rate_limiter.rs
+++ b/components/cdc/src/rate_limiter.rs
@@ -82,7 +82,7 @@ impl<E> RateLimiter<E> {
                 self.state.has_blocked.store(true, Ordering::SeqCst);
 
                 info!("cdc send_scan_event backoff"; "queue_size" => queue_size, "attempts" => attempts);
-                let backoff_ms: u64 = 2 << min(attempts, 12);
+                let backoff_ms: u64 = 32 << min(attempts, 10);
                 tokio::time::delay_for(std::time::Duration::from_millis(backoff_ms)).await;
                 attempts += 1;
 
@@ -92,7 +92,7 @@ impl<E> RateLimiter<E> {
         }
 
         sink_clone.try_send(event).map_err(|e| {
-            warn!("cdc send_realtime_event error"; "err" => ?e);
+            warn!("cdc send_scan_event error"; "err" => ?e);
             match e {
                 crossbeam::TrySendError::Disconnected(_) => {
                     state_clone.is_sink_closed.store(true, Ordering::SeqCst);

--- a/components/cdc/src/rate_limiter.rs
+++ b/components/cdc/src/rate_limiter.rs
@@ -1,17 +1,311 @@
-// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use tikv_util::mpsc::batch::Sender;
 use crate::service::CdcEvent;
 use std::sync::atomic::{AtomicBool, Ordering};
+use kvproto::cdcpb::Event;
+use crossbeam::channel::TrySendError;
+use crate::metrics::*;
+use futures::Future;
+use std::sync::Arc;
+use std::boxed::Box;
+use std::cmp::min;
 
-pub struct RateLimiter {
-    sink: Sender<CdcEvent>,
-    is_sink_closed: AtomicBool,
-    block_scan_threshold: usize,
+#[derive(Debug)]
+pub enum RateLimiterError<E> {
+    SenderError(TrySendError<E>),
+    SinkClosedError(usize),
+    TryAgainError,
 }
 
-impl RateLimiter {
-    pub fn record_realtime_event(len: usize) {
-        
+pub struct RateLimiter<E> {
+    sink: Sender<E>,
+    state: Arc<State>,
+}
+
+struct State {
+    is_sink_closed: AtomicBool,
+    block_scan_threshold: usize,
+    close_sink_threshold: usize,
+    #[cfg(test)]
+    has_blocked: AtomicBool,
+}
+
+impl<E> RateLimiter<E> {
+    pub fn new(sink: Sender<E>, block_scan_threshold: usize, close_sink_threshold: usize) -> RateLimiter<E> {
+        return RateLimiter {
+            sink,
+            state: Arc::new(State {
+                is_sink_closed: AtomicBool::new(false),
+                block_scan_threshold,
+                close_sink_threshold,
+                #[cfg(test)]
+                has_blocked: AtomicBool::new(false)
+            }),
+        };
+    }
+
+    pub fn send_realtime_event(&self, event: E) -> Result<(), RateLimiterError<E>> {
+        if self.state.is_sink_closed.load(Ordering::SeqCst) {
+            return Err(RateLimiterError::SinkClosedError(0));
+        }
+
+        let queue_size = self.sink.get_pending_count();
+        CDC_SINK_QUEUE_SIZE_HISTOGRAM.observe(queue_size as f64);
+        if queue_size >= self.state.close_sink_threshold {
+            warn!("cdc send_realtime_event queue length reached threshold"; "queue_size" => queue_size);
+            self.state.is_sink_closed.store(true, Ordering::SeqCst);
+            return Err(RateLimiterError::SinkClosedError(queue_size));
+        }
+
+        self.sink.try_send(event).map_err(|e| {
+            warn!("cdc send_realtime_event error"; "err" => ?e);
+            self.state.is_sink_closed.store(true, Ordering::SeqCst);
+            RateLimiterError::SenderError(e)
+        })?;
+
+        Ok(())
+    }
+
+    pub async fn send_scan_event(&self, event: E) -> Result<(), RateLimiterError<E>> {
+        let state_clone = self.state.clone();
+        let sink_clone = self.sink.clone();
+        let mut attempts: u64 = 0;
+
+        loop {
+            if state_clone.is_sink_closed.load(Ordering::SeqCst) {
+                return Err(RateLimiterError::SinkClosedError(0));
+            }
+
+            let queue_size = sink_clone.get_pending_count();
+            CDC_SINK_QUEUE_SIZE_HISTOGRAM.observe(queue_size as f64);
+
+            if queue_size >= state_clone.block_scan_threshold {
+                // used for unit testing
+                #[cfg(test)]
+                self.state.has_blocked.store(true, Ordering::SeqCst);
+
+                info!("cdc send_scan_event backoff"; "queue_size" => queue_size, "attempts" => attempts);
+                let backoff_ms: u64 = 2 << min(attempts, 12);
+                tokio::time::delay_for(std::time::Duration::from_millis(backoff_ms)).await;
+                attempts += 1;
+
+                continue;
+            }
+            break;
+        }
+
+        sink_clone.try_send(event).map_err(|e| {
+            warn!("cdc send_realtime_event error"; "err" => ?e);
+            match e {
+                crossbeam::TrySendError::Disconnected(_) => {
+                    state_clone.is_sink_closed.store(true, Ordering::SeqCst);
+                    info!("cdc sink closed");
+                }
+                _ => {}
+            }
+            RateLimiterError::SenderError(e)
+        })
+    }
+
+    pub fn notify_close(self) {
+        self.state.is_sink_closed.store(true, Ordering::SeqCst);
+    }
+}
+
+impl<E> Clone for RateLimiter<E> {
+    fn clone(&self) -> Self {
+        RateLimiter {
+            sink: self.sink.clone(),
+            state: self.state.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tikv_util::mpsc::batch::{unbounded, bounded};
+
+    type MockCdcEvent = u64;
+
+    #[test]
+    fn test_basic_realtime() -> Result<(), RateLimiterError<MockCdcEvent>>  {
+        let (tx, rx) = unbounded::<MockCdcEvent>(1);
+        let rate_limiter = RateLimiter::new(tx, 1024, 1024);
+
+        for i in 0..10u64 {
+            rate_limiter.send_realtime_event(i)?;
+        }
+
+        for i in 0..10u64 {
+            assert_eq!(rx.recv().unwrap(), i);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_basic_scan() -> Result<(), RateLimiterError<MockCdcEvent>>  {
+        let (tx, rx) = unbounded::<MockCdcEvent>(1);
+        let rate_limiter = RateLimiter::new(tx, 1024, 1024);
+
+        for i in 0..10u64 {
+            rate_limiter.send_scan_event(i).await?;
+        }
+
+        for i in 0..10u64 {
+            assert_eq!(rx.recv().unwrap(), i);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_realtime_disconnected() -> Result<(), RateLimiterError<MockCdcEvent>>  {
+        let (tx, rx) = unbounded::<MockCdcEvent>(1);
+        let rate_limiter = RateLimiter::new(tx, 1024, 1024);
+
+        rate_limiter.send_realtime_event(1)?;
+        rate_limiter.send_realtime_event(2)?;
+        rate_limiter.send_realtime_event(3)?;
+        drop(rx);
+        match rate_limiter.send_realtime_event(4) {
+            Ok(_) => panic!("expected error"),
+            Err(RateLimiterError::SenderError(e)) => {},
+            _ => panic!("expected SenderError")
+        }
+
+        match rate_limiter.send_realtime_event(5) {
+            Ok(_) => panic!("expected error"),
+            Err(RateLimiterError::SinkClosedError(len)) => assert_eq!(len, 0),
+            _ => panic!("expected SinkClosedError")
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_disconnected() -> Result<(), RateLimiterError<MockCdcEvent>>  {
+        let (tx, rx) = unbounded::<MockCdcEvent>(1);
+        let rate_limiter = RateLimiter::new(tx, 1024, 1024);
+
+        rate_limiter.send_scan_event(1).await?;
+        rate_limiter.send_scan_event(2).await?;
+        rate_limiter.send_scan_event(3).await?;
+        drop(rx);
+        match rate_limiter.send_scan_event(4).await {
+            Ok(_) => panic!("expected error"),
+            Err(RateLimiterError::SenderError(e)) => {},
+            _ => panic!("expected SenderError")
+        }
+
+        match rate_limiter.send_scan_event(5).await {
+            Ok(_) => panic!("expected error"),
+            Err(RateLimiterError::SinkClosedError(len)) => assert_eq!(len, 0),
+            _ => panic!("expected SinkClosedError")
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_realtime_congested() -> Result<(), RateLimiterError<MockCdcEvent>>  {
+        let (tx, rx) = unbounded::<MockCdcEvent>(1);
+        let rate_limiter = RateLimiter::new(tx, 1024, 5);
+
+        rate_limiter.send_realtime_event(1)?;
+        rate_limiter.send_realtime_event(2)?;
+        rate_limiter.send_realtime_event(3)?;
+        rate_limiter.send_realtime_event(4)?;
+        rate_limiter.send_realtime_event(5)?;
+        match rate_limiter.send_realtime_event(6) {
+            Ok(_) => panic!("expected error"),
+            Err(RateLimiterError::SinkClosedError(len)) => assert_eq!(len, 5),
+            _ => panic!("expected SinkClosedError")
+        }
+
+        match rate_limiter.send_realtime_event(6) {
+            Ok(_) => panic!("expected error"),
+            Err(RateLimiterError::SinkClosedError(len)) => assert_eq!(len, 0),
+            _ => panic!("expected SinkClosedError")
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_backoff_normal() -> Result<(), RateLimiterError<MockCdcEvent>>  {
+        let (tx, rx) = unbounded::<MockCdcEvent>(1);
+        let rate_limiter = RateLimiter::new(tx, 5, 1024);
+
+        rate_limiter.send_realtime_event(1)?;
+        rate_limiter.send_realtime_event(2)?;
+        rate_limiter.send_scan_event(3).await?;
+        rate_limiter.send_scan_event(4).await?;
+        rate_limiter.send_scan_event(5).await?;
+        assert_eq!(rate_limiter.state.has_blocked.load(Ordering::SeqCst), false);
+
+        let rate_limiter_clone = rate_limiter.clone();
+        tokio::spawn(async move {
+            rate_limiter_clone.send_scan_event(6).await.unwrap();
+            assert_eq!(rate_limiter.state.has_blocked.load(Ordering::SeqCst), true);
+        });
+
+        tokio::time::delay_for(std::time::Duration::from_millis(200)).await;
+        let finished = Arc::new(AtomicBool::new(false));
+        let finished_clone = finished.clone();
+        std::thread::spawn(move || {
+            assert_eq!(rx.recv().unwrap(), 1);
+            assert_eq!(rx.recv().unwrap(), 2);
+            assert_eq!(rx.recv().unwrap(), 3);
+            assert_eq!(rx.recv().unwrap(), 4);
+            assert_eq!(rx.recv().unwrap(), 5);
+            assert_eq!(rx.recv().unwrap(), 6);
+            finished_clone.store(true, Ordering::SeqCst);
+        });
+
+        while !finished.load(Ordering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_backoff_disconnected() -> Result<(), RateLimiterError<MockCdcEvent>>  {
+        let (tx, rx) = unbounded::<MockCdcEvent>(1);
+        let rate_limiter = RateLimiter::new(tx, 5, 1024);
+
+        rate_limiter.send_realtime_event(1)?;
+        rate_limiter.send_realtime_event(2)?;
+        rate_limiter.send_scan_event(3).await?;
+        rate_limiter.send_scan_event(4).await?;
+        rate_limiter.send_scan_event(5).await?;
+        assert_eq!(rate_limiter.state.has_blocked.load(Ordering::SeqCst), false);
+
+        let rate_limiter_clone = rate_limiter.clone();
+        let finished = Arc::new(AtomicBool::new(false));
+        let finished_clone = finished.clone();
+
+        tokio::spawn(async move {
+            match rate_limiter_clone.send_scan_event(6).await {
+                Ok(_) => panic!("expected error"),
+                Err(RateLimiterError::SinkClosedError(len)) => assert_eq!(len, 0),
+                _ => panic!("expected SinkClosedError")
+            }
+            assert_eq!(rate_limiter_clone.state.has_blocked.load(Ordering::SeqCst), true);
+            finished_clone.store(true, Ordering::SeqCst);
+        });
+
+        tokio::time::delay_for(std::time::Duration::from_millis(200)).await;
+        drop(rx);
+        rate_limiter.notify_close();
+
+        while !finished.load(Ordering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+
+        Ok(())
     }
 }

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -24,7 +24,7 @@ use tokio::sync::mpsc::channel as tokio_bounded_channel;
 
 use crate::delegate::{Downstream, DownstreamID};
 use crate::endpoint::{Deregister, Task};
-use crate::rate_limiter::{new_pair, RateLimiter, DrainerError};
+use crate::rate_limiter::{new_pair, DrainerError, RateLimiter};
 use futures::ready;
 #[cfg(feature = "prost-codec")]
 use kvproto::cdcpb::event::Event as Event_oneof_event;
@@ -447,8 +447,7 @@ impl ChangeData for Service {
         mut sink: DuplexSink<ChangeDataEvent>,
     ) {
         // TODO determine the right values
-        // 2048 is likely too low for production.
-        let (rate_limiter, drainer) = new_pair::<CdcEvent>(64, 2048);
+        let (rate_limiter, drainer) = new_pair::<CdcEvent>(128, 2048);
         let peer = ctx.peer();
         let conn = Conn::new(rate_limiter, peer.clone());
         let conn_id = conn.get_id();

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -264,7 +264,7 @@ where
                     _ => {}
                 }
             },
-            other => {},
+            _ => {},
         }
 
         this.buf.as_mut().unwrap().push(event);
@@ -415,14 +415,7 @@ impl Conn {
     }
 
     pub fn flush(&self) {
-        /*
-        if !self.sink.is_empty() {
-            if let Some(notifier) = self.sink.get_notifier() {
-                notifier.notify();
-            }
-        }
-         */
-        // no-op for now
+       self.sink.start_flush();
     }
 }
 

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -31,6 +31,7 @@ const CDC_MSG_MAX_BATCH_SIZE: usize = 128;
 // Assume the average size of event is 1KB.
 // 2 = (CDC_MSG_MAX_BATCH_SIZE * 1KB / CDC_EVENT_MAX_BATCH_SIZE).ceil() + 1 /* reserve for ResolvedTs */;
 const CDC_EVENT_MAX_BATCH_SIZE: usize = 2;
+const CDC_SINK_MAX_QUEUE_SIZE: usize = 1024;
 
 /// A unique identifier of a Connection.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -279,7 +280,6 @@ impl ChangeData for Service {
         stream: RequestStream<ChangeDataRequest>,
         mut sink: DuplexSink<ChangeDataEvent>,
     ) {
-        // TODO: make it a bounded channel.
         let (tx, rx) = batch::unbounded(CDC_MSG_NOTIFY_COUNT);
         let peer = ctx.peer();
         let conn = Conn::new(tx, peer);

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -546,6 +546,7 @@ impl ChangeData for Service {
             match drain_res {
                 Ok(_) => {
                     info!("cdc drainer exit"; "downstream" => peer.clone(), "conn_id" => ?conn_id);
+                    let _ = sink.close().await;
                 },
                 Err(e) => {
                     error!("cdc drainer exit"; "downstream" => peer.clone(), "conn_id" => ?conn_id, "error" => ?e);
@@ -558,7 +559,6 @@ impl ChangeData for Service {
             }
 
             info!("cdc send half closed"; "downstream" => peer.clone(), "conn_id" => ?conn_id);
-            let _ = sink.close().await;
         });
     }
 }

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -31,7 +31,6 @@ const CDC_MSG_MAX_BATCH_SIZE: usize = 128;
 // Assume the average size of event is 1KB.
 // 2 = (CDC_MSG_MAX_BATCH_SIZE * 1KB / CDC_EVENT_MAX_BATCH_SIZE).ceil() + 1 /* reserve for ResolvedTs */;
 const CDC_EVENT_MAX_BATCH_SIZE: usize = 2;
-const CDC_SINK_MAX_QUEUE_SIZE: usize = 1024;
 
 /// A unique identifier of a Connection.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use collections::HashMap;
-use futures::future::{self, BoxFuture, Future, FutureExt, TryFutureExt};
+use futures::future::{self, BoxFuture, Future, TryFutureExt};
 use futures::sink::{Sink, SinkExt};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use futures::task::{AtomicWaker, Context, Poll};
@@ -169,7 +169,7 @@ impl EventBatcher {
     }
 }
 
-struct EventBatcherSink<S, E>
+pub struct EventBatcherSink<S, E>
 where
     S: Sink<(ChangeDataEvent, grpcio::WriteFlags), Error = E> + Send + Unpin,
 {
@@ -187,7 +187,7 @@ impl<S, E> EventBatcherSink<S, E>
 where
     S: Sink<(ChangeDataEvent, grpcio::WriteFlags), Error = E> + Send + Unpin,
 {
-    fn new(sink: S) -> Self {
+    pub fn new(sink: S) -> Self {
         Self {
             buf: None,
             send_buf: VecDeque::new(),

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -325,11 +325,9 @@ impl ChangeData for Service {
             );
 
             let mut close_tx_clone = close_tx.clone();
-            downstream.set_cancel_func(move |_| {
-                match close_tx_clone.try_send(()) {
-                    Ok(_) => info!("cdc send sink close command successful"),
-                    Err(e) => info!("cdc send sink close command failed"; "err" => ?e)
-                }
+            downstream.set_cancel_func(move |_| match close_tx_clone.try_send(()) {
+                Ok(_) => info!("cdc send sink close command successful"),
+                Err(e) => info!("cdc send sink close command failed"; "err" => ?e),
             });
 
             let ret = scheduler

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -546,13 +546,13 @@ impl ChangeData for Service {
             match drain_res {
                 Ok(_) => {
                     info!("cdc drainer exit"; "downstream" => peer.clone(), "conn_id" => ?conn_id);
-                    let _ = sink.close().await;
+                    let _ = sink.fail(RpcStatus::new(RpcStatusCode::CANCELLED, Some("upstreams closed".into()))).await;
                 },
                 Err(e) => {
                     error!("cdc drainer exit"; "downstream" => peer.clone(), "conn_id" => ?conn_id, "error" => ?e);
                     match e {
                         DrainerError::RateLimitExceededError => {
-                            let _ = sink.close().await;
+                            let _ = sink.fail(RpcStatus::new(RpcStatusCode::CANCELLED, Some("stream congested".into()))).await;
                         },
                         _ => {},
                     }

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -379,7 +379,9 @@ fn test_cdc_scan() {
     mutation.value = v.clone();
     suite.must_kv_prewrite(1, vec![mutation], k.clone(), start_ts2);
 
-    let req = suite.new_changedata_request(1);
+    let mut req = suite.new_changedata_request(1);
+    let req_id = 1u64;
+    req.set_request_id(req_id);
     let (mut req_tx, event_feed_wrap, receive_event) =
         new_event_feed(suite.get_region_cdc_client(1));
     block_on(req_tx.send((req, WriteFlags::default()))).unwrap();
@@ -388,7 +390,9 @@ fn test_cdc_scan() {
         events.extend(receive_event(false).events.into_iter());
     }
     assert_eq!(events.len(), 2, "{:?}", events);
-    match events.remove(0).event.unwrap() {
+    let event = events.remove(0);
+    assert_eq!(event.request_id, req_id);
+    match event.event.unwrap() {
         // Batch size is set to 2.
         Event_oneof_event::Entries(es) => {
             assert!(es.entries.len() == 2, "{:?}", es);
@@ -407,7 +411,9 @@ fn test_cdc_scan() {
         }
         other => panic!("unknown event {:?}", other),
     }
-    match events.pop().unwrap().event.unwrap() {
+    let event = events.pop().unwrap();
+    assert_eq!(event.request_id, req_id);
+    match event.event.unwrap() {
         // Then it outputs Initialized event.
         Event_oneof_event::Entries(es) => {
             assert!(es.entries.len() == 1, "{:?}", es);
@@ -431,6 +437,7 @@ fn test_cdc_scan() {
     suite.must_kv_prewrite(1, vec![mutation], k.clone(), start_ts3);
 
     let mut req = suite.new_changedata_request(1);
+    req.set_request_id(req_id);
     req.checkpoint_ts = checkpoint_ts.into_inner();
     let (mut req_tx, resp_rx) = suite.get_region_cdc_client(1).event_feed().unwrap();
     event_feed_wrap.replace(Some(resp_rx));
@@ -440,7 +447,9 @@ fn test_cdc_scan() {
         events.extend(receive_event(false).events.to_vec());
     }
     assert_eq!(events.len(), 2, "{:?}", events);
-    match events.remove(0).event.unwrap() {
+    let event = events.remove(0);
+    assert_eq!(event.request_id, req_id);
+    match event.event.unwrap() {
         // Batch size is set to 2.
         Event_oneof_event::Entries(es) => {
             assert!(es.entries.len() == 2, "{:?}", es);
@@ -462,7 +471,9 @@ fn test_cdc_scan() {
         other => panic!("unknown event {:?}", other),
     }
     assert_eq!(events.len(), 1, "{:?}", events);
-    match events.pop().unwrap().event.unwrap() {
+    let event = events.pop().unwrap();
+    assert_eq!(event.request_id, req_id);
+    match event.event.unwrap() {
         // Then it outputs Initialized event.
         Event_oneof_event::Entries(es) => {
             assert!(es.entries.len() == 1, "{:?}", es);

--- a/components/tikv_util/src/mpsc/batch.rs
+++ b/components/tikv_util/src/mpsc/batch.rs
@@ -486,7 +486,7 @@ mod tests {
 
     #[test]
     fn test_sender_pending_count() {
-        let (tx, mut rx) = unbounded::<i32>(10);
+        let (tx, rx) = unbounded::<i32>(10);
         assert_eq!(tx.get_pending_count(), 0);
         tx.send(1).unwrap();
         assert_eq!(tx.get_pending_count(), 1);

--- a/components/tikv_util/src/mpsc/batch.rs
+++ b/components/tikv_util/src/mpsc/batch.rs
@@ -51,7 +51,7 @@ impl State {
         let t = self.recv_task.swap(null_mut(), Ordering::AcqRel);
         if !t.is_null() {
             self.pending.store(0, Ordering::Release);
-            // Safety: see comment on `recv_task`.
+            // Safety: see comment on `recv_task`.hannel.
             let t = unsafe { Box::from_raw(t) };
             t.wake();
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2247,7 +2247,7 @@ impl Default for CdcConfig {
         Self {
             min_ts_interval: ReadableDuration::secs(1),
             old_value_cache_size: 1024,
-            hibernate_regions_compatible: true,
+            hibernate_regions_compatible: false,
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
TiKV is prone to OOM if CDC is trying to send a large amount of data.

### What is changed and how it works?

What's Changed:
- rate_limiter is implemented which separates CDC events into real-time events and scan events.
- CDC incremental scan data is sent in an async function, leveraging the tokio-runtime used for scanning data from the disk.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
    - CDC might not reach optimal performance.

### Release note <!-- bugfixes or new feature need a release note -->
- add flow control to CDC