### PR TITLE
coprv2: enable tests for plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5254,6 +5254,7 @@ dependencies = [
  "engine_traits",
  "engine_traits_tests",
  "error_code",
+ "example_plugin",
  "fail",
  "file_system",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,6 +220,9 @@ test_util = { path = "components/test_util", default-features = false }
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 zipf = "6.1.0"
 
+[build-dependencies]
+example_plugin = { path = "components/test_coprocessor_plugin/example_plugin" }
+
 [patch.crates-io]
 # TODO: remove this when new raft-rs is published.
 raft = { git = "https://github.com/tikv/raft-rs", branch = "master", default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,22 @@ use std::env;
 use std::path::Path;
 
 fn main() {
+    locate_coprocessor_plugins(&["example-plugin"]);
+}
+
+/// Locates compiled coprocessor plugins and makes their paths available via environment variables.
+///
+/// This is a bit hacky, but can be removed as soon as RFC
+/// <https://rust-lang.github.io/rfcs/3028-cargo-binary-dependencies.html> is available.
+///
+/// Why do we need this?
+/// This is because we want to use some coprocessor tests during tests. We can't just add them as a
+/// `dev-dependency`, because of how the CI works. Thus, we want to include them in our tests with
+/// `include_bytes!()`. However, we don't really know where the artifacts are located, so we need to
+/// find them with this function and expose the locations via environment variables.
+///
+/// Coprocessor plugins need to be added as a `build-dependency` in `Cargo.toml` for TiKV.
+fn locate_coprocessor_plugins(plugin_names: &[&str]) {
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let build_dir = Path::new(&out_dir)
         .parent()
@@ -12,11 +28,26 @@ fn main() {
         .unwrap()
         .parent()
         .unwrap();
-    let plugin_path = build_dir.join("libexample_plugin.so");
 
-    println!("cargo:rerun-if-changed={}", plugin_path.display());
-    println!(
-        "cargo:rustc-env=CARGO_DYLIB_FILE_EXAMPLE_PLUGIN={}",
-        plugin_path.display()
-    );
+    for plugin_name in plugin_names {
+        let plugin_path = build_dir.join(pkgname_to_libname(plugin_name));
+        println!("cargo:rerun-if-changed={}", plugin_path.display());
+        println!(
+            "cargo:rustc-env=CARGO_DYLIB_FILE_EXAMPLE_PLUGIN={}",
+            plugin_path.display()
+        );
+    }
+}
+
+/// Converts a Rust `dylib` crate name to the platform specific library name for the compiled
+/// artifact.
+pub fn pkgname_to_libname(pkgname: &str) -> String {
+    let pkgname = pkgname.to_string().replace("-", "_");
+    if cfg!(target_os = "windows") {
+        format!("{}.dll", pkgname)
+    } else if cfg!(target_os = "macos") {
+        format!("lib{}.dylib", pkgname)
+    } else {
+        format!("lib{}.so", pkgname)
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,8 @@ fn main() {
         .parent()
         .unwrap();
     let plugin_path = build_dir.join("libexample_plugin.so");
+
+    println!("cargo:rerun-if-changed={}", plugin_path.display());
     println!(
         "cargo:rustc-env=CARGO_DYLIB_FILE_EXAMPLE_PLUGIN={}",
         plugin_path.display()

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let build_dir = Path::new(&out_dir)
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+    let plugin_path = build_dir.join("libexample_plugin.so");
+    println!(
+        "cargo:rustc-env=CARGO_DYLIB_FILE_EXAMPLE_PLUGIN={}",
+        plugin_path.display()
+    );
+}

--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,8 @@ fn locate_coprocessor_plugins(plugin_names: &[&str]) {
         let plugin_path = build_dir.join(pkgname_to_libname(plugin_name));
         println!("cargo:rerun-if-changed={}", plugin_path.display());
         println!(
-            "cargo:rustc-env=CARGO_DYLIB_FILE_EXAMPLE_PLUGIN={}",
+            "cargo:rustc-env=CARGO_DYLIB_FILE_{}={}",
+            plugin_name.to_string().replace("-", "_").to_uppercase(),
             plugin_path.display()
         );
     }

--- a/src/coprocessor_v2/plugin_registry.rs
+++ b/src/coprocessor_v2/plugin_registry.rs
@@ -547,6 +547,7 @@ mod tests {
 
         // trigger loading
         std::fs::copy(&original_library_path, &library_path).unwrap();
+        // fs watcher detects changes in every 3 seconds, therefore, wait 4 seconds so as to make sure the watcher is triggered.
         std::thread::sleep(Duration::from_secs(4));
 
         assert!(registry.get_plugin(plugin_name).is_some());
@@ -557,6 +558,7 @@ mod tests {
 
         // trigger rename
         std::fs::rename(&library_path, &library_path_2).unwrap();
+        // fs watcher detects changes in every 3 seconds, therefore, wait 4 seconds so as to make sure the watcher is triggered.
         std::thread::sleep(Duration::from_secs(4));
 
         assert!(registry.get_plugin(plugin_name).is_some());
@@ -567,6 +569,7 @@ mod tests {
 
         // trigger unloading
         std::fs::remove_file(&library_path_2).unwrap();
+        // fs watcher detects changes in every 3 seconds, therefore, wait 4 seconds so as to make sure the watcher is triggered.
         std::thread::sleep(Duration::from_secs(4));
 
         assert!(registry.get_plugin(plugin_name).is_none());

--- a/src/coprocessor_v2/plugin_registry.rs
+++ b/src/coprocessor_v2/plugin_registry.rs
@@ -450,7 +450,7 @@ mod tests {
     use std::sync::Once;
 
     static INIT: Once = Once::new();
-    static EXAMPLE_PLUGIN: &'static [u8] = include_bytes!(env!("CARGO_DYLIB_FILE_EXAMPLE_PLUGIN"));
+    static EXAMPLE_PLUGIN: &[u8] = include_bytes!(env!("CARGO_DYLIB_FILE_EXAMPLE_PLUGIN"));
 
     fn initialize_library() -> PathBuf {
         let lib_path = std::env::temp_dir().join(&pkgname_to_libname("example-plugin"));

--- a/src/coprocessor_v2/plugin_registry.rs
+++ b/src/coprocessor_v2/plugin_registry.rs
@@ -450,10 +450,7 @@ mod tests {
     use std::sync::Once;
 
     static INIT: Once = Once::new();
-
-    #[cfg(target_os = "linux")]
-    static EXAMPLE_PLUGIN: &'static [u8] =
-        include_bytes!("../../target/debug/libexample_plugin.so");
+    static EXAMPLE_PLUGIN: &'static [u8] = include_bytes!(env!("CARGO_DYLIB_FILE_EXAMPLE_PLUGIN"));
 
     fn initialize_library() -> PathBuf {
         let lib_path = std::env::temp_dir().join(&pkgname_to_libname("example-plugin"));


### PR DESCRIPTION
Signed-off-by: Andreas Zimmerer <andreas.zimmerer@tum.de>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: #9747  <!-- REMOVE this line if no issue to close -->

**[do not merge yet; PR currently only for experimenting with the CI]**

Problem Summary:

Previously, we commented out the tests because they always failed in CI. Why? Because they require `libexample_plugin.so`, which is being built by Cargo, but then not uploaded as an "artifact" for when the tests are executed.
We came to the conclusion, that we should somehow use `include_bytes!()` to include the library into the tests. This PR tries to fix this.

### What is changed and how it works?

Proposal: [RFC](https://github.com/tikv/rfcs/pull/63) <!-- REMOVE this line if not applicable -->

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

 * No release note