### PR TITLE
raftstore: update applied_index_term after snapshot

### DIFF
--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1615,6 +1615,16 @@ where
         self.schedule_applying_snapshot();
         let prev_region = self.region().clone();
         self.set_region(snap_region);
+        if self.truncated_index() == self.applied_index() {
+            self.applied_index_term = self.truncated_term();
+        } else {
+            panic!(
+                "{} applied index should be equal to truncated index after snapshot: {} != {}",
+                self.tag,
+                self.applied_index(),
+                self.truncated_index()
+            );
+        }
 
         Some(ApplySnapResult {
             prev_region,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10225 <!-- REMOVE this line if no issue to close -->

Problem Summary:

After applying snapshot applied_term should also be updated, otherwise
it can produce snapshot with wrong term and cause panic in follower.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
- fix follower meta corruption in rare cases with more than 4 replicas
```