### PR TITLE
tidb_query: fix panic when input of cast_string_as_time is invalid UTF-8 bytes

### DIFF
--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -2330,17 +2330,17 @@ mod tests {
         }
 
         // If the input is invalid UTF-8 bytes, it should return error.
-        assert!(
-            RpnFnScalarEvaluator::new()
-                .push_param(vec![0, 159, 146, 150])
-                .return_field_type(
-                    FieldTypeBuilder::new()
-                        .tp(FieldTypeTp::DateTime)
-                        .decimal(1)
-                        .build(),
-                )
-                .evaluate::<Time>(ScalarFuncSig::CastStringAsTime)
-                .is_err()
+        let (res, ctx) = RpnFnScalarEvaluator::new()
+            .push_param(vec![0, 159, 146, 150])
+            .evaluate_raw(
+                FieldTypeBuilder::new().tp(FieldTypeTp::DateTime).build(),
+                ScalarFuncSig::CastStringAsTime,
+            );
+        assert!(matches!(res.unwrap(), ScalarValue::DateTime(None)));
+        check_warning(
+            &ctx,
+            Some(ERR_TRUNCATE_WRONG_VALUE),
+            "should have warning when casting invalid utf-8 to time",
         );
     }
 


### PR DESCRIPTION

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9970

### What is changed and how it works?

The underlying bytes of a string may not be valid UTF-8 bytes. It is unsafe to convert it to a `str` without checking. In #9970, it causes a panic when calling `trim` on the `str`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- Fix potential panics when input of cast_string_as_time is invalid UTF-8 bytes