### PR TITLE
tests: fix flaky test_rate_limited_*_flow

### DIFF
--- a/components/file_system/src/rate_limiter.rs
+++ b/components/file_system/src/rate_limiter.rs
@@ -722,31 +722,31 @@ mod tests {
         {
             let _write = start_background_jobs(
                 &limiter,
-                2, /*job_count*/
+                1, /*job_count*/
                 Request(
                     IOType::ForegroundWrite,
                     IOOp::Write,
-                    write_work * bytes_per_sec / 100 / 1000 / 2,
+                    write_work * bytes_per_sec / 100 / 1000,
                 ),
                 Some(Duration::from_millis(1)),
             );
             let _compaction = start_background_jobs(
                 &limiter,
-                2, /*job_count*/
+                1, /*job_count*/
                 Request(
                     IOType::Compaction,
                     IOOp::Write,
-                    compaction_work * bytes_per_sec / 100 / 1000 / 2,
+                    compaction_work * bytes_per_sec / 100 / 1000,
                 ),
                 Some(Duration::from_millis(1)),
             );
             let _import = start_background_jobs(
                 &limiter,
-                2, /*job_count*/
+                1, /*job_count*/
                 Request(
                     IOType::Import,
                     IOOp::Write,
-                    import_work * bytes_per_sec / 100 / 1000 / 2,
+                    import_work * bytes_per_sec / 100 / 1000,
                 ),
                 Some(Duration::from_millis(1)),
             );

--- a/components/file_system/src/rate_limiter.rs
+++ b/components/file_system/src/rate_limiter.rs
@@ -539,8 +539,8 @@ mod tests {
 
     macro_rules! approximate_eq {
         ($left:expr, $right:expr) => {
-            assert!(($left) >= ($right) * 0.9);
-            assert!(($right) >= ($left) * 0.9);
+            assert!(($left) >= ($right) * 0.85);
+            assert!(($right) >= ($left) * 0.85);
         };
     }
 


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What problem does this PR solve?

Issue Number: close #10303 close #10306

test_rate_limited_hybrid_flow and test_rate_limited_light_flow sometimes failed in rush hours.

### What is changed and how it works?

What's Changed:

Reduce number of threads spawned in test (from 6 to 3), and tune up tolerance (from 10% to 15%).

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```