### PR TITLE
import: fix upgrade bug for import_file 

### DIFF
--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -356,7 +356,7 @@ pub fn path_to_sst_meta<P: AsRef<Path>>(path: P) -> Result<SstMeta> {
         return Err(Error::InvalidSSTPath(path.to_owned()));
     }
     let elems: Vec<_> = file_name.trim_end_matches(SST_SUFFIX).split('_').collect();
-    if elems.len() != 5 {
+    if elems.len() < 4 {
         return Err(Error::InvalidSSTPath(path.to_owned()));
     }
 
@@ -366,7 +366,9 @@ pub fn path_to_sst_meta<P: AsRef<Path>>(path: P) -> Result<SstMeta> {
     meta.set_region_id(elems[1].parse()?);
     meta.mut_region_epoch().set_conf_ver(elems[2].parse()?);
     meta.mut_region_epoch().set_version(elems[3].parse()?);
-    meta.set_cf_name(elems[4].to_owned());
+    if elems.len() > 4 {
+        meta.set_cf_name(elems[4].to_owned());
+    }
     Ok(meta)
 }
 
@@ -390,6 +392,27 @@ mod test {
         assert_eq!(path.to_str().unwrap(), &expected_path);
 
         let new_meta = path_to_sst_meta(path).unwrap();
+        assert_eq!(meta, new_meta);
+    }
+
+    #[test]
+    fn test_path_to_sst_meta() {
+        let importer_dir = tempfile::tempdir().unwrap();
+        let uuid = Uuid::new_v4();
+        let mut meta = SstMeta::default();
+        meta.set_uuid(uuid.as_bytes().to_vec());
+        meta.set_region_id(1);
+        meta.mut_region_epoch().set_conf_ver(222);
+        meta.mut_region_epoch().set_version(333);
+        let path = PathBuf::from(format!(
+            "{}_{}_{}_{}{}",
+            UuidBuilder::from_slice(meta.get_uuid()).unwrap().build(),
+            meta.get_region_id(),
+            meta.get_region_epoch().get_conf_ver(),
+            meta.get_region_epoch().get_version(),
+            SST_SUFFIX,
+        ));
+        let new_meta = path_to_sst_meta(&path).unwrap();
         assert_eq!(meta, new_meta);
     }
 }

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -397,7 +397,6 @@ mod test {
 
     #[test]
     fn test_path_to_sst_meta() {
-        let importer_dir = tempfile::tempdir().unwrap();
         let uuid = Uuid::new_v4();
         let mut meta = SstMeta::default();
         meta.set_uuid(uuid.as_bytes().to_vec());

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -367,6 +367,8 @@ pub fn path_to_sst_meta<P: AsRef<Path>>(path: P) -> Result<SstMeta> {
     meta.mut_region_epoch().set_conf_ver(elems[2].parse()?);
     meta.mut_region_epoch().set_version(elems[3].parse()?);
     if elems.len() > 4 {
+        // If we upgrade TiKV from 3.0.x to 4.0.x and higher version, we can not read cf_name from
+        // the file path, because TiKV 3.0.x does not encode cf_name to path.
         meta.set_cf_name(elems[4].to_owned());
     }
     Ok(meta)


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/10902

Problem Summary:


### What is changed and how it works?

Do not return error when found the file path is in 3.0 format

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```