### PR TITLE
grafana: add instance to flow control metrics legend

### DIFF
--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -13090,7 +13090,7 @@
               "expr": "sum(tikv_scheduler_l0_flow{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance, cf)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{cf}}_l0_flow",
+              "legendFormat": "{{cf}}_l0_flow-{{instance}}",
               "metric": "",
               "refId": "D",
               "step": 40
@@ -13099,7 +13099,7 @@
               "expr": "sum(tikv_scheduler_flush_flow{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance, cf)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{cf}}_flush_flow",
+              "legendFormat": "{{cf}}_flush_flow-{{instance}}",
               "metric": "",
               "refId": "E",
               "step": 40
@@ -13108,7 +13108,7 @@
               "expr": "sum(tikv_scheduler_l0_target_flow{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "target_flow",
+              "legendFormat": "target_flow-{{instance}}",
               "metric": "",
               "refId": "A",
               "step": 40
@@ -13118,7 +13118,7 @@
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "total_l0_flow",
+              "legendFormat": "total_l0_flow-{{instance}}",
               "metric": "",
               "refId": "B",
               "step": 40
@@ -13128,7 +13128,7 @@
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "total_flush_flow",
+              "legendFormat": "total_flush_flow-{{instance}}",
               "metric": "",
               "refId": "C",
               "step": 40
@@ -13322,7 +13322,7 @@
               "expr": "max(tikv_scheduler_l0{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "l0",
+              "legendFormat": "l0-{{instance}}",
               "metric": "",
               "refId": "A",
               "step": 40
@@ -13331,7 +13331,7 @@
               "expr": "max(tikv_scheduler_memtable{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "memtable",
+              "legendFormat": "memtable-{{instance}}",
               "metric": "",
               "refId": "B",
               "step": 40
@@ -13340,7 +13340,7 @@
               "expr": "max(tikv_scheduler_l0_avg{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "avg_l0",
+              "legendFormat": "avg_l0-{{instance}}",
               "metric": "",
               "refId": "C",
               "step": 40
@@ -13349,7 +13349,7 @@
               "expr": "max(tikv_scheduler_flush_l0{tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "flush_l0",
+              "legendFormat": "flush_l0-{{instance}}",
               "metric": "",
               "refId": "D",
               "step": 40


### PR DESCRIPTION

### What problem does this PR solve?

Previously data of different tikv nodes are mixed together, making the graph hard to read:

![图片](https://user-images.githubusercontent.com/17217495/129558014-851bdc0e-7206-40cf-8696-8fca9a71588e.png)

### What is changed and how it works?

The tikv instance is added to the legend:

![图片](https://user-images.githubusercontent.com/17217495/129559265-6203dc1c-e67b-439d-8e4d-f0ebe8c95d5f.png)

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```