### PR TITLE
raftstore: continue GC  snapshot files when it encounters a corrupted snapshot

### DIFF
--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -2110,6 +2110,7 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                 "store_id" => self.fsm.store.id,
                 "region_id" => region_id,
             );
+
             let gc_snap = PeerMsg::CasualMessage(CasualMessage::GcSnap { snaps });
             match self.ctx.router.send(region_id, gc_snap) {
                 Ok(()) => Ok(()),
@@ -2126,7 +2127,16 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
                         "snaps" => ?snaps,
                     );
                     for (key, is_sending) in snaps {
-                        let snap = self.ctx.snap_mgr.get_snapshot_for_gc(&key, is_sending)?;
+                        let snap = match self.ctx.snap_mgr.get_snapshot_for_gc(&key, is_sending) {
+                            Ok(snap) => snap,
+                            Err(e) => {
+                                error!(%e;
+                                    "failed to load snapshot";
+                                    "snapshot" => ?key,
+                                );
+                                continue;
+                            }
+                        };
                         self.ctx
                             .snap_mgr
                             .delete_snapshot(&key, snap.as_ref(), false);

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1247,6 +1247,11 @@ impl SnapManager {
         let _lock = self.core.registry.rl();
         let base = &self.core.base;
         let s = Snapshot::new(base, key, is_sending, CheckPolicy::None, &self.core)?;
+        fail_point!(
+            "get_snapshot_for_gc",
+            key.region_id == 2 && key.idx == 1,
+            |_| { Err(box_err!("invalid cf number of snapshot meta")) }
+        );
         Ok(Box::new(s))
     }
 

--- a/tests/failpoints/cases/test_snap.rs
+++ b/tests/failpoints/cases/test_snap.rs
@@ -6,6 +6,9 @@ use std::time::Duration;
 use std::{fs, io, thread};
 
 use raft::eraftpb::MessageType;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::PathBuf;
 use test_raftstore::*;
 use tikv_util::config::*;
 use tikv_util::time::Instant;
@@ -466,4 +469,74 @@ fn test_cancel_snapshot_generating() {
         let snap_index = parts[3].parse::<u64>().unwrap();
         assert!(snap_index > truncated_idx);
     }
+}
+
+#[test]
+fn test_snapshot_gc_after_failed() {
+    let mut cluster = new_server_cluster(0, 3);
+    configure_for_snapshot(&mut cluster);
+    cluster.cfg.raft_store.snap_gc_timeout = ReadableDuration::millis(300);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    // Disable default max peer count check.
+    pd_client.disable_default_operator();
+    let r1 = cluster.run_conf_change();
+    cluster.must_put(b"k1", b"v1");
+    pd_client.must_add_peer(r1, new_peer(2, 2));
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+    pd_client.must_add_peer(r1, new_peer(3, 3));
+    let snap_dir = cluster.get_snap_dir(3);
+    fail::cfg("get_snapshot_for_gc", "return(0)").unwrap();
+    for idx in 1..3 {
+        // idx 1 will fail in fail_point("get_snapshot_for_gc"), but idx 2 will succeed
+        for suffix in &[".meta", "_default.sst"] {
+            let f = format!("gen_{}_{}_{}{}", 2, 6, idx, suffix);
+            let mut snap_file_path = PathBuf::from(&snap_dir);
+            snap_file_path.push(&f);
+            let snap_file_path = snap_file_path.as_path();
+            let mut file = match File::create(&snap_file_path) {
+                Err(why) => panic!("couldn't create {:?}: {}", snap_file_path, why),
+                Ok(file) => file,
+            };
+
+            // write any data, in fact we don't check snapshot file corrupted or not in GC;
+            if let Err(why) = file.write_all(b"some bytes") {
+                panic!("couldn't write to {:?}: {}", snap_file_path, why)
+            }
+        }
+    }
+    let now = Instant::now();
+    loop {
+        let snap_keys = cluster.get_snap_mgr(3).list_idle_snap().unwrap();
+        if snap_keys.is_empty() {
+            panic!("no snapshot file is found");
+        }
+
+        let mut found_unexpected_file = false;
+        let mut found_expected_file = false;
+        for (snap_key, _is_sending) in snap_keys {
+            if snap_key.region_id == 2 && snap_key.idx == 1 {
+                found_expected_file = true;
+            }
+            if snap_key.idx == 2 && snap_key.region_id == 2 {
+                if now.saturating_elapsed() > Duration::from_secs(10) {
+                    panic!("unexpected snapshot file found. {:?}", snap_key);
+                }
+                found_unexpected_file = true;
+                break;
+            }
+        }
+
+        if !found_expected_file {
+            panic!("The expected snapshot file is not found");
+        }
+
+        if !found_unexpected_file {
+            break;
+        }
+
+        sleep_ms(400);
+    }
+    fail::cfg("get_snapshot_for_gc", "off").unwrap();
+    cluster.sim.wl().clear_recv_filters(3);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #10813 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?
When snapshot GC runs into problem (such as file corrupted), today it stopped processing other GC-able snapshot files.
This PR will make it continue processing rest of the snapshot files.

### Related changes

Tests <!-- At least one of them must be included. -->
- Unit test

Side effects
No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
RaftStore Snapshot GC fix: fix the issue that snapshot GC missed GC snapshot files when there's one snapshot file failed to be GC-ed. 
```
/cc @BusyJay 