### PR TITLE
tikv-ctl: allow get_all_regions from remote, drop-unapplied-raftlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,12 +266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
 
 [[package]]
-name = "base16"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
-
-[[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,7 +653,6 @@ name = "cmd"
 version = "0.0.1"
 dependencies = [
  "backup",
- "base16",
  "cdc",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-5.0#1a69d0b093f173db790cd58c9dbe9a457a3d311a"
+source = "git+https://github.com/andylokandy/kvproto?rev=b16d6dec4a1a7a40ea8bf336f26a1ff34cb51810#b16d6dec4a1a7a40ea8bf336f26a1ff34cb51810"
 dependencies = [
  "futures 0.3.8",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/andylokandy/kvproto?rev=b16d6dec4a1a7a40ea8bf336f26a1ff34cb51810#b16d6dec4a1a7a40ea8bf336f26a1ff34cb51810"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-5.0#7d7377864e93be88508a52cae3b3f9a6f4137f57"
 dependencies = [
  "futures 0.3.8",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
 
 [[package]]
+name = "base16"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
+
+[[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +659,7 @@ name = "cmd"
 version = "0.0.1"
 dependencies = [
  "backup",
+ "base16",
  "cdc",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,12 @@ test_util = { path = "components/test_util", default-features = false }
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 zipf = "6.1.0"
 
+# When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
+# kvproto at the same time.
+# After the PR on kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
+[patch.'https://github.com/pingcap/kvproto']
+kvproto = {git = "https://github.com/andylokandy/kvproto", rev="b16d6dec4a1a7a40ea8bf336f26a1ff34cb51810"}
+
 [patch.crates-io]
 # TODO: remove this when new raft-rs is published.
 raft = { git = "https://github.com/tikv/raft-rs", rev = "91a60ce417d55d4ca4d96b29963e3e3fa7f7d8d7", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,12 +216,6 @@ test_util = { path = "components/test_util", default-features = false }
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 zipf = "6.1.0"
 
-# When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
-# kvproto at the same time.
-# After the PR on kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
-[patch.'https://github.com/pingcap/kvproto']
-kvproto = {git = "https://github.com/andylokandy/kvproto", rev="b16d6dec4a1a7a40ea8bf336f26a1ff34cb51810"}
-
 [patch.crates-io]
 # TODO: remove this when new raft-rs is published.
 raft = { git = "https://github.com/tikv/raft-rs", rev = "91a60ce417d55d4ca4d96b29963e3e3fa7f7d8d7", default-features = false }
@@ -240,6 +234,12 @@ rusoto_sts = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr-
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
+
+# When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
+# kvproto at the same time.
+# After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
+# [patch.'https://github.com/pingcap/kvproto']
+# kvproto = {git = "https://github.com/your_github_id/kvproto", branch="your_branch"}
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -120,7 +120,6 @@ toml = "0.5"
 txn_types = { path = "../components/txn_types", default-features = false }
 vlog = "0.1.4"
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
-base16 = "0.2.1"
 
 [build-dependencies]
 time = "0.1"

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -16,55 +16,55 @@ sse = ["tikv/sse"]
 mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
 bcc-iosnoop = ["tikv/bcc-iosnoop"]
-cloud-aws = [ "encryption_export/cloud-aws" ]
-cloud-gcp = [ "encryption_export/cloud-gcp" ]
+cloud-aws = ["encryption_export/cloud-aws"]
+cloud-gcp = ["encryption_export/cloud-gcp"]
 protobuf-codec = [
-  "backup/protobuf-codec",
-  "cdc/protobuf-codec",
-  "concurrency_manager/protobuf-codec",
-  "encryption_export/protobuf-codec",
-  "engine_rocks/protobuf-codec",
-  "engine_traits/protobuf-codec",
-  "error_code/protobuf-codec",
-  "grpcio/protobuf-codec",
-  "keys/protobuf-codec",
-  "kvproto/protobuf-codec",
-  "pd_client/protobuf-codec",
-  "raft/protobuf-codec",
-  "raftstore/protobuf-codec",
-  "raft_log_engine/protobuf-codec",
-  "security/protobuf-codec",
-  "tikv/protobuf-codec",
-  "tikv_util/protobuf-codec",
-  "txn_types/protobuf-codec",
-  "file_system/protobuf-codec",
+    "backup/protobuf-codec",
+    "cdc/protobuf-codec",
+    "concurrency_manager/protobuf-codec",
+    "encryption_export/protobuf-codec",
+    "engine_rocks/protobuf-codec",
+    "engine_traits/protobuf-codec",
+    "error_code/protobuf-codec",
+    "grpcio/protobuf-codec",
+    "keys/protobuf-codec",
+    "kvproto/protobuf-codec",
+    "pd_client/protobuf-codec",
+    "raft/protobuf-codec",
+    "raftstore/protobuf-codec",
+    "raft_log_engine/protobuf-codec",
+    "security/protobuf-codec",
+    "tikv/protobuf-codec",
+    "tikv_util/protobuf-codec",
+    "txn_types/protobuf-codec",
+    "file_system/protobuf-codec",
 ]
 prost-codec = [
-  "backup/prost-codec",
-  "cdc/prost-codec",
-  "concurrency_manager/prost-codec",
-  "encryption_export/prost-codec",
-  "engine_rocks/prost-codec",
-  "engine_traits/prost-codec",
-  "error_code/prost-codec",
-  "grpcio/prost-codec",
-  "keys/prost-codec",
-  "kvproto/prost-codec",
-  "pd_client/prost-codec",
-  "raft/prost-codec",
-  "raftstore/prost-codec",
-  "raft_log_engine/prost-codec",
-  "security/prost-codec",
-  "tikv/prost-codec",
-  "tikv_util/prost-codec",
-  "txn_types/prost-codec",
-  "file_system/prost-codec",
+    "backup/prost-codec",
+    "cdc/prost-codec",
+    "concurrency_manager/prost-codec",
+    "encryption_export/prost-codec",
+    "engine_rocks/prost-codec",
+    "engine_traits/prost-codec",
+    "error_code/prost-codec",
+    "grpcio/prost-codec",
+    "keys/prost-codec",
+    "kvproto/prost-codec",
+    "pd_client/prost-codec",
+    "raft/prost-codec",
+    "raftstore/prost-codec",
+    "raft_log_engine/prost-codec",
+    "security/prost-codec",
+    "tikv/prost-codec",
+    "tikv_util/prost-codec",
+    "txn_types/prost-codec",
+    "file_system/prost-codec",
 ]
 test-engines-rocksdb = [
-  "tikv/test-engines-rocksdb",
+    "tikv/test-engines-rocksdb",
 ]
 test-engines-panic = [
-  "tikv/test-engines-panic",
+    "tikv/test-engines-panic",
 ]
 
 [lib]
@@ -92,7 +92,7 @@ file_system = { path = "../components/file_system", default-features = false }
 fs2 = "0.4"
 futures = "0.3"
 tokio = { version = "0.2", features = ["rt-threaded", "time"] }
-grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
+grpcio = { version = "0.8", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../components/keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
@@ -120,6 +120,7 @@ toml = "0.5"
 txn_types = { path = "../components/txn_types", default-features = false }
 vlog = "0.1.4"
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
+base16 = "0.2.1"
 
 [build-dependencies]
 time = "0.1"

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -17,7 +17,6 @@ use std::thread;
 use std::time::Duration;
 use std::{process, str, u64};
 
-use base16::encode_upper;
 use clap::{crate_authors, App, AppSettings, Arg, ArgMatches, SubCommand};
 use futures::{executor::block_on, future, stream, Stream, StreamExt, TryStreamExt};
 use grpcio::{CallOption, ChannelBuilder, Environment};
@@ -205,7 +204,7 @@ trait DebugExecutor {
             }
             let region_object = json!({
                 "region_id": region_id,
-                "region_local_state_key": encode_upper(&keys::region_state_key(region_id)),
+                "region_local_state_key": base16::encode_upper(&keys::region_state_key(region_id)),
                 "region_local_state": r.region_local_state.map(|s| {
                     let r = s.get_region();
                     let region_epoch = r.get_region_epoch();
@@ -213,8 +212,8 @@ trait DebugExecutor {
                     json!({
                 "region": json!({
                     "id": r.get_id(),
-                    "start_key": encode_upper(r.get_start_key()),
-                    "end_key": encode_upper(r.get_end_key()),
+                    "start_key": base16::encode_upper(r.get_start_key()),
+                    "end_key": base16::encode_upper(r.get_end_key()),
                     "region_epoch": json!({
                         "conf_ver": region_epoch.get_conf_ver(),
                         "version": region_epoch.get_version()
@@ -226,7 +225,7 @@ trait DebugExecutor {
                         })).collect::<Vec<_>>(),
                 }),
             })}),
-                "raft_local_state_key": encode_upper(&keys::raft_state_key(region_id)),
+                "raft_local_state_key": base16::encode_upper(&keys::raft_state_key(region_id)),
                 "raft_local_state": r.raft_local_state.map(|s| {
                     let hard_state = s.get_hard_state();
                     json!({
@@ -238,7 +237,7 @@ trait DebugExecutor {
                     "last_index": s.get_last_index(),
                 })
                 }),
-                "raft_apply_state_key": encode_upper(&keys::apply_state_key(region_id)),
+                "raft_apply_state_key": base16::encode_upper(&keys::apply_state_key(region_id)),
                 "raft_apply_state": r.raft_apply_state.map(|s|{
                     let truncated_state = s.get_truncated_state();
                     json!({
@@ -2026,7 +2025,7 @@ fn main() {
         v1!("{}", escape(&from_hex(hex).unwrap()));
         return;
     } else if let Some(escaped) = matches.value_of("escaped-to-hex") {
-        v1!("{}", log_wrappers::hex_encode_upper(unescape(escaped)));
+        v1!("{}", hex::encode_upper(unescape(escaped)));
         return;
     } else if let Some(encoded) = matches.value_of("decode") {
         match Key::from_encoded(unescape(encoded)).into_raw() {

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -2269,7 +2269,11 @@ fn main() {
                     .collect::<Result<Vec<_>, _>>()
                     .expect("parse regions fail")
             });
-            debug_executor.remove_fail_stores(store_ids, region_ids, matches.is_present("promote-learner"));
+            debug_executor.remove_fail_stores(
+                store_ids,
+                region_ids,
+                matches.is_present("promote-learner"),
+            );
         } else if let Some(matches) = matches.subcommand_matches("remove-regions") {
             let region_ids = matches
                 .values_of("regions")

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -536,6 +536,10 @@ trait DebugExecutor {
     /// Recover the cluster when given `store_ids` are failed.
     fn remove_fail_stores(&self, store_ids: Vec<u64>, region_ids: Option<Vec<u64>>);
 
+    fn remove_regions(&self, region_ids: Vec<u64>);
+
+    fn drop_unapplied_raftlog(&self, region_ids: Option<Vec<u64>>);
+
     /// Recreate the region with metadata from pd, but alloc new id for it.
     fn recreate_region(&self, sec_mgr: Arc<SecurityManager>, pd_cfg: &PdConfig, region_id: u64);
 
@@ -763,13 +767,20 @@ impl DebugExecutor for DebugClient {
     fn print_bad_regions(&self) {
         unimplemented!("only available for local mode");
     }
-
     fn remove_fail_stores(&self, _: Vec<u64>, _: Option<Vec<u64>>) {
-        self.check_local_mode();
+        unimplemented!("only available for local mode");
+    }
+
+    fn remove_regions(&self, _: Vec<u64>) {
+        unimplemented!("only available for local mode");
+    }
+
+    fn drop_unapplied_raftlog(&self, _: Option<Vec<u64>>) {
+        unimplemented!("only available for local mode");
     }
 
     fn recreate_region(&self, _: Arc<SecurityManager>, _: &PdConfig, _: u64) {
-        self.check_local_mode();
+        unimplemented!("only available for local mode");
     }
 
     fn check_region_consistency(&self, region_id: u64) {
@@ -945,6 +956,20 @@ impl<ER: RaftEngine> DebugExecutor for Debugger<ER> {
     fn remove_fail_stores(&self, store_ids: Vec<u64>, region_ids: Option<Vec<u64>>) {
         v1!("removing stores {:?} from configurations...", store_ids);
         self.remove_failed_stores(store_ids, region_ids)
+            .unwrap_or_else(|e| perror_and_exit("Debugger::remove_fail_stores", e));
+        v1!("success");
+    }
+
+    fn remove_regions(&self, region_ids: Vec<u64>) {
+        v1!("removing regions {:?} from configurations...", region_ids);
+        self.remove_regions(region_ids)
+            .unwrap_or_else(|e| perror_and_exit("Debugger::remove_fail_stores", e));
+        v1!("success");
+    }
+
+    fn drop_unapplied_raftlog(&self, region_ids: Option<Vec<u64>>) {
+        v1!("removing unapplied raftlog on region {:?} ...", region_ids);
+        self.drop_unapplied_raftlog(region_ids)
             .unwrap_or_else(|e| perror_and_exit("Debugger::remove_fail_stores", e));
         v1!("success");
     }
@@ -1537,6 +1562,7 @@ fn main() {
                 .about("Unsafely recover the cluster when the majority replicas are failed")
                 .subcommand(
                     SubCommand::with_name("remove-fail-stores")
+                        .about("Remove the failed machines from the peer list for the regions")
                         .arg(
                             Arg::with_name("stores")
                                 .required(true)
@@ -1548,6 +1574,45 @@ fn main() {
                                 .value_delimiter(",")
                                 .help("Stores to be removed"),
                         )
+                        .arg(
+                            Arg::with_name("regions")
+                                .required_unless("all-regions")
+                                .conflicts_with("all-regions")
+                                .takes_value(true)
+                                .short("r")
+                                .multiple(true)
+                                .use_delimiter(true)
+                                .require_delimiter(true)
+                                .value_delimiter(",")
+                                .help("Only for these regions"),
+                        )
+                        .arg(
+                            Arg::with_name("all-regions")
+                                .required_unless("regions")
+                                .conflicts_with("regions")
+                                .long("all-regions")
+                                .takes_value(false)
+                                .help("Do the command for all regions"),
+                        )
+                )
+                .subcommand(
+                    SubCommand::with_name("remove-regions")
+                        .about("Remove the peers in this store for the regions")
+                        .arg(
+                            Arg::with_name("regions")
+                                .required(true)
+                                .takes_value(true)
+                                .short("r")
+                                .multiple(true)
+                                .use_delimiter(true)
+                                .require_delimiter(true)
+                                .value_delimiter(",")
+                                .help("Only for these regions"),
+                        )
+                )
+                .subcommand(
+                    SubCommand::with_name("drop-unapplied-raftlog")
+                        .about("Remove unapplied raftlogs on the regions")
                         .arg(
                             Arg::with_name("regions")
                                 .required_unless("all-regions")
@@ -2175,6 +2240,23 @@ fn main() {
                     .expect("parse regions fail")
             });
             debug_executor.remove_fail_stores(store_ids, region_ids);
+        } else if let Some(matches) = matches.subcommand_matches("remove-regions") {
+            let region_ids = matches
+                .values_of("regions")
+                .map(|ids| {
+                    ids.map(str::parse)
+                        .collect::<Result<Vec<_>, _>>()
+                        .expect("parse regions fail")
+                })
+                .unwrap();
+            debug_executor.remove_regions(region_ids);
+        } else if let Some(matches) = matches.subcommand_matches("drop-unapplied-raftlog") {
+            let region_ids = matches.values_of("regions").map(|ids| {
+                ids.map(str::parse)
+                    .collect::<Result<Vec<_>, _>>()
+                    .expect("parse regions fail")
+            });
+            debug_executor.drop_unapplied_raftlog(region_ids);
         } else {
             ve1!("{}", matches.usage());
         }

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -1609,6 +1609,8 @@ fn main() {
                         )
                         .arg(
                             Arg::with_name("promote-learner")
+                                .long("promote-learner")
+                                .takes_value(false)
                                 .required(false)
                                 .help("Promote learner to voter"),
                         )

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -204,7 +204,7 @@ trait DebugExecutor {
             }
             let region_object = json!({
                 "region_id": region_id,
-                "region_local_state_key": base16::encode_upper(&keys::region_state_key(region_id)),
+                "region_local_state_key": hex::encode_upper(&keys::region_state_key(region_id)),
                 "region_local_state": r.region_local_state.map(|s| {
                     let r = s.get_region();
                     let region_epoch = r.get_region_epoch();
@@ -212,8 +212,8 @@ trait DebugExecutor {
                     json!({
                 "region": json!({
                     "id": r.get_id(),
-                    "start_key": base16::encode_upper(r.get_start_key()),
-                    "end_key": base16::encode_upper(r.get_end_key()),
+                    "start_key": hex::encode_upper(r.get_start_key()),
+                    "end_key": hex::encode_upper(r.get_end_key()),
                     "region_epoch": json!({
                         "conf_ver": region_epoch.get_conf_ver(),
                         "version": region_epoch.get_version()
@@ -225,7 +225,7 @@ trait DebugExecutor {
                         })).collect::<Vec<_>>(),
                 }),
             })}),
-                "raft_local_state_key": base16::encode_upper(&keys::raft_state_key(region_id)),
+                "raft_local_state_key": hex::encode_upper(&keys::raft_state_key(region_id)),
                 "raft_local_state": r.raft_local_state.map(|s| {
                     let hard_state = s.get_hard_state();
                     json!({
@@ -237,7 +237,7 @@ trait DebugExecutor {
                     "last_index": s.get_last_index(),
                 })
                 }),
-                "raft_apply_state_key": base16::encode_upper(&keys::apply_state_key(region_id)),
+                "raft_apply_state_key": hex::encode_upper(&keys::apply_state_key(region_id)),
                 "raft_apply_state": r.raft_apply_state.map(|s|{
                     let truncated_state = s.get_truncated_state();
                     json!({
@@ -585,8 +585,6 @@ trait DebugExecutor {
         promote_learner: bool,
     );
 
-    fn remove_regions(&self, region_ids: Vec<u64>);
-
     fn drop_unapplied_raftlog(&self, region_ids: Option<Vec<u64>>);
 
     /// Recreate the region with metadata from pd, but alloc new id for it.
@@ -821,10 +819,6 @@ impl DebugExecutor for DebugClient {
         unimplemented!("only available for local mode");
     }
 
-    fn remove_regions(&self, _: Vec<u64>) {
-        unimplemented!("only available for local mode");
-    }
-
     fn drop_unapplied_raftlog(&self, _: Option<Vec<u64>>) {
         unimplemented!("only available for local mode");
     }
@@ -1011,13 +1005,6 @@ impl<ER: RaftEngine> DebugExecutor for Debugger<ER> {
     ) {
         v1!("removing stores {:?} from configurations...", store_ids);
         self.remove_failed_stores(store_ids, region_ids, promote_learner)
-            .unwrap_or_else(|e| perror_and_exit("Debugger::remove_fail_stores", e));
-        v1!("success");
-    }
-
-    fn remove_regions(&self, region_ids: Vec<u64>) {
-        v1!("removing regions {:?} from configurations...", region_ids);
-        self.remove_regions(region_ids)
             .unwrap_or_else(|e| perror_and_exit("Debugger::remove_fail_stores", e));
         v1!("success");
     }
@@ -1673,21 +1660,6 @@ fn main() {
                         )
                 )
                 .subcommand(
-                    SubCommand::with_name("remove-regions")
-                        .about("Remove the peers in this store for the regions")
-                        .arg(
-                            Arg::with_name("regions")
-                                .required(true)
-                                .takes_value(true)
-                                .short("r")
-                                .multiple(true)
-                                .use_delimiter(true)
-                                .require_delimiter(true)
-                                .value_delimiter(",")
-                                .help("Only for these regions"),
-                        )
-                )
-                .subcommand(
                     SubCommand::with_name("drop-unapplied-raftlog")
                         .about("Remove unapplied raftlogs on the regions")
                         .arg(
@@ -2323,16 +2295,6 @@ fn main() {
                 region_ids,
                 matches.is_present("promote-learner"),
             );
-        } else if let Some(matches) = matches.subcommand_matches("remove-regions") {
-            let region_ids = matches
-                .values_of("regions")
-                .map(|ids| {
-                    ids.map(str::parse)
-                        .collect::<Result<Vec<_>, _>>()
-                        .expect("parse regions fail")
-                })
-                .unwrap();
-            debug_executor.remove_regions(region_ids);
         } else if let Some(matches) = matches.subcommand_matches("drop-unapplied-raftlog") {
             let region_ids = matches.values_of("regions").map(|ids| {
                 ids.map(str::parse)

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -17,12 +17,12 @@ use std::thread;
 use std::time::Duration;
 use std::{process, str, u64};
 
+use base16::encode_upper;
 use clap::{crate_authors, App, AppSettings, Arg, ArgMatches, SubCommand};
 use futures::{executor::block_on, future, stream, Stream, StreamExt, TryStreamExt};
 use grpcio::{CallOption, ChannelBuilder, Environment};
 use protobuf::Message;
 use serde_json::json;
-use base16::encode_upper;
 
 use encryption_export::{
     create_backend, data_key_manager_from_config, encryption_method_from_db_encryption_method,
@@ -58,7 +58,7 @@ const METRICS_JEMALLOC: &str = "jemalloc";
 
 const LOCK_FILE_ERROR: &str = "IO error: While lock file";
 
-type MvccInfoStream = Pin<Box<dyn Stream<Item=Result<(Vec<u8>, MvccInfo), String>>>>;
+type MvccInfoStream = Pin<Box<dyn Stream<Item = Result<(Vec<u8>, MvccInfo), String>>>>;
 
 fn perror_and_exit<E: Error>(prefix: &str, e: E) -> ! {
     ve1!("{}: {}", prefix, e);
@@ -207,56 +207,55 @@ trait DebugExecutor {
             let raft_state_key = keys::raft_state_key(region_id);
             let apply_state_key = keys::apply_state_key(region_id);
             if use_json {
-                region_objects.push(
-                    json!({
-                        "region_id": region_id,
-                        "region_state_key": encode_upper(&region_state_key),
-                        "region_state": r.region_local_state.map(|s| {
-                            let r = s.get_region();
-                            let region_epoch = r.get_region_epoch();
-                            let peers = r.get_peers();
-                            json!({
-                        "region": json!({
-                            "id": r.get_id(),
-                            "start_key": encode_upper(r.get_start_key()),
-                            "end_key": encode_upper(r.get_end_key()),
-                            "region_epoch": json!({
-                                "conf_ver": region_epoch.get_conf_ver(),
-                                "version": region_epoch.get_version()
-                            }),
-                            "peers": peers.into_iter().map(|p| json!({
-                                    "id": p.get_id(),
-                                    "store_id": p.get_store_id(),
-                                    "role": format!("{:?}", p.get_role()),
-                                })).collect::<Vec<_>>(),
+                region_objects.push(json!({
+                    "region_id": region_id,
+                    "region_state_key": encode_upper(&region_state_key),
+                    "region_state": r.region_local_state.map(|s| {
+                        let r = s.get_region();
+                        let region_epoch = r.get_region_epoch();
+                        let peers = r.get_peers();
+                        json!({
+                    "region": json!({
+                        "id": r.get_id(),
+                        "start_key": encode_upper(r.get_start_key()),
+                        "end_key": encode_upper(r.get_end_key()),
+                        "region_epoch": json!({
+                            "conf_ver": region_epoch.get_conf_ver(),
+                            "version": region_epoch.get_version()
                         }),
-                    })}),
-                        "raft_state_key": encode_upper(&raft_state_key),
-                        "raft_state_key": r.raft_local_state.map(|s| {
-                            let hard_state = s.get_hard_state();
-                            json!({
-                            "hard_state": json!({
-                                "term": hard_state.get_term(),
-                                "vote": hard_state.get_vote(),
-                                "commit": hard_state.get_commit(),
-                            }),
-                            "last_index": s.get_last_index(),
-                        })
+                        "peers": peers.into_iter().map(|p| json!({
+                                "id": p.get_id(),
+                                "store_id": p.get_store_id(),
+                                "role": format!("{:?}", p.get_role()),
+                            })).collect::<Vec<_>>(),
+                    }),
+                })}),
+                    "raft_state_key": encode_upper(&raft_state_key),
+                    "raft_state_key": r.raft_local_state.map(|s| {
+                        let hard_state = s.get_hard_state();
+                        json!({
+                        "hard_state": json!({
+                            "term": hard_state.get_term(),
+                            "vote": hard_state.get_vote(),
+                            "commit": hard_state.get_commit(),
                         }),
-                        "apply_state_key": encode_upper(&apply_state_key),
-                        "apply_state": r.raft_apply_state.map(|s|{
-                            let truncated_state = s.get_truncated_state();
-                            json!({
-                            "applied_index": s.get_applied_index(),
-                            "commit_index": s.get_commit_index(),
-                            "commit_term": s.get_commit_term(),
-                            "truncated_state": json!({
-                                "index": truncated_state.get_index(),
-                                "term": truncated_state.get_term(),
-                            })
+                        "last_index": s.get_last_index(),
+                    })
+                    }),
+                    "apply_state_key": encode_upper(&apply_state_key),
+                    "apply_state": r.raft_apply_state.map(|s|{
+                        let truncated_state = s.get_truncated_state();
+                        json!({
+                        "applied_index": s.get_applied_index(),
+                        "commit_index": s.get_commit_index(),
+                        "commit_term": s.get_commit_term(),
+                        "truncated_state": json!({
+                            "index": truncated_state.get_index(),
+                            "term": truncated_state.get_term(),
                         })
-                        })
-                    }));
+                    })
+                    })
+                }));
             } else {
                 v1!("region id: {}", region_id);
                 v1!("region state key: {}", escape(&region_state_key));
@@ -267,7 +266,7 @@ trait DebugExecutor {
                 v1!("apply state: {:?}", r.raft_apply_state);
             }
             if use_json {
-                v1!("{}", json!({"region_infos": region_objects}));
+                v1!("{}", json!({ "region_infos": region_objects }));
             }
         }
     }
@@ -1137,7 +1136,7 @@ fn warning_prompt(message: &str) -> bool {
         "Type \"{}\" to continue, anything else to exit",
         EXPECTED
     ))
-        .unwrap();
+    .unwrap();
     if input == EXPECTED {
         true
     } else {
@@ -2123,7 +2122,7 @@ fn main() {
                         .values_of("ids")
                         .map(|ids| ids.map(|id| id.parse::<u64>().unwrap()).collect()),
                 )
-                    .unwrap();
+                .unwrap();
             }
             ("dump-file", Some(matches)) => {
                 let path = matches

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -192,9 +192,9 @@ trait DebugExecutor {
         v1!("total region size: {}", convert_gbmb(total_size as u64));
     }
 
-    fn dump_region_info(&self, region_ids: Option<Vec<u64>>, skip_tombstone: bool, use_json: bool) {
+    fn dump_region_info(&self, region_ids: Option<Vec<u64>>, skip_tombstone: bool) {
         let region_ids = region_ids.unwrap_or_else(|| self.get_all_regions_in_store());
-        let mut region_objects = vec![];
+        let mut region_objects = serde_json::map::Map::new();
         for region_id in region_ids {
             let r = self.get_region_info(region_id);
             if skip_tombstone {
@@ -203,72 +203,62 @@ trait DebugExecutor {
                     return;
                 }
             }
-            let region_state_key = keys::region_state_key(region_id);
-            let raft_state_key = keys::raft_state_key(region_id);
-            let apply_state_key = keys::apply_state_key(region_id);
-            if use_json {
-                region_objects.push(json!({
-                    "region_id": region_id,
-                    "region_state_key": encode_upper(&region_state_key),
-                    "region_state": r.region_local_state.map(|s| {
-                        let r = s.get_region();
-                        let region_epoch = r.get_region_epoch();
-                        let peers = r.get_peers();
-                        json!({
-                    "region": json!({
-                        "id": r.get_id(),
-                        "start_key": encode_upper(r.get_start_key()),
-                        "end_key": encode_upper(r.get_end_key()),
-                        "region_epoch": json!({
-                            "conf_ver": region_epoch.get_conf_ver(),
-                            "version": region_epoch.get_version()
-                        }),
-                        "peers": peers.into_iter().map(|p| json!({
-                                "id": p.get_id(),
-                                "store_id": p.get_store_id(),
-                                "role": format!("{:?}", p.get_role()),
-                            })).collect::<Vec<_>>(),
+            let region_object = json!({
+                "region_id": region_id,
+                "region_local_state_key": encode_upper(&keys::region_state_key(region_id)),
+                "region_local_state": r.region_local_state.map(|s| {
+                    let r = s.get_region();
+                    let region_epoch = r.get_region_epoch();
+                    let peers = r.get_peers();
+                    json!({
+                "region": json!({
+                    "id": r.get_id(),
+                    "start_key": encode_upper(r.get_start_key()),
+                    "end_key": encode_upper(r.get_end_key()),
+                    "region_epoch": json!({
+                        "conf_ver": region_epoch.get_conf_ver(),
+                        "version": region_epoch.get_version()
                     }),
-                })}),
-                    "raft_state_key": encode_upper(&raft_state_key),
-                    "raft_state_key": r.raft_local_state.map(|s| {
-                        let hard_state = s.get_hard_state();
-                        json!({
-                        "hard_state": json!({
-                            "term": hard_state.get_term(),
-                            "vote": hard_state.get_vote(),
-                            "commit": hard_state.get_commit(),
-                        }),
-                        "last_index": s.get_last_index(),
-                    })
+                    "peers": peers.into_iter().map(|p| json!({
+                            "id": p.get_id(),
+                            "store_id": p.get_store_id(),
+                            "role": format!("{:?}", p.get_role()),
+                        })).collect::<Vec<_>>(),
+                }),
+            })}),
+                "raft_local_state_key": encode_upper(&keys::raft_state_key(region_id)),
+                "raft_local_state": r.raft_local_state.map(|s| {
+                    let hard_state = s.get_hard_state();
+                    json!({
+                    "hard_state": json!({
+                        "term": hard_state.get_term(),
+                        "vote": hard_state.get_vote(),
+                        "commit": hard_state.get_commit(),
                     }),
-                    "apply_state_key": encode_upper(&apply_state_key),
-                    "apply_state": r.raft_apply_state.map(|s|{
-                        let truncated_state = s.get_truncated_state();
-                        json!({
-                        "applied_index": s.get_applied_index(),
-                        "commit_index": s.get_commit_index(),
-                        "commit_term": s.get_commit_term(),
-                        "truncated_state": json!({
-                            "index": truncated_state.get_index(),
-                            "term": truncated_state.get_term(),
-                        })
+                    "last_index": s.get_last_index(),
+                })
+                }),
+                "raft_apply_state_key": encode_upper(&keys::apply_state_key(region_id)),
+                "raft_apply_state": r.raft_apply_state.map(|s|{
+                    let truncated_state = s.get_truncated_state();
+                    json!({
+                    "applied_index": s.get_applied_index(),
+                    "commit_index": s.get_commit_index(),
+                    "commit_term": s.get_commit_term(),
+                    "truncated_state": json!({
+                        "index": truncated_state.get_index(),
+                        "term": truncated_state.get_term(),
                     })
-                    })
-                }));
-            } else {
-                v1!("region id: {}", region_id);
-                v1!("region state key: {}", escape(&region_state_key));
-                v1!("region state: {:?}", r.region_local_state);
-                v1!("raft state key: {}", escape(&raft_state_key));
-                v1!("raft state: {:?}", r.raft_local_state);
-                v1!("apply state key: {}", escape(&apply_state_key));
-                v1!("apply state: {:?}", r.raft_apply_state);
-            }
-            if use_json {
-                v1!("{}", json!({ "region_infos": region_objects }));
-            }
+                })
+                })
+            });
+            region_objects.insert(region_id.to_string(), region_object);
         }
+
+        v1!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "region_infos": region_objects })).unwrap()
+        );
     }
 
     fn dump_raft_log(&self, region: u64, index: u64) {
@@ -1298,11 +1288,6 @@ fn main() {
                                 .takes_value(false)
                                 .help("Print info for all regions"),
                         )
-                        .arg(Arg::with_name("json")
-                            .long("json")
-                            .takes_value(false)
-                            .help("Print info in JSON format")
-                        )
                         .arg(
                             Arg::with_name("skip-tombstone")
                                 .long("skip-tombstone")
@@ -2191,14 +2176,13 @@ fn main() {
             debug_executor.dump_raft_log(id, index);
         } else if let Some(matches) = matches.subcommand_matches("region") {
             let skip_tombstone = matches.is_present("skip-tombstone");
-            let json = matches.is_present("json");
             let regions = matches.values_of("regions").map(|values| {
                 values
                     .map(str::parse)
                     .collect::<Result<Vec<_>, _>>()
                     .expect("parse regions fail")
             });
-            debug_executor.dump_region_info(regions, skip_tombstone, json);
+            debug_executor.dump_region_info(regions, skip_tombstone);
         } else {
             let _ = app.print_help();
         }

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -218,7 +218,7 @@ trait DebugExecutor {
                         "conf_ver": region_epoch.get_conf_ver(),
                         "version": region_epoch.get_version()
                     }),
-                    "peers": peers.into_iter().map(|p| json!({
+                    "peers": peers.iter().map(|p| json!({
                             "id": p.get_id(),
                             "store_id": p.get_store_id(),
                             "role": format!("{:?}", p.get_role()),
@@ -816,6 +816,7 @@ impl DebugExecutor for DebugClient {
     fn print_bad_regions(&self) {
         unimplemented!("only available for local mode");
     }
+
     fn remove_fail_stores(&self, _: Vec<u64>, _: Option<Vec<u64>>, _: bool) {
         unimplemented!("only available for local mode");
     }
@@ -1008,7 +1009,7 @@ impl<ER: RaftEngine> DebugExecutor for Debugger<ER> {
         region_ids: Option<Vec<u64>>,
         promote_learner: bool,
     ) {
-        println!("removing stores {:?} from configurations...", store_ids);
+        v1!("removing stores {:?} from configurations...", store_ids);
         self.remove_failed_stores(store_ids, region_ids, promote_learner)
             .unwrap_or_else(|e| perror_and_exit("Debugger::remove_fail_stores", e));
         v1!("success");
@@ -1269,6 +1270,7 @@ fn main() {
                         .about("print region info")
                         .arg(
                             Arg::with_name("regions")
+                                .aliases(&["region"])
                                 .required_unless("all-regions")
                                 .conflicts_with("all-regions")
                                 .takes_value(true)

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -204,7 +204,6 @@ trait DebugExecutor {
             }
             let region_object = json!({
                 "region_id": region_id,
-                "region_local_state_key": hex::encode_upper(&keys::region_state_key(region_id)),
                 "region_local_state": r.region_local_state.map(|s| {
                     let r = s.get_region();
                     let region_epoch = r.get_region_epoch();
@@ -225,7 +224,6 @@ trait DebugExecutor {
                         })).collect::<Vec<_>>(),
                 }),
             })}),
-                "raft_local_state_key": hex::encode_upper(&keys::raft_state_key(region_id)),
                 "raft_local_state": r.raft_local_state.map(|s| {
                     let hard_state = s.get_hard_state();
                     json!({
@@ -237,7 +235,6 @@ trait DebugExecutor {
                     "last_index": s.get_last_index(),
                 })
                 }),
-                "raft_apply_state_key": hex::encode_upper(&keys::apply_state_key(region_id)),
                 "raft_apply_state": r.raft_apply_state.map(|s|{
                     let truncated_state = s.get_truncated_state();
                     json!({

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -209,43 +209,44 @@ trait DebugExecutor {
                     let region_epoch = r.get_region_epoch();
                     let peers = r.get_peers();
                     json!({
-                "region": json!({
-                    "id": r.get_id(),
-                    "start_key": hex::encode_upper(r.get_start_key()),
-                    "end_key": hex::encode_upper(r.get_end_key()),
-                    "region_epoch": json!({
-                        "conf_ver": region_epoch.get_conf_ver(),
-                        "version": region_epoch.get_version()
-                    }),
-                    "peers": peers.iter().map(|p| json!({
-                            "id": p.get_id(),
-                            "store_id": p.get_store_id(),
-                            "role": format!("{:?}", p.get_role()),
-                        })).collect::<Vec<_>>(),
+                        "region": json!({
+                            "id": r.get_id(),
+                            "start_key": hex::encode_upper(r.get_start_key()),
+                            "end_key": hex::encode_upper(r.get_end_key()),
+                            "region_epoch": json!({
+                                "conf_ver": region_epoch.get_conf_ver(),
+                                "version": region_epoch.get_version()
+                            }),
+                            "peers": peers.iter().map(|p| json!({
+                                "id": p.get_id(),
+                                "store_id": p.get_store_id(),
+                                "role": format!("{:?}", p.get_role()),
+                            })).collect::<Vec<_>>(),
+                        }),
+                    })
                 }),
-            })}),
                 "raft_local_state": r.raft_local_state.map(|s| {
                     let hard_state = s.get_hard_state();
                     json!({
-                    "hard_state": json!({
-                        "term": hard_state.get_term(),
-                        "vote": hard_state.get_vote(),
-                        "commit": hard_state.get_commit(),
-                    }),
-                    "last_index": s.get_last_index(),
-                })
+                        "hard_state": json!({
+                            "term": hard_state.get_term(),
+                            "vote": hard_state.get_vote(),
+                            "commit": hard_state.get_commit(),
+                        }),
+                        "last_index": s.get_last_index(),
+                    })
                 }),
-                "raft_apply_state": r.raft_apply_state.map(|s|{
+                "raft_apply_state": r.raft_apply_state.map(|s| {
                     let truncated_state = s.get_truncated_state();
                     json!({
-                    "applied_index": s.get_applied_index(),
-                    "commit_index": s.get_commit_index(),
-                    "commit_term": s.get_commit_term(),
-                    "truncated_state": json!({
-                        "index": truncated_state.get_index(),
-                        "term": truncated_state.get_term(),
+                        "applied_index": s.get_applied_index(),
+                        "commit_index": s.get_commit_index(),
+                        "commit_term": s.get_commit_term(),
+                        "truncated_state": json!({
+                            "index": truncated_state.get_index(),
+                            "term": truncated_state.get_term(),
+                        })
                     })
-                })
                 })
             });
             region_objects.insert(region_id.to_string(), region_object);

--- a/cmd/src/bin/tikv-ctl.rs
+++ b/cmd/src/bin/tikv-ctl.rs
@@ -180,7 +180,7 @@ trait DebugExecutor {
     }
 
     fn dump_all_region_size(&self, cfs: Vec<&str>) {
-        let regions = self.get_all_meta_regions();
+        let regions = self.get_all_regions_in_store();
         let regions_number = regions.len();
         let mut total_size = 0;
         for region in regions {
@@ -211,7 +211,7 @@ trait DebugExecutor {
     }
 
     fn dump_all_region_info(&self, skip_tombstone: bool) {
-        for region in self.get_all_meta_regions() {
+        for region in self.get_all_regions_in_store() {
             self.dump_region_info(region, skip_tombstone);
         }
     }
@@ -574,7 +574,7 @@ trait DebugExecutor {
         self.recover_all(threads, read_only);
     }
 
-    fn get_all_meta_regions(&self) -> Vec<u64>;
+    fn get_all_regions_in_store(&self) -> Vec<u64>;
 
     fn get_value_by_key(&self, cf: &str, key: Vec<u8>) -> Vec<u8>;
 
@@ -625,8 +625,10 @@ impl DebugExecutor for DebugClient {
         process::exit(-1);
     }
 
-    fn get_all_meta_regions(&self) -> Vec<u64> {
-        unimplemented!();
+    fn get_all_regions_in_store(&self) -> Vec<u64> {
+        DebugClient::get_all_regions_in_store(&self, &GetAllRegionsInStoreRequest::default())
+            .unwrap_or_else(|e| perror_and_exit("DebugClient::get_all_regions_in_store", e))
+            .take_regions()
     }
 
     fn get_value_by_key(&self, cf: &str, key: Vec<u8>) -> Vec<u8> {
@@ -822,9 +824,9 @@ impl DebugExecutor for DebugClient {
 impl<ER: RaftEngine> DebugExecutor for Debugger<ER> {
     fn check_local_mode(&self) {}
 
-    fn get_all_meta_regions(&self) -> Vec<u64> {
-        self.get_all_meta_regions()
-            .unwrap_or_else(|e| perror_and_exit("Debugger::get_all_meta_regions", e))
+    fn get_all_regions_in_store(&self) -> Vec<u64> {
+        self.get_all_regions_in_store()
+            .unwrap_or_else(|e| perror_and_exit("Debugger::get_all_regions_in_store", e))
     }
 
     fn get_value_by_key(&self, cf: &str, key: Vec<u8>) -> Vec<u8> {

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -11,10 +11,17 @@ use crate::range::Range;
 
 #[derive(Clone, Debug)]
 pub enum DeleteStrategy {
+    /// Delete the SST files that are fullly fit in range. However, the SST files that are partially
+    /// overlapped with the range will not be touched.
     DeleteFiles,
+    /// Delete the data stored in Titan.
     DeleteBlobs,
+    /// Scan for keys and then delete. Useful when we know the keys in range are not too many.
     DeleteByKey,
+    /// Delete by range. Note that this is experimental and you should check whether it is enbaled
+    /// in config before using it.
     DeleteByRange,
+    /// Delete by ingesting a SST file with deletions. Useful when the number of ranges is too many.
     DeleteByWriter { sst_path: String },
 }
 

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -550,6 +550,7 @@ where
 
     fn delete_all_in_range(&self, ranges: &[Range]) -> Result<()> {
         for cf in self.engine.cf_names() {
+            // CF_LOCK usually contains fewer keys than other CFs, so we delete them by key.
             let strategy = if cf == CF_LOCK {
                 DeleteStrategy::DeleteByKey
             } else if self.use_delete_range {

--- a/scripts/check-redact-log
+++ b/scripts/check-redact-log
@@ -7,12 +7,12 @@ function error_msg() {
 }
 
 if [[ "$(uname)" == "Darwin" ]] ; then
-   if grep -r -n --color=always --include '*.rs' --exclude hex.rs --exclude-dir target 'encode_upper' . | grep -v log_wrappers ; then
+   if grep -r -n --color=always --include '*.rs' --exclude hex.rs --exclude tikv-ctl.rs --exclude-dir target 'encode_upper' . | grep -v log_wrappers ; then
 	error_msg
 	exit 1
    fi
 else
-    if grep -r -n -P '(?<!hex_)encode_upper' -C 1 --color=always --include \*.rs --exclude hex.rs --exclude-dir target . ; then
+    if grep -r -n -P '(?<!hex_)encode_upper' -C 1 --color=always --include \*.rs --exclude hex.rs --exclude tikv-ctl.rs --exclude-dir target . ; then
 	error_msg
         exit 1
      fi

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -141,7 +141,7 @@ impl<ER: RaftEngine> Debugger<ER> {
     }
 
     /// Get all regions holding region meta data from raft CF in KV storage.
-    pub fn get_all_meta_regions(&self) -> Result<Vec<u64>> {
+    pub fn get_all_regions_in_store(&self) -> Result<Vec<u64>> {
         let db = &self.engines.kv;
         let cf = CF_RAFT;
         let start_key = keys::REGION_META_MIN_KEY;

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -267,7 +267,7 @@ impl<ER: RaftEngine> Debugger<ER> {
             if end.is_empty() { None } else { Some(end) },
             limit as usize,
         )
-        .map_err(|e| box_err!(e))
+            .map_err(|e| box_err!(e))
     }
 
     /// Scan raw keys for given range `[start, end)` in given cf.
@@ -973,9 +973,9 @@ fn dump_mvcc_properties(db: &Arc<DB>, start: &[u8], end: &[u8]) -> Result<Vec<(S
         ("mvcc.num_versions", mvcc_properties.num_versions),
         ("mvcc.max_row_versions", mvcc_properties.max_row_versions),
     ]
-    .iter()
-    .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-    .collect();
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
 
     // Entries and delete marks of RocksDB.
     let num_deletes = num_entries - mvcc_properties.num_versions;
@@ -1466,33 +1466,33 @@ mod tests {
         // For normal case.
         assert!(region_overlap(
             &new_region(b"a", b"z"),
-            &new_region(b"b", b"y")
+            &new_region(b"b", b"y"),
         ));
         assert!(region_overlap(
             &new_region(b"a", b"n"),
-            &new_region(b"m", b"z")
+            &new_region(b"m", b"z"),
         ));
         assert!(!region_overlap(
             &new_region(b"a", b"m"),
-            &new_region(b"n", b"z")
+            &new_region(b"n", b"z"),
         ));
 
         // For the first or last region.
         assert!(region_overlap(
             &new_region(b"m", b""),
-            &new_region(b"a", b"n")
+            &new_region(b"a", b"n"),
         ));
         assert!(region_overlap(
             &new_region(b"a", b"n"),
-            &new_region(b"m", b"")
+            &new_region(b"m", b""),
         ));
         assert!(region_overlap(
             &new_region(b"", b""),
-            &new_region(b"m", b"")
+            &new_region(b"m", b""),
         ));
         assert!(!region_overlap(
             &new_region(b"a", b"m"),
-            &new_region(b"n", b"")
+            &new_region(b"n", b""),
         ));
     }
 
@@ -1535,7 +1535,7 @@ mod tests {
                     CFOptions::new(CF_RAFT, ColumnFamilyOptions::new()),
                 ],
             )
-            .unwrap(),
+                .unwrap(),
         );
 
         let engines = Engines::new(

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -669,6 +669,13 @@ impl<ER: RaftEngine> Debugger<ER> {
         let region_ids = region_ids.unwrap_or(self.get_all_regions_in_store()?);
         for region_id in region_ids {
             let region_state = self.region_info(region_id)?;
+
+            // It's safe to unwrap region_local_state here, because get_all_regions_in_store()
+            // guarantees that the region state exists in kvdb.
+            if region_state.region_local_state.unwrap().state == PeerState::Tombstone {
+                continue;
+            }
+
             let old_raft_local_state = region_state.raft_local_state.ok_or_else(|| {
                 Error::Other(format!("No RaftLocalState found for region {}", region_id).into())
             })?;

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -154,6 +154,7 @@ impl<ER: RaftEngine> Debugger<ER> {
             regions.push(id);
             Ok(true)
         }));
+        regions.sort();
         Ok(regions)
     }
 

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -16,7 +16,7 @@ use engine_traits::{
 };
 use engine_traits::{MvccProperties, Range, WriteBatchExt, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use kvproto::debugpb::{self, Db as DBType};
-use kvproto::metapb::Region;
+use kvproto::metapb::{PeerRole, Region};
 use kvproto::raft_serverpb::*;
 use protobuf::Message;
 use raft::eraftpb::Entry;
@@ -556,6 +556,7 @@ impl<ER: RaftEngine> Debugger<ER> {
         &self,
         store_ids: Vec<u64>,
         region_ids: Option<Vec<u64>>,
+        promote_learner: bool,
     ) -> Result<()> {
         let store_id = self.get_store_id()?;
         if store_ids.iter().any(|&s| s == store_id) {
@@ -583,6 +584,43 @@ impl<ER: RaftEngine> Debugger<ER> {
 
                 let region_id = region_state.get_region().get_id();
                 let old_peers = region_state.mut_region().take_peers();
+
+                if promote_learner {
+                    if new_peers
+                        .iter()
+                        .filter(|peer| peer.get_role() != PeerRole::Learner)
+                        .count()
+                        != 0
+                    {
+                        // no need to promote learner, do nothing
+                    } else if new_peers
+                        .iter()
+                        .filter(|peer| peer.get_role() == PeerRole::Learner)
+                        .count()
+                        > 1
+                    {
+                        error!(
+                            "failed to promote learner due to multiple learners, skip promote learner";
+                            "region_id" => region_id,
+                        )
+                    } else {
+                        for peer in &mut new_peers {
+                            match peer.get_role() {
+                                PeerRole::Voter
+                                | PeerRole::IncomingVoter
+                                | PeerRole::DemotingVoter => {}
+                                PeerRole::Learner => {
+                                    info!(
+                                        "promote learner";
+                                        "region_id" => region_id,
+                                        "peer_id" => peer.get_id(),
+                                    );
+                                    peer.set_role(PeerRole::Voter);
+                                }
+                            }
+                        }
+                    }
+                }
                 info!(
                     "peers changed";
                     "region_id" => region_id,
@@ -1344,7 +1382,7 @@ mod tests {
     use std::sync::Arc;
 
     use engine_rocks::raw::{ColumnFamilyOptions, DBOptions};
-    use kvproto::metapb::{Peer, Region};
+    use kvproto::metapb::{Peer, PeerRole, Region};
     use raft::eraftpb::EntryType;
     use tempfile::Builder;
 
@@ -1355,13 +1393,22 @@ mod tests {
     use engine_traits::{Mutable, SyncMutable};
     use engine_traits::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 
-    fn init_region_state(engine: &Arc<DB>, region_id: u64, stores: &[u64]) -> Region {
+    fn init_region_state(
+        engine: &Arc<DB>,
+        region_id: u64,
+        stores: &[u64],
+        mut learner: usize,
+    ) -> Region {
         let mut region = Region::default();
         region.set_id(region_id);
         for (i, &store_id) in stores.iter().enumerate() {
             let mut peer = Peer::default();
             peer.set_id(i as u64);
             peer.set_store_id(store_id);
+            if learner > 0 {
+                peer.set_role(PeerRole::Learner);
+                learner -= 1;
+            }
             region.mut_peers().push(peer);
         }
         let mut region_state = RegionLocalState::default();
@@ -1663,21 +1710,21 @@ mod tests {
         let engine = &debugger.engines.kv;
 
         // region 1 with peers at stores 11, 12, 13.
-        let region_1 = init_region_state(engine.as_inner(), 1, &[11, 12, 13]);
+        let region_1 = init_region_state(engine.as_inner(), 1, &[11, 12, 13], 0);
         // Got the target region from pd, which doesn't contains the store.
         let mut target_region_1 = region_1.clone();
         target_region_1.mut_peers().remove(0);
         target_region_1.mut_region_epoch().set_conf_ver(100);
 
         // region 2 with peers at stores 11, 12, 13.
-        let region_2 = init_region_state(engine.as_inner(), 2, &[11, 12, 13]);
+        let region_2 = init_region_state(engine.as_inner(), 2, &[11, 12, 13], 0);
         // Got the target region from pd, which has different peer_id.
         let mut target_region_2 = region_2.clone();
         target_region_2.mut_peers()[0].set_id(100);
         target_region_2.mut_region_epoch().set_conf_ver(100);
 
         // region 3 with peers at stores 21, 22, 23.
-        let region_3 = init_region_state(engine.as_inner(), 3, &[21, 22, 23]);
+        let region_3 = init_region_state(engine.as_inner(), 3, &[21, 22, 23], 0);
         // Got the target region from pd but the peers are not changed.
         let mut target_region_3 = region_3;
         target_region_3.mut_region_epoch().set_conf_ver(100);
@@ -1721,7 +1768,7 @@ mod tests {
         assert!(!errors.is_empty());
 
         // region 1 with peers at stores 11, 12, 13.
-        init_region_state(engine.as_inner(), 1, &[11, 12, 13]);
+        init_region_state(engine.as_inner(), 1, &[11, 12, 13], 0);
         let mut expected_state = get_region_state(engine.as_inner(), 1);
         expected_state.set_state(PeerState::Tombstone);
 
@@ -1751,14 +1798,23 @@ mod tests {
                 .collect::<Vec<_>>()
         };
 
+        let get_region_learner = |engine: &Arc<DB>, region_id: u64| {
+            get_region_state(engine, region_id)
+                .get_region()
+                .get_peers()
+                .iter()
+                .filter(|p| p.get_role() == PeerRole::Learner)
+                .count()
+        };
+
         // region 1 with peers at stores 11, 12, 13 and 14.
-        init_region_state(engine.as_inner(), 1, &[11, 12, 13, 14]);
+        init_region_state(engine.as_inner(), 1, &[11, 12, 13, 14], 0);
         // region 2 with peers at stores 21, 22 and 23.
-        init_region_state(engine.as_inner(), 2, &[21, 22, 23]);
+        init_region_state(engine.as_inner(), 2, &[21, 22, 23], 0);
 
         // Only remove specified stores from region 1.
         debugger
-            .remove_failed_stores(vec![13, 14, 21, 23], Some(vec![1]))
+            .remove_failed_stores(vec![13, 14, 21, 23], Some(vec![1]), false)
             .unwrap();
 
         // 13 and 14 should be removed from region 1.
@@ -1767,14 +1823,38 @@ mod tests {
         assert_eq!(get_region_stores(engine.as_inner(), 2), &[21, 22, 23]);
 
         // Remove specified stores from all regions.
-        debugger.remove_failed_stores(vec![11, 23], None).unwrap();
+        debugger
+            .remove_failed_stores(vec![11, 23], None, false)
+            .unwrap();
 
         assert_eq!(get_region_stores(engine.as_inner(), 1), &[12]);
         assert_eq!(get_region_stores(engine.as_inner(), 2), &[21, 22]);
 
         // Should fail when the store itself is in the failed list.
-        init_region_state(engine.as_inner(), 3, &[100, 31, 32, 33]);
-        debugger.remove_failed_stores(vec![100], None).unwrap_err();
+        init_region_state(engine.as_inner(), 3, &[100, 31, 32, 33], 0);
+        debugger
+            .remove_failed_stores(vec![100], None, false)
+            .unwrap_err();
+
+        // no learner, promote learner does nothing
+        init_region_state(engine.as_inner(), 4, &[41, 42, 43, 44], 0);
+        debugger.remove_failed_stores(vec![44], None, true).unwrap();
+        assert_eq!(get_region_stores(engine.as_inner(), 4), &[41, 42, 43]);
+        assert_eq!(get_region_learner(engine.as_inner(), 4), 0);
+
+        // promote learner
+        init_region_state(engine.as_inner(), 5, &[51, 52, 53, 54], 1);
+        debugger
+            .remove_failed_stores(vec![52, 53, 54], None, true)
+            .unwrap();
+        assert_eq!(get_region_stores(engine.as_inner(), 5), &[51]);
+        assert_eq!(get_region_learner(engine.as_inner(), 5), 0);
+
+        // no need to promote learner
+        init_region_state(engine.as_inner(), 6, &[61, 62, 63, 64], 1);
+        debugger.remove_failed_stores(vec![64], None, true).unwrap();
+        assert_eq!(get_region_stores(engine.as_inner(), 6), &[61, 62, 63]);
+        assert_eq!(get_region_learner(engine.as_inner(), 6), 1);
     }
 
     #[test]

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -708,7 +708,6 @@ impl<ER: RaftEngine> Debugger<ER> {
                 region_id,
                 &raft_local_state,
             ));
-            // write kv rocksdb first in case of restart happen between two write
             let mut write_opts = WriteOptions::new();
             write_opts.set_sync(true);
             box_try!(kv_wb.write_opt(&write_opts));
@@ -1869,9 +1868,9 @@ mod tests {
         let kv_engine = &debugger.engines.kv;
         let raft_engine = &debugger.engines.raft;
 
-        init_region_state(kv_engine.as_inner(), 1, &[100, 101]);
-        init_region_state(kv_engine.as_inner(), 2, &[100, 102]);
-        init_region_state(kv_engine.as_inner(), 3, &[100, 103]);
+        init_region_state(kv_engine.as_inner(), 1, &[100, 101], 1);
+        init_region_state(kv_engine.as_inner(), 2, &[100, 102], 1);
+        init_region_state(kv_engine.as_inner(), 3, &[100, 103], 1);
         init_raft_state(kv_engine, raft_engine, 1, 100, 90, 80);
         init_raft_state(kv_engine, raft_engine, 2, 100, 90, 80);
         init_raft_state(kv_engine, raft_engine, 3, 100, 90, 80);
@@ -1893,8 +1892,8 @@ mod tests {
         let kv_engine = &debugger.engines.kv;
         let raft_engine = &debugger.engines.raft;
 
-        init_region_state(kv_engine.as_inner(), 1, &[100, 101]);
-        init_region_state(kv_engine.as_inner(), 2, &[100, 103]);
+        init_region_state(kv_engine.as_inner(), 1, &[100, 101], 1);
+        init_region_state(kv_engine.as_inner(), 2, &[100, 103], 1);
         init_raft_state(kv_engine, raft_engine, 1, 100, 90, 80);
         init_raft_state(kv_engine, raft_engine, 2, 80, 80, 80);
 

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -267,7 +267,7 @@ impl<ER: RaftEngine> Debugger<ER> {
             if end.is_empty() { None } else { Some(end) },
             limit as usize,
         )
-            .map_err(|e| box_err!(e))
+        .map_err(|e| box_err!(e))
     }
 
     /// Scan raw keys for given range `[start, end)` in given cf.
@@ -973,9 +973,9 @@ fn dump_mvcc_properties(db: &Arc<DB>, start: &[u8], end: &[u8]) -> Result<Vec<(S
         ("mvcc.num_versions", mvcc_properties.num_versions),
         ("mvcc.max_row_versions", mvcc_properties.max_row_versions),
     ]
-        .iter()
-        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-        .collect();
+    .iter()
+    .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+    .collect();
 
     // Entries and delete marks of RocksDB.
     let num_deletes = num_entries - mvcc_properties.num_versions;
@@ -1535,7 +1535,7 @@ mod tests {
                     CFOptions::new(CF_RAFT, ColumnFamilyOptions::new()),
                 ],
             )
-                .unwrap(),
+            .unwrap(),
         );
 
         let engines = Engines::new(

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -683,9 +683,23 @@ impl<ER: RaftEngine> Debugger<ER> {
                 end_key: &keys::enc_end_key(&region),
             };
 
+            // clear data
+            kv.delete_all_in_range(DeleteStrategy::DeleteFiles, &[key_range])
+                .unwrap_or_else(|e| {
+                    error!("failed to delete files in range"; "err" => %e);
+                });
+            kv.delete_all_in_range(DeleteStrategy::DeleteByKey, &[key_range])
+                .unwrap_or_else(|e| {
+                    error!("failed to delete by range"; "err" => %e);
+                });
+            kv.delete_all_in_range(DeleteStrategy::DeleteBlobs, &[key_range])
+                .unwrap_or_else(|e| {
+                    error!("failed to delete blobs in range"; "err" => %e);
+                });
+
+            // clear meta
             let mut kv_wb = kv.write_batch();
             let mut raft_wb = raft.log_batch(1024);
-
             box_try!(raftstore::store::clear_meta(
                 &self.engines,
                 &mut kv_wb,
@@ -693,7 +707,6 @@ impl<ER: RaftEngine> Debugger<ER> {
                 region_id,
                 &raft_local_state,
             ));
-
             // write kv rocksdb first in case of restart happen between two write
             let mut write_opts = WriteOptions::new();
             write_opts.set_sync(true);
@@ -701,15 +714,6 @@ impl<ER: RaftEngine> Debugger<ER> {
             box_try!(raft.consume(&mut raft_wb, true));
 
             // FIXME: Add tombstone?
-
-            kv.delete_all_in_range(DeleteStrategy::DeleteFiles, &[key_range])
-                .unwrap_or_else(|e| {
-                    error!("failed to delete files in range"; "err" => %e);
-                });
-            kv.delete_all_in_range(DeleteStrategy::DeleteBlobs, &[key_range])
-                .unwrap_or_else(|e| {
-                    error!("failed to delete files in range"; "err" => %e);
-                });
 
             info!(
                 "removed peer";

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -10,9 +10,9 @@ use engine_rocks::raw::{CompactOptions, DBBottommostLevelCompaction, DB};
 use engine_rocks::util::get_cf_handle;
 use engine_rocks::{Compat, RocksEngine, RocksEngineIterator, RocksWriteBatch};
 use engine_traits::{
-    Engines, IterOptions, Iterable, Iterator as EngineIterator, Mutable, Peekable, RaftEngine,
-    RangePropertiesExt, SeekKey, TableProperties, TablePropertiesCollection, TablePropertiesExt,
-    WriteBatch, WriteOptions,
+    DeleteStrategy, Engines, IterOptions, Iterable, Iterator as EngineIterator, MiscExt, Mutable,
+    Peekable, RaftEngine, RangePropertiesExt, SeekKey, SyncMutable, TableProperties,
+    TablePropertiesCollection, TablePropertiesExt, WriteBatch, WriteOptions,
 };
 use engine_traits::{MvccProperties, Range, WriteBatchExt, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use kvproto::debugpb::{self, Db as DBType};
@@ -30,7 +30,6 @@ use raftstore::coprocessor::get_region_approximate_middle;
 use raftstore::store::util as raftstore_util;
 use raftstore::store::PeerStorage;
 use raftstore::store::{write_initial_apply_state, write_initial_raft_state, write_peer_state};
-use tikv_util::codec::bytes;
 use tikv_util::config::ReadableSize;
 use tikv_util::keybuilder::KeyBuilder;
 use tikv_util::worker::Worker;
@@ -624,6 +623,128 @@ impl<ER: RaftEngine> Debugger<ER> {
         Ok(())
     }
 
+    pub fn remove_regions(&self, region_ids: Vec<u64>) -> Result<()> {
+        let kv = &self.engines.kv;
+        let raft = &self.engines.raft;
+
+        for region_id in region_ids {
+            let region_state = self.region_info(region_id)?;
+            let raft_local_state = region_state.raft_local_state.ok_or_else(|| {
+                Error::Other(format!("No RaftLocalState found for region {}", region_id).into())
+            })?;
+            let raft_apply_state = region_state.raft_apply_state.ok_or_else(|| {
+                Error::Other(format!("No RaftApplyState found for region {}", region_id).into())
+            })?;
+            let region_local_state = region_state.region_local_state.ok_or_else(|| {
+                Error::Other(format!("No RegionLocalState found for region {}", region_id).into())
+            })?;
+
+            let region = region_local_state.region.unwrap();
+            let key_range = Range {
+                start_key: &keys::enc_start_key(&region),
+                end_key: &keys::enc_end_key(&region),
+            };
+
+            let mut kv_wb = kv.write_batch();
+            let mut raft_wb = raft.log_batch(1024);
+
+            box_try!(raftstore::store::clear_meta(
+                &self.engines,
+                &mut kv_wb,
+                &mut raft_wb,
+                region_id,
+                &raft_local_state,
+            ));
+
+            // write kv rocksdb first in case of restart happen between two write
+            let mut write_opts = WriteOptions::new();
+            write_opts.set_sync(true);
+            box_try!(kv_wb.write_opt(&write_opts));
+            box_try!(raft.consume(&mut raft_wb, true));
+
+            // FIXME: Add tombstone?
+
+            kv.delete_all_in_range(DeleteStrategy::DeleteFiles, &[key_range])
+                .unwrap_or_else(|e| {
+                    error!("failed to delete files in range"; "err" => %e);
+                });
+            kv.delete_all_in_range(DeleteStrategy::DeleteBlobs, &[key_range])
+                .unwrap_or_else(|e| {
+                    error!("failed to delete files in range"; "err" => %e);
+                });
+
+            info!(
+                "removed peer";
+                "region_id" => region_id,
+                "raft_local_state" => ?raft_local_state,
+                "raft_apply_state" => ?raft_apply_state,
+                "region_local_state" => ?raft_apply_state,
+            );
+        }
+
+        Ok(())
+    }
+
+    pub fn drop_unapplied_raftlog(&self, region_ids: Option<Vec<u64>>) -> Result<()> {
+        let kv = &self.engines.kv;
+        let raft = &self.engines.raft;
+
+        let region_ids = region_ids.unwrap_or(self.get_all_regions_in_store()?);
+        for region_id in region_ids {
+            let region_state = self.region_info(region_id)?;
+            let old_raft_local_state = region_state.raft_local_state.ok_or_else(|| {
+                Error::Other(format!("No RaftLocalState found for region {}", region_id).into())
+            })?;
+            let old_raft_apply_state = region_state.raft_apply_state.ok_or_else(|| {
+                Error::Other(format!("No RaftApplyState found for region {}", region_id).into())
+            })?;
+
+            let applied_index = old_raft_apply_state.applied_index;
+            let last_index = old_raft_local_state.last_index;
+
+            let new_raft_local_state = RaftLocalState {
+                last_index: applied_index,
+                ..old_raft_local_state.clone()
+            };
+            let new_raft_apply_state = RaftApplyState {
+                commit_index: applied_index,
+                ..old_raft_apply_state.clone()
+            };
+
+            info!(
+                "dropping unapplied raft log";
+                "region_id" => region_id,
+                "old_raft_local_state" => ?old_raft_local_state,
+                "new_raft_local_state" => ?new_raft_local_state,
+                "old_raft_apply_state" => ?old_raft_apply_state,
+                "new_raft_apply_state" => ?new_raft_apply_state,
+            );
+
+            // flush the changes
+            box_try!(kv.put_msg_cf(
+                CF_RAFT,
+                &keys::apply_state_key(region_id),
+                &new_raft_apply_state
+            ));
+            box_try!(raft.put_raft_state(region_id, &new_raft_local_state));
+            let deleted_logs = box_try!(raft.gc(region_id, applied_index + 1, last_index + 1));
+            raft.sync().unwrap();
+            kv.sync().unwrap();
+
+            info!(
+                "dropped unapplied raft log";
+                "region_id" => region_id,
+                "old_raft_local_state" => ?old_raft_local_state,
+                "new_raft_local_state" => ?new_raft_local_state,
+                "old_raft_apply_state" => ?old_raft_apply_state,
+                "new_raft_apply_state" => ?new_raft_apply_state,
+                "deleted logs" => deleted_logs,
+            );
+        }
+
+        Ok(())
+    }
+
     pub fn recreate_region(&self, region: Region) -> Result<()> {
         let region_id = region.get_id();
         let kv = &self.engines.kv;
@@ -750,16 +871,17 @@ impl<ER: RaftEngine> Debugger<ER> {
         let mut res = dump_mvcc_properties(self.engines.kv.as_inner(), &start, &end)?;
 
         let middle_key = match box_try!(get_region_approximate_middle(&self.engines.kv, region)) {
-            Some(data_key) => {
-                let mut key = keys::origin_key(&data_key);
-                box_try!(bytes::decode_bytes(&mut key, false))
-            }
+            Some(data_key) => keys::origin_key(&data_key).to_vec(),
             None => Vec::new(),
         };
 
-        // Middle key of the range.
         res.push((
-            "middle_key_by_approximate_size".to_owned(),
+            "region.start_key".to_owned(),
+            hex::encode(&region.start_key),
+        ));
+        res.push(("region.end_key".to_owned(), hex::encode(&region.end_key)));
+        res.push((
+            "region.middle_key_by_approximate_size".to_owned(),
             hex::encode(&middle_key),
         ));
 
@@ -1250,6 +1372,28 @@ mod tests {
         region
     }
 
+    fn init_raft_state(
+        kv_engine: &RocksEngine,
+        raft_engine: &RocksEngine,
+        region_id: u64,
+        last_index: u64,
+        commit_index: u64,
+        applied_index: u64,
+    ) {
+        let apply_state_key = keys::apply_state_key(region_id);
+        let mut apply_state = RaftApplyState::default();
+        apply_state.set_applied_index(applied_index);
+        apply_state.set_commit_index(commit_index);
+        kv_engine
+            .put_msg_cf(CF_RAFT, &apply_state_key, &apply_state)
+            .unwrap();
+
+        let raft_state_key = keys::raft_state_key(region_id);
+        let mut raft_state = RaftLocalState::default();
+        raft_state.set_last_index(last_index);
+        raft_engine.put_msg(&raft_state_key, &raft_state).unwrap();
+    }
+
     fn get_region_state(engine: &Arc<DB>, region_id: u64) -> RegionLocalState {
         let key = keys::region_state_key(region_id);
         engine
@@ -1631,6 +1775,73 @@ mod tests {
         // Should fail when the store itself is in the failed list.
         init_region_state(engine.as_inner(), 3, &[100, 31, 32, 33]);
         debugger.remove_failed_stores(vec![100], None).unwrap_err();
+    }
+
+    #[test]
+    fn test_remove_region() {
+        let debugger = new_debugger();
+        debugger.set_store_id(100);
+        let kv_engine = &debugger.engines.kv;
+        let raft_engine = &debugger.engines.raft;
+
+        init_region_state(kv_engine.as_inner(), 1, &[100, 101]);
+        init_region_state(kv_engine.as_inner(), 2, &[100, 102]);
+        init_region_state(kv_engine.as_inner(), 3, &[100, 103]);
+        init_raft_state(kv_engine, raft_engine, 1, 100, 90, 80);
+        init_raft_state(kv_engine, raft_engine, 2, 100, 90, 80);
+        init_raft_state(kv_engine, raft_engine, 3, 100, 90, 80);
+
+        debugger.remove_regions(vec![1, 2]).unwrap();
+
+        debugger.region_info(1).unwrap_err();
+        debugger.region_info(2).unwrap_err();
+        debugger.region_info(3).unwrap();
+
+        // Should fail if the region does not exist.
+        debugger.remove_regions(vec![1]).unwrap_err();
+    }
+
+    #[test]
+    fn test_drop_unapplied_raftlog() {
+        let debugger = new_debugger();
+        debugger.set_store_id(100);
+        let kv_engine = &debugger.engines.kv;
+        let raft_engine = &debugger.engines.raft;
+
+        init_region_state(kv_engine.as_inner(), 1, &[100, 101]);
+        init_region_state(kv_engine.as_inner(), 2, &[100, 103]);
+        init_raft_state(kv_engine, raft_engine, 1, 100, 90, 80);
+        init_raft_state(kv_engine, raft_engine, 2, 80, 80, 80);
+
+        let region_info_2_before = debugger.region_info(2).unwrap();
+
+        // Drop raftlog on all regions
+        debugger.drop_unapplied_raftlog(None).unwrap();
+
+        let region_info_1 = debugger.region_info(1).unwrap();
+        let region_info_2 = debugger.region_info(2).unwrap();
+
+        assert_eq!(
+            region_info_1.raft_local_state.as_ref().unwrap().last_index,
+            80
+        );
+        assert_eq!(
+            region_info_1
+                .raft_apply_state
+                .as_ref()
+                .unwrap()
+                .applied_index,
+            80
+        );
+        assert_eq!(
+            region_info_1
+                .raft_apply_state
+                .as_ref()
+                .unwrap()
+                .commit_index,
+            80
+        );
+        assert_eq!(region_info_2, region_info_2_before);
     }
 
     #[test]

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -484,6 +484,30 @@ impl<ER: RaftEngine, T: RaftStoreRouter<RocksEngine> + 'static> debugpb::Debug f
 
         self.handle_response(ctx, sink, f, TAG);
     }
+
+    fn get_all_regions_in_store(
+        &mut self,
+        ctx: RpcContext<'_>,
+        _: GetAllRegionsInStoreRequest,
+        sink: UnarySink<GetAllRegionsInStoreResponse>,
+    ) {
+        const TAG: &str = "debug_get_all_regions_in_store";
+        let debugger = self.debugger.clone();
+
+        let f = self
+            .pool
+            .spawn(async move {
+                let mut resp = GetAllRegionsInStoreResponse::default();
+                match debugger.get_all_regions_in_store() {
+                    Ok(regions) => resp.set_regions(regions),
+                    Err(_) => resp.set_regions(vec![]),
+                }
+                Ok(resp)
+            })
+            .map(|res| res.unwrap());
+
+        self.handle_response(ctx, sink, f, TAG);
+    }
 }
 
 fn region_detail<T: RaftStoreRouter<RocksEngine>>(


### PR DESCRIPTION
Signed-off-by: Andy Lok <andylokandy@hotmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What is changed and how it works?

1. Allow getting region info for all regions from the remote store:

`tikv-ctl --host 127.0.0.1:20160 raft region --all-regions`

2. Print region start key and end key with:

`tikv-ctl --host 127.0.0.1:20160 region-properties -r 1`

3. Added subcommand:

- `tikv-ctl unsafe-recover remove-failed-stores -s 1,2,3 -r 1,2,3 --promote-learner`: Promote the learner to leader if only one learner exists
- `tikv-ctl unsafe-recover drop-unapplied-raftlog -r 1,2,3`: regress the commit index to the apply index for the region

### Related changes

- https://github.com/pingcap/kvproto/pull/797
- PR to update `pingcap/docs`/`pingcap/docs-cn`: yes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
1. Allow getting region info for all regions on the remote store:

`tikv-ctl --host 127.0.0.1:20160 raft region --all-regions`

2. Print region start key and end key with:

`tikv-ctl --host 127.0.0.1:20160 region-properties -r 1`

3. Added subcommand:

- `tikv-ctl unsafe-recover remove-failed-stores -s 1,2,3 -r 1,2,3 --promote-learner`: Promote the learner to leader if only one learner exists
- `tikv-ctl unsafe-recover drop-unapplied-raftlog -r 1,2,3`: regress the commit index to the apply index for the region
```