### PR TITLE
resource_metering: tiny fix for linux cpu collector 

### DIFF
--- a/components/resource_metering/src/cpu/recorder/linux.rs
+++ b/components/resource_metering/src/cpu/recorder/linux.rs
@@ -266,6 +266,7 @@ impl CpuRecorder {
 
                         if delta_ms != 0 {
                             *records.entry(prev_tag).or_insert(0) += delta_ms;
+                            thread_stat.prev_stat = stat;
                         }
                     }
 
@@ -281,7 +282,6 @@ impl CpuRecorder {
                     // Store the beginning stat for the current tag.
                     if cur_tag.is_some() {
                         thread_stat.prev_tag = cur_tag;
-                        thread_stat.prev_stat = stat;
                     }
                 }
             }

--- a/components/resource_metering/src/cpu/recorder/linux.rs
+++ b/components/resource_metering/src/cpu/recorder/linux.rs
@@ -261,10 +261,11 @@ impl CpuRecorder {
                         let prev_cpu_ticks = (thread_stat.prev_stat.utime as u64)
                             .wrapping_add(thread_stat.prev_stat.stime as u64);
                         let current_cpu_ticks = (stat.utime as u64).wrapping_add(stat.stime as u64);
-                        let delta_ticks = current_cpu_ticks.wrapping_sub(prev_cpu_ticks);
+                        let delta_ms = current_cpu_ticks.wrapping_sub(prev_cpu_ticks) * 1_000
+                            / (*CLK_TCK as u64);
 
-                        if delta_ticks != 0 {
-                            *records.entry(prev_tag).or_insert(0) += delta_ticks;
+                        if delta_ms != 0 {
+                            *records.entry(prev_tag).or_insert(0) += delta_ms;
                         }
                     }
 
@@ -330,11 +331,6 @@ impl CpuRecorder {
             records.duration = duration;
 
             if !records.records.is_empty() {
-                // convert from tag -> clock ticks to tag -> ms.
-                for (tag, v) in records.records.iter_mut() {
-                    let ticks = *v;
-                    *v = ticks * 1_000 / (*CLK_TCK as u64);
-                }
                 let records = Arc::new(records);
                 for collector in self.collectors.values() {
                     collector.collect(records.clone());

--- a/components/resource_metering/src/cpu/recorder/mod.rs
+++ b/components/resource_metering/src/cpu/recorder/mod.rs
@@ -73,7 +73,7 @@ pub struct CpuRecords {
     pub begin_unix_time_secs: u64,
     pub duration: Duration,
 
-    // First collect as tag -> clock ticks. Before do collect, convert to tag -> ms.
+    // tag -> ms
     pub records: HashMap<ResourceMeteringTag, u64>,
 }
 

--- a/components/resource_metering/src/cpu/recorder/mod.rs
+++ b/components/resource_metering/src/cpu/recorder/mod.rs
@@ -73,7 +73,7 @@ pub struct CpuRecords {
     pub begin_unix_time_secs: u64,
     pub duration: Duration,
 
-    // tag -> ms
+    // First collect as tag -> clock ticks. Before do collect, convert to tag -> ms.
     pub records: HashMap<ResourceMeteringTag, u64>,
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Before this PR, the resource_metering collected CPU doesn't match the real thread CPU usage.

### What is changed and how it works?




### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```