### PR TITLE
pd_client: prevent a large number of reconnections in a short time (#9840)

### DIFF
--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -28,7 +28,7 @@ pub use self::client::RpcClient;
 pub use self::config::Config;
 pub use self::errors::{Error, Result};
 pub use self::util::validate_endpoints;
-pub use self::util::RECONNECT_INTERVAL_SEC;
+pub use self::util::REQUEST_RECONNECT_INTERVAL;
 
 use std::ops::Deref;
 

--- a/components/pd_client/src/metrics.rs
+++ b/components/pd_client/src/metrics.rs
@@ -15,6 +15,12 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
+    pub static ref PD_RECONNECT_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
+        "tikv_pd_reconnect_total",
+        "Total number of PD reconnections.",
+        &["type"]
+    )
+    .unwrap();
     pub static ref PD_VALIDATE_PEER_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
         "tikv_pd_validate_peer_total",
         "Total number of pd worker validate peer task.",

--- a/components/test_pd/src/mocker/leader_change.rs
+++ b/components/test_pd/src/mocker/leader_change.rs
@@ -55,6 +55,10 @@ impl PdMocker for LeaderChange {
         if now - inner.r.ts > LeaderChange::get_leader_interval() {
             inner.r.idx += 1;
             inner.r.ts = now;
+            debug!(
+                "[LeaderChange] change leader to {:?}",
+                inner.resps[inner.r.idx % inner.resps.len()].get_leader()
+            );
             return Some(Err("not leader".to_owned()));
         }
 
@@ -66,18 +70,12 @@ impl PdMocker for LeaderChange {
     }
 
     fn get_region_by_id(&self, _: &GetRegionByIdRequest) -> Option<Result<GetRegionResponse>> {
-        let mut inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock().unwrap();
         let now = Instant::now();
         if now.duration_since(inner.r.ts) > LeaderChange::get_leader_interval() {
-            inner.r.idx += 1;
-            inner.r.ts = now;
-            debug!(
-                "[LeaderChange] change leader to {:?}",
-                inner.resps[inner.r.idx % inner.resps.len()].get_leader()
-            );
+            return Some(Err("not leader".to_owned()));
         }
-
-        Some(Err("not leader".to_owned()))
+        Some(Ok(GetRegionResponse::default()))
     }
 
     fn set_endpoints(&self, eps: Vec<String>) {

--- a/components/test_pd/src/mocker/retry.rs
+++ b/components/test_pd/src/mocker/retry.rs
@@ -2,10 +2,9 @@
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::thread;
-use std::time::Duration;
 
 use kvproto::pdpb::*;
-use pd_client::RECONNECT_INTERVAL_SEC;
+use pd_client::REQUEST_RECONNECT_INTERVAL;
 
 use super::*;
 
@@ -32,7 +31,7 @@ impl Retry {
             return true;
         }
         // let's sleep awhile, so that client will update its connection.
-        thread::sleep(Duration::from_secs(RECONNECT_INTERVAL_SEC));
+        thread::sleep(REQUEST_RECONNECT_INTERVAL);
         false
     }
 }

--- a/components/test_pd/src/mocker/service.rs
+++ b/components/test_pd/src/mocker/service.rs
@@ -276,4 +276,31 @@ impl PdMocker for Service {
         resp.set_header(header);
         Some(Ok(resp))
     }
+
+    fn put_store(&self, _: &PutStoreRequest) -> Option<Result<PutStoreResponse>> {
+        let mut resp = PutStoreResponse::default();
+        let header = Service::header();
+        resp.set_header(header);
+        Some(Ok(resp))
+    }
+
+    fn get_cluster_config(
+        &self,
+        _: &GetClusterConfigRequest,
+    ) -> Option<Result<GetClusterConfigResponse>> {
+        let mut resp = GetClusterConfigResponse::default();
+        let header = Service::header();
+        resp.set_header(header);
+        Some(Ok(resp))
+    }
+
+    fn get_gc_safe_point(
+        &self,
+        _: &GetGcSafePointRequest,
+    ) -> Option<Result<GetGcSafePointResponse>> {
+        let mut resp = GetGcSafePointResponse::default();
+        let header = Service::header();
+        resp.set_header(header);
+        Some(Ok(resp))
+    }
 }

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -5906,6 +5906,99 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": 1,
+          "description": " \tThe count of reconnections between TiKV and PD",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 23
+          },
+          "id": 7985,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(delta(tikv_pd_reconnect_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ type }}",
+              "refId": "A",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PD reconnections",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "opm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": 1,
           "description": "The total number of peers validated by the PD worker",
           "fill": 1,
           "gridPos": {

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -35,12 +35,13 @@ use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use super::Result;
 use crate::config::ConfigController;
 use configuration::Configuration;
-use pd_client::RpcClient;
+use pd_client::{RpcClient, REQUEST_RECONNECT_INTERVAL};
 use security::{self, SecurityConfig};
 use tikv_alloc::error::ProfError;
 use tikv_util::collections::HashMap;
@@ -494,6 +495,7 @@ where
             // refresh the pd leader
             if let Err(e) = pd_client.reconnect() {
                 warn!("failed to reconnect pd client"; "err" => ?e);
+                thread::sleep(REQUEST_RECONNECT_INTERVAL);
             }
         }
         warn!(
@@ -553,6 +555,7 @@ where
             // refresh the pd leader
             if let Err(e) = pd_client.reconnect() {
                 warn!("failed to reconnect pd client"; "err" => ?e);
+                thread::sleep(REQUEST_RECONNECT_INTERVAL);
             }
         }
         warn!(

--- a/tests/failpoints/cases/test_pd_client.rs
+++ b/tests/failpoints/cases/test_pd_client.rs
@@ -81,6 +81,10 @@ fn test_pd_client_deadlock() {
             func();
             tx.send(()).unwrap();
         });
+        // Only allow to reconnect once for a func.
+        client.handle_reconnect(move || {
+            fail::cfg(leader_client_reconnect_fp, "return").unwrap();
+        });
         // Remove the fail point to let the PD client thread go on.
         fail::remove(leader_client_reconnect_fp);
         if rx.recv_timeout(Duration::from_millis(500)).is_err() {

--- a/tests/failpoints/cases/test_pd_client.rs
+++ b/tests/failpoints/cases/test_pd_client.rs
@@ -73,8 +73,8 @@ fn test_pd_client_deadlock() {
     for (name, func) in test_funcs {
         fail::cfg(leader_client_reconnect_fp, "pause").unwrap();
         // Wait for the PD client thread blocking on the fail point.
-        // The RECONNECT_INTERVAL_SEC is 1s so sleeps 2s here.
-        thread::sleep(Duration::from_secs(2));
+        // The GLOBAL_RECONNECT_INTERVAL is 0.1s so sleeps 0.2s here.
+        thread::sleep(Duration::from_millis(200));
 
         let (tx, rx) = mpsc::channel();
         let handle = thread::spawn(move || {
@@ -109,4 +109,25 @@ fn test_pd_client_deadlock() {
         ))
         .forget();
     rx.recv_timeout(Duration::from_millis(3000)).unwrap();
+}
+
+// Reconnection will be speed limited.
+#[test]
+fn test_reconnect_limit() {
+    let leader_client_reconnect_fp = "leader_client_reconnect";
+    let (_server, client) = new_test_server_and_client(ReadableDuration::secs(100));
+
+    // The GLOBAL_RECONNECT_INTERVAL is 0.1s so sleeps 0.2s here.
+    thread::sleep(Duration::from_millis(200));
+
+    // The first reconnection will succeed, and the last_update will not be updated.
+    fail::cfg(leader_client_reconnect_fp, "return").unwrap();
+    client.reconnect().unwrap();
+    // The subsequent reconnection will be cancelled.
+    for _ in 0..10 {
+        let ret = client.reconnect();
+        assert!(format!("{:?}", ret.unwrap_err()).contains("cancel reconnection"));
+    }
+
+    fail::remove(leader_client_reconnect_fp);
 }

--- a/tests/failpoints/cases/test_pd_client.rs
+++ b/tests/failpoints/cases/test_pd_client.rs
@@ -83,8 +83,7 @@ fn test_pd_client_deadlock() {
         });
         // Remove the fail point to let the PD client thread go on.
         fail::remove(leader_client_reconnect_fp);
-        // The REQUEST_RECONNECT_INTERVAL is 1s so waits 1.5s here. Not required for version 5.0 or higher.
-        if rx.recv_timeout(Duration::from_millis(1500)).is_err() {
+        if rx.recv_timeout(Duration::from_millis(500)).is_err() {
             panic!("PdClient::{}() hangs", name);
         }
         handle.join().unwrap();

--- a/tests/failpoints/cases/test_pd_client.rs
+++ b/tests/failpoints/cases/test_pd_client.rs
@@ -83,7 +83,8 @@ fn test_pd_client_deadlock() {
         });
         // Remove the fail point to let the PD client thread go on.
         fail::remove(leader_client_reconnect_fp);
-        if rx.recv_timeout(Duration::from_millis(500)).is_err() {
+        // The REQUEST_RECONNECT_INTERVAL is 1s so waits 1.5s here. Not required for version 5.0 or higher.
+        if rx.recv_timeout(Duration::from_millis(1500)).is_err() {
             panic!("PdClient::{}() hangs", name);
         }
         handle.join().unwrap();

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -332,8 +332,8 @@ fn restart_leader(mgr: SecurityManager) {
     server.stop();
     server.start(&mgr, eps);
 
-    // RECONNECT_INTERVAL_SEC is 1s.
-    thread::sleep(Duration::from_secs(1));
+    // The GLOBAL_RECONNECT_INTERVAL is 0.1s so sleeps 0.2s here.
+    thread::sleep(Duration::from_millis(200));
 
     let region = client.get_region_by_id(region.get_id()).wait().unwrap();
     assert_eq!(region.unwrap().get_id(), region_id);


### PR DESCRIPTION
cherry-pick #9840 to release-4.0
cherry-pick #9880 to release-4.0
cherry-pick a part of #9501 to release-4.0 (related #9548)

### What problem does this PR solve?
Issue Number: related #9799

Problem Summary:

Too many uninterrupted reconnection.

### What is changed and how it works?
What's Changed:

* Cancel some unnecessary reconnection.
* Add reconnect metrics.
* Optimize the test.

### Related changes
* Need to cherry-pick to the release branch

### Check List
Tests

* Unit test
* Manual test
  
  * 3 PD / 3 TiKV / 1000 Region
  * Manually make PD no leader
  * Add metrics (will be in another PR)
    
    * Before ![image](https://user-images.githubusercontent.com/19789302/111725356-e2bbc200-88a1-11eb-84d8-8a357ae88e69.png)
    * After ![image](https://user-images.githubusercontent.com/19789302/111726549-24e60300-88a4-11eb-9dda-5c5f16e6f3f0.png)

### Release note
* pd_client: prevent a large number of reconnections in a short time
