### PR TITLE
txn_types: ignore all locks if get with MaxU64 has resolved locks

### DIFF
--- a/components/txn_types/src/timestamp.rs
+++ b/components/txn_types/src/timestamp.rs
@@ -166,6 +166,15 @@ impl TsSet {
             TsSet::Set(set) => set.contains(&ts),
         }
     }
+
+    // Returns if the set is empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            TsSet::Empty => true,
+            TsSet::Vec(vec) => vec.is_empty(),
+            TsSet::Set(set) => set.is_empty(),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### What problem does this PR solve?

It is reported that https://github.com/pingcap/tidb/pull/22789 causes some regression because more CPU is used in TiDB.

I **limit the TiDB CPU to 400%** and run sysbench point select and it shows the regression. But https://github.com/pingcap/tidb/pull/22789 optimizes point select in conflicted scenarios. (The conflicted scenaros is running sysbench point select and update_index with zipfian distribution at the same time)

<img width="714" alt="图片" src="https://user-images.githubusercontent.com/17217495/114708590-1fbe8b80-9d5e-11eb-9270-3104bf71a070.png">
<img width="716" alt="图片" src="https://user-images.githubusercontent.com/17217495/114708886-83e14f80-9d5e-11eb-9058-65c7d70ec785.png">

### What is changed and how it works?

I propose to revert https://github.com/pingcap/tidb/pull/22789 and use this PR to improve conflicted scenarios.

If the reading request is using max u64 as the snapshot ts and it brings some resolved locks, it must have resolved the first lock it met. In this case, other locks should never block this reading request.

The benchmark result is as follows.

<img width="713" alt="图片" src="https://user-images.githubusercontent.com/17217495/114709409-1eda2980-9d5f-11eb-9138-655d86327d95.png">
<img width="712" alt="图片" src="https://user-images.githubusercontent.com/17217495/114709908-b9d30380-9d5f-11eb-87ae-385d06546427.png">


The effect is not as good as the previous solution, but does not affect point select with no conflicts.

### Related changes
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

- Bypass all locks when MaxU64 get has resolved any lock.