### PR TITLE
storage: optimize strategy of batch commands 

### DIFF
--- a/components/test_storage/src/assert_storage.rs
+++ b/components/test_storage/src/assert_storage.rs
@@ -239,7 +239,6 @@ impl<E: Engine> AssertionStorage<E> {
             .batch_get_command(self.ctx.clone(), &keys, ts)
             .unwrap()
             .into_iter()
-            .map(|(x, _, _)| x)
             .collect();
         let expect: Vec<Option<Vec<u8>>> = expect
             .into_iter()

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -11,8 +11,8 @@ use tikv::storage::config::Config;
 use tikv::storage::kv::RocksEngine;
 use tikv::storage::lock_manager::DummyLockManager;
 use tikv::storage::{
-    txn::commands, Engine, PerfStatisticsDelta, PrewriteResult, Result, Statistics, Storage,
-    TestEngineBuilder, TestStorageBuilder, TxnStatus,
+    test_util::GetProcessor, txn::commands, Engine, PerfStatisticsDelta, PrewriteResult, Result,
+    Statistics, Storage, TestEngineBuilder, TestStorageBuilder, TxnStatus,
 };
 use txn_types::{Key, KvPair, Mutation, TimeStamp, Value};
 
@@ -127,7 +127,8 @@ impl<E: Engine> SyncTestStorage<E> {
         ctx: Context,
         keys: &[&[u8]],
         start_ts: u64,
-    ) -> Result<Vec<(Option<Vec<u8>>, Statistics, PerfStatisticsDelta)>> {
+    ) -> Result<Vec<Option<Vec<u8>>>> {
+        let mut ids = vec![];
         let requests: Vec<GetRequest> = keys
             .to_owned()
             .into_iter()
@@ -136,13 +137,14 @@ impl<E: Engine> SyncTestStorage<E> {
                 req.set_context(ctx.clone());
                 req.set_key(key.to_owned());
                 req.set_version(start_ts);
+                ids.push(ids.len() as u64);
                 req
             })
             .collect();
-        let resp = block_on(self.store.batch_get_command(requests))?;
+        let p = GetProcessor::new();
+        block_on(self.store.batch_get_command(requests, ids, p.clone()))?;
         let mut values = vec![];
-
-        for value in resp.into_iter() {
+        for value in p.take_data().into_iter() {
             values.push(value?);
         }
         Ok(values)

--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -11,7 +11,7 @@ use tikv::storage::config::Config;
 use tikv::storage::kv::RocksEngine;
 use tikv::storage::lock_manager::DummyLockManager;
 use tikv::storage::{
-    test_util::GetProcessor, txn::commands, Engine, PerfStatisticsDelta, PrewriteResult, Result,
+    test_util::GetConsumer, txn::commands, Engine, PerfStatisticsDelta, PrewriteResult, Result,
     Statistics, Storage, TestEngineBuilder, TestStorageBuilder, TxnStatus,
 };
 use txn_types::{Key, KvPair, Mutation, TimeStamp, Value};
@@ -141,7 +141,7 @@ impl<E: Engine> SyncTestStorage<E> {
                 req
             })
             .collect();
-        let p = GetProcessor::new();
+        let p = GetConsumer::new();
         block_on(self.store.batch_get_command(requests, ids, p.clone()))?;
         let mut values = vec![];
         for value in p.take_data().into_iter() {

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -4008,6 +4008,20 @@
               "intervalFactor": 2,
               "legendFormat": "avg response",
               "refId": "D"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(tikv_server_request_batch_size_bucket{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "99% kv get batch",
+              "refId": "E"
+            },
+            {
+              "expr": "sum(rate(tikv_server_request_batch_size_sum{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) / sum(rate(tikv_server_request_batch_size_count{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "avg kv batch",
+              "refId": "F"
             }
           ],
           "thresholds": [],

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -25,6 +25,7 @@ pub enum ReadPool {
         pool: yatp::ThreadPool<TaskCell>,
         running_tasks: IntGauge,
         max_tasks: usize,
+        pool_size: usize,
     },
 }
 
@@ -44,10 +45,12 @@ impl ReadPool {
                 pool,
                 running_tasks,
                 max_tasks,
+                pool_size,
             } => ReadPoolHandle::Yatp {
                 remote: pool.remote().clone(),
                 running_tasks: running_tasks.clone(),
                 max_tasks: *max_tasks,
+                pool_size: *pool_size,
             },
         }
     }
@@ -64,6 +67,7 @@ pub enum ReadPoolHandle {
         remote: Remote<TaskCell>,
         running_tasks: IntGauge,
         max_tasks: usize,
+        pool_size: usize,
     },
 }
 
@@ -90,6 +94,7 @@ impl ReadPoolHandle {
                 remote,
                 running_tasks,
                 max_tasks,
+                ..
             } => {
                 let running_tasks = running_tasks.clone();
                 // Note that the running task number limit is not strict.
@@ -100,6 +105,7 @@ impl ReadPoolHandle {
                     return Err(ReadPoolError::UnifiedReadPoolFull);
                 }
 
+                running_tasks.inc();
                 let fixed_level = match priority {
                     CommandPri::High => Some(0),
                     CommandPri::Normal => None,
@@ -108,7 +114,6 @@ impl ReadPoolHandle {
                 let extras = Extras::new_multilevel(task_id, fixed_level);
                 let task_cell = TaskCell::new(
                     async move {
-                        running_tasks.inc();
                         f.await;
                         running_tasks.dec();
                     },
@@ -142,6 +147,31 @@ impl ReadPoolHandle {
         async move {
             res?;
             rx.map_err(ReadPoolError::from).await
+        }
+    }
+
+    pub fn get_normal_pool_size(&self) -> usize {
+        match self {
+            ReadPoolHandle::FuturePools {
+                read_pool_normal, ..
+            } => read_pool_normal.get_pool_size(),
+            ReadPoolHandle::Yatp { pool_size, .. } => *pool_size,
+        }
+    }
+
+    pub fn get_queue_size_per_worker(&self) -> usize {
+        match self {
+            ReadPoolHandle::FuturePools {
+                read_pool_normal, ..
+            } => {
+                read_pool_normal.get_running_task_count() as usize
+                    / read_pool_normal.get_pool_size()
+            }
+            ReadPoolHandle::Yatp {
+                running_tasks,
+                pool_size,
+                ..
+            } => running_tasks.get() as usize / *pool_size,
         }
     }
 }
@@ -208,6 +238,7 @@ pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(
         max_tasks: config
             .max_tasks_per_worker
             .saturating_mul(config.max_thread_count),
+        pool_size: config.max_thread_count,
     }
 }
 

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -398,7 +398,7 @@ lazy_static! {
             "tikv_server_request_batch_size",
             "Size of request batch input",
             &["type"],
-            exponential_buckets(1f64, 5f64, 10).unwrap()
+            vec![1.0, 2.0, 4.0, 8.0, 12.0, 16.0, 20.0, 24.0, 28.0, 32.0, 64.0]
         )
         .unwrap();
     pub static ref REQUEST_BATCH_RATIO_HISTOGRAM_VEC: RequestBatchRatioHistogramVec =

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -162,9 +162,8 @@ make_static_metric! {
     }
 
     pub label_enum BatchableRequestKind {
-        point_get,
-        prewrite,
-        commit,
+        kv_get,
+        raw_get,
     }
 
     pub struct GrpcMsgHistogramGlobal: Histogram {
@@ -399,15 +398,6 @@ lazy_static! {
             "Size of request batch input",
             &["type"],
             vec![1.0, 2.0, 4.0, 8.0, 12.0, 16.0, 20.0, 24.0, 28.0, 32.0, 64.0]
-        )
-        .unwrap();
-    pub static ref REQUEST_BATCH_RATIO_HISTOGRAM_VEC: RequestBatchRatioHistogramVec =
-        register_static_histogram_vec!(
-            RequestBatchRatioHistogramVec,
-            "tikv_server_request_batch_ratio",
-            "Ratio of request batch output to input",
-            &["type"],
-            exponential_buckets(1f64, 5f64, 10).unwrap()
         )
         .unwrap();
     pub static ref CPU_CORES_QUOTA_GAUGE: Gauge = register_gauge!(

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -65,7 +65,6 @@ pub struct Server<T: RaftStoreRouter<RocksEngine> + 'static, S: StoreAddrResolve
     stats_pool: Option<Runtime>,
     grpc_thread_load: Arc<ThreadLoad>,
     yatp_read_pool: Option<ReadPool>,
-    readpool_normal_thread_load: Arc<ThreadLoad>,
     debug_thread_pool: Arc<Runtime>,
     health_service: HealthService,
     timer: Handle,
@@ -100,8 +99,6 @@ impl<T: RaftStoreRouter<RocksEngine> + Unpin, S: StoreAddrResolver + 'static> Se
             None
         };
         let grpc_thread_load = Arc::new(ThreadLoad::with_threshold(cfg.heavy_load_threshold));
-        let readpool_normal_thread_load =
-            Arc::new(ThreadLoad::with_threshold(cfg.heavy_load_threshold));
 
         let snap_worker = Worker::new("snap-handler");
         let lazy_worker = snap_worker.lazy_build("snap-handler");
@@ -114,7 +111,6 @@ impl<T: RaftStoreRouter<RocksEngine> + Unpin, S: StoreAddrResolver + 'static> Se
             raft_router.clone(),
             lazy_worker.scheduler(),
             Arc::clone(&grpc_thread_load),
-            Arc::clone(&readpool_normal_thread_load),
             cfg.enable_request_batch,
             proxy,
         );
@@ -167,7 +163,6 @@ impl<T: RaftStoreRouter<RocksEngine> + Unpin, S: StoreAddrResolver + 'static> Se
             stats_pool,
             grpc_thread_load,
             yatp_read_pool,
-            readpool_normal_thread_load,
             debug_thread_pool,
             health_service,
             timer: GLOBAL_TIMER_HANDLE.clone(),
@@ -237,10 +232,6 @@ impl<T: RaftStoreRouter<RocksEngine> + Unpin, S: StoreAddrResolver + 'static> Se
             let tl = Arc::clone(&self.grpc_thread_load);
             ThreadLoadStatistics::new(LOAD_STATISTICS_SLOTS, GRPC_THREAD_PREFIX, tl)
         };
-        let mut readpool_normal_load_stats = {
-            let tl = Arc::clone(&self.readpool_normal_thread_load);
-            ThreadLoadStatistics::new(LOAD_STATISTICS_SLOTS, READPOOL_NORMAL_THREAD_PREFIX, tl)
-        };
         let mut delay = self
             .timer
             .interval(Instant::now(), LOAD_STATISTICS_INTERVAL)
@@ -249,7 +240,6 @@ impl<T: RaftStoreRouter<RocksEngine> + Unpin, S: StoreAddrResolver + 'static> Se
             p.spawn(async move {
                 while let Some(Ok(i)) = delay.next().await {
                     grpc_load_stats.record(i);
-                    readpool_normal_load_stats.record(i);
                 }
             });
         };

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -1,32 +1,41 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::server::metrics::GRPC_MSG_HISTOGRAM_STATIC;
+use crate::server::metrics::REQUEST_BATCH_SIZE_HISTOGRAM_VEC;
 use crate::server::service::kv::batch_commands_response;
+use crate::storage::kv::{PerfStatisticsDelta, Statistics};
 use crate::storage::{
     errors::{extract_key_error, extract_region_error},
     kv::Engine,
     lock_manager::LockManager,
     Storage,
 };
+use crate::storage::{ResponseBatchConsumer, Result};
 use kvproto::kvrpcpb::*;
 use tikv_util::future::poll_future_notify;
 use tikv_util::mpsc::batch::Sender;
-use tikv_util::time::{duration_to_sec, Instant};
+
+pub const MAX_BATCH_GET_REQUEST_COUNT: usize = 10;
+pub const MIN_BATCH_GET_REQUEST_COUNT: usize = 4;
+pub const MAX_QUEUE_SIZE_PER_WORKER: usize = 16;
 
 pub struct ReqBatcher {
     gets: Vec<GetRequest>,
     raw_gets: Vec<RawGetRequest>,
     get_ids: Vec<u64>,
     raw_get_ids: Vec<u64>,
+    queue_size: usize,
 }
 
 impl ReqBatcher {
-    pub fn new() -> ReqBatcher {
+    pub fn new(mut queue_size: usize) -> ReqBatcher {
+        queue_size = std::cmp::min(queue_size, MAX_BATCH_GET_REQUEST_COUNT);
         ReqBatcher {
             gets: vec![],
             raw_gets: vec![],
             get_ids: vec![],
             raw_get_ids: vec![],
+            queue_size,
         }
     }
 
@@ -53,14 +62,15 @@ impl ReqBatcher {
         storage: &Storage<E, L>,
         tx: &Sender<(u64, batch_commands_response::Response)>,
     ) {
-        if self.gets.len() > 10 {
-            let gets = std::mem::replace(&mut self.gets, vec![]);
-            let ids = std::mem::replace(&mut self.get_ids, vec![]);
+        if self.gets.len() >= self.queue_size {
+            let gets = std::mem::take(&mut self.gets);
+            let ids = std::mem::take(&mut self.get_ids);
             future_batch_get_command(storage, ids, gets, tx.clone());
         }
-        if self.raw_gets.len() > 16 {
-            let gets = std::mem::replace(&mut self.raw_gets, vec![]);
-            let ids = std::mem::replace(&mut self.raw_get_ids, vec![]);
+
+        if self.raw_gets.len() >= self.queue_size {
+            let gets = std::mem::take(&mut self.raw_gets);
+            let ids = std::mem::take(&mut self.raw_get_ids);
             future_batch_raw_get_command(storage, ids, gets, tx.clone());
         }
     }
@@ -83,60 +93,124 @@ impl ReqBatcher {
     }
 }
 
+pub struct BatcherBuilder {
+    pool_size: usize,
+    enable_batch: bool,
+}
+
+impl BatcherBuilder {
+    pub fn new(enable_batch: bool, pool_size: usize) -> Self {
+        BatcherBuilder {
+            enable_batch,
+            pool_size,
+        }
+    }
+    pub fn build(&self, queue_per_worker: usize, req_batch_size: usize) -> Option<ReqBatcher> {
+        if !self.enable_batch {
+            return None;
+        }
+        if req_batch_size >= MIN_BATCH_GET_REQUEST_COUNT
+            && queue_per_worker >= MAX_QUEUE_SIZE_PER_WORKER
+        {
+            return Some(ReqBatcher::new(req_batch_size));
+        }
+        if req_batch_size > self.pool_size * MIN_BATCH_GET_REQUEST_COUNT
+            && queue_per_worker >= MIN_BATCH_GET_REQUEST_COUNT
+        {
+            return Some(ReqBatcher::new(req_batch_size / self.pool_size));
+        }
+        None
+    }
+}
+
+pub struct GetCommandResponseConsumer {
+    tx: Sender<(u64, batch_commands_response::Response)>,
+}
+
+impl ResponseBatchConsumer<(Option<Vec<u8>>, Statistics, PerfStatisticsDelta)>
+    for GetCommandResponseConsumer
+{
+    fn consume(&self, id: u64, res: Result<(Option<Vec<u8>>, Statistics, PerfStatisticsDelta)>) {
+        let mut resp = GetResponse::default();
+        if let Some(err) = extract_region_error(&res) {
+            resp.set_region_error(err);
+        } else {
+            match res {
+                Ok((val, statistics, perf_statistics_delta)) => {
+                    let scan_detail_v2 = resp.mut_exec_details_v2().mut_scan_detail_v2();
+                    statistics.write_scan_detail(scan_detail_v2);
+                    perf_statistics_delta.write_scan_detail(scan_detail_v2);
+                    match val {
+                        Some(val) => resp.set_value(val),
+                        None => resp.set_not_found(true),
+                    }
+                }
+                Err(e) => resp.set_error(extract_key_error(&e)),
+            }
+        }
+
+        let res = batch_commands_response::Response {
+            cmd: Some(batch_commands_response::response::Cmd::Get(resp)),
+            ..Default::default()
+        };
+        if self.tx.send_and_notify((id, res)).is_err() {
+            error!("KvService response batch commands fail");
+        }
+    }
+}
+
+impl ResponseBatchConsumer<Option<Vec<u8>>> for GetCommandResponseConsumer {
+    fn consume(&self, id: u64, res: Result<Option<Vec<u8>>>) {
+        let mut resp = RawGetResponse::default();
+        if let Some(err) = extract_region_error(&res) {
+            resp.set_region_error(err);
+        } else {
+            match res {
+                Ok(Some(val)) => resp.set_value(val),
+                Ok(None) => resp.set_not_found(true),
+                Err(e) => resp.set_error(format!("{}", e)),
+            }
+        }
+        let res = batch_commands_response::Response {
+            cmd: Some(batch_commands_response::response::Cmd::RawGet(resp)),
+            ..Default::default()
+        };
+        if self.tx.send_and_notify((id, res)).is_err() {
+            error!("KvService response batch commands fail");
+        }
+    }
+}
+
 fn future_batch_get_command<E: Engine, L: LockManager>(
     storage: &Storage<E, L>,
     requests: Vec<u64>,
     gets: Vec<GetRequest>,
     tx: Sender<(u64, batch_commands_response::Response)>,
 ) {
-    let begin_instant = Instant::now_coarse();
-    let ret = storage.batch_get_command(gets);
+    // let begin_instant = Instant::now_coarse();
+    REQUEST_BATCH_SIZE_HISTOGRAM_VEC
+        .point_get
+        .observe(gets.len() as f64);
+    let begin_instant = tikv_util::time::Instant::now_coarse();
+    let ids = requests.clone();
+    let res = storage.batch_get_command(
+        gets,
+        requests,
+        GetCommandResponseConsumer { tx: tx.clone() },
+    );
     let f = async move {
-        match ret.await {
-            Ok(ret) => {
-                for (v, req) in ret.into_iter().zip(requests) {
-                    let mut resp = GetResponse::default();
-                    if let Some(err) = extract_region_error(&v) {
-                        resp.set_region_error(err);
-                    } else {
-                        match v {
-                            Ok((val, statistics, perf_statistics_delta)) => {
-                                let scan_detail_v2 =
-                                    resp.mut_exec_details_v2().mut_scan_detail_v2();
-                                statistics.write_scan_detail(scan_detail_v2);
-                                perf_statistics_delta.write_scan_detail(scan_detail_v2);
-                                match val {
-                                    Some(val) => resp.set_value(val),
-                                    None => resp.set_not_found(true),
-                                }
-                            }
-                            Err(e) => resp.set_error(extract_key_error(&e)),
-                        }
-                    }
-                    let res = batch_commands_response::Response {
-                        cmd: Some(batch_commands_response::response::Cmd::Get(resp)),
-                        ..Default::default()
-                    };
-                    if tx.send_and_notify((req, res)).is_err() {
-                        error!("KvService response batch commands fail");
-                    }
-                }
-            }
-            e => {
-                let mut resp = GetResponse::default();
-                if let Some(err) = extract_region_error(&e) {
-                    resp.set_region_error(err);
-                } else if let Err(e) = e {
-                    resp.set_error(extract_key_error(&e));
-                }
+        // This error can only cause by readpool busy.
+        let res = res.await;
+        if let Some(e) = extract_region_error(&res) {
+            let mut resp = GetResponse::default();
+            resp.set_region_error(e);
+            for id in ids {
                 let res = batch_commands_response::Response {
-                    cmd: Some(batch_commands_response::response::Cmd::Get(resp)),
+                    cmd: Some(batch_commands_response::response::Cmd::Get(resp.clone())),
                     ..Default::default()
                 };
-                for req in requests {
-                    if tx.send_and_notify((req, res.clone())).is_err() {
-                        error!("KvService response batch commands fail");
-                    }
+                if tx.send_and_notify((id, res)).is_err() {
+                    error!("KvService response batch commands fail");
                 }
             }
         }
@@ -153,55 +227,32 @@ fn future_batch_raw_get_command<E: Engine, L: LockManager>(
     gets: Vec<RawGetRequest>,
     tx: Sender<(u64, batch_commands_response::Response)>,
 ) {
-    let begin_instant = Instant::now_coarse();
-    let ret = storage.raw_batch_get_command(gets);
+    let ids = requests.clone();
+    let begin_instant = tikv_util::time::Instant::now_coarse();
+    let res = storage.raw_batch_get_command(
+        gets,
+        requests,
+        GetCommandResponseConsumer { tx: tx.clone() },
+    );
     let f = async move {
-        match ret.await {
-            Ok(v) => {
-                if requests.len() != v.len() {
-                    error!("KvService batch response size mismatch");
-                }
-                for (req, v) in requests.into_iter().zip(v.into_iter()) {
-                    let mut resp = RawGetResponse::default();
-                    if let Some(err) = extract_region_error(&v) {
-                        resp.set_region_error(err);
-                    } else {
-                        match v {
-                            Ok(Some(val)) => resp.set_value(val),
-                            Ok(None) => resp.set_not_found(true),
-                            Err(e) => resp.set_error(format!("{}", e)),
-                        }
-                    }
-                    let res = batch_commands_response::Response {
-                        cmd: Some(batch_commands_response::response::Cmd::RawGet(resp)),
-                        ..Default::default()
-                    };
-                    if tx.send_and_notify((req, res)).is_err() {
-                        error!("KvService response batch commands fail");
-                    }
-                }
-            }
-            e => {
-                let mut resp = RawGetResponse::default();
-                if let Some(err) = extract_region_error(&e) {
-                    resp.set_region_error(err);
-                } else if let Err(e) = e {
-                    resp.set_error(format!("{}", e));
-                }
+        // This error can only cause by readpool busy.
+        let res = res.await;
+        if let Some(e) = extract_region_error(&res) {
+            let mut resp = RawGetResponse::default();
+            resp.set_region_error(e);
+            for id in ids {
                 let res = batch_commands_response::Response {
-                    cmd: Some(batch_commands_response::response::Cmd::RawGet(resp)),
+                    cmd: Some(batch_commands_response::response::Cmd::RawGet(resp.clone())),
                     ..Default::default()
                 };
-                for req in requests {
-                    if tx.send_and_notify((req, res.clone())).is_err() {
-                        error!("KvService response batch commands fail");
-                    }
+                if tx.send_and_notify((id, res)).is_err() {
+                    error!("KvService response batch commands fail");
                 }
             }
         }
         GRPC_MSG_HISTOGRAM_STATIC
             .raw_batch_get_command
-            .observe(duration_to_sec(begin_instant.elapsed()));
+            .observe(begin_instant.elapsed_secs());
     };
     poll_future_notify(f);
 }

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -874,7 +874,7 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
                     batch.maybe_commit(&storage, &tx);
                 }
             }
-            if let Some(mut batch) = batcher {
+            if let Some(batch) = batcher {
                 batch.commit(&storage, &tx);
             }
             future::ok(())

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 use tikv_util::time::{duration_to_sec, Instant};
 
-use super::batch::ReqBatcher;
+use super::batch::{BatcherBuilder, ReqBatcher};
 use crate::coprocessor::Endpoint;
 use crate::server::gc_worker::GcWorker;
 use crate::server::load_statistics::ThreadLoad;
@@ -67,8 +67,6 @@ pub struct Service<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: Lock
 
     grpc_thread_load: Arc<ThreadLoad>,
 
-    readpool_normal_thread_load: Arc<ThreadLoad>,
-
     proxy: Proxy,
 }
 
@@ -87,7 +85,6 @@ impl<
             snap_scheduler: self.snap_scheduler.clone(),
             enable_req_batch: self.enable_req_batch,
             grpc_thread_load: self.grpc_thread_load.clone(),
-            readpool_normal_thread_load: self.readpool_normal_thread_load.clone(),
             proxy: self.proxy.clone(),
         }
     }
@@ -102,7 +99,6 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Servi
         ch: T,
         snap_scheduler: Scheduler<SnapTask>,
         grpc_thread_load: Arc<ThreadLoad>,
-        readpool_normal_thread_load: Arc<ThreadLoad>,
         enable_req_batch: bool,
         proxy: Proxy,
     ) -> Self {
@@ -113,7 +109,6 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Servi
             ch,
             snap_scheduler,
             grpc_thread_load,
-            readpool_normal_thread_load,
             enable_req_batch,
             proxy,
         }
@@ -865,22 +860,22 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
         let peer = ctx.peer();
         let storage = self.storage.clone();
         let cop = self.cop.clone();
-        let enable_req_batch = self.enable_req_batch;
+        let pool_size = storage.get_normal_pool_size();
+        let batch_builder = BatcherBuilder::new(self.enable_req_batch, pool_size);
         let request_handler = stream.try_for_each(move |mut req| {
             let request_ids = req.take_request_ids();
             let requests: Vec<_> = req.take_requests().into();
-            let mut batcher = if enable_req_batch && requests.len() > 2 {
-                Some(ReqBatcher::new())
-            } else {
-                None
-            };
+            let queue = storage.get_readpool_queue_per_worker();
+            let mut batcher = batch_builder.build(queue, request_ids.len());
             GRPC_REQ_BATCH_COMMANDS_SIZE.observe(requests.len() as f64);
             for (id, req) in request_ids.into_iter().zip(requests) {
                 handle_batch_commands_request(&mut batcher, &storage, &cop, &peer, id, req, &tx);
+                if let Some(batch) = batcher.as_mut() {
+                    batch.maybe_commit(&storage, &tx);
+                }
             }
             if let Some(mut batch) = batcher {
                 batch.commit(&storage, &tx);
-                storage.release_snapshot();
             }
             future::ok(())
         });
@@ -1038,7 +1033,7 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
     }
 }
 
-fn response_batch_commands_request<F>(
+pub fn response_batch_commands_request<F>(
     id: u64,
     resp: F,
     tx: Sender<(u64, batch_commands_response::Response)>,
@@ -1091,7 +1086,6 @@ fn handle_batch_commands_request<E: Engine, L: LockManager>(
                 },
                 Some(batch_commands_request::request::Cmd::Get(req)) => {
                     if batcher.as_mut().map_or(false, |req_batch| {
-                        req_batch.maybe_commit(storage, tx);
                         req_batch.can_batch_get(&req)
                     }) {
                         batcher.as_mut().unwrap().add_get_request(req, id);
@@ -1105,7 +1099,6 @@ fn handle_batch_commands_request<E: Engine, L: LockManager>(
                 },
                 Some(batch_commands_request::request::Cmd::RawGet(req)) => {
                     if batcher.as_mut().map_or(false, |req_batch| {
-                        req_batch.maybe_commit(storage, tx);
                         req_batch.can_batch_raw_get(&req)
                     }) {
                         batcher.as_mut().unwrap().add_raw_get_request(req, id);
@@ -1185,7 +1178,7 @@ async fn future_handle_empty(
     }
 }
 
-fn future_get<E: Engine, L: LockManager>(
+pub fn future_get<E: Engine, L: LockManager>(
     storage: &Storage<E, L>,
     mut req: GetRequest,
 ) -> impl Future<Output = ServerResult<GetResponse>> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -247,6 +247,14 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
         self.engine.release_snapshot();
     }
 
+    pub fn get_readpool_queue_per_worker(&self) -> usize {
+        self.read_pool.get_queue_size_per_worker()
+    }
+
+    pub fn get_normal_pool_size(&self) -> usize {
+        self.read_pool.get_normal_pool_size()
+    }
+
     #[inline]
     fn with_tls_engine<F, R>(f: F) -> R
     where
@@ -382,123 +390,128 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
     /// Get values of a set of keys with separate context from a snapshot, return a list of `Result`s.
     ///
     /// Only writes that are committed before their respective `start_ts` are visible.
-    pub fn batch_get_command(
+    pub fn batch_get_command<
+        P: 'static + ResponseBatchConsumer<(Option<Vec<u8>>, Statistics, PerfStatisticsDelta)>,
+    >(
         &self,
         requests: Vec<GetRequest>,
-    ) -> impl Future<Output = Result<Vec<Result<(Option<Vec<u8>>, Statistics, PerfStatisticsDelta)>>>>
-    {
+        ids: Vec<u64>,
+        consumer: P,
+    ) -> impl Future<Output = Result<()>> {
         const CMD: CommandKind = CommandKind::batch_get_command;
         // all requests in a batch have the same region, epoch, term, replica_read
         let priority = requests[0].get_context().get_priority();
         let concurrency_manager = self.concurrency_manager.clone();
-        let res =
-            self.read_pool.spawn_handle(
-                async move {
-                    KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
-                    KV_COMMAND_KEYREAD_HISTOGRAM_STATIC
-                        .get(CMD)
-                        .observe(requests.len() as f64);
-                    let command_duration = tikv_util::time::Instant::now_coarse();
-                    let read_id = Some(ThreadReadId::new());
-                    let mut statistics = Statistics::default();
-                    let mut results = Vec::default();
-                    let mut req_snaps = vec![];
+        let res = self.read_pool.spawn_handle(
+            async move {
+                KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
+                KV_COMMAND_KEYREAD_HISTOGRAM_STATIC
+                    .get(CMD)
+                    .observe(requests.len() as f64);
+                let command_duration = tikv_util::time::Instant::now_coarse();
+                let read_id = Some(ThreadReadId::new());
+                let mut statistics = Statistics::default();
+                let mut req_snaps = vec![];
 
-                    for mut req in requests {
-                        let region_id = req.get_context().get_region_id();
-                        let peer = req.get_context().get_peer();
-                        tls_collect_qps(region_id, peer, &req.get_key(), &req.get_key(), false);
-                        let key = Key::from_raw(req.get_key());
-                        let start_ts = req.get_version().into();
-                        let mut ctx = req.take_context();
-                        let isolation_level = ctx.get_isolation_level();
-                        let fill_cache = !ctx.get_not_fill_cache();
-                        let bypass_locks = TsSet::vec_from_u64s(ctx.take_resolved_locks());
-                        let region_id = ctx.get_region_id();
+                for (mut req, id) in requests.into_iter().zip(ids) {
+                    let region_id = req.get_context().get_region_id();
+                    let peer = req.get_context().get_peer();
+                    tls_collect_qps(region_id, peer, &req.get_key(), &req.get_key(), false);
+                    let key = Key::from_raw(req.get_key());
+                    let start_ts = req.get_version().into();
+                    let mut ctx = req.take_context();
+                    let isolation_level = ctx.get_isolation_level();
+                    let fill_cache = !ctx.get_not_fill_cache();
+                    let bypass_locks = TsSet::vec_from_u64s(ctx.take_resolved_locks());
+                    let region_id = ctx.get_region_id();
 
-                        let snap_ctx = match prepare_snap_ctx(
-                            &ctx,
-                            iter::once(&key),
-                            start_ts,
-                            &bypass_locks,
-                            &concurrency_manager,
-                            CMD,
-                        ) {
-                            Ok(mut snap_ctx) => {
-                                snap_ctx.read_id = read_id.clone();
-                                snap_ctx
-                            }
-                            Err(e) => {
-                                req_snaps.push(Err(e));
-                                continue;
-                            }
-                        };
+                    let snap_ctx = match prepare_snap_ctx(
+                        &ctx,
+                        iter::once(&key),
+                        start_ts,
+                        &bypass_locks,
+                        &concurrency_manager,
+                        CMD,
+                    ) {
+                        Ok(mut snap_ctx) => {
+                            snap_ctx.read_id = if ctx.get_stale_read() {
+                                None
+                            } else {
+                                read_id.clone()
+                            };
+                            snap_ctx
+                        }
+                        Err(e) => {
+                            consumer.consume(id, Err(e));
+                            continue;
+                        }
+                    };
 
-                        let snap = Self::with_tls_engine(|engine| Self::snapshot(engine, snap_ctx));
-                        req_snaps.push(Ok((
-                            snap,
-                            key,
-                            start_ts,
-                            isolation_level,
-                            fill_cache,
-                            bypass_locks,
-                            region_id,
-                        )));
-                    }
-                    Self::with_tls_engine(|engine| engine.release_snapshot());
-                    for req_snap in req_snaps {
-                        let (
-                            snap,
-                            key,
-                            start_ts,
-                            isolation_level,
-                            fill_cache,
-                            bypass_locks,
-                            region_id,
-                        ) = match req_snap {
-                            Ok(req_snap) => req_snap,
-                            Err(e) => {
-                                results.push(Err(e));
-                                continue;
-                            }
-                        };
-                        match snap.await {
-                            Ok(snapshot) => {
-                                match PointGetterBuilder::new(snapshot, start_ts)
-                                    .fill_cache(fill_cache)
-                                    .isolation_level(isolation_level)
-                                    .multi(false)
-                                    .bypass_locks(bypass_locks)
-                                    .build()
-                                {
-                                    Ok(mut point_getter) => {
-                                        let perf_statistics = PerfStatisticsInstant::new();
-                                        let v = point_getter.get(&key);
-                                        let stat = point_getter.take_statistics();
-                                        metrics::tls_collect_read_flow(region_id, &stat);
-                                        statistics.add(&stat);
-                                        results.push(
-                                            v.map_err(|e| Error::from(txn::Error::from(e)))
-                                                .map(|v| (v, stat, perf_statistics.delta())),
-                                        );
-                                    }
-                                    Err(e) => results.push(Err(Error::from(txn::Error::from(e)))),
+                    let snap = Self::with_tls_engine(|engine| Self::snapshot(engine, snap_ctx));
+                    req_snaps.push((
+                        snap,
+                        key,
+                        start_ts,
+                        isolation_level,
+                        fill_cache,
+                        bypass_locks,
+                        region_id,
+                        id,
+                    ));
+                }
+                Self::with_tls_engine(|engine| engine.release_snapshot());
+                for req_snap in req_snaps {
+                    let (
+                        snap,
+                        key,
+                        start_ts,
+                        isolation_level,
+                        fill_cache,
+                        bypass_locks,
+                        region_id,
+                        id,
+                    ) = req_snap;
+                    match snap.await {
+                        Ok(snapshot) => {
+                            match PointGetterBuilder::new(snapshot, start_ts)
+                                .fill_cache(fill_cache)
+                                .isolation_level(isolation_level)
+                                .multi(false)
+                                .bypass_locks(bypass_locks)
+                                .build()
+                            {
+                                Ok(mut point_getter) => {
+                                    let perf_statistics = PerfStatisticsInstant::new();
+                                    let v = point_getter.get(&key);
+                                    let stat = point_getter.take_statistics();
+                                    metrics::tls_collect_read_flow(region_id, &stat);
+                                    statistics.add(&stat);
+                                    consumer.consume(
+                                        id,
+                                        v.map_err(|e| Error::from(txn::Error::from(e)))
+                                            .map(|v| (v, stat, perf_statistics.delta())),
+                                    );
+                                }
+                                Err(e) => {
+                                    consumer.consume(id, Err(Error::from(txn::Error::from(e))));
                                 }
                             }
-                            Err(e) => {
-                                results.push(Err(e));
-                            }
+                        }
+                        Err(e) => {
+                            consumer.consume(id, Err(e));
                         }
                     }
-                    metrics::tls_collect_scan_details(CMD, &statistics);
-                    SCHED_HISTOGRAM_VEC_STATIC
-                        .get(CMD)
-                        .observe(command_duration.elapsed_secs());
-                    Ok(results)
-                },
-                priority,
-                thread_rng().next_u64(),
-            );
+                }
+                metrics::tls_collect_scan_details(CMD, &statistics);
+                SCHED_HISTOGRAM_VEC_STATIC
+                    .get(CMD)
+                    .observe(command_duration.elapsed_secs());
+
+                Ok(())
+            },
+            priority,
+            thread_rng().next_u64(),
+        );
         async move {
             res.map_err(|_| Error::from(ErrorInner::SchedTooBusy))
                 .await?
@@ -1001,10 +1014,12 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
     }
 
     /// Get the values of a set of raw keys, return a list of `Result`s.
-    pub fn raw_batch_get_command(
+    pub fn raw_batch_get_command<P: 'static + ResponseBatchConsumer<Option<Vec<u8>>>>(
         &self,
         gets: Vec<RawGetRequest>,
-    ) -> impl Future<Output = Result<Vec<Result<Option<Vec<u8>>>>>> {
+        ids: Vec<u64>,
+        consumer: P,
+    ) -> impl Future<Output = Result<()>> {
         const CMD: CommandKind = CommandKind::raw_batch_get_command;
         // all requests in a batch have the same region, epoch, term, replica_read
         let priority = gets[0].get_context().get_priority();
@@ -1028,20 +1043,19 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                     .observe(gets.len() as f64);
                 let command_duration = tikv_util::time::Instant::now_coarse();
                 let read_id = Some(ThreadReadId::new());
-                let mut results = Vec::default();
                 let mut snaps = vec![];
-                for req in gets {
+                for (req, id) in gets.into_iter().zip(ids) {
                     let snap_ctx = SnapContext {
                         pb_ctx: req.get_context(),
                         read_id: read_id.clone(),
                         ..Default::default()
                     };
                     let snap = Self::with_tls_engine(|engine| Self::snapshot(engine, snap_ctx));
-                    snaps.push((req, snap));
+                    snaps.push((id, req, snap));
                 }
                 Self::with_tls_engine(|engine| engine.release_snapshot());
                 let begin_instant = Instant::now_coarse();
-                for (mut req, snap) in snaps {
+                for (id, mut req, snap) in snaps {
                     let ctx = req.take_context();
                     let cf = req.take_cf();
                     let key = req.take_key();
@@ -1049,16 +1063,25 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                         Ok(snapshot) => {
                             let mut stats = Statistics::default();
                             let store = RawStore::new(snapshot, enable_ttl);
-                            let cf = Self::rawkv_cf(&cf)?;
-                            results.push(store.raw_get_key_value(
-                                cf,
-                                &Key::from_encoded(key),
-                                &mut stats,
-                            ));
-                            tls_collect_read_flow(ctx.get_region_id(), &stats);
+                            match Self::rawkv_cf(&cf) {
+                                Ok(cf) => {
+                                    consumer.consume(
+                                        id,
+                                        store.raw_get_key_value(
+                                            cf,
+                                            &Key::from_encoded(key),
+                                            &mut stats,
+                                        ),
+                                    );
+                                    tls_collect_read_flow(ctx.get_region_id(), &stats);
+                                }
+                                Err(e) => {
+                                    consumer.consume(id, Err(e));
+                                }
+                            }
                         }
                         Err(e) => {
-                            results.push(Err(e));
+                            consumer.consume(id, Err(e));
                         }
                     }
                 }
@@ -1069,7 +1092,7 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                 SCHED_HISTOGRAM_VEC_STATIC
                     .get(CMD)
                     .observe(command_duration.elapsed_secs());
-                Ok(results)
+                Ok(())
             },
             priority,
             thread_rng().next_u64(),
@@ -1781,6 +1804,10 @@ impl<E: Engine, L: LockManager> TestStorageBuilder<E, L> {
     }
 }
 
+pub trait ResponseBatchConsumer<ConsumeResponse: Sized>: Send {
+    fn consume(&self, id: u64, res: Result<ConsumeResponse>);
+}
+
 pub mod test_util {
     use super::*;
     use crate::storage::txn::commands;
@@ -1943,8 +1970,10 @@ mod tests {
     use engine_rocks::raw_util::CFOptions;
     use engine_traits::{CF_LOCK, CF_RAFT, CF_WRITE};
     use errors::extract_key_error;
+    use errors::extract_region_error;
     use futures::executor::block_on;
     use kvproto::kvrpcpb::{CommandPri, Op};
+    use std::sync::Mutex;
     use std::{
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -1955,6 +1984,42 @@ mod tests {
     };
     use tikv_util::config::ReadableSize;
     use txn_types::{Mutation, WriteType};
+
+    #[derive(Clone)]
+    pub struct GetProcessor {
+        pub data: Arc<Mutex<Vec<(u64, Result<Option<Vec<u8>>>)>>>,
+    }
+
+    impl GetProcessor {
+        pub fn new() -> Self {
+            Self {
+                data: Arc::new(Mutex::new(vec![])),
+            }
+        }
+
+        pub fn take_data(self) -> Vec<Result<Option<Vec<u8>>>> {
+            let mut data = self.data.lock().unwrap();
+            let mut results = std::mem::take(&mut *data);
+            results.sort_by_key(|k| k.0);
+            results.into_iter().map(|v| v.1).collect()
+        }
+    }
+
+    impl ResponseBatchConsumer<(Option<Vec<u8>>, Statistics, PerfStatisticsDelta)> for GetProcessor {
+        fn consume(
+            &self,
+            id: u64,
+            res: Result<(Option<Vec<u8>>, Statistics, PerfStatisticsDelta)>,
+        ) {
+            self.data.lock().unwrap().push((id, res.map(|(v, ..)| v)));
+        }
+    }
+
+    impl ResponseBatchConsumer<Option<Vec<u8>>> for GetProcessor {
+        fn consume(&self, id: u64, res: Result<Option<Vec<u8>>>) {
+            self.data.lock().unwrap().push((id, res));
+        }
+    }
 
     #[test]
     fn test_prewrite_blocks_read() {
@@ -2123,12 +2188,15 @@ mod tests {
                 1.into(),
             )),
         );
-        let x = block_on(storage.batch_get_command(vec![
-            create_get_request(b"c", 1),
-            create_get_request(b"d", 1),
-        ]))
+        let processor = GetProcessor::new();
+        block_on(storage.batch_get_command(
+            vec![create_get_request(b"c", 1), create_get_request(b"d", 1)],
+            vec![1, 2],
+            processor.clone(),
+        ))
         .unwrap();
-        for v in x {
+        let data = processor.take_data();
+        for v in data {
             expect_error(
                 |e| match e {
                     Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(mvcc::Error(
@@ -2802,11 +2870,14 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
-        let mut x = block_on(storage.batch_get_command(vec![
-            create_get_request(b"c", 2),
-            create_get_request(b"d", 2),
-        ]))
+        let processor = GetProcessor::new();
+        block_on(storage.batch_get_command(
+            vec![create_get_request(b"c", 2), create_get_request(b"d", 2)],
+            vec![1, 2],
+            processor.clone(),
+        ))
         .unwrap();
+        let mut x = processor.take_data();
         expect_error(
             |e| match e {
                 Error(box ErrorInner::Txn(TxnError(box TxnErrorInner::Mvcc(mvcc::Error(
@@ -2816,7 +2887,7 @@ mod tests {
             },
             x.remove(0),
         );
-        assert_eq!(x.remove(0).unwrap().0, None);
+        assert_eq!(x.remove(0).unwrap(), None);
         storage
             .sched_txn_command(
                 commands::Commit::new(
@@ -2833,17 +2904,24 @@ mod tests {
             )
             .unwrap();
         rx.recv().unwrap();
-        let x: Vec<Option<Vec<u8>>> = block_on(storage.batch_get_command(vec![
-            create_get_request(b"c", 5),
-            create_get_request(b"x", 5),
-            create_get_request(b"a", 5),
-            create_get_request(b"b", 5),
-        ]))
-        .unwrap()
-        .into_iter()
-        .map(|x| x.unwrap())
-        .map(|(x, _, _)| x)
-        .collect();
+        let processor = GetProcessor::new();
+        block_on(storage.batch_get_command(
+            vec![
+                create_get_request(b"c", 5),
+                create_get_request(b"x", 5),
+                create_get_request(b"a", 5),
+                create_get_request(b"b", 5),
+            ],
+            vec![1, 2, 3, 4],
+            processor.clone(),
+        ))
+        .unwrap();
+
+        let x: Vec<Option<Vec<u8>>> = processor
+            .take_data()
+            .into_iter()
+            .map(|x| x.unwrap())
+            .collect();
         assert_eq!(
             x,
             vec![
@@ -3539,17 +3617,21 @@ mod tests {
         rx.recv().unwrap();
 
         // Verify pairs in a batch
+        let mut ids = vec![];
         let cmds = test_data
             .iter()
             .map(|&(ref k, _)| {
                 let mut req = RawGetRequest::default();
                 req.set_key(k.clone());
+                ids.push(ids.len() as u64);
                 req
             })
             .collect();
         let results: Vec<Option<Vec<u8>>> = test_data.into_iter().map(|(_, v)| Some(v)).collect();
-        let x: Vec<Option<Vec<u8>>> = block_on(storage.raw_batch_get_command(cmds))
-            .unwrap()
+        let processor = GetProcessor::new();
+        block_on(storage.raw_batch_get_command(cmds, ids, processor.clone())).unwrap();
+        let x: Vec<Option<Vec<u8>>> = processor
+            .take_data()
             .into_iter()
             .map(|x| x.unwrap())
             .collect();
@@ -6023,7 +6105,10 @@ mod tests {
         req2.set_context(ctx);
         req2.set_key(b"key".to_vec());
         req2.set_version(100);
-        let res = block_on(storage.batch_get_command(vec![req1, req2])).unwrap();
+        let processor = GetProcessor::new();
+        block_on(storage.batch_get_command(vec![req1, req2], vec![1, 2], processor.clone()))
+            .unwrap();
+        let res = processor.take_data();
         assert!(res[0].is_ok());
         let key_error = extract_key_error(&res[1].as_ref().unwrap_err());
         assert_eq!(key_error.get_locked().get_key(), b"key");


### PR DESCRIPTION
cherry-pick #10098 to release-5.0

----

Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number:  close #10046

Problem Summary:

### What is changed and how it works?
If the CPU load of TiKV read pool is not very high, batch get request together may cause latency increase. Because batchrequest process every sub request one by one in order, but if you put them into readpool, they can be processed in parallel.
Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
I judge whether the readpool is busy by readpool queue length. If the queue length is very long, TiKV will batch request together, otherwise it will put them into readpool separately.
We can see that this PR fixes QPS regression and makes lower P99 latency in TiKV than master without batch.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Fix sysbench point-get performance regression when TiKV readpool is not busy.
