### PR TITLE
config: Make labels' format constaint consistent with PD

### DIFF
--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -40,9 +40,6 @@ const DEFAULT_SNAP_MAX_BYTES_PER_SEC: u64 = 100 * 1024 * 1024;
 
 const DEFAULT_MAX_GRPC_SEND_MSG_LEN: i32 = 10 * 1024 * 1024;
 
-const LABEL_KEY_FORMAT: &str = "^[$]?[A-Za-z0-9]([-A-Za-z0-9_./]*[A-Za-z0-9])?$";
-const LABEL_VALUE_FORMAT: &str = "^[-A-Za-z0-9_./]*$";
-
 /// A clone of `grpc::CompressionAlgorithms` with serde supports.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -288,31 +285,33 @@ impl Config {
     }
 }
 
-fn validate_label_key(s: &str) -> Result<()> {
-    let report_err = || box_err!("store label key: {:?} not match {}", s, LABEL_KEY_FORMAT);
-    let format = Regex::new(LABEL_KEY_FORMAT).unwrap();
+lazy_static! {
+    static ref LABEL_KEY_FORMAT: Regex =
+        Regex::new("^[$]?[A-Za-z0-9]([-A-Za-z0-9_./]*[A-Za-z0-9])?$").unwrap();
+    static ref LABEL_VALUE_FORMAT: Regex = Regex::new("^[-A-Za-z0-9_./]*$").unwrap();
+}
 
-    if format.is_match(s) {
+fn validate_label_key(s: &str) -> Result<()> {
+    if LABEL_KEY_FORMAT.is_match(s) {
         Ok(())
     } else {
-        Err(report_err())
+        Err(box_err!(
+            "store label key: {:?} not match {}",
+            s,
+            *LABEL_KEY_FORMAT
+        ))
     }
 }
 
 fn validate_label_value(s: &str) -> Result<()> {
-    let report_err = || {
-        box_err!(
-            "store label value: {:?} not match {}",
-            s,
-            LABEL_VALUE_FORMAT
-        )
-    };
-    let format = Regex::new(LABEL_VALUE_FORMAT).unwrap();
-
-    if format.is_match(s) {
+    if LABEL_VALUE_FORMAT.is_match(s) {
         Ok(())
     } else {
-        Err(report_err())
+        Err(box_err!(
+            "store label value: {:?} not match {}",
+            s,
+            *LABEL_VALUE_FORMAT
+        ))
     }
 }
 


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9699 

Problem Summary: Labels can be specified via TiKV's config file and it will be then reported to PD. However the format constraint of labels is not consistent between TiKV and PD. This PR changes TiKV's format constraint so that more formats are allowed, so that it's now consistent with PD.

### What is changed and how it works?

What's Changed: Updated format constraint of labels in TiKV's config file.

### Related changes

- Need to cherry-pick to the release branch
  - It depends

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

-

### Release note <!-- bugfixes or new feature need a release note -->

* Make the format constraint of labels consistent with PD's.