### PR TITLE
raftstore: separate read write ready (#10592)

### DIFF
--- a/components/batch-system/src/batch.rs
+++ b/components/batch-system/src/batch.rs
@@ -12,6 +12,7 @@ use crate::router::Router;
 use crossbeam::channel::{self, SendError};
 use file_system::{set_io_type, IOType};
 use std::borrow::Cow;
+use std::ops::{Deref, DerefMut};
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
@@ -81,11 +82,60 @@ macro_rules! impl_sched {
 impl_sched!(NormalScheduler, FsmTypes::Normal, Fsm = N);
 impl_sched!(ControlScheduler, FsmTypes::Control, Fsm = C);
 
+/// Fsm that contains tracked offset for accessing in `PollHandler::end` function.
+pub trait TrackedFsm: Deref + DerefMut {
+    /// Get the offset of current fsm in `PollHandler::end`.
+    ///
+    /// It's not valid anymore after `PollHandler::end` is finished.
+    fn offset(&self) -> usize;
+}
+
+pub struct NormalFsm<N> {
+    fsm: Box<N>,
+    timer: Instant,
+    offset: usize,
+    policy: Option<ReschedulePolicy>,
+}
+
+impl<N> NormalFsm<N> {
+    #[inline]
+    fn new(fsm: Box<N>) -> NormalFsm<N> {
+        NormalFsm {
+            fsm,
+            timer: Instant::now_coarse(),
+            offset: 0,
+            policy: None,
+        }
+    }
+}
+
+impl<N> Deref for NormalFsm<N> {
+    type Target = N;
+
+    #[inline]
+    fn deref(&self) -> &N {
+        &self.fsm
+    }
+}
+
+impl<N> DerefMut for NormalFsm<N> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut N {
+        &mut self.fsm
+    }
+}
+
+impl<N> TrackedFsm for NormalFsm<N> {
+    #[inline]
+    fn offset(&self) -> usize {
+        self.offset
+    }
+}
+
 /// A basic struct for a round of polling.
 #[allow(clippy::vec_box)]
 pub struct Batch<N, C> {
-    normals: Vec<Box<N>>,
-    timers: Vec<Instant>,
+    normals: Vec<Option<NormalFsm<N>>>,
     control: Option<Box<C>>,
 }
 
@@ -94,7 +144,6 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
     pub fn with_capacity(cap: usize) -> Batch<N, C> {
         Batch {
             normals: Vec::with_capacity(cap),
-            timers: Vec::with_capacity(cap),
             control: None,
         }
     }
@@ -102,8 +151,7 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
     fn push(&mut self, fsm: FsmTypes<N, C>) -> bool {
         match fsm {
             FsmTypes::Normal(n) => {
-                self.normals.push(n);
-                self.timers.push(Instant::now_coarse());
+                self.normals.push(Some(NormalFsm::new(n)));
             }
             FsmTypes::Control(c) => {
                 assert!(self.control.is_none());
@@ -120,7 +168,6 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
 
     fn clear(&mut self) {
         self.normals.clear();
-        self.timers.clear();
         self.control.take();
     }
 
@@ -129,20 +176,19 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
     /// Only when channel length is larger than `checked_len` will trigger
     /// further notification. This function may fail if channel length is
     /// larger than the given value before FSM is released.
-    pub fn release(&mut self, index: usize, checked_len: usize) {
-        let mut fsm = self.normals.swap_remove(index);
+    fn release(&mut self, mut fsm: NormalFsm<N>, checked_len: usize) -> Option<NormalFsm<N>> {
         let mailbox = fsm.take_mailbox().unwrap();
-        mailbox.release(fsm);
+        mailbox.release(fsm.fsm);
         if mailbox.len() == checked_len {
-            self.timers.swap_remove(index);
+            None
         } else {
             match mailbox.take_fsm() {
-                None => (),
+                // It's rescheduled by other thread.
+                None => None,
                 Some(mut s) => {
                     s.set_mailbox(Cow::Owned(mailbox));
-                    let last_index = self.normals.len();
-                    self.normals.push(s);
-                    self.normals.swap(index, last_index);
+                    fsm.fsm = s;
+                    Some(fsm)
                 }
             }
         }
@@ -153,25 +199,49 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
     /// This method should only be called when the FSM is stopped.
     /// If there are still messages in channel, the FSM is untouched and
     /// the function will return false to let caller to keep polling.
-    pub fn remove(&mut self, index: usize) {
-        let mut fsm = self.normals.swap_remove(index);
+    fn remove(&mut self, mut fsm: NormalFsm<N>) -> Option<NormalFsm<N>> {
         let mailbox = fsm.take_mailbox().unwrap();
         if mailbox.is_empty() {
-            mailbox.release(fsm);
-            self.timers.swap_remove(index);
+            // It will be removed only when it's already closed, so no new messages can
+            // be scheduled, hence don't need to consider rescheduling.
+            mailbox.release(fsm.fsm);
+            None
         } else {
             fsm.set_mailbox(Cow::Owned(mailbox));
-            let last_index = self.normals.len();
-            self.normals.push(fsm);
-            self.normals.swap(index, last_index);
+            Some(fsm)
         }
     }
 
     /// Schedule the normal FSM located at `index`.
-    pub fn reschedule(&mut self, router: &BatchRouter<N, C>, index: usize) {
-        let fsm = self.normals.swap_remove(index);
-        self.timers.swap_remove(index);
-        router.normal_scheduler.schedule(fsm);
+    ///
+    /// If `inplace`, the relative position of all fsm will not be changed; otherwise, the fsm
+    /// will be popped and the last fsm will be swap in to reduce memory copy.
+    pub fn schedule(&mut self, router: &BatchRouter<N, C>, index: usize, inplace: bool) {
+        let to_schedule = match self.normals[index].take() {
+            Some(f) => f,
+            None => {
+                if !inplace {
+                    self.normals.swap_remove(index);
+                }
+                return;
+            }
+        };
+        let mut res = match to_schedule.policy {
+            Some(ReschedulePolicy::Release(l)) => self.release(to_schedule, l),
+            Some(ReschedulePolicy::Remove) => self.remove(to_schedule),
+            Some(ReschedulePolicy::Schedule) => {
+                router.normal_scheduler.schedule(to_schedule.fsm);
+                None
+            }
+            None => Some(to_schedule),
+        };
+        if let Some(f) = &mut res {
+            // failed to reschedule
+            f.policy.take();
+            self.normals[index] = res;
+        } else if !inplace {
+            self.normals.swap_remove(index);
+        }
     }
 
     /// Same as `release`, but working on control FSM.
@@ -197,6 +267,27 @@ impl<N: Fsm, C: Fsm> Batch<N, C> {
             let s = self.control.take().unwrap();
             control_box.release(s);
         }
+    }
+}
+
+/// The result for `PollHandler::handle_control`.
+pub enum HandleResult {
+    /// The Fsm still needs to be processed.
+    KeepProcessing,
+    /// The Fsm should stop at the progress.
+    StopAt {
+        /// The count of messages that have been acknowleged by handler. The fsm should be
+        /// released until new messages arrive.
+        progress: usize,
+        /// Whether the fsm should be released before `end`.
+        skip_end: bool,
+    },
+}
+
+impl HandleResult {
+    #[inline]
+    pub fn stop_at(progress: usize, skip_end: bool) -> HandleResult {
+        HandleResult::StopAt { progress, skip_end }
     }
 }
 
@@ -232,10 +323,20 @@ pub trait PollHandler<N, C> {
     /// This function is called when handling readiness for normal FSM.
     ///
     /// The returned value is handled in the same way as `handle_control`.
-    fn handle_normal(&mut self, normal: &mut N) -> Option<usize>;
+    fn handle_normal(&mut self, normal: &mut impl TrackedFsm<Target = N>) -> HandleResult;
+
+    /// This function is called after `handle_normal` is called for all fsm and before calling
+    /// `end`. The function is expected to run lightweight work. If any fsms expects to skip
+    /// `end`, its offset should be pushed to `to_skip_end`.
+    fn light_end(
+        &mut self,
+        _batch: &mut [Option<impl TrackedFsm<Target = N>>],
+        _to_skip_end: &mut Vec<usize>,
+    ) {
+    }
 
     /// This function is called at the end of every round.
-    fn end(&mut self, batch: &mut [Box<N>]);
+    fn end(&mut self, batch: &mut [Option<impl TrackedFsm<Target = N>>]);
 
     /// This function is called when batch system is going to sleep.
     fn pause(&mut self) {}
@@ -284,6 +385,7 @@ impl<N: Fsm, C: Fsm, Handler: PollHandler<N, C>> Poller<N, C, Handler> {
     fn poll(&mut self) {
         let mut batch = Batch::with_capacity(self.max_batch_size);
         let mut reschedule_fsms = Vec::with_capacity(self.max_batch_size);
+        let mut to_skip_end = Vec::with_capacity(self.max_batch_size);
 
         // Fetch batch after every round is finished. It's helpful to protect regions
         // from becoming hungry if some regions are hot points. Since we fetch new fsm every time
@@ -307,24 +409,33 @@ impl<N: Fsm, C: Fsm, Handler: PollHandler<N, C>> Poller<N, C, Handler> {
 
             let mut hot_fsm_count = 0;
             for (i, p) in batch.normals.iter_mut().enumerate() {
-                let len = self.handler.handle_normal(p);
+                let p = p.as_mut().unwrap();
+                p.offset = i;
+                let res = self.handler.handle_normal(p);
                 if p.is_stopped() {
-                    reschedule_fsms.push((i, ReschedulePolicy::Remove));
+                    p.policy = Some(ReschedulePolicy::Remove);
+                    reschedule_fsms.push(i);
                 } else if p.get_priority() != self.handler.get_priority() {
-                    reschedule_fsms.push((i, ReschedulePolicy::Schedule));
+                    p.policy = Some(ReschedulePolicy::Schedule);
+                    reschedule_fsms.push(i);
                 } else {
-                    if batch.timers[i].saturating_elapsed() >= self.reschedule_duration {
+                    if p.timer.saturating_elapsed() >= self.reschedule_duration {
                         hot_fsm_count += 1;
                         // We should only reschedule a half of the hot regions, otherwise,
                         // it's possible all the hot regions are fetched in a batch the
                         // next time.
                         if hot_fsm_count % 2 == 0 {
-                            reschedule_fsms.push((i, ReschedulePolicy::Schedule));
+                            p.policy = Some(ReschedulePolicy::Schedule);
+                            reschedule_fsms.push(i);
                             continue;
                         }
                     }
-                    if let Some(l) = len {
-                        reschedule_fsms.push((i, ReschedulePolicy::Release(l)));
+                    if let HandleResult::StopAt { progress, skip_end } = res {
+                        p.policy = Some(ReschedulePolicy::Release(progress));
+                        reschedule_fsms.push(i);
+                        if skip_end {
+                            to_skip_end.push(i);
+                        }
                     }
                 }
             }
@@ -339,24 +450,32 @@ impl<N: Fsm, C: Fsm, Handler: PollHandler<N, C>> Poller<N, C, Handler> {
                 if !run || fsm_cnt >= batch.normals.len() {
                     break;
                 }
-                let len = self.handler.handle_normal(&mut batch.normals[fsm_cnt]);
-                if batch.normals[fsm_cnt].is_stopped() {
-                    reschedule_fsms.push((fsm_cnt, ReschedulePolicy::Remove));
-                } else if let Some(l) = len {
-                    reschedule_fsms.push((fsm_cnt, ReschedulePolicy::Release(l)));
+                let p = batch.normals[fsm_cnt].as_mut().unwrap();
+                p.offset = fsm_cnt;
+                let res = self.handler.handle_normal(p);
+                if p.is_stopped() {
+                    p.policy = Some(ReschedulePolicy::Remove);
+                    reschedule_fsms.push(fsm_cnt);
+                } else if let HandleResult::StopAt { progress, skip_end } = res {
+                    p.policy = Some(ReschedulePolicy::Release(progress));
+                    reschedule_fsms.push(fsm_cnt);
+                    if skip_end {
+                        to_skip_end.push(fsm_cnt);
+                    }
                 }
                 fsm_cnt += 1;
             }
+            self.handler.light_end(&mut batch.normals, &mut to_skip_end);
+            for offset in &to_skip_end {
+                batch.schedule(&self.router, *offset, true);
+            }
+            to_skip_end.clear();
             self.handler.end(&mut batch.normals);
 
             // Because release use `swap_remove` internally, so using pop here
             // to remove the correct FSM.
-            while let Some((r, mark)) = reschedule_fsms.pop() {
-                match mark {
-                    ReschedulePolicy::Release(l) => batch.release(r, l),
-                    ReschedulePolicy::Remove => batch.remove(r),
-                    ReschedulePolicy::Schedule => batch.reschedule(&self.router, r),
-                }
+            while let Some(r) = reschedule_fsms.pop() {
+                batch.schedule(&self.router, r, false);
             }
         }
         batch.clear();

--- a/components/batch-system/src/lib.rs
+++ b/components/batch-system/src/lib.rs
@@ -9,7 +9,9 @@ mod router;
 #[cfg(feature = "test-runner")]
 pub mod test_runner;
 
-pub use self::batch::{create_system, BatchRouter, BatchSystem, HandlerBuilder, PollHandler};
+pub use self::batch::{
+    create_system, BatchRouter, BatchSystem, HandleResult, HandlerBuilder, PollHandler, TrackedFsm,
+};
 pub use self::config::Config;
 pub use self::fsm::{Fsm, Priority};
 pub use self::mailbox::{BasicMailbox, Mailbox};

--- a/components/engine_rocks/src/raft_engine.rs
+++ b/components/engine_rocks/src/raft_engine.rs
@@ -250,6 +250,7 @@ impl RaftLogBatch for RocksWriteBatch {
         self.put_msg(&keys::raft_state_key(raft_group_id), state)
     }
 
+    #[inline]
     fn persist_size(&self) -> usize {
         self.data_size()
     }

--- a/components/engine_traits/src/raft_engine.rs
+++ b/components/engine_traits/src/raft_engine.rs
@@ -96,7 +96,6 @@ pub trait RaftLogBatch: Send {
     /// The data size of this RaftLogBatch.
     fn persist_size(&self) -> usize;
 
-    /// Whether it is empty or not.
     fn is_empty(&self) -> bool;
 
     /// Merge another RaftLogBatch to itself.

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -74,8 +74,12 @@ impl RaftLogBatchTrait for RaftLogBatch {
         Ok(())
     }
 
+    #[inline]
     fn persist_size(&self) -> usize {
-        panic!("persist_size is not implemented for raft engine");
+        // TODO: This is not data size, but sufficient for current usage.
+        // Data size is useful when controlling bytes per sync, so it's better
+        // to implement it correctly.
+        self.0.items.len()
     }
 
     fn is_empty(&self) -> bool {

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -17,7 +17,8 @@ use std::vec::Drain;
 use std::{cmp, usize};
 
 use batch_system::{
-    BasicMailbox, BatchRouter, BatchSystem, Fsm, HandlerBuilder, PollHandler, Priority,
+    BasicMailbox, BatchRouter, BatchSystem, Fsm, HandleResult, HandlerBuilder, PollHandler,
+    Priority, TrackedFsm,
 };
 use collections::{HashMap, HashMapEntry, HashSet};
 use crossbeam::channel::{TryRecvError, TrySendError};
@@ -3722,48 +3723,51 @@ where
         }
     }
 
-    fn handle_normal(&mut self, normal: &mut ApplyFsm<EK>) -> Option<usize> {
-        let mut expected_msg_count = None;
+    fn handle_normal(
+        &mut self,
+        normal: &mut impl TrackedFsm<Target = ApplyFsm<EK>>,
+    ) -> HandleResult {
+        let mut handle_result = HandleResult::KeepProcessing;
         normal.delegate.handle_start = Some(Instant::now_coarse());
         if normal.delegate.yield_state.is_some() {
             if normal.delegate.wait_merge_state.is_some() {
                 // We need to query the length first, otherwise there is a race
                 // condition that new messages are queued after resuming and before
                 // query the length.
-                expected_msg_count = Some(normal.receiver.len());
+                handle_result = HandleResult::stop_at(normal.receiver.len(), false);
             }
             normal.resume_pending(&mut self.apply_ctx);
             if normal.delegate.wait_merge_state.is_some() {
                 // Yield due to applying CommitMerge, this fsm can be released if its
-                // channel msg count equals to expected_msg_count because it will receive
+                // channel msg count equals to last count because it will receive
                 // a new message if its source region has applied all needed logs.
-                return expected_msg_count;
+                return handle_result;
             } else if normal.delegate.yield_state.is_some() {
                 // Yield due to other reasons, this fsm must not be released because
                 // it's possible that no new message will be sent to itself.
                 // The remaining messages will be handled in next rounds.
-                return None;
+                return HandleResult::KeepProcessing;
             }
-            expected_msg_count = None;
+            handle_result = HandleResult::KeepProcessing;
         }
         fail_point!("before_handle_normal_3", normal.delegate.id() == 3, |_| {
-            None
+            HandleResult::KeepProcessing
         });
         fail_point!(
             "before_handle_normal_1003",
             normal.delegate.id() == 1003,
-            |_| { None }
+            |_| { HandleResult::KeepProcessing }
         );
         while self.msg_buf.len() < self.messages_per_tick {
             match normal.receiver.try_recv() {
                 Ok(msg) => self.msg_buf.push(msg),
                 Err(TryRecvError::Empty) => {
-                    expected_msg_count = Some(0);
+                    handle_result = HandleResult::stop_at(0, false);
                     break;
                 }
                 Err(TryRecvError::Disconnected) => {
                     normal.delegate.stopped = true;
-                    expected_msg_count = Some(0);
+                    handle_result = HandleResult::stop_at(0, false);
                     break;
                 }
             }
@@ -3773,17 +3777,17 @@ where
 
         if normal.delegate.wait_merge_state.is_some() {
             // Check it again immediately as catching up logs can be very fast.
-            expected_msg_count = Some(0);
+            handle_result = HandleResult::stop_at(0, false);
         } else if normal.delegate.yield_state.is_some() {
             // Let it continue to run next time.
-            expected_msg_count = None;
+            handle_result = HandleResult::KeepProcessing;
         }
-        expected_msg_count
+        handle_result
     }
 
-    fn end(&mut self, fsms: &mut [Box<ApplyFsm<EK>>]) {
+    fn end(&mut self, fsms: &mut [Option<impl TrackedFsm<Target = ApplyFsm<EK>>>]) {
         self.apply_ctx.flush();
-        for fsm in fsms {
+        for fsm in fsms.iter_mut().flatten() {
             fsm.delegate.last_flush_applied_index = fsm.delegate.apply_state.get_applied_index();
             fsm.delegate.update_memory_trace(&mut self.trace_event);
         }

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -11,7 +11,9 @@ use std::{cmp, mem, u64};
 use batch_system::{BasicMailbox, Fsm};
 use collections::HashMap;
 use engine_traits::CF_RAFT;
-use engine_traits::{Engines, KvEngine, RaftEngine, SSTMetaInfo, WriteBatchExt};
+use engine_traits::{
+    Engines, KvEngine, RaftEngine, RaftLogBatch, SSTMetaInfo, WriteBatch, WriteBatchExt,
+};
 use error_code::ErrorCodeExt;
 use fail::fail_point;
 use kvproto::errorpb;
@@ -1041,26 +1043,36 @@ where
         }
     }
 
-    pub fn collect_ready(&mut self) {
+    /// Collect ready if any.
+    ///
+    /// Returns false is no readiness is generated.
+    pub fn collect_ready(&mut self, offset: usize) -> bool {
         let has_ready = self.fsm.has_ready;
         self.fsm.has_ready = false;
         if !has_ready || self.fsm.stopped {
-            return;
+            return false;
         }
         self.ctx.pending_count += 1;
         self.ctx.has_ready = true;
+        let written = self.ctx.kv_wb.data_size() + self.ctx.raft_wb.persist_size();
         let res = self.fsm.peer.handle_raft_ready_append(self.ctx);
         if let Some(mut r) = res {
             // This bases on an assumption that fsm array passed in `end` method will have
             // the same order of processing.
-            r.batch_offset = self.ctx.processed_fsm_count;
+            r.batch_offset = offset;
             self.on_role_changed(&r.ready);
             if r.ctx.has_new_entries {
                 self.register_raft_gc_log_tick();
                 self.register_entry_cache_evict_tick();
             }
-            self.ctx.ready_res.push(r);
+            if self.ctx.kv_wb.data_size() + self.ctx.raft_wb.persist_size() != written {
+                self.ctx.ready_res.push(r);
+            } else {
+                self.ctx.readonly_ready_res.push(r);
+            }
+            return true;
         }
+        false
     }
 
     pub fn post_raft_ready_append(&mut self, ready: CollectedReady) {

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -11,7 +11,8 @@ use std::time::{Duration, Instant};
 use std::{mem, u64};
 
 use batch_system::{
-    BasicMailbox, BatchRouter, BatchSystem, Fsm, HandlerBuilder, PollHandler, Priority,
+    BasicMailbox, BatchRouter, BatchSystem, Fsm, HandleResult, HandlerBuilder, PollHandler,
+    Priority, TrackedFsm,
 };
 use crossbeam::channel::{TryRecvError, TrySendError};
 use engine_traits::PerfContext;
@@ -347,8 +348,6 @@ where
     EK: KvEngine,
     ER: RaftEngine,
 {
-    /// The count of processed normal Fsm.
-    pub processed_fsm_count: usize,
     pub cfg: Config,
     pub store: metapb::Store,
     pub pd_scheduler: Scheduler<PdTask<EK>>,
@@ -388,6 +387,7 @@ where
     pub sync_log: bool,
     pub has_ready: bool,
     pub ready_res: Vec<CollectedReady>,
+    pub readonly_ready_res: Vec<CollectedReady>,
     pub current_time: Option<Timespec>,
     pub perf_context: EK::PerfContext,
     pub tick_batch: Vec<PeerTickBatch>,
@@ -674,7 +674,11 @@ pub struct RaftPoller<EK: KvEngine + 'static, ER: RaftEngine + 'static, T: 'stat
 }
 
 impl<EK: KvEngine, ER: RaftEngine, T: Transport> RaftPoller<EK, ER, T> {
-    fn handle_raft_ready(&mut self, peers: &mut [Box<PeerFsm<EK, ER>>]) {
+    fn handle_raft_ready(
+        &mut self,
+        peers: &mut [Option<impl TrackedFsm<Target = PeerFsm<EK, ER>>>],
+        to_skip_end: &mut Vec<usize>,
+    ) {
         // Only enable the fail point when the store id is equal to 3, which is
         // the id of slow store in tests.
         fail_point!("on_raft_ready", self.poll_ctx.store_id() == 3, |_| {});
@@ -683,8 +687,27 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> RaftPoller<EK, ER, T> {
         {
             self.poll_ctx.trans.flush();
         }
-        let ready_cnt = self.poll_ctx.ready_res.len();
+        let ready_cnt = self.poll_ctx.ready_res.len() + self.poll_ctx.readonly_ready_res.len();
+        if !self.poll_ctx.readonly_ready_res.is_empty() {
+            let mut readonly_ready_res = mem::take(&mut self.poll_ctx.readonly_ready_res);
+            for ready in readonly_ready_res.drain(..) {
+                to_skip_end.push(ready.batch_offset);
+                PeerFsmDelegate::new(
+                    peers[ready.batch_offset].as_mut().unwrap(),
+                    &mut self.poll_ctx,
+                )
+                .post_raft_ready_append(ready);
+            }
+            self.poll_ctx.readonly_ready_res = readonly_ready_res;
+        }
         self.poll_ctx.raft_metrics.ready.has_ready_region += ready_cnt as u64;
+    }
+
+    fn handle_raft_ready_write(
+        &mut self,
+        peers: &mut [Option<impl TrackedFsm<Target = PeerFsm<EK, ER>>>],
+    ) {
+        let ready_cnt = self.poll_ctx.ready_res.len();
         fail_point!("raft_before_save");
         if !self.poll_ctx.kv_wb.is_empty() {
             let mut write_opts = WriteOptions::new();
@@ -729,8 +752,11 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> RaftPoller<EK, ER, T> {
         if ready_cnt != 0 {
             let mut ready_res = mem::take(&mut self.poll_ctx.ready_res);
             for ready in ready_res.drain(..) {
-                PeerFsmDelegate::new(&mut peers[ready.batch_offset], &mut self.poll_ctx)
-                    .post_raft_ready_append(ready);
+                PeerFsmDelegate::new(
+                    &mut peers[ready.batch_offset].as_mut().unwrap(),
+                    &mut self.poll_ctx,
+                )
+                .post_raft_ready_append(ready);
             }
         }
         let dur = self.timer.saturating_elapsed();
@@ -789,7 +815,6 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
 {
     fn begin(&mut self, _batch_size: usize) {
         self.previous_metrics = self.poll_ctx.raft_metrics.clone();
-        self.poll_ctx.processed_fsm_count = 0;
         self.poll_ctx.pending_count = 0;
         self.poll_ctx.sync_log = false;
         self.poll_ctx.has_ready = false;
@@ -844,8 +869,11 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
         expected_msg_count
     }
 
-    fn handle_normal(&mut self, peer: &mut PeerFsm<EK, ER>) -> Option<usize> {
-        let mut expected_msg_count = None;
+    fn handle_normal(
+        &mut self,
+        peer: &mut impl TrackedFsm<Target = PeerFsm<EK, ER>>,
+    ) -> HandleResult {
+        let mut handle_result = HandleResult::KeepProcessing;
 
         fail_point!(
             "pause_on_peer_collect_message",
@@ -877,27 +905,46 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
                     self.peer_msg_buf.push(msg);
                 }
                 Err(TryRecvError::Empty) => {
-                    expected_msg_count = Some(0);
+                    handle_result = HandleResult::stop_at(0, false);
                     break;
                 }
                 Err(TryRecvError::Disconnected) => {
                     peer.stop();
-                    expected_msg_count = Some(0);
+                    handle_result = HandleResult::stop_at(0, false);
                     break;
                 }
             }
         }
+        let offset = peer.offset();
         let mut delegate = PeerFsmDelegate::new(peer, &mut self.poll_ctx);
         delegate.handle_msgs(&mut self.peer_msg_buf);
-        delegate.collect_ready();
-        self.poll_ctx.processed_fsm_count += 1;
-        expected_msg_count
+        // No readiness is generated, skipping calling ready and release early.
+        if !delegate.collect_ready(offset) {
+            if let HandleResult::StopAt { skip_end, .. } = &mut handle_result {
+                *skip_end = true;
+            }
+        }
+        handle_result
     }
 
-    fn end(&mut self, peers: &mut [Box<PeerFsm<EK, ER>>]) {
+    fn light_end(
+        &mut self,
+        peers: &mut [Option<impl TrackedFsm<Target = PeerFsm<EK, ER>>>],
+        to_skip_end: &mut Vec<usize>,
+    ) {
         self.flush_ticks();
+        for peer in peers.iter_mut().flatten() {
+            peer.update_memory_trace(&mut self.trace_event);
+        }
+        MEMTRACE_PEERS.trace(mem::take(&mut self.trace_event));
         if self.poll_ctx.has_ready {
-            self.handle_raft_ready(peers);
+            self.handle_raft_ready(peers, to_skip_end);
+        }
+    }
+
+    fn end(&mut self, peers: &mut [Option<impl TrackedFsm<Target = PeerFsm<EK, ER>>>]) {
+        if self.poll_ctx.has_ready {
+            self.handle_raft_ready_write(peers);
         }
         self.poll_ctx.current_time = None;
         self.poll_ctx
@@ -920,11 +967,6 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> PollHandler<PeerFsm<EK, ER>, St
                 warn!("send control msg to apply router failed"; "err" => ?e);
             }
         }
-
-        for peer in peers {
-            peer.update_memory_trace(&mut self.trace_event);
-        }
-        MEMTRACE_PEERS.trace(mem::take(&mut self.trace_event));
     }
 
     fn pause(&mut self) {
@@ -1135,7 +1177,6 @@ where
 
     fn build(&mut self, _: Priority) -> RaftPoller<EK, ER, T> {
         let mut ctx = PollContext {
-            processed_fsm_count: 0,
             cfg: self.cfg.value().clone(),
             store: self.store.clone(),
             pd_scheduler: self.pd_scheduler.clone(),
@@ -1164,6 +1205,7 @@ where
             sync_log: false,
             has_ready: false,
             ready_res: Vec::new(),
+            readonly_ready_res: Vec::new(),
             current_time: None,
             perf_context: self
                 .engines

--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -79,12 +79,12 @@ impl CGroupSys {
         let path = if self.is_v2 {
             let group = self.cgroups.get("").unwrap();
             let (root, mount_point) = self.mount_points.get("").unwrap();
-            let path = build_path(group, &root, mount_point);
+            let path = build_path(group, root, mount_point);
             format!("{}/memory.max", path.to_str().unwrap())
         } else {
             let group = self.cgroups.get("memory").unwrap();
             let (root, mount_point) = self.mount_points.get("memory").unwrap();
-            let path = build_path(group, &root, mount_point);
+            let path = build_path(group, root, mount_point);
             format!("{}/memory.limit_in_bytes", path.to_str().unwrap())
         };
         read_to_string(&path).map_or(-1, |x| parse_memory_max(x.trim()))
@@ -94,12 +94,12 @@ impl CGroupSys {
         let path = if self.is_v2 {
             let group = self.cgroups.get("").unwrap();
             let (root, mount_point) = self.mount_points.get("").unwrap();
-            let path = build_path(group, &root, mount_point);
+            let path = build_path(group, root, mount_point);
             format!("{}/cpuset.cpus", path.to_str().unwrap())
         } else {
             let group = self.cgroups.get("cpuset").unwrap();
             let (root, mount_point) = self.mount_points.get("cpuset").unwrap();
-            let path = build_path(group, &root, mount_point);
+            let path = build_path(group, root, mount_point);
             format!("{}/cpuset.cpus", path.to_str().unwrap())
         };
         read_to_string(&path).map_or_else(|_| HashSet::new(), |x| parse_cpu_cores(x.trim()))
@@ -110,7 +110,7 @@ impl CGroupSys {
         if self.is_v2 {
             let group = self.cgroups.get("").unwrap();
             let (root, mount_point) = self.mount_points.get("").unwrap();
-            let path = build_path(group, &root, mount_point);
+            let path = build_path(group, root, mount_point);
             let path = format!("{}/cpu.max", path.to_str().unwrap());
             if let Ok(buffer) = read_to_string(&path) {
                 return parse_cpu_quota_v2(buffer.trim());
@@ -118,7 +118,7 @@ impl CGroupSys {
         } else {
             let group = self.cgroups.get("cpu").unwrap();
             let (root, mount_point) = self.mount_points.get("cpu").unwrap();
-            let path = build_path(group, &root, mount_point);
+            let path = build_path(group, root, mount_point);
             let path1 = format!("{}/cpu.cfs_quota_us", path.to_str().unwrap());
             let path2 = format!("{}/cpu.cfs_period_us", path.to_str().unwrap());
             if let (Ok(buffer1), Ok(buffer2)) = (read_to_string(&path1), read_to_string(&path2)) {
@@ -198,10 +198,10 @@ fn cgroup_mountinfos_v2() -> HashMap<String, (String, PathBuf)> {
 
 // `root` is mounted on `mount_point`. `path` is a sub path of `root`.
 // This is used to build an absolute path starts with `mount_point`.
-fn build_path(path: &str, root: &str, mount_point: &PathBuf) -> PathBuf {
+fn build_path(path: &str, root: &str, mount_point: &Path) -> PathBuf {
     assert!(path.starts_with('/') && root.starts_with('/'));
     let relative = path.strip_prefix(root).unwrap();
-    let mut absolute = mount_point.clone();
+    let mut absolute = mount_point.to_path_buf();
     absolute.push(relative);
     absolute
 }

--- a/components/tikv_util/src/sys/cgroup.rs
+++ b/components/tikv_util/src/sys/cgroup.rs
@@ -4,7 +4,7 @@ use procfs::process::Process;
 use std::collections::{HashMap, HashSet};
 use std::fs::read_to_string;
 use std::mem::MaybeUninit;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 // ## Differences between cgroup v1 and v2:
 // ### memory subsystem, memory limitation


### PR DESCRIPTION

### What problem does this PR solve?

Close #10475.

Read ready can be processed early to reduce read latency.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
- separate read write ready to reduce read latency
```