### PR TITLE
copr: fix unsound unsafe transmute

### DIFF
--- a/components/tidb_query_aggr/src/impl_avg.rs
+++ b/components/tidb_query_aggr/src/impl_avg.rs
@@ -381,8 +381,8 @@ mod tests {
         assert_eq!(result[0].to_int_vec(), &[Some(0)]);
         assert_eq!(result[1].to_decimal_vec(), &[None]);
 
-        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), 1))).unwrap();
-        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), 2))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), &1))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), &2))).unwrap();
         result[0].clear();
         result[1].clear();
         state.push_result(&mut ctx, &mut result[..]).unwrap();

--- a/components/tidb_query_aggr/src/impl_count.rs
+++ b/components/tidb_query_aggr/src/impl_count.rs
@@ -191,7 +191,7 @@ mod tests {
 
         let mut result = [VectorValue::with_capacity(0, EvalType::Int)];
 
-        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), 1))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), &1))).unwrap();
 
         result[0].clear();
         state.push_result(&mut ctx, &mut result).unwrap();

--- a/components/tidb_query_aggr/src/impl_first.rs
+++ b/components/tidb_query_aggr/src/impl_first.rs
@@ -228,14 +228,14 @@ mod tests {
 
         let mut result = [VectorValue::with_capacity(0, EvalType::Enum)];
 
-        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), 1))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), &1))).unwrap();
         state.push_result(&mut ctx, &mut result[..]).unwrap();
         assert_eq!(
             result[0].to_enum_vec(),
             vec![Some(Enum::new("bbb".as_bytes().to_vec(), 1))]
         );
 
-        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), 2))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), &2))).unwrap();
         state.push_result(&mut ctx, &mut result[..]).unwrap();
         assert_eq!(
             result[0].to_enum_vec(),

--- a/components/tidb_query_aggr/src/impl_max_min.rs
+++ b/components/tidb_query_aggr/src/impl_max_min.rs
@@ -526,7 +526,7 @@ mod tests {
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(result[0].to_enum_vec(), &[None]);
 
-        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), 1))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), &1))).unwrap();
         result[0].clear();
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(
@@ -534,8 +534,8 @@ mod tests {
             vec![Some(Enum::new("bbb".as_bytes().to_vec(), 1))]
         );
 
-        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), 1))).unwrap();
-        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), 2))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), &1))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), &2))).unwrap();
         result[0].clear();
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(

--- a/components/tidb_query_aggr/src/impl_sum.rs
+++ b/components/tidb_query_aggr/src/impl_sum.rs
@@ -326,14 +326,14 @@ mod tests {
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(result[0].to_decimal_vec(), &[None]);
 
-        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), 2))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), &2))).unwrap();
         result[0].clear();
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(result[0].to_decimal_vec(), vec![Some(Decimal::from(2))]);
 
-        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), 1))).unwrap();
-        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), 2))).unwrap();
-        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), 2))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), &1))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), &2))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), &2))).unwrap();
         result[0].clear();
         state.push_result(&mut ctx, &mut result).unwrap();
         assert_eq!(result[0].to_decimal_vec(), vec![Some(Decimal::from(7))]);

--- a/components/tidb_query_aggr/src/impl_variance.rs
+++ b/components/tidb_query_aggr/src/impl_variance.rs
@@ -477,8 +477,8 @@ mod tests {
         assert_eq!(result[1].to_decimal_vec(), &[None]);
         assert_eq!(result[2].to_decimal_vec(), &[None]);
 
-        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), 1))).unwrap();
-        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), 2))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("bbb".as_bytes(), &1))).unwrap();
+        update!(state, &mut ctx, Some(EnumRef::new("aaa".as_bytes(), &2))).unwrap();
         result[0].clear();
         result[1].clear();
         result[2].clear();

--- a/components/tidb_query_datatype/src/codec/data_type/chunked_vec_enum.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/chunked_vec_enum.rs
@@ -174,10 +174,10 @@ mod tests {
         x.push(Some(Enum::new("我成功了".as_bytes().to_vec(), 3)));
 
         assert_eq!(x.get(0), None);
-        assert_eq!(x.get(1), Some(EnumRef::new("我强爆啊".as_bytes(), 2)));
+        assert_eq!(x.get(1), Some(EnumRef::new("我强爆啊".as_bytes(), &2)));
         assert_eq!(x.get(2), None);
-        assert_eq!(x.get(3), Some(EnumRef::new("我好强啊".as_bytes(), 1)));
-        assert_eq!(x.get(4), Some(EnumRef::new("我成功了".as_bytes(), 3)));
+        assert_eq!(x.get(3), Some(EnumRef::new("我好强啊".as_bytes(), &1)));
+        assert_eq!(x.get(4), Some(EnumRef::new("我成功了".as_bytes(), &3)));
         assert_eq!(x.len(), 5);
         assert!(!x.is_empty());
     }
@@ -197,7 +197,7 @@ mod tests {
         x.truncate(3);
         assert_eq!(x.len(), 3);
         assert_eq!(x.get(0), None);
-        assert_eq!(x.get(1), Some(EnumRef::new("我强爆啊".as_bytes(), 2)));
+        assert_eq!(x.get(1), Some(EnumRef::new("我强爆啊".as_bytes(), &2)));
         assert_eq!(x.get(2), None);
 
         x.truncate(1);
@@ -224,9 +224,9 @@ mod tests {
         assert!(y.is_empty());
 
         assert_eq!(x.get(0), None);
-        assert_eq!(x.get(1), Some(EnumRef::new("我强爆啊".as_bytes(), 2)));
+        assert_eq!(x.get(1), Some(EnumRef::new("我强爆啊".as_bytes(), &2)));
         assert_eq!(x.get(2), None);
-        assert_eq!(x.get(3), Some(EnumRef::new("我好强啊".as_bytes(), 1)));
-        assert_eq!(x.get(4), Some(EnumRef::new("我成功了".as_bytes(), 3)));
+        assert_eq!(x.get(3), Some(EnumRef::new("我好强啊".as_bytes(), &1)));
+        assert_eq!(x.get(4), Some(EnumRef::new("我成功了".as_bytes(), &3)));
     }
 }

--- a/components/tidb_query_datatype/src/codec/data_type/chunked_vec_enum.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/chunked_vec_enum.rs
@@ -3,7 +3,7 @@
 use super::bit_vec::BitVec;
 use super::{ChunkRef, ChunkedVec, UnsafeRefInto};
 use super::{Enum, EnumRef};
-use crate::codec::data_type::{ChunkedVecBytes, ChunkedVecSized, Int};
+use crate::codec::data_type::{retain_lifetime_transmute, ChunkedVecBytes, ChunkedVecSized, Int};
 use crate::impl_chunked_vec_common;
 
 /// `ChunkedVecEnum` is a vector storing `Option<Enum>`.
@@ -35,7 +35,9 @@ impl ChunkedVecEnum {
         assert!(idx < self.len());
         if let Some(value) = self.values.get_option_ref(idx) {
             let name = self.names.get(idx).unwrap();
-            Some(EnumRef::new(name, *value as u64))
+            Some(EnumRef::new(name, unsafe {
+                retain_lifetime_transmute(value)
+            }))
         } else {
             None
         }

--- a/components/tidb_query_datatype/src/codec/data_type/mod.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/mod.rs
@@ -257,6 +257,10 @@ macro_rules! impl_evaluable_type {
     };
 }
 
+unsafe fn retain_lifetime_transmute<'a, T, U>(from: &'a T) -> &'a U {
+    std::mem::transmute(from)
+}
+
 impl Evaluable for Int {
     const EVAL_TYPE: EvalType = EvalType::Int;
 
@@ -266,7 +270,7 @@ impl Evaluable for Int {
             ScalarValue::Int(x) => x.as_ref(),
             ScalarValue::Enum(x) => x
                 .as_ref()
-                .map(|x| unsafe { &*(x.value_ref() as *const u64 as *const i64) }),
+                .map(|x| unsafe { retain_lifetime_transmute::<u64, i64>(x.value_ref()) }),
             _ => unimplemented!(),
         }
     }
@@ -276,7 +280,7 @@ impl Evaluable for Int {
         match v {
             ScalarValueRef::Int(x) => x,
             ScalarValueRef::Enum(x) => {
-                x.map(|x| unsafe { &*(x.value_ref() as *const u64 as *const i64) })
+                x.map(|x| unsafe { retain_lifetime_transmute::<u64, i64>(x.value_ref()) })
             }
             _ => unimplemented!(),
         }

--- a/components/tidb_query_datatype/src/codec/data_type/mod.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/mod.rs
@@ -257,8 +257,10 @@ macro_rules! impl_evaluable_type {
     };
 }
 
-unsafe fn retain_lifetime_transmute<'a, T, U>(from: &'a T) -> &'a U {
-    std::mem::transmute(from)
+unsafe fn retain_lifetime_transmute<T, U>(from: &T) -> &U {
+    // with the help of elided lifetime, we can ensure &T and &U
+    // shares the same lifetime.
+    &*(from as *const T as *const U)
 }
 
 impl Evaluable for Int {

--- a/components/tidb_query_datatype/src/codec/mysql/enums.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/enums.rs
@@ -190,14 +190,14 @@ impl<'a> ToString for EnumRef<'a> {
 pub trait EnumEncoder: NumberEncoder {
     #[inline]
     fn write_enum(&mut self, data: EnumRef) -> Result<()> {
-        self.write_u64_le(*data.value as u64)?;
+        self.write_u64_le(*data.value)?;
         self.write_bytes(data.name)?;
         Ok(())
     }
 
     #[inline]
     fn write_enum_uint(&mut self, data: EnumRef) -> Result<()> {
-        self.write_u64_le(*data.value as u64)?;
+        self.write_u64_le(*data.value)?;
         Ok(())
     }
 

--- a/components/tidb_query_datatype/src/codec/mysql/enums.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/enums.rs
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_as_str() {
-        let cases = vec![("c", 1, "c"), ("b", 2, "b"), ("a", 3, "a")];
+        let cases = vec![("c", &1, "c"), ("b", &2, "b"), ("a", &3, "a")];
 
         for (name, value, expect) in cases {
             let e = EnumRef {

--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -1709,10 +1709,10 @@ mod tests {
 
         let cs = vec![
             // (input, expect)
-            (EnumRef::new("enum".as_bytes(), 0), 0),
-            (EnumRef::new("int".as_bytes(), 1), 1),
-            (EnumRef::new("real".as_bytes(), 2), 2),
-            (EnumRef::new("string".as_bytes(), 3), 3),
+            (EnumRef::new("enum".as_bytes(), &0), 0),
+            (EnumRef::new("int".as_bytes(), &1), 1),
+            (EnumRef::new("real".as_bytes(), &2), 2),
+            (EnumRef::new("string".as_bytes(), &3), 3),
         ];
 
         for (input, expect) in cs {
@@ -1730,10 +1730,10 @@ mod tests {
 
         let cs = vec![
             // (input, expect)
-            (EnumRef::new("enum".as_bytes(), 0), Real::from(0.)),
-            (EnumRef::new("int".as_bytes(), 1), Real::from(1.)),
-            (EnumRef::new("real".as_bytes(), 2), Real::from(2.)),
-            (EnumRef::new("string".as_bytes(), 3), Real::from(3.)),
+            (EnumRef::new("enum".as_bytes(), &0), Real::from(0.)),
+            (EnumRef::new("int".as_bytes(), &1), Real::from(1.)),
+            (EnumRef::new("real".as_bytes(), &2), Real::from(2.)),
+            (EnumRef::new("string".as_bytes(), &3), Real::from(3.)),
         ];
 
         for (input, expect) in cs {
@@ -1751,22 +1751,22 @@ mod tests {
         let cs = vec![
             // (input, expect)
             (
-                EnumRef::new("enum".as_bytes(), 0),
+                EnumRef::new("enum".as_bytes(), &0),
                 Bytes::from(""),
                 String::from(""),
             ),
             (
-                EnumRef::new("int".as_bytes(), 1),
+                EnumRef::new("int".as_bytes(), &1),
                 Bytes::from("int"),
                 String::from("int"),
             ),
             (
-                EnumRef::new("real".as_bytes(), 2),
+                EnumRef::new("real".as_bytes(), &2),
                 Bytes::from("real"),
                 String::from("real"),
             ),
             (
-                EnumRef::new("string".as_bytes(), 3),
+                EnumRef::new("string".as_bytes(), &3),
                 Bytes::from("string"),
                 String::from("string"),
             ),


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?

As pointed out by @sticnarf https://github.com/tikv/tikv/pull/9648#pullrequestreview-643187256 , transmute of enum value is unsound. This PR intends to fix this.

<del>For the first step, we just let the compiler fail. I'll propose a fix soon.</del>

Now we have made all transmute sound by retaining lifetime `retain_lifetime_transmute`.

What's Changed:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* No release note