### PR TITLE
Fix ineffective alert rule for low space

### DIFF
--- a/metrics/alertmanager/tikv.rules.yml
+++ b/metrics/alertmanager/tikv.rules.yml
@@ -301,17 +301,17 @@ groups:
       value: '{{ $value }}'
       summary: TiKV pending task too much
 
-  - alert: TiKV_low_space_and_add_region
-    expr: count( (sum(tikv_store_size_bytes{type="available"}) by (instance) / sum(tikv_store_size_bytes{type="capacity"}) by (instance) < 0.2) and (sum(tikv_raftstore_snapshot_traffic_total{type="applying"}) by (instance) > 0 ) ) > 0
+  - alert: TiKV_low_space
+    expr: sum(tikv_store_size_bytes{type="available"}) by (instance) / sum(tikv_store_size_bytes{type="capacity"}) by (instance) < 0.2
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr:  count( (sum(tikv_store_size_bytes{type="available"}) by (instance) / sum(tikv_store_size_bytes{type="capacity"}) by (instance) < 0.2) and (sum(tikv_raftstore_snapshot_traffic_total{type="applying"}) by (instance) > 0 ) ) > 0
+      expr:  sum(tikv_store_size_bytes{type="available"}) by (instance) / sum(tikv_store_size_bytes{type="capacity"}) by (instance) < 0.2
     annotations:
       description: 'cluster: ENV_LABELS_ENV, type: {{ $labels.type }}, instance: {{ $labels.instance }}, values: {{ $value }}'
       value: '{{ $value }}'
-      summary: TiKV low_space and add_region
+      summary: TiKV available space too small
 
   - alert: TiKV_approximate_region_size
     expr: histogram_quantile(0.99, sum(rate(tikv_raftstore_region_size_bucket[1m])) by (le)) > 1073741824

--- a/metrics/alertmanager/tikv.rules.yml
+++ b/metrics/alertmanager/tikv.rules.yml
@@ -311,7 +311,7 @@ groups:
     annotations:
       description: 'cluster: ENV_LABELS_ENV, type: {{ $labels.type }}, instance: {{ $labels.instance }}, values: {{ $value }}'
       value: '{{ $value }}'
-      summary: TiKV available space too small
+      summary: TiKV available disk space too low
 
   - alert: TiKV_approximate_region_size
     expr: histogram_quantile(0.99, sum(rate(tikv_raftstore_region_size_bucket[1m])) by (le)) > 1073741824


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What problem does this PR solve?

Problem Summary:

Apply snapshot counter was disabled in #4066 and removed in #10099, but `low_space_and_add_region` alert rule still uses it as a condition.

### What is changed and how it works?

What's Changed: Unconditionally alert low space.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests

- No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```