### PR TITLE
Add tikv_channel_full metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,8 @@ dependencies = [
  "crossbeam",
  "derive_more",
  "file_system",
+ "lazy_static",
+ "prometheus",
  "serde",
  "serde_derive",
  "slog",

--- a/components/batch-system/Cargo.toml
+++ b/components/batch-system/Cargo.toml
@@ -26,6 +26,8 @@ serde_derive = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 derive_more = { version = "0.99", optional = true }
+prometheus = { version = "0.12", default-features = false, features = ["nightly"] }
+lazy_static = "1.3"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/components/batch-system/src/lib.rs
+++ b/components/batch-system/src/lib.rs
@@ -4,6 +4,7 @@ mod batch;
 mod config;
 mod fsm;
 mod mailbox;
+mod metrics;
 mod router;
 
 #[cfg(feature = "test-runner")]

--- a/components/batch-system/src/metrics.rs
+++ b/components/batch-system/src/metrics.rs
@@ -1,0 +1,13 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use lazy_static::lazy_static;
+use prometheus::*;
+
+lazy_static! {
+    pub static ref CHANNEL_FULL_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
+        "tikv_channel_full_total",
+        "Total number of channel full errors.",
+        &["type"]
+    )
+    .unwrap();
+}

--- a/components/batch-system/src/router.rs
+++ b/components/batch-system/src/router.rs
@@ -2,6 +2,7 @@
 
 use crate::fsm::{Fsm, FsmScheduler, FsmState};
 use crate::mailbox::{BasicMailbox, Mailbox};
+use crate::metrics::CHANNEL_FULL_COUNTER_VEC;
 use collections::HashMap;
 use crossbeam::channel::{SendError, TrySendError};
 use std::cell::Cell;
@@ -211,7 +212,9 @@ where
             match mailbox.try_send(m, &self.normal_scheduler) {
                 Ok(()) => Some(Ok(())),
                 r @ Err(TrySendError::Full(_)) => {
-                    // TODO: report channel full
+                    CHANNEL_FULL_COUNTER_VEC
+                        .with_label_values(&["normal"])
+                        .inc();
                     Some(r)
                 }
                 Err(TrySendError::Disconnected(m)) => {
@@ -265,7 +268,9 @@ where
         match self.control_box.try_send(msg, &self.control_scheduler) {
             Ok(()) => Ok(()),
             r @ Err(TrySendError::Full(_)) => {
-                // TODO: record metrics.
+                CHANNEL_FULL_COUNTER_VEC
+                    .with_label_values(&["control"])
+                    .inc();
                 r
             }
             r => r,


### PR DESCRIPTION
Signed-off-by: sampras lopes <sampraslop995@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #10377

Problem Summary:

### What is changed and how it works?

What's Changed:
- Add `tikv_channel_full` metric for monitoring channel full events

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test

Monitor the `tikv_channel_full_total` metric on grafana

Side effects
No

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```