### PR TITLE
ignore some unstable CI about thread stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4754,6 +4754,7 @@ dependencies = [
 name = "test_raftstore"
 version = "0.0.1"
 dependencies = [
+ "backtrace",
  "collections",
  "concurrency_manager",
  "crossbeam",

--- a/components/tikv_util/src/metrics/threads_linux.rs
+++ b/components/tikv_util/src/metrics/threads_linux.rs
@@ -493,7 +493,7 @@ mod tests {
     use super::*;
 
     #[test]
-    // #[ignore] // CI gets 0 as stats.
+    #[ignore] // CI gets 0 as stats.
     fn test_thread_stat_io() {
         let name = "testthreadio";
         let (tx, rx) = sync::mpsc::channel();
@@ -578,7 +578,7 @@ mod tests {
     }
 
     #[test]
-    // #[ignore] // CI gets 0 as stats.
+    #[ignore] // CI gets 0 as stats.
     fn test_thread_io_statistics() {
         let s1 = "testio123";
         let s2 = "test45678";

--- a/components/tikv_util/src/metrics/threads_linux.rs
+++ b/components/tikv_util/src/metrics/threads_linux.rs
@@ -493,6 +493,7 @@ mod tests {
     use super::*;
 
     #[test]
+    // #[ignore] // CI gets 0 as stats.
     fn test_thread_stat_io() {
         let name = "testthreadio";
         let (tx, rx) = sync::mpsc::channel();
@@ -577,6 +578,7 @@ mod tests {
     }
 
     #[test]
+    // #[ignore] // CI gets 0 as stats.
     fn test_thread_io_statistics() {
         let s1 = "testio123";
         let s2 = "test45678";


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What is changed and how it works?

Ignore some unstable CI about thread stats.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```