### PR TITLE
storage: Make snapshot trait return iterator instead of cursor

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -11,7 +11,7 @@ use std::{borrow::Cow, time::*};
 use concurrency_manager::ConcurrencyManager;
 use configuration::Configuration;
 use engine_rocks::raw::DB;
-use engine_traits::{name_to_cf, CfName, IterOptions, SstCompressionType, DATA_KEY_PREFIX_LEN};
+use engine_traits::{name_to_cf, CfName, SstCompressionType};
 use external_storage::*;
 use file_system::{IOType, WithIOType};
 use futures::channel::mpsc::*;
@@ -22,7 +22,7 @@ use raft::StateRole;
 use raftstore::coprocessor::RegionInfoProvider;
 use raftstore::store::util::find_peer;
 use tikv::config::BackupConfig;
-use tikv::storage::kv::{Engine, ScanMode, SnapContext, Snapshot};
+use tikv::storage::kv::{CursorBuilder, Engine, ScanMode, SnapContext};
 use tikv::storage::mvcc::Error as MvccError;
 use tikv::storage::txn::{
     EntryBatch, Error as TxnError, SnapshotStore, TxnEntryScanner, TxnEntryStore,
@@ -337,11 +337,10 @@ impl BackupRange {
         let start = Instant::now();
         let mut statistics = Statistics::default();
         let cfstatistics = statistics.mut_cf_statistics(self.cf);
-        let mut option = IterOptions::default();
-        if let Some(end) = self.end_key.clone() {
-            option.set_upper_bound(end.as_encoded(), DATA_KEY_PREFIX_LEN);
-        }
-        let mut cursor = snapshot.iter_cf(self.cf, option, ScanMode::Forward)?;
+        let mut cursor = CursorBuilder::new(&snapshot, self.cf)
+            .range(None, self.end_key.clone())
+            .scan_mode(ScanMode::Forward)
+            .build()?;
         if let Some(begin) = self.start_key.clone() {
             if !cursor.seek(&begin, cfstatistics)? {
                 return Ok(statistics);

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -1,21 +1,19 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::cell::RefCell;
-use std::ops::{Bound, Deref};
+use std::ops::Deref;
 use std::sync::{Arc, RwLock};
 
 use collections::HashMap;
 use engine_rocks::RocksEngine;
-use engine_traits::{
-    IterOptions, KvEngine, ReadOptions, CF_DEFAULT, CF_WRITE, DATA_KEY_PREFIX_LEN,
-};
+use engine_traits::{KvEngine, ReadOptions, CF_DEFAULT, CF_WRITE};
 use kvproto::metapb::{Peer, Region};
 use raft::StateRole;
 use raftstore::coprocessor::*;
 use raftstore::store::fsm::ObserveID;
 use raftstore::store::RegionSnapshot;
 use raftstore::Error as RaftStoreError;
-use tikv::storage::{Cursor, ScanMode, Snapshot as EngineSnapshot, Statistics};
+use tikv::storage::{Cursor, CursorBuilder, ScanMode, Snapshot as EngineSnapshot, Statistics};
 use tikv_util::time::Instant;
 use tikv_util::worker::Scheduler;
 use txn_types::{Key, MutationType, OldValue, TimeStamp, Value, WriteRef, WriteType};
@@ -236,16 +234,15 @@ impl<S: EngineSnapshot> OldValueReader<S> {
     }
 
     fn new_write_cursor(&self, key: &Key) -> Cursor<S::Iter> {
-        let mut iter_opts = IterOptions::default();
         let ts = Key::decode_ts_from(key.as_encoded()).unwrap();
         let upper = Key::from_encoded_slice(Key::truncate_ts_for(key.as_encoded()).unwrap())
             .append_ts(TimeStamp::zero());
-        iter_opts.set_fill_cache(false);
-        iter_opts.set_hint_max_ts(Bound::Included(ts.into_inner()));
-        iter_opts.set_lower_bound(key.as_encoded(), DATA_KEY_PREFIX_LEN);
-        iter_opts.set_upper_bound(upper.as_encoded(), DATA_KEY_PREFIX_LEN);
-        self.snapshot
-            .iter_cf(CF_WRITE, iter_opts, ScanMode::Mixed)
+        CursorBuilder::new(&self.snapshot, CF_WRITE)
+            .fill_cache(false)
+            .scan_mode(ScanMode::Mixed)
+            .range(Some(key.clone()), Some(upper))
+            .hint_max_ts(Some(ts))
+            .build()
             .unwrap()
     }
 

--- a/components/engine_traits/src/options.rs
+++ b/components/engine_traits/src/options.rs
@@ -105,9 +105,8 @@ impl IterOptions {
     }
 
     #[inline]
-    pub fn use_prefix_seek(mut self) -> IterOptions {
+    pub fn use_prefix_seek(&mut self) {
         self.seek_mode = SeekMode::Prefix;
-        self
     }
 
     #[inline]
@@ -218,9 +217,8 @@ impl IterOptions {
     }
 
     #[inline]
-    pub fn set_prefix_same_as_start(mut self, enable: bool) -> IterOptions {
+    pub fn set_prefix_same_as_start(&mut self, enable: bool) {
         self.prefix_same_as_start = enable;
-        self
     }
 
     #[inline]
@@ -229,9 +227,8 @@ impl IterOptions {
     }
 
     #[inline]
-    pub fn set_max_skippable_internal_keys(mut self, threshold: u64) -> IterOptions {
+    pub fn set_max_skippable_internal_keys(&mut self, threshold: u64) {
         self.max_skippable_internal_keys = threshold;
-        self
     }
 }
 

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -553,7 +553,7 @@ impl<S: Snapshot> EngineSnapshot for RegionSnapshot<S> {
         fail_point!("raftkv_snapshot_iter_cf", |_| Err(box_err!(
             "injected error for iter_cf"
         )));
-        Ok(RegionSnapshot::iter_cf(self, cf, iter_opt)?)
+        RegionSnapshot::iter_cf(self, cf, iter_opt).map_err(kv::Error::from)
     }
 
     #[inline]

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -28,9 +28,9 @@ use txn_types::{Key, TimeStamp, TxnExtra, TxnExtraScheduler, Value};
 
 use super::metrics::*;
 use crate::storage::kv::{
-    write_modifies, Callback, CbContext, Cursor, Engine, Error as KvError,
-    ErrorInner as KvErrorInner, ExtCallback, Iterator as EngineIterator, Modify, ScanMode,
-    SnapContext, Snapshot as EngineSnapshot, WriteData,
+    write_modifies, Callback, CbContext, Engine, Error as KvError, ErrorInner as KvErrorInner,
+    ExtCallback, Iterator as EngineIterator, Modify, SnapContext, Snapshot as EngineSnapshot,
+    WriteData,
 };
 use crate::storage::mvcc::{Error as MvccError, ErrorInner as MvccErrorInner};
 use crate::storage::{self, kv};
@@ -542,33 +542,18 @@ impl<S: Snapshot> EngineSnapshot for RegionSnapshot<S> {
         Ok(v.map(|v| v.to_vec()))
     }
 
-    fn iter(&self, iter_opt: IterOptions, mode: ScanMode) -> kv::Result<Cursor<Self::Iter>> {
+    fn iter(&self, iter_opt: IterOptions) -> kv::Result<Self::Iter> {
         fail_point!("raftkv_snapshot_iter", |_| Err(box_err!(
             "injected error for iter"
         )));
-        let prefix_seek = iter_opt.prefix_seek_used();
-        Ok(Cursor::new(
-            RegionSnapshot::iter(self, iter_opt),
-            mode,
-            prefix_seek,
-        ))
+        Ok(RegionSnapshot::iter(self, iter_opt))
     }
 
-    fn iter_cf(
-        &self,
-        cf: CfName,
-        iter_opt: IterOptions,
-        mode: ScanMode,
-    ) -> kv::Result<Cursor<Self::Iter>> {
+    fn iter_cf(&self, cf: CfName, iter_opt: IterOptions) -> kv::Result<Self::Iter> {
         fail_point!("raftkv_snapshot_iter_cf", |_| Err(box_err!(
             "injected error for iter_cf"
         )));
-        let prefix_seek = iter_opt.prefix_seek_used();
-        Ok(Cursor::new(
-            RegionSnapshot::iter_cf(self, cf, iter_opt)?,
-            mode,
-            prefix_seek,
-        ))
+        Ok(RegionSnapshot::iter_cf(self, cf, iter_opt)?)
     }
 
     #[inline]

--- a/src/storage/kv/cursor.rs
+++ b/src/storage/kv/cursor.rs
@@ -569,11 +569,12 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
             iter_opt.set_hint_max_ts(Bound::Included(ts.into_inner()));
         }
         iter_opt.set_key_only(self.key_only);
-        iter_opt = iter_opt.set_max_skippable_internal_keys(self.max_skippable_internal_keys);
+        iter_opt.set_max_skippable_internal_keys(self.max_skippable_internal_keys);
 
         // prefix_seek is only used for single key, so set prefix_same_as_start for safety.
         if self.prefix_seek {
-            iter_opt = iter_opt.use_prefix_seek().set_prefix_same_as_start(true);
+            iter_opt.use_prefix_seek();
+            iter_opt.set_prefix_same_as_start(true);
         }
         Ok(Cursor::new(
             self.snapshot.iter_cf(self.cf, iter_opt)?,
@@ -645,11 +646,10 @@ mod tests {
 
         let snap = RegionSnapshot::<RocksSnapshot>::from_raw(engine, region);
         let mut statistics = CfStatistics::default();
-        let it = snap.iter(
-            IterOptions::default()
-                .use_prefix_seek()
-                .set_prefix_same_as_start(true),
-        );
+        let mut iter_opt = IterOptions::default();
+        iter_opt.use_prefix_seek();
+        iter_opt.set_prefix_same_as_start(true);
+        let it = snap.iter(iter_opt);
         let mut iter = Cursor::new(it, ScanMode::Mixed, true);
 
         assert!(!iter

--- a/src/storage/kv/cursor.rs
+++ b/src/storage/kv/cursor.rs
@@ -456,6 +456,8 @@ pub struct CursorBuilder<'a, S: Snapshot> {
     hint_min_ts: Option<TimeStamp>,
     // hint for we will only scan data with commit ts <= hint_max_ts
     hint_max_ts: Option<TimeStamp>,
+    key_only: bool,
+    max_skippable_internal_keys: u64,
 }
 
 impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
@@ -472,6 +474,8 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
             lower_bound: None,
             hint_min_ts: None,
             hint_max_ts: None,
+            key_only: false,
+            max_skippable_internal_keys: 0,
         }
     }
 
@@ -531,6 +535,18 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
         self
     }
 
+    #[inline]
+    pub fn key_only(mut self, key_only: bool) -> Self {
+        self.key_only = key_only;
+        self
+    }
+
+    #[inline]
+    pub fn max_skippable_internal_keys(mut self, count: u64) -> Self {
+        self.max_skippable_internal_keys = count;
+        self
+    }
+
     /// Build `Cursor` from the current configuration.
     pub fn build(self) -> Result<Cursor<S::Iter>> {
         let l_bound = if let Some(b) = self.lower_bound {
@@ -552,11 +568,18 @@ impl<'a, S: 'a + Snapshot> CursorBuilder<'a, S> {
         if let Some(ts) = self.hint_max_ts {
             iter_opt.set_hint_max_ts(Bound::Included(ts.into_inner()));
         }
+        iter_opt.set_key_only(self.key_only);
+        iter_opt = iter_opt.set_max_skippable_internal_keys(self.max_skippable_internal_keys);
+
         // prefix_seek is only used for single key, so set prefix_same_as_start for safety.
         if self.prefix_seek {
             iter_opt = iter_opt.use_prefix_seek().set_prefix_same_as_start(true);
         }
-        self.snapshot.iter_cf(self.cf, iter_opt, self.scan_mode)
+        Ok(Cursor::new(
+            self.snapshot.iter_cf(self.cf, iter_opt)?,
+            self.scan_mode,
+            self.prefix_seek,
+        ))
     }
 }
 

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -24,8 +24,8 @@ use tikv_util::escape;
 use tikv_util::worker::{Runnable, Scheduler, Worker};
 
 use super::{
-    Callback, CbContext, Cursor, Engine, Error, ErrorInner, ExtCallback,
-    Iterator as EngineIterator, Modify, Result, ScanMode, SnapContext, Snapshot, WriteData,
+    Callback, CbContext, Engine, Error, ErrorInner, ExtCallback, Iterator as EngineIterator,
+    Modify, Result, SnapContext, Snapshot, WriteData,
 };
 
 pub use engine_rocks::RocksSnapshot;
@@ -361,23 +361,14 @@ impl Snapshot for Arc<RocksSnapshot> {
         Ok(v.map(|v| v.to_vec()))
     }
 
-    fn iter(&self, iter_opt: IterOptions, mode: ScanMode) -> Result<Cursor<Self::Iter>> {
+    fn iter(&self, iter_opt: IterOptions) -> Result<Self::Iter> {
         trace!("RocksSnapshot: create iterator");
-        let prefix_seek = iter_opt.prefix_seek_used();
-        let iter = self.iterator_opt(iter_opt)?;
-        Ok(Cursor::new(iter, mode, prefix_seek))
+        Ok(self.iterator_opt(iter_opt)?)
     }
 
-    fn iter_cf(
-        &self,
-        cf: CfName,
-        iter_opt: IterOptions,
-        mode: ScanMode,
-    ) -> Result<Cursor<Self::Iter>> {
+    fn iter_cf(&self, cf: CfName, iter_opt: IterOptions) -> Result<Self::Iter> {
         trace!("RocksSnapshot: create cf iterator");
-        let prefix_seek = iter_opt.prefix_seek_used();
-        let iter = self.iterator_cf_opt(cf, iter_opt)?;
-        Ok(Cursor::new(iter, mode, prefix_seek))
+        Ok(self.iterator_cf_opt(cf, iter_opt)?)
     }
 }
 
@@ -425,6 +416,7 @@ mod tests {
     use super::super::tests::*;
     use super::super::CfStatistics;
     use super::*;
+    use crate::storage::{Cursor, CursorBuilder, ScanMode};
     use txn_types::TimeStamp;
 
     #[test]
@@ -498,7 +490,7 @@ mod tests {
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
         let iter_opt = IterOptions::default().set_max_skippable_internal_keys(1);
-        let mut iter = snapshot.iter(iter_opt, ScanMode::Forward).unwrap();
+        let mut iter = Cursor::new(snapshot.iter(iter_opt).unwrap(), ScanMode::Forward, false);
 
         let mut statistics = CfStatistics::default();
         let res = iter.seek(&Key::from_raw(b"foo"), &mut statistics);
@@ -522,9 +514,11 @@ mod tests {
         must_delete(engine, b"foo5");
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut iter = snapshot
-            .iter(IterOptions::default(), ScanMode::Forward)
-            .unwrap();
+        let mut iter = Cursor::new(
+            snapshot.iter(IterOptions::default()).unwrap(),
+            ScanMode::Forward,
+            false,
+        );
 
         let mut statistics = CfStatistics::default();
 
@@ -593,11 +587,10 @@ mod tests {
             .unwrap();
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let iter_opt = IterOptions::default()
-            .use_prefix_seek()
-            .set_prefix_same_as_start(true);
-        let mut iter = snapshot
-            .iter_cf("write", iter_opt, ScanMode::Forward)
+        let mut iter = CursorBuilder::new(&snapshot, CF_WRITE)
+            .prefix_seek(true)
+            .scan_mode(ScanMode::Forward)
+            .build()
             .unwrap();
 
         let mut statistics = CfStatistics::default();

--- a/src/storage/kv/rocksdb_engine.rs
+++ b/src/storage/kv/rocksdb_engine.rs
@@ -489,7 +489,8 @@ mod tests {
         must_put(&engine, b"foo2", b"bar2");
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let iter_opt = IterOptions::default().set_max_skippable_internal_keys(1);
+        let mut iter_opt = IterOptions::default();
+        iter_opt.set_max_skippable_internal_keys(1);
         let mut iter = Cursor::new(snapshot.iter(iter_opt).unwrap(), ScanMode::Forward, false);
 
         let mut statistics = CfStatistics::default();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -49,9 +49,9 @@ use self::kv::SnapContext;
 pub use self::{
     errors::{get_error_kind_from_header, get_tag_from_header, Error, ErrorHeaderKind, ErrorInner},
     kv::{
-        CbContext, CfStatistics, Cursor, Engine, FlowStatistics, FlowStatsReporter, Iterator,
-        PerfStatisticsDelta, PerfStatisticsInstant, RocksEngine, ScanMode, Snapshot, Statistics,
-        TestEngineBuilder,
+        CbContext, CfStatistics, Cursor, CursorBuilder, Engine, FlowStatistics, FlowStatsReporter,
+        Iterator, PerfStatisticsDelta, PerfStatisticsInstant, RocksEngine, ScanMode, Snapshot,
+        Statistics, TestEngineBuilder,
     },
     read_pool::{build_read_pool, build_read_pool_for_test},
     txn::{Latches, Lock as LatchLock, ProcessResult, Scanner, SnapshotStore, Store},

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -1164,7 +1164,7 @@ mod tests {
     fn test_out_of_sync_max_ts() {
         use crate::storage::{kv::Result, CfName, ConcurrencyManager, DummyLockManager, Value};
         use engine_rocks::RocksEngineIterator;
-        use engine_traits::ReadOptions;
+        use engine_traits::{IterOptions, ReadOptions};
         use kvproto::kvrpcpb::ExtraOp;
         #[derive(Clone)]
         struct MockSnapshot;

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -1162,10 +1162,7 @@ mod tests {
 
     #[test]
     fn test_out_of_sync_max_ts() {
-        use crate::storage::{
-            kv::Result, CfName, ConcurrencyManager, Cursor, DummyLockManager, IterOptions,
-            ScanMode, Value,
-        };
+        use crate::storage::{kv::Result, CfName, ConcurrencyManager, DummyLockManager, Value};
         use engine_rocks::RocksEngineIterator;
         use engine_traits::ReadOptions;
         use kvproto::kvrpcpb::ExtraOp;
@@ -1184,15 +1181,10 @@ mod tests {
             fn get_cf_opt(&self, _: ReadOptions, _: CfName, _: &Key) -> Result<Option<Value>> {
                 unimplemented!()
             }
-            fn iter(&self, _: IterOptions, _: ScanMode) -> Result<Cursor<Self::Iter>> {
+            fn iter(&self, _: IterOptions) -> Result<Self::Iter> {
                 unimplemented!()
             }
-            fn iter_cf(
-                &self,
-                _: CfName,
-                _: IterOptions,
-                _: ScanMode,
-            ) -> Result<Cursor<Self::Iter>> {
+            fn iter_cf(&self, _: CfName, _: IterOptions) -> Result<Self::Iter> {
                 unimplemented!()
             }
             fn is_max_ts_synced(&self) -> bool {

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -596,8 +596,8 @@ impl Scanner for FixtureStoreScanner {
 mod tests {
     use super::*;
     use crate::storage::kv::{
-        Cursor, Engine, Iterator, Result as EngineResult, RocksEngine, RocksSnapshot, ScanMode,
-        SnapContext, TestEngineBuilder, WriteData,
+        Engine, Iterator, Result as EngineResult, RocksEngine, RocksSnapshot, SnapContext,
+        TestEngineBuilder, WriteData,
     };
     use crate::storage::mvcc::{Mutation, MvccTxn};
     use crate::storage::txn::{
@@ -768,24 +768,11 @@ mod tests {
         fn get_cf_opt(&self, _: ReadOptions, _: CfName, _: &Key) -> EngineResult<Option<Value>> {
             Ok(None)
         }
-        fn iter(&self, _: IterOptions, _: ScanMode) -> EngineResult<Cursor<Self::Iter>> {
-            Ok(Cursor::new(
-                MockRangeSnapshotIter::default(),
-                ScanMode::Forward,
-                false,
-            ))
+        fn iter(&self, _: IterOptions) -> EngineResult<Self::Iter> {
+            Ok(MockRangeSnapshotIter::default())
         }
-        fn iter_cf(
-            &self,
-            _: CfName,
-            _: IterOptions,
-            _: ScanMode,
-        ) -> EngineResult<Cursor<Self::Iter>> {
-            Ok(Cursor::new(
-                MockRangeSnapshotIter::default(),
-                ScanMode::Forward,
-                false,
-            ))
+        fn iter_cf(&self, _: CfName, _: IterOptions) -> EngineResult<Self::Iter> {
+            Ok(MockRangeSnapshotIter::default())
         }
         fn lower_bound(&self) -> Option<&[u8]> {
             Some(self.start.as_slice())

--- a/tests/integrations/storage/test_raftkv.rs
+++ b/tests/integrations/storage/test_raftkv.rs
@@ -391,9 +391,11 @@ fn assert_none_cf<E: Engine>(ctx: SnapContext<'_>, engine: &E, cf: CfName, key: 
 
 fn assert_seek<E: Engine>(ctx: SnapContext<'_>, engine: &E, key: &[u8], pair: (&[u8], &[u8])) {
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut cursor = snapshot
-        .iter(IterOptions::default(), ScanMode::Mixed)
-        .unwrap();
+    let mut cursor = Cursor::new(
+        snapshot.iter(IterOptions::default()).unwrap(),
+        ScanMode::Mixed,
+        false,
+    );
     let mut statistics = CfStatistics::default();
     cursor.seek(&Key::from_raw(key), &mut statistics).unwrap();
     assert_eq!(cursor.key(&mut statistics), &*bytes::encode_bytes(pair.0));
@@ -408,9 +410,11 @@ fn assert_seek_cf<E: Engine>(
     pair: (&[u8], &[u8]),
 ) {
     let snapshot = engine.snapshot(ctx).unwrap();
-    let mut cursor = snapshot
-        .iter_cf(cf, IterOptions::default(), ScanMode::Mixed)
-        .unwrap();
+    let mut cursor = Cursor::new(
+        snapshot.iter_cf(cf, IterOptions::default()).unwrap(),
+        ScanMode::Mixed,
+        false,
+    );
     let mut statistics = CfStatistics::default();
     cursor.seek(&Key::from_raw(key), &mut statistics).unwrap();
     assert_eq!(cursor.key(&mut statistics), &*bytes::encode_bytes(pair.0));
@@ -483,9 +487,11 @@ fn seek<E: Engine>(ctx: SnapContext<'_>, engine: &E) {
     assert_seek(ctx.clone(), engine, b"y", (b"z", b"2"));
     assert_seek(ctx.clone(), engine, b"x\x00", (b"z", b"2"));
     let snapshot = engine.snapshot(ctx.clone()).unwrap();
-    let mut iter = snapshot
-        .iter(IterOptions::default(), ScanMode::Mixed)
-        .unwrap();
+    let mut iter = Cursor::new(
+        snapshot.iter(IterOptions::default()).unwrap(),
+        ScanMode::Mixed,
+        false,
+    );
     let mut statistics = CfStatistics::default();
     assert!(!iter
         .seek(&Key::from_raw(b"z\x00"), &mut statistics)
@@ -498,9 +504,11 @@ fn near_seek<E: Engine>(ctx: SnapContext<'_>, engine: &E) {
     must_put(ctx.pb_ctx, engine, b"x", b"1");
     must_put(ctx.pb_ctx, engine, b"z", b"2");
     let snapshot = engine.snapshot(ctx.clone()).unwrap();
-    let mut cursor = snapshot
-        .iter(IterOptions::default(), ScanMode::Mixed)
-        .unwrap();
+    let mut cursor = Cursor::new(
+        snapshot.iter(IterOptions::default()).unwrap(),
+        ScanMode::Mixed,
+        false,
+    );
     assert_near_seek(&mut cursor, b"x", (b"x", b"1"));
     assert_near_seek(&mut cursor, b"a", (b"x", b"1"));
     assert_near_reverse_seek(&mut cursor, b"z1", (b"z", b"2"));


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?


A prerequisite change of #9758, so TTLIterator can wrap RegionIterator directly

### What is changed and how it works?

Change iter() of Snapshot trait from
```rust
     fn iter(&self, iter_opt: IterOptions, mode: ScanMode) -> EngineResult<Cursor<Self::Iter>> 
```
to 
```rust
     fn iter(&self, iter_opt: IterOptions) -> EngineResult<Self::Iter> 
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

- None