### PR TITLE
*: fix disk full leads to batch perf back off

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -553,6 +553,7 @@ where
 {
     fsm: &'a mut PeerFsm<EK, ER>,
     ctx: &'a mut PollContext<EK, ER, T>,
+    disk_full_opt: DiskFullOpt,
 }
 
 impl<'a, EK, ER, T: Transport> PeerFsmDelegate<'a, EK, ER, T>
@@ -564,7 +565,11 @@ where
         fsm: &'a mut PeerFsm<EK, ER>,
         ctx: &'a mut PollContext<EK, ER, T>,
     ) -> PeerFsmDelegate<'a, EK, ER, T> {
-        PeerFsmDelegate { fsm, ctx }
+        PeerFsmDelegate {
+            fsm,
+            ctx,
+            disk_full_opt: DiskFullOpt::NotAllowedOnFull,
+        }
     }
 
     pub fn handle_msgs(&mut self, msgs: &mut Vec<PeerMsg<EK>>) {
@@ -585,6 +590,11 @@ where
                         .propose
                         .request_wait_time
                         .observe(duration_to_sec(cmd.send_time.saturating_elapsed()) as f64);
+                    // If cur cmd is set with special flag, then we need all the batch to be set with it.
+                    // Because, if not, then it will lead to ddl or other ops failure when disk is almost full.
+                    if cmd.extra_opts.disk_full_opt != DiskFullOpt::NotAllowedOnFull {
+                        self.disk_full_opt = cmd.extra_opts.disk_full_opt;
+                    }
                     if let Some(Err(e)) = cmd.extra_opts.deadline.map(|deadline| deadline.check()) {
                         cmd.callback.invoke_with_response(new_error(e.into()));
                         continue;
@@ -593,10 +603,6 @@ where
                     let req_size = cmd.request.compute_size();
                     if self.ctx.cfg.cmd_batch
                         && self.fsm.batch_req_builder.can_batch(&cmd.request, req_size)
-                        // Avoid to merge requests with different `DiskFullOpt`s into one,
-                        // so that normal writes can be rejected when proposing if the
-                        // store's disk is full.
-                        && cmd.extra_opts.disk_full_opt == DiskFullOpt::NotAllowedOnFull
                     {
                         self.fsm.batch_req_builder.add(cmd, req_size);
                         if self.fsm.batch_req_builder.should_finish() {
@@ -604,11 +610,7 @@ where
                         }
                     } else {
                         self.propose_batch_raft_command();
-                        self.propose_raft_command(
-                            cmd.request,
-                            cmd.callback,
-                            cmd.extra_opts.disk_full_opt,
-                        )
+                        self.propose_raft_command(cmd.request, cmd.callback)
                     }
                 }
                 PeerMsg::Tick(tick) => self.on_tick(tick),
@@ -648,7 +650,7 @@ where
 
     fn propose_batch_raft_command(&mut self) {
         if let Some(cmd) = self.fsm.batch_req_builder.build(&mut self.ctx.raft_metrics) {
-            self.propose_raft_command(cmd.request, cmd.callback, DiskFullOpt::NotAllowedOnFull)
+            self.propose_raft_command(cmd.request, cmd.callback)
         }
     }
 
@@ -913,7 +915,6 @@ where
                     },
                 )
             })),
-            DiskFullOpt::NotAllowedOnFull,
         );
     }
 
@@ -1024,7 +1025,7 @@ where
             self.region().get_region_epoch().clone(),
             self.fsm.peer.peer.clone(),
         );
-        self.propose_raft_command(msg, cb, DiskFullOpt::NotAllowedOnFull);
+        self.propose_raft_command(msg, cb);
     }
 
     fn on_role_changed(&mut self, ready: &Ready) {
@@ -2754,7 +2755,7 @@ where
             request.set_admin_request(admin);
             request
         };
-        self.propose_raft_command(req, Callback::None, DiskFullOpt::AllowedOnAlmostFull);
+        self.propose_raft_command(req, Callback::None);
     }
 
     fn on_check_merge(&mut self) {
@@ -3453,12 +3454,7 @@ where
         }
     }
 
-    fn propose_raft_command(
-        &mut self,
-        mut msg: RaftCmdRequest,
-        cb: Callback<EK::Snapshot>,
-        diskfullopt: DiskFullOpt,
-    ) {
+    fn propose_raft_command(&mut self, mut msg: RaftCmdRequest, cb: Callback<EK::Snapshot>) {
         match self.pre_propose_raft_command(&msg) {
             Ok(Some(resp)) => {
                 cb.invoke_with_response(resp);
@@ -3504,7 +3500,11 @@ where
         let mut resp = RaftCmdResponse::default();
         let term = self.fsm.peer.term();
         bind_term(&mut resp, term);
-        if self.fsm.peer.propose(self.ctx, cb, msg, resp, diskfullopt) {
+        if self
+            .fsm
+            .peer
+            .propose(self.ctx, cb, msg, resp, self.disk_full_opt)
+        {
             self.fsm.has_ready = true;
         }
 
@@ -3679,7 +3679,7 @@ where
         let peer = self.fsm.peer.peer.clone();
         let term = self.fsm.peer.get_index_term(compact_idx);
         let request = new_compact_log_request(region_id, peer, compact_idx, term);
-        self.propose_raft_command(request, Callback::None, DiskFullOpt::AllowedOnAlmostFull);
+        self.propose_raft_command(request, Callback::None);
 
         self.fsm.skip_gc_raft_log_ticks = 0;
         self.register_raft_gc_log_tick();
@@ -4118,7 +4118,7 @@ where
             self.fsm.peer.peer.clone(),
             &self.fsm.peer.consistency_state,
         );
-        self.propose_raft_command(req, Callback::None, DiskFullOpt::NotAllowedOnFull);
+        self.propose_raft_command(req, Callback::None);
     }
 
     fn on_ingest_sst_result(&mut self, ssts: Vec<SSTMetaInfo>) {


### PR DESCRIPTION
Signed-off-by: tier-cap <zhengxiaojin@pingcap.com>

### What problem does this PR solve?
Issue Number: https://github.com/tikv/tikv/issues/10716
Problem Summary:
Raft batch performance down when tikv disk full opt setting blocks batch.

### What is changed and how it works?
Let all the batch be set with the same flag if some raftcmd is set.

### Related changes
- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List
Tests
- Performance regression

### Release note
```
None
```