### PR TITLE
record grpc duration correctly

### DIFF
--- a/components/test_storage/src/sync_storage.rs
+++ b/components/test_storage/src/sync_storage.rs
@@ -14,6 +14,7 @@ use tikv::storage::{
     test_util::GetConsumer, txn::commands, Engine, PerfStatisticsDelta, PrewriteResult, Result,
     Statistics, Storage, TestEngineBuilder, TestStorageBuilder, TxnStatus,
 };
+use tikv_util::time::Instant;
 use txn_types::{Key, KvPair, Mutation, TimeStamp, Value};
 
 /// A builder to build a `SyncTestStorage`.
@@ -142,7 +143,10 @@ impl<E: Engine> SyncTestStorage<E> {
             })
             .collect();
         let p = GetConsumer::new();
-        block_on(self.store.batch_get_command(requests, ids, p.clone()))?;
+        block_on(
+            self.store
+                .batch_get_command(requests, ids, p.clone(), Instant::now()),
+        )?;
         let mut values = vec![];
         for value in p.take_data().into_iter() {
             values.push(value?);

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -1,8 +1,9 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::server::metrics::GRPC_MSG_HISTOGRAM_STATIC;
-use crate::server::metrics::REQUEST_BATCH_SIZE_HISTOGRAM_VEC;
-use crate::server::service::kv::batch_commands_response;
+use crate::server::metrics::{GrpcTypeKind, REQUEST_BATCH_SIZE_HISTOGRAM_VEC};
+use crate::server::service::kv::{
+    batch_commands_response, GrpcRequestDuration, MeasuredSingleResponse,
+};
 use crate::storage::kv::{PerfStatisticsDelta, Statistics};
 use crate::storage::{
     errors::{extract_key_error, extract_region_error},
@@ -63,7 +64,7 @@ impl ReqBatcher {
     pub fn maybe_commit<E: Engine, L: LockManager>(
         &mut self,
         storage: &Storage<E, L>,
-        tx: &Sender<(u64, batch_commands_response::Response)>,
+        tx: &Sender<MeasuredSingleResponse>,
     ) {
         if self.gets.len() >= self.batch_size {
             let gets = std::mem::take(&mut self.gets);
@@ -81,7 +82,7 @@ impl ReqBatcher {
     pub fn commit<E: Engine, L: LockManager>(
         self,
         storage: &Storage<E, L>,
-        tx: &Sender<(u64, batch_commands_response::Response)>,
+        tx: &Sender<MeasuredSingleResponse>,
     ) {
         if !self.gets.is_empty() {
             future_batch_get_command(
@@ -135,13 +136,18 @@ impl BatcherBuilder {
 }
 
 pub struct GetCommandResponseConsumer {
-    tx: Sender<(u64, batch_commands_response::Response)>,
+    tx: Sender<MeasuredSingleResponse>,
 }
 
 impl ResponseBatchConsumer<(Option<Vec<u8>>, Statistics, PerfStatisticsDelta)>
     for GetCommandResponseConsumer
 {
-    fn consume(&self, id: u64, res: Result<(Option<Vec<u8>>, Statistics, PerfStatisticsDelta)>) {
+    fn consume(
+        &self,
+        id: u64,
+        res: Result<(Option<Vec<u8>>, Statistics, PerfStatisticsDelta)>,
+        begin: Instant,
+    ) {
         let mut resp = GetResponse::default();
         if let Some(err) = extract_region_error(&res) {
             resp.set_region_error(err);
@@ -164,14 +170,16 @@ impl ResponseBatchConsumer<(Option<Vec<u8>>, Statistics, PerfStatisticsDelta)>
             cmd: Some(batch_commands_response::response::Cmd::Get(resp)),
             ..Default::default()
         };
-        if self.tx.send_and_notify((id, res)).is_err() {
+        let mesure = GrpcRequestDuration::new(begin, GrpcTypeKind::kv_batch_get_command);
+        let task = MeasuredSingleResponse::new(id, res, mesure);
+        if self.tx.send_and_notify(task).is_err() {
             error!("KvService response batch commands fail");
         }
     }
 }
 
 impl ResponseBatchConsumer<Option<Vec<u8>>> for GetCommandResponseConsumer {
-    fn consume(&self, id: u64, res: Result<Option<Vec<u8>>>) {
+    fn consume(&self, id: u64, res: Result<Option<Vec<u8>>>, begin: Instant) {
         let mut resp = RawGetResponse::default();
         if let Some(err) = extract_region_error(&res) {
             resp.set_region_error(err);
@@ -186,7 +194,9 @@ impl ResponseBatchConsumer<Option<Vec<u8>>> for GetCommandResponseConsumer {
             cmd: Some(batch_commands_response::response::Cmd::RawGet(resp)),
             ..Default::default()
         };
-        if self.tx.send_and_notify((id, res)).is_err() {
+        let mesure = GrpcRequestDuration::new(begin, GrpcTypeKind::raw_batch_get_command);
+        let task = MeasuredSingleResponse::new(id, res, mesure);
+        if self.tx.send_and_notify(task).is_err() {
             error!("KvService response batch commands fail");
         }
     }
@@ -196,7 +206,7 @@ fn future_batch_get_command<E: Engine, L: LockManager>(
     storage: &Storage<E, L>,
     requests: Vec<u64>,
     gets: Vec<GetRequest>,
-    tx: Sender<(u64, batch_commands_response::Response)>,
+    tx: Sender<MeasuredSingleResponse>,
     begin_instant: tikv_util::time::Instant,
 ) {
     REQUEST_BATCH_SIZE_HISTOGRAM_VEC
@@ -207,6 +217,7 @@ fn future_batch_get_command<E: Engine, L: LockManager>(
         gets,
         requests,
         GetCommandResponseConsumer { tx: tx.clone() },
+        begin_instant,
     );
     let f = async move {
         // This error can only cause by readpool busy.
@@ -219,14 +230,14 @@ fn future_batch_get_command<E: Engine, L: LockManager>(
                     cmd: Some(batch_commands_response::response::Cmd::Get(resp.clone())),
                     ..Default::default()
                 };
-                if tx.send_and_notify((id, res)).is_err() {
+                let measure =
+                    GrpcRequestDuration::new(begin_instant, GrpcTypeKind::kv_batch_get_command);
+                let task = MeasuredSingleResponse::new(id, res, measure);
+                if tx.send_and_notify(task).is_err() {
                     error!("KvService response batch commands fail");
                 }
             }
         }
-        GRPC_MSG_HISTOGRAM_STATIC
-            .kv_batch_get_command
-            .observe(begin_instant.saturating_elapsed_secs());
     };
     poll_future_notify(f);
 }
@@ -235,7 +246,7 @@ fn future_batch_raw_get_command<E: Engine, L: LockManager>(
     storage: &Storage<E, L>,
     requests: Vec<u64>,
     gets: Vec<RawGetRequest>,
-    tx: Sender<(u64, batch_commands_response::Response)>,
+    tx: Sender<MeasuredSingleResponse>,
     begin_instant: tikv_util::time::Instant,
 ) {
     REQUEST_BATCH_SIZE_HISTOGRAM_VEC
@@ -258,14 +269,14 @@ fn future_batch_raw_get_command<E: Engine, L: LockManager>(
                     cmd: Some(batch_commands_response::response::Cmd::RawGet(resp.clone())),
                     ..Default::default()
                 };
-                if tx.send_and_notify((id, res)).is_err() {
+                let measure =
+                    GrpcRequestDuration::new(begin_instant, GrpcTypeKind::raw_batch_get_command);
+                let task = MeasuredSingleResponse::new(id, res, measure);
+                if tx.send_and_notify(task).is_err() {
                     error!("KvService response batch commands fail");
                 }
             }
         }
-        GRPC_MSG_HISTOGRAM_STATIC
-            .raw_batch_get_command
-            .observe(begin_instant.saturating_elapsed_secs());
     };
     poll_future_notify(f);
 }

--- a/src/server/service/mod.rs
+++ b/src/server/service/mod.rs
@@ -8,4 +8,7 @@ mod kv;
 pub use self::debug::Service as DebugService;
 pub use self::diagnostics::Service as DiagnosticsService;
 pub use self::kv::Service as KvService;
-pub use self::kv::{batch_commands_request, batch_commands_response};
+pub use self::kv::{
+    batch_commands_request, batch_commands_response, GrpcRequestDuration, MeasuredBatchResponse,
+    MeasuredSingleResponse,
+};


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

In the current implementation, "grpc request duration" only represents the time of handling the request, but the time of collecting responses in batch-channel is excluded.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```