### PR TITLE
txn: add the pessimistic prewrite failpoint

### DIFF
--- a/tests/failpoints/cases/test_transaction.rs
+++ b/tests/failpoints/cases/test_transaction.rs
@@ -26,13 +26,17 @@ fn test_txn_failpoints() {
     fail::remove("commit");
 
     let v1 = b"v1";
+    let (k2, v2) = (b"k2", b"v2");
     must_acquire_pessimistic_lock(&engine, k, k, 30, 30);
     fail::cfg("pessimistic_prewrite", "return()").unwrap();
     must_pessimistic_prewrite_put_err(&engine, k, v1, k, 30, 30, true);
+    must_prewrite_put(&engine, k2, v2, k2, 31);
     fail::remove("pessimistic_prewrite");
     must_pessimistic_prewrite_put(&engine, k, v1, k, 30, 30, true);
     must_commit(&engine, k, 30, 40);
+    must_commit(&engine, k2, 31, 41);
     must_get(&engine, k, 50, v1);
+    must_get(&engine, k2, 50, v2);
 }
 
 #[test]


### PR DESCRIPTION
Signed-off-by: cfzjywxk <lsswxrxr@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
The `pessimistic_prewrite` failpoint is lost after some refactors, leading to some tests failure using the master branch.

### What is changed and how it works?

What's Changed:
Try to add back the failpoint. 
Maybe it's better to seperate the `pessimistic_prewrite` and `optimistic_prewrite` code path.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->


- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->
- No release note.