### PR TITLE
raftstore: support witness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#91a52cd9e8db8dec6147114c94d1678fffc0a5ba"
+source = "git+https://github.com/coocood/kvproto?branch=witness#cfa3ec35d9e049478b3ab78232c40b32bcab1147"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,8 +258,8 @@ procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b7
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-# [patch.'https://github.com/pingcap/kvproto']
-# kvproto = {git = "https://github.com/your_github_id/kvproto", branch="your_branch"}
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = {git = "https://github.com/coocood/kvproto", branch="witness"}
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -545,7 +545,7 @@ where
 
         let tag = format!("[region {}] {}", region.get_id(), peer.get_id());
 
-        let ps = PeerStorage::new(engines, region, sched, peer.get_id(), tag.clone())?;
+        let ps = PeerStorage::new(engines, region, sched, peer.get_id(), peer.get_witness(), tag.clone())?;
 
         let applied_index = ps.applied_index();
 
@@ -1385,6 +1385,9 @@ where
         if let Some(ss) = ready.ss() {
             match ss.raft_state {
                 StateRole::Leader => {
+                    if self.peer.get_witness() {
+                        return
+                    }
                     // The local read can only be performed after a new leader has applied
                     // the first empty entry on its term. After that the lease expiring time
                     // should be updated to
@@ -1919,6 +1922,7 @@ where
             };
             let apply = Apply::new(
                 self.peer_id(),
+                self.peer.get_witness(),
                 self.region_id,
                 self.term(),
                 committed_entries,

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -685,7 +685,6 @@ where
     pub engines: Engines<EK, ER>,
 
     peer_id: u64,
-    witness: bool,
     region: metapb::Region,
     raft_state: RaftLocalState,
     apply_state: RaftApplyState,
@@ -777,7 +776,6 @@ where
         Ok(PeerStorage {
             engines,
             peer_id,
-            witness,
             region: region.clone(),
             raft_state,
             apply_state,

--- a/components/raftstore/src/store/region_snapshot.rs
+++ b/components/raftstore/src/store/region_snapshot.rs
@@ -402,7 +402,7 @@ mod tests {
         ER: RaftEngine,
     {
         let (sched, _) = worker::dummy_scheduler();
-        PeerStorage::new(engines, r, sched, 0, "".to_owned()).unwrap()
+        PeerStorage::new(engines, r, sched, 0, false, "".to_owned()).unwrap()
     }
 
     fn load_default_dataset<EK, ER>(engines: Engines<EK, ER>) -> (PeerStorage<EK, ER>, DataSet)

--- a/components/tidb_query_executors/src/index_scan_executor.rs
+++ b/components/tidb_query_executors/src/index_scan_executor.rs
@@ -298,6 +298,9 @@ impl ScanExecutorImpl for IndexScanExecutorImpl {
         value: &[u8],
         columns: &mut LazyBatchColumnVec,
     ) -> Result<()> {
+        if key[0] == table::GLOBAL_PARTITION_FIRST_BYTE {
+            key = &key[table::GLOBAL_PARTITION_PREFIX_LEN..]
+        }
         check_index_key(key)?;
         key = &key[table::PREFIX_LEN + table::ID_LEN..];
         if self.index_version == -1 {

--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -305,6 +305,10 @@ impl ScanExecutorImpl for TableScanExecutorImpl {
         columns: &mut LazyBatchColumnVec,
     ) -> Result<()> {
         use tidb_query_datatype::codec::{datum, table};
+        let mut key = key;
+        if key[0] == table::GLOBAL_PARTITION_FIRST_BYTE {
+            key = &key[table::GLOBAL_PARTITION_PREFIX_LEN..]
+        }
 
         let columns_len = self.schema.len();
         let mut decoded_columns = 0;

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -502,23 +502,23 @@ impl<ER: RaftEngine> Debugger<ER> {
             let region = local_state.get_region();
             let store_id = self.get_store_id()?;
 
-            let peer_id = raftstore_util::find_peer(region, store_id)
-                .map(|peer| peer.get_id())
+            let peer = raftstore_util::find_peer(region, store_id)
                 .ok_or_else(|| {
                     Error::Other("RegionLocalState doesn't contains peer itself".into())
                 })?;
 
-            let tag = format!("[region {}] {}", region.get_id(), peer_id);
+            let tag = format!("[region {}] {}", region.get_id(), peer.get_id());
             let peer_storage = box_try!(PeerStorage::<RocksEngine, ER>::new(
                 self.engines.clone(),
                 region,
                 fake_snap_worker.scheduler(),
-                peer_id,
+                peer.get_id(),
+                peer.get_witness(),
                 tag,
             ));
 
             let raft_cfg = raft::Config {
-                id: peer_id,
+                id: peer.get_id(),
                 election_tick: 10,
                 heartbeat_tick: 2,
                 max_size_per_msg: ReadableSize::mb(1).0,


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:
Support 1 witness role in 3 replica that doesn't apply raft log.

### What is changed and how it works?

What's Changed:

Support witness

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
   run tpcc with 3 replica with 1 witness, randomly kill and restart a node, the tpcc keep running without error.

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

None