### PR TITLE
txn: considering the write type processing prewrite errors

### DIFF
--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -444,12 +444,16 @@ impl<K: PrewriteKind> Prewriter<K> {
             reader: &mut SnapshotReader<impl Snapshot>,
             key: &Key,
         ) -> Result<(Vec<std::result::Result<(), StorageError>>, TimeStamp)> {
-            if let TxnCommitRecord::SingleRecord { commit_ts, .. } =
+            if let TxnCommitRecord::SingleRecord { commit_ts, write } =
                 reader.get_txn_commit_record(key)?
             {
-                info!("prewrited transaction has been committed";
+                if write.write_type == WriteType::Rollback {
+                    Err(prewrite_result.unwrap_err().into())
+                } else {
+                    info!("prewrited transaction has been committed";
                     "start_ts" => reader.start_ts, "commit_ts" => commit_ts);
-                Ok((vec![], commit_ts))
+                    Ok((vec![], commit_ts))
+                }
             } else {
                 Err(prewrite_result.unwrap_err().into())
             }
@@ -1686,5 +1690,64 @@ mod tests {
             }
             res => panic!("unexpected result {:?}", res),
         }
+    }
+
+    #[test]
+    fn test_prewrite_rolledback_transaction() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let cm = ConcurrencyManager::new(1.into());
+        let mut statistics = Statistics::default();
+
+        let k1 = b"k1";
+        let v1 = b"v1";
+        let v2 = b"v2";
+
+        // Test the write conflict path.
+        must_acquire_pessimistic_lock(&engine, k1, v1, 1, 1);
+        must_rollback(&engine, k1, 1, true);
+        must_prewrite_put(&engine, k1, v2, k1, 5);
+        must_commit(&engine, k1, 5, 6);
+        let prewrite_cmd = Prewrite::new(
+            vec![Mutation::Put((Key::from_raw(k1), v1.to_vec()))],
+            k1.to_vec(),
+            1.into(),
+            10,
+            false,
+            2,
+            2.into(),
+            10.into(),
+            Some(vec![]),
+            false,
+            Context::default(),
+        );
+        let context = WriteContext {
+            lock_mgr: &DummyLockManager {},
+            concurrency_manager: cm.clone(),
+            extra_op: ExtraOp::Noop,
+            statistics: &mut statistics,
+            async_apply_prewrite: false,
+        };
+        let snap = engine.snapshot(Default::default()).unwrap();
+        assert!(prewrite_cmd.cmd.process_write(snap, context).is_err());
+
+        // Test the pessimistic lock is not found path.
+        must_acquire_pessimistic_lock(&engine, k1, v1, 10, 10);
+        must_rollback(&engine, k1, 10, true);
+        must_acquire_pessimistic_lock(&engine, k1, v1, 15, 15);
+        let prewrite_cmd = PrewritePessimistic::with_defaults(
+            vec![(Mutation::Put((Key::from_raw(k1), v1.to_vec())), true)],
+            k1.to_vec(),
+            10.into(),
+            10.into(),
+        );
+        let context = WriteContext {
+            lock_mgr: &DummyLockManager {},
+            concurrency_manager: cm,
+            extra_op: ExtraOp::Noop,
+            statistics: &mut statistics,
+            async_apply_prewrite: false,
+        };
+        let snap = engine.snapshot(Default::default()).unwrap();
+        assert!(prewrite_cmd.cmd.process_write(snap, context).is_err());
     }
 }


### PR DESCRIPTION
Signed-off-by: cfzjywxk <lsswxrxr@163.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: #10552

Problem Summary:
The jepsen case append failed with incompatible oreder in the inner test environment:
```
2021-07-10 14:36:12,631{GMT}    INFO    [jepsen test runner] jepsen.core: {:perf
 {:latency-graph {:valid? true},
  :rate-graph {:valid? true},
  :valid? true},
 :workload
 {:valid? false,
  :anomaly-types (:incompatible-order),
  :anomalies
  {:incompatible-order ({:key 3, :values [[4 1 2 5 3] [4 1 2 5 6]]})}},
 :valid? false}

Analysis invalid! (ﾉಥ益ಥ）ﾉ ┻━┻
```

In https://github.com/tikv/tikv/pull/10522, we do not return errors if the prewrite keys are already committed, the returned record type needes to be considered processing errors.

### What is changed and how it works?

What's Changed:
Check the write record type.


### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
NONE
```