### PR TITLE
storage: do not report WriteConflict or PessimisticLockNotFound if txn is committed

### DIFF
--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -367,10 +367,9 @@ impl<K: PrewriteKind> Prewriter<K> {
         // Set extra op here for getting the write record when check write conflict in prewrite.
 
         let rows = self.mutations.len();
-        let (locks, final_min_commit_ts) =
-            self.prewrite(&mut txn, &mut reader, context.extra_op)?;
-
+        let res = self.prewrite(&mut txn, &mut reader, context.extra_op);
         context.statistics.add(&reader.take_statistics());
+        let (locks, final_min_commit_ts) = res?;
 
         Ok(self.write_result(
             locks,

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -10,7 +10,7 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{
         has_data_in_range, Error as MvccError, ErrorInner as MvccErrorInner, MvccTxn,
-        SnapshotReader,
+        Result as MvccResult, SnapshotReader, TxnCommitRecord,
     },
     txn::{
         actions::prewrite::{prewrite, CommitKind, TransactionKind, TransactionProperties},
@@ -26,7 +26,7 @@ use crate::storage::{
 use engine_traits::CF_WRITE;
 use kvproto::kvrpcpb::ExtraOp;
 use std::mem;
-use txn_types::{Key, Mutation, OldValues, TimeStamp, TxnExtra, Write, WriteType};
+use txn_types::{Key, Mutation, OldValue, OldValues, TimeStamp, TxnExtra, Write, WriteType};
 
 pub(crate) const FORWARD_MIN_MUTATIONS_NUM: usize = 12;
 
@@ -433,6 +433,30 @@ impl<K: PrewriteKind> Prewriter<K> {
         let mut final_min_commit_ts = TimeStamp::zero();
         let mut locks = Vec::new();
 
+        // Furthur check whether the prewrited transaction has been committed
+        // when encountering a WriteConflict or PessimisticLockNotFound error.
+        // This extra check manages to make prewrite idempotent after the transaction
+        // was committed.
+        // Note that this check cannot fully guarantee idempotence because an MVCC
+        // GC can remove the old committed records, then we cannot determine
+        // whether the transaction has been committed, so the error is still returned.
+        fn check_committed_record(
+            prewrite_result: MvccResult<(TimeStamp, OldValue)>,
+            reader: &mut SnapshotReader<impl Snapshot>,
+            key: &Key,
+        ) -> Result<(Vec<std::result::Result<(), StorageError>>, TimeStamp)> {
+            if let TxnCommitRecord::SingleRecord { commit_ts, .. } =
+                reader.get_txn_commit_record(key)?
+            {
+                info!("prewrited transaction has been committed";
+                    "start_ts" => reader.start_ts, "commit_ts" => commit_ts);
+                Ok((vec![], commit_ts))
+            } else {
+                prewrite_result?;
+                unreachable!()
+            }
+        }
+
         for m in mem::take(&mut self.mutations) {
             let is_pessimistic_lock = m.is_pessimistic_lock();
             let m = m.into_mutation();
@@ -456,6 +480,16 @@ impl<K: PrewriteKind> Prewriter<K> {
                         self.old_values
                             .insert(key, (old_value, Some(mutation_type)));
                     }
+                }
+                Err(MvccError(box MvccErrorInner::WriteConflict {
+                    start_ts,
+                    conflict_commit_ts,
+                    ..
+                })) if conflict_commit_ts > start_ts => {
+                    return check_committed_record(prewrite_result, reader, &key);
+                }
+                Err(MvccError(box MvccErrorInner::PessimisticLockNotFound { .. })) => {
+                    return check_committed_record(prewrite_result, reader, &key);
                 }
                 Err(MvccError(box MvccErrorInner::CommitTsTooLarge { .. })) | Ok((..)) => {
                     // fallback to not using async commit or 1pc
@@ -714,6 +748,10 @@ pub(in crate::storage::txn) fn fallback_1pc_locks(txn: &mut MvccTxn) {
 mod tests {
     use super::*;
     use crate::storage::txn::actions::acquire_pessimistic_lock::tests::must_pessimistic_locked;
+    use crate::storage::txn::actions::tests::{
+        must_pessimistic_prewrite_put_async_commit, must_prewrite_put,
+        must_prewrite_put_async_commit,
+    };
     use crate::storage::{
         mvcc::{tests::*, Error as MvccError, ErrorInner as MvccErrorInner},
         txn::{
@@ -721,14 +759,14 @@ mod tests {
             commands::test_util::{
                 commit, pessimistic_prewrite_with_cm, prewrite, prewrite_with_cm, rollback,
             },
-            tests::{must_acquire_pessimistic_lock, must_rollback},
+            tests::{must_acquire_pessimistic_lock, must_commit, must_rollback},
             Error, ErrorInner,
         },
-        Engine, Snapshot, Statistics, TestEngineBuilder,
+        DummyLockManager, Engine, Snapshot, Statistics, TestEngineBuilder,
     };
     use concurrency_manager::ConcurrencyManager;
     use engine_traits::CF_WRITE;
-    use kvproto::kvrpcpb::Context;
+    use kvproto::kvrpcpb::{Context, ExtraOp};
     use txn_types::{Key, Mutation, TimeStamp};
 
     fn inner_test_prewrite_skip_constraint_check(pri_key_number: u8, write_num: usize) {
@@ -1333,8 +1371,6 @@ mod tests {
     // this test shows which stage in raft can we return the response
     #[test]
     fn test_response_stage() {
-        use crate::storage::DummyLockManager;
-        use kvproto::kvrpcpb::ExtraOp;
         let cm = ConcurrencyManager::new(42.into());
         let start_ts = TimeStamp::new(10);
         let keys = [b"k1", b"k2"];
@@ -1461,6 +1497,196 @@ mod tests {
             let snap = engine.snapshot(Default::default()).unwrap();
             let result = cmd.cmd.process_write(snap, context).unwrap();
             assert_eq!(result.response_policy, case.expected);
+        }
+    }
+
+    #[test]
+    fn test_optimistic_prewrite_committed_transaction() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let cm = ConcurrencyManager::new(1.into());
+        let mut statistics = Statistics::default();
+
+        let key = b"k";
+
+        // T1: start_ts = 5, commit_ts = 10, async commit
+        must_prewrite_put_async_commit(&engine, key, b"v1", key, &Some(vec![]), 5, 10);
+        must_commit(&engine, key, 5, 10);
+
+        // T2: start_ts = 15, commit_ts = 16, 1PC
+        let cmd = Prewrite::with_1pc(
+            vec![Mutation::Put((Key::from_raw(key), b"v2".to_vec()))],
+            key.to_vec(),
+            15.into(),
+            TimeStamp::default(),
+        );
+        let result = prewrite_command(&engine, cm.clone(), &mut statistics, cmd).unwrap();
+        let one_pc_commit_ts = result.one_pc_commit_ts;
+
+        // T3 is after T1 and T2
+        must_prewrite_put(&engine, key, b"v3", key, 20);
+        must_commit(&engine, key, 20, 25);
+
+        // Repeating the T1 prewrite request
+        let cmd = Prewrite::new(
+            vec![Mutation::Put((Key::from_raw(key), b"v1".to_vec()))],
+            key.to_vec(),
+            5.into(),
+            200,
+            false,
+            1,
+            10.into(),
+            TimeStamp::default(),
+            Some(vec![]),
+            false,
+            Context::default(),
+        );
+        let context = WriteContext {
+            lock_mgr: &DummyLockManager {},
+            concurrency_manager: cm.clone(),
+            extra_op: ExtraOp::Noop,
+            statistics: &mut statistics,
+            async_apply_prewrite: false,
+        };
+        let snap = engine.snapshot(Default::default()).unwrap();
+        let result = cmd.cmd.process_write(snap, context).unwrap();
+        assert!(result.to_be_write.modifies.is_empty()); // should not make real modifies
+        assert!(result.lock_guards.is_empty());
+        match result.pr {
+            ProcessResult::PrewriteResult { result } => {
+                assert!(result.locks.is_empty());
+                assert_eq!(result.min_commit_ts, 10.into()); // equals to the real commit ts
+                assert_eq!(result.one_pc_commit_ts, 0.into()); // not using 1PC
+            }
+            res => panic!("unexpected result {:?}", res),
+        }
+
+        // Repeating the T2 prewrite request
+        let cmd = Prewrite::with_1pc(
+            vec![Mutation::Put((Key::from_raw(key), b"v2".to_vec()))],
+            key.to_vec(),
+            15.into(),
+            TimeStamp::default(),
+        );
+        let context = WriteContext {
+            lock_mgr: &DummyLockManager {},
+            concurrency_manager: cm,
+            extra_op: ExtraOp::Noop,
+            statistics: &mut statistics,
+            async_apply_prewrite: false,
+        };
+        let snap = engine.snapshot(Default::default()).unwrap();
+        let result = cmd.cmd.process_write(snap, context).unwrap();
+        assert!(result.to_be_write.modifies.is_empty()); // should not make real modifies
+        assert!(result.lock_guards.is_empty());
+        match result.pr {
+            ProcessResult::PrewriteResult { result } => {
+                assert!(result.locks.is_empty());
+                assert_eq!(result.min_commit_ts, 0.into()); // 1PC does not need this
+                assert_eq!(result.one_pc_commit_ts, one_pc_commit_ts); // equals to the previous 1PC commit_ts
+            }
+            res => panic!("unexpected result {:?}", res),
+        }
+    }
+
+    #[test]
+    fn test_pessimistic_prewrite_committed_transaction() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let cm = ConcurrencyManager::new(1.into());
+        let mut statistics = Statistics::default();
+
+        let key = b"k";
+
+        // T1: start_ts = 5, commit_ts = 10, async commit
+        must_acquire_pessimistic_lock(&engine, key, key, 5, 5);
+        must_pessimistic_prewrite_put_async_commit(
+            &engine,
+            key,
+            b"v1",
+            key,
+            &Some(vec![]),
+            5,
+            5,
+            true,
+            10,
+        );
+        must_commit(&engine, key, 5, 10);
+
+        // T2: start_ts = 15, commit_ts = 16, 1PC
+        must_acquire_pessimistic_lock(&engine, key, key, 15, 15);
+        let cmd = PrewritePessimistic::with_1pc(
+            vec![(Mutation::Put((Key::from_raw(key), b"v2".to_vec())), true)],
+            key.to_vec(),
+            15.into(),
+            15.into(),
+            TimeStamp::default(),
+        );
+        let result = prewrite_command(&engine, cm.clone(), &mut statistics, cmd).unwrap();
+        let one_pc_commit_ts = result.one_pc_commit_ts;
+
+        // T3 is after T1 and T2
+        must_prewrite_put(&engine, key, b"v3", key, 20);
+        must_commit(&engine, key, 20, 25);
+
+        // Repeating the T1 prewrite request
+        let cmd = PrewritePessimistic::new(
+            vec![(Mutation::Put((Key::from_raw(key), b"v1".to_vec())), true)],
+            key.to_vec(),
+            5.into(),
+            200,
+            5.into(),
+            1,
+            10.into(),
+            TimeStamp::default(),
+            Some(vec![]),
+            false,
+            Context::default(),
+        );
+        let context = WriteContext {
+            lock_mgr: &DummyLockManager {},
+            concurrency_manager: cm.clone(),
+            extra_op: ExtraOp::Noop,
+            statistics: &mut statistics,
+            async_apply_prewrite: false,
+        };
+        let snap = engine.snapshot(Default::default()).unwrap();
+        let result = cmd.cmd.process_write(snap, context).unwrap();
+        assert!(result.to_be_write.modifies.is_empty()); // should not make real modifies
+        assert!(result.lock_guards.is_empty());
+        match result.pr {
+            ProcessResult::PrewriteResult { result } => {
+                assert!(result.locks.is_empty());
+                assert_eq!(result.min_commit_ts, 10.into()); // equals to the real commit ts
+                assert_eq!(result.one_pc_commit_ts, 0.into()); // not using 1PC
+            }
+            res => panic!("unexpected result {:?}", res),
+        }
+
+        // Repeating the T2 prewrite request
+        let cmd = PrewritePessimistic::with_1pc(
+            vec![(Mutation::Put((Key::from_raw(key), b"v2".to_vec())), true)],
+            key.to_vec(),
+            15.into(),
+            15.into(),
+            TimeStamp::default(),
+        );
+        let context = WriteContext {
+            lock_mgr: &DummyLockManager {},
+            concurrency_manager: cm,
+            extra_op: ExtraOp::Noop,
+            statistics: &mut statistics,
+            async_apply_prewrite: false,
+        };
+        let snap = engine.snapshot(Default::default()).unwrap();
+        let result = cmd.cmd.process_write(snap, context).unwrap();
+        assert!(result.to_be_write.modifies.is_empty()); // should not make real modifies
+        assert!(result.lock_guards.is_empty());
+        match result.pr {
+            ProcessResult::PrewriteResult { result } => {
+                assert!(result.locks.is_empty());
+                assert_eq!(result.min_commit_ts, 0.into()); // 1PC does not need this
+                assert_eq!(result.one_pc_commit_ts, one_pc_commit_ts); // equals to the previous 1PC commit_ts
+            }
+            res => panic!("unexpected result {:?}", res),
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/tikv/tikv/issues/10468#issuecomment-869491061 mentioned that prewrite is not idempotent if the transaction has been committed.

### What is changed and how it works?

If GC has not cleared the old commit record, it is possible for us to determine whether the prewrite request is a repeated one and needn't report an error.

This PR checks the commit records after we encounter a WriteConflict or PessimisticLockNotFound error,

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU (on conflict or error cases)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Make prewrite as idempotent as possible to reduce the chance of undetermined errors.
```

### Benchmark

The most affected case should be conflicted optimistic case. (Though I think it's now not so common because pessimistic transactions are more suitable for high-conflict workloads).

I run go-ycsb zipfian _pure update_ workload on a 10,000 rows table with 256 threads.

This PR:

```
UPDATE - Takes(s): 10.0, Count: 93105, OPS: 9336.9, Avg(us): 18966, Min(us): 1543, Max(us): 453143, 99th(us): 192000, 99.9th(us): 339000, 99.99th(us): 407000
UPDATE_ERROR - Takes(s): 9.7, Count: 2508, OPS: 259.7, Avg(us): 300213, Min(us): 125987, Max(us): 462624, 99th(us): 431000, 99.9th(us): 458000, 99.99th(us): 463000
UPDATE - Takes(s): 20.0, Count: 186752, OPS: 9350.7, Avg(us): 18895, Min(us): 1543, Max(us): 453143, 99th(us): 193000, 99.9th(us): 341000, 99.99th(us): 411000
UPDATE_ERROR - Takes(s): 19.7, Count: 5122, OPS: 260.6, Avg(us): 302969, Min(us): 125987, Max(us): 506923, 99th(us): 434000, 99.9th(us): 466000, 99.99th(us): 507000
UPDATE - Takes(s): 30.0, Count: 273042, OPS: 9110.0, Avg(us): 19477, Min(us): 1300, Max(us): 3249883, 99th(us): 199000, 99.9th(us): 343000, 99.99th(us): 418000
UPDATE_ERROR - Takes(s): 29.7, Count: 7597, OPS: 256.2, Avg(us): 305794, Min(us): 119940, Max(us): 506923, 99th(us): 436000, 99.9th(us): 468000, 99.99th(us): 507000
UPDATE - Takes(s): 40.0, Count: 358257, OPS: 8962.8, Avg(us): 19725, Min(us): 1296, Max(us): 3249883, 99th(us): 200000, 99.9th(us): 347000, 99.99th(us): 422000
UPDATE_ERROR - Takes(s): 39.7, Count: 10140, OPS: 255.7, Avg(us): 309163, Min(us): 119940, Max(us): 3453809, 99th(us): 438000, 99.9th(us): 481000, 99.99th(us): 3425000
UPDATE - Takes(s): 50.0, Count: 444358, OPS: 8892.2, Avg(us): 19844, Min(us): 1283, Max(us): 3249883, 99th(us): 201000, 99.9th(us): 348000, 99.99th(us): 425000
UPDATE_ERROR - Takes(s): 49.7, Count: 12716, OPS: 256.1, Avg(us): 309749, Min(us): 119940, Max(us): 3453809, 99th(us): 439000, 99.9th(us): 493000, 99.99th(us): 3425000
UPDATE - Takes(s): 60.0, Count: 529690, OPS: 8832.1, Avg(us): 19904, Min(us): 1283, Max(us): 3249883, 99th(us): 202000, 99.9th(us): 349000, 99.99th(us): 423000
UPDATE_ERROR - Takes(s): 59.7, Count: 15374, OPS: 257.7, Avg(us): 310597, Min(us): 119940, Max(us): 3453809, 99th(us): 440000, 99.9th(us): 483000, 99.99th(us): 3425000
UPDATE - Takes(s): 70.0, Count: 612903, OPS: 8759.3, Avg(us): 20061, Min(us): 1283, Max(us): 3249883, 99th(us): 203000, 99.9th(us): 349000, 99.99th(us): 425000
UPDATE_ERROR - Takes(s): 69.7, Count: 17900, OPS: 257.0, Avg(us): 311746, Min(us): 119940, Max(us): 3483265, 99th(us): 443000, 99.9th(us): 493000, 99.99th(us): 3454000
UPDATE - Takes(s): 80.0, Count: 701883, OPS: 8776.6, Avg(us): 20039, Min(us): 1283, Max(us): 3249883, 99th(us): 203000, 99.9th(us): 349000, 99.99th(us): 423000
UPDATE_ERROR - Takes(s): 79.7, Count: 20454, OPS: 256.8, Avg(us): 311394, Min(us): 119940, Max(us): 3483265, 99th(us): 442000, 99.9th(us): 487000, 99.99th(us): 3425000
UPDATE - Takes(s): 90.0, Count: 791101, OPS: 8792.8, Avg(us): 20012, Min(us): 1283, Max(us): 3249883, 99th(us): 202000, 99.9th(us): 349000, 99.99th(us): 420000
UPDATE_ERROR - Takes(s): 89.7, Count: 23040, OPS: 257.0, Avg(us): 310968, Min(us): 119940, Max(us): 3483265, 99th(us): 441000, 99.9th(us): 485000, 99.99th(us): 3425000
UPDATE - Takes(s): 100.0, Count: 868321, OPS: 8685.4, Avg(us): 20208, Min(us): 1283, Max(us): 3249883, 99th(us): 205000, 99.9th(us): 354000, 99.99th(us): 449000
UPDATE_ERROR - Takes(s): 99.7, Count: 25482, OPS: 255.7, Avg(us): 314208, Min(us): 119940, Max(us): 3483265, 99th(us): 463000, 99.9th(us): 989000, 99.99th(us): 3425000
UPDATE - Takes(s): 110.0, Count: 947932, OPS: 8619.8, Avg(us): 20331, Min(us): 1283, Max(us): 3249883, 99th(us): 206000, 99.9th(us): 356000, 99.99th(us): 450000
UPDATE_ERROR - Takes(s): 109.7, Count: 28032, OPS: 255.6, Avg(us): 315396, Min(us): 119940, Max(us): 3483265, 99th(us): 470000, 99.9th(us): 980000, 99.99th(us): 3425000
UPDATE - Takes(s): 120.0, Count: 1029876, OPS: 8584.3, Avg(us): 20396, Min(us): 1283, Max(us): 3249883, 99th(us): 207000, 99.9th(us): 357000, 99.99th(us): 456000
UPDATE_ERROR - Takes(s): 119.7, Count: 30583, OPS: 255.6, Avg(us): 316032, Min(us): 119940, Max(us): 3483265, 99th(us): 481000, 99.9th(us): 969000, 99.99th(us): 3398000
UPDATE - Takes(s): 130.0, Count: 1112016, OPS: 8555.8, Avg(us): 20453, Min(us): 1283, Max(us): 3249883, 99th(us): 207000, 99.9th(us): 356000, 99.99th(us): 446000
UPDATE_ERROR - Takes(s): 129.7, Count: 33174, OPS: 255.9, Avg(us): 316163, Min(us): 119940, Max(us): 3483265, 99th(us): 473000, 99.9th(us): 942000, 99.99th(us): 3398000
UPDATE - Takes(s): 140.0, Count: 1191578, OPS: 8513.0, Avg(us): 20540, Min(us): 1283, Max(us): 3249883, 99th(us): 209000, 99.9th(us): 358000, 99.99th(us): 456000
UPDATE_ERROR - Takes(s): 139.7, Count: 35714, OPS: 255.7, Avg(us): 316844, Min(us): 119940, Max(us): 3483265, 99th(us): 484000, 99.9th(us): 937000, 99.99th(us): 3398000
UPDATE - Takes(s): 150.0, Count: 1266933, OPS: 8447.7, Avg(us): 20679, Min(us): 1279, Max(us): 3249883, 99th(us): 210000, 99.9th(us): 364000, 99.99th(us): 782000
UPDATE_ERROR - Takes(s): 149.7, Count: 38111, OPS: 254.7, Avg(us): 318931, Min(us): 119940, Max(us): 3483265, 99th(us): 505000, 99.9th(us): 1098000, 99.99th(us): 3398000
UPDATE - Takes(s): 160.0, Count: 1337995, OPS: 8363.9, Avg(us): 20834, Min(us): 1239, Max(us): 3249883, 99th(us): 212000, 99.9th(us): 367000, 99.99th(us): 781000
UPDATE_ERROR - Takes(s): 159.7, Count: 40548, OPS: 254.0, Avg(us): 320242, Min(us): 119940, Max(us): 3483265, 99th(us): 525000, 99.9th(us): 1095000, 99.99th(us): 3387000
UPDATE - Takes(s): 170.0, Count: 1416184, OPS: 8331.9, Avg(us): 20916, Min(us): 1239, Max(us): 3249883, 99th(us): 213000, 99.9th(us): 370000, 99.99th(us): 781000
UPDATE_ERROR - Takes(s): 169.7, Count: 43038, OPS: 253.7, Avg(us): 321703, Min(us): 119940, Max(us): 3483265, 99th(us): 550000, 99.9th(us): 1094000, 99.99th(us): 3371000
UPDATE - Takes(s): 180.0, Count: 1491944, OPS: 8289.9, Avg(us): 20990, Min(us): 1239, Max(us): 3249883, 99th(us): 214000, 99.9th(us): 371000, 99.99th(us): 778000
UPDATE_ERROR - Takes(s): 179.7, Count: 45633, OPS: 254.0, Avg(us): 322384, Min(us): 119940, Max(us): 3483265, 99th(us): 550000, 99.9th(us): 1094000, 99.99th(us): 3387000
UPDATE - Takes(s): 190.0, Count: 1570391, OPS: 8266.4, Avg(us): 21037, Min(us): 1239, Max(us): 3249883, 99th(us): 214000, 99.9th(us): 372000, 99.99th(us): 766000
UPDATE_ERROR - Takes(s): 189.7, Count: 48163, OPS: 253.9, Avg(us): 322818, Min(us): 119940, Max(us): 3483265, 99th(us): 548000, 99.9th(us): 1093000, 99.99th(us): 3387000
UPDATE - Takes(s): 200.0, Count: 1645466, OPS: 8228.3, Avg(us): 21123, Min(us): 1239, Max(us): 3249883, 99th(us): 215000, 99.9th(us): 373000, 99.99th(us): 756000
UPDATE_ERROR - Takes(s): 199.7, Count: 50603, OPS: 253.4, Avg(us): 323912, Min(us): 119940, Max(us): 3483265, 99th(us): 564000, 99.9th(us): 1089000, 99.99th(us): 3371000
UPDATE - Takes(s): 210.0, Count: 1726178, OPS: 8221.0, Avg(us): 21114, Min(us): 1239, Max(us): 3249883, 99th(us): 215000, 99.9th(us): 373000, 99.99th(us): 729000
UPDATE_ERROR - Takes(s): 209.7, Count: 53265, OPS: 254.1, Avg(us): 324031, Min(us): 119940, Max(us): 3483265, 99th(us): 557000, 99.9th(us): 1087000, 99.99th(us): 3371000
UPDATE - Takes(s): 220.0, Count: 1805384, OPS: 8207.2, Avg(us): 21127, Min(us): 1239, Max(us): 3249883, 99th(us): 215000, 99.9th(us): 372000, 99.99th(us): 729000
UPDATE_ERROR - Takes(s): 219.7, Count: 55924, OPS: 254.6, Avg(us): 324088, Min(us): 119940, Max(us): 3483265, 99th(us): 550000, 99.9th(us): 1087000, 99.99th(us): 3371000
```

Master:

```
UPDATE - Takes(s): 10.0, Count: 95809, OPS: 9610.2, Avg(us): 18355, Min(us): 1440, Max(us): 452292, 99th(us): 184000, 99.9th(us): 323000, 99.99th(us): 358000
UPDATE_ERROR - Takes(s): 9.7, Count: 2543, OPS: 263.4, Avg(us): 301359, Min(us): 133746, Max(us): 482745, 99th(us): 425000, 99.9th(us): 454000, 99.99th(us): 483000
UPDATE - Takes(s): 20.0, Count: 186519, OPS: 9342.9, Avg(us): 18612, Min(us): 1430, Max(us): 452292, 99th(us): 191000, 99.9th(us): 341000, 99.99th(us): 410000
UPDATE_ERROR - Takes(s): 19.6, Count: 5286, OPS: 269.0, Avg(us): 304839, Min(us): 133746, Max(us): 492736, 99th(us): 434000, 99.9th(us): 468000, 99.99th(us): 493000
UPDATE - Takes(s): 30.0, Count: 277143, OPS: 9249.1, Avg(us): 18814, Min(us): 1430, Max(us): 3413618, 99th(us): 192000, 99.9th(us): 343000, 99.99th(us): 421000
UPDATE_ERROR - Takes(s): 29.6, Count: 7920, OPS: 267.1, Avg(us): 306803, Min(us): 133746, Max(us): 3317775, 99th(us): 434000, 99.9th(us): 468000, 99.99th(us): 3318000
UPDATE - Takes(s): 40.0, Count: 365921, OPS: 9156.4, Avg(us): 19043, Min(us): 1430, Max(us): 3413618, 99th(us): 194000, 99.9th(us): 344000, 99.99th(us): 416000
UPDATE_ERROR - Takes(s): 39.6, Count: 10508, OPS: 265.0, Avg(us): 307602, Min(us): 133746, Max(us): 3317775, 99th(us): 437000, 99.9th(us): 471000, 99.99th(us): 504000
UPDATE - Takes(s): 50.0, Count: 453599, OPS: 9078.5, Avg(us): 19179, Min(us): 1298, Max(us): 3413618, 99th(us): 196000, 99.9th(us): 345000, 99.99th(us): 413000
UPDATE_ERROR - Takes(s): 49.6, Count: 13147, OPS: 264.8, Avg(us): 308861, Min(us): 133746, Max(us): 3317775, 99th(us): 438000, 99.9th(us): 472000, 99.99th(us): 504000
UPDATE - Takes(s): 60.0, Count: 540580, OPS: 9014.9, Avg(us): 19311, Min(us): 1253, Max(us): 3413618, 99th(us): 198000, 99.9th(us): 348000, 99.99th(us): 416000
UPDATE_ERROR - Takes(s): 59.6, Count: 15758, OPS: 264.2, Avg(us): 309459, Min(us): 133746, Max(us): 3317775, 99th(us): 440000, 99.9th(us): 476000, 99.99th(us): 504000
UPDATE - Takes(s): 70.0, Count: 626236, OPS: 8950.9, Avg(us): 19443, Min(us): 1253, Max(us): 3413618, 99th(us): 198000, 99.9th(us): 349000, 99.99th(us): 417000
UPDATE_ERROR - Takes(s): 69.6, Count: 18367, OPS: 263.7, Avg(us): 310378, Min(us): 126970, Max(us): 3317775, 99th(us): 442000, 99.9th(us): 477000, 99.99th(us): 517000
UPDATE - Takes(s): 80.0, Count: 711504, OPS: 8897.8, Avg(us): 19585, Min(us): 1235, Max(us): 3413618, 99th(us): 199000, 99.9th(us): 349000, 99.99th(us): 415000
UPDATE_ERROR - Takes(s): 79.6, Count: 20906, OPS: 262.5, Avg(us): 311106, Min(us): 126970, Max(us): 3318026, 99th(us): 442000, 99.9th(us): 478000, 99.99th(us): 504000
UPDATE - Takes(s): 90.0, Count: 796359, OPS: 8852.0, Avg(us): 19693, Min(us): 1223, Max(us): 3413618, 99th(us): 200000, 99.9th(us): 349000, 99.99th(us): 419000
UPDATE_ERROR - Takes(s): 89.6, Count: 23459, OPS: 261.7, Avg(us): 311654, Min(us): 126970, Max(us): 3318026, 99th(us): 443000, 99.9th(us): 478000, 99.99th(us): 517000
UPDATE - Takes(s): 100.0, Count: 876086, OPS: 8764.0, Avg(us): 19884, Min(us): 1223, Max(us): 3413618, 99th(us): 202000, 99.9th(us): 353000, 99.99th(us): 445000
UPDATE_ERROR - Takes(s): 99.6, Count: 25875, OPS: 259.7, Avg(us): 314398, Min(us): 126970, Max(us): 3339014, 99th(us): 455000, 99.9th(us): 853000, 99.99th(us): 3318000
UPDATE - Takes(s): 110.0, Count: 956537, OPS: 8698.3, Avg(us): 20026, Min(us): 1223, Max(us): 3413618, 99th(us): 204000, 99.9th(us): 354000, 99.99th(us): 448000
UPDATE_ERROR - Takes(s): 109.7, Count: 28380, OPS: 258.8, Avg(us): 315641, Min(us): 120200, Max(us): 3339014, 99th(us): 461000, 99.9th(us): 850000, 99.99th(us): 3318000
UPDATE - Takes(s): 120.0, Count: 1039149, OPS: 8662.1, Avg(us): 20083, Min(us): 1223, Max(us): 3413618, 99th(us): 204000, 99.9th(us): 355000, 99.99th(us): 449000
UPDATE_ERROR - Takes(s): 119.6, Count: 31003, OPS: 259.1, Avg(us): 316235, Min(us): 120200, Max(us): 3339014, 99th(us): 465000, 99.9th(us): 843000, 99.99th(us): 997000
UPDATE - Takes(s): 130.0, Count: 1123734, OPS: 8646.5, Avg(us): 20102, Min(us): 1223, Max(us): 3413618, 99th(us): 204000, 99.9th(us): 356000, 99.99th(us): 447000
UPDATE_ERROR - Takes(s): 129.6, Count: 33654, OPS: 259.6, Avg(us): 316329, Min(us): 120200, Max(us): 3339014, 99th(us): 463000, 99.9th(us): 841000, 99.99th(us): 997000
UPDATE - Takes(s): 140.0, Count: 1197992, OPS: 8559.3, Avg(us): 20272, Min(us): 1223, Max(us): 3413618, 99th(us): 206000, 99.9th(us): 361000, 99.99th(us): 469000
UPDATE_ERROR - Takes(s): 139.6, Count: 36141, OPS: 258.8, Avg(us): 318394, Min(us): 120200, Max(us): 3339014, 99th(us): 477000, 99.9th(us): 839000, 99.99th(us): 997000
UPDATE - Takes(s): 150.0, Count: 1269412, OPS: 8464.8, Avg(us): 20488, Min(us): 1223, Max(us): 3413618, 99th(us): 210000, 99.9th(us): 376000, 99.99th(us): 573000
UPDATE_ERROR - Takes(s): 149.6, Count: 38445, OPS: 256.9, Avg(us): 321121, Min(us): 120200, Max(us): 3339014, 99th(us): 568000, 99.9th(us): 865000, 99.99th(us): 1104000
UPDATE - Takes(s): 160.0, Count: 1349012, OPS: 8433.2, Avg(us): 20565, Min(us): 1223, Max(us): 3413618, 99th(us): 211000, 99.9th(us): 377000, 99.99th(us): 601000
UPDATE_ERROR - Takes(s): 159.6, Count: 40867, OPS: 256.0, Avg(us): 322217, Min(us): 120200, Max(us): 3339014, 99th(us): 675000, 99.9th(us): 866000, 99.99th(us): 1052000
UPDATE - Takes(s): 170.0, Count: 1421234, OPS: 8361.9, Avg(us): 20728, Min(us): 1223, Max(us): 3413618, 99th(us): 212000, 99.9th(us): 379000, 99.99th(us): 589000
UPDATE_ERROR - Takes(s): 169.6, Count: 43308, OPS: 255.3, Avg(us): 323423, Min(us): 120200, Max(us): 3339014, 99th(us): 664000, 99.9th(us): 864000, 99.99th(us): 1052000
UPDATE - Takes(s): 180.0, Count: 1499722, OPS: 8333.5, Avg(us): 20800, Min(us): 1223, Max(us): 3413618, 99th(us): 213000, 99.9th(us): 382000, 99.99th(us): 602000
UPDATE_ERROR - Takes(s): 179.6, Count: 45779, OPS: 254.8, Avg(us): 324046, Min(us): 120200, Max(us): 3339014, 99th(us): 681000, 99.9th(us): 862000, 99.99th(us): 1052000
UPDATE - Takes(s): 190.0, Count: 1580185, OPS: 8318.4, Avg(us): 20842, Min(us): 1223, Max(us): 3413618, 99th(us): 213000, 99.9th(us): 381000, 99.99th(us): 589000
UPDATE_ERROR - Takes(s): 189.6, Count: 48273, OPS: 254.5, Avg(us): 324276, Min(us): 120200, Max(us): 3339014, 99th(us): 673000, 99.9th(us): 859000, 99.99th(us): 1052000
UPDATE - Takes(s): 200.0, Count: 1661331, OPS: 8308.1, Avg(us): 20876, Min(us): 1223, Max(us): 3413618, 99th(us): 214000, 99.9th(us): 381000, 99.99th(us): 582000
UPDATE_ERROR - Takes(s): 199.6, Count: 50754, OPS: 254.2, Avg(us): 324420, Min(us): 120200, Max(us): 3339014, 99th(us): 663000, 99.9th(us): 857000, 99.99th(us): 1052000
UPDATE - Takes(s): 210.0, Count: 1734926, OPS: 8263.0, Avg(us): 20991, Min(us): 1223, Max(us): 3413618, 99th(us): 215000, 99.9th(us): 385000, 99.99th(us): 592000
UPDATE_ERROR - Takes(s): 209.6, Count: 53149, OPS: 253.5, Avg(us): 325355, Min(us): 120200, Max(us): 3339014, 99th(us): 678000, 99.9th(us): 853000, 99.99th(us): 1052000
UPDATE - Takes(s): 220.0, Count: 1814176, OPS: 8247.5, Avg(us): 21040, Min(us): 1223, Max(us): 3413618, 99th(us): 215000, 99.9th(us): 384000, 99.99th(us): 585000
UPDATE_ERROR - Takes(s): 219.7, Count: 55610, OPS: 253.2, Avg(us): 325429, Min(us): 120200, Max(us): 3339014, 99th(us): 668000, 99.9th(us): 852000, 99.99th(us): 1052000
UPDATE - Takes(s): 230.0, Count: 1883713, OPS: 8191.3, Avg(us): 21178, Min(us): 1223, Max(us): 3413618, 99th(us): 216000, 99.9th(us): 385000, 99.99th(us): 586000
UPDATE_ERROR - Takes(s): 229.6, Count: 57888, OPS: 252.1, Avg(us): 327065, Min(us): 120200, Max(us): 3339014, 99th(us): 684000, 99.9th(us): 855000, 99.99th(us): 1052000
UPDATE - Takes(s): 240.0, Count: 1961110, OPS: 8172.4, Avg(us): 21221, Min(us): 1223, Max(us): 3413618, 99th(us): 216000, 99.9th(us): 385000, 99.99th(us): 580000
```

The difference is not so significant.