### PR TITLE
fix cgroup for containers with mountinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,7 @@ dependencies = [
  "crc32fast",
  "libc 0.2.86",
  "libz-sys",
+ "miniz-sys",
  "miniz_oxide",
 ]
 
@@ -2147,24 +2148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
-name = "libflate"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784f4ec5908a9d7f4e53658906386667e8b02e9389a47cfebf45d324ba9e8d25"
-dependencies = [
- "adler32",
- "crc32fast",
- "libflate_lz77",
- "rle-decode-fast",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
-
-[[package]]
 name = "libfuzzer-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2358,16 @@ name = "mime"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
+
+[[package]]
+name = "miniz-sys"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
+dependencies = [
+ "cc",
+ "libc 0.2.86",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -3160,17 +3153,17 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.7.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c434e93ef69c216e68e4f417c927b4f31502c3560b72cfdb6827e2321c5c6b3e"
+checksum = "ab8809e0c18450a2db0f236d2a44ec0b4c1412d0eb936233579f0990faa5d5cd"
 dependencies = [
  "bitflags",
  "byteorder",
  "chrono",
+ "flate2",
  "hex 0.4.2",
  "lazy_static",
  "libc 0.2.86",
- "libflate",
 ]
 
 [[package]]
@@ -3839,12 +3832,6 @@ dependencies = [
  "web-sys",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rocksdb"

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -71,7 +71,7 @@ yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 page_size = "0.4"
-procfs = "0.7"
+procfs = "0.9"
 
 [dev-dependencies]
 panic_hook = { path = "../panic_hook" }

--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -31,6 +31,21 @@ use std::path::PathBuf;
 //
 // For more details about cgrop v2, PTAL
 // https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html.
+//
+// The above examples are implicitly based on a premise that paths in `/proc/self/cgroup`
+// can be appended to `/sys/fs/cgroup` directly to get the final paths. Generally it's
+// correct for Linux hosts but maybe wrong for containers. For containers, cgroup file systems
+// can be based on other mount points. For example:
+//
+// /proc/self/cgroup:
+//   4:memory:/path/to/the/controller
+// /proc/self/mountinfo:
+//   34 25 0:30 /path/to/the/controller /sys/fs/cgroup/memory relatime - cgroup cgroup memory
+// `path/to/the/controller` is possible to be not accessable in the container. However from the
+// `mountinfo` file we can know the path is mounted on `sys/fs/cgroup/memory`, then we can build
+// the absolute path based on the mountinfo file.
+//
+// For the format of the mountinfo file, PTAL https://man7.org/linux/man-pages/man5/proc.5.html.
 
 const CONTROLLERS: &[&str] = &["memory", "cpuset", "cpu"];
 
@@ -181,6 +196,8 @@ fn cgroup_mountinfos_v2() -> HashMap<String, (String, PathBuf)> {
     ret
 }
 
+// `root` is mounted on `mount_point`. `path` is a sub path of `root`.
+// This is used to build an absolute path starts with `mount_point`.
 fn build_path(path: &str, root: &str, mount_point: &PathBuf) -> PathBuf {
     assert!(path.starts_with('/') && root.starts_with('/'));
     let relative = path.strip_prefix(root).unwrap();

--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -1,9 +1,10 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use procfs::process::Process;
 use std::collections::{HashMap, HashSet};
 use std::fs::read_to_string;
 use std::mem::MaybeUninit;
-use std::process;
+use std::path::PathBuf;
 
 // ## Differences between cgroup v1 and v2:
 // ### memory subsystem, memory limitation
@@ -31,31 +32,45 @@ use std::process;
 // For more details about cgrop v2, PTAL
 // https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html.
 
+const CONTROLLERS: &[&str] = &["memory", "cpuset", "cpu"];
+
 pub struct CGroupSys {
+    // map[controller] -> path.
     cgroups: HashMap<String, String>,
+    // map[controller] -> (root, mount_point).
+    mount_points: HashMap<String, (String, PathBuf)>,
     is_v2: bool,
 }
 
 impl CGroupSys {
     pub fn new() -> Self {
-        let lines = read_to_string(&format!("/proc/{}/cgroup", process::id())).unwrap();
+        let lines = read_to_string("/proc/self/cgroup").unwrap();
         let is_v2 = is_cgroup2_unified_mode();
-        let cgroups = if !is_v2 {
-            parse_proc_cgroup_v1(&lines)
+        let (cgroups, mount_points) = if !is_v2 {
+            (parse_proc_cgroup_v1(&lines), cgroup_mountinfos_v1())
         } else {
-            parse_proc_cgroup_v2(&lines)
+            (parse_proc_cgroup_v2(&lines), cgroup_mountinfos_v2())
         };
-        CGroupSys { cgroups, is_v2 }
+
+        CGroupSys {
+            cgroups,
+            mount_points,
+            is_v2,
+        }
     }
 
     /// -1 means no limit.
     pub fn memory_limit_in_bytes(&self) -> i64 {
         let path = if self.is_v2 {
             let group = self.cgroups.get("").unwrap();
-            format!("/sys/fs/cgroup/{}/memory.max", group)
+            let (root, mount_point) = self.mount_points.get("").unwrap();
+            let path = build_path(group, &root, mount_point);
+            format!("{}/memory.max", path.to_str().unwrap())
         } else {
             let group = self.cgroups.get("memory").unwrap();
-            format!("/sys/fs/cgroup/memory/{}/memory.limit_in_bytes", group)
+            let (root, mount_point) = self.mount_points.get("memory").unwrap();
+            let path = build_path(group, &root, mount_point);
+            format!("{}/memory.limit_in_bytes", path.to_str().unwrap())
         };
         read_to_string(&path).map_or(-1, |x| parse_memory_max(x.trim()))
     }
@@ -63,10 +78,14 @@ impl CGroupSys {
     pub fn cpuset_cores(&self) -> HashSet<usize> {
         let path = if self.is_v2 {
             let group = self.cgroups.get("").unwrap();
-            format!("/sys/fs/cgroup/{}/cpuset.cpus", group)
+            let (root, mount_point) = self.mount_points.get("").unwrap();
+            let path = build_path(group, &root, mount_point);
+            format!("{}/cpuset.cpus", path.to_str().unwrap())
         } else {
             let group = self.cgroups.get("cpuset").unwrap();
-            format!("/sys/fs/cgroup/cpuset/{}/cpuset.cpus", group)
+            let (root, mount_point) = self.mount_points.get("cpuset").unwrap();
+            let path = build_path(group, &root, mount_point);
+            format!("{}/cpuset.cpus", path.to_str().unwrap())
         };
         read_to_string(&path).map_or_else(|_| HashSet::new(), |x| parse_cpu_cores(x.trim()))
     }
@@ -75,14 +94,18 @@ impl CGroupSys {
     pub fn cpu_quota(&self) -> Option<f64> {
         if self.is_v2 {
             let group = self.cgroups.get("").unwrap();
-            let path = format!("/sys/fs/cgroup/{}/cpu.max", group);
+            let (root, mount_point) = self.mount_points.get("").unwrap();
+            let path = build_path(group, &root, mount_point);
+            let path = format!("{}/cpu.max", path.to_str().unwrap());
             if let Ok(buffer) = read_to_string(&path) {
                 return parse_cpu_quota_v2(buffer.trim());
             }
         } else {
             let group = self.cgroups.get("cpu").unwrap();
-            let path1 = format!("/sys/fs/cgroup/cpu/{}/cpu.cfs_quota_us", group);
-            let path2 = format!("/sys/fs/cgroup/cpu/{}/cpu.cfs_period_us", group);
+            let (root, mount_point) = self.mount_points.get("cpu").unwrap();
+            let path = build_path(group, &root, mount_point);
+            let path1 = format!("{}/cpu.cfs_quota_us", path.to_str().unwrap());
+            let path2 = format!("{}/cpu.cfs_period_us", path.to_str().unwrap());
             if let (Ok(buffer1), Ok(buffer2)) = (read_to_string(&path1), read_to_string(&path2)) {
                 return parse_cpu_quota_v1(buffer1.trim(), buffer2.trim());
             }
@@ -127,6 +150,43 @@ fn parse_proc_cgroup_v2(lines: &str) -> HashMap<String, String> {
     assert_eq!(subsystems.len(), 1);
     assert_eq!(subsystems.keys().next().unwrap(), "");
     subsystems
+}
+
+fn cgroup_mountinfos_v1() -> HashMap<String, (String, PathBuf)> {
+    let mut ret = HashMap::new();
+    let infos = Process::myself().and_then(|x| x.mountinfo()).unwrap();
+    for cg_info in infos.into_iter().filter(|x| x.fs_type == "cgroup") {
+        for controller in CONTROLLERS {
+            if cg_info.super_options.contains_key(*controller) {
+                let key = controller.to_string();
+                let value = (cg_info.root, cg_info.mount_point);
+                assert!(ret.insert(key, value).is_none());
+                break;
+            }
+        }
+    }
+    for controller in CONTROLLERS {
+        assert!(ret.contains_key(*controller));
+    }
+    ret
+}
+
+fn cgroup_mountinfos_v2() -> HashMap<String, (String, PathBuf)> {
+    let mut ret = HashMap::new();
+    let infos = Process::myself().and_then(|x| x.mountinfo()).unwrap();
+    let mut cg_infos = infos.into_iter().filter(|x| x.fs_type == "cgroup2");
+    let cg_info = cg_infos.next().unwrap();
+    assert!(cg_infos.next().is_none()); // Only one item for cgroup-2.
+    ret.insert("".to_string(), (cg_info.root, cg_info.mount_point));
+    ret
+}
+
+fn build_path(path: &str, root: &str, mount_point: &PathBuf) -> PathBuf {
+    assert!(path.starts_with('/') && root.starts_with('/'));
+    let relative = path.strip_prefix(root).unwrap();
+    let mut absolute = mount_point.clone();
+    absolute.push(relative);
+    absolute
 }
 
 fn parse_memory_max(line: &str) -> i64 {

--- a/components/tikv_util/src/sys/mod.rs
+++ b/components/tikv_util/src/sys/mod.rs
@@ -22,16 +22,7 @@ static MEMORY_USAGE_HIGH_WATER: AtomicU64 = AtomicU64::new(u64::MAX);
 
 #[cfg(target_os = "linux")]
 lazy_static! {
-    static ref SELF_CGROUP: cgroup::CGroupSys = {
-        let x = cgroup::CGroupSys::new();
-        info!(
-            "cgroup quota: memory={:?}, cpu={:?}, cores={:?}",
-            ReadableSize(x.memory_limit_in_bytes() as u64),
-            x.cpu_quota(),
-            x.cpuset_cores(),
-        );
-        x
-    };
+    static ref SELF_CGROUP: cgroup::CGroupSys = cgroup::CGroupSys::new();
 }
 
 pub struct SysQuota;
@@ -76,6 +67,14 @@ impl SysQuota {
     }
 
     pub fn log_quota() {
+        #[cfg(target_os = "linux")]
+        info!(
+            "cgroup quota: memory={:?}, cpu={:?}, cores={:?}",
+            ReadableSize(SELF_CGROUP.memory_limit_in_bytes() as u64),
+            SELF_CGROUP.cpu_quota(),
+            SELF_CGROUP.cpuset_cores(),
+        );
+
         info!(
             "memory limit in bytes: {}, cpu cores quota: {}",
             Self::memory_limit_in_bytes(),

--- a/components/tikv_util/src/sys/mod.rs
+++ b/components/tikv_util/src/sys/mod.rs
@@ -22,7 +22,16 @@ static MEMORY_USAGE_HIGH_WATER: AtomicU64 = AtomicU64::new(u64::MAX);
 
 #[cfg(target_os = "linux")]
 lazy_static! {
-    static ref SELF_CGROUP: cgroup::CGroupSys = cgroup::CGroupSys::new();
+    static ref SELF_CGROUP: cgroup::CGroupSys = {
+        let x = cgroup::CGroupSys::new();
+        info!(
+            "cgroup quota: memory={:?}, cpu={:?}, cores={:?}",
+            ReadableSize(x.memory_limit_in_bytes() as u64),
+            x.cpu_quota(),
+            x.cpuset_cores(),
+        );
+        x
+    };
 }
 
 pub struct SysQuota;


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

#10536 introduces a critical bug about cgroup in containers. `mountinfo` is not considered correctly, which leads to get resource quota incorrectly.

Issue Number: close https://github.com/tikv/tikv/issues/10694.

### What is changed and how it works?
Consider `mountinfo` correctly in cgroup code.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

The new log outputs:
```
[mod.rs:71] ["cgroup quota: memory=ReadableSize(8589934592), cpu=Some(3.0), cores={8, 12, 28}"]
```
/proc/self/cgroup:
```
11:devices:/kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope
10:cpuset:/kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope
9:hugetlb:/kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope
8:memory:/kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope
7:freezer:/kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope
6:pids:/kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope
5:net_prio,net_cls:/kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope
4:cpuacct,cpu:/kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope
3:blkio:/kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope
2:perf_event:/kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope
1:name=systemd:/kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope
```
/proc/self/mountinfo:
```
15527 15524 0:1716 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,mode=755
15528 15527 0:22 /kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope /sys/fs/cgroup/systemd ro,nosuid,nodev,noexec,relatime master:9 - cgroup cgroup rw,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd
15529 15527 0:24 /kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope /sys/fs/cgroup/perf_event ro,nosuid,nodev,noexec,relatime master:10 - cgroup cgroup rw,perf_event
15530 15527 0:25 /kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope /sys/fs/cgroup/blkio ro,nosuid,nodev,noexec,relatime master:11 - cgroup cgroup rw,blkio
15531 15527 0:26 /kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope /sys/fs/cgroup/cpu,cpuacct ro,nosuid,nodev,noexec,relatime master:12 - cgroup cgroup rw,cpuacct,cpu
15552 15527 0:27 /kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope /sys/fs/cgroup/net_cls,net_prio ro,nosuid,nodev,noexec,relatime master:13 - cgroup cgroup rw,net_prio,net_cls
15555 15527 0:28 /kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope /sys/fs/cgroup/pids ro,nosuid,nodev,noexec,relatime master:14 - cgroup cgroup rw,pids
15556 15527 0:29 /kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope /sys/fs/cgroup/freezer ro,nosuid,nodev,noexec,relatime master:15 - cgroup cgroup rw,freezer
15557 15527 0:30 /kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope /sys/fs/cgroup/memory ro,nosuid,nodev,noexec,relatime master:16 - cgroup cgroup rw,memory
15560 15527 0:31 /kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope /sys/fs/cgroup/hugetlb ro,nosuid,nodev,noexec,relatime master:17 - cgroup cgroup rw,hugetlb
15562 15527 0:32 /kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope /sys/fs/cgroup/cpuset ro,nosuid,nodev,noexec,relatime master:18 - cgroup cgroup rw,cpuset
15563 15527 0:33 /kubepods.slice/kubepods-pod8982120b_bf8d_468e_806b_ef174e1e8f53.slice/docker-4c887edd435bd040df29998fc0b6487d8c8037da4d33f3e014c8a41370f880e7.scope /sys/fs/cgroup/devices ro,nosuid,nodev,noexec,relatime master:19 - cgroup cgroup rw,devices
```
It shows that the patch works fine with TiKV in a container with special `mountinfo`.

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```