### PR TITLE
cdc: limit scan task concurrency (#10262)

### DIFF
--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -295,7 +295,7 @@ impl Delegate {
 
     fn error_event(&self, err: Error) -> EventError {
         let mut err_event = EventError::default();
-        let mut err = err.extract_error_header();
+        let mut err = err.extract_region_error();
         if err.has_not_leader() {
             let not_leader = err.take_not_leader();
             err_event.set_not_leader(not_leader);

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -23,7 +23,7 @@ use kvproto::cdcpb::{
     Event_oneof_event, ResolvedTs,
 };
 use kvproto::kvrpcpb::{CheckLeaderRequest, ExtraOp as TxnExtraOp, LeaderInfo};
-use kvproto::metapb::{PeerRole, Region};
+use kvproto::metapb::{PeerRole, Region, RegionEpoch};
 use kvproto::tikvpb::TikvClient;
 use pd_client::{Feature, PdClient};
 use raftstore::coprocessor::CmdBatch;
@@ -43,6 +43,7 @@ use tikv_util::timer::SteadyTimer;
 use tikv_util::worker::{Runnable, RunnableWithTimer, ScheduleError, Scheduler};
 use tikv_util::{box_err, box_try, debug, error, impl_display_as_debug, info, warn};
 use tokio::runtime::{Builder, Runtime};
+use tokio::sync::Semaphore;
 use txn_types::{Key, Lock, LockType, TimeStamp, TxnExtra, TxnExtraScheduler};
 
 use crate::channel::{MemoryQuota, SendError};
@@ -61,7 +62,7 @@ pub enum Deregister {
         conn_id: ConnID,
         err: Option<Error>,
     },
-    Region {
+    Delegate {
         region_id: u64,
         observe_id: ObserveID,
         err: Error,
@@ -87,12 +88,12 @@ impl fmt::Debug for Deregister {
                 .field("conn_id", conn_id)
                 .field("err", err)
                 .finish(),
-            Deregister::Region {
+            Deregister::Delegate {
                 ref region_id,
                 ref observe_id,
                 ref err,
             } => de
-                .field("deregister", &"region")
+                .field("deregister", &"delegate")
                 .field("region_id", region_id)
                 .field("observe_id", observe_id)
                 .field("err", err)
@@ -227,6 +228,7 @@ pub struct Endpoint<T> {
     concurrency_manager: ConcurrencyManager,
 
     workers: Runtime,
+    scan_concurrency_semaphore: Arc<Semaphore>,
 
     scan_speed_limter: Limiter,
     max_scan_batch_bytes: usize,
@@ -265,9 +267,10 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
         let workers = Builder::new()
             .threaded_scheduler()
             .thread_name("cdcwkr")
-            .core_threads(4)
+            .core_threads(cfg.incremental_scan_threads)
             .build()
             .unwrap();
+        let scan_concurrency_semaphore = Arc::new(Semaphore::new(cfg.incremental_scan_concurrency));
         let tso_worker = Builder::new()
             .threaded_scheduler()
             .thread_name("tso")
@@ -299,6 +302,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             max_scan_batch_bytes,
             max_scan_batch_size,
             workers,
+            scan_concurrency_semaphore,
             raft_router,
             observer,
             store_meta,
@@ -363,7 +367,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                     );
                 }
             }
-            Deregister::Region {
+            Deregister::Delegate {
                 region_id,
                 observe_id,
                 err,
@@ -507,15 +511,17 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                 reader.txn_extra_op.store(txn_extra_op);
             }
         }
+        let region_epoch = request.take_region_epoch();
         let observe_id = delegate.handle.id;
         let mut init = Initializer {
             sched,
             region_id,
+            region_epoch,
             conn_id,
             downstream_id,
             sink: conn.get_sink().clone(),
             request_id: request.get_request_id(),
-            downstream_state: downstream_state.clone(),
+            downstream_state,
             txn_extra_op: delegate.txn_extra_op,
             speed_limter: self.scan_speed_limter.clone(),
             max_scan_batch_bytes: self.max_scan_batch_bytes,
@@ -525,57 +531,21 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             build_resolver: is_new_delegate,
         };
 
-        let (cb, fut) = tikv_util::future::paired_future_callback();
-        let scheduler = self.scheduler.clone();
-        let deregister_downstream = move |err| {
-            warn!("cdc send capture change cmd failed"; "region_id" => region_id, "error" => ?err);
-            let deregister = if is_new_delegate {
-                // Deregister region if it's the first scan task, because the
-                // task also build resolver.
-                Deregister::Region {
-                    region_id,
-                    observe_id,
-                    err,
-                }
-            } else {
-                Deregister::Downstream {
-                    region_id,
-                    downstream_id,
-                    conn_id,
-                    err: Some(err),
-                }
-            };
-            if let Err(e) = scheduler.schedule(Task::Deregister(deregister)) {
-                error!("cdc schedule cdc task failed"; "error" => ?e);
-            }
-        };
-        let scheduler = self.scheduler.clone();
-        if let Err(e) = self.raft_router.significant_send(
-            region_id,
-            SignificantMsg::CaptureChange {
-                cmd: change_cmd,
-                region_epoch: request.take_region_epoch(),
-                callback: Callback::Read(Box::new(move |resp| {
-                    if let Err(e) = scheduler.schedule(Task::InitDownstream {
-                        downstream_id,
-                        downstream_state,
-                        cb: Box::new(move || {
-                            cb(resp);
-                        }),
-                    }) {
-                        error!("cdc schedule cdc task failed"; "error" => ?e);
-                    }
-                })),
-            },
-        ) {
-            warn!("cdc send capture change cmd failed"; "region_id" => region_id, "error" => ?e);
-            deregister_downstream(Error::request(e.into()));
-            return;
-        }
+        let raft_router = self.raft_router.clone();
+        let concurrency_semaphore = self.scan_concurrency_semaphore.clone();
         self.workers.spawn(async move {
-            match fut.await {
-                Ok(resp) => init.on_change_cmd(resp).await,
-                Err(e) => deregister_downstream(Error::Other(box_err!(e))),
+            CDC_SCAN_TASKS.with_label_values(&["total"]).inc();
+            match init
+                .initialize(change_cmd, raft_router, concurrency_semaphore)
+                .await
+            {
+                Ok(()) => {
+                    CDC_SCAN_TASKS.with_label_values(&["finish"]).inc();
+                }
+                Err(e) => {
+                    CDC_SCAN_TASKS.with_label_values(&["abort"]).inc();
+                    init.deregister_downstream(e)
+                }
             }
         });
     }
@@ -592,8 +562,8 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                 }
                 if let Err(e) = delegate.on_batch(batch, &old_value_cb, &mut self.old_value_cache) {
                     assert!(delegate.has_failed());
-                    // Delegate has error, deregister the corresponding region.
-                    deregister = Some(Deregister::Region {
+                    // Delegate has error, deregister the delegate.
+                    deregister = Some(Deregister::Delegate {
                         region_id,
                         observe_id: delegate.handle.id,
                         err: e,
@@ -832,7 +802,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
                         }))),
                     ) {
                         warn!("cdc send LeaderCallback failed"; "err" => ?e, "min_ts" => min_ts);
-                        let deregister = Deregister::Region {
+                        let deregister = Deregister::Delegate {
                             observe_id,
                             region_id,
                             err: Error::request(e.into()),
@@ -1028,6 +998,7 @@ struct Initializer {
     sink: crate::channel::Sink,
 
     region_id: u64,
+    region_epoch: RegionEpoch,
     observe_id: ObserveID,
     downstream_id: DownstreamID,
     downstream_state: Arc<AtomicCell<DownstreamState>>,
@@ -1044,58 +1015,85 @@ struct Initializer {
 }
 
 impl Initializer {
-    async fn on_change_cmd(&mut self, mut resp: ReadResponse<RocksSnapshot>) {
-        CDC_SCAN_TASKS.with_label_values(&["total"]).inc();
-        let deregister = if let Some(region_snapshot) = resp.snapshot {
+    async fn initialize<T: 'static + RaftStoreRouter<RocksEngine>>(
+        &mut self,
+        change_cmd: ChangeObserver,
+        raft_router: T,
+        concurrency_semaphore: Arc<Semaphore>,
+    ) -> Result<()> {
+        let _permit = concurrency_semaphore.acquire().await;
+
+        // When downstream_state is Stopped, it means the corresponding delegate
+        // is stopped. The initialization can be safely canceled.
+        //
+        // Acquiring a permit may take some time, it is possiable that
+        // initialization can be canceled.
+        if self.downstream_state.load() == DownstreamState::Stopped {
+            info!("cdc async incremental scan canceled";
+                "region_id" => self.region_id,
+                "downstream_id" => ?self.downstream_id,
+                "observe_id" => ?self.observe_id,
+                "conn_id" => ?self.conn_id);
+            return Err(box_err!("scan canceled"));
+        }
+
+        CDC_SCAN_TASKS.with_label_values(&["ongoing"]).inc();
+        tikv_util::defer!({
+            CDC_SCAN_TASKS.with_label_values(&["ongoing"]).dec();
+        });
+
+        // To avoid holding too many snapshots and holding them too long,
+        // we need to acquire scan concurrency permit before taking snapshot.
+        let sched = self.sched.clone();
+        let region_epoch = self.region_epoch.clone();
+        let downstream_id = self.downstream_id;
+        let downstream_state = self.downstream_state.clone();
+        let (cb, fut) = tikv_util::future::paired_future_callback();
+        if let Err(e) = raft_router.significant_send(
+            self.region_id,
+            SignificantMsg::CaptureChange {
+                cmd: change_cmd,
+                region_epoch,
+                callback: Callback::Read(Box::new(move |resp| {
+                    if let Err(e) = sched.schedule(Task::InitDownstream {
+                        downstream_id,
+                        downstream_state,
+                        cb: Box::new(move || {
+                            cb(resp);
+                        }),
+                    }) {
+                        error!("cdc schedule cdc task failed"; "error" => ?e);
+                    }
+                })),
+            },
+        ) {
+            warn!("cdc send capture change cmd failed";
+            "region_id" => self.region_id, "error" => ?e);
+            return Err(Error::request(e.into()));
+        }
+
+        match fut.await {
+            Ok(resp) => self.on_change_cmd_response(resp).await,
+            Err(e) => Err(Error::Other(box_err!(e))),
+        }
+    }
+
+    async fn on_change_cmd_response(
+        &mut self,
+        mut resp: ReadResponse<RocksSnapshot>,
+    ) -> Result<()> {
+        if let Some(region_snapshot) = resp.snapshot {
             assert_eq!(self.region_id, region_snapshot.get_region().get_id());
             let region = region_snapshot.get_region().clone();
-            // Require barrier before finishing incremental scan, because
-            // CDC needs to make sure resovled ts events can only be sent after
-            // incremental scan is finished.
-            let require_barrier = true;
-
-            let res = self
-                .async_incremental_scan(region_snapshot, region, require_barrier)
-                .await;
-
-            if res.is_ok() {
-                CDC_SCAN_TASKS.with_label_values(&["finish"]).inc();
-                return;
-            }
-
-            CDC_SCAN_TASKS.with_label_values(&["abort"]).inc();
-            let err = res.unwrap_err();
-            // Deregister downstream if incremental scan fails.
-            if self.build_resolver {
-                Deregister::Region {
-                    region_id: self.region_id,
-                    observe_id: self.observe_id,
-                    err,
-                }
-            } else {
-                Deregister::Downstream {
-                    region_id: self.region_id,
-                    downstream_id: self.downstream_id,
-                    conn_id: self.conn_id,
-                    err: Some(err),
-                }
-            }
+            self.async_incremental_scan(region_snapshot, region).await
         } else {
-            CDC_SCAN_TASKS.with_label_values(&["abort"]).inc();
             assert!(
                 resp.response.get_header().has_error(),
                 "no snapshot and no error? {:?}",
                 resp.response
             );
             let err = resp.response.take_header().take_error();
-            Deregister::Region {
-                region_id: self.region_id,
-                observe_id: self.observe_id,
-                err: Error::request(err),
-            }
-        };
-        if let Err(e) = self.sched.schedule(Task::Deregister(deregister)) {
-            error!("cdc schedule cdc task failed"; "error" => ?e);
+            Err(Error::request(err))
         }
     }
 
@@ -1103,7 +1101,6 @@ impl Initializer {
         &mut self,
         snap: S,
         region: Region,
-        require_barrier: bool,
     ) -> Result<()> {
         let downstream_id = self.downstream_id;
         let region_id = region.get_id();
@@ -1131,7 +1128,9 @@ impl Initializer {
         let conn_id = self.conn_id;
         let mut done = false;
         while !done {
-            if self.downstream_state.load() != DownstreamState::Normal {
+            // When downstream_state is Stopped, it means the corresponding
+            // delegate is stopped. The initialization can be safely canceled.
+            if self.downstream_state.load() == DownstreamState::Stopped {
                 info!("cdc async incremental scan canceled";
                     "region_id" => region_id,
                     "downstream_id" => ?downstream_id,
@@ -1146,8 +1145,7 @@ impl Initializer {
             }
             debug!("cdc scan entries"; "len" => entries.len(), "region_id" => region_id);
             fail_point!("before_schedule_incremental_scan");
-            self.sink_scan_events(entries, done, require_barrier)
-                .await?;
+            self.sink_scan_events(entries, done).await?;
         }
 
         let takes = start.elapsed();
@@ -1203,12 +1201,7 @@ impl Initializer {
         Ok(entries)
     }
 
-    async fn sink_scan_events(
-        &mut self,
-        entries: Vec<Option<TxnEntry>>,
-        done: bool,
-        require_barrier: bool,
-    ) -> Result<()> {
+    async fn sink_scan_events(&mut self, entries: Vec<Option<TxnEntry>>, done: bool) -> Result<()> {
         let mut barrier = None;
         let mut events = Delegate::convert_to_grpc_events(self.region_id, self.request_id, entries);
         if done {
@@ -1220,11 +1213,12 @@ impl Initializer {
             error!("cdc send scan event failed"; "req_id" => ?self.request_id);
             return Err(Error::Sink(e));
         }
-        if require_barrier {
-            if let Some(barrier) = barrier {
-                // Make sure tikv sends out all scan events.
-                let _ = barrier.await;
-            }
+
+        if let Some(barrier) = barrier {
+            // CDC needs to make sure resovled ts events can only be sent after
+            // incremental scan is finished.
+            // Wait the barrier to ensure tikv sends out all scan events.
+            let _ = barrier.await;
         }
 
         Ok(())
@@ -1251,6 +1245,33 @@ impl Initializer {
             region,
         }) {
             error!("cdc schedule task failed"; "error" => ?e);
+        }
+    }
+
+    // Deregister downstream when the Initializer fails to initialize.
+    fn deregister_downstream(&self, err: Error) {
+        let deregister = if self.build_resolver || err.has_region_error() {
+            // Deregister delegate on the conditions,
+            // * It fails to build a resolver. A delegate requires a resolver
+            //   to advance resolved ts.
+            // * A region error. It usually mean a peer is not leader or
+            //   a leader meets an error and can not serve.
+            Deregister::Delegate {
+                region_id: self.region_id,
+                observe_id: self.observe_id,
+                err,
+            }
+        } else {
+            Deregister::Downstream {
+                region_id: self.region_id,
+                downstream_id: self.downstream_id,
+                conn_id: self.conn_id,
+                err: Some(err),
+            }
+        };
+
+        if let Err(e) = self.sched.schedule(Task::Deregister(deregister)) {
+            error!("cdc schedule cdc task failed"; "error" => ?e);
         }
     }
 }
@@ -1369,10 +1390,12 @@ mod tests {
     use collections::HashSet;
     use engine_traits::DATA_CFS;
     use futures::executor::block_on;
+    use futures::StreamExt;
     use kvproto::cdcpb::Header;
     #[cfg(feature = "prost-codec")]
     use kvproto::cdcpb::{event::Event as Event_oneof_event, Header};
     use kvproto::errorpb::Error as ErrorHeader;
+    use raftstore::coprocessor::ObserveHandle;
     use raftstore::errors::Error as RaftStoreError;
     use raftstore::store::msg::CasualMessage;
     use raftstore::store::util::RegionReadProgress;
@@ -1380,7 +1403,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::fmt::Display;
     use std::sync::atomic::AtomicU64;
-    use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
+    use std::sync::mpsc::{channel, sync_channel, Receiver, RecvTimeoutError, Sender};
     use tempfile::TempDir;
     use test_raftstore::MockRaftStoreRouter;
     use test_raftstore::TestPdClient;
@@ -1440,6 +1463,7 @@ mod tests {
             sink,
 
             region_id: 1,
+            region_epoch: RegionEpoch::default(),
             observe_id: ObserveID::new(),
             downstream_id: DownstreamID::new(),
             downstream_state,
@@ -1537,7 +1561,8 @@ mod tests {
         let snap = engine.snapshot(Default::default()).unwrap();
         // Buffer must be large enough to unblock async incremental scan.
         let buffer = 1000;
-        let (mut worker, _pool, mut initializer, rx, drain) = mock_initializer(total_bytes, buffer);
+        let (mut worker, pool, mut initializer, rx, mut drain) =
+            mock_initializer(total_bytes, buffer);
         let check_result = || loop {
             let task = rx.recv().unwrap();
             match task {
@@ -1549,20 +1574,21 @@ mod tests {
             }
         };
         // To not block test by barrier.
-        let require_barrier = false;
-        block_on(initializer.async_incremental_scan(snap.clone(), region.clone(), require_barrier))
-            .unwrap();
+        pool.spawn(async move {
+            let mut d = drain.drain();
+            while d.next().await.is_some() {}
+        });
+
+        block_on(initializer.async_incremental_scan(snap.clone(), region.clone())).unwrap();
         check_result();
 
         initializer.max_scan_batch_bytes = total_bytes;
-        block_on(initializer.async_incremental_scan(snap.clone(), region.clone(), require_barrier))
-            .unwrap();
+        block_on(initializer.async_incremental_scan(snap.clone(), region.clone())).unwrap();
         check_result();
 
         initializer.max_scan_batch_bytes = total_bytes / 3;
         let start_1_3 = Instant::now();
-        block_on(initializer.async_incremental_scan(snap.clone(), region.clone(), require_barrier))
-            .unwrap();
+        block_on(initializer.async_incremental_scan(snap.clone(), region.clone())).unwrap();
         check_result();
         // 2s to allow certain inaccuracy.
         assert!(
@@ -1573,8 +1599,7 @@ mod tests {
 
         let start_1_6 = Instant::now();
         initializer.max_scan_batch_bytes = total_bytes / 6;
-        block_on(initializer.async_incremental_scan(snap.clone(), region.clone(), require_barrier))
-            .unwrap();
+        block_on(initializer.async_incremental_scan(snap.clone(), region.clone())).unwrap();
         check_result();
         // 4s to allow certain inaccuracy.
         assert!(
@@ -1584,8 +1609,7 @@ mod tests {
         );
 
         initializer.build_resolver = false;
-        block_on(initializer.async_incremental_scan(snap.clone(), region.clone(), require_barrier))
-            .unwrap();
+        block_on(initializer.async_incremental_scan(snap.clone(), region.clone())).unwrap();
 
         loop {
             let task = rx.recv_timeout(Duration::from_millis(100));
@@ -1598,8 +1622,7 @@ mod tests {
 
         // Test cancellation.
         initializer.downstream_state.store(DownstreamState::Stopped);
-        block_on(initializer.async_incremental_scan(snap.clone(), region, require_barrier))
-            .unwrap_err();
+        block_on(initializer.async_incremental_scan(snap.clone(), region)).unwrap_err();
 
         // Cancel error should trigger a deregsiter.
         let mut region = Region::default();
@@ -1611,53 +1634,105 @@ mod tests {
             response: Default::default(),
             txn_extra_op: Default::default(),
         };
-        block_on(initializer.on_change_cmd(resp.clone()));
-        loop {
-            let task = rx.recv_timeout(Duration::from_millis(100));
-            match task {
-                Ok(Task::Deregister(Deregister::Downstream { region_id, .. })) => {
-                    assert_eq!(region_id, initializer.region_id);
-                    break;
-                }
-                Ok(other) => panic!("unexpected task {:?}", other),
-                Err(e) => panic!("unexpected err {:?}", e),
-            }
-        }
+        block_on(initializer.on_change_cmd_response(resp.clone())).unwrap_err();
 
-        // Test deregister regoin when resolver fails to build.
-        // Scan is canceled.
-        initializer.build_resolver = true;
-        initializer.downstream_state.store(DownstreamState::Stopped);
-        block_on(initializer.on_change_cmd(resp.clone()));
-
-        loop {
-            let task = rx.recv_timeout(Duration::from_millis(100));
-            match task {
-                Ok(Task::Deregister(Deregister::Region { region_id, .. })) => {
-                    assert_eq!(region_id, initializer.region_id);
-                    break;
-                }
-                Ok(other) => panic!("unexpected task {:?}", other),
-                Err(e) => panic!("unexpected err {:?}", e),
-            }
-        }
-
-        // Sink is disconnected.
-        drop(drain);
-        initializer.build_resolver = true;
+        // Disconnect sink by dropping runtime (it also drops drain).
+        drop(pool);
         initializer.downstream_state.store(DownstreamState::Normal);
-        block_on(initializer.on_change_cmd(resp));
-        loop {
-            let task = rx.recv_timeout(Duration::from_millis(100));
-            match task {
-                Ok(Task::Deregister(Deregister::Region { region_id, .. })) => {
-                    assert_eq!(region_id, initializer.region_id);
-                    break;
-                }
-                Ok(other) => panic!("unexpected task {:?}", other),
-                Err(e) => panic!("unexpected err {:?}", e),
+        block_on(initializer.on_change_cmd_response(resp)).unwrap_err();
+
+        worker.stop();
+    }
+
+    #[test]
+    fn test_initializer_deregister_downstream() {
+        let total_bytes = 1;
+        let buffer = 1;
+        let (mut worker, _pool, mut initializer, rx, _drain) =
+            mock_initializer(total_bytes, buffer);
+
+        // Errors reported by region should deregister region.
+        initializer.build_resolver = false;
+        initializer.deregister_downstream(Error::request(ErrorHeader::default()));
+        let task = rx.recv_timeout(Duration::from_millis(100));
+        match task {
+            Ok(Task::Deregister(Deregister::Delegate { region_id, .. })) => {
+                assert_eq!(region_id, initializer.region_id);
             }
+            Ok(other) => panic!("unexpected task {:?}", other),
+            Err(e) => panic!("unexpected err {:?}", e),
         }
+
+        initializer.build_resolver = false;
+        initializer.deregister_downstream(Error::Other(box_err!("test")));
+        let task = rx.recv_timeout(Duration::from_millis(100));
+        match task {
+            Ok(Task::Deregister(Deregister::Downstream { region_id, .. })) => {
+                assert_eq!(region_id, initializer.region_id);
+            }
+            Ok(other) => panic!("unexpected task {:?}", other),
+            Err(e) => panic!("unexpected err {:?}", e),
+        }
+
+        // Test deregister region when resolver fails to build.
+        initializer.build_resolver = true;
+        initializer.deregister_downstream(Error::Other(box_err!("test")));
+        let task = rx.recv_timeout(Duration::from_millis(100));
+        match task {
+            Ok(Task::Deregister(Deregister::Delegate { region_id, .. })) => {
+                assert_eq!(region_id, initializer.region_id);
+            }
+            Ok(other) => panic!("unexpected task {:?}", other),
+            Err(e) => panic!("unexpected err {:?}", e),
+        }
+
+        worker.stop();
+    }
+
+    #[test]
+    fn test_initializer_initialize() {
+        let total_bytes = 1;
+        let buffer = 1;
+        let (mut worker, pool, mut initializer, _rx, _drain) =
+            mock_initializer(total_bytes, buffer);
+
+        let change_cmd = ChangeObserver::from_cdc(1, ObserveHandle::new());
+        let raft_router = MockRaftStoreRouter::new();
+        let concurrency_semaphore = Arc::new(Semaphore::new(1));
+
+        initializer.downstream_state.store(DownstreamState::Stopped);
+        block_on(initializer.initialize(
+            change_cmd,
+            raft_router.clone(),
+            concurrency_semaphore.clone(),
+        ))
+        .unwrap_err();
+
+        let (tx, rx) = sync_channel(1);
+        let concurrency_semaphore_ = concurrency_semaphore.clone();
+        pool.spawn(async move {
+            let _permit = concurrency_semaphore_.acquire().await;
+            tx.send(()).unwrap();
+            tx.send(()).unwrap();
+            tx.send(()).unwrap();
+        });
+        rx.recv_timeout(Duration::from_millis(200)).unwrap();
+
+        let (tx1, rx1) = sync_channel(1);
+        let change_cmd = ChangeObserver::from_cdc(1, ObserveHandle::new());
+        pool.spawn(async move {
+            let res = initializer
+                .initialize(change_cmd, raft_router, concurrency_semaphore)
+                .await;
+            tx1.send(res).unwrap();
+        });
+        // Must timeout because there is no enough permit.
+        rx1.recv_timeout(Duration::from_millis(200)).unwrap_err();
+
+        // Release the permit
+        rx.recv_timeout(Duration::from_millis(200)).unwrap();
+        let res = rx1.recv_timeout(Duration::from_millis(200)).unwrap();
+        res.unwrap_err();
 
         worker.stop();
     }
@@ -1736,6 +1811,9 @@ mod tests {
             version: semver::Version::new(4, 0, 6),
         });
         assert_eq!(ep.capture_regions.len(), 1);
+        task_rx
+            .recv_timeout(Duration::from_millis(100))
+            .unwrap_err();
 
         // duplicate request error.
         let downstream = Downstream::new("".to_string(), region_epoch.clone(), 2, conn_id, true);
@@ -1762,6 +1840,9 @@ mod tests {
             panic!("unknown cdc event {:?}", cdc_event);
         }
         assert_eq!(ep.capture_regions.len(), 1);
+        task_rx
+            .recv_timeout(Duration::from_millis(100))
+            .unwrap_err();
 
         // Compatibility error.
         let downstream = Downstream::new("".to_string(), region_epoch, 3, conn_id, true);
@@ -1788,12 +1869,15 @@ mod tests {
             panic!("unknown cdc event {:?}", cdc_event);
         }
         assert_eq!(ep.capture_regions.len(), 1);
+        task_rx
+            .recv_timeout(Duration::from_millis(100))
+            .unwrap_err();
 
         // The first scan task of a region is initiated in register, and when it
         // fails, it should send a deregister region task, otherwise the region
         // delegate does not have resolver.
         //
-        // Test non-exist regoin in raft router.
+        // Test non-exist region in raft router.
         let mut req = ChangeDataRequest::default();
         req.set_region_id(100);
         let region_epoch = req.get_region_epoch().clone();
@@ -1808,7 +1892,7 @@ mod tests {
         assert_eq!(ep.capture_regions.len(), 2);
         let task = task_rx.recv_timeout(Duration::from_millis(100)).unwrap();
         match task.unwrap() {
-            Task::Deregister(Deregister::Region { region_id, err, .. }) => {
+            Task::Deregister(Deregister::Delegate { region_id, err, .. }) => {
                 assert_eq!(region_id, 100);
                 assert!(matches!(err, Error::Request(_)), "{:?}", err);
             }
@@ -1830,7 +1914,7 @@ mod tests {
         assert_eq!(ep.capture_regions.len(), 3);
         let task = task_rx.recv_timeout(Duration::from_millis(100)).unwrap();
         match task.unwrap() {
-            Task::Deregister(Deregister::Region { region_id, err, .. }) => {
+            Task::Deregister(Deregister::Delegate { region_id, err, .. }) => {
                 assert_eq!(region_id, 101);
                 assert!(matches!(err, Error::Other(_)), "{:?}", err);
             }
@@ -2071,7 +2155,7 @@ mod tests {
             version: semver::Version::new(0, 0, 0),
         });
         assert_eq!(ep.capture_regions.len(), 1);
-        let deregister = Deregister::Region {
+        let deregister = Deregister::Delegate {
             region_id: 1,
             // A stale ObserveID (different from the actual one).
             observe_id: ObserveID::new(),

--- a/components/cdc/src/errors.rs
+++ b/components/cdc/src/errors.rs
@@ -4,7 +4,7 @@ use std::io::Error as IoError;
 use std::{error, result};
 
 use engine_traits::Error as EngineTraitsError;
-use kvproto::errorpb::Error as ErrorHeader;
+use kvproto::errorpb;
 use thiserror::Error;
 use tikv::storage::kv::{Error as EngineError, ErrorInner as EngineErrorInner};
 use tikv::storage::mvcc::{Error as MvccError, ErrorInner as MvccErrorInner};
@@ -29,17 +29,11 @@ pub enum Error {
     #[error("Mvcc error {0}")]
     Mvcc(#[from] MvccError),
     #[error("Request error {0:?}")]
-    Request(Box<ErrorHeader>),
+    Request(Box<errorpb::Error>),
     #[error("Engine traits error {0}")]
     EngineTraits(#[from] EngineTraitsError),
     #[error("Sink send error {0:?}")]
     Sink(#[from] SendError),
-}
-
-impl Error {
-    pub fn request(err: ErrorHeader) -> Error {
-        Error::Request(Box::new(err))
-    }
 }
 
 macro_rules! impl_from {
@@ -62,7 +56,25 @@ impl_from! {
 pub type Result<T> = result::Result<T, Error>;
 
 impl Error {
-    pub fn extract_error_header(self) -> ErrorHeader {
+    pub fn request(err: errorpb::Error) -> Error {
+        Error::Request(Box::new(err))
+    }
+
+    pub fn has_region_error(&self) -> bool {
+        matches!(
+            self,
+            Error::Engine(EngineError(box EngineErrorInner::Request(_)))
+                | Error::Txn(TxnError(box TxnErrorInner::Engine(EngineError(
+                    box EngineErrorInner::Request(_),
+                ))))
+                | Error::Txn(TxnError(box TxnErrorInner::Mvcc(MvccError(
+                    box MvccErrorInner::Engine(EngineError(box EngineErrorInner::Request(_))),
+                ))))
+                | Error::Request(_)
+        )
+    }
+
+    pub fn extract_region_error(self) -> errorpb::Error {
         match self {
             Error::Engine(EngineError(box EngineErrorInner::Request(e)))
             | Error::Txn(TxnError(box TxnErrorInner::Engine(EngineError(
@@ -72,8 +84,9 @@ impl Error {
                 box MvccErrorInner::Engine(EngineError(box EngineErrorInner::Request(e))),
             ))))
             | Error::Request(box e) => e,
+            // TODO: it should be None, add more cdc errors.
             other => {
-                let mut e = ErrorHeader::default();
+                let mut e = errorpb::Error::default();
                 e.set_message(format!("{:?}", other));
                 e
             }

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -142,7 +142,7 @@ impl RoleObserver for CdcObserver {
             if let Some(observe_id) = self.is_subscribed(region_id) {
                 // Unregister all downstreams.
                 let store_err = RaftStoreError::NotLeader(region_id, None);
-                let deregister = Deregister::Region {
+                let deregister = Deregister::Delegate {
                     region_id,
                     observe_id,
                     err: CdcError::request(store_err.into()),
@@ -167,7 +167,7 @@ impl RegionChangeObserver for CdcObserver {
             if let Some(observe_id) = self.is_subscribed(region_id) {
                 // Unregister all downstreams.
                 let store_err = RaftStoreError::RegionNotFound(region_id);
-                let deregister = Deregister::Region {
+                let deregister = Deregister::Delegate {
                     region_id,
                     observe_id,
                     err: CdcError::request(store_err.into()),
@@ -238,7 +238,7 @@ mod tests {
         let mut ctx = ObserverContext::new(&region);
         observer.on_role_change(&mut ctx, StateRole::Follower);
         match rx.recv_timeout(Duration::from_millis(10)).unwrap().unwrap() {
-            Task::Deregister(Deregister::Region {
+            Task::Deregister(Deregister::Delegate {
                 region_id,
                 observe_id,
                 ..

--- a/src/config.rs
+++ b/src/config.rs
@@ -2215,6 +2215,8 @@ pub struct CdcConfig {
     pub min_ts_interval: ReadableDuration,
     pub old_value_cache_size: usize,
     pub hibernate_regions_compatible: bool,
+    pub incremental_scan_threads: usize,
+    pub incremental_scan_concurrency: usize,
     pub incremental_scan_speed_limit: ReadableSize,
     pub sink_memory_quota: ReadableSize,
 }
@@ -2225,12 +2227,37 @@ impl Default for CdcConfig {
             min_ts_interval: ReadableDuration::secs(1),
             old_value_cache_size: 1024,
             hibernate_regions_compatible: true,
+            // 4 threads for incremental scan.
+            incremental_scan_threads: 4,
+            // At most 6 concurrent running tasks.
+            incremental_scan_concurrency: 6,
             // TiCDC requires a SSD, the typical write speed of SSD
             // is more than 500MB/s, so 128MB/s is enough.
             incremental_scan_speed_limit: ReadableSize::mb(128),
             // 512MB memory for CDC sink.
             sink_memory_quota: ReadableSize::mb(512),
         }
+    }
+}
+
+impl CdcConfig {
+    fn validate(&mut self) -> Result<(), Box<dyn Error>> {
+        if self.old_value_cache_size == 0 {
+            return Err("cdc.old-value-cache-size can't be 0".into());
+        }
+        if self.min_ts_interval == ReadableDuration::secs(0) {
+            return Err("cdc.min-ts-interval can't be 0s".into());
+        }
+        if self.incremental_scan_threads == 0 {
+            return Err("cdc.incremental-scan-threads can't be 0".into());
+        }
+        if self.incremental_scan_concurrency < self.incremental_scan_threads {
+            return Err(
+                "cdc.incremental-scan-concurrency must be larger than cdc.incremental-scan-threads"
+                    .into(),
+            );
+        }
+        Ok(())
     }
 }
 
@@ -2528,6 +2555,7 @@ impl TiKvConfig {
         self.security.validate()?;
         self.import.validate()?;
         self.backup.validate()?;
+        self.cdc.validate()?;
         self.pessimistic_txn.validate()?;
         self.gc.validate()?;
         self.resolved_ts.validate()?;
@@ -4074,5 +4102,50 @@ mod tests {
         cfg.coprocessor_v2.coprocessor_plugin_directory = None; // Default is `None`, which is represented by not setting the key.
 
         assert_eq!(cfg, default_cfg);
+    }
+
+    #[test]
+    fn test_cdc() {
+        let content = r#"
+            [cdc]
+        "#;
+        let mut cfg: TiKvConfig = toml::from_str(content).unwrap();
+        cfg.validate().unwrap();
+
+        let content = r#"
+            [cdc]
+            old-value-cache-size = 0
+        "#;
+        let mut cfg: TiKvConfig = toml::from_str(content).unwrap();
+        cfg.validate().unwrap_err();
+
+        let content = r#"
+            [cdc]
+            min-ts-interval = "0s"
+        "#;
+        let mut cfg: TiKvConfig = toml::from_str(content).unwrap();
+        cfg.validate().unwrap_err();
+
+        let content = r#"
+            [cdc]
+            incremental-scan-threads = 0
+        "#;
+        let mut cfg: TiKvConfig = toml::from_str(content).unwrap();
+        cfg.validate().unwrap_err();
+
+        let content = r#"
+            [cdc]
+            incremental-scan-concurrency = 0
+        "#;
+        let mut cfg: TiKvConfig = toml::from_str(content).unwrap();
+        cfg.validate().unwrap_err();
+
+        let content = r#"
+            [cdc]
+            incremental-scan-concurrency = 1
+            incremental-scan-threads = 2
+        "#;
+        let mut cfg: TiKvConfig = toml::from_str(content).unwrap();
+        cfg.validate().unwrap_err();
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2248,9 +2248,6 @@ impl Default for CdcConfig {
 
 impl CdcConfig {
     fn validate(&mut self) -> Result<(), Box<dyn Error>> {
-        if self.old_value_cache_size == 0 {
-            return Err("cdc.old-value-cache-size can't be 0".into());
-        }
         if self.min_ts_interval == ReadableDuration::secs(0) {
             return Err("cdc.min-ts-interval can't be 0s".into());
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4115,12 +4115,13 @@ mod tests {
         let mut cfg: TiKvConfig = toml::from_str(content).unwrap();
         cfg.validate().unwrap();
 
+        // old-value-cache-size is deprecated, 0 must not report error.
         let content = r#"
             [cdc]
             old-value-cache-size = 0
         "#;
         let mut cfg: TiKvConfig = toml::from_str(content).unwrap();
-        cfg.validate().unwrap_err();
+        cfg.validate().unwrap();
 
         let content = r#"
             [cdc]

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -681,6 +681,8 @@ fn test_serde_custom_tikv_config() {
         min_ts_interval: ReadableDuration::secs(4),
         old_value_cache_size: 512,
         hibernate_regions_compatible: false,
+        incremental_scan_threads: 3,
+        incremental_scan_concurrency: 4,
         incremental_scan_speed_limit: ReadableSize(7),
         sink_memory_quota: ReadableSize::mb(7),
     };

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -573,6 +573,8 @@ pipelined = false
 min-ts-interval = "4s"
 old-value-cache-size = 512
 hibernate-regions-compatible = false
+incremental-scan-threads = 3
+incremental-scan-concurrency = 4
 incremental-scan-speed-limit = 7
 sink-memory-quota = "7MB"
 


### PR DESCRIPTION
cherry-pick #10262 to release-5.1

-----------

### What problem does this PR solve?

Close https://github.com/tikv/tikv/issues/10114
Close https://github.com/pingcap/ticdc/issues/1844
Problem Summary:

### What is changed and how it works?

Limit CDC scan concurrency.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test

Tested with TiCDC v4.0.13


<!--StartFragment--><b style="font-weight:normal;" ><div dir="ltr" style="margin-left:0pt;" align="left">
v5.0.2 | This PR
-- | --
![image](https://user-images.githubusercontent.com/2150711/120879685-bb9aa400-c5f7-11eb-9cd1-f4892f7382cb.png)  | ![image](https://user-images.githubusercontent.com/2150711/120879723-fa305e80-c5f7-11eb-9f9e-b7dba3d1df00.png)
![image](https://user-images.githubusercontent.com/2150711/120879701-da009f80-c5f7-11eb-9f0d-2b266ec6225f.png) | ![image](https://user-images.githubusercontent.com/2150711/120879727-05838a00-c5f8-11eb-921b-b68c5ae9e037.png)
![image](https://user-images.githubusercontent.com/2150711/120879830-c9045e00-c5f8-11eb-8b4b-e55be4336fde.png) | ![image](https://user-images.githubusercontent.com/2150711/120879807-9490a200-c5f8-11eb-9545-bb6ce6b8990f.png)

</div></b><!--EndFragment-->



### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix OOM when TiCDC resumes a changefeed in a cluster that has lots of regions being captured. 
```