### PR TITLE
cdc: fix old value cache may always missed

### DIFF
--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -761,7 +761,7 @@ fn test_old_value_basic() {
     // Insert value
     let mut m1 = Mutation::default();
     let k1 = b"k1".to_vec();
-    m1.set_op(Op::Put);
+    m1.set_op(Op::Insert);
     m1.key = k1.clone();
     m1.value = b"v1".to_vec();
     let ts1 = block_on(suite.cluster.pd_client.get_tso()).unwrap();

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -126,6 +126,10 @@ impl TestSuite {
                 .push(Box::new(move || {
                     create_change_data(cdc::Service::new(scheduler.clone()))
                 }));
+            sim.txn_extra_schedulers.insert(
+                id,
+                Arc::new(cdc::CdcTxnExtraScheduler::new(worker.scheduler().clone())),
+            );
             let scheduler = worker.scheduler();
             let cdc_ob = cdc::CdcObserver::new(scheduler.clone());
             obs.insert(id, cdc_ob.clone());

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -59,6 +59,7 @@ use tikv_util::config::VersionTrack;
 use tikv_util::time::ThreadReadId;
 use tikv_util::worker::{Builder as WorkerBuilder, FutureWorker, LazyWorker};
 use tikv_util::HandyRwLock;
+use txn_types::TxnExtraScheduler;
 
 type SimulateStoreTransport = SimulateTransport<ServerRaftStoreRouter<RocksEngine, RocksEngine>>;
 type SimulateServerTransport =
@@ -122,6 +123,7 @@ pub struct ServerCluster {
     pub pending_services: HashMap<u64, PendingServices>,
     pub coprocessor_hooks: HashMap<u64, CopHooks>,
     pub security_mgr: Arc<SecurityManager>,
+    pub txn_extra_schedulers: HashMap<u64, Arc<dyn TxnExtraScheduler>>,
     snap_paths: HashMap<u64, TempDir>,
     pd_client: Arc<TestPdClient>,
     raft_client: RaftClient<AddressMap, RaftStoreBlackHole>,
@@ -164,6 +166,7 @@ impl ServerCluster {
             raft_client,
             concurrency_managers: HashMap::default(),
             env,
+            txn_extra_schedulers: HashMap::default(),
         }
     }
 
@@ -245,7 +248,10 @@ impl Simulator for ServerCluster {
             raft_engine.clone(),
         ));
 
-        let engine = RaftKv::new(sim_router.clone(), engines.kv.clone());
+        let mut engine = RaftKv::new(sim_router.clone(), engines.kv.clone());
+        if let Some(scheduler) = self.txn_extra_schedulers.remove(&node_id) {
+            engine.set_txn_extra_scheduler(scheduler);
+        }
 
         let latest_ts =
             block_on(self.pd_client.get_tso()).expect("failed to get timestamp from PD");

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -249,6 +249,8 @@ impl MutationType {
     pub fn may_have_old_value(&self) -> bool {
         matches!(
             self,
+            // Insert operations don't have old value but need to update a flag
+            // for indicating that not seeking for old value for it.
             MutationType::Put | MutationType::Delete | MutationType::Insert
         )
     }

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -247,7 +247,10 @@ pub enum MutationType {
 
 impl MutationType {
     pub fn may_have_old_value(&self) -> bool {
-        matches!(self, MutationType::Put | MutationType::Delete)
+        matches!(
+            self,
+            MutationType::Put | MutationType::Delete | MutationType::Insert
+        )
     }
 }
 

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -447,6 +447,7 @@ impl<K: PrewriteKind> Prewriter<K> {
                     if (secondaries.is_some() || self.try_one_pc) && final_min_commit_ts < ts {
                         final_min_commit_ts = ts;
                     }
+                    let key = key.append_ts(txn.start_ts);
                     if old_value.specified() {
                         self.old_values.insert(key, (old_value, mutation_type));
                     }


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
Previously we refactored the logic about old-value in the transaction layer (see #9173). This introduces a bug that the old-value cache will be always missed because the key of the cache doesn't contains `start ts`.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
* Append start ts to the key of the cache
* Make insert operations updating the cache
* Make the cache works in the tests

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* cdc: fix old value cache maybe always missed