### PR TITLE
raftstore: enable hibernate regions by default

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -251,7 +251,7 @@ impl Default for Config {
             apply_batch_system: BatchSystemConfig::default(),
             store_batch_system: BatchSystemConfig::default(),
             future_poll_size: 1,
-            hibernate_regions: tikv_util::build_on_master_branch(),
+            hibernate_regions: true,
             dev_assert: false,
             apply_yield_duration: ReadableDuration::millis(500),
 


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

### What problem does this PR solve?

Problem Summary:
Turn on hibernate regions by default. Hibernate region is crucial to reduce raftstore heartbeat CPU usage, especially for clusters with high number of regions. Hibernate region was enabled by default only on master (i.e. nightly build). This PR enable it by default.

Hibernate region RFC: https://github.com/tikv/rfcs/blob/master/text/2019-03-04-hibernate-raft.md

### What is changed and how it works?

What's Changed: Turn on hibernate regions by default. 

### Related changes

- Need to cherry-pick to the release branch: release-5.0, for 5.0.2 release.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- See https://github.com/tikv/tikv/projects/48 for previous issues and improvements for hibernate regions.

Side effects
- Expected to reduce raftstore heartbeat CPU usage, especially for clusters with many regions.

### Release note <!-- bugfixes or new feature need a release note -->
- Enable hibernate regions by default (i.e. `raftstore.hibernate-regions = true`).