### PR TITLE
txn: remove the `command_method` abstraction

### DIFF
--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -50,7 +50,7 @@ impl CommandExt for AcquirePessimisticLock {
     ctx!();
     tag!(acquire_pessimistic_lock);
     ts!(start_ts);
-    command_method!(can_be_pipelined, bool, true);
+    property!(can_be_pipelined);
 
     fn write_bytes(&self) -> usize {
         self.keys

--- a/src/storage/txn/commands/macros.rs
+++ b/src/storage/txn/commands/macros.rs
@@ -130,10 +130,10 @@ macro_rules! gen_lock {
     };
 }
 
-macro_rules! command_method {
-    ($name:ident, $return_ty: ty, $value: expr) => {
-        fn $name(&self) -> $return_ty {
-            $value
+macro_rules! property {
+    ($property:ident) => {
+        fn $property(&self) -> bool {
+            true
         }
     };
 }

--- a/src/storage/txn/commands/mvcc_by_key.rs
+++ b/src/storage/txn/commands/mvcc_by_key.rs
@@ -23,9 +23,11 @@ impl CommandExt for MvccByKey {
     ctx!();
     tag!(key_mvcc);
     property!(readonly);
+
     fn write_bytes(&self) -> usize {
         0
     }
+
     gen_lock!(empty);
 }
 

--- a/src/storage/txn/commands/mvcc_by_key.rs
+++ b/src/storage/txn/commands/mvcc_by_key.rs
@@ -22,12 +22,10 @@ command! {
 impl CommandExt for MvccByKey {
     ctx!();
     tag!(key_mvcc);
-    command_method!(readonly, bool, true);
-
+    property!(readonly);
     fn write_bytes(&self) -> usize {
         0
     }
-
     gen_lock!(empty);
 }
 

--- a/src/storage/txn/commands/mvcc_by_start_ts.rs
+++ b/src/storage/txn/commands/mvcc_by_start_ts.rs
@@ -23,7 +23,7 @@ impl CommandExt for MvccByStartTs {
     ctx!();
     tag!(start_ts_mvcc);
     ts!(start_ts);
-    command_method!(readonly, bool, true);
+    property!(readonly);
 
     fn write_bytes(&self) -> usize {
         0

--- a/src/storage/txn/commands/resolve_lock.rs
+++ b/src/storage/txn/commands/resolve_lock.rs
@@ -47,9 +47,7 @@ command! {
 impl CommandExt for ResolveLock {
     ctx!();
     tag!(resolve_lock);
-
-    command_method!(readonly, bool, false);
-    command_method!(is_sys_cmd, bool, true);
+    property!(is_sys_cmd);
 
     fn write_bytes(&self) -> usize {
         self.key_locks

--- a/src/storage/txn/commands/resolve_lock_lite.rs
+++ b/src/storage/txn/commands/resolve_lock_lite.rs
@@ -30,7 +30,7 @@ impl CommandExt for ResolveLockLite {
     ctx!();
     tag!(resolve_lock_lite);
     ts!(start_ts);
-    command_method!(is_sys_cmd, bool, true);
+    property!(is_sys_cmd);
     write_bytes!(resolve_keys: multiple);
     gen_lock!(resolve_keys: multiple);
 }

--- a/src/storage/txn/commands/resolve_lock_readphase.rs
+++ b/src/storage/txn/commands/resolve_lock_readphase.rs
@@ -27,8 +27,10 @@ command! {
 impl CommandExt for ResolveLockReadPhase {
     ctx!();
     tag!(resolve_lock);
-    command_method!(readonly, bool, true);
-    command_method!(write_bytes, usize, 0);
+    property!(readonly);
+    fn write_bytes(&self) -> usize {
+        0
+    }
     gen_lock!(empty);
 }
 

--- a/src/storage/txn/commands/resolve_lock_readphase.rs
+++ b/src/storage/txn/commands/resolve_lock_readphase.rs
@@ -28,9 +28,11 @@ impl CommandExt for ResolveLockReadPhase {
     ctx!();
     tag!(resolve_lock);
     property!(readonly);
+
     fn write_bytes(&self) -> usize {
         0
     }
+
     gen_lock!(empty);
 }
 


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

### What problem does this PR solve?

Just a refactor.

Problem Summary:

The `command_method` macro makes less difference for human readability or simplicity.

### What is changed and how it works?

What's Changed:

- Remove `command_method`
- Add `property`

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```