### PR TITLE
tidb_query: fix read empty value for the clustered PK column in the 2nd index with latin1_bin

### DIFF
--- a/components/tidb_query_datatype/src/def/field_type.rs
+++ b/components/tidb_query_datatype/src/def/field_type.rs
@@ -130,6 +130,10 @@ impl Collation {
             n => Err(DataTypeError::UnsupportedCollation { code: n }),
         }
     }
+
+    pub fn is_bin_collation(&self) -> bool {
+        matches!(self, Collation::Utf8Mb4Bin | Collation::Latin1Bin)
+    }
 }
 
 impl fmt::Display for Collation {
@@ -289,7 +293,7 @@ pub trait FieldTypeAccessor {
         self.is_non_binary_string_like()
             && (!self
                 .collation()
-                .map(|col| col == Collation::Utf8Mb4Bin)
+                .map(|col| col.is_bin_collation())
                 .unwrap_or(false)
                 || self.is_varchar_like())
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/24548

Problem Summary:

`Latin1Bin` didn't be  judged as Bin collation 

### What is changed and how it works?

What's Changed:

`Latin1Bin` should be judged as Bin collation 

### Related changes

- Need to cherry-pick to the release branch 5.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- Fix read empty value for the clustered primary key column in the secondary index when collation is latin1_bin.