### PR TITLE
raftstore: fix a panic about EntryCache::append

### DIFF
--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -187,6 +187,7 @@ impl EntryCache {
                 let truncate_to = cache_len
                     .checked_sub((cache_last_index - first_index + 1) as usize)
                     .unwrap_or_default();
+                let trunc_to_idx = self.cache[truncate_to].index;
                 for e in self.cache.drain(truncate_to..) {
                     mem_size_change -=
                         (bytes_capacity(&e.data) + bytes_capacity(&e.context)) as i64;
@@ -195,7 +196,7 @@ impl EntryCache {
                     // Only committed entries can be traced, and only uncommitted entries
                     // can be truncated. So there won't be any overlaps.
                     let cached_last = cached.range.end - 1;
-                    assert!(cached_last < truncate_to as u64);
+                    assert!(cached_last < trunc_to_idx);
                 }
             } else if cache_last_index + 1 < first_index {
                 panic!(
@@ -2525,18 +2526,54 @@ mod tests {
 
     #[test]
     fn test_storage_cache_size_change() {
+        let new_padded_entry = |index: u64, term: u64, pad_len: usize| {
+            let mut e = new_entry(index, term);
+            e.data = vec![b'x'; pad_len].into();
+            e
+        };
+
+        // Test the initial data structure size.
         let (tx, rx) = mpsc::sync_channel(8);
         let mut cache = EntryCache::new_with_cb(move |c: i64| tx.send(c).unwrap());
         assert_eq!(rx.try_recv().unwrap(), 896);
 
-        cache.append("", &[new_entry(1, 1), new_entry(2, 1)]);
+        cache.append(
+            "",
+            &[new_padded_entry(101, 1, 1), new_padded_entry(102, 1, 2)],
+        );
+        assert_eq!(rx.try_recv().unwrap(), 3);
+
+        // Test size change for one overlapped entry.
+        cache.append("", &[new_padded_entry(102, 2, 3)]);
+        assert_eq!(rx.try_recv().unwrap(), 1);
+
+        // Test size change for all overlapped entries.
+        cache.append(
+            "",
+            &[new_padded_entry(101, 3, 4), new_padded_entry(102, 3, 5)],
+        );
+        assert_eq!(rx.try_recv().unwrap(), 5);
+
+        cache.append("", &[new_padded_entry(103, 3, 6)]);
+        assert_eq!(rx.try_recv().unwrap(), 6);
+
+        // Test trace a dangle entry.
+        let cached_entries = CachedEntries::new(vec![new_padded_entry(100, 1, 1)]);
+        cache.trace_cached_entries(cached_entries);
+        assert_eq!(rx.try_recv().unwrap(), 1);
+
+        // Test trace an entry which is still in cache.
+        let cached_entries = CachedEntries::new(vec![new_padded_entry(102, 3, 5)]);
+        cache.trace_cached_entries(cached_entries);
         assert_eq!(rx.try_recv().unwrap(), 0);
 
-        cache.append("", &[new_entry(2, 2)]);
-        assert_eq!(rx.try_recv().unwrap(), 0);
+        // Test compare `cached_last` with `trunc_to_idx` in `EntryCache::append_impl`.
+        cache.append("", &[new_padded_entry(103, 4, 7)]);
+        assert_eq!(rx.try_recv().unwrap(), 1);
 
-        cache.append("", &[new_entry(1, 2), new_entry(2, 2)]);
-        assert_eq!(rx.try_recv().unwrap(), 0);
+        // Test compact all entries and traced dangle entries.
+        cache.compact_to(104);
+        assert_eq!(rx.try_recv().unwrap(), -17);
 
         drop(cache);
         assert_eq!(rx.try_recv().unwrap(), -896);


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

Fix a panic in `EntryCache::append`. The panic stack:
```
thread 'raftstore-1-1::test_node_leader_change_with_log_overlap' panicked at 'assertion failed: cached_last < truncate_to as u64', components/raftstore/src/store/peer_storage.rs:198:21
stack backtrace:
   0: rust_begin_unwind
             at /rustc/16bf626a31cb5b121d0bca2baa969b4f67eb0dab/library/std/src/panicking.rs:493:5
   1: core::panicking::panic_fmt
             at /rustc/16bf626a31cb5b121d0bca2baa969b4f67eb0dab/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/16bf626a31cb5b121d0bca2baa969b4f67eb0dab/library/core/src/panicking.rs:50:5
   3: raftstore::store::peer_storage::EntryCache::append_impl
             at /home/jay/Documents/workspace/tikv/components/raftstore/src/store/peer_storage.rs:198:21
   4: raftstore::store::peer_storage::EntryCache::append
             at /home/jay/Documents/workspace/tikv/components/raftstore/src/store/peer_storage.rs:172:32
   5: raftstore::store::peer_storage::PeerStorage<EK,ER>::append
             at /home/jay/Documents/workspace/tikv/components/raftstore/src/store/peer_storage.rs:1148:13
   6: raftstore::store::peer_storage::PeerStorage<EK,ER>::handle_raft_ready
             at /home/jay/Documents/workspace/tikv/components/raftstore/src/store/peer_storage.rs:1541:13
   7: raftstore::store::peer::Peer<EK,ER>::handle_raft_ready_append
             at /home/jay/Documents/workspace/tikv/components/raftstore/src/store/peer.rs:1790:32
   8: raftstore::store::fsm::peer::PeerFsmDelegate<EK,ER,T>::collect_ready
             at /home/jay/Documents/workspace/tikv/components/raftstore/src/store/fsm/peer.rs:964:19
   9: <raftstore::store::fsm::store::RaftPoller<EK,ER,T> as batch_system::batch::PollHandler<raftstore::store::fsm::peer::PeerFsm<EK,ER>,raftstore::store::fsm::store::StoreFsm<EK>>>::handle_normal
             at /home/jay/Documents/workspace/tikv/components/raftstore/src/store/fsm/store.rs:884:9
  10: batch_system::batch::Poller<N,C,Handler>::poll
             at /home/jay/Documents/workspace/tikv/components/batch-system/src/batch.rs:310:27
  11: batch_system::batch::BatchSystem<N,C>::start_poller::{{closure}}
             at /home/jay/Documents/workspace/tikv/components/batch-system/src/batch.rs:422:17
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

### What is changed and how it works?

Fix the bug by comparing entry index with another, instead of with an offset in a vector.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```