### PR TITLE
speed up snapshot for ongoing online stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#7d50a22e4b4fb0da7e003ac72d639711cf3ead5e"
+source = "git+https://github.com/hicqu/kvproto?branch=store-heartbeat-resp-store-status#206bc9bc27e4b09f87d034e7b977024161a6673b"
 dependencies = [
  "futures 0.3.7",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,9 @@ protobuf = { git = "https://github.com/pingcap/rust-protobuf", rev = "65e9df20fb
 protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "65e9df20fbcbcf2409d5ee86a2332ecd04c534f8" }
 openssl-src = { git = "https://github.com/busyjay/openssl-src-rs", branch = "patch-for-m1" }
 
+[patch."https://github.com/pingcap/kvproto.git"]
+kvproto = { git = "https://github.com/hicqu/kvproto", branch = "store-heartbeat-resp-store-status", default-features = false }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -709,10 +709,12 @@ where
             .set(available as i64);
 
         let router = self.router.clone();
+        let snap_mgr = self.snap_mgr.clone();
         let resp = self.pd_client.store_heartbeat(stats);
         let f = async move {
             match resp.await {
                 Ok(mut resp) => {
+                    snap_mgr.update_store_status(resp.get_store_status());
                     if let Some(status) = resp.replication_status.take() {
                         let _ = router.send_control(StoreMsg::UpdateReplicationMode(status));
                     }


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

For an ongoing online store it's unnecessary to use configured `snap_max_bytes_per_sync` for I/O speed limiter, because there aren't Region leaders on the store. It's OK to use an infinate speed limiter to speed up Region replicas moving.

### What is changed and how it works?

Use an infinate I/O speed limiter for ongoing online stores.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* No release note.