### PR TITLE
raftstore: calculate slow score periodically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,6 +2788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "page_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,6 +3437,7 @@ dependencies = [
  "memory_trace_macros",
  "online_config",
  "openssl",
+ "ordered-float 2.7.0",
  "panic_hook",
  "pd_client",
  "prometheus",
@@ -5026,7 +5036,7 @@ dependencies = [
  "num",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 1.1.1",
  "protobuf",
  "regex",
  "serde",

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -84,6 +84,7 @@ lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }
 memory_trace_macros = { path = "../memory_trace_macros" }
+ordered-float = "2.6"
 pd_client = { path = "../pd_client", default-features = false }
 prometheus = { version = "0.12", features = ["nightly"] }
 prometheus-static-metric = "0.5"

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -217,6 +217,9 @@ pub struct Config {
     #[serde(skip_serializing)]
     #[online_config(skip)]
     pub clean_stale_peer_delay: ReadableDuration,
+
+    // Interval to inspect the latency of raftstore for slow store detection.
+    pub inspect_interval: ReadableDuration,
 }
 
 impl Default for Config {
@@ -293,6 +296,7 @@ impl Default for Config {
             region_max_size: ReadableSize(0),
             region_split_size: ReadableSize(0),
             clean_stale_peer_delay: ReadableDuration::minutes(0),
+            inspect_interval: ReadableDuration::millis(500),
         }
     }
 }

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -1395,6 +1395,7 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             .spawn("apply".to_owned(), apply_poller_builder);
 
         let pd_runner = PdRunner::new(
+            &cfg,
             store.get_id(),
             Arc::clone(&pd_client),
             self.router.clone(),

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -620,4 +620,15 @@ lazy_static! {
         "Number of peers in hibernated state.",
         &["state"],
     ).unwrap();
+
+    pub static ref STORE_INSPECT_DURTION_HISTOGRAM: HistogramVec =
+        register_histogram_vec!(
+            "tikv_raftstore_slow_score_duration_seconds",
+            "Bucketed histogram of inspect duration.",
+            &["type"],
+            exponential_buckets(0.0005, 2.0, 20).unwrap()
+        ).unwrap();
+
+    pub static ref STORE_SLOW_SCORE_GAUGE: Gauge =
+    register_gauge!("tikv_raftstore_slow_score", "Slow score of the store.").unwrap();
 }

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -24,15 +24,16 @@ use kvproto::{metapb, pdpb};
 use prometheus::local::LocalHistogram;
 use raft::eraftpb::ConfChangeType;
 use yatp::Remote;
+use ordered_float::OrderedFloat;
 
 use crate::store::cmd_resp::new_error;
 use crate::store::metrics::*;
-use crate::store::util::{is_epoch_stale, ConfChangeKind, KeysInfoFormatter};
+use crate::store::util::{is_epoch_stale, ConfChangeKind, KeysInfoFormatter, RaftstoreDuration, LatencyInspector};
 use crate::store::worker::query_stats::QueryStats;
 use crate::store::worker::split_controller::{SplitInfo, TOP_N};
 use crate::store::worker::{AutoSplitController, ReadStats};
 use crate::store::{
-    Callback, CasualMessage, PeerMsg, RaftCommand, RaftRouter, SnapManager, StoreInfo, StoreMsg,
+    Callback, CasualMessage, PeerMsg, RaftCommand, RaftRouter, SnapManager, StoreInfo, StoreMsg, Config,
 };
 
 use collections::HashMap;
@@ -46,7 +47,7 @@ use tikv_util::sys::disk;
 use tikv_util::time::UnixSecs;
 use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 use tikv_util::topn::TopN;
-use tikv_util::worker::{Runnable, ScheduleError, Scheduler};
+use tikv_util::worker::{Runnable, ScheduleError, Scheduler, RunnableWithTimer};
 use tikv_util::{box_err, debug, error, info, thd_name, warn};
 
 type RecordPairVec = Vec<pdpb::RecordPair>;
@@ -150,12 +151,17 @@ where
     QueryRegionLeader {
         region_id: u64,
     },
+    UpdateSlowScore {
+        id: u64,
+        duration: RaftstoreDuration,
+    },
 }
 
 pub struct StoreStat {
     pub engine_total_bytes_read: u64,
     pub engine_total_keys_read: u64,
     pub engine_total_query_num: QueryStats,
+    
     pub engine_last_total_bytes_read: u64,
     pub engine_last_total_keys_read: u64,
     pub engine_last_query_num: QueryStats,
@@ -307,6 +313,9 @@ where
             ),
             Task::QueryRegionLeader { region_id } => {
                 write!(f, "query the leader of region {}", region_id)
+            },
+            Task::UpdateSlowScore { id, ref duration } => {
+                write!(f, "compute slow score: id {}, duration {:?}", id, duration)
             }
         }
     }
@@ -496,6 +505,88 @@ fn hotspot_query_num_report_threshold() -> u64 {
     HOTSPOT_QUERY_RATE_THRESHOLD * 10
 }
 
+struct SlowScore {
+    value: OrderedFloat<f64>,
+    last_update_time: Instant,
+
+    timeout_requests: usize,
+    total_requests: usize,
+
+    inspect_interval: Duration,
+    // The maximal tolerated timeout ratio.
+    ratio_thresh: OrderedFloat<f64>,
+    // Minimal time that the score could be decreased from 100 to 1.
+    min_ttr: Duration,
+
+    // After how many ticks the value need to be updated.
+    round_ticks: u64,
+    // Indentify every ticks.
+    last_tick_id: u64,
+    // If the last tick does not finished, it would be recorded as a timeout.
+    last_tick_finished: bool,
+}
+
+impl SlowScore {
+    fn new(inspect_interval: Duration) -> SlowScore {
+        SlowScore {
+            value: OrderedFloat(1.0),
+
+            timeout_requests: 0,
+            total_requests: 0,
+
+            inspect_interval,
+            ratio_thresh: OrderedFloat(0.1),
+            min_ttr: Duration::from_secs(5 * 60),
+            last_update_time: Instant::now(),
+            round_ticks: 30,
+            last_tick_id: 0,
+            last_tick_finished: true,
+        }
+    }
+
+    fn record(&mut self, id: u64, duration: Duration) {
+        if id != self.last_tick_id {
+            return;
+        }
+        self.last_tick_finished = true;
+        self.total_requests += 1;
+        if duration >= self.inspect_interval {
+            self.timeout_requests += 1;
+        }
+    }
+
+    fn update(&mut self) -> f64 {
+        let elapsed = self.last_update_time.elapsed();
+        self.update_impl(elapsed).into()
+    }
+
+    fn get(&self) -> f64 {
+        self.value.into()
+    }
+
+    fn update_impl(&mut self, elapsed: Duration) -> OrderedFloat<f64> {
+        if self.timeout_requests == 0 {
+            let desc = 100.0 * (elapsed.as_millis() as f64 / self.min_ttr.as_millis() as f64);
+            if OrderedFloat(desc) > self.value {
+                self.value = 1.0.into();
+            } else {
+                self.value -= desc;
+            }
+        } else {
+            let timeout_ratio = self.timeout_requests as f64 / self.total_requests as f64;
+            let near_thresh =
+                cmp::min(OrderedFloat(timeout_ratio), self.ratio_thresh) / self.ratio_thresh;
+            let value = self.value * (OrderedFloat(1.0) + near_thresh);
+            self.value = cmp::min(OrderedFloat(100.0), value);
+        }
+
+        self.total_requests = 0;
+        self.timeout_requests = 0;
+        self.last_update_time = Instant::now();
+        self.value
+    }
+}
+
 pub struct Runner<EK, ER, T>
 where
     EK: KvEngine,
@@ -520,6 +611,7 @@ where
     concurrency_manager: ConcurrencyManager,
     snap_mgr: SnapManager,
     remote: Remote<yatp::task::future::TaskCell>,
+    slow_score: SlowScore,
 }
 
 impl<EK, ER, T> Runner<EK, ER, T>
@@ -531,6 +623,7 @@ where
     const INTERVAL_DIVISOR: u32 = 2;
 
     pub fn new(
+        cfg: &Config,
         store_id: u64,
         pd_client: Arc<T>,
         router: RaftRouter<EK, ER>,
@@ -560,6 +653,7 @@ where
             concurrency_manager,
             snap_mgr,
             remote,
+            slow_score: SlowScore::new(cfg.inspect_interval.0)
         }
     }
 
@@ -840,6 +934,9 @@ where
         STORE_SIZE_GAUGE_VEC
             .with_label_values(&["available"])
             .set(available as i64);
+        
+        let slow_score = self.slow_score.get();
+        stats.set_slow_score(slow_score as u64);
 
         let router = self.router.clone();
         let resp = self.pd_client.store_heartbeat(stats);
@@ -1338,11 +1435,76 @@ where
                 max_ts_sync_status,
             } => self.handle_update_max_timestamp(region_id, initial_status, max_ts_sync_status),
             Task::QueryRegionLeader { region_id } => self.handle_query_region_leader(region_id),
+            Task::UpdateSlowScore { id, duration } => self.slow_score.record(id, duration.sum()),
         };
     }
 
     fn shutdown(&mut self) {
         self.stats_monitor.stop();
+    }
+}
+
+impl<EK, ER, T> RunnableWithTimer for Runner<EK, ER, T>
+where
+    EK: KvEngine,
+    ER: RaftEngine,
+    T: PdClient + 'static,
+{
+    fn on_timeout(&mut self) {
+        if !self.slow_score.last_tick_finished {
+            self.slow_score
+                .record(self.slow_score.last_tick_id, Duration::from_secs(1));
+        }
+        let scheduler = self.scheduler.clone();
+        let id = self.slow_score.last_tick_id + 1;
+        self.slow_score.last_tick_id += 1;
+        self.slow_score.last_tick_finished = false;
+        if self.slow_score.last_tick_id % self.slow_score.round_ticks == 0 {
+            let slow_score = self.slow_score.update();
+            STORE_SLOW_SCORE_GAUGE.set(slow_score);
+        }
+
+        let inspector = LatencyInspector::new(
+            id,
+            Box::new(move |id, duration| {
+                let dur = duration.sum();
+
+                STORE_INSPECT_DURTION_HISTOGRAM
+                    .with_label_values(&["store_process"])
+                    .observe(tikv_util::time::duration_to_sec(
+                        duration.store_process_duration.unwrap(),
+                    ));
+                STORE_INSPECT_DURTION_HISTOGRAM
+                    .with_label_values(&["store_wait"])
+                    .observe(tikv_util::time::duration_to_sec(
+                        duration.store_wait_duration.unwrap(),
+                    ));
+                STORE_INSPECT_DURTION_HISTOGRAM
+                    .with_label_values(&["apply_process"])
+                    .observe(tikv_util::time::duration_to_sec(
+                        duration.apply_process_duration.unwrap(),
+                    ));
+                STORE_INSPECT_DURTION_HISTOGRAM
+                    .with_label_values(&["apply_wait"])
+                    .observe(tikv_util::time::duration_to_sec(
+                        duration.apply_wait_duration.unwrap(),
+                    ));
+                STORE_INSPECT_DURTION_HISTOGRAM
+                    .with_label_values(&["all"])
+                    .observe(tikv_util::time::duration_to_sec(dur));
+                if let Err(e) = scheduler.schedule(Task::UpdateSlowScore { id, duration }) {
+                    warn!("schedule pd task failed"; "err" => ?e);
+                }
+            }),
+        );
+        let msg = StoreMsg::LatencyInspect{send_time: tikv_util::time::Instant::now(), inspector};
+        if let Err(e) = self.router.send_control(msg) {
+            warn!("pd worker send latency inspecter failed"; "err" => ?e);
+        }
+    }
+
+    fn get_interval(&self) -> Duration {
+        self.slow_score.inspect_interval
     }
 }
 
@@ -1643,5 +1805,51 @@ mod tests {
         let mut store_stats = pdpb::StoreStats::default();
         store_stats = collect_report_read_peer_stats(1, report_stats, store_stats);
         assert_eq!(store_stats.peer_stats.len(), 3)
+    }
+
+    #[test]
+    fn test_slow_score() {
+        let mut slow_score = SlowScore::new(Duration::from_millis(500));
+        slow_score.timeout_requests = 5;
+        slow_score.total_requests = 100;
+        assert_eq!(
+            OrderedFloat(1.5),
+            slow_score.update_impl(Duration::from_secs(10))
+        );
+
+        slow_score.timeout_requests = 10;
+        slow_score.total_requests = 100;
+        assert_eq!(
+            OrderedFloat(3.0),
+            slow_score.update_impl(Duration::from_secs(10))
+        );
+
+        slow_score.timeout_requests = 20;
+        slow_score.total_requests = 100;
+        assert_eq!(
+            OrderedFloat(6.0),
+            slow_score.update_impl(Duration::from_secs(10))
+        );
+
+        slow_score.timeout_requests = 100;
+        slow_score.total_requests = 100;
+        assert_eq!(
+            OrderedFloat(12.0),
+            slow_score.update_impl(Duration::from_secs(10))
+        );
+
+        slow_score.timeout_requests = 11;
+        slow_score.total_requests = 100;
+        assert_eq!(
+            OrderedFloat(24.0),
+            slow_score.update_impl(Duration::from_secs(10))
+        );
+
+        slow_score.timeout_requests = 0;
+        slow_score.total_requests = 100;
+        assert_eq!(
+            OrderedFloat(19.0),
+            slow_score.update_impl(Duration::from_secs(15))
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Problem Summary:

Address #10539.

### What is changed and how it works?

What's Changed:

* Add a tick to pd worker, inspect raftstore latency and calculate slow score periodically.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```
* Introduce a mechanism to detect slow tikv store