### PR TITLE
PD: Fix not tick PD heartbeat after reconnected

### DIFF
--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -262,7 +262,7 @@ pub trait PdClient: Send + Sync {
     }
 }
 
-const REQUEST_TIMEOUT: u64 = 2; // 2s
+const REQUEST_TIMEOUT: u64 = 1; // 1s
 
 /// Takes the peer address (for sending raft messages) from a store.
 pub fn take_peer_address(store: &mut metapb::Store) -> String {

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -41,8 +41,8 @@ const MAX_RETRY_TIMES: u64 = 5;
 const MAX_RETRY_DURATION: Duration = Duration::from_secs(10);
 
 // FIXME: Use a request-independent way to handle reconnection.
-const GLOBAL_RECONNECT_INTERVAL: Duration = Duration::from_millis(100); // 0.1s
-pub const REQUEST_RECONNECT_INTERVAL: Duration = Duration::from_secs(1); // 1s
+const GLOBAL_RECONNECT_INTERVAL: Duration = Duration::from_millis(200); // 0.2s
+pub const REQUEST_RECONNECT_INTERVAL: Duration = Duration::from_secs(2); // 2s
 
 pub struct TargetInfo {
     target_url: String,
@@ -365,7 +365,7 @@ pub struct Request<Req, F> {
     func: F,
 }
 
-const MAX_REQUEST_COUNT: usize = 3;
+const MAX_REQUEST_COUNT: usize = 2;
 
 impl<Req, Resp, F> Request<Req, F>
 where

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -576,7 +576,7 @@ where
                 PeerMsg::Start => self.start(),
                 PeerMsg::HeartbeatPd => {
                     if self.fsm.peer.is_leader() {
-                        self.register_pd_heartbeat_tick()
+                        self.on_pd_heartbeat_tick();
                     }
                 }
                 PeerMsg::Noop => {}


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
PD client will notify raftstore-thread to send heartbeat again after it lost connection from leader but succeeded to reconnect again. But raftstore just registered this tick rather than send it at once. So PD can not refresh the region info as soon as possible.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```