### PR TITLE
raftstore: fix find_propose_time may return older instant

### DIFF
--- a/components/raftstore/src/lib.rs
+++ b/components/raftstore/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(div_duration)]
 #![feature(min_specialization)]
 #![feature(box_patterns)]
+#![feature(vecdeque_binary_search)]
 
 #[macro_use]
 extern crate bitflags;

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -636,7 +636,7 @@ fn timespec_to_u64(ts: Timespec) -> u64 {
 ///
 /// If nsec is negative or GE than 1_000_000_000(nano seconds pre second).
 #[inline]
-fn u64_to_timespec(u: u64) -> Timespec {
+pub(crate) fn u64_to_timespec(u: u64) -> Timespec {
     let sec = u >> TIMESPEC_SEC_SHIFT;
     let nsec = (u & TIMESPEC_NSEC_MASK) << TIMESPEC_NSEC_SHIFT;
     Timespec::new(sec as i64, nsec as i32)


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9748 

Problem Summary:

See https://github.com/tikv/tikv/issues/9748

### What is changed and how it works?

What's Changed:

Use `VecDeque::binary_search_by_key` to find proposal

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- raftstore: fix find_propose_time may return older instant