### PR TITLE
raftstore: skip clearing callback when shutdown

### DIFF
--- a/components/batch-system/src/batch.rs
+++ b/components/batch-system/src/batch.rs
@@ -18,7 +18,7 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 use tikv_util::mpsc;
 use tikv_util::time::Instant;
-use tikv_util::{debug, error, info, thd_name, warn};
+use tikv_util::{debug, error, info, safe_panic, thd_name, warn};
 
 /// A unify type for FSMs so that they can be sent to channel easily.
 enum FsmTypes<N, C> {
@@ -465,9 +465,7 @@ where
             }
         }
         if let Some(e) = last_error {
-            if !thread::panicking() {
-                panic!("failed to join worker thread: {:?}", e);
-            }
+            safe_panic!("failed to join worker thread: {:?}", e);
         }
         info!("batch system {} is stopped.", name_prefix);
     }

--- a/components/batch-system/src/batch.rs
+++ b/components/batch-system/src/batch.rs
@@ -413,9 +413,11 @@ where
             max_batch_size: self.max_batch_size,
             reschedule_duration: self.reschedule_duration,
         };
+        let props = tikv_util::thread_group::current_properties();
         let t = thread::Builder::new()
             .name(name)
             .spawn(move || {
+                tikv_util::thread_group::set_properties(props);
                 set_io_type(IOType::ForegroundWrite);
                 poller.poll();
             })

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3577,7 +3577,7 @@ where
     EK: KvEngine,
 {
     fn drop(&mut self) {
-        if tikv_util::thread_group::is_shutdown().unwrap_or(false) {
+        if tikv_util::thread_group::is_shutdown(!cfg!(test)) {
             self.delegate.clear_all_commands_silently()
         } else {
             self.delegate.clear_all_commands_as_stale();
@@ -3836,7 +3836,7 @@ where
                         "target region is not found, drop proposals";
                         "region_id" => region_id
                     );
-                    if !tikv_util::thread_group::is_shutdown().unwrap_or(false) {
+                    if !tikv_util::thread_group::is_shutdown(!cfg!(test)) {
                         for p in apply.cbs.drain(..) {
                             let cmd = PendingCmd::<EK::Snapshot>::new(p.index, p.term, p.cb);
                             notify_region_removed(apply.region_id, apply.peer_id, cmd);

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1406,6 +1406,7 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
         // Wait all workers finish.
         let handle = workers.pd_worker.stop();
         self.apply_system.shutdown();
+        fail_point!("after_shutdown_apply");
         self.system.shutdown();
         if let Some(h) = handle {
             h.join().unwrap();

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -376,7 +376,7 @@ impl<S: Snapshot> CmdEpochChecker<S> {
 
 impl<S: Snapshot> Drop for CmdEpochChecker<S> {
     fn drop(&mut self) {
-        if tikv_util::thread_group::is_shutdown().unwrap_or(false) {
+        if tikv_util::thread_group::is_shutdown(!cfg!(test)) {
             for mut state in self.proposed_admin_cmd.drain(..) {
                 state.cbs.clear();
             }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -374,9 +374,15 @@ impl<S: Snapshot> CmdEpochChecker<S> {
 
 impl<S: Snapshot> Drop for CmdEpochChecker<S> {
     fn drop(&mut self) {
-        for state in self.proposed_admin_cmd.drain(..) {
-            for cb in state.cbs {
-                apply::notify_stale_req(self.term, cb);
+        if tikv_util::thread_group::is_shutdown().unwrap_or(false) {
+            for mut state in self.proposed_admin_cmd.drain(..) {
+                state.cbs.clear();
+            }
+        } else {
+            for state in self.proposed_admin_cmd.drain(..) {
+                for cb in state.cbs {
+                    apply::notify_stale_req(self.term, cb);
+                }
             }
         }
     }
@@ -1866,6 +1872,12 @@ where
         ctx: &mut PollContext<EK, ER, T>,
         committed_entries: Vec<Entry>,
     ) {
+        fail_point!(
+            "before_leader_handle_committed_entries",
+            self.is_leader(),
+            |_| ()
+        );
+
         assert!(
             !self.is_applying_snapshot(),
             "{} is applying snapshot when it is ready to handle committed entries",

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -348,10 +348,12 @@ where
         self.sender = Some(sender);
 
         let scheduler = self.scheduler.clone();
+        let props = tikv_util::thread_group::current_properties();
 
         let h = Builder::new()
             .name(thd_name!("stats-monitor"))
             .spawn(move || {
+                tikv_util::thread_group::set_properties(props);
                 tikv_alloc::add_thread_memory_accessor();
                 let mut thread_stats = ThreadInfoStatistics::new();
                 while let Err(mpsc::RecvTimeoutError::Timeout) = rx.recv_timeout(collect_interval) {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -90,6 +90,7 @@ use tikv_util::{
     config::{ensure_dir_exist, VersionTrack},
     math::MovingAvgU32,
     sys::{register_memory_usage_high_water, SysQuota},
+    thread_group::GroupProperties,
     time::Monitor,
     worker::{Builder as WorkerBuilder, FutureWorker, LazyWorker, Worker},
 };
@@ -196,6 +197,7 @@ struct Servers<ER: RaftEngine> {
 
 impl<ER: RaftEngine> TiKVServer<ER> {
     fn init(mut config: TiKvConfig) -> TiKVServer<ER> {
+        tikv_util::thread_group::set_properties(Some(GroupProperties::default()));
         // It is okay use pd config and security config before `init_config`,
         // because these configs must be provided by command line, and only
         // used during startup process.
@@ -563,11 +565,15 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         };
 
         // The `DebugService` and `DiagnosticsService` will share the same thread pool
+        let props = tikv_util::thread_group::current_properties();
         let debug_thread_pool = Arc::new(
             Builder::new_multi_thread()
                 .thread_name(thd_name!("debugger"))
                 .worker_threads(1)
-                .on_thread_start(tikv_alloc::add_thread_memory_accessor)
+                .on_thread_start(move || {
+                    tikv_alloc::add_thread_memory_accessor();
+                    tikv_util::thread_group::set_properties(props.clone());
+                })
                 .on_thread_stop(tikv_alloc::remove_thread_memory_accessor)
                 .build()
                 .unwrap(),
@@ -1048,6 +1054,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
     }
 
     fn stop(self) {
+        tikv_util::thread_group::mark_shutdown();
         let mut servers = self.servers.unwrap();
         servers
             .server

--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -13,6 +13,7 @@ use tikv::read_pool::ReadPool;
 use tikv::server::Config;
 use tikv::storage::kv::RocksEngine;
 use tikv::storage::{Engine, TestEngineBuilder};
+use tikv_util::thread_group::GroupProperties;
 
 #[derive(Clone)]
 pub struct ProductTable(Table);
@@ -82,6 +83,7 @@ pub fn init_data_with_details<E: Engine>(
         store.commit_with_ctx(ctx);
     }
 
+    tikv_util::thread_group::set_properties(Some(GroupProperties::default()));
     let pool = ReadPool::from(readpool_impl::build_read_pool_for_test(
         &CoprReadPoolConfig::default_for_test(),
         store.get_engine(),

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -328,11 +328,7 @@ impl<T: Simulator> Cluster<T> {
         self.group_props[&node_id].mark_shutdown();
         match self.sim.write() {
             Ok(mut sim) => sim.stop_node(node_id),
-            Err(_) => {
-                if !thread::panicking() {
-                    panic!("failed to acquire write lock.")
-                }
-            }
+            Err(_) => safe_panic!("failed to acquire write lock."),
         }
         self.pd_client.shutdown_store(node_id);
         debug!("node {} stopped", node_id);
@@ -703,12 +699,9 @@ impl<T: Simulator> Cluster<T> {
         match self.sim.read() {
             Ok(s) => keys = s.get_node_ids(),
             Err(_) => {
-                if thread::panicking() {
-                    // Leave the resource to avoid double panic.
-                    return;
-                } else {
-                    panic!("failed to acquire read lock");
-                }
+                safe_panic!("failed to acquire read lock");
+                // Leave the resource to avoid double panic.
+                return;
             }
         }
         for id in keys {

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -34,6 +34,7 @@ use raftstore::store::*;
 use raftstore::{Error, Result};
 use tikv::config::TiKvConfig;
 use tikv::server::Result as ServerResult;
+use tikv_util::thread_group::GroupProperties;
 use tikv_util::HandyRwLock;
 
 use super::*;
@@ -137,6 +138,7 @@ pub struct Cluster<T: Simulator> {
     pub engines: HashMap<u64, Engines<RocksEngine, RocksEngine>>,
     key_managers_map: HashMap<u64, Option<Arc<DataKeyManager>>>,
     pub labels: HashMap<u64, HashMap<String, String>>,
+    group_props: HashMap<u64, GroupProperties>,
 
     pub sim: Arc<RwLock<T>>,
     pub pd_client: Arc<TestPdClient>,
@@ -163,6 +165,7 @@ impl<T: Simulator> Cluster<T> {
             engines: HashMap::default(),
             key_managers_map: HashMap::default(),
             labels: HashMap::default(),
+            group_props: HashMap::default(),
             sim,
             pd_client,
         }
@@ -233,6 +236,9 @@ impl<T: Simulator> Cluster<T> {
             let key_mgr = self.key_managers.last().unwrap().clone();
             let store_meta = Arc::new(Mutex::new(StoreMeta::new(PENDING_MSG_CAP)));
 
+            let props = GroupProperties::default();
+            tikv_util::thread_group::set_properties(Some(props.clone()));
+
             let mut sim = self.sim.wl();
             let node_id = sim.run_node(
                 0,
@@ -243,6 +249,7 @@ impl<T: Simulator> Cluster<T> {
                 router,
                 system,
             )?;
+            self.group_props.insert(node_id, props);
             self.engines.insert(node_id, engines);
             self.store_metas.insert(node_id, store_meta);
             self.key_managers_map.insert(node_id, key_mgr);
@@ -304,6 +311,9 @@ impl<T: Simulator> Cluster<T> {
                 .insert(Arc::new(Mutex::new(StoreMeta::new(PENDING_MSG_CAP))))
                 .clone(),
         };
+        let props = GroupProperties::default();
+        self.group_props.insert(node_id, props.clone());
+        tikv_util::thread_group::set_properties(Some(props));
         debug!("calling run node"; "node_id" => node_id);
         // FIXME: rocksdb event listeners may not work, because we change the router.
         self.sim
@@ -315,6 +325,7 @@ impl<T: Simulator> Cluster<T> {
 
     pub fn stop_node(&mut self, node_id: u64) {
         debug!("stopping node {}", node_id);
+        self.group_props[&node_id].mark_shutdown();
         match self.sim.write() {
             Ok(mut sim) => sim.stop_node(node_id),
             Err(_) => {

--- a/components/test_raftstore/src/pd.rs
+++ b/components/test_raftstore/src/pd.rs
@@ -1,11 +1,11 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::cmp;
 use std::collections::BTreeMap;
 use std::collections::Bound::{Excluded, Unbounded};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
-use std::{cmp, thread};
 
 use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use futures::compat::Future01CompatExt;
@@ -1213,9 +1213,7 @@ impl TestPdClient {
                 c.stores.remove(&store_id);
             }
             Err(e) => {
-                if !thread::panicking() {
-                    panic!("failed to acquire write lock: {:?}", e)
-                }
+                safe_panic!("failed to acquire write lock: {:?}", e)
             }
         }
     }

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -57,6 +57,7 @@ use tikv::{
     server::raftkv::ReplicaReadLockChecker,
 };
 use tikv_util::config::VersionTrack;
+use tikv_util::thread_group::GroupProperties;
 use tikv_util::time::ThreadReadId;
 use tikv_util::worker::{Builder as WorkerBuilder, FutureWorker, LazyWorker};
 use tikv_util::HandyRwLock;
@@ -111,6 +112,7 @@ struct ServerMeta {
     raw_apply_router: ApplyRouter<RocksEngine>,
     gc_worker: GcWorker<RaftKv<RocksEngine, SimulateStoreTransport>, SimulateStoreTransport>,
     rts_worker: Option<LazyWorker<resolved_ts::Task<RocksSnapshot>>>,
+    group_properties: GroupProperties,
 }
 
 type PendingServices = Vec<Box<dyn Fn() -> Service>>;
@@ -210,6 +212,8 @@ impl Simulator for ServerCluster {
         router: RaftRouter<RocksEngine, RocksEngine>,
         system: RaftBatchSystem<RocksEngine, RocksEngine>,
     ) -> ServerResult<u64> {
+        let props = GroupProperties::default();
+        tikv_util::thread_group::set_properties(Some(props.clone()));
         let (tmp_str, tmp) = if node_id == 0 || !self.snap_paths.contains_key(&node_id) {
             let p = Builder::new().prefix("test_cluster").tempdir().unwrap();
             (p.path().to_str().unwrap().to_owned(), Some(p))
@@ -481,6 +485,7 @@ impl Simulator for ServerCluster {
                 sim_trans: simulate_trans,
                 gc_worker,
                 rts_worker,
+                group_properties: props,
             },
         );
         self.addrs.insert(node_id, format!("{}", addr));
@@ -504,6 +509,7 @@ impl Simulator for ServerCluster {
 
     fn stop_node(&mut self, node_id: u64) {
         if let Some(mut meta) = self.metas.remove(&node_id) {
+            meta.group_properties.mark_shutdown();
             meta.server.stop().unwrap();
             meta.node.stop();
             // resolved ts worker started, let's stop it

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -605,16 +605,20 @@ pub fn new_incompatible_server_cluster(id: u64, count: usize) -> Cluster<ServerC
     Cluster::new(id, count, sim, pd_client)
 }
 
-pub fn must_new_cluster() -> (Cluster<ServerCluster>, metapb::Peer, Context) {
-    must_new_and_configure_cluster(|_| ())
+pub fn must_new_cluster_mul(count: usize) -> (Cluster<ServerCluster>, metapb::Peer, Context) {
+    must_new_and_configure_cluster_mul(count, |_| ())
 }
 
 pub fn must_new_and_configure_cluster(
+    configure: impl FnMut(&mut Cluster<ServerCluster>),
+) -> (Cluster<ServerCluster>, metapb::Peer, Context) {
+    must_new_and_configure_cluster_mul(1, configure)
+}
+
+fn must_new_and_configure_cluster_mul(
+    count: usize,
     mut configure: impl FnMut(&mut Cluster<ServerCluster>),
-) -> (Cluster<ServerCluster>, metapb::Peer, Context)
-where
-{
-    let count = 1;
+) -> (Cluster<ServerCluster>, metapb::Peer, Context) {
     let mut cluster = new_server_cluster(0, count);
     configure(&mut cluster);
     cluster.run();
@@ -631,7 +635,13 @@ where
 }
 
 pub fn must_new_cluster_and_kv_client() -> (Cluster<ServerCluster>, TikvClient, Context) {
-    let (cluster, leader, ctx) = must_new_cluster();
+    must_new_cluster_and_kv_client_mul(1)
+}
+
+pub fn must_new_cluster_and_kv_client_mul(
+    count: usize,
+) -> (Cluster<ServerCluster>, TikvClient, Context) {
+    let (cluster, leader, ctx) = must_new_cluster_mul(count);
 
     let env = Arc::new(Environment::new(1));
     let channel =
@@ -642,7 +652,7 @@ pub fn must_new_cluster_and_kv_client() -> (Cluster<ServerCluster>, TikvClient, 
 }
 
 pub fn must_new_cluster_and_debug_client() -> (Cluster<ServerCluster>, DebugClient, u64) {
-    let (cluster, leader, _) = must_new_cluster();
+    let (cluster, leader, _) = must_new_cluster_mul(1);
 
     let env = Arc::new(Environment::new(1));
     let channel =

--- a/components/tikv_util/src/callback.rs
+++ b/components/tikv_util/src/callback.rs
@@ -45,7 +45,9 @@ where
     fn drop(&mut self) {
         if let (Some(callback), Some(arg_on_drop)) = (self.callback.take(), self.arg_on_drop.take())
         {
-            callback(arg_on_drop());
+            if !crate::thread_group::is_shutdown().unwrap_or(false) {
+                callback(arg_on_drop());
+            }
         }
     }
 }

--- a/components/tikv_util/src/callback.rs
+++ b/components/tikv_util/src/callback.rs
@@ -45,7 +45,7 @@ where
     fn drop(&mut self) {
         if let (Some(callback), Some(arg_on_drop)) = (self.callback.take(), self.arg_on_drop.take())
         {
-            if !crate::thread_group::is_shutdown().unwrap_or(false) {
+            if !crate::thread_group::is_shutdown(!cfg!(test)) {
                 callback(arg_on_drop());
             }
         }

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -38,6 +38,7 @@ pub mod metrics;
 pub mod mpsc;
 pub mod stream;
 pub mod sys;
+pub mod thread_group;
 pub mod time;
 pub mod timer;
 pub mod worker;

--- a/components/tikv_util/src/thread_group.rs
+++ b/components/tikv_util/src/thread_group.rs
@@ -1,0 +1,55 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! Provides util functions to manage share properties across threads.
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+#[derive(Default)]
+struct GroupPropertiesInner {
+    pub shutdown: AtomicBool,
+}
+
+#[derive(Default, Clone)]
+pub struct GroupProperties {
+    inner: Arc<GroupPropertiesInner>,
+}
+
+impl GroupProperties {
+    #[inline]
+    pub fn mark_shutdown(&self) {
+        self.inner.shutdown.store(true, Ordering::SeqCst);
+    }
+}
+
+thread_local! {
+    static PROPERTIES: RefCell<Option<GroupProperties>> = RefCell::new(None);
+}
+
+pub fn current_properties() -> Option<GroupProperties> {
+    PROPERTIES.with(|p| p.borrow().clone())
+}
+
+pub fn set_properties(props: Option<GroupProperties>) {
+    PROPERTIES.with(move |p| {
+        p.replace(props);
+    })
+}
+
+/// Checks if the system is shutdown.
+pub fn is_shutdown() -> Option<bool> {
+    PROPERTIES.with(|p| {
+        p.borrow()
+            .as_ref()
+            .map(|props| props.inner.shutdown.load(Ordering::SeqCst))
+    })
+}
+
+pub fn mark_shutdown() {
+    PROPERTIES.with(|p| {
+        if let Some(props) = &mut *p.borrow_mut() {
+            props.mark_shutdown();
+        }
+    })
+}

--- a/components/tikv_util/src/thread_group.rs
+++ b/components/tikv_util/src/thread_group.rs
@@ -42,8 +42,9 @@ pub fn is_shutdown(ensure_set: bool) -> bool {
     PROPERTIES.with(|p| {
         if let Some(props) = &*p.borrow() {
             props.inner.shutdown.load(Ordering::SeqCst)
-        } else if ensure_set && !std::thread::panicking() {
-            panic!("group properties is not set");
+        } else if ensure_set {
+            safe_panic!("group properties is not set");
+            false
         } else {
             false
         }

--- a/components/tikv_util/src/time.rs
+++ b/components/tikv_util/src/time.rs
@@ -119,10 +119,12 @@ impl Monitor {
         D: Fn() + Send + 'static,
         N: Fn() -> SystemTime + Send + 'static,
     {
+        let props = crate::thread_group::current_properties();
         let (tx, rx) = mpsc::channel();
         let h = Builder::new()
             .name(thd_name!("time-monitor"))
             .spawn(move || {
+                crate::thread_group::set_properties(props);
                 tikv_alloc::add_thread_memory_accessor();
                 while rx.try_recv().is_err() {
                     let before = now();

--- a/components/tikv_util/src/timer.rs
+++ b/components/tikv_util/src/timer.rs
@@ -86,9 +86,11 @@ lazy_static! {
 
 fn start_global_timer() -> Handle {
     let (tx, rx) = mpsc::channel();
+    let props = crate::thread_group::current_properties();
     Builder::new()
         .name(thd_name!("timer"))
         .spawn(move || {
+            crate::thread_group::set_properties(props);
             tikv_alloc::add_thread_memory_accessor();
             let mut timer = tokio_timer::Timer::default();
             tx.send(timer.handle()).unwrap();

--- a/components/tikv_util/src/worker/future.rs
+++ b/components/tikv_util/src/worker/future.rs
@@ -149,9 +149,13 @@ impl<T: Display + Send + 'static> Worker<T> {
         }
 
         let rx = receiver.take().unwrap();
+        let props = crate::thread_group::current_properties();
         let h = Builder::new()
             .name(thd_name!(self.scheduler.name.as_ref()))
-            .spawn(move || poll(runner, rx))?;
+            .spawn(move || {
+                crate::thread_group::set_properties(props);
+                poll(runner, rx)
+            })?;
 
         self.handle = Some(h);
         Ok(())

--- a/components/tikv_util/src/yatp_pool/mod.rs
+++ b/components/tikv_util/src/yatp_pool/mod.rs
@@ -4,6 +4,7 @@ mod future_pool;
 mod metrics;
 pub use future_pool::{Full, FuturePool};
 
+use crate::thread_group::GroupProperties;
 use crate::time::{Duration, Instant};
 use fail::fail_point;
 use std::sync::Arc;
@@ -79,6 +80,7 @@ impl Config {
 pub struct YatpPoolRunner<T: PoolTicker> {
     inner: FutureRunner,
     ticker: TickerWrapper<T>,
+    props: Option<GroupProperties>,
     after_start: Option<Arc<dyn Fn() + Send + Sync>>,
     before_stop: Option<Arc<dyn Fn() + Send + Sync>>,
     before_pause: Option<Arc<dyn Fn() + Send + Sync>>,
@@ -88,6 +90,9 @@ impl<T: PoolTicker> Runner for YatpPoolRunner<T> {
     type TaskCell = TaskCell;
 
     fn start(&mut self, local: &mut Local<Self::TaskCell>) {
+        if let Some(props) = self.props.take() {
+            crate::thread_group::set_properties(Some(props));
+        }
         self.inner.start(local);
         if let Some(f) = self.after_start.take() {
             f();
@@ -133,6 +138,7 @@ impl<T: PoolTicker> YatpPoolRunner<T> {
         YatpPoolRunner {
             inner,
             ticker,
+            props: crate::thread_group::current_properties(),
             after_start,
             before_stop,
             before_pause,

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -64,10 +64,12 @@ where
         engine: E,
         importer: Arc<SSTImporter>,
     ) -> ImportSSTService<E, Router> {
+        let props = tikv_util::thread_group::current_properties();
         let threads = ThreadPoolBuilder::new()
             .pool_size(cfg.num_threads)
             .name_prefix("sst-importer")
             .after_start(move |_| {
+                tikv_util::thread_group::set_properties(props.clone());
                 tikv_alloc::add_thread_memory_accessor();
                 set_io_type(IOType::Import);
             })

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -429,9 +429,11 @@ impl<ER: RaftEngine> Debugger<ER> {
             let start_key = range_borders[thread_index].clone();
             let end_key = range_borders[thread_index + 1].clone();
 
+            let props = tikv_util::thread_group::current_properties();
             let thread = ThreadBuilder::new()
                 .name(format!("mvcc-recover-thread-{}", thread_index))
                 .spawn(move || {
+                    tikv_util::thread_group::set_properties(props);
                     tikv_alloc::add_thread_memory_accessor();
                     info!(
                         "thread {}: started on range [{}, {})",

--- a/src/server/gc_worker/gc_manager.rs
+++ b/src/server/gc_worker/gc_manager.rs
@@ -271,9 +271,11 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider + 'static> GcManager<S, R> {
 
         let (tx, rx) = mpsc::channel();
         self.gc_manager_ctx.set_stop_signal_receiver(rx);
+        let props = tikv_util::thread_group::current_properties();
         let res: Result<_> = ThreadBuilder::new()
             .name(thd_name!("gc-manager"))
             .spawn(move || {
+                tikv_util::thread_group::set_properties(props);
                 tikv_alloc::add_thread_memory_accessor();
                 self.run();
                 tikv_alloc::remove_thread_memory_accessor();

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -1192,9 +1192,7 @@ fn test_mvcc_concurrent_commit_and_rollback_at_shutdown() {
     rollback_req.set_context(ctx.clone());
     rollback_req.start_version = rollback_start_version;
     rollback_req.mut_keys().push(k.clone());
-    let _rollback_resp = client
-        .kv_batch_rollback_async(&rollback_req)
-        .unwrap();
+    let _rollback_resp = client.kv_batch_rollback_async(&rollback_req).unwrap();
 
     // Sleep some time to make sure both commit and rollback are queued in latch.
     thread::sleep(Duration::from_millis(100));

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -1193,7 +1193,7 @@ fn test_mvcc_concurrent_commit_and_rollback_at_shutdown() {
     rollback_req.start_version = rollback_start_version;
     rollback_req.mut_keys().push(k.clone());
     let _rollback_resp = client
-        .kv_batch_rollback_async(&rollback_req.clone())
+        .kv_batch_rollback_async(&rollback_req)
         .unwrap();
 
     // Sleep some time to make sure both commit and rollback are queued in latch.
@@ -1221,8 +1221,8 @@ fn test_mvcc_concurrent_commit_and_rollback_at_shutdown() {
     ts += 1;
     let get_version = ts;
     let mut get_req = GetRequest::default();
-    get_req.set_context(ctx.clone());
-    get_req.key = k.clone();
+    get_req.set_context(ctx);
+    get_req.key = k;
     get_req.version = get_version;
     let get_resp = client.kv_get(&get_req).unwrap();
     assert!(

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -6,13 +6,16 @@ use std::thread;
 use std::time::Duration;
 
 use grpcio::*;
-use kvproto::kvrpcpb::{self, Context, Op, PrewriteRequest, RawPutRequest};
+use kvproto::kvrpcpb::{
+    self, BatchRollbackRequest, CommitRequest, Context, GetRequest, Op, PrewriteRequest,
+    RawPutRequest,
+};
 use kvproto::tikvpb::TikvClient;
 
 use collections::HashMap;
 use errors::{extract_key_error, extract_region_error};
 use futures::executor::block_on;
-use test_raftstore::{must_get_equal, must_get_none, new_peer, new_server_cluster};
+use test_raftstore::*;
 use tikv::storage::lock_manager::DummyLockManager;
 use tikv::storage::txn::{commands, Error as TxnError, ErrorInner as TxnErrorInner};
 use tikv::storage::{self, test_util::*, *};
@@ -1137,4 +1140,95 @@ fn test_before_propose_deadline() {
         rx.recv().unwrap(),
         Err(StorageError(box StorageErrorInner::DeadlineExceeded))
     ));
+}
+
+/// Checks if concurrent transaction works correctly during shutdown.
+///
+/// During shutdown, all pending writes will fail with error so its latch will be released.
+/// Then other writes in the latch queue will be continued to be processed, which can break
+/// the correctness of latch: underlying command result is always determined, it should be
+/// either always success written or never be written.
+#[test]
+fn test_mvcc_concurrent_commit_and_rollback_at_shutdown() {
+    let (mut cluster, mut client, mut ctx) = must_new_cluster_and_kv_client_mul(3);
+    let k = b"key".to_vec();
+    // Use big value to force it in default cf.
+    let v = vec![0; 10240];
+
+    let mut ts = 0;
+
+    // Prewrite
+    ts += 1;
+    let prewrite_start_version = ts;
+    let mut mutation = kvrpcpb::Mutation::default();
+    mutation.set_op(Op::Put);
+    mutation.set_key(k.clone());
+    mutation.set_value(v.clone());
+    must_kv_prewrite(
+        &client,
+        ctx.clone(),
+        vec![mutation],
+        k.clone(),
+        prewrite_start_version,
+    );
+
+    // So all following operation will not be committed by this leader.
+    let leader_fp = "before_leader_handle_committed_entries";
+    fail::cfg(leader_fp, "pause").unwrap();
+
+    // Commit
+    ts += 1;
+    let commit_version = ts;
+    let mut commit_req = CommitRequest::default();
+    commit_req.set_context(ctx.clone());
+    commit_req.start_version = prewrite_start_version;
+    commit_req.mut_keys().push(k.clone());
+    commit_req.commit_version = commit_version;
+    let _commit_resp = client.kv_commit_async(&commit_req).unwrap();
+
+    // Rollback
+    let rollback_start_version = prewrite_start_version;
+    let mut rollback_req = BatchRollbackRequest::default();
+    rollback_req.set_context(ctx.clone());
+    rollback_req.start_version = rollback_start_version;
+    rollback_req.mut_keys().push(k.clone());
+    let _rollback_resp = client
+        .kv_batch_rollback_async(&rollback_req.clone())
+        .unwrap();
+
+    // Sleep some time to make sure both commit and rollback are queued in latch.
+    thread::sleep(Duration::from_millis(100));
+    let shutdown_fp = "after_shutdown_apply";
+    fail::cfg_callback(shutdown_fp, move || {
+        fail::remove(leader_fp);
+        // Sleep some time to ensure all logs can be replicated.
+        thread::sleep(Duration::from_millis(300));
+    })
+    .unwrap();
+    let mut leader = cluster.leader_of_region(1).unwrap();
+    cluster.stop_node(leader.get_store_id());
+
+    // So a new leader should be elected.
+    cluster.must_put(b"k2", b"v2");
+    leader = cluster.leader_of_region(1).unwrap();
+    ctx.set_peer(leader.clone());
+    let env = Arc::new(Environment::new(1));
+    let channel =
+        ChannelBuilder::new(env).connect(&cluster.sim.rl().get_addr(leader.get_store_id()));
+    client = TikvClient::new(channel);
+
+    // The first request is commit, the second is rollback, the first one should succeed.
+    ts += 1;
+    let get_version = ts;
+    let mut get_req = GetRequest::default();
+    get_req.set_context(ctx.clone());
+    get_req.key = k.clone();
+    get_req.version = get_version;
+    let get_resp = client.kv_get(&get_req).unwrap();
+    assert!(
+        !get_resp.has_region_error() && !get_resp.has_error(),
+        "{:?}",
+        get_resp
+    );
+    assert_eq!(get_resp.value, v);
 }

--- a/tests/integrations/server/gc_worker.rs
+++ b/tests/integrations/server/gc_worker.rs
@@ -269,7 +269,7 @@ fn test_applied_lock_collector() {
 // This case ensures it's performed correctly.
 #[test]
 fn test_gc_bypass_raft() {
-    let (cluster, leader, ctx) = must_new_cluster();
+    let (cluster, leader, ctx) = must_new_cluster_mul(1);
     cluster.pd_client.disable_default_operator();
 
     let env = Arc::new(Environment::new(1));


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number:
close #10353 
close #10307 

Problem Summary:

If callbacks are cleared during shutdown, latch may not work as expected
as it expects deterministic result. So this PR drops all callbacks
instead of invoking.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
skip clearing callback during gracefully shutdown to avoid breaking ACID in some cases
```