### PR TITLE
don't clean snapshot when applying

### DIFF
--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -3272,6 +3272,7 @@ where
 
     /// Handles peer destroy. When a peer is destroyed, the corresponding apply delegate should be removed too.
     fn handle_destroy<W: WriteBatch<EK>>(&mut self, ctx: &mut ApplyContext<EK, W>, d: Destroy) {
+        fail_point!("before_apply_handle_destroy", |_| {});
         assert_eq!(d.region_id, self.delegate.region_id());
         if d.merge_from_snapshot {
             assert_eq!(self.delegate.stopped, false);

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2061,6 +2061,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                 "schedule snap gc";
                 "store_id" => self.fsm.store.id,
                 "region_id" => region_id,
+                "snaps" => ?snaps,
             );
             let gc_snap = PeerMsg::CasualMessage(CasualMessage::GcSnap { snaps });
             match self.ctx.router.send(region_id, gc_snap) {

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -965,6 +965,15 @@ where
         self.region = region;
     }
 
+    pub fn peer_state(&self) -> Option<PeerState> {
+        let rid = self.region.id;
+        self.engines
+            .kv
+            .get_msg_cf(CF_RAFT, &keys::region_state_key(rid))
+            .unwrap()
+            .map(|s: RegionLocalState| s.get_state())
+    }
+
     pub fn raw_snapshot(&self) -> EK::Snapshot {
         self.engines.kv.snapshot()
     }

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -747,10 +747,7 @@ impl Snapshot {
     }
 
     fn delete(&self) {
-        debug!(
-            "deleting snapshot file";
-            "snapshot" => %self.path(),
-        );
+        debug!("deleting snapshot file"; "snapshot" => %self.path());
         for cf_file in &self.cf_files {
             // Delete cloned files.
             delete_file_if_exist(&cf_file.clone_path).unwrap();
@@ -873,10 +870,7 @@ impl Snapshot {
     }
 
     pub fn save(&mut self) -> io::Result<()> {
-        debug!(
-            "saving to snapshot file";
-            "snapshot" => %self.path(),
-        );
+        debug!("saving to snapshot file"; "snapshot" => %self.path());
         for cf_file in &mut self.cf_files {
             if cf_file.size == 0 {
                 // Skip empty cf file.
@@ -1328,11 +1322,7 @@ impl SnapManager {
     }
 
     pub fn register(&self, key: SnapKey, entry: SnapEntry) {
-        debug!(
-            "register snapshot";
-            "key" => %key,
-            "entry" => ?entry,
-        );
+        debug!("register snapshot"; "key" => %key, "entry" => ?entry);
         match self.core.registry.wl().entry(key) {
             Entry::Occupied(mut e) => {
                 if e.get().contains(&entry) {
@@ -1351,11 +1341,7 @@ impl SnapManager {
     }
 
     pub fn deregister(&self, key: &SnapKey, entry: &SnapEntry) {
-        debug!(
-            "deregister snapshot";
-            "key" => %key,
-            "entry" => ?entry,
-        );
+        debug!("deregister snapshot"; "key" => %key, "entry" => ?entry);
         let mut need_clean = false;
         let mut handled = false;
         let registry = &mut self.core.registry.wl();

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1098,6 +1098,17 @@ impl<T: Simulator> Cluster<T> {
             .unwrap()
     }
 
+    pub fn has_snapshot_raft_state(&self, region_id: u64, store_id: u64) -> bool {
+        self.get_engine(store_id)
+            .c()
+            .get_msg_cf::<RaftLocalState>(
+                engine_traits::CF_RAFT,
+                &keys::snapshot_raft_state_key(region_id),
+            )
+            .unwrap()
+            .is_some()
+    }
+
     pub fn wait_last_index(
         &mut self,
         region_id: u64,


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

Fix a panic bug about "file doesn't exist" when applying a snapshot.
Here is a log sector of tiflash:
```
[2021/06/24 10:49:12.737 +08:00] [INFO] [raft.rs:1064] ["became follower at term 9"] [term=9] [raft_id=175749763] [region_id=157802790]
[2021/06/24 10:49:12.997 +08:00] [INFO] [snap.rs:239] ["saving snapshot file"] [file=/data1/tidb-data/tiflash-9000/flash/snap/rev_157802790_9_656810_(default|lock|write).ss
[2021/06/24 10:49:13.008 +08:00] [INFO] [raft_log.rs:531] ["log [committed=0, persisted=0, applied=0, unstable.offset=1, unstable.entries.len()=0] starts to restore snapsho
[2021/06/24 10:49:13.008 +08:00] [INFO] [raft.rs:2443] ["switched to configuration"] [config="Configuration { voters: Configuration { incoming: Configuration { voters: {157[2021/06/24 10:49:13.008 +08:00] [INFO] [raft.rs:2427] ["restored snapshot"] [snapshot_term=9] [snapshot_index=656810] [last_term=9] [last_index=656810] [commit=656810] [ra[2021/06/24 10:49:13.008 +08:00] [INFO] [raft.rs:2308] ["[commit: 656810, term: 9] restored snapshot [index: 656810, term: 9]"] [snapshot_term=9] [snapshot_index=656810] [c
[2021/06/24 10:49:13.008 +08:00] [INFO] [peer_storage.rs:1130] ["begin to apply snapshot"] [peer_id=175749763] [region_id=157802790]
[2021/06/24 10:49:13.008 +08:00] [INFO] [peer_storage.rs:1173] ["apply snapshot with state ok"] [state="applied_index: 656810 truncated_state { index: 656810 term: 9 }"] [r[2021/06/24 10:49:13.008 +08:00] [INFO] [peer.rs:2968] ["snapshot is applied"] [region="id: 157802790 start_key: 7480000000000000FF9A5F7292000000E0FF6C9C880000000000FA end_
[2021/06/24 11:13:40.813 +08:00] [INFO] [peer.rs:1456] ["target peer id is larger, destroying self"] [target_peer="id: 175755143 store_id: 148534374 role: Learner"] [peer_i[2021/06/24 11:14:24.752 +08:00] [INFO] [peer.rs:735] ["deleting applied snap file"] [snap_file=157802790_9_656810] [peer_id=175749763] [region_id=157802790]
[2021/06/24 13:33:35.553 +08:00] [INFO] [store.rs:976] ["region is applying snapshot"] [store_id=148534374] [region="id: 157802790 start_key: 7480000000000000FF9A5F72920000
[2021/06/24 13:33:35.553 +08:00] [INFO] [peer.rs:189] ["create peer"] [peer_id=175749763] [region_id=157802790]
[2021/06/24 13:33:35.553 +08:00] [INFO] [raft.rs:2443] ["switched to configuration"] [config="Configuration { voters: Configuration { incoming: Configuration { voters: {157
[2021/06/24 13:33:35.553 +08:00] [INFO] [raft.rs:1064] ["became follower at term 9"] [term=9] [raft_id=175749763] [region_id=157802790]
[2021/06/24 13:33:35.553 +08:00] [INFO] [raft.rs:375] [newRaft] [peers="Configuration { incoming: Configuration { voters: {157802793, 157802794, 157802795} }, outgoing: Con
[2021/06/24 13:33:35.553 +08:00] [INFO] [raw_node.rs:285] ["RawNode created with id 175749763."] [id=175749763] [raft_id=175749763] [region_id=157802790]
[2021/06/24 13:33:35.638 +08:00] [INFO] [region.rs:377] ["begin apply snap data"] [region_id=157802790]
[2021/06/24 13:33:35.639 +08:00] [INFO] [region.rs:411] ["apply data to engine-store"] [region_id=157802790]
[2021/06/24 13:33:35.639 +08:00] [ERROR] [region.rs:469] ["failed to apply snap!!!"] [err_code=KV:Raftstore:SnapUnknown] [err="Other(\"[components/raftstore/src/store/worke

```

### What is changed and how it works?

The root cause is the snapshot is deleted when the peer is deleted. However the deletion of the peer can be not persisted, so after restart the instance, the peer will continue to apply the snapshot.

This PR ensures that snapshot won't be deleted during applying.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```