### PR TITLE
sst_importer: fix the file exists issue in link file (#10416) (#10421)

### DIFF
--- a/components/test_sst_importer/src/lib.rs
+++ b/components/test_sst_importer/src/lib.rs
@@ -9,7 +9,6 @@ use engine_rocks::RocksSstReader;
 pub use engine_rocks::RocksSstWriter;
 use engine_rocks::RocksSstWriterBuilder;
 use engine_traits::KvEngine;
-use engine_traits::SstReader;
 use engine_traits::SstWriter;
 use engine_traits::SstWriterBuilder;
 use kvproto::import_sstpb::*;
@@ -75,8 +74,8 @@ where
     new_test_engine_with_options_and_env(path, cfs, apply, None)
 }
 
-pub fn new_sst_reader(path: &str) -> RocksSstReader {
-    RocksSstReader::open(path).expect("test sst reader")
+pub fn new_sst_reader(path: &str, e: Option<Arc<Env>>) -> RocksSstReader {
+    RocksSstReader::open_with_env(path, e).expect("test sst reader")
 }
 
 pub fn new_sst_writer(path: &str) -> RocksSstWriter {

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use collections::HashSet;
 
-use engine_traits::{name_to_cf, KvEngine, CF_DEFAULT, CF_WRITE};
+use engine_traits::{KvEngine, CF_DEFAULT, CF_WRITE};
 use file_system::{set_io_type, IOType};
 use futures::executor::{ThreadPool, ThreadPoolBuilder};
 use futures::{TryFutureExt, TryStreamExt};
@@ -23,7 +23,6 @@ use kvproto::kvrpcpb::Context;
 use kvproto::raft_cmdpb::*;
 
 use crate::server::CONFIG_ROCKSDB_GAUGE;
-use engine_traits::{SstExt, SstWriterBuilder};
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::Callback;
 use sst_importer::send_rpc_response;
@@ -302,15 +301,6 @@ where
                 .with_label_values(&["queue"])
                 .observe(start.elapsed().as_secs_f64());
 
-            // SST writer must not be opened in gRPC threads, because it may be
-            // blocked for a long time due to IO, especially, when encryption at rest
-            // is enabled, and it leads to gRPC keepalive timeout.
-            let sst_writer = <E as SstExt>::SstWriterBuilder::new()
-                .set_db(&engine)
-                .set_cf(name_to_cf(req.get_sst().get_cf_name()).unwrap())
-                .build(importer.get_path(req.get_sst()).to_str().unwrap())
-                .unwrap();
-
             // FIXME: download() should be an async fn, to allow BR to cancel
             // a download task.
             // Unfortunately, this currently can't happen because the S3Storage
@@ -321,7 +311,7 @@ where
                 req.get_name(),
                 req.get_rewrite_rule(),
                 limiter,
-                sst_writer,
+                engine,
             );
             let mut resp = DownloadResponse::default();
             match res {


### PR DESCRIPTION
* cherry pick #10416 to release-5.0

Signed-off-by: ti-srebot <ti-srebot@pingcap.com>

* Resolve conflicts

Signed-off-by: 3pointer <luancheng@pingcap.com>

Co-authored-by: 3pointer <luancheng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that br reports file already exists error when TDE enabled during restoration.