### PR TITLE
txn: return min_commit_ts for check_not_exists

### DIFF
--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -34,8 +34,7 @@ pub fn prewrite<S: Snapshot>(
         "prewrite"
     };
     fail_point!(fail_point, |err| Err(
-        crate::storage::mvcc::txn::make_txn_error(err, &mutation.key, mutation.txn_props.start_ts)
-            .into()
+        crate::storage::mvcc::txn::make_txn_error(err, &mutation.key, txn_props.start_ts).into()
     ));
 
     let lock_status = match txn.reader.load_lock(&mutation.key)? {
@@ -59,7 +58,14 @@ pub fn prewrite<S: Snapshot>(
     };
 
     if mutation.should_not_write {
-        return Ok((TimeStamp::zero(), OldValue::Unspecified));
+        let min_commit_ts = if mutation.need_min_commit_ts() {
+            // Don't calculate the min_commit_ts according to the concurrency manager's max_ts
+            // for a should_not_write mutation because it's not persisted and doesn't change data.
+            cmp::max(txn_props.min_commit_ts, txn_props.start_ts.next())
+        } else {
+            TimeStamp::zero()
+        };
+        return Ok((min_commit_ts, OldValue::Unspecified));
     }
 
     let old_value = if txn_props.need_old_value && mutation.mutation_type.may_have_old_value() {
@@ -358,12 +364,15 @@ impl<'a> PrewriteMutation<'a> {
         }
     }
 
+    fn need_min_commit_ts(&self) -> bool {
+        matches!(
+            &self.txn_props.commit_kind,
+            CommitKind::Async(_) | CommitKind::OnePc(_)
+        )
+    }
+
     fn try_one_pc(&self) -> bool {
-        match &self.txn_props.commit_kind {
-            CommitKind::TwoPc => false,
-            CommitKind::OnePc(_) => true,
-            CommitKind::Async(_) => false,
-        }
+        matches!(&self.txn_props.commit_kind, CommitKind::OnePc(_))
     }
 }
 
@@ -596,7 +605,24 @@ pub mod tests {
         let cm = ConcurrencyManager::new(42.into());
         let snapshot = engine.snapshot(Default::default()).unwrap();
 
-        // min_commit_ts must be > max_ts
+        // should_not_write mutations don't write locks or change data so that they needn't ask
+        // the concurrency manager for max_ts. Its min_commit_ts may be less than or equal to max_ts.
+        let mut props = optimistic_async_props(b"k0", 10.into(), 50.into(), 2, false);
+        props.min_commit_ts = 11.into();
+        let mut txn = MvccTxn::new(snapshot.clone(), 10.into(), false, cm.clone());
+        let (min_ts, _) = prewrite(
+            &mut txn,
+            &props,
+            Mutation::CheckNotExists(Key::from_raw(b"k0")),
+            &Some(vec![]),
+            false,
+        )
+        .unwrap();
+        assert!(min_ts > props.start_ts);
+        assert!(min_ts >= props.min_commit_ts);
+        assert!(min_ts < 42.into());
+
+        // should_write mutations' min_commit_ts must be > max_ts
         let mut txn = MvccTxn::new(snapshot.clone(), 10.into(), false, cm.clone());
         let (min_ts, _) = prewrite(
             &mut txn,
@@ -609,46 +635,59 @@ pub mod tests {
         assert!(min_ts > 42.into());
         assert!(min_ts < 50.into());
 
-        // min_commit_ts must be > start_ts
-        let mut txn = MvccTxn::new(snapshot, 44.into(), false, cm);
-        let (min_ts, _) = prewrite(
-            &mut txn,
-            &optimistic_async_props(b"k3", 44.into(), 50.into(), 2, false),
-            Mutation::Put((Key::from_raw(b"k3"), b"v1".to_vec())),
-            &Some(vec![b"k4".to_vec()]),
-            false,
-        )
-        .unwrap();
-        assert!(min_ts > 44.into());
-        assert!(min_ts < 50.into());
+        for &should_not_write in &[false, true] {
+            let mutation = if should_not_write {
+                Mutation::CheckNotExists(Key::from_raw(b"k3"))
+            } else {
+                Mutation::Put((Key::from_raw(b"k3"), b"v1".to_vec()))
+            };
 
-        // min_commit_ts must be > for_update_ts
-        let mut props = optimistic_async_props(b"k5", 44.into(), 50.into(), 2, false);
-        props.kind = TransactionKind::Pessimistic(45.into());
-        let (min_ts, _) = prewrite(
-            &mut txn,
-            &props,
-            Mutation::Put((Key::from_raw(b"k5"), b"v1".to_vec())),
-            &Some(vec![b"k6".to_vec()]),
-            false,
-        )
-        .unwrap();
-        assert!(min_ts > 45.into());
-        assert!(min_ts < 50.into());
+            // min_commit_ts must be > start_ts
+            let mut txn = MvccTxn::new(snapshot.clone(), 44.into(), false, cm.clone());
+            let (min_ts, _) = prewrite(
+                &mut txn,
+                &optimistic_async_props(b"k3", 44.into(), 50.into(), 2, false),
+                mutation.clone(),
+                &Some(vec![b"k4".to_vec()]),
+                false,
+            )
+            .unwrap();
+            assert!(min_ts > 44.into());
+            assert!(min_ts < 50.into());
+            txn.take_guards();
 
-        // min_commit_ts must be >= txn min_commit_ts
-        let mut props = optimistic_async_props(b"k7", 44.into(), 50.into(), 2, false);
-        props.min_commit_ts = 46.into();
-        let (min_ts, _) = prewrite(
-            &mut txn,
-            &props,
-            Mutation::Put((Key::from_raw(b"k7"), b"v1".to_vec())),
-            &Some(vec![b"k8".to_vec()]),
-            false,
-        )
-        .unwrap();
-        assert!(min_ts >= 46.into());
-        assert!(min_ts < 50.into());
+            // min_commit_ts must be > for_update_ts
+            if !should_not_write {
+                let mut props = optimistic_async_props(b"k5", 44.into(), 50.into(), 2, false);
+                props.kind = TransactionKind::Pessimistic(45.into());
+                let (min_ts, _) = prewrite(
+                    &mut txn,
+                    &props,
+                    mutation.clone(),
+                    &Some(vec![b"k6".to_vec()]),
+                    false,
+                )
+                .unwrap();
+                assert!(min_ts > 45.into());
+                assert!(min_ts < 50.into());
+                txn.take_guards();
+            }
+
+            // min_commit_ts must be >= txn min_commit_ts
+            let mut props = optimistic_async_props(b"k7", 44.into(), 50.into(), 2, false);
+            props.min_commit_ts = 46.into();
+            let (min_ts, _) = prewrite(
+                &mut txn,
+                &props,
+                mutation.clone(),
+                &Some(vec![b"k8".to_vec()]),
+                false,
+            )
+            .unwrap();
+            assert!(min_ts >= 46.into());
+            assert!(min_ts < 50.into());
+            txn.take_guards();
+        }
     }
 
     #[test]


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:

TiKV always returns min_commit_ts=0 for `check_not_exists` operations. It may result in unnecessary falling back for async commit.

### What is changed and how it works?

What's Changed:

`check_not_exists` operations don't write locks or change data, so we needn't ask the concurrency manager for the max_ts. Its min_commit_ts is `max(start_ts + 1, req.min_commit_ts)`.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->
* No release note.