### PR TITLE
raftstore: remove unnecessary assert on merge check

### DIFF
--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2814,7 +2814,15 @@ where
                 last_index
             ));
         }
-        assert!(min_matched >= min_committed);
+        if min_matched < min_committed {
+            warn!(
+                "min_matched < min_committed, raft progress is inaccurate";
+                "region_id" => self.region_id,
+                "peer_id" => self.peer.get_id(),
+                "min_matched" => min_matched,
+                "min_committed" => min_committed,
+            );
+        }
         let mut entry_size = 0;
         for entry in self
             .raft_group

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2801,8 +2801,8 @@ where
                 "min_matched" => min_m,
                 "min_committed" => min_c,
             );
-            // Reset `min_matched` to `min_committed`, since a raft log is committed,
-            // the peer should also has replicated it
+            // Reset `min_matched` to `min_committed`, since the raft log at `min_committed` is
+            // known to be committed in all peers, all of the peers should also have replicated it
             min_m = min_c;
         }
         Ok((min_m, min_c))


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #9980 

Problem Summary:

The `raft-r`'s `pr.committed_index` may be inaccurate (see https://github.com/tikv/raft-rs/issues/426) and cause panic on `pre_propose_prepare_merge` check

### What is changed and how it works?

What's Changed:

Replace the assert with a warning log since the assert just for robustness and is not a fatal error if it fail

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->
- No release note