### PR TITLE
raftstore: fix the committed group not assign after apply snapshot

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3163,13 +3163,11 @@ where
             "region" => ?region,
         );
 
-        if prev_region.get_peers() != region.get_peers() {
-            let mut state = self.ctx.global_replication_state.lock().unwrap();
-            let gb = state
-                .calculate_commit_group(self.fsm.peer.replication_mode_version, region.get_peers());
-            self.fsm.peer.raft_group.raft.clear_commit_group();
-            self.fsm.peer.raft_group.raft.assign_commit_groups(gb);
-        }
+        let mut state = self.ctx.global_replication_state.lock().unwrap();
+        let gb = state
+            .calculate_commit_group(self.fsm.peer.replication_mode_version, region.get_peers());
+        self.fsm.peer.raft_group.raft.clear_commit_group();
+        self.fsm.peer.raft_group.raft.assign_commit_groups(gb);
 
         let mut meta = self.ctx.store_meta.lock().unwrap();
         debug!(


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

Issue Number: close https://github.com/tikv/tikv/issues/10772 <!-- REMOVE this line if no issue to close -->

Problem Summary:


### What problem does this PR solve?
Step:  ingest network isolation chaos -> wait 10m -> delete  network isolation chaos

**From the logs**:
1. assign the committed group
2. restore the snapshot (will clear commit group) https://github.com/tikv/raft-rs/blob/74d3bb58f19741cecc16698008103a446559837d/src/raft.rs#L2567-L2575
3. finished apply snapshot
4. transfer leader operator let the `tc2` peer (this peer) became leader
5. blocking on: `still not reach integrity over label`, and you can see all commit groups are 0.

```
[2021/08/23 12:24:14.766 +00:00] [Info] [raft.rs:1092] ["became follower at term 6"] [term=6] [raft_id=1332] [region_id=1108]
[2021/08/23 12:26:10.659 +00:00] [Info] [peer.rs:702] ["switch replication mode"] [peer_id=1332] [region_id=1108] [version=1376]
[2021/08/23 12:26:14.065 +00:00] [Info] [peer.rs:689] ["Debug DR on pdates replication mode."] [gb="[(1111, 2), (1332, 1), (1343, 2)]"] [peer_id=1332] [region_id=1108]
[2021/08/23 12:26:14.065 +00:00] [Info] [peer.rs:702] ["switch replication mode"] [peer_id=1332] [region_id=1108] [version=1472]
[2021/08/23 12:26:21.572 +00:00] [Info] [raft_log.rs:614] ["log [committed=20652, persisted=20653, applied=20652, unstable.offset=20654, unstable.entries.len()=0] starts to restore snapshot [index: 350273, term: 6]"] [snapshot_term=6] [snapshot_index=350273] [log="committed=20652, persisted=20653, applied=20652, unstable.offset=20654, unstable.entries.len()=0"] [raft_id=1332] [region_id=1108]
[2021/08/23 12:26:21.572 +00:00] [Info] [raft.rs:2609] ["switched to configuration"] [config="Configuration { voters: Configuration { incoming: Configuration { voters: {1111, 1332, 1343} }, outgoing: Configuration { voters: {} } }, learners: {}, learners_next: {}, auto_leave: false }"] [raft_id=1332] [region_id=1108]
[2021/08/23 12:26:21.572 +00:00] [Info] [raft.rs:2593] ["restored snapshot"] [snapshot_term=6] [snapshot_index=350273] [last_term=6] [last_index=350273] [commit=350273] [raft_id=1332] [region_id=1108]
[2021/08/23 12:26:21.572 +00:00] [Info] [raft.rs:2474] ["[commit: 350273, term: 6] restored snapshot [index: 350273, term: 6]"] [snapshot_term=6] [snapshot_index=350273] [commit=350273] [term=6] [raft_id=1332] [region_id=1108]
[2021/08/23 12:26:21.572 +00:00] [Info] [peer_storage.rs:1244] ["begin to apply snapshot"] [peer_id=1332] [region_id=1108]
[2021/08/23 12:26:21.629 +00:00] [Info] [peer_storage.rs:1638] ["finish clear peer meta"] [takes=56.321771ms] [raft_key=1] [apply_key=1] [meta_key=1] [region_id=1108]
[2021/08/23 12:26:21.629 +00:00] [Info] [peer_storage.rs:1287] ["apply snapshot with state ok"] [state="applied_index: 350273 commit_index: 20652 commit_term: 6 truncated_state { index: 350273 term: 6 }"] [region="id: 1108 start_key: 7480000000000000FF885F728000000000FF0ABA320000000000FA end_key: 7480000000000000FF8900000000000000F8 region_epoch { conf_ver: 53 version: 58 } peers { id: 1111 store_id: 4 } peers { id: 1332 store_id: 5 } peers { id: 1343 store_id: 108 }"] [peer_id=1332] [region_id=1108]
[2021/08/23 12:26:21.631 +00:00] [Info] [apply.rs:3196] ["re-register to apply delegates"] [term=6] [peer_id=1332] [region_id=1108]
[2021/08/23 12:26:21.631 +00:00] [Info] [peer.rs:3117] ["snapshot is applied"] [region="id: 1108 start_key: 7480000000000000FF885F728000000000FF0ABA320000000000FA end_key: 7480000000000000FF8900000000000000F8 region_epoch { conf_ver: 53 version: 58 } peers { id: 1111 store_id: 4 } peers { id: 1332 store_id: 5 } peers { id: 1343 store_id: 108 }"] [peer_id=1332] [region_id=1108]
[2021/08/23 12:26:21.631 +00:00] [Info] [peer.rs:3174] ["region changed after applying snapshot"] [region="id: 1108 start_key: 7480000000000000FF885F728000000000FF0ABA320000000000FA end_key: 7480000000000000FF8900000000000000F8 region_epoch { conf_ver: 53 version: 58 } peers { id: 1111 store_id: 4 } peers { id: 1332 store_id: 5 } peers { id: 1343 store_id: 108 }"] [prev_region="id: 1108 start_key: 7480000000000000FF885F728000000000FF0ABA320000000000FA end_key: 7480000000000000FF8900000000000000F8 region_epoch { conf_ver: 53 version: 58 } peers { id: 1111 store_id: 4 } peers { id: 1332 store_id: 5 } peers { id: 1343 store_id: 108 }"] [peer_id=1332] [region_id=1108]
[2021/08/23 12:26:21.631 +00:00] [Info] [region_info_accessor.rs:238] ["trying to create region but it already exists, try to update it"] [region_id=1108]
[2021/08/23 12:28:53.865 +00:00] [Info] [region.rs:325] ["begin apply snap data"] [region_id=1108]
[2021/08/23 12:28:54.277 +00:00] [Info] [region.rs:390] ["apply new data"] [time_takes=25.590424ms] [region_id=1108]
[2021/08/23 12:28:56.289 +00:00] [Info] [raft.rs:1336] ["received a message with higher term from 1343"] ["msg type"=MsgRequestVote] [message_term=7] [term=6] [from=1343] [raft_id=1332] [region_id=1108]
[2021/08/23 12:28:56.289 +00:00] [Info] [raft.rs:1092] ["became follower at term 7"] [term=7] [raft_id=1332] [region_id=1108]
[2021/08/23 12:28:56.289 +00:00] [Info] [raft.rs:1532] ["[logterm: 6, index: 351667, vote: 0] cast vote for 1343 [logterm: 6, index: 351667] at term 7"] ["msg type"=MsgRequestVote] [term=7] [msg_index=351667] [msg_term=6] [from=1343] [vote=0] [log_index=351667] [log_term=6] [raft_id=1332] [region_id=1108]
[2021/08/23 12:29:32.107 +00:00] [Info] [peer.rs:857] ["deleting applied snap file"] [snap_file=1108_6_350273] [peer_id=1332] [region_id=1108]
[2021/08/23 12:31:56.965 +00:00] [Info] [raft.rs:2304] ["[term 7] received MsgTimeoutNow from 1343 and starts an election to get leadership."] [from=1343] [term=7] [raft_id=1332] [region_id=1108]
[2021/08/23 12:31:56.965 +00:00] [Info] [raft.rs:1517] ["starting a new election"] [term=7] [raft_id=1332] [region_id=1108]
[2021/08/23 12:31:56.965 +00:00] [Info] [raft.rs:1116] ["became candidate at term 8"] [term=8] [raft_id=1332] [region_id=1108]
[2021/08/23 12:31:56.965 +00:00] [Info] [raft.rs:1271] ["broadcasting vote request"] [to="[1111, 1343]"] [log_index=351669] [log_term=7] [term=8] [type=MsgRequestVote] [raft_id=1332] [region_id=1108]
[2021/08/23 12:31:56.966 +00:00] [Info] [raft.rs:2175] ["received votes response"] [term=8] [type=MsgRequestVoteResponse] [approvals=2] [rejections=0] [from=1111] [vote=true] [raft_id=1332] [region_id=1108]
[2021/08/23 12:31:56.966 +00:00] [Info] [raft.rs:1200] ["became leader at term 8"] [term=8] [raft_id=1332] [region_id=1108]
[2021/08/23 12:31:56.967 +00:00] [Info] [peer.rs:3664] ["require updating max ts"] [initial_status=34359738484] [region_id=1108]
[2021/08/23 12:31:56.967 +00:00] [Info] [peer.rs:3419] ["still not reach integrity over label"] [progress="[]"] [peer_id=1332] [region_id=1108] [status=None]
[2021/08/23 12:31:56.967 +00:00] [Info] [peer.rs:3433] ["DEBUG DR: Unknow status"] [peer_id=1332] [region_id=1108] [term=8] [apply_to_current_term=false] [status=None]
[2021/08/23 12:31:56.967 +00:00] [Info] [pd.rs:1235] ["succeed to update max timestamp"] [region_id=1108]
[2021/08/23 12:31:56.968 +00:00] [Info] [peer.rs:3419] ["still not reach integrity over label"] [progress="[]"] [peer_id=1332] [region_id=1108] [status=None]
[2021/08/23 12:31:56.968 +00:00] [Info] [peer.rs:3433] ["DEBUG DR: Unknow status"] [peer_id=1332] [region_id=1108] [term=8] [apply_to_current_term=false] [status=None]
[2021/08/23 12:31:57.123 +00:00] [Info] [peer.rs:3419] ["still not reach integrity over label"] [progress="[]"] [peer_id=1332] [region_id=1108] [status=None]
[2021/08/23 12:31:57.123 +00:00] [Info] [peer.rs:3433] ["DEBUG DR: Unknow status"] [peer_id=1332] [region_id=1108] [term=8] [apply_to_current_term=false] [status=None]
[2021/08/23 12:32:56.967 +00:00] [Info] [peer.rs:3419] ["still not reach integrity over label"] [progress="[(1111, 0, 351670), (1332, 0, 351670), (1343, 0, 351670)]"] [peer_id=1332] [region_id=1108] [status=Some(false)]
[2021/08/23 12:33:56.968 +00:00] [Info] [peer.rs:3419] ["still not reach integrity over label"] [progress="[(1111, 0, 351670), (1332, 0, 351670), (1343, 0, 351670)]"] [peer_id=1332] [region_id=1108] [status=Some(false)]
[2021/08/23 12:34:56.969 +00:00] [Info] [peer.rs:3419] ["still not reach integrity over label"] [progress="[(1111, 0, 351670), (1332, 0, 351670), (1343, 0, 351670)]"] [peer_id=1332] [region_id=1108] [status=Some(false)]
[2021/08/23 12:35:56.970 +00:00] [Info] [peer.rs:3419] ["still not reach integrity over label"] [progress="[(1111, 0, 351670), (1332, 0, 351670), (1343, 0, 351670)]"] [peer_id=1332] [region_id=1108] [status=Some(false)]
[2021/08/23 12:36:56.971 +00:00] [Info] [peer.rs:3419] ["still not reach integrity over label"] [progress="[(1111, 0, 351670), (1332, 0, 351670), (1343, 0, 351670)]"] [peer_id=1332] [region_id=1108] [status=Some(false)]
[2021/08/23 12:37:56.972 +00:00] [Info] [peer.rs:3419] ["still not reach integrity over label"] [progress="[(1111, 0, 351670), (1332, 0, 351670), (1343, 0, 351670)]"] [peer_id=1332] [region_id=1108] [status=Some(false)]
[2021/08/23 12:38:56.973 +00:00] [Info] [peer.rs:3419] ["still not reach integrity over label"] [progress="[(1111, 0, 351670), (1332, 0, 351670), (1343, 0, 351670)]"] [peer_id=1332] [region_id=1108] [status=Some(false)]
```

### What is changed and how it works?
re-assign the commit group everytime after apply snapshot

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
raftstore: fix the committed group not assign after apply snapshot
```