### PR TITLE
Rewritten ScannerBuilder and ScannerConfig

### DIFF
--- a/components/cdc/src/endpoint.rs
+++ b/components/cdc/src/endpoint.rs
@@ -1123,7 +1123,7 @@ impl Initializer {
         let start = Instant::now_coarse();
         // Time range: (checkpoint_ts, current]
         let current = TimeStamp::max();
-        let mut scanner = ScannerBuilder::new(snap, current, false)
+        let mut scanner = ScannerBuilder::new(snap, current)
             .fill_cache(false)
             .range(None, None)
             .build_delta_scanner(self.checkpoint_ts, self.txn_extra_op)

--- a/components/resolved_ts/src/scanner.rs
+++ b/components/resolved_ts/src/scanner.rs
@@ -108,7 +108,7 @@ impl<T: 'static + RaftStoreRouter<E>, E: KvEngine> ScannerPool<T, E> {
                     } else {
                         TxnExtraOp::Noop
                     };
-                    let mut scanner = ScannerBuilder::new(snap, TimeStamp::max(), false)
+                    let mut scanner = ScannerBuilder::new(snap, TimeStamp::max())
                         .range(None, None)
                         .build_delta_scanner(task.checkpoint_ts, txn_extra_op)
                         .unwrap();

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -552,7 +552,8 @@ mod tests {
         // 4 4 5 5 5 5 5 6 7 7 7 7 7 8 8 8 8 8 9 9 9 9 9 10 10
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND.into(), true)
+        let mut scanner = ScannerBuilder::new(snapshot, REVERSE_SEEK_BOUND.into())
+            .desc(true)
             .range(None, Some(Key::from_raw(&[11_u8])))
             .build()
             .unwrap();
@@ -778,7 +779,8 @@ mod tests {
         );
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, (REVERSE_SEEK_BOUND * 2).into(), true)
+        let mut scanner = ScannerBuilder::new(snapshot, (REVERSE_SEEK_BOUND * 2).into())
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -863,7 +865,8 @@ mod tests {
         );
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, (REVERSE_SEEK_BOUND * 2).into(), true)
+        let mut scanner = ScannerBuilder::new(snapshot, (REVERSE_SEEK_BOUND * 2).into())
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -939,7 +942,8 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 1.into(), true)
+        let mut scanner = ScannerBuilder::new(snapshot, 1.into())
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -1019,7 +1023,8 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 1.into(), true)
+        let mut scanner = ScannerBuilder::new(snapshot, 1.into())
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -1107,7 +1112,8 @@ mod tests {
         }
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, (REVERSE_SEEK_BOUND + 1).into(), true)
+        let mut scanner = ScannerBuilder::new(snapshot, (REVERSE_SEEK_BOUND + 1).into())
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -1203,7 +1209,8 @@ mod tests {
         let snapshot = engine.snapshot(Default::default()).unwrap();
 
         // Test both bound specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
+            .desc(true)
             .range(Some(Key::from_raw(&[3u8])), Some(Key::from_raw(&[5u8])))
             .build()
             .unwrap();
@@ -1225,7 +1232,8 @@ mod tests {
         );
 
         // Test left bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
+            .desc(true)
             .range(None, Some(Key::from_raw(&[3u8])))
             .build()
             .unwrap();
@@ -1247,7 +1255,8 @@ mod tests {
         );
 
         // Test right bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), true)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
+            .desc(true)
             .range(Some(Key::from_raw(&[5u8])), None)
             .build()
             .unwrap();
@@ -1269,7 +1278,8 @@ mod tests {
         );
 
         // Test both bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot, 10.into(), true)
+        let mut scanner = ScannerBuilder::new(snapshot, 10.into())
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();
@@ -1339,7 +1349,8 @@ mod tests {
 
         // Call reverse scan
         let ts = 2.into();
-        let mut scanner = ScannerBuilder::new(snapshot, ts, true)
+        let mut scanner = ScannerBuilder::new(snapshot, ts)
+            .desc(true)
             .range(None, Some(k))
             .build()
             .unwrap();
@@ -1362,7 +1373,8 @@ mod tests {
             .collect();
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, read_ts, true)
+        let mut scanner = ScannerBuilder::new(snapshot, read_ts)
+            .desc(true)
             .range(None, None)
             .build()
             .unwrap();

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -1040,7 +1040,7 @@ mod latest_kv_tests {
         }
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, 10.into())
             .range(None, None)
             .build()
             .unwrap();
@@ -1109,7 +1109,7 @@ mod latest_kv_tests {
         must_commit(&engine, b"b", SEEK_BOUND / 2, SEEK_BOUND / 2);
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into())
             .range(None, None)
             .build()
             .unwrap();
@@ -1191,7 +1191,7 @@ mod latest_kv_tests {
         must_commit(&engine, b"b", SEEK_BOUND, SEEK_BOUND);
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into())
             .range(None, None)
             .build()
             .unwrap();
@@ -1269,7 +1269,7 @@ mod latest_kv_tests {
         let snapshot = engine.snapshot(Default::default()).unwrap();
 
         // Test both bound specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
             .range(Some(Key::from_raw(&[3u8])), Some(Key::from_raw(&[5u8])))
             .build()
             .unwrap();
@@ -1291,7 +1291,7 @@ mod latest_kv_tests {
         );
 
         // Test left bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
             .range(None, Some(Key::from_raw(&[3u8])))
             .build()
             .unwrap();
@@ -1313,7 +1313,7 @@ mod latest_kv_tests {
         );
 
         // Test right bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
             .range(Some(Key::from_raw(&[5u8])), None)
             .build()
             .unwrap();
@@ -1335,7 +1335,7 @@ mod latest_kv_tests {
         );
 
         // Test both bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, 10.into())
             .range(None, None)
             .build()
             .unwrap();
@@ -1383,7 +1383,7 @@ mod latest_kv_tests {
             .collect();
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, read_ts, false)
+        let mut scanner = ScannerBuilder::new(snapshot, read_ts)
             .range(None, None)
             .build()
             .unwrap();
@@ -1435,7 +1435,7 @@ mod latest_entry_tests {
         }
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, 10.into())
             .range(None, None)
             .build_entry_scanner(0.into(), false)
             .unwrap();
@@ -1508,7 +1508,7 @@ mod latest_entry_tests {
         must_commit(&engine, b"b", SEEK_BOUND / 2, SEEK_BOUND / 2);
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into())
             .range(None, None)
             .build_entry_scanner(0.into(), false)
             .unwrap();
@@ -1592,7 +1592,7 @@ mod latest_entry_tests {
         must_commit(&engine, b"b", SEEK_BOUND, SEEK_BOUND);
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into())
             .range(None, None)
             .build_entry_scanner(0.into(), false)
             .unwrap();
@@ -1672,7 +1672,7 @@ mod latest_entry_tests {
         let snapshot = engine.snapshot(Default::default()).unwrap();
 
         // Test both bound specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
             .range(Some(Key::from_raw(&[3u8])), Some(Key::from_raw(&[5u8])))
             .build_entry_scanner(0.into(), false)
             .unwrap();
@@ -1691,7 +1691,7 @@ mod latest_entry_tests {
         assert_eq!(scanner.next_entry().unwrap(), None);
 
         // Test left bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
             .range(None, Some(Key::from_raw(&[3u8])))
             .build_entry_scanner(0.into(), false)
             .unwrap();
@@ -1700,7 +1700,7 @@ mod latest_entry_tests {
         assert_eq!(scanner.next_entry().unwrap(), None);
 
         // Test right bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
             .range(Some(Key::from_raw(&[5u8])), None)
             .build_entry_scanner(0.into(), false)
             .unwrap();
@@ -1709,7 +1709,7 @@ mod latest_entry_tests {
         assert_eq!(scanner.next_entry().unwrap(), None);
 
         // Test both bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, 10.into())
             .range(None, None)
             .build_entry_scanner(0.into(), false)
             .unwrap();
@@ -1783,7 +1783,7 @@ mod latest_entry_tests {
 
         let check = |ts: u64, after_ts: u64, output_delete, expected: Vec<&TxnEntry>| {
             let snapshot = engine.snapshot(Default::default()).unwrap();
-            let mut scanner = ScannerBuilder::new(snapshot, ts.into(), false)
+            let mut scanner = ScannerBuilder::new(snapshot, ts.into())
                 .range(None, None)
                 .build_entry_scanner(after_ts.into(), output_delete)
                 .unwrap();
@@ -1818,7 +1818,7 @@ mod latest_entry_tests {
             .collect();
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, read_ts, false)
+        let mut scanner = ScannerBuilder::new(snapshot, read_ts)
             .range(None, None)
             .build_entry_scanner(0.into(), false)
             .unwrap();
@@ -1871,7 +1871,7 @@ mod delta_entry_tests {
         }
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, 10.into())
             .range(None, None)
             .build_delta_scanner(0.into(), ExtraOp::Noop)
             .unwrap();
@@ -1943,7 +1943,7 @@ mod delta_entry_tests {
         must_commit(&engine, b"b", SEEK_BOUND / 2, SEEK_BOUND / 2);
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into())
             .range(None, None)
             .build_delta_scanner(0.into(), ExtraOp::Noop)
             .unwrap();
@@ -2029,7 +2029,7 @@ mod delta_entry_tests {
         must_commit(&engine, b"b", SEEK_BOUND + 1, SEEK_BOUND + 1);
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, (SEEK_BOUND * 2).into())
             .range(None, None)
             .build_delta_scanner(8.into(), ExtraOp::Noop)
             .unwrap();
@@ -2109,7 +2109,7 @@ mod delta_entry_tests {
         let snapshot = engine.snapshot(Default::default()).unwrap();
 
         // Test both bound specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
             .range(Some(Key::from_raw(&[3u8])), Some(Key::from_raw(&[5u8])))
             .build_delta_scanner(4.into(), ExtraOp::Noop)
             .unwrap();
@@ -2128,7 +2128,7 @@ mod delta_entry_tests {
         assert_eq!(scanner.next_entry().unwrap(), None);
 
         // Test left bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
             .range(None, Some(Key::from_raw(&[3u8])))
             .build_delta_scanner(4.into(), ExtraOp::Noop)
             .unwrap();
@@ -2137,7 +2137,7 @@ mod delta_entry_tests {
         assert_eq!(scanner.next_entry().unwrap(), None);
 
         // Test right bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot.clone(), 10.into())
             .range(Some(Key::from_raw(&[5u8])), None)
             .build_delta_scanner(4.into(), ExtraOp::Noop)
             .unwrap();
@@ -2146,7 +2146,7 @@ mod delta_entry_tests {
         assert_eq!(scanner.next_entry().unwrap(), None);
 
         // Test both bound not specified.
-        let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, 10.into())
             .range(None, None)
             .build_delta_scanner(4.into(), ExtraOp::Noop)
             .unwrap();
@@ -2366,16 +2366,13 @@ mod delta_entry_tests {
             } else {
                 Some(Key::from_raw(to_key))
             };
-            let mut scanner = ScannerBuilder::new(
-                engine.snapshot(Default::default()).unwrap(),
-                to_ts.into(),
-                false,
-            )
-            .hint_min_ts(Some(from_ts.into()))
-            .hint_max_ts(Some(to_ts.into()))
-            .range(from_key, to_key)
-            .build_delta_scanner(from_ts.into(), ExtraOp::Noop)
-            .unwrap();
+            let mut scanner =
+                ScannerBuilder::new(engine.snapshot(Default::default()).unwrap(), to_ts.into())
+                    .hint_min_ts(Some(from_ts.into()))
+                    .hint_max_ts(Some(to_ts.into()))
+                    .range(from_key, to_key)
+                    .build_delta_scanner(from_ts.into(), ExtraOp::Noop)
+                    .unwrap();
 
             let mut actual = vec![];
             while let Some(entry) = scanner.next_entry().unwrap() {
@@ -2508,7 +2505,7 @@ mod delta_entry_tests {
 
         let check = |after_ts: u64, expected: Vec<&TxnEntry>| {
             let snapshot = engine.snapshot(Default::default()).unwrap();
-            let mut scanner = ScannerBuilder::new(snapshot, TimeStamp::max(), false)
+            let mut scanner = ScannerBuilder::new(snapshot, TimeStamp::max())
                 .range(None, None)
                 .build_delta_scanner(after_ts.into(), ExtraOp::ReadOldValue)
                 .unwrap();
@@ -2545,7 +2542,7 @@ mod delta_entry_tests {
         prepare_test_data_for_check_gc_fence(&engine);
 
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, TimeStamp::max(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, TimeStamp::max())
             .range(None, None)
             .build_delta_scanner(40.into(), ExtraOp::ReadOldValue)
             .unwrap();
@@ -2577,7 +2574,7 @@ mod delta_entry_tests {
             must_prewrite_put(&engine, key, value, b"k1", 55);
         }
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, TimeStamp::max(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, TimeStamp::max())
             .range(None, None)
             .build_delta_scanner(40.into(), ExtraOp::ReadOldValue)
             .unwrap();
@@ -2613,7 +2610,7 @@ mod delta_entry_tests {
             must_commit(&engine, key, 55, 56);
         }
         let snapshot = engine.snapshot(Default::default()).unwrap();
-        let mut scanner = ScannerBuilder::new(snapshot, TimeStamp::max(), false)
+        let mut scanner = ScannerBuilder::new(snapshot, TimeStamp::max())
             .range(None, None)
             .build_delta_scanner(40.into(), ExtraOp::ReadOldValue)
             .unwrap();

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -356,7 +356,8 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
     ) -> Result<MvccScanner<S>> {
         // Check request bounds with physical bound
         self.verify_range(&lower_bound, &upper_bound)?;
-        let scanner = ScannerBuilder::new(self.snapshot.clone(), self.start_ts, desc)
+        let scanner = ScannerBuilder::new(self.snapshot.clone(), self.start_ts)
+            .desc(desc)
             .range(lower_bound, upper_bound)
             .omit_value(key_only)
             .fill_cache(self.fill_cache)
@@ -387,16 +388,15 @@ impl<S: Snapshot> TxnEntryStore for SnapshotStore<S> {
             // Scan ts in (after_ts, start_ts].
             (Some(after_ts.next()), Some(self.start_ts))
         };
-        let scanner =
-            ScannerBuilder::new(self.snapshot.clone(), self.start_ts, false /* desc */)
-                .range(lower_bound, upper_bound)
-                .omit_value(false)
-                .fill_cache(self.fill_cache)
-                .isolation_level(self.isolation_level)
-                .bypass_locks(self.bypass_locks.clone())
-                .hint_min_ts(min_ts)
-                .hint_max_ts(max_ts)
-                .build_entry_scanner(after_ts, output_delete)?;
+        let scanner = ScannerBuilder::new(self.snapshot.clone(), self.start_ts)
+            .range(lower_bound, upper_bound)
+            .omit_value(false)
+            .fill_cache(self.fill_cache)
+            .isolation_level(self.isolation_level)
+            .bypass_locks(self.bypass_locks.clone())
+            .hint_min_ts(min_ts)
+            .hint_max_ts(max_ts)
+            .build_entry_scanner(after_ts, output_delete)?;
 
         Ok(scanner)
     }

--- a/tests/integrations/storage/test_titan.rs
+++ b/tests/integrations/storage/test_titan.rs
@@ -410,7 +410,7 @@ fn test_delete_files_in_range_for_titan() {
     r.set_start_key(b"a".to_vec());
     r.set_end_key(b"z".to_vec());
     let snapshot = RegionSnapshot::<RocksSnapshot>::from_raw(engines1.kv, r);
-    let mut scanner = ScannerBuilder::new(snapshot, 10.into(), false)
+    let mut scanner = ScannerBuilder::new(snapshot, 10.into())
         .range(Some(Key::from_raw(b"a")), None)
         .build()
         .unwrap();


### PR DESCRIPTION
Signed-off-by: Shashwat Jaiswal <shashwatjaiswal2001@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #5531

Problem Summary: Improperly structured Builder pattern.

### What is changed and how it works?

Proposal: Simple fix.
What's Changed: ```desc``` has been made optional (false by default) in ScannerConfig

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```