### PR TITLE
print log for space reserve failure

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -429,6 +429,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         let available = disk_stats.available_space();
         if available > reserve_space {
             file_system::reserve_space_for_recover(&self.config.storage.data_dir, reserve_space)
+                .map_err(|e| panic!("Failed to reserve space for recovery: {}.", e))
                 .unwrap();
         } else {
             warn!("no enough disk space left to create the place holder file");


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

### What problem does this PR solve?

Internal issue: https://internal.pingcap.net/jira/browse/TIDB-10490

When TiKV tries to reserve space for recovery, and encounters an IO error, the log message is confusing.

### What is changed and how it works?

What's Changed: Print out which step is TiKV failing at.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```