### PR TITLE
Fix flow controller for missing throttle cf

### DIFF
--- a/src/storage/txn/flow_controller.rs
+++ b/src/storage/txn/flow_controller.rs
@@ -763,7 +763,7 @@ impl<E: KvEngine> FlowChecker<E> {
             };
             self.limiter.speed_limit() + diff * 1024.0 * 1024.0
         } else {
-            INFINITY
+            f64::INFINITY
         };
 
         self.update_speed_limit(throttle);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #10752 

Problem Summary:

The throttle CF is not set when the throttle speed is initialized in the case of memtable accumulation.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
- set throttle CF for memtable accumulation
- simplify spare tick logic
- fix unexpected behavior for memtable debt

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```