### PR TITLE
Fuzz: oss-fuzz integration

### DIFF
--- a/fuzz/cli.rs
+++ b/fuzz/cli.rs
@@ -298,7 +298,7 @@ fn run_afl(target: &str) -> Result<()> {
 fn build_honggfuzz(target: &str) -> Result<()> {
     pre_check(
         Command::new("cargo").args(&["hfuzz", "version"]),
-        "cargo install honggfuzz --version 0.5.45",
+        "cargo install honggfuzz",
     )?;
 
     let fuzzer = Fuzzer::Honggfuzz;
@@ -337,7 +337,7 @@ fn build_honggfuzz(target: &str) -> Result<()> {
 fn run_honggfuzz(target: &str) -> Result<()> {
     pre_check(
         Command::new("cargo").args(&["hfuzz", "version"]),
-        "cargo install honggfuzz --version 0.5.45",
+        "cargo install honggfuzz",
     )?;
 
     let fuzzer = Fuzzer::Honggfuzz;

--- a/fuzz/fuzzer-afl/Cargo.toml
+++ b/fuzz/fuzzer-afl/Cargo.toml
@@ -13,4 +13,4 @@ fuzz-targets = { path = "../targets", default-features = false }
 
 # AFL only works for x86 targets
 [target.'cfg(all(not(target_os = "windows"), target_arch = "x86_64"))'.dependencies]
-afl = "0.6"
+afl = "0.10"

--- a/fuzz/fuzzer-honggfuzz/Cargo.toml
+++ b/fuzz/fuzzer-honggfuzz/Cargo.toml
@@ -12,4 +12,4 @@ prost-codec = ["fuzz-targets/prost-codec"]
 fuzz-targets = { path = "../targets", default-features = false }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-honggfuzz = "0.5.47"
+honggfuzz = "0.5"

--- a/fuzz/fuzzer-libfuzzer/Cargo.toml
+++ b/fuzz/fuzzer-libfuzzer/Cargo.toml
@@ -10,4 +10,4 @@ prost-codec = ["fuzz-targets/prost-codec"]
 
 [dependencies]
 fuzz-targets = { path = "../targets", default-features = false }
-libfuzzer-sys = "0.3.1"
+libfuzzer-sys = "0.4"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: none

Problem Summary:
This is a preparation for oss-fuzz integration cf https://github.com/google/oss-fuzz/pull/5702
cc @breeswish 

### What is changed and how it works?

What's Changed:
- bump fuzzers crates versions
- use another option `build` to fuzz utility (to build and not run a target)

### Check List <!--REMOVE the items that are not applicable-->

Tests 
- Integration test

Well, this is adding more integrations tests...

### Release note

- No release note
