### PR TITLE
resolved_ts: delay matching default cf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3842,6 +3842,7 @@ dependencies = [
  "test_util",
  "thiserror",
  "tikv",
+ "tikv_kv",
  "tikv_util",
  "tokio",
  "txn_types",

--- a/components/batch-system/benches/batch-system.rs
+++ b/components/batch-system/benches/batch-system.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 fn end_hook(tx: &std::sync::mpsc::Sender<()>) -> Message {
     let tx = tx.clone();
-    Message::Callback(Box::new(move |_| {
+    Message::Callback(Box::new(move |_, _| {
         tx.send(()).unwrap();
     }))
 }

--- a/components/resolved_ts/Cargo.toml
+++ b/components/resolved_ts/Cargo.toml
@@ -72,6 +72,7 @@ test_raftstore = { path = "../test_raftstore", default-features = false }
 test_util = { path = "../test_util", default-features = false }
 panic_hook = { path = "../panic_hook" }
 raft = { version = "0.6.0-alpha", default-features = false }
+tikv_kv = { path = "../tikv_kv" }
 
 [[test]]
 name = "integrations"

--- a/components/resolved_ts/src/cmd.rs
+++ b/components/resolved_ts/src/cmd.rs
@@ -209,6 +209,7 @@ struct RowChange {
 
 fn group_row_changes(requests: Vec<Request>) -> HashMap<Key, RowChange> {
     let mut changes: HashMap<Key, RowChange> = HashMap::default();
+    // The changes about default cf was recorded here and need to be matched with a `write` or a `lock`.
     let mut unmatched_default = HashMap::default();
     for mut req in requests {
         match req.get_cmd_type() {

--- a/components/resolved_ts/src/cmd.rs
+++ b/components/resolved_ts/src/cmd.rs
@@ -209,6 +209,7 @@ struct RowChange {
 
 fn group_row_changes(requests: Vec<Request>) -> HashMap<Key, RowChange> {
     let mut changes: HashMap<Key, RowChange> = HashMap::default();
+    let mut unmatched_default = HashMap::default();
     for mut req in requests {
         match req.get_cmd_type() {
             CmdType::Put => {
@@ -231,9 +232,7 @@ fn group_row_changes(requests: Vec<Request>) -> HashMap<Key, RowChange> {
                     "" | CF_DEFAULT => {
                         if let Ok(ts) = key.decode_ts() {
                             let key = key.truncate_ts().unwrap();
-                            let mut row = changes.entry(key).or_default();
-                            assert!(row.default.is_none());
-                            row.default = Some(KeyOp::Put(Some(ts), value));
+                            unmatched_default.insert(key, KeyOp::Put(Some(ts), value));
                         }
                     }
                     other => {
@@ -263,6 +262,11 @@ fn group_row_changes(requests: Vec<Request>) -> HashMap<Key, RowChange> {
             }
         }
     }
+    for (key, default) in unmatched_default {
+        if let Some(row) = changes.get_mut(&key) {
+            row.default = Some(default);
+        }
+    }
     changes
 }
 
@@ -277,6 +281,7 @@ mod tests {
     use tikv::storage::txn::tests::*;
     use tikv::storage::txn::{prewrite, CommitKind, TransactionKind, TransactionProperties};
     use tikv::storage::Engine;
+    use tikv_kv::Modify;
     use txn_types::{Key, LockType, WriteType};
 
     use super::{group_row_changes, ChangeLog, ChangeRow};
@@ -285,6 +290,13 @@ mod tests {
     fn test_cmd_encode() {
         let rocks_engine = TestEngineBuilder::new().build().unwrap();
         let engine = MockEngineBuilder::from_rocks_engine(rocks_engine).build();
+
+        let reqs = modifies_to_requests(vec![Modify::Put(
+            "default",
+            Key::from_raw(b"k1"),
+            b"v1".to_vec(),
+        )]);
+        assert!(ChangeLog::encode_rows(group_row_changes(reqs), false).is_empty());
 
         must_prewrite_put(&engine, b"k1", b"v1", b"k1", 1);
         must_commit(&engine, b"k1", 1, 2);

--- a/components/resolved_ts/src/cmd.rs
+++ b/components/resolved_ts/src/cmd.rs
@@ -152,7 +152,7 @@ impl ChangeLog {
 }
 
 pub(crate) fn decode_write(key: &[u8], value: &[u8], is_apply: bool) -> Option<Write> {
-    let write = WriteRef::parse(value).unwrap().to_owned();
+    let write = WriteRef::parse(value).ok()?.to_owned();
     // Drop the record it self but keep only the overlapped rollback information if gc_fence exists.
     if is_apply && write.gc_fence.is_some() {
         // `gc_fence` is set means the write record has been rewritten.
@@ -171,7 +171,7 @@ pub(crate) fn decode_write(key: &[u8], value: &[u8], is_apply: bool) -> Option<W
 }
 
 pub(crate) fn decode_lock(key: &[u8], value: &[u8]) -> Option<Lock> {
-    let lock = Lock::parse(value).unwrap();
+    let lock = Lock::parse(value).ok()?;
     match lock.lock_type {
         LockType::Put | LockType::Delete => Some(lock),
         other => {

--- a/components/resolved_ts/src/cmd.rs
+++ b/components/resolved_ts/src/cmd.rs
@@ -219,11 +219,12 @@ fn group_row_changes(requests: Vec<Request>) -> HashMap<Key, RowChange> {
                 let value = put.take_value();
                 match put.cf.as_str() {
                     CF_WRITE => {
-                        let ts = key.decode_ts().unwrap();
-                        let key = key.truncate_ts().unwrap();
-                        let mut row = changes.entry(key).or_default();
-                        assert!(row.write.is_none());
-                        row.write = Some(KeyOp::Put(Some(ts), value));
+                        if let Ok(ts) = key.decode_ts() {
+                            let key = key.truncate_ts().unwrap();
+                            let mut row = changes.entry(key).or_default();
+                            assert!(row.write.is_none());
+                            row.write = Some(KeyOp::Put(Some(ts), value));
+                        }
                     }
                     CF_LOCK => {
                         let mut row = changes.entry(key).or_default();

--- a/components/resolved_ts/src/cmd.rs
+++ b/components/resolved_ts/src/cmd.rs
@@ -237,7 +237,7 @@ fn group_row_changes(requests: Vec<Request>) -> HashMap<Key, RowChange> {
                         }
                     }
                     other => {
-                        panic!("invalid cf {}", other);
+                        debug!("resolved ts invalid cf {}", other);
                     }
                 }
             }
@@ -251,7 +251,7 @@ fn group_row_changes(requests: Vec<Request>) -> HashMap<Key, RowChange> {
                     }
                     "" | CF_WRITE | CF_DEFAULT => {}
                     other => {
-                        panic!("invalid cf {}", other);
+                        debug!("resolved ts invalid cf {}", other);
                     }
                 }
             }

--- a/components/resolved_ts/tests/integrations/mod.rs
+++ b/components/resolved_ts/tests/integrations/mod.rs
@@ -14,6 +14,8 @@ fn test_resolved_ts_basic() {
     let region = suite.cluster.get_region(&[]);
     let (k, v) = (b"k1", b"v");
     suite.cluster.must_put(k, v);
+    suite.cluster.must_put_cf("write", k, v);
+    suite.cluster.must_put_cf("lock", k, v);
     // Prewrite
     let start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
     let mut mutation = Mutation::default();


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
Filter out invalid default cf value by delaying matching it with write or lock.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* N/A