### PR TITLE
txn: add more log info for fallback

### DIFF
--- a/components/txn_types/src/lock.rs
+++ b/components/txn_types/src/lock.rs
@@ -58,7 +58,7 @@ impl LockType {
     }
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone)]
 pub struct Lock {
     pub lock_type: LockType,
     pub primary: Vec<u8>,
@@ -79,6 +79,31 @@ pub struct Lock {
     // while committing is relatively expensive. So the solution is putting the ts of the rollback
     // to the lock.
     pub rollback_ts: Vec<TimeStamp>,
+}
+
+impl std::fmt::Debug for Lock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut secondary_keys = std::vec::Vec::with_capacity(self.secondaries.len());
+        for key in self.secondaries.iter() {
+            secondary_keys.push(log_wrappers::Value::key(key))
+        }
+        f.debug_struct("Lock")
+            .field("lock_type", &self.lock_type)
+            .field("primary_key", &log_wrappers::Value::key(&self.primary))
+            .field("start_ts", &self.ts)
+            .field("ttl", &self.ttl)
+            .field(
+                "short_value",
+                &log_wrappers::Value::value(self.short_value.as_ref().unwrap_or(&b"".to_vec())),
+            )
+            .field("for_update_ts", &self.for_update_ts)
+            .field("txn_size", &self.txn_size)
+            .field("min_commit_ts", &self.min_commit_ts)
+            .field("use_async_commit", &self.use_async_commit)
+            .field("secondaries", &secondary_keys)
+            .field("rollback_ts", &self.rollback_ts)
+            .finish()
+    }
 }
 
 impl Lock {
@@ -658,5 +683,61 @@ mod tests {
         Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, 140.into(), &empty).unwrap();
         Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, 150.into(), &empty).unwrap_err();
         Lock::check_ts_conflict(Cow::Borrowed(&lock), &key, 160.into(), &empty).unwrap_err();
+    }
+
+    #[test]
+    fn test_customize_debug() {
+        let mut lock = Lock::new(
+            LockType::Put,
+            b"pk".to_vec(),
+            100.into(),
+            3,
+            Option::from(b"short_value".to_vec()),
+            101.into(),
+            10,
+            127.into(),
+        )
+        .use_async_commit(vec![
+            b"secondary_k1".to_vec(),
+            b"secondary_kkkkk2".to_vec(),
+            b"secondary_k3k3k3k3k3k3".to_vec(),
+            b"secondary_k4".to_vec(),
+        ]);
+
+        assert_eq!(
+            format!("{:?}", lock),
+            "Lock { lock_type: Put, primary_key: 706B, start_ts: TimeStamp(100), ttl: 3, \
+            short_value: 73686F72745F76616C7565, for_update_ts: TimeStamp(101), txn_size: 10, \
+            min_commit_ts: TimeStamp(127), use_async_commit: true, \
+            secondaries: [7365636F6E646172795F6B31, 7365636F6E646172795F6B6B6B6B6B32, \
+            7365636F6E646172795F6B336B336B336B336B336B33, 7365636F6E646172795F6B34], rollback_ts: [] }"
+        );
+        log_wrappers::set_redact_info_log(true);
+        let redact_result = format!("{:?}", lock);
+        log_wrappers::set_redact_info_log(false);
+        assert_eq!(
+            redact_result,
+            "Lock { lock_type: Put, primary_key: ?, start_ts: TimeStamp(100), ttl: 3, \
+            short_value: ?, for_update_ts: TimeStamp(101), txn_size: 10, min_commit_ts: TimeStamp(127), \
+            use_async_commit: true, secondaries: [?, ?, ?, ?], rollback_ts: [] }"
+        );
+
+        lock.short_value = None;
+        lock.secondaries = Vec::default();
+        assert_eq!(
+            format!("{:?}", lock),
+            "Lock { lock_type: Put, primary_key: 706B, start_ts: TimeStamp(100), ttl: 3, short_value: , \
+            for_update_ts: TimeStamp(101), txn_size: 10, min_commit_ts: TimeStamp(127), \
+            use_async_commit: true, secondaries: [], rollback_ts: [] }"
+        );
+        log_wrappers::set_redact_info_log(true);
+        let redact_result = format!("{:?}", lock);
+        log_wrappers::set_redact_info_log(false);
+        assert_eq!(
+            redact_result,
+            "Lock { lock_type: Put, primary_key: ?, start_ts: TimeStamp(100), ttl: 3, short_value: ?, \
+            for_update_ts: TimeStamp(101), txn_size: 10, min_commit_ts: TimeStamp(127), \
+            use_async_commit: true, secondaries: [], rollback_ts: [] }"
+        );
     }
 }

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -428,9 +428,11 @@ fn async_commit_timestamps(
         let max_commit_ts = max_commit_ts;
         if (!max_commit_ts.is_zero() && min_commit_ts > max_commit_ts) || injected_fallback {
             warn!("commit_ts is too large, fallback to normal 2PC";
+                "key" => log_wrappers::Value::key(key.as_encoded()),
                 "start_ts" => start_ts,
                 "min_commit_ts" => min_commit_ts,
-                "max_commit_ts" => max_commit_ts);
+                "max_commit_ts" => max_commit_ts,
+                "lock" => ?lock);
             return Err(ErrorInner::CommitTsTooLarge {
                 start_ts,
                 min_commit_ts,


### PR DESCRIPTION
Signed-off-by: cfzjywxk <lsswxrxr@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:


The log would be like

[WARN] [prewrite.rs:418] ["commit_ts is too large, fallback to normal 2PC"] [lock="Lock { lock_type: Put, primary_key: 7480000000000000CA5F69800000000000000103800000000000001E, start_ts: TimeStamp(423917153942241283), ttl: 3001, short_value: 000000000000005A, for_update_ts: TimeStamp(0), txn_size: 2, min_commit_ts: TimeStamp(423917153942241284), use_async_commit: true, secondaries: [], rollback_ts: [] }"] [max_commit_ts=423917154467053571] [min_commit_ts=423917154571124747] [start_ts=423917153942241283] [key=7480000000000000FFCA5F698000000000FF0000010380000000FF0000005A00000000FB]



Print more info when fallback happens:
- From the `key` info, we could know which prewrite batch it is, and from which key the fallback happens.
- From the `txn_size` we could know if it is a retried prewrite request(https://github.com/pingcap/tidb/blob/master/store/tikv/prewrite.go#L154).

This could be useful debugging issues, maybe we could lower the log level or removing it after it's quite stable.

### What is changed and how it works?

What's Changed:
- Add some more log info.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->
- No release note.