### PR TITLE
raftstore: add the RegionNotInitialized error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?rev=73468940541b2e801cb5f9739cd0cf6465889e72#73468940541b2e801cb5f9739cd0cf6465889e72"
+source = "git+https://github.com/pingcap/kvproto.git?rev=f42e582bf0bb6bc2aee647e5f4126d51ccf6d377#f42e582bf0bb6bc2aee647e5f4126d51ccf6d377"
 dependencies = [
  "futures 0.3.8",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ hyper-openssl = "0.8"
 http = "0"
 into_other = { path = "components/into_other", default-features = false }
 keys = { path = "components/keys", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 libc = "0.2"
 libloading = "0.7"

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -95,7 +95,7 @@ tokio = { version = "0.2", features = ["rt-threaded", "time"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../../components/keys", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../../components/log_wrappers" }

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -77,7 +77,7 @@ futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 pd_client = { path = "../pd_client", default-features = false }

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -57,7 +57,7 @@ engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 raftstore = { path = "../raftstore", default-features = false }

--- a/components/cloud/Cargo.toml
+++ b/components/cloud/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1"
 derive_more = "0.99.3"
 error_code = { path = "../error_code", default-features = false }
 futures-io = "0.3"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 rusoto_core = "0.45.0"

--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -32,7 +32,7 @@ grpcio = { version = "0.9",  default-features = false, features = ["openssl-vend
 http = "0.2.0"
 hyper = "0.13.3"
 hyper-tls = "0.4.1"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rusoto_core = "0.45.0"
 rusoto_credential = "0.45.0"
 rusoto_kms = { version = "0.45.0", features = ["serialize_structs"] }

--- a/components/cloud/gcp/Cargo.toml
+++ b/components/cloud/gcp/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = { version = "0.3", default-features = false, features = ["io"] }
 http = "0.2.0"
 hyper = "0.13.3"
 hyper-tls = "0.4.1"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 # better to not use slog-global, but pass in the logger
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -39,7 +39,7 @@ lazy_static = "1.3"
 prometheus = { version = "0.10", features = ["nightly"] }
 futures-util = { version = "0.3", default-features = false, features = ["std", "io"] }
 hex = "0.4.2"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 rand = "0.7"

--- a/components/encryption/export/Cargo.toml
+++ b/components/encryption/export/Cargo.toml
@@ -35,7 +35,7 @@ derive_more = "0.99.3"
 encryption = { path = "../", default-features = false }
 error_code = { path = "../../error_code", default-features = false }
 file_system = { path = "../../file_system", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/components/engine_panic/Cargo.toml
+++ b/components/engine_panic/Cargo.toml
@@ -27,6 +27,6 @@ engine_traits = { path = "../engine_traits", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
 # FIXME: Remove this dep from the engine_traits interface
 tikv_util = { path = "../tikv_util", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 txn_types = { path = "../txn_types", default-features = false }

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -64,7 +64,7 @@ configuration = { path = "../configuration" }
 tempfile = "3.0"
 serde = "1.0"
 serde_derive = "1.0"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 protobuf = "2"
 fail = "0.4"
@@ -75,6 +75,6 @@ package = "rocksdb"
 features = ["encryption", "static_libcpp"]
 
 [dev-dependencies]
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rand = "0.7"
 toml = "0.5"

--- a/components/engine_traits/Cargo.toml
+++ b/components/engine_traits/Cargo.toml
@@ -35,7 +35,7 @@ txn_types = { path = "../txn_types", default-features = false }
 serde = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 
 [dev-dependencies]

--- a/components/error_code/Cargo.toml
+++ b/components/error_code/Cargo.toml
@@ -26,7 +26,7 @@ path = "bin.rs"
 [dependencies]
 lazy_static = "1.3"
 raft = { version = "0.6.0-alpha", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 toml = "0.5"

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -37,7 +37,7 @@ futures-executor = "0.3"
 futures-io = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { optional = true, version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 libloading = { optional = true, version = "0.7.0" }
 prometheus = { version = "0.10", default-features = false, features = ["nightly", "push"] }

--- a/components/external_storage/export/Cargo.toml
+++ b/components/external_storage/export/Cargo.toml
@@ -80,7 +80,7 @@ futures = { optional = true, version = "0.3" }
 futures-executor = { optional = true, version = "0.3" }
 futures-io = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libloading = { optional = true, version = "0.7.0" }
 once_cell = { optional = true, version = "1.3.1" }
 protobuf = { optional = true, version = "2" }

--- a/components/into_other/Cargo.toml
+++ b/components/into_other/Cargo.toml
@@ -19,5 +19,5 @@ prost-codec = [
 
 [dependencies]
 engine_traits = { path = "../engine_traits", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -17,7 +17,7 @@ prost-codec = [
 
 [dependencies]
 byteorder = "1.2"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 thiserror = "1.0"
 tikv_alloc = { path = "../tikv_alloc" }

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -28,7 +28,7 @@ failpoints = ["fail/failpoints"]
 error_code = { path = "../error_code", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/raft_log_engine/Cargo.toml
+++ b/components/raft_log_engine/Cargo.toml
@@ -31,7 +31,7 @@ time = "0.1"
 configuration = { path = "../configuration" }
 serde = "1.0"
 serde_derive = "1.0"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 raft-engine = { git = "https://github.com/tikv/raft-engine", branch = "master" }
 protobuf = "2"

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -75,7 +75,7 @@ futures = "0.3"
 futures-util = { version = "0.3.1", default-features = false, features = ["io"] }
 into_other = { path = "../into_other",  default-features = false }
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/raftstore/src/errors.rs
+++ b/components/raftstore/src/errors.rs
@@ -228,6 +228,11 @@ impl From<Error> for errorpb::Error {
                 e.set_safe_ts(safe_ts);
                 errorpb.set_data_is_not_ready(e);
             }
+            Error::RegionNotInitialized(region_id) => {
+                let mut e = errorpb::RegionNotInitialized::default();
+                e.set_region_id(region_id);
+                errorpb.set_region_not_initialized(e);
+            }
             _ => {}
         };
 

--- a/components/resolved_ts/Cargo.toml
+++ b/components/resolved_ts/Cargo.toml
@@ -48,7 +48,7 @@ fail = "0.4"
 futures = "0.3"
 grpcio = { version = "0.9", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 pd_client = { path = "../pd_client", default-features = false }

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -88,7 +88,7 @@ tokio = { version = "0.2", features = ["rt-threaded"] }
 grpcio = { version = "0.9", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -49,7 +49,7 @@ futures = { version = "0.3", features = ["thread-pool"] }
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.10", default-features = false }

--- a/components/test_backup/Cargo.toml
+++ b/components/test_backup/Cargo.toml
@@ -36,7 +36,7 @@ futures = "0.3"
 futures-executor = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rand = "0.7"
 tempfile = "3.0"
 test_raftstore = { path = "../test_raftstore" }

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -40,7 +40,7 @@ test-engines-panic = [
 [dependencies]
 engine_rocks = { path = "../engine_rocks", default-features = false }
 futures = "0.3"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 protobuf = "2"
 test_storage = { path = "../test_storage", default-features = false }
 tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }

--- a/components/test_pd/Cargo.toml
+++ b/components/test_pd/Cargo.toml
@@ -25,7 +25,7 @@ prost-codec = [
 fail = "0.4"
 futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 pd_client = { path = "../pd_client", default-features = false }

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -59,7 +59,7 @@ grpcio = { version = "0.9",  default-features = false, features = ["openssl-vend
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/test_sst_importer/Cargo.toml
+++ b/components/test_sst_importer/Cargo.toml
@@ -28,5 +28,5 @@ crc32fast = "1.2"
 engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -33,7 +33,7 @@ test-engines-panic = [
 
 [dependencies]
 futures = "0.3"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raftstore = { path = "../raftstore", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 test_raftstore = { path = "../test_raftstore", default-features = false }

--- a/components/test_util/Cargo.toml
+++ b/components/test_util/Cargo.toml
@@ -27,7 +27,7 @@ cloud-gcp = [ "encryption_export/cloud-gcp" ]
 encryption_export = { path = "../encryption/export", default-features = false }
 fail = "0.4"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rand = "0.7"
 rand_isaac = "0.2"
 security = { path = "../security", default-features = false }

--- a/components/tidb_query_common/Cargo.toml
+++ b/components/tidb_query_common/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.1"
 derive_more = "0.99.3"
 error_code = { path = "../error_code", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 prometheus = { version = "0.10", features = ["nightly"] }
 prometheus-static-metric = "0.4"
 lazy_static = "1.3"

--- a/components/tidb_query_datatype/Cargo.toml
+++ b/components/tidb_query_datatype/Cargo.toml
@@ -33,7 +33,7 @@ chrono-tz = "0.5.1"
 codec = { path = "../codec", default-features = false }
 error_code = { path = "../error_code", default-features = false }
 hex = "0.4"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 match_template = { path = "../match_template" }
 nom = { version = "5.1.0", default-features = false, features = ["std"] }

--- a/components/tidb_query_executors/Cargo.toml
+++ b/components/tidb_query_executors/Cargo.toml
@@ -32,7 +32,7 @@ prost-codec = [
 protobuf = "2.8"
 codec = { path = "../codec", default-features = false }
 fail = "0.4"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 match_template = { path = "../match_template" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }

--- a/components/tikv_kv/Cargo.toml
+++ b/components/tikv_kv/Cargo.toml
@@ -47,7 +47,7 @@ fail = "0.4"
 file_system = { path = "../file_system" }
 futures = { version = "0.3", features = ["thread-pool", "compat"] }
 into_other = { path = "../into_other", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.10", features = ["nightly"] }
 prometheus-static-metric = "0.4"

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -61,7 +61,7 @@ tokio = { version = "0.2", features = ["rt-util", "rt-threaded"] }
 tokio-executor = "0.1"
 tokio-timer = "0.2"
 url = "2"
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 protobuf = "2"
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 

--- a/components/txn_types/Cargo.toml
+++ b/components/txn_types/Cargo.toml
@@ -25,7 +25,7 @@ bitflags = "1.0.1"
 farmhash = "1.1.5"
 error_code = { path = "../error_code", default-features = false }
 codec = { path = "../codec", default-features = false }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = "2.3"
 thiserror = "1.0"
 tikv_alloc = { path = "../tikv_alloc" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -124,7 +124,7 @@ futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 grpcio-health = { version = "0.9", default-features = false }
 log_wrappers = { path = "../components/log_wrappers" }
-kvproto = { rev = "73468940541b2e801cb5f9739cd0cf6465889e72", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "f42e582bf0bb6bc2aee647e5f4126d51ccf6d377", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 paste = "1.0"
 pd_client = { path = "../components/pd_client", default-features = false }
 protobuf = "2.8"


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com

### What problem does this PR solve?

Part of pingcap/tidb#21094. Close pingcap/tidb#23271.

Add the `RegionNotInitialized` error.

### What is changed and how it works?

- Update `kvproto` version.
- Update `impl From<Error> for errorpb::Error`.

### Related changes

- pingcap/kvproto#734
- pingcap/tidb#24956

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```