### PR TITLE
coprocessor: reduce the slow log count by changing the req_lifetime to total_process_time

### DIFF
--- a/components/tikv_util/src/logger/mod.rs
+++ b/components/tikv_util/src/logger/mod.rs
@@ -31,7 +31,7 @@ pub const DATETIME_ROTATE_SUFFIX: &str = "%Y-%m-%d-%H:%M:%S%.f";
 const SLOG_CHANNEL_SIZE: usize = 10240;
 // Default is DropAndReport.
 // It is not desirable to have dropped logs in our use case.
-const SLOG_CHANNEL_OVERFLOW_STRATEGY: OverflowStrategy = OverflowStrategy::Block;
+const SLOG_CHANNEL_OVERFLOW_STRATEGY: OverflowStrategy = OverflowStrategy::Drop;
 const TIMESTAMP_FORMAT: &str = "%Y/%m/%d %H:%M:%S%.3f %:z";
 
 static LOG_LEVEL: AtomicUsize = AtomicUsize::new(usize::max_value());

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -246,7 +246,7 @@ impl Tracker {
 
         let total_storage_stats = std::mem::take(&mut self.total_storage_stats);
 
-        if self.req_lifetime > self.slow_log_threshold {
+        if self.total_process_time > self.slow_log_threshold {
             let first_range = self.req_ctx.ranges.first();
             let some_table_id = first_range.as_ref().map(|range| {
                 tidb_query_datatype::codec::table::decode_table_id(range.get_start())


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

#10841 *:Logger thread can be bottleneck and slow down the whole TiKV instance 

Problem Summary:

### What is changed and how it works?

Proposal: #10841

What's Changed:

### Related changes

- Need to cherry-pick to the release branch
release-3.0
release-3.1
release-4.0
release-5.0
release-5.1
release-5.2

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Slow log will only consider time spent on processing the request. 
- Drop log instead of blocking threads when slogger thread is overloaded and queue is filled up. 

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
- TiKV coprocessor slow log will only consider time spent on processing the request. 
- Drop log instead of blocking threads when slogger thread is overloaded and queue is filled up. 
```