### PR TITLE
cdc: deregister region when resolver fails to build (#9987)

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -487,6 +487,7 @@ impl<T: 'static + RaftStoreRouter> Endpoint<T> {
                 reader.txn_extra_op.store(txn_extra_op);
             }
         }
+        let observe_id = delegate.id;
         let init = Initializer {
             sched,
             region_id,
@@ -497,7 +498,7 @@ impl<T: 'static + RaftStoreRouter> Endpoint<T> {
             speed_limter: self.scan_speed_limter.clone(),
             max_scan_batch_bytes: self.max_scan_batch_bytes,
             max_scan_batch_size: self.max_scan_batch_size,
-            observe_id: delegate.id,
+            observe_id,
             checkpoint_ts: checkpoint_ts.into(),
             build_resolver: is_new_delegate,
         };
@@ -506,11 +507,21 @@ impl<T: 'static + RaftStoreRouter> Endpoint<T> {
         let scheduler = self.scheduler.clone();
         let deregister_downstream = move |err| {
             warn!("cdc send capture change cmd failed"; "region_id" => region_id, "error" => ?err);
-            let deregister = Deregister::Downstream {
-                region_id,
-                downstream_id,
-                conn_id,
-                err: Some(err),
+            let deregister = if is_new_delegate {
+                // Deregister region if it's the first scan task, because the
+                // task also build resolver.
+                Deregister::Region {
+                    region_id,
+                    observe_id,
+                    err,
+                }
+            } else {
+                Deregister::Downstream {
+                    region_id,
+                    downstream_id,
+                    conn_id,
+                    err: Some(err),
+                }
             };
             if let Err(e) = scheduler.schedule(Task::Deregister(deregister)) {
                 error!("cdc schedule cdc task failed"; "error" => ?e);
@@ -829,7 +840,6 @@ impl Initializer {
 
     async fn async_incremental_scan<S: Snapshot + 'static>(&self, snap: S, region: Region) {
         let downstream_id = self.downstream_id;
-        let conn_id = self.conn_id;
         let region_id = region.get_id();
         debug!("cdc async incremental scan";
             "region_id" => region_id,
@@ -859,22 +869,14 @@ impl Initializer {
                     "downstream_id" => ?downstream_id,
                     "observe_id" => ?self.observe_id,
                     "conn_id" => ?self.conn_id);
+                self.deregister_downstream(None);
                 return;
             }
             let entries = match self.scan_batch(&mut scanner, resolver.as_mut()).await {
                 Ok(res) => res,
                 Err(e) => {
                     error!("cdc scan entries failed"; "error" => ?e, "region_id" => region_id);
-                    // TODO: record in metrics.
-                    let deregister = Deregister::Downstream {
-                        region_id,
-                        downstream_id,
-                        conn_id,
-                        err: Some(e),
-                    };
-                    if let Err(e) = self.sched.schedule(Task::Deregister(deregister)) {
-                        error!("cdc schedule cdc task failed"; "error" => ?e, "region_id" => region_id);
-                    }
+                    self.deregister_downstream(Some(e));
                     return;
                 }
             };
@@ -908,6 +910,10 @@ impl Initializer {
         scanner: &mut DeltaScanner<S>,
         resolver: Option<&mut Resolver>,
     ) -> Result<Vec<Option<TxnEntry>>> {
+        fail_point!("cdc_scan_batch_fail", |_| {
+            Err(Error::Rocks("injected error".to_string()))
+        });
+
         let mut entries = Vec::with_capacity(self.max_scan_batch_size);
         let mut total_bytes = 0;
         let mut total_size = 0;
@@ -969,6 +975,27 @@ impl Initializer {
             region,
         }) {
             error!("cdc schedule task failed"; "error" => ?e);
+        }
+    }
+
+    fn deregister_downstream(&self, err: Option<Error>) {
+        // TODO: record in metrics.
+        let deregister = if self.build_resolver {
+            Deregister::Region {
+                region_id: self.region_id,
+                observe_id: self.observe_id,
+                err: err.unwrap_or_else(|| Error::Other(box_err!("scan error"))), // TODO: convert rate_limiter error
+            }
+        } else {
+            Deregister::Downstream {
+                region_id: self.region_id,
+                downstream_id: self.downstream_id,
+                conn_id: self.conn_id,
+                err, // TODO: convert rate_limiter error
+            }
+        };
+        if let Err(e) = self.sched.schedule(Task::Deregister(deregister)) {
+            error!("cdc schedule task failed"; "error" => ?e, "region_id" => self.region_id);
         }
     }
 }
@@ -1142,10 +1169,11 @@ mod tests {
             expected_locks.entry(ts).or_default().insert(k.to_vec());
         }
 
-        let region = Region::default();
+        let mut region = Region::default();
         let snap = engine.snapshot(&Context::default()).unwrap();
 
         let (mut worker, _pool, mut initializer, rx) = mock_initializer(total_bytes);
+        region.id = initializer.region_id;
         let check_result = || loop {
             let task = rx.recv().unwrap();
             match task {
@@ -1202,13 +1230,21 @@ mod tests {
 
         // Test cancellation.
         initializer.downstream_state.store(DownstreamState::Stopped);
-        block_on(initializer.async_incremental_scan(snap, region));
+        block_on(initializer.async_incremental_scan(snap, region.clone()));
 
         loop {
             let task = rx.recv_timeout(Duration::from_secs(1));
             match task {
+                Ok(Task::Deregister(Deregister::Downstream { region_id, .. })) => {
+                    assert_eq!(
+                        region_id,
+                        region.get_id(),
+                        "unexpected region id {:?}",
+                        region_id
+                    );
+                    break;
+                }
                 Ok(t) => panic!("unepxected task {} received", t),
-                Err(RecvTimeoutError::Timeout) => break,
                 Err(e) => panic!("unexpected err {:?}", e),
             }
         }
@@ -1276,7 +1312,7 @@ mod tests {
 
     #[test]
     fn test_register() {
-        let (task_sched, _task_rx) = dummy_scheduler();
+        let (task_sched, task_rx) = dummy_scheduler();
         let raft_router = MockRaftStoreRouter::new();
         let _raft_rx = raft_router.add_region(1 /* region id */, 100 /* cap */);
         let observer = CdcObserver::new(task_sched.clone());
@@ -1288,7 +1324,7 @@ mod tests {
             },
             pd_client,
             task_sched,
-            raft_router,
+            raft_router.clone(),
             observer,
             Arc::new(Mutex::new(StoreMeta::new(0))),
         );
@@ -1358,6 +1394,54 @@ mod tests {
             panic!("unknown cdc event {:?}", cdc_event);
         }
         assert_eq!(ep.capture_regions.len(), 1);
+
+        // The first scan task of a region is initiated in register, and when it
+        // fails, it should send a deregister region task, otherwise the region
+        // delegate does not have resolver.
+        //
+        // Test non-exist regoin in raft router.
+        let mut req = ChangeDataRequest::default();
+        req.set_region_id(100);
+        let region_epoch = req.get_region_epoch().clone();
+        let downstream = Downstream::new("".to_string(), region_epoch.clone(), 1, conn_id, true);
+        ep.run(Task::Register {
+            request: req.clone(),
+            downstream,
+            conn_id,
+            version: semver::Version::new(4, 0, 8),
+        });
+        // Region 100 is inserted into capture_regions.
+        assert_eq!(ep.capture_regions.len(), 2);
+        let task = task_rx.recv_timeout(Duration::from_millis(100)).unwrap();
+        match task.unwrap() {
+            Task::Deregister(Deregister::Region { region_id, err, .. }) => {
+                assert_eq!(region_id, 100);
+                assert!(matches!(err, Error::Request(_)), "{:?}", err);
+            }
+            other => panic!("unexpected task {:?}", other),
+        }
+
+        // Test errors on CaptureChange message.
+        req.set_region_id(101);
+        let raft_rx = raft_router.add_region(101 /* region id */, 100 /* cap */);
+        let downstream = Downstream::new("".to_string(), region_epoch, 1, conn_id, true);
+        ep.run(Task::Register {
+            request: req,
+            downstream,
+            conn_id,
+            version: semver::Version::new(4, 0, 8),
+        });
+        // Drop CaptureChange message, it should cause scan task failure.
+        let _ = raft_rx.recv_timeout(Duration::from_millis(100)).unwrap();
+        assert_eq!(ep.capture_regions.len(), 3);
+        let task = task_rx.recv_timeout(Duration::from_millis(100)).unwrap();
+        match task.unwrap() {
+            Task::Deregister(Deregister::Region { region_id, err, .. }) => {
+                assert_eq!(region_id, 101);
+                assert!(matches!(err, Error::Other(_)), "{:?}", err);
+            }
+            other => panic!("unexpected task {:?}", other),
+        }
     }
 
     #[test]

--- a/components/cdc/src/lib.rs
+++ b/components/cdc/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(box_patterns)]
+#![feature(matches_macro)]
 
 #[macro_use]
 extern crate failure;

--- a/components/cdc/tests/failpoints/mod.rs
+++ b/components/cdc/tests/failpoints/mod.rs
@@ -3,6 +3,7 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(test_util::run_failpoint_tests)]
 
+mod test_endpoint;
 mod test_observe;
 mod test_register;
 mod test_resolve;

--- a/components/cdc/tests/failpoints/test_endpoint.rs
+++ b/components/cdc/tests/failpoints/test_endpoint.rs
@@ -1,0 +1,147 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+use crate::{new_event_feed, TestSuite};
+use futures::{Future, Sink};
+use grpcio::WriteFlags;
+#[cfg(feature = "prost-codec")]
+use kvproto::cdcpb::event::{Event as Event_oneof_event, LogType as EventLogType};
+#[cfg(not(feature = "prost-codec"))]
+use kvproto::cdcpb::*;
+use kvproto::kvrpcpb::*;
+use pd_client::PdClient;
+use test_raftstore::*;
+
+#[test]
+fn test_cdc_double_scan_deregister() {
+    let mut suite = TestSuite::new(1);
+
+    let (k, v) = (b"key1".to_vec(), b"value".to_vec());
+    // Prewrite
+    let start_ts1 = suite.cluster.pd_client.get_tso().wait().unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.clone();
+    mutation.value = v;
+    suite.must_kv_prewrite(1, vec![mutation], k.clone(), start_ts1);
+    // Commit
+    let commit_ts1 = suite.cluster.pd_client.get_tso().wait().unwrap();
+    suite.must_kv_commit(1, vec![k], start_ts1, commit_ts1);
+
+    let fp = "cdc_incremental_scan_start";
+    fail::cfg(fp, "pause").unwrap();
+
+    let req = suite.new_changedata_request(1);
+    let (req_tx, event_feed_wrap, _receive_event) = new_event_feed(suite.get_region_cdc_client(1));
+    let req_tx = req_tx.send((req, WriteFlags::default())).wait().unwrap();
+
+    // wait for the first connection to start incremental scan
+    sleep_ms(1000);
+
+    let req = suite.new_changedata_request(1);
+    let (req_tx_1, event_feed_wrap_1, receive_event_1) =
+        new_event_feed(suite.get_region_cdc_client(1));
+    let _req_tx_1 = req_tx_1.send((req, WriteFlags::default())).wait().unwrap();
+
+    // close connection
+    drop(req_tx);
+    event_feed_wrap.replace(None);
+
+    // wait for the connection to close
+    sleep_ms(300);
+
+    fail::cfg(fp, "off").unwrap();
+
+    'outer: loop {
+        let event = receive_event_1(false);
+        let mut event_vec = event.events.to_vec();
+        while !event_vec.is_empty() {
+            if let Event_oneof_event::Error(err) = event_vec.pop().unwrap().event.unwrap() {
+                assert!(err.has_region_not_found(), "{:?}", err);
+                break 'outer;
+            }
+        }
+    }
+
+    event_feed_wrap_1.replace(None);
+    suite.stop();
+}
+
+#[test]
+fn test_cdc_double_scan_io_error() {
+    let mut suite = TestSuite::new(1);
+
+    let (k, v) = (b"key1".to_vec(), b"value".to_vec());
+    // Prewrite
+    let start_ts1 = suite.cluster.pd_client.get_tso().wait().unwrap();
+    let mut mutation = Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.key = k.clone();
+    mutation.value = v;
+    suite.must_kv_prewrite(1, vec![mutation], k.clone(), start_ts1);
+    // Commit
+    let commit_ts1 = suite.cluster.pd_client.get_tso().wait().unwrap();
+    suite.must_kv_commit(1, vec![k], start_ts1, commit_ts1);
+
+    fail::cfg("cdc_incremental_scan_start", "pause").unwrap();
+    fail::cfg("cdc_scan_batch_fail", "1*return").unwrap();
+
+    let req = suite.new_changedata_request(1);
+    let (req_tx, event_feed_wrap, receive_event) = new_event_feed(suite.get_region_cdc_client(1));
+    let _req_tx = req_tx.send((req, WriteFlags::default())).wait().unwrap();
+
+    // wait for the first connection to start incremental scan
+    sleep_ms(1000);
+
+    let req = suite.new_changedata_request(1);
+    let (req_tx_1, event_feed_wrap_1, receive_event_1) =
+        new_event_feed(suite.get_region_cdc_client(1));
+    let _req_tx_1 = req_tx_1.send((req, WriteFlags::default())).wait().unwrap();
+
+    // wait for the second connection to start incremental scan
+    sleep_ms(1000);
+
+    // unpause
+    fail::cfg("cdc_incremental_scan_start", "off").unwrap();
+
+    'outer: loop {
+        let event = receive_event(true);
+        if let Some(resolved_ts) = event.resolved_ts.as_ref() {
+            // resolved ts has been pushed, so this conn is good.
+            if resolved_ts.regions.len() == 1 {
+                break 'outer;
+            }
+        }
+        let mut event_vec = event.events.to_vec();
+        while !event_vec.is_empty() {
+            if let Event_oneof_event::Error(err) = event_vec.pop().unwrap().event.unwrap() {
+                assert!(err.has_region_not_found(), "{:?}", err);
+                break 'outer;
+            }
+        }
+    }
+
+    'outer1: loop {
+        let event = receive_event_1(true);
+        if let Some(resolved_ts) = event.resolved_ts.as_ref() {
+            // resolved ts has been pushed, so this conn is good.
+            if resolved_ts.regions.len() == 1 {
+                break 'outer1;
+            }
+        }
+        let mut event_vec = event.events.to_vec();
+        while !event_vec.is_empty() {
+            match event_vec.pop().unwrap().event.unwrap() {
+                Event_oneof_event::Error(err) => {
+                    assert!(err.has_region_not_found(), "{:?}", err);
+                    break 'outer1;
+                }
+                e => {
+                    tikv_util::debug!("cdc receive event {:?}", e);
+                }
+            }
+        }
+    }
+
+    event_feed_wrap.replace(None);
+    event_feed_wrap_1.replace(None);
+    suite.stop();
+}


### PR DESCRIPTION
This PR cherry-pick #9987

------------------

### What problem does this PR solve?

https://github.com/pingcap/ticdc/issues/1626

Problem Summary:

When a CDC incremental scan fails, if the connection is responsible for building the resolver for that region, it should handle its exit properly so that other connections can have a usable resolver.

### What is changed and how it works?

What's Changed:

The current design makes it hard to handle it elegantly, so as a workaround, a failed incremental scan will deregister the whole region if it is supposed to build the resolver.

### Related changes

- Need to handle this in the master branch.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- Fix interference between connections to the same region.