### PR TITLE
Fix TiKV panic when enable Titan and upgrade from pre-5.0 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,7 +2179,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#98a4d149a1437a98453486f91809c4320166353c"
+source = "git+https://github.com/tikv/rust-rocksdb.git#dcc1f836a2ae7a7ee71b6aed8cd4107e04a4b829"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2198,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#98a4d149a1437a98453486f91809c4320166353c"
+source = "git+https://github.com/tikv/rust-rocksdb.git#dcc1f836a2ae7a7ee71b6aed8cd4107e04a4b829"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#98a4d149a1437a98453486f91809c4320166353c"
+source = "git+https://github.com/tikv/rust-rocksdb.git#dcc1f836a2ae7a7ee71b6aed8cd4107e04a4b829"
 dependencies = [
  "libc 0.2.86",
  "librocksdb_sys",


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

### What problem does this PR solve?

Issue Number: close #10774 

Problem Summary:
Fix Titan upgrade issue by including https://github.com/tikv/titan/pull/221

### What is changed and how it works?

What's Changed: see the linked issue and the titan fix.

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

CI

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix TiKV panic when Titan is enabled and upgrade from < 5.0 versions to >= 5.0 versions. A cluster may hit the issue if it was upgraded from TiKV 3.x and enabled Titan before the upgrade in the past.
```