### PR TITLE
*: make PROST work again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ protobuf-codec = [
   "tidb_query_executors/protobuf-codec",
   "tidb_query_expr/protobuf-codec",
   "tipb/protobuf-codec",
+  "tikv_kv/protobuf-codec",
   "tikv_util/protobuf-codec",
   "txn_types/protobuf-codec",
   "grpcio-health/protobuf-codec",
@@ -85,6 +86,7 @@ prost-codec = [
   "tidb_query_executors/prost-codec",
   "tidb_query_expr/prost-codec",
   "tipb/prost-codec",
+  "tikv_kv/prost-codec",
   "tikv_util/prost-codec",
   "txn_types/prost-codec",
   "grpcio-health/prost-codec",
@@ -193,7 +195,7 @@ tidb_query_expr = { path = "components/tidb_query_expr", default-features = fals
 tidb_query_aggr = { path = "components/tidb_query_aggr", default-features = false }
 tidb_query_executors = { path = "components/tidb_query_executors", default-features = false }
 tikv_alloc = { path = "components/tikv_alloc" }
-tikv_kv = { path = "components/tikv_kv" }
+tikv_kv = { path = "components/tikv_kv", default-features = false }
 tikv_util = { path = "components/tikv_util", default-features = false }
 collections = { path = "components/collections" }
 coprocessor_plugin_api = { path = "components/coprocessor_plugin_api" }

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -24,6 +24,7 @@ protobuf-codec = [
   "engine_rocks/protobuf-codec",
   "engine_traits/protobuf-codec",
   "error_code/protobuf-codec",
+  "file_system/protobuf-codec",
   "grpcio/protobuf-codec",
   "keys/protobuf-codec",
   "kvproto/protobuf-codec",
@@ -44,6 +45,7 @@ prost-codec = [
   "engine_rocks/prost-codec",
   "engine_traits/prost-codec",
   "error_code/prost-codec",
+  "file_system/prost-codec",
   "grpcio/prost-codec",
   "keys/prost-codec",
   "kvproto/prost-codec",
@@ -67,47 +69,47 @@ nortcheck = ["engine_rocks/nortcheck"]
 
 [dependencies]
 backup = { path = "../backup", default-features = false }
-cdc = { path = "../cdc" }
+cdc = { path = "../cdc", default-features = false }
 chrono = "0.4"
 tempfile = "3.0"
 clap = "2.32"
 collections = { path = "../collections" }
-concurrency_manager = { path = "../concurrency_manager" }
+concurrency_manager = { path = "../concurrency_manager", default-features = false }
 crossbeam = "0.7"
-encryption = { path = "../encryption" }
+encryption = { path = "../encryption", default-features = false }
 encryption_export = { path = "../encryption/export", default-features = false }
-engine_rocks = { path = "../engine_rocks" }
-engine_traits = { path = "../engine_traits" }
-error_code = { path = "../error_code" }
-file_system = { path = "../file_system" }
+engine_rocks = { path = "../engine_rocks", default-features = false }
+engine_traits = { path = "../engine_traits", default-features = false }
+error_code = { path = "../error_code", default-features = false }
+file_system = { path = "../file_system", default-features = false }
 fs2 = "0.4"
 futures = "0.3"
 tokio = { version = "0.2", features = ["rt-threaded"] }
 grpcio = { version = "0.8", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
-keys = { path = "../keys" }
+keys = { path = "../keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }
 nix = "0.11"
-pd_client = { path = "../pd_client" }
+pd_client = { path = "../pd_client", default-features = false }
 prometheus = { version = "0.10", features = ["nightly"] }
 promptly = "0.3.0"
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }
-raft_log_engine = { path = "../raft_log_engine" }
-raftstore = { path = "../raftstore" }
+raft_log_engine = { path = "../raft_log_engine", default-features = false }
+raftstore = { path = "../raftstore", default-features = false }
 rand = "0.7"
-security = { path = "../security" }
+security = { path = "../security", default-features = false }
 serde_json = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 tikv = { path = "../..", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
-tikv_util = { path = "../tikv_util" }
+tikv_util = { path = "../tikv_util", default-features = false }
 toml = "0.5"
-txn_types = { path = "../txn_types" }
+txn_types = { path = "../txn_types", default-features = false }
 vlog = "0.1.4"
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 


### PR DESCRIPTION

### What problem does this PR solve?

From some time ago, build with `PROST=1` receives error like:

```
error[E0592]: duplicate definitions with name `generate_files`
  --> /home/yilin/.cargo/registry/src/github.com-1ecc6299db9ec823/protobuf-build-0.12.0/src/protobuf_impl.rs:63:5
   |
63 |     pub fn generate_files(&self) {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `generate_files`
   |
  ::: /home/yilin/.cargo/registry/src/github.com-1ecc6299db9ec823/protobuf-build-0.12.0/src/prost_impl.rs:5:5
   |
5  |     pub fn generate_files(&self) {
   |     ---------------------------- other definition for `generate_files`

error: aborting due to previous error
```

This is because some components depend on protobuf-codec unconditionally. https://github.com/tikv/tikv/pull/9969 should fix most of previous mistakes but my #8793 introduces some more.

This PR fixes all new mistakes and make PROST work again.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

`PROST=1 make build` works now.


### Release note <!-- bugfixes or new feature need a release note -->

- No release note