### PR TITLE
coprocessor: Prevent reloading from unloaded plugins

### DIFF
--- a/src/coprocessor_v2/plugin_registry.rs
+++ b/src/coprocessor_v2/plugin_registry.rs
@@ -279,7 +279,7 @@ struct PluginRegistryInner {
     /// Provides a mapping from the plugin's name to the actual instance.
     loaded_plugins: HashMap<String, (OsString, Arc<LoadedPlugin>)>,
 
-    /// Paths of loaded *and* unloaded plugins.
+    /// Original paths that plugins loaded from.
     /// Files in this list should not be loaded again.
     library_paths: HashSet<OsString>,
 }

--- a/src/coprocessor_v2/plugin_registry.rs
+++ b/src/coprocessor_v2/plugin_registry.rs
@@ -584,7 +584,7 @@ mod tests {
         // fs watcher detects changes in every 3 seconds, therefore, wait 4 seconds so as to make sure the watcher is triggered.
         std::thread::sleep(Duration::from_secs(4));
 
-        // plugin will not unloading
+        // plugin will not be unloadad
         assert!(registry.get_plugin(plugin_name).is_some());
     }
 }

--- a/src/coprocessor_v2/plugin_registry.rs
+++ b/src/coprocessor_v2/plugin_registry.rs
@@ -580,11 +580,11 @@ mod tests {
             &library_path_2
         );
 
-        // trigger unloading
         std::fs::remove_file(&library_path_2).unwrap();
         // fs watcher detects changes in every 3 seconds, therefore, wait 4 seconds so as to make sure the watcher is triggered.
         std::thread::sleep(Duration::from_secs(4));
 
-        assert!(registry.get_plugin(plugin_name).is_none());
+        // plugin will not unloading
+        assert!(registry.get_plugin(plugin_name).is_some());
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #10854 <!-- REMOVE this line if no issue to close -->

Problem Summary:

It solves the coprocessor hot reloading correctness issue by simply forbid reloading.

### What is changed and how it works?

What's Changed:

It [turns out](https://github.com/andylokandy/rfcs/blob/plugin/text/0063-coprocessor-plugin.md#auto-loading-1) that due to TLS related problems, the coprocessor plugin cannot hot reload correctly. The original plan is to prevent deletion and modification of the loaded plugin using file locks. But that's not possible because there's no reliable way to acquire a mandatory file lock. To solve this problem, this PR simply ~~unloads the  plugin whenever it removed or changed, and forbid future reloading from the same path~~ forbid unloading from loaded plugins regardless of file status.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
<!-- - Manual test (add detailed scripts or steps below)-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
