### PR TITLE
coprocessor_plugin_api: Use atomic for allocator functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +633,7 @@ name = "coprocessor_plugin_api"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "atomic",
  "rustc_version 0.3.3",
 ]
 

--- a/components/coprocessor_plugin_api/Cargo.toml
+++ b/components/coprocessor_plugin_api/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
+atomic = "0.5"
 
 [build-dependencies]
 rustc_version = "0.3"

--- a/components/coprocessor_plugin_api/src/allocator.rs
+++ b/components/coprocessor_plugin_api/src/allocator.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
+use atomic::{Atomic, Ordering};
 use std::alloc::{GlobalAlloc, Layout};
-use std::sync::atomic::{AtomicPtr, Ordering};
 
 type AllocFn = unsafe fn(Layout) -> *mut u8;
 type DeallocFn = unsafe fn(*mut u8, Layout);
@@ -18,19 +18,19 @@ pub struct HostAllocatorPtr {
 
 /// An allocator that forwards invocations to the host (TiKV) of the plugin.
 pub struct HostAllocator {
-    alloc_fn: AtomicPtr<AllocFn>,
-    dealloc_fn: AtomicPtr<DeallocFn>,
+    alloc_fn: Atomic<Option<AllocFn>>,
+    dealloc_fn: Atomic<Option<DeallocFn>>,
 }
 
 impl HostAllocator {
     /// Creates a new [`HostAllocator`].
     ///
-    /// The internal function pointers are set to `nullptr`, so any attempt to allocate memory
-    /// before a call to [`set_allocator()`] will result in a segmentation fault.
+    /// The internal function pointers are initially `None`, so any attempt to allocate memory
+    /// before a call to [`set_allocator()`] will result in a panic.
     pub const fn new() -> Self {
         HostAllocator {
-            alloc_fn: AtomicPtr::new(std::ptr::null_mut()),
-            dealloc_fn: AtomicPtr::new(std::ptr::null_mut()),
+            alloc_fn: Atomic::new(None),
+            dealloc_fn: Atomic::new(None),
         }
     }
 
@@ -39,17 +39,27 @@ impl HostAllocator {
     /// because otherwise the [`HostAllocator`] is in an invalid state.
     pub fn set_allocator(&self, allocator: HostAllocatorPtr) {
         self.alloc_fn
-            .store(allocator.alloc_fn as *mut _, Ordering::SeqCst);
+            .store(Some(allocator.alloc_fn), Ordering::SeqCst);
         self.dealloc_fn
-            .store(allocator.dealloc_fn as *mut _, Ordering::SeqCst);
+            .store(Some(allocator.dealloc_fn), Ordering::SeqCst);
     }
 }
 
 unsafe impl GlobalAlloc for HostAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        (*self.alloc_fn.load(Ordering::Relaxed))(layout)
+        self.alloc_fn.load(Ordering::Relaxed).unwrap()(layout)
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        (*self.dealloc_fn.load(Ordering::Relaxed))(ptr, layout)
+        self.dealloc_fn.load(Ordering::Relaxed).unwrap()(ptr, layout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_is_lock_free() {
+        assert!(Atomic::<AllocFn>::is_lock_free());
     }
 }

--- a/components/coprocessor_plugin_api/src/allocator.rs
+++ b/components/coprocessor_plugin_api/src/allocator.rs
@@ -60,6 +60,6 @@ mod tests {
 
     #[test]
     fn atomic_is_lock_free() {
-        assert!(Atomic::<AllocFn>::is_lock_free());
+        assert!(Atomic::<Option<AllocFn>>::is_lock_free());
     }
 }

--- a/components/coprocessor_plugin_api/src/lib.rs
+++ b/components/coprocessor_plugin_api/src/lib.rs
@@ -25,8 +25,6 @@
 //! struct MyPlugin;
 //!
 //! impl CoprocessorPlugin for MyPlugin {
-//!     fn name(&self) -> &'static str { "my-plugin" }
-//!
 //!     fn on_raw_coprocessor_request(
 //!         &self,
 //!         ranges: Vec<Range<Key>>,

--- a/src/coprocessor_v2/endpoint.rs
+++ b/src/coprocessor_v2/endpoint.rs
@@ -4,7 +4,6 @@ use coprocessor_plugin_api::*;
 use kvproto::kvrpcpb;
 use semver::VersionReq;
 use std::future::Future;
-use std::ops::Not;
 use std::sync::Arc;
 
 use super::config::Config;
@@ -87,18 +86,15 @@ impl Endpoint {
         let version_req = VersionReq::parse(&req.copr_version_req)
             .map_err(|e| CoprocessorError::Other(format!("{}", e)))?;
         let plugin_version = plugin.version();
-        version_req
-            .matches(&plugin_version)
-            .not()
-            .then(|| {})
-            .ok_or_else(|| {
-                CoprocessorError::Other(format!(
-                    "The plugin '{}' with version '{}' does not satisfy the version constraint '{}'",
-                    plugin.name(),
-                    plugin_version,
-                    version_req,
-                ))
-            })?;
+
+        if !version_req.matches(&plugin_version) {
+            return Err(CoprocessorError::Other(format!(
+                "The plugin '{}' with version '{}' does not satisfy the version constraint '{}'",
+                plugin.name(),
+                plugin_version,
+                version_req,
+            )));
+        }
 
         let raw_storage_api = RawStorageImpl::new(req.take_context(), storage);
         let ranges = req


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:

1. The current implementation causes a segmentation fault whenever an allocation/deallocation occurs.
2. The coprocessor plugin version check matches any version except the one requested.

### What is changed and how it works?

`AtomicPtr<AllocFn>` stores a pointer to a function pointer, so the deref on line 50 and 53 is incorrect as the types don't match (`*mut AllocFn` vs `AllocFn`).

Also inverts the version check for the coprocessor plugins.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

*Unit test*
The unit tests unfortunately do not catch this issue, since the allocator function pointers are not used during the tests: https://github.com/tikv/tikv/blob/master/components/coprocessor_plugin_api/src/util.rs#L90

Since `example_plugin` gets included as a dev-dependency we cannot set `#[global_allocator]` since it would conflict with https://github.com/tikv/tikv/blob/master/components/tikv_alloc/src/lib.rs#L129-L130.

There is some discussion about it here: https://github.com/tikv/tikv/pull/10112

*Manual test (add detailed scripts or steps below)*
I have done manual testing by loading and using a coprocessor plugin successfully in tikv.

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Use atomic crate for coprocessor_plugin_api allocator functions
```