### PR TITLE
fix wrong coprocessor alert rules

### DIFF
--- a/metrics/alertmanager/tikv.rules.yml
+++ b/metrics/alertmanager/tikv.rules.yml
@@ -242,24 +242,24 @@ groups:
       summary: TiKV scheduler command duration seconds more than 1s
 
   - alert: TiKV_coprocessor_request_error
-    expr: increase(tikv_coprocessor_request_error{reason!="lock"}[10m]) > 100
+    expr: increase(tikv_coprocessor_request_error{reason!="meet_lock"}[10m]) > 100
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr:  increase(tikv_coprocessor_request_error{reason!="lock"}[10m]) > 100
+      expr:  increase(tikv_coprocessor_request_error{reason!="meet_lock"}[10m]) > 100
     annotations:
       description: 'cluster: ENV_LABELS_ENV, reason: {{ $labels.reason }}, instance: {{ $labels.instance }}, values: {{ $value }}'
       value: '{{ $value }}'
       summary: TiKV coprocessor request error
 
   - alert: TiKV_coprocessor_request_lock_error
-    expr: increase(tikv_coprocessor_request_error{reason="lock"}[10m]) > 10000
+    expr: increase(tikv_coprocessor_request_error{reason="meet_lock"}[10m]) > 10000
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr:  increase(tikv_coprocessor_request_error{reason="lock"}[10m]) > 10000
+      expr:  increase(tikv_coprocessor_request_error{reason="meet_lock"}[10m]) > 10000
     annotations:
       description: 'cluster: ENV_LABELS_ENV, reason: {{ $labels.reason }}, instance: {{ $labels.instance }}, values: {{ $value }}'
       value: '{{ $value }}'


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What problem does this PR solve?

Problem Summary:

Coprocessor error type "lock" is renamed to "meet_lock" in #5155

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```