### PR TITLE
cdc: Refactor `EventBatcherSink`

### DIFF
--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -157,78 +157,95 @@ impl EventBatcher {
     }
 }
 
+/// represents the state machine used internally in EventBatcherSink
+enum EventBatcherSinkState {
+    // Ready to receive new data
+    Ready(Vec<CdcEvent>),
+    // In the process of sending a batch of assembled ChangeDataEvent
+    Sending(VecDeque<ChangeDataEvent>),
+    // Flushing the inner sink after Sending
+    Flushing,
+    // Closing down the sink
+    Closing,
+}
+
 pub struct EventBatcherSink<S, E>
-where
-    S: Sink<(ChangeDataEvent, grpcio::WriteFlags), Error = E> + Send + Unpin,
+    where
+        S: Sink<(ChangeDataEvent, grpcio::WriteFlags), Error = E> + Send + Unpin,
 {
-    // buf stores events just received.
-    buf: Option<Vec<CdcEvent>>,
-    // a queue for protobuf events ready to send out.
-    send_buf: VecDeque<ChangeDataEvent>,
+    // the internal state machine of this sink
+    state: EventBatcherSinkState,
     // the final downstream sink
     inner_sink: S,
 }
 
 impl<S, E> EventBatcherSink<S, E>
-where
-    S: Sink<(ChangeDataEvent, grpcio::WriteFlags), Error = E> + Send + Unpin,
+    where
+        S: Sink<(ChangeDataEvent, grpcio::WriteFlags), Error = E> + Send + Unpin,
 {
     pub fn new(sink: S) -> Self {
         Self {
-            buf: None,
-            send_buf: VecDeque::new(),
+            state: EventBatcherSinkState::Ready(Vec::new()),
             inner_sink: sink,
         }
     }
 
     /// converts all buffered CdcEvents into ChangeDataEvents.
-    /// consumes `buf`
     fn prepare_flush(&mut self) {
-        assert!(self.buf.is_some());
+        let old_state = std::mem::replace(
+            &mut self.state,
+            EventBatcherSinkState::Sending(VecDeque::new()),
+        );
+        if let EventBatcherSinkState::Ready(buf) = old_state {
+            let mut batcher = EventBatcher::with_capacity(CDC_EVENT_MAX_BATCH_SIZE);
+            buf.into_iter().for_each(|event| batcher.push(event));
 
-        let mut batcher = EventBatcher::with_capacity(CDC_EVENT_MAX_BATCH_SIZE);
-        self.buf
-            .take()
-            .unwrap()
-            .into_iter()
-            .for_each(|event| batcher.push(event));
-        batcher
-            .build()
-            .into_iter()
-            .for_each(|event| self.send_buf.push_back(event));
+            match self.state {
+                EventBatcherSinkState::Sending(ref mut send_buf) => {
+                    batcher
+                        .build()
+                        .into_iter()
+                        .for_each(|event| send_buf.push_back(event));
+                }
+                _ => unreachable!(),
+            }
+        } else {
+            panic!("cdc unexpected EventBatcherSinkState");
+        }
     }
 }
 
 impl<S, E> Sink<(CdcEvent, grpcio::WriteFlags)> for EventBatcherSink<S, E>
-where
-    S: Sink<(ChangeDataEvent, grpcio::WriteFlags), Error = E> + Send + Unpin,
+    where
+        S: Sink<(ChangeDataEvent, grpcio::WriteFlags), Error = E> + Send + Unpin,
 {
     type Error = E;
 
-    /// Will block the task if:
-    /// 1) there are ChangeDataEvents not sent out, or buf` has at least 1024 messages,
-    /// and 2) they cannot be successfully flushed down the `inner_sink` immediately.
+    /// returns Ready if and only if (1) the state machine is in Ready state, and (2)
+    /// there are not so many CdcEvents in the buffer.
+    /// If (1) is not satisfied, it means that this is NOT the first poll to this function in preparation to
+    /// start_send, so there must be the result of the task being awaken by a block in poll_flush, so we call
+    /// poll_flush.
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.get_mut();
 
-        if !this.send_buf.is_empty() {
-            ready!(this.poll_flush_unpin(cx))?;
-        }
-
-        if this.buf.is_none() {
-            this.buf = Some(vec![]);
-            return Poll::Ready(Ok(()));
-        }
-
-        // We set the threshold to flush the inner_sink to 32
-        // TODO find a way to determine the best number
-        if this.buf.as_ref().unwrap().len() >= 32 {
-            this.prepare_flush();
-            ready!(this.inner_sink.poll_flush_unpin(cx))?;
-
-            assert!(this.buf.is_none());
-            this.buf = Some(vec![]);
-            return Poll::Ready(Ok(()));
+        match this.state {
+            EventBatcherSinkState::Ready(ref buf) => {
+                if buf.len() >= 2 {
+                    // converts CdcEvent to ChangeDataEvent
+                    this.prepare_flush();
+                    ready!(this.poll_flush_unpin(cx))?;
+                }
+            }
+            EventBatcherSinkState::Sending(_) => {
+                ready!(this.poll_flush_unpin(cx))?;
+            }
+            EventBatcherSinkState::Flushing => {
+                ready!(this.poll_flush_unpin(cx))?;
+            }
+            EventBatcherSinkState::Closing => {
+                panic!("sink is closing");
+            }
         }
 
         Poll::Ready(Ok(()))
@@ -237,11 +254,21 @@ where
     /// Will always succeed as long as called correctly.
     fn start_send(self: Pin<&mut Self>, item: (CdcEvent, WriteFlags)) -> Result<(), Self::Error> {
         let this = self.get_mut();
-        assert!(this.buf.is_some());
-
-        let (event, _) = item;
-        this.buf.as_mut().unwrap().push(event);
-        Ok(())
+        match this.state {
+            EventBatcherSinkState::Ready(ref mut buf) => {
+                buf.push(item.0);
+                Ok(())
+            }
+            EventBatcherSinkState::Sending(_) => {
+                panic!("cdc unexpected start_send");
+            }
+            EventBatcherSinkState::Flushing => {
+                panic!("cdc unexpected start_send");
+            }
+            EventBatcherSinkState::Closing => {
+                panic!("sink is closing");
+            }
+        }
     }
 
     /// Converts any CdcEvents in `buf` to ChangeDataEvents,
@@ -253,35 +280,74 @@ where
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.get_mut();
 
-        if this.buf.is_some() {
-            this.prepare_flush();
-        }
-
-        assert!(this.buf.is_none());
-
-        let flag = WriteFlags::default().buffer_hint(false);
-        while !this.send_buf.is_empty() {
-            ready!(this.inner_sink.poll_ready_unpin(cx))?;
-            let event = this.send_buf.pop_front().unwrap();
-
-            let latest_resolved_ts = event.get_resolved_ts().get_ts();
-            if latest_resolved_ts > 0 {
-                CDC_GRPC_WRITE_RESOLVED_TS.set(
-                    txn_types::TimeStamp::new(event.get_resolved_ts().get_ts()).physical() as i64,
-                );
+        match this.state {
+            EventBatcherSinkState::Ready(_) => {
+                this.prepare_flush();
+                ready!(this.poll_flush_unpin(cx))?;
             }
+            EventBatcherSinkState::Sending(ref mut send_buf) => {
+                let mut flag = WriteFlags::default().buffer_hint(true);
+                while !send_buf.is_empty() {
+                    ready!(this.inner_sink.poll_ready_unpin(cx))?;
+                    let event = send_buf.pop_front().unwrap();
 
-            this.inner_sink.start_send_unpin((event, flag))?;
+                    let latest_resolved_ts = event.get_resolved_ts().get_ts();
+                    if latest_resolved_ts > 0 {
+                        CDC_GRPC_WRITE_RESOLVED_TS.set(
+                            txn_types::TimeStamp::new(event.get_resolved_ts().get_ts()).physical()
+                                as i64,
+                        );
+                    }
+
+                    if send_buf.is_empty() {
+                        flag = flag.buffer_hint(false);
+                    }
+                    this.inner_sink.start_send_unpin((event, flag))?;
+                }
+
+                this.state = EventBatcherSinkState::Flushing;
+                ready!(this.inner_sink.poll_flush_unpin(cx))?;
+                this.state = EventBatcherSinkState::Ready(Vec::new());
+            }
+            EventBatcherSinkState::Flushing => {
+                ready!(this.inner_sink.poll_flush_unpin(cx))?;
+                this.state = EventBatcherSinkState::Ready(Vec::new());
+            }
+            EventBatcherSinkState::Closing => {
+                panic!("sink is closing");
+            }
         }
 
-        ready!(this.inner_sink.poll_flush_unpin(cx))?;
         Poll::Ready(Ok(()))
     }
 
     /// Closes the underlying `inner_sink`.
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.get_mut();
-        this.inner_sink.poll_close_unpin(cx)
+
+        match this.state {
+            EventBatcherSinkState::Ready(_) => {
+                this.prepare_flush();
+                ready!(this.poll_flush_unpin(cx))?;
+                this.state = EventBatcherSinkState::Closing;
+                ready!(this.inner_sink.poll_close_unpin(cx))?;
+            }
+            EventBatcherSinkState::Sending(_) => {
+                ready!(this.poll_flush_unpin(cx))?;
+                this.state = EventBatcherSinkState::Closing;
+                ready!(this.inner_sink.poll_close_unpin(cx))?;
+            }
+            EventBatcherSinkState::Flushing => {
+                ready!(this.poll_flush_unpin(cx))?;
+                this.state = EventBatcherSinkState::Closing;
+                ready!(this.inner_sink.poll_close_unpin(cx))?;
+            }
+            EventBatcherSinkState::Closing => {
+                ready!(this.inner_sink.poll_close_unpin(cx))?;
+            }
+        }
+
+        Poll::Ready(Ok(()))
     }
 }
 

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -633,7 +633,6 @@ mod tests {
             futures::channel::mpsc::unbounded::<(ChangeDataEvent, grpcio::WriteFlags)>();
         let mut batch_sink = EventBatcherSink::new(sink);
         let send_task = tokio::spawn(async move {
-            let flag = grpcio::WriteFlags::default().buffer_hint(false);
             for i in 0..1000000u64 {
                 let mut resolved_ts = ResolvedTs::default();
                 resolved_ts.set_ts(i);
@@ -661,7 +660,6 @@ mod tests {
             futures::channel::mpsc::unbounded::<(ChangeDataEvent, grpcio::WriteFlags)>();
         let mut batch_sink = EventBatcherSink::new(sink);
         let send_task = tokio::spawn(async move {
-            let flag = grpcio::WriteFlags::default().buffer_hint(false);
             for i in 0..1000000u64 {
                 let mut resolved_ts = ResolvedTs::default();
                 resolved_ts.set_ts(i);
@@ -687,7 +685,6 @@ mod tests {
         let (sink, mut rx) = futures::channel::mpsc::channel(8);
         let mut batch_sink = EventBatcherSink::new(sink);
         let send_task = tokio::spawn(async move {
-            let flag = grpcio::WriteFlags::default().buffer_hint(false);
             for i in 0..1000u64 {
                 let mut resolved_ts = ResolvedTs::default();
                 resolved_ts.set_ts(i);


### PR DESCRIPTION
### What problem does this PR solve?
- Refactored ``EventBatcherSink`
- Fixed a potential violation of the calling convention of future-like functions.

### What is changed and how it works?
- Redesigned `EventBatcherSink` with an internal state that's easy to reason about.
- Ensured that tasks blocked while polling the inner sink poll the inner sink again once awaken.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->
- Optimize CDC sink