### PR TITLE
cdc: limit scan speed

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -114,20 +114,20 @@ impl Downstream {
     pub fn sink_event(&self, mut event: Event) {
         event.set_request_id(self.req_id);
         if self.sink.is_none() {
-            info!("drop event, no sink";
-                "conn_id" => ?self.conn_id, "downstream_id" => ?self.id);
+            info!("cdc drop event, no sink";
+                "conn_id" => ?self.conn_id, "downstream_id" => ?self.id, "req_id" => self.req_id);
             return;
         }
         let sink = self.sink.as_ref().unwrap();
         if let Err(e) = sink.try_send(CdcEvent::Event(event)) {
             match e {
                 crossbeam::TrySendError::Disconnected(_) => {
-                    debug!("send event failed, disconnected";
-                        "conn_id" => ?self.conn_id, "downstream_id" => ?self.id);
+                    debug!("cdc send event failed, disconnected";
+                        "conn_id" => ?self.conn_id, "downstream_id" => ?self.id, "req_id" => self.req_id);
                 }
                 crossbeam::TrySendError::Full(_) => {
-                    info!("send event failed, full";
-                        "conn_id" => ?self.conn_id, "downstream_id" => ?self.id);
+                    info!("cdc send event failed, full";
+                        "conn_id" => ?self.conn_id, "downstream_id" => ?self.id, "req_id" => self.req_id);
                 }
             }
         }
@@ -248,7 +248,7 @@ impl Delegate {
                 true,  /* check_ver */
                 true,  /* include_region */
             ) {
-                info!("fail to subscribe downstream";
+                info!("cdc fail to subscribe downstream";
                     "region_id" => region.get_id(),
                     "downstream_id" => ?downstream.get_id(),
                     "conn_id" => ?downstream.get_conn_id(),
@@ -343,7 +343,7 @@ impl Delegate {
         // Stop observe further events.
         self.enabled.store(false, Ordering::SeqCst);
 
-        info!("region met error";
+        info!("cdc met region error";
             "region_id" => self.region_id, "error" => ?err);
         let change_data_err = self.error_event(err);
         for d in &self.downstreams {
@@ -393,24 +393,24 @@ impl Delegate {
             }
         }
         self.resolver = Some(resolver);
-        info!("region is ready"; "region_id" => self.region_id);
+        info!("cdc region is ready"; "region_id" => self.region_id);
         pending.take_downstreams()
     }
 
     /// Try advance and broadcast resolved ts.
     pub fn on_min_ts(&mut self, min_ts: TimeStamp) -> Option<TimeStamp> {
         if self.resolver.is_none() {
-            debug!("region resolver not ready";
+            debug!("cdc region resolver not ready";
                 "region_id" => self.region_id, "min_ts" => min_ts);
             return None;
         }
-        debug!("try to advance ts"; "region_id" => self.region_id, "min_ts" => min_ts);
+        debug!("cdc try to advance ts"; "region_id" => self.region_id, "min_ts" => min_ts);
         let resolver = self.resolver.as_mut().unwrap();
         let resolved_ts = match resolver.resolve(min_ts) {
             Some(rts) => rts,
             None => return None,
         };
-        debug!("resolved ts updated";
+        debug!("cdc resolved ts updated";
             "region_id" => self.region_id, "resolved_ts" => resolved_ts);
         CDC_RESOLVED_TS_GAP_HISTOGRAM
             .observe((min_ts.physical() - resolved_ts.physical()) as f64 / 1000f64);
@@ -466,7 +466,8 @@ impl Delegate {
         let downstream = if let Some(d) = downstreams.iter().find(|d| d.id == downstream_id) {
             d
         } else {
-            warn!("downstream not found"; "downstream_id" => ?downstream_id, "region_id" => self.region_id);
+            warn!("cdc downstream not found";
+                "downstream_id" => ?downstream_id, "region_id" => self.region_id);
             return;
         };
 
@@ -804,7 +805,7 @@ fn decode_write(key: Vec<u8>, value: &[u8], row: &mut EventRow, is_apply: bool) 
         WriteType::Delete => (EventRowOpType::Delete, EventLogType::Commit),
         WriteType::Rollback => (EventRowOpType::Unknown, EventLogType::Rollback),
         other => {
-            debug!("skip write record"; "write" => ?other, "key" => %key);
+            debug!("cdc skip write record"; "write" => ?other, "key" => %key);
             return true;
         }
     };
@@ -830,7 +831,7 @@ fn decode_lock(key: Vec<u8>, lock: Lock, row: &mut EventRow) -> bool {
         LockType::Put => EventRowOpType::Put,
         LockType::Delete => EventRowOpType::Delete,
         other => {
-            debug!("skip lock record";
+            debug!("cdc skip lock record";
                 "type" => ?other,
                 "start_ts" => ?lock.ts,
                 "key" => &log_wrappers::Value::key(&key),

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::cell::RefCell;
+use std::f64::INFINITY;
 use std::fmt;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -33,7 +34,7 @@ use tikv::storage::txn::TxnEntryScanner;
 use tikv::storage::Statistics;
 use tikv_util::impl_display_as_debug;
 use tikv_util::lru::LruCache;
-use tikv_util::time::Instant;
+use tikv_util::time::{Instant, Limiter};
 use tikv_util::timer::SteadyTimer;
 use tikv_util::worker::{Runnable, RunnableWithTimer, ScheduleError, Scheduler};
 use tokio::runtime::{Builder, Runtime};
@@ -239,7 +240,6 @@ pub struct Endpoint<T> {
     pd_client: Arc<dyn PdClient>,
     timer: SteadyTimer,
     min_ts_interval: Duration,
-    scan_batch_size: usize,
     tso_worker: Runtime,
     store_meta: Arc<Mutex<StoreMeta>>,
     /// The concurrency manager for transactions. It's needed for CDC to check locks when
@@ -247,6 +247,9 @@ pub struct Endpoint<T> {
     concurrency_manager: ConcurrencyManager,
 
     workers: Runtime,
+
+    scan_speed_limter: Limiter,
+    max_scan_batch_bytes: usize,
 
     min_resolved_ts: TimeStamp,
     min_ts_region_id: u64,
@@ -283,6 +286,13 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             .core_threads(1)
             .build()
             .unwrap();
+        let speed_limter = Limiter::new(if cfg.incremental_scan_speed_limit.0 > 0 {
+            cfg.incremental_scan_speed_limit.0 as f64
+        } else {
+            INFINITY
+        });
+        // For scan efficiency, the scan batch bytes should be around 1MB.
+        let max_scan_batch_bytes = 1024 * 1024;
         let ep = Endpoint {
             env,
             security_mgr,
@@ -292,12 +302,13 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             pd_client,
             tso_worker,
             timer: SteadyTimer::default(),
+            scan_speed_limter: speed_limter,
+            max_scan_batch_bytes,
             workers,
             raft_router,
             observer,
             store_meta,
             concurrency_manager,
-            scan_batch_size: 1024,
             min_ts_interval: cfg.min_ts_interval.0,
             min_resolved_ts: TimeStamp::max(),
             min_ts_region_id: 0,
@@ -314,7 +325,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
     }
 
     pub fn set_scan_batch_size(&mut self, scan_batch_size: usize) {
-        self.scan_batch_size = scan_batch_size;
+        self.max_scan_batch_bytes = scan_batch_size;
     }
 
     fn on_deregister(&mut self, deregister: Deregister) {
@@ -465,7 +476,6 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
         let downstream_state = downstream.get_state();
         let checkpoint_ts = request.checkpoint_ts;
         let sched = self.scheduler.clone();
-        let batch_size = self.scan_batch_size;
 
         if !delegate.subscribe(downstream) {
             conn.unsubscribe(request.get_region_id());
@@ -502,9 +512,10 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             region_id,
             conn_id,
             downstream_id,
-            batch_size,
             downstream_state: downstream_state.clone(),
             txn_extra_op: delegate.txn_extra_op,
+            speed_limter: self.scan_speed_limter.clone(),
+            max_scan_batch_bytes: self.max_scan_batch_bytes,
             observe_id: delegate.id,
             checkpoint_ts: checkpoint_ts.into(),
             build_resolver: is_new_delegate,
@@ -548,7 +559,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
         }
         self.workers.spawn(async move {
             match fut.await {
-                Ok(resp) => init.on_change_cmd(resp),
+                Ok(resp) => init.on_change_cmd(resp).await,
                 Err(e) => deregister_downstream(Error::Other(box_err!(e))),
             }
         });
@@ -1007,18 +1018,20 @@ struct Initializer {
     downstream_state: Arc<AtomicCell<DownstreamState>>,
     conn_id: ConnID,
     checkpoint_ts: TimeStamp,
-    batch_size: usize,
     txn_extra_op: TxnExtraOp,
+
+    speed_limter: Limiter,
+    max_scan_batch_bytes: usize,
 
     build_resolver: bool,
 }
 
 impl Initializer {
-    fn on_change_cmd(&self, mut resp: ReadResponse<RocksSnapshot>) {
+    async fn on_change_cmd(&self, mut resp: ReadResponse<RocksSnapshot>) {
         if let Some(region_snapshot) = resp.snapshot {
             assert_eq!(self.region_id, region_snapshot.get_region().get_id());
             let region = region_snapshot.get_region().clone();
-            self.async_incremental_scan(region_snapshot, region);
+            self.async_incremental_scan(region_snapshot, region).await;
         } else {
             assert!(
                 resp.response.get_header().has_error(),
@@ -1037,7 +1050,7 @@ impl Initializer {
         }
     }
 
-    fn async_incremental_scan<S: Snapshot + 'static>(&self, snap: S, region: Region) {
+    async fn async_incremental_scan<S: Snapshot + 'static>(&self, snap: S, region: Region) {
         let downstream_id = self.downstream_id;
         let conn_id = self.conn_id;
         let region_id = region.get_id();
@@ -1070,7 +1083,7 @@ impl Initializer {
                     "observe_id" => ?self.observe_id);
                 return;
             }
-            let entries = match Self::scan_batch(&mut scanner, self.batch_size, resolver.as_mut()) {
+            let entries = match self.scan_batch(&mut scanner, resolver.as_mut()).await {
                 Ok(res) => res,
                 Err(e) => {
                     error!("cdc scan entries failed"; "error" => ?e, "region_id" => region_id);
@@ -1112,15 +1125,19 @@ impl Initializer {
         CDC_SCAN_DURATION_HISTOGRAM.observe(takes.as_secs_f64());
     }
 
-    fn scan_batch<S: Snapshot>(
+    async fn scan_batch<S: Snapshot>(
+        &self,
         scanner: &mut DeltaScanner<S>,
-        batch_size: usize,
         resolver: Option<&mut Resolver>,
     ) -> Result<Vec<Option<TxnEntry>>> {
-        let mut entries = Vec::with_capacity(batch_size);
-        while entries.len() < entries.capacity() {
+        // Assume 1KB per entry.
+        let cap = self.max_scan_batch_bytes / 1024;
+        let mut entries = Vec::with_capacity(cap);
+        let mut total_bytes = 0;
+        while total_bytes <= self.max_scan_batch_bytes {
             match scanner.next_entry()? {
                 Some(entry) => {
+                    total_bytes += entry.size();
                     entries.push(Some(entry));
                 }
                 None => {
@@ -1129,6 +1146,7 @@ impl Initializer {
                 }
             }
         }
+        self.speed_limter.consume(total_bytes).await;
 
         if let Some(resolver) = resolver {
             // Track the locks.
@@ -1279,6 +1297,7 @@ mod tests {
     use super::*;
     use collections::HashSet;
     use engine_traits::DATA_CFS;
+    use futures::executor::block_on;
     #[cfg(feature = "prost-codec")]
     use kvproto::cdcpb::event::Event as Event_oneof_event;
     use kvproto::errorpb::Error as ErrorHeader;
@@ -1336,7 +1355,8 @@ mod tests {
             downstream_state,
             conn_id: ConnID::new(),
             checkpoint_ts: 1.into(),
-            batch_size: 1,
+            speed_limter: Limiter::new(INFINITY),
+            max_scan_batch_bytes: 1,
             txn_extra_op: TxnExtraOp::Noop,
             build_resolver: true,
         };
@@ -1416,22 +1436,22 @@ mod tests {
             }
         };
 
-        initializer.async_incremental_scan(snap.clone(), region.clone());
+        block_on(initializer.async_incremental_scan(snap.clone(), region.clone()));
         check_result();
-        initializer.batch_size = 1000;
-        initializer.async_incremental_scan(snap.clone(), region.clone());
-        check_result();
-
-        initializer.batch_size = 10;
-        initializer.async_incremental_scan(snap.clone(), region.clone());
+        initializer.max_scan_batch_bytes = 1000;
+        block_on(initializer.async_incremental_scan(snap.clone(), region.clone()));
         check_result();
 
-        initializer.batch_size = 11;
-        initializer.async_incremental_scan(snap.clone(), region.clone());
+        initializer.max_scan_batch_bytes = 10;
+        block_on(initializer.async_incremental_scan(snap.clone(), region.clone()));
+        check_result();
+
+        initializer.max_scan_batch_bytes = 11;
+        block_on(initializer.async_incremental_scan(snap.clone(), region.clone()));
         check_result();
 
         initializer.build_resolver = false;
-        initializer.async_incremental_scan(snap.clone(), region.clone());
+        block_on(initializer.async_incremental_scan(snap.clone(), region.clone()));
 
         loop {
             let task = rx.recv_timeout(Duration::from_secs(1));
@@ -1445,7 +1465,7 @@ mod tests {
 
         // Test cancellation.
         initializer.downstream_state.store(DownstreamState::Stopped);
-        initializer.async_incremental_scan(snap, region);
+        block_on(initializer.async_incremental_scan(snap, region));
 
         loop {
             let task = rx.recv_timeout(Duration::from_secs(1));

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1046,10 +1046,10 @@ impl Initializer {
     async fn on_change_cmd(&self, mut resp: ReadResponse<RocksSnapshot>) {
         CDC_SCAN_TASKS.with_label_values(&["total"]).inc();
         if let Some(region_snapshot) = resp.snapshot {
-            CDC_SCAN_TASKS.with_label_values(&["finish"]).inc();
             assert_eq!(self.region_id, region_snapshot.get_region().get_id());
             let region = region_snapshot.get_region().clone();
             self.async_incremental_scan(region_snapshot, region).await;
+            CDC_SCAN_TASKS.with_label_values(&["finish"]).inc();
         } else {
             CDC_SCAN_TASKS.with_label_values(&["abort"]).inc();
             assert!(

--- a/components/cdc/src/metrics.rs
+++ b/components/cdc/src/metrics.rs
@@ -16,6 +16,11 @@ lazy_static! {
         exponential_buckets(0.005, 2.0, 20).unwrap()
     )
     .unwrap();
+    pub static ref CDC_SCAN_BYTES: IntCounter = register_int_counter!(
+        "tikv_cdc_scan_bytes_total",
+        "Total bytes of CDC incremental scan"
+    )
+    .unwrap();
     pub static ref CDC_MIN_RESOLVED_TS_REGION: IntGauge = register_int_gauge!(
         "tikv_cdc_min_resolved_ts_region",
         "The region which has minimal resolved ts"

--- a/components/cdc/src/metrics.rs
+++ b/components/cdc/src/metrics.rs
@@ -21,6 +21,12 @@ lazy_static! {
         "Total bytes of CDC incremental scan"
     )
     .unwrap();
+    pub static ref CDC_SCAN_TASKS: IntGaugeVec = register_int_gauge_vec!(
+        "tikv_cdc_scan_tasks",
+        "Total number of CDC incremental scan tasks",
+        &["type"]
+    )
+    .unwrap();
     pub static ref CDC_MIN_RESOLVED_TS_REGION: IntGauge = register_int_gauge!(
         "tikv_cdc_min_resolved_ts_region",
         "The region which has minimal resolved ts"
@@ -39,6 +45,12 @@ lazy_static! {
     pub static ref CDC_CAPTURED_REGION_COUNT: IntGauge = register_int_gauge!(
         "tikv_cdc_captured_region_total",
         "Total number of CDC captured regions"
+    )
+    .unwrap();
+    pub static ref CDC_REGION_RESOLVE_STATUS_GAUGE_VEC: IntGaugeVec = register_int_gauge_vec!(
+        "tikv_cdc_region_resolve_status",
+        "The status of CDC captured regions",
+        &["status"]
     )
     .unwrap();
     pub static ref CDC_OLD_VALUE_CACHE_MISS: IntGauge = register_int_gauge!(

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -172,7 +172,7 @@ impl<E: KvEngine> CmdObserver<E> for CdcObserver {
                 multi: batches,
                 old_value_cb: Box::new(get_old_value),
             }) {
-                warn!("schedule cdc task failed"; "error" => ?e);
+                warn!("cdc schedule task failed"; "error" => ?e);
             }
         }
     }
@@ -191,7 +191,7 @@ impl RoleObserver for CdcObserver {
                     err: CdcError::Request(store_err.into()),
                 };
                 if let Err(e) = self.sched.schedule(Task::Deregister(deregister)) {
-                    error!("schedule cdc task failed"; "error" => ?e);
+                    error!("cdc schedule cdc task failed"; "error" => ?e);
                 }
             }
         }
@@ -216,7 +216,7 @@ impl RegionChangeObserver for CdcObserver {
                     err: CdcError::Request(store_err.into()),
                 };
                 if let Err(e) = self.sched.schedule(Task::Deregister(deregister)) {
-                    error!("schedule cdc task failed"; "error" => ?e);
+                    error!("cdc schedule cdc task failed"; "error" => ?e);
                 }
             }
         }

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -185,7 +185,7 @@ impl Conn {
                 if version == &ver {
                     None
                 } else {
-                    error!("different version on the same connection";
+                    error!("cdc different version on the same connection";
                         "previous version" => ?version, "version" => ?ver,
                         "downstream" => ?self.peer, "conn_id" => ?self.id);
                     Some(Compatibility {
@@ -199,7 +199,8 @@ impl Conn {
                 if v407_bacth_resoled_ts <= ver {
                     features.toggle(FeatureGate::BATCH_RESOLVED_TS);
                 }
-                info!("cdc connection version"; "version" => ver.to_string(), "features" => ?features);
+                info!("cdc connection version";
+                    "version" => ver.to_string(), "features" => ?features, "downstream" => ?self.peer);
                 self.version = Some((ver, features));
                 None
             }
@@ -362,10 +363,10 @@ impl ChangeData for Service {
             }
             match res {
                 Ok(()) => {
-                    info!("cdc send half closed"; "downstream" => peer, "conn_id" => ?conn_id);
+                    info!("cdc receive closed"; "downstream" => peer, "conn_id" => ?conn_id);
                 }
                 Err(e) => {
-                    warn!("cdc send failed"; "error" => ?e, "downstream" => peer, "conn_id" => ?conn_id);
+                    warn!("cdc receive failed"; "error" => ?e, "downstream" => peer, "conn_id" => ?conn_id);
                 }
             }
         });
@@ -382,7 +383,7 @@ impl ChangeData for Service {
             }
             match res {
                 Ok(_s) => {
-                    info!("cdc send half closed"; "downstream" => peer, "conn_id" => ?conn_id);
+                    info!("cdc send closed"; "downstream" => peer, "conn_id" => ?conn_id);
                     let _ = sink.close().await;
                 }
                 Err(e) => {

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -20,7 +20,6 @@ use pd_client::PdClient;
 use raft::eraftpb::MessageType;
 use test_raftstore::sleep_ms;
 use test_raftstore::*;
-use tikv_util::config::ReadableSize;
 use tikv_util::HandyRwLock;
 use txn_types::{Key, Lock, LockType};
 
@@ -654,12 +653,7 @@ fn test_duplicate_subscribe() {
 
 #[test]
 fn test_cdc_batch_size_limit() {
-    let mut cluster = new_server_cluster(1, 1);
-    // Do not set limiter in the test.
-    cluster.cfg.cdc.incremental_scan_speed_limit = ReadableSize(0);
-    // Increase the Raft tick interval to make this test case running reliably.
-    configure_for_lease_read(&mut cluster, Some(100), None);
-    let mut suite = TestSuite::with_cluster(1, cluster);
+    let mut suite = TestSuite::new(1);
 
     // Prewrite
     let start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();

--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -661,7 +661,7 @@ fn test_cdc_batch_size_limit() {
     let k1 = b"k1".to_vec();
     m1.set_op(Op::Put);
     m1.key = k1.clone();
-    m1.value = vec![0; 6 * 1024 * 1024];
+    m1.value = vec![0; 6];
     let mut m2 = Mutation::default();
     let k2 = b"k2".to_vec();
     m2.set_op(Op::Put);

--- a/components/cdc/tests/mod.rs
+++ b/components/cdc/tests/mod.rs
@@ -75,7 +75,7 @@ pub fn new_event_feed(
         if !keep_resolved_ts && change_data_event.has_resolved_ts() {
             continue;
         }
-        tikv_util::info!("receive event {:?}", change_data_event);
+        tikv_util::info!("cdc receive event {:?}", change_data_event);
         break change_data_event;
     };
     (
@@ -160,7 +160,7 @@ impl TestSuite {
                 sim.security_mgr.clone(),
             );
             cdc_endpoint.set_min_ts_interval(Duration::from_millis(100));
-            cdc_endpoint.set_scan_batch_size(2);
+            cdc_endpoint.set_max_scan_batch_size(2);
             concurrency_managers.insert(*id, cm);
             worker.start(cdc_endpoint);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2256,6 +2256,7 @@ pub struct CdcConfig {
     pub min_ts_interval: ReadableDuration,
     pub old_value_cache_size: usize,
     pub hibernate_regions_compatible: bool,
+    pub incremental_scan_speed_limit: ReadableSize,
 }
 
 impl Default for CdcConfig {
@@ -2264,6 +2265,9 @@ impl Default for CdcConfig {
             min_ts_interval: ReadableDuration::secs(1),
             old_value_cache_size: 1024,
             hibernate_regions_compatible: true,
+            // TiCDC requires a SSD, the typical write speed of SSD
+            // is more than 500MB/s, so 128MB/s is enough.
+            incremental_scan_speed_limit: ReadableSize::mb(128),
         }
     }
 }

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -1304,8 +1304,8 @@ mod tests {
     fn test_txn_entry_size() {
         assert_eq!(
             TxnEntry::Prewrite {
-                default: (vec![0; 10], vec![0, 10]),
-                lock: (vec![0; 10], vec![0, 10]),
+                default: (vec![0; 10], vec![0; 10]),
+                lock: (vec![0; 10], vec![0; 10]),
                 old_value: None,
             }
             .size(),
@@ -1314,8 +1314,8 @@ mod tests {
 
         assert_eq!(
             TxnEntry::Prewrite {
-                default: (vec![0; 10], vec![0, 10]),
-                lock: (vec![0; 10], vec![0, 10]),
+                default: (vec![0; 10], vec![0; 10]),
+                lock: (vec![0; 10], vec![0; 10]),
                 old_value: Some(vec![0; 10]),
             }
             .size(),
@@ -1324,8 +1324,8 @@ mod tests {
 
         assert_eq!(
             TxnEntry::Commit {
-                default: (vec![0; 10], vec![0, 10]),
-                write: (vec![0; 10], vec![0, 10]),
+                default: (vec![0; 10], vec![0; 10]),
+                write: (vec![0; 10], vec![0; 10]),
                 old_value: None,
             }
             .size(),
@@ -1334,8 +1334,8 @@ mod tests {
 
         assert_eq!(
             TxnEntry::Commit {
-                default: (vec![0; 10], vec![0, 10]),
-                write: (vec![0; 10], vec![0, 10]),
+                default: (vec![0; 10], vec![0; 10]),
+                write: (vec![0; 10], vec![0; 10]),
                 old_value: Some(vec![0; 10]),
             }
             .size(),

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -180,6 +180,35 @@ impl TxnEntry {
             _ => unreachable!(),
         }
     }
+
+    pub fn size(&self) -> usize {
+        let mut size = 0;
+        match self {
+            TxnEntry::Commit {
+                default,
+                write,
+                old_value,
+            } => {
+                size += default.0.len();
+                size += default.1.len();
+                size += write.0.len();
+                size += write.1.len();
+                size += old_value.as_ref().map_or(0, |v| v.len())
+            }
+            TxnEntry::Prewrite {
+                default,
+                lock,
+                old_value,
+            } => {
+                size += default.0.len();
+                size += default.1.len();
+                size += lock.0.len();
+                size += lock.1.len();
+                size += old_value.as_ref().map_or(0, |v| v.len())
+            }
+        }
+        size
+    }
 }
 
 /// A batch of transaction entries.
@@ -1269,6 +1298,49 @@ mod tests {
             Some((Key::from_raw(b"abcd"), vec![]))
         );
         assert_eq!(scanner.next().unwrap(), None);
+    }
+
+    #[test]
+    fn test_txn_entry_size() {
+        assert_eq!(
+            TxnEntry::Prewrite {
+                default: (vec![0; 10], vec![0, 10]),
+                lock: (vec![0; 10], vec![0, 10]),
+                old_value: None,
+            }
+            .size(),
+            40
+        );
+
+        assert_eq!(
+            TxnEntry::Prewrite {
+                default: (vec![0; 10], vec![0, 10]),
+                lock: (vec![0; 10], vec![0, 10]),
+                old_value: Some(vec![0; 10]),
+            }
+            .size(),
+            50
+        );
+
+        assert_eq!(
+            TxnEntry::Commit {
+                default: (vec![0; 10], vec![0, 10]),
+                write: (vec![0; 10], vec![0, 10]),
+                old_value: None,
+            }
+            .size(),
+            40
+        );
+
+        assert_eq!(
+            TxnEntry::Commit {
+                default: (vec![0; 10], vec![0, 10]),
+                write: (vec![0; 10], vec![0, 10]),
+                old_value: Some(vec![0; 10]),
+            }
+            .size(),
+            50
+        );
     }
 }
 

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -711,6 +711,7 @@ fn test_serde_custom_tikv_config() {
         min_ts_interval: ReadableDuration::secs(4),
         old_value_cache_size: 512,
         hibernate_regions_compatible: false,
+        incremental_scan_speed_limit: ReadableSize(7),
     };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -615,6 +615,7 @@ pipelined = false
 min-ts-interval = "4s"
 old-value-cache-size = 512
 hibernate-regions-compatible = false
+incremental-scan-speed-limit = 7
 
 [split]
 detect-times = 10


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary: Limit TiKV CDC scan speed to avoid OOM.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

![image](https://user-images.githubusercontent.com/2150711/113390195-d2d4cf80-93c3-11eb-9895-05143e8d7a7a.png)

TiKV keeps OOM on the left of the above graph. With this PR TiKV does not OOM and keeps in constant memory consumption. 

### Release note <!-- bugfixes or new feature need a release note -->

- Limit CDC scan speed to avoid OOM.