### PR TITLE
raftstore: remove unnecessary stat record

### DIFF
--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -3487,6 +3487,9 @@ where
             approximate_keys: self.approximate_keys,
             replication_status: self.region_replication_status(),
         });
+        self.peer_stat.written_bytes = 0;
+        self.peer_stat.written_keys = 0;
+        self.peer_stat.written_query_stats.clean();
         if let Err(e) = ctx.pd_scheduler.schedule(task) {
             error!(
                 "failed to notify pd";

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -206,7 +206,7 @@ pub struct PeerStat {
     pub store_report_read_bytes: u64,
     pub store_report_read_keys: u64,
     pub store_report_read_stats: QueryStats,
-    
+
     pub last_region_report_ts: UnixSecs,
     pub approximate_keys: u64,
     pub approximate_size: u64,
@@ -1026,8 +1026,12 @@ where
             peer_stat.store_report_read_keys += region_info.flow.read_keys as u64;
             self.store_stat.engine_total_bytes_read += region_info.flow.read_bytes as u64;
             self.store_stat.engine_total_keys_read += region_info.flow.read_keys as u64;
-            peer_stat.region_report_read_stats.add_query_stats(&region_info.query_stats.0);
-            peer_stat.store_report_read_stats.add_query_stats(&region_info.query_stats.0);
+            peer_stat
+                .region_report_read_stats
+                .add_query_stats(&region_info.query_stats.0);
+            peer_stat
+                .store_report_read_stats
+                .add_query_stats(&region_info.query_stats.0);
             self.store_stat
                 .engine_total_query_num
                 .add_query_stats(&region_info.query_stats.0);
@@ -1234,7 +1238,6 @@ where
                     let read_keys_delta = peer_stat.region_report_read_keys;
                     peer_stat.region_report_read_bytes = 0;
                     peer_stat.region_report_read_keys = 0;
-
 
                     let written_bytes_delta = hb_task.written_bytes;
                     let written_keys_delta = hb_task.written_keys;

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1241,7 +1241,7 @@ where
 
                     let written_bytes_delta = hb_task.written_bytes;
                     let written_keys_delta = hb_task.written_keys;
-                    let written_query_stats_delta = hb_task.written_query_stats.clone();
+                    let written_query_stats_delta = hb_task.written_query_stats;
                     let mut query_stats = peer_stat.region_report_read_stats.clone();
                     peer_stat.region_report_read_stats.clean();
                     query_stats.add_query_stats(&written_query_stats_delta.0); // add write info

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1238,9 +1238,6 @@ where
                     let read_keys_delta = peer_stat.region_report_read_keys;
                     peer_stat.region_report_read_bytes = 0;
                     peer_stat.region_report_read_keys = 0;
-
-                    let written_bytes_delta = hb_task.written_bytes;
-                    let written_keys_delta = hb_task.written_keys;
                     let written_query_stats_delta = hb_task.written_query_stats;
                     let mut query_stats = peer_stat.region_report_read_stats.clone();
                     peer_stat.region_report_read_stats.clean();
@@ -1254,8 +1251,8 @@ where
                     (
                         read_bytes_delta,
                         read_keys_delta,
-                        written_bytes_delta,
-                        written_keys_delta,
+                        hb_task.written_bytes,
+                        hb_task.written_keys,
                         last_report_ts,
                         query_stats.0,
                     )

--- a/components/raftstore/src/store/worker/query_stats.rs
+++ b/components/raftstore/src/store/worker/query_stats.rs
@@ -81,6 +81,12 @@ impl QueryStats {
         mem::swap(&mut self.0, &mut query_stats);
         query_stats
     }
+
+    pub fn clean(&mut self) {
+        for kind in QUERY_KINDS {
+            self.set_query_num(*kind, 0);
+        }
+    }
 }
 
 pub fn is_read_query(kind: QueryKind) -> bool {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

Currently we get read/write report stat by minus total sum of stat with last recorded stat for store heartbeat report and region heartbeat report.

If we can clean the stat after each reporting, the last report stat will be unnecessary to maintain which will also be helpful for PD.

### What is changed and how it works?

Clean the stat after each reporting.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

```release-note
None
```