### PR TITLE
*: the `start_ts` of stale read request should not used to update `max_ts`

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -106,7 +106,9 @@ impl<E: Engine> Endpoint<E> {
 
     fn check_memory_locks(&self, req_ctx: &ReqContext) -> Result<()> {
         let start_ts = req_ctx.txn_start_ts;
-        self.concurrency_manager.update_max_ts(start_ts);
+        if !req_ctx.context.get_stale_read() {
+            self.concurrency_manager.update_max_ts(start_ts);
+        }
         if req_ctx.context.get_isolation_level() == IsolationLevel::Si {
             let begin_instant = Instant::now();
             for range in &req_ctx.ranges {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -691,7 +691,9 @@ impl<E: Engine, L: LockManager> Storage<E, L> {
                 let bypass_locks = TsSet::from_u64s(ctx.take_resolved_locks());
 
                 // Update max_ts and check the in-memory lock table before getting the snapshot
-                concurrency_manager.update_max_ts(start_ts);
+                if !ctx.get_stale_read() {
+                    concurrency_manager.update_max_ts(start_ts);
+                }
                 if ctx.get_isolation_level() == IsolationLevel::Si {
                     let begin_instant = Instant::now();
                     concurrency_manager
@@ -1730,7 +1732,9 @@ fn prepare_snap_ctx<'a>(
     cmd: CommandKind,
 ) -> Result<SnapContext<'a>> {
     // Update max_ts and check the in-memory lock table before getting the snapshot
-    concurrency_manager.update_max_ts(start_ts);
+    if !pb_ctx.get_stale_read() {
+        concurrency_manager.update_max_ts(start_ts);
+    }
     fail_point!("before-storage-check-memory-locks");
     let isolation_level = pb_ctx.get_isolation_level();
     if isolation_level == IsolationLevel::Si {

--- a/tests/failpoints/cases/test_replica_stale_read.rs
+++ b/tests/failpoints/cases/test_replica_stale_read.rs
@@ -52,6 +52,14 @@ impl PeerClient {
         must_kv_prewrite(&self.cli, self.ctx.clone(), muts, pk, ts)
     }
 
+    fn must_kv_prewrite_async_commit(&self, muts: Vec<Mutation>, pk: Vec<u8>, ts: u64) {
+        must_kv_prewrite_with(&self.cli, self.ctx.clone(), muts, pk, ts, true, false)
+    }
+
+    fn must_kv_prewrite_one_pc(&self, muts: Vec<Mutation>, pk: Vec<u8>, ts: u64) {
+        must_kv_prewrite_with(&self.cli, self.ctx.clone(), muts, pk, ts, false, true)
+    }
+
     fn must_kv_commit(&self, keys: Vec<Vec<u8>>, start_ts: u64, commit_ts: u64) {
         must_kv_commit(
             &self.cli,
@@ -650,4 +658,57 @@ fn test_stale_read_on_learner() {
 
     // We can read on the learner with the newst ts
     learner_client2.must_kv_read_equal(b"key1".to_vec(), b"value1".to_vec(), get_tso(&pd_client));
+}
+
+// Testing that stale read request with a future ts should not update the `concurency_manager`'s `max_ts`
+#[test]
+fn test_stale_read_future_ts_not_update_max_ts() {
+    let (cluster, pd_client, leader_client) = prepare_for_stale_read(new_peer(1, 1));
+    let mut follower_client2 = PeerClient::new(&cluster, 1, new_peer(2, 2));
+    follower_client2.ctx.set_stale_read(true);
+
+    // Write `(key1, value1)`
+    leader_client.must_kv_write(
+        &pd_client,
+        vec![new_mutation(Op::Put, &b"key1"[..], &b"value1"[..])],
+        b"key1".to_vec(),
+    );
+
+    // Perform stale read with a future ts should return error
+    let read_ts = get_tso(&pd_client) + 10000000;
+    let resp = follower_client2.kv_read(b"key1".to_vec(), read_ts);
+    assert!(resp.get_region_error().has_data_is_not_ready());
+
+    // The `max_ts` should not updated by the stale read request, so we can prewrite and commit
+    // `async_commit` transaction with a ts that smaller than the `read_ts`
+    let prewrite_ts = get_tso(&pd_client);
+    assert!(prewrite_ts < read_ts);
+    leader_client.must_kv_prewrite_async_commit(
+        vec![new_mutation(Op::Put, &b"key2"[..], &b"value1"[..])],
+        b"key2".to_vec(),
+        prewrite_ts,
+    );
+    let commit_ts = get_tso(&pd_client);
+    assert!(commit_ts < read_ts);
+    leader_client.must_kv_commit(vec![b"key2".to_vec()], prewrite_ts, commit_ts);
+    follower_client2.must_kv_read_equal(b"key2".to_vec(), b"value1".to_vec(), get_tso(&pd_client));
+
+    // Perform stale read with a future ts should return error
+    let read_ts = get_tso(&pd_client) + 10000000;
+    let resp = follower_client2.kv_read(b"key1".to_vec(), read_ts);
+    assert!(resp.get_region_error().has_data_is_not_ready());
+
+    // The `max_ts` should not updated by the stale read request, so we can prewrite and commit
+    // `one_pc` transaction with a ts that smaller than the `read_ts`
+    let prewrite_ts = get_tso(&pd_client);
+    assert!(prewrite_ts < read_ts);
+    leader_client.must_kv_prewrite_one_pc(
+        vec![new_mutation(Op::Put, &b"key3"[..], &b"value1"[..])],
+        b"key3".to_vec(),
+        prewrite_ts,
+    );
+    let commit_ts = get_tso(&pd_client);
+    assert!(commit_ts < read_ts);
+    leader_client.must_kv_commit(vec![b"key3".to_vec()], prewrite_ts, commit_ts);
+    follower_client2.must_kv_read_equal(b"key3".to_vec(), b"value1".to_vec(), get_tso(&pd_client));
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

Currently, if we use a future ts as the `start_ts` of stale read transaction, the stale read request will be rejected by TiKV with the `DataIsNotReady` error until the `resolved_ts` is catch up with the future ts. 

But before the request is rejected, we use its `starte_ts` to update the `max_ts`, because the `starte_ts` is a future ts which will result in the commit request reject by `commit_ts_expired` error and keep retrying, also 1pc transaction will fallback to 2pc.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Don't update the `max_ts` with the `start_ts` from a stale read transaction, it is okay because TiKV will reject stale read request with `starts_ts` < `resolved_ts`, and the `resolved_ts` have already used to update the `max_ts`.

### Related changes
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Not use the stale read request's `start_ts` to update `max_ts` to avoid commit request keep retrying
```