### PR TITLE
copr:sub_date_and_string

### DIFF
--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -470,6 +470,33 @@ pub fn sub_duration_and_string(
     Ok(Some(res))
 }
 
+#[inline]
+#[rpn_fn(capture = [ctx])]
+pub fn sub_date_and_string(
+    ctx: &mut EvalContext,
+    arg0: &DateTime,
+    arg1: BytesRef,
+) -> Result<Option<DateTime>> {
+    let arg1 = std::str::from_utf8(arg1).map_err(Error::Encoding)?;
+    let arg1 = match Duration::parse(ctx, arg1, MAX_FSP) {
+        Ok(arg) => arg,
+        Err(_) => return Ok(None),
+    };
+    let mut res = match arg0.checked_sub(ctx, arg1) {
+        Some(res) => res,
+        None => {
+            return ctx
+                .handle_invalid_time_error(Error::overflow(
+                    "DATE",
+                    format!("({} - {})", arg0, arg1),
+                ))
+                .map(|_| Ok(None))?;
+        }
+    };
+    res.set_time_type(TimeType::Date)?;
+    Ok(Some(res))
+}
+
 #[rpn_fn(capture = [ctx])]
 #[inline]
 pub fn from_days(ctx: &mut EvalContext, arg: &Int) -> Result<Option<DateTime>> {
@@ -2307,6 +2334,50 @@ mod tests {
                 .evaluate::<Duration>(ScalarFuncSig::DurationDurationTimeDiff)
                 .unwrap();
             assert_eq!(output, expected, "got {}", output.unwrap().to_string());
+        }
+    }
+
+    #[test]
+    fn test_sub_date_and_string() {
+        let mut ctx = EvalContext::default();
+        let cases = vec![
+            (Some("2021-03-26"), Some("00:00:00"), Some("2021-03-26")),
+            (Some("2021-03-26"), Some("23:59:59"), Some("2021-03-25")),
+            (Some("2021-03-27"), Some("24:00:01"), Some("2021-03-25")),
+            (Some("2021-03-28"), Some("48:00:01"), Some("2021-03-25")),
+            (Some("2021-03-26"), Some("-00:01:00"), Some("2021-03-26")),
+            (
+                Some("2021-03-26 00:00:30"),
+                Some("-00:01:00"),
+                Some("2021-03-26"),
+            ),
+            (
+                Some("2022-12-31 23:00:00"),
+                Some("1 01:30:30"),
+                Some("2022-12-30"),
+            ),
+            (
+                Some("2021-03-26"),
+                Some("00:00:00.123456"),
+                Some("2021-03-25"),
+            ),
+            // null cases
+            (None, None, None),
+            (None, Some("11:30:45.123456"), None),
+            (Some("2019-01-01 01:00:00"), None, None),
+        ];
+        for (arg0, arg1, exp) in cases {
+            let exp = exp.map(|exp| Time::parse_datetime(&mut ctx, exp, MAX_FSP, true).unwrap());
+            let arg0 =
+                arg0.map(|arg0| Time::parse_datetime(&mut ctx, arg0, MAX_FSP, true).unwrap());
+            let arg1 = arg1.map(|arg1| arg1.as_bytes().to_vec());
+
+            let output = RpnFnScalarEvaluator::new()
+                .push_param(arg0)
+                .push_param(arg1)
+                .evaluate(ScalarFuncSig::SubDateAndString);
+            let output = output.unwrap();
+            assert_eq!(output, exp);
         }
     }
 }

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -702,6 +702,7 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::SubDurationAndString => sub_duration_and_string_fn_meta(),
         ScalarFuncSig::MakeTime => make_time_fn_meta(),
         ScalarFuncSig::DurationDurationTimeDiff => duration_duration_time_diff_fn_meta(),
+        ScalarFuncSig::SubDateAndString => sub_date_and_string_fn_meta(),
         _ => return Err(other_err!(
             "ScalarFunction {:?} is not supported in batch mode",
             value

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -443,11 +443,11 @@
 # consistency-check-method = "mvcc"
 
 [coprocessor-v2]
-## Path to the directory where compiled coprocessor plugins are located.
-## Plugins in this directory will be automatically loaded by TiKV.
-## If a coprocessor plugin file is deleted, it will be automatically unloaded.
-## If the config value is not set, hot-reloading will be disabled.
+# Path to the directory where compiled coprocessor plugins are located.
+# Plugins in this directory will be automatically loaded by TiKV.
+# If the config value is not set, the coprocessor plugin will be disabled.
 # coprocessor-plugin-directory = "./coprocessors"
+
 
 [rocksdb]
 ## Maximum number of threads of RocksDB background jobs.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -443,11 +443,11 @@
 # consistency-check-method = "mvcc"
 
 [coprocessor-v2]
-# Path to the directory where compiled coprocessor plugins are located.
-# Plugins in this directory will be automatically loaded by TiKV.
-# If the config value is not set, the coprocessor plugin will be disabled.
+## Path to the directory where compiled coprocessor plugins are located.
+## Plugins in this directory will be automatically loaded by TiKV.
+## If a coprocessor plugin file is deleted, it will be automatically unloaded.
+## If the config value is not set, hot-reloading will be disabled.
 # coprocessor-plugin-directory = "./coprocessors"
-
 
 [rocksdb]
 ## Maximum number of threads of RocksDB background jobs.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: fix #9016

Problem Summary:

### What is changed and how it works?

What's Changed:add push-down & test for sub_date_and_string

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
```