### PR TITLE
cdc: fix missing ResolvedTs import in prost-codec (#10285)

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -13,7 +13,7 @@ use futures::compat::Future01CompatExt;
 use grpcio::{ChannelBuilder, Environment};
 #[cfg(feature = "prost-codec")]
 use kvproto::cdcpb::{
-    event::Event as Event_oneof_event, ChangeDataRequest,
+    event::Event as Event_oneof_event, ChangeDataRequest, ResolvedTs,
     DuplicateRequest as ErrorDuplicateRequest, Error as EventError, Event,
 };
 #[cfg(not(feature = "prost-codec"))]

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -13,8 +13,8 @@ use futures::compat::Future01CompatExt;
 use grpcio::{ChannelBuilder, Environment};
 #[cfg(feature = "prost-codec")]
 use kvproto::cdcpb::{
-    event::Event as Event_oneof_event, ChangeDataRequest, ResolvedTs,
-    DuplicateRequest as ErrorDuplicateRequest, Error as EventError, Event,
+    event::Event as Event_oneof_event, ChangeDataRequest,
+    DuplicateRequest as ErrorDuplicateRequest, Error as EventError, Event, ResolvedTs,
 };
 #[cfg(not(feature = "prost-codec"))]
 use kvproto::cdcpb::{


### PR DESCRIPTION
cherry-pick #10285 to release-5.0 

----

### What problem does this PR solve?

Problem Summary:

The `ResolvedTs` name is not imported when using prost-codec, making the code fail to compile there.

### What is changed and how it works?

What's Changed:

Add back the import.

### Related changes

- Need to cherry-pick to the release branch
   * release-5.0, release-4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
    * make build with prost codec 🤷

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```