### PR TITLE
txn: make prewrite idempotent when falling back to 2PC

### DIFF
--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -28,15 +28,22 @@ pub fn prewrite<S: Snapshot>(
 ) -> Result<(TimeStamp, OldValue)> {
     let mut mutation = PrewriteMutation::from_mutation(mutation, secondary_keys, txn_props)?;
 
-    let fail_point = if txn_props.is_pessimistic() {
-        "pessimistic_prewrite"
-    } else {
-        "prewrite"
-    };
-    fail_point!(fail_point, |err| Err(
-        crate::storage::mvcc::txn::make_txn_error(err, &mutation.key, mutation.txn_props.start_ts)
+    #[cfg(feature = "failpoints")]
+    {
+        let fail_point = if txn_props.is_pessimistic() {
+            "pessimistic_prewrite"
+        } else {
+            "prewrite"
+        };
+        fail_point!(fail_point, |err| Err(
+            crate::storage::mvcc::txn::make_txn_error(
+                err,
+                &mutation.key,
+                mutation.txn_props.start_ts
+            )
             .into()
-    ));
+        ));
+    }
 
     let lock_status = match txn.reader.load_lock(&mutation.key)? {
         Some(lock) => mutation.check_lock(lock, is_pessimistic_lock)?,
@@ -246,7 +253,12 @@ impl<'a> PrewriteMutation<'a> {
 
         // Duplicated command. No need to overwrite the lock and data.
         MVCC_DUPLICATE_CMD_COUNTER_VEC.prewrite.inc();
-        Ok(LockStatus::Locked(lock.min_commit_ts))
+        let min_commit_ts = if lock.use_async_commit {
+            lock.min_commit_ts
+        } else {
+            TimeStamp::zero()
+        };
+        Ok(LockStatus::Locked(min_commit_ts))
     }
 
     fn check_for_newer_version<S: Snapshot>(&self, txn: &mut MvccTxn<S>) -> Result<Option<Write>> {

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -665,7 +665,9 @@ pub mod test_util {
             _ => unreachable!(),
         };
         let ctx = Context::default();
-        engine.write(&ctx, ret.to_be_write).unwrap();
+        if !ret.to_be_write.modifies.is_empty() {
+            engine.write(&ctx, ret.to_be_write).unwrap();
+        }
         Ok(res)
     }
 

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -441,18 +441,19 @@ impl<K: PrewriteKind> Prewriter<K> {
                 secondaries = &self.secondary_keys;
             }
 
+            let need_min_commit_ts = secondaries.is_some() || self.try_one_pc;
             let prewrite_result = prewrite(txn, &props, m, secondaries, is_pessimistic_lock);
             match prewrite_result {
-                Ok((ts, old_value)) => {
-                    if (secondaries.is_some() || self.try_one_pc) && final_min_commit_ts < ts {
+                Ok((ts, old_value)) if !(need_min_commit_ts && ts.is_zero()) => {
+                    if need_min_commit_ts && final_min_commit_ts < ts {
                         final_min_commit_ts = ts;
                     }
-                    let key = key.append_ts(txn.start_ts);
                     if old_value.specified() {
+                        let key = key.append_ts(txn.start_ts);
                         self.old_values.insert(key, (old_value, mutation_type));
                     }
                 }
-                Err(MvccError(box MvccErrorInner::CommitTsTooLarge { .. })) => {
+                Err(MvccError(box MvccErrorInner::CommitTsTooLarge { .. })) | Ok((_, _)) => {
                     // fallback to not using async commit or 1pc
                     props.commit_kind = CommitKind::TwoPc;
                     async_commit_pk = None;
@@ -1074,25 +1075,28 @@ mod tests {
         ];
         let mut statistics = Statistics::default();
         // calculated_ts > max_commit_ts
-        let cmd = super::Prewrite::new(
-            mutations,
-            k1.to_vec(),
-            20.into(),
-            0,
-            false,
-            2,
-            TimeStamp::default(),
-            40.into(),
-            Some(vec![k2.to_vec()]),
-            false,
-            Context::default(),
-        );
+        // Test the idempotency of prewrite when falling back to 2PC.
+        for _ in 0..2 {
+            let cmd = super::Prewrite::new(
+                mutations.clone(),
+                k1.to_vec(),
+                20.into(),
+                0,
+                false,
+                2,
+                21.into(),
+                40.into(),
+                Some(vec![k2.to_vec()]),
+                false,
+                Context::default(),
+            );
 
-        let res = prewrite_command(&engine, cm, &mut statistics, cmd).unwrap();
-        assert!(res.min_commit_ts.is_zero());
-        assert!(res.one_pc_commit_ts.is_zero());
-        assert!(!must_locked(&engine, k1, 20).use_async_commit);
-        assert!(!must_locked(&engine, k2, 20).use_async_commit);
+            let res = prewrite_command(&engine, cm.clone(), &mut statistics, cmd).unwrap();
+            assert!(res.min_commit_ts.is_zero());
+            assert!(res.one_pc_commit_ts.is_zero());
+            assert!(!must_locked(&engine, k1, 20).use_async_commit);
+            assert!(!must_locked(&engine, k2, 20).use_async_commit);
+        }
     }
 
     #[test]

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -1283,11 +1283,16 @@ fn test_prewrite_check_max_commit_ts() {
     mutation.set_value(b"v2".to_vec());
     req.mut_mutations().push(mutation);
     req.set_start_version(20);
+    req.set_min_commit_ts(21);
     req.set_max_commit_ts(50);
     req.set_lock_ttl(20000);
     req.set_use_async_commit(true);
-    let resp = client.kv_prewrite(&req).unwrap();
-    assert_eq!(resp.get_min_commit_ts(), 0);
+    // Test the idempotency of prewrite when falling back to 2PC.
+    for _ in 0..2 {
+        let resp = client.kv_prewrite(&req).unwrap();
+        assert_eq!(resp.get_min_commit_ts(), 0);
+        assert_eq!(resp.get_one_pc_commit_ts(), 0);
+    }
     // There shouldn't be locks remaining in the lock table.
     assert!(cm.read_range_check(None, None, |_, _| Err(())).is_ok());
 }


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/23477

Problem Summary:

`Prewrite` is not idempotent when falling back to 2PC:
1. A async-commit prewrite request succeeded in writing a fallback lock. Its response is `min_commit_ts == 0`.
2. Following duplicated prewrite requests returns `min_commit_ts != 0` which makes clients think it can go on with async-commit protocol.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Make prewrite idempotent.

### Related changes
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.