### PR TITLE
server: Replace RocksEngine with KvEngine typaram

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -195,16 +195,15 @@ struct TiKVEngines<ER: RaftEngine> {
 
 struct Servers<ER: RaftEngine> {
     lock_mgr: LockManager,
-    server: Server<
-        RaftRouter<RocksEngine, ER>,
-        resolve::PdStoreAddrResolver,
-        RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>,
-    >,
+    server: ServerType<ER>,
     node: Node<RpcClient, ER>,
     importer: Arc<SSTImporter>,
     cdc_scheduler: tikv_util::worker::Scheduler<cdc::Task>,
     cdc_memory_quota: MemoryQuota,
 }
+
+type ServerType<ER> = Server<RaftRouter<RocksEngine, ER>, resolve::PdStoreAddrResolver, RaftKvType<ER>>;
+type RaftKvType<ER> = RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>;
 
 impl<ER: RaftEngine> TiKVServer<ER> {
     fn init(mut config: TiKvConfig) -> TiKVServer<ER> {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -195,7 +195,11 @@ struct TiKVEngines<ER: RaftEngine> {
 
 struct Servers<ER: RaftEngine> {
     lock_mgr: LockManager,
-    server: Server<RaftRouter<RocksEngine, ER>, resolve::PdStoreAddrResolver, RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>>,
+    server: Server<
+        RaftRouter<RocksEngine, ER>,
+        resolve::PdStoreAddrResolver,
+        RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>,
+    >,
     node: Node<RpcClient, ER>,
     importer: Arc<SSTImporter>,
     cdc_scheduler: tikv_util::worker::Scheduler<cdc::Task>,

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -195,16 +195,16 @@ struct TiKVEngines<ER: RaftEngine> {
 
 struct Servers<ER: RaftEngine> {
     lock_mgr: LockManager,
-    server: ServerType<ER>,
+    server: LocalServer<ER>,
     node: Node<RpcClient, ER>,
     importer: Arc<SSTImporter>,
     cdc_scheduler: tikv_util::worker::Scheduler<cdc::Task>,
     cdc_memory_quota: MemoryQuota,
 }
 
-type ServerType<ER> =
-    Server<RaftRouter<RocksEngine, ER>, resolve::PdStoreAddrResolver, RaftKvType<ER>>;
-type RaftKvType<ER> = RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>;
+type LocalServer<ER> =
+    Server<RaftRouter<RocksEngine, ER>, resolve::PdStoreAddrResolver, LocalRaftKv<ER>>;
+type LocalRaftKv<ER> = RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>;
 
 impl<ER: RaftEngine> TiKVServer<ER> {
     fn init(mut config: TiKvConfig) -> TiKVServer<ER> {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -202,7 +202,8 @@ struct Servers<ER: RaftEngine> {
     cdc_memory_quota: MemoryQuota,
 }
 
-type ServerType<ER> = Server<RaftRouter<RocksEngine, ER>, resolve::PdStoreAddrResolver, RaftKvType<ER>>;
+type ServerType<ER> =
+    Server<RaftRouter<RocksEngine, ER>, resolve::PdStoreAddrResolver, RaftKvType<ER>>;
 type RaftKvType<ER> = RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>;
 
 impl<ER: RaftEngine> TiKVServer<ER> {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -195,7 +195,7 @@ struct TiKVEngines<ER: RaftEngine> {
 
 struct Servers<ER: RaftEngine> {
     lock_mgr: LockManager,
-    server: Server<RaftRouter<RocksEngine, ER>, resolve::PdStoreAddrResolver>,
+    server: Server<RaftRouter<RocksEngine, ER>, resolve::PdStoreAddrResolver, RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>>,
     node: Node<RpcClient, ER>,
     importer: Arc<SSTImporter>,
     cdc_scheduler: tikv_util::worker::Scheduler<cdc::Task>,

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -105,7 +105,7 @@ impl StoreAddrResolver for AddressMap {
 
 struct ServerMeta {
     node: Node<TestPdClient, RocksEngine>,
-    server: Server<SimulateStoreTransport, PdStoreAddrResolver>,
+    server: Server<SimulateStoreTransport, PdStoreAddrResolver, SimulateEngine>,
     sim_router: SimulateStoreTransport,
     sim_trans: SimulateServerTransport,
     raw_router: RaftRouter<RocksEngine, RocksEngine>,

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -95,7 +95,10 @@ lazy_static! {
     ).unwrap();
 }
 
-pub trait CompactionFilterInitializer<EK> where EK: KvEngine {
+pub trait CompactionFilterInitializer<EK>
+where
+    EK: KvEngine,
+{
     fn init_compaction_filter(
         &self,
         store_id: u64,

--- a/src/server/gc_worker/compaction_filter.rs
+++ b/src/server/gc_worker/compaction_filter.rs
@@ -44,7 +44,7 @@ struct GcContext {
     safe_point: Arc<AtomicU64>,
     cfg_tracker: GcWorkerConfigManager,
     feature_gate: FeatureGate,
-    gc_scheduler: FutureScheduler<GcTask>,
+    gc_scheduler: FutureScheduler<GcTask<RocksEngine>>,
     region_info_provider: Arc<dyn RegionInfoProvider + 'static>,
     #[cfg(any(test, feature = "failpoints"))]
     callbacks_on_drop: Vec<Arc<dyn Fn(&WriteCompactionFilter) + Send + Sync>>,
@@ -95,19 +95,19 @@ lazy_static! {
     ).unwrap();
 }
 
-pub trait CompactionFilterInitializer {
+pub trait CompactionFilterInitializer<EK> where EK: KvEngine {
     fn init_compaction_filter(
         &self,
         store_id: u64,
         safe_point: Arc<AtomicU64>,
         cfg_tracker: GcWorkerConfigManager,
         feature_gate: FeatureGate,
-        gc_scheduler: FutureScheduler<GcTask>,
+        gc_scheduler: FutureScheduler<GcTask<EK>>,
         region_info_provider: Arc<dyn RegionInfoProvider>,
     );
 }
 
-impl<EK> CompactionFilterInitializer for EK
+impl<EK> CompactionFilterInitializer<EK> for EK
 where
     EK: KvEngine,
 {
@@ -117,21 +117,21 @@ where
         _safe_point: Arc<AtomicU64>,
         _cfg_tracker: GcWorkerConfigManager,
         _feature_gate: FeatureGate,
-        _gc_scheduler: FutureScheduler<GcTask>,
+        _gc_scheduler: FutureScheduler<GcTask<EK>>,
         _region_info_provider: Arc<dyn RegionInfoProvider>,
     ) {
         info!("Compaction filter is not supported for this engine.");
     }
 }
 
-impl CompactionFilterInitializer for RocksEngine {
+impl CompactionFilterInitializer<RocksEngine> for RocksEngine {
     fn init_compaction_filter(
         &self,
         store_id: u64,
         safe_point: Arc<AtomicU64>,
         cfg_tracker: GcWorkerConfigManager,
         feature_gate: FeatureGate,
-        gc_scheduler: FutureScheduler<GcTask>,
+        gc_scheduler: FutureScheduler<GcTask<RocksEngine>>,
         region_info_provider: Arc<dyn RegionInfoProvider>,
     ) {
         info!("initialize GC context for compaction filter");
@@ -234,7 +234,7 @@ struct WriteCompactionFilter {
     encountered_errors: bool,
 
     write_batch: RocksWriteBatch,
-    gc_scheduler: FutureScheduler<GcTask>,
+    gc_scheduler: FutureScheduler<GcTask<RocksEngine>>,
     // A key batch which is going to be sent to the GC worker.
     mvcc_deletions: Vec<Key>,
     // The count of records covered the current mvcc-deletion mark. The mvcc-deletion
@@ -265,7 +265,7 @@ impl WriteCompactionFilter {
         engine: RocksEngine,
         safe_point: u64,
         context: &CompactionFilterContext,
-        gc_scheduler: FutureScheduler<GcTask>,
+        gc_scheduler: FutureScheduler<GcTask<RocksEngine>>,
         regions_provider: (u64, Arc<dyn RegionInfoProvider>),
     ) -> Self {
         // Safe point must have been initialized.
@@ -306,7 +306,7 @@ impl WriteCompactionFilter {
 
     // `log_on_error` indicates whether to print an error log on scheduling failures.
     // It's only enabled for `GcTask::OrphanVersions`.
-    fn schedule_gc_task(&self, task: GcTask, log_on_error: bool) {
+    fn schedule_gc_task(&self, task: GcTask<RocksEngine>, log_on_error: bool) {
         if let Err(e) = self.gc_scheduler.schedule(task) {
             if log_on_error {
                 error!("compaction filter schedule {} fail", e.0);
@@ -692,8 +692,8 @@ pub mod test_utils {
         pub start: Option<&'a [u8]>,
         pub end: Option<&'a [u8]>,
         pub target_level: Option<usize>,
-        pub gc_scheduler: FutureScheduler<GcTask>,
-        pub gc_receiver: UnboundedReceiver<Option<GcTask>>,
+        pub gc_scheduler: FutureScheduler<GcTask<RocksEngine>>,
+        pub gc_receiver: UnboundedReceiver<Option<GcTask<RocksEngine>>>,
         pub(super) callbacks_on_drop: Vec<Arc<dyn Fn(&WriteCompactionFilter) + Send + Sync>>,
     }
 

--- a/src/server/gc_worker/gc_manager.rs
+++ b/src/server/gc_worker/gc_manager.rs
@@ -8,6 +8,7 @@ use std::thread::{self, Builder as ThreadBuilder, JoinHandle};
 use std::time::{Duration, Instant};
 use tikv_util::worker::FutureScheduler;
 use txn_types::{Key, TimeStamp};
+use engine_traits::KvEngine;
 
 use crate::server::metrics::*;
 use raftstore::coprocessor::RegionInfoProvider;
@@ -215,7 +216,7 @@ impl GcManagerHandle {
 /// Controls how GC runs automatically on the TiKV.
 /// It polls safe point periodically, and when the safe point is updated, `GcManager` will start to
 /// scan all regions (whose leader is on this TiKV), and does GC on all those regions.
-pub(super) struct GcManager<S: GcSafePointProvider, R: RegionInfoProvider> {
+pub(super) struct GcManager<S: GcSafePointProvider, R: RegionInfoProvider, E: KvEngine> {
     cfg: AutoGcConfig<S, R>,
 
     /// The current safe point. `GcManager` will try to update it periodically. When `safe_point` is
@@ -225,7 +226,7 @@ pub(super) struct GcManager<S: GcSafePointProvider, R: RegionInfoProvider> {
     safe_point_last_check_time: Instant,
 
     /// Used to schedule `GcTask`s.
-    worker_scheduler: FutureScheduler<GcTask>,
+    worker_scheduler: FutureScheduler<GcTask<E>>,
 
     /// Holds the running status. It will tell us if `GcManager` should stop working and exit.
     gc_manager_ctx: GcManagerContext,
@@ -234,14 +235,14 @@ pub(super) struct GcManager<S: GcSafePointProvider, R: RegionInfoProvider> {
     feature_gate: FeatureGate,
 }
 
-impl<S: GcSafePointProvider, R: RegionInfoProvider + 'static> GcManager<S, R> {
+impl<S: GcSafePointProvider, R: RegionInfoProvider + 'static, E: KvEngine> GcManager<S, R, E> {
     pub fn new(
         cfg: AutoGcConfig<S, R>,
         safe_point: Arc<AtomicU64>,
-        worker_scheduler: FutureScheduler<GcTask>,
+        worker_scheduler: FutureScheduler<GcTask<E>>,
         cfg_tracker: GcWorkerConfigManager,
         feature_gate: FeatureGate,
-    ) -> GcManager<S, R> {
+    ) -> GcManager<S, R, E> {
         GcManager {
             cfg,
             safe_point,
@@ -625,8 +626,9 @@ mod tests {
     use std::mem;
     use std::sync::mpsc::{channel, Receiver, Sender};
     use tikv_util::worker::{FutureRunnable, FutureWorker};
+    use engine_rocks::RocksEngine;
 
-    fn take_callback(t: &mut GcTask) -> Callback<()> {
+    fn take_callback(t: &mut GcTask<RocksEngine>) -> Callback<()> {
         let callback = match t {
             GcTask::Gc {
                 ref mut callback, ..
@@ -669,11 +671,11 @@ mod tests {
     }
 
     struct MockGcRunner {
-        tx: Sender<GcTask>,
+        tx: Sender<GcTask<RocksEngine>>,
     }
 
-    impl FutureRunnable<GcTask> for MockGcRunner {
-        fn run(&mut self, mut t: GcTask) {
+    impl FutureRunnable<GcTask<RocksEngine>> for MockGcRunner {
+        fn run(&mut self, mut t: GcTask<RocksEngine>) {
             let cb = take_callback(&mut t);
             self.tx.send(t).unwrap();
             cb(Ok(()));
@@ -683,10 +685,10 @@ mod tests {
     /// A set of utilities that helps testing `GcManager`.
     /// The safe_point polling interval is set to 100 ms.
     struct GcManagerTestUtil {
-        gc_manager: Option<GcManager<MockSafePointProvider, MockRegionInfoProvider>>,
-        worker: FutureWorker<GcTask>,
+        gc_manager: Option<GcManager<MockSafePointProvider, MockRegionInfoProvider, RocksEngine>>,
+        worker: FutureWorker<GcTask<RocksEngine>>,
         safe_point_sender: Sender<TimeStamp>,
-        gc_task_receiver: Receiver<GcTask>,
+        gc_task_receiver: Receiver<GcTask<RocksEngine>>,
     }
 
     impl GcManagerTestUtil {
@@ -723,7 +725,7 @@ mod tests {
         }
 
         /// Collect `GcTask`s that `GcManager` tried to execute.
-        pub fn collect_scheduled_tasks(&self) -> Vec<GcTask> {
+        pub fn collect_scheduled_tasks(&self) -> Vec<GcTask<RocksEngine>> {
             self.gc_task_receiver.try_iter().collect()
         }
 

--- a/src/server/gc_worker/gc_manager.rs
+++ b/src/server/gc_worker/gc_manager.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use engine_traits::KvEngine;
 use pd_client::FeatureGate;
 use std::cmp::Ordering;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
@@ -8,7 +9,6 @@ use std::thread::{self, Builder as ThreadBuilder, JoinHandle};
 use std::time::{Duration, Instant};
 use tikv_util::worker::FutureScheduler;
 use txn_types::{Key, TimeStamp};
-use engine_traits::KvEngine;
 
 use crate::server::metrics::*;
 use raftstore::coprocessor::RegionInfoProvider;
@@ -617,6 +617,7 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider + 'static, E: KvEngine> GcMan
 mod tests {
     use super::*;
     use crate::storage::Callback;
+    use engine_rocks::RocksEngine;
     use kvproto::metapb;
     use raft::StateRole;
     use raftstore::coprocessor::Result as CopResult;
@@ -626,7 +627,6 @@ mod tests {
     use std::mem;
     use std::sync::mpsc::{channel, Receiver, Sender};
     use tikv_util::worker::{FutureRunnable, FutureWorker};
-    use engine_rocks::RocksEngine;
 
     fn take_callback(t: &mut GcTask<RocksEngine>) -> Callback<()> {
         let callback = match t {

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -10,8 +10,8 @@ use std::time::Instant;
 use std::vec::IntoIter;
 
 use concurrency_manager::ConcurrencyManager;
-use engine_rocks::{RocksWriteBatch};
 use engine_traits::{
+    KvEngine,
     DeleteStrategy, MiscExt, Range, WriteBatch, WriteOptions, CF_DEFAULT, CF_LOCK, CF_WRITE,
 };
 use file_system::{IOType, WithIOType};
@@ -68,7 +68,7 @@ impl<T: PdClient + 'static> GcSafePointProvider for Arc<T> {
     }
 }
 
-pub enum GcTask {
+pub enum GcTask<E> where E: KvEngine {
     Gc {
         region_id: u64,
         start_key: Vec<u8>,
@@ -105,12 +105,12 @@ pub enum GcTask {
     /// until `DefaultCompactionFilter` is introduced.
     ///
     /// The tracking issue: <https://github.com/tikv/tikv/issues/9719>.
-    OrphanVersions { wb: RocksWriteBatch, id: usize },
+    OrphanVersions { wb: E::WriteBatch, id: usize },
     #[cfg(any(test, feature = "testexport"))]
     Validate(Box<dyn FnOnce(&GcConfig, &Limiter) + Send>),
 }
 
-impl GcTask {
+impl<E> GcTask<E> where E: KvEngine {
     pub fn get_enum_label(&self) -> GcCommandKind {
         match self {
             GcTask::Gc { .. } => GcCommandKind::gc,
@@ -124,7 +124,7 @@ impl GcTask {
     }
 }
 
-impl Display for GcTask {
+impl<E> Display for GcTask<E> where E: KvEngine {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             GcTask::Gc {
@@ -510,13 +510,13 @@ where
     }
 }
 
-impl<E, RR> FutureRunnable<GcTask> for GcRunner<E, RR>
+impl<E, RR> FutureRunnable<GcTask<E::Local>> for GcRunner<E, RR>
 where
     E: Engine,
     RR: RaftStoreRouter<E::Local>,
 {
     #[inline]
-    fn run(&mut self, task: GcTask) {
+    fn run(&mut self, task: GcTask<E::Local>) {
         let _io_type_guard = WithIOType::new(IOType::Gc);
         let enum_label = task.get_enum_label();
 
@@ -632,14 +632,14 @@ where
 }
 
 /// When we failed to schedule a `GcTask` to `GcRunner`, use this to handle the `ScheduleError`.
-fn handle_gc_task_schedule_error(e: FutureWorkerStopped<GcTask>) -> Result<()> {
+fn handle_gc_task_schedule_error(e: FutureWorkerStopped<GcTask<impl KvEngine>>) -> Result<()> {
     error!("failed to schedule gc task"; "err" => %e);
     Err(box_err!("failed to schedule gc task: {:?}", e))
 }
 
 /// Schedules a `GcTask` to the `GcRunner`.
 fn schedule_gc(
-    scheduler: &FutureScheduler<GcTask>,
+    scheduler: &FutureScheduler<GcTask<impl KvEngine>>,
     region_id: u64,
     start_key: Vec<u8>,
     end_key: Vec<u8>,
@@ -659,7 +659,7 @@ fn schedule_gc(
 
 /// Does GC synchronously.
 pub fn sync_gc(
-    scheduler: &FutureScheduler<GcTask>,
+    scheduler: &FutureScheduler<GcTask<impl KvEngine>>,
     region_id: u64,
     start_key: Vec<u8>,
     end_key: Vec<u8>,
@@ -693,8 +693,8 @@ where
     /// How many strong references. The worker will be stopped
     /// once there are no more references.
     refs: Arc<AtomicUsize>,
-    worker: Arc<Mutex<FutureWorker<GcTask>>>,
-    worker_scheduler: FutureScheduler<GcTask>,
+    worker: Arc<Mutex<FutureWorker<GcTask<E::Local>>>>,
+    worker_scheduler: FutureScheduler<GcTask<E::Local>>,
 
     applied_lock_collector: Option<Arc<AppliedLockCollector>>,
 
@@ -849,7 +849,7 @@ where
         Ok(())
     }
 
-    pub fn scheduler(&self) -> FutureScheduler<GcTask> {
+    pub fn scheduler(&self) -> FutureScheduler<GcTask<E::Local>> {
         self.worker_scheduler.clone()
     }
 

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -11,8 +11,8 @@ use std::vec::IntoIter;
 
 use concurrency_manager::ConcurrencyManager;
 use engine_traits::{
-    KvEngine,
-    DeleteStrategy, MiscExt, Range, WriteBatch, WriteOptions, CF_DEFAULT, CF_LOCK, CF_WRITE,
+    DeleteStrategy, KvEngine, MiscExt, Range, WriteBatch, WriteOptions, CF_DEFAULT, CF_LOCK,
+    CF_WRITE,
 };
 use file_system::{IOType, WithIOType};
 use futures::executor::block_on;
@@ -68,7 +68,10 @@ impl<T: PdClient + 'static> GcSafePointProvider for Arc<T> {
     }
 }
 
-pub enum GcTask<E> where E: KvEngine {
+pub enum GcTask<E>
+where
+    E: KvEngine,
+{
     Gc {
         region_id: u64,
         start_key: Vec<u8>,
@@ -110,7 +113,10 @@ pub enum GcTask<E> where E: KvEngine {
     Validate(Box<dyn FnOnce(&GcConfig, &Limiter) + Send>),
 }
 
-impl<E> GcTask<E> where E: KvEngine {
+impl<E> GcTask<E>
+where
+    E: KvEngine,
+{
     pub fn get_enum_label(&self) -> GcCommandKind {
         match self {
             GcTask::Gc { .. } => GcCommandKind::gc,
@@ -124,7 +130,10 @@ impl<E> GcTask<E> where E: KvEngine {
     }
 }
 
-impl<E> Display for GcTask<E> where E: KvEngine {
+impl<E> Display for GcTask<E>
+where
+    E: KvEngine,
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             GcTask::Gc {
@@ -985,7 +994,7 @@ mod tests {
     use crate::storage::mvcc::tests::must_get_none;
     use crate::storage::txn::tests::{must_commit, must_prewrite_delete, must_prewrite_put};
     use crate::storage::{txn::commands, Engine, Storage, TestStorageBuilder};
-    use engine_rocks::{util::get_cf_handle, RocksSnapshot, RocksEngine};
+    use engine_rocks::{util::get_cf_handle, RocksEngine, RocksSnapshot};
     use engine_traits::KvEngine;
     use futures::executor::block_on;
     use kvproto::kvrpcpb::Op;

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -13,7 +13,7 @@ use crate::server::Config as ServerConfig;
 use crate::storage::{config::Config as StorageConfig, Storage};
 use concurrency_manager::ConcurrencyManager;
 use engine_rocks::RocksEngine;
-use engine_traits::{Engines, Peekable, RaftEngine, KvEngine};
+use engine_traits::{Engines, KvEngine, Peekable, RaftEngine};
 use kvproto::metapb;
 use kvproto::raft_serverpb::StoreIdent;
 use kvproto::replication_modepb::ReplicationStatus;
@@ -43,7 +43,7 @@ pub fn create_raft_storage<S, EK>(
 ) -> Result<Storage<RaftKv<EK, S>, LockManager>>
 where
     S: RaftStoreRouter<EK> + LocalReadRouter<EK> + 'static,
-    EK: KvEngine
+    EK: KvEngine,
 {
     let store = Storage::from_engine(
         engine,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -50,7 +50,8 @@ pub const STATS_THREAD_PREFIX: &str = "transport-stats";
 ///
 /// It hosts various internal components, including gRPC, the raftstore router
 /// and a snapshot worker.
-pub struct Server<T: RaftStoreRouter<E::Local> + 'static, S: StoreAddrResolver + 'static, E: Engine> {
+pub struct Server<T: RaftStoreRouter<E::Local> + 'static, S: StoreAddrResolver + 'static, E: Engine>
+{
     env: Arc<Environment>,
     /// A GrpcServer builder or a GrpcServer.
     ///
@@ -73,7 +74,9 @@ pub struct Server<T: RaftStoreRouter<E::Local> + 'static, S: StoreAddrResolver +
     timer: Handle,
 }
 
-impl<T: RaftStoreRouter<E::Local> + Unpin, S: StoreAddrResolver + 'static, E: Engine> Server<T, S, E> {
+impl<T: RaftStoreRouter<E::Local> + Unpin, S: StoreAddrResolver + 'static, E: Engine>
+    Server<T, S, E>
+{
     #[allow(clippy::too_many_arguments)]
     pub fn new<L: LockManager>(
         store_id: u64,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -20,7 +20,6 @@ use crate::server::gc_worker::GcWorker;
 use crate::server::Proxy;
 use crate::storage::lock_manager::LockManager;
 use crate::storage::{Engine, Storage};
-use engine_rocks::RocksEngine;
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::{CheckLeaderTask, SnapManager};
 use security::SecurityManager;
@@ -51,7 +50,7 @@ pub const STATS_THREAD_PREFIX: &str = "transport-stats";
 ///
 /// It hosts various internal components, including gRPC, the raftstore router
 /// and a snapshot worker.
-pub struct Server<T: RaftStoreRouter<RocksEngine> + 'static, S: StoreAddrResolver + 'static> {
+pub struct Server<T: RaftStoreRouter<E::Local> + 'static, S: StoreAddrResolver + 'static, E: Engine> {
     env: Arc<Environment>,
     /// A GrpcServer builder or a GrpcServer.
     ///
@@ -59,7 +58,7 @@ pub struct Server<T: RaftStoreRouter<RocksEngine> + 'static, S: StoreAddrResolve
     builder_or_server: Option<Either<ServerBuilder, GrpcServer>>,
     local_addr: SocketAddr,
     // Transport.
-    trans: ServerTransport<T, S, RocksEngine>,
+    trans: ServerTransport<T, S, E::Local>,
     raft_router: T,
     // For sending/receiving snapshots.
     snap_mgr: SnapManager,
@@ -74,9 +73,9 @@ pub struct Server<T: RaftStoreRouter<RocksEngine> + 'static, S: StoreAddrResolve
     timer: Handle,
 }
 
-impl<T: RaftStoreRouter<RocksEngine> + Unpin, S: StoreAddrResolver + 'static> Server<T, S> {
+impl<T: RaftStoreRouter<E::Local> + Unpin, S: StoreAddrResolver + 'static, E: Engine> Server<T, S, E> {
     #[allow(clippy::too_many_arguments)]
-    pub fn new<E: Engine, L: LockManager>(
+    pub fn new<L: LockManager>(
         store_id: u64,
         cfg: &Arc<VersionTrack<Config>>,
         security_mgr: &Arc<SecurityManager>,
@@ -189,7 +188,7 @@ impl<T: RaftStoreRouter<RocksEngine> + Unpin, S: StoreAddrResolver + 'static> Se
         self.snap_worker.scheduler()
     }
 
-    pub fn transport(&self) -> ServerTransport<T, S, RocksEngine> {
+    pub fn transport(&self) -> ServerTransport<T, S, E::Local> {
         self.trans.clone()
     }
 
@@ -322,7 +321,7 @@ pub mod test_router {
     use raftstore::store::*;
     use raftstore::Result as RaftStoreResult;
 
-    use engine_rocks::RocksSnapshot;
+    use engine_rocks::{RocksEngine, RocksSnapshot};
     use engine_traits::{KvEngine, Snapshot};
     use kvproto::raft_serverpb::RaftMessage;
 

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -23,7 +23,6 @@ use crate::storage::{
     SecondaryLocksStatus, Storage, TxnStatus,
 };
 use crate::{forward_duplex, forward_unary};
-use engine_rocks::RocksEngine;
 use futures::compat::Future01CompatExt;
 use futures::future::{self, Future, FutureExt, TryFutureExt};
 use futures::sink::SinkExt;
@@ -52,7 +51,7 @@ const GRPC_MSG_MAX_BATCH_SIZE: usize = 128;
 const GRPC_MSG_NOTIFY_SIZE: usize = 8;
 
 /// Service handles the RPC messages for the `Tikv` service.
-pub struct Service<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> {
+pub struct Service<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager> {
     store_id: u64,
     /// Used to handle requests related to GC.
     gc_worker: GcWorker<E, T>,
@@ -76,7 +75,7 @@ pub struct Service<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: Lock
     proxy: Proxy,
 }
 
-impl<T: RaftStoreRouter<RocksEngine> + Clone + 'static, E: Engine + Clone, L: LockManager + Clone>
+impl<T: RaftStoreRouter<E::Local> + Clone + 'static, E: Engine + Clone, L: LockManager + Clone>
     Clone for Service<T, E, L>
 {
     fn clone(&self) -> Self {
@@ -96,7 +95,7 @@ impl<T: RaftStoreRouter<RocksEngine> + Clone + 'static, E: Engine + Clone, L: Lo
     }
 }
 
-impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Service<T, E, L> {
+impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager> Service<T, E, L> {
     /// Constructs a new `Service` which provides the `Tikv` service.
     pub fn new(
         store_id: u64,
@@ -156,7 +155,7 @@ macro_rules! handle_request {
     }
 }
 
-impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
+impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager> Tikv
     for Service<T, E, L>
 {
     handle_request!(kv_get, future_get, GetRequest, GetResponse);

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -155,9 +155,7 @@ macro_rules! handle_request {
     }
 }
 
-impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager> Tikv
-    for Service<T, E, L>
-{
+impl<T: RaftStoreRouter<E::Local> + 'static, E: Engine, L: LockManager> Tikv for Service<T, E, L> {
     handle_request!(kv_get, future_get, GetRequest, GetResponse);
     handle_request!(kv_scan, future_scan, ScanRequest, ScanResponse);
     handle_request!(

--- a/tests/integrations/config/dynamic/gc_worker.rs
+++ b/tests/integrations/config/dynamic/gc_worker.rs
@@ -43,7 +43,7 @@ fn setup_cfg_controller(
     (gc_worker, cfg_controller)
 }
 
-fn validate<F>(scheduler: &FutureScheduler<GcTask>, f: F)
+fn validate<F>(scheduler: &FutureScheduler<GcTask<engine_rocks::RocksEngine>>, f: F)
 where
     F: FnOnce(&GcConfig, &Limiter) + Send + 'static,
 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: https://github.com/tikv/tikv/issues/6402

Problem Summary:

tikv::server is one of the last modules that is still concretely using RocksEngine in a way that prevents tikv from being started with another engine.

### What is changed and how it works?

Just replacing more uses of RocksEngine with KvEngine typarams in tikv::server.

This unfortunately requires type-parameterizing GcTask, which in turn forces some new type parameters elsewhere. But it's the only way I know to proceed.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```