### PR TITLE
cloud: fix missing region config for aws

### DIFF
--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -104,7 +104,7 @@ impl Config {
             bucket: StringNonEmpty::required_field(input.bucket, "bucket")?,
             prefix: StringNonEmpty::opt(input.prefix),
             storage_class: storage_class.clone(),
-            region: None,
+            region: StringNonEmpty::opt(input.region),
         };
         let access_key_pair = match StringNonEmpty::opt(input.access_key) {
             None => None,
@@ -657,10 +657,16 @@ mod tests {
         let mut input = InputConfig::default();
         input.set_bucket("bucket".to_owned());
         input.set_prefix("backup 02/prefix/".to_owned());
+        input.set_region("us-west-2".to_owned());
         let c1 = Config::from_input(input.clone()).unwrap();
         let c2 = Config::from_cloud_dynamic(&cloud_dynamic_from_input(input)).unwrap();
         assert_eq!(c1.bucket.bucket, c2.bucket.bucket);
         assert_eq!(c1.bucket.prefix, c2.bucket.prefix);
+        assert_eq!(c1.bucket.region, c2.bucket.region);
+        assert_eq!(
+            c1.bucket.region,
+            StringNonEmpty::opt("us-west-2".to_owned())
+        );
     }
 
     fn cloud_dynamic_from_input(mut s3: InputConfig) -> CloudDynamic {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:
#9706 miss the region config for s3 storage. will cause error `The bucket you are attempting to access must be addressed using the specified endpoint.` This PR fix it.

### What is changed and how it works?

What's Changed:
set region config.

### Related changes

- Need to cherry-pick to the release branch after #9706 pick to release.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
```
[root@CentOS76_VM s3_region]# AWS_ACCESS_KEY_ID=xxx AWS_SECRET_ACCESS_KEY=xxx./br restore table --db sysbench --table sbtest1 --pd 127.0.0.1:2379 -s s3://dbaas-benchmark/xxx/ --s3.region us-west-2 --check-requirements=false
Detail BR log in /tmp/br.log.2021-05-25T13.08.09+0800
Table restore <-----------------------------------------------------------/....................................................> 53.25%Table restore <---------------------------------------------------------------------------------------------------------------> 100.00%
Table restore <---------------------------------------------------------------------------------------------------------------> 100.00%
[2021/05/25 13:13:59.415 +08:00] [INFO] [collector.go:60] ["Table restore Success summary: total restore files: 39, total success: 39, total failed: 0, total take(Table restore time): 11m20.421168418s, total take(real time): 5m50.326250937s, total kv: 20000000, total size(MB): 2422.33, avg speed(MB/s): 3.56"] ["split region"=93.082593ms] ["restore checksum"=5m45.212433314s] ["restore ranges"=38] [Size=18356207286]
```

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that missing region config for aws s3.