### PR TITLE
sst_importer: fix the file exists issue in link file

### DIFF
--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -66,6 +66,11 @@ impl SSTImporter {
         path.save
     }
 
+    pub fn get_tmp_path(&self, meta: &SstMeta) -> PathBuf {
+        let path = self.dir.join(meta).unwrap();
+        path.temp
+    }
+
     pub fn create(&self, meta: &SstMeta) -> Result<ImportFile> {
         match self.dir.create(meta, self.key_manager.clone()) {
             Ok(f) => {
@@ -1285,7 +1290,7 @@ mod tests {
         let sst_writer = <TestEngine as SstExt>::SstWriterBuilder::new()
             .set_db(&db)
             .set_cf(name_to_cf(meta.get_cf_name()).unwrap())
-            .build(importer.get_path(meta).to_str().unwrap())
+            .build(importer.get_tmp_path(meta).to_str().unwrap())
             .unwrap();
         Ok(sst_writer)
     }

--- a/components/test_sst_importer/src/lib.rs
+++ b/components/test_sst_importer/src/lib.rs
@@ -9,7 +9,6 @@ use engine_rocks::RocksSstReader;
 pub use engine_rocks::RocksSstWriter;
 use engine_rocks::RocksSstWriterBuilder;
 use engine_traits::KvEngine;
-use engine_traits::SstReader;
 use engine_traits::SstWriter;
 use engine_traits::SstWriterBuilder;
 use kvproto::import_sstpb::*;
@@ -75,8 +74,8 @@ where
     new_test_engine_with_options_and_env(path, cfs, apply, None)
 }
 
-pub fn new_sst_reader(path: &str) -> RocksSstReader {
-    RocksSstReader::open(path).expect("test sst reader")
+pub fn new_sst_reader(path: &str, e: Option<Arc<Env>>) -> RocksSstReader {
+    RocksSstReader::open_with_env(path, e).expect("test sst reader")
 }
 
 pub fn new_sst_writer(path: &str) -> RocksSstWriter {

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use collections::HashSet;
 
-use engine_traits::{name_to_cf, KvEngine, CF_WRITE};
+use engine_traits::{KvEngine, CF_WRITE};
 use file_system::{set_io_type, IOType};
 use futures::executor::{ThreadPool, ThreadPoolBuilder};
 use futures::{TryFutureExt, TryStreamExt};
@@ -23,7 +23,6 @@ use kvproto::kvrpcpb::Context;
 use kvproto::raft_cmdpb::*;
 
 use crate::server::CONFIG_ROCKSDB_GAUGE;
-use engine_traits::{SstExt, SstWriterBuilder};
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::Callback;
 use sst_importer::send_rpc_response;
@@ -300,15 +299,6 @@ where
                 .with_label_values(&["queue"])
                 .observe(start.elapsed().as_secs_f64());
 
-            // SST writer must not be opened in gRPC threads, because it may be
-            // blocked for a long time due to IO, especially, when encryption at rest
-            // is enabled, and it leads to gRPC keepalive timeout.
-            let sst_writer = <E as SstExt>::SstWriterBuilder::new()
-                .set_db(&engine)
-                .set_cf(name_to_cf(req.get_sst().get_cf_name()).unwrap())
-                .build(importer.get_path(req.get_sst()).to_str().unwrap())
-                .unwrap();
-
             // FIXME: download() should be an async fn, to allow BR to cancel
             // a download task.
             // Unfortunately, this currently can't happen because the S3Storage
@@ -319,7 +309,7 @@ where
                 req.get_name(),
                 req.get_rewrite_rule(),
                 limiter,
-                sst_writer,
+                engine,
             );
             let mut resp = DownloadResponse::default();
             match res {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/br/issues/1179
Problem Summary:
After change `rename file` to `link file` in https://github.com/tikv/tikv/pull/9285/, TiKV will have an external [check](https://github.com/hunterlxt/tikv/blob/9d123f7b03c57679bbf410540ad05b1265ae441b/components/encryption/src/manager/mod.rs#L338-L344). which makes restore fail due to sst_importer will create an empty file in sst writer[#build](https://github.com/tikv/tikv/blob/bfc3c47d3ae6d34065892ddcd59f8599b7e59214/src/import/sst_service.rs#L309). 
This bug happenned when TDE enabled.

### What is changed and how it works?


What's Changed:
This PR tries to fix it by move sst_writer#buid into download after link_file.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->

Fix the issue that br reports file already exists error when TDE enabled during restoration.
