### PR TITLE
service: normal errors shouldn't break store connections

### DIFF
--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -626,6 +626,10 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
                 let to_store_id = msg.get_to_peer().get_store_id();
                 if to_store_id != store_id {
                     warn!("store not match"; "self" => store_id, "given" => to_store_id);
+                    return future::err(Error::from(RaftStoreError::StoreNotMatch {
+                        to_store_id,
+                        my_store_id: store_id,
+                    }));
                 } else if let Err(e) = ch.send_raft_msg(msg) {
                     warn!("dispatch raft msg from gRPC to raftstore fail"; "err" => ?e);
                 }
@@ -663,6 +667,10 @@ impl<T: RaftStoreRouter<RocksEngine> + 'static, E: Engine, L: LockManager> Tikv
                     let to_store_id = msg.get_to_peer().get_store_id();
                     if to_store_id != store_id {
                         warn!("store not match"; "self" => store_id, "given" => to_store_id);
+                        return future::err(Error::from(RaftStoreError::StoreNotMatch {
+                            to_store_id,
+                            my_store_id: store_id,
+                        }));
                     } else if let Err(e) = ch.send_raft_msg(msg) {
                         warn!("dispatch raft msg from gRPC to raftstore fail"; "err" => ?e);
                     }


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What is changed and how it works?

After receiving raft messages in the service layer, it's possible to meet errors when dispatching them to raftstore. Potential reasons could be the target Region is removed, or similar something.

We have met such a error log:
![Lark20210622-174611](https://user-images.githubusercontent.com/8407317/122903212-c38d6e80-d381-11eb-92a8-f9c99d57947c.png)

Those errors shouldn't break store connections.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```