### PR TITLE
resolved_ts: skip default cf cmd with invalid ts

### DIFF
--- a/components/resolved_ts/src/cmd.rs
+++ b/components/resolved_ts/src/cmd.rs
@@ -229,11 +229,12 @@ fn group_row_changes(requests: Vec<Request>) -> HashMap<Key, RowChange> {
                         row.lock = Some(KeyOp::Put(None, value));
                     }
                     "" | CF_DEFAULT => {
-                        let ts = key.decode_ts().unwrap();
-                        let key = key.truncate_ts().unwrap();
-                        let mut row = changes.entry(key).or_default();
-                        assert!(row.default.is_none());
-                        row.default = Some(KeyOp::Put(Some(ts), value));
+                        if let Ok(ts) = key.decode_ts() {
+                            let key = key.truncate_ts().unwrap();
+                            let mut row = changes.entry(key).or_default();
+                            assert!(row.default.is_none());
+                            row.default = Some(KeyOp::Put(Some(ts), value));
+                        }
                     }
                     other => {
                         panic!("invalid cf {}", other);

--- a/components/resolved_ts/tests/integrations/mod.rs
+++ b/components/resolved_ts/tests/integrations/mod.rs
@@ -13,6 +13,7 @@ fn test_resolved_ts_basic() {
     let mut suite = TestSuite::new(1);
     let region = suite.cluster.get_region(&[]);
     let (k, v) = (b"k1", b"v");
+    suite.cluster.must_put(k, v);
     // Prewrite
     let start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
     let mut mutation = Mutation::default();


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
For now `resolved_ts` worker can not work on rawkv mode.

### What is changed and how it works?

A temporary solution that skips the default cf commands which do not has valid ts.

From @NingLin-P, in the next step, we could skip the default cf commands in apply worker if cdc doesn't need to observe the region. That will solve this problem fundamentally.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* N/A