### PR TITLE
remove the upper limit for space reserving

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -73,16 +73,11 @@ use tikv::{
         ttl::TTLChecker,
         Node, RaftKv, Server, CPU_CORES_QUOTA_GAUGE, DEFAULT_CLUSTER_ID, GRPC_THREAD_PREFIX,
     },
-    storage::{
-        self,
-        config::{StorageConfigManger, MAX_RESERVED_SPACE_GB},
-        mvcc::MvccConsistencyCheckObserver,
-        Engine,
-    },
+    storage::{self, config::StorageConfigManger, mvcc::MvccConsistencyCheckObserver, Engine},
 };
 use tikv_util::{
     check_environment_variables,
-    config::{ensure_dir_exist, ReadableSize, VersionTrack},
+    config::{ensure_dir_exist, VersionTrack},
     sys::sys_quota::SysQuota,
     time::Monitor,
     timer::GLOBAL_TIMER_HANDLE,
@@ -377,18 +372,15 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         }
         file_system::reserve_space_for_recover(
             &self.config.storage.data_dir,
-            cmp::min(
-                ReadableSize::gb(MAX_RESERVED_SPACE_GB).0,
-                if self.config.storage.reserve_space.0 == 0 {
-                    0
-                } else {
-                    // Max one of configured `reserve_space` and `storage.capacity * 5%`.
-                    cmp::max(
-                        (capacity as f64 * 0.05) as u64,
-                        self.config.storage.reserve_space.0,
-                    )
-                },
-            ),
+            if self.config.storage.reserve_space.0 == 0 {
+                0
+            } else {
+                // Max one of configured `reserve_space` and `storage.capacity * 5%`.
+                cmp::max(
+                    (capacity as f64 * 0.05) as u64,
+                    self.config.storage.reserve_space.0,
+                )
+            },
         )
         .unwrap();
     }

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -209,13 +209,10 @@
 ## latency jittering when apply duration is not stable.
 # enable-async-apply-prewrite = false
 
-## Reserve some space to ensure recovering the store from `no space left` must success. The
-## configured value only indicates the lower limit, and 20GB is the upper limit. In this range,
+## Reserve some space to ensure recovering the store from `no space left` must succeed.
 ## `max(reserve-space, capacity * 5%)` will be reserved exactly.
 ##
-## Set it to 0 will cause no space is reserved at all.
-##
-## Generally it's not necessary to change it. This configuration could be deprecated in future.
+## Set it to 0 will cause no space is reserved at all. It's generally used for tests.
 # reserve-space = "5GB"
 
 [storage.block-cache]

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -27,9 +27,6 @@ const MAX_SCHED_CONCURRENCY: usize = 2 * 1024 * 1024;
 const DEFAULT_SCHED_PENDING_WRITE_MB: u64 = 100;
 
 const DEFAULT_RESERVED_SPACE_GB: u64 = 5;
-// 20GB for reserved space is enough because size of one compaction is limited,
-// generally less than 2GB.
-pub const MAX_RESERVED_SPACE_GB: u64 = 20;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Configuration)]
 #[serde(default)]
@@ -90,13 +87,6 @@ impl Config {
                 concurrency. To save memory, change it from {:?} to {:?}",
                   self.scheduler_concurrency, MAX_SCHED_CONCURRENCY);
             self.scheduler_concurrency = MAX_SCHED_CONCURRENCY;
-        }
-        if self.reserve_space.0 > ReadableSize::gb(MAX_RESERVED_SPACE_GB).0 {
-            self.reserve_space = ReadableSize::gb(MAX_RESERVED_SPACE_GB);
-            warn!(
-                "reserve-space is too large, sanitized to {:?}",
-                self.reserve_space
-            );
         }
         Ok(())
     }


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

Remove the space reserving upper limit because the upper limit(20GB) is not enough.

Issue Number: close #9831 .

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->
* No release note