### PR TITLE
tests: fix flaky test_read_index_retry_lock_checking

### DIFF
--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -317,7 +317,9 @@ fn test_read_index_retry_lock_checking() {
     let mut cluster = new_node_cluster(0, 2);
 
     // Use long election timeout and short lease.
-    configure_for_lease_read(&mut cluster, Some(10), Some(10));
+    configure_for_lease_read(&mut cluster, Some(50), Some(20));
+    cluster.cfg.raft_store.raft_store_max_leader_lease =
+        ReadableDuration(Duration::from_millis(100));
 
     let pd_client = Arc::clone(&cluster.pd_client);
     pd_client.disable_default_operator();
@@ -364,7 +366,7 @@ fn test_read_index_retry_lock_checking() {
     // resp1 should contain key is locked error
     assert!(
         resp1
-            .recv_timeout(Duration::from_secs(1))
+            .recv_timeout(Duration::from_secs(2))
             .unwrap()
             .responses[0]
             .get_read_index()
@@ -373,7 +375,7 @@ fn test_read_index_retry_lock_checking() {
     // resp2 should has a successful read index
     assert!(
         resp2
-            .recv_timeout(Duration::from_secs(1))
+            .recv_timeout(Duration::from_secs(2))
             .unwrap()
             .responses[0]
             .get_read_index()


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

https://github.com/tikv/tikv/pull/10273#issuecomment-851829389 reports that `test_read_index_retry_lock_checking` always fails.

### What is changed and how it works?

The failure is on the first `async_read_index_on_peer`. Previously the election timeout is set to very short, then an election may happen before the read. So we receive a `Stale command` error instead of waiting.

This PR increases election timeout to solve the problem.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```