### PR TITLE
cdc: reduce scan batch bytes

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -258,7 +258,10 @@ impl<T: 'static + RaftStoreRouter> Endpoint<T> {
             INFINITY
         });
         // For scan efficiency, the scan batch bytes should be around 1MB.
-        let max_scan_batch_bytes = 1024 * 1024;
+        // TODO: To avoid consume too much memory when there are many concurrent
+        //       scan tasks (peak memory = 1MB * N tasks), we reduce the size
+        //       to 16KB as a workaround.
+        let max_scan_batch_bytes = 16 * 1024;
         // Assume 1KB per entry.
         let max_scan_batch_size = 1024;
         let ep = Endpoint {


### PR DESCRIPTION
It's a cherry-pick of #10133.

---------

### What problem does this PR solve?

To avoid consume too much memory when there are many concurrent
scan tasks (peak memory = 1MB * N tasks), we reduce the size
to 16KB as a workaround.

Issue Number: #10114 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

To be added:

### Release note <!-- bugfixes or new feature need a release note -->

- Reduce memory usage of CDC initial scan.