### PR TITLE
resolved_ts: ignore pessimistic lock while scanning locks

### DIFF
--- a/components/resolved_ts/src/scanner.rs
+++ b/components/resolved_ts/src/scanner.rs
@@ -18,7 +18,7 @@ use tikv::storage::mvcc::{DeltaScanner, MvccReader, ScannerBuilder};
 use tikv::storage::txn::{TxnEntry, TxnEntryScanner};
 use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 use tokio::runtime::{Builder, Runtime};
-use txn_types::{Key, Lock, TimeStamp};
+use txn_types::{Key, Lock, LockType, TimeStamp};
 
 use crate::errors::{Error, Result};
 use crate::metrics::RTS_SCAN_DURATION_HISTOGRAM;
@@ -227,8 +227,15 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> ScannerPool<T, E> {
         start: Option<&Key>,
         _checkpoint_ts: TimeStamp,
     ) -> Result<(Vec<(Key, Lock)>, bool)> {
-        let (locks, has_remaining) =
-            reader.scan_locks(start, None, |_| true, DEFAULT_SCAN_BATCH_SIZE)?;
+        let (locks, has_remaining) = reader.scan_locks(
+            start,
+            None,
+            |lock| match lock.lock_type {
+                LockType::Put | LockType::Delete => true,
+                _ => false,
+            },
+            DEFAULT_SCAN_BATCH_SIZE,
+        )?;
         Ok((locks, has_remaining))
     }
 

--- a/components/resolved_ts/src/scanner.rs
+++ b/components/resolved_ts/src/scanner.rs
@@ -230,10 +230,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> ScannerPool<T, E> {
         let (locks, has_remaining) = reader.scan_locks(
             start,
             None,
-            |lock| match lock.lock_type {
-                LockType::Put | LockType::Delete => true,
-                _ => false,
-            },
+            |lock| matches!(lock.lock_type, LockType::Put | LockType::Delete),
             DEFAULT_SCAN_BATCH_SIZE,
         )?;
         Ok((locks, has_remaining))

--- a/tests/failpoints/cases/test_replica_stale_read.rs
+++ b/tests/failpoints/cases/test_replica_stale_read.rs
@@ -62,6 +62,10 @@ impl PeerClient {
             commit_ts,
         )
     }
+
+    fn must_kv_pessimistic_lock(&self, key: Vec<u8>, ts: u64) {
+        must_kv_pessimistic_lock(&self.cli, self.ctx.clone(), key, ts)
+    }
 }
 
 fn prepare_for_stale_read(leader: Peer) -> (Cluster<ServerCluster>, Arc<TestPdClient>, PeerClient) {
@@ -576,4 +580,29 @@ fn test_stale_read_after_rollback_merge() {
     source_client3.ctx.set_stale_read(true);
     // the `safe_ts` should resume updating after merge rollback so we can read `key1` with the newest ts
     source_client3.must_kv_read_equal(b"key1".to_vec(), b"value1".to_vec(), get_tso(&pd_client));
+}
+
+// Testing that the new leader should ignore the pessimistic lock that wrote by the previous
+// leader and keep updating the `safe_ts`
+#[test]
+fn test_new_leader_ignore_pessimistic_lock() {
+    let (mut cluster, pd_client, leader_client) = prepare_for_stale_read(new_peer(1, 1));
+
+    // Write (`key1`, `value1`)
+    leader_client.must_kv_write(
+        &pd_client,
+        vec![new_mutation(Op::Put, &b"key1"[..], &b"value1"[..])],
+        b"key1".to_vec(),
+    );
+
+    // Leave a pessimistic lock on the region
+    leader_client.must_kv_pessimistic_lock(b"key2".to_vec(), get_tso(&pd_client));
+
+    // Transfer to a new leader
+    cluster.must_transfer_leader(1, new_peer(2, 2));
+
+    let mut follower_client3 = PeerClient::new(&cluster, 1, new_peer(3, 3));
+    follower_client3.ctx.set_stale_read(true);
+    // The new leader should be able to update `safe_ts` so we can read `key1` with the newest ts
+    follower_client3.must_kv_read_equal(b"key1".to_vec(), b"value1".to_vec(), get_tso(&pd_client));
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

The `resolved-ts` worker scan pessimistic lock and tracking them, which should be ignored (like how cdc behave), because the pessimistic lock just for blocking incoming write not incoming read, tracking these lock may cause `safe_ts` can't be updated.

### What is changed and how it works?

What's Changed:

Filter pessimistic lock  while scanning lock

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
resolved_ts: ignore pessimistic lock while scanning locks
```