### PR TITLE
drop router shoulnd't reset memtrace because it's clonable

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3792,16 +3792,6 @@ where
     pub router: BatchRouter<ApplyFsm<EK>, ControlFsm>,
 }
 
-impl<EK> Drop for ApplyRouter<EK>
-where
-    EK: KvEngine,
-{
-    fn drop(&mut self) {
-        MEMTRACE_APPLY_ROUTER_ALIVE.trace(TraceEvent::Reset(0));
-        MEMTRACE_APPLY_ROUTER_LEAK.trace(TraceEvent::Reset(0));
-    }
-}
-
 impl<EK> Deref for ApplyRouter<EK>
 where
     EK: KvEngine,


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

Drop `RaftRouter` shouldn't reset memtrace because it's clonable.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  Without the patch: 
<img width="909" alt="图片" src="https://user-images.githubusercontent.com/8407317/123913606-fd2d2d80-d9b0-11eb-835c-3b07592d186f.png">
  with the patch: 
<img width="902" alt="图片" src="https://user-images.githubusercontent.com/8407317/123916874-b5a8a080-d9b4-11eb-8384-05ce71910bbd.png">

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```