### PR TITLE
tidb_query: use macro_rules instead of declarative macros

### DIFF
--- a/components/tidb_query_aggr/src/impl_max_min.rs
+++ b/components/tidb_query_aggr/src/impl_max_min.rs
@@ -5,9 +5,10 @@ use std::convert::TryFrom;
 
 use tidb_query_codegen::AggrFunction;
 use tidb_query_common::Result;
-use tidb_query_datatype::codec::collation::*;
+use tidb_query_datatype::codec::collation::Collator;
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::expr::EvalContext;
+use tidb_query_datatype::match_template_collator;
 use tidb_query_datatype::{Collation, EvalType, FieldTypeAccessor};
 use tidb_query_expr::RpnExpression;
 use tipb::{Expr, ExprType, FieldType};

--- a/components/tidb_query_datatype/src/codec/batch/lazy_column.rs
+++ b/components/tidb_query_datatype/src/codec/batch/lazy_column.rs
@@ -11,7 +11,6 @@ use crate::codec::data_type::{ChunkedVec, LogicalRows, VectorValue};
 use crate::codec::datum_codec::RawDatumDecoder;
 use crate::codec::Result;
 use crate::expr::EvalContext;
-
 use crate::match_template_evaltype;
 
 /// A container stores an array of datums, which can be either raw (not decoded), or decoded into

--- a/components/tidb_query_datatype/src/codec/batch/lazy_column.rs
+++ b/components/tidb_query_datatype/src/codec/batch/lazy_column.rs
@@ -7,10 +7,12 @@ use tikv_util::buffer_vec::BufferVec;
 use tipb::FieldType;
 
 use crate::codec::chunk::{ChunkColumnEncoder, Column};
-use crate::codec::data_type::{match_template_evaluable, ChunkedVec, LogicalRows, VectorValue};
+use crate::codec::data_type::{ChunkedVec, LogicalRows, VectorValue};
 use crate::codec::datum_codec::RawDatumDecoder;
 use crate::codec::Result;
 use crate::expr::EvalContext;
+
+use crate::match_template_evaltype;
 
 /// A container stores an array of datums, which can be either raw (not decoded), or decoded into
 /// the `VectorValue` type.
@@ -168,7 +170,7 @@ impl LazyBatchColumn {
 
         let mut decoded_column = VectorValue::with_capacity(raw_vec_len, eval_type);
 
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match &mut decoded_column {
                 VectorValue::TT(vec) => {
                     match logical_rows {

--- a/components/tidb_query_datatype/src/codec/collation/collator/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/mod.rs
@@ -26,8 +26,8 @@ pub const PADDING_SPACE: char = 0x20 as char;
 
 #[cfg(test)]
 mod tests {
-    use crate::codec::collation::match_template_collator;
     use crate::codec::collation::Collator;
+    use crate::match_template_collator;
     use crate::Collation;
 
     #[test]
@@ -35,7 +35,6 @@ mod tests {
     fn test_compare() {
         use std::cmp::Ordering;
         use std::collections::hash_map::DefaultHasher;
-        use std::hash::Hasher;
 
         let collations = [
             (Collation::Utf8Mb4Bin, 0),

--- a/components/tidb_query_datatype/src/codec/collation/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/mod.rs
@@ -12,20 +12,25 @@ use codec::prelude::*;
 use num::Unsigned;
 
 use crate::codec::Result;
-use collator::*;
 
-pub macro match_template_collator($t:tt, $($tail:tt)*) {
-    match_template::match_template! {
-        $t = [
-            Binary => CollatorBinary,
-            Utf8Mb4Bin => CollatorUtf8Mb4Bin,
-            Utf8Mb4BinNoPadding => CollatorUtf8Mb4BinNoPadding,
-            Utf8Mb4GeneralCi => CollatorUtf8Mb4GeneralCi,
-            Utf8Mb4UnicodeCi => CollatorUtf8Mb4UnicodeCi,
-            Latin1Bin => CollatorLatin1Bin,
-        ],
-        $($tail)*
-    }
+#[macro_export]
+macro_rules! match_template_collator {
+     ($t:tt, $($tail:tt)*) => {{
+         #[allow(unused_imports)]
+         use $crate::codec::collation::collator::*;
+
+         match_template::match_template! {
+             $t = [
+                Binary => CollatorBinary,
+                Utf8Mb4Bin => CollatorUtf8Mb4Bin,
+                Utf8Mb4BinNoPadding => CollatorUtf8Mb4BinNoPadding,
+                Utf8Mb4GeneralCi => CollatorUtf8Mb4GeneralCi,
+                Utf8Mb4UnicodeCi => CollatorUtf8Mb4UnicodeCi,
+                Latin1Bin => CollatorLatin1Bin,
+            ],
+            $($tail)*
+         }
+     }}
 }
 
 pub trait Charset {

--- a/components/tidb_query_datatype/src/codec/data_type/mod.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/mod.rs
@@ -13,6 +13,19 @@ mod vector;
 
 pub use logical_rows::{LogicalRows, BATCH_MAX_SIZE, IDENTICAL_LOGICAL_ROWS};
 
+#[macro_export]
+macro_rules! match_template_evaltype {
+    ($t:tt, $($tail:tt)*) => {{
+        #[allow(unused_imports)]
+        use $crate::codec::data_type::{Int, Real, Decimal, Bytes, DateTime, Duration, Json, Set, Enum};
+
+        match_template::match_template! {
+            $t = [Int, Real, Decimal, Bytes, DateTime, Duration, Json, Set, Enum],
+            $($tail)*
+        }}
+    }
+}
+
 // Concrete eval types without a nullable wrapper.
 pub type Int = i64;
 pub type Real = ordered_float::NotNan<f64>;
@@ -144,13 +157,6 @@ impl<'a> AsMySQLBool for Option<SetRef<'a>> {
             None => Ok(false),
             Some(ref v) => v.as_mysql_bool(context),
         }
-    }
-}
-
-pub macro match_template_evaluable($t:tt, $($tail:tt)*) {
-    match_template::match_template! {
-        $t = [Int, Real, Decimal, Bytes, DateTime, Duration, Json, Set, Enum],
-        $($tail)*
     }
 }
 

--- a/components/tidb_query_datatype/src/codec/data_type/scalar.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/scalar.rs
@@ -2,7 +2,8 @@
 
 use std::cmp::Ordering;
 
-use crate::codec::collation::{match_template_collator, Collator};
+use crate::codec::collation::Collator;
+use crate::{match_template_collator, match_template_evaltype};
 use crate::{Collation, EvalType, FieldTypeAccessor};
 use match_template::match_template;
 use tipb::FieldType;
@@ -38,7 +39,7 @@ pub enum ScalarValue {
 impl ScalarValue {
     #[inline]
     pub fn eval_type(&self) -> EvalType {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 ScalarValue::TT(_) => EvalType::TT,
             }
@@ -62,7 +63,7 @@ impl ScalarValue {
 
     #[inline]
     pub fn is_none(&self) -> bool {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 ScalarValue::TT(v) => v.is_none(),
             }
@@ -71,7 +72,7 @@ impl ScalarValue {
 
     #[inline]
     pub fn is_some(&self) -> bool {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 ScalarValue::TT(v) => v.is_some(),
             }
@@ -82,7 +83,7 @@ impl ScalarValue {
 impl AsMySQLBool for ScalarValue {
     #[inline]
     fn as_mysql_bool(&self, context: &mut EvalContext) -> Result<bool> {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 ScalarValue::TT(v) => v.as_ref().as_mysql_bool(context),
             }
@@ -201,7 +202,7 @@ impl<'a> ScalarValueRef<'a> {
 
     #[inline]
     pub fn eval_type(&self) -> EvalType {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 ScalarValueRef::TT(_) => EvalType::TT,
             }
@@ -475,7 +476,7 @@ impl<'a> Ord for ScalarValueRef<'a> {
 
 impl<'a> PartialOrd for ScalarValueRef<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match (self, other) {
                 // v1 and v2 are `Option<T>`. However, in MySQL NULL values are considered lower
                 // than any non-NULL value, so using `Option::PartialOrd` directly is fine.

--- a/components/tidb_query_datatype/src/codec/data_type/vector.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/vector.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::{EvalType, FieldTypeAccessor};
+use crate::{match_template_collator, match_template_evaltype, EvalType, FieldTypeAccessor};
 
 use super::scalar::ScalarValueRef;
 use super::*;
@@ -30,7 +30,7 @@ impl VectorValue {
     /// to `capacity`.
     #[inline]
     pub fn with_capacity(capacity: usize, eval_tp: EvalType) -> Self {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match eval_tp {
                 EvalType::TT => VectorValue::TT(ChunkedVec::with_capacity(capacity)),
             }
@@ -40,7 +40,7 @@ impl VectorValue {
     /// Creates a new empty `VectorValue` with the same eval type.
     #[inline]
     pub fn clone_empty(&self, capacity: usize) -> Self {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 VectorValue::TT(_) => VectorValue::TT(ChunkedVec::with_capacity(capacity)),
             }
@@ -50,7 +50,7 @@ impl VectorValue {
     /// Returns the `EvalType` used to construct current column.
     #[inline]
     pub fn eval_type(&self) -> EvalType {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 VectorValue::TT(_) => EvalType::TT,
             }
@@ -60,7 +60,7 @@ impl VectorValue {
     /// Returns the number of datums contained in this column.
     #[inline]
     pub fn len(&self) -> usize {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 VectorValue::TT(v) => v.len(),
             }
@@ -80,7 +80,7 @@ impl VectorValue {
     /// If `len` is greater than the column's current length, this has no effect.
     #[inline]
     pub fn truncate(&mut self, len: usize) {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 VectorValue::TT(v) => v.truncate(len),
             }
@@ -96,7 +96,7 @@ impl VectorValue {
     /// Returns the number of elements this column can hold without reallocating.
     #[inline]
     pub fn capacity(&self) -> usize {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 VectorValue::TT(v) => v.capacity(),
             }
@@ -110,7 +110,7 @@ impl VectorValue {
     /// Panics if `other` does not have the same `EvalType` as `Self`.
     #[inline]
     pub fn append(&mut self, other: &mut VectorValue) {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 VectorValue::TT(self_vec) => match other {
                     VectorValue::TT(other_vec) => {
@@ -131,7 +131,7 @@ impl VectorValue {
         outputs: &mut [bool],
     ) -> tidb_query_common::error::Result<()> {
         assert!(outputs.len() >= self.len());
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 VectorValue::TT(v) => {
                     let l = self.len();
@@ -151,7 +151,7 @@ impl VectorValue {
     /// Panics if index is out of range.
     #[inline]
     pub fn get_scalar_ref(&self, index: usize) -> ScalarValueRef<'_> {
-        match_template_evaluable! {
+        match_template_evaltype! {
             TT, match self {
                 VectorValue::TT(v) => ScalarValueRef::TT(v.get_option_ref(index)),
             }
@@ -393,7 +393,7 @@ impl VectorValue {
         ctx: &mut EvalContext,
         output: &mut Vec<u8>,
     ) -> Result<()> {
-        use crate::codec::collation::{match_template_collator, Collator};
+        use crate::codec::collation::Collator;
         use crate::codec::datum_codec::EvaluableDatumEncoder;
         use crate::Collation;
 

--- a/components/tidb_query_datatype/src/lib.rs
+++ b/components/tidb_query_datatype/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(proc_macro_hygiene)]
 #![feature(min_specialization)]
 #![feature(test)]
-#![feature(decl_macro)]
 #![feature(str_internals)]
 
 #[macro_use]

--- a/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
+++ b/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
@@ -18,9 +18,10 @@ use tidb_query_aggr::*;
 use tidb_query_common::storage::IntervalRange;
 use tidb_query_common::Result;
 use tidb_query_datatype::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
-use tidb_query_datatype::codec::collation::{match_template_collator, SortKey};
+use tidb_query_datatype::codec::collation::SortKey;
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::expr::{EvalConfig, EvalContext};
+use tidb_query_datatype::match_template_collator;
 use tidb_query_expr::{RpnExpression, RpnExpressionBuilder, RpnStackNode};
 
 pub macro match_template_hashable($t:tt, $($tail:tt)*) {

--- a/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
+++ b/components/tidb_query_executors/src/fast_hash_aggr_executor.rs
@@ -24,11 +24,13 @@ use tidb_query_datatype::expr::{EvalConfig, EvalContext};
 use tidb_query_datatype::match_template_collator;
 use tidb_query_expr::{RpnExpression, RpnExpressionBuilder, RpnStackNode};
 
-pub macro match_template_hashable($t:tt, $($tail:tt)*) {
-    match_template::match_template! {
-        $t = [Int, Real, Bytes, Duration, Decimal, DateTime],
-        $($tail)*
-    }
+macro_rules! match_template_hashable {
+    ($t:tt, $($tail:tt)*) => {{
+        match_template::match_template! {
+            $t = [Int, Real, Bytes, Duration, Decimal, DateTime],
+            $($tail)*
+        }
+    }}
 }
 
 /// Fast Hash Aggregation Executor uses hash when comparing group key. It only supports one

--- a/components/tidb_query_executors/src/lib.rs
+++ b/components/tidb_query_executors/src/lib.rs
@@ -11,7 +11,6 @@
 #![feature(proc_macro_hygiene)]
 #![feature(specialization)]
 #![feature(const_fn)]
-#![feature(decl_macro)]
 #![feature(const_fn_fn_ptr_basics)]
 #![feature(const_mut_refs)]
 

--- a/components/tidb_query_executors/src/selection_executor.rs
+++ b/components/tidb_query_executors/src/selection_executor.rs
@@ -11,6 +11,7 @@ use tidb_query_common::storage::IntervalRange;
 use tidb_query_common::Result;
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::expr::{EvalConfig, EvalContext};
+use tidb_query_datatype::match_template_evaltype;
 use tidb_query_expr::RpnStackNode;
 use tidb_query_expr::{RpnExpression, RpnExpressionBuilder};
 
@@ -95,7 +96,7 @@ impl<Src: BatchExecutor> BatchSelectionExecutor<Src> {
                 }
                 RpnStackNode::Vector { value, .. } => {
                     let eval_result_logical_rows = value.logical_rows_struct();
-                    match_template_evaluable! {
+                    match_template_evaltype! {
                         TT, match value.as_ref() {
                             VectorValue::TT(eval_result) => {
                                 update_logical_rows_by_vector_value(

--- a/components/tidb_query_executors/src/simple_aggr_executor.rs
+++ b/components/tidb_query_executors/src/simple_aggr_executor.rs
@@ -16,6 +16,7 @@ use tidb_query_common::Result;
 use tidb_query_datatype::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::expr::EvalConfig;
+use tidb_query_datatype::match_template_evaltype;
 use tidb_query_expr::RpnStackNode;
 
 pub struct BatchSimpleAggregationExecutor<Src: BatchExecutor>(
@@ -154,7 +155,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SimpleAggregationImpl 
 
             match aggr_fn_input {
                 RpnStackNode::Scalar { value, .. } => {
-                    match_template_evaluable! {
+                    match_template_evaltype! {
                         TT, match value.as_scalar_value_ref() {
                             ScalarValueRef::TT(scalar_value) => {
                                 update_repeat!(
@@ -170,7 +171,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for SimpleAggregationImpl 
                 RpnStackNode::Vector { value, .. } => {
                     let physical_vec = value.as_ref();
                     let logical_rows = value.logical_rows();
-                    match_template_evaluable! {
+                    match_template_evaltype! {
                         TT, match physical_vec {
                             VectorValue::TT(vec) => {
                                 update_vector!(

--- a/components/tidb_query_executors/src/stream_aggr_executor.rs
+++ b/components/tidb_query_executors/src/stream_aggr_executor.rs
@@ -16,6 +16,7 @@ use tidb_query_common::Result;
 use tidb_query_datatype::codec::batch::{LazyBatchColumn, LazyBatchColumnVec};
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::expr::{EvalConfig, EvalContext};
+use tidb_query_datatype::match_template_evaltype;
 use tidb_query_expr::RpnStackNode;
 use tidb_query_expr::{RpnExpression, RpnExpressionBuilder};
 
@@ -367,7 +368,7 @@ impl<Src: BatchExecutor> AggregationExecutorImpl<Src> for BatchStreamAggregation
             .drain(keys_range)
             .zip((0..group_by_exps_len).cycle())
         {
-            match_template_evaluable! {
+            match_template_evaltype! {
                 TT, match key {
                     ScalarValue::TT(key) => {
                         group_by_columns[group_index].mut_decoded().push(key);
@@ -403,7 +404,7 @@ fn update_current_states(
         for (state, aggr_fn_input) in current_states.iter_mut().zip(aggr_expr_results) {
             match aggr_fn_input {
                 RpnStackNode::Scalar { value, .. } => {
-                    match_template_evaluable! {
+                    match_template_evaltype! {
                         TT, match value.as_scalar_value_ref() {
                             ScalarValueRef::TT(scalar_value) => {
                                 update_repeat!(
@@ -419,7 +420,7 @@ fn update_current_states(
                 RpnStackNode::Vector { value, .. } => {
                     let physical_vec = value.as_ref();
                     let logical_rows = value.logical_rows();
-                    match_template_evaluable! {
+                    match_template_evaltype! {
                         TT, match physical_vec {
                             VectorValue::TT(vec) => {
                                 update_vector!(

--- a/components/tidb_query_executors/src/util/hash_aggr_helper.rs
+++ b/components/tidb_query_executors/src/util/hash_aggr_helper.rs
@@ -6,6 +6,7 @@ use tidb_query_aggr::{update, AggrFunctionState};
 use tidb_query_common::Result;
 use tidb_query_datatype::codec::batch::LazyBatchColumnVec;
 use tidb_query_datatype::codec::data_type::*;
+use tidb_query_datatype::match_template_evaltype;
 use tidb_query_expr::RpnStackNode;
 
 pub struct HashAggregationHelper;
@@ -36,7 +37,7 @@ impl HashAggregationHelper {
             )?;
             match aggr_expr_result {
                 RpnStackNode::Scalar { value, .. } => {
-                    match_template_evaluable! {
+                    match_template_evaltype! {
                         TT, match value.as_scalar_value_ref() {
                             ScalarValueRef::TT(scalar_value) => {
                                 for offset in states_offset_each_logical_row {
@@ -50,7 +51,7 @@ impl HashAggregationHelper {
                 RpnStackNode::Vector { value, .. } => {
                     let physical_vec = value.as_ref();
                     let logical_rows = value.logical_rows_struct();
-                    match_template_evaluable! {
+                    match_template_evaltype! {
                         TT, match physical_vec {
                             VectorValue::TT(vec) => {
                                 for (states_offset, physical_idx) in states_offset_each_logical_row

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -48,8 +48,8 @@ use tidb_query_datatype::{Collation, FieldTypeAccessor, FieldTypeFlag};
 use tipb::{Expr, FieldType, ScalarFuncSig};
 
 use tidb_query_common::Result;
-use tidb_query_datatype::codec::collation::*;
 use tidb_query_datatype::codec::data_type::*;
+use tidb_query_datatype::match_template_collator;
 
 use self::impl_arithmetic::*;
 use self::impl_cast::*;

--- a/components/tidb_query_expr/src/types/expr_builder.rs
+++ b/components/tidb_query_expr/src/types/expr_builder.rs
@@ -12,7 +12,7 @@ use tidb_query_common::Result;
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::codec::mysql::{EnumDecoder, JsonDecoder, MAX_FSP};
 use tidb_query_datatype::expr::EvalContext;
-use tidb_query_datatype::{codec::data_type::*, match_template_evaltype};
+use tidb_query_datatype::match_template_evaltype;
 
 /// Helper to build an `RpnExpression`.
 #[derive(Debug)]

--- a/components/tidb_query_expr/src/types/expr_builder.rs
+++ b/components/tidb_query_expr/src/types/expr_builder.rs
@@ -12,6 +12,7 @@ use tidb_query_common::Result;
 use tidb_query_datatype::codec::data_type::*;
 use tidb_query_datatype::codec::mysql::{EnumDecoder, JsonDecoder, MAX_FSP};
 use tidb_query_datatype::expr::EvalContext;
+use tidb_query_datatype::{codec::data_type::*, match_template_evaltype};
 
 /// Helper to build an `RpnExpression`.
 #[derive(Debug)]
@@ -373,7 +374,7 @@ fn handle_node_constant(
 
 #[inline]
 fn get_scalar_value_null(eval_type: EvalType) -> ScalarValue {
-    match_template_evaluable! {
+    match_template_evaltype! {
         TT, match eval_type {
             EvalType::TT => ScalarValue::TT(None),
         }

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -342,7 +342,8 @@ impl<S: Snapshot> SampleBuilder<S> {
     async fn collect_columns_stats(
         &mut self,
     ) -> Result<(AnalyzeColumnsResult, Option<AnalyzeIndexResult>)> {
-        use tidb_query_datatype::codec::collation::{match_template_collator, Collator};
+        use tidb_query_datatype::codec::collation::Collator;
+        use tidb_query_datatype::match_template_collator;
         let columns_without_handle_len =
             self.columns_info.len() - self.columns_info[0].get_pk_handle() as usize;
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Now, we use declarative macros whose syntax looks like `macro xxx() {}`, and need to enable the unstable feature [`decl_macro`](https://doc.rust-lang.org/unstable-book/language-features/decl-macro.html).

The IDE support for declarative macros isn't provided well; it's hard to resolve and expand it on IDE, therefore, it brings poor dev experience.

### What is changed and how it works?

What's Changed:

Replace declarative macros with `macro_rules`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->
- Clean up declarative macros