### PR TITLE
Fixing codespell errors

### DIFF
--- a/components/batch-system/src/batch.rs
+++ b/components/batch-system/src/batch.rs
@@ -221,7 +221,7 @@ pub trait PollHandler<N, C> {
     /// This function is called when handling readiness for control FSM.
     ///
     /// If returned value is Some, then it represents a length of channel. This
-    /// function will only be called for the same fsm after channel's lengh is
+    /// function will only be called for the same fsm after channel's length is
     /// larger than the value. If it returns None, then this function will
     /// still be called for the same FSM in the next loop unless the FSM is
     /// stopped.

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -71,7 +71,7 @@ pub struct Downstream {
     // TODO: include cdc request.
     /// A unique identifier of the Downstream.
     id: DownstreamID,
-    // The reqeust ID set by CDC to identify events corresponding different requests.
+    // The request ID set by CDC to identify events corresponding different requests.
     req_id: u64,
     conn_id: ConnID,
     // The IP address of downstream.
@@ -408,7 +408,7 @@ impl Delegate {
         old_value_cb: &OldValueCallback,
         old_value_cache: &mut OldValueCache,
     ) -> Result<()> {
-        // Stale CmdBatch, drop it sliently.
+        // Stale CmdBatch, drop it silently.
         if batch.cdc_id != self.handle.id {
             return Ok(());
         }

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -349,7 +349,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                             .compare_exchange(TxnExtraOp::ReadOldValue, TxnExtraOp::Noop)
                         {
                             panic!(
-                                "unexpect txn extra op {:?}, region_id: {:?}, downstream_id: {:?}, conn_id: {:?}",
+                                "unexpected txn extra op {:?}, region_id: {:?}, downstream_id: {:?}, conn_id: {:?}",
                                 e, region_id, downstream_id, conn_id
                             );
                         }

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -64,7 +64,7 @@ impl CdcObserver {
     /// Subscribe an region, the observer will sink events of the region into
     /// its scheduler.
     ///
-    /// Return pervious ObserveID if there is one.
+    /// Return previous ObserveID if there is one.
     pub fn subscribe_region(&self, region_id: u64, observe_id: ObserveID) -> Option<ObserveID> {
         self.observe_regions
             .write()

--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -137,7 +137,7 @@ impl EventBatcher {
                 self.last_size = CDC_MAX_RESP_SIZE;
             }
             CdcEvent::Barrier(_) => {
-                // Barrier requires events must be batched accross the barrier.
+                // Barrier requires events must be batched across the barrier.
                 self.last_size = CDC_MAX_RESP_SIZE;
             }
         }

--- a/components/cdc/tests/failpoints/test_resolve.rs
+++ b/components/cdc/tests/failpoints/test_resolve.rs
@@ -113,7 +113,7 @@ fn test_stale_resolver() {
                     assert_eq!(e.get_type(), EventLogType::Initialized, "{:?}", es);
                 }
                 _ => {
-                    panic!("unexepected event length {:?}", es);
+                    panic!("unexpected event length {:?}", es);
                 }
             },
             Event_oneof_event::Error(e) => panic!("{:?}", e),

--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -1334,7 +1334,7 @@ mod benches {
         let mut offset = 0;
         let chunk_len = ENC_GROUP_SIZE + 1;
         loop {
-            // everytime make ENC_GROUP_SIZE + 1 elements as a decode unit
+            // every time make ENC_GROUP_SIZE + 1 elements as a decode unit
             let next_offset = offset + chunk_len;
             let chunk = if next_offset <= data.len() {
                 &data[offset..next_offset]
@@ -1398,7 +1398,7 @@ mod benches {
                 );
             }
             write_offset += ENC_GROUP_SIZE;
-            // everytime make ENC_GROUP_SIZE + 1 elements as a decode unit
+            // every time make ENC_GROUP_SIZE + 1 elements as a decode unit
             read_offset += ENC_GROUP_SIZE + 1;
 
             // the last byte in decode unit is for marker which indicates pad size

--- a/components/configuration/src/lib.rs
+++ b/components/configuration/src/lib.rs
@@ -105,7 +105,7 @@ impl_into!(ConfigChange, Module);
 /// at the output of serializing `Self::Encoder`
 /// 3. `#[config(submodule)]` field, these fields represent the
 /// submodule, and should also derive `Configuration`
-/// 4. normal fields, the type of these fields should be implment
+/// 4. normal fields, the type of these fields should be implement
 /// `Into` and `From` for `ConfigValue`
 pub trait Configuration<'a> {
     type Encoder: serde::Serialize;

--- a/components/encryption/src/crypter.rs
+++ b/components/encryption/src/crypter.rs
@@ -69,9 +69,9 @@ pub fn get_method_key_length(method: EncryptionMethod) -> usize {
     }
 }
 
-// IV's the length should be 12 btyes for GCM mode.
+// IV's the length should be 12 bytes for GCM mode.
 const GCM_IV_12: usize = 12;
-// IV's the length should be 16 btyes for CTR mode.
+// IV's the length should be 16 bytes for CTR mode.
 const CTR_IV_16: usize = 16;
 
 #[derive(Debug, Clone, Copy)]
@@ -120,7 +120,7 @@ impl Iv {
     }
 }
 
-// The length GCM tag must be 16 btyes.
+// The length GCM tag must be 16 bytes.
 const GCM_TAG_LEN: usize = 16;
 
 pub struct AesGcmTag([u8; GCM_TAG_LEN]);

--- a/components/encryption/src/master_key/kms.rs
+++ b/components/encryption/src/master_key/kms.rs
@@ -128,7 +128,7 @@ impl KmsBackend {
             Some(val) if val.as_slice() == vendor_name => (),
             None => {
                 return Err(
-                    // If vender is missing in metadata, it could be the encrypted content is invalid
+                    // If vendor is missing in metadata, it could be the encrypted content is invalid
                     // or corrupted, but it is also possible that the content is encrypted using the
                     // FileBackend. Return WrongMasterKey anyway.
                     Error::WrongMasterKey(box_err!("missing KMS vendor")),

--- a/components/engine_traits/src/lib.rs
+++ b/components/engine_traits/src/lib.rs
@@ -139,7 +139,7 @@
 //!
 //! # The porting process
 //!
-//! These are some guidelines that seem to make the porting managable. As the
+//! These are some guidelines that seem to make the porting manageable. As the
 //! process continues new strategies are discovered and written here. This is a
 //! big refactoring and will take many monthse.
 //!
@@ -216,7 +216,7 @@
 //! # Refactoring tips
 //!
 //! - Port modules with the fewest RocksDB dependencies at a time, modifying
-//!   those modules's callers to convert to and from the engine traits as
+//!   those modules' callers to convert to and from the engine traits as
 //!   needed. Move in and out of the engine_traits world with the
 //!   `RocksDB::from_ref` and `RocksDB::as_inner` methods.
 //!

--- a/components/engine_traits/src/perf_context.rs
+++ b/components/engine_traits/src/perf_context.rs
@@ -14,7 +14,7 @@ pub enum PerfLevel {
 /// Extensions for measuring engine performance.
 ///
 /// A PerfContext is created with a specific measurement level,
-/// and a 'kind' which represents wich tikv subsystem measurements are being
+/// and a 'kind' which represents which tikv subsystem measurements are being
 /// collected for.
 ///
 /// In rocks, `PerfContext` uses global state, and does not require

--- a/components/engine_traits_tests/src/basic_read_write.rs
+++ b/components/engine_traits_tests/src/basic_read_write.rs
@@ -12,7 +12,7 @@ fn non_cf_methods_are_default_cf() {
     let db = engine_cfs(ALL_CFS);
     // Use the non-cf put function
     db.engine.put(b"foo", b"bar").unwrap();
-    // Retreive with the cf get function
+    // Retrieve with the cf get function
     let value = db.engine.get_value_cf(CF_DEFAULT, b"foo").unwrap();
     let value = value.expect("value");
     assert_eq!(b"bar", &*value);

--- a/components/error_code/src/pd.rs
+++ b/components/error_code/src/pd.rs
@@ -6,7 +6,7 @@ define_error_codes!(
     IO => ("IO", "", ""),
     CLUSTER_BOOTSTRAPPED => ("ClusterBootstraped", "", ""),
     CLUSTER_NOT_BOOTSTRAPPED => ("ClusterNotBootstraped", "", ""),
-    INCOMPATIBLE => ("Imcompatible", "", ""),
+    INCOMPATIBLE => ("Incompatible", "", ""),
     GRPC => ("gRPC", "", ""),
     REGION_NOT_FOUND => ("RegionNotFound", "", ""),
     STORE_TOMBSTONE => ("StoreTombstone", "", ""),

--- a/components/file_system/src/iosnoop/biosnoop.c
+++ b/components/file_system/src/iosnoop/biosnoop.c
@@ -33,8 +33,8 @@ BPF_HASH(type_by_pid, u32, io_type *);
 BPF_HASH(stats_by_type, io_type, struct stats_t);
 
 // the latency includes OS queued time
-// When using BPF_ARRAY_OF_MAPS, hist_arrays[idx].increment() is not availble
-// due to bpf API limition. So define separate hists for every io type.
+// When using BPF_ARRAY_OF_MAPS, hist_arrays[idx].increment() is not available
+// due to bpf API limitation. So define separate hists for every io type.
 BPF_HISTOGRAM(other_read_latency, int, 25);
 BPF_HISTOGRAM(foreground_read_read_latency, int, 25);
 BPF_HISTOGRAM(foreground_write_read_latency, int, 25);
@@ -95,7 +95,7 @@ int trace_req_start(struct pt_regs *ctx, struct request *req) {
   return 0;
 }
 
-// trace_req_completion may be called in interrput context. In that case,
+// trace_req_completion may be called in interrupt context. In that case,
 // `bpf_get_current_pid_tgid` and `bpf_probe_read` can not work as expected.
 // So caching type in `trace_pid_start` which wouldn't be called in interrupt
 // context and query the type by req in `info_by_req`.

--- a/components/raftstore/src/coprocessor/consistency_check.rs
+++ b/components/raftstore/src/coprocessor/consistency_check.rs
@@ -9,7 +9,7 @@ use crate::coprocessor::{ConsistencyCheckMethod, Coprocessor};
 use crate::Result;
 
 pub trait ConsistencyCheckObserver<E: KvEngine>: Coprocessor {
-    /// Update context. Return `true` if later observers should be skiped.
+    /// Update context. Return `true` if later observers should be skipped.
     fn update_context(&self, context: &mut Vec<u8>) -> bool;
 
     /// Compute hash for `region`. The policy is extracted from `context`.
@@ -36,7 +36,7 @@ impl<E: KvEngine> ConsistencyCheckObserver<E> for Raw<E> {
     fn update_context(&self, context: &mut Vec<u8>) -> bool {
         context.push(ConsistencyCheckMethod::Raw as u8);
         // Raw consistency check is the most heavy and strong one.
-        // So all others can be skiped.
+        // So all others can be skipped.
         true
     }
 

--- a/components/raftstore/src/coprocessor/split_check/table.rs
+++ b/components/raftstore/src/coprocessor/split_check/table.rs
@@ -156,7 +156,7 @@ where
                     split_key = to_encoded_table_prefix(encoded_end_key);
                 }
             }
-            // The region starts from tabel area to non-table area.
+            // The region starts from table area to non-table area.
             (Ordering::Equal, Ordering::Greater) => {
                 // As the comment above, outside needs scan for finding a split key.
                 first_encoded_table_prefix = to_encoded_table_prefix(encoded_start_key);

--- a/components/raftstore/src/store/compaction_guard.rs
+++ b/components/raftstore/src/store/compaction_guard.rs
@@ -371,7 +371,7 @@ mod tests {
 
         // Create two overlapping SST files then force compaction.
         // Region "a" will share a SST file with region "b", since region "a" is too small.
-        // Region "c" will be splitted into two SSTs, since its size is larger than
+        // Region "c" will be split into two SSTs, since its size is larger than
         // target_file_size_base.
         let value = vec![b'v'; 1024];
         db.put(b"za1", b"").unwrap();

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -976,7 +976,7 @@ where
 
             return self.process_raft_cmd(apply_ctx, index, term, cmd);
         }
-        // TOOD(cdc): should we observe empty cmd, aka leader change?
+        // TODO(cdc): should we observe empty cmd, aka leader change?
 
         self.apply_state.set_applied_index(index);
         self.applied_index_term = term;
@@ -1424,7 +1424,7 @@ where
         self.metrics.size_diff_hint += value.len() as i64;
         if !req.get_put().get_cf().is_empty() {
             let cf = req.get_put().get_cf();
-            // TODO: don't allow write preseved cfs.
+            // TODO: don't allow write preserved cfs.
             if cf == CF_LOCK {
                 self.metrics.lock_cf_written_bytes += key.len() as u64;
                 self.metrics.lock_cf_written_bytes += value.len() as u64;
@@ -2213,7 +2213,7 @@ where
                         // This peer must be the first one on local store. So if this peer is created on the other side,
                         // it means no `RegionLocalState` in kv engine.
                         panic!(
-                            "{} failed to replace region {} peer {} because state {:?} alread exist in kv engine",
+                            "{} failed to replace region {} peer {} because state {:?} already exist in kv engine",
                             self.tag, region_id, new_split_peer.peer_id, state
                         );
                     }

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1747,7 +1747,7 @@ where
                     > exist_region.get_region_epoch().get_version()
             {
                 // If snapshot's epoch version is greater than exist region's, the exist region
-                // may has been merged/splitted already.
+                // may has been merged/split already.
                 let _ = self.ctx.router.force_send(
                     exist_region.get_id(),
                     PeerMsg::CasualMessage(CasualMessage::RegionOverlapped),
@@ -2234,7 +2234,7 @@ where
                 continue;
             }
 
-            // Check if this new region should be splitted
+            // Check if this new region should be split
             let new_split_peer = new_split_regions.get(&new_region.get_id()).unwrap();
             if new_split_peer.result.is_some() {
                 if let Err(e) = self
@@ -2538,7 +2538,7 @@ where
                 {
                     Ok(ents) => ents,
                     Err(e) => panic!(
-                        "[region {}] {} failed to get merge entires: {:?}, low:{}, commit: {}",
+                        "[region {}] {} failed to get merge entries: {:?}, low:{}, commit: {}",
                         self.fsm.region_id(),
                         self.fsm.peer_id(),
                         e,
@@ -3762,7 +3762,7 @@ where
             if group_state == GroupState::Idle {
                 self.fsm.peer.ping();
                 if !self.fsm.peer.is_leader() {
-                    // If leader is able to receive messge but can't send out any,
+                    // If leader is able to receive message but can't send out any,
                     // follower should be able to start an election.
                     self.fsm.hibernate_state.reset(GroupState::PreChaos);
                 } else {

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1733,7 +1733,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
             if msg.get_region_epoch().get_version() > exist_region.get_region_epoch().get_version()
             {
                 // If new region's epoch version is greater than exist region's, the exist region
-                // may has been merged/splitted already.
+                // may has been merged/split already.
                 let _ = self.ctx.router.force_send(
                     exist_region.get_id(),
                     PeerMsg::CasualMessage(CasualMessage::RegionOverlapped),
@@ -2382,8 +2382,8 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                                 if let Some(pr) =
                                     meta.region_read_progress.get(&leader_info.region_id)
                                 {
-                                    // TODO: `update_safe_ts` reqiure to acquire a mutex, although the mutex
-                                    // won't be contended, but acquiring a large amount of uncontended mutexs
+                                    // TODO: `update_safe_ts` require to acquire a mutex, although the mutex
+                                    // won't be contended, but acquiring a large amount of uncontended mutexes
                                     // could still be time consuming, should move this operation to other thread
                                     // to avoid blocking `raftstore` threads
                                     pr.update_safe_ts(

--- a/components/raftstore/src/store/local_metrics.rs
+++ b/components/raftstore/src/store/local_metrics.rs
@@ -382,7 +382,7 @@ impl Default for RaftMetrics {
 }
 
 impl RaftMetrics {
-    /// Flushs all metrics
+    /// Flushes all metrics
     pub fn flush(&mut self) {
         self.ready.flush();
         self.send_message.flush();

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -224,7 +224,7 @@ impl StoreTick {
 
 #[derive(Debug)]
 pub enum MergeResultKind {
-    /// Its target peer applys `CommitMerge` log.
+    /// Its target peer applies `CommitMerge` log.
     FromTargetLog,
     /// Its target peer receives snapshot.
     /// In step 1, this peer should mark `pending_move` is true and destroy its apply fsm.

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -433,7 +433,7 @@ where
     pub approximate_size: u64,
     /// Approximate keys of the region.
     pub approximate_keys: u64,
-    /// Whether this region has calculated region size by split-check thread. If we just splitted
+    /// Whether this region has calculated region size by split-check thread. If we just split
     ///  the region or ingested one file which may be overlapped with the existed data, the
     /// `approximate_size` is not very accurate.
     pub has_calculated_region_size: bool,
@@ -721,7 +721,7 @@ where
         );
         if log_idx < self.raft_group.raft.raft_log.committed {
             // There are maybe some logs not included in CommitMergeRequest's entries, like CompactLog,
-            // so the commit index may exceed the last index of the entires from CommitMergeRequest.
+            // so the commit index may exceed the last index of the entries from CommitMergeRequest.
             // If that, no need to append
             if self.raft_group.raft.raft_log.committed - log_idx > entries.len() as u64 {
                 return None;
@@ -1411,10 +1411,10 @@ where
 
     /// Correctness depends on the order between calling this function and notifying other peers
     /// the new commit index.
-    /// It is due to the interaction between lease and split/merge.(details are decribed below)
+    /// It is due to the interaction between lease and split/merge.(details are described below)
     ///
     /// Note that in addition to the hearbeat/append msg, the read index response also can notify
-    /// other peers the new commit index. There are three place where TiKV handles read index resquest.
+    /// other peers the new commit index. There are three place where TiKV handles read index request.
     /// The first place is in raft-rs, so it's like hearbeat/append msg, call this function and
     /// then send the response. The second place is in `Step`, we should use the commit index
     /// of `PeerStorage` which is the greatest commit index that can be observed outside.

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1491,7 +1491,7 @@ where
         // For now, it is ensured by
         // 1. After `PrepareMerge` log is committed, the source region leader's lease will be
         //    suspected immediately which makes the local reader not serve read request.
-        // 2. No read request can be responsed in peer fsm during merging.
+        // 2. No read request can be responded in peer fsm during merging.
         // These conditions are used to prevent reading **stale** data in the past.
         // At present, they are also used to prevent reading **corrupt** data.
         for r in &ctx.destroyed_regions {

--- a/components/raftstore/src/store/read_queue.rs
+++ b/components/raftstore/src/store/read_queue.rs
@@ -295,7 +295,7 @@ where
         Some(res)
     }
 
-    /// Raft could have not been ready to handle the poped task. So put it back into the queue.
+    /// Raft could have not been ready to handle the popped task. So put it back into the queue.
     pub fn push_front(&mut self, read: ReadIndexRequest<S>) {
         debug_assert!(read.read_index.is_some());
         self.reads.push_front(read);
@@ -496,7 +496,7 @@ mod tests {
             ..Default::default()
         };
 
-        // Push a pending comand when the peer is follower.
+        // Push a pending command when the peer is follower.
         let id = Uuid::new_v4();
         let req = ReadIndexRequest::with_command(
             id,
@@ -540,7 +540,7 @@ mod tests {
             ..Default::default()
         };
 
-        // Push a pending read comand when the peer is leader.
+        // Push a pending read command when the peer is leader.
         let id = Uuid::new_v4();
         let req = ReadIndexRequest::with_command(
             id,
@@ -583,7 +583,7 @@ mod tests {
 
         let ids: [Uuid; 2] = [Uuid::new_v4(), Uuid::new_v4()];
         for id in &ids {
-            // Push a pending read comand when the peer is follower.
+            // Push a pending read command when the peer is follower.
             let req = ReadIndexRequest::with_command(
                 *id,
                 RaftCmdRequest::default(),

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1917,7 +1917,7 @@ pub mod tests {
             write_batch_size: TEST_WRITE_BATCH_SIZE,
             coprocessor_host: CoprocessorHost::<KvTestEngine>::default(),
         };
-        // Verify thte snapshot applying is ok.
+        // Verify the snapshot applying is ok.
         assert!(s4.apply(options).is_ok());
 
         // Ensure `delete()` works to delete the dest snapshot.

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -326,7 +326,7 @@ pub fn check_term(req: &RaftCmdRequest, term: u64) -> Result<()> {
     if header.get_term() == 0 || term <= header.get_term() + 1 {
         Ok(())
     } else {
-        // If header's term is 2 verions behind current term,
+        // If header's term is 2 versions behind current term,
         // leadership may have been changed away.
         Err(Error::StaleCommand)
     }
@@ -597,7 +597,7 @@ impl fmt::Debug for RemoteLease {
     }
 }
 
-// Contants used in `timespec_to_u64` and `u64_to_timespec`.
+// Constants used in `timespec_to_u64` and `u64_to_timespec`.
 const NSEC_PER_MSEC: i32 = 1_000_000;
 const TIMESPEC_NSEC_SHIFT: usize = 32 - NSEC_PER_MSEC.leading_zeros() as usize;
 
@@ -1175,7 +1175,7 @@ mod tests {
     fn gen_region(
         voters: &[u64],
         learners: &[u64],
-        incomming_v: &[u64],
+        incoming_v: &[u64],
         demoting_v: &[u64],
     ) -> metapb::Region {
         let mut region = metapb::Region::default();
@@ -1191,7 +1191,7 @@ mod tests {
         }
         push_peer!(voters, metapb::PeerRole::Voter);
         push_peer!(learners, metapb::PeerRole::Learner);
-        push_peer!(incomming_v, metapb::PeerRole::IncomingVoter);
+        push_peer!(incoming_v, metapb::PeerRole::IncomingVoter);
         push_peer!(demoting_v, metapb::PeerRole::DemotingVoter);
         region
     }
@@ -1206,15 +1206,15 @@ mod tests {
             (vec![1], vec![2], vec![3, 4], vec![5, 6]),
         ];
 
-        for (voter, learner, incomming, demoting) in cases {
+        for (voter, learner, incoming, demoting) in cases {
             let region = gen_region(
                 voter.as_slice(),
                 learner.as_slice(),
-                incomming.as_slice(),
+                incoming.as_slice(),
                 demoting.as_slice(),
             );
             let cs = conf_state_from_region(&region);
-            if incomming.is_empty() && demoting.is_empty() {
+            if incoming.is_empty() && demoting.is_empty() {
                 // Not in joint
                 assert!(cs.get_voters_outgoing().is_empty());
                 assert!(cs.get_learners_next().is_empty());
@@ -1226,7 +1226,7 @@ mod tests {
                     |id| cs.get_voters().contains(id) && cs.get_voters_outgoing().contains(id)
                 ));
                 assert!(learner.iter().all(|id| cs.get_learners().contains(id)));
-                assert!(incomming.iter().all(|id| cs.get_voters().contains(id)));
+                assert!(incoming.iter().all(|id| cs.get_voters().contains(id)));
                 assert!(
                     demoting
                         .iter()
@@ -1493,7 +1493,7 @@ mod tests {
         req.mut_header().set_term(7);
         check_term(&req, 7).unwrap();
         check_term(&req, 8).unwrap();
-        // If header's term is 2 verions behind current term,
+        // If header's term is 2 versions behind current term,
         // leadership may have been changed away.
         check_term(&req, 9).unwrap_err();
         check_term(&req, 10).unwrap_err();

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -260,7 +260,7 @@ where
                 ref write_io_rates,
             } => write!(
                 f,
-                "get store's informations: cpu_usages {:?}, read_io_rates {:?}, write_io_rates {:?}",
+                "get store's information: cpu_usages {:?}, read_io_rates {:?}, write_io_rates {:?}",
                 cpu_usages, read_io_rates, write_io_rates,
             ),
             Task::UpdateMaxTimestamp { region_id, .. } => write!(
@@ -831,7 +831,7 @@ where
                     }
                 }
                 Ok(None) => {
-                    // splitted Region has not yet reported to PD.
+                    // split Region has not yet reported to PD.
                     // TODO: handle merge
                 }
                 Err(e) => {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -254,7 +254,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
     /// #  Fatal errors
     ///
     /// - If `dynamic config` feature is enabled and failed to register config to PD
-    /// - If some critical configs (like data dir) are differrent from last run
+    /// - If some critical configs (like data dir) are different from last run
     /// - If the config can't pass `validate()`
     /// - If the max open file descriptor limit is not high enough to support
     ///   the main database and the raft database.

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1814,7 +1814,7 @@ mod tests {
         let mut batch = WriteBatch::default();
         let mut pairs = vec![];
 
-        // put short value kv in wirte cf
+        // put short value kv in write cf
         let mut pair = Pair::default();
         pair.set_key(b"k1".to_vec());
         pair.set_value(b"short_value".to_vec());

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -57,7 +57,7 @@ impl Default for Store {
 enum SchedulePolicy {
     /// Repeat an Operator.
     Repeat(isize),
-    /// Repeat till succcess.
+    /// Repeat till success.
     TillSuccess,
     /// Stop immediately.
     Stop,

--- a/components/test_raftstore/src/transport_simulate.rs
+++ b/components/test_raftstore/src/transport_simulate.rs
@@ -766,7 +766,7 @@ impl Filter for RandomLatencyFilter {
         let mut to_send = vec![];
         let mut to_delay = vec![];
         let mut delayed_msgs = self.delayed_msgs.lock().unwrap();
-        // check whether to send those messages which are delayed previouly
+        // check whether to send those messages which are delayed previously
         // and check whether to send any newly incoming message if they are not delayed
         for m in delayed_msgs.drain(..).chain(msgs.drain(..)) {
             if self.will_delay(&m) {

--- a/components/tidb_query_datatype/src/codec/convert.rs
+++ b/components/tidb_query_datatype/src/codec/convert.rs
@@ -559,10 +559,10 @@ fn decimal_as_u64(ctx: &mut EvalContext, dec: Decimal, tp: FieldTypeTp) -> Resul
 /// in best effort, but without context.
 pub fn bytes_to_int_without_context(bytes: &[u8]) -> Result<i64> {
     // trim
-    let mut trimed = bytes.iter().skip_while(|&&b| b == b' ' || b == b'\t');
+    let mut trimmed = bytes.iter().skip_while(|&&b| b == b' ' || b == b'\t');
     let mut negative = false;
     let mut r = Some(0i64);
-    if let Some(&c) = trimed.next() {
+    if let Some(&c) = trimmed.next() {
         if c == b'-' {
             negative = true;
         } else if (b'0'..=b'9').contains(&c) {
@@ -571,7 +571,7 @@ pub fn bytes_to_int_without_context(bytes: &[u8]) -> Result<i64> {
             return Ok(0);
         }
 
-        for c in trimed.take_while(|&c| (b'0'..=b'9').contains(c)) {
+        for c in trimmed.take_while(|&c| (b'0'..=b'9').contains(c)) {
             let cur = i64::from(*c - b'0');
             r = r.and_then(|r| r.checked_mul(10)).and_then(|r| {
                 if negative {
@@ -593,16 +593,16 @@ pub fn bytes_to_int_without_context(bytes: &[u8]) -> Result<i64> {
 /// in best effort, but without context.
 pub fn bytes_to_uint_without_context(bytes: &[u8]) -> Result<u64> {
     // trim
-    let mut trimed = bytes.iter().skip_while(|&&b| b == b' ' || b == b'\t');
+    let mut trimmed = bytes.iter().skip_while(|&&b| b == b' ' || b == b'\t');
     let mut r = Some(0u64);
-    if let Some(&c) = trimed.next() {
+    if let Some(&c) = trimmed.next() {
         if (b'0'..=b'9').contains(&c) {
             r = Some(u64::from(c) - u64::from(b'0'));
         } else if c != b'+' {
             return Ok(0);
         }
 
-        for c in trimed.take_while(|&c| (b'0'..=b'9').contains(c)) {
+        for c in trimmed.take_while(|&c| (b'0'..=b'9').contains(c)) {
             r = r
                 .and_then(|r| r.checked_mul(10))
                 .and_then(|r| r.checked_add(u64::from(*c - b'0')));

--- a/components/tidb_query_datatype/src/codec/data_type/chunked_vec_set.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/chunked_vec_set.rs
@@ -20,7 +20,7 @@ use tikv_util::buffer_vec::BufferVec;
 /// stored representation issue
 ///
 /// TODO: add way to set set column data
-/// TODO: code fot set/enum looks nearly the same, considering refactor them using macro
+/// TODO: code for set/enum looks nearly the same, considering refactor them using macro
 #[derive(Debug, Clone)]
 pub struct ChunkedVecSet {
     data: Arc<BufferVec>,

--- a/components/tidb_query_datatype/src/codec/data_type/mod.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/mod.rs
@@ -182,15 +182,15 @@ pub trait Evaluable: Clone + std::fmt::Debug + Send + Sync + 'static {
     const EVAL_TYPE: EvalType;
 
     /// Borrows this concrete type from a `ScalarValue` in the same type;
-    /// panics if the varient mismatches.
+    /// panics if the variant mismatches.
     fn borrow_scalar_value(v: &ScalarValue) -> Option<&Self>;
 
     /// Borrows this concrete type from a `ScalarValueRef` in the same type;
-    /// panics if the varient mismatches.
+    /// panics if the variant mismatches.
     fn borrow_scalar_value_ref(v: ScalarValueRef<'_>) -> Option<&Self>;
 
     /// Borrows a slice of this concrete type from a `VectorValue` in the same type;
-    /// panics if the varient mismatches.
+    /// panics if the variant mismatches.
     fn borrow_vector_value(v: &VectorValue) -> &ChunkedVecSized<Self>;
 }
 
@@ -198,7 +198,7 @@ pub trait EvaluableRet: Clone + std::fmt::Debug + Send + Sync + 'static {
     const EVAL_TYPE: EvalType;
     type ChunkedType: ChunkedVec<Self>;
     /// Converts a vector of this concrete type into a `VectorValue` in the same type;
-    /// panics if the varient mismatches.
+    /// panics if the variant mismatches.
     fn cast_chunk_into_vector_value(vec: Self::ChunkedType) -> VectorValue;
 }
 
@@ -363,15 +363,15 @@ pub trait EvaluableRef<'a>: Clone + std::fmt::Debug + Send + Sync {
     type EvaluableType: EvaluableRet;
 
     /// Borrows this concrete type from a `ScalarValue` in the same type;
-    /// panics if the varient mismatches.
+    /// panics if the variant mismatches.
     fn borrow_scalar_value(v: &'a ScalarValue) -> Option<Self>;
 
     /// Borrows this concrete type from a `ScalarValueRef` in the same type;
-    /// panics if the varient mismatches.
+    /// panics if the variant mismatches.
     fn borrow_scalar_value_ref(v: ScalarValueRef<'a>) -> Option<Self>;
 
     /// Borrows a slice of this concrete type from a `VectorValue` in the same type;
-    /// panics if the varient mismatches.
+    /// panics if the variant mismatches.
     fn borrow_vector_value(v: &'a VectorValue) -> Self::ChunkedType;
 
     /// Convert this reference to owned type

--- a/components/tidb_query_datatype/src/codec/mysql/binary_literal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/binary_literal.rs
@@ -68,32 +68,32 @@ impl BinaryLiteral {
             ));
         }
 
-        let trimed = if s.starts_with('x') || s.starts_with('X') {
+        let trimmed = if s.starts_with('x') || s.starts_with('X') {
             // format is x'val' or X'val'
-            let trimed = s[1..].trim_start_matches('\'');
-            let trimed = trimed.trim_end_matches('\'');
-            if trimed.len() % 2 != 0 {
+            let trimmed = s[1..].trim_start_matches('\'');
+            let trimmed = trimmed.trim_end_matches('\'');
+            if trimmed.len() % 2 != 0 {
                 return Err(box_err!(
                     "invalid hexadecimal format, must even numbers, but {}",
                     s.len()
                 ));
             }
-            trimed
+            trimmed
         } else if s.starts_with("0x") {
             s.trim_start_matches("0x")
         } else {
             // here means format is not x'val', X'val' or 0xval.
             return Err(box_err!("invalid hexadecimal format: {}", s));
         };
-        if trimed.is_empty() {
+        if trimmed.is_empty() {
             return Ok(BinaryLiteral(vec![]));
         }
-        let v = if trimed.len() % 2 != 0 {
+        let v = if trimmed.len() % 2 != 0 {
             let mut head = vec![b'0'];
-            head.extend(trimed.as_bytes());
+            head.extend(trimmed.as_bytes());
             box_try!(hex::decode(head))
         } else {
-            box_try!(hex::decode(trimed.as_bytes()))
+            box_try!(hex::decode(trimmed.as_bytes()))
         };
         Ok(BinaryLiteral(v))
     }
@@ -105,25 +105,25 @@ impl BinaryLiteral {
         if s.is_empty() {
             return Err(box_err!("invalid empty string for parsing bit type"));
         }
-        let trimed = if s.starts_with('b') || s.starts_with('B') {
+        let trimmed = if s.starts_with('b') || s.starts_with('B') {
             // format is b'val' or B'val'
-            let trimed = s[1..].trim_start_matches('\'');
-            trimed.trim_end_matches('\'')
+            let trimmed = s[1..].trim_start_matches('\'');
+            trimmed.trim_end_matches('\'')
         } else if s.starts_with("0b") {
             s.trim_start_matches("0b")
         } else {
             // here means format is not b'val', B'val' or 0bval.
             return Err(box_err!("invalid hexadecimal format: {}", s));
         };
-        if trimed.is_empty() {
+        if trimmed.is_empty() {
             return Ok(BinaryLiteral(vec![]));
         }
 
         // Align the length to 8
-        let aligned_len = (trimed.len() + 7) & (!7);
+        let aligned_len = (trimmed.len() + 7) & (!7);
         let mut padding_str = "0".repeat(8);
-        padding_str.push_str(trimed);
-        let start = trimed.len() + 8 - aligned_len;
+        padding_str.push_str(trimmed);
+        let start = trimmed.len() + 8 - aligned_len;
         let substr = &padding_str[start..];
         let len = substr.len() >> 3;
         let mut buf = Vec::with_capacity(len);
@@ -147,14 +147,14 @@ impl BinaryLiteral {
             s.push_str(&format!("{:08b}", *b));
         }
         if trim_zero {
-            let trimed = s.trim_start_matches('0');
-            if trimed.is_empty() {
+            let trimmed = s.trim_start_matches('0');
+            if trimmed.is_empty() {
                 s.clear();
                 s.push_str("b'0'");
                 return s;
             }
-            let trimed_len = s.len() - trimed.len();
-            s.drain(0..trimed_len);
+            let trimmed_len = s.len() - trimmed.len();
+            s.drain(0..trimmed_len);
         }
         s.insert_str(0, "b'");
         s.push('\'');
@@ -320,7 +320,7 @@ mod tests {
             ),
             ("x''", vec![], false),
         ];
-        for (input, exptected, err) in cs {
+        for (input, expected, err) in cs {
             if err {
                 assert!(
                     BinaryLiteral::from_hex_str(input).is_err(),
@@ -329,7 +329,7 @@ mod tests {
                 );
             } else {
                 let lit = BinaryLiteral::from_hex_str(input).unwrap();
-                assert_eq!(lit.0, exptected);
+                assert_eq!(lit.0, expected);
             }
         }
     }
@@ -406,13 +406,13 @@ mod tests {
             ),
         ];
 
-        for (input, exptected, err) in cs {
+        for (input, expected, err) in cs {
             if err {
                 let lit = BinaryLiteral::from_bit_str(input);
                 assert!(lit.is_err(), "input: {}, lit: {:?}", input, lit);
             } else {
                 let lit = BinaryLiteral::from_bit_str(input).unwrap();
-                assert_eq!(lit.0, exptected);
+                assert_eq!(lit.0, expected);
             }
         }
     }

--- a/components/tidb_query_datatype/src/codec/mysql/json/jcodec.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/jcodec.rs
@@ -230,7 +230,7 @@ pub trait JsonDecoder: NumberDecoder {
     // `read_json` decodes value encoded by `write_json` before.
     fn read_json(&mut self) -> Result<Json> {
         if self.bytes().is_empty() {
-            return Err(box_err!("Cant read json from empty bytes"));
+            return Err(box_err!("Can't read json from empty bytes"));
         }
         let tp: JsonType = self.read_u8()?.try_into()?;
         let value = match tp {

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -202,7 +202,7 @@ impl TryFrom<FieldTypeTp> for TimeType {
             FieldTypeTp::Date => TimeType::Date,
             FieldTypeTp::DateTime => TimeType::DateTime,
             FieldTypeTp::Timestamp => TimeType::Timestamp,
-            // TODO: Remove the support of transfering `Unspecified` to `DateTime`
+            // TODO: Remove the support of transferring `Unspecified` to `DateTime`
             FieldTypeTp::Unspecified => TimeType::DateTime,
             _ => return Err(box_err!("Time does not support field type {}", time_type)),
         })

--- a/components/tidb_query_executors/src/index_scan_executor.rs
+++ b/components/tidb_query_executors/src/index_scan_executor.rs
@@ -64,7 +64,7 @@ impl<S: Storage> BatchIndexScanExecutor<S> {
         // forbidden soon.
         //
         // Note 4: When process global indexes, an extra partition ID column with column ID
-        // `table::EXTRA_PARTITION_ID_COL_ID` will append to column info to indicate which partiton
+        // `table::EXTRA_PARTITION_ID_COL_ID` will append to column info to indicate which partition
         // handles belong to. See https://github.com/pingcap/parser/pull/1010 for more information.
         let pid_column_cnt = columns_info.last().map_or(0, |ci| {
             (ci.get_column_id() == table::EXTRA_PARTITION_ID_COL_ID) as usize

--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -339,7 +339,7 @@ impl ScanExecutorImpl for TableScanExecutorImpl {
                 let (datum, remain) = datum::split_datum(handle, false)?;
                 handle = remain;
 
-                // If the column info of the coresponding primary column id is missing, we ignore this slice of the datum.
+                // If the column info of the corresponding primary column id is missing, we ignore this slice of the datum.
                 if let Some(&index) = index {
                     if !self.is_column_filled[index] {
                         columns[index].mut_raw().push(datum);

--- a/components/tikv_util/src/codec/bytes.rs
+++ b/components/tikv_util/src/codec/bytes.rs
@@ -175,7 +175,7 @@ pub fn decode_bytes(data: &mut BytesSlice<'_>, desc: bool) -> Result<Vec<u8>> {
     let mut offset = 0;
     let chunk_len = ENC_GROUP_SIZE + 1;
     loop {
-        // everytime make ENC_GROUP_SIZE + 1 elements as a decode unit
+        // every time make ENC_GROUP_SIZE + 1 elements as a decode unit
         let next_offset = offset + chunk_len;
         let chunk = if next_offset <= data.len() {
             &data[offset..next_offset]
@@ -240,7 +240,7 @@ pub fn decode_bytes_in_place(data: &mut Vec<u8>, desc: bool) -> Result<()> {
             );
         }
         write_offset += ENC_GROUP_SIZE;
-        // everytime make ENC_GROUP_SIZE + 1 elements as a decode unit
+        // every time make ENC_GROUP_SIZE + 1 elements as a decode unit
         read_offset += ENC_GROUP_SIZE + 1;
 
         // the last byte in decode unit is for marker which indicates pad size
@@ -395,7 +395,7 @@ mod tests {
             assert_eq!(encode_bytes(&source), asc);
             assert_eq!(encode_bytes_desc(&source), desc);
 
-            // apppend timestamp, the timestamp bytes should not affect decode result
+            // append timestamp, the timestamp bytes should not affect decode result
             asc.encode_u64_desc(0).unwrap();
             desc.encode_u64_desc(0).unwrap();
             {

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -302,7 +302,7 @@ impl FromStr for ReadableDuration {
     fn from_str(dur_str: &str) -> Result<ReadableDuration, String> {
         let dur_str = dur_str.trim();
         if !dur_str.is_ascii() {
-            return Err(format!("unexpect ascii string: {}", dur_str));
+            return Err(format!("unexpected ascii string: {}", dur_str));
         }
         let err_msg = "valid duration, only d, h, m, s, ms are supported.".to_owned();
         let mut left = dur_str.as_bytes();
@@ -664,7 +664,7 @@ mod check_kernel {
     /// `check_kernel_params` checks kernel parameters, following are checked so far:
     ///   - `net.core.somaxconn` should be greater or equal to 32768.
     ///   - `net.ipv4.tcp_syncookies` should be 0
-    ///   - `vm.swappiness` shoud be 0
+    ///   - `vm.swappiness` should be 0
     ///
     /// Note that: It works on **Linux** only.
     pub fn check_kernel() -> Vec<ConfigError> {
@@ -1146,7 +1146,7 @@ impl TomlLine {
         TomlLine::parse_kv(kv)
     }
 
-    // Parse `Keys`, only bare keys and dotted keys are supportted
+    // Parse `Keys`, only bare keys and dotted keys are supported
     // bare keys only contains chars of A-Za-z0-9_-
     // dotted keys are a sequence of bare key joined with a '.'
     fn parse_key(s: &str) -> Option<String> {
@@ -1178,7 +1178,7 @@ impl TomlLine {
     }
 }
 
-/// TomlWriter use to update the config file and only cover the most commom toml
+/// TomlWriter use to update the config file and only cover the most common toml
 /// format that used by tikv config file, toml format like: quoted keys, multi-line
 /// value, inline table, etc, are not supported, see <https://github.com/toml-lang/toml>
 /// for more detail.

--- a/components/tikv_util/src/future.rs
+++ b/components/tikv_util/src/future.rs
@@ -76,7 +76,7 @@ pub fn poll_future_notify<F: Future<Output = ()> + Send + 'static>(f: F) {
     waker.wake();
 }
 
-// BatchCommandsWaker is used to make business pool notifiy completion queues directly.
+// BatchCommandsWaker is used to make business pool notify completion queues directly.
 struct BatchCommandsWaker(Mutex<Option<BoxFuture<'static, ()>>>);
 
 impl ArcWake for BatchCommandsWaker {

--- a/components/tikv_util/src/log.rs
+++ b/components/tikv_util/src/log.rs
@@ -6,8 +6,8 @@ macro_rules! crit( ($($args:tt)+) => {
     ::slog_global::crit!($($args)+)
 };);
 
-/// Logs a error level message using the slog global logger. /// Use '?' to output error in debug format or '%' to ouput error in display format.
-/// As the third and forth rules shown, the last log field should follow a ',' to seperate the 'err' field. eg. `error!(?e, "msg"; "foo" => foo,);`
+/// Logs a error level message using the slog global logger. /// Use '?' to output error in debug format or '%' to output error in display format.
+/// As the third and forth rules shown, the last log field should follow a ',' to separate the 'err' field. eg. `error!(?e, "msg"; "foo" => foo,);`
 /// If you don't want to output error code, just use the common form like other macros.
 /// Require `slog_global` dependency and `#![feature(min_speacilization)]` in all crates.
 #[macro_export]

--- a/components/tikv_util/src/mpsc/mod.rs
+++ b/components/tikv_util/src/mpsc/mod.rs
@@ -200,7 +200,7 @@ pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
 
 const CHECK_INTERVAL: usize = 8;
 
-/// A sender of channel that limits the maximun pending messages count loosely.
+/// A sender of channel that limits the maximum pending messages count loosely.
 pub struct LooseBoundedSender<T> {
     sender: Sender<T>,
     tried_cnt: Cell<usize>,

--- a/components/tikv_util/src/worker/future.rs
+++ b/components/tikv_util/src/worker/future.rs
@@ -182,7 +182,7 @@ impl<T: Display + Send + 'static> Worker<T> {
     /// Stops the worker thread.
     pub fn stop(&mut self) -> Option<thread::JoinHandle<()>> {
         // close sender explicitly so the background thread will exit.
-        info!("stoping worker"; "worker" => &self.scheduler.name);
+        info!("stopping worker"; "worker" => &self.scheduler.name);
         let handle = self.handle.take()?;
         if let Err(e) = self.scheduler.sender.unbounded_send(None) {
             warn!("failed to stop worker thread"; "err" => ?e);

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -218,7 +218,7 @@ impl Key {
 
 impl Clone for Key {
     fn clone(&self) -> Self {
-        // default clone implemention use self.len() to reserve capacity
+        // default clone implementation use self.len() to reserve capacity
         // for the sake of appending ts, we need to reserve more
         let mut key = Vec::with_capacity(self.0.capacity());
         key.extend_from_slice(&self.0);

--- a/metrics/grafana/performance_read.json
+++ b/metrics/grafana/performance_read.json
@@ -2264,7 +2264,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "99% gRPC messge duration",
+          "title": "99% gRPC message duration",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/metrics/grafana/tikv_trouble_shooting.json
+++ b/metrics/grafana/tikv_trouble_shooting.json
@@ -3347,7 +3347,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "99% gRPC messge duration",
+          "title": "99% gRPC message duration",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -4866,7 +4866,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "99% gRPC messge duration",
+          "title": "99% gRPC message duration",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -2791,7 +2791,7 @@ fn to_config_change(change: HashMap<String, String>) -> CfgResult<ConfigChange> 
                 field.replace("-", "_")
             };
             return match typed.get(&f) {
-                None => Err(format!("unexpect fields: {}", field).into()),
+                None => Err(format!("unexpected fields: {}", field).into()),
                 Some(ConfigValue::Skip) => {
                     Err(format!("config {} can not be changed", field).into())
                 }
@@ -2802,7 +2802,7 @@ fn to_config_change(change: HashMap<String, String>) -> CfgResult<ConfigChange> 
                     {
                         return helper(fields, n_dst, m, value);
                     }
-                    panic!("unexpect config value");
+                    panic!("unexpected config value");
                 }
                 Some(v) => {
                     if fields.is_empty() {
@@ -2815,7 +2815,7 @@ fn to_config_change(change: HashMap<String, String>) -> CfgResult<ConfigChange> 
                         };
                     }
                     let c: Vec<_> = fields.into_iter().rev().collect();
-                    Err(format!("unexpect fields: {}", c[..].join(".")).into())
+                    Err(format!("unexpected fields: {}", c[..].join(".")).into())
                 }
             };
         }
@@ -2866,7 +2866,7 @@ fn to_toml_encode(change: HashMap<String, String>) -> CfgResult<HashMap<String, 
                 Some(ConfigValue::Module(m)) => helper(fields, m),
                 Some(c) => {
                     if !fields.is_empty() {
-                        return Err(format!("unexpect fields: {:?}", fields).into());
+                        return Err(format!("unexpected fields: {:?}", fields).into());
                     }
                     match c {
                         ConfigValue::Duration(_)
@@ -2977,7 +2977,7 @@ impl ConfigController {
         for (name, change) in diff.into_iter() {
             match change {
                 ConfigValue::Module(change) => {
-                    // update a submodule's config only if changes had been sucessfully
+                    // update a submodule's config only if changes had been successfully
                     // dispatched to corresponding config manager, to avoid dispatch change twice
                     if let Some(mgr) = inner.config_mgrs.get_mut(&Module::from(name.as_str())) {
                         if let Err(e) = mgr.dispatch(change.clone()) {

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -323,7 +323,7 @@ where
                 }
                 cmd.mut_header().set_term(header.get_current_term());
                 // Here we shall check whether the file has been ingested before. This operation
-                // must execute after geting a snapshot from raftstore to make sure that the
+                // must execute after getting a snapshot from raftstore to make sure that the
                 // current leader has applied to current term.
                 if !importer.exist(&m) {
                     return Ok(resp);

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -151,7 +151,7 @@ impl Default for Config {
             grpc_stream_initial_window_size: ReadableSize(DEFAULT_GRPC_STREAM_INITIAL_WINDOW_SIZE),
             grpc_memory_pool_quota: ReadableSize(DEFAULT_GRPC_MEMORY_POOL_QUOTA),
             // There will be a heartbeat every secs, it's weird a connection will be idle for more
-            // than 10 senconds.
+            // than 10 seconds.
             grpc_keepalive_time: ReadableDuration::secs(10),
             grpc_keepalive_timeout: ReadableDuration::secs(3),
             concurrent_send_snap_limit: 32,

--- a/src/server/gc_worker/applied_lock_collector.rs
+++ b/src/server/gc_worker/applied_lock_collector.rs
@@ -596,7 +596,7 @@ mod tests {
         start_collecting(&c, 3).unwrap_err();
         get_collected_locks(&c, 3).unwrap_err();
         get_collected_locks(&c, 4).unwrap();
-        // Do not allow stoping observing with a different max_ts.
+        // Do not allow stopping observing with a different max_ts.
         stop_collecting(&c, 3).unwrap_err();
         stop_collecting(&c, 5).unwrap_err();
         stop_collecting(&c, 4).unwrap();

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -31,12 +31,12 @@ const DEFAULT_DELETE_BATCH_SIZE: usize = 256 * 1024;
 const DEFAULT_DELETE_BATCH_COUNT: usize = 128;
 
 // The default version that can enable compaction filter for GC. This is necessary because after
-// compaction filter is enabled, it's impossible to fallback to ealier version which modifications
+// compaction filter is enabled, it's impossible to fallback to earlier version which modifications
 // of GC are distributed to other replicas by Raft.
 const COMPACTION_FILTER_GC_FEATURE: Feature = Feature::require(5, 0, 0);
 
 // Global context to create a compaction filter for write CF. It's necessary as these fields are
-// not available when construcing `WriteCompactionFilterFactory`.
+// not available when constructing `WriteCompactionFilterFactory`.
 struct GcContext {
     db: RocksEngine,
     store_id: u64,
@@ -75,7 +75,7 @@ lazy_static! {
     .unwrap();
     static ref GC_COMPACTION_FILTER_PERFORM: IntCounter = register_int_counter!(
         "tikv_gc_compaction_filter_perform",
-        "perfrom GC in compaction filter"
+        "perform GC in compaction filter"
     )
     .unwrap();
 
@@ -928,7 +928,7 @@ pub mod tests {
         gc_and_check(true, b"zkey1");
     }
 
-    // Test if there are not enought garbage in SST files involved by a compaction, no compaction
+    // Test if there are not enough garbage in SST files involved by a compaction, no compaction
     // filter will be created.
     #[test]
     fn test_mvcc_properties() {

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -682,7 +682,7 @@ where
 {
     engine: E,
 
-    /// `raft_store_router` is useful to signal raftstore clean region size informations.
+    /// `raft_store_router` is useful to signal raftstore clean region size information.
     raft_store_router: RR,
 
     config_manager: GcWorkerConfigManager,

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -168,7 +168,7 @@ impl DetectTable {
         let ttl = self.ttl;
 
         let mut stack = vec![wait_for_ts];
-        // Memorize the pushed vertexes to avoid duplicate search, and maps to the predecessor of
+        // Memorize the pushed vertices to avoid duplicate search, and maps to the predecessor of
         // the vertex.
         // Since the graph is a DAG instead of a tree, a vertex may have multiple predecessors. But
         // it's ok if we only remember one: for each vertex, if it has a route to the goal (txn_ts),

--- a/src/server/proxy.rs
+++ b/src/server/proxy.rs
@@ -87,7 +87,7 @@ impl ClientPool {
                     .stream_initial_window_size(cfg.grpc_stream_initial_window_size.0 as i32)
                     .max_receive_message_len(-1)
                     .max_send_message_len(-1)
-                    // Memory should be limited by incomming connections already.
+                    // Memory should be limited by incoming connections already.
                     // And maintaining a shared resource quota doesn't seem easy.
                     .keepalive_time(cfg.grpc_keepalive_time.into())
                     .keepalive_timeout(cfg.grpc_keepalive_timeout.into())

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -91,7 +91,7 @@ impl Queue {
         self.connected.store(false, Ordering::SeqCst);
     }
 
-    /// Wakes up consumer to retrive message.
+    /// Wakes up consumer to retrieve message.
     fn notify(&self) {
         if !self.buf.is_empty() {
             let t = self.waker.lock().unwrap().take();
@@ -293,7 +293,7 @@ where
                 .report_snapshot_status(self.region_id, self.to_peer_id, status)
         {
             error!(?e;
-                "report snapshot to peer failes";
+                "report snapshot to peer fails";
                 "to_peer_id" => self.to_peer_id,
                 "to_store_id" => self.to_store_id,
                 "region_id" => self.region_id,

--- a/src/server/raftkv.rs
+++ b/src/server/raftkv.rs
@@ -414,7 +414,7 @@ where
                 }
                 Ok(CmdRes::Snap(_)) => write_cb((
                     cb_ctx,
-                    Err(box_err!("unexpect snapshot, should mutate instead.")),
+                    Err(box_err!("unexpected snapshot, should mutate instead.")),
                 )),
                 Err(e) => {
                     let status_kind = get_status_kind_from_engine_error(&e);

--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -375,7 +375,7 @@ fn disk_hardware_info(collector: &mut Vec<ServerInfoItem>) {
             (
                 "fstype",
                 std::str::from_utf8(disk.get_file_system())
-                    .unwrap_or("unkonwn")
+                    .unwrap_or("unknown")
                     .to_string(),
             ),
             (

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -738,7 +738,7 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
         };
 
         if let Err(e) = self.ch.send_casual_msg(region_id, req) {
-            // Retrun region error instead a gRPC error.
+            // Return region error instead a gRPC error.
             let mut resp = SplitRegionResponse::default();
             resp.set_region_error(raftstore_error_to_region_error(e, region_id));
             ctx.spawn(
@@ -833,7 +833,7 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
         // We must deal with all requests which acquire read-quorum in raftstore-thread,
         // so just send it as an command.
         if let Err(e) = self.ch.send_command(cmd, Callback::Read(cb)) {
-            // Retrun region error instead a gRPC error.
+            // Return region error instead a gRPC error.
             let mut resp = ReadIndexResponse::default();
             resp.set_region_error(raftstore_error_to_region_error(e, region_id));
             ctx.spawn(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -5712,7 +5712,7 @@ mod tests {
 
         // Commit
         prewrite_locks(&keys, 10.into());
-        // If locks don't exsit, hashes of released locks should be empty.
+        // If locks don't exist, hashes of released locks should be empty.
         for empty_hashes in &[false, true] {
             storage
                 .sched_txn_command(
@@ -5884,7 +5884,7 @@ mod tests {
                 assert_wake_up_msg_eq(msg1, 70.into(), key_hashes, 0.into(), true);
                 assert_wake_up_msg_eq(msg2, 75.into(), committed_key_hashes, 76.into(), false);
             }
-            _ => panic!("unexpect msg"),
+            _ => panic!("unexpected msg"),
         }
 
         // CheckTxnStatus

--- a/src/storage/mvcc/consistency_check.rs
+++ b/src/storage/mvcc/consistency_check.rs
@@ -68,7 +68,7 @@ impl<E: KvEngine> ConsistencyCheckObserver<E> for Mvcc<E> {
                 8,
             );
         }
-        // Skiped all other observers.
+        // Skipped all other observers.
         true
     }
 

--- a/src/storage/txn/actions/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/actions/acquire_pessimistic_lock.rs
@@ -87,7 +87,7 @@ pub fn acquire_pessimistic_lock<S: Snapshot>(
         if need_value {
             val = reader.get(&key, for_update_ts)?;
         }
-        // Pervious write is not loaded.
+        // Previous write is not loaded.
         let (prev_write_loaded, prev_write) = (false, None);
         let old_value = load_old_value(
             need_old_value,
@@ -626,7 +626,7 @@ pub mod tests {
         // Prewrite on non-pessimistic key meets write with larger commit_ts than current
         // for_update_ts (non-pessimistic data conflict).
         // Normally non-pessimistic keys in pessimistic transactions are used when we are sure that
-        // there won't be conflicts. So this case is also not checked, and prewrite will succeeed.
+        // there won't be conflicts. So this case is also not checked, and prewrite will succeed.
         must_pessimistic_prewrite_put(&engine, k, v, k, 47, 48, false);
         must_locked(&engine, k, 47);
         must_cleanup(&engine, k, 47, 0);

--- a/src/storage/txn/actions/cleanup.rs
+++ b/src/storage/txn/actions/cleanup.rs
@@ -207,7 +207,7 @@ pub mod tests {
 
         // Try to cleanup another transaction's lock. Does nothing.
         must_succeed(&engine, k, ts(10, 1), ts(120, 0));
-        // If there is no exisiting lock when cleanup, it may be a pessimistic transaction,
+        // If there is no existing lock when cleanup, it may be a pessimistic transaction,
         // so the rollback should be protected.
         must_get_rollback_protected(&engine, k, ts(10, 1), true);
         must_locked(&engine, k, ts(10, 0));

--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -128,7 +128,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLock 
             let pr = ProcessResult::PessimisticLockRes { res };
             let extra = TxnExtra {
                 old_values: self.old_values,
-                // One pc status is unkown AcquirePessimisticLock stage.
+                // One pc status is unknown AcquirePessimisticLock stage.
                 one_pc: false,
             };
             let write_data = WriteData::new(txn.into_modifies(), extra);

--- a/src/storage/txn/latch.rs
+++ b/src/storage/txn/latch.rs
@@ -101,7 +101,7 @@ pub struct Lock {
 }
 
 impl Lock {
-    /// Creates a lock specifing all the required latches for a command.
+    /// Creates a lock specifying all the required latches for a command.
     pub fn new<'a, K, I>(keys: I) -> Lock
     where
         K: Hash + 'a,

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -142,13 +142,13 @@ pub enum TxnEntry {
         write: KvPair,
         old_value: Option<Value>,
     },
-    // TOOD: Add more entry if needed.
+    // TODO: Add more entry if needed.
 }
 
 impl TxnEntry {
     /// This method will return a kv pair whose
     /// content and encode are same as a kv pair
-    /// reture by ```StoreScanner::next```
+    /// returned by ```StoreScanner::next```
     pub fn into_kvpair(self) -> Result<(Vec<u8>, Vec<u8>)> {
         match self {
             TxnEntry::Commit { default, write, .. } => {

--- a/tests/failpoints/cases/test_cmd_epoch_checker.rs
+++ b/tests/failpoints/cases/test_cmd_epoch_checker.rs
@@ -378,7 +378,7 @@ fn test_not_invoke_committed_cb_when_fail_to_commit() {
     cluster.must_transfer_leader(1, new_peer(1, 1));
     cluster.must_put(b"k", b"v");
 
-    // Partiton the leader and followers to let the leader fails to commit the proposal.
+    // Partition the leader and followers to let the leader fails to commit the proposal.
     cluster.partition(vec![1], vec![2, 3]);
     let write_req = make_write_req(&mut cluster, b"k1");
     let (cb, cb_receivers) = make_cb(&write_req);

--- a/tests/failpoints/cases/test_conf_change.rs
+++ b/tests/failpoints/cases/test_conf_change.rs
@@ -204,7 +204,7 @@ fn test_stale_peer_cache() {
 // The test is for this situation:
 // suppose there are 3 peers (1, 2, and 3) in a Raft group, and then
 // 1. propose to add peer 4 on the current leader 1;
-// 2. leader 1 appends entries to peer 3, and peer 3 applys them;
+// 2. leader 1 appends entries to peer 3, and peer 3 applies them;
 // 3. a new proposal to remove peer 4 is proposed;
 // 4. peer 1 sends a snapshot with latest configuration [1, 2, 3] to peer 3;
 // 5. peer 3 restores the snapshot into memory;

--- a/tests/failpoints/cases/test_import_service.rs
+++ b/tests/failpoints/cases/test_import_service.rs
@@ -121,7 +121,7 @@ fn test_ingest_reentrant() {
         .get_path(&meta);
 
     let checksum1 = calc_crc32(save_path.clone()).unwrap();
-    // Do ingest and it will ingest successs.
+    // Do ingest and it will ingest success.
     let resp = import.ingest(&ingest).unwrap();
     assert!(!resp.has_error());
 

--- a/tests/failpoints/cases/test_replica_read.rs
+++ b/tests/failpoints/cases/test_replica_read.rs
@@ -424,7 +424,7 @@ fn test_replica_read_after_transfer_leader() {
 
     cluster.add_send_filter(IsolationFilterFactory::new(3));
 
-    // peer 2 does not know the latest commit index if it cann't receive hearbeat.
+    // peer 2 does not know the latest commit index if it can't receive hearbeat.
     // It's because the mechanism of notifying commit index in raft-rs is lazy.
     let recv_filter_2 = Box::new(
         RegionPacketFilter::new(1, 2)

--- a/tests/failpoints/cases/test_replica_stale_read.rs
+++ b/tests/failpoints/cases/test_replica_stale_read.rs
@@ -177,7 +177,7 @@ fn test_stale_read_basic_flow_lock() {
         b"key1".to_vec(),
     );
 
-    // Assert `(key1, value2)` can't be readed with `commit_ts2` due to it's larger than the `start_ts` of `key2`.
+    // Assert `(key1, value2)` can't be read with `commit_ts2` due to it's larger than the `start_ts` of `key2`.
     let resp = follower_client2.kv_read(b"key1".to_vec(), commit_ts2);
     assert!(resp.get_region_error().has_data_is_not_ready());
     // Still can read `(key1, value1)` since `commit_ts1` is less than the `key2` lock's `start_ts`

--- a/tests/failpoints/cases/test_snap.rs
+++ b/tests/failpoints/cases/test_snap.rs
@@ -123,7 +123,7 @@ fn test_generate_snapshot() {
     fail::cfg("snapshot_delete_after_send", "off").unwrap();
     must_empty_dir(cluster.get_snap_dir(1));
 
-    // The task is droped so that we can't get the snapshot on store 5.
+    // The task is dropped so that we can't get the snapshot on store 5.
     fail::cfg("snapshot_enter_do_build", "pause").unwrap();
     must_get_none(&cluster.get_engine(5), b"k2");
 
@@ -436,7 +436,7 @@ fn test_receive_old_snapshot() {
     fail::remove(peer_2_handle_snap_mgr_gc_fp);
 }
 
-/// Test if snapshot can be genereated when there is a ready with no newly
+/// Test if snapshot can be generated when there is a ready with no newly
 /// committed entries.
 /// The failpoint `before_no_ready_gen_snap_task` is used for skipping
 /// the code path that snapshot is generated when there is no ready.

--- a/tests/failpoints/cases/test_stale_peer.rs
+++ b/tests/failpoints/cases/test_stale_peer.rs
@@ -121,7 +121,7 @@ fn test_stale_learner_restart() {
         thread::sleep(Duration::from_millis(10));
     }
     if state.last_index != last_index {
-        panic!("store 2 has not catched up logs after 5 secs.");
+        panic!("store 2 has not caught up logs after 5 secs.");
     }
     cluster.shutdown();
     must_get_none(&cluster.get_engine(2), b"k2");

--- a/tests/integrations/pd/test_rpc_client.rs
+++ b/tests/integrations/pd/test_rpc_client.rs
@@ -570,7 +570,7 @@ fn test_cluster_version() {
     assert!(feature_gate.can_enable(feature_b));
     assert!(!feature_gate.can_enable(feature_c));
 
-    // After reconnect the version should be still accessable.
+    // After reconnect the version should be still accessible.
     // The GLOBAL_RECONNECT_INTERVAL is 0.1s so sleeps 0.2s here.
     thread::sleep(Duration::from_millis(200));
     client.reconnect().unwrap();

--- a/tests/integrations/raftstore/test_bootstrap.rs
+++ b/tests/integrations/raftstore/test_bootstrap.rs
@@ -23,7 +23,7 @@ use tikv_util::worker::{dummy_scheduler, Builder as WorkerBuilder, FutureWorker}
 fn test_bootstrap_idempotent<T: Simulator>(cluster: &mut Cluster<T>) {
     // assume that there is a node  bootstrap the cluster and add region in pd successfully
     cluster.add_first_region().unwrap();
-    // now at same time start the another node, and will recive cluster is not bootstrap
+    // now at same time start the another node, and will receive cluster is not bootstrap
     // it will try to bootstrap with a new region, but will failed
     // the region number still 1
     cluster.start().unwrap();

--- a/tests/integrations/raftstore/test_compact_lock_cf.rs
+++ b/tests/integrations/raftstore/test_compact_lock_cf.rs
@@ -42,7 +42,7 @@ fn test_compact_lock_cf<T: Simulator>(cluster: &mut Cluster<T>) {
         let (k, v) = (format!("k{}", i), format!("value{}", i));
         cluster.must_put_cf(CF_LOCK, k.as_bytes(), v.as_bytes());
     }
-    // Generate one sst, if there are datas only in one memtable, no compactions will be triggered.
+    // Generate one sst, if there are data only in one memtable, no compactions will be triggered.
     flush(cluster);
 
     // Write more 40 bytes, still not reach lock_cf_compact_bytes_threshold,

--- a/tests/integrations/raftstore/test_joint_consensus.rs
+++ b/tests/integrations/raftstore/test_joint_consensus.rs
@@ -155,13 +155,13 @@ fn test_request_in_joint_state() {
 
     // Request can be handled as usual
     cluster.must_put(b"k2", b"v2");
-    // Both new and old configuation have the newest log
+    // Both new and old configuration have the newest log
     must_get_equal(&cluster.get_engine(2), b"k2", b"v2");
     must_get_equal(&cluster.get_engine(3), b"k2", b"v2");
 
     let region = cluster.get_region(b"k1");
 
-    // Isolated peer 2, so the old configuation can't reach quorum
+    // Isolated peer 2, so the old configuration can't reach quorum
     cluster.add_send_filter(IsolationFilterFactory::new(2));
     let rx = cluster
         .async_request(put_request(&region, 1, b"k3", b"v3"))
@@ -172,7 +172,7 @@ fn test_request_in_joint_state() {
     );
     cluster.clear_send_filters();
 
-    // Isolated peer 3, so the new configuation can't reach quorum
+    // Isolated peer 3, so the new configuration can't reach quorum
     cluster.add_send_filter(IsolationFilterFactory::new(3));
     let rx = cluster
         .async_request(put_request(&region, 1, b"k4", b"v4"))

--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -57,7 +57,7 @@ fn test_replica_read_not_applied() {
     configure_for_lease_read(&mut cluster, Some(50), Some(30));
     let max_lease = Duration::from_secs(1);
     cluster.cfg.raft_store.raft_store_max_leader_lease = ReadableDuration(max_lease);
-    // After the leader has committed to its term, pending reads on followers can be responsed.
+    // After the leader has committed to its term, pending reads on followers can be responded.
     // However followers can receive `ReadIndexResp` after become candidate if the leader has
     // hibernated. So, disable the feature to avoid read requests on followers to be cleared as
     // stale.
@@ -239,7 +239,7 @@ fn test_read_hibernated_region() {
 }
 
 /// The read index response can advance the commit index.
-/// But in previous implemtation, we forget to set term in read index response
+/// But in previous implementation, we forget to set term in read index response
 /// which causes panic in raft-rs. This test is to reproduce the case.
 #[test]
 fn test_replica_read_on_stale_peer() {
@@ -299,7 +299,7 @@ fn test_read_index_out_of_order() {
     );
     cluster.sim.wl().add_recv_filter(1, filter);
 
-    // Can't get read resonse because heartbeat responses are blocked.
+    // Can't get read response because heartbeat responses are blocked.
     let r1 = cluster.get_region(b"k1");
     let resp1 = async_read_on_peer(&mut cluster, new_peer(1, 1), r1.clone(), b"k1", true, true);
     assert!(resp1.recv_timeout(Duration::from_secs(2)).is_err());
@@ -487,7 +487,7 @@ fn test_read_local_after_snapshpot_replace_peer() {
     cluster.must_put(b"k3", b"v3");
     // wait peer 1003 apply snapshot
     must_get_equal(&cluster.get_engine(3), b"k3", b"v3");
-    // value can be readed from `engine` doesn't mean applying snapshot is finished
+    // value can be read from `engine` doesn't mean applying snapshot is finished
     // wait little more time
     sleep_ms(100);
 
@@ -496,7 +496,7 @@ fn test_read_local_after_snapshpot_replace_peer() {
     let resp = resp.recv_timeout(Duration::from_secs(1)).unwrap();
     // should not have `mismatch peer id` error
     if resp.get_header().has_error() {
-        panic!("unexpect err: {:?}", resp.get_header().get_error());
+        panic!("unexpected err: {:?}", resp.get_header().get_error());
     }
     let exp_value = resp.get_responses()[0].get_get().get_value();
     assert_eq!(exp_value, b"v3");

--- a/tests/integrations/server/lock_manager.rs
+++ b/tests/integrations/server/lock_manager.rs
@@ -208,7 +208,7 @@ fn test_detect_deadlock_basic() {
 fn test_detect_deadlock_when_transfer_leader() {
     let mut cluster = new_cluster_for_deadlock_test(3);
     // Transfer the leader of region 1 to store(2).
-    // The leader of deadlock detector should also be transfered to store(2).
+    // The leader of deadlock detector should also be transferred to store(2).
     must_transfer_leader(&mut cluster, b"", 2);
     deadlock_detector_leader_must_be(&mut cluster, 2);
     must_detect_deadlock(&mut cluster, b"k", 10);
@@ -221,7 +221,7 @@ fn test_detect_deadlock_when_split_region() {
     // After split, the leader is still store(1).
     deadlock_detector_leader_must_be(&mut cluster, 1);
     must_detect_deadlock(&mut cluster, b"k", 10);
-    // Transfer the new region's leader to store(2) and deadlock occours on it.
+    // Transfer the new region's leader to store(2) and deadlock occurs on it.
     must_transfer_leader(&mut cluster, b"k1", 2);
     deadlock_detector_leader_must_be(&mut cluster, 1);
     must_detect_deadlock(&mut cluster, b"k1", 10);
@@ -231,7 +231,7 @@ fn test_detect_deadlock_when_split_region() {
 fn test_detect_deadlock_when_transfer_region() {
     let mut cluster = new_cluster_for_deadlock_test(4);
     // Transfer the leader region to store(4) and the leader of deadlock detector should be
-    // also transfered.
+    // also transferred.
     must_transfer_region(&mut cluster, b"k", 1, 4, 4);
     deadlock_detector_leader_must_be(&mut cluster, 4);
     must_detect_deadlock(&mut cluster, b"k", 10);

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -219,7 +219,7 @@ fn test_batch_size_limit() {
     assert_eq!(msg_count.load(Ordering::SeqCst), 10);
 }
 
-// Try to create a mock server with `service`. The server will be binded wiht a random
+// Try to create a mock server with `service`. The server will be binded with a random
 // port chosen between [`min_port`, `max_port`]. Return `None` if no port is available.
 fn create_mock_server<T>(service: T, min_port: u16, max_port: u16) -> Option<(Server, u16)>
 where


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5456

Problem Summary: Spelling typos in the code easily found by codespell program.

### What is changed and how it works?

What's Changed: Nothing changed in the behavior, only code spelling errors have been fixed.

### Related changes

- Needs to include the codespell check in the CI

The codespell command used to check this was `codespell -L crate,nd,ser,hist,ths,ba,hel,te,ans src components cmd fuzz tests`

### Check List

Tests

- No code

### Release note
- No release note