### PR TITLE
test: fix warning

### DIFF
--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -1932,7 +1932,7 @@ fn main() {
 
     // Bypass the sst dump command to RocksDB.
     if let Some(cmd) = matches.subcommand_matches("sst_dump") {
-        run_sst_dump_command(&cmd, &cfg);
+        run_sst_dump_command(cmd, &cfg);
         return;
     }
 

--- a/components/raftstore/src/store/async_io/write_router.rs
+++ b/components/raftstore/src/store/async_io/write_router.rs
@@ -251,7 +251,7 @@ mod tests {
         }
 
         fn must_same_msg_count(&self, id: usize, mut count: usize) {
-            while let Ok(_) = self.receivers[id].try_recv() {
+            while self.receivers[id].try_recv().is_ok() {
                 if count == 0 {
                     panic!("msg count is smaller");
                 }

--- a/src/storage/txn/flow_controller.rs
+++ b/src/storage/txn/flow_controller.rs
@@ -2,7 +2,6 @@
 
 use std::cmp::PartialOrd;
 use std::collections::VecDeque;
-use std::f64::INFINITY;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender};
@@ -117,7 +116,7 @@ impl FlowController {
 
         Self {
             discard_ratio: Arc::new(AtomicU32::new(0)),
-            limiter: Arc::new(Limiter::new(INFINITY)),
+            limiter: Arc::new(Limiter::new(f64::INFINITY)),
             enabled: Arc::new(AtomicBool::new(false)),
             tx,
             handle: None,
@@ -129,7 +128,7 @@ impl FlowController {
         engine: E,
         flow_info_receiver: Receiver<FlowInfo>,
     ) -> Self {
-        let limiter = Arc::new(Limiter::new(INFINITY));
+        let limiter = Arc::new(Limiter::new(f64::INFINITY));
         let discard_ratio = Arc::new(AtomicU32::new(0));
         let checker = FlowChecker::new(config, engine, discard_ratio.clone(), limiter.clone());
         let (tx, rx) = mpsc::sync_channel(5);
@@ -174,7 +173,7 @@ impl FlowController {
     }
 
     pub fn is_unlimited(&self) -> bool {
-        self.limiter.speed_limit() == INFINITY
+        self.limiter.speed_limit() == f64::INFINITY
     }
 }
 
@@ -583,7 +582,7 @@ impl<E: KvEngine> FlowChecker<E> {
         }
         SCHED_WRITE_FLOW_GAUGE.set(0);
         SCHED_THROTTLE_FLOW_GAUGE.set(0);
-        self.limiter.set_speed_limit(INFINITY);
+        self.limiter.set_speed_limit(f64::INFINITY);
         SCHED_DISCARD_RATIO_GAUGE.set(0);
         self.discard_ratio.store(0, Ordering::Relaxed);
     }
@@ -718,7 +717,7 @@ impl<E: KvEngine> FlowChecker<E> {
         }
 
         let checker = self.cf_checkers.get_mut(cf).unwrap();
-        let is_throttled = self.limiter.speed_limit() != INFINITY;
+        let is_throttled = self.limiter.speed_limit() != f64::INFINITY;
         let should_throttle =
             checker.last_num_memtables.get_avg() > self.memtables_threshold as f64;
         let throttle = if !is_throttled {
@@ -728,9 +727,9 @@ impl<E: KvEngine> FlowChecker<E> {
                     .inc();
                 checker.init_speed = true;
                 let x = self.write_flow_recorder.get_percentile_90();
-                if x == 0 { INFINITY } else { x as f64 }
+                if x == 0 { f64::INFINITY } else { x as f64 }
             } else {
-                INFINITY
+                f64::INFINITY
             }
         } else if !should_throttle
             || checker.last_num_memtables.get_recent() < self.memtables_threshold
@@ -738,7 +737,7 @@ impl<E: KvEngine> FlowChecker<E> {
             // should not throttle memtable
             checker.memtable_debt = 0.0;
             if checker.init_speed {
-                INFINITY
+                f64::INFINITY
             } else {
                 self.limiter.speed_limit() + checker.memtable_debt * 1024.0 * 1024.0
             }
@@ -765,7 +764,7 @@ impl<E: KvEngine> FlowChecker<E> {
     }
 
     fn tick_l0(&mut self) {
-        if self.limiter.speed_limit() != INFINITY {
+        if self.limiter.speed_limit() != f64::INFINITY {
             let cf = self.throttle_cf.as_ref().unwrap();
             let checker = self.cf_checkers.get_mut(cf).unwrap();
             if checker.last_num_l0_files <= self.l0_files_threshold {
@@ -855,7 +854,7 @@ impl<E: KvEngine> FlowChecker<E> {
 
         let checker = self.cf_checkers.get_mut(&cf).unwrap();
 
-        let is_throttled = self.limiter.speed_limit() != INFINITY;
+        let is_throttled = self.limiter.speed_limit() != f64::INFINITY;
         let should_throttle = checker.last_num_l0_files > self.l0_files_threshold;
 
         let throttle = if !is_throttled && should_throttle {
@@ -866,7 +865,7 @@ impl<E: KvEngine> FlowChecker<E> {
             self.num_l0_for_last_update_target_flow = Some(checker.last_num_l0_files);
             self.l0_target_flow = checker.short_term_l0_production_flow.get_avg();
             let x = self.write_flow_recorder.get_percentile_90();
-            if x == 0 { INFINITY } else { x as f64 }
+            if x == 0 { f64::INFINITY } else { x as f64 }
         } else if is_throttled && should_throttle {
             // refresh down flow if last num l0 files
             if let Some(num_l0_for_last_update_target_flow) =
@@ -913,7 +912,7 @@ impl<E: KvEngine> FlowChecker<E> {
                 self.limiter.speed_limit() * (1.0 + LIMIT_UP_PERCENT)
             }
         } else {
-            INFINITY
+            f64::INFINITY
         };
 
         self.update_speed_limit(throttle)
@@ -926,9 +925,9 @@ impl<E: KvEngine> FlowChecker<E> {
         if throttle > MAX_THROTTLE_SPEED {
             self.throttle_cf = None;
             self.num_l0_for_last_update_target_flow = None;
-            throttle = INFINITY;
+            throttle = f64::INFINITY;
         }
-        SCHED_THROTTLE_FLOW_GAUGE.set(if throttle == INFINITY {
+        SCHED_THROTTLE_FLOW_GAUGE.set(if throttle == f64::INFINITY {
             0
         } else {
             throttle as i64
@@ -1049,10 +1048,10 @@ impl<E: KvEngine> FlowChecker<E> {
     }
 
     fn increase_speed_limit(&mut self, cf: String) {
-        let throttle = if self.limiter.speed_limit() == INFINITY {
+        let throttle = if self.limiter.speed_limit() == f64::INFINITY {
             self.throttle_cf = Some(cf);
             let x = self.write_flow_recorder.get_percentile_90();
-            if x == 0 { INFINITY } else { x as f64 }
+            if x == 0 { f64::INFINITY } else { x as f64 }
         } else {
             // Use PID algorithm to change the flow so up flow can be increased
             // rapidly when the target flow is quite larger than flush flow.
@@ -1075,10 +1074,10 @@ impl<E: KvEngine> FlowChecker<E> {
     }
 
     fn decrease_speed_limit(&mut self, cf: String) {
-        let throttle = if self.limiter.speed_limit() == INFINITY {
+        let throttle = if self.limiter.speed_limit() == f64::INFINITY {
             self.throttle_cf = Some(cf);
             let x = self.write_flow_recorder.get_percentile_90();
-            if x == 0 { INFINITY } else { x as f64 }
+            if x == 0 { f64::INFINITY } else { x as f64 }
         } else {
             self.limiter.speed_limit() * (1.0 - LIMIT_DOWN_PERCENT)
         };
@@ -1102,7 +1101,7 @@ mod tests {
         smoother.observe(5);
         smoother.observe(0);
 
-        assert_eq!(smoother.get_avg(), 2.8);
+        assert!((smoother.get_avg() - 2.8).abs() < f64::EPSILON);
         assert_eq!(smoother.get_recent(), 0);
         assert_eq!(smoother.get_max(), 5);
         assert_eq!(smoother.get_percentile_90(), 4);
@@ -1117,10 +1116,10 @@ mod tests {
         smoother.observe(4.0);
         smoother.observe(5.0);
         smoother.observe(9.0);
-        assert_eq!(smoother.get_avg(), 4.6);
-        assert_eq!(smoother.get_recent(), 9.0);
-        assert_eq!(smoother.get_max(), 9.0);
-        assert_eq!(smoother.get_percentile_90(), 5.0);
+        assert!((smoother.get_avg() - 4.6).abs() < f64::EPSILON);
+        assert!((smoother.get_recent() - 9.0).abs() < f64::EPSILON);
+        assert!((smoother.get_max() - 9.0).abs() < f64::EPSILON);
+        assert!((smoother.get_percentile_90() - 5.0).abs() < f64::EPSILON);
         assert_eq!(smoother.trend(), Trend::Increasing);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10697

Problem Summary: fix the warning during `make clippy`

### What is changed and how it works?

Rust-clippy issues about the warning: [(== or !=) exact comparison to f32/f64 · Issue #46](https://github.com/rust-lang/rust-clippy/issues/46)

What's Changed:

- Fixing the warning
- Replacing std::f64::INFINITY with f64::INFINITY

### Check List 

Tests

- Unit test

Side effects

```
None
```

### Release note 

```release-note
None
```