### PR TITLE
txn: don't pass latches in when gen_lock()

### DIFF
--- a/src/storage/txn/commands/macros.rs
+++ b/src/storage/txn/commands/macros.rs
@@ -107,37 +107,25 @@ macro_rules! write_bytes {
 
 macro_rules! gen_lock {
     (empty) => {
-        fn gen_lock(
-            &self,
-            _latches: &crate::storage::txn::latch::Latches,
-        ) -> crate::storage::txn::latch::Lock {
-            crate::storage::txn::latch::Lock::new(vec![])
+        fn gen_lock(&self) -> crate::storage::txn::latch::Lock {
+            crate::storage::txn::latch::Lock::new::<(), _>(vec![])
         }
     };
     ($field: ident) => {
-        fn gen_lock(
-            &self,
-            latches: &crate::storage::txn::latch::Latches,
-        ) -> crate::storage::txn::latch::Lock {
-            latches.gen_lock(std::iter::once(&self.$field))
+        fn gen_lock(&self) -> crate::storage::txn::latch::Lock {
+            crate::storage::txn::latch::Lock::new(std::iter::once(&self.$field))
         }
     };
     ($field: ident: multiple) => {
-        fn gen_lock(
-            &self,
-            latches: &crate::storage::txn::latch::Latches,
-        ) -> crate::storage::txn::latch::Lock {
-            latches.gen_lock(&self.$field)
+        fn gen_lock(&self) -> crate::storage::txn::latch::Lock {
+            crate::storage::txn::latch::Lock::new(&self.$field)
         }
     };
     ($field: ident: multiple$transform: tt) => {
-        fn gen_lock(
-            &self,
-            latches: &crate::storage::txn::latch::Latches,
-        ) -> crate::storage::txn::latch::Lock {
+        fn gen_lock(&self) -> crate::storage::txn::latch::Lock {
             #![allow(unused_parens)]
             let keys = self.$field.iter().map($transform);
-            latches.gen_lock(keys)
+            crate::storage::txn::latch::Lock::new(keys)
         }
     };
 }

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -51,7 +51,7 @@ use txn_types::{Key, TimeStamp, Value, Write};
 use crate::storage::kv::WriteData;
 use crate::storage::lock_manager::{self, LockManager, WaitTimeout};
 use crate::storage::mvcc::{Lock as MvccLock, MvccReader, ReleasedLock};
-use crate::storage::txn::latch::{self, Latches};
+use crate::storage::txn::latch;
 use crate::storage::txn::{ProcessResult, Result};
 use crate::storage::types::{
     MvccInfo, PessimisticLockRes, PrewriteResult, SecondaryLocksStatus, StorageCallbackType,
@@ -457,7 +457,7 @@ pub trait CommandExt: Display {
 
     fn write_bytes(&self) -> usize;
 
-    fn gen_lock(&self, _latches: &Latches) -> latch::Lock;
+    fn gen_lock(&self) -> latch::Lock;
 }
 
 pub struct WriteContext<'a, L: LockManager> {
@@ -586,8 +586,8 @@ impl Command {
         self.command_ext().write_bytes()
     }
 
-    pub fn gen_lock(&self, latches: &Latches) -> latch::Lock {
-        self.command_ext().gen_lock(latches)
+    pub fn gen_lock(&self) -> latch::Lock {
+        self.command_ext().gen_lock()
     }
 
     pub fn can_be_pipelined(&self) -> bool {

--- a/src/storage/txn/latch.rs
+++ b/src/storage/txn/latch.rs
@@ -213,10 +213,10 @@ mod tests {
     fn test_wakeup() {
         let latches = Latches::new(256);
 
-        let slots_a = vec!["k1", "k3", "k5"];
-        let mut lock_a = Lock::new(slots_a.iter());
-        let slots_b = vec!["k4", "k5", "k6"];
-        let mut lock_b = Lock::new(slots_b.iter());
+        let keys_a = vec!["k1", "k3", "k5"];
+        let mut lock_a = Lock::new(keys_a.iter());
+        let keys_b = vec!["k4", "k5", "k6"];
+        let mut lock_b = Lock::new(keys_b.iter());
         let cid_a: u64 = 1;
         let cid_b: u64 = 2;
 
@@ -241,12 +241,12 @@ mod tests {
     fn test_wakeup_by_multi_cmds() {
         let latches = Latches::new(256);
 
-        let slots_a = vec!["k1", "k2", "k3"];
-        let slots_b = vec!["k4", "k5", "k6"];
-        let slots_c = vec!["k3", "k4"];
-        let mut lock_a = Lock::new(slots_a.iter());
-        let mut lock_b = Lock::new(slots_b.iter());
-        let mut lock_c = Lock::new(slots_c.iter());
+        let keys_a = vec!["k1", "k2", "k3"];
+        let keys_b = vec!["k4", "k5", "k6"];
+        let keys_c = vec!["k3", "k4"];
+        let mut lock_a = Lock::new(keys_a.iter());
+        let mut lock_b = Lock::new(keys_b.iter());
+        let mut lock_c = Lock::new(keys_c.iter());
         let cid_a: u64 = 1;
         let cid_b: u64 = 2;
         let cid_c: u64 = 3;
@@ -284,14 +284,14 @@ mod tests {
     fn test_wakeup_by_small_latch_slot() {
         let latches = Latches::new(5);
 
-        let slots_a = vec!["k1", "k2", "k3"];
-        let slots_b = vec!["k6", "k7", "k8"];
-        let slots_c = vec!["k3", "k4"];
-        let slots_d = vec!["k7", "k10"];
-        let mut lock_a = Lock::new(slots_a.iter());
-        let mut lock_b = Lock::new(slots_b.iter());
-        let mut lock_c = Lock::new(slots_c.iter());
-        let mut lock_d = Lock::new(slots_d.iter());
+        let keys_a = vec!["k1", "k2", "k3"];
+        let keys_b = vec!["k6", "k7", "k8"];
+        let keys_c = vec!["k3", "k4"];
+        let keys_d = vec!["k7", "k10"];
+        let mut lock_a = Lock::new(keys_a.iter());
+        let mut lock_b = Lock::new(keys_b.iter());
+        let mut lock_c = Lock::new(keys_c.iter());
+        let mut lock_d = Lock::new(keys_d.iter());
         let cid_a: u64 = 1;
         let cid_b: u64 = 2;
         let cid_c: u64 = 3;

--- a/src/storage/txn/latch.rs
+++ b/src/storage/txn/latch.rs
@@ -213,9 +213,9 @@ mod tests {
     fn test_wakeup() {
         let latches = Latches::new(256);
 
-        let slots_a = vec![1, 3, 5];
+        let slots_a = vec!["k1", "k3", "k5"];
         let mut lock_a = Lock::new(slots_a.iter());
-        let slots_b = vec![4, 5, 6];
+        let slots_b = vec!["k4", "k5", "k6"];
         let mut lock_b = Lock::new(slots_b.iter());
         let cid_a: u64 = 1;
         let cid_b: u64 = 2;
@@ -241,9 +241,9 @@ mod tests {
     fn test_wakeup_by_multi_cmds() {
         let latches = Latches::new(256);
 
-        let slots_a = vec![1, 2, 3];
-        let slots_b = vec![4, 5, 6];
-        let slots_c = vec![3, 4];
+        let slots_a = vec!["k1", "k2", "k3"];
+        let slots_b = vec!["k4", "k5", "k6"];
+        let slots_c = vec!["k3", "k4"];
         let mut lock_a = Lock::new(slots_a.iter());
         let mut lock_b = Lock::new(slots_b.iter());
         let mut lock_c = Lock::new(slots_c.iter());
@@ -284,10 +284,10 @@ mod tests {
     fn test_wakeup_by_small_latch_slot() {
         let latches = Latches::new(5);
 
-        let slots_a = vec![1, 2, 3];
-        let slots_b = vec![6, 7, 8];
-        let slots_c = vec![3, 4];
-        let slots_d = vec![7, 10];
+        let slots_a = vec!["k1", "k2", "k3"];
+        let slots_b = vec!["k6", "k7", "k8"];
+        let slots_c = vec!["k3", "k4"];
+        let slots_d = vec!["k7", "k10"];
         let mut lock_a = Lock::new(slots_a.iter());
         let mut lock_b = Lock::new(slots_b.iter());
         let mut lock_c = Lock::new(slots_c.iter());


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

`latches` is not used when `gen_lock()`

### What is changed and how it works?

remove `latches` when `gen_lock()`

### Release note <!-- bugfixes or new feature need a release note -->

- No release note