### PR TITLE
alertmanager: no GC cannot work alert if no compaction happens

### DIFF
--- a/metrics/alertmanager/tikv.rules.yml
+++ b/metrics/alertmanager/tikv.rules.yml
@@ -14,7 +14,7 @@ groups:
       summary: TiKV memory used too fast
 
   - alert: TiKV_GC_can_not_work
-    expr: sum(increase(tikv_gcworker_gc_tasks_vec{task="gc"}[1d])) < 1 and sum(increase(tikv_gc_compaction_filter_perform[1d])) < 1
+    expr: sum(increase(tikv_gcworker_gc_tasks_vec{task="gc"}[1d])) < 1 and (sum(increase(tikv_gc_compaction_filter_perform[1d])) < 1 and sum(increase(tikv_engine_event_total{db="kv", cf="write", type="compaction"}[1d])) >= 1)
     for: 1m
     labels:
       env: ENV_LABELS_ENV


### PR DESCRIPTION

### What problem does this PR solve?

After TiDB 5.0, compaction filter is the default GC approach. If the cluster is idle thus no compaction is triggered, the GC compaction filter will not be triggered. Then, there will be a false "GC can not work" alert which is really annoying.

### What is changed and how it works?

This PR modifies the alertmanager rule of "GC can not work". It raises the alert only if there are compaction operations while no GC compaction filter runs.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Avoid false "GC can not work" alert under low write flow.
```