### PR TITLE
Replace some RocksEngine with KvEngine type parameters in tikv::server

### DIFF
--- a/components/engine_traits/src/engine.rs
+++ b/components/engine_traits/src/engine.rs
@@ -31,6 +31,7 @@ pub trait KvEngine:
     + Sync
     + Clone
     + Debug
+    + Unpin
     + 'static
 {
     /// A consistent read-only snapshot of the database

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -63,7 +63,7 @@ use txn_types::TxnExtraScheduler;
 
 type SimulateStoreTransport = SimulateTransport<ServerRaftStoreRouter<RocksEngine, RocksEngine>>;
 type SimulateServerTransport =
-    SimulateTransport<ServerTransport<SimulateStoreTransport, PdStoreAddrResolver>>;
+    SimulateTransport<ServerTransport<SimulateStoreTransport, PdStoreAddrResolver, RocksEngine>>;
 
 pub type SimulateEngine = RaftKv<RocksEngine, SimulateStoreTransport>;
 
@@ -126,7 +126,7 @@ pub struct ServerCluster {
     pub txn_extra_schedulers: HashMap<u64, Arc<dyn TxnExtraScheduler>>,
     snap_paths: HashMap<u64, TempDir>,
     pd_client: Arc<TestPdClient>,
-    raft_client: RaftClient<AddressMap, RaftStoreBlackHole>,
+    raft_client: RaftClient<AddressMap, RaftStoreBlackHole, RocksEngine>,
     concurrency_managers: HashMap<u64, ConcurrencyManager>,
     env: Arc<Environment>,
 }

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -6,6 +6,7 @@ use crate::server::{self, Config, StoreAddrResolver};
 use collections::{HashMap, HashSet};
 use crossbeam::queue::ArrayQueue;
 use engine_rocks::RocksEngine;
+use engine_traits::KvEngine;
 use futures::channel::oneshot;
 use futures::compat::Future01CompatExt;
 use futures::task::{Context, Poll, Waker};
@@ -296,9 +297,10 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static> SnapshotReporter<T> {
     }
 }
 
-fn report_unreachable<R>(router: &R, msg: &RaftMessage)
+fn report_unreachable<R, E>(router: &R, msg: &RaftMessage)
 where
-    R: RaftStoreRouter<RocksEngine>,
+    R: RaftStoreRouter<E>,
+    E: KvEngine,
 {
     let to_peer = msg.get_to_peer();
     if msg.get_message().has_snapshot() {

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -428,7 +428,7 @@ impl<R, M, B, E> Future for RaftCall<R, M, B, E>
 where
     R: RaftStoreRouter<E> + Unpin + 'static,
     B: Buffer<OutputMessage = M> + Unpin,
-    E: KvEngine + Unpin,
+    E: KvEngine,
 {
     type Output = ();
 
@@ -521,7 +521,7 @@ impl<S, R, E> StreamBackEnd<S, R, E>
 where
     S: StoreAddrResolver,
     R: RaftStoreRouter<E> + Unpin + 'static,
-    E: KvEngine + Unpin
+    E: KvEngine
 {
     fn resolve(&self) -> impl Future<Output = server::Result<String>> {
         let (tx, rx) = oneshot::channel();
@@ -662,7 +662,7 @@ async fn start<S, R, E>(
 ) where
     S: StoreAddrResolver + Send,
     R: RaftStoreRouter<E> + Unpin + Send + 'static,
-    E: KvEngine + Unpin
+    E: KvEngine
 {
     let mut last_wake_time = Instant::now();
     let mut retry_times = 0;
@@ -773,7 +773,7 @@ impl<S, R, E> RaftClient<S, R, E>
 where
     S: StoreAddrResolver + Send + 'static,
     R: RaftStoreRouter<E> + Unpin + Send + 'static,
-    E: KvEngine + Unpin,
+    E: KvEngine,
 {
     pub fn new(builder: ConnectionBuilder<S, R>) -> RaftClient<S, R, E> {
         let future_pool = Arc::new(

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -656,13 +656,14 @@ async fn maybe_backoff(cfg: &Config, last_wake_time: &mut Instant, retry_times: 
 /// 4. fallback to legacy API if incompatible
 ///
 /// Every failure during the process should trigger retry automatically.
-async fn start<S, R>(
-    back_end: StreamBackEnd<S, R, RocksEngine>,
+async fn start<S, R, E>(
+    back_end: StreamBackEnd<S, R, E>,
     conn_id: usize,
     pool: Arc<Mutex<ConnectionPool>>,
 ) where
     S: StoreAddrResolver + Send,
-    R: RaftStoreRouter<RocksEngine> + Unpin + Send + 'static,
+    R: RaftStoreRouter<E> + Unpin + Send + 'static,
+    E: KvEngine + Unpin
 {
     let mut last_wake_time = Instant::now();
     let mut retry_times = 0;

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -6,7 +6,6 @@ use crate::server::{self, Config, StoreAddrResolver};
 use collections::{HashMap, HashSet};
 use crossbeam::queue::ArrayQueue;
 use engine_traits::KvEngine;
-use std::marker::PhantomData;
 use futures::channel::oneshot;
 use futures::compat::Future01CompatExt;
 use futures::task::{Context, Poll, Waker};
@@ -23,6 +22,7 @@ use raftstore::router::RaftStoreRouter;
 use security::SecurityManager;
 use std::collections::VecDeque;
 use std::ffi::CString;
+use std::marker::PhantomData;
 use std::marker::Unpin;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
@@ -269,7 +269,9 @@ struct SnapshotReporter<T, E> {
 }
 
 impl<T, E> SnapshotReporter<T, E>
-where T: RaftStoreRouter<E> + 'static, E: KvEngine
+where
+    T: RaftStoreRouter<E> + 'static,
+    E: KvEngine,
 {
     pub fn report(&self, status: SnapshotStatus) {
         debug!(
@@ -521,7 +523,7 @@ impl<S, R, E> StreamBackEnd<S, R, E>
 where
     S: StoreAddrResolver,
     R: RaftStoreRouter<E> + Unpin + 'static,
-    E: KvEngine
+    E: KvEngine,
 {
     fn resolve(&self) -> impl Future<Output = server::Result<String>> {
         let (tx, rx) = oneshot::channel();
@@ -662,7 +664,7 @@ async fn start<S, R, E>(
 ) where
     S: StoreAddrResolver + Send,
     R: RaftStoreRouter<E> + Unpin + Send + 'static,
-    E: KvEngine
+    E: KvEngine,
 {
     let mut last_wake_time = Instant::now();
     let mut retry_times = 0;

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -56,7 +56,7 @@ pub struct Server<T: RaftStoreRouter<RocksEngine> + 'static, S: StoreAddrResolve
     builder_or_server: Option<Either<ServerBuilder, GrpcServer>>,
     local_addr: SocketAddr,
     // Transport.
-    trans: ServerTransport<T, S>,
+    trans: ServerTransport<T, S, RocksEngine>,
     raft_router: T,
     // For sending/receiving snapshots.
     snap_mgr: SnapManager,
@@ -185,7 +185,7 @@ impl<T: RaftStoreRouter<RocksEngine> + Unpin, S: StoreAddrResolver + 'static> Se
         self.debug_thread_pool.handle()
     }
 
-    pub fn transport(&self) -> ServerTransport<T, S> {
+    pub fn transport(&self) -> ServerTransport<T, S, RocksEngine> {
         self.trans.clone()
     }
 

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -14,7 +14,7 @@ where
     T: RaftStoreRouter<RocksEngine> + 'static,
     S: StoreAddrResolver + 'static,
 {
-    raft_client: RaftClient<S, T>,
+    raft_client: RaftClient<S, T, RocksEngine>,
 }
 
 impl<T, S> Clone for ServerTransport<T, S>
@@ -32,7 +32,7 @@ where
 impl<T: RaftStoreRouter<RocksEngine> + 'static, S: StoreAddrResolver + 'static>
     ServerTransport<T, S>
 {
-    pub fn new(raft_client: RaftClient<S, T>) -> ServerTransport<T, S> {
+    pub fn new(raft_client: RaftClient<S, T, RocksEngine>) -> ServerTransport<T, S> {
         ServerTransport { raft_client }
     }
 }

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -4,43 +4,52 @@ use kvproto::raft_serverpb::RaftMessage;
 
 use crate::server::raft_client::RaftClient;
 use crate::server::resolve::StoreAddrResolver;
-use engine_rocks::RocksEngine;
+use engine_traits::KvEngine;
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::Transport;
 use raftstore::Result as RaftStoreResult;
+use std::marker::PhantomData;
 
-pub struct ServerTransport<T, S>
+pub struct ServerTransport<T, S, E>
 where
-    T: RaftStoreRouter<RocksEngine> + 'static,
+    T: RaftStoreRouter<E> + 'static,
     S: StoreAddrResolver + 'static,
+    E: KvEngine,
 {
-    raft_client: RaftClient<S, T, RocksEngine>,
+    raft_client: RaftClient<S, T, E>,
+    engine: PhantomData<E>,
 }
 
-impl<T, S> Clone for ServerTransport<T, S>
+impl<T, S, E> Clone for ServerTransport<T, S, E>
 where
-    T: RaftStoreRouter<RocksEngine> + 'static,
+    T: RaftStoreRouter<E> + 'static,
     S: StoreAddrResolver + 'static,
+    E: KvEngine,
 {
     fn clone(&self) -> Self {
         ServerTransport {
             raft_client: self.raft_client.clone(),
+            engine: PhantomData,
         }
     }
 }
 
-impl<T: RaftStoreRouter<RocksEngine> + 'static, S: StoreAddrResolver + 'static>
-    ServerTransport<T, S>
+impl<T, S, E> ServerTransport<T, S, E>
+where E: KvEngine, T: RaftStoreRouter<E> + 'static, S: StoreAddrResolver + 'static
 {
-    pub fn new(raft_client: RaftClient<S, T, RocksEngine>) -> ServerTransport<T, S> {
-        ServerTransport { raft_client }
+    pub fn new(raft_client: RaftClient<S, T, E>) -> ServerTransport<T, S, E> {
+        ServerTransport {
+            raft_client,
+            engine: PhantomData,
+        }
     }
 }
 
-impl<T, S> Transport for ServerTransport<T, S>
+impl<T, S, E> Transport for ServerTransport<T, S, E>
 where
-    T: RaftStoreRouter<RocksEngine> + Unpin + 'static,
+    T: RaftStoreRouter<E> + Unpin + 'static,
     S: StoreAddrResolver + Unpin + 'static,
+    E: KvEngine + Unpin,
 {
     fn send(&mut self, msg: RaftMessage) -> RaftStoreResult<()> {
         match self.raft_client.send(msg) {

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -49,7 +49,7 @@ impl<T, S, E> Transport for ServerTransport<T, S, E>
 where
     T: RaftStoreRouter<E> + Unpin + 'static,
     S: StoreAddrResolver + Unpin + 'static,
-    E: KvEngine + Unpin,
+    E: KvEngine,
 {
     fn send(&mut self, msg: RaftMessage) -> RaftStoreResult<()> {
         match self.raft_client.send(msg) {

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -35,7 +35,10 @@ where
 }
 
 impl<T, S, E> ServerTransport<T, S, E>
-where E: KvEngine, T: RaftStoreRouter<E> + 'static, S: StoreAddrResolver + 'static
+where
+    E: KvEngine,
+    T: RaftStoreRouter<E> + 'static,
+    S: StoreAddrResolver + 'static,
 {
     pub fn new(raft_client: RaftClient<S, T, E>) -> ServerTransport<T, S, E> {
         ServerTransport {

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -44,7 +44,7 @@ impl StoreAddrResolver for StaticResolver {
     }
 }
 
-fn get_raft_client<R, T>(router: R, resolver: T) -> RaftClient<T, R>
+fn get_raft_client<R, T>(router: R, resolver: T) -> RaftClient<T, R, RocksEngine>
 where
     R: RaftStoreRouter<RocksEngine> + Unpin + 'static,
     T: StoreAddrResolver + 'static,
@@ -58,7 +58,7 @@ where
     RaftClient::new(builder)
 }
 
-fn get_raft_client_by_port(port: u16) -> RaftClient<StaticResolver, RaftStoreBlackHole> {
+fn get_raft_client_by_port(port: u16) -> RaftClient<StaticResolver, RaftStoreBlackHole, RocksEngine> {
     get_raft_client(RaftStoreBlackHole, StaticResolver::new(port))
 }
 

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -58,7 +58,9 @@ where
     RaftClient::new(builder)
 }
 
-fn get_raft_client_by_port(port: u16) -> RaftClient<StaticResolver, RaftStoreBlackHole, RocksEngine> {
+fn get_raft_client_by_port(
+    port: u16,
+) -> RaftClient<StaticResolver, RaftStoreBlackHole, RocksEngine> {
     get_raft_client(RaftStoreBlackHole, StaticResolver::new(port))
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Making the tikv crate generic over storage engines.

Part of https://github.com/tikv/tikv/issues/6402

### What is changed and how it works?

Just replacing instances of RocksEngine with KvEngine-bound type parameters in the tikv::server module.

I discovered that KvEngines need to be Unpin here, so I went ahead and made all KvEngines Unpin so engine authors can find that out early.

### Related changes



### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.