### PR TITLE
Remove two uses of engine_rocks from tikv_kv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5400,6 +5400,7 @@ version = "0.1.0"
 dependencies = [
  "backtrace",
  "derive_more",
+ "engine_panic",
  "engine_rocks",
  "engine_traits",
  "error_code",

--- a/components/tikv_kv/Cargo.toml
+++ b/components/tikv_kv/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 default = ["protobuf-codec", "test-engines-rocksdb"]
 failpoints = ["fail/failpoints"]
 protobuf-codec = [
+  "engine_panic/protobuf-codec",
   "engine_rocks/protobuf-codec",
   "engine_traits/protobuf-codec",
   "error_code/protobuf-codec",
@@ -19,6 +20,7 @@ protobuf-codec = [
   "txn_types/protobuf-codec",
 ]
 prost-codec = [
+  "engine_panic/prost-codec",
   "engine_rocks/prost-codec",
   "engine_traits/prost-codec",
   "error_code/prost-codec",
@@ -37,6 +39,7 @@ test-engines-panic = [
 [dependencies]
 backtrace = "0.3"
 derive_more = "0.99.3"
+engine_panic = { path = "../engine_panic", default-features = false }
 engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 error_code = { path = "../error_code", default-features = false }

--- a/components/tikv_kv/src/btree_engine.rs
+++ b/components/tikv_kv/src/btree_engine.rs
@@ -7,7 +7,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::RangeBounds;
 use std::sync::{Arc, RwLock};
 
-use engine_rocks::RocksEngine;
+use engine_panic::PanicEngine;
 use engine_traits::{CfName, IterOptions, ReadOptions, CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::Context;
 use txn_types::{Key, Value};
@@ -71,9 +71,9 @@ impl Default for BTreeEngine {
 
 impl Engine for BTreeEngine {
     type Snap = BTreeEngineSnapshot;
-    type Local = RocksEngine;
+    type Local = PanicEngine;
 
-    fn kv_engine(&self) -> RocksEngine {
+    fn kv_engine(&self) -> PanicEngine {
         unimplemented!();
     }
 

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -32,7 +32,6 @@ use std::fmt;
 use std::time::Duration;
 use std::{error, ptr, result};
 
-use engine_rocks::RocksTablePropertiesCollection;
 use engine_traits::util::append_expire_ts;
 use engine_traits::{CfName, CF_DEFAULT};
 use engine_traits::{IterOptions, KvEngine as LocalEngine, MvccProperties, ReadOptions};
@@ -213,19 +212,6 @@ pub trait Engine: Send + Clone + 'static {
 
     fn delete_cf(&self, ctx: &Context, cf: CfName, key: Key) -> Result<()> {
         self.write(ctx, WriteData::from_modifies(vec![Modify::Delete(cf, key)]))
-    }
-
-    fn get_properties(&self, start: &[u8], end: &[u8]) -> Result<RocksTablePropertiesCollection> {
-        self.get_properties_cf(CF_DEFAULT, start, end)
-    }
-
-    fn get_properties_cf(
-        &self,
-        _: CfName,
-        _start: &[u8],
-        _end: &[u8],
-    ) -> Result<RocksTablePropertiesCollection> {
-        Err(box_err!("no user properties"))
     }
 
     fn get_mvcc_properties_cf(

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -10,10 +10,10 @@ use std::{sync::Arc, time::Duration};
 
 use bitflags::bitflags;
 use concurrency_manager::ConcurrencyManager;
-use engine_rocks::{RocksEngine, RocksSnapshot, RocksTablePropertiesCollection};
+use engine_rocks::{RocksEngine, RocksSnapshot};
 use engine_traits::CF_DEFAULT;
 use engine_traits::{CfName, KvEngine};
-use engine_traits::{MvccProperties, MvccPropertiesExt, TablePropertiesExt};
+use engine_traits::{MvccProperties, MvccPropertiesExt};
 use kvproto::kvrpcpb::Context;
 use kvproto::raft_cmdpb::{
     CmdType, DeleteRangeRequest, DeleteRequest, PutRequest, RaftCmdRequest, RaftCmdResponse,
@@ -471,19 +471,6 @@ where
 
     fn release_snapshot(&self) {
         self.router.release_snapshot_cache();
-    }
-
-    fn get_properties_cf(
-        &self,
-        cf: CfName,
-        start: &[u8],
-        end: &[u8],
-    ) -> kv::Result<RocksTablePropertiesCollection> {
-        let start = keys::data_key(start);
-        let end = keys::data_end_key(end);
-        self.engine
-            .get_range_properties_cf(cf, &start, &end)
-            .map_err(|e| e.into())
     }
 
     fn get_mvcc_properties_cf(


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue: https://github.com/tikv/tikv/issues/9609

Problem Summary:

tikv_kv uses engine_rocks directly and it should not.

### What is changed and how it works?

- Remove the get_properties / get_properties_cf methods from tikv_kv::Engine trait. These are fortunately unused.
- Use PanicEngine instead of RocksEngine as an unimplemented placeholder in BTreeEngine
   - Ultimately no concrete engine should be used here, but this is an easy way to get rid of RocksEngine, and PanicEngine is more semantically appropriate here.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->


### Release note <!-- bugfixes or new feature need a release note -->

- No release note.