### PR TITLE
ensure the panic log is flushed

### DIFF
--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -435,31 +435,29 @@ pub fn set_panic_hook(panic_abort: bool, data_dir: &str) {
         .unwrap();
 
     let data_dir = data_dir.to_string();
-    let orig_hook = panic::take_hook();
+
     panic::set_hook(Box::new(move |info: &panic::PanicInfo<'_>| {
-        use slog::Drain;
-        if slog_global::borrow_global().is_enabled(::slog::Level::Error) {
-            let msg = match info.payload().downcast_ref::<&'static str>() {
-                Some(s) => *s,
-                None => match info.payload().downcast_ref::<String>() {
-                    Some(s) => &s[..],
-                    None => "Box<Any>",
-                },
-            };
-            let thread = thread::current();
-            let name = thread.name().unwrap_or("<unnamed>");
-            let loc = info
-                .location()
-                .map(|l| format!("{}:{}", l.file(), l.line()));
-            let bt = backtrace::Backtrace::new();
-            crit!("{}", msg;
-                "thread_name" => name,
-                "location" => loc.unwrap_or_else(|| "<unknown>".to_owned()),
-                "backtrace" => format_args!("{:?}", bt),
-            );
-        } else {
-            orig_hook(info);
-        }
+        let msg = match info.payload().downcast_ref::<&'static str>() {
+            Some(s) => *s,
+            None => match info.payload().downcast_ref::<String>() {
+                Some(s) => &s[..],
+                None => "Box<Any>",
+            },
+        };
+
+        let thread = thread::current();
+        let name = thread.name().unwrap_or("<unnamed>");
+        let loc = info
+            .location()
+            .map(|l| format!("{}:{}", l.file(), l.line()));
+        let bt = backtrace::Backtrace::new();
+        crit!("{}", msg;
+            "thread_name" => name,
+            "location" => loc.unwrap_or_else(|| "<unknown>".to_owned()),
+            "backtrace" => format_args!("{:?}", bt),
+        );
+        // This may be needed to allow the above log statements to flush
+        thread::sleep(Duration::from_millis(2));
 
         // There might be remaining logs in the async logger.
         // To collect remaining logs and also collect future logs, replace the old one with a

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -750,6 +750,12 @@ where
                             (Method::GET, "/debug/pprof/profile") => {
                                 Self::dump_rsperf_to_resp(req).await
                             }
+                            (Method::GET, "/debug/fail_point") => {
+                                info!("debug fail point API start");
+                                fail_point!("debug_fail_point");
+                                info!("debug fail point API finish");
+                                Ok(Response::default())
+                            }
                             (Method::GET, path) if path.starts_with("/region") => {
                                 Self::dump_region_meta(req, router).await
                             }


### PR DESCRIPTION
I noticed that the panic message was missing from the output.
Adding a very small sleep fixed this. I did try some other approaches to flushing, but I couldn't get any of them to work.
Additionally TiKV will now print out the panic error message just by itself as the very last output: this avoids having to look up past the stacktrace.

I also added a status server API `/debug/fail_point`. It can be used like this to trigger a panic, but it requires setting the feature `failpoints`.

Tests

- Manual test before and after

```
curl localhost:20180/fail/debug_fail_point -X PUT -d 'panic'
curl localhost:20180/debug/fail_point
```

Side effects

Additional 2ms sleep before abort.

### Release note

* Ensure panic output is flushed to the log