### PR TITLE
coprv2: check plugin version on coprocessor requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5304,6 +5304,7 @@ dependencies = [
  "regex",
  "rev_lines",
  "security",
+ "semver 0.11.0",
  "serde",
  "serde_derive",
  "serde_ignored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,7 @@ rand = "0.7.3"
 regex = "1.3"
 rev_lines = "0.2.1"
 security = { path = "components/security", default-features = false }
+semver = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_ignored = "0.1"

--- a/components/coprocessor_plugin_api/src/plugin_api.rs
+++ b/components/coprocessor_plugin_api/src/plugin_api.rs
@@ -45,10 +45,6 @@ impl From<StorageError> for PluginError {
 /// Plugins can run setup code in their constructor and teardown code by implementing
 /// [`std::ops::Drop`].
 pub trait CoprocessorPlugin: Send + Sync {
-    /// Returns the name of the plugin.
-    /// Requests that are sent to TiKV coprocessor must have a matching `copr_name` field.
-    fn name(&self) -> &'static str;
-
     /// Handles a request to the coprocessor.
     ///
     /// The data in the `request` parameter is exactly the same data that was passed with the

--- a/components/coprocessor_plugin_api/src/util.rs
+++ b/components/coprocessor_plugin_api/src/util.rs
@@ -3,19 +3,24 @@
 use super::allocator::HostAllocatorPtr;
 use super::plugin_api::CoprocessorPlugin;
 
-/// Name of the exported constructor function for the plugin in the `dylib`.
+/// Name of the exported constructor with signature [`PluginConstructorSignature`] for the plugin.
 pub static PLUGIN_CONSTRUCTOR_SYMBOL: &[u8] = b"_plugin_create";
-/// Name of the exported function to get build information about the plugin.
+/// Name of the exported function with signature [`PluginGetBuildInfoSignature`] to get build
+/// information about the plugin.
 pub static PLUGIN_GET_BUILD_INFO_SYMBOL: &[u8] = b"_plugin_get_build_info";
+/// Name of the exported function with signature [`PluginGetPluginInfoSignature`] to get some
+/// information about the plugin.
+pub static PLUGIN_GET_PLUGIN_INFO_SYMBOL: &[u8] = b"_plugin_get_plugin_info";
 
-/// Type signature of the exported constructor function for the plugin in the `dylib`.
-/// See also [`PLUGIN_CONSTRUCTOR_SYMBOL`].
+/// Type signature of the exported function with symbol [`PLUGIN_CONSTRUCTOR_SYMBOL`].
 pub type PluginConstructorSignature =
     unsafe fn(host_allocator: HostAllocatorPtr) -> *mut dyn CoprocessorPlugin;
 
-/// Type signature of the exported function to get build information about the plugin.
-/// See also [`PLUGIN_GET_BUILD_INFO_SYMBOL`].
+/// Type signature of the exported function with symbol [`PLUGIN_GET_BUILD_INFO_SYMBOL`].
 pub type PluginGetBuildInfoSignature = extern "C" fn() -> BuildInfo;
+
+/// Type signature of the exported function with symbol [`PLUGIN_GET_PLUGIN_INFO_SYMBOL`].
+pub type PluginGetPluginInfoSignature = extern "C" fn() -> PluginInfo;
 
 /// Automatically collected build information about the plugin that is exposed from the library.
 ///
@@ -42,7 +47,23 @@ impl BuildInfo {
     }
 }
 
+
+/// Information about the plugin, like its name and version.
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginInfo {
+    /// The name of the plugin.
+    pub name: &'static str,
+    /// The version string of the plugin. Should follow semantic versioning.
+    pub version: &'static str,
+}
+
 /// Declare a plugin for the library so that it can be loaded by TiKV.
+///
+/// The macro has three different versions:
+/// * `declare_plugin!(plugin_name, plugin_version, plugin_ctor)` which gives you full control.
+/// * `declare_plugin!(plugin_name, plugin_ctor)` automatically fetches the version from `Cargo.toml`.
+/// * `declare_plugin!(plugin_ctor)` automatically fetches plugin name and version from `Cargo.toml`.
 ///
 /// # Notes
 /// This works by automatically generating an `extern "C"` function with a
@@ -55,6 +76,16 @@ impl BuildInfo {
 #[macro_export]
 macro_rules! declare_plugin {
     ($plugin_ctor:expr) => {
+        declare_plugin!(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+            $plugin_ctor
+        );
+    };
+    ($plugin_name:expr, $plugin_ctor:expr) => {
+        declare_plugin!($plugin_name, env!("CARGO_PKG_VERSION"), $plugin_ctor);
+    };
+    ($plugin_name:expr, $plugin_version:expr, $plugin_ctor:expr) => {
         #[cfg(not(test))]
         #[global_allocator]
         static HOST_ALLOCATOR: $crate::allocator::HostAllocator =
@@ -63,6 +94,14 @@ macro_rules! declare_plugin {
         #[no_mangle]
         pub unsafe extern "C" fn _plugin_get_build_info() -> $crate::BuildInfo {
             $crate::BuildInfo::get()
+        }
+
+        #[no_mangle]
+        pub unsafe extern "C" fn _plugin_get_plugin_info() -> $crate::PluginInfo {
+            $crate::PluginInfo {
+                name: $plugin_name,
+                version: $plugin_version,
+            }
         }
 
         #[no_mangle]

--- a/components/coprocessor_plugin_api/src/util.rs
+++ b/components/coprocessor_plugin_api/src/util.rs
@@ -64,6 +64,8 @@ pub struct PluginInfo {
 /// * `declare_plugin!(plugin_name, plugin_ctor)` automatically fetches the version from `Cargo.toml`.
 /// * `declare_plugin!(plugin_ctor)` automatically fetches plugin name and version from `Cargo.toml`.
 ///
+/// The types of `plugin_name` and `plugin_version` have to be `&'static str` literals.
+///
 /// # Notes
 /// This works by automatically generating an `extern "C"` function with a
 /// pre-defined signature and symbol name. Therefore you will only be able to

--- a/components/coprocessor_plugin_api/src/util.rs
+++ b/components/coprocessor_plugin_api/src/util.rs
@@ -47,7 +47,6 @@ impl BuildInfo {
     }
 }
 
-
 /// Information about the plugin, like its name and version.
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/components/test_coprocessor_plugin/example_plugin/src/lib.rs
+++ b/components/test_coprocessor_plugin/example_plugin/src/lib.rs
@@ -6,10 +6,6 @@ use coprocessor_plugin_api::*;
 struct ExamplePlugin;
 
 impl CoprocessorPlugin for ExamplePlugin {
-    fn name(&self) -> &'static str {
-        "example-plugin"
-    }
-
     fn on_raw_coprocessor_request(
         &self,
         _region: &Region,

--- a/src/coprocessor_v2/endpoint.rs
+++ b/src/coprocessor_v2/endpoint.rs
@@ -80,7 +80,7 @@ impl Endpoint {
             .then(|| {})
             .ok_or_else(|| {
                 CoprocessorError::Other(format!(
-                    "The plugin '{}' with version '{}' does not satisfy the version constraint '{:?}'",
+                    "The plugin '{}' with version '{}' does not satisfy the version constraint '{}'",
                     plugin.name(),
                     plugin_version,
                     version_req,

--- a/src/coprocessor_v2/endpoint.rs
+++ b/src/coprocessor_v2/endpoint.rs
@@ -2,7 +2,9 @@
 
 use coprocessor_plugin_api::{CoprocessorPlugin, PluginError, RawResponse, Region, RegionEpoch};
 use kvproto::coprocessor_v2 as coprv2pb;
+use semver::VersionReq;
 use std::future::Future;
+use std::ops::Not;
 use std::sync::Arc;
 
 use super::plugin_registry::PluginRegistry;
@@ -65,6 +67,23 @@ impl Endpoint {
                 CoprocessorError::Other(format!(
                     "No registered coprocessor with name '{}'",
                     req.copr_name
+                ))
+            })?;
+
+        // Check whether the found plugin satisfies the version constraint.
+        let version_req = VersionReq::parse(&req.copr_version_constraint)
+            .map_err(|e| CoprocessorError::Other(format!("{}", e)))?;
+        let plugin_version = plugin.version();
+        version_req
+            .matches(&plugin_version)
+            .not()
+            .then(|| {})
+            .ok_or_else(|| {
+                CoprocessorError::Other(format!(
+                    "The plugin '{}' with version '{}' does not satisfy the version constraint '{:?}'",
+                    plugin.name(),
+                    plugin_version,
+                    version_req,
                 ))
             })?;
 

--- a/src/coprocessor_v2/plugin_registry.rs
+++ b/src/coprocessor_v2/plugin_registry.rs
@@ -454,6 +454,7 @@ fn is_library_file<P: AsRef<Path>>(path: P) -> bool {
 //        let loaded_plugin = unsafe { LoadedPlugin::new(&library_path).unwrap() };
 //
 //        assert_eq!(loaded_plugin.name(), "example_plugin");
+//        assert_eq!(loaded_plugin.version(), &Version::parse("0.1.0").unwrap());
 //    }
 //
 //    #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

This PR add the ability to check plugin version on coprocessor requests.
We now collect the plugin version in `declare_plugin!` macro (either passed explicitly or from Cargo.toml).
When calling the new coprocessor endpoint, we now check whether the loaded plugin does satisfy `copr_version_constraint`.

Issue Number: #9747  <!-- REMOVE this line if no issue to close -->



### What is changed and how it works?

Proposal: [RFC](https://github.com/andylokandy/rfcs/blob/plugin/text/2021-02-24-coprocessor-plugin.md) <!-- REMOVE this line if not applicable -->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

 * No release note