### PR TITLE
coprv2: plugin version checks (part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ checksum = "59206260f98d163b3ca42fb29fe551dbcda1d43cf70a244066b2a0666a8fb2a9"
 dependencies = [
  "cc",
  "clap",
- "rustc_version",
+ "rustc_version 0.2.3",
  "xdg",
 ]
 
@@ -735,6 +735,7 @@ name = "coprocessor_plugin_api"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "rustc_version 0.3.3",
 ]
 
 [[package]]
@@ -2401,7 +2402,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -3009,6 +3010,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,7 +3290,7 @@ dependencies = [
  "byteorder",
  "libc 0.2.86",
  "nom 2.2.1",
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -3900,7 +3910,7 @@ dependencies = [
  "pin-project 0.4.8",
  "rusoto_credential",
  "rusoto_signature",
- "rustc_version",
+ "rustc_version 0.2.3",
  "serde",
  "serde_json",
  "tokio",
@@ -3987,7 +3997,7 @@ dependencies = [
  "percent-encoding",
  "pin-project 0.4.8",
  "rusoto_credential",
- "rustc_version",
+ "rustc_version 0.2.3",
  "serde",
  "sha2",
  "time 0.2.23",
@@ -4063,6 +4073,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -4161,7 +4180,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
  "serde",
 ]
 
@@ -4171,7 +4190,16 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -4179,6 +4207,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -4528,7 +4565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version",
+ "rustc_version 0.2.3",
  "stdweb-derive",
  "stdweb-internal-macros",
  "stdweb-internal-runtime",
@@ -5752,6 +5789,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unchecked-index"

--- a/components/coprocessor_plugin_api/Cargo.toml
+++ b/components/coprocessor_plugin_api/Cargo.toml
@@ -7,3 +7,6 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
+
+[build-dependencies]
+rustc_version = "0.3"

--- a/components/coprocessor_plugin_api/build.rs
+++ b/components/coprocessor_plugin_api/build.rs
@@ -1,0 +1,14 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+fn main() {
+    println!("cargo:rerun-if-changed=*");
+    println!("cargo:rustc-env=API_VERSION={}", env!("CARGO_PKG_VERSION"));
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+    println!(
+        "cargo:rustc-env=RUSTC_VERSION={}",
+        rustc_version::version_meta().unwrap().short_version_string
+    );
+}

--- a/components/coprocessor_plugin_api/src/util.rs
+++ b/components/coprocessor_plugin_api/src/util.rs
@@ -4,10 +4,38 @@ use super::allocator::HostAllocatorPtr;
 use super::plugin_api::CoprocessorPlugin;
 
 /// Name of the exported constructor function for the plugin in the `dylib`.
-pub const PLUGIN_CONSTRUCTOR_SYMBOL: &[u8] = b"_plugin_create";
+pub static PLUGIN_CONSTRUCTOR_SYMBOL: &[u8] = b"_plugin_create";
+/// Name of the exported function to get build information about the plugin.
+pub static PLUGIN_GET_BUILD_INFO_SYMBOL: &[u8] = b"_plugin_get_build_info";
+
 /// Type signature of the exported constructor function for the plugin in the `dylib`.
+/// See also [`PLUGIN_CONSTRUCTOR_SYMBOL`].
 pub type PluginConstructorSignature =
     unsafe fn(host_allocator: HostAllocatorPtr) -> *mut dyn CoprocessorPlugin;
+/// Type signature of the exported function to get build information about the plugin.
+/// See also [`PLUGIN_GET_BUILD_INFO_SYMBOL`].
+pub type PluginGetBuildInfo = extern "C" fn() -> BuildInfo;
+
+/// Build information about the plugin.
+///
+/// Will be automatically created when using [`declare_plugin!(...)`](declare_plugin).
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildInfo {
+    pub api_version: &'static str,
+    pub target: &'static str,
+    pub rustc: &'static str,
+}
+
+impl BuildInfo {
+    pub const fn get() -> Self {
+        Self {
+            api_version: env!("API_VERSION"),
+            target: env!("TARGET"),
+            rustc: env!("RUSTC_VERSION"),
+        }
+    }
+}
 
 /// Declare a plugin for the library so that it can be loaded by TiKV.
 ///
@@ -27,11 +55,16 @@ macro_rules! declare_plugin {
         static HOST_ALLOCATOR: $crate::allocator::HostAllocator =
             $crate::allocator::HostAllocator::new();
 
-        #[cfg(not(test))]
+        #[no_mangle]
+        pub unsafe extern "C" fn _plugin_get_build_info() -> $crate::BuildInfo {
+            $crate::BuildInfo::get()
+        }
+
         #[no_mangle]
         pub unsafe extern "C" fn _plugin_create(
             host_allocator: $crate::allocator::HostAllocatorPtr,
         ) -> *mut $crate::CoprocessorPlugin {
+            #[cfg(not(test))]
             HOST_ALLOCATOR.set_allocator(host_allocator);
 
             let boxed: Box<dyn $crate::CoprocessorPlugin> = Box::new($plugin_ctor);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Introduces version checks for API version and rustc version of plugins.

Issue Number: #9747 <!-- REMOVE this line if no issue to close -->

Problem Summary:

When loading a coprocessor plugin, we need to make sure that it actually runs. 
Thus, we need to make sure that the following things match up:
 * the version of the `coprocessor_plugin_api` crate the plugin was compiled with.
 * the rustc version the plugin was compiled with (has to be the same as the rustc version TiKV was compiled with because Rust does not guarantee a stable ABI)
 * the `target` platform the plugin was compiled for and the target platform of TiKV

### What is changed and how it works?

All in all, it is very similar to the [POC](https://github.com/andylokandy/plugin).

Proposal: [Coprocessor V2 RFC](https://github.com/andylokandy/rfcs/blob/plugin/text/2021-02-24-coprocessor-plugin.md) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- based on PR #9925 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test (TODO: I'm not entirely sure how to test this, help appreciated!)

### Release note <!-- bugfixes or new feature need a release note -->

 * No release note.