### PR TITLE
server: stop status server early when gracefully shutdown

### DIFF
--- a/cmd/src/server.rs
+++ b/cmd/src/server.rs
@@ -123,6 +123,7 @@ struct TiKVServer {
     encryption_key_manager: Option<Arc<DataKeyManager>>,
     engines: Option<Engines>,
     servers: Option<Servers>,
+    status_server: Option<Box<dyn Stop>>,
     region_info_accessor: RegionInfoAccessor,
     coprocessor_host: Option<CoprocessorHost>,
     to_stop: Vec<Box<dyn Stop>>,
@@ -182,6 +183,7 @@ impl TiKVServer {
             encryption_key_manager: None,
             engines: None,
             servers: None,
+            status_server: None,
             region_info_accessor,
             coprocessor_host,
             to_stop: vec![Box::new(resolve_worker)],
@@ -804,12 +806,15 @@ impl TiKVServer {
             ) {
                 error!(%e; "failed to bind addr for status service");
             } else {
-                self.to_stop.push(status_server);
+                self.status_server = Some(status_server);
             }
         }
     }
 
-    fn stop(self) {
+    fn stop(mut self) {
+        if let Some(status_server) = self.status_server.take() {
+            status_server.stop();
+        }
         let mut servers = self.servers.unwrap();
         servers
             .server


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/25244

Problem Summary:

v4.0 TiDB introduced a mechanism that if a request sent to TiKV fails due to network problem, TiDB will check the liveness status of the TiKV through an HTTP API. If it's still reachable, TiDB will retry to send requests to it forever until backoff timeout.

However, TiKV may shut down slowly.
```
Jun 08 11:32:21 583d114d1e09 systemd[1]: Stopping tikv service...
Jun 08 11:33:51 583d114d1e09 systemd[1]: tikv-20160.service stop-sigterm timed out. Killing.
Jun 08 11:33:53 583d114d1e09 systemd[1]: tikv-20160.service: main process exited, code=killed, status=9/KILL
Jun 08 11:33:53 583d114d1e09 systemd[1]: Stopped tikv service.
Jun 08 11:33:53 583d114d1e09 systemd[1]: Unit tikv-20160.service entered failed state.
Jun 08 11:33:53 583d114d1e09 systemd[1]: tikv-20160.service failed.
Jun 08 11:33:53 583d114d1e09 systemd[1]: Started tikv service.
Jun 08 11:33:53 583d114d1e09 run_tikv.sh[74711]: sync ...
Jun 08 11:33:53 583d114d1e09 run_tikv.sh[74711]: real        0m0.103s
Jun 08 11:33:53 583d114d1e09 run_tikv.sh[74711]: user        0m0.000s
Jun 08 11:33:53 583d114d1e09 run_tikv.sh[74711]: sys        0m0.101s
Jun 08 11:33:53 583d114d1e09 run_tikv.sh[74711]: ok
```
The gRPC service is stopped but the liveness check API still works.
```
[2021/06/08 11:32:21.557 +08:00] [WARN] [client_batch.go:530] ["no available connections"] [target=10.0.2.222:20160]
...
[2021/06/08 11:33:53.034 +08:00] [INFO] [region_cache.go:1660] ["[liveness] request kv status fail"] [store=10.0.2.222:20180] [error="Get http://10.0.2.222:20180/status: dial tcp 10.0.2.222:20180: connect: connection refused"]
```

### What is changed and how it works?

What's Changed:

Stop the status server which provides the early.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```