### PR TITLE
storage: prevent repeated non-pessimistic lock prewrite from writing locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/sticnarf/kvproto.git?branch=retry-request#8d2b59e1523b6951db34504409eef00562d5da87"
+source = "git+https://github.com/sticnarf/kvproto.git?branch=retry-request#c188a7230e0f0e04ff8e7277fd77383599cf4dc2"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/sticnarf/kvproto.git?branch=retry-request#c188a7230e0f0e04ff8e7277fd77383599cf4dc2"
+source = "git+https://github.com/sticnarf/kvproto.git?branch=retry-request#95a64a5fa684f04415abd2796015c54d5e71ca49"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#2ac2a7984b2d01b96ed56fd8474f4bf80fa33c51"
+source = "git+https://github.com/sticnarf/kvproto.git?branch=retry-request#8d2b59e1523b6951db34504409eef00562d5da87"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/sticnarf/kvproto.git?branch=retry-request#95a64a5fa684f04415abd2796015c54d5e71ca49"
+source = "git+https://github.com/pingcap/kvproto.git#91a52cd9e8db8dec6147114c94d1678fffc0a5ba"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,6 +252,9 @@ rusoto_mock = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr
 rusoto_s3 = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr-styles" }
 rusoto_sts = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr-styles" }
 
+[patch.'https://github.com/pingcap/kvproto.git']
+kvproto = { git = "https://github.com/sticnarf/kvproto.git", branch = "retry-request" }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,9 +252,6 @@ rusoto_mock = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr
 rusoto_s3 = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr-styles" }
 rusoto_sts = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr-styles" }
 
-[patch.'https://github.com/pingcap/kvproto.git']
-kvproto = { git = "https://github.com/sticnarf/kvproto.git", branch = "retry-request" }
-
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 

--- a/components/resolved_ts/src/cmd.rs
+++ b/components/resolved_ts/src/cmd.rs
@@ -396,7 +396,7 @@ mod tests {
                 lock_ttl: 2000,
                 min_commit_ts: 10.into(),
                 need_old_value: false,
-                retry_request: false,
+                is_retry_request: false,
             },
             Mutation::Put((k1.clone(), b"v4".to_vec())),
             &None,

--- a/components/resolved_ts/src/cmd.rs
+++ b/components/resolved_ts/src/cmd.rs
@@ -396,6 +396,7 @@ mod tests {
                 lock_ttl: 2000,
                 min_commit_ts: 10.into(),
                 need_old_value: false,
+                retry_request: false,
             },
             Mutation::Put((k1.clone(), b"v4".to_vec())),
             &None,

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -611,6 +611,7 @@ pub mod tests {
                 lock_ttl: 0,
                 min_commit_ts: TimeStamp::default(),
                 need_old_value: false,
+                retry_request: false,
             }
         }
 

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -611,7 +611,7 @@ pub mod tests {
                 lock_ttl: 0,
                 min_commit_ts: TimeStamp::default(),
                 need_old_value: false,
-                retry_request: false,
+                is_retry_request: false,
             }
         }
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -709,6 +709,7 @@ pub(crate) mod tests {
             lock_ttl: 0,
             min_commit_ts: TimeStamp::default(),
             need_old_value: false,
+            retry_request: false,
         }
     }
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -716,7 +716,7 @@ pub(crate) mod tests {
             lock_ttl: 0,
             min_commit_ts: TimeStamp::default(),
             need_old_value: false,
-            retry_request: false,
+            is_retry_request: false,
         }
     }
 

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -1011,6 +1011,7 @@ pub(crate) mod tests {
                     expected_lock_info.get_txn_size(),
                     TimeStamp::zero(),
                     TimeStamp::zero(),
+                    false,
                 );
             } else {
                 expected_lock_info.set_lock_type(Op::PessimisticLock);

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -159,6 +159,13 @@ impl MvccTxn {
         lock.rollback_ts.push(self.start_ts);
         self.put_lock(key.clone(), &lock);
     }
+
+    pub(crate) fn clear(&mut self) {
+        self.write_size = 0;
+        self.modifies.clear();
+        self.locks_for_1pc.clear();
+        self.guards.clear();
+    }
 }
 
 impl fmt::Debug for MvccTxn {

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -276,6 +276,7 @@ pub mod tests {
             1,
             ts(60, 1),
             TimeStamp::zero(),
+            false,
         );
         // The min_commit_ts is ts(70, 0) other than ts(60, 1) in prewrite request.
         must_large_txn_locked(&engine, k, ts(60, 0), 100, ts(70, 1), false);

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -79,7 +79,7 @@ pub fn prewrite<S: Snapshot>(
     // we need to check the key has not been committed before if it is a retry request.
     //
     // It is to prevent the following case:
-    // The key was prewrited successfully before, but the response is lost. The client resend
+    // The key was prewritten successfully before, but the response is lost. The client resends
     // the same request after the transaction is resolved (to become committed). If we still
     // write the lock, the client might commit these keys more than once.
     //
@@ -97,7 +97,9 @@ pub fn prewrite<S: Snapshot>(
                 if write.write_type != WriteType::Rollback =>
             {
                 info!("prewrited transaction has been committed";
-                    "start_ts" => txn_props.start_ts, "commit_ts" => commit_ts);
+                    "start_ts" => txn_props.start_ts, "commit_ts" => commit_ts,
+                    "key" => ?mutation.key, "mutation_type" => ?mutation.mutation_type,
+                    "write_type" => ?write.write_type);
                 return Ok((commit_ts, OldValue::Unspecified));
             }
             _ => {}

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -5,7 +5,7 @@ use crate::storage::{
             CONCURRENCY_MANAGER_LOCK_DURATION_HISTOGRAM, MVCC_CONFLICT_COUNTER,
             MVCC_DUPLICATE_CMD_COUNTER_VEC,
         },
-        Error, ErrorInner, Lock, LockType, MvccTxn, Result, SnapshotReader,
+        Error, ErrorInner, Lock, LockType, MvccTxn, Result, SnapshotReader, TxnCommitRecord,
     },
     txn::actions::check_data_constraint::check_data_constraint,
     txn::LockInfo,
@@ -73,6 +73,34 @@ pub fn prewrite<S: Snapshot>(
             TimeStamp::zero()
         };
         return Ok((min_commit_ts, OldValue::Unspecified));
+    }
+
+    // For keys that do not need pessimistic locks in a pessimistic async-commit transaction,
+    // we need to check the key has not been committed before.
+    //
+    // It is to prevent the following case:
+    // The key was prewrited successfully before, but the response is lost. The client resend
+    // the same request after the transaction is resolved (to become committed). If we still
+    // write the lock, the client might commit these keys more than once.
+    //
+    // If the commit record is Rollback, it is still safe for us to write the Lock because the primary
+    // key of the transaction must also be rolled back, and this lock will be eventually rolled back.
+    // For simplicity, we don't handle this case specially, making it the same behavior as the Rollback
+    // record is collapsed.
+    if txn_props.is_pessimistic()
+        && !is_pessimistic_lock
+        && matches!(txn_props.commit_kind, CommitKind::Async(..))
+    {
+        match reader.get_txn_commit_record(&mutation.key)? {
+            TxnCommitRecord::SingleRecord { commit_ts, write }
+                if write.write_type != WriteType::Rollback =>
+            {
+                info!("prewrited transaction has been committed";
+                    "start_ts" => txn_props.start_ts, "commit_ts" => commit_ts);
+                return Ok((commit_ts, OldValue::Unspecified));
+            }
+            _ => {}
+        }
     }
 
     let old_value = if txn_props.need_old_value
@@ -520,13 +548,7 @@ pub mod tests {
     #[cfg(test)]
     use crate::storage::{
         kv::RocksSnapshot,
-        txn::{
-            commands::prewrite::fallback_1pc_locks,
-            tests::{
-                must_acquire_pessimistic_lock, must_cleanup_with_gc_fence, must_commit,
-                must_prewrite_delete, must_prewrite_lock, must_prewrite_put, must_rollback,
-            },
-        },
+        txn::{commands::prewrite::fallback_1pc_locks, tests::*},
     };
     use crate::storage::{mvcc::tests::*, Engine};
     use concurrency_manager::ConcurrencyManager;
@@ -1157,6 +1179,59 @@ pub mod tests {
             .unwrap();
             assert_eq!(&old_value, expected_value, "key: {}", key);
         }
+    }
+
+    #[test]
+    fn test_resend_prewrite_non_pessimistic_lock() {
+        let engine = crate::storage::TestEngineBuilder::new().build().unwrap();
+
+        must_acquire_pessimistic_lock(&engine, b"k1", b"k1", 10, 10);
+        must_pessimistic_prewrite_put_async_commit(
+            &engine,
+            b"k1",
+            b"v1",
+            b"k1",
+            &Some(vec![b"k2".to_vec()]),
+            10,
+            10,
+            true,
+            15,
+        );
+        must_pessimistic_prewrite_put_async_commit(
+            &engine,
+            b"k2",
+            b"v2",
+            b"k1",
+            &Some(vec![]),
+            10,
+            10,
+            false,
+            15,
+        );
+
+        // The transaction may be committed by another reader.
+        must_commit(&engine, b"k1", 10, 20);
+        must_commit(&engine, b"k2", 10, 20);
+
+        // This is a resent prewrite
+        must_pessimistic_prewrite_put_async_commit(
+            &engine,
+            b"k2",
+            b"v2",
+            b"k1",
+            &Some(vec![]),
+            10,
+            10,
+            false,
+            15,
+        );
+        // Commit repeatedly, these operations should have no effect.
+        must_commit(&engine, b"k1", 10, 25);
+        must_commit(&engine, b"k2", 10, 25);
+
+        // Seek from 30, we should read commit_ts = 20 instead of 25.
+        must_seek_write(&engine, b"k1", 30, 10, 20, WriteType::Put);
+        must_seek_write(&engine, b"k2", 30, 10, 20, WriteType::Put);
     }
 
     #[test]

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -100,6 +100,7 @@ pub fn prewrite<S: Snapshot>(
                     "start_ts" => txn_props.start_ts, "commit_ts" => commit_ts,
                     "key" => ?mutation.key, "mutation_type" => ?mutation.mutation_type,
                     "write_type" => ?write.write_type);
+                txn.clear();
                 return Ok((commit_ts, OldValue::Unspecified));
             }
             _ => {}

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -89,7 +89,7 @@ pub fn prewrite<S: Snapshot>(
     // record is collapsed.
     if txn_props.is_pessimistic()
         && !is_pessimistic_lock
-        && txn_props.retry_request
+        && txn_props.is_retry_request
         && matches!(txn_props.commit_kind, CommitKind::Async(..))
     {
         match reader.get_txn_commit_record(&mutation.key)? {
@@ -160,7 +160,7 @@ pub struct TransactionProperties<'a> {
     pub lock_ttl: u64,
     pub min_commit_ts: TimeStamp,
     pub need_old_value: bool,
-    pub retry_request: bool,
+    pub is_retry_request: bool,
 }
 
 impl<'a> TransactionProperties<'a> {
@@ -574,7 +574,7 @@ pub mod tests {
             lock_ttl: 0,
             min_commit_ts: TimeStamp::default(),
             need_old_value: false,
-            retry_request: false,
+            is_retry_request: false,
         }
     }
 
@@ -599,7 +599,7 @@ pub mod tests {
             lock_ttl: 2000,
             min_commit_ts: 10.into(),
             need_old_value: true,
-            retry_request: false,
+            is_retry_request: false,
         }
     }
 
@@ -908,7 +908,7 @@ pub mod tests {
                 lock_ttl: 0,
                 min_commit_ts: TimeStamp::default(),
                 need_old_value: true,
-                retry_request: false,
+                is_retry_request: false,
             },
             Mutation::CheckNotExists(Key::from_raw(key)),
             &None,
@@ -939,7 +939,7 @@ pub mod tests {
             lock_ttl: 2000,
             min_commit_ts: 10.into(),
             need_old_value: true,
-            retry_request: false,
+            is_retry_request: false,
         };
         // calculated commit_ts = 43 ≤ 50, ok
         let (_, old_value) = prewrite(
@@ -988,7 +988,7 @@ pub mod tests {
             lock_ttl: 2000,
             min_commit_ts: 10.into(),
             need_old_value: true,
-            retry_request: false,
+            is_retry_request: false,
         };
         // calculated commit_ts = 43 ≤ 50, ok
         let (_, old_value) = prewrite(
@@ -1096,7 +1096,7 @@ pub mod tests {
             lock_ttl: 2000,
             min_commit_ts: 51.into(),
             need_old_value: true,
-            retry_request: false,
+            is_retry_request: false,
         };
 
         let cases = vec![
@@ -1155,7 +1155,7 @@ pub mod tests {
             lock_ttl: 2000,
             min_commit_ts: 51.into(),
             need_old_value: true,
-            retry_request: false,
+            is_retry_request: false,
         };
 
         let cases: Vec<_> = vec![
@@ -1274,7 +1274,7 @@ pub mod tests {
                 lock_ttl: 0,
                 min_commit_ts: TimeStamp::default(),
                 need_old_value: true,
-                retry_request: false,
+                is_retry_request: false,
             };
             let snapshot = engine.snapshot(Default::default()).unwrap();
             let cm = ConcurrencyManager::new(start_ts);
@@ -1327,7 +1327,7 @@ pub mod tests {
             lock_ttl: 0,
             min_commit_ts: TimeStamp::default(),
             need_old_value: true,
-            retry_request: false,
+            is_retry_request: false,
         };
         let snapshot = engine.snapshot(Default::default()).unwrap();
         let cm = ConcurrencyManager::new(start_ts);
@@ -1467,7 +1467,7 @@ pub mod tests {
                     lock_ttl: 0,
                     min_commit_ts: TimeStamp::default(),
                     need_old_value: true,
-                    retry_request: false,
+                    is_retry_request: false,
                 };
                 let (_, old_value) = prewrite(
                     &mut txn,
@@ -1502,7 +1502,7 @@ pub mod tests {
                     lock_ttl: 0,
                     min_commit_ts: TimeStamp::default(),
                     need_old_value: true,
-                    retry_request: false,
+                    is_retry_request: false,
                 };
                 let (_, old_value) = prewrite(
                     &mut txn,

--- a/src/storage/txn/actions/prewrite.rs
+++ b/src/storage/txn/actions/prewrite.rs
@@ -1225,16 +1225,20 @@ pub mod tests {
         must_commit(&engine, b"k2", 10, 20);
 
         // This is a resent prewrite
-        must_pessimistic_prewrite_put_async_commit(
+        must_prewrite_put_impl(
             &engine,
             b"k2",
             b"v2",
             b"k1",
             &Some(vec![]),
-            10,
-            10,
+            10.into(),
             false,
-            15,
+            100,
+            10.into(),
+            1,
+            15.into(),
+            TimeStamp::default(),
+            true,
         );
         // Commit repeatedly, these operations should have no effect.
         must_commit(&engine, b"k1", 10, 25);

--- a/src/storage/txn/actions/tests.rs
+++ b/src/storage/txn/actions/tests.rs
@@ -24,6 +24,7 @@ pub fn must_prewrite_put_impl<E: Engine>(
     txn_size: u64,
     min_commit_ts: TimeStamp,
     max_commit_ts: TimeStamp,
+    is_retry_request: bool,
 ) {
     let ctx = Context::default();
     let snapshot = engine.snapshot(Default::default()).unwrap();
@@ -54,7 +55,7 @@ pub fn must_prewrite_put_impl<E: Engine>(
             lock_ttl,
             min_commit_ts,
             need_old_value: false,
-            is_retry_request: false,
+            is_retry_request,
         },
         mutation,
         &secondary_keys,
@@ -84,6 +85,7 @@ pub fn must_prewrite_put<E: Engine>(
         0,
         TimeStamp::default(),
         TimeStamp::default(),
+        false,
     );
 }
 
@@ -109,6 +111,7 @@ pub fn must_pessimistic_prewrite_put<E: Engine>(
         0,
         TimeStamp::default(),
         TimeStamp::default(),
+        false,
     );
 }
 
@@ -135,6 +138,7 @@ pub fn must_pessimistic_prewrite_put_with_ttl<E: Engine>(
         0,
         TimeStamp::default(),
         TimeStamp::default(),
+        false,
     );
 }
 
@@ -164,6 +168,7 @@ pub fn must_prewrite_put_for_large_txn<E: Engine>(
         0,
         min_commit_ts,
         TimeStamp::default(),
+        false,
     );
 }
 
@@ -190,6 +195,7 @@ pub fn must_prewrite_put_async_commit<E: Engine>(
         0,
         min_commit_ts.into(),
         TimeStamp::default(),
+        false,
     );
 }
 
@@ -218,6 +224,7 @@ pub fn must_pessimistic_prewrite_put_async_commit<E: Engine>(
         0,
         min_commit_ts.into(),
         TimeStamp::default(),
+        false,
     );
 }
 

--- a/src/storage/txn/actions/tests.rs
+++ b/src/storage/txn/actions/tests.rs
@@ -54,7 +54,7 @@ pub fn must_prewrite_put_impl<E: Engine>(
             lock_ttl,
             min_commit_ts,
             need_old_value: false,
-            retry_request: false,
+            is_retry_request: false,
         },
         mutation,
         &secondary_keys,
@@ -241,7 +241,7 @@ fn default_txn_props(
         lock_ttl: 0,
         min_commit_ts: TimeStamp::default(),
         need_old_value: false,
-        retry_request: false,
+        is_retry_request: false,
     }
 }
 fn must_prewrite_put_err_impl<E: Engine>(

--- a/src/storage/txn/actions/tests.rs
+++ b/src/storage/txn/actions/tests.rs
@@ -54,6 +54,7 @@ pub fn must_prewrite_put_impl<E: Engine>(
             lock_ttl,
             min_commit_ts,
             need_old_value: false,
+            retry_request: false,
         },
         mutation,
         &secondary_keys,
@@ -240,6 +241,7 @@ fn default_txn_props(
         lock_ttl: 0,
         min_commit_ts: TimeStamp::default(),
         need_old_value: false,
+        retry_request: false,
     }
 }
 fn must_prewrite_put_err_impl<E: Engine>(

--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -921,6 +921,7 @@ pub mod tests {
             1,
             /* min_commit_ts */ TimeStamp::zero(),
             /* max_commit_ts */ TimeStamp::zero(),
+            false,
         );
         must_success(
             &engine,
@@ -1042,6 +1043,7 @@ pub mod tests {
             1,
             /* min_commit_ts */ TimeStamp::zero(),
             /* max_commit_ts */ TimeStamp::zero(),
+            false,
         );
         must_success(
             &engine,

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -423,7 +423,7 @@ impl<K: PrewriteKind> Prewriter<K> {
             lock_ttl: self.lock_ttl,
             min_commit_ts: self.min_commit_ts,
             need_old_value: extra_op == ExtraOp::ReadOldValue,
-            retry_request: self.ctx.retry_request,
+            is_retry_request: self.is_ctx.is_retry_request,
         };
 
         let async_commit_pk = self

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -1720,6 +1720,7 @@ mod tests {
         )
         .unwrap();
         let commit_ts = res.one_pc_commit_ts;
+        cm.update_max_ts(commit_ts.next());
         // repeate the prewrite
         let res = pessimistic_prewrite_with_cm(
             &engine,

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -423,6 +423,7 @@ impl<K: PrewriteKind> Prewriter<K> {
             lock_ttl: self.lock_ttl,
             min_commit_ts: self.min_commit_ts,
             need_old_value: extra_op == ExtraOp::ReadOldValue,
+            retry_request: self.ctx.retry_request,
         };
 
         let async_commit_pk = self

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -423,7 +423,7 @@ impl<K: PrewriteKind> Prewriter<K> {
             lock_ttl: self.lock_ttl,
             min_commit_ts: self.min_commit_ts,
             need_old_value: extra_op == ExtraOp::ReadOldValue,
-            is_retry_request: self.is_ctx.is_retry_request,
+            is_retry_request: self.ctx.is_retry_request,
         };
 
         let async_commit_pk = self

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -452,7 +452,9 @@ impl<K: PrewriteKind> Prewriter<K> {
                 TxnCommitRecord::SingleRecord { commit_ts, write }
                     if write.write_type != WriteType::Rollback =>
                 {
-                    info!("prewrited transaction has been committed"; "start_ts" => reader.start_ts, "commit_ts" => commit_ts);
+                    info!("prewrited transaction has been committed";
+                        "start_ts" => reader.start_ts, "commit_ts" => commit_ts,
+                        "key" => ?key, "write_type" => ?write.write_type);
                     Ok((vec![], commit_ts))
                 }
                 _ => Err(prewrite_result.unwrap_err().into()),

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -692,6 +692,7 @@ mod tests {
                             lock_ttl: 0,
                             min_commit_ts: TimeStamp::default(),
                             need_old_value: false,
+                            retry_request: false,
                         },
                         Mutation::Put((Key::from_raw(key), key.to_vec())),
                         &None,

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -692,7 +692,7 @@ mod tests {
                             lock_ttl: 0,
                             min_commit_ts: TimeStamp::default(),
                             need_old_value: false,
-                            retry_request: false,
+                            is_retry_request: false,
                         },
                         Mutation::Put((Key::from_raw(key), key.to_vec())),
                         &None,

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -45,6 +45,7 @@ where
             lock_ttl: 0,
             min_commit_ts: TimeStamp::default(),
             need_old_value: false,
+            retry_request: false,
         };
         prewrite(
             &mut txn,
@@ -93,6 +94,7 @@ fn mvcc_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Bench
                     lock_ttl: 0,
                     min_commit_ts: TimeStamp::default(),
                     need_old_value: false,
+                    retry_request: false,
                 };
                 prewrite(&mut txn, &mut reader, &txn_props, mutation, &None, false).unwrap();
             }

--- a/tests/benches/hierarchy/mvcc/mod.rs
+++ b/tests/benches/hierarchy/mvcc/mod.rs
@@ -45,7 +45,7 @@ where
             lock_ttl: 0,
             min_commit_ts: TimeStamp::default(),
             need_old_value: false,
-            retry_request: false,
+            is_retry_request: false,
         };
         prewrite(
             &mut txn,
@@ -94,7 +94,7 @@ fn mvcc_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &Bench
                     lock_ttl: 0,
                     min_commit_ts: TimeStamp::default(),
                     need_old_value: false,
-                    retry_request: false,
+                    is_retry_request: false,
                 };
                 prewrite(&mut txn, &mut reader, &txn_props, mutation, &None, false).unwrap();
             }

--- a/tests/benches/hierarchy/txn/mod.rs
+++ b/tests/benches/hierarchy/txn/mod.rs
@@ -41,7 +41,7 @@ where
             lock_ttl: 0,
             min_commit_ts: TimeStamp::default(),
             need_old_value: false,
-            retry_request: false,
+            is_retry_request: false,
         };
         prewrite(
             &mut txn,
@@ -87,7 +87,7 @@ fn txn_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchC
                     lock_ttl: 0,
                     min_commit_ts: TimeStamp::default(),
                     need_old_value: false,
-                    retry_request: false,
+                    is_retry_request: false,
                 };
                 prewrite(&mut txn, &mut reader, &txn_props, mutation, &None, false).unwrap();
                 let write_data = WriteData::from_modifies(txn.into_modifies());

--- a/tests/benches/hierarchy/txn/mod.rs
+++ b/tests/benches/hierarchy/txn/mod.rs
@@ -41,6 +41,7 @@ where
             lock_ttl: 0,
             min_commit_ts: TimeStamp::default(),
             need_old_value: false,
+            retry_request: false,
         };
         prewrite(
             &mut txn,
@@ -86,6 +87,7 @@ fn txn_prewrite<E: Engine, F: EngineFactory<E>>(b: &mut Bencher, config: &BenchC
                     lock_ttl: 0,
                     min_commit_ts: TimeStamp::default(),
                     need_old_value: false,
+                    retry_request: false,
                 };
                 prewrite(&mut txn, &mut reader, &txn_props, mutation, &None, false).unwrap();
                 let write_data = WriteData::from_modifies(txn.into_modifies());


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/26359

### What is changed and how it works?

Considering a pessimistic async-commit transaction, both row keys and index keys are prewritten successfully but the prewrite responses of the index keys are lost. Then, some other transactions commit the transaction by resolving locks because all locks exist. After that, the original committer resends the prewrite request of the index keys.

In the previous implementation, prewriting index keys of a pessimistic transaction will just write the locks again. The committer receives success and starts committing the transaction. Now the commit TS is different from the commit TS used by resolving locks. So the index keys will be committed twice, making the transaction have two different commit TS.

This PR just adds an additional check when prewriting the non-pessimistic lock keys. If the commit record already exists, we should not write the lock again.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the bug that index keys in a pessimistic transaction may be repeatedly committed.
```