### PR TITLE
storage: implement proper sematic for RawCAS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#a02e2549f82fe0f35455717fcb0a107ab264c486"
+source = "git+https://github.com/pingcap/kvproto.git#6ed99a08e262d8a32d6355dcba91cf99cb92074a"
 dependencies = [
  "futures 0.3.7",
  "grpcio",

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -333,7 +333,7 @@ impl<E: Engine> SyncTestStorage<E> {
         )
     }
 
-    pub fn raw_compare_and_set_atomic(
+    pub fn raw_compare_and_swap_atomic(
         &self,
         ctx: Context,
         cf: String,
@@ -342,7 +342,7 @@ impl<E: Engine> SyncTestStorage<E> {
         value: Vec<u8>,
         ttl: u64,
     ) -> Result<(Option<Vec<u8>>, bool)> {
-        wait_op!(|cb| self.store.raw_compare_and_set_atomic(
+        wait_op!(|cb| self.store.raw_compare_and_swap_atomic(
             ctx,
             cf,
             key,

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -41,7 +41,7 @@ make_auto_flush_static_metric! {
         raw_delete_range,
         raw_batch_delete,
         raw_get_key_ttl,
-        raw_compare_and_set,
+        raw_compare_and_swap,
         ver_get,
         ver_batch_get,
         ver_mut,

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -287,8 +287,8 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
     );
 
     handle_request!(
-        raw_compare_and_set,
-        future_raw_compare_and_set,
+        raw_compare_and_swap,
+        future_raw_compare_and_swap,
         RawCasRequest,
         RawCasResponse
     );
@@ -1667,7 +1667,7 @@ fn future_raw_get_key_ttl<E: Engine, L: LockManager>(
     }
 }
 
-fn future_raw_compare_and_set<E: Engine, L: LockManager>(
+fn future_raw_compare_and_swap<E: Engine, L: LockManager>(
     storage: &Storage<E, L>,
     mut req: RawCasRequest,
 ) -> impl Future<Output = ServerResult<RawCasResponse>> {
@@ -1677,7 +1677,7 @@ fn future_raw_compare_and_set<E: Engine, L: LockManager>(
     } else {
         Some(req.take_previous_value())
     };
-    let res = storage.raw_compare_and_set_atomic(
+    let res = storage.raw_compare_and_swap_atomic(
         req.take_context(),
         req.take_cf(),
         req.take_key(),
@@ -1696,13 +1696,13 @@ fn future_raw_compare_and_set<E: Engine, L: LockManager>(
             resp.set_region_error(err);
         } else {
             match v {
-                Ok((val, not_equal)) => {
-                    if not_equal {
-                        resp.set_not_equal(true);
-                        if let Some(val) = val {
-                            resp.set_value(val);
-                        }
+                Ok((val, succeed)) => {
+                    if let Some(val) = val {
+                        resp.set_previous_value(val);
+                    } else {
+                        resp.set_previous_not_exist(true);
                     }
+                    resp.set_succeed(succeed);
                 }
                 Err(e) => resp.set_error(format!("{}", e)),
             }

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -131,7 +131,7 @@ make_auto_flush_static_metric! {
         raw_delete_range,
         raw_batch_delete,
         raw_get_key_ttl,
-        raw_compare_and_set,
+        raw_compare_and_swap,
         raw_atomic_store,
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -63,7 +63,7 @@ pub use self::{
 use crate::read_pool::{ReadPool, ReadPoolHandle};
 use crate::storage::metrics::CommandKind;
 use crate::storage::mvcc::MvccReader;
-use crate::storage::txn::commands::{RawAtomicStore, RawCompareAndSet};
+use crate::storage::txn::commands::{RawAtomicStore, RawCompareAndSwap};
 
 use crate::storage::{
     config::Config,
@@ -1571,7 +1571,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
         }
     }
 
-    pub fn raw_compare_and_set_atomic(
+    pub fn raw_compare_and_swap_atomic(
         &self,
         ctx: Context,
         cf: String,
@@ -1591,7 +1591,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
             None
         };
         let cmd =
-            RawCompareAndSet::new(cf, Key::from_encoded(key), previous_value, value, ttl, ctx);
+            RawCompareAndSwap::new(cf, Key::from_encoded(key), previous_value, value, ttl, ctx);
         self.sched_txn_command(cmd, cb)
     }
 

--- a/src/storage/txn/commands/atomic_store.rs
+++ b/src/storage/txn/commands/atomic_store.rs
@@ -12,7 +12,7 @@ use engine_traits::CfName;
 use txn_types::Mutation;
 
 command! {
-    /// Run Put or Delete for keys which may be changed by `RawCompareAndSet`.
+    /// Run Put or Delete for keys which may be changed by `RawCompareAndSwap`.
     RawAtomicStore:
         cmd_ty => (),
         display => "kv::command::atomic_store {:?}", (ctx),

--- a/src/storage/txn/commands/compare_and_swap.rs
+++ b/src/storage/txn/commands/compare_and_swap.rs
@@ -14,7 +14,7 @@ use txn_types::{Key, Value};
 
 command! {
     /// RawCompareAndSwap checks whether the previous value of the key equals to the given value.
-    /// If they are equal, write the new value. The bool indicates whether the comparison succeed.
+    /// If they are equal, write the new value. The bool indicates whether they are equal.
     /// The previous value is always returned regardless of whether the new value is set.
     RawCompareAndSwap:
         cmd_ty => (Option<Value>, bool),

--- a/src/storage/txn/commands/compare_and_swap.rs
+++ b/src/storage/txn/commands/compare_and_swap.rs
@@ -13,11 +13,12 @@ use engine_traits::CfName;
 use txn_types::{Key, Value};
 
 command! {
-    /// CompareAndSet to check whether the previous value of the key equals to the given value.
-    /// If they are equal, write the new value, otherwise return the previous value.
-    RawCompareAndSet:
+    /// RawCompareAndSwap checks whether the previous value of the key equals to the given value.
+    /// If they are equal, write the new value. The bool indicates whether the comparison succeed.
+    /// The previous value is always returned regardless of whether the new value is set.
+    RawCompareAndSwap:
         cmd_ty => (Option<Value>, bool),
-        display => "kv::command::raw_compare_and_set {:?}", (ctx),
+        display => "kv::command::raw_compare_and_swap {:?}", (ctx),
         content => {
             cf: CfName,
             key: Key,
@@ -27,9 +28,9 @@ command! {
         }
 }
 
-impl CommandExt for RawCompareAndSet {
+impl CommandExt for RawCompareAndSwap {
     ctx!();
-    tag!(raw_compare_and_set);
+    tag!(raw_compare_and_swap);
     gen_lock!(key);
 
     fn write_bytes(&self) -> usize {
@@ -37,7 +38,7 @@ impl CommandExt for RawCompareAndSet {
     }
 }
 
-impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for RawCompareAndSet {
+impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for RawCompareAndSwap {
     fn process_write(self, snapshot: S, _: WriteContext<'_, L>) -> Result<WriteResult> {
         let (cf, key, value, previous_value, ctx) =
             (self.cf, self.key, self.value, self.previous_value, self.ctx);
@@ -55,17 +56,17 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for RawCompareAndSet {
                 m.with_ttl(ts);
             }
             data.push(m);
-            ProcessResult::RawCompareAndSetRes {
-                previous_value: None,
-                not_equal: false,
+            ProcessResult::RawCompareAndSwapRes {
+                previous_value: old_value,
+                succeed: true,
             }
         } else {
-            ProcessResult::RawCompareAndSetRes {
+            ProcessResult::RawCompareAndSwapRes {
                 previous_value: old_value,
-                not_equal: true,
+                succeed: false,
             }
         };
-        fail_point!("txn_commands_compare_and_set");
+        fail_point!("txn_commands_compare_and_swap");
         let rows = data.len();
         let to_be_write = WriteData::from_modifies(data);
         Ok(WriteResult {
@@ -94,7 +95,8 @@ mod tests {
         let engine = TestEngineBuilder::new().build().unwrap();
         let cm = concurrency_manager::ConcurrencyManager::new(1.into());
         let key = b"k";
-        let cmd = RawCompareAndSet::new(
+
+        let cmd = RawCompareAndSwap::new(
             CF_DEFAULT,
             Key::from_encoded(key.to_vec()),
             None,
@@ -102,10 +104,11 @@ mod tests {
             None,
             Context::default(),
         );
+        let (prev_val, succeed) = sched_command(&engine, cm.clone(), cmd).unwrap();
+        assert!(prev_val.is_none());
+        assert!(succeed);
 
-        let ret = sched_command(&engine, cm.clone(), cmd).unwrap();
-        assert!(ret.is_none());
-        let cmd = RawCompareAndSet::new(
+        let cmd = RawCompareAndSwap::new(
             CF_DEFAULT,
             Key::from_encoded(key.to_vec()),
             None,
@@ -113,16 +116,28 @@ mod tests {
             None,
             Context::default(),
         );
-        let ret = sched_command(&engine, cm, cmd).unwrap();
-        assert!(ret.is_some());
-        assert_eq!(ret.unwrap(), b"v1".to_vec());
+        let (prev_val, succeed) = sched_command(&engine, cm.clone(), cmd).unwrap();
+        assert_eq!(prev_val, Some(b"v1".to_vec()));
+        assert!(!succeed);
+
+        let cmd = RawCompareAndSwap::new(
+            CF_DEFAULT,
+            Key::from_encoded(key.to_vec()),
+            Some(b"v1".to_vec()),
+            b"v3".to_vec(),
+            None,
+            Context::default(),
+        );
+        let (prev_val, succeed) = sched_command(&engine, cm.clone(), cmd).unwrap();
+        assert_eq!(prev_val, Some(b"v1".to_vec()));
+        assert!(succeed);
     }
 
     pub fn sched_command<E: Engine>(
         engine: &E,
         cm: ConcurrencyManager,
         cmd: TypedCommand<(Option<Value>, bool)>,
-    ) -> Result<Option<Value>> {
+    ) -> Result<(Option<Value>, bool)> {
         let snap = engine.snapshot(Default::default())?;
         use crate::storage::DummyLockManager;
         use kvproto::kvrpcpb::ExtraOp;
@@ -136,18 +151,17 @@ mod tests {
         };
         let ret = cmd.cmd.process_write(snap, context)?;
         match ret.pr {
-            ProcessResult::RawCompareAndSetRes {
+            ProcessResult::RawCompareAndSwapRes {
                 previous_value,
-                not_equal,
+                succeed,
             } => {
-                if not_equal {
-                    return Ok(previous_value);
+                if succeed {
+                    let ctx = Context::default();
+                    engine.write(&ctx, ret.to_be_write).unwrap();
                 }
+                Ok((previous_value, succeed))
             }
-            _ => unreachable!(),
-        };
-        let ctx = Context::default();
-        engine.write(&ctx, ret.to_be_write).unwrap();
-        Ok(None)
+            _ => unreachable!()
+        }
     }
 }

--- a/src/storage/txn/commands/compare_and_swap.rs
+++ b/src/storage/txn/commands/compare_and_swap.rs
@@ -128,7 +128,7 @@ mod tests {
             None,
             Context::default(),
         );
-        let (prev_val, succeed) = sched_command(&engine, cm.clone(), cmd).unwrap();
+        let (prev_val, succeed) = sched_command(&engine, cm, cmd).unwrap();
         assert_eq!(prev_val, Some(b"v1".to_vec()));
         assert!(succeed);
     }

--- a/src/storage/txn/commands/compare_and_swap.rs
+++ b/src/storage/txn/commands/compare_and_swap.rs
@@ -161,7 +161,7 @@ mod tests {
                 }
                 Ok((previous_value, succeed))
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 }

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod check_secondary_locks;
 pub(crate) mod check_txn_status;
 pub(crate) mod cleanup;
 pub(crate) mod commit;
-pub(crate) mod compare_and_set;
+pub(crate) mod compare_and_swap;
 pub(crate) mod mvcc_by_key;
 pub(crate) mod mvcc_by_start_ts;
 pub(crate) mod pause;
@@ -27,7 +27,7 @@ pub use check_secondary_locks::CheckSecondaryLocks;
 pub use check_txn_status::CheckTxnStatus;
 pub use cleanup::Cleanup;
 pub use commit::Commit;
-pub use compare_and_set::RawCompareAndSet;
+pub use compare_and_swap::RawCompareAndSwap;
 pub use mvcc_by_key::MvccByKey;
 pub use mvcc_by_start_ts::MvccByStartTs;
 pub use pause::Pause;
@@ -84,7 +84,7 @@ pub enum Command {
     Pause(Pause),
     MvccByKey(MvccByKey),
     MvccByStartTs(MvccByStartTs),
-    RawCompareAndSet(RawCompareAndSet),
+    RawCompareAndSwap(RawCompareAndSwap),
     RawAtomicStore(RawAtomicStore),
 }
 
@@ -489,7 +489,7 @@ impl Command {
             Command::Pause(t) => t,
             Command::MvccByKey(t) => t,
             Command::MvccByStartTs(t) => t,
-            Command::RawCompareAndSet(t) => t,
+            Command::RawCompareAndSwap(t) => t,
             Command::RawAtomicStore(t) => t,
         }
     }
@@ -512,7 +512,7 @@ impl Command {
             Command::Pause(t) => t,
             Command::MvccByKey(t) => t,
             Command::MvccByStartTs(t) => t,
-            Command::RawCompareAndSet(t) => t,
+            Command::RawCompareAndSwap(t) => t,
             Command::RawAtomicStore(t) => t,
         }
     }
@@ -549,7 +549,7 @@ impl Command {
             Command::CheckTxnStatus(t) => t.process_write(snapshot, context),
             Command::CheckSecondaryLocks(t) => t.process_write(snapshot, context),
             Command::Pause(t) => t.process_write(snapshot, context),
-            Command::RawCompareAndSet(t) => t.process_write(snapshot, context),
+            Command::RawCompareAndSwap(t) => t.process_write(snapshot, context),
             Command::RawAtomicStore(t) => t.process_write(snapshot, context),
             _ => panic!("unsupported write command"),
         }

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -72,9 +72,9 @@ pub enum ProcessResult {
     SecondaryLocksStatus {
         status: SecondaryLocksStatus,
     },
-    RawCompareAndSetRes {
+    RawCompareAndSwapRes {
         previous_value: Option<Value>,
-        not_equal: bool,
+        succeed: bool,
     },
 }
 

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -200,7 +200,7 @@ storage_callback! {
     Prewrite(PrewriteResult) ProcessResult::PrewriteResult { result } => result,
     PessimisticLock(Result<PessimisticLockRes>) ProcessResult::PessimisticLockRes { res } => res,
     SecondaryLocksStatus(SecondaryLocksStatus) ProcessResult::SecondaryLocksStatus { status } => status,
-    RawCompareAndSet((Option<Value>, bool)) ProcessResult::RawCompareAndSetRes { previous_value, not_equal } => (previous_value, not_equal),
+    RawCompareAndSwap((Option<Value>, bool)) ProcessResult::RawCompareAndSwapRes { previous_value, succeed } => (previous_value, succeed),
 }
 
 pub trait StorageCallbackType: Sized {

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -996,7 +996,7 @@ fn test_atomic_cas_lock_by_latch() {
 
     let latch_acquire_success_fp = "txn_scheduler_acquire_success";
     let latch_acquire_fail_fp = "txn_scheduler_acquire_fail";
-    let pending_cas_fp = "txn_commands_compare_and_set";
+    let pending_cas_fp = "txn_commands_compare_and_swap";
     let wakeup_latch_fp = "txn_scheduler_try_to_wake_up";
     let (cas_tx, cas_rx) = channel();
     let cas_rx = Mutex::new(Some(cas_rx));
@@ -1027,7 +1027,7 @@ fn test_atomic_cas_lock_by_latch() {
     .unwrap();
     let (cb, f1) = paired_future_callback();
     storage
-        .raw_compare_and_set_atomic(
+        .raw_compare_and_swap_atomic(
             ctx.clone(),
             "".to_string(),
             b"key".to_vec(),
@@ -1042,7 +1042,7 @@ fn test_atomic_cas_lock_by_latch() {
     acquire_flag.store(false, Ordering::Release);
     let (cb, f2) = paired_future_callback();
     storage
-        .raw_compare_and_set_atomic(
+        .raw_compare_and_swap_atomic(
             ctx.clone(),
             "".to_string(),
             b"key".to_vec(),

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -50,9 +50,9 @@ fn test_rawkv() {
     cas_req.key = k.clone();
     cas_req.value = v0.clone();
     cas_req.previous_not_exist = true;
-    let resp = client.raw_compare_and_set(&cas_req).unwrap();
+    let resp = client.raw_compare_and_swap(&cas_req).unwrap();
     assert!(!resp.has_region_error());
-    assert!(!resp.get_not_equal());
+    assert!(resp.get_succeed());
 
     // Raw get
     let mut get_req = RawGetRequest::default();
@@ -64,8 +64,8 @@ fn test_rawkv() {
     cas_req.value = v1.clone();
     cas_req.previous_not_exist = false;
     cas_req.previous_value = v0;
-    let resp = client.raw_compare_and_set(&cas_req).unwrap();
-    assert!(!resp.get_not_equal());
+    let resp = client.raw_compare_and_swap(&cas_req).unwrap();
+    assert!(resp.get_succeed());
     let get_resp = client.raw_get(&get_req).unwrap();
     assert_eq!(get_resp.value, v1);
 
@@ -127,9 +127,9 @@ fn test_rawkv_ttl() {
     cas_req.value = v0.clone();
     cas_req.previous_not_exist = false;
     cas_req.previous_value = v1.clone();
-    let resp = client.raw_compare_and_set(&cas_req).unwrap();
+    let resp = client.raw_compare_and_swap(&cas_req).unwrap();
     assert!(!resp.has_region_error());
-    assert!(resp.get_not_equal());
+    assert!(!resp.get_succeed());
 
     let mut cas_req = RawCasRequest::default();
     cas_req.set_context(ctx.clone());
@@ -138,9 +138,9 @@ fn test_rawkv_ttl() {
     cas_req.previous_not_exist = true;
     cas_req.previous_value = vec![];
     cas_req.ttl = 100;
-    let resp = client.raw_compare_and_set(&cas_req).unwrap();
+    let resp = client.raw_compare_and_swap(&cas_req).unwrap();
     assert!(!resp.has_region_error());
-    assert!(!resp.get_not_equal());
+    assert!(resp.get_succeed());
     // Raw get
     let mut get_req = RawGetRequest::default();
     get_req.set_context(ctx.clone());
@@ -154,8 +154,8 @@ fn test_rawkv_ttl() {
     cas_req.previous_not_exist = false;
     cas_req.previous_value = v0;
     cas_req.ttl = 140;
-    let resp = client.raw_compare_and_set(&cas_req).unwrap();
-    assert!(!resp.get_not_equal());
+    let resp = client.raw_compare_and_swap(&cas_req).unwrap();
+    assert!(resp.get_succeed());
     let get_resp = client.raw_get(&get_req).unwrap();
     assert_eq!(get_resp.value, v1);
 

--- a/tests/integrations/server/mod.rs
+++ b/tests/integrations/server/mod.rs
@@ -179,7 +179,7 @@ trait MockKvService {
         RawDeleteRangeResponse
     );
     unary_call!(raw_get_key_ttl, RawGetKeyTtlRequest, RawGetKeyTtlResponse);
-    unary_call!(raw_compare_and_set, RawCasRequest, RawCasResponse);
+    unary_call!(raw_compare_and_swap, RawCasRequest, RawCasResponse);
     unary_call!(ver_get, VerGetRequest, VerGetResponse);
     unary_call!(ver_batch_get, VerBatchGetRequest, VerBatchGetResponse);
     unary_call!(ver_mut, VerMutRequest, VerMutResponse);
@@ -301,7 +301,7 @@ impl<T: MockKvService + Clone + Send + 'static> Tikv for MockKv<T> {
         RawDeleteRangeResponse
     );
     unary_call_dispatch!(raw_get_key_ttl, RawGetKeyTtlRequest, RawGetKeyTtlResponse);
-    unary_call_dispatch!(raw_compare_and_set, RawCasRequest, RawCasResponse);
+    unary_call_dispatch!(raw_compare_and_swap, RawCasRequest, RawCasResponse);
     unary_call_dispatch!(ver_get, VerGetRequest, VerGetResponse);
     unary_call_dispatch!(ver_batch_get, VerBatchGetRequest, VerBatchGetResponse);
     unary_call_dispatch!(ver_mut, VerMutRequest, VerMutResponse);

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -399,8 +399,8 @@ fn test_atomic_basic() {
             0,
         )
         .unwrap();
-    assert!(prev_val.is_none());
-    assert!(!succeed);
+    assert!(succeed);
+    assert_eq!(prev_val, Some(b"v1".to_vec()));
     let value = storage
         .raw_get(ctx.clone(), "default".to_string(), b"k1".to_vec())
         .unwrap();

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -377,8 +377,8 @@ fn test_atomic_basic() {
             0,
         )
         .unwrap();
-    let (ret, not_equal) = storage
-        .raw_compare_and_set_atomic(
+    let (prev_val, succeed) = storage
+        .raw_compare_and_swap_atomic(
             ctx.clone(),
             "default".to_string(),
             b"k1".to_vec(),
@@ -387,11 +387,10 @@ fn test_atomic_basic() {
             0,
         )
         .unwrap();
-    assert!(ret.is_some());
-    assert!(not_equal);
-    assert_eq!(b"v1".to_vec(), ret.unwrap());
-    let (ret, not_equal) = storage
-        .raw_compare_and_set_atomic(
+    assert!(!succeed);
+    assert_eq!(prev_val, Some(b"v1".to_vec()));
+    let (prev_val, succeed) = storage
+        .raw_compare_and_swap_atomic(
             ctx.clone(),
             "default".to_string(),
             b"k1".to_vec(),
@@ -400,8 +399,8 @@ fn test_atomic_basic() {
             0,
         )
         .unwrap();
-    assert!(ret.is_none());
-    assert!(!not_equal);
+    assert!(prev_val.is_none());
+    assert!(!succeed);
     let value = storage
         .raw_get(ctx.clone(), "default".to_string(), b"k1".to_vec())
         .unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

When comparison failed, the previous RawCAS implementation can't distinguish the previous value between empty value and none value.

[kvproto changes](https://github.com/pingcap/kvproto/pull/742)

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

- Renamed `compare_and_set` to `compare_and_swap`
- In the `RawCASRespond`, return `succeed` instead `not_equal`
- Add `previous_not_exist` to `RawCASRespond`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- No release note