### PR TITLE
tikv-ctl: Migrate clap to structopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -5267,6 +5267,7 @@ dependencies = [
  "signal",
  "slog",
  "slog-global",
+ "structopt",
  "tempfile",
  "tikv",
  "tikv_alloc",

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -85,6 +85,7 @@ chrono = "0.4"
 crossbeam = "0.8"
 tempfile = "3.0"
 clap = "2.32"
+structopt = "0.3"
 concurrency_manager = { path = "../../components/concurrency_manager", default-features = false }
 encryption_export = { path = "../../components/encryption/export", default-features = false }
 engine_rocks = { path = "../../components/engine_rocks", default-features = false }

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -1123,7 +1123,7 @@ static VERSION_INFO: SyncLazy<String> = SyncLazy::new(|| {
     tikv::tikv_version_info(build_timestamp)
 });
 
-const RAW_KEY_HINT: &'static str = "Raw key (generally starts with \"z\") in escaped form";
+const RAW_KEY_HINT: &str = "Raw key (generally starts with \"z\") in escaped form";
 
 #[derive(StructOpt)]
 #[structopt(

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -1832,7 +1832,7 @@ fn main() {
             if let Some(hex) = opt.hex_to_escaped.as_deref() {
                 println!("{}", escape(&from_hex(hex).unwrap()));
             } else if let Some(escaped) = opt.escaped_to_hex.as_deref() {
-                println!("{}", log_wrappers::hex_encode_upper(unescape(escaped)));
+                println!("{}", hex::encode_upper(unescape(escaped)));
             } else if let Some(encoded) = opt.decode.as_deref() {
                 match Key::from_encoded(unescape(encoded)).into_raw() {
                     Ok(k) => println!("{}", escape(&k)),
@@ -1868,24 +1868,6 @@ fn main() {
     if let Cmd::DumpSnapMeta { file } = cmd {
         let path = file.as_ref();
         return dump_snap_meta_file(path);
-    }
-
-    // Deal with arguments about key utils.
-    if let Some(hex) = opt.hex_to_escaped.as_deref() {
-        println!("{}", escape(&from_hex(hex).unwrap()));
-        return;
-    } else if let Some(escaped) = opt.escaped_to_hex.as_deref() {
-        println!("{}", hex::encode_upper(unescape(escaped)));
-        return;
-    } else if let Some(encoded) = opt.decode.as_deref() {
-        match Key::from_encoded(unescape(encoded)).into_raw() {
-            Ok(k) => println!("{}", escape(&k)),
-            Err(e) => println!("decode meets error: {}", e),
-        };
-        return;
-    } else if let Some(decoded) = opt.encode.as_deref() {
-        println!("{}", Key::from_raw(&unescape(decoded)));
-        return;
     }
 
     if let Cmd::DecryptFile { file, out_file } = cmd {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10793

What's Changed:

Add `structopt` as a dependency, for parsing command line options of `tikv-ctl`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  - I tried my best to ensure CLI behaviour keep the same after the migration. Most codes are transformed literally.
  - The `--help` output for every subcommand is printed and compared between clap version and structopt version, so that we can ensure we have the same number of arguments/flags with flag types unchanged.
  - I tested most command in the [`tikv-ctl` part of TiKV documention](https://tikv.org/docs/dev/reference/tools/tikv-ctl/) manually. But supported flags are too many. I am not able to test every possible flag/argument combination to ensure correctness.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```