### PR TITLE
Add load base split backup policy: split by half

### DIFF
--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -376,21 +376,19 @@ impl AutoSplitController {
             recorder.record(key_ranges);
             if recorder.is_ready() {
                 let key = recorder.collect(&self.cfg);
-                if !key.is_empty() {
-                    let split_info = SplitInfo {
-                        region_id,
-                        split_key: key,
-                        peer: recorder.peer.clone(),
-                    };
-                    split_infos.push(split_info);
-                    info!(
-                        "load base split region";
-                        "region_id"=>region_id,
-                        "size"=>approximate_size,
-                        "keys"=>approximate_keys,
-                        "qps"=>qps
-                    );
-                }
+                let split_info = SplitInfo {
+                    region_id,
+                    split_key: key,
+                    peer: recorder.peer.clone(),
+                };
+                split_infos.push(split_info);
+                info!(
+                    "load base split region";
+                    "region_id"=>region_id,
+                    "size"=>approximate_size,
+                    "keys"=>approximate_keys,
+                    "qps"=>qps
+                );
                 self.recorders.remove(&region_id);
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
For regions where both qps and size exceed the threshold, the current strategy may fail to split because no suitable split key can be found, so for this case, we directly split in half to ensure that there are no regions in the cluster where both exceed the threshold.

### What is changed and how it works?

What's Changed:

- Move the determine if split key is empty to pd.rs

- Add split by  half when split key is empty

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->
- no release note