### PR TITLE
raftstore: fix not schedule split check

### DIFF
--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -4,8 +4,6 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::fmt::{self, Display, Formatter};
 use std::mem;
-use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
-use std::sync::Arc;
 
 use engine_traits::{CfName, IterOptions, Iterable, Iterator, KvEngine, CF_WRITE, LARGE_CFS};
 use kvproto::metapb::Region;
@@ -139,8 +137,6 @@ pub enum Task {
     Validate(Box<dyn FnOnce(&Config) + Send>),
     GetRegionApproximateSizeAndKeys {
         region: Region,
-        pending_tasks: Arc<AtomicU64>,
-        cb: Box<dyn FnOnce(u64, u64) + Send>,
     },
 }
 
@@ -345,14 +341,7 @@ where
             Task::ChangeConfig(c) => self.change_cfg(c),
             #[cfg(any(test, feature = "testexport"))]
             Task::Validate(f) => f(&self.coprocessor.cfg),
-            Task::GetRegionApproximateSizeAndKeys {
-                region,
-                pending_tasks,
-                cb,
-            } => {
-                if pending_tasks.fetch_sub(1, AtomicOrdering::SeqCst) > 1 {
-                    return;
-                }
+            Task::GetRegionApproximateSizeAndKeys { region } => {
                 let size =
                     get_region_approximate_size(&self.engine, &region, 0).unwrap_or_default();
                 let keys =
@@ -365,7 +354,6 @@ where
                     region.get_id(),
                     CasualMessage::RegionApproximateKeys { keys },
                 );
-                cb(size, keys);
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/10111

Problem Summary:
TiKV will schedule a task to get approximate size when the leader of TiKV tries to send a heartbeat message to PD but it finds that it has not gotten approximate size before. This task will reset the approximate size of peer and it will cause the condition of split check does not match. In these case, the regions will not split even if the TiKV restarts and ticks a split-check task again.


### What is changed and how it works?
I just change the task type to split check task for heartbeat-pd. 

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- No release note.
