### PR TITLE
raft_client: Lift the default value of max_grpc_send_msg_len to 64MB

### DIFF
--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -43,7 +43,11 @@ const MIN_ENDPOINT_MAX_CONCURRENCY: usize = 4;
 
 const DEFAULT_SNAP_MAX_BYTES_PER_SEC: u64 = 100 * 1024 * 1024;
 
-const DEFAULT_MAX_GRPC_SEND_MSG_LEN: i32 = 10 * 1024 * 1024;
+// Lift default value to 64MB.
+// In fact the hard limit of sent message size may not be necessary.
+// Because we have the batch size as soft limit
+// https://github.com/tikv/tikv/issues/9714
+const DEFAULT_MAX_GRPC_SEND_MSG_LEN: i32 = 64 * 1024 * 1024;
 
 /// A clone of `grpc::CompressionAlgorithms` with serde supports.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Issue Number: close #9714

### Problem Summary:

The RaftClient's way of estimating size is not accurate, partly because it does not count the field name into the size, also it does not fully check all the fields of RaftMessage to estimate the size. And thus the estimated size is not accurate in some scenarios and that leads to exceeding Grpc's own check which uses compute_size.
We prefer not call compute_size here simply because we tested in some cases it could lead to P99.99 latency goes up more than 10%.

### What's Changed:
Lift the default size of max_grpc_send_msg_len to 64MB. 

### Check List
Tests
    - Unittest
    - Manual test

### Release note <!-- bugfixes or new feature need a release note -->
None

/cc @BusyJay @gengliqi 