### PR TITLE
raftstore: disable hibernate region except on master

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -246,7 +246,7 @@ impl Default for Config {
             apply_batch_system: BatchSystemConfig::default(),
             store_batch_system: BatchSystemConfig::default(),
             future_poll_size: 1,
-            hibernate_regions: true,
+            hibernate_regions: tikv_util::build_on_master_branch(),
             dev_assert: false,
             apply_yield_duration: ReadableDuration::millis(500),
 

--- a/components/test_raftstore/src/common-test.toml
+++ b/components/test_raftstore/src/common-test.toml
@@ -67,6 +67,7 @@ merge-check-tick-interval = "100ms"
 pd-heartbeat-tick-interval = "20ms"
 raft-reject-transfer-leader-duration = "0s"
 dev-assert = true
+hibernate-regions = true
 
 [coprocessor]
 

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -539,9 +539,7 @@ pub fn empty_shared_slice<T>() -> Arc<[T]> {
 
 /// A useful hook to check if master branch is being built.
 pub fn build_on_master_branch() -> bool {
-    option_env!("TIKV_BUILD_GIT_BRANCH").map_or(false, |b| {
-        "master" == b
-    })
+    option_env!("TIKV_BUILD_GIT_BRANCH").map_or(false, |b| "master" == b)
 }
 
 #[cfg(test)]

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -537,6 +537,13 @@ pub fn empty_shared_slice<T>() -> Arc<[T]> {
     Vec::new().into()
 }
 
+/// A useful hook to check if master branch is being built.
+pub fn build_on_master_branch() -> bool {
+    option_env!("TIKV_BUILD_GIT_BRANCH").map_or(false, |b| {
+        "master" == b
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:

This PR adds a function to check if the binary is built on master
branch. Hibernate region is an experimental features that should
not be enabled on release branch, but it's enabled by accident on
5.0.0-rc. Checking branch name at build time can prevent such mistake
from happening again.

The side effect of the PR is binary built in PR will also have hibernate
regions disabled even it's checkout from master.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
- disable hibernate region by default as it's still unstable