### PR TITLE
fix unstable test case test_pending_peers

### DIFF
--- a/tests/failpoints/cases/test_pending_peers.rs
+++ b/tests/failpoints/cases/test_pending_peers.rs
@@ -21,7 +21,9 @@ fn test_pending_peers() {
     let region_id = cluster.run_conf_change();
     pd_client.must_add_peer(region_id, new_peer(2, 2));
 
+    // To ensure peer 2 is not pending.
     cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
 
     fail::cfg(region_worker_fp, "sleep(2000)").unwrap();
     pd_client.must_add_peer(region_id, new_peer(3, 3));


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

fix unstable test case test_pending_peers.
Close #10512 .

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```