### PR TITLE
copr: fix panic when exceeds deadline before polling

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -421,8 +421,9 @@ impl<E: Engine> Endpoint<E> {
         tracker.on_begin_all_items();
 
         let deadline = tracker.req_ctx.deadline;
-        let handle_request_future =
-            check_deadline(track(handler.handle_request(), &mut tracker), deadline);
+        let handle_request_future = check_deadline(handler.handle_request(), deadline);
+        let handle_request_future = track(handle_request_future, &mut tracker);
+
         let deadline_res = if let Some(semaphore) = &semaphore {
             limit_concurrency(handle_request_future, semaphore, LIGHT_TASK_THRESHOLD).await
         } else {
@@ -1614,6 +1615,52 @@ mod tests {
                     .get_wait_wall_time_ms(),
                 wait_time + HANDLE_ERROR_MS + COARSE_ERROR_MS
             );
+        }
+    }
+
+    #[test]
+    fn test_exceed_deadline() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            PerfLevel::EnableCount,
+        );
+
+        {
+            let handler_builder = Box::new(|_, _: &_| {
+                thread::sleep(Duration::from_millis(600));
+                Ok(UnaryFixture::new(Ok(coppb::Response::default())).into_boxed())
+            });
+
+            let mut config = ReqContext::default_for_test();
+            config.deadline = Deadline::from_now(Duration::from_millis(500));
+
+            let resp = block_on(copr.handle_unary_request(config, handler_builder)).unwrap();
+            assert_eq!(resp.get_data().len(), 0);
+            assert!(!resp.get_other_error().is_empty());
+        }
+
+        {
+            let handler_builder = Box::new(|_, _: &_| {
+                Ok(
+                    UnaryFixture::new_with_duration_yieldable(Ok(coppb::Response::default()), 1500)
+                        .into_boxed(),
+                )
+            });
+
+            let mut config = ReqContext::default_for_test();
+            config.deadline = Deadline::from_now(Duration::from_millis(1000));
+
+            let resp = block_on(copr.handle_unary_request(config, handler_builder)).unwrap();
+            assert_eq!(resp.get_data().len(), 0);
+            assert!(!resp.get_other_error().is_empty());
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>


### What problem does this PR solve?

Issue Number: close #10852 

Problem Summary:

[`get_exec_details`](https://github.com/tikv/tikv/blob/19e4d00ad7965681b5139cd71c7eaf8290cc22ce/src/coprocessor/tracker.rs#L185-L192) expects to poll the tracked future at least once, or it will panic.

### What is changed and how it works?

What's Changed:

Poll the tracked future at least once.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```