### PR TITLE
raftstore: faster lookup for admin epoch checker

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -59,10 +59,7 @@ use crate::store::peer::Peer;
 use crate::store::peer_storage::{
     self, write_initial_apply_state, write_peer_state, ENTRY_MEM_SIZE,
 };
-use crate::store::util::{
-    check_region_epoch, compare_region_epoch, is_learner, ChangePeerI, ConfChangeKind,
-    KeysInfoFormatter, ADMIN_CMD_EPOCH_MAP,
-};
+use crate::store::util::{check_region_epoch, compare_region_epoch, is_learner, ChangePeerI, ConfChangeKind, KeysInfoFormatter, admin_cmd_epoch_lookup};
 use crate::store::{cmd_resp, util, Config, RegionSnapshot, RegionTask};
 use crate::{Error, Result};
 
@@ -1213,8 +1210,8 @@ where
         }
         if let Some(epoch) = origin_epoch {
             let cmd_type = req.get_admin_request().get_cmd_type();
-            let epoch_state = *ADMIN_CMD_EPOCH_MAP.get(&cmd_type).unwrap();
-            // The chenge-epoch behavior **MUST BE** equal to the settings in `ADMIN_CMD_EPOCH_MAP`
+            let epoch_state = admin_cmd_epoch_lookup(cmd_type);
+            // The chenge-epoch behavior **MUST BE** equal to the settings in `admin_cmd_epoch_lookup`
             if (epoch_state.change_ver
                 && epoch.get_version() == self.region.get_region_epoch().get_version())
                 || (epoch_state.change_conf_ver

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -59,7 +59,10 @@ use crate::store::peer::Peer;
 use crate::store::peer_storage::{
     self, write_initial_apply_state, write_peer_state, ENTRY_MEM_SIZE,
 };
-use crate::store::util::{check_region_epoch, compare_region_epoch, is_learner, ChangePeerI, ConfChangeKind, KeysInfoFormatter, admin_cmd_epoch_lookup};
+use crate::store::util::{
+    admin_cmd_epoch_lookup, check_region_epoch, compare_region_epoch, is_learner, ChangePeerI,
+    ConfChangeKind, KeysInfoFormatter,
+};
 use crate::store::{cmd_resp, util, Config, RegionSnapshot, RegionTask};
 use crate::{Error, Result};
 
@@ -1211,7 +1214,7 @@ where
         if let Some(epoch) = origin_epoch {
             let cmd_type = req.get_admin_request().get_cmd_type();
             let epoch_state = admin_cmd_epoch_lookup(cmd_type);
-            // The chenge-epoch behavior **MUST BE** equal to the settings in `admin_cmd_epoch_lookup`
+            // The change-epoch behavior **MUST BE** equal to the settings in `admin_cmd_epoch_lookup`
             if (epoch_state.change_ver
                 && epoch.get_version() == self.region.get_region_epoch().get_version())
                 || (epoch_state.change_conf_ver

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -45,7 +45,7 @@ use crate::store::fsm::store::PollContext;
 use crate::store::fsm::{apply, Apply, ApplyMetrics, ApplyTask, CollectedReady, Proposal};
 use crate::store::hibernate_state::GroupState;
 use crate::store::msg::RaftCommand;
-use crate::store::util::{RegionReadProgress, admin_cmd_epoch_lookup};
+use crate::store::util::{admin_cmd_epoch_lookup, RegionReadProgress};
 use crate::store::worker::{HeartbeatTask, ReadDelegate, ReadExecutor, ReadProgress, RegionTask};
 use crate::store::{
     Callback, Config, GlobalReplicationState, PdTask, ReadIndexContext, ReadResponse,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -45,7 +45,7 @@ use crate::store::fsm::store::PollContext;
 use crate::store::fsm::{apply, Apply, ApplyMetrics, ApplyTask, CollectedReady, Proposal};
 use crate::store::hibernate_state::GroupState;
 use crate::store::msg::RaftCommand;
-use crate::store::util::RegionReadProgress;
+use crate::store::util::{RegionReadProgress, admin_cmd_epoch_lookup};
 use crate::store::worker::{HeartbeatTask, ReadDelegate, ReadExecutor, ReadProgress, RegionTask};
 use crate::store::{
     Callback, Config, GlobalReplicationState, PdTask, ReadIndexContext, ReadResponse,
@@ -72,7 +72,7 @@ use super::read_queue::{ReadIndexQueue, ReadIndexRequest};
 use super::transport::Transport;
 use super::util::{
     self, check_region_epoch, is_initial_msg, AdminCmdEpochState, ChangePeerI, ConfChangeKind,
-    Lease, LeaseState, ADMIN_CMD_EPOCH_MAP, NORMAL_REQ_CHECK_CONF_VER, NORMAL_REQ_CHECK_VER,
+    Lease, LeaseState, NORMAL_REQ_CHECK_CONF_VER, NORMAL_REQ_CHECK_VER,
 };
 use super::DestroyPeerJob;
 
@@ -245,7 +245,7 @@ impl<S: Snapshot> ProposedAdminCmd<S> {
 }
 
 struct CmdEpochChecker<S: Snapshot> {
-    // Although it's a deque, because of the characteristics of the settings from `ADMIN_CMD_EPOCH_MAP`,
+    // Although it's a deque, because of the characteristics of the settings from `admin_cmd_epoch_lookup`,
     // the max size of admin cmd is 2, i.e. split/merge and change peer.
     proposed_admin_cmd: VecDeque<ProposedAdminCmd<S>>,
     term: u64,
@@ -283,8 +283,7 @@ impl<S: Snapshot> CmdEpochChecker<S> {
             (NORMAL_REQ_CHECK_VER, NORMAL_REQ_CHECK_CONF_VER)
         } else {
             let cmd_type = req.get_admin_request().get_cmd_type();
-            // Due to `test_admin_cmd_epoch_map_include_all_cmd_type`, using unwrap is ok.
-            let epoch_state = *ADMIN_CMD_EPOCH_MAP.get(&cmd_type).unwrap();
+            let epoch_state = admin_cmd_epoch_lookup(cmd_type);
             (epoch_state.check_ver, epoch_state.check_conf_ver)
         };
         self.last_conflict_index(check_ver, check_conf_ver)
@@ -292,8 +291,7 @@ impl<S: Snapshot> CmdEpochChecker<S> {
 
     pub fn post_propose(&mut self, cmd_type: AdminCmdType, index: u64, term: u64) {
         self.maybe_update_term(term);
-        // Due to `test_admin_cmd_epoch_map_include_all_cmd_type`, using unwrap is ok.
-        let epoch_state = *ADMIN_CMD_EPOCH_MAP.get(&cmd_type).unwrap();
+        let epoch_state = admin_cmd_epoch_lookup(cmd_type);
         assert!(
             self.last_conflict_index(epoch_state.check_ver, epoch_state.check_conf_ver)
                 .is_none()

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -202,7 +202,7 @@ impl AdminCmdEpochState {
 /// will break upgrade compatibility and correctness dependency of `CmdEpochChecker`.
 /// Please remember it is very difficult to fix the issues arising from not following this rule.
 ///
-/// If you really want to change an admin cmd behavior, please add a new admin cmd and **do not**
+/// If you really want to change an admin cmd behavior, please add a new admin cmd and **DO NOT**
 /// delete the old one.
 pub fn admin_cmd_epoch_lookup(admin_cmp_type: AdminCmdType) -> AdminCmdEpochState {
     match admin_cmp_type {


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

### What problem does this PR solve?

Problem Summary:

`lazy_static` + `Hashmap` introduces much overhead.

### What is changed and how it works?

Use `match` instead.

What's Changed:

Benches:
```rust
lazy_static! {
    pub static ref ADMIN_CMD_EPOCH_MAP: HashMap<AdminCmdType, AdminCmdEpochState> = [
        (AdminCmdType::InvalidAdmin, AdminCmdEpochState::new(false, false, false, false)),
        (AdminCmdType::CompactLog, AdminCmdEpochState::new(false, false, false, false)),
        (AdminCmdType::ComputeHash, AdminCmdEpochState::new(false, false, false, false)),
        (AdminCmdType::VerifyHash, AdminCmdEpochState::new(false, false, false, false)),
        // Change peer
        (AdminCmdType::ChangePeer, AdminCmdEpochState::new(false, true, false, true)),
        (AdminCmdType::ChangePeerV2, AdminCmdEpochState::new(false, true, false, true)),
        // Split
        (AdminCmdType::Split, AdminCmdEpochState::new(true, true, true, false)),
        (AdminCmdType::BatchSplit, AdminCmdEpochState::new(true, true, true, false)),
        // Merge
        (AdminCmdType::PrepareMerge, AdminCmdEpochState::new(true, true, true, true)),
        (AdminCmdType::CommitMerge, AdminCmdEpochState::new(true, true, true, false)),
        (AdminCmdType::RollbackMerge, AdminCmdEpochState::new(true, true, true, false)),
        // Transfer leader
        (AdminCmdType::TransferLeader, AdminCmdEpochState::new(true, true, false, false)),
    ].iter().copied().collect();
}

pub fn admin_cmd_epoch_lookup(admin_cmp_type: AdminCmdType) -> AdminCmdEpochState {
    match admin_cmp_type {
        AdminCmdType::InvalidAdmin => AdminCmdEpochState::new(false, false, false, false),
        AdminCmdType::CompactLog => AdminCmdEpochState::new(false, false, false, false),
        AdminCmdType::ComputeHash => AdminCmdEpochState::new(false, false, false, false),
        AdminCmdType::VerifyHash => AdminCmdEpochState::new(false, false, false, false),
        // Change peer
        AdminCmdType::ChangePeer => AdminCmdEpochState::new(false, true, false, true),
        AdminCmdType::ChangePeerV2 => AdminCmdEpochState::new(false, true, false, true),
        // Split
        AdminCmdType::Split => AdminCmdEpochState::new(true, true, true, false),
        AdminCmdType::BatchSplit => AdminCmdEpochState::new(true, true, true, false),
        // Merge
        AdminCmdType::PrepareMerge => AdminCmdEpochState::new(true, true, true, true),
        AdminCmdType::CommitMerge => AdminCmdEpochState::new(true, true, true, false),
        AdminCmdType::RollbackMerge => AdminCmdEpochState::new(true, true, true, false),
        // Transfer leader
        AdminCmdType::TransferLeader => AdminCmdEpochState::new(true, true, false, false),
    }
}

#[cfg(test)]
mod tests1 {
    use test::{Bencher, black_box};
    use super::*;
    use protobuf::ProtobufEnum;

    #[bench]
    fn match_lookup(b: &mut Bencher) {
        b.iter(|| {
            for x in AdminCmdType::values() {
                black_box(admin_cmd_epoch_lookup(*x));
            }
        })
    }

    #[bench]
    fn lazy_static_map_lookup(b: &mut Bencher) {
        b.iter(|| {
            for x in AdminCmdType::values() {
                black_box(*ADMIN_CMD_EPOCH_MAP.get(x).unwrap());
            }
        })
    }
}
```

Output:
```
running 2 tests
test store::util::tests1::lazy_static_map_lookup                              ... bench:          30 ns/iter (+/- 3)
test store::util::tests1::match_lookup                                        ... bench:           2 ns/iter (+/- 0)
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- Tiny performance improvement