### PR TITLE
README.md: replace TiKV roadmap url

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can view the list of [TiKV Adopters](https://tikv.org/adopters/).
 
 ## TiKV roadmap
 
-You can see the [TiKV Roadmap](docs/ROADMAP.md).
+You can see the [TiKV Roadmap](https://tikv.org/docs/4.0/roadmap/).
 
 ## TiKV software stack
 


### PR DESCRIPTION
The previous file is inaccessible. so I changed the url.