### PR TITLE
Check stale file information and remove Rename operation in encryption module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#53453446f16a25784ada946db6f35cd876131b2b"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#cc16af35a321afe37fa2332638d0d7d0e362c962"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#53453446f16a25784ada946db6f35cd876131b2b"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#cc16af35a321afe37fa2332638d0d7d0e362c962"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -3510,7 +3510,7 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#53453446f16a25784ada946db6f35cd876131b2b"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-4.x#cc16af35a321afe37fa2332638d0d7d0e362c962"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/components/encryption/src/file_dict_file.rs
+++ b/components/encryption/src/file_dict_file.rs
@@ -261,33 +261,6 @@ impl FileDictionaryFile {
         Ok(())
     }
 
-    /// Replace existed file entry with new file information.
-    ///
-    /// Warning: `self.write(file_dict)` must be called before.
-    pub fn replace(&mut self, src_name: &str, dst_name: &str, info: FileInfo) -> Result<()> {
-        assert_ne!(src_name, dst_name);
-        self.file_dict.files.remove(src_name);
-        self.file_dict
-            .files
-            .insert(dst_name.to_owned(), info.clone());
-        if self.enable_log {
-            let file = self.append_file.as_mut().unwrap();
-            let mut bytes1 = Self::convert_record_to_bytes(dst_name, LogRecord::INSERT(info))?;
-            let bytes2 = Self::convert_record_to_bytes(src_name, LogRecord::REMOVE)?;
-            bytes1.extend_from_slice(&bytes2);
-            file.write_all(&bytes1)?;
-            file.sync_all()?;
-
-            self.removed += 1;
-            self.file_size += bytes1.len();
-            self.check_compact()?;
-        } else {
-            self.rewrite()?;
-        }
-        self.update_metrics();
-        Ok(())
-    }
-
     /// This function needs to be called after each append operation to check
     /// if compact is needed.
     fn check_compact(&mut self) -> Result<()> {
@@ -449,9 +422,8 @@ mod tests {
         assert_eq!(*file_dict.files.get("info3").unwrap(), info3);
         assert_eq!(file_dict.files.len(), 2);
 
-        file_dict_file
-            .replace("info3", "info5", info5.clone())
-            .unwrap();
+        file_dict_file.insert("info5", &info5).unwrap();
+        file_dict_file.remove("info3").unwrap();
 
         let file_dict = file_dict_file.recovery().unwrap();
         assert_eq!(file_dict.files.get("info1"), None);
@@ -578,9 +550,10 @@ mod tests {
             file_dict.insert(&"f1".to_owned(), &info1).unwrap();
             file_dict.insert(&"f2".to_owned(), &info2).unwrap();
             file_dict.insert(&"f3".to_owned(), &info3).unwrap();
-            file_dict
-                .replace(&"f3".to_owned(), &"f4".to_owned(), info4.clone())
-                .unwrap();
+
+            file_dict.insert("f4", &info4).unwrap();
+            file_dict.remove("f3").unwrap();
+
             file_dict.remove(&"f2".to_owned()).unwrap();
         }
         // Try open as v1 file. Should fail.

--- a/components/engine_rocks/src/encryption.rs
+++ b/components/engine_rocks/src/encryption.rs
@@ -50,9 +50,6 @@ impl<T: EncryptionKeyManager> DBEncryptionKeyManager for WrappedEncryptionKeyMan
     fn link_file(&self, src_fname: &str, dst_fname: &str) -> Result<()> {
         self.manager.link_file(src_fname, dst_fname)
     }
-    fn rename_file(&self, src_fname: &str, dst_fname: &str) -> Result<()> {
-        self.manager.rename_file(src_fname, dst_fname)
-    }
 }
 
 fn convert_file_encryption_info(input: FileEncryptionInfo) -> DBFileEncryptionInfo {

--- a/components/engine_traits/src/encryption.rs
+++ b/components/engine_traits/src/encryption.rs
@@ -8,7 +8,6 @@ pub trait EncryptionKeyManager: Sync + Send {
     fn new_file(&self, fname: &str) -> Result<FileEncryptionInfo>;
     fn delete_file(&self, fname: &str) -> Result<()>;
     fn link_file(&self, src_fname: &str, dst_fname: &str) -> Result<()>;
-    fn rename_file(&self, src_fname: &str, dst_fname: &str) -> Result<()>;
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1485,7 +1485,8 @@ impl SnapManagerCore {
             let dst = cf_file.path.to_str().unwrap();
             // It's ok that the cf file is moved but machine fails before `mgr.rename_file`
             // because without metadata file, saved cf files are nothing.
-            mgr.rename_file(src, dst)?;
+            mgr.link_file(src, dst)?;
+            mgr.delete_file(src)?;
         }
         let (checksum, size) = calc_checksum_and_size(&cf_file.path, mgr)?;
         cf_file.checksum = checksum;

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -358,7 +358,8 @@ impl SSTImporter {
                     .save
                     .to_str()
                     .ok_or_else(|| Error::InvalidSSTPath(path.save.clone()))?;
-                key_manager.rename_file(temp_str, save_str)?;
+                key_manager.link_file(temp_str, save_str)?;
+                key_manager.delete_file(temp_str)?;
             }
             IMPORTER_DOWNLOAD_DURATION
                 .with_label_values(&["rename"])
@@ -579,7 +580,8 @@ impl<E: KvEngine> SSTWriter<E> {
                 .save
                 .to_str()
                 .ok_or_else(|| Error::InvalidSSTPath(import_path.save.clone()))?;
-            key_manager.rename_file(temp_str, save_str)?;
+            key_manager.link_file(temp_str, save_str)?;
+            key_manager.delete_file(temp_str)?;
         }
         // sync the directory after rename
         import_path.save.pop();
@@ -825,10 +827,11 @@ impl ImportFile {
         }
         fs::rename(&self.path.temp, &self.path.save)?;
         if let Some(ref manager) = self.key_manager {
-            manager.rename_file(
+            manager.link_file(
                 self.path.temp.to_str().unwrap(),
                 self.path.save.to_str().unwrap(),
             )?;
+            manager.delete_file(self.path.temp.to_str().unwrap())?;
         }
         Ok(())
     }


### PR DESCRIPTION
Signed-off-by: Xintao <hunterlxt@live.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->
cherry-pick #9285 to release-4.0

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/9115

Problem Summary:

This PR is to solve the stale information encountered in the encryption dictionary

- Delete: When deleting a file but failing to execute `delete_file` on `file_dict`, the stale information leaves
- Rename: When a new `dst_fname` is added to the dictionary file, but the real `rename` is not successful or execute `rename` but failed to delete `src_fname`
- Link: When a new `dst_fname` is added to the dictionary file, the subsequent operations don't finish.

In the above situation, some stale file information will appear in the encrypted file dictionary. We need to deal with these errors instead of generating and returning errors.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
```release-note
Check stale file information from encryption file dict
```