### PR TITLE
[DNM] txn: Add the raw key to `lock_manager::Lock` for preparing implemeting data_locks view in TiDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#3cd2fc5fad226caeffed72297e3e13a571f5592e"
+source = "git+https://github.com/longfangsong/kvproto#fafc84d6d2e047a32369aaf576f371696de96a84"
 dependencies = [
  "futures 0.3.7",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ fs2 = "0.4"
 futures = { version = "0.3", features = ["thread-pool", "compat"] }
 futures-executor = "0.3.1"
 futures-util = { version = "0.3.1", default-features = false, features = ["io", "async-await"] }
-grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
+grpcio = { version = "0.8", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 hyper-tls = "0.4"
 itertools = "0.8"
@@ -217,6 +217,8 @@ openssl-src = { git = "https://github.com/busyjay/openssl-src-rs", branch = "pat
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
+[patch.'https://github.com/pingcap/kvproto.git']
+kvproto = { git = "https://github.com/longfangsong/kvproto", default-features = false }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -246,7 +246,7 @@ impl LockManagerTrait for LockManager {
         // but the waiter_mgr haven't processed it, subsequent WakeUp msgs may be lost.
         self.waiter_count.fetch_add(1, Ordering::SeqCst);
         self.waiter_mgr_scheduler
-            .wait_for(start_ts, cb, pr, lock, timeout);
+            .wait_for(start_ts, cb, pr, lock.clone(), timeout);
 
         // If it is the first lock the transaction tries to lock, it won't cause deadlock.
         if !is_first_lock {
@@ -259,6 +259,7 @@ impl LockManagerTrait for LockManager {
         &self,
         lock_ts: TimeStamp,
         hashes: Vec<u64>,
+        keys: Vec<Vec<u8>>,
         commit_ts: TimeStamp,
         is_pessimistic_txn: bool,
     ) {
@@ -266,7 +267,7 @@ impl LockManagerTrait for LockManager {
         // Try to wake up them.
         if !hashes.is_empty() && self.has_waiter() {
             self.waiter_mgr_scheduler
-                .wake_up(lock_ts, hashes, commit_ts);
+                .wake_up(lock_ts, hashes, keys, commit_ts);
         }
         // If a pessimistic transaction is committed or rolled back and it once sent requests to
         // detect deadlock, clean up its wait-for entries in the deadlock detector.

--- a/src/storage/lock_manager.rs
+++ b/src/storage/lock_manager.rs
@@ -4,9 +4,10 @@ use crate::storage::{txn::ProcessResult, types::StorageCallback};
 use std::time::Duration;
 use txn_types::TimeStamp;
 
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub struct Lock {
     pub ts: TimeStamp,
+    pub key: Vec<u8>,
     pub hash: u64,
 }
 
@@ -69,6 +70,7 @@ pub trait LockManager: Clone + Send + 'static {
         &self,
         lock_ts: TimeStamp,
         hashes: Vec<u64>,
+        keys: Vec<Vec<u8>>,
         commit_ts: TimeStamp,
         is_pessimistic_txn: bool,
     );
@@ -101,6 +103,7 @@ impl LockManager for DummyLockManager {
         &self,
         _lock_ts: TimeStamp,
         _hashes: Vec<u64>,
+        _keys: Vec<Vec<u8>>,
         _commit_ts: TimeStamp,
         _is_pessimistic_txn: bool,
     ) {

--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -62,6 +62,7 @@ fn extract_lock_from_result<T>(res: &StorageResult<T>) -> Lock {
             box MvccErrorInner::KeyIsLocked(info),
         )))))) => Lock {
             ts: info.get_lock_version().into(),
+            key: info.get_key().to_vec(),
             hash: Key::from_raw(info.get_key()).gen_hash(),
         },
         _ => panic!("unexpected mvcc error"),

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -332,6 +332,7 @@ pub(super) struct ReleasedLocks {
     start_ts: TimeStamp,
     commit_ts: TimeStamp,
     hashes: Vec<u64>,
+    keys: Vec<Vec<u8>>,
     pessimistic: bool,
 }
 
@@ -387,7 +388,13 @@ impl ReleasedLocks {
 
     // Wake up pessimistic transactions that waiting for these locks.
     pub fn wake_up<L: LockManager>(self, lock_mgr: &L) {
-        lock_mgr.wake_up(self.start_ts, self.hashes, self.commit_ts, self.pessimistic);
+        lock_mgr.wake_up(
+            self.start_ts,
+            self.hashes,
+            self.keys,
+            self.commit_ts,
+            self.pessimistic,
+        );
     }
 }
 


### PR DESCRIPTION
Signed-off-by: longfangsong <longfangsong@icloud.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

⚠️：DNM, rely on [this pr](https://github.com/pingcap/kvproto/pull/739) in kvproto needs to be updated first.

### What problem does this PR solve?

Problem Summary: Currently, there're no way to view the locks associated with a transaction with SQL, which sometimes makes diagnosing related problems hard.

### What is changed and how it works?

What's Changed:

Proposal: [TiDB Transaction related views](https://docs.google.com/document/d/1WktXEUYO7LgDfJsgbCPbi6vMb5XYbiSW7gG6hRfk-no/edit#heading=h.aqlm47iqhdnk)

What's Changed:

Store the raw key together with the hash value in `lock_manager::Lock` for querying by TiDB.

### Check List <!--REMOVE the items that are not applicable-->

(WIP) Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->
- No Release note