### PR TITLE
cdc: fix deregister panic when old value is not enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "thiserror",
  "tikv",
  "tikv_util",
+ "time 0.1.42",
  "tokio",
  "txn_types",
 ]

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -88,6 +88,7 @@ test_raftstore = { path = "../test_raftstore", default-features = false }
 test_util = { path = "../test_util", default-features = false }
 panic_hook = { path = "../panic_hook" }
 raft = { version = "0.6.0-alpha", default-features = false }
+time = "0.1"
 
 [[test]]
 name = "integrations"

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -344,15 +344,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                 if is_last {
                     let delegate = self.capture_regions.remove(&region_id).unwrap();
                     if let Some(reader) = self.store_meta.lock().unwrap().readers.get(&region_id) {
-                        if let Err(e) = reader
-                            .txn_extra_op
-                            .compare_exchange(TxnExtraOp::ReadOldValue, TxnExtraOp::Noop)
-                        {
-                            panic!(
-                                "unexpect txn extra op {:?}, region_id: {:?}, downstream_id: {:?}, conn_id: {:?}",
-                                e, region_id, downstream_id, conn_id
-                            );
-                        }
+                        reader.txn_extra_op.store(TxnExtraOp::Noop);
                     }
                     // Do not continue to observe the events of the region.
                     let id = delegate.handle.id;
@@ -1379,8 +1371,11 @@ mod tests {
     use kvproto::errorpb::Error as ErrorHeader;
     use raftstore::errors::Error as RaftStoreError;
     use raftstore::store::msg::CasualMessage;
+    use raftstore::store::util::RegionReadProgress;
+    use raftstore::store::{ReadDelegate, TrackVer};
     use std::collections::BTreeMap;
     use std::fmt::Display;
+    use std::sync::atomic::AtomicU64;
     use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
     use tempfile::TempDir;
     use test_raftstore::MockRaftStoreRouter;
@@ -1390,6 +1385,7 @@ mod tests {
     use tikv::storage::TestEngineBuilder;
     use tikv_util::config::ReadableDuration;
     use tikv_util::worker::{dummy_scheduler, LazyWorker, ReceiverWrapper};
+    use time::Timespec;
 
     use super::*;
     use crate::channel;
@@ -1462,6 +1458,23 @@ mod tests {
         MockRaftStoreRouter,
         ReceiverWrapper<Task>,
     ) {
+        let mut region = Region::default();
+        region.set_id(1);
+        let store_meta = Arc::new(Mutex::new(StoreMeta::new(0)));
+        let read_delegate = ReadDelegate {
+            tag: String::new(),
+            region: Arc::new(region),
+            peer_id: 2,
+            term: 1,
+            applied_index_term: 1,
+            leader_lease: None,
+            last_valid_ts: Timespec::new(0, 0),
+            txn_extra_op: Arc::new(AtomicCell::new(TxnExtraOp::default())),
+            max_ts_sync_status: Arc::new(AtomicU64::new(0)),
+            track_ver: TrackVer::new(),
+            read_progress: Arc::new(RegionReadProgress::new(0, 0)),
+        };
+        store_meta.lock().unwrap().readers.insert(1, read_delegate);
         let (task_sched, task_rx) = dummy_scheduler();
         let raft_router = MockRaftStoreRouter::new();
         let observer = CdcObserver::new(task_sched.clone());
@@ -1474,7 +1487,7 @@ mod tests {
             task_sched,
             raft_router.clone(),
             observer,
-            Arc::new(Mutex::new(StoreMeta::new(0))),
+            store_meta,
             ConcurrencyManager::new(1.into()),
             env,
             security_mgr,

--- a/components/external_storage/export/src/export.rs
+++ b/components/external_storage/export/src/export.rs
@@ -172,7 +172,7 @@ fn create_backend_inner(backend: &Backend) -> io::Result<Box<dyn ExternalStorage
             }
         },
         #[cfg(not(any(feature = "cloud-gcp", feature = "cloud-aws")))]
-        _ => Err(bad_backend(backend.clone())),
+        _ => return Err(bad_backend(backend.clone())),
     };
     record_storage_create(start, &*storage);
     Ok(storage)

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -55,7 +55,7 @@ pub use self::transport::{CasualRouter, ProposalRouter, StoreRouter, Transport};
 pub use self::util::RegionReadProgress;
 pub use self::worker::{
     AutoSplitController, FlowStatistics, FlowStatsReporter, PdTask, ReadDelegate, ReadStats,
-    SplitConfig, SplitConfigManager,
+    SplitConfig, SplitConfigManager, TrackVer,
 };
 pub use self::worker::{KeyEntry, LocalReader, RegionTask};
 pub use self::worker::{SplitCheckRunner, SplitCheckTask};

--- a/components/raftstore/src/store/worker/mod.rs
+++ b/components/raftstore/src/store/worker/mod.rs
@@ -21,7 +21,7 @@ pub use self::pd::{
     FlowStatistics, FlowStatsReporter, HeartbeatTask, Runner as PdRunner, Task as PdTask,
 };
 pub use self::raftlog_gc::{Runner as RaftlogGcRunner, Task as RaftlogGcTask};
-pub use self::read::{LocalReader, Progress as ReadProgress, ReadDelegate, ReadExecutor};
+pub use self::read::{LocalReader, Progress as ReadProgress, ReadDelegate, ReadExecutor, TrackVer};
 pub use self::region::{Runner as RegionRunner, Task as RegionTask};
 pub use self::split_check::{KeyEntry, Runner as SplitCheckRunner, Task as SplitCheckTask};
 pub use self::split_config::{SplitConfig, SplitConfigManager};

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -139,21 +139,21 @@ pub trait ReadExecutor<E: KvEngine> {
 /// A read only delegate of `Peer`.
 #[derive(Clone, Debug)]
 pub struct ReadDelegate {
-    region: Arc<metapb::Region>,
-    peer_id: u64,
-    term: u64,
-    applied_index_term: u64,
-    leader_lease: Option<RemoteLease>,
-    last_valid_ts: Timespec,
+    pub region: Arc<metapb::Region>,
+    pub peer_id: u64,
+    pub term: u64,
+    pub applied_index_term: u64,
+    pub leader_lease: Option<RemoteLease>,
+    pub last_valid_ts: Timespec,
 
-    tag: String,
+    pub tag: String,
     pub txn_extra_op: Arc<AtomicCell<TxnExtraOp>>,
-    max_ts_sync_status: Arc<AtomicU64>,
-    read_progress: Arc<RegionReadProgress>,
+    pub max_ts_sync_status: Arc<AtomicU64>,
+    pub read_progress: Arc<RegionReadProgress>,
 
     // `track_ver` used to keep the local `ReadDelegate` in `LocalReader`
     // up-to-date with the global `ReadDelegate` stored at `StoreMeta`
-    track_ver: TrackVer,
+    pub track_ver: TrackVer,
 }
 
 impl Drop for ReadDelegate {
@@ -164,7 +164,7 @@ impl Drop for ReadDelegate {
 }
 
 #[derive(Debug)]
-struct TrackVer {
+pub struct TrackVer {
     version: Arc<AtomicU64>,
     local_ver: u64,
     // source set to `true` means the `TrackVer` is created by `TrackVer::new` instead
@@ -175,7 +175,7 @@ struct TrackVer {
 }
 
 impl TrackVer {
-    fn new() -> TrackVer {
+    pub fn new() -> TrackVer {
         TrackVer {
             version: Arc::new(AtomicU64::from(0)),
             local_ver: 0,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10118 

### What is changed and how it works?

Remove panic, `compare_exchange` is expected to fail when downstream does not require old value.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note. (The bug is not released yet.)