### PR TITLE
cdc: fix deregister panic when old value is not enabled (#10206)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "test_util",
  "tikv",
  "tikv_util",
+ "time 0.1.42",
  "tokio-threadpool",
  "txn_types",
 ]

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -71,6 +71,7 @@ tempfile = "3.0"
 test_raftstore = { path = "../test_raftstore" }
 test_util = { path = "../test_util" }
 panic_hook = { path = "../panic_hook" }
+time = "0.1"
 
 [[test]]
 name = "integrations"

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -342,15 +342,7 @@ impl<T: 'static + RaftStoreRouter> Endpoint<T> {
                 if is_last {
                     let delegate = self.capture_regions.remove(&region_id).unwrap();
                     if let Some(reader) = self.store_meta.lock().unwrap().readers.get(&region_id) {
-                        if let Err(e) = reader
-                            .txn_extra_op
-                            .compare_exchange(TxnExtraOp::ReadOldValue, TxnExtraOp::Noop)
-                        {
-                            panic!(
-                                "unexpect txn extra op {:?}, region_id: {:?}, downstream_id: {:?}, conn_id: {:?}",
-                                e, region_id, downstream_id, conn_id
-                            );
-                        }
+                        reader.txn_extra_op.store(TxnExtraOp::Noop);
                     }
                     // Do not continue to observe the events of the region.
                     let oid = self.observer.unsubscribe_region(region_id, delegate.id);
@@ -1148,8 +1140,10 @@ mod tests {
     use kvproto::kvrpcpb::Context;
     use raftstore::errors::Error as RaftStoreError;
     use raftstore::store::msg::CasualMessage;
+    use raftstore::store::ReadDelegate;
     use std::collections::BTreeMap;
     use std::fmt::Display;
+    use std::sync::atomic::AtomicBool;
     use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
     use tempfile::TempDir;
     use test_raftstore::MockRaftStoreRouter;
@@ -1160,6 +1154,7 @@ mod tests {
     use tikv_util::collections::HashSet;
     use tikv_util::config::ReadableDuration;
     use tikv_util::worker::{dummy_scheduler, Builder as WorkerBuilder, Worker};
+    use time::Timespec;
 
     use super::*;
     use crate::channel;
@@ -1671,6 +1666,21 @@ mod tests {
         let (task_sched, _task_rx) = dummy_scheduler();
         let raft_router = MockRaftStoreRouter::new();
         let _raft_rx = raft_router.add_region(1 /* region id */, 100 /* cap */);
+        let mut region = Region::default();
+        region.set_id(1);
+        let store_meta = Arc::new(Mutex::new(StoreMeta::new(0)));
+        let read_delegate = ReadDelegate {
+            tag: String::new(),
+            region: region.clone(),
+            peer_id: 2,
+            term: 1,
+            applied_index_term: 1,
+            leader_lease: None,
+            last_valid_ts: RefCell::new(Timespec::new(0, 0)),
+            invalid: Arc::new(AtomicBool::new(false)),
+            txn_extra_op: Arc::new(AtomicCell::new(TxnExtraOp::default())),
+        };
+        store_meta.lock().unwrap().readers.insert(1, read_delegate);
         let observer = CdcObserver::new(task_sched.clone());
         let pd_client = Arc::new(TestPdClient::new(0, true));
         let mut ep = Endpoint::new(
@@ -1679,7 +1689,7 @@ mod tests {
             task_sched,
             raft_router,
             observer,
-            Arc::new(Mutex::new(StoreMeta::new(0))),
+            store_meta,
         );
         let (tx, rx) = channel::canal(1);
         let mut rx = rx.drain();

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -32,15 +32,15 @@ use crate::store::fsm::store::StoreMeta;
 /// A read only delegate of `Peer`.
 #[derive(Clone, Debug)]
 pub struct ReadDelegate {
-    region: metapb::Region,
-    peer_id: u64,
-    term: u64,
-    applied_index_term: u64,
-    leader_lease: Option<RemoteLease>,
-    last_valid_ts: RefCell<Timespec>,
+    pub region: metapb::Region,
+    pub peer_id: u64,
+    pub term: u64,
+    pub applied_index_term: u64,
+    pub leader_lease: Option<RemoteLease>,
+    pub last_valid_ts: RefCell<Timespec>,
 
-    tag: String,
-    invalid: Arc<AtomicBool>,
+    pub tag: String,
+    pub invalid: Arc<AtomicBool>,
     pub txn_extra_op: Arc<AtomicCell<TxnExtraOp>>,
 }
 


### PR DESCRIPTION
This is a cherry-pick of #10206.

------------

### What problem does this PR solve?

Issue Number: close #10118 

### What is changed and how it works?

Remove panic, `compare_exchange` is expected to fail when downstream does not require old value.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note. (The bug is not released yet.)