### PR TITLE
raftstore: continue GC snapshot files when it encounters a corrupted snapshot (#10831)

### DIFF
--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1239,6 +1239,11 @@ impl SnapManager {
         let _lock = self.core.registry.rl();
         let base = &self.core.base;
         let s = Snapshot::new(base, key, is_sending, CheckPolicy::None, &self.core)?;
+        fail_point!(
+            "get_snapshot_for_gc",
+            key.region_id == 2 && key.idx == 1,
+            |_| { Err(box_err!("invalid cf number of snapshot meta")) }
+        );
         Ok(Box::new(s))
     }
 

--- a/tests/failpoints/cases/test_snap.rs
+++ b/tests/failpoints/cases/test_snap.rs
@@ -7,8 +7,14 @@ use std::{fs, io, mem, thread};
 
 use fail;
 use raft::eraftpb::MessageType;
+<<<<<<< HEAD
 
 use raftstore::store::*;
+=======
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::PathBuf;
+>>>>>>> 56b3ae673... raftstore: continue GC  snapshot files when it encounters a corrupted snapshot (#10831)
 use test_raftstore::*;
 use tikv_util::config::*;
 use tikv_util::time::Instant;
@@ -470,3 +476,168 @@ fn test_receive_old_snapshot() {
 
     fail::remove(peer_2_handle_snap_mgr_gc_fp);
 }
+<<<<<<< HEAD
+=======
+
+/// Test if snapshot can be genereated when there is a ready with no newly
+/// committed entries.
+/// The failpoint `before_no_ready_gen_snap_task` is used for skipping
+/// the code path that snapshot is generated when there is no ready.
+#[test]
+fn test_gen_snapshot_with_no_committed_entries_ready() {
+    let mut cluster = new_node_cluster(0, 3);
+    configure_for_snapshot(&mut cluster);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+    let on_raft_gc_log_tick_fp = "on_raft_gc_log_tick";
+    fail::cfg(on_raft_gc_log_tick_fp, "return()").unwrap();
+
+    let before_no_ready_gen_snap_task_fp = "before_no_ready_gen_snap_task";
+    fail::cfg(before_no_ready_gen_snap_task_fp, "return()").unwrap();
+
+    cluster.run();
+
+    cluster.add_send_filter(IsolationFilterFactory::new(3));
+
+    for i in 1..10 {
+        cluster.must_put(format!("k{}", i).as_bytes(), b"v1");
+    }
+
+    fail::remove(on_raft_gc_log_tick_fp);
+    sleep_ms(100);
+
+    cluster.clear_send_filters();
+    // Snapshot should be generated and sent after leader 1 receives the heartbeat
+    // response from peer 3.
+    must_get_equal(&cluster.get_engine(3), b"k9", b"v1");
+}
+
+// Test snapshot generating can be canceled by Raft log GC correctly. It does
+// 1. pause snapshot generating with a failpoint, and then add a new peer;
+// 2. append more Raft logs to the region to trigger raft log compactions;
+// 3. disable the failpoint to continue snapshot generating;
+// 4. the generated snapshot should have a larger index than the latest `truncated_idx`.
+#[test]
+fn test_cancel_snapshot_generating() {
+    let mut cluster = new_node_cluster(0, 5);
+    cluster.cfg.raft_store.snap_mgr_gc_tick_interval = ReadableDuration(Duration::from_secs(100));
+    cluster.cfg.raft_store.raft_log_gc_tick_interval = ReadableDuration::millis(10);
+    cluster.cfg.raft_store.raft_log_gc_count_limit = 10;
+    cluster.cfg.raft_store.merge_max_log_gap = 5;
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    pd_client.disable_default_operator();
+    let rid = cluster.run_conf_change();
+    let snap_dir = cluster.get_snap_dir(1);
+
+    pd_client.must_add_peer(rid, new_peer(2, 2));
+    cluster.must_put(b"k0", b"v0");
+    must_get_equal(&cluster.get_engine(2), b"k0", b"v0");
+    pd_client.must_add_peer(rid, new_peer(3, 3));
+    cluster.must_put(b"k1", b"v1");
+    must_get_equal(&cluster.get_engine(3), b"k1", b"v1");
+
+    // Remove snapshot files generated for initial configuration changes.
+    for entry in fs::read_dir(&snap_dir).unwrap() {
+        let entry = entry.unwrap();
+        fs::remove_file(entry.path()).unwrap();
+    }
+
+    fail::cfg("before_region_gen_snap", "pause").unwrap();
+    pd_client.must_add_peer(rid, new_learner_peer(4, 4));
+
+    // Snapshot generatings will be canceled by raft log GC.
+    let mut truncated_idx = cluster.truncated_state(rid, 1).get_index();
+    truncated_idx += 20;
+    (0..20).for_each(|_| cluster.must_put(b"kk", b"vv"));
+    cluster.wait_log_truncated(rid, 1, truncated_idx);
+
+    fail::cfg("before_region_gen_snap", "off").unwrap();
+    // Wait for all snapshot generating tasks are consumed.
+    thread::sleep(Duration::from_millis(100));
+
+    // New generated snapshot files should have a larger index than truncated index.
+    for entry in fs::read_dir(&snap_dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let file_name = path.file_name().unwrap().to_str().unwrap();
+        if !file_name.ends_with(".meta") {
+            continue;
+        }
+        let parts: Vec<_> = file_name[0..file_name.len() - 5].split('_').collect();
+        let snap_index = parts[3].parse::<u64>().unwrap();
+        assert!(snap_index > truncated_idx);
+    }
+}
+
+#[test]
+fn test_snapshot_gc_after_failed() {
+    let mut cluster = new_server_cluster(0, 3);
+    configure_for_snapshot(&mut cluster);
+    cluster.cfg.raft_store.snap_gc_timeout = ReadableDuration::millis(300);
+
+    let pd_client = Arc::clone(&cluster.pd_client);
+    // Disable default max peer count check.
+    pd_client.disable_default_operator();
+    let r1 = cluster.run_conf_change();
+    cluster.must_put(b"k1", b"v1");
+    pd_client.must_add_peer(r1, new_peer(2, 2));
+    must_get_equal(&cluster.get_engine(2), b"k1", b"v1");
+    pd_client.must_add_peer(r1, new_peer(3, 3));
+    let snap_dir = cluster.get_snap_dir(3);
+    fail::cfg("get_snapshot_for_gc", "return(0)").unwrap();
+    for idx in 1..3 {
+        // idx 1 will fail in fail_point("get_snapshot_for_gc"), but idx 2 will succeed
+        for suffix in &[".meta", "_default.sst"] {
+            let f = format!("gen_{}_{}_{}{}", 2, 6, idx, suffix);
+            let mut snap_file_path = PathBuf::from(&snap_dir);
+            snap_file_path.push(&f);
+            let snap_file_path = snap_file_path.as_path();
+            let mut file = match File::create(&snap_file_path) {
+                Err(why) => panic!("couldn't create {:?}: {}", snap_file_path, why),
+                Ok(file) => file,
+            };
+
+            // write any data, in fact we don't check snapshot file corrupted or not in GC;
+            if let Err(why) = file.write_all(b"some bytes") {
+                panic!("couldn't write to {:?}: {}", snap_file_path, why)
+            }
+        }
+    }
+    let now = Instant::now();
+    loop {
+        let snap_keys = cluster.get_snap_mgr(3).list_idle_snap().unwrap();
+        if snap_keys.is_empty() {
+            panic!("no snapshot file is found");
+        }
+
+        let mut found_unexpected_file = false;
+        let mut found_expected_file = false;
+        for (snap_key, _is_sending) in snap_keys {
+            if snap_key.region_id == 2 && snap_key.idx == 1 {
+                found_expected_file = true;
+            }
+            if snap_key.idx == 2 && snap_key.region_id == 2 {
+                if now.saturating_elapsed() > Duration::from_secs(10) {
+                    panic!("unexpected snapshot file found. {:?}", snap_key);
+                }
+                found_unexpected_file = true;
+                break;
+            }
+        }
+
+        if !found_expected_file {
+            panic!("The expected snapshot file is not found");
+        }
+
+        if !found_unexpected_file {
+            break;
+        }
+
+        sleep_ms(400);
+    }
+    fail::cfg("get_snapshot_for_gc", "off").unwrap();
+    cluster.sim.wl().clear_recv_filters(3);
+}
+>>>>>>> 56b3ae673... raftstore: continue GC  snapshot files when it encounters a corrupted snapshot (#10831)


### PR DESCRIPTION
cherry-pick[ #10831 ](https://github.com/tikv/tikv/pull/10831)to release-4.0

What problem does this PR solve?

Issue Number: close #10813

Problem Summary:

What is changed and how it works?

When snapshot GC runs into problem (such as file corrupted), today it stopped processing other GC-able snapshot files.
This PR will make it continue processing rest of the snapshot files.

Related changes

Tests

Unit test
Side effects
No.

Release note

RaftStore Snapshot GC fix: fix the issue that snapshot GC missed GC snapshot files when there's one snapshot file failed to be GC-ed. 
/cc @BusyJay

