### PR TITLE
*:fix one bug about drop table/truncate table failed when TiKV is almost disk full

### DIFF
--- a/components/file_system/src/lib.rs
+++ b/components/file_system/src/lib.rs
@@ -412,7 +412,7 @@ impl<R: Read> Read for Sha256Reader<R> {
     }
 }
 
-const SPACE_PLACEHOLDER_FILE: &str = "space_placeholder_file";
+pub const SPACE_PLACEHOLDER_FILE: &str = "space_placeholder_file";
 
 /// Create a file with hole, to reserve space for TiKV.
 pub fn reserve_space_for_recover<P: AsRef<Path>>(data_dir: P, file_size: u64) -> io::Result<()> {

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2319,7 +2319,10 @@ where
                 if self.check_disk_usages_before_propose(ctx, disk_full_opt, &mut stores) {
                     self.propose_normal(ctx, req)
                 } else {
-                    let errmsg = String::from("propose failed: disk full");
+                    let errmsg = format!(
+                        "propose failed: tikv disk full, cmd-disk_full_opt={:?}, leader-diskUsage={:?}",
+                        disk_full_opt, ctx.self_disk_usage
+                    );
                     Err(Error::DiskFull(stores, errmsg))
                 }
             }
@@ -2329,7 +2332,10 @@ where
                 if self.check_disk_usages_before_propose(ctx, disk_full_opt, &mut stores) {
                     self.propose_conf_change(ctx, &req)
                 } else {
-                    let errmsg = String::from("propose failed: disk full");
+                    let errmsg = format!(
+                        "propose failed: tikv disk full, cmd-disk_full_opt={:?}, leader-diskUsage={:?}",
+                        disk_full_opt, ctx.self_disk_usage
+                    );
                     Err(Error::DiskFull(stores, errmsg))
                 }
             }

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -46,7 +46,6 @@ use futures::FutureExt;
 use pd_client::metrics::*;
 use pd_client::{Error, PdClient, RegionStat};
 use tikv_util::metrics::ThreadInfoStatistics;
-use tikv_util::sys::disk;
 use tikv_util::time::UnixSecs;
 use tikv_util::timer::GLOBAL_TIMER_HANDLE;
 use tikv_util::topn::TopN;
@@ -895,13 +894,6 @@ where
         let mut available = capacity.checked_sub(used_size).unwrap_or_default();
         // We only care about rocksdb SST file size, so we should check disk available here.
         available = cmp::min(available, disk_stats.available_space());
-        available = available
-            .checked_sub(disk::get_disk_reserved_space())
-            .unwrap_or_default();
-
-        if disk::is_disk_full() {
-            available = 0;
-        }
 
         if available == 0 {
             warn!("no available space");

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -140,10 +140,6 @@ impl WriteData {
         self.disk_full_opt = DiskFullOpt::AllowedOnAlmostFull
     }
 
-    pub fn set_allowed_on_disk_already_full(&mut self) {
-        self.disk_full_opt = DiskFullOpt::AllowedOnAlreadyFull
-    }
-
     pub fn set_disk_full_opt(&mut self, level: DiskFullOpt) {
         self.disk_full_opt = level
     }

--- a/components/tikv_util/src/sys/disk.rs
+++ b/components/tikv_util/src/sys/disk.rs
@@ -55,8 +55,3 @@ pub fn get_disk_status(_store_id: u64) -> DiskUsage {
         _ => panic!("Disk Status Value not meet expectations"),
     }
 }
-
-pub fn is_disk_full() -> bool {
-    let s = DISK_STATUS.load(Ordering::Acquire);
-    !matches!(s, 0)
-}

--- a/src/storage/txn/commands/check_txn_status.rs
+++ b/src/storage/txn/commands/check_txn_status.rs
@@ -121,7 +121,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckTxnStatus {
 
         let pr = ProcessResult::TxnStatus { txn_status };
         let mut write_data = WriteData::from_modifies(txn.into_modifies());
-        write_data.set_allowed_on_disk_already_full();
+        write_data.set_allowed_on_disk_almost_full();
         Ok(WriteResult {
             ctx: self.ctx,
             to_be_write: write_data,

--- a/src/storage/txn/commands/commit.rs
+++ b/src/storage/txn/commands/commit.rs
@@ -63,7 +63,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Commit {
             txn_status: TxnStatus::committed(self.commit_ts),
         };
         let mut write_data = WriteData::from_modifies(txn.into_modifies());
-        write_data.set_allowed_on_disk_already_full();
+        write_data.set_allowed_on_disk_almost_full();
         Ok(WriteResult {
             ctx: self.ctx,
             to_be_write: write_data,

--- a/src/storage/txn/commands/pessimistic_rollback.rs
+++ b/src/storage/txn/commands/pessimistic_rollback.rs
@@ -80,7 +80,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for PessimisticRollback {
         released_locks.wake_up(context.lock_mgr);
 
         let mut write_data = WriteData::from_modifies(txn.into_modifies());
-        write_data.set_allowed_on_disk_already_full();
+        write_data.set_allowed_on_disk_almost_full();
         Ok(WriteResult {
             ctx,
             to_be_write: write_data,

--- a/src/storage/txn/commands/rollback.rs
+++ b/src/storage/txn/commands/rollback.rs
@@ -52,7 +52,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Rollback {
         released_locks.wake_up(context.lock_mgr);
 
         let mut write_data = WriteData::from_modifies(txn.into_modifies());
-        write_data.set_allowed_on_disk_already_full();
+        write_data.set_allowed_on_disk_almost_full();
         Ok(WriteResult {
             ctx: self.ctx,
             to_be_write: write_data,

--- a/src/storage/txn/commands/txn_heart_beat.rs
+++ b/src/storage/txn/commands/txn_heart_beat.rs
@@ -79,7 +79,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for TxnHeartBeat {
             txn_status: TxnStatus::uncommitted(lock, false),
         };
         let mut write_data = WriteData::from_modifies(txn.into_modifies());
-        write_data.set_allowed_on_disk_already_full();
+        write_data.set_allowed_on_disk_almost_full();
         Ok(WriteResult {
             ctx: self.ctx,
             to_be_write: write_data,

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -728,18 +728,9 @@ impl<E: Engine, L: LockManager> Scheduler<E, L> {
                 response_policy,
             }) => {
                 SCHED_STAGE_COUNTER_VEC.get(tag).write.inc();
-                match ctx.get_disk_full_opt() {
-                    DiskFullOpt::AllowedOnAlreadyFull => {
-                        to_be_write.disk_full_opt = DiskFullOpt::AllowedOnAlreadyFull
-                    }
-                    DiskFullOpt::AllowedOnAlmostFull => {
-                        // Like Delete operation, TiDB marks it with AllowedOnAlmostFull
-                        // But TiKV just treats it as Normal prewrite.
-                        if to_be_write.disk_full_opt != DiskFullOpt::AllowedOnAlreadyFull {
-                            to_be_write.disk_full_opt = DiskFullOpt::AllowedOnAlmostFull
-                        }
-                    }
-                    _ => {}
+
+                if ctx.get_disk_full_opt() == DiskFullOpt::AllowedOnAlmostFull {
+                    to_be_write.disk_full_opt = DiskFullOpt::AllowedOnAlmostFull
                 }
 
                 if let Some(lock_info) = lock_info {

--- a/tests/failpoints/cases/test_disk_full.rs
+++ b/tests/failpoints/cases/test_disk_full.rs
@@ -202,16 +202,15 @@ fn test_disk_full_txn_behaviors(usage: DiskUsage) {
     lead_client.must_kv_pessimistic_lock(b"k7".to_vec(), start_ts);
 
     // Test pessimistic commit is allowed.
-    // FIXME: the case can't pass.
-    // fail::cfg(get_fp(usage, 1), "return").unwrap();
-    // let res = lead_client.try_kv_prewrite(
-    //     vec![new_mutation(Op::Put, b"k5", b"v5")],
-    //     b"k4".to_vec(),
-    //     start_ts,
-    //     DiskFullOpt::NotAllowedOnFull,
-    // );
-    // assert!(!res.get_region_error().has_disk_full());
-    // lead_client.must_kv_commit(vec![b"k7".to_vec()], start_ts, get_tso(&pd_client));
+    fail::cfg(get_fp(usage, 1), "return").unwrap();
+    let res = lead_client.try_kv_prewrite(
+        vec![new_mutation(Op::Put, b"k5", b"v5")],
+        b"k4".to_vec(),
+        start_ts,
+        DiskFullOpt::AllowedOnAlmostFull,
+    );
+    assert!(!res.get_region_error().has_disk_full());
+    lead_client.must_kv_commit(vec![b"k7".to_vec()], start_ts, get_tso(&pd_client));
 
     fail::remove(get_fp(usage, 1));
     let lock_ts = get_tso(&pd_client);


### PR DESCRIPTION
### What problem does this PR solve?

Fix drop table failed when TiKV is almost disk full.

Problem Summary:
1. Push data until TiKV is disk full.
2. Exec Drop Table, then it will be blocked.

### What is changed and how it works?
1. Proposal will be accepted by leader if TiKV is not disk full, except with special flag.
2. Newest PR change the judge condition only AllowedOnAlmostFull, but left deal with the AllowedOnAlreadyFull.
3. This PR unifies these differences.


### Related changes
- Need to cherry-pick to the release branch

### Check List


### Release note

```
None
```