### PR TITLE
enable GC in compaction filter by default

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -971,7 +971,7 @@
 # max-write-bytes-per-sec = "0"
 
 ## Enable GC by compaction filter or not.
-# enable-compaction-filter = false
+# enable-compaction-filter = true
 
 ## Garbage ratio threshold to trigger a GC.
 # ratio-threshold = 1.1

--- a/src/server/gc_worker/config.rs
+++ b/src/server/gc_worker/config.rs
@@ -29,7 +29,7 @@ impl Default for GcConfig {
             ratio_threshold: DEFAULT_GC_RATIO_THRESHOLD,
             batch_keys: DEFAULT_GC_BATCH_KEYS,
             max_write_bytes_per_sec: ReadableSize(DEFAULT_GC_MAX_WRITE_BYTES_PER_SEC),
-            enable_compaction_filter: false,
+            enable_compaction_filter: true,
             compaction_filter_skip_version_check: false,
         }
     }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -699,7 +699,7 @@ fn test_serde_custom_tikv_config() {
         ratio_threshold: 1.2,
         batch_keys: 256,
         max_write_bytes_per_sec: ReadableSize::mb(10),
-        enable_compaction_filter: true,
+        enable_compaction_filter: false,
         compaction_filter_skip_version_check: true,
     };
     value.pessimistic_txn = PessimisticTxnConfig {

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -602,7 +602,7 @@ import-mode-timeout = "1453s"
 ratio-threshold = 1.2
 batch-keys = 256
 max-write-bytes-per-sec = "10MB"
-enable-compaction-filter = true
+enable-compaction-filter = false
 compaction-filter-skip-version-check = true
 
 [pessimistic-txn]


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

enable GC in compaction filter by default.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.