### PR TITLE
storage: Remove Mvcc from storage::Error

### DIFF
--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -7,7 +7,7 @@ use std::io::Error as IoError;
 
 use crate::storage::{
     kv::{self, Error as EngineError, ErrorInner as EngineErrorInner},
-    mvcc::{self, Error as MvccError, ErrorInner as MvccErrorInner},
+    mvcc::{Error as MvccError, ErrorInner as MvccErrorInner},
     txn::{self, Error as TxnError, ErrorInner as TxnErrorInner},
     Result,
 };
@@ -26,11 +26,6 @@ quick_error! {
             display("{}", err)
         }
         Txn(err: txn::Error) {
-            from()
-            cause(err)
-            display("{}", err)
-        }
-        Mvcc(err: mvcc::Error) {
             from()
             cause(err)
             display("{}", err)
@@ -107,7 +102,6 @@ impl ErrorCodeExt for Error {
         match self.0.as_ref() {
             ErrorInner::Engine(e) => e.error_code(),
             ErrorInner::Txn(e) => e.error_code(),
-            ErrorInner::Mvcc(e) => e.error_code(),
             ErrorInner::Closed => error_code::storage::CLOSED,
             ErrorInner::Other(_) => error_code::storage::UNKNOWN,
             ErrorInner::Io(_) => error_code::storage::IO,
@@ -250,7 +244,6 @@ pub fn extract_key_error(err: &Error) -> kvrpcpb::KeyError {
         | Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Engine(EngineError(
             box EngineErrorInner::KeyIsLocked(info),
         )))))
-        | Error(box ErrorInner::Mvcc(MvccError(box MvccErrorInner::KeyIsLocked(info))))
         | Error(box ErrorInner::Engine(EngineError(box EngineErrorInner::KeyIsLocked(info)))) => {
             key_error.set_locked(info.clone());
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -669,7 +669,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                                 .get(CMD)
                                 .locked
                                 .observe(begin_instant.elapsed().as_secs_f64());
-                            mvcc::Error::from(e)
+                            txn::Error::from_mvcc(e)
                         })?;
                     CHECK_MEM_LOCK_DURATION_HISTOGRAM_VEC
                         .get(CMD)
@@ -800,7 +800,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                                 .get(CMD)
                                 .locked
                                 .observe(begin_instant.elapsed().as_secs_f64());
-                            Err(mvcc::Error::from(mvcc::ErrorInner::KeyIsLocked(
+                            Err(txn::Error::from_mvcc(mvcc::ErrorInner::KeyIsLocked(
                                 lock.clone().into_lock_info(key.to_raw()?),
                             )))
                         } else {
@@ -1667,7 +1667,7 @@ fn prepare_snap_ctx<'a>(
                         .get(cmd)
                         .locked
                         .observe(begin_instant.elapsed().as_secs_f64());
-                    mvcc::Error::from(e)
+                    txn::Error::from_mvcc(e)
                 })?;
         }
         CHECK_MEM_LOCK_DURATION_HISTOGRAM_VEC

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -20,6 +20,7 @@ mod latch;
 mod store;
 
 use crate::storage::{
+    mvcc::Error as MvccError,
     types::{MvccInfo, PessimisticLockRes, PrewriteResult, SecondaryLocksStatus, TxnStatus},
     Error as StorageError, Result as StorageResult,
 };
@@ -186,6 +187,10 @@ pub struct Error(pub Box<ErrorInner>);
 impl Error {
     pub fn maybe_clone(&self) -> Option<Error> {
         self.0.maybe_clone().map(Error::from)
+    }
+    pub fn from_mvcc<T: Into<MvccError>>(err: T) -> Self {
+        let err = err.into();
+        Error::from(ErrorInner::Mvcc(err))
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
`storage::mvcc::Error` has been included in `storage::txn::Error::Mvcc`, it is not necessary to define it in storage::Error. And  as we all know, `MVCC` (Multi-Version Concurrency Control) is just one kind of transaction implement. Not all databases implement transaction with `MVCC`, so we shall not define a kind of error type in `storage::Error`.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- No release note.
