### PR TITLE
Set grpc.dns_ares_query_timeout for all client requests

### DIFF
--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -8,6 +8,7 @@ extern crate vlog;
 use std::borrow::ToOwned;
 use std::cmp::Ordering;
 use std::error::Error;
+use std::ffi::CString;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -156,7 +157,8 @@ fn new_debug_client(host: &str, mgr: Arc<SecurityManager>) -> DebugClient {
         .max_receive_message_len(1 << 30) // 1G.
         .max_send_message_len(1 << 30)
         .keepalive_time(Duration::from_secs(10))
-        .keepalive_timeout(Duration::from_secs(3));
+        .keepalive_timeout(Duration::from_secs(3))
+        .raw_cfg_int(CString::new("dns_ares_query_timeout").unwrap(), 2_000);
 
     let channel = mgr.connect(cb, host);
     DebugClient::new(channel)

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -1,5 +1,6 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::ffi::CString;
 use std::pin::Pin;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -538,7 +539,8 @@ impl PdConnector {
         let channel = {
             let cb = ChannelBuilder::new(self.env.clone())
                 .keepalive_time(Duration::from_secs(10))
-                .keepalive_timeout(Duration::from_secs(3));
+                .keepalive_timeout(Duration::from_secs(3))
+                .raw_cfg_int(CString::new("dns_ares_query_timeout").unwrap(), 2_000);
             self.security_mgr.connect(cb, addr_trim)
         };
         let client = PdClientStub::new(channel);

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -104,6 +104,8 @@ pub struct Config {
     pub grpc_keepalive_time: ReadableDuration,
     #[config(skip)]
     pub grpc_keepalive_timeout: ReadableDuration,
+    #[config(skip)]
+    pub dns_ares_query_timeout: ReadableDuration,
     /// How many snapshots can be sent concurrently.
     pub concurrent_send_snap_limit: usize,
     /// How many snapshots can be recv concurrently.
@@ -193,6 +195,7 @@ impl Default for Config {
             // than 10 senconds.
             grpc_keepalive_time: ReadableDuration::secs(10),
             grpc_keepalive_timeout: ReadableDuration::secs(3),
+            dns_ares_query_timeout: ReadableDuration::secs(2),
             concurrent_send_snap_limit: 32,
             concurrent_recv_snap_limit: 32,
             end_point_concurrency: None, // deprecated

--- a/src/server/lock_manager/client.rs
+++ b/src/server/lock_manager/client.rs
@@ -8,6 +8,7 @@ use futures::stream::{StreamExt, TryStreamExt};
 use grpcio::{ChannelBuilder, EnvBuilder, Environment, WriteFlags};
 use kvproto::deadlock::*;
 use security::SecurityManager;
+use std::ffi::CString;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -39,7 +40,8 @@ impl Client {
     pub fn new(env: Arc<Environment>, security_mgr: Arc<SecurityManager>, addr: &str) -> Self {
         let cb = ChannelBuilder::new(env)
             .keepalive_time(Duration::from_secs(10))
-            .keepalive_timeout(Duration::from_secs(3));
+            .keepalive_timeout(Duration::from_secs(3))
+            .raw_cfg_int(CString::new("dns_ares_query_timeout").unwrap(), 2_000);
         let channel = security_mgr.connect(cb, addr);
         let client = DeadlockClient::new(channel);
         Self {

--- a/src/server/proxy.rs
+++ b/src/server/proxy.rs
@@ -14,6 +14,7 @@ use grpcio::{CallOption, Channel, ChannelBuilder, Environment, MetadataBuilder, 
 use kvproto::tikvpb::TikvClient;
 use security::SecurityManager;
 
+use std::convert::TryInto;
 use std::ffi::CString;
 use std::future::Future;
 use std::str;
@@ -92,6 +93,9 @@ impl ClientPool {
                     // And maintaining a shared resource quota doesn't seem easy.
                     .keepalive_time(cfg.grpc_keepalive_time.into())
                     .keepalive_timeout(cfg.grpc_keepalive_timeout.into())
+                    .raw_cfg_int(
+                        CString::new("dns_ares_query_timeout").unwrap(),
+                        cfg.dns_ares_query_timeout.as_millis().try_into().unwrap())
                     .raw_cfg_int(CString::new("connection id").unwrap(), self.last_pos as i32);
                 let ch = mgr.connect(cb, addr);
                 let client = Client {

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -21,6 +21,7 @@ use raftstore::errors::DiscardReason;
 use raftstore::router::RaftStoreRouter;
 use security::SecurityManager;
 use std::collections::VecDeque;
+use std::convert::TryInto;
 use std::ffi::CString;
 use std::marker::PhantomData;
 use std::marker::Unpin;
@@ -579,6 +580,9 @@ where
             .max_send_message_len(self.builder.cfg.max_grpc_send_msg_len)
             .keepalive_time(self.builder.cfg.grpc_keepalive_time.0)
             .keepalive_timeout(self.builder.cfg.grpc_keepalive_timeout.0)
+            .raw_cfg_int(
+                CString::new("dns_ares_query_timeout").unwrap(),
+                self.builder.cfg.dns_ares_query_timeout.as_millis().try_into().unwrap())
             .default_compression_algorithm(self.builder.cfg.grpc_compression_algorithm())
             // hack: so it's different args, grpc will always create a new connection.
             .raw_cfg_int(

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,5 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::convert::TryInto;
+use std::ffi::CString;
 use std::i32;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
@@ -135,6 +137,9 @@ impl<T: RaftStoreRouter<RocksEngine> + Unpin, S: StoreAddrResolver + 'static> Se
             .http2_max_ping_strikes(i32::MAX) // For pings without data from clients.
             .keepalive_time(cfg.value().grpc_keepalive_time.into())
             .keepalive_timeout(cfg.value().grpc_keepalive_timeout.into())
+            .raw_cfg_int(
+                CString::new("dns_ares_query_timeout").unwrap(),
+                cfg.value().dns_ares_query_timeout.as_millis().try_into().unwrap())
             .build_args();
         let health_service = HealthService::default();
         let builder = {

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -79,6 +79,7 @@ fn test_serde_custom_tikv_config() {
         grpc_stream_initial_window_size: ReadableSize(12_345),
         grpc_keepalive_time: ReadableDuration::secs(3),
         grpc_keepalive_timeout: ReadableDuration::secs(60),
+        dns_ares_query_timeout: ReadableDuration::secs(55),
         end_point_concurrency: None,
         end_point_max_tasks: None,
         end_point_stack_size: None,


### PR DESCRIPTION
Attempting to solve #9942

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->