### PR TITLE
handle majority disk full peers correctly

### DIFF
--- a/components/raftstore/src/store/async_io/write_router.rs
+++ b/components/raftstore/src/store/async_io/write_router.rs
@@ -251,7 +251,7 @@ mod tests {
         }
 
         fn must_same_msg_count(&self, id: usize, mut count: usize) {
-            while let Ok(_) = self.receivers[id].try_recv() {
+            while self.receivers[id].try_recv().is_ok() {
                 if count == 0 {
                     panic!("msg count is smaller");
                 }

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -420,7 +420,7 @@ impl<EK: KvEngine> fmt::Debug for CasualMessage<EK> {
 }
 
 /// control options for raftcmd.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct RaftCmdExtraOpts {
     pub deadline: Option<Deadline>,
     pub disk_full_opt: DiskFullOpt,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1392,6 +1392,11 @@ where
 
                     if !ctx.store_disk_usages.is_empty() {
                         self.refill_disk_full_peers(ctx);
+                        debug!(
+                            "become leader refills disk full peers to {:?}",
+                            self.disk_full_peers;
+                            "region_id" => self.region_id,
+                        );
                     }
                 }
                 StateRole::Follower => {

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1389,10 +1389,15 @@ where
                     // A more recent read may happen on the old leader. So max ts should
                     // be updated after a peer becomes leader.
                     self.require_updating_max_ts(&ctx.pd_scheduler);
+
+                    if !ctx.store_disk_usages.is_empty() {
+                        self.refill_disk_full_peers(ctx);
+                    }
                 }
                 StateRole::Follower => {
                     self.leader_lease.expire();
                     self.mut_store().cancel_generating_snap(None);
+                    self.disk_full_peers = Default::default();
                 }
                 _ => {}
             }
@@ -3337,35 +3342,35 @@ where
         self.want_rollback_merge_peers.insert(peer_id);
     }
 
-    fn maybe_refill_disk_full_peers<T>(&mut self, ctx: &mut PollContext<EK, ER, T>) {
-        if !self.disk_full_peers.any || !self.disk_full_peers.peers.is_empty() {
-            return;
+    pub fn refill_disk_full_peers<T>(&mut self, ctx: &mut PollContext<EK, ER, T>) {
+        // Before refill `disk_full_peers`, reset `max_inflight_msgs` for them.
+        for peer in mem::take(&mut self.disk_full_peers).peers.into_keys() {
+            let raft = &mut self.raft_group.raft;
+            raft.adjust_max_inflight_msgs(peer, ctx.cfg.raft_max_inflight_msgs);
         }
 
         // Collect disk full peers and all peers' `next_idx` to find a potential quorum.
         let peers_len = self.get_store().region().get_peers().len();
-        let mut disk_full_peers = HashSet::default();
+        let mut normal_peers = HashSet::default();
         let mut next_idxs = Vec::with_capacity(peers_len);
         for peer in self.get_store().region().get_peers() {
             let (peer_id, store_id) = (peer.get_id(), peer.get_store_id());
             let usage = ctx.store_disk_usages.get(&store_id);
-            if let Some(ref usage) = usage {
-                assert!(!matches!(usage, DiskUsage::Normal));
-                disk_full_peers.insert(peer_id);
+            if usage.is_none() {
+                // Always treat the leader itself as normal.
+                normal_peers.insert(peer_id);
             }
-            let raft = &self.raft_group.raft;
-            if let Some(pr) = raft.prs().get(peer_id) {
+            if let Some(pr) = self.raft_group.raft.prs().get(peer_id) {
                 next_idxs.push((peer_id, pr.next_idx, usage));
             }
         }
 
-        if disk_full_peers.is_empty() {
-            self.disk_full_peers = DiskFullPeers::default();
+        if normal_peers.len() == peers_len {
             return;
         }
 
         let raft = &mut self.raft_group.raft;
-        self.disk_full_peers.majority = raft.prs().has_quorum(&disk_full_peers);
+        self.disk_full_peers.majority = !raft.prs().has_quorum(&normal_peers);
         for &(peer, _, usage) in &next_idxs {
             if let Some(usage) = usage {
                 self.disk_full_peers.peers.insert(peer, (*usage, false));
@@ -3411,8 +3416,6 @@ where
         disk_full_opt: DiskFullOpt,
         disk_full_stores: &mut Vec<u64>,
     ) -> bool {
-        self.maybe_refill_disk_full_peers(ctx);
-
         // Propose can be rejected if the store itself's disk is full.
         let self_allowed = match disk_full_opt {
             DiskFullOpt::NotAllowedOnFull => matches!(ctx.self_disk_usage, DiskUsage::Normal),
@@ -3423,7 +3426,7 @@ where
             return false;
         }
 
-        if !self.disk_full_peers.any || !self.disk_full_peers.majority {
+        if self.disk_full_peers.is_empty() || !self.disk_full_peers.majority {
             return true;
         }
 
@@ -3434,17 +3437,28 @@ where
             return true;
         }
 
-        disk_full_stores.extend(ctx.store_disk_usages.keys());
+        disk_full_stores.extend(self.disk_full_peers.peers.keys());
         false
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct DiskFullPeers {
-    pub any: bool,
-    pub majority: bool,
+    majority: bool,
     // Indicates whether a peer can help to establish a quorum.
-    pub peers: HashMap<u64, (DiskUsage, bool)>,
+    peers: HashMap<u64, (DiskUsage, bool)>,
+}
+
+impl DiskFullPeers {
+    pub fn is_empty(&self) -> bool {
+        self.peers.is_empty()
+    }
+    pub fn has(&self, peer_id: u64) -> bool {
+        !self.peers.is_empty() && self.peers.contains_key(&peer_id)
+    }
+    pub fn get(&self, peer_id: u64) -> Option<DiskUsage> {
+        self.peers.get(&peer_id).map(|x| x.0)
+    }
 }
 
 impl<EK, ER> Peer<EK, ER>
@@ -3571,10 +3585,11 @@ where
         let mut send_msg = self.prepare_raft_message();
         let ty = msg.get_type();
         debug!("send extra msg";
-        "region_id" => self.region_id,
-        "peer_id" => self.peer.get_id(),
-        "msg_type" => ?ty,
-        "to" => to.get_id());
+            "region_id" => self.region_id,
+            "peer_id" => self.peer.get_id(),
+            "msg_type" => ?ty,
+            "to" => to.get_id()
+        );
         send_msg.set_extra_msg(msg);
         send_msg.set_to_peer(to.clone());
         if let Err(e) = trans.send(send_msg) {
@@ -3619,6 +3634,7 @@ where
             "msg_type" => ?msg_type,
             "msg_size" => msg.compute_size(),
             "to" => to_peer_id,
+            "disk_usage" => ?send_msg.disk_usage,
         );
 
         send_msg.set_to_peer(to_peer);

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -354,11 +354,12 @@ impl Simulator for NodeCluster {
         self.nodes.keys().cloned().collect()
     }
 
-    fn async_command_on_node(
+    fn async_command_on_node_with_opts(
         &self,
         node_id: u64,
         request: RaftCmdRequest,
         cb: Callback<RocksSnapshot>,
+        opts: RaftCmdExtraOpts,
     ) -> Result<()> {
         if !self
             .trans
@@ -380,7 +381,7 @@ impl Simulator for NodeCluster {
             .get(&node_id)
             .cloned()
             .unwrap();
-        router.send_command(request, cb, RaftCmdExtraOpts::default())
+        router.send_command(request, cb, opts)
     }
 
     fn async_read(

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -528,17 +528,18 @@ impl Simulator for ServerCluster {
         self.metas.keys().cloned().collect()
     }
 
-    fn async_command_on_node(
+    fn async_command_on_node_with_opts(
         &self,
         node_id: u64,
         request: RaftCmdRequest,
         cb: Callback<RocksSnapshot>,
+        opts: RaftCmdExtraOpts,
     ) -> Result<()> {
         let router = match self.metas.get(&node_id) {
             None => return Err(box_err!("missing sender for store {}", node_id)),
             Some(meta) => meta.sim_router.clone(),
         };
-        router.send_command(request, cb, RaftCmdExtraOpts::default())
+        router.send_command(request, cb, opts)
     }
 
     fn async_read(

--- a/tests/failpoints/cases/test_disk_full.rs
+++ b/tests/failpoints/cases/test_disk_full.rs
@@ -3,6 +3,7 @@
 use super::test_replica_stale_read::{get_tso, PeerClient};
 use kvproto::disk_usage::DiskUsage;
 use kvproto::kvrpcpb::{DiskFullOpt, Op};
+use kvproto::metapb::Region;
 use kvproto::raft_cmdpb::*;
 use raft::eraftpb::MessageType;
 use raftstore::store::msg::*;
@@ -14,6 +15,14 @@ fn assert_disk_full(resp: &RaftCmdResponse) {
     assert!(resp.get_header().get_error().has_disk_full());
 }
 
+fn disk_full_stores(resp: &RaftCmdResponse) -> Vec<u64> {
+    let region_error = resp.get_header().get_error();
+    assert!(region_error.has_disk_full());
+    let mut stores = region_error.get_disk_full().get_store_id().to_vec();
+    stores.sort();
+    stores
+}
+
 fn get_fp(usage: DiskUsage, store_id: u64) -> String {
     match usage {
         DiskUsage::AlmostFull => format!("disk_almost_full_peer_{}", store_id),
@@ -22,8 +31,20 @@ fn get_fp(usage: DiskUsage, store_id: u64) -> String {
     }
 }
 
+fn ensure_disk_usage_is_reported<T: Simulator>(
+    cluster: &mut Cluster<T>,
+    peer_id: u64,
+    store_id: u64,
+    region: &Region,
+) {
+    let peer = new_peer(store_id, peer_id);
+    let key = region.get_start_key();
+    let ch = async_read_on_peer(cluster, peer, region.clone(), key, true, true);
+    assert!(ch.recv_timeout(Duration::from_secs(1)).is_ok());
+}
+
 fn test_disk_full_leader_behaviors(usage: DiskUsage) {
-    let mut cluster = new_server_cluster(0, 3);
+    let mut cluster = new_node_cluster(0, 3);
     cluster.pd_client.disable_default_operator();
     cluster.run();
 
@@ -84,7 +105,7 @@ fn test_disk_full_for_region_leader() {
 }
 
 fn test_disk_full_follower_behaviors(usage: DiskUsage) {
-    let mut cluster = new_server_cluster(0, 3);
+    let mut cluster = new_node_cluster(0, 3);
     cluster.pd_client.disable_default_operator();
     cluster.run();
 
@@ -227,4 +248,92 @@ fn test_disk_full_txn_behaviors(usage: DiskUsage) {
 #[test]
 fn test_disk_full_for_txn_operations() {
     test_disk_full_txn_behaviors(DiskUsage::AlmostFull);
+}
+
+#[test]
+fn test_majority_disk_full() {
+    let mut cluster = new_node_cluster(0, 3);
+    // To ensure the thread has full store disk usage infomation.
+    cluster.cfg.raft_store.store_batch_system.pool_size = 1;
+    cluster.pd_client.disable_default_operator();
+    cluster.run();
+
+    // To ensure all replicas are not pending.
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(1), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+
+    cluster.must_transfer_leader(1, new_peer(1, 1));
+    let region = cluster.get_region(b"k1");
+    let epoch = region.get_region_epoch().clone();
+
+    // To ensure followers have reported disk usages to the leader.
+    for i in 1..3 {
+        fail::cfg(get_fp(DiskUsage::AlmostFull, i + 1), "return").unwrap();
+        ensure_disk_usage_is_reported(&mut cluster, i + 1, i + 1, &region);
+    }
+
+    // Normal proposals will be rejected because of majority peers' disk full.
+    let ch = cluster.async_put(b"k2", b"v2").unwrap();
+    let resp = ch.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert_eq!(disk_full_stores(&resp), vec![2, 3]);
+
+    // Proposals with special `DiskFullOpt`s can be accepted even if all peers are disk full.
+    fail::cfg(get_fp(DiskUsage::AlmostFull, 1), "return").unwrap();
+    let reqs = vec![new_put_cmd(b"k3", b"v3")];
+    let put = new_request(1, epoch.clone(), reqs, false);
+    let mut opts = RaftCmdExtraOpts::default();
+    opts.disk_full_opt = DiskFullOpt::AllowedOnAlmostFull;
+    let ch = cluster.async_request_with_opts(put, opts).unwrap();
+    let resp = ch.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert!(!resp.get_header().has_error());
+
+    // Reset disk full status for peer 2 and 3. 2 follower reads must success because the leader
+    // will continue to append entries to followers after the new disk usages are reported.
+    for i in 1..3 {
+        fail::remove(get_fp(DiskUsage::AlmostFull, i + 1));
+        ensure_disk_usage_is_reported(&mut cluster, i + 1, i + 1, &region);
+        must_get_equal(&cluster.get_engine(i + 1), b"k3", b"v3");
+    }
+
+    // To ensure followers have reported disk usages to the leader.
+    for i in 1..3 {
+        fail::cfg(get_fp(DiskUsage::AlreadyFull, i + 1), "return").unwrap();
+        ensure_disk_usage_is_reported(&mut cluster, i + 1, i + 1, &region);
+    }
+
+    // Proposals with special `DiskFullOpt`s will still be rejected if majority peers are already
+    // disk full.
+    let reqs = vec![new_put_cmd(b"k3", b"v3")];
+    let put = new_request(1, epoch.clone(), reqs, false);
+    let mut opts = RaftCmdExtraOpts::default();
+    opts.disk_full_opt = DiskFullOpt::AllowedOnAlmostFull;
+    let ch = cluster.async_request_with_opts(put, opts).unwrap();
+    let resp = ch.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert_eq!(disk_full_stores(&resp), vec![2, 3]);
+
+    // Peer 2 disk usage changes from already full to almost full.
+    fail::remove(get_fp(DiskUsage::AlreadyFull, 2));
+    fail::cfg(get_fp(DiskUsage::AlmostFull, 2), "return").unwrap();
+    ensure_disk_usage_is_reported(&mut cluster, 2, 2, &region);
+
+    // Configuration change should be alloed.
+    cluster.pd_client.must_remove_peer(1, new_peer(2, 2));
+
+    // After the last configuration change is applied, the raft group will be like
+    // `[(1, DiskUsage::AlmostFull), (3, DiskUsage::AlreadyFull)]`. So no more proposals
+    // should be allowed.
+    let reqs = vec![new_put_cmd(b"k4", b"v4")];
+    let put = new_request(1, epoch.clone(), reqs, false);
+    let mut opts = RaftCmdExtraOpts::default();
+    opts.disk_full_opt = DiskFullOpt::AllowedOnAlmostFull;
+    let ch = cluster.async_request_with_opts(put, opts).unwrap();
+    let resp = ch.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert_eq!(disk_full_stores(&resp), vec![3]);
+
+    for i in 0..3 {
+        fail::remove(get_fp(DiskUsage::AlreadyFull, i + 1));
+        fail::remove(get_fp(DiskUsage::AlmostFull, i + 1));
+    }
 }


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

* Recalculate a commit quorum for configuration changes and role changes.
* Keep ticking if any followers are almost disk full.
* And add integration test cases for region majority peers disk full.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```