### PR TITLE
snapshot: remove unnecessary trait generics

### DIFF
--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -50,8 +50,8 @@ pub use self::replication_mode::{GlobalReplicationState, StoreGroup};
 pub use self::snap::{
     check_abort, copy_snapshot,
     snap_io::{apply_sst_cf_file, build_sst_cf_file},
-    ApplyOptions, Error as SnapError, GenericSnapshot, SnapEntry, SnapKey, SnapManager,
-    SnapManagerBuilder, Snapshot, SnapshotStatistics,
+    ApplyOptions, Error as SnapError, SnapEntry, SnapKey, SnapManager, SnapManagerBuilder,
+    Snapshot, SnapshotStatistics,
 };
 pub use self::transport::{CasualRouter, ProposalRouter, StoreRouter, Transport};
 pub use self::util::RegionReadProgress;

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -183,41 +183,9 @@ where
     pub coprocessor_host: CoprocessorHost<EK>,
 }
 
-/// `Snapshot` is a trait for snapshot.
-/// It's used in these scenarios:
-///   1. build local snapshot
-///   2. read local snapshot and then replicate it to remote raftstores
-///   3. receive snapshot from remote raftstore and write it to local storage
-///   4. apply snapshot
-///   5. snapshot gc
-pub trait Snapshot<EK: KvEngine>: GenericSnapshot {
-    fn build(
-        &mut self,
-        engine: &EK,
-        kv_snap: &EK::Snapshot,
-        region: &Region,
-        snap_data: &mut RaftSnapshotData,
-        stat: &mut SnapshotStatistics,
-    ) -> RaftStoreResult<()>;
-    fn apply(&mut self, options: ApplyOptions<EK>) -> Result<()>;
-}
-
-/// `GenericSnapshot` is a snapshot not tied to any KV engines.
-pub trait GenericSnapshot: Read + Write + Send {
-    fn path(&self) -> &str;
-    fn exists(&self) -> bool;
-    fn delete(&self);
-    fn meta(&self) -> io::Result<Metadata>;
-    fn total_size(&self) -> io::Result<u64>;
-    fn save(&mut self) -> io::Result<()>;
-}
-
 // A helper function to copy snapshot.
 // Only used in tests.
-pub fn copy_snapshot(
-    mut from: Box<dyn GenericSnapshot>,
-    mut to: Box<dyn GenericSnapshot>,
-) -> io::Result<()> {
+pub fn copy_snapshot(mut from: Box<Snapshot>, mut to: Box<Snapshot>) -> io::Result<()> {
     if !to.exists() {
         io::copy(&mut from, &mut to)?;
         to.save()?;
@@ -226,7 +194,7 @@ pub fn copy_snapshot(
 }
 
 // Try to delete the specified snapshot, return true if the deletion is done.
-fn retry_delete_snapshot(mgr: &SnapManagerCore, key: &SnapKey, snap: &dyn GenericSnapshot) -> bool {
+fn retry_delete_snapshot(mgr: &SnapManagerCore, key: &SnapKey, snap: &Snapshot) -> bool {
     let d = time::Duration::from_millis(DELETE_RETRY_TIME_MILLIS);
     for _ in 0..DELETE_RETRY_MAX_TIMES {
         if mgr.delete_snapshot(key, snap, true) {
@@ -343,7 +311,7 @@ struct MetaFile {
     pub tmp_path: PathBuf,
 }
 
-pub struct Snap {
+pub struct Snapshot {
     key: SnapKey,
     display_path: String,
     dir_path: PathBuf,
@@ -362,7 +330,7 @@ enum CheckPolicy {
     None,
 }
 
-impl Snap {
+impl Snapshot {
     fn new<T: Into<PathBuf>>(
         dir: T,
         key: &SnapKey,
@@ -407,7 +375,7 @@ impl Snap {
             ..Default::default()
         };
 
-        let mut s = Snap {
+        let mut s = Snapshot {
             key: key.clone(),
             display_path,
             dir_path,
@@ -773,22 +741,44 @@ impl Snap {
         self.save_meta_file()?;
         Ok(())
     }
+
+    // TODO: It's very hard to handle key manager correctly without lock `SnapManager`.
+    // Let's do it later.
+    fn delete(&self) {
+        debug!(
+            "deleting snapshot file";
+            "snapshot" => %self.path(),
+        );
+        for cf_file in &self.cf_files {
+            // Delete cloned files.
+            delete_file_if_exist(&cf_file.clone_path).unwrap();
+
+            // Delete temp files.
+            if self.hold_tmp_files {
+                delete_file_if_exist(&cf_file.tmp_path).unwrap();
+            }
+
+            // Delete cf files.
+            delete_file_if_exist(&cf_file.path).unwrap();
+        }
+        delete_file_if_exist(&self.meta_file.path).unwrap();
+        if self.hold_tmp_files {
+            delete_file_if_exist(&self.meta_file.tmp_path).unwrap();
+        }
+    }
 }
 
-impl fmt::Debug for Snap {
+impl fmt::Debug for Snapshot {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Snap")
+        f.debug_struct("Snapshot")
             .field("key", &self.key)
             .field("display_path", &self.display_path)
             .finish()
     }
 }
 
-impl<EK> Snapshot<EK> for Snap
-where
-    EK: KvEngine,
-{
-    fn build(
+impl Snapshot {
+    pub fn build<EK: KvEngine>(
         &mut self,
         engine: &EK,
         kv_snap: &EK::Snapshot,
@@ -819,7 +809,7 @@ where
         Ok(())
     }
 
-    fn apply(&mut self, options: ApplyOptions<EK>) -> Result<()> {
+    pub fn apply<EK: KvEngine>(&mut self, options: ApplyOptions<EK>) -> Result<()> {
         box_try!(self.validate(&options.db, false));
 
         let abort_checker = ApplyAbortChecker(options.abort);
@@ -856,54 +846,27 @@ where
         }
         Ok(())
     }
-}
 
-impl GenericSnapshot for Snap {
-    fn path(&self) -> &str {
+    pub fn path(&self) -> &str {
         &self.display_path
     }
 
-    fn exists(&self) -> bool {
+    pub fn exists(&self) -> bool {
         self.cf_files
             .iter()
             .all(|cf_file| cf_file.size == 0 || file_exists(&cf_file.path))
             && file_exists(&self.meta_file.path)
     }
 
-    // TODO: It's very hard to handle key manager correctly without lock `SnapManager`.
-    // Let's do it later.
-    fn delete(&self) {
-        debug!(
-            "deleting snapshot file";
-            "snapshot" => %self.path(),
-        );
-        for cf_file in &self.cf_files {
-            // Delete cloned files.
-            delete_file_if_exist(&cf_file.clone_path).unwrap();
-
-            // Delete temp files.
-            if self.hold_tmp_files {
-                delete_file_if_exist(&cf_file.tmp_path).unwrap();
-            }
-
-            // Delete cf files.
-            delete_file_if_exist(&cf_file.path).unwrap();
-        }
-        delete_file_if_exist(&self.meta_file.path).unwrap();
-        if self.hold_tmp_files {
-            delete_file_if_exist(&self.meta_file.tmp_path).unwrap();
-        }
-    }
-
-    fn meta(&self) -> io::Result<Metadata> {
+    pub fn meta(&self) -> io::Result<Metadata> {
         file_system::metadata(&self.meta_file.path)
     }
 
-    fn total_size(&self) -> io::Result<u64> {
+    pub fn total_size(&self) -> io::Result<u64> {
         Ok(self.cf_files.iter().fold(0, |acc, x| acc + x.size))
     }
 
-    fn save(&mut self) -> io::Result<()> {
+    pub fn save(&mut self) -> io::Result<()> {
         debug!(
             "saving to snapshot file";
             "snapshot" => %self.path(),
@@ -975,7 +938,7 @@ impl snap_io::StaleDetector for ApplyAbortChecker {
     }
 }
 
-impl Read for Snap {
+impl Read for Snapshot {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
@@ -1000,7 +963,7 @@ impl Read for Snap {
     }
 }
 
-impl Write for Snap {
+impl Write for Snapshot {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
@@ -1076,7 +1039,7 @@ impl Write for Snap {
     }
 }
 
-impl Drop for Snap {
+impl Drop for Snapshot {
     fn drop(&mut self) {
         // cleanup if some of the cf files and meta file is partly written
         if self
@@ -1250,10 +1213,7 @@ impl SnapManager {
 
     // NOTE: it calculates snapshot size by scanning the base directory.
     // Don't call it in raftstore thread until the size limitation mechanism gets refactored.
-    pub fn get_snapshot_for_building<EK: KvEngine>(
-        &self,
-        key: &SnapKey,
-    ) -> RaftStoreResult<Box<dyn Snapshot<EK>>> {
+    pub fn get_snapshot_for_building(&self, key: &SnapKey) -> RaftStoreResult<Box<Snapshot>> {
         let mut old_snaps = None;
         while self.get_total_snap_size()? > self.max_total_snap_size() {
             if old_snaps.is_none() {
@@ -1281,7 +1241,7 @@ impl SnapManager {
         }
 
         let base = &self.core.base;
-        let f = Snap::new_for_building(base, key, &self.core)?;
+        let f = Snapshot::new_for_building(base, key, &self.core)?;
         Ok(Box::new(f))
     }
 
@@ -1289,20 +1249,17 @@ impl SnapManager {
         &self,
         key: &SnapKey,
         is_sending: bool,
-    ) -> RaftStoreResult<Box<dyn GenericSnapshot>> {
+    ) -> RaftStoreResult<Box<Snapshot>> {
         let _lock = self.core.registry.rl();
         let base = &self.core.base;
-        let s = Snap::new(base, key, is_sending, CheckPolicy::None, &self.core)?;
+        let s = Snapshot::new(base, key, is_sending, CheckPolicy::None, &self.core)?;
         Ok(Box::new(s))
     }
 
-    pub fn get_snapshot_for_sending(
-        &self,
-        key: &SnapKey,
-    ) -> RaftStoreResult<Box<dyn GenericSnapshot>> {
+    pub fn get_snapshot_for_sending(&self, key: &SnapKey) -> RaftStoreResult<Box<Snapshot>> {
         let _lock = self.core.registry.rl();
         let base = &self.core.base;
-        let mut s = Snap::new_for_sending(base, key, &self.core)?;
+        let mut s = Snapshot::new_for_sending(base, key, &self.core)?;
         let key_manager = match self.core.encryption_key_manager.as_ref() {
             Some(m) => m,
             None => return Ok(Box::new(s)),
@@ -1322,19 +1279,19 @@ impl SnapManager {
         &self,
         key: &SnapKey,
         data: &[u8],
-    ) -> RaftStoreResult<Box<dyn GenericSnapshot>> {
+    ) -> RaftStoreResult<Box<Snapshot>> {
         let _lock = self.core.registry.rl();
         let mut snapshot_data = RaftSnapshotData::default();
         snapshot_data.merge_from_bytes(data)?;
         let base = &self.core.base;
-        let f = Snap::new_for_receiving(base, key, &self.core, snapshot_data.take_meta())?;
+        let f = Snapshot::new_for_receiving(base, key, &self.core, snapshot_data.take_meta())?;
         Ok(Box::new(f))
     }
 
-    fn get_concrete_snapshot_for_applying(&self, key: &SnapKey) -> RaftStoreResult<Box<Snap>> {
+    fn get_concrete_snapshot_for_applying(&self, key: &SnapKey) -> RaftStoreResult<Box<Snapshot>> {
         let _lock = self.core.registry.rl();
         let base = &self.core.base;
-        let s = Snap::new_for_applying(base, key, &self.core)?;
+        let s = Snapshot::new_for_applying(base, key, &self.core)?;
         if !s.exists() {
             return Err(RaftStoreError::Other(From::from(format!(
                 "snapshot of {:?} not exists.",
@@ -1344,17 +1301,14 @@ impl SnapManager {
         Ok(Box::new(s))
     }
 
-    pub fn get_snapshot_for_applying(
-        &self,
-        key: &SnapKey,
-    ) -> RaftStoreResult<Box<dyn GenericSnapshot>> {
+    pub fn get_snapshot_for_applying(&self, key: &SnapKey) -> RaftStoreResult<Box<Snapshot>> {
         Ok(self.get_concrete_snapshot_for_applying(key)?)
     }
 
     pub fn get_snapshot_for_applying_to_engine<EK: KvEngine>(
         &self,
         key: &SnapKey,
-    ) -> RaftStoreResult<Box<dyn Snapshot<EK>>> {
+    ) -> RaftStoreResult<Box<Snapshot>> {
         Ok(self.get_concrete_snapshot_for_applying(key)?)
     }
 
@@ -1459,12 +1413,7 @@ impl SnapManager {
         }
     }
 
-    pub fn delete_snapshot(
-        &self,
-        key: &SnapKey,
-        snap: &dyn GenericSnapshot,
-        check_entry: bool,
-    ) -> bool {
+    pub fn delete_snapshot(&self, key: &SnapKey, snap: &Snapshot, check_entry: bool) -> bool {
         self.core.delete_snapshot(key, snap, check_entry)
     }
 }
@@ -1494,12 +1443,7 @@ impl SnapManagerCore {
     }
 
     // Return true if it successfully delete the specified snapshot.
-    fn delete_snapshot(
-        &self,
-        key: &SnapKey,
-        snap: &dyn GenericSnapshot,
-        check_entry: bool,
-    ) -> bool {
+    fn delete_snapshot(&self, key: &SnapKey, snap: &Snapshot, check_entry: bool) -> bool {
         let registry = self.registry.rl();
         if check_entry {
             if let Some(e) = registry.get(key) {
@@ -1614,9 +1558,8 @@ pub mod tests {
     use tikv_util::time::Limiter;
 
     use super::{
-        ApplyOptions, GenericSnapshot, Snap, SnapEntry, SnapKey, SnapManager, SnapManagerBuilder,
-        SnapManagerCore, Snapshot, SnapshotStatistics, META_FILE_SUFFIX, SNAPSHOT_CFS,
-        SNAP_GEN_PREFIX,
+        ApplyOptions, SnapEntry, SnapKey, SnapManager, SnapManagerBuilder, SnapManagerCore,
+        Snapshot, SnapshotStatistics, META_FILE_SUFFIX, SNAPSHOT_CFS, SNAP_GEN_PREFIX,
     };
 
     use crate::coprocessor::CoprocessorHost;
@@ -1819,7 +1762,7 @@ pub mod tests {
             .unwrap();
         let key = SnapKey::new(1, 1, 1);
         let prefix = format!("{}_{}", SNAP_GEN_PREFIX, key);
-        let display_path = Snap::get_display_path(dir.path(), &prefix);
+        let display_path = Snapshot::get_display_path(dir.path(), &prefix);
         assert_ne!(display_path, "");
     }
 
@@ -1854,7 +1797,7 @@ pub mod tests {
 
         let mgr_core = create_manager_core(src_dir.path().to_str().unwrap());
 
-        let mut s1 = Snap::new_for_building(src_dir.path(), &key, &mgr_core).unwrap();
+        let mut s1 = Snapshot::new_for_building(src_dir.path(), &key, &mgr_core).unwrap();
 
         // Ensure that this snapshot file doesn't exist before being built.
         assert!(!s1.exists());
@@ -1863,7 +1806,7 @@ pub mod tests {
         let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s1,
             &db,
             &snapshot,
@@ -1883,14 +1826,14 @@ pub mod tests {
         assert_eq!(stat.kv_count, get_kv_count(&snapshot));
 
         // Ensure this snapshot could be read for sending.
-        let mut s2 = Snap::new_for_sending(src_dir.path(), &key, &mgr_core).unwrap();
+        let mut s2 = Snapshot::new_for_sending(src_dir.path(), &key, &mgr_core).unwrap();
         assert!(s2.exists());
 
         // TODO check meta data correct.
         let _ = s2.meta().unwrap();
 
         let mut s3 =
-            Snap::new_for_receiving(src_dir.path(), &key, &mgr_core, snap_data.take_meta())
+            Snapshot::new_for_receiving(src_dir.path(), &key, &mgr_core, snap_data.take_meta())
                 .unwrap();
         assert!(!s3.exists());
 
@@ -1911,7 +1854,7 @@ pub mod tests {
         assert_eq!(mgr_core.get_total_snap_size().unwrap(), size);
 
         // Ensure a snapshot could be applied to DB.
-        let mut s4 = Snap::new_for_applying(src_dir.path(), &key, &mgr_core).unwrap();
+        let mut s4 = Snapshot::new_for_applying(src_dir.path(), &key, &mgr_core).unwrap();
         assert!(s4.exists());
 
         let dst_db_dir = Builder::new()
@@ -1969,13 +1912,13 @@ pub mod tests {
         let key = SnapKey::new(region_id, 1, 1);
         let mgr_core = create_manager_core(dir.path().to_str().unwrap());
 
-        let mut s1 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s1 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(!s1.exists());
 
         let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s1,
             &db,
             &snapshot,
@@ -1986,10 +1929,10 @@ pub mod tests {
         .unwrap();
         assert!(s1.exists());
 
-        let mut s2 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s2 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(s2.exists());
 
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s2,
             &db,
             &snapshot,
@@ -2107,10 +2050,10 @@ pub mod tests {
         mgr: &SnapManagerCore,
         snapshot_meta: SnapshotMeta,
     ) {
-        let mut from = Snap::new_for_sending(from_dir.path(), key, mgr).unwrap();
+        let mut from = Snapshot::new_for_sending(from_dir.path(), key, mgr).unwrap();
         assert!(from.exists());
 
-        let mut to = Snap::new_for_receiving(to_dir.path(), key, mgr, snapshot_meta).unwrap();
+        let mut to = Snapshot::new_for_receiving(to_dir.path(), key, mgr, snapshot_meta).unwrap();
 
         assert!(!to.exists());
         let _ = io::copy(&mut from, &mut to).unwrap();
@@ -2135,13 +2078,13 @@ pub mod tests {
             .unwrap();
         let key = SnapKey::new(region_id, 1, 1);
         let mgr_core = create_manager_core(dir.path().to_str().unwrap());
-        let mut s1 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s1 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(!s1.exists());
 
         let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s1,
             &db,
             &snapshot,
@@ -2154,11 +2097,11 @@ pub mod tests {
 
         corrupt_snapshot_size_in(dir.path());
 
-        assert!(Snap::new_for_sending(dir.path(), &key, &mgr_core,).is_err());
+        assert!(Snapshot::new_for_sending(dir.path(), &key, &mgr_core,).is_err());
 
-        let mut s2 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s2 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(!s2.exists());
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s2,
             &db,
             &snapshot,
@@ -2185,7 +2128,7 @@ pub mod tests {
         assert_eq!(1, metas.len());
         let snap_meta = metas.pop().unwrap();
 
-        let mut s5 = Snap::new_for_applying(dst_dir.path(), &key, &mgr_core).unwrap();
+        let mut s5 = Snapshot::new_for_applying(dst_dir.path(), &key, &mgr_core).unwrap();
         assert!(s5.exists());
 
         let dst_db_dir = Builder::new()
@@ -2203,8 +2146,8 @@ pub mod tests {
         assert!(s5.apply(options).is_err());
 
         corrupt_snapshot_size_in(dst_dir.path());
-        assert!(Snap::new_for_receiving(dst_dir.path(), &key, &mgr_core, snap_meta,).is_err());
-        assert!(Snap::new_for_applying(dst_dir.path(), &key, &mgr_core).is_err());
+        assert!(Snapshot::new_for_receiving(dst_dir.path(), &key, &mgr_core, snap_meta,).is_err());
+        assert!(Snapshot::new_for_applying(dst_dir.path(), &key, &mgr_core).is_err());
     }
 
     #[test]
@@ -2224,13 +2167,13 @@ pub mod tests {
             .unwrap();
         let key = SnapKey::new(region_id, 1, 1);
         let mgr_core = create_manager_core(dir.path().to_str().unwrap());
-        let mut s1 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s1 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(!s1.exists());
 
         let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s1,
             &db,
             &snapshot,
@@ -2243,11 +2186,11 @@ pub mod tests {
 
         assert_eq!(1, corrupt_snapshot_meta_file(dir.path()));
 
-        assert!(Snap::new_for_sending(dir.path(), &key, &mgr_core,).is_err());
+        assert!(Snapshot::new_for_sending(dir.path(), &key, &mgr_core,).is_err());
 
-        let mut s2 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s2 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(!s2.exists());
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s2,
             &db,
             &snapshot,
@@ -2272,9 +2215,9 @@ pub mod tests {
 
         assert_eq!(1, corrupt_snapshot_meta_file(dst_dir.path()));
 
-        assert!(Snap::new_for_applying(dst_dir.path(), &key, &mgr_core,).is_err());
+        assert!(Snapshot::new_for_applying(dst_dir.path(), &key, &mgr_core,).is_err());
         assert!(
-            Snap::new_for_receiving(dst_dir.path(), &key, &mgr_core, snap_data.take_meta(),)
+            Snapshot::new_for_receiving(dst_dir.path(), &key, &mgr_core, snap_data.take_meta(),)
                 .is_err()
         );
     }
@@ -2317,12 +2260,12 @@ pub mod tests {
         let snapshot = db.snapshot();
         let key1 = SnapKey::new(1, 1, 1);
         let mgr_core = create_manager_core(&path);
-        let mut s1 = Snap::new_for_building(&path, &key1, &mgr_core).unwrap();
+        let mut s1 = Snapshot::new_for_building(&path, &key1, &mgr_core).unwrap();
         let mut region = gen_test_region(1, 1, 1);
         let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s1,
             &db,
             &snapshot,
@@ -2331,10 +2274,11 @@ pub mod tests {
             &mut stat,
         )
         .unwrap();
-        let mut s = Snap::new_for_sending(&path, &key1, &mgr_core).unwrap();
+        let mut s = Snapshot::new_for_sending(&path, &key1, &mgr_core).unwrap();
         let expected_size = s.total_size().unwrap();
         let mut s2 =
-            Snap::new_for_receiving(&path, &key1, &mgr_core, snap_data.get_meta().clone()).unwrap();
+            Snapshot::new_for_receiving(&path, &key1, &mgr_core, snap_data.get_meta().clone())
+                .unwrap();
         let n = io::copy(&mut s, &mut s2).unwrap();
         assert_eq!(n, expected_size);
         s2.save().unwrap();
@@ -2342,8 +2286,9 @@ pub mod tests {
         let key2 = SnapKey::new(2, 1, 1);
         region.set_id(2);
         snap_data.set_region(region);
-        let s3 = Snap::new_for_building(&path, &key2, &mgr_core).unwrap();
-        let s4 = Snap::new_for_receiving(&path, &key2, &mgr_core, snap_data.take_meta()).unwrap();
+        let s3 = Snapshot::new_for_building(&path, &key2, &mgr_core).unwrap();
+        let s4 =
+            Snapshot::new_for_receiving(&path, &key2, &mgr_core, snap_data.take_meta()).unwrap();
 
         assert!(s1.exists());
         assert!(s2.exists());

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -362,7 +362,10 @@ where
         defer!({
             self.mgr.deregister(&snap_key, &SnapEntry::Applying);
         });
-        let mut s = box_try!(self.mgr.get_snapshot_for_applying_to_engine(&snap_key));
+        let mut s = box_try!(
+            self.mgr
+                .get_snapshot_for_applying_to_engine::<EK>(&snap_key)
+        );
         if !s.exists() {
             return Err(box_err!("missing snapshot file {}", s.path()));
         }

--- a/src/server/snap.rs
+++ b/src/server/snap.rs
@@ -1,6 +1,7 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::fmt::{self, Display, Formatter};
+use std::io::{Read, Write};
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -23,7 +24,7 @@ use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 use engine_traits::KvEngine;
 use file_system::{IOType, WithIOType};
 use raftstore::router::RaftStoreRouter;
-use raftstore::store::{GenericSnapshot, SnapEntry, SnapKey, SnapManager};
+use raftstore::store::{SnapEntry, SnapKey, SnapManager, Snapshot};
 use security::SecurityManager;
 use tikv_util::config::{Tracker, VersionTrack};
 use tikv_util::worker::Runnable;
@@ -66,7 +67,7 @@ impl Display for Task {
 
 struct SnapChunk {
     first: Option<SnapshotChunk>,
-    snap: Box<dyn GenericSnapshot>,
+    snap: Box<Snapshot>,
     remain_bytes: usize,
 }
 
@@ -170,7 +171,7 @@ pub fn send_snap(
         match recv_result {
             Ok(_) => {
                 fail_point!("snapshot_delete_after_send");
-                chunks.snap.delete();
+                mgr.delete_snapshot(&key, &*chunks.snap, true);
                 // TODO: improve it after rustc resolves the bug.
                 // Call `info` in the closure directly will cause rustc
                 // panic with `Cannot create local mono-item for DefId`.
@@ -188,7 +189,7 @@ pub fn send_snap(
 
 struct RecvSnapContext {
     key: SnapKey,
-    file: Option<Box<dyn GenericSnapshot>>,
+    file: Option<Box<Snapshot>>,
     raft_msg: RaftMessage,
     _with_io_type: WithIOType,
 }
@@ -278,7 +279,8 @@ fn recv_snap<R: RaftStoreRouter<impl KvEngine> + 'static>(
             if data.is_empty() {
                 return Err(box_err!("{} receive chunk with empty data", context.key));
             }
-            if let Err(e) = context.file.as_mut().unwrap().write_all(&data) {
+            let f = context.file.as_mut().unwrap();
+            if let Err(e) = Write::write_all(&mut *f, &data) {
                 let key = &context.key;
                 let path = context.file.as_mut().unwrap().path();
                 let e = box_err!("{} failed to write snapshot file {}: {}", key, path, e);


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What is changed and how it works?

Simplify snapshot code by removing useless trait generics.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```