### PR TITLE
statistic: return user-visible scanned bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/zhongzc/kvproto.git?rev=56e6249a4d4383169123dcf8ea78ced2551e36a0#56e6249a4d4383169123dcf8ea78ced2551e36a0"
+source = "git+https://github.com/pingcap/kvproto.git?rev=706fcaf286c8dd07ef59349c089f53289a32ce4c#706fcaf286c8dd07ef59349c089f53289a32ce4c"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4754,6 +4754,7 @@ dependencies = [
 name = "test_raftstore"
 version = "0.0.1"
 dependencies = [
+ "backtrace",
  "collections",
  "concurrency_manager",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?rev=dda0a102bc6ac7371e1f99cd2797825aa210b4a0#dda0a102bc6ac7371e1f99cd2797825aa210b4a0"
+source = "git+https://github.com/zhongzc/kvproto.git?rev=503d8d2d9ea4fce91a660fbf157f7e6f7392da7e#503d8d2d9ea4fce91a660fbf157f7e6f7392da7e"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/zhongzc/kvproto.git?rev=503d8d2d9ea4fce91a660fbf157f7e6f7392da7e#503d8d2d9ea4fce91a660fbf157f7e6f7392da7e"
+source = "git+https://github.com/zhongzc/kvproto.git?rev=56e6249a4d4383169123dcf8ea78ced2551e36a0#56e6249a4d4383169123dcf8ea78ced2551e36a0"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -364,4 +364,4 @@ overflow-checks = false
 rpath = false
 
 [patch.'https://github.com/pingcap/kvproto.git']
-kvproto = { git = "https://github.com/zhongzc/kvproto.git", rev = "503d8d2d9ea4fce91a660fbf157f7e6f7392da7e", default-features = false }
+kvproto = { git = "https://github.com/zhongzc/kvproto.git", rev = "56e6249a4d4383169123dcf8ea78ced2551e36a0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -362,3 +362,6 @@ incremental = false
 debug-assertions = false
 overflow-checks = false
 rpath = false
+
+[patch.'https://github.com/pingcap/kvproto.git']
+kvproto = { git = "https://github.com/zhongzc/kvproto.git", rev = "503d8d2d9ea4fce91a660fbf157f7e6f7392da7e", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ hyper-openssl = "0.9"
 http = "0"
 into_other = { path = "components/into_other", default-features = false }
 keys = { path = "components/keys", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 libc = "0.2"
 libloading = "0.7"
@@ -362,6 +362,3 @@ incremental = false
 debug-assertions = false
 overflow-checks = false
 rpath = false
-
-[patch.'https://github.com/pingcap/kvproto.git']
-kvproto = { git = "https://github.com/zhongzc/kvproto.git", rev = "56e6249a4d4383169123dcf8ea78ced2551e36a0", default-features = false }

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -97,7 +97,7 @@ tokio = { version = "1.5", features = ["rt-multi-thread", "time"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../../components/keys", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../../components/log_wrappers" }

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -77,7 +77,7 @@ futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 pd_client = { path = "../pd_client", default-features = false }

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -59,7 +59,7 @@ engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 raftstore = { path = "../raftstore", default-features = false }

--- a/components/cloud/Cargo.toml
+++ b/components/cloud/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 derive_more = "0.99.3"
 error_code = { path = "../error_code", default-features = false }
 futures-io = "0.3"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 rusoto_core = "0.46.0"

--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -32,7 +32,7 @@ grpcio = { version = "0.9",  default-features = false, features = ["openssl-vend
 http = "0.2.0"
 hyper = "0.14"
 hyper-tls = "0.5"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rusoto_core = "0.46.0"
 rusoto_credential = "0.46.0"
 rusoto_kms = { version = "0.46.0", features = ["serialize_structs"] }

--- a/components/cloud/gcp/Cargo.toml
+++ b/components/cloud/gcp/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = { version = "0.3", default-features = false, features = ["io"] }
 http = "0.2.0"
 hyper = "0.14"
 hyper-tls = "0.5"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 # better to not use slog-global, but pass in the logger
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = "1.3"
 prometheus = { version = "0.12", features = ["nightly"] }
 futures-util = { version = "0.3", default-features = false, features = ["std", "io"] }
 hex = "0.4.2"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 rand = "0.8"

--- a/components/encryption/export/Cargo.toml
+++ b/components/encryption/export/Cargo.toml
@@ -36,7 +36,7 @@ derive_more = "0.99.3"
 encryption = { path = "../", default-features = false }
 error_code = { path = "../../error_code", default-features = false }
 file_system = { path = "../../file_system", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/components/engine_panic/Cargo.toml
+++ b/components/engine_panic/Cargo.toml
@@ -27,6 +27,6 @@ engine_traits = { path = "../engine_traits", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
 # FIXME: Remove this dep from the engine_traits interface
 tikv_util = { path = "../tikv_util", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 txn_types = { path = "../txn_types", default-features = false }

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -65,7 +65,7 @@ online_config = { path = "../online_config" }
 tempfile = "3.0"
 serde = "1.0"
 serde_derive = "1.0"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 protobuf = "2"
 fail = "0.4"

--- a/components/engine_traits/Cargo.toml
+++ b/components/engine_traits/Cargo.toml
@@ -36,7 +36,7 @@ txn_types = { path = "../txn_types", default-features = false }
 serde = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 
 [dev-dependencies]

--- a/components/error_code/Cargo.toml
+++ b/components/error_code/Cargo.toml
@@ -26,7 +26,7 @@ path = "bin.rs"
 [dependencies]
 lazy_static = "1.3"
 raft = { version = "0.6.0-alpha", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 toml = "0.5"

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -38,7 +38,7 @@ futures-executor = "0.3"
 futures-io = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { optional = true, version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 libloading = { optional = true, version = "0.7.0" }
 prometheus = { version = "0.12", default-features = false, features = ["nightly", "push"] }

--- a/components/external_storage/export/Cargo.toml
+++ b/components/external_storage/export/Cargo.toml
@@ -81,7 +81,7 @@ futures = { optional = true, version = "0.3" }
 futures-executor = { optional = true, version = "0.3" }
 futures-io = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libloading = { optional = true, version = "0.7.0" }
 once_cell = { optional = true, version = "1.3.1" }
 protobuf = { optional = true, version = "2" }

--- a/components/into_other/Cargo.toml
+++ b/components/into_other/Cargo.toml
@@ -19,5 +19,5 @@ prost-codec = [
 
 [dependencies]
 engine_traits = { path = "../engine_traits", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -17,7 +17,7 @@ prost-codec = [
 
 [dependencies]
 byteorder = "1.2"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 thiserror = "1.0"
 tikv_alloc = { path = "../tikv_alloc" }

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -28,7 +28,7 @@ failpoints = ["fail/failpoints"]
 error_code = { path = "../error_code", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/raft_log_engine/Cargo.toml
+++ b/components/raft_log_engine/Cargo.toml
@@ -32,7 +32,7 @@ time = "0.1"
 online_config = { path = "../online_config" }
 serde = "1.0"
 serde_derive = "1.0"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 raft-engine = { git = "https://github.com/tikv/raft-engine", branch = "master" }
 protobuf = "2"

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -77,7 +77,7 @@ futures = "0.3"
 futures-util = { version = "0.3.1", default-features = false, features = ["io"] }
 into_other = { path = "../into_other",  default-features = false }
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/resolved_ts/Cargo.toml
+++ b/components/resolved_ts/Cargo.toml
@@ -50,7 +50,7 @@ fail = "0.4"
 futures = "0.3"
 grpcio = { version = "0.9", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 pd_client = { path = "../pd_client", default-features = false }

--- a/components/resource_metering/Cargo.toml
+++ b/components/resource_metering/Cargo.toml
@@ -22,7 +22,7 @@ crossbeam = "0.8"
 pin-project = "1.0"
 prometheus = { version = "0.12", features = ["nightly"] }
 prometheus-static-metric = "0.5"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 tikv_util = { path = "../tikv_util" }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 online_config = { path = "../online_config" }

--- a/components/resource_metering/src/cpu/collector/linux.rs
+++ b/components/resource_metering/src/cpu/collector/linux.rs
@@ -4,7 +4,6 @@ use crate::cpu::collector::{Collector, CollectorId};
 
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering::Relaxed;
-use std::sync::Arc;
 
 use crossbeam::channel::{unbounded, Receiver, Sender};
 use lazy_static::lazy_static;
@@ -26,10 +25,7 @@ pub(crate) enum CollectorRegistrationMsg {
 }
 
 pub fn register_collector(collector: Box<dyn Collector>) -> CollectorHandle {
-    lazy_static! {
-        static ref NEXT_COLLECTOR_ID: Arc<AtomicU64> = Arc::new(AtomicU64::new(1));
-    }
-
+    static NEXT_COLLECTOR_ID: AtomicU64 = AtomicU64::new(1);
     let id = CollectorId(NEXT_COLLECTOR_ID.fetch_add(1, Relaxed));
     COLLECTOR_REGISTRATION_CHANNEL
         .0

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -90,7 +90,7 @@ tokio = { version = "1.5", features = ["rt-multi-thread"] }
 grpcio = { version = "0.9", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -49,7 +49,7 @@ futures = { version = "0.3", features = ["thread-pool"] }
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.12", default-features = false }

--- a/components/test_backup/Cargo.toml
+++ b/components/test_backup/Cargo.toml
@@ -36,7 +36,7 @@ futures = "0.3"
 futures-executor = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rand = "0.8"
 tempfile = "3.0"
 test_raftstore = { path = "../test_raftstore" }

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -41,7 +41,7 @@ test-engines-panic = [
 [dependencies]
 engine_rocks = { path = "../engine_rocks", default-features = false }
 futures = "0.3"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 protobuf = "2"
 test_storage = { path = "../test_storage", default-features = false }
 tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }

--- a/components/test_pd/Cargo.toml
+++ b/components/test_pd/Cargo.toml
@@ -25,7 +25,7 @@ prost-codec = [
 fail = "0.4"
 futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 pd_client = { path = "../pd_client", default-features = false }

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -60,7 +60,7 @@ grpcio = { version = "0.9",  default-features = false, features = ["openssl-vend
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/test_sst_importer/Cargo.toml
+++ b/components/test_sst_importer/Cargo.toml
@@ -28,5 +28,5 @@ crc32fast = "1.2"
 engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -33,7 +33,7 @@ test-engines-panic = [
 
 [dependencies]
 futures = "0.3"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raftstore = { path = "../raftstore", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 test_raftstore = { path = "../test_raftstore", default-features = false }

--- a/components/test_util/Cargo.toml
+++ b/components/test_util/Cargo.toml
@@ -27,7 +27,7 @@ cloud-gcp = [ "encryption_export/cloud-gcp" ]
 encryption_export = { path = "../encryption/export", default-features = false }
 fail = "0.4"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rand = "0.8"
 rand_isaac = "0.3"
 security = { path = "../security", default-features = false }

--- a/components/tidb_query_common/Cargo.toml
+++ b/components/tidb_query_common/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.1"
 derive_more = "0.99.3"
 error_code = { path = "../error_code", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 prometheus = { version = "0.12", features = ["nightly"] }
 prometheus-static-metric = "0.5"
 lazy_static = "1.3"

--- a/components/tidb_query_datatype/Cargo.toml
+++ b/components/tidb_query_datatype/Cargo.toml
@@ -34,7 +34,7 @@ chrono-tz = "0.5.1"
 codec = { path = "../codec", default-features = false }
 error_code = { path = "../error_code", default-features = false }
 hex = "0.4"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 match_template = { path = "../match_template" }
 nom = { version = "5.1.0", default-features = false, features = ["std"] }

--- a/components/tidb_query_executors/Cargo.toml
+++ b/components/tidb_query_executors/Cargo.toml
@@ -33,7 +33,7 @@ prost-codec = [
 protobuf = "2.8"
 codec = { path = "../codec", default-features = false }
 fail = "0.4"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 match_template = { path = "../match_template" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }

--- a/components/tikv_kv/Cargo.toml
+++ b/components/tikv_kv/Cargo.toml
@@ -47,7 +47,7 @@ fail = "0.4"
 file_system = { path = "../file_system" }
 futures = { version = "0.3", features = ["thread-pool", "compat"] }
 into_other = { path = "../into_other", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.12", features = ["nightly"] }
 prometheus-static-metric = "0.5"

--- a/components/tikv_kv/src/stats.rs
+++ b/components/tikv_kv/src/stats.rs
@@ -176,6 +176,11 @@ pub struct Statistics {
     pub lock: CfStatistics,
     pub write: CfStatistics,
     pub data: CfStatistics,
+
+    // Number of bytes of user key-value pairs.
+    // Note that a value comes from either write cf (due to it's a short value) or data cf, we can't
+    // embed this field into `CfStatistics`.
+    pub processed_size: usize,
 }
 
 impl Statistics {
@@ -199,6 +204,7 @@ impl Statistics {
         self.lock.add(&other.lock);
         self.write.add(&other.write);
         self.data.add(&other.data);
+        self.processed_size += other.processed_size;
     }
 
     /// Deprecated
@@ -225,6 +231,7 @@ impl Statistics {
     pub fn write_scan_detail(&self, detail_v2: &mut ScanDetailV2) {
         detail_v2.set_processed_versions(self.write.processed_keys as u64);
         detail_v2.set_total_versions(self.write.total_op_count() as u64);
+        detail_v2.set_processed_versions_size(self.processed_size as u64);
     }
 }
 

--- a/components/tikv_kv/src/stats.rs
+++ b/components/tikv_kv/src/stats.rs
@@ -178,8 +178,12 @@ pub struct Statistics {
     pub data: CfStatistics,
 
     // Number of bytes of user key-value pairs.
-    // Note that a value comes from either write cf (due to it's a short value) or data cf, we can't
-    // embed this field into `CfStatistics`.
+    //
+    // A user key in mem-comparable format doesn't contain timestamp but some markers and
+    // paddings, so its size is still a little bit greater than the one at client view.
+    //
+    // Note that a value comes from either write cf (due to it's a short value) or default cf, we
+    // can't embed this `processed_size` field into `CfStatistics`.
     pub processed_size: usize,
 }
 

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -62,7 +62,7 @@ tokio = { version = "1.5", features = ["rt-multi-thread"] }
 tokio-executor = "0.1"
 tokio-timer = "0.2"
 url = "2"
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 protobuf = "2"
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 

--- a/components/tikv_util/src/codec/bytes.rs
+++ b/components/tikv_util/src/codec/bytes.rs
@@ -278,6 +278,20 @@ pub fn decode_bytes_in_place(data: &mut Vec<u8>, desc: bool) -> Result<()> {
     }
 }
 
+// Returns the decoded key length of the given encoded key which is assumed valid without actually
+// decoding it.
+pub fn unchecked_decoded_len(encoded: &[u8], desc: bool) -> usize {
+    let group_cnt = encoded.len() / (ENC_GROUP_SIZE + 1);
+    let last_group_marker = encoded[(group_cnt * (ENC_GROUP_SIZE + 1)) - 1];
+    let last_group_size = ENC_GROUP_SIZE
+        - if desc {
+            last_group_marker as usize
+        } else {
+            (ENC_MARKER - last_group_marker) as usize
+        };
+    (group_cnt - 1) * ENC_GROUP_SIZE + last_group_size
+}
+
 /// Returns whether `encoded` bytes is encoded from `raw`. Returns `false` if `encoded` is invalid.
 pub fn is_encoded_from(encoded: &[u8], raw: &[u8], desc: bool) -> bool {
     let check_single_chunk = |encoded: &[u8], raw: &[u8]| {
@@ -393,7 +407,9 @@ mod tests {
 
         for (source, mut asc, mut desc) in pairs {
             assert_eq!(encode_bytes(&source), asc);
+            assert_eq!(unchecked_decoded_len(&asc, false), source.len());
             assert_eq!(encode_bytes_desc(&source), desc);
+            assert_eq!(unchecked_decoded_len(&desc, true), source.len());
 
             // apppend timestamp, the timestamp bytes should not affect decode result
             asc.encode_u64_desc(0).unwrap();
@@ -402,6 +418,7 @@ mod tests {
                 let asc_offset = asc.as_ptr() as usize;
                 let mut asc_input = asc.as_slice();
                 assert_eq!(source, decode_bytes(&mut asc_input, false).unwrap());
+                assert_eq!(unchecked_decoded_len(&asc, false), source.len());
                 assert_eq!(
                     asc_input.as_ptr() as usize - asc_offset,
                     asc.len() - number::U64_SIZE
@@ -414,6 +431,7 @@ mod tests {
                 let desc_offset = desc.as_ptr() as usize;
                 let mut desc_input = desc.as_slice();
                 assert_eq!(source, decode_bytes(&mut desc_input, true).unwrap());
+                assert_eq!(unchecked_decoded_len(&desc, true), source.len());
                 assert_eq!(
                     desc_input.as_ptr() as usize - desc_offset,
                     desc.len() - number::U64_SIZE
@@ -652,6 +670,15 @@ mod tests {
     }
 
     #[bench]
+    fn bench_decoded_len(b: &mut Bencher) {
+        let key = [b'x'; 10000];
+        let encoded = encode_bytes(&key);
+        b.iter(|| {
+            unchecked_decoded_len(&encoded, false);
+        });
+    }
+
+    #[bench]
     fn bench_decode_small(b: &mut Bencher) {
         let key = [b'x'; 30];
         let encoded = encode_bytes(&key);
@@ -668,6 +695,15 @@ mod tests {
         b.iter(|| {
             let mut encoded = encoded.clone();
             decode_bytes_in_place(&mut encoded, false).unwrap();
+        });
+    }
+
+    #[bench]
+    fn bench_decoded_len_small(b: &mut Bencher) {
+        let key = [b'x'; 30];
+        let encoded = encode_bytes(&key);
+        b.iter(|| {
+            unchecked_decoded_len(&encoded, false);
         });
     }
 

--- a/components/txn_types/Cargo.toml
+++ b/components/txn_types/Cargo.toml
@@ -25,7 +25,7 @@ bitflags = "1.0.1"
 farmhash = "1.1.5"
 error_code = { path = "../error_code", default-features = false }
 codec = { path = "../codec", default-features = false }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = "2.3"
 thiserror = "1.0"
 tikv_alloc = { path = "../tikv_alloc" }

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -210,6 +210,11 @@ impl Key {
         bytes::is_encoded_from(&self.0, raw_key, false)
     }
 
+    /// Returns length of the key in raw representation
+    pub fn raw_len(&self) -> usize {
+        bytes::unchecked_decoded_len(&self.0, false)
+    }
+
     /// TiDB uses the same hash algorithm.
     pub fn gen_hash(&self) -> u64 {
         farmhash::fingerprint64(&self.to_raw().unwrap())

--- a/components/txn_types/src/types.rs
+++ b/components/txn_types/src/types.rs
@@ -210,11 +210,6 @@ impl Key {
         bytes::is_encoded_from(&self.0, raw_key, false)
     }
 
-    /// Returns length of the key in raw representation
-    pub fn raw_len(&self) -> usize {
-        bytes::unchecked_decoded_len(&self.0, false)
-    }
-
     /// TiDB uses the same hash algorithm.
     pub fn gen_hash(&self) -> u64 {
         farmhash::fingerprint64(&self.to_raw().unwrap())

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -209,6 +209,7 @@ impl Tracker {
 
         let mut detail_v2 = ScanDetailV2::default();
         detail_v2.set_processed_versions(self.total_storage_stats.write.processed_keys as u64);
+        detail_v2.set_processed_versions_size(self.total_storage_stats.processed_size as u64);
         detail_v2.set_total_versions(self.total_storage_stats.write.total_op_count() as u64);
         detail_v2.set_rocksdb_delete_skipped_count(
             self.total_perf_stats.0.internal_delete_skipped_count as u64,
@@ -267,6 +268,7 @@ impl Tracker {
                 "tag" => self.req_ctx.tag.get_str(),
                 "scan.is_desc" => self.req_ctx.is_desc_scan,
                 "scan.processed" => total_storage_stats.write.processed_keys,
+                "scan.processed_size" => total_storage_stats.processed_size,
                 "scan.total" => total_storage_stats.write.total_op_count(),
                 "scan.ranges" => self.req_ctx.ranges.len(),
                 "scan.range.first" => ?first_range,

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -291,13 +291,13 @@ impl<S: Snapshot> PointGetter<S> {
                     match write.short_value {
                         Some(value) => {
                             // Value is carried in `write`.
-                            self.statistics.processed_size += user_key.raw_len() + value.len();
+                            self.statistics.processed_size += user_key.len() + value.len();
                             return Ok(Some(value.to_vec()));
                         }
                         None => {
                             let start_ts = write.start_ts;
                             let value = self.load_data_from_default_cf(start_ts, user_key)?;
-                            self.statistics.processed_size += user_key.raw_len() + value.len();
+                            self.statistics.processed_size += user_key.len() + value.len();
                             return Ok(Some(value));
                         }
                     }
@@ -569,12 +569,12 @@ mod tests {
         let s = getter.take_statistics();
         // We have to check every version
         assert_seek_next_prev(&s.write, 1, 40, 0);
-        assert_eq!(s.processed_size, 264);
+        assert_eq!(s.processed_size, 269);
         // Get again
         must_get_value(&mut getter, b"foo2", b"foo2v");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 40, 0);
-        assert_eq!(s.processed_size, 264);
+        assert_eq!(s.processed_size, 269);
 
         // Get a smaller key
         must_get_none(&mut getter, b"foo1");
@@ -592,12 +592,12 @@ mod tests {
         must_get_value(&mut getter, b"zz", b"zzv");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 260);
+        assert_eq!(s.processed_size, 267);
         // Get again
         must_get_value(&mut getter, b"zz", b"zzv");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 260);
+        assert_eq!(s.processed_size, 267);
     }
 
     #[test]
@@ -668,7 +668,7 @@ mod tests {
         must_get_value(&mut getter, b"foo", b"bar");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 6);
+        assert_eq!(s.processed_size, 12);
     }
 
     /// Some ts larger than get ts
@@ -681,12 +681,12 @@ mod tests {
         must_get_value(&mut getter, b"bar", b"barv");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 262);
+        assert_eq!(s.processed_size, 268);
 
         must_get_value(&mut getter, b"bar", b"barv");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 262);
+        assert_eq!(s.processed_size, 268);
 
         must_get_none(&mut getter, b"bo");
         let s = getter.take_statistics();
@@ -701,7 +701,7 @@ mod tests {
         must_get_value(&mut getter, b"foo1", b"foo1");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 264);
+        assert_eq!(s.processed_size, 269);
 
         must_get_none(&mut getter, b"zz");
         let s = getter.take_statistics();
@@ -711,12 +711,12 @@ mod tests {
         must_get_value(&mut getter, b"foo1", b"foo1");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 264);
+        assert_eq!(s.processed_size, 269);
 
         must_get_value(&mut getter, b"bar", b"barv");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 262);
+        assert_eq!(s.processed_size, 268);
     }
 
     /// All ts larger than get ts
@@ -767,7 +767,7 @@ mod tests {
         must_get_none(&mut getter, b"foo2");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 7, 0, 0);
-        assert_eq!(s.processed_size, 546);
+        assert_eq!(s.processed_size, 568);
 
         let mut getter = new_multi_point_getter(&engine, 4.into());
         must_get_none(&mut getter, b"a");
@@ -778,7 +778,7 @@ mod tests {
         must_get_none(&mut getter, b"zz");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 3, 0, 0);
-        assert_eq!(s.processed_size, 264);
+        assert_eq!(s.processed_size, 269);
     }
 
     /// Single Point Getter can only get once.

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -296,7 +296,6 @@ impl<S: Snapshot> PointGetter<S> {
                         }
                         None => {
                             let start_ts = write.start_ts;
-                            // Value is carried in `default`.
                             let value = self.load_data_from_default_cf(start_ts, user_key)?;
                             self.statistics.processed_size += user_key.raw_len() + value.len();
                             return Ok(Some(value));

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -569,12 +569,22 @@ mod tests {
         let s = getter.take_statistics();
         // We have to check every version
         assert_seek_next_prev(&s.write, 1, 40, 0);
-        assert_eq!(s.processed_size, 269);
+        assert_eq!(
+            s.processed_size,
+            Key::from_raw(b"foo2").len()
+                + b"foo2".len()
+                + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len()
+        );
         // Get again
         must_get_value(&mut getter, b"foo2", b"foo2v");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 40, 0);
-        assert_eq!(s.processed_size, 269);
+        assert_eq!(
+            s.processed_size,
+            Key::from_raw(b"foo2").len()
+                + b"foo2".len()
+                + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len()
+        );
 
         // Get a smaller key
         must_get_none(&mut getter, b"foo1");
@@ -592,11 +602,18 @@ mod tests {
         must_get_value(&mut getter, b"zz", b"zzv");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 267);
+        assert_eq!(
+            s.processed_size,
+            Key::from_raw(b"zz").len() + b"zz".len() + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len()
+        );
         // Get again
         must_get_value(&mut getter, b"zz", b"zzv");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
+        assert_eq!(
+            s.processed_size,
+            Key::from_raw(b"zz").len() + b"zz".len() + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len()
+        );
         assert_eq!(s.processed_size, 267);
     }
 
@@ -668,7 +685,7 @@ mod tests {
         must_get_value(&mut getter, b"foo", b"bar");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 12);
+        assert_eq!(s.processed_size, Key::from_raw(b"foo").len() + b"bar".len());
     }
 
     /// Some ts larger than get ts
@@ -681,12 +698,18 @@ mod tests {
         must_get_value(&mut getter, b"bar", b"barv");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 268);
+        assert_eq!(
+            s.processed_size,
+            Key::from_raw(b"bar").len() + b"bar".len() + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len()
+        );
 
         must_get_value(&mut getter, b"bar", b"barv");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 268);
+        assert_eq!(
+            s.processed_size,
+            Key::from_raw(b"bar").len() + b"bar".len() + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len()
+        );
 
         must_get_none(&mut getter, b"bo");
         let s = getter.take_statistics();
@@ -701,7 +724,12 @@ mod tests {
         must_get_value(&mut getter, b"foo1", b"foo1");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 269);
+        assert_eq!(
+            s.processed_size,
+            Key::from_raw(b"foo1").len()
+                + b"foo1".len()
+                + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len()
+        );
 
         must_get_none(&mut getter, b"zz");
         let s = getter.take_statistics();
@@ -711,12 +739,20 @@ mod tests {
         must_get_value(&mut getter, b"foo1", b"foo1");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 269);
+        assert_eq!(
+            s.processed_size,
+            Key::from_raw(b"foo1").len()
+                + b"foo1".len()
+                + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len()
+        );
 
         must_get_value(&mut getter, b"bar", b"barv");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
-        assert_eq!(s.processed_size, 268);
+        assert_eq!(
+            s.processed_size,
+            Key::from_raw(b"bar").len() + b"bar".len() + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len()
+        );
     }
 
     /// All ts larger than get ts
@@ -767,7 +803,14 @@ mod tests {
         must_get_none(&mut getter, b"foo2");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 7, 0, 0);
-        assert_eq!(s.processed_size, 568);
+        assert_eq!(
+            s.processed_size,
+            (Key::from_raw(b"bar").len() + b"barval".len()) * 2
+                + (Key::from_raw(b"foo1").len()
+                    + b"foo1".len()
+                    + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len())
+                    * 2
+        );
 
         let mut getter = new_multi_point_getter(&engine, 4.into());
         must_get_none(&mut getter, b"a");
@@ -778,7 +821,12 @@ mod tests {
         must_get_none(&mut getter, b"zz");
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 3, 0, 0);
-        assert_eq!(s.processed_size, 269);
+        assert_eq!(
+            s.processed_size,
+            Key::from_raw(b"foo1").len()
+                + b"foo1".len()
+                + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len()
+        );
     }
 
     /// Single Point Getter can only get once.

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -614,7 +614,6 @@ mod tests {
             s.processed_size,
             Key::from_raw(b"zz").len() + b"zz".len() + "v".repeat(SHORT_VALUE_MAX_LEN + 1).len()
         );
-        assert_eq!(s.processed_size, 267);
     }
 
     #[test]

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -582,6 +582,7 @@ mod tests {
         let s = getter.take_statistics();
         assert_seek_next_prev(&s.write, 1, 0, 0);
         assert_eq!(s.processed_size, 0);
+
         // Get a key that does not exist
         must_get_none(&mut getter, b"z");
         let s = getter.take_statistics();

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -1044,7 +1044,6 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 1);
-        assert_eq!(statistics.processed_size, 14);
         assert_eq!(
             statistics.processed_size,
             Key::from_raw(b"c").len() + b"value".len()
@@ -1166,7 +1165,6 @@ mod tests {
             statistics.write.prev,
             (REVERSE_SEEK_BOUND - 1 + SEEK_BOUND - 1) as usize
         );
-        assert_eq!(statistics.processed_size, 10);
         assert_eq!(
             statistics.processed_size,
             Key::from_raw(b"b").len() + vec![(REVERSE_SEEK_BOUND + 1) as u8].len()

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -180,7 +180,7 @@ impl<S: Snapshot> BackwardKvScanner<S> {
 
             if let Some(v) = result? {
                 self.statistics.write.processed_keys += 1;
-                self.statistics.processed_size += current_user_key.raw_len() + v.len();
+                self.statistics.processed_size += current_user_key.len() + v.len();
                 return Ok(Some((current_user_key, v)));
             }
         }
@@ -579,7 +579,7 @@ mod tests {
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.seek_for_prev, 1);
-        assert_eq!(statistics.processed_size, 2);
+        assert_eq!(statistics.processed_size, 10);
 
         // Before get key [9]:
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
@@ -608,7 +608,7 @@ mod tests {
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.seek_for_prev, 0);
-        assert_eq!(statistics.processed_size, 2);
+        assert_eq!(statistics.processed_size, 10);
 
         // Before get key [8]:
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
@@ -646,7 +646,7 @@ mod tests {
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
         assert_eq!(statistics.write.seek_for_prev, 0);
-        assert_eq!(statistics.processed_size, 2);
+        assert_eq!(statistics.processed_size, 10);
 
         // Before get key [7]:
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
@@ -682,7 +682,7 @@ mod tests {
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
         assert_eq!(statistics.write.seek_for_prev, 0);
-        assert_eq!(statistics.processed_size, 2);
+        assert_eq!(statistics.processed_size, 10);
 
         // Before get key [5]:
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
@@ -718,7 +718,7 @@ mod tests {
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
         assert_eq!(statistics.write.seek_for_prev, 0);
-        assert_eq!(statistics.processed_size, 2);
+        assert_eq!(statistics.processed_size, 10);
 
         // Scan end.
         assert_eq!(scanner.next().unwrap(), None);
@@ -787,7 +787,7 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 1);
-        assert_eq!(statistics.processed_size, 6);
+        assert_eq!(statistics.processed_size, 14);
 
         // Use N/2 prev and reach out of bound:
         //   b_1 b_0 c_8
@@ -869,7 +869,7 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 1);
-        assert_eq!(statistics.processed_size, 8);
+        assert_eq!(statistics.processed_size, 16);
 
         // Use N/2+1 prev and reach out of bound:
         //   b_2 b_1 b_0 c_8
@@ -883,7 +883,7 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, (REVERSE_SEEK_BOUND / 2 + 1) as usize);
-        assert_eq!(statistics.processed_size, 8);
+        assert_eq!(statistics.processed_size, 16);
 
         // Cursor remains invalid, so nothing should happen.
         assert_eq!(scanner.next().unwrap(), None);
@@ -939,7 +939,7 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 1);
-        assert_eq!(statistics.processed_size, 6);
+        assert_eq!(statistics.processed_size, 14);
 
         // Before:
         //   b_2 b_1 c_1
@@ -957,7 +957,7 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, (SEEK_BOUND / 2) as usize);
-        assert_eq!(statistics.processed_size, 2);
+        assert_eq!(statistics.processed_size, 10);
 
         // Next we should get nothing.
         assert_eq!(scanner.next().unwrap(), None);
@@ -1013,7 +1013,7 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 1);
-        assert_eq!(statistics.processed_size, 6);
+        assert_eq!(statistics.processed_size, 14);
 
         // Before:
         //   b_5 b_4 b_3 b_2 b_1 c_1
@@ -1037,7 +1037,7 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 1);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, SEEK_BOUND as usize);
-        assert_eq!(statistics.processed_size, 2);
+        assert_eq!(statistics.processed_size, 10);
 
         // Next we should get nothing.
         assert_eq!(scanner.next().unwrap(), None);
@@ -1095,7 +1095,7 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 1);
-        assert_eq!(statistics.processed_size, 6);
+        assert_eq!(statistics.processed_size, 14);
 
         // Before:
         //   b_11 b_10 b_9 b_8 b_7 b_6 b_5 b_4 b_3 b_2 b_1 c_1
@@ -1125,7 +1125,7 @@ mod tests {
             statistics.write.prev,
             (REVERSE_SEEK_BOUND - 1 + SEEK_BOUND - 1) as usize
         );
-        assert_eq!(statistics.processed_size, 2);
+        assert_eq!(statistics.processed_size, 10);
 
         // Next we should get nothing.
         assert_eq!(scanner.next().unwrap(), None);
@@ -1173,7 +1173,7 @@ mod tests {
             Some((Key::from_raw(&[3u8]), vec![3u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 4);
+        assert_eq!(scanner.take_statistics().processed_size, 20);
 
         // Test left bound not specified.
         let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), true)
@@ -1189,7 +1189,7 @@ mod tests {
             Some((Key::from_raw(&[1u8]), vec![1u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 4);
+        assert_eq!(scanner.take_statistics().processed_size, 20);
 
         // Test right bound not specified.
         let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), true)
@@ -1205,7 +1205,7 @@ mod tests {
             Some((Key::from_raw(&[5u8]), vec![5u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 4);
+        assert_eq!(scanner.take_statistics().processed_size, 20);
 
         // Test both bound not specified.
         let mut scanner = ScannerBuilder::new(snapshot, 10.into(), true)
@@ -1237,7 +1237,7 @@ mod tests {
             Some((Key::from_raw(&[1u8]), vec![1u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 12);
+        assert_eq!(scanner.take_statistics().processed_size, 60);
     }
 
     #[test]

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -579,7 +579,10 @@ mod tests {
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.seek_for_prev, 1);
-        assert_eq!(statistics.processed_size, 10);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(&[10_u8]).len() + vec![(REVERSE_SEEK_BOUND / 2 - 1) as u8].len()
+        );
 
         // Before get key [9]:
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
@@ -608,7 +611,10 @@ mod tests {
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.seek_for_prev, 0);
-        assert_eq!(statistics.processed_size, 10);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(&[9_u8]).len() + vec![(REVERSE_SEEK_BOUND) as u8].len()
+        );
 
         // Before get key [8]:
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
@@ -646,7 +652,10 @@ mod tests {
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
         assert_eq!(statistics.write.seek_for_prev, 0);
-        assert_eq!(statistics.processed_size, 10);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(&[8_u8]).len() + vec![(REVERSE_SEEK_BOUND / 2 - 1) as u8].len()
+        );
 
         // Before get key [7]:
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
@@ -683,6 +692,10 @@ mod tests {
         assert_eq!(statistics.write.next, 1);
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.processed_size, 10);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(&[6_u8]).len() + vec![0_u8].len()
+        );
 
         // Before get key [5]:
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
@@ -718,7 +731,10 @@ mod tests {
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
         assert_eq!(statistics.write.seek_for_prev, 0);
-        assert_eq!(statistics.processed_size, 10);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(&[4_u8]).len() + vec![REVERSE_SEEK_BOUND as u8].len()
+        );
 
         // Scan end.
         assert_eq!(scanner.next().unwrap(), None);
@@ -787,7 +803,10 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 1);
-        assert_eq!(statistics.processed_size, 14);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(b"c").len() + b"value".len()
+        );
 
         // Use N/2 prev and reach out of bound:
         //   b_1 b_0 c_8
@@ -869,7 +888,10 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 1);
-        assert_eq!(statistics.processed_size, 16);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(b"c").len() + b"value_c".len()
+        );
 
         // Use N/2+1 prev and reach out of bound:
         //   b_2 b_1 b_0 c_8
@@ -883,7 +905,10 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, (REVERSE_SEEK_BOUND / 2 + 1) as usize);
-        assert_eq!(statistics.processed_size, 16);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(b"b").len() + b"value_b".len()
+        );
 
         // Cursor remains invalid, so nothing should happen.
         assert_eq!(scanner.next().unwrap(), None);
@@ -939,7 +964,10 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 1);
-        assert_eq!(statistics.processed_size, 14);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(b"c").len() + b"value".len()
+        );
 
         // Before:
         //   b_2 b_1 c_1
@@ -950,14 +978,17 @@ mod tests {
         // ^cursor
         assert_eq!(
             scanner.next().unwrap(),
-            Some((Key::from_raw(b"b"), vec![1u8].to_vec())),
+            Some((Key::from_raw(b"b"), vec![1u8])),
         );
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, (SEEK_BOUND / 2) as usize);
-        assert_eq!(statistics.processed_size, 10);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(b"b").len() + vec![1u8].len()
+        );
 
         // Next we should get nothing.
         assert_eq!(scanner.next().unwrap(), None);
@@ -1014,6 +1045,10 @@ mod tests {
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 1);
         assert_eq!(statistics.processed_size, 14);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(b"c").len() + b"value".len()
+        );
 
         // Before:
         //   b_5 b_4 b_3 b_2 b_1 c_1
@@ -1037,7 +1072,10 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 1);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, SEEK_BOUND as usize);
-        assert_eq!(statistics.processed_size, 10);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(b"b").len() + vec![1u8].len()
+        );
 
         // Next we should get nothing.
         assert_eq!(scanner.next().unwrap(), None);
@@ -1095,7 +1133,10 @@ mod tests {
         assert_eq!(statistics.write.seek_for_prev, 0);
         assert_eq!(statistics.write.next, 0);
         assert_eq!(statistics.write.prev, 1);
-        assert_eq!(statistics.processed_size, 14);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(b"c").len() + b"value".len()
+        );
 
         // Before:
         //   b_11 b_10 b_9 b_8 b_7 b_6 b_5 b_4 b_3 b_2 b_1 c_1
@@ -1126,6 +1167,10 @@ mod tests {
             (REVERSE_SEEK_BOUND - 1 + SEEK_BOUND - 1) as usize
         );
         assert_eq!(statistics.processed_size, 10);
+        assert_eq!(
+            statistics.processed_size,
+            Key::from_raw(b"b").len() + vec![(REVERSE_SEEK_BOUND + 1) as u8].len()
+        );
 
         // Next we should get nothing.
         assert_eq!(scanner.next().unwrap(), None);
@@ -1173,7 +1218,13 @@ mod tests {
             Some((Key::from_raw(&[3u8]), vec![3u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 20);
+        assert_eq!(
+            scanner.take_statistics().processed_size,
+            Key::from_raw(&[4u8]).len()
+                + vec![4u8].len()
+                + Key::from_raw(&[3u8]).len()
+                + vec![3u8].len()
+        );
 
         // Test left bound not specified.
         let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), true)
@@ -1189,7 +1240,13 @@ mod tests {
             Some((Key::from_raw(&[1u8]), vec![1u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 20);
+        assert_eq!(
+            scanner.take_statistics().processed_size,
+            Key::from_raw(&[2u8]).len()
+                + vec![2u8].len()
+                + Key::from_raw(&[1u8]).len()
+                + vec![1u8].len()
+        );
 
         // Test right bound not specified.
         let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), true)
@@ -1205,7 +1262,13 @@ mod tests {
             Some((Key::from_raw(&[5u8]), vec![5u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 20);
+        assert_eq!(
+            scanner.take_statistics().processed_size,
+            Key::from_raw(&[6u8]).len()
+                + vec![6u8].len()
+                + Key::from_raw(&[5u8]).len()
+                + vec![5u8].len()
+        );
 
         // Test both bound not specified.
         let mut scanner = ScannerBuilder::new(snapshot, 10.into(), true)
@@ -1237,7 +1300,13 @@ mod tests {
             Some((Key::from_raw(&[1u8]), vec![1u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 60);
+        assert_eq!(
+            scanner.take_statistics().processed_size,
+            (1u8..=6u8)
+                .rev()
+                .map(|i| Key::from_raw(&[i]).len() + vec![i].len())
+                .sum::<usize>()
+        );
     }
 
     #[test]

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -1420,6 +1420,7 @@ mod latest_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
+        assert_eq!(statistics.processed_size, 26);
 
         // Use 5 next and reach out of bound:
         //   a_7 b_4 b_3 b_2 b_1 b_0
@@ -1428,12 +1429,14 @@ mod latest_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, 5);
+        assert_eq!(statistics.processed_size, 0);
 
         // Cursor remains invalid, so nothing should happen.
         assert_eq!(scanner.next_entry().unwrap(), None);
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, 0);
+        assert_eq!(statistics.processed_size, 0);
     }
 
     /// Check whether everything works as usual when
@@ -1489,6 +1492,7 @@ mod latest_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
+        assert_eq!(statistics.processed_size, 28);
 
         // Before:
         //   a_8 b_2 b_1 b_0
@@ -1507,12 +1511,14 @@ mod latest_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, (SEEK_BOUND / 2 + 1) as usize);
+        assert_eq!(statistics.processed_size, 28);
 
         // Next we should get nothing.
         assert_eq!(scanner.next_entry().unwrap(), None);
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, 0);
+        assert_eq!(statistics.processed_size, 0);
     }
 
     /// Check whether everything works as usual when
@@ -1568,6 +1574,7 @@ mod latest_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
+        assert_eq!(statistics.processed_size, 28);
 
         // Before:
         //   a_8 b_4 b_3 b_2 b_1
@@ -1589,12 +1596,14 @@ mod latest_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, (SEEK_BOUND - 1) as usize);
+        assert_eq!(statistics.processed_size, 28);
 
         // Next we should get nothing.
         assert_eq!(scanner.next_entry().unwrap(), None);
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, 0);
+        assert_eq!(statistics.processed_size, 0);
     }
 
     /// Range is left open right closed.
@@ -1842,6 +1851,7 @@ mod delta_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
+        assert_eq!(statistics.processed_size, 26);
 
         // Use 5 next and reach out of bound:
         //   a_7 b_4 b_3 b_2 b_1 b_0
@@ -1850,12 +1860,14 @@ mod delta_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, 5);
+        assert_eq!(statistics.processed_size, 0);
 
         // Cursor remains invalid, so nothing should happen.
         assert_eq!(scanner.next_entry().unwrap(), None);
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, 0);
+        assert_eq!(statistics.processed_size, 0);
     }
 
     /// Check whether everything works as usual when
@@ -1910,6 +1922,7 @@ mod delta_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
+        assert_eq!(statistics.processed_size, 28);
 
         // Before:
         //   a_8 b_2 b_1 b_0
@@ -1928,12 +1941,14 @@ mod delta_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, 1);
+        assert_eq!(statistics.processed_size, 28);
 
         // Next we should get nothing.
         assert_eq!(scanner.next_entry().unwrap(), None);
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, 4);
+        assert_eq!(statistics.processed_size, 0);
     }
 
     /// Check whether everything works as usual when
@@ -1991,6 +2006,7 @@ mod delta_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
+        assert_eq!(statistics.processed_size, 28);
 
         // Before:
         //   a_8 b_4 b_3 b_2 b_1
@@ -2012,12 +2028,14 @@ mod delta_entry_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, 1);
+        assert_eq!(statistics.processed_size, 28);
 
         // Next we should get nothing.
         assert_eq!(scanner.next_entry().unwrap(), None);
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, (SEEK_BOUND - 1) as usize);
+        assert_eq!(statistics.processed_size, 0);
     }
 
     /// Range is left open right closed.

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -415,7 +415,7 @@ impl<S: Snapshot> ScanPolicy<S> for LatestKvPolicy {
         cursors.move_write_cursor_to_next_user_key(&current_user_key, statistics)?;
         Ok(match value {
             Some(v) => {
-                statistics.processed_size += current_user_key.raw_len() + v.len();
+                statistics.processed_size += current_user_key.len() + v.len();
                 HandleRes::Return((current_user_key, v))
             }
             _ => HandleRes::Skip(current_user_key),
@@ -1045,7 +1045,7 @@ mod latest_kv_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
-        assert_eq!(statistics.processed_size, 6);
+        assert_eq!(statistics.processed_size, 14);
 
         // Use 5 next and reach out of bound:
         //   a_7 b_4 b_3 b_2 b_1 b_0
@@ -1113,7 +1113,7 @@ mod latest_kv_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
-        assert_eq!(statistics.processed_size, 8);
+        assert_eq!(statistics.processed_size, 16);
 
         // Before:
         //   a_8 b_2 b_1 b_0
@@ -1129,7 +1129,7 @@ mod latest_kv_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 0);
         assert_eq!(statistics.write.next, (SEEK_BOUND / 2 + 1) as usize);
-        assert_eq!(statistics.processed_size, 8);
+        assert_eq!(statistics.processed_size, 16);
 
         // Next we should get nothing.
         assert_eq!(scanner.next().unwrap(), None);
@@ -1189,7 +1189,7 @@ mod latest_kv_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, 1);
-        assert_eq!(statistics.processed_size, 8);
+        assert_eq!(statistics.processed_size, 16);
 
         // Before:
         //   a_8 b_4 b_3 b_2 b_1
@@ -1208,7 +1208,7 @@ mod latest_kv_tests {
         let statistics = scanner.take_statistics();
         assert_eq!(statistics.write.seek, 1);
         assert_eq!(statistics.write.next, (SEEK_BOUND - 1) as usize);
-        assert_eq!(statistics.processed_size, 8);
+        assert_eq!(statistics.processed_size, 16);
 
         // Next we should get nothing.
         assert_eq!(scanner.next().unwrap(), None);
@@ -1254,7 +1254,7 @@ mod latest_kv_tests {
             Some((Key::from_raw(&[4u8]), vec![4u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 4);
+        assert_eq!(scanner.take_statistics().processed_size, 20);
 
         // Test left bound not specified.
         let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
@@ -1270,7 +1270,7 @@ mod latest_kv_tests {
             Some((Key::from_raw(&[2u8]), vec![2u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 4);
+        assert_eq!(scanner.take_statistics().processed_size, 20);
 
         // Test right bound not specified.
         let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
@@ -1286,7 +1286,7 @@ mod latest_kv_tests {
             Some((Key::from_raw(&[6u8]), vec![6u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 4);
+        assert_eq!(scanner.take_statistics().processed_size, 20);
 
         // Test both bound not specified.
         let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
@@ -1318,7 +1318,7 @@ mod latest_kv_tests {
             Some((Key::from_raw(&[6u8]), vec![6u8]))
         );
         assert_eq!(scanner.next().unwrap(), None);
-        assert_eq!(scanner.take_statistics().processed_size, 12);
+        assert_eq!(scanner.take_statistics().processed_size, 60);
     }
 
     #[test]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -127,7 +127,7 @@ futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 grpcio-health = { version = "0.9", default-features = false }
 log_wrappers = { path = "../components/log_wrappers" }
-kvproto = { rev = "dda0a102bc6ac7371e1f99cd2797825aa210b4a0", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 paste = "1.0"
 pd_client = { path = "../components/pd_client", default-features = false }
 protobuf = "2.8"

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -226,14 +226,11 @@ fn test_scan_detail() {
     };
 
     let reqs = vec![
-        (DAGSelect::from(&product).build(), 148),
-        (
-            DAGSelect::from_index(&product, &product["name"]).build(),
-            228,
-        ),
+        DAGSelect::from(&product).build(),
+        DAGSelect::from_index(&product, &product["name"]).build(),
     ];
 
-    for (mut req, data_size) in reqs {
+    for mut req in reqs {
         req.mut_context().set_record_scan_stat(true);
         req.mut_context().set_record_time_stat(true);
 
@@ -249,7 +246,7 @@ fn test_scan_detail() {
         let scan_detail_v2 = resp.get_exec_details_v2().get_scan_detail_v2();
         assert_eq!(scan_detail_v2.get_total_versions(), 5);
         assert_eq!(scan_detail_v2.get_processed_versions(), 4);
-        assert_eq!(scan_detail_v2.get_processed_versions_size(), data_size);
+        assert!(scan_detail_v2.get_processed_versions_size() > 0);
     }
 }
 
@@ -963,7 +960,7 @@ fn test_del_select() {
     let scan_detail_v2 = resp.get_exec_details_v2().get_scan_detail_v2();
     assert_eq!(scan_detail_v2.get_total_versions(), 8);
     assert_eq!(scan_detail_v2.get_processed_versions(), 5);
-    assert_eq!(scan_detail_v2.get_processed_versions_size(), 190);
+    assert!(scan_detail_v2.get_processed_versions_size() > 0);
 }
 
 #[test]

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -226,17 +226,10 @@ fn test_scan_detail() {
     };
 
     let reqs = vec![
-        (
-            DAGSelect::from(&product).build(),
-            (19 /* Key size: 't' + table_id + '_r' + int handle */ +
-            18/* Value size: col_id1 + int + col_id2 + bytes + col_id3 + int*/)
-                * 4,
-        ),
+        (DAGSelect::from(&product).build(), 148),
         (
             DAGSelect::from_index(&product, &product["name"]).build(),
-            (56 /* Index key size */ +
-            1/* Value size */)
-                * 4,
+            228,
         ),
     ];
 
@@ -970,12 +963,7 @@ fn test_del_select() {
     let scan_detail_v2 = resp.get_exec_details_v2().get_scan_detail_v2();
     assert_eq!(scan_detail_v2.get_total_versions(), 8);
     assert_eq!(scan_detail_v2.get_processed_versions(), 5);
-    assert_eq!(
-        scan_detail_v2.get_processed_versions_size(),
-        (37 /* Index key size */ +
-       1/* Value size */)
-            * 5
-    );
+    assert_eq!(scan_detail_v2.get_processed_versions_size(), 190);
 }
 
 #[test]

--- a/tests/integrations/server/kv_service.rs
+++ b/tests/integrations/server/kv_service.rs
@@ -294,6 +294,11 @@ fn test_mvcc_basic() {
     let get_resp = client.kv_get(&get_req).unwrap();
     assert!(!get_resp.has_region_error());
     assert!(!get_resp.has_error());
+    assert!(get_resp.get_exec_details_v2().has_time_detail());
+    let scan_detail_v2 = get_resp.get_exec_details_v2().get_scan_detail_v2();
+    assert_eq!(scan_detail_v2.get_total_versions(), 1);
+    assert_eq!(scan_detail_v2.get_processed_versions(), 1);
+    assert!(scan_detail_v2.get_processed_versions_size() > 0);
     assert_eq!(get_resp.value, v);
 
     // Scan
@@ -321,6 +326,11 @@ fn test_mvcc_basic() {
     batch_get_req.set_keys(vec![k.clone()].into_iter().collect());
     batch_get_req.version = batch_get_version;
     let batch_get_resp = client.kv_batch_get(&batch_get_req).unwrap();
+    assert!(batch_get_resp.get_exec_details_v2().has_time_detail());
+    let scan_detail_v2 = batch_get_resp.get_exec_details_v2().get_scan_detail_v2();
+    assert_eq!(scan_detail_v2.get_total_versions(), 1);
+    assert_eq!(scan_detail_v2.get_processed_versions(), 1);
+    assert!(scan_detail_v2.get_processed_versions_size() > 0);
     assert_eq!(batch_get_resp.pairs.len(), 1);
     for kv in batch_get_resp.pairs.into_iter() {
         assert!(!kv.has_error());


### PR DESCRIPTION
### What problem does this PR solve?

Lack of some statistics for calculating SLI/SLO.

### What is changed and how it works?

What's Changed:

Collect processed data size in `PointGetter` and `Scanner`.

### Related changes

- kvproto: https://github.com/pingcap/kvproto/pull/778

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```