### PR TITLE
storage: record key and start_ts in committed error

### DIFF
--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -231,7 +231,7 @@ pub fn extract_region_error<T>(res: &Result<T>) -> Option<errorpb::Error> {
 pub fn extract_committed(err: &Error) -> Option<TimeStamp> {
     match *err {
         Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
-            box MvccErrorInner::Committed { commit_ts },
+            box MvccErrorInner::Committed { commit_ts, .. },
         ))))) => Some(commit_ts),
         _ => None,
     }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -366,7 +366,9 @@ pub(crate) fn make_txn_error(
                 ErrorInner::KeyIsLocked(info)
             }
             "committed" => ErrorInner::Committed {
-                commit_ts: TimeStamp::zero(),
+                start_ts,
+                commit_ts: start_ts.next(),
+                key: key.to_raw().unwrap(),
             },
             "pessimisticlockrolledback" => ErrorInner::PessimisticLockRolledBack {
                 start_ts,

--- a/src/storage/txn/actions/cleanup.rs
+++ b/src/storage/txn/actions/cleanup.rs
@@ -48,7 +48,7 @@ pub fn cleanup<S: Snapshot>(
                 Err(ErrorInner::Committed {
                     start_ts: txn.start_ts,
                     commit_ts,
-                    key: key.into_raw()?
+                    key: key.into_raw()?,
                 }
                 .into())
             }

--- a/src/storage/txn/actions/cleanup.rs
+++ b/src/storage/txn/actions/cleanup.rs
@@ -20,7 +20,7 @@ pub fn cleanup<S: Snapshot>(
     protect_rollback: bool,
 ) -> MvccResult<Option<ReleasedLock>> {
     fail_point!("cleanup", |err| Err(
-        crate::storage::mvcc::txn::make_txn_error(err, &key, txn.start_ts,).into()
+        crate::storage::mvcc::txn::make_txn_error(err, &key, txn.start_ts).into()
     ));
 
     match txn.reader.load_lock(&key)? {
@@ -38,14 +38,19 @@ pub fn cleanup<S: Snapshot>(
         }
         l => match check_txn_status_missing_lock(
             txn,
-            key,
+            key.clone(),
             l,
             MissingLockAction::rollback_protect(protect_rollback),
             false,
         )? {
             TxnStatus::Committed { commit_ts } => {
                 MVCC_CONFLICT_COUNTER.rollback_committed.inc();
-                Err(ErrorInner::Committed { commit_ts }.into())
+                Err(ErrorInner::Committed {
+                    start_ts: txn.start_ts,
+                    commit_ts,
+                    key: key.into_raw()?
+                }
+                .into())
             }
             TxnStatus::RolledBack => {
                 // Return Ok on Rollback already exist.


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
Problem Summary:
I need to debug an issue of resolveing lock, but I can't get the start_ts and key from the `Committed` error:
```
resolveLocks failed: unexpected resolve err: abort:"Txn(Mvcc(Committed { commit_ts: TimeStamp(423311069165125656) }))" 
```

### What is changed and how it works?
What's Changed:
record key and start_ts in `Committed` error


### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->
- No release note