### PR TITLE
external_storage: Fix force-style-path become useless

### DIFF
--- a/components/external_storage/src/s3.rs
+++ b/components/external_storage/src/s3.rs
@@ -41,7 +41,10 @@ impl S3Storage {
     /// Create a new S3 storage for the given config.
     pub fn new(config: &Config) -> io::Result<S3Storage> {
         Self::check_config(config)?;
-        let client = new_client!(S3Client, config);
+        let mut client = new_client!(S3Client, config);
+        if config.force_path_style {
+            client.config_mut().addressing_style = AddressingStyle::Path;
+        }
         Ok(S3Storage {
             config: config.clone(),
             client,


### PR DESCRIPTION


### What problem does this PR solve?

Problem Summary:

Since #10242 merged 2 days ago, the force-path-style flag is always ignored, and all S3 requests always use the virtual host addressing style.

### What is changed and how it works?

In release-4.0, the `S3Storage` type has 2 constructors, `S3Storage::new` and `S3Storage::with_request_dispatcher`, which are independent from each other:

https://github.com/tikv/tikv/blob/72f119bcc5390dfc7a67fd37f34e579306998f3f/components/external_storage/src/s3.rs#L42-L66

This is not the case for 5.0 and up, where there are 3 constructors and all forward to the same underlying function `S3Storage::new_creds_dispatcher`:

https://github.com/tikv/tikv/blob/63b63edfbb9bbf8aeb875aad28c59f082eeb55d4/components/external_storage/src/s3.rs#L36-L83

The `force_path_style` configuration is done in the constructor. Because of the function path difference between the versions, the cherry-pick PR only copy the force-path-style code to `S3Storage::with_request_dispatcher`, but not `S3Storage::new`. This caused the force-path-style flag to be ignored in paths which used the `::new` constructor instead of `::with_request_dispatcher`.

This PR add back the force-path-style handling to the `::new` constructor.

As explained above, this PR is a 4.0-only fix, and no need to be carried forward.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
   * Without this fix, BR 4.0 cannot backup to minio (which uses path-style normally).
   * After applying this fix, BR 4.0 can backup to minio.

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```