### PR TITLE
resolved_ts: fix online changing `resolved-ts.advance-ts-interval` can't take effect immediately

### DIFF
--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -72,8 +72,7 @@ impl<E: KvEngine> AdvanceTsWorker<E> {
 }
 
 impl<E: KvEngine> AdvanceTsWorker<E> {
-    pub fn register_advance_event(&self, advance_ts_interval: Duration, regions: Vec<u64>) {
-        let timeout = self.timer.delay(advance_ts_interval);
+    pub fn advance_ts_for_regions(&self, regions: Vec<u64>) {
         let pd_client = self.pd_client.clone();
         let scheduler = self.scheduler.clone();
         let cm: ConcurrencyManager = self.concurrency_manager.clone();
@@ -84,7 +83,6 @@ impl<E: KvEngine> AdvanceTsWorker<E> {
         let region_read_progress = self.region_read_progress.clone();
 
         let fut = async move {
-            let _ = timeout.compat().await;
             // Ignore get tso errors since we will retry every `advance_ts_interval`.
             let mut min_ts = pd_client.get_tso().await.unwrap_or_default();
 
@@ -97,10 +95,6 @@ impl<E: KvEngine> AdvanceTsWorker<E> {
                 if min_mem_lock_ts < min_ts {
                     min_ts = min_mem_lock_ts;
                 }
-            }
-
-            if let Err(e) = scheduler.schedule(Task::RegisterAdvanceEvent) {
-                info!("failed to schedule register advance event"; "err" => ?e);
             }
 
             let regions = Self::region_resolved_ts_store(
@@ -122,6 +116,18 @@ impl<E: KvEngine> AdvanceTsWorker<E> {
                 }) {
                     info!("failed to schedule advance event"; "err" => ?e);
                 }
+            }
+        };
+        self.worker.spawn(fut);
+    }
+
+    pub fn register_next_event(&self, advance_ts_interval: Duration, cfg_version: usize) {
+        let scheduler = self.scheduler.clone();
+        let timeout = self.timer.delay(advance_ts_interval);
+        let fut = async move {
+            let _ = timeout.compat().await;
+            if let Err(e) = scheduler.schedule(Task::RegisterAdvanceEvent { cfg_version }) {
+                info!("failed to schedule register advance event"; "err" => ?e);
             }
         };
         self.worker.spawn(fut);

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -246,6 +246,7 @@ impl ObserveRegion {
 
 pub struct Endpoint<T, E: KvEngine, C> {
     cfg: ResolvedTsConfig,
+    cfg_version: usize,
     store_meta: Arc<Mutex<StoreMeta>>,
     region_read_progress: RegionReadProgressRegistry,
     regions: HashMap<u64, ObserveRegion>,
@@ -286,6 +287,7 @@ where
         let scanner_pool = ScannerPool::new(cfg.scan_lock_pool_size, raft_router);
         let ep = Self {
             cfg: cfg.clone(),
+            cfg_version: 0,
             scheduler,
             store_meta,
             region_read_progress,
@@ -295,7 +297,7 @@ where
             regions: HashMap::default(),
             _phantom: PhantomData::default(),
         };
-        ep.register_advance_event();
+        ep.register_advance_event(ep.cfg_version);
         ep
     }
 
@@ -548,10 +550,32 @@ where
         }
     }
 
-    fn register_advance_event(&self) {
+    fn register_advance_event(&self, cfg_version: usize) {
+        // Ignore advance event that registered with previous `advance_ts_interval` config
+        if self.cfg_version != cfg_version {
+            return;
+        }
         let regions = self.regions.keys().into_iter().copied().collect();
+        self.advance_worker.advance_ts_for_regions(regions);
         self.advance_worker
-            .register_advance_event(self.cfg.advance_ts_interval.0, regions);
+            .register_next_event(self.cfg.advance_ts_interval.0, self.cfg_version);
+    }
+
+    fn handle_change_config(&mut self, change: ConfigChange) {
+        let prev = format!("{:?}", self.cfg);
+        let prev_advance_ts_interval = self.cfg.advance_ts_interval;
+        self.cfg.update(change);
+        if self.cfg.advance_ts_interval != prev_advance_ts_interval {
+            // Increase the `cfg_version` to reject advance event that registered before
+            self.cfg_version += 1;
+            // Advance `resolved-ts` immediately after `advance_ts_interval` changed
+            self.register_advance_event(self.cfg_version);
+        }
+        info!(
+            "resolved-ts config changed";
+            "prev" => prev,
+            "current" => ?self.cfg,
+        );
     }
 }
 
@@ -569,7 +593,9 @@ pub enum Task<S: Snapshot> {
         observe_id: ObserveID,
         cause: String,
     },
-    RegisterAdvanceEvent,
+    RegisterAdvanceEvent {
+        cfg_version: usize,
+    },
     AdvanceResolvedTs {
         regions: Vec<u64>,
         ts: TimeStamp,
@@ -639,7 +665,9 @@ impl<S: Snapshot> fmt::Debug for Task<S> {
                 .field("observe_id", &observe_id)
                 .field("apply_index", &apply_index)
                 .finish(),
-            Task::RegisterAdvanceEvent => de.field("name", &"register_advance_event").finish(),
+            Task::RegisterAdvanceEvent { .. } => {
+                de.field("name", &"register_advance_event").finish()
+            }
             Task::ChangeConfig { ref change } => de
                 .field("name", &"change_config")
                 .field("change", &change)
@@ -685,16 +713,8 @@ where
                 entries,
                 apply_index,
             } => self.handle_scan_locks(region_id, observe_id, entries, apply_index),
-            Task::RegisterAdvanceEvent => self.register_advance_event(),
-            Task::ChangeConfig { change } => {
-                let prev = format!("{:?}", self.cfg);
-                self.cfg.update(change);
-                info!(
-                    "resolved-ts config changed";
-                    "prev" => prev,
-                    "current" => ?self.cfg,
-                );
-            }
+            Task::RegisterAdvanceEvent { cfg_version } => self.register_advance_event(cfg_version),
+            Task::ChangeConfig { change } => self.handle_change_config(change),
         }
     }
 }

--- a/components/resolved_ts/tests/integrations/mod.rs
+++ b/components/resolved_ts/tests/integrations/mod.rs
@@ -14,18 +14,21 @@ use test_raftstore::sleep_ms;
 fn test_resolved_ts_basic() {
     let mut suite = TestSuite::new(1);
     let region = suite.cluster.get_region(&[]);
-    let (k, v) = (b"k1", b"v");
-    suite.cluster.must_put(k, v);
-    suite.cluster.must_put_cf("write", k, v);
-    suite.cluster.must_put_cf("lock", k, v);
+
     // Prewrite
+    let (k, v) = (b"k1", b"v");
     let start_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
     let mut mutation = Mutation::default();
     mutation.set_op(Op::Put);
     mutation.key = k.to_vec();
     mutation.value = v.to_vec();
     suite.must_kv_prewrite(region.id, vec![mutation], k.to_vec(), start_ts);
-    suite.must_get_rts(region.id, start_ts);
+
+    // The `resolved-ts` won't be updated due to there is lock on the region,
+    // the `resolved-ts` may not be the `start_ts` of the lock if the `resolved-ts`
+    // is updated with a newer ts before the prewrite request come, but still the
+    // `resolved-ts` won't be updated
+    let rts = suite.region_resolved_ts(region.id).unwrap();
 
     // Split region
     suite.cluster.must_split(&region, k);
@@ -34,13 +37,13 @@ fn test_resolved_ts_basic() {
     let current_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
     // Resolved ts of region1 should be advanced
     suite.must_get_rts_ge(r1.id, current_ts);
-    // Resolved ts of region2 should be equal to start ts
-    suite.must_get_rts(r2.id, start_ts);
+    // Resolved ts of region2 should be equal to rts
+    suite.must_get_rts(r2.id, rts);
 
     // Merge region2 to region1
     suite.cluster.must_try_merge(r2.id, r1.id);
-    // Resolved ts of region1 should be equal to start ts
-    suite.must_get_rts(r1.id, start_ts);
+    // Resolved ts of region1 should be equal to rts
+    suite.must_get_rts(r1.id, rts);
 
     // Commit
     let commit_ts = block_on(suite.cluster.pd_client.get_tso()).unwrap();
@@ -85,4 +88,6 @@ fn test_dynamic_change_advance_ts_interval() {
         region.id,
         block_on(suite.cluster.pd_client.get_tso()).unwrap(),
     );
+
+    suite.stop();
 }

--- a/components/resolved_ts/tests/mod.rs
+++ b/components/resolved_ts/tests/mod.rs
@@ -351,6 +351,7 @@ impl TestSuite {
             }
             sleep_ms(100)
         }
+        panic!("fail to get same ts after 50 trys");
     }
 
     pub fn must_get_rts_ge(&mut self, region_id: u64, rts: TimeStamp) {
@@ -362,5 +363,6 @@ impl TestSuite {
             }
             sleep_ms(100)
         }
+        panic!("fail to get greater ts after 50 trys");
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #10426 

Problem Summary:

Online changing `resolved-ts.advance-ts-interval` can't take effect immediately

### What is changed and how it works?

What's Changed:

Register new advance ts event right after config change and add `cfg_version` to reject advance ts event that previous registered.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix online changing `resolved-ts.advance-ts-interval` can't take effect immediately
```