### PR TITLE
cdc: fix EventBatcher statistics

### DIFF
--- a/components/cdc/src/service.rs
+++ b/components/cdc/src/service.rs
@@ -151,7 +151,7 @@ impl EventBatcher {
                 }
                 self.last_size += size;
                 self.buffer.last_mut().unwrap().mut_events().push(e);
-                self.total_resolved_ts_bytes += size as usize;
+                self.total_event_bytes += size as usize;
             }
             CdcEvent::ResolvedTs(r) => {
                 let mut change_data_event = ChangeDataEvent::default();
@@ -160,7 +160,7 @@ impl EventBatcher {
 
                 // Make sure the next message is not batched with ResolvedTs.
                 self.last_size = CDC_MAX_RESP_SIZE;
-                self.total_event_bytes += size as usize;
+                self.total_resolved_ts_bytes += size as usize;
             }
             CdcEvent::Barrier(_) => {
                 // Barrier requires events must be batched accross the barrier.
@@ -173,6 +173,7 @@ impl EventBatcher {
         self.buffer
     }
 
+    // Return the total bytes of event and resolved ts.
     pub fn statistics(&self) -> (usize, usize) {
         (self.total_event_bytes, self.total_resolved_ts_bytes)
     }
@@ -523,6 +524,52 @@ mod tests {
                 ],
                 vec![CdcEvent::Event(event_big)],
             ],
+        );
+    }
+
+    #[test]
+    fn test_event_batcher_statistics() {
+        let mut event_small = Event::default();
+        let row_small = EventRow::default();
+        let mut event_entries = EventEntries::default();
+        event_entries.entries = vec![row_small].into();
+        event_small.event = Some(Event_oneof_event::Entries(event_entries));
+
+        let mut resolved_ts = ResolvedTs::default();
+        resolved_ts.set_ts(1);
+
+        let mut batcher = EventBatcher::with_capacity(1024);
+        batcher.push(CdcEvent::Event(event_small.clone()));
+        assert_eq!(
+            batcher.statistics(),
+            (CdcEvent::Event(event_small.clone()).size() as usize, 0)
+        );
+
+        batcher.push(CdcEvent::ResolvedTs(resolved_ts.clone()));
+        assert_eq!(
+            batcher.statistics(),
+            (
+                CdcEvent::Event(event_small.clone()).size() as usize,
+                CdcEvent::ResolvedTs(resolved_ts.clone()).size() as usize
+            )
+        );
+
+        batcher.push(CdcEvent::Event(event_small.clone()));
+        assert_eq!(
+            batcher.statistics(),
+            (
+                CdcEvent::Event(event_small.clone()).size() as usize * 2,
+                CdcEvent::ResolvedTs(resolved_ts.clone()).size() as usize
+            )
+        );
+
+        batcher.push(CdcEvent::ResolvedTs(resolved_ts.clone()));
+        assert_eq!(
+            batcher.statistics(),
+            (
+                CdcEvent::Event(event_small).size() as usize * 2,
+                CdcEvent::ResolvedTs(resolved_ts).size() as usize * 2
+            )
         );
     }
 


### PR DESCRIPTION
Signed-off-by: Neil Shen <overvenus@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Fix EventBatcher statistics (the total bytes of event and resolved ts are swapped by mistake).

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

Not released yet, so none.

```release-note
None
```