### PR TITLE
raftstore: Refactor SplitObserver.adjust_key()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3404,6 +3404,7 @@ dependencies = [
  "futures 0.3.15",
  "futures-util",
  "into_other",
+ "itertools 0.10.0",
  "keys",
  "kvproto",
  "lazy_static",

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -76,6 +76,7 @@ fs2 = "0.4"
 futures = "0.3"
 futures-util = { version = "0.3.1", default-features = false, features = ["io"] }
 into_other = { path = "../into_other",  default-features = false }
+itertools = "0.10"
 keys = { path = "../keys", default-features = false }
 kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"

--- a/components/raftstore/src/coprocessor/split_observer.rs
+++ b/components/raftstore/src/coprocessor/split_observer.rs
@@ -49,7 +49,7 @@ fn is_valid_split_key(key: &[u8], index: usize, region: &Region) -> bool {
 }
 
 /// `SplitObserver` adjusts the split key so that it won't separate
-/// multiple MVCC versions of a key into two region.
+/// multiple MVCC versions of a key into two regions.
 #[derive(Clone)]
 pub struct SplitObserver;
 
@@ -81,7 +81,7 @@ impl SplitObserver {
         if ajusted_splits.is_empty() {
             Err("no valid key found for split.".to_owned())
         } else {
-            // Rewrite the splites.
+            // Rewrite the splits.
             std::mem::swap(splits, &mut ajusted_splits);
             Ok(())
         }

--- a/components/raftstore/src/coprocessor/split_observer.rs
+++ b/components/raftstore/src/coprocessor/split_observer.rs
@@ -61,7 +61,7 @@ impl SplitObserver {
         ctx: &mut ObserverContext<'_>,
         splits: &mut Vec<SplitRequest>,
     ) -> Result<(), String> {
-        let mut ajusted_splits = std::mem::take(splits)
+        let ajusted_splits = std::mem::take(splits)
             .into_iter()
             .enumerate()
             .filter_map(|(i, mut split)| {
@@ -94,7 +94,7 @@ impl SplitObserver {
             Err("no valid key found for split.".to_owned())
         } else {
             // Rewrite the splits.
-            std::mem::swap(splits, &mut ajusted_splits);
+            *splits = ajusted_splits;
             Ok(())
         }
     }

--- a/components/raftstore/src/coprocessor/split_observer.rs
+++ b/components/raftstore/src/coprocessor/split_observer.rs
@@ -59,7 +59,7 @@ impl SplitObserver {
         ctx: &mut ObserverContext<'_>,
         splits: &mut Vec<SplitRequest>,
     ) -> Result<(), String> {
-        let mut ajusted_splits = std::mem::replace(splits, Vec::new())
+        let mut ajusted_splits = std::mem::take(splits)
             .into_iter()
             .enumerate()
             .filter_map(|(i, mut split)| {

--- a/components/raftstore/src/coprocessor/split_observer.rs
+++ b/components/raftstore/src/coprocessor/split_observer.rs
@@ -77,7 +77,7 @@ impl SplitObserver {
         // Make sure that the split keys are sorted.
         ajusted_splits.sort_unstable_by(|l, r| l.get_split_key().cmp(r.get_split_key()));
 
-        // Rewrite the splitest
+        // Rewrite the splites
         std::mem::swap(splits, &mut ajusted_splits);
         Ok(())
     }

--- a/components/raftstore/src/coprocessor/split_observer.rs
+++ b/components/raftstore/src/coprocessor/split_observer.rs
@@ -74,12 +74,17 @@ impl SplitObserver {
             })
             .collect::<Vec<_>>();
 
-        // Make sure that the split keys are sorted.
-        ajusted_splits.sort_unstable_by(|l, r| l.get_split_key().cmp(r.get_split_key()));
+        // Make sure that the split keys are sorted and unique.
+        ajusted_splits.sort_by(|l, r| l.get_split_key().cmp(r.get_split_key()));
+        ajusted_splits.dedup();
 
-        // Rewrite the splites
-        std::mem::swap(splits, &mut ajusted_splits);
-        Ok(())
+        if ajusted_splits.is_empty() {
+            Err("no valid key found for split.".to_owned())
+        } else {
+            // Rewrite the splites.
+            std::mem::swap(splits, &mut ajusted_splits);
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

The `SplitObserver.adjust_key()` is unclear. So renamed the function and move the checks of keys to the `on_split()`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```