### PR TITLE
tikv-ctl: add remove-regions and drop-unapplied-raftlog

### DIFF
--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -515,6 +515,10 @@ trait DebugExecutor {
     /// Recover the cluster when given `store_ids` are failed.
     fn remove_fail_stores(&self, store_ids: Vec<u64>, region_ids: Option<Vec<u64>>);
 
+    fn remove_regions(&self, region_ids: Vec<u64>);
+
+    fn drop_unapplied_raftlog(&self, region_ids: Option<Vec<u64>>);
+
     /// Recreate the region with metadata from pd, but alloc new id for it.
     fn recreate_region(&self, sec_mgr: Arc<SecurityManager>, pd_cfg: &PdConfig, region_id: u64);
 
@@ -741,12 +745,20 @@ impl DebugExecutor for DebugClient {
         unimplemented!("only available for local mode");
     }
 
+    fn drop_unapplied_raftlog(&self, _: Option<Vec<u64>>) {
+        unimplemented!("only available for local mode");
+    }
+
     fn remove_fail_stores(&self, _: Vec<u64>, _: Option<Vec<u64>>) {
-        self.check_local_mode();
+        unimplemented!("only available for local mode");
+    }
+
+    fn remove_regions(&self, _: Vec<u64>) {
+        unimplemented!("only available for local mode");
     }
 
     fn recreate_region(&self, _: Arc<SecurityManager>, _: &PdConfig, _: u64) {
-        self.check_local_mode();
+        unimplemented!("only available for local mode");
     }
 
     fn check_region_consistency(&self, region_id: u64) {
@@ -922,6 +934,20 @@ impl<ER: RaftEngine> DebugExecutor for Debugger<ER> {
     fn remove_fail_stores(&self, store_ids: Vec<u64>, region_ids: Option<Vec<u64>>) {
         v1!("removing stores {:?} from configurations...", store_ids);
         self.remove_failed_stores(store_ids, region_ids)
+            .unwrap_or_else(|e| perror_and_exit("Debugger::remove_fail_stores", e));
+        v1!("success");
+    }
+
+    fn remove_regions(&self, region_ids: Vec<u64>) {
+        v1!("removing regions {:?} from configurations...", region_ids);
+        self.remove_regions(region_ids)
+            .unwrap_or_else(|e| perror_and_exit("Debugger::remove_fail_stores", e));
+        v1!("success");
+    }
+
+    fn drop_unapplied_raftlog(&self, region_ids: Option<Vec<u64>>) {
+        v1!("removing unapplied raftlog on region {:?} ...", region_ids);
+        self.drop_unapplied_raftlog(region_ids)
             .unwrap_or_else(|e| perror_and_exit("Debugger::remove_fail_stores", e));
         v1!("success");
     }
@@ -1514,6 +1540,7 @@ fn main() {
                 .about("Unsafely recover the cluster when the majority replicas are failed")
                 .subcommand(
                     SubCommand::with_name("remove-fail-stores")
+                        .about("Remove the failed machines from the peer list for the regions")
                         .arg(
                             Arg::with_name("stores")
                                 .required(true)
@@ -1525,6 +1552,45 @@ fn main() {
                                 .value_delimiter(",")
                                 .help("Stores to be removed"),
                         )
+                        .arg(
+                            Arg::with_name("regions")
+                                .required_unless("all-regions")
+                                .conflicts_with("all-regions")
+                                .takes_value(true)
+                                .short("r")
+                                .multiple(true)
+                                .use_delimiter(true)
+                                .require_delimiter(true)
+                                .value_delimiter(",")
+                                .help("Only for these regions"),
+                        )
+                        .arg(
+                            Arg::with_name("all-regions")
+                                .required_unless("regions")
+                                .conflicts_with("regions")
+                                .long("all-regions")
+                                .takes_value(false)
+                                .help("Do the command for all regions"),
+                        )
+                )
+                .subcommand(
+                    SubCommand::with_name("remove-regions")
+                        .about("Remove the peers in this store for the regions")
+                        .arg(
+                            Arg::with_name("regions")
+                                .required(true)
+                                .takes_value(true)
+                                .short("r")
+                                .multiple(true)
+                                .use_delimiter(true)
+                                .require_delimiter(true)
+                                .value_delimiter(",")
+                                .help("Only for these regions"),
+                        )
+                )
+                .subcommand(
+                    SubCommand::with_name("drop-unapplied-raftlog")
+                        .about("Remove unapplied raftlogs on the regions")
                         .arg(
                             Arg::with_name("regions")
                                 .required_unless("all-regions")
@@ -2152,6 +2218,23 @@ fn main() {
                     .expect("parse regions fail")
             });
             debug_executor.remove_fail_stores(store_ids, region_ids);
+        } else if let Some(matches) = matches.subcommand_matches("remove-regions") {
+            let region_ids = matches
+                .values_of("regions")
+                .map(|ids| {
+                    ids.map(str::parse)
+                        .collect::<Result<Vec<_>, _>>()
+                        .expect("parse regions fail")
+                })
+                .unwrap();
+            debug_executor.remove_regions(region_ids);
+        } else if let Some(matches) = matches.subcommand_matches("drop-unapplied-raftlog") {
+            let region_ids = matches.values_of("regions").map(|ids| {
+                ids.map(str::parse)
+                    .collect::<Result<Vec<_>, _>>()
+                    .expect("parse regions fail")
+            });
+            debug_executor.drop_unapplied_raftlog(region_ids);
         } else {
             ve1!("{}", matches.usage());
         }

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -622,6 +622,14 @@ impl<ER: RaftEngine> Debugger<ER> {
         Ok(())
     }
 
+    pub fn drop_unapplied_raftlog(&self, region_ids: Option<Vec<u64>>) -> Result<()> {
+        unimplemented!()
+    }
+
+    pub fn remove_regions(&self, region_ids: Vec<u64>) -> Result<()> {
+        unimplemented!()
+    }
+
     pub fn recreate_region(&self, region: Region) -> Result<()> {
         let region_id = region.get_id();
         let kv = &self.engines.kv;
@@ -748,16 +756,17 @@ impl<ER: RaftEngine> Debugger<ER> {
         let mut res = dump_mvcc_properties(self.engines.kv.as_inner(), &start, &end)?;
 
         let middle_key = match box_try!(get_region_approximate_middle(&self.engines.kv, region)) {
-            Some(data_key) => {
-                let mut key = keys::origin_key(&data_key);
-                box_try!(bytes::decode_bytes(&mut key, false))
-            }
+            Some(data_key) => keys::origin_key(&data_key).to_vec(),
             None => Vec::new(),
         };
 
-        // Middle key of the range.
         res.push((
-            "middle_key_by_approximate_size".to_owned(),
+            "region.start_key".to_owned(),
+            hex::encode(&region.start_key),
+        ));
+        res.push(("region.end_key".to_owned(), hex::encode(&region.end_key)));
+        res.push((
+            "region.middle_key_by_approximate_size".to_owned(),
             hex::encode(&middle_key),
         ));
 


### PR DESCRIPTION
Signed-off-by: Andy Lok <andylokandy@hotmail.com>

Problem Summary:

### What is changed and how it works?

added subcommand

- `tikv-ctl unsafe-recover remove-regions -r 1,2,3` : removes the peer of the region on this store
- `tikv-ctl unsafe-recover drop-unapplied-raftlog -r 1,2,3`: regress the commit index to the apply index for the region

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
added subcommand `tikv-ctl unsafe-recover remove-regions -r 1,2,3` and `tikv-ctl unsafe-recover drop-unapplied-raftlog -r 1,2,3`
```