### PR TITLE
Remove commit of kvproto for every Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#ab6bb38882c491c8ee9da13112cb1d9a35695180"
+source = "git+https://github.com/pingcap/kvproto.git#706fcaf286c8dd07ef59349c089f53289a32ce4c"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?rev=706fcaf286c8dd07ef59349c089f53289a32ce4c#706fcaf286c8dd07ef59349c089f53289a32ce4c"
+source = "git+https://github.com/pingcap/kvproto.git#ab6bb38882c491c8ee9da13112cb1d9a35695180"
 dependencies = [
  "futures 0.3.15",
  "grpcio",
@@ -3393,7 +3393,6 @@ dependencies = [
  "crossbeam",
  "derivative",
  "encryption",
- "encryption_export",
  "engine_panic",
  "engine_rocks",
  "engine_test",
@@ -3405,7 +3404,6 @@ dependencies = [
  "futures 0.3.15",
  "futures-util",
  "into_other",
- "itertools 0.10.0",
  "keys",
  "kvproto",
  "lazy_static",
@@ -4756,7 +4754,6 @@ dependencies = [
 name = "test_raftstore"
 version = "0.0.1"
 dependencies = [
- "backtrace",
  "collections",
  "concurrency_manager",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,6 +3393,7 @@ dependencies = [
  "crossbeam",
  "derivative",
  "encryption",
+ "encryption_export",
  "engine_panic",
  "engine_rocks",
  "engine_test",
@@ -3404,6 +3405,7 @@ dependencies = [
  "futures 0.3.15",
  "futures-util",
  "into_other",
+ "itertools 0.10.0",
  "keys",
  "kvproto",
  "lazy_static",
@@ -4754,6 +4756,7 @@ dependencies = [
 name = "test_raftstore"
 version = "0.0.1"
 dependencies = [
+ "backtrace",
  "collections",
  "concurrency_manager",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ hyper-openssl = "0.9"
 http = "0"
 into_other = { path = "components/into_other", default-features = false }
 keys = { path = "components/keys", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 libc = "0.2"
 libloading = "0.7"

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -93,11 +93,11 @@ error_code = { path = "../../components/error_code", default-features = false }
 file_system = { path = "../../components/file_system", default-features = false }
 fs2 = "0.4"
 futures = "0.3"
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 tokio = { version = "1.5", features = ["rt-multi-thread", "time"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../../components/keys", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../../components/log_wrappers" }

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -77,7 +77,7 @@ futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 pd_client = { path = "../pd_client", default-features = false }

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -59,7 +59,7 @@ engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 raftstore = { path = "../raftstore", default-features = false }

--- a/components/cloud/Cargo.toml
+++ b/components/cloud/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 derive_more = "0.99.3"
 error_code = { path = "../error_code", default-features = false }
 futures-io = "0.3"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 rusoto_core = "0.46.0"

--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -32,7 +32,7 @@ grpcio = { version = "0.9",  default-features = false, features = ["openssl-vend
 http = "0.2.0"
 hyper = "0.14"
 hyper-tls = "0.5"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rusoto_core = "0.46.0"
 rusoto_credential = "0.46.0"
 rusoto_kms = { version = "0.46.0", features = ["serialize_structs"] }

--- a/components/cloud/gcp/Cargo.toml
+++ b/components/cloud/gcp/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = { version = "0.3", default-features = false, features = ["io"] }
 http = "0.2.0"
 hyper = "0.14"
 hyper-tls = "0.5"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 # better to not use slog-global, but pass in the logger
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = "1.3"
 prometheus = { version = "0.12", features = ["nightly"] }
 futures-util = { version = "0.3", default-features = false, features = ["std", "io"] }
 hex = "0.4.2"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 rand = "0.8"

--- a/components/encryption/export/Cargo.toml
+++ b/components/encryption/export/Cargo.toml
@@ -36,7 +36,7 @@ derive_more = "0.99.3"
 encryption = { path = "../", default-features = false }
 error_code = { path = "../../error_code", default-features = false }
 file_system = { path = "../../file_system", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/components/engine_panic/Cargo.toml
+++ b/components/engine_panic/Cargo.toml
@@ -27,6 +27,6 @@ engine_traits = { path = "../engine_traits", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
 # FIXME: Remove this dep from the engine_traits interface
 tikv_util = { path = "../tikv_util", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 txn_types = { path = "../txn_types", default-features = false }

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -65,7 +65,7 @@ online_config = { path = "../online_config" }
 tempfile = "3.0"
 serde = "1.0"
 serde_derive = "1.0"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 protobuf = "2"
 fail = "0.4"

--- a/components/engine_traits/Cargo.toml
+++ b/components/engine_traits/Cargo.toml
@@ -36,7 +36,7 @@ txn_types = { path = "../txn_types", default-features = false }
 serde = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 
 [dev-dependencies]

--- a/components/error_code/Cargo.toml
+++ b/components/error_code/Cargo.toml
@@ -26,7 +26,7 @@ path = "bin.rs"
 [dependencies]
 lazy_static = "1.3"
 raft = { version = "0.6.0-alpha", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 toml = "0.5"

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -38,7 +38,7 @@ futures-executor = "0.3"
 futures-io = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { optional = true, version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 libloading = { optional = true, version = "0.7.0" }
 prometheus = { version = "0.12", default-features = false, features = ["nightly", "push"] }

--- a/components/external_storage/export/Cargo.toml
+++ b/components/external_storage/export/Cargo.toml
@@ -81,7 +81,15 @@ futures = { optional = true, version = "0.3" }
 futures-executor = { optional = true, version = "0.3" }
 futures-io = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+
+
+
+
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
+
+
+
+
 libloading = { optional = true, version = "0.7.0" }
 once_cell = { optional = true, version = "1.3.1" }
 protobuf = { optional = true, version = "2" }

--- a/components/external_storage/export/Cargo.toml
+++ b/components/external_storage/export/Cargo.toml
@@ -81,15 +81,7 @@ futures = { optional = true, version = "0.3" }
 futures-executor = { optional = true, version = "0.3" }
 futures-io = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
-
-
-
-
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
-
-
-
-
 libloading = { optional = true, version = "0.7.0" }
 once_cell = { optional = true, version = "1.3.1" }
 protobuf = { optional = true, version = "2" }

--- a/components/into_other/Cargo.toml
+++ b/components/into_other/Cargo.toml
@@ -19,5 +19,5 @@ prost-codec = [
 
 [dependencies]
 engine_traits = { path = "../engine_traits", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -17,7 +17,7 @@ prost-codec = [
 
 [dependencies]
 byteorder = "1.2"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 thiserror = "1.0"
 tikv_alloc = { path = "../tikv_alloc" }

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -28,7 +28,7 @@ failpoints = ["fail/failpoints"]
 error_code = { path = "../error_code", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/raft_log_engine/Cargo.toml
+++ b/components/raft_log_engine/Cargo.toml
@@ -32,7 +32,7 @@ time = "0.1"
 online_config = { path = "../online_config" }
 serde = "1.0"
 serde_derive = "1.0"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 raft-engine = { git = "https://github.com/tikv/raft-engine", branch = "master" }
 protobuf = "2"

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -76,6 +76,7 @@ fs2 = "0.4"
 futures = "0.3"
 futures-util = { version = "0.3.1", default-features = false, features = ["io"] }
 into_other = { path = "../into_other",  default-features = false }
+itertools = "0.10"
 keys = { path = "../keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
@@ -114,6 +115,7 @@ yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 engine_test = { path = "../engine_test", default-features = false }
 
 [dev-dependencies]
+encryption_export = { path = "../encryption/export", default-features = false }
 engine_rocks = { path = "../engine_rocks", default-features = false }
 panic_hook = { path = "../panic_hook" }
 test_sst_importer = { path = "../test_sst_importer", default-features = false }

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -76,9 +76,8 @@ fs2 = "0.4"
 futures = "0.3"
 futures-util = { version = "0.3.1", default-features = false, features = ["io"] }
 into_other = { path = "../into_other",  default-features = false }
-itertools = "0.10"
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }
@@ -115,7 +114,6 @@ yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 engine_test = { path = "../engine_test", default-features = false }
 
 [dev-dependencies]
-encryption_export = { path = "../encryption/export", default-features = false }
 engine_rocks = { path = "../engine_rocks", default-features = false }
 panic_hook = { path = "../panic_hook" }
 test_sst_importer = { path = "../test_sst_importer", default-features = false }

--- a/components/resolved_ts/Cargo.toml
+++ b/components/resolved_ts/Cargo.toml
@@ -50,7 +50,7 @@ fail = "0.4"
 futures = "0.3"
 grpcio = { version = "0.9", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 pd_client = { path = "../pd_client", default-features = false }

--- a/components/resource_metering/Cargo.toml
+++ b/components/resource_metering/Cargo.toml
@@ -22,7 +22,7 @@ crossbeam = "0.8"
 pin-project = "1.0"
 prometheus = { version = "0.12", features = ["nightly"] }
 prometheus-static-metric = "0.5"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 tikv_util = { path = "../tikv_util" }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 online_config = { path = "../online_config" }

--- a/components/resource_metering/src/reporter.rs
+++ b/components/resource_metering/src/reporter.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use collections::HashMap;
 use futures::SinkExt;
 use grpcio::{CallOption, ChannelBuilder, Environment, WriteFlags};
-use kvproto::resource_usage_agent::{ReportCpuTimeRequest, ResourceUsageAgentClient};
+use kvproto::resource_usage_agent::{CpuTimeRecord, ResourceUsageAgentClient};
 use tikv_util::time::Duration;
 use tikv_util::worker::{Runnable, RunnableWithTimer, Scheduler};
 
@@ -202,7 +202,7 @@ impl RunnableWithTimer for ResourceMeteringReporter {
                         defer!(reporting.store(false, SeqCst));
 
                         for (tag, (timestamp_list, cpu_time_ms_list, _)) in records {
-                            let mut req = ReportCpuTimeRequest::default();
+                            let mut req = CpuTimeRecord::default();
                             req.set_resource_group_tag(tag);
                             req.set_record_list_timestamp_sec(timestamp_list);
                             req.set_record_list_cpu_time_ms(cpu_time_ms_list);
@@ -214,7 +214,7 @@ impl RunnableWithTimer for ResourceMeteringReporter {
                         // others
                         let timestamp_list = others.keys().cloned().collect::<Vec<_>>();
                         let cpu_time_ms_list = others.values().cloned().collect::<Vec<_>>();
-                        let mut req = ReportCpuTimeRequest::default();
+                        let mut req = CpuTimeRecord::default();
                         req.set_record_list_timestamp_sec(timestamp_list);
                         req.set_record_list_cpu_time_ms(cpu_time_ms_list);
                         if tx.send((req, WriteFlags::default())).await.is_err() {

--- a/components/resource_metering/src/reporter.rs
+++ b/components/resource_metering/src/reporter.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use collections::HashMap;
 use futures::SinkExt;
 use grpcio::{CallOption, ChannelBuilder, Environment, WriteFlags};
-use kvproto::resource_usage_agent::{CpuTimeRecord, ResourceUsageAgentClient};
+use kvproto::resource_usage_agent::{ReportCpuTimeRequest, ResourceUsageAgentClient};
 use tikv_util::time::Duration;
 use tikv_util::worker::{Runnable, RunnableWithTimer, Scheduler};
 
@@ -202,7 +202,7 @@ impl RunnableWithTimer for ResourceMeteringReporter {
                         defer!(reporting.store(false, SeqCst));
 
                         for (tag, (timestamp_list, cpu_time_ms_list, _)) in records {
-                            let mut req = CpuTimeRecord::default();
+                            let mut req = ReportCpuTimeRequest::default();
                             req.set_resource_group_tag(tag);
                             req.set_record_list_timestamp_sec(timestamp_list);
                             req.set_record_list_cpu_time_ms(cpu_time_ms_list);
@@ -214,7 +214,7 @@ impl RunnableWithTimer for ResourceMeteringReporter {
                         // others
                         let timestamp_list = others.keys().cloned().collect::<Vec<_>>();
                         let cpu_time_ms_list = others.values().cloned().collect::<Vec<_>>();
-                        let mut req = CpuTimeRecord::default();
+                        let mut req = ReportCpuTimeRequest::default();
                         req.set_record_list_timestamp_sec(timestamp_list);
                         req.set_record_list_cpu_time_ms(cpu_time_ms_list);
                         if tx.send((req, WriteFlags::default())).await.is_err() {

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -90,7 +90,7 @@ tokio = { version = "1.5", features = ["rt-multi-thread"] }
 grpcio = { version = "0.9", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -49,7 +49,7 @@ futures = { version = "0.3", features = ["thread-pool"] }
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.12", default-features = false }

--- a/components/test_backup/Cargo.toml
+++ b/components/test_backup/Cargo.toml
@@ -36,7 +36,7 @@ futures = "0.3"
 futures-executor = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rand = "0.8"
 tempfile = "3.0"
 test_raftstore = { path = "../test_raftstore" }

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -41,7 +41,7 @@ test-engines-panic = [
 [dependencies]
 engine_rocks = { path = "../engine_rocks", default-features = false }
 futures = "0.3"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 protobuf = "2"
 test_storage = { path = "../test_storage", default-features = false }
 tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }

--- a/components/test_pd/Cargo.toml
+++ b/components/test_pd/Cargo.toml
@@ -25,7 +25,7 @@ prost-codec = [
 fail = "0.4"
 futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 pd_client = { path = "../pd_client", default-features = false }

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -51,6 +51,7 @@ test-engines-panic = [
 ]
 
 [dependencies]
+backtrace = "0.3"
 crossbeam = "0.8"
 engine_traits = { path = "../engine_traits", default-features = false }
 engine_rocks = { path = "../engine_rocks", default-features = false }

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -51,7 +51,6 @@ test-engines-panic = [
 ]
 
 [dependencies]
-backtrace = "0.3"
 crossbeam = "0.8"
 engine_traits = { path = "../engine_traits", default-features = false }
 engine_rocks = { path = "../engine_rocks", default-features = false }
@@ -61,7 +60,7 @@ grpcio = { version = "0.9",  default-features = false, features = ["openssl-vend
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 protobuf = "2.8"
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/test_sst_importer/Cargo.toml
+++ b/components/test_sst_importer/Cargo.toml
@@ -28,5 +28,5 @@ crc32fast = "1.2"
 engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 keys = { path = "../keys", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -33,7 +33,7 @@ test-engines-panic = [
 
 [dependencies]
 futures = "0.3"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 raftstore = { path = "../raftstore", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 test_raftstore = { path = "../test_raftstore", default-features = false }

--- a/components/test_util/Cargo.toml
+++ b/components/test_util/Cargo.toml
@@ -27,7 +27,7 @@ cloud-gcp = [ "encryption_export/cloud-gcp" ]
 encryption_export = { path = "../encryption/export", default-features = false }
 fail = "0.4"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 rand = "0.8"
 rand_isaac = "0.3"
 security = { path = "../security", default-features = false }

--- a/components/tidb_query_common/Cargo.toml
+++ b/components/tidb_query_common/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.1"
 derive_more = "0.99.3"
 error_code = { path = "../error_code", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 prometheus = { version = "0.12", features = ["nightly"] }
 prometheus-static-metric = "0.5"
 lazy_static = "1.3"

--- a/components/tidb_query_datatype/Cargo.toml
+++ b/components/tidb_query_datatype/Cargo.toml
@@ -34,7 +34,7 @@ chrono-tz = "0.5.1"
 codec = { path = "../codec", default-features = false }
 error_code = { path = "../error_code", default-features = false }
 hex = "0.4"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 lazy_static = "1.3"
 match_template = { path = "../match_template" }
 nom = { version = "5.1.0", default-features = false, features = ["std"] }

--- a/components/tidb_query_executors/Cargo.toml
+++ b/components/tidb_query_executors/Cargo.toml
@@ -33,7 +33,7 @@ prost-codec = [
 protobuf = "2.8"
 codec = { path = "../codec", default-features = false }
 fail = "0.4"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 match_template = { path = "../match_template" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }

--- a/components/tikv_kv/Cargo.toml
+++ b/components/tikv_kv/Cargo.toml
@@ -47,7 +47,7 @@ fail = "0.4"
 file_system = { path = "../file_system" }
 futures = { version = "0.3", features = ["thread-pool", "compat"] }
 into_other = { path = "../into_other", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.12", features = ["nightly"] }
 prometheus-static-metric = "0.5"

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -62,7 +62,7 @@ tokio = { version = "1.5", features = ["rt-multi-thread"] }
 tokio-executor = "0.1"
 tokio-timer = "0.2"
 url = "2"
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 protobuf = "2"
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 

--- a/components/txn_types/Cargo.toml
+++ b/components/txn_types/Cargo.toml
@@ -25,7 +25,7 @@ bitflags = "1.0.1"
 farmhash = "1.1.5"
 error_code = { path = "../error_code", default-features = false }
 codec = { path = "../codec", default-features = false }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 slog = "2.3"
 thiserror = "1.0"
 tikv_alloc = { path = "../tikv_alloc" }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -589,12 +589,3 @@ fn pb_error_inc(type_: &str, e: &errorpb::Error) {
 
     IMPORTER_ERROR_VEC.with_label_values(&[type_, label]).inc();
 }
-
-fn make_request_header(mut context: Context) -> RaftRequestHeader {
-    let region_id = context.get_region_id();
-    let mut header = RaftRequestHeader::default();
-    header.set_peer(context.take_peer());
-    header.set_region_id(region_id);
-    header.set_region_epoch(context.take_region_epoch());
-    header
-}

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -10,7 +10,7 @@ use engine_traits::{KvEngine, CF_WRITE};
 use file_system::{set_io_type, IOType};
 use futures::executor::{ThreadPool, ThreadPoolBuilder};
 use futures::{TryFutureExt, TryStreamExt};
-use grpcio::{ClientStreamingSink, RequestStream, ServerStreamingSink, RpcContext, UnarySink};
+use grpcio::{ClientStreamingSink, RequestStream, RpcContext, UnarySink};
 use kvproto::errorpb;
 
 #[cfg(feature = "prost-codec")]
@@ -553,15 +553,6 @@ where
 
         self.threads.spawn_ok(buf_driver);
         self.threads.spawn_ok(handle_task);
-    }
-
-    fn duplicate_detect(
-        &mut self,
-        _ctx: RpcContext<'_>,
-        _request: DuplicateDetectRequest,
-        _sink: ServerStreamingSink<DuplicateDetectResponse>,
-    ) {
-        unimplemented!();
     }
 }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -127,7 +127,7 @@ futures = "0.3"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }
 grpcio-health = { version = "0.9", default-features = false }
 log_wrappers = { path = "../components/log_wrappers" }
-kvproto = { rev = "706fcaf286c8dd07ef59349c089f53289a32ce4c", git = "https://github.com/pingcap/kvproto.git", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false }
 paste = "1.0"
 pd_client = { path = "../components/pd_client", default-features = false }
 protobuf = "2.8"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
The package manager Cargo could keep the dependency library in one commit version, so we do not need to set it in every Cargo.toml, or we must change a lot of files every time we need to update kvproto.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- None
