### PR TITLE
Make it possible to launch tikv-server with non-rocks KV engines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4244,6 +4244,7 @@ dependencies = [
  "crossbeam",
  "encryption",
  "encryption_export",
+ "engine_panic",
  "engine_rocks",
  "engine_traits",
  "error_code",

--- a/components/engine_panic/src/engine.rs
+++ b/components/engine_panic/src/engine.rs
@@ -20,9 +20,6 @@ impl KvEngine for PanicEngine {
     fn sync(&self) -> Result<()> {
         panic!()
     }
-    fn bad_downcast<T: 'static>(&self) -> &T {
-        panic!()
-    }
 }
 
 impl Peekable for PanicEngine {

--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -1,6 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::any::Any;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -103,11 +102,6 @@ impl KvEngine for RocksEngine {
 
     fn reset_statistics(&self) {
         self.db.reset_statistics();
-    }
-
-    fn bad_downcast<T: 'static>(&self) -> &T {
-        let e: &dyn Any = &self.db;
-        e.downcast_ref().expect("bad engine downcast")
     }
 }
 

--- a/components/engine_traits/src/engine.rs
+++ b/components/engine_traits/src/engine.rs
@@ -1,5 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::any::Any;
 use std::fmt::Debug;
 
 use crate::*;
@@ -52,7 +53,9 @@ pub trait KvEngine:
 
     /// Cast to a concrete engine type
     ///
-    /// This only exists as a temporary hack during refactoring.
-    /// It cannot be used forever.
-    fn bad_downcast<T: 'static>(&self) -> &T;
+    /// This is used for a few temporary purposes in tikv.
+    fn bad_downcast<T: KvEngine>(&self) -> Option<&T> {
+        let e: &dyn Any = self;
+        e.downcast_ref()
+    }
 }

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -23,6 +23,7 @@ protobuf-codec = [
   "cdc/protobuf-codec",
   "concurrency_manager/protobuf-codec",
   "encryption_export/protobuf-codec",
+  "engine_panic/protobuf-codec",
   "engine_rocks/protobuf-codec",
   "engine_traits/protobuf-codec",
   "error_code/protobuf-codec",
@@ -44,6 +45,7 @@ prost-codec = [
   "cdc/prost-codec",
   "concurrency_manager/prost-codec",
   "encryption_export/prost-codec",
+  "engine_panic/prost-codec",
   "engine_rocks/prost-codec",
   "engine_traits/prost-codec",
   "error_code/prost-codec",
@@ -80,6 +82,7 @@ concurrency_manager = { path = "../concurrency_manager", default-features = fals
 crossbeam = "0.8"
 encryption = { path = "../encryption", default-features = false }
 encryption_export = { path = "../encryption/export", default-features = false }
+engine_panic = { path = "../engine_panic", default-features = false }
 engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 error_code = { path = "../error_code", default-features = false }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -31,7 +31,7 @@ use encryption_export::{data_key_manager_from_config, DataKeyManager};
 use engine_rocks::{from_rocks_compression_type, get_env, RocksEngine};
 use engine_traits::{
     compaction_job::CompactionJobInfo, CFOptionsExt, ColumnFamilyOptions, Engines, MiscExt,
-    RaftEngine, CF_DEFAULT, CF_LOCK, CF_WRITE,
+    RaftEngine, CF_DEFAULT, CF_LOCK, CF_WRITE, KvEngine,
 };
 use error_code::ErrorCodeExt;
 use file_system::{
@@ -174,7 +174,7 @@ struct TiKVServer<ER: RaftEngine> {
     store_path: PathBuf,
     snap_mgr: Option<SnapManager>, // Will be filled in `init_servers`.
     encryption_key_manager: Option<Arc<DataKeyManager>>,
-    engines: Option<TiKVEngines<ER>>,
+    engines: Option<TiKVEngines<RocksEngine, ER>>,
     servers: Option<Servers<ER>>,
     region_info_accessor: RegionInfoAccessor,
     coprocessor_host: Option<CoprocessorHost<RocksEngine>>,
@@ -185,10 +185,10 @@ struct TiKVServer<ER: RaftEngine> {
     background_worker: Worker,
 }
 
-struct TiKVEngines<ER: RaftEngine> {
-    engines: Engines<RocksEngine, ER>,
+struct TiKVEngines<EK: KvEngine, ER: RaftEngine> {
+    engines: Engines<EK, ER>,
     store_meta: Arc<Mutex<StoreMeta>>,
-    engine: RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>,
+    engine: RaftKv<EK, ServerRaftStoreRouter<EK, ER>>,
 }
 
 struct Servers<ER: RaftEngine> {
@@ -1433,10 +1433,10 @@ impl<R: RaftEngine> EngineMetricsManager<R> {
     }
 
     pub fn flush(&mut self, now: Instant) {
-        self.engines.kv.flush_metrics("kv");
+        KvEngine::flush_metrics(&self.engines.kv, "kv");
         self.engines.raft.flush_metrics("raft");
         if now.saturating_duration_since(self.last_reset) >= DEFAULT_ENGINE_METRICS_RESET_INTERVAL {
-            self.engines.kv.reset_statistics();
+            KvEngine::reset_statistics(&self.engines.kv);
             self.engines.raft.reset_statistics();
             self.last_reset = now;
         }

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1126,6 +1126,13 @@ impl<EK: KvEngine + CreateKvEngine<ER>, ER: RaftEngine> TiKVServer<EK, ER> {
 
 }
 
+/// Encapsulates differences in server startup between KV engines.
+///
+/// This mostly exists because there is not feature parity between
+/// engine_rocks and engine_traits, with some features not being fully
+/// abstracted. In the short term, TiKV should be able to operate
+/// without those features, but in the long term, they need to be implemented
+/// for all engines, and this trait reduced or deleted.
 trait CreateKvEngine<ER>: KvEngine where ER: RaftEngine {
     fn create_kv_engine(config: &TiKvConfig,
                         region_info_accessor: &RegionInfoAccessor,

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1232,11 +1232,13 @@ where EK: KvEngine + CreateKvEngine<ER>,
     }
 }
 
-impl TiKVServer<RocksEngine, RocksEngine> {
+impl<EK> TiKVServer<EK, RocksEngine>
+where EK: KvEngine + CreateKvEngine<RocksEngine>
+{
     fn init_raw_engines(
         &mut self,
         limiter: Option<Arc<IORateLimiter>>,
-    ) -> (Engines<RocksEngine, RocksEngine>, Arc<EnginesResourceInfo<RocksEngine>>) {
+    ) -> (Engines<EK, RocksEngine>, Arc<EnginesResourceInfo<EK>>) {
         let env = get_env(self.encryption_key_manager.clone(), limiter).unwrap();
         let block_cache = self.config.storage.block_cache.build_shared_cache();
 
@@ -1284,13 +1286,15 @@ impl TiKVServer<RocksEngine, RocksEngine> {
     }
 }
 
-impl TiKVServer<RocksEngine, RaftLogEngine> {
+impl<EK> TiKVServer<EK, RaftLogEngine>
+where EK: KvEngine + CreateKvEngine<RaftLogEngine>
+{
     fn init_raw_engines(
         &mut self,
         limiter: Option<Arc<IORateLimiter>>,
     ) -> (
-        Engines<RocksEngine, RaftLogEngine>,
-        Arc<EnginesResourceInfo<RocksEngine>>,
+        Engines<EK, RaftLogEngine>,
+        Arc<EnginesResourceInfo<EK>>,
     ) {
         let env = get_env(self.encryption_key_manager.clone(), limiter).unwrap();
         let block_cache = self.config.storage.block_cache.build_shared_cache();

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1028,7 +1028,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         engines_info: Arc<EnginesResourceInfo>,
     ) {
         let mut engine_metrics =
-            EngineMetricsManager::new(self.engines.as_ref().unwrap().engines.clone());
+            EngineMetricsManager::<RocksEngine, ER>::new(self.engines.as_ref().unwrap().engines.clone());
         let mut io_metrics = IOMetricsManager::new(fetcher);
         self.background_worker
             .spawn_interval_task(DEFAULT_METRICS_FLUSH_INTERVAL, move || {
@@ -1419,13 +1419,13 @@ impl<T: fmt::Display + Send + 'static> Stop for LazyWorker<T> {
     }
 }
 
-pub struct EngineMetricsManager<R: RaftEngine> {
-    engines: Engines<RocksEngine, R>,
+pub struct EngineMetricsManager<EK: KvEngine, R: RaftEngine> {
+    engines: Engines<EK, R>,
     last_reset: Instant,
 }
 
-impl<R: RaftEngine> EngineMetricsManager<R> {
-    pub fn new(engines: Engines<RocksEngine, R>) -> Self {
+impl<EK: KvEngine, R: RaftEngine> EngineMetricsManager<EK, R> {
+    pub fn new(engines: Engines<EK, R>) -> Self {
         EngineMetricsManager {
             engines,
             last_reset: Instant::now(),

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1213,9 +1213,12 @@ impl<ER> CreateKvEngine<ER> for RocksEngine where ER: RaftEngine {
     }
 }
 
-impl<ER: RaftEngine> TiKVServer<RocksEngine, ER> {
-    fn create_kv_engine(&self, env: Arc<engine_rocks::raw::Env>, block_cache: &Option<engine_rocks::raw::Cache>) -> RocksEngine {
-        RocksEngine::create_kv_engine(
+impl<EK, ER> TiKVServer<EK, ER>
+where EK: KvEngine + CreateKvEngine<ER>,
+      ER: RaftEngine
+{
+    fn create_kv_engine(&self, env: Arc<engine_rocks::raw::Env>, block_cache: &Option<engine_rocks::raw::Cache>) -> EK {
+        EK::create_kv_engine(
             &self.config,
             &self.region_info_accessor,
             &self.store_path,
@@ -1224,8 +1227,8 @@ impl<ER: RaftEngine> TiKVServer<RocksEngine, ER> {
             block_cache)
     }
 
-    fn register_kv_config(&mut self, kv_engine: RocksEngine) {
-        <RocksEngine as CreateKvEngine<ER>>::register_kv_config(&kv_engine, &self.config, &mut self.cfg_controller)
+    fn register_kv_config(&mut self, kv_engine: EK) {
+        <EK as CreateKvEngine<ER>>::register_kv_config(&kv_engine, &self.config, &mut self.cfg_controller)
     }
 }
 

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -193,16 +193,16 @@ struct TiKVEngines<EK: KvEngine, ER: RaftEngine> {
 
 struct Servers<ER: RaftEngine> {
     lock_mgr: LockManager,
-    server: LocalServer<ER>,
+    server: LocalServer<RocksEngine, ER>,
     node: Node<RpcClient, ER>,
     importer: Arc<SSTImporter>,
     cdc_scheduler: tikv_util::worker::Scheduler<cdc::Task>,
     cdc_memory_quota: MemoryQuota,
 }
 
-type LocalServer<ER> =
-    Server<RaftRouter<RocksEngine, ER>, resolve::PdStoreAddrResolver, LocalRaftKv<ER>>;
-type LocalRaftKv<ER> = RaftKv<RocksEngine, ServerRaftStoreRouter<RocksEngine, ER>>;
+type LocalServer<EK, ER> =
+    Server<RaftRouter<EK, ER>, resolve::PdStoreAddrResolver, LocalRaftKv<EK, ER>>;
+type LocalRaftKv<EK, ER> = RaftKv<EK, ServerRaftStoreRouter<EK, ER>>;
 
 impl<ER: RaftEngine> TiKVServer<ER> {
     fn init(mut config: TiKvConfig) -> TiKVServer<ER> {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -175,7 +175,7 @@ struct TiKVServer<ER: RaftEngine> {
     snap_mgr: Option<SnapManager>, // Will be filled in `init_servers`.
     encryption_key_manager: Option<Arc<DataKeyManager>>,
     engines: Option<TiKVEngines<RocksEngine, ER>>,
-    servers: Option<Servers<ER>>,
+    servers: Option<Servers<RocksEngine, ER>>,
     region_info_accessor: RegionInfoAccessor,
     coprocessor_host: Option<CoprocessorHost<RocksEngine>>,
     to_stop: Vec<Box<dyn Stop>>,
@@ -191,9 +191,9 @@ struct TiKVEngines<EK: KvEngine, ER: RaftEngine> {
     engine: RaftKv<EK, ServerRaftStoreRouter<EK, ER>>,
 }
 
-struct Servers<ER: RaftEngine> {
+struct Servers<EK: KvEngine, ER: RaftEngine> {
     lock_mgr: LockManager,
-    server: LocalServer<RocksEngine, ER>,
+    server: LocalServer<EK, ER>,
     node: Node<RpcClient, ER>,
     importer: Arc<SSTImporter>,
     cdc_scheduler: tikv_util::worker::Scheduler<cdc::Task>,

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -194,7 +194,7 @@ struct TiKVEngines<EK: KvEngine, ER: RaftEngine> {
 struct Servers<EK: KvEngine, ER: RaftEngine> {
     lock_mgr: LockManager,
     server: LocalServer<EK, ER>,
-    node: Node<RpcClient, ER>,
+    node: Node<RpcClient, EK, ER>,
     importer: Arc<SSTImporter>,
     cdc_scheduler: tikv_util::worker::Scheduler<cdc::Task>,
     cdc_memory_quota: MemoryQuota,

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1036,7 +1036,7 @@ impl<EK: KvEngine, ER: RaftEngine> TiKVServer<EK, ER> {
             });
     }
 
-    fn init_storage_stats_task(&self, engines: Engines<RocksEngine, ER>) {
+    fn init_storage_stats_task(&self, engines: Engines<EK, ER>) {
         let config_disk_capacity: u64 = self.config.raft_store.capacity.0;
         let store_path = self.store_path.clone();
         let snap_mgr = self.snap_mgr.clone().unwrap();

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -975,30 +975,34 @@ impl<ER: RaftEngine> TiKVServer<ER> {
             .unwrap_or_else(|e| fatal!("failed to start lock manager: {}", e));
 
         // Backup service.
-        let mut backup_worker = Box::new(self.background_worker.lazy_build("backup-endpoint"));
-        let backup_scheduler = backup_worker.scheduler();
-        let backup_service = backup::Service::new(backup_scheduler);
-        if servers
-            .server
-            .register_service(create_backup(backup_service))
-            .is_some()
-        {
-            fatal!("failed to register backup service");
-        }
+        if let Some(kv) = engines.engines.kv.bad_downcast::<RocksEngine>() {
+            let raw_rocks_engine = kv.as_inner().clone();
 
-        let backup_endpoint = backup::Endpoint::new(
-            servers.node.id(),
-            engines.engine.clone(),
-            self.region_info_accessor.clone(),
-            engines.engines.kv.as_inner().clone(),
-            self.config.backup.clone(),
-            self.concurrency_manager.clone(),
-        );
-        self.cfg_controller.as_mut().unwrap().register(
-            tikv::config::Module::Backup,
-            Box::new(backup_endpoint.get_config_manager()),
-        );
-        backup_worker.start(backup_endpoint);
+            let mut backup_worker = Box::new(self.background_worker.lazy_build("backup-endpoint"));
+            let backup_scheduler = backup_worker.scheduler();
+            let backup_service = backup::Service::new(backup_scheduler);
+            if servers
+                .server
+                .register_service(create_backup(backup_service))
+                .is_some()
+            {
+                fatal!("failed to register backup service");
+            }
+
+            let backup_endpoint = backup::Endpoint::new(
+                servers.node.id(),
+                engines.engine.clone(),
+                self.region_info_accessor.clone(),
+                raw_rocks_engine,
+                self.config.backup.clone(),
+                self.concurrency_manager.clone(),
+            );
+            self.cfg_controller.as_mut().unwrap().register(
+                tikv::config::Module::Backup,
+                Box::new(backup_endpoint.get_config_manager()),
+            );
+            backup_worker.start(backup_endpoint);
+        }
 
         let cdc_service = cdc::Service::new(
             servers.cdc_scheduler.clone(),

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -152,6 +152,7 @@ pub fn run_tikv(config: TiKvConfig) {
     // and that the ability to launch with kv as PanicEngine mostly
     // exists to prove that alternate engines can typecheck,
     // while other engines are in development.
+    #[allow(clippy::collapsible_else_if)]
     if std::env::var("TIKV_USE_PANIC_KV_ENGINE").ok().is_none() {
         if !config.raft_engine.enable {
             run_impl!(RocksEngine, RocksEngine)

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -30,7 +30,7 @@ use concurrency_manager::ConcurrencyManager;
 use encryption_export::{data_key_manager_from_config, DataKeyManager};
 use engine_rocks::{from_rocks_compression_type, get_env, RocksEngine};
 use engine_traits::{
-    compaction_job::CompactionJobInfo, CFOptionsExt, ColumnFamilyOptions, Engines, MiscExt,
+    compaction_job::CompactionJobInfo, ColumnFamilyOptions, Engines, MiscExt,
     RaftEngine, CF_DEFAULT, CF_LOCK, CF_WRITE, KvEngine,
 };
 use error_code::ErrorCodeExt;
@@ -1014,7 +1014,7 @@ impl<EK: KvEngine, ER: RaftEngine> TiKVServer<EK, ER> {
     fn init_metrics_flusher(
         &mut self,
         fetcher: BytesFetcher,
-        engines_info: Arc<EnginesResourceInfo>,
+        engines_info: Arc<EnginesResourceInfo<EK>>,
     ) {
         let mut engine_metrics =
             EngineMetricsManager::<EK, ER>::new(self.engines.as_ref().unwrap().engines.clone());
@@ -1199,7 +1199,7 @@ impl TiKVServer<RocksEngine, RocksEngine> {
     fn init_raw_engines(
         &mut self,
         limiter: Option<Arc<IORateLimiter>>,
-    ) -> (Engines<RocksEngine, RocksEngine>, Arc<EnginesResourceInfo>) {
+    ) -> (Engines<RocksEngine, RocksEngine>, Arc<EnginesResourceInfo<RocksEngine>>) {
         let env = get_env(self.encryption_key_manager.clone(), limiter).unwrap();
         let block_cache = self.config.storage.block_cache.build_shared_cache();
 
@@ -1253,7 +1253,7 @@ impl TiKVServer<RocksEngine, RaftLogEngine> {
         limiter: Option<Arc<IORateLimiter>>,
     ) -> (
         Engines<RocksEngine, RaftLogEngine>,
-        Arc<EnginesResourceInfo>,
+        Arc<EnginesResourceInfo<RocksEngine>>,
     ) {
         let env = get_env(self.encryption_key_manager.clone(), limiter).unwrap();
         let block_cache = self.config.storage.block_cache.build_shared_cache();
@@ -1422,18 +1422,18 @@ impl<EK: KvEngine, R: RaftEngine> EngineMetricsManager<EK, R> {
     }
 }
 
-pub struct EnginesResourceInfo {
-    kv_engine: RocksEngine,
+pub struct EnginesResourceInfo<EK: KvEngine> {
+    kv_engine: EK,
     raft_engine: Option<RocksEngine>,
     latest_normalized_pending_bytes: AtomicU32,
     normalized_pending_bytes_collector: MovingAvgU32,
 }
 
-impl EnginesResourceInfo {
+impl<EK: KvEngine> EnginesResourceInfo<EK> {
     const SCALE_FACTOR: u64 = 100;
 
     pub fn new(
-        kv_engine: RocksEngine,
+        kv_engine: EK,
         raft_engine: Option<RocksEngine>,
         max_samples_to_preserve: usize,
     ) -> Self {
@@ -1448,13 +1448,13 @@ impl EnginesResourceInfo {
     pub fn update(&self, _now: Instant) {
         let mut normalized_pending_bytes = 0;
 
-        fn fetch_engine_cf(engine: &RocksEngine, cf: &str, normalized_pending_bytes: &mut u32) {
+        fn fetch_engine_cf<EK: KvEngine>(engine: &EK, cf: &str, normalized_pending_bytes: &mut u32) {
             if let Ok(cf_opts) = engine.get_options_cf(cf) {
                 if let Ok(Some(b)) = engine.get_cf_compaction_pending_bytes(cf) {
                     if cf_opts.get_soft_pending_compaction_bytes_limit() > 0 {
                         *normalized_pending_bytes = std::cmp::max(
                             *normalized_pending_bytes,
-                            (b * EnginesResourceInfo::SCALE_FACTOR
+                            (b * EnginesResourceInfo::<EK>::SCALE_FACTOR
                                 / cf_opts.get_soft_pending_compaction_bytes_limit())
                                 as u32,
                         );
@@ -1479,7 +1479,7 @@ impl EnginesResourceInfo {
     }
 }
 
-impl IOBudgetAdjustor for EnginesResourceInfo {
+impl<EK: KvEngine> IOBudgetAdjustor for EnginesResourceInfo<EK> {
     fn adjust(&self, total_budgets: usize) -> usize {
         let score = self.latest_normalized_pending_bytes.load(Ordering::Relaxed) as f32
             / Self::SCALE_FACTOR as f32;

--- a/components/server/src/signal_handler.rs
+++ b/components/server/src/signal_handler.rs
@@ -36,7 +36,7 @@ mod imp {
 
 #[cfg(not(unix))]
 mod imp {
-    use engine_traits::{Engines, KvEngine};
+    use engine_traits::{Engines, KvEngine, RaftEngine};
 
-    pub fn wait_for_signal(_: Option<Engines<impl KvEngine, RocksEngine>>) {}
+    pub fn wait_for_signal<ER: RaftEngine>(_: Option<Engines<impl KvEngine, ER>>) {}
 }

--- a/components/server/src/signal_handler.rs
+++ b/components/server/src/signal_handler.rs
@@ -4,7 +4,7 @@ pub use self::imp::wait_for_signal;
 
 #[cfg(unix)]
 mod imp {
-    use engine_traits::{Engines, MiscExt, RaftEngine, KvEngine};
+    use engine_traits::{Engines, KvEngine, MiscExt, RaftEngine};
     use libc::c_int;
     use nix::sys::signal::{SIGHUP, SIGINT, SIGTERM, SIGUSR1, SIGUSR2};
     use signal::trap::Trap;

--- a/components/server/src/signal_handler.rs
+++ b/components/server/src/signal_handler.rs
@@ -4,15 +4,14 @@ pub use self::imp::wait_for_signal;
 
 #[cfg(unix)]
 mod imp {
-    use engine_rocks::RocksEngine;
-    use engine_traits::{Engines, MiscExt, RaftEngine};
+    use engine_traits::{Engines, MiscExt, RaftEngine, KvEngine};
     use libc::c_int;
     use nix::sys::signal::{SIGHUP, SIGINT, SIGTERM, SIGUSR1, SIGUSR2};
     use signal::trap::Trap;
     use tikv_util::metrics;
 
     #[allow(dead_code)]
-    pub fn wait_for_signal<ER: RaftEngine>(engines: Option<Engines<RocksEngine, ER>>) {
+    pub fn wait_for_signal<ER: RaftEngine>(engines: Option<Engines<impl KvEngine, ER>>) {
         let trap = Trap::trap(&[SIGTERM, SIGINT, SIGHUP, SIGUSR1, SIGUSR2]);
         for sig in trap {
             match sig {
@@ -37,8 +36,7 @@ mod imp {
 
 #[cfg(not(unix))]
 mod imp {
-    use engine_rocks::RocksEngine;
-    use engine_traits::Engines;
+    use engine_traits::{Engines, KvEngine};
 
-    pub fn wait_for_signal(_: Option<Engines<RocksEngine, RocksEngine>>) {}
+    pub fn wait_for_signal(_: Option<Engines<impl KvEngine, RocksEngine>>) {}
 }

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -128,7 +128,7 @@ type SimulateChannelTransport = SimulateTransport<ChannelTransport>;
 pub struct NodeCluster {
     trans: ChannelTransport,
     pd_client: Arc<TestPdClient>,
-    nodes: HashMap<u64, Node<TestPdClient, RocksEngine>>,
+    nodes: HashMap<u64, Node<TestPdClient, RocksEngine, RocksEngine>>,
     snap_mgrs: HashMap<u64, SnapManager>,
     simulate_trans: HashMap<u64, SimulateChannelTransport>,
     concurrency_managers: HashMap<u64, ConcurrencyManager>,
@@ -177,7 +177,7 @@ impl NodeCluster {
         self.post_create_coprocessor_host = Some(op)
     }
 
-    pub fn get_node(&mut self, node_id: u64) -> Option<&mut Node<TestPdClient, RocksEngine>> {
+    pub fn get_node(&mut self, node_id: u64) -> Option<&mut Node<TestPdClient, RocksEngine, RocksEngine>> {
         self.nodes.get_mut(&node_id)
     }
 

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -177,7 +177,10 @@ impl NodeCluster {
         self.post_create_coprocessor_host = Some(op)
     }
 
-    pub fn get_node(&mut self, node_id: u64) -> Option<&mut Node<TestPdClient, RocksEngine, RocksEngine>> {
+    pub fn get_node(
+        &mut self,
+        node_id: u64,
+    ) -> Option<&mut Node<TestPdClient, RocksEngine, RocksEngine>> {
         self.nodes.get_mut(&node_id)
     }
 

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -104,7 +104,7 @@ impl StoreAddrResolver for AddressMap {
 }
 
 struct ServerMeta {
-    node: Node<TestPdClient, RocksEngine>,
+    node: Node<TestPdClient, RocksEngine, RocksEngine>,
     server: Server<SimulateStoreTransport, PdStoreAddrResolver, SimulateEngine>,
     sim_router: SimulateStoreTransport,
     sim_trans: SimulateServerTransport,

--- a/src/server/node.rs
+++ b/src/server/node.rs
@@ -12,8 +12,7 @@ use crate::server::lock_manager::LockManager;
 use crate::server::Config as ServerConfig;
 use crate::storage::{config::Config as StorageConfig, Storage};
 use concurrency_manager::ConcurrencyManager;
-use engine_rocks::RocksEngine;
-use engine_traits::{Engines, KvEngine, Peekable, RaftEngine};
+use engine_traits::{Engines, KvEngine, RaftEngine};
 use kvproto::metapb;
 use kvproto::raft_serverpb::StoreIdent;
 use kvproto::replication_modepb::ReplicationStatus;
@@ -58,11 +57,11 @@ where
 
 /// A wrapper for the raftstore which runs Multi-Raft.
 // TODO: we will rename another better name like RaftStore later.
-pub struct Node<C: PdClient + 'static, ER: RaftEngine> {
+pub struct Node<C: PdClient + 'static, EK: KvEngine, ER: RaftEngine> {
     cluster_id: u64,
     store: metapb::Store,
     store_cfg: Arc<VersionTrack<StoreConfig>>,
-    system: RaftBatchSystem<RocksEngine, ER>,
+    system: RaftBatchSystem<EK, ER>,
     has_started: bool,
 
     pd_client: Arc<C>,
@@ -70,20 +69,21 @@ pub struct Node<C: PdClient + 'static, ER: RaftEngine> {
     bg_worker: Worker,
 }
 
-impl<C, ER> Node<C, ER>
+impl<C, EK, ER> Node<C, EK, ER>
 where
     C: PdClient,
+    EK: KvEngine,
     ER: RaftEngine,
 {
     /// Creates a new Node.
     pub fn new(
-        system: RaftBatchSystem<RocksEngine, ER>,
+        system: RaftBatchSystem<EK, ER>,
         cfg: &ServerConfig,
         store_cfg: Arc<VersionTrack<StoreConfig>>,
         pd_client: Arc<C>,
         state: Arc<Mutex<GlobalReplicationState>>,
         bg_worker: Worker,
-    ) -> Node<C, ER> {
+    ) -> Node<C, EK, ER> {
         let mut store = metapb::Store::default();
         store.set_id(INVALID_ID);
         if cfg.advertise_addr.is_empty() {
@@ -132,7 +132,7 @@ where
         }
     }
 
-    pub fn try_bootstrap_store(&mut self, engines: Engines<RocksEngine, ER>) -> Result<()> {
+    pub fn try_bootstrap_store(&mut self, engines: Engines<EK, ER>) -> Result<()> {
         let mut store_id = self.check_store(&engines)?;
         if store_id == INVALID_ID {
             store_id = self.alloc_id()?;
@@ -152,12 +152,12 @@ where
     #[allow(clippy::too_many_arguments)]
     pub fn start<T>(
         &mut self,
-        engines: Engines<RocksEngine, ER>,
+        engines: Engines<EK, ER>,
         trans: T,
         snap_mgr: SnapManager,
-        pd_worker: LazyWorker<PdTask<RocksEngine>>,
+        pd_worker: LazyWorker<PdTask<EK>>,
         store_meta: Arc<Mutex<StoreMeta>>,
-        coprocessor_host: CoprocessorHost<RocksEngine>,
+        coprocessor_host: CoprocessorHost<EK>,
         importer: Arc<SSTImporter>,
         split_check_scheduler: Scheduler<SplitCheckTask>,
         auto_split_controller: AutoSplitController,
@@ -209,17 +209,17 @@ where
 
     /// Gets a transmission end of a channel which is used to send `Msg` to the
     /// raftstore.
-    pub fn get_router(&self) -> RaftRouter<RocksEngine, ER> {
+    pub fn get_router(&self) -> RaftRouter<EK, ER> {
         self.system.router()
     }
     /// Gets a transmission end of a channel which is used send messages to apply worker.
-    pub fn get_apply_router(&self) -> ApplyRouter<RocksEngine> {
+    pub fn get_apply_router(&self) -> ApplyRouter<EK> {
         self.system.apply_router()
     }
 
     // check store, return store id for the engine.
     // If the store is not bootstrapped, use INVALID_ID.
-    fn check_store(&self, engines: &Engines<RocksEngine, ER>) -> Result<u64> {
+    fn check_store(&self, engines: &Engines<EK, ER>) -> Result<u64> {
         let res = engines.kv.get_msg::<StoreIdent>(keys::STORE_IDENT_KEY)?;
         if res.is_none() {
             return Ok(INVALID_ID);
@@ -268,7 +268,7 @@ where
     #[doc(hidden)]
     pub fn prepare_bootstrap_cluster(
         &self,
-        engines: &Engines<RocksEngine, ER>,
+        engines: &Engines<EK, ER>,
         store_id: u64,
     ) -> Result<metapb::Region> {
         let region_id = self.alloc_id()?;
@@ -292,7 +292,7 @@ where
 
     fn check_or_prepare_bootstrap_cluster(
         &self,
-        engines: &Engines<RocksEngine, ER>,
+        engines: &Engines<EK, ER>,
         store_id: u64,
     ) -> Result<Option<metapb::Region>> {
         if let Some(first_region) = engines.kv.get_msg(keys::PREPARE_BOOTSTRAP_KEY)? {
@@ -306,7 +306,7 @@ where
 
     fn bootstrap_cluster(
         &mut self,
-        engines: &Engines<RocksEngine, ER>,
+        engines: &Engines<EK, ER>,
         first_region: metapb::Region,
     ) -> Result<()> {
         let region_id = first_region.get_id();
@@ -368,12 +368,12 @@ where
     fn start_store<T>(
         &mut self,
         store_id: u64,
-        engines: Engines<RocksEngine, ER>,
+        engines: Engines<EK, ER>,
         trans: T,
         snap_mgr: SnapManager,
-        pd_worker: LazyWorker<PdTask<RocksEngine>>,
+        pd_worker: LazyWorker<PdTask<EK>>,
         store_meta: Arc<Mutex<StoreMeta>>,
-        coprocessor_host: CoprocessorHost<RocksEngine>,
+        coprocessor_host: CoprocessorHost<EK>,
         importer: Arc<SSTImporter>,
         split_check_scheduler: Scheduler<SplitCheckTask>,
         auto_split_controller: AutoSplitController,

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -6,7 +6,7 @@ use crate::config::BLOCK_CACHE_RATE;
 use crate::server::ttl::TTLCheckerTask;
 use crate::server::CONFIG_ROCKSDB_GAUGE;
 use engine_rocks::raw::{Cache, LRUCacheOptions, MemoryAllocator};
-use engine_traits::{ColumnFamilyOptions, CF_DEFAULT, KvEngine};
+use engine_traits::{ColumnFamilyOptions, KvEngine, CF_DEFAULT};
 use file_system::{get_io_rate_limiter, IOPriority, IORateLimitMode, IORateLimiter, IOType};
 use libc::c_int;
 use online_config::{ConfigChange, ConfigManager, ConfigValue, OnlineConfig, Result as CfgResult};


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/10528

Part of https://github.com/tikv/tikv/issues/6402

Problem Summary:

Make it possible to typecheck tikv-server with non-rocks KV engines, and to launch tikv-server with PanicEngine.

### What is changed and how it works?

What's Changed:

This is the last set of steps necessary to run tikv-server with a non-rocks KV engine. After this patch set it is possible to launch tikv-server with PanicEngine. This engine doesn't do anything, but it does ensure that tikv-server typechecks with alternate engines.

The big changes here are in components/server/src/server.rs, which is responsible for constructing the server.

These changes are kinda ugly, so this needs some good review.

There are still some limitations. Primarily, non-rocks engines are not able to launch the debug service or the backup service. These two still have hard rocks dependencies for now. This patch works around these limitations by introducing a `CreateKvEngine` trait that is implemented for all KV engines, and that contains some empty methods for PanicEngine.

The CreateKvEngine trait should be able to be deleted with time and refactoring.

Note that this patch series contains commits that temporarily introduce some ugly dynamic casts; those dynamic casts are later removed before the end of the series.

I have an out of tree engine, SimpleEngine, that is _almost_ able to complete the startup sequence and reach a steady-state where it doesn't crash. I am focused on getting that engine to more-or-less work, while reworking engine_traits to remove rocksisms, before attempting to add a "real" alternate engine. For others though, it should be feasible to work toward alternate KV engines right now.


### Related changes


### Check List <!--REMOVE the items that are not applicable-->


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```