### PR TITLE
raftstore: adjust max_down_peer_duration based on hibernate timeout

### DIFF
--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -228,7 +228,7 @@ impl Default for Config {
             snap_mgr_gc_tick_interval: ReadableDuration::minutes(1),
             snap_gc_timeout: ReadableDuration::hours(4),
             messages_per_tick: 4096,
-            max_peer_down_duration: ReadableDuration::minutes(5),
+            max_peer_down_duration: ReadableDuration::minutes(10),
             max_leader_missing_duration: ReadableDuration::hours(2),
             abnormal_leader_missing_duration: ReadableDuration::minutes(10),
             peer_stale_state_check_interval: ReadableDuration::minutes(5),
@@ -433,6 +433,15 @@ impl Config {
         if self.future_poll_size == 0 {
             return Err(box_err!("future-poll-size should be greater than 0."));
         }
+
+        // Avoid hibernated peer being reported as down peer.
+        if self.hibernate_regions {
+            self.max_peer_down_duration = std::cmp::max(
+                self.max_peer_down_duration,
+                self.peer_stale_state_check_interval * 2,
+            );
+        }
+
         Ok(())
     }
 
@@ -781,5 +790,12 @@ mod tests {
         cfg.raft_election_timeout_ticks = 11;
         cfg.raft_store_max_leader_lease = ReadableDuration::secs(11);
         assert!(cfg.validate().is_err());
+
+        cfg = Config::new();
+        cfg.hibernate_regions = true;
+        cfg.max_peer_down_duration = ReadableDuration::minutes(5);
+        cfg.peer_stale_state_check_interval = ReadableDuration::minutes(5);
+        assert!(cfg.validate().is_ok());
+        assert_eq!(cfg.max_peer_down_duration, ReadableDuration::minutes(10));
     }
 }

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -352,7 +352,7 @@
 
 ## How long the peer will be considered down and reported to PD when it hasn't been active for this
 ## time.
-# max-peer-down-duration = "5m"
+# max-peer-down-duration = "10m"
 
 ## Interval to check whether to start manual compaction for a Region.
 # region-compact-check-interval = "5m"


### PR DESCRIPTION
Signed-off-by: yiwu <yiwu@pingcap.com>

### What problem does this PR solve?

Issue Number: close #10017

Problem Summary: Adjust `max_down_peer_duration` to be at least 2 * `peer_stale_state_check_interval`, so that peers in hibernated state would not be reported as down peer by mistake.

### What is changed and how it works?

What's Changed: 
Adjust `max_down_peer_duration` to be at least 2 * `peer_stale_state_check_interval` when hibernated regions is enabled.

### Related changes

N/A

### Check List

Tests 

CI

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Adjust max_down_peer_duration to 10 minutes. This is to avoid hibernated peers being reported as down peer by mistake.
```