### PR TITLE
test: fix unstable test test_report_approximate_size_after_split_check

### DIFF
--- a/tests/failpoints/cases/test_split_region.rs
+++ b/tests/failpoints/cases/test_split_region.rs
@@ -685,7 +685,7 @@ fn test_report_approximate_size_after_split_check() {
         .get_region_approximate_keys(region_id)
         .unwrap_or_default();
     assert!(approximate_size == 0 && approximate_keys == 0);
-    let (tx, rx) = mpsc::sync_channel(10);
+    let (tx, rx) = mpsc::channel();
     let tx = Arc::new(Mutex::new(tx));
 
     fail::cfg_callback("on_split_region_check_tick", move || {


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #10511 #10447 

Problem Summary:

The test failed because timeout of `cluster.batch_put`, before calling `cluster.batch_put`, the test setup the `failpoint` which sending msg to the sender of a `sync_channel(10)` but only receive the values after `cluster.batch_put`. If the `failpoint` trigger multiple times and call `send` more than 10 times, any incoming `failpoint` trigger will be blocking and cause `raftstore` stuck.

### What is changed and how it works?

What's Changed:

Replace `mpsc::sync_channel` with `mpsc::channel`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```