### PR TITLE
engine: update rust-rocksdb for backward compatibility fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#72334ceb658740d2addae0c57b8156a46f7a8f19"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#3617d6803bd4306757e293bc7c8e0ecfce2bcf00"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2246,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#72334ceb658740d2addae0c57b8156a46f7a8f19"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#3617d6803bd4306757e293bc7c8e0ecfce2bcf00"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -3856,7 +3856,7 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#72334ceb658740d2addae0c57b8156a46f7a8f19"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#3617d6803bd4306757e293bc7c8e0ecfce2bcf00"
 dependencies = [
  "libc 0.2.86",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#3617d6803bd4306757e293bc7c8e0ecfce2bcf00"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#53ff7e7a8fff03058ce03b9d520227cc4aff90b8"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2246,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#3617d6803bd4306757e293bc7c8e0ecfce2bcf00"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#53ff7e7a8fff03058ce03b9d520227cc4aff90b8"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -3856,7 +3856,7 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#3617d6803bd4306757e293bc7c8e0ecfce2bcf00"
+source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.0#53ff7e7a8fff03058ce03b9d520227cc4aff90b8"
 dependencies = [
  "libc 0.2.86",
  "librocksdb_sys",


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What problem does this PR solve?

Problem Summary:

1. https://github.com/tikv/rocksdb/pull/252 introduced a new RocksDB configuration item to v5.2.0, making it unable to rollback to older versions.

The error message reads:
```
[lib.rs:466] ["failed to load_latest_options \"Invalid argument: Unable to parse the specified CF option disable_write_stall\""]
```
2. TiKV panic when enable Titan and upgrade from pre-5.0 version.

### What is changed and how it works?

What's Changed:

https://github.com/tikv/rocksdb/pull/258
https://github.com/tikv/titan/pull/223

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
- Fix TiKV panic when enable Titan and upgrade from pre-5.0 version
- Fix newer TiKV can't rollback to 5.0.x
```