### PR TITLE
Makefile: Remove outdated TODO

### DIFF
--- a/ci-build/Makefile
+++ b/ci-build/Makefile
@@ -11,7 +11,6 @@ ${LOCAL_DIR}/lib/libgflags.a:
 	make && \
 	make install
 
-# TODO: use official archive once https://github.com/SimonKagstrom/kcov/pull/146 is resolved and published.
 ${LOCAL_DIR}/bin/kcov:
 	cd /tmp && \
 	curl -L https://github.com/SimonKagstrom/kcov/archive/v33.tar.gz -o kcov.tar.gz && \


### PR DESCRIPTION
This TODO is already fixed by e3349e122d6bc1ff0ecc08b6ebdfbe218f6f40cc.

Signed-off-by: tison <wander4096@gmail.com>

### Release note

```release-note
None
```