### PR TITLE
raftstore: skip to inspect apply latency

### DIFF
--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1504,16 +1504,6 @@ where
                         duration.store_wait_duration.unwrap(),
                     ));
                 STORE_INSPECT_DURTION_HISTOGRAM
-                    .with_label_values(&["apply_process"])
-                    .observe(tikv_util::time::duration_to_sec(
-                        duration.apply_process_duration.unwrap(),
-                    ));
-                STORE_INSPECT_DURTION_HISTOGRAM
-                    .with_label_values(&["apply_wait"])
-                    .observe(tikv_util::time::duration_to_sec(
-                        duration.apply_wait_duration.unwrap(),
-                    ));
-                STORE_INSPECT_DURTION_HISTOGRAM
                     .with_label_values(&["all"])
                     .observe(tikv_util::time::duration_to_sec(dur));
                 if let Err(e) = scheduler.schedule(Task::UpdateSlowScore { id, duration }) {


### PR DESCRIPTION
Signed-off-by: 5kbpers <tangminghua@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #10744

Problem Summary:
For now, we have serval unaddressed known issues about apply worker:
* The scan operations could hold the db mutex of rocksdb for a long time. https://github.com/tikv/rocksdb/pull/250
* `apply log duration` and `apply wait duration` could be large under some workloads with hotpots

With these issues the durations related to apply worker will introduce some uncertainty to the slow store detection. And the performance of the durations related to store worker is relatively stable in our tests. So this PR skips to inspect the durations related to apply worker.

### What is changed and how it works?

What's Changed:
* Skip to inspect apply latency

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```