### PR TITLE
Cleanup IO rate limiter related code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,6 +1465,7 @@ dependencies = [
  "maligned",
  "nix 0.19.0",
  "openssl",
+ "parking_lot 0.11.0",
  "prometheus",
  "prometheus-static-metric",
  "rand 0.7.3",
@@ -2293,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#317625fb85ef201e89d1d3a59340005419efcd1e"
+source = "git+https://github.com/tikv/rust-rocksdb.git#41d7180df72cf5aae97fbae9a18aec52ad29dfcc"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2312,7 +2313,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#317625fb85ef201e89d1d3a59340005419efcd1e"
+source = "git+https://github.com/tikv/rust-rocksdb.git#41d7180df72cf5aae97fbae9a18aec52ad29dfcc"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -3266,9 +3267,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.5"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-error"
@@ -3935,7 +3936,7 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#317625fb85ef201e89d1d3a59340005419efcd1e"
+source = "git+https://github.com/tikv/rust-rocksdb.git#41d7180df72cf5aae97fbae9a18aec52ad29dfcc"
 dependencies = [
  "libc 0.2.86",
  "librocksdb_sys",
@@ -4954,6 +4955,7 @@ dependencies = [
  "engine_rocks",
  "engine_traits",
  "fail",
+ "file_system",
  "futures 0.3.8",
  "grpcio",
  "keys",
@@ -5516,6 +5518,7 @@ dependencies = [
  "engine_traits",
  "error_code",
  "fail",
+ "file_system",
  "futures 0.3.8",
  "into_other",
  "keys",

--- a/components/engine_panic/src/cf_options.rs
+++ b/components/engine_panic/src/cf_options.rs
@@ -24,6 +24,9 @@ impl ColumnFamilyOptions for PanicColumnFamilyOptions {
     fn new() -> Self {
         panic!()
     }
+    fn get_max_write_buffer_number(&self) -> u32 {
+        panic!()
+    }
     fn get_level_zero_slowdown_writes_trigger(&self) -> u32 {
         panic!()
     }

--- a/components/engine_panic/src/misc.rs
+++ b/components/engine_panic/src/misc.rs
@@ -73,6 +73,14 @@ impl MiscExt for PanicEngine {
         panic!()
     }
 
+    fn get_cf_num_immutable_mem_table(&self, cf: &str) -> Result<Option<u64>> {
+        panic!()
+    }
+
+    fn get_cf_compaction_pending_bytes(&self, cf: &str) -> Result<Option<u64>> {
+        panic!()
+    }
+
     fn is_stalled_or_stopped(&self) -> bool {
         panic!()
     }

--- a/components/engine_rocks/src/cf_options.rs
+++ b/components/engine_rocks/src/cf_options.rs
@@ -50,6 +50,10 @@ impl ColumnFamilyOptions for RocksColumnFamilyOptions {
         RocksColumnFamilyOptions::from_raw(RawCFOptions::new())
     }
 
+    fn get_max_write_buffer_number(&self) -> u32 {
+        self.0.get_max_write_buffer_number()
+    }
+
     fn get_level_zero_slowdown_writes_trigger(&self) -> u32 {
         self.0.get_level_zero_slowdown_writes_trigger()
     }

--- a/components/engine_rocks/src/event_listener.rs
+++ b/components/engine_rocks/src/event_listener.rs
@@ -35,8 +35,12 @@ impl rocksdb::EventListener for RocksEventListener {
         }
     }
 
-    fn on_compaction_begin(&self, _info: &CompactionJobInfo) {
-        set_io_type(IOType::Compaction);
+    fn on_compaction_begin(&self, info: &CompactionJobInfo) {
+        if info.base_input_level() == 0 {
+            set_io_type(IOType::LevelZeroCompaction);
+        } else {
+            set_io_type(IOType::Compaction);
+        }
     }
 
     fn on_compaction_completed(&self, info: &CompactionJobInfo) {
@@ -56,17 +60,25 @@ impl rocksdb::EventListener for RocksEventListener {
                 &info.compaction_reason().to_string(),
             ])
             .inc();
-        if get_io_type() == IOType::Compaction {
+        if info.base_input_level() == 0 && get_io_type() == IOType::LevelZeroCompaction
+            || info.base_input_level() != 0 && get_io_type() == IOType::Compaction
+        {
             set_io_type(IOType::Other);
         }
     }
 
-    fn on_subcompaction_begin(&self, _info: &SubcompactionJobInfo) {
-        set_io_type(IOType::Compaction);
+    fn on_subcompaction_begin(&self, info: &SubcompactionJobInfo) {
+        if info.base_input_level() == 0 {
+            set_io_type(IOType::LevelZeroCompaction);
+        } else {
+            set_io_type(IOType::Compaction);
+        }
     }
 
-    fn on_subcompaction_completed(&self, _info: &SubcompactionJobInfo) {
-        if get_io_type() == IOType::Compaction {
+    fn on_subcompaction_completed(&self, info: &SubcompactionJobInfo) {
+        if info.base_input_level() == 0 && get_io_type() == IOType::LevelZeroCompaction
+            || info.base_input_level() != 0 && get_io_type() == IOType::Compaction
+        {
             set_io_type(IOType::Other);
         }
     }

--- a/components/engine_rocks/src/file_system.rs
+++ b/components/engine_rocks/src/file_system.rs
@@ -6,12 +6,15 @@ use rocksdb::FileSystemInspector as DBFileSystemInspector;
 use std::sync::Arc;
 
 // Use engine::Env directly since Env is not abstracted.
-pub fn get_env(base_env: Option<Arc<Env>>) -> Result<Arc<Env>, String> {
+pub fn get_env(
+    base_env: Option<Arc<Env>>,
+    limiter: Option<Arc<file_system::IORateLimiter>>,
+) -> Result<Arc<Env>, String> {
     let base_env = base_env.unwrap_or_else(|| Arc::new(Env::default()));
     Ok(Arc::new(Env::new_file_system_inspected_env(
         base_env,
         WrappedFileSystemInspector {
-            inspector: EngineFileSystemInspector::new(),
+            inspector: EngineFileSystemInspector::from_limiter(limiter),
         },
     )?))
 }
@@ -38,18 +41,18 @@ mod tests {
     use crate::raw::{ColumnFamilyOptions, DBCompressionType};
     use crate::raw_util::{new_engine_opt, CFOptions};
     use engine_traits::{CompactExt, CF_DEFAULT};
-    use file_system::{IOOp, IORateLimiterStatistics, IOType, WithIORateLimit};
+    use file_system::{IOOp, IORateLimiter, IORateLimiterStatistics, IOType};
     use keys::data_key;
     use rocksdb::Writable;
     use rocksdb::{DBOptions, DB};
     use std::sync::Arc;
     use tempfile::Builder;
 
-    fn new_test_db(dir: &str) -> (Arc<DB>, Arc<IORateLimiterStatistics>, WithIORateLimit) {
-        let (guard, stats) = WithIORateLimit::new(0);
+    fn new_test_db(dir: &str) -> (Arc<DB>, Arc<IORateLimiterStatistics>) {
+        let limiter = Arc::new(IORateLimiter::new(0, true /*enable_statistics*/));
         let mut db_opts = DBOptions::new();
         db_opts.add_event_listener(RocksEventListener::new("test_db"));
-        let env = get_env(None).unwrap();
+        let env = get_env(None, Some(limiter.clone())).unwrap();
         db_opts.set_env(env);
         let mut cf_opts = ColumnFamilyOptions::new();
         cf_opts.set_disable_auto_compactions(true);
@@ -57,7 +60,7 @@ mod tests {
         let db = Arc::new(
             new_engine_opt(dir, db_opts, vec![CFOptions::new(CF_DEFAULT, cf_opts)]).unwrap(),
         );
-        (db, stats, guard)
+        (db, limiter.statistics().unwrap())
     }
 
     #[test]
@@ -68,7 +71,7 @@ mod tests {
             .tempdir()
             .unwrap();
 
-        let (db, stats, _guard) = new_test_db(temp_dir.path().to_str().unwrap());
+        let (db, stats) = new_test_db(temp_dir.path().to_str().unwrap());
         let value = vec![b'v'; value_size];
 
         db.put(&data_key(b"a1"), &value).unwrap();
@@ -91,9 +94,9 @@ mod tests {
                 1,     /*max_subcompactions*/
             )
             .unwrap();
-        assert!(stats.fetch(IOType::Compaction, IOOp::Read) > value_size * 4);
-        assert!(stats.fetch(IOType::Compaction, IOOp::Read) < value_size * 5);
-        assert!(stats.fetch(IOType::Compaction, IOOp::Write) > value_size * 3);
-        assert!(stats.fetch(IOType::Compaction, IOOp::Write) < value_size * 4);
+        assert!(stats.fetch(IOType::LevelZeroCompaction, IOOp::Read) > value_size * 4);
+        assert!(stats.fetch(IOType::LevelZeroCompaction, IOOp::Read) < value_size * 5);
+        assert!(stats.fetch(IOType::LevelZeroCompaction, IOOp::Write) > value_size * 3);
+        assert!(stats.fetch(IOType::LevelZeroCompaction, IOOp::Write) < value_size * 4);
     }
 }

--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -329,6 +329,22 @@ impl MiscExt for RocksEngine {
         ))
     }
 
+    fn get_cf_num_immutable_mem_table(&self, cf: &str) -> Result<Option<u64>> {
+        let handle = util::get_cf_handle(self.as_inner(), cf)?;
+        Ok(crate::util::get_cf_num_immutable_mem_table(
+            self.as_inner(),
+            &handle,
+        ))
+    }
+
+    fn get_cf_compaction_pending_bytes(&self, cf: &str) -> Result<Option<u64>> {
+        let handle = util::get_cf_handle(self.as_inner(), cf)?;
+        Ok(crate::util::get_cf_compaction_pending_bytes(
+            self.as_inner(),
+            &handle,
+        ))
+    }
+
     fn is_stalled_or_stopped(&self) -> bool {
         const ROCKSDB_IS_WRITE_STALLED: &str = "rocksdb.is-write-stalled";
         const ROCKSDB_IS_WRITE_STOPPED: &str = "rocksdb.is-write-stopped";

--- a/components/engine_rocks/src/rocks_metrics.rs
+++ b/components/engine_rocks/src/rocks_metrics.rs
@@ -940,7 +940,7 @@ pub fn flush_engine_properties(engine: &DB, name: &str, shared_block_cache: bool
 
         // Pending compaction bytes
         if let Some(pending_compaction_bytes) =
-            engine.get_property_int_cf(handle, ROCKSDB_PENDING_COMPACTION_BYTES)
+            crate::util::get_cf_compaction_pending_bytes(engine, handle)
         {
             STORE_ENGINE_PENDING_COMPACTION_BYTES_VEC
                 .with_label_values(&[name, cf])
@@ -974,7 +974,7 @@ pub fn flush_engine_properties(engine: &DB, name: &str, shared_block_cache: bool
         }
 
         // Num immutable mem-table
-        if let Some(v) = crate::util::get_num_immutable_mem_table(engine, handle) {
+        if let Some(v) = crate::util::get_cf_num_immutable_mem_table(engine, handle) {
             STORE_ENGINE_NUM_IMMUTABLE_MEM_TABLE_VEC
                 .with_label_values(&[name, cf])
                 .set(v as i64);

--- a/components/engine_rocks/src/util.rs
+++ b/components/engine_rocks/src/util.rs
@@ -152,8 +152,13 @@ pub fn get_cf_num_blob_files_at_level(engine: &DB, handle: &CFHandle, level: usi
 }
 
 /// Gets the number of immutable mem-table of given column family.
-pub fn get_num_immutable_mem_table(engine: &DB, handle: &CFHandle) -> Option<u64> {
+pub fn get_cf_num_immutable_mem_table(engine: &DB, handle: &CFHandle) -> Option<u64> {
     engine.get_property_int_cf(handle, ROCKSDB_NUM_IMMUTABLE_MEM_TABLE)
+}
+
+/// Gets the amount of pending compaction bytes of given column family.
+pub fn get_cf_compaction_pending_bytes(engine: &DB, handle: &CFHandle) -> Option<u64> {
+    engine.get_property_int_cf(handle, ROCKSDB_PENDING_COMPACTION_BYTES)
 }
 
 pub struct FixedSuffixSliceTransform {

--- a/components/engine_traits/src/cf_options.rs
+++ b/components/engine_traits/src/cf_options.rs
@@ -15,6 +15,7 @@ pub trait ColumnFamilyOptions {
     type TitanDBOptions: TitanDBOptions;
 
     fn new() -> Self;
+    fn get_max_write_buffer_number(&self) -> u32;
     fn get_level_zero_slowdown_writes_trigger(&self) -> u32;
     fn get_level_zero_stop_writes_trigger(&self) -> u32;
     fn set_level_zero_file_num_compaction_trigger(&mut self, v: i32);

--- a/components/engine_traits/src/file_system.rs
+++ b/components/engine_traits/src/file_system.rs
@@ -20,6 +20,10 @@ impl EngineFileSystemInspector {
             limiter: get_io_rate_limiter(),
         }
     }
+
+    pub fn from_limiter(limiter: Option<Arc<IORateLimiter>>) -> Self {
+        EngineFileSystemInspector { limiter }
+    }
 }
 
 impl FileSystemInspector for EngineFileSystemInspector {

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -83,5 +83,9 @@ pub trait MiscExt: CFNamesExt {
 
     fn get_cf_num_files_at_level(&self, cf: &str, level: usize) -> Result<Option<u64>>;
 
+    fn get_cf_num_immutable_mem_table(&self, cf: &str) -> Result<Option<u64>>;
+
+    fn get_cf_compaction_pending_bytes(&self, cf: &str) -> Result<Option<u64>>;
+
     fn is_stalled_or_stopped(&self) -> bool;
 }

--- a/components/file_system/Cargo.toml
+++ b/components/file_system/Cargo.toml
@@ -23,6 +23,7 @@ lazy_static = "1.3"
 libc = "0.2"
 nix = "0.19"
 openssl = "0.10"
+parking_lot = "0.11"
 prometheus = { version = "0.10", features = ["nightly"] }
 prometheus-static-metric = "0.4"
 strum = { version = "0.20", features = ["derive"] }
@@ -36,4 +37,3 @@ maligned = "0.2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bcc = { version = "0.0.30", optional = true }
-

--- a/components/file_system/src/file.rs
+++ b/components/file_system/src/file.rs
@@ -2,6 +2,7 @@
 
 use super::{get_io_rate_limiter, get_io_type, IOOp, IORateLimiter};
 
+use std::fmt::{self, Debug, Formatter};
 use std::fs;
 use std::io::{self, Read, Seek, Write};
 use std::path::Path;
@@ -10,10 +11,15 @@ use std::sync::Arc;
 use fs2::FileExt;
 
 /// A wrapper around `std::fs::File` with capability to track and regulate IO flow.
-#[derive(Debug)]
 pub struct File {
     inner: fs::File,
     limiter: Option<Arc<IORateLimiter>>,
+}
+
+impl Debug for File {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.inner)
+    }
 }
 
 impl File {
@@ -25,12 +31,30 @@ impl File {
         })
     }
 
+    #[cfg(test)]
+    pub fn open_with_limiter<P: AsRef<Path>>(
+        path: P,
+        limiter: Option<Arc<IORateLimiter>>,
+    ) -> io::Result<File> {
+        let inner = fs::File::open(path)?;
+        Ok(File { inner, limiter })
+    }
+
     pub fn create<P: AsRef<Path>>(path: P) -> io::Result<File> {
         let inner = fs::File::create(path)?;
         Ok(File {
             inner,
             limiter: get_io_rate_limiter(),
         })
+    }
+
+    #[cfg(test)]
+    pub fn create_with_limiter<P: AsRef<Path>>(
+        path: P,
+        limiter: Option<Arc<IORateLimiter>>,
+    ) -> io::Result<File> {
+        let inner = fs::File::create(path)?;
+        Ok(File { inner, limiter })
     }
 
     pub fn from_raw_file(file: fs::File) -> io::Result<File> {
@@ -210,14 +234,16 @@ mod tests {
 
     #[test]
     fn test_instrumented_file() {
-        let (_guard, stats) = WithIORateLimit::new(1);
+        // make sure read at most one bytes at a time
+        let limiter = Arc::new(IORateLimiter::new(1, true /*enable_statistics*/));
+        let stats = limiter.statistics().unwrap();
 
         let tmp_dir = TempDir::new().unwrap();
         let tmp_file = tmp_dir.path().join("instrumented.txt");
-        let content = String::from("magic words");
+        let content = String::from("drink full and descend");
         {
             let _guard = WithIOType::new(IOType::ForegroundWrite);
-            let mut f = File::create(&tmp_file).unwrap();
+            let mut f = File::create_with_limiter(&tmp_file, Some(limiter.clone())).unwrap();
             f.write_all(content.as_bytes()).unwrap();
             f.sync_all().unwrap();
             assert_eq!(
@@ -226,17 +252,14 @@ mod tests {
             );
         }
         {
-            let _guard = WithIOType::new(IOType::ForegroundRead);
+            let _guard = WithIOType::new(IOType::Export);
             let mut buffer = String::new();
-            let mut f = File::open(&tmp_file).unwrap();
+            let mut f = File::open_with_limiter(&tmp_file, Some(limiter)).unwrap();
             assert_eq!(f.read_to_string(&mut buffer).unwrap(), content.len());
             assert_eq!(buffer, content);
             // read_to_string only exit when file.read() returns zero, which means
             // it requires two EOF reads to finish the call.
-            assert_eq!(
-                stats.fetch(IOType::ForegroundRead, IOOp::Read),
-                content.len() + 2
-            );
+            assert_eq!(stats.fetch(IOType::Export, IOOp::Read), content.len() + 2);
         }
     }
 }

--- a/components/file_system/src/iosnoop/biosnoop.c
+++ b/components/file_system/src/iosnoop/biosnoop.c
@@ -16,6 +16,7 @@ typedef enum {
   ForegroundWrite,
   Flush,
   Compaction,
+  LevelZeroCompaction,
   Replication,
   LoadBalance,
   Gc,
@@ -40,6 +41,7 @@ BPF_HISTOGRAM(foreground_read_read_latency, int, 25);
 BPF_HISTOGRAM(foreground_write_read_latency, int, 25);
 BPF_HISTOGRAM(flush_read_latency, int, 25);
 BPF_HISTOGRAM(compaction_read_latency, int, 25);
+BPF_HISTOGRAM(level_zero_compaction_read_latency, int, 25);
 BPF_HISTOGRAM(replication_read_latency, int, 25);
 BPF_HISTOGRAM(load_balance_read_latency, int, 25);
 BPF_HISTOGRAM(gc_read_latency, int, 25);
@@ -51,6 +53,7 @@ BPF_HISTOGRAM(foreground_read_write_latency, int, 25);
 BPF_HISTOGRAM(foreground_write_write_latency, int, 25);
 BPF_HISTOGRAM(flush_write_latency, int, 25);
 BPF_HISTOGRAM(compaction_write_latency, int, 25);
+BPF_HISTOGRAM(level_zero_compaction_write_latency, int, 25);
 BPF_HISTOGRAM(replication_write_latency, int, 25);
 BPF_HISTOGRAM(load_balance_write_latency, int, 25);
 BPF_HISTOGRAM(gc_write_latency, int, 25);
@@ -162,6 +165,13 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req) {
       compaction_write_latency.increment(bpf_log2l(delta));
     } else {
       compaction_read_latency.increment(bpf_log2l(delta));
+    }
+    break;
+  case LevelZeroCompaction:
+    if (rwflag == 1) {
+      level_zero_replication_write_latency.increment(bpf_log2l(delta));
+    } else {
+      level_zero_compaction_read_latency.increment(bpf_log2l(delta));
     }
     break;
   case Replication:

--- a/components/file_system/src/lib.rs
+++ b/components/file_system/src/lib.rs
@@ -29,7 +29,6 @@ pub use std::fs::{
 
 use std::io::{self, ErrorKind, Read, Write};
 use std::path::Path;
-use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use openssl::error::ErrorStack;
@@ -60,49 +59,6 @@ pub enum IOType {
     Gc = 8,
     Import = 9,
     Export = 10,
-}
-
-impl IOType {
-    pub fn as_str(&self) -> &str {
-        match *self {
-            IOType::Other => "other",
-            IOType::ForegroundRead => "foreground_read",
-            IOType::ForegroundWrite => "foreground_write",
-            IOType::Flush => "flush",
-            IOType::LevelZeroCompaction => "level_zero_compaction",
-            IOType::Compaction => "compaction",
-            IOType::Replication => "replication",
-            IOType::LoadBalance => "load_balance",
-            IOType::Gc => "gc",
-            IOType::Import => "import",
-            IOType::Export => "export",
-        }
-    }
-}
-
-impl FromStr for IOType {
-    type Err = String;
-    fn from_str(s: &str) -> Result<IOType, String> {
-        match s {
-            "other" => Ok(IOType::Other),
-            "foreground_read" => Ok(IOType::ForegroundRead),
-            "foreground_write" => Ok(IOType::ForegroundWrite),
-            "flush" => Ok(IOType::Flush),
-            "level_zero_compaction" => Ok(IOType::LevelZeroCompaction),
-            "compaction" => Ok(IOType::Compaction),
-            "replication" => Ok(IOType::Replication),
-            "load_balance" => Ok(IOType::LoadBalance),
-            "gc" => Ok(IOType::Gc),
-            "import" => Ok(IOType::Import),
-            "export" => Ok(IOType::Export),
-            s => Err(format!(
-                "expect in the list: [other, foreground_read, foreground_write, flush, \
-                level_zero_compaction, compaction, replication, load_balance, gc, import\
-                , export], got: {:?}",
-                s
-            )),
-        }
-    }
 }
 
 pub struct WithIOType {

--- a/components/file_system/src/metrics.rs
+++ b/components/file_system/src/metrics.rs
@@ -10,6 +10,7 @@ make_static_metric! {
         foreground_write,
         flush,
         compaction,
+        level_zero_compaction,
         replication,
         load_balance,
         gc,

--- a/components/file_system/src/metrics_manager.rs
+++ b/components/file_system/src/metrics_manager.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::Duration;
 
 use strum::EnumCount;
 
@@ -53,7 +53,7 @@ impl MetricsManager {
         }
     }
 
-    pub fn flush(&mut self, _now: Instant) {
+    pub fn flush(&mut self, _duration: Duration) {
         flush_io_latency_metrics();
         flush_io_bytes!(
             self.fetcher,
@@ -84,6 +84,12 @@ impl MetricsManager {
             compaction,
             IOType::Compaction,
             self.last_fetch[IOType::Compaction as usize]
+        );
+        flush_io_bytes!(
+            self.fetcher,
+            level_zero_compaction,
+            IOType::LevelZeroCompaction,
+            self.last_fetch[IOType::LevelZeroCompaction as usize]
         );
         flush_io_bytes!(
             self.fetcher,

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -26,7 +26,7 @@ use engine_traits::{
     EncryptionKeyManager, IngestExternalFileOptions, Iterator, KvEngine, SSTMetaInfo, SeekKey,
     SstReader, SstWriter, SstWriterBuilder, CF_DEFAULT, CF_WRITE,
 };
-use file_system::{sync_dir, File, OpenOptions};
+use file_system::{get_io_rate_limiter, sync_dir, File, OpenOptions};
 use tikv_util::time::Limiter;
 use txn_types::{is_short_value, Key, TimeStamp, Write as KvWrite, WriteRef, WriteType};
 
@@ -217,7 +217,7 @@ impl SSTImporter {
         // now validate the SST file.
         let path_str = path.temp.to_str().unwrap();
         let env = get_encrypted_env(self.key_manager.clone(), None /*base_env*/)?;
-        let env = get_inspected_env(Some(env))?;
+        let env = get_inspected_env(Some(env), get_io_rate_limiter())?;
         // Use abstracted SstReader after Env is abstracted.
         let sst_reader = RocksSstReader::open_with_env(path_str, Some(env))?;
         sst_reader.verify_checksum()?;
@@ -635,7 +635,7 @@ impl ImportDir {
         // now validate the SST file.
         let path_str = path.save.to_str().unwrap();
         let env = get_encrypted_env(key_manager.clone(), None /*base_env*/)?;
-        let env = get_inspected_env(Some(env))?;
+        let env = get_inspected_env(Some(env), get_io_rate_limiter())?;
 
         let sst_reader = RocksSstReader::open_with_env(&path_str, Some(env))?;
         sst_reader.verify_checksum()?;

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -53,6 +53,7 @@ test-engines-panic = [
 crossbeam = "0.8"
 engine_traits = { path = "../engine_traits", default-features = false }
 engine_rocks = { path = "../engine_rocks", default-features = false }
+file_system = { path = "../file_system" }
 futures = "0.3"
 grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
 lazy_static = "1.3"

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -22,8 +22,10 @@ use encryption_export::DataKeyManager;
 use engine_rocks::raw::DB;
 use engine_rocks::{Compat, RocksEngine, RocksSnapshot};
 use engine_traits::{
-    CompactExt, Engines, Iterable, MiscExt, Mutable, Peekable, WriteBatch, WriteBatchExt, CF_RAFT,
+    CompactExt, Engines, Iterable, MiscExt, Mutable, Peekable, WriteBatch, WriteBatchExt,
+    CF_DEFAULT, CF_RAFT,
 };
+use file_system::IORateLimiter;
 use pd_client::PdClient;
 use raftstore::store::fsm::store::{StoreMeta, PENDING_MSG_CAP};
 use raftstore::store::fsm::{create_raft_batch_system, RaftBatchSystem, RaftRouter};
@@ -131,6 +133,7 @@ pub struct Cluster<T: Simulator> {
     pub dbs: Vec<Engines<RocksEngine, RocksEngine>>,
     pub store_metas: HashMap<u64, Arc<Mutex<StoreMeta>>>,
     key_managers: Vec<Option<Arc<DataKeyManager>>>,
+    pub io_rate_limiter: Option<Arc<IORateLimiter>>,
     pub engines: HashMap<u64, Engines<RocksEngine, RocksEngine>>,
     key_managers_map: HashMap<u64, Option<Arc<DataKeyManager>>>,
     pub labels: HashMap<u64, HashMap<String, String>>,
@@ -156,6 +159,7 @@ impl<T: Simulator> Cluster<T> {
             dbs: vec![],
             store_metas: HashMap::default(),
             key_managers: vec![],
+            io_rate_limiter: None,
             engines: HashMap::default(),
             key_managers_map: HashMap::default(),
             labels: HashMap::default(),
@@ -194,13 +198,17 @@ impl<T: Simulator> Cluster<T> {
     }
 
     fn create_engine(&mut self, router: Option<RaftRouter<RocksEngine, RocksEngine>>) {
-        let (engines, key_manager, dir) = create_test_engine(router, &self.cfg);
+        let (engines, key_manager, dir) =
+            create_test_engine(router, self.io_rate_limiter.clone(), &self.cfg);
         self.dbs.push(engines);
         self.key_managers.push(key_manager);
         self.paths.push(dir);
     }
 
     pub fn create_engines(&mut self) {
+        self.io_rate_limiter = Some(Arc::new(IORateLimiter::new(
+            0, true, /*enable_statistics*/
+        )));
         for _ in 0..self.count {
             self.create_engine(None);
         }
@@ -242,7 +250,14 @@ impl<T: Simulator> Cluster<T> {
     pub fn compact_data(&self) {
         for engine in self.engines.values() {
             let db = &engine.kv;
-            db.compact_range("default", None, None, false, 1).unwrap();
+            db.compact_range(CF_DEFAULT, None, None, false, 1).unwrap();
+        }
+    }
+
+    pub fn flush_data(&self) {
+        for engine in self.engines.values() {
+            let db = &engine.kv;
+            db.flush_cf(CF_DEFAULT, true /*sync*/).unwrap();
         }
     }
 
@@ -812,7 +827,7 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn get(&mut self, key: &[u8]) -> Option<Vec<u8>> {
-        self.get_impl("default", key, false)
+        self.get_impl(CF_DEFAULT, key, false)
     }
 
     pub fn get_cf(&mut self, cf: &str, key: &[u8]) -> Option<Vec<u8>> {
@@ -820,7 +835,7 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn must_get(&mut self, key: &[u8]) -> Option<Vec<u8>> {
-        self.get_impl("default", key, true)
+        self.get_impl(CF_DEFAULT, key, true)
     }
 
     fn get_impl(&mut self, cf: &str, key: &[u8], read_quorum: bool) -> Option<Vec<u8>> {
@@ -906,7 +921,7 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn must_put(&mut self, key: &[u8], value: &[u8]) {
-        self.must_put_cf("default", key, value);
+        self.must_put_cf(CF_DEFAULT, key, value);
     }
 
     pub fn must_put_cf(&mut self, cf: &str, key: &[u8], value: &[u8]) {
@@ -926,7 +941,7 @@ impl<T: Simulator> Cluster<T> {
     pub fn put(&mut self, key: &[u8], value: &[u8]) -> result::Result<(), PbError> {
         let resp = self.request(
             key,
-            vec![new_put_cf_cmd("default", key, value)],
+            vec![new_put_cf_cmd(CF_DEFAULT, key, value)],
             false,
             Duration::from_secs(5),
         );
@@ -938,7 +953,7 @@ impl<T: Simulator> Cluster<T> {
     }
 
     pub fn must_delete(&mut self, key: &[u8]) {
-        self.must_delete_cf("default", key)
+        self.must_delete_cf(CF_DEFAULT, key)
     }
 
     pub fn must_delete_cf(&mut self, cf: &str, key: &[u8]) {

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -35,6 +35,7 @@ use engine_rocks::{
 use engine_rocks::{CompactionListener, RocksCompactionJobInfo};
 use engine_rocks::{Compat, RocksEngine, RocksSnapshot};
 use engine_traits::{Engines, Iterable, Peekable};
+use file_system::IORateLimiter;
 use futures::executor::block_on;
 use raftstore::store::fsm::RaftRouter;
 use raftstore::store::*;
@@ -588,6 +589,7 @@ fn dummpy_filter(_: &RocksCompactionJobInfo) -> bool {
 pub fn create_test_engine(
     // TODO: pass it in for all cases.
     router: Option<RaftRouter<RocksEngine, RocksEngine>>,
+    limiter: Option<Arc<IORateLimiter>>,
     cfg: &TiKvConfig,
 ) -> (
     Engines<RocksEngine, RocksEngine>,
@@ -601,7 +603,7 @@ pub fn create_test_engine(
             .map(Arc::new);
 
     let env = get_encrypted_env(key_manager.clone(), None).unwrap();
-    let env = get_inspected_env(Some(env)).unwrap();
+    let env = get_inspected_env(Some(env), limiter).unwrap();
     let cache = cfg.storage.block_cache.build_shared_cache();
 
     let kv_path = dir.path().join(DEFAULT_ROCKSDB_SUB_DIR);

--- a/components/tikv_kv/Cargo.toml
+++ b/components/tikv_kv/Cargo.toml
@@ -44,6 +44,7 @@ engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 error_code = { path = "../error_code", default-features = false }
 fail = "0.4"
+file_system = { path = "../file_system" }
 futures = { version = "0.3", features = ["thread-pool", "compat"] }
 into_other = { path = "../into_other", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, rev="511a3225c29f9272af83d28efed92eba835cd34f" }

--- a/components/tikv_util/src/worker/pool.rs
+++ b/components/tikv_util/src/worker/pool.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::compat::Future01CompatExt;
+use futures::compat::Stream01CompatExt;
 use futures::future::{self, FutureExt};
 use futures::stream::StreamExt;
 
@@ -340,8 +341,18 @@ impl Worker {
         )
     }
 
-    pub fn clone_raw_handle(&self) -> Remote<yatp::task::future::TaskCell> {
-        self.remote.clone()
+    pub fn spawn_interval_task<F>(&self, interval: Duration, mut func: F)
+    where
+        F: FnMut() + Send + 'static,
+    {
+        let mut interval = GLOBAL_TIMER_HANDLE
+            .interval(std::time::Instant::now(), interval)
+            .compat();
+        self.remote.spawn(async move {
+            while let Some(Ok(_)) = interval.next().await {
+                func();
+            }
+        });
     }
 
     fn delay_notify<T: Display + Send + 'static>(tx: UnboundedSender<Msg<T>>, timeout: Duration) {

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -18,6 +18,7 @@ use engine_rocks::{
 use engine_traits::{
     KvEngine, MiscExt, Mutable, MvccProperties, WriteBatch, WriteBatchExt, WriteOptions,
 };
+use file_system::{IOType, WithIOType};
 use pd_client::{Feature, FeatureGate};
 use prometheus::{local::*, *};
 use raftstore::coprocessor::RegionInfoProvider;
@@ -417,6 +418,7 @@ impl WriteCompactionFilter {
             wb: &RocksWriteBatch,
             wopts: &WriteOptions,
         ) -> Result<(), engine_traits::Error> {
+            let _io_type_guard = WithIOType::new(IOType::Gc);
             fail_point!("write_compaction_filter_flush_write_batch", true, |_| {
                 Err(engine_traits::Error::Engine(
                     "Ingested fail point".to_string(),

--- a/src/storage/kv/test_engine_builder.rs
+++ b/src/storage/kv/test_engine_builder.rs
@@ -5,7 +5,9 @@ use crate::storage::kv::{Result, RocksEngine};
 use engine_rocks::raw::ColumnFamilyOptions;
 use engine_rocks::raw_util::CFOptions;
 use engine_traits::{CfName, ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+use file_system::IORateLimiter;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 // Duplicated from rocksdb_engine
 const TEMP_DIR: &str = "";
@@ -17,6 +19,7 @@ const TEMP_DIR: &str = "";
 pub struct TestEngineBuilder {
     path: Option<PathBuf>,
     cfs: Option<Vec<CfName>>,
+    io_rate_limiter: Option<Arc<IORateLimiter>>,
     enable_ttl: bool,
 }
 
@@ -25,6 +28,7 @@ impl TestEngineBuilder {
         Self {
             path: None,
             cfs: None,
+            io_rate_limiter: None,
             enable_ttl: false,
         }
     }
@@ -47,6 +51,11 @@ impl TestEngineBuilder {
 
     pub fn ttl(mut self, b: bool) -> Self {
         self.enable_ttl = b;
+        self
+    }
+
+    pub fn io_rate_limiter(mut self, limiter: Option<Arc<IORateLimiter>>) -> Self {
+        self.io_rate_limiter = limiter;
         self
     }
 
@@ -77,7 +86,13 @@ impl TestEngineBuilder {
                 _ => CFOptions::new(*cf, ColumnFamilyOptions::new()),
             })
             .collect();
-        RocksEngine::new(&path, &cfs, Some(cfs_opts), cache.is_some())
+        RocksEngine::new(
+            &path,
+            &cfs,
+            Some(cfs_opts),
+            cache.is_some(),
+            self.io_rate_limiter,
+        )
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2544,7 +2544,13 @@ mod tests {
                 CFOptions::new(CF_WRITE, cfg_rocksdb.writecf.build_opt(&cache, None)),
                 CFOptions::new(CF_RAFT, cfg_rocksdb.raftcf.build_opt(&cache)),
             ];
-            RocksEngine::new(&path, &cfs, Some(cfs_opts), cache.is_some())
+            RocksEngine::new(
+                &path,
+                &cfs,
+                Some(cfs_opts),
+                cache.is_some(),
+                None, /*io_rate_limiter*/
+            )
         }
         .unwrap();
         let storage = TestStorageBuilder::<_, DummyLockManager>::from_engine_and_lock_mgr(


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What problem does this PR solve?

Prepping for #9197

### What is changed and how it works?

What's Changed:

1. Purge unnecessary dependency on global IO rate limiter
2. Port some RocksDB accessors
3. Introduce `LevelZeroCompaction` IO type
4. Fix some broken IO tagging

### Related changes

### Check List

Tests
- Unit test

### Release note

- No release note