### PR TITLE
Replace RocksEngine with KvEngine in lock manager

### DIFF
--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -909,7 +909,7 @@ pub mod tests {
     use futures::executor::block_on;
     use security::SecurityConfig;
     use tikv_util::worker::FutureWorker;
-    use engine_rocks::RocksEngine;
+    use engine_test::kv::KvTestEngine;
 
     #[test]
     fn test_detect_table() {
@@ -1066,7 +1066,7 @@ pub mod tests {
     }
 
     fn start_deadlock_detector(
-        host: &mut CoprocessorHost<RocksEngine>,
+        host: &mut CoprocessorHost<KvTestEngine>,
     ) -> (FutureWorker<Task>, Scheduler) {
         let waiter_mgr_worker = FutureWorker::new("dummy-waiter-mgr");
         let waiter_mgr_scheduler = WaiterMgrScheduler::new(waiter_mgr_worker.scheduler());

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -906,10 +906,10 @@ impl Deadlock for Service {
 pub mod tests {
     use super::*;
     use crate::server::resolve::Callback;
+    use engine_test::kv::KvTestEngine;
     use futures::executor::block_on;
     use security::SecurityConfig;
     use tikv_util::worker::FutureWorker;
-    use engine_test::kv::KvTestEngine;
 
     #[test]
     fn test_detect_table() {

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -8,7 +8,7 @@ use super::{Error, Result};
 use crate::server::resolve::StoreAddrResolver;
 use crate::storage::lock_manager::Lock;
 use collections::{HashMap, HashSet};
-use engine_rocks::RocksEngine;
+use engine_traits::KvEngine;
 use futures::future::{self, FutureExt, TryFutureExt};
 use futures::sink::SinkExt;
 use futures::stream::TryStreamExt;
@@ -402,7 +402,7 @@ impl RoleChangeNotifier {
         }
     }
 
-    pub(crate) fn register(self, host: &mut CoprocessorHost<RocksEngine>) {
+    pub(crate) fn register(self, host: &mut CoprocessorHost<impl KvEngine>) {
         host.registry
             .register_role_observer(1, BoxRoleObserver::new(self.clone()));
         host.registry
@@ -909,6 +909,7 @@ pub mod tests {
     use futures::executor::block_on;
     use security::SecurityConfig;
     use tikv_util::worker::FutureWorker;
+    use engine_rocks::RocksEngine;
 
     #[test]
     fn test_detect_table() {

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -188,7 +188,10 @@ impl LockManager {
 
     /// Creates a `RoleChangeNotifier` of the deadlock detector worker and registers it to
     /// the `CoprocessorHost` to observe the role change events of the leader region.
-    pub fn register_detector_role_change_observer(&self, host: &mut CoprocessorHost<impl KvEngine>) {
+    pub fn register_detector_role_change_observer(
+        &self,
+        host: &mut CoprocessorHost<impl KvEngine>,
+    ) {
         let role_change_notifier = RoleChangeNotifier::new(self.detector_scheduler.clone());
         role_change_notifier.register(host);
     }
@@ -286,10 +289,10 @@ mod tests {
     use self::metrics::*;
     use self::waiter_manager::tests::*;
     use super::*;
+    use engine_test::kv::KvTestEngine;
     use raftstore::coprocessor::RegionChangeEvent;
     use security::SecurityConfig;
     use tikv_util::config::ReadableDuration;
-    use engine_test::kv::KvTestEngine;
 
     use std::thread;
     use std::time::Duration;

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -28,7 +28,7 @@ use raftstore::coprocessor::CoprocessorHost;
 
 use collections::HashSet;
 use crossbeam::utils::CachePadded;
-use engine_rocks::RocksEngine;
+use engine_traits::KvEngine;
 use parking_lot::Mutex;
 use pd_client::PdClient;
 use security::SecurityManager;
@@ -188,7 +188,7 @@ impl LockManager {
 
     /// Creates a `RoleChangeNotifier` of the deadlock detector worker and registers it to
     /// the `CoprocessorHost` to observe the role change events of the leader region.
-    pub fn register_detector_role_change_observer(&self, host: &mut CoprocessorHost<RocksEngine>) {
+    pub fn register_detector_role_change_observer(&self, host: &mut CoprocessorHost<impl KvEngine>) {
         let role_change_notifier = RoleChangeNotifier::new(self.detector_scheduler.clone());
         role_change_notifier.register(host);
     }
@@ -289,6 +289,7 @@ mod tests {
     use raftstore::coprocessor::RegionChangeEvent;
     use security::SecurityConfig;
     use tikv_util::config::ReadableDuration;
+    use engine_test::kv::KvTestEngine;
 
     use std::thread;
     use std::time::Duration;
@@ -298,7 +299,7 @@ mod tests {
     use raft::StateRole;
 
     fn start_lock_manager() -> LockManager {
-        let mut coprocessor_host = CoprocessorHost::default();
+        let mut coprocessor_host = CoprocessorHost::<KvTestEngine>::default();
 
         let mut lock_mgr = LockManager::new(false);
         let cfg = Config {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

More work on making tikv generic over engines.

https://github.com/tikv/tikv/issues/6402

### What is changed and how it works?

This replaces all uses of RocksEngine in tikv::server::lock_manager with either `impl KvEngine`, or, in test cases, KvTestEngine.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.