### PR TITLE
cdc, mvcc: always read old value when cdc requires

### DIFF
--- a/components/cdc/tests/integrations/test_cdc.rs
+++ b/components/cdc/tests/integrations/test_cdc.rs
@@ -797,7 +797,8 @@ fn test_old_value_basic() {
     m6.value = b"v6".to_vec();
     suite.must_kv_prewrite(1, vec![m6], k1.clone(), 10.into());
     suite.must_kv_commit(1, vec![k1.clone()], 10.into(), 11.into());
-    // Delete value
+    // Delete value in pessimistic txn.
+    // In pessimistic txn, CDC must use for_update_ts to read the old value.
     let mut m7 = Mutation::default();
     m7.set_op(Op::PessimisticLock);
     m7.key = k1.clone();

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -1626,5 +1626,21 @@ mod tests {
                 assert_eq!(result, case.expected, "case #{}", i);
             }
         }
+
+        // Must return Oldvalue::None when prev_write_loaded is true and prev_write is None.
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut reader = MvccReader::new(snapshot, None, true, IsolationLevel::Si);
+        let prev_write_loaded = true;
+        let prev_write = None;
+        let result = reader
+            .get_old_value(
+                &Key::from_raw(b"a"),
+                TimeStamp::new(25),
+                prev_write_loaded,
+                prev_write,
+            )
+            .unwrap();
+        assert_eq!(result, OldValue::None);
     }
 }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -469,8 +469,10 @@ impl<S: Snapshot> MvccTxn<S> {
                 let prev_write_loaded = false;
                 // The mutation reads and get a previous write.
                 let prev_write = None;
+                // In pessimistic txn, it must use for_update_ts to read
+                // the old value.
                 self.reader
-                    .get_old_value(&key, self.start_ts, prev_write_loaded, prev_write)?
+                    .get_old_value(&key, for_update_ts, prev_write_loaded, prev_write)?
             }
         } else {
             OldValue::Unspecified

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -611,6 +611,7 @@ impl<S: Snapshot> MvccTxn<S> {
             return Ok(());
         }
 
+        #[allow(clippy::if_same_then_else)]
         let old_value = if self.extra_op == ExtraOp::ReadOldValue
             && matches!(
                 mutation_type,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #9996 #9981

Reading old value costs too much CPU for CDC endpoint thread, leading to OOM. 

### What is changed and how it works?

Always read old value in txn layer when cdc requires old value.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

Fix CDC OOM issue caused by reading old values.
