### PR TITLE
apply: reduce cmd clone for cmd observer

### DIFF
--- a/components/batch-system/benches/batch-system.rs
+++ b/components/batch-system/benches/batch-system.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 fn end_hook(tx: &std::sync::mpsc::Sender<()>) -> Message {
     let tx = tx.clone();
-    Message::Callback(Box::new(move |_| {
+    Message::Callback(Box::new(move |_, _| {
         tx.send(()).unwrap();
     }))
 }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -465,7 +465,10 @@ impl Delegate {
         if batch.cdc_id != self.id {
             return Ok(());
         }
-        for cmd in batch.into_iter(self.region_id) {
+        for cmd in batch
+            .into_iter(self.region_id)
+            .map(|cmd| Cmd::unwrap_arc(cmd))
+        {
             let Cmd {
                 index,
                 mut request,

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -108,7 +108,7 @@ impl<E: KvEngine> CmdObserver<E> for CdcObserver {
             .push(CmdBatch::new(cdc_id, rts_id, region_id));
     }
 
-    fn on_apply_cmd(&self, cdc_id: ObserveID, rts_id: ObserveID, region_id: u64, cmd: Cmd) {
+    fn on_apply_cmd(&self, cdc_id: ObserveID, rts_id: ObserveID, region_id: u64, cmd: Arc<Cmd>) {
         self.cmd_batches
             .borrow_mut()
             .last_mut()
@@ -328,7 +328,11 @@ mod tests {
             observe_id,
             observe_id,
             0,
-            Cmd::new(0, RaftCmdRequest::default(), RaftCmdResponse::default()),
+            Arc::new(Cmd::new(
+                0,
+                RaftCmdRequest::default(),
+                RaftCmdResponse::default(),
+            )),
         );
         observer.on_flush_apply(engine);
 

--- a/components/raftstore/src/coprocessor/mod.rs
+++ b/components/raftstore/src/coprocessor/mod.rs
@@ -77,7 +77,7 @@ pub trait AdminObserver: Coprocessor {
     fn pre_apply_admin(&self, _: &mut ObserverContext<'_>, _: &AdminRequest) {}
 
     /// Hook to call after applying admin request.
-    fn post_apply_admin(&self, _: &mut ObserverContext<'_>, _: &mut AdminResponse) {}
+    fn post_apply_admin(&self, _: &mut ObserverContext<'_>, _: &AdminResponse) {}
 }
 
 pub trait QueryObserver: Coprocessor {
@@ -92,7 +92,7 @@ pub trait QueryObserver: Coprocessor {
     fn pre_apply_query(&self, _: &mut ObserverContext<'_>, _: &[Request]) {}
 
     /// Hook to call after applying write request.
-    fn post_apply_query(&self, _: &mut ObserverContext<'_>, _: &mut Cmd) {}
+    fn post_apply_query(&self, _: &mut ObserverContext<'_>, _: &Cmd) {}
 }
 
 pub trait ApplySnapshotObserver: Coprocessor {

--- a/components/resolved_ts/src/cmd.rs
+++ b/components/resolved_ts/src/cmd.rs
@@ -43,6 +43,7 @@ impl ChangeLog {
     pub fn encode_change_log(region_id: u64, batch: CmdBatch) -> Vec<ChangeLog> {
         batch
             .into_iter(region_id)
+            .map(|cmd| Cmd::unwrap_arc(cmd))
             .map(|cmd| {
                 let Cmd {
                     index,

--- a/components/resolved_ts/src/observer.rs
+++ b/components/resolved_ts/src/observer.rs
@@ -58,7 +58,7 @@ impl<E: KvEngine> CmdObserver<E> for Observer<E> {
             .push(CmdBatch::new(cdc_id, rts_id, region_id));
     }
 
-    fn on_apply_cmd(&self, cdc_id: ObserveID, rts_id: ObserveID, region_id: u64, cmd: Cmd) {
+    fn on_apply_cmd(&self, cdc_id: ObserveID, rts_id: ObserveID, region_id: u64, cmd: Arc<Cmd>) {
         self.cmd_batches
             .borrow_mut()
             .last_mut()

--- a/src/server/gc_worker/applied_lock_collector.rs
+++ b/src/server/gc_worker/applied_lock_collector.rs
@@ -167,7 +167,7 @@ impl LockObserver {
 impl Coprocessor for LockObserver {}
 
 impl QueryObserver for LockObserver {
-    fn post_apply_query(&self, _: &mut ObserverContext<'_>, cmd: &mut Cmd) {
+    fn post_apply_query(&self, _: &mut ObserverContext<'_>, cmd: &Cmd) {
         fail_point!("notify_lock_observer_query");
         let max_ts = self.state.load_max_ts();
         if max_ts.is_zero() {
@@ -689,7 +689,7 @@ mod tests {
             make_apply_request(b"1".to_vec(), b"1".to_vec(), CF_DEFAULT, CmdType::Put),
             make_apply_request(b"2".to_vec(), b"2".to_vec(), CF_LOCK, CmdType::Delete),
         ];
-        coprocessor_host.post_apply(&Region::default(), &mut make_raft_cmd(req));
+        coprocessor_host.post_apply(&Region::default(), &make_raft_cmd(req));
         expected_result.push(locks[0].clone());
         assert_eq!(
             get_collected_locks(&c, 100).unwrap(),
@@ -714,7 +714,7 @@ mod tests {
                 .filter(|l| l.get_lock_version() <= 100)
                 .cloned(),
         );
-        coprocessor_host.post_apply(&Region::default(), &mut make_raft_cmd(req.clone()));
+        coprocessor_host.post_apply(&Region::default(), &make_raft_cmd(req.clone()));
         assert_eq!(
             get_collected_locks(&c, 100).unwrap(),
             (expected_result, true)
@@ -724,7 +724,7 @@ mod tests {
         // dropped.
         start_collecting(&c, 110).unwrap();
         assert_eq!(get_collected_locks(&c, 110).unwrap(), (vec![], true));
-        coprocessor_host.post_apply(&Region::default(), &mut make_raft_cmd(req));
+        coprocessor_host.post_apply(&Region::default(), &make_raft_cmd(req));
         assert_eq!(get_collected_locks(&c, 110).unwrap(), (locks, true));
     }
 
@@ -820,7 +820,7 @@ mod tests {
         // The value is not a valid lock.
         let (k, v) = (Key::from_raw(b"k1").into_encoded(), b"v1".to_vec());
         let req = make_apply_request(k.clone(), v.clone(), CF_LOCK, CmdType::Put);
-        coprocessor_host.post_apply(&Region::default(), &mut make_raft_cmd(vec![req]));
+        coprocessor_host.post_apply(&Region::default(), &make_raft_cmd(vec![req]));
         assert_eq!(get_collected_locks(&c, 1).unwrap(), (vec![], false));
 
         // `is_clean` should be reset after invoking `start_collecting`.
@@ -846,8 +846,8 @@ mod tests {
         let batch_generate_locks = |count| {
             let (k, v) = lock_info_to_kv(lock.clone());
             let req = make_apply_request(k, v, CF_LOCK, CmdType::Put);
-            let mut raft_cmd = make_raft_cmd(vec![req; count]);
-            coprocessor_host.post_apply(&Region::default(), &mut raft_cmd);
+            let raft_cmd = make_raft_cmd(vec![req; count]);
+            coprocessor_host.post_apply(&Region::default(), &raft_cmd);
         };
 
         batch_generate_locks(MAX_COLLECT_SIZE - 1);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #10077 <!-- REMOVE this line if no issue to close -->

Problem Summary:
Reduce cmd clone for cmd observer


### What is changed and how it works?

What's Changed:

* Change `Cmd` buffered in `ApplyCallback` to `Arc<Cmd>`
* Change function signatures related to `CmdObserver` to `Arc<Cmd>`
* Change signature of `post_apply` of coprocessor to use immutable reference of `Cmd`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
* N/A