### PR TITLE
coprv2: plugin version checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,7 @@ name = "coprocessor_plugin_api"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "rustc_version",
 ]
 
 [[package]]

--- a/components/coprocessor_plugin_api/Cargo.toml
+++ b/components/coprocessor_plugin_api/Cargo.toml
@@ -7,3 +7,6 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
+
+[build-dependencies]
+rustc_version = "0.2"

--- a/components/coprocessor_plugin_api/build.rs
+++ b/components/coprocessor_plugin_api/build.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 fn main() {
-    println!("cargo:rerun-if-changed=*");
-    println!("cargo:rustc-env=API_VERSION={}", env!("CARGO_PKG_VERSION"));
     println!(
         "cargo:rustc-env=TARGET={}",
         std::env::var("TARGET").unwrap()

--- a/components/coprocessor_plugin_api/build.rs
+++ b/components/coprocessor_plugin_api/build.rs
@@ -1,0 +1,14 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+fn main() {
+    println!("cargo:rerun-if-changed=*");
+    println!("cargo:rustc-env=API_VERSION={}", env!("CARGO_PKG_VERSION"));
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+    println!(
+        "cargo:rustc-env=RUSTC_VERSION={}",
+        rustc_version::version_meta().unwrap().short_version_string
+    );
+}

--- a/components/coprocessor_plugin_api/src/util.rs
+++ b/components/coprocessor_plugin_api/src/util.rs
@@ -35,7 +35,7 @@ pub struct BuildInfo {
 impl BuildInfo {
     pub const fn get() -> Self {
         Self {
-            api_version: env!("API_VERSION"),
+            api_version: env!("CARGO_PKG_VERSION"),
             target: env!("TARGET"),
             rustc: env!("RUSTC_VERSION"),
         }


### PR DESCRIPTION
### What problem does this PR solve?
Introduces version checks for API version and rustc version of plugins.

**This PR is the same as https://github.com/tikv/tikv/pull/10075**

Issue Number: #9747

Problem Summary:

When loading a coprocessor plugin, we need to make sure that it actually runs.
Thus, we need to make sure that the following things match up:

* the version of the `coprocessor_plugin_api` crate the plugin was compiled with.
* the rustc version the plugin was compiled with (has to be the same as the rustc version TiKV was compiled with because Rust does not guarantee a stable ABI)
* the `target` platform the plugin was compiled for and the target platform of TiKV

### What is changed and how it works?
All in all, it is very similar to the [POC](https://github.com/andylokandy/plugin).

Proposal: [Coprocessor V2 RFC](https://github.com/andylokandy/rfcs/blob/plugin/text/2021-02-24-coprocessor-plugin.md)

What's Changed:

### Related changes
* based on PR #9925

### Check List
Tests

* Unit test (TODO: I'm not entirely sure how to test this, help appreciated!)

### Release note
* No release note.
