### PR TITLE
*: disable disk full checks and actions temporarily

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -1307,6 +1307,10 @@ where
     }
 
     fn handle_reported_disk_usage(&mut self, msg: &RaftMessage) {
+        // Mocked
+        if matches!(msg.disk_usage, DiskUsage::Normal) {
+            return;
+        }
         let store_id = msg.get_from_peer().get_store_id();
         let peer_id = msg.get_from_peer().get_id();
         let refill_disk_usages = if matches!(msg.disk_usage, DiskUsage::Normal) {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -427,12 +427,9 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         }
         disk::set_disk_reserved_space(reserve_space);
         let available = disk_stats.available_space();
-        if available > reserve_space / 2 {
-            file_system::reserve_space_for_recover(
-                &self.config.storage.data_dir,
-                reserve_space / 5,
-            )
-            .unwrap();
+        if available > reserve_space {
+            file_system::reserve_space_for_recover(&self.config.storage.data_dir, reserve_space)
+                .unwrap();
         } else {
             warn!("no enough disk space left to create the place holder file");
         }

--- a/components/tikv_util/src/sys/disk.rs
+++ b/components/tikv_util/src/sys/disk.rs
@@ -20,12 +20,13 @@ pub fn get_disk_reserved_space() -> u64 {
 }
 
 pub fn set_disk_status(status: DiskUsage) {
-    let s = match status {
+    let _ = match status {
         DiskUsage::Normal => 0,
         DiskUsage::AlmostFull => 1,
         DiskUsage::AlreadyFull => 2,
     };
-    DISK_STATUS.store(s, Ordering::Release);
+    // Mocked
+    DISK_STATUS.store(0, Ordering::Release);
 }
 
 pub fn get_disk_status(_store_id: u64) -> DiskUsage {
@@ -47,7 +48,8 @@ pub fn get_disk_status(_store_id: u64) -> DiskUsage {
     fail_point!("disk_already_full_peer_3", _store_id == 3, |_| {
         DiskUsage::AlreadyFull
     });
-    let s = DISK_STATUS.load(Ordering::Acquire);
+    // Mock this to close, next open. let s = DISK_STATUS.load(Ordering::Acquire);
+    let s = 0;
     match s {
         0 => DiskUsage::Normal,
         1 => DiskUsage::AlmostFull,

--- a/tests/failpoints/cases/test_disk_full.rs
+++ b/tests/failpoints/cases/test_disk_full.rs
@@ -12,6 +12,9 @@ use std::thread;
 use std::time::Duration;
 use test_raftstore::*;
 
+fn mocked() -> bool {
+    true
+}
 fn assert_disk_full(resp: &RaftCmdResponse) {
     assert!(resp.get_header().get_error().has_disk_full());
 }
@@ -45,6 +48,10 @@ fn ensure_disk_usage_is_reported<T: Simulator>(
 }
 
 fn test_disk_full_leader_behaviors(usage: DiskUsage) {
+    // Mocked in v5.2
+    if !matches!(usage, DiskUsage::Normal) {
+        return;
+    }
     let mut cluster = new_node_cluster(0, 3);
     cluster.pd_client.disable_default_operator();
     cluster.run();
@@ -106,6 +113,10 @@ fn test_disk_full_for_region_leader() {
 }
 
 fn test_disk_full_follower_behaviors(usage: DiskUsage) {
+    // Mocked in v5.2
+    if !matches!(usage, DiskUsage::Normal) {
+        return;
+    }
     let mut cluster = new_node_cluster(0, 3);
     cluster.pd_client.disable_default_operator();
     cluster.run();
@@ -153,6 +164,10 @@ fn test_disk_full_for_region_follower() {
 }
 
 fn test_disk_full_txn_behaviors(usage: DiskUsage) {
+    // Mocked in v5.2
+    if !matches!(usage, DiskUsage::Normal) {
+        return;
+    }
     let mut cluster = new_server_cluster(0, 3);
     cluster.pd_client.disable_default_operator();
     cluster.run();
@@ -252,6 +267,10 @@ fn test_disk_full_for_txn_operations() {
 
 #[test]
 fn test_majority_disk_full() {
+    // Mocked
+    if mocked() {
+        return;
+    }
     let mut cluster = new_node_cluster(0, 3);
     // To ensure the thread has full store disk usage infomation.
     cluster.cfg.raft_store.store_batch_system.pool_size = 1;
@@ -340,6 +359,10 @@ fn test_majority_disk_full() {
 
 #[test]
 fn test_disk_full_followers_with_hibernate_regions() {
+    // Mocked.
+    if mocked() {
+        return;
+    }
     let mut cluster = new_node_cluster(0, 2);
     // To ensure the thread has full store disk usage infomation.
     cluster.cfg.raft_store.store_batch_system.pool_size = 1;


### PR DESCRIPTION
Signed-off-by: tier-cap <zhengxiaojin@pingcap.com>

### What problem does this PR solve?
Close cloud TiKV disk full feature in v5.2.

### What is changed and how it works?
1. revert the disk place holder file size.
2. set the disk usage status normal and mock all update.
3. mock the disk stats worker.
4. mock handle_reported_disk_usage.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List

Tests
- Disable the integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

```
None
```