### PR TITLE
cloud: fix test_s3_storage

### DIFF
--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -525,6 +525,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "failpoints")]
     fn test_s3_storage() {
         let magic_contents = "5678";
         let bucket_name = StringNonEmpty::required("mybucket".to_string()).unwrap();

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -524,8 +524,8 @@ mod tests {
         assert!(S3Storage::new(config).is_err());
     }
 
-    #[test]
     #[cfg(feature = "failpoints")]
+    #[test]
     fn test_s3_storage() {
         let magic_contents = "5678";
         let bucket_name = StringNonEmpty::required("mybucket".to_string()).unwrap();


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

### What problem does this PR solve?

Issue Number: close #10574 

Problem Summary: test_s3_storage is only available when failpoint is available. Fixing it.

### What is changed and how it works?

What's Changed: run test_s3_storage only when failpoint is available

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
run the test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```