### PR TITLE
encryption: Ignore log record parse error caused by write failure before

### DIFF
--- a/components/encryption/src/errors.rs
+++ b/components/encryption/src/errors.rs
@@ -19,7 +19,7 @@ pub enum Error {
     Other(#[from] Box<dyn error::Error + Sync + Send>),
     // Only when the parsing record is the last one, and the
     // length is insufficient or the crc checksum fails.
-    #[error("Recoverable types of parsing file dict error")]
+    #[error("Recoverable tail record corruption while parsing file dictionary")]
     TailRecordParseIncomplete,
     // Currently only in use by cloud KMS
     #[error("Cloud KMS error {0}")]

--- a/components/encryption/src/errors.rs
+++ b/components/encryption/src/errors.rs
@@ -17,6 +17,10 @@ pub trait RetryCodedError: Debug + Display + ErrorCodeExt + RetryError + Send + 
 pub enum Error {
     #[error("Other error {0}")]
     Other(#[from] Box<dyn error::Error + Sync + Send>),
+    // Only when the parsing record is the last one, and the
+    // length is insufficient or the crc checksum fails.
+    #[error("Recoverable types of parsing file dict error")]
+    TailRecordParseIncomplete,
     // Currently only in use by cloud KMS
     #[error("Cloud KMS error {0}")]
     RetryCodedError(Box<dyn RetryCodedError>),
@@ -70,6 +74,7 @@ impl ErrorCodeExt for Error {
     fn error_code(&self) -> ErrorCode {
         match self {
             Error::RetryCodedError(err) => (*err).error_code(),
+            Error::TailRecordParseIncomplete => error_code::encryption::PARSE_INCOMPLETE,
             Error::Rocks(_) => error_code::encryption::ROCKS,
             Error::Io(_) => error_code::encryption::IO,
             Error::Crypter(_) => error_code::encryption::CRYPTER,
@@ -88,6 +93,7 @@ impl RetryError for Error {
         // However, only Error::Tls should be encountered
         match self {
             Error::RetryCodedError(err) => err.is_retryable(),
+            Error::TailRecordParseIncomplete => true,
             Error::Rocks(_) => true,
             Error::Io(_) => true,
             Error::Crypter(_) => true,

--- a/components/encryption/src/file_dict_file.rs
+++ b/components/encryption/src/file_dict_file.rs
@@ -5,7 +5,7 @@ use file_system::{rename, File, OpenOptions};
 use kvproto::encryptionpb::{EncryptedContent, FileDictionary, FileInfo};
 use protobuf::Message;
 use rand::{thread_rng, RngCore};
-use tikv_util::{box_err, info, set_panic_mark, warn};
+use tikv_util::{box_err, set_panic_mark, warn};
 
 use crate::encrypted_file::{EncryptedFile, Header, Version, TMP_FILE_SUFFIX};
 use crate::master_key::{Backend, PlaintextBackend};
@@ -194,7 +194,7 @@ impl FileDictionaryFile {
                             }
                         }
                         Err(e @ Error::TailRecordParseIncomplete) => {
-                            info!(
+                            warn!(
                                 "{:?} occurred and the last complete filename is {}",
                                 e, last_record_name
                             );

--- a/components/encryption/src/lib.rs
+++ b/components/encryption/src/lib.rs
@@ -12,11 +12,12 @@ mod metrics;
 
 pub use self::config::*;
 pub use self::crypter::{
-    encryption_method_from_db_encryption_method, verify_encryption_config, AesGcmCrypter, Iv,
-    PlainKey,
+    compat, encryption_method_from_db_encryption_method, verify_encryption_config, AesGcmCrypter,
+    Iv, PlainKey,
 };
 pub use self::encrypted_file::EncryptedFile;
 pub use self::errors::{Error, Result, RetryCodedError};
+pub use self::file_dict_file::FileDictionaryFile;
 pub use self::io::{create_aes_ctr_crypter, DecrypterReader, EncrypterReader, EncrypterWriter};
 pub use self::manager::{DataKeyManager, DataKeyManagerArgs};
 pub use self::master_key::{

--- a/components/error_code/src/encryption.rs
+++ b/components/error_code/src/encryption.rs
@@ -9,5 +9,6 @@ define_error_codes!(
     PROTO => ("Proto", "", ""),
     UNKNOWN_ENCRYPTION => ("UnknownEncryption", "", ""),
     WRONG_MASTER_KEY => ("WrongMasterKey", "", ""),
-    BOTH_MASTER_KEY_FAIL => ("BothMasterKeyFail", "", "")
+    BOTH_MASTER_KEY_FAIL => ("BothMasterKeyFail", "", ""),
+    PARSE_INCOMPLETE => ("TailRecordParseIncomplete", "", "")
 );

--- a/tests/failpoints/cases/mod.rs
+++ b/tests/failpoints/cases/mod.rs
@@ -6,6 +6,7 @@ mod test_cmd_epoch_checker;
 mod test_conf_change;
 mod test_coprocessor;
 mod test_early_apply;
+mod test_encryption;
 mod test_gc_worker;
 mod test_import_service;
 mod test_kv_service;

--- a/tests/failpoints/cases/test_encryption.rs
+++ b/tests/failpoints/cases/test_encryption.rs
@@ -16,7 +16,9 @@ fn test_file_dict_file_record_corrupted() {
     .unwrap();
     let info1 = create_file_info(1, EncryptionMethod::Aes256Ctr);
     let info2 = create_file_info(2, EncryptionMethod::Unknown);
-    fail::cfg("file_dict_log_append_incomplete", "return(8)").unwrap();
+    // 9 represents that the first 9 bytes will be discarded.
+    // Crc32 (4 bytes) + File name length (2 bytes) + FileInfo length (2 bytes) + Log type (1 bytes)
+    fail::cfg("file_dict_log_append_incomplete", "return(9)").unwrap();
     file_dict_file.insert("info1", &info1).unwrap();
     fail::remove("file_dict_log_append_incomplete");
     file_dict_file.insert("info2", &info2).unwrap();
@@ -33,7 +35,7 @@ fn test_file_dict_file_record_corrupted() {
     let info1 = create_file_info(1, EncryptionMethod::Aes256Ctr);
     let info2 = create_file_info(2, EncryptionMethod::Unknown);
     file_dict_file.insert("info1", &info1).unwrap();
-    fail::cfg("file_dict_log_append_incomplete", "return(8)").unwrap();
+    fail::cfg("file_dict_log_append_incomplete", "return(9)").unwrap();
     file_dict_file.insert("info2", &info2).unwrap();
     fail::remove("file_dict_log_append_incomplete");
     // The ending record can be discarded.

--- a/tests/failpoints/cases/test_encryption.rs
+++ b/tests/failpoints/cases/test_encryption.rs
@@ -16,9 +16,9 @@ fn test_file_dict_file_record_corrupted() {
     .unwrap();
     let info1 = create_file_info(1, EncryptionMethod::Aes256Ctr);
     let info2 = create_file_info(2, EncryptionMethod::Unknown);
-    fail::cfg("file_dict_log_insert_error", "return").unwrap();
+    fail::cfg("file_dict_log_append_incomplete", "return(8)").unwrap();
     file_dict_file.insert("info1", &info1).unwrap();
-    fail::remove("file_dict_log_insert_error");
+    fail::remove("file_dict_log_append_incomplete");
     file_dict_file.insert("info2", &info2).unwrap();
     // Intermediate record damage is not allowed.
     assert!(file_dict_file.recovery().is_err());
@@ -33,9 +33,9 @@ fn test_file_dict_file_record_corrupted() {
     let info1 = create_file_info(1, EncryptionMethod::Aes256Ctr);
     let info2 = create_file_info(2, EncryptionMethod::Unknown);
     file_dict_file.insert("info1", &info1).unwrap();
-    fail::cfg("file_dict_log_insert_error", "return").unwrap();
+    fail::cfg("file_dict_log_append_incomplete", "return(8)").unwrap();
     file_dict_file.insert("info2", &info2).unwrap();
-    fail::remove("file_dict_log_insert_error");
+    fail::remove("file_dict_log_append_incomplete");
     // The ending record can be discarded.
     let file_dict = file_dict_file.recovery().unwrap();
     assert_eq!(*file_dict.files.get("info1").unwrap(), info1);

--- a/tests/failpoints/cases/test_encryption.rs
+++ b/tests/failpoints/cases/test_encryption.rs
@@ -1,0 +1,51 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use encryption::compat;
+use encryption::FileDictionaryFile;
+use kvproto::encryptionpb::{EncryptionMethod, FileInfo};
+
+#[test]
+fn test_file_dict_file_record_corrupted() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let mut file_dict_file = FileDictionaryFile::new(
+        tempdir.path(),
+        "test_file_dict_file_record_corrupted_1",
+        true,
+        10, /*file_rewrite_threshold*/
+    )
+    .unwrap();
+    let info1 = create_file_info(1, EncryptionMethod::Aes256Ctr);
+    let info2 = create_file_info(2, EncryptionMethod::Unknown);
+    fail::cfg("file_dict_log_insert_error", "return").unwrap();
+    file_dict_file.insert("info1", &info1).unwrap();
+    fail::remove("file_dict_log_insert_error");
+    file_dict_file.insert("info2", &info2).unwrap();
+    // Intermediate record damage is not allowed.
+    assert!(file_dict_file.recovery().is_err());
+
+    let mut file_dict_file = FileDictionaryFile::new(
+        tempdir.path(),
+        "test_file_dict_file_record_corrupted_2",
+        true,
+        10, /*file_rewrite_threshold*/
+    )
+    .unwrap();
+    let info1 = create_file_info(1, EncryptionMethod::Aes256Ctr);
+    let info2 = create_file_info(2, EncryptionMethod::Unknown);
+    file_dict_file.insert("info1", &info1).unwrap();
+    fail::cfg("file_dict_log_insert_error", "return").unwrap();
+    file_dict_file.insert("info2", &info2).unwrap();
+    fail::remove("file_dict_log_insert_error");
+    // The ending record can be discarded.
+    let file_dict = file_dict_file.recovery().unwrap();
+    assert_eq!(*file_dict.files.get("info1").unwrap(), info1);
+    assert_eq!(file_dict.files.len(), 1);
+}
+
+fn create_file_info(id: u64, method: EncryptionMethod) -> FileInfo {
+    FileInfo {
+        key_id: id,
+        method: compat(method),
+        ..Default::default()
+    }
+}


### PR DESCRIPTION
Signed-off-by: Xintao <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9886 

Problem Summary:

When the file dict fails to be appended and written for some reason, we believe that this record can be safely discarded because the corresponding file has not been actually modified

### What is changed and how it works?

Add a new error type and ignore these errors.

### Related changes

- Need to cherry-pick to the release-4.x

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->
- Fix the bug that TiKV cannot startup when the end of file dict file is damaged.