### PR TITLE
*: Fix truncated thread name

### DIFF
--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -4822,7 +4822,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"unified_read_po*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"read_pool*\"}[1m])) by (instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -10535,7 +10535,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tikv_multilevel_level_elapsed{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=\"unified-read-pool\"}[1m])) by (level)",
+              "expr": "sum(rate(tikv_multilevel_level_elapsed{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=\"read-pool\"}[1m])) by (level)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{level}}",
@@ -10623,7 +10623,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "tikv_multilevel_level0_chance{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=\"unified-read-pool\"}",
+              "expr": "tikv_multilevel_level0_chance{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=\"read-pool\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{instance}}",

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -4822,7 +4822,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"read_pool*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"unified_read*\"}[1m])) by (instance)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -4965,7 +4965,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_norm.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_nl.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - normal",
@@ -4974,7 +4974,7 @@
               "step": 4
             },
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_high.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_hi.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - high",
@@ -4983,7 +4983,7 @@
               "step": 4
             },
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_low.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_lo.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - low",
@@ -10535,7 +10535,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tikv_multilevel_level_elapsed{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=\"read-pool\"}[1m])) by (level)",
+              "expr": "sum(rate(tikv_multilevel_level_elapsed{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=\"unified-read\"}[1m])) by (level)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{level}}",
@@ -10623,7 +10623,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "tikv_multilevel_level0_chance{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=\"read-pool\"}",
+              "expr": "tikv_multilevel_level0_chance{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=\"unified-read\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{instance}}",

--- a/metrics/grafana/tikv_summary.json
+++ b/metrics/grafana/tikv_summary.json
@@ -3908,7 +3908,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_norm.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_nl.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - normal",
@@ -3917,7 +3917,7 @@
               "step": 4
             },
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_high.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_hi.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - high",
@@ -3926,7 +3926,7 @@
               "step": 4
             },
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_low.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_lo.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - low",

--- a/metrics/grafana/tikv_trouble_shooting.json
+++ b/metrics/grafana/tikv_trouble_shooting.json
@@ -338,7 +338,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_norm.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_nl.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - normal",
@@ -347,7 +347,7 @@
               "step": 4
             },
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_high.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_hi.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - high",
@@ -356,7 +356,7 @@
               "step": 4
             },
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_low.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_lo.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - low",
@@ -3755,7 +3755,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_norm.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_nl.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - normal",
@@ -3764,7 +3764,7 @@
               "step": 4
             },
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_high.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_hi.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - high",
@@ -3773,7 +3773,7 @@
               "step": 4
             },
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_low.*\"}[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", name=~\"store_read_lo.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} - low",

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -170,14 +170,14 @@ fn get_unified_read_pool_name() -> String {
 
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     format!(
-        "read-pool-test-{}",
+        "unified-read-test-{}",
         COUNTER.fetch_add(1, Ordering::Relaxed)
     )
 }
 
 #[cfg(not(test))]
 fn get_unified_read_pool_name() -> String {
-    "read-pool".to_string()
+    "unified-read".to_string()
 }
 
 pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -170,14 +170,14 @@ fn get_unified_read_pool_name() -> String {
 
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     format!(
-        "unified-read-pool-test-{}",
+        "read-pool-test-{}",
         COUNTER.fetch_add(1, Ordering::Relaxed)
     )
 }
 
 #[cfg(not(test))]
 fn get_unified_read_pool_name() -> String {
-    "unified-read-pool".to_string()
+    "read-pool".to_string()
 }
 
 pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -41,7 +41,7 @@ use crate::read_pool::ReadPool;
 const LOAD_STATISTICS_SLOTS: usize = 4;
 const LOAD_STATISTICS_INTERVAL: Duration = Duration::from_millis(100);
 pub const GRPC_THREAD_PREFIX: &str = "grpc-server";
-pub const READPOOL_NORMAL_THREAD_PREFIX: &str = "store-read-norm";
+pub const READPOOL_NORMAL_THREAD_PREFIX: &str = "store-read-nl";
 pub const STATS_THREAD_PREFIX: &str = "transport-stats";
 
 /// The TiKV server

--- a/src/storage/read_pool.rs
+++ b/src/storage/read_pool.rs
@@ -26,7 +26,7 @@ pub fn build_read_pool<E: Engine, R: FlowStatsReporter>(
     reporter: R,
     engine: E,
 ) -> Vec<FuturePool> {
-    let names = vec!["store-read-low", "store-read-normal", "store-read-high"];
+    let names = vec!["store-read-lo", "store-read-nl", "store-read-hi"];
     let configs: Vec<Config> = config.to_yatp_pool_configs();
     assert_eq!(configs.len(), 3);
 
@@ -57,7 +57,7 @@ pub fn build_read_pool_for_test<E: Engine>(
     config: &StorageReadPoolConfig,
     engine: E,
 ) -> Vec<FuturePool> {
-    let names = vec!["store-read-low", "store-read-normal", "store-read-high"];
+    let names = vec!["store-read-lo", "store-read-nl", "store-read-hi"];
     let configs: Vec<Config> = config.to_yatp_pool_configs();
     assert_eq!(configs.len(), 3);
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:

The max length of thread name is 16 limited by kernel. The length of thread name of unified read pool and storage read pool exceeds 16. Kernel truncates the thread name so that we can't group by the thread name in metrics conveniently. See
<img width="1892" alt="截屏2021-04-12 下午5 35 44" src="https://user-images.githubusercontent.com/13497871/114387622-409fa900-9bc5-11eb-97b5-80f83cc46c52.png">

### What is changed and how it works?

What's Changed:

- Change thread name of `unified-read-pool` to `unified-read`
- Change thread name of `store-read-low/normal/high` to `store-read-lo/nl/hi`

### Check List <!--REMOVE the items that are not applicable-->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

- None