### PR TITLE
encryption: Ignore log record parse error caused by write failure before (#9938)

### DIFF
--- a/components/encryption/src/errors.rs
+++ b/components/encryption/src/errors.rs
@@ -9,23 +9,14 @@ use std::{error, result};
 /// The error type for encryption.
 #[derive(Debug, Fail)]
 pub enum Error {
-<<<<<<< HEAD
     #[fail(display = "Other error {}", _0)]
     Other(Box<dyn error::Error + Sync + Send>),
     #[fail(display = "RocksDB error {}", _0)]
-=======
-    #[error("Other error {0}")]
-    Other(#[from] Box<dyn error::Error + Sync + Send>),
+    Rocks(String),
     // Only when the parsing record is the last one, and the
     // length is insufficient or the crc checksum fails.
-    #[error("Recoverable tail record corruption while parsing file dictionary")]
+    #[fail(display = "Recoverable tail record corruption while parsing file dictionary")]
     TailRecordParseIncomplete,
-    // Currently only in use by cloud KMS
-    #[error("Cloud KMS error {0}")]
-    RetryCodedError(Box<dyn RetryCodedError>),
-    #[error("RocksDB error {0}")]
->>>>>>> 4b328ed55... encryption: Ignore log record parse error caused by write failure before (#9938)
-    Rocks(String),
     #[fail(display = "IO error {}", _0)]
     Io(IoError),
     #[fail(display = "OpenSSL error {}", _0)]
@@ -80,11 +71,7 @@ pub type Result<T> = result::Result<T, Error>;
 impl ErrorCodeExt for Error {
     fn error_code(&self) -> ErrorCode {
         match self {
-<<<<<<< HEAD
-=======
-            Error::RetryCodedError(err) => (*err).error_code(),
             Error::TailRecordParseIncomplete => error_code::encryption::PARSE_INCOMPLETE,
->>>>>>> 4b328ed55... encryption: Ignore log record parse error caused by write failure before (#9938)
             Error::Rocks(_) => error_code::encryption::ROCKS,
             Error::Io(_) => error_code::encryption::IO,
             Error::Crypter(_) => error_code::encryption::CRYPTER,
@@ -96,25 +83,3 @@ impl ErrorCodeExt for Error {
         }
     }
 }
-<<<<<<< HEAD
-=======
-
-impl RetryError for Error {
-    fn is_retryable(&self) -> bool {
-        // This should be refined.
-        // However, only Error::Tls should be encountered
-        match self {
-            Error::RetryCodedError(err) => err.is_retryable(),
-            Error::TailRecordParseIncomplete => true,
-            Error::Rocks(_) => true,
-            Error::Io(_) => true,
-            Error::Crypter(_) => true,
-            Error::Proto(_) => true,
-            Error::UnknownEncryption => true,
-            Error::WrongMasterKey(_) => false,
-            Error::BothMasterKeyFail(_, _) => false,
-            Error::Other(_) => true,
-        }
-    }
-}
->>>>>>> 4b328ed55... encryption: Ignore log record parse error caused by write failure before (#9938)

--- a/components/encryption/src/errors.rs
+++ b/components/encryption/src/errors.rs
@@ -9,9 +9,22 @@ use std::{error, result};
 /// The error type for encryption.
 #[derive(Debug, Fail)]
 pub enum Error {
+<<<<<<< HEAD
     #[fail(display = "Other error {}", _0)]
     Other(Box<dyn error::Error + Sync + Send>),
     #[fail(display = "RocksDB error {}", _0)]
+=======
+    #[error("Other error {0}")]
+    Other(#[from] Box<dyn error::Error + Sync + Send>),
+    // Only when the parsing record is the last one, and the
+    // length is insufficient or the crc checksum fails.
+    #[error("Recoverable tail record corruption while parsing file dictionary")]
+    TailRecordParseIncomplete,
+    // Currently only in use by cloud KMS
+    #[error("Cloud KMS error {0}")]
+    RetryCodedError(Box<dyn RetryCodedError>),
+    #[error("RocksDB error {0}")]
+>>>>>>> 4b328ed55... encryption: Ignore log record parse error caused by write failure before (#9938)
     Rocks(String),
     #[fail(display = "IO error {}", _0)]
     Io(IoError),
@@ -67,6 +80,11 @@ pub type Result<T> = result::Result<T, Error>;
 impl ErrorCodeExt for Error {
     fn error_code(&self) -> ErrorCode {
         match self {
+<<<<<<< HEAD
+=======
+            Error::RetryCodedError(err) => (*err).error_code(),
+            Error::TailRecordParseIncomplete => error_code::encryption::PARSE_INCOMPLETE,
+>>>>>>> 4b328ed55... encryption: Ignore log record parse error caused by write failure before (#9938)
             Error::Rocks(_) => error_code::encryption::ROCKS,
             Error::Io(_) => error_code::encryption::IO,
             Error::Crypter(_) => error_code::encryption::CRYPTER,
@@ -78,3 +96,25 @@ impl ErrorCodeExt for Error {
         }
     }
 }
+<<<<<<< HEAD
+=======
+
+impl RetryError for Error {
+    fn is_retryable(&self) -> bool {
+        // This should be refined.
+        // However, only Error::Tls should be encountered
+        match self {
+            Error::RetryCodedError(err) => err.is_retryable(),
+            Error::TailRecordParseIncomplete => true,
+            Error::Rocks(_) => true,
+            Error::Io(_) => true,
+            Error::Crypter(_) => true,
+            Error::Proto(_) => true,
+            Error::UnknownEncryption => true,
+            Error::WrongMasterKey(_) => false,
+            Error::BothMasterKeyFail(_, _) => false,
+            Error::Other(_) => true,
+        }
+    }
+}
+>>>>>>> 4b328ed55... encryption: Ignore log record parse error caused by write failure before (#9938)

--- a/components/encryption/src/file_dict_file.rs
+++ b/components/encryption/src/file_dict_file.rs
@@ -4,10 +4,7 @@ use byteorder::{BigEndian, ByteOrder};
 use kvproto::encryptionpb::{EncryptedContent, FileDictionary, FileInfo};
 use protobuf::Message;
 use rand::{thread_rng, RngCore};
-<<<<<<< HEAD
-=======
 use tikv_util::{box_err, set_panic_mark, warn};
->>>>>>> 4b328ed55... encryption: Ignore log record parse error caused by write failure before (#9938)
 
 use crate::encrypted_file::{EncryptedFile, Header, Version, TMP_FILE_SUFFIX};
 use crate::master_key::{Backend, PlaintextBackend};

--- a/components/encryption/src/file_dict_file.rs
+++ b/components/encryption/src/file_dict_file.rs
@@ -4,10 +4,15 @@ use byteorder::{BigEndian, ByteOrder};
 use kvproto::encryptionpb::{EncryptedContent, FileDictionary, FileInfo};
 use protobuf::Message;
 use rand::{thread_rng, RngCore};
+<<<<<<< HEAD
+=======
+use tikv_util::{box_err, set_panic_mark, warn};
+>>>>>>> 4b328ed55... encryption: Ignore log record parse error caused by write failure before (#9938)
 
 use crate::encrypted_file::{EncryptedFile, Header, Version, TMP_FILE_SUFFIX};
 use crate::master_key::{Backend, PlaintextBackend};
 use crate::metrics::*;
+use crate::Error;
 use crate::Result;
 
 use std::fs::{rename, File, OpenOptions};
@@ -165,23 +170,40 @@ impl FileDictionaryFile {
             }
             Version::V2 => {
                 file_dict.merge_from_bytes(content)?;
+                let mut last_record_name = String::new();
                 // parse the remained records
                 while !remained.is_empty() {
                     // If the parsing get errors, manual intervention is required to recover.
-                    let (used_size, file_name, mode) = Self::parse_next_record(remained)?;
-                    remained.consume(used_size);
-                    match mode {
-                        LogRecord::INSERT(info) => {
-                            file_dict.files.insert(file_name, info);
-                        }
-                        LogRecord::REMOVE => {
-                            let original = file_dict.files.remove(&file_name);
-                            if original.is_none() {
-                                return Err(box_err!(
-                                    "Try to recovery from log file but remove a null entry, file name: {}",
-                                    file_name
-                                ));
+                    match Self::parse_next_record(remained) {
+                        Ok((used_size, file_name, mode)) => {
+                            remained.consume(used_size);
+                            last_record_name = file_name.clone();
+                            match mode {
+                                LogRecord::INSERT(info) => {
+                                    file_dict.files.insert(file_name, info);
+                                }
+                                LogRecord::REMOVE => {
+                                    let original = file_dict.files.remove(&file_name);
+                                    if original.is_none() {
+                                        return Err(box_err!(
+                                            "Try to recovery from log file but remove a null entry, file name: {}",
+                                            file_name
+                                        ));
+                                    }
+                                }
                             }
+                        }
+                        Err(e @ Error::TailRecordParseIncomplete) => {
+                            warn!(
+                                "{:?} occurred and the last complete filename is {}",
+                                e, last_record_name
+                            );
+                            break;
+                        }
+                        Err(e) => {
+                            // This error is unrecoverable and manual intervention is required.
+                            set_panic_mark();
+                            return Err(e);
                         }
                     }
                 }
@@ -199,6 +221,16 @@ impl FileDictionaryFile {
         if self.enable_log {
             let file = self.append_file.as_mut().unwrap();
             let bytes = Self::convert_record_to_bytes(name, LogRecord::INSERT(info.clone()))?;
+
+            fail::fail_point!("file_dict_log_append_incomplete", |truncate_num| {
+                let mut bytes = bytes.clone();
+                let truncate_num: usize = truncate_num.map_or(0, |c| c.parse().unwrap());
+                bytes.truncate(truncate_num);
+                file.write_all(&bytes)?;
+                file.sync_all()?;
+                Ok(())
+            });
+
             file.write_all(&bytes)?;
             file.sync_all()?;
 
@@ -302,10 +334,11 @@ impl FileDictionaryFile {
 
     fn parse_next_record(mut remained: &[u8]) -> Result<(usize, String, LogRecord)> {
         if remained.len() < Self::RECORD_HEADER_SIZE {
-            return Err(box_err!(
-                "file corrupted! record header size is too small: {}",
-                remained.len()
-            ));
+            warn!(
+                "file corrupted! record header size is too small, discarded the tail record";
+                "size" => remained.len(),
+            );
+            return Err(Error::TailRecordParseIncomplete);
         }
 
         // parse header
@@ -315,11 +348,13 @@ impl FileDictionaryFile {
         let mode = remained[Self::RECORD_HEADER_SIZE - 1];
         remained.consume(Self::RECORD_HEADER_SIZE);
         if remained.len() < name_len + info_len {
-            return Err(box_err!(
-                "file corrupted! record content size is too small: {}, expect: {}",
-                remained.len(),
-                name_len + info_len
-            ));
+            warn!(
+                "file corrupted! record content size is too small, discarded the tail record";
+                "content size" => remained.len(),
+                "expected name length" => name_len,
+                "expected content length" =>info_len,
+            );
+            return Err(Error::TailRecordParseIncomplete);
         }
 
         // checksum crc32
@@ -327,11 +362,22 @@ impl FileDictionaryFile {
         digest.update(&remained[0..name_len + info_len]);
         let crc32_checksum = digest.finalize();
         if crc32_checksum != crc32 {
-            return Err(box_err!(
-                "file corrupted! crc32 mismatch {} != {}",
-                crc32,
-                crc32_checksum
-            ));
+            remained.consume(name_len + info_len);
+            if remained.is_empty() {
+                // Only when this record is the last one can the panic be skipped.
+                warn!(
+                    "file corrupted! crc32 mismatch, discarded the tail record";
+                    "expected crc32" => crc32,
+                    "checksum crc32" => crc32_checksum,
+                );
+                return Err(Error::TailRecordParseIncomplete);
+            } else {
+                return Err(box_err!(
+                    "file corrupted! crc32 mismatch {} != {}",
+                    crc32,
+                    crc32_checksum
+                ));
+            }
         }
 
         // read file name

--- a/components/encryption/src/lib.rs
+++ b/components/encryption/src/lib.rs
@@ -24,7 +24,8 @@ mod metrics;
 
 pub use self::config::*;
 pub use self::crypter::{
-    encryption_method_from_db_encryption_method, verify_encryption_config, AesGcmCrypter, Iv,
+    compat, encryption_method_from_db_encryption_method, verify_encryption_config, AesGcmCrypter,
+    Iv,
 };
 pub use self::encrypted_file::EncryptedFile;
 pub use self::errors::{Error, Result};

--- a/components/encryption/src/lib.rs
+++ b/components/encryption/src/lib.rs
@@ -24,10 +24,19 @@ mod metrics;
 
 pub use self::config::*;
 pub use self::crypter::{
+<<<<<<< HEAD
     encryption_method_from_db_encryption_method, verify_encryption_config, AesGcmCrypter, Iv,
 };
 pub use self::encrypted_file::EncryptedFile;
 pub use self::errors::{Error, Result};
+=======
+    compat, encryption_method_from_db_encryption_method, verify_encryption_config, AesGcmCrypter,
+    Iv, PlainKey,
+};
+pub use self::encrypted_file::EncryptedFile;
+pub use self::errors::{Error, Result, RetryCodedError};
+pub use self::file_dict_file::FileDictionaryFile;
+>>>>>>> 4b328ed55... encryption: Ignore log record parse error caused by write failure before (#9938)
 pub use self::io::{create_aes_ctr_crypter, DecrypterReader, EncrypterReader, EncrypterWriter};
 pub use self::manager::DataKeyManager;
 pub use self::master_key::{Backend, FileBackend, KmsBackend};

--- a/components/encryption/src/lib.rs
+++ b/components/encryption/src/lib.rs
@@ -24,19 +24,11 @@ mod metrics;
 
 pub use self::config::*;
 pub use self::crypter::{
-<<<<<<< HEAD
     encryption_method_from_db_encryption_method, verify_encryption_config, AesGcmCrypter, Iv,
 };
 pub use self::encrypted_file::EncryptedFile;
 pub use self::errors::{Error, Result};
-=======
-    compat, encryption_method_from_db_encryption_method, verify_encryption_config, AesGcmCrypter,
-    Iv, PlainKey,
-};
-pub use self::encrypted_file::EncryptedFile;
-pub use self::errors::{Error, Result, RetryCodedError};
 pub use self::file_dict_file::FileDictionaryFile;
->>>>>>> 4b328ed55... encryption: Ignore log record parse error caused by write failure before (#9938)
 pub use self::io::{create_aes_ctr_crypter, DecrypterReader, EncrypterReader, EncrypterWriter};
 pub use self::manager::DataKeyManager;
 pub use self::master_key::{Backend, FileBackend, KmsBackend};

--- a/components/error_code/src/encryption.rs
+++ b/components/error_code/src/encryption.rs
@@ -9,5 +9,6 @@ define_error_codes!(
     PROTO => ("Proto", "", ""),
     UNKNOWN_ENCRYPTION => ("UnknownEncryption", "", ""),
     WRONG_MASTER_KEY => ("WrongMasterKey", "", ""),
-    BOTH_MASTER_KEY_FAIL => ("BothMasterKeyFail", "", "")
+    BOTH_MASTER_KEY_FAIL => ("BothMasterKeyFail", "", ""),
+    PARSE_INCOMPLETE => ("TailRecordParseIncomplete", "", "")
 );

--- a/tests/failpoints/cases/mod.rs
+++ b/tests/failpoints/cases/mod.rs
@@ -5,6 +5,7 @@ mod test_cmd_epoch_checker;
 mod test_conf_change;
 mod test_coprocessor;
 mod test_early_apply;
+mod test_encryption;
 mod test_gc_worker;
 mod test_import_service;
 mod test_merge;

--- a/tests/failpoints/cases/test_encryption.rs
+++ b/tests/failpoints/cases/test_encryption.rs
@@ -1,0 +1,53 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use encryption::compat;
+use encryption::FileDictionaryFile;
+use kvproto::encryptionpb::{EncryptionMethod, FileInfo};
+
+#[test]
+fn test_file_dict_file_record_corrupted() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let mut file_dict_file = FileDictionaryFile::new(
+        tempdir.path(),
+        "test_file_dict_file_record_corrupted_1",
+        true,
+        10, /*file_rewrite_threshold*/
+    )
+    .unwrap();
+    let info1 = create_file_info(1, EncryptionMethod::Aes256Ctr);
+    let info2 = create_file_info(2, EncryptionMethod::Unknown);
+    // 9 represents that the first 9 bytes will be discarded.
+    // Crc32 (4 bytes) + File name length (2 bytes) + FileInfo length (2 bytes) + Log type (1 bytes)
+    fail::cfg("file_dict_log_append_incomplete", "return(9)").unwrap();
+    file_dict_file.insert("info1", &info1).unwrap();
+    fail::remove("file_dict_log_append_incomplete");
+    file_dict_file.insert("info2", &info2).unwrap();
+    // Intermediate record damage is not allowed.
+    assert!(file_dict_file.recovery().is_err());
+
+    let mut file_dict_file = FileDictionaryFile::new(
+        tempdir.path(),
+        "test_file_dict_file_record_corrupted_2",
+        true,
+        10, /*file_rewrite_threshold*/
+    )
+    .unwrap();
+    let info1 = create_file_info(1, EncryptionMethod::Aes256Ctr);
+    let info2 = create_file_info(2, EncryptionMethod::Unknown);
+    file_dict_file.insert("info1", &info1).unwrap();
+    fail::cfg("file_dict_log_append_incomplete", "return(9)").unwrap();
+    file_dict_file.insert("info2", &info2).unwrap();
+    fail::remove("file_dict_log_append_incomplete");
+    // The ending record can be discarded.
+    let file_dict = file_dict_file.recovery().unwrap();
+    assert_eq!(*file_dict.files.get("info1").unwrap(), info1);
+    assert_eq!(file_dict.files.len(), 1);
+}
+
+fn create_file_info(id: u64, method: EncryptionMethod) -> FileInfo {
+    FileInfo {
+        key_id: id,
+        method: compat(method),
+        ..Default::default()
+    }
+}


### PR DESCRIPTION
git push --set-upstream origin xt/pick-9938

Signed-off-by: Xintao hunterlxt@live.com

## What problem does this PR solve?
Issue Number: close #9886

Problem Summary:

When the file dict fails to be appended and written for some reason, we believe that this record can be safely discarded because the corresponding file has not been actually modified

## What is changed and how it works?
Add a new error type and ignore these errors.

## Related changes
Need to cherry-pick to the release-4.x

## Check List
Tests

Unit test
Integration test
Manual test (add detailed scripts or steps below)
No code
Side effects

N/A

## Release note
- Fix the bug that TiKV cannot startup when the end of file dict file is damaged.