### PR TITLE
Abstract cdc crate over engines

### DIFF
--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -9,7 +9,6 @@ default = ["protobuf-codec", "test-engines-rocksdb"]
 protobuf-codec = [
   "protobuf/bytes",
   "concurrency_manager/protobuf-codec",
-  "engine_rocks/protobuf-codec",
   "engine_traits/protobuf-codec",
   "grpcio/protobuf-codec",
   "kvproto/protobuf-codec",
@@ -24,7 +23,6 @@ protobuf-codec = [
 ]
 prost-codec = [
   "concurrency_manager/prost-codec",
-  "engine_rocks/prost-codec",
   "engine_traits/prost-codec",
   "grpcio/prost-codec",
   "kvproto/prost-codec",
@@ -55,7 +53,6 @@ failpoints = ["tikv/failpoints"]
 [dependencies]
 bitflags = "1.0"
 crossbeam = "0.8"
-engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
@@ -84,6 +81,7 @@ prost = "0.7"
 futures-timer = "3.0"
 
 [dev-dependencies]
+engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 tempfile = "3.0"
 test_raftstore = { path = "../test_raftstore", default-features = false }

--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -2,13 +2,14 @@
 
 use std::f64::INFINITY;
 use std::fmt;
+use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use collections::HashMap;
 use concurrency_manager::ConcurrencyManager;
 use crossbeam::atomic::AtomicCell;
-use engine_rocks::{RocksEngine, RocksSnapshot};
+use engine_traits::{KvEngine, Snapshot as EngineSnapshot};
 use fail::fail_point;
 use futures::compat::Future01CompatExt;
 use grpcio::{ChannelBuilder, Environment};
@@ -211,11 +212,12 @@ impl fmt::Debug for Task {
 
 const METRICS_FLUSH_INTERVAL: u64 = 10_000; // 10s
 
-pub struct Endpoint<T> {
+pub struct Endpoint<T, E> {
     capture_regions: HashMap<u64, Delegate>,
     connections: HashMap<ConnID, Conn>,
     scheduler: Scheduler<Task>,
     raft_router: T,
+    engine: PhantomData<E>,
     observer: CdcObserver,
 
     pd_client: Arc<dyn PdClient>,
@@ -251,7 +253,7 @@ pub struct Endpoint<T> {
     security_mgr: Arc<SecurityManager>,
 }
 
-impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
+impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Endpoint<T, E> {
     pub fn new(
         cfg: &CdcConfig,
         pd_client: Arc<dyn PdClient>,
@@ -263,7 +265,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
         env: Arc<Environment>,
         security_mgr: Arc<SecurityManager>,
         sink_memory_quota: MemoryQuota,
-    ) -> Endpoint<T> {
+    ) -> Endpoint<T, E> {
         let workers = Builder::new_multi_thread()
             .thread_name("cdcwkr")
             .worker_threads(cfg.incremental_scan_threads)
@@ -302,6 +304,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Endpoint<T> {
             workers,
             scan_concurrency_semaphore,
             raft_router,
+            engine: PhantomData,
             observer,
             store_meta,
             concurrency_manager,
@@ -1015,7 +1018,7 @@ struct Initializer {
 }
 
 impl Initializer {
-    async fn initialize<T: 'static + RaftStoreRouter<RocksEngine>>(
+    async fn initialize<T: 'static + RaftStoreRouter<E>, E: KvEngine>(
         &mut self,
         change_cmd: ChangeObserver,
         raft_router: T,
@@ -1080,7 +1083,7 @@ impl Initializer {
 
     async fn on_change_cmd_response(
         &mut self,
-        mut resp: ReadResponse<RocksSnapshot>,
+        mut resp: ReadResponse<impl EngineSnapshot>,
     ) -> Result<()> {
         if let Some(region_snapshot) = resp.snapshot {
             assert_eq!(self.region_id, region_snapshot.get_region().get_id());
@@ -1276,7 +1279,7 @@ impl Initializer {
     }
 }
 
-impl<T: 'static + RaftStoreRouter<RocksEngine>> Runnable for Endpoint<T> {
+impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> Runnable for Endpoint<T, E> {
     type Task = Task;
 
     fn run(&mut self, task: Task) {
@@ -1328,7 +1331,7 @@ impl<T: 'static + RaftStoreRouter<RocksEngine>> Runnable for Endpoint<T> {
     }
 }
 
-impl<T: 'static + RaftStoreRouter<RocksEngine>> RunnableWithTimer for Endpoint<T> {
+impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> RunnableWithTimer for Endpoint<T, E> {
     fn on_timeout(&mut self) {
         CDC_CAPTURED_REGION_COUNT.set(self.capture_regions.len() as i64);
         CDC_REGION_RESOLVE_STATUS_GAUGE_VEC
@@ -1383,6 +1386,7 @@ impl TxnExtraScheduler for CdcTxnExtraScheduler {
 #[cfg(test)]
 mod tests {
     use collections::HashSet;
+    use engine_rocks::RocksEngine;
     use engine_traits::DATA_CFS;
     use futures::executor::block_on;
     use futures::StreamExt;
@@ -1477,7 +1481,7 @@ mod tests {
     fn mock_endpoint(
         cfg: &CdcConfig,
     ) -> (
-        Endpoint<MockRaftStoreRouter>,
+        Endpoint<MockRaftStoreRouter, RocksEngine>,
         MockRaftStoreRouter,
         ReceiverWrapper<Task>,
     ) {

--- a/components/cdc/src/observer.rs
+++ b/components/cdc/src/observer.rs
@@ -3,7 +3,6 @@
 use std::sync::{Arc, RwLock};
 
 use collections::HashMap;
-use engine_rocks::RocksEngine;
 use engine_traits::KvEngine;
 use fail::fail_point;
 use kvproto::metapb::{Peer, Region};
@@ -43,7 +42,7 @@ impl CdcObserver {
         }
     }
 
-    pub fn register_to(&self, coprocessor_host: &mut CoprocessorHost<RocksEngine>) {
+    pub fn register_to(&self, coprocessor_host: &mut CoprocessorHost<impl KvEngine>) {
         // use 0 as the priority of the cmd observer. CDC should have a higher priority than
         // the `resolved-ts`'s cmd observer
         coprocessor_host


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

One of the last crates needed to abstract over engines before tikv-server can be started with a non-rocks kv engine.

Part of https://github.com/tikv/tikv/issues/6402

### What is changed and how it works?

Just replacing RocksEngine with KvEngine typarams.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```