### PR TITLE
storage: check deadline before executing scheduler command

### DIFF
--- a/components/error_code/src/storage.rs
+++ b/components/error_code/src/storage.rs
@@ -19,6 +19,7 @@ define_error_codes!(
     BAD_FORMAT_WRITE => ("BadFormatWrite", "",""),
     KEY_IS_LOCKED => ("KeyIsLocked", "", ""),
     MAX_TIMESTAMP_NOT_SYNCED => ("MaxTimestampNotSynced", "", ""),
+    DEADLINE_EXCEEDED => ("DeadlineExceeded", "", ""),
 
     COMMITTED => ("Committed", "", ""),
     PESSIMISTIC_LOCK_ROLLED_BACK => ("PessimisticLockRolledBack", "", ""),

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -50,6 +50,9 @@ pub enum ErrorInner {
 
     #[error("ttl is not enabled, but get put request with ttl")]
     TTLNotEnabled,
+
+    #[error("deadline exceeded")]
+    DeadlineExceeded,
 }
 
 /// Errors for storage module. Wrapper type of `ErrorInner`.
@@ -85,6 +88,7 @@ impl ErrorCodeExt for Error {
             ErrorInner::KeyTooLarge { .. } => error_code::storage::KEY_TOO_LARGE,
             ErrorInner::InvalidCf(_) => error_code::storage::INVALID_CF,
             ErrorInner::TTLNotEnabled => error_code::storage::TTL_NOT_ENABLED,
+            ErrorInner::DeadlineExceeded => error_code::storage::DEADLINE_EXCEEDED,
         }
     }
 }
@@ -195,6 +199,11 @@ pub fn extract_region_error<T>(res: &Result<T>) -> Option<errorpb::Error> {
             // temporarily, the client should retry the request in other TiKVs.
             let mut err = errorpb::Error::default();
             err.set_message("TiKV is Closing".to_string());
+            Some(err)
+        }
+        Err(Error(box ErrorInner::DeadlineExceeded)) => {
+            let mut err = errorpb::Error::default();
+            err.set_message("Deadline is exceeded".to_string());
             Some(err)
         }
         _ => None,

--- a/src/storage/errors.rs
+++ b/src/storage/errors.rs
@@ -9,6 +9,7 @@ use kvproto::{errorpb, kvrpcpb};
 use thiserror::Error;
 
 use error_code::{self, ErrorCode, ErrorCodeExt};
+use tikv_util::deadline::DeadlineError;
 use txn_types::{KvPair, TimeStamp};
 
 use crate::storage::{
@@ -53,6 +54,12 @@ pub enum ErrorInner {
 
     #[error("deadline exceeded")]
     DeadlineExceeded,
+}
+
+impl From<DeadlineError> for ErrorInner {
+    fn from(_: DeadlineError) -> Self {
+        ErrorInner::DeadlineExceeded
+    }
 }
 
 /// Errors for storage module. Wrapper type of `ErrorInner`.

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -13,10 +13,13 @@ use collections::HashMap;
 use errors::{extract_key_error, extract_region_error};
 use futures::executor::block_on;
 use test_raftstore::{must_get_equal, must_get_none, new_peer, new_server_cluster};
-use tikv::storage::kv::{Error as KvError, ErrorInner as KvErrorInner, SnapContext};
 use tikv::storage::lock_manager::DummyLockManager;
 use tikv::storage::txn::{commands, Error as TxnError, ErrorInner as TxnErrorInner};
 use tikv::storage::{self, test_util::*, *};
+use tikv::storage::{
+    kv::{Error as KvError, ErrorInner as KvErrorInner, SnapContext},
+    Error as StorageError, ErrorInner as StorageErrorInner,
+};
 use tikv_util::future::paired_future_callback;
 use tikv_util::HandyRwLock;
 use txn_types::Key;
@@ -1058,4 +1061,46 @@ fn test_atomic_cas_lock_by_latch() {
     let f = storage.raw_get(ctx, "".to_string(), b"key".to_vec());
     let ret = block_on(f).unwrap().unwrap();
     assert_eq!(b"v2".to_vec(), ret);
+}
+
+#[test]
+fn test_before_async_write_deadline() {
+    let mut cluster = new_server_cluster(0, 1);
+    cluster.run();
+
+    let engine = cluster
+        .sim
+        .read()
+        .unwrap()
+        .storages
+        .get(&1)
+        .unwrap()
+        .clone();
+    let storage = TestStorageBuilder::<_, DummyLockManager>::from_engine_and_lock_mgr(
+        engine,
+        DummyLockManager {},
+    )
+    .build()
+    .unwrap();
+
+    let mut ctx = Context::default();
+    ctx.set_region_id(1);
+    ctx.set_region_epoch(cluster.get_region_epoch(1));
+    ctx.set_peer(cluster.leader_of_region(1).unwrap());
+    ctx.max_execution_duration_ms = 200;
+    let (tx, rx) = channel();
+    fail::cfg("cleanup", "sleep(500)").unwrap();
+    storage
+        .sched_txn_command(
+            commands::Rollback::new(vec![Key::from_raw(b"k")], 10.into(), ctx),
+            Box::new(move |res: storage::Result<_>| {
+                tx.send(res).unwrap();
+            }),
+        )
+        .unwrap();
+
+    assert!(matches!(
+        rx.recv().unwrap(),
+        Err(StorageError(box StorageErrorInner::DeadlineExceeded))
+    ));
 }


### PR DESCRIPTION

### What problem does this PR solve?

Part of #10166 

### What is changed and how it works?

When `max_execution_duration_ms` in `Context` is set, we check whether the deadline is exceeded before acquiring the latches. So a scheduler command that waits in the scheduler for too long will not execute to waste resource.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- Check deadline before executing scheduler command