### PR TITLE
*: re-enable clippy in CI checks

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -1118,7 +1118,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
                     .join(Path::new(file_system::SPACE_PLACEHOLDER_FILE));
 
                 let placeholder_size: u64 =
-                    file_system::get_file_size(&placeholer_file_path).unwrap_or_else(|_| 0);
+                    file_system::get_file_size(&placeholer_file_path).unwrap_or(0);
 
                 let used_size = snap_size + kv_size + raft_size + placeholder_size;
                 let capacity = if config_disk_capacity == 0 || disk_cap < config_disk_capacity {

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -35,6 +35,6 @@ CLIPPY_LINTS=(-A clippy::module_inception  \
         -W clippy::dbg_macro \
         -W clippy::todo)
 
-cargo clippy --workspace --fix --allow-staged --no-default-features \
+cargo clippy --workspace --no-default-features \
 	--exclude fuzz-targets --exclude fuzzer-honggfuzz --exclude fuzzer-afl --exclude fuzzer-libfuzzer \
 	--features "${TIKV_ENABLE_FEATURES}" "$@" -- "${CLIPPY_LINTS[@]}"

--- a/tests/failpoints/cases/test_disk_full.rs
+++ b/tests/failpoints/cases/test_disk_full.rs
@@ -20,7 +20,7 @@ fn disk_full_stores(resp: &RaftCmdResponse) -> Vec<u64> {
     let region_error = resp.get_header().get_error();
     assert!(region_error.has_disk_full());
     let mut stores = region_error.get_disk_full().get_store_id().to_vec();
-    stores.sort();
+    stores.sort_unstable();
     stores
 }
 
@@ -325,7 +325,7 @@ fn test_majority_disk_full() {
     // `[(1, DiskUsage::AlmostFull), (3, DiskUsage::AlreadyFull)]`. So no more proposals
     // should be allowed.
     let reqs = vec![new_put_cmd(b"k4", b"v4")];
-    let put = new_request(1, epoch.clone(), reqs, false);
+    let put = new_request(1, epoch, reqs, false);
     let mut opts = RaftCmdExtraOpts::default();
     opts.disk_full_opt = DiskFullOpt::AllowedOnAlmostFull;
     let ch = cluster.async_request_with_opts(put, opts).unwrap();


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Re-enable clippy.

Problem Summary:

### What is changed and how it works?

https://github.com/tikv/tikv/pull/10638, clippy errors are accidentally disabled in CI. This PR re-enabled it and fixed several clippy issues.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```