### PR TITLE
allow to build one snapshot twice (#10454) (#10463)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,6 +3514,7 @@ dependencies = [
  "crc32fast",
  "crossbeam 0.8.0",
  "encryption",
+ "encryption_export",
  "engine_panic",
  "engine_rocks",
  "engine_test",

--- a/components/encryption/src/manager/mod.rs
+++ b/components/encryption/src/manager/mod.rs
@@ -708,9 +708,7 @@ impl EncryptionKeyManager for DataKeyManager {
     }
 
     fn link_file(&self, src_fname: &str, dst_fname: &str) -> IoResult<()> {
-        let _ = self.dicts.link_file(src_fname, dst_fname)?;
-        // For now we ignore file not found.
-        // TODO: propagate it back up as an Option.
+        self.dicts.link_file(src_fname, dst_fname)?;
         Ok(())
     }
 }

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -107,6 +107,7 @@ yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 engine_test = { path = "../engine_test", default-features = false }
 
 [dev-dependencies]
+encryption_export = { path = "../encryption/export", default-features = false }
 engine_rocks = { path = "../engine_rocks", default-features = false }
 panic_hook = { path = "../panic_hook" }
 test_sst_importer = { path = "../test_sst_importer", default-features = false }

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -48,8 +48,8 @@ pub use self::replication_mode::{GlobalReplicationState, StoreGroup};
 pub use self::snap::{
     check_abort, copy_snapshot,
     snap_io::{apply_sst_cf_file, build_sst_cf_file},
-    ApplyOptions, Error as SnapError, GenericSnapshot, SnapEntry, SnapKey, SnapManager,
-    SnapManagerBuilder, Snapshot, SnapshotStatistics,
+    ApplyOptions, Error as SnapError, SnapEntry, SnapKey, SnapManager, SnapManagerBuilder,
+    Snapshot, SnapshotStatistics,
 };
 pub use self::transport::{CasualRouter, ProposalRouter, StoreRouter, Transport};
 pub use self::worker::{

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -186,41 +186,9 @@ where
     pub coprocessor_host: CoprocessorHost<EK>,
 }
 
-/// `Snapshot` is a trait for snapshot.
-/// It's used in these scenarios:
-///   1. build local snapshot
-///   2. read local snapshot and then replicate it to remote raftstores
-///   3. receive snapshot from remote raftstore and write it to local storage
-///   4. apply snapshot
-///   5. snapshot gc
-pub trait Snapshot<EK: KvEngine>: GenericSnapshot {
-    fn build(
-        &mut self,
-        engine: &EK,
-        kv_snap: &EK::Snapshot,
-        region: &Region,
-        snap_data: &mut RaftSnapshotData,
-        stat: &mut SnapshotStatistics,
-    ) -> RaftStoreResult<()>;
-    fn apply(&mut self, options: ApplyOptions<EK>) -> Result<()>;
-}
-
-/// `GenericSnapshot` is a snapshot not tied to any KV engines.
-pub trait GenericSnapshot: Read + Write + Send {
-    fn path(&self) -> &str;
-    fn exists(&self) -> bool;
-    fn delete(&self);
-    fn meta(&self) -> io::Result<Metadata>;
-    fn total_size(&self) -> io::Result<u64>;
-    fn save(&mut self) -> io::Result<()>;
-}
-
 // A helper function to copy snapshot.
 // Only used in tests.
-pub fn copy_snapshot(
-    mut from: Box<dyn GenericSnapshot>,
-    mut to: Box<dyn GenericSnapshot>,
-) -> io::Result<()> {
+pub fn copy_snapshot(mut from: Box<Snapshot>, mut to: Box<Snapshot>) -> io::Result<()> {
     if !to.exists() {
         io::copy(&mut from, &mut to)?;
         to.save()?;
@@ -229,7 +197,7 @@ pub fn copy_snapshot(
 }
 
 // Try to delete the specified snapshot, return true if the deletion is done.
-fn retry_delete_snapshot(mgr: &SnapManagerCore, key: &SnapKey, snap: &dyn GenericSnapshot) -> bool {
+fn retry_delete_snapshot(mgr: &SnapManagerCore, key: &SnapKey, snap: &Snapshot) -> bool {
     let d = time::Duration::from_millis(DELETE_RETRY_TIME_MILLIS);
     for _ in 0..DELETE_RETRY_MAX_TIMES {
         if mgr.delete_snapshot(key, snap, true) {
@@ -346,7 +314,7 @@ struct MetaFile {
     pub tmp_path: PathBuf,
 }
 
-pub struct Snap {
+pub struct Snapshot {
     key: SnapKey,
     display_path: String,
     dir_path: PathBuf,
@@ -365,7 +333,7 @@ enum CheckPolicy {
     None,
 }
 
-impl Snap {
+impl Snapshot {
     fn new<T: Into<PathBuf>>(
         dir: T,
         key: &SnapKey,
@@ -410,7 +378,7 @@ impl Snap {
             ..Default::default()
         };
 
-        let mut s = Snap {
+        let mut s = Snapshot {
             key: key.clone(),
             display_path,
             dir_path,
@@ -751,6 +719,10 @@ impl Snap {
                 self.mgr.rename_tmp_cf_file_for_send(cf_file)?;
             } else {
                 delete_file_if_exist(&cf_file.tmp_path).unwrap();
+                if let Some(ref mgr) = self.mgr.encryption_key_manager {
+                    let src = cf_file.tmp_path.to_str().unwrap();
+                    mgr.delete_file(src)?;
+                }
             }
 
             SNAPSHOT_CF_KV_COUNT
@@ -776,22 +748,46 @@ impl Snap {
         self.save_meta_file()?;
         Ok(())
     }
+
+    fn delete(&self) {
+        debug!(
+            "deleting snapshot file";
+            "snapshot" => %self.path(),
+        );
+        for cf_file in &self.cf_files {
+            // Delete cloned files.
+            delete_file_if_exist(&cf_file.clone_path).unwrap();
+
+            // Delete temp files.
+            if self.hold_tmp_files {
+                delete_file_if_exist(&cf_file.tmp_path).unwrap();
+            }
+
+            // Delete cf files.
+            delete_file_if_exist(&cf_file.path).unwrap();
+            if let Some(ref mgr) = self.mgr.encryption_key_manager {
+                let path = cf_file.path.to_str().unwrap();
+                mgr.delete_file(path).unwrap();
+            }
+        }
+        delete_file_if_exist(&self.meta_file.path).unwrap();
+        if self.hold_tmp_files {
+            delete_file_if_exist(&self.meta_file.tmp_path).unwrap();
+        }
+    }
 }
 
-impl fmt::Debug for Snap {
+impl fmt::Debug for Snapshot {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Snap")
+        f.debug_struct("Snapshot")
             .field("key", &self.key)
             .field("display_path", &self.display_path)
             .finish()
     }
 }
 
-impl<EK> Snapshot<EK> for Snap
-where
-    EK: KvEngine,
-{
-    fn build(
+impl Snapshot {
+    pub fn build<EK: KvEngine>(
         &mut self,
         engine: &EK,
         kv_snap: &EK::Snapshot,
@@ -822,7 +818,7 @@ where
         Ok(())
     }
 
-    fn apply(&mut self, options: ApplyOptions<EK>) -> Result<()> {
+    pub fn apply<EK: KvEngine>(&mut self, options: ApplyOptions<EK>) -> Result<()> {
         box_try!(self.validate(&options.db, false));
 
         let abort_checker = ApplyAbortChecker(options.abort);
@@ -859,54 +855,27 @@ where
         }
         Ok(())
     }
-}
 
-impl GenericSnapshot for Snap {
-    fn path(&self) -> &str {
+    pub fn path(&self) -> &str {
         &self.display_path
     }
 
-    fn exists(&self) -> bool {
+    pub fn exists(&self) -> bool {
         self.cf_files
             .iter()
             .all(|cf_file| cf_file.size == 0 || file_exists(&cf_file.path))
             && file_exists(&self.meta_file.path)
     }
 
-    // TODO: It's very hard to handle key manager correctly without lock `SnapManager`.
-    // Let's do it later.
-    fn delete(&self) {
-        debug!(
-            "deleting snapshot file";
-            "snapshot" => %self.path(),
-        );
-        for cf_file in &self.cf_files {
-            // Delete cloned files.
-            delete_file_if_exist(&cf_file.clone_path).unwrap();
-
-            // Delete temp files.
-            if self.hold_tmp_files {
-                delete_file_if_exist(&cf_file.tmp_path).unwrap();
-            }
-
-            // Delete cf files.
-            delete_file_if_exist(&cf_file.path).unwrap();
-        }
-        delete_file_if_exist(&self.meta_file.path).unwrap();
-        if self.hold_tmp_files {
-            delete_file_if_exist(&self.meta_file.tmp_path).unwrap();
-        }
+    pub fn meta(&self) -> io::Result<Metadata> {
+        file_system::metadata(&self.meta_file.path)
     }
 
-    fn meta(&self) -> io::Result<Metadata> {
-        fs::metadata(&self.meta_file.path)
-    }
-
-    fn total_size(&self) -> io::Result<u64> {
+    pub fn total_size(&self) -> io::Result<u64> {
         Ok(self.cf_files.iter().fold(0, |acc, x| acc + x.size))
     }
 
-    fn save(&mut self) -> io::Result<()> {
+    pub fn save(&mut self) -> io::Result<()> {
         debug!(
             "saving to snapshot file";
             "snapshot" => %self.path(),
@@ -978,7 +947,7 @@ impl snap_io::StaleDetector for ApplyAbortChecker {
     }
 }
 
-impl Read for Snap {
+impl Read for Snapshot {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
@@ -1003,7 +972,7 @@ impl Read for Snap {
     }
 }
 
-impl Write for Snap {
+impl Write for Snapshot {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
@@ -1068,20 +1037,10 @@ impl Write for Snap {
     }
 }
 
-impl Drop for Snap {
+impl Drop for Snapshot {
     fn drop(&mut self) {
-        // cleanup if some of the cf files and meta file is partly written
-        if self
-            .cf_files
-            .iter()
-            .any(|cf_file| file_exists(&cf_file.tmp_path))
-            || file_exists(&self.meta_file.tmp_path)
-        {
-            self.delete();
-            return;
-        }
-        // cleanup if data corruption happens and any file goes missing
-        if !self.exists() {
+        // Cleanup if the snapshot is not built or received successfully.
+        if self.hold_tmp_files {
             self.delete();
         }
     }
@@ -1240,12 +1199,12 @@ impl SnapManager {
         self.core.registry.rl().contains_key(key)
     }
 
-    // NOTE: it calculates snapshot size by scanning the base directory.
-    // Don't call it in raftstore thread until the size limitation mechanism gets refactored.
-    pub fn get_snapshot_for_building<EK: KvEngine>(
-        &self,
-        key: &SnapKey,
-    ) -> RaftStoreResult<Box<dyn Snapshot<EK>>> {
+    /// Get a `Snapshot` can be used for `build`. Concurrent calls are allowed
+    /// because only one caller can lock temporary disk files.
+    ///
+    /// NOTE: it calculates snapshot size by scanning the base directory.
+    /// Don't call it in raftstore thread until the size limitation mechanism gets refactored.
+    pub fn get_snapshot_for_building(&self, key: &SnapKey) -> RaftStoreResult<Box<Snapshot>> {
         let mut old_snaps = None;
         while self.get_total_snap_size()? > self.max_total_snap_size() {
             if old_snaps.is_none() {
@@ -1273,7 +1232,7 @@ impl SnapManager {
         }
 
         let base = &self.core.base;
-        let f = Snap::new_for_building(base, key, &self.core)?;
+        let f = Snapshot::new_for_building(base, key, &self.core)?;
         Ok(Box::new(f))
     }
 
@@ -1281,20 +1240,17 @@ impl SnapManager {
         &self,
         key: &SnapKey,
         is_sending: bool,
-    ) -> RaftStoreResult<Box<dyn GenericSnapshot>> {
+    ) -> RaftStoreResult<Box<Snapshot>> {
         let _lock = self.core.registry.rl();
         let base = &self.core.base;
-        let s = Snap::new(base, key, is_sending, CheckPolicy::None, &self.core)?;
+        let s = Snapshot::new(base, key, is_sending, CheckPolicy::None, &self.core)?;
         Ok(Box::new(s))
     }
 
-    pub fn get_snapshot_for_sending(
-        &self,
-        key: &SnapKey,
-    ) -> RaftStoreResult<Box<dyn GenericSnapshot>> {
+    pub fn get_snapshot_for_sending(&self, key: &SnapKey) -> RaftStoreResult<Box<Snapshot>> {
         let _lock = self.core.registry.rl();
         let base = &self.core.base;
-        let mut s = Snap::new_for_sending(base, key, &self.core)?;
+        let mut s = Snapshot::new_for_sending(base, key, &self.core)?;
         let key_manager = match self.core.encryption_key_manager.as_ref() {
             Some(m) => m,
             None => return Ok(Box::new(s)),
@@ -1310,23 +1266,25 @@ impl SnapManager {
         Ok(Box::new(s))
     }
 
+    /// Get a `Snapshot` can be used for writting and then `save`. Concurrent calls
+    /// are allowed because only one caller can lock temporary disk files.
     pub fn get_snapshot_for_receiving(
         &self,
         key: &SnapKey,
         data: &[u8],
-    ) -> RaftStoreResult<Box<dyn GenericSnapshot>> {
+    ) -> RaftStoreResult<Box<Snapshot>> {
         let _lock = self.core.registry.rl();
         let mut snapshot_data = RaftSnapshotData::default();
         snapshot_data.merge_from_bytes(data)?;
         let base = &self.core.base;
-        let f = Snap::new_for_receiving(base, key, &self.core, snapshot_data.take_meta())?;
+        let f = Snapshot::new_for_receiving(base, key, &self.core, snapshot_data.take_meta())?;
         Ok(Box::new(f))
     }
 
-    fn get_concrete_snapshot_for_applying(&self, key: &SnapKey) -> RaftStoreResult<Box<Snap>> {
+    pub fn get_snapshot_for_applying(&self, key: &SnapKey) -> RaftStoreResult<Box<Snapshot>> {
         let _lock = self.core.registry.rl();
         let base = &self.core.base;
-        let s = Snap::new_for_applying(base, key, &self.core)?;
+        let s = Snapshot::new_for_applying(base, key, &self.core)?;
         if !s.exists() {
             return Err(RaftStoreError::Other(From::from(format!(
                 "snapshot of {:?} not exists.",
@@ -1334,20 +1292,6 @@ impl SnapManager {
             ))));
         }
         Ok(Box::new(s))
-    }
-
-    pub fn get_snapshot_for_applying(
-        &self,
-        key: &SnapKey,
-    ) -> RaftStoreResult<Box<dyn GenericSnapshot>> {
-        Ok(self.get_concrete_snapshot_for_applying(key)?)
-    }
-
-    pub fn get_snapshot_for_applying_to_engine<EK: KvEngine>(
-        &self,
-        key: &SnapKey,
-    ) -> RaftStoreResult<Box<dyn Snapshot<EK>>> {
-        Ok(self.get_concrete_snapshot_for_applying(key)?)
     }
 
     /// Get the approximate size of snap file exists in snap directory.
@@ -1439,12 +1383,7 @@ impl SnapManager {
         }
     }
 
-    pub fn delete_snapshot(
-        &self,
-        key: &SnapKey,
-        snap: &dyn GenericSnapshot,
-        check_entry: bool,
-    ) -> bool {
+    pub fn delete_snapshot(&self, key: &SnapKey, snap: &Snapshot, check_entry: bool) -> bool {
         self.core.delete_snapshot(key, snap, check_entry)
     }
 }
@@ -1474,12 +1413,7 @@ impl SnapManagerCore {
     }
 
     // Return true if it successfully delete the specified snapshot.
-    fn delete_snapshot(
-        &self,
-        key: &SnapKey,
-        snap: &dyn GenericSnapshot,
-        check_entry: bool,
-    ) -> bool {
+    fn delete_snapshot(&self, key: &SnapKey, snap: &Snapshot, check_entry: bool) -> bool {
         let registry = self.registry.rl();
         if check_entry {
             if let Some(e) = registry.get(key) {
@@ -1511,7 +1445,13 @@ impl SnapManagerCore {
             let dst = cf_file.path.to_str().unwrap();
             // It's ok that the cf file is moved but machine fails before `mgr.rename_file`
             // because without metadata file, saved cf files are nothing.
-            mgr.link_file(src, dst)?;
+            while let Err(e) = mgr.link_file(src, dst) {
+                if e.kind() == ErrorKind::AlreadyExists {
+                    mgr.delete_file(dst)?;
+                    continue;
+                }
+                return Err(e.into());
+            }
             mgr.delete_file(src)?;
         }
         let (checksum, size) = calc_checksum_and_size(&cf_file.path, mgr)?;
@@ -1575,6 +1515,8 @@ pub mod tests {
     use std::sync::atomic::{AtomicU64, AtomicUsize};
     use std::sync::{Arc, RwLock};
 
+    use encryption::{EncryptionConfig, FileConfig, MasterKeyConfig};
+    use encryption_export::data_key_manager_from_config;
     use engine_test::ctor::{CFOptions, ColumnFamilyOptions, DBOptions, EngineConstructorExt};
     use engine_test::kv::KvTestEngine;
     use engine_test::raft::RaftTestEngine;
@@ -1583,6 +1525,7 @@ pub mod tests {
     use engine_traits::{ExternalSstFileInfo, SstExt, SstWriter, SstWriterBuilder};
     use engine_traits::{KvEngine, Snapshot as EngineSnapshot};
     use engine_traits::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
+    use kvproto::encryptionpb::EncryptionMethod;
     use kvproto::metapb::{Peer, Region};
     use kvproto::raft_serverpb::{
         RaftApplyState, RaftSnapshotData, RegionLocalState, SnapshotMeta,
@@ -1594,9 +1537,8 @@ pub mod tests {
     use tikv_util::time::Limiter;
 
     use super::{
-        ApplyOptions, GenericSnapshot, Snap, SnapEntry, SnapKey, SnapManager, SnapManagerBuilder,
-        SnapManagerCore, Snapshot, SnapshotStatistics, META_FILE_SUFFIX, SNAPSHOT_CFS,
-        SNAP_GEN_PREFIX,
+        ApplyOptions, SnapEntry, SnapKey, SnapManager, SnapManagerBuilder, SnapManagerCore,
+        Snapshot, SnapshotStatistics, META_FILE_SUFFIX, SNAPSHOT_CFS, SNAP_GEN_PREFIX,
     };
 
     use crate::coprocessor::CoprocessorHost;
@@ -1750,6 +1692,27 @@ pub mod tests {
         db_opt
     }
 
+    fn create_enc_dir(prefix: &str) -> (TempDir, String, String) {
+        let dir = Builder::new().prefix(prefix).tempdir().unwrap();
+        let master_path = dir.path().join("master_key");
+
+        let mut f = OpenOptions::new()
+            .create_new(true)
+            .append(true)
+            .open(&master_path)
+            .unwrap();
+        // A 32 bytes key (in hex) followed by one '\n'.
+        f.write_all(&[b'A'; 64]).unwrap();
+        f.write_all(&[b'\n'; 1]).unwrap();
+
+        let dict_path = dir.path().join("dict");
+        file_system::create_dir_all(&dict_path).unwrap();
+
+        let key_path = master_path.to_str().unwrap().to_owned();
+        let dict_path = dict_path.to_str().unwrap().to_owned();
+        (dir, key_path, dict_path)
+    }
+
     #[test]
     fn test_gen_snapshot_meta() {
         let mut cf_file = Vec::with_capacity(super::SNAPSHOT_CFS.len());
@@ -1799,7 +1762,7 @@ pub mod tests {
             .unwrap();
         let key = SnapKey::new(1, 1, 1);
         let prefix = format!("{}_{}", SNAP_GEN_PREFIX, key);
-        let display_path = Snap::get_display_path(dir.path(), &prefix);
+        let display_path = Snapshot::get_display_path(dir.path(), &prefix);
         assert_ne!(display_path, "");
     }
 
@@ -1834,7 +1797,7 @@ pub mod tests {
 
         let mgr_core = create_manager_core(src_dir.path().to_str().unwrap());
 
-        let mut s1 = Snap::new_for_building(src_dir.path(), &key, &mgr_core).unwrap();
+        let mut s1 = Snapshot::new_for_building(src_dir.path(), &key, &mgr_core).unwrap();
 
         // Ensure that this snapshot file doesn't exist before being built.
         assert!(!s1.exists());
@@ -1843,7 +1806,7 @@ pub mod tests {
         let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s1,
             &db,
             &snapshot,
@@ -1863,14 +1826,14 @@ pub mod tests {
         assert_eq!(stat.kv_count, get_kv_count(&snapshot));
 
         // Ensure this snapshot could be read for sending.
-        let mut s2 = Snap::new_for_sending(src_dir.path(), &key, &mgr_core).unwrap();
+        let mut s2 = Snapshot::new_for_sending(src_dir.path(), &key, &mgr_core).unwrap();
         assert!(s2.exists());
 
         // TODO check meta data correct.
         let _ = s2.meta().unwrap();
 
         let mut s3 =
-            Snap::new_for_receiving(src_dir.path(), &key, &mgr_core, snap_data.take_meta())
+            Snapshot::new_for_receiving(src_dir.path(), &key, &mgr_core, snap_data.take_meta())
                 .unwrap();
         assert!(!s3.exists());
 
@@ -1891,7 +1854,7 @@ pub mod tests {
         assert_eq!(mgr_core.get_total_snap_size().unwrap(), size);
 
         // Ensure a snapshot could be applied to DB.
-        let mut s4 = Snap::new_for_applying(src_dir.path(), &key, &mgr_core).unwrap();
+        let mut s4 = Snapshot::new_for_applying(src_dir.path(), &key, &mgr_core).unwrap();
         assert!(s4.exists());
 
         let dst_db_dir = Builder::new()
@@ -1949,13 +1912,13 @@ pub mod tests {
         let key = SnapKey::new(region_id, 1, 1);
         let mgr_core = create_manager_core(dir.path().to_str().unwrap());
 
-        let mut s1 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s1 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(!s1.exists());
 
         let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s1,
             &db,
             &snapshot,
@@ -1966,10 +1929,10 @@ pub mod tests {
         .unwrap();
         assert!(s1.exists());
 
-        let mut s2 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s2 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(s2.exists());
 
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s2,
             &db,
             &snapshot,
@@ -2087,10 +2050,10 @@ pub mod tests {
         mgr: &SnapManagerCore,
         snapshot_meta: SnapshotMeta,
     ) {
-        let mut from = Snap::new_for_sending(from_dir.path(), key, mgr).unwrap();
+        let mut from = Snapshot::new_for_sending(from_dir.path(), key, mgr).unwrap();
         assert!(from.exists());
 
-        let mut to = Snap::new_for_receiving(to_dir.path(), key, mgr, snapshot_meta).unwrap();
+        let mut to = Snapshot::new_for_receiving(to_dir.path(), key, mgr, snapshot_meta).unwrap();
 
         assert!(!to.exists());
         let _ = io::copy(&mut from, &mut to).unwrap();
@@ -2115,13 +2078,13 @@ pub mod tests {
             .unwrap();
         let key = SnapKey::new(region_id, 1, 1);
         let mgr_core = create_manager_core(dir.path().to_str().unwrap());
-        let mut s1 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s1 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(!s1.exists());
 
         let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s1,
             &db,
             &snapshot,
@@ -2134,11 +2097,11 @@ pub mod tests {
 
         corrupt_snapshot_size_in(dir.path());
 
-        assert!(Snap::new_for_sending(dir.path(), &key, &mgr_core,).is_err());
+        assert!(Snapshot::new_for_sending(dir.path(), &key, &mgr_core,).is_err());
 
-        let mut s2 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s2 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(!s2.exists());
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s2,
             &db,
             &snapshot,
@@ -2165,7 +2128,7 @@ pub mod tests {
         assert_eq!(1, metas.len());
         let snap_meta = metas.pop().unwrap();
 
-        let mut s5 = Snap::new_for_applying(dst_dir.path(), &key, &mgr_core).unwrap();
+        let mut s5 = Snapshot::new_for_applying(dst_dir.path(), &key, &mgr_core).unwrap();
         assert!(s5.exists());
 
         let dst_db_dir = Builder::new()
@@ -2183,8 +2146,8 @@ pub mod tests {
         assert!(s5.apply(options).is_err());
 
         corrupt_snapshot_size_in(dst_dir.path());
-        assert!(Snap::new_for_receiving(dst_dir.path(), &key, &mgr_core, snap_meta,).is_err());
-        assert!(Snap::new_for_applying(dst_dir.path(), &key, &mgr_core).is_err());
+        assert!(Snapshot::new_for_receiving(dst_dir.path(), &key, &mgr_core, snap_meta,).is_err());
+        assert!(Snapshot::new_for_applying(dst_dir.path(), &key, &mgr_core).is_err());
     }
 
     #[test]
@@ -2204,13 +2167,13 @@ pub mod tests {
             .unwrap();
         let key = SnapKey::new(region_id, 1, 1);
         let mgr_core = create_manager_core(dir.path().to_str().unwrap());
-        let mut s1 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s1 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(!s1.exists());
 
         let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s1,
             &db,
             &snapshot,
@@ -2223,11 +2186,11 @@ pub mod tests {
 
         assert_eq!(1, corrupt_snapshot_meta_file(dir.path()));
 
-        assert!(Snap::new_for_sending(dir.path(), &key, &mgr_core,).is_err());
+        assert!(Snapshot::new_for_sending(dir.path(), &key, &mgr_core,).is_err());
 
-        let mut s2 = Snap::new_for_building(dir.path(), &key, &mgr_core).unwrap();
+        let mut s2 = Snapshot::new_for_building(dir.path(), &key, &mgr_core).unwrap();
         assert!(!s2.exists());
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s2,
             &db,
             &snapshot,
@@ -2252,11 +2215,14 @@ pub mod tests {
 
         assert_eq!(1, corrupt_snapshot_meta_file(dst_dir.path()));
 
-        assert!(Snap::new_for_applying(dst_dir.path(), &key, &mgr_core,).is_err());
-        assert!(
-            Snap::new_for_receiving(dst_dir.path(), &key, &mgr_core, snap_data.take_meta(),)
-                .is_err()
-        );
+        assert!(Snapshot::new_for_applying(dst_dir.path(), &key, &mgr_core,).is_err());
+        assert!(Snapshot::new_for_receiving(
+            dst_dir.path(),
+            &key,
+            &mgr_core,
+            snap_data.take_meta(),
+        )
+        .is_err());
     }
 
     #[test]
@@ -2297,12 +2263,12 @@ pub mod tests {
         let snapshot = db.snapshot();
         let key1 = SnapKey::new(1, 1, 1);
         let mgr_core = create_manager_core(&path);
-        let mut s1 = Snap::new_for_building(&path, &key1, &mgr_core).unwrap();
+        let mut s1 = Snapshot::new_for_building(&path, &key1, &mgr_core).unwrap();
         let mut region = gen_test_region(1, 1, 1);
         let mut snap_data = RaftSnapshotData::default();
         snap_data.set_region(region.clone());
         let mut stat = SnapshotStatistics::new();
-        Snapshot::<KvTestEngine>::build(
+        Snapshot::build::<KvTestEngine>(
             &mut s1,
             &db,
             &snapshot,
@@ -2311,10 +2277,11 @@ pub mod tests {
             &mut stat,
         )
         .unwrap();
-        let mut s = Snap::new_for_sending(&path, &key1, &mgr_core).unwrap();
+        let mut s = Snapshot::new_for_sending(&path, &key1, &mgr_core).unwrap();
         let expected_size = s.total_size().unwrap();
         let mut s2 =
-            Snap::new_for_receiving(&path, &key1, &mgr_core, snap_data.get_meta().clone()).unwrap();
+            Snapshot::new_for_receiving(&path, &key1, &mgr_core, snap_data.get_meta().clone())
+                .unwrap();
         let n = io::copy(&mut s, &mut s2).unwrap();
         assert_eq!(n, expected_size);
         s2.save().unwrap();
@@ -2322,8 +2289,9 @@ pub mod tests {
         let key2 = SnapKey::new(2, 1, 1);
         region.set_id(2);
         snap_data.set_region(region);
-        let s3 = Snap::new_for_building(&path, &key2, &mgr_core).unwrap();
-        let s4 = Snap::new_for_receiving(&path, &key2, &mgr_core, snap_data.take_meta()).unwrap();
+        let s3 = Snapshot::new_for_building(&path, &key2, &mgr_core).unwrap();
+        let s4 =
+            Snapshot::new_for_receiving(&path, &key2, &mgr_core, snap_data.take_meta()).unwrap();
 
         assert!(s1.exists());
         assert!(s2.exists());
@@ -2345,7 +2313,7 @@ pub mod tests {
         assert_eq!(mgr.get_total_snap_size().unwrap(), 0);
     }
 
-    fn check_registry_around_deregister(mgr: SnapManager, key: &SnapKey, entry: &SnapEntry) {
+    fn check_registry_around_deregister(mgr: &SnapManager, key: &SnapKey, entry: &SnapEntry) {
         let snap_keys = mgr.list_idle_snap().unwrap();
         assert!(snap_keys.is_empty());
         assert!(mgr.has_registered(key));
@@ -2387,7 +2355,7 @@ pub mod tests {
             .unwrap();
         let v = snap_data.write_to_bytes().unwrap();
 
-        check_registry_around_deregister(src_mgr.clone(), &key, &SnapEntry::Generating);
+        check_registry_around_deregister(&src_mgr, &key, &SnapEntry::Generating);
 
         // Ensure the snapshot being sent will not be deleted on GC.
         src_mgr.register(key.clone(), SnapEntry::Sending);
@@ -2409,8 +2377,8 @@ pub mod tests {
         assert_eq!(n, expected_size);
         s3.save().unwrap();
 
-        check_registry_around_deregister(src_mgr.clone(), &key, &SnapEntry::Sending);
-        check_registry_around_deregister(dst_mgr.clone(), &key, &SnapEntry::Receiving);
+        check_registry_around_deregister(&src_mgr, &key, &SnapEntry::Sending);
+        check_registry_around_deregister(&dst_mgr, &key, &SnapEntry::Receiving);
 
         // Ensure the snapshot to be applied will not be deleted on GC.
         let mut snap_keys = dst_mgr.list_idle_snap().unwrap();
@@ -2535,5 +2503,51 @@ pub mod tests {
         src_mgr.init().unwrap();
         // The sst_path will be deleted by SnapManager because it is a temp filet.
         assert!(!file_system::file_exists(&sst_path));
+    }
+
+    #[test]
+    fn test_build_with_encryption() {
+        let (_enc_dir, key_path, dict_path) = create_enc_dir(&"test_build_with_encryption_enc");
+        let enc_cfg = EncryptionConfig {
+            data_encryption_method: EncryptionMethod::Aes128Ctr,
+            master_key: MasterKeyConfig::File {
+                config: FileConfig { path: key_path },
+            },
+            ..Default::default()
+        };
+        let enc_mgr = data_key_manager_from_config(&enc_cfg, &dict_path)
+            .unwrap()
+            .map(Arc::new);
+        assert!(enc_mgr.is_some());
+
+        let snap_dir = Builder::new()
+            .prefix("test_build_with_encryption_snap")
+            .tempdir()
+            .unwrap();
+        let _mgr_path = snap_dir.path().to_str().unwrap();
+        let snap_mgr = SnapManagerBuilder::default()
+            .encryption_key_manager(enc_mgr)
+            .build(snap_dir.path().to_str().unwrap());
+        snap_mgr.init().unwrap();
+
+        let kv_dir = Builder::new()
+            .prefix("test_build_with_encryption_kv")
+            .tempdir()
+            .unwrap();
+        let db: KvTestEngine = open_test_db(kv_dir.path(), None, None).unwrap();
+        let snapshot = db.snapshot();
+        let key = SnapKey::new(1, 1, 1);
+        let region = gen_test_region(1, 1, 1);
+
+        // Test one snapshot can be built multi times. DataKeyManager should be handled correctly.
+        for _ in 0..2 {
+            let mut s1 = snap_mgr.get_snapshot_for_building(&key).unwrap();
+            let mut snap_data = RaftSnapshotData::default();
+            snap_data.set_region(region.clone());
+            let mut stat = SnapshotStatistics::new();
+            s1.build(&db, &snapshot, &region, &mut snap_data, &mut stat)
+                .unwrap();
+            assert!(snap_mgr.delete_snapshot(&key, &s1, false));
+        }
     }
 }

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -352,7 +352,7 @@ where
         defer!({
             self.mgr.deregister(&snap_key, &SnapEntry::Applying);
         });
-        let mut s = box_try!(self.mgr.get_snapshot_for_applying_to_engine(&snap_key));
+        let mut s = box_try!(self.mgr.get_snapshot_for_applying(&snap_key));
         if !s.exists() {
             return Err(box_err!("missing snapshot file {}", s.path()));
         }


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>
### What is changed and how it works?

Cherry pick #10454 , which fixes a panic bug when generating one snapshot twice.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```