### PR TITLE
tikv-ctl: allow get_all_regions from remote, drop-unapplied-raftlog (…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-5.0#7790f94ac2ad2a1141fc63089e335135e79d1961"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-5.0#7d7377864e93be88508a52cae3b3f9a6f4137f57"
 dependencies = [
  "futures 0.3.8",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-5.0#7d7377864e93be88508a52cae3b3f9a6f4137f57"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-5.0-20210906#1b9b1a231378ef66b2c6be9a1b9a7f6996d0f5fd"
 dependencies = [
  "futures 0.3.8",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,12 @@ rusoto_sts = { git = "https://github.com/tikv/rusoto", branch = "gh1482-s3-addr-
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "5125fc1a69496b73b26b3c08b6e8afc3c665a56e" }
 
+# When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
+# kvproto at the same time.
+# After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
+# [patch.'https://github.com/pingcap/kvproto']
+# kvproto = {git = "https://github.com/your_github_id/kvproto", branch="your_branch"}
+
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md
 # Without resolver = 2, using `cargo build --features x` to build `cmd`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ hyper-openssl = "0.8"
 http = "0"
 into_other = { path = "components/into_other", default-features = false }
 keys = { path = "components/keys", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 lazy_static = "1.3"
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -16,55 +16,55 @@ sse = ["tikv/sse"]
 mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
 bcc-iosnoop = ["tikv/bcc-iosnoop"]
-cloud-aws = [ "encryption_export/cloud-aws" ]
-cloud-gcp = [ "encryption_export/cloud-gcp" ]
+cloud-aws = ["encryption_export/cloud-aws"]
+cloud-gcp = ["encryption_export/cloud-gcp"]
 protobuf-codec = [
-  "backup/protobuf-codec",
-  "cdc/protobuf-codec",
-  "concurrency_manager/protobuf-codec",
-  "encryption_export/protobuf-codec",
-  "engine_rocks/protobuf-codec",
-  "engine_traits/protobuf-codec",
-  "error_code/protobuf-codec",
-  "grpcio/protobuf-codec",
-  "keys/protobuf-codec",
-  "kvproto/protobuf-codec",
-  "pd_client/protobuf-codec",
-  "raft/protobuf-codec",
-  "raftstore/protobuf-codec",
-  "raft_log_engine/protobuf-codec",
-  "security/protobuf-codec",
-  "tikv/protobuf-codec",
-  "tikv_util/protobuf-codec",
-  "txn_types/protobuf-codec",
-  "file_system/protobuf-codec",
+    "backup/protobuf-codec",
+    "cdc/protobuf-codec",
+    "concurrency_manager/protobuf-codec",
+    "encryption_export/protobuf-codec",
+    "engine_rocks/protobuf-codec",
+    "engine_traits/protobuf-codec",
+    "error_code/protobuf-codec",
+    "grpcio/protobuf-codec",
+    "keys/protobuf-codec",
+    "kvproto/protobuf-codec",
+    "pd_client/protobuf-codec",
+    "raft/protobuf-codec",
+    "raftstore/protobuf-codec",
+    "raft_log_engine/protobuf-codec",
+    "security/protobuf-codec",
+    "tikv/protobuf-codec",
+    "tikv_util/protobuf-codec",
+    "txn_types/protobuf-codec",
+    "file_system/protobuf-codec",
 ]
 prost-codec = [
-  "backup/prost-codec",
-  "cdc/prost-codec",
-  "concurrency_manager/prost-codec",
-  "encryption_export/prost-codec",
-  "engine_rocks/prost-codec",
-  "engine_traits/prost-codec",
-  "error_code/prost-codec",
-  "grpcio/prost-codec",
-  "keys/prost-codec",
-  "kvproto/prost-codec",
-  "pd_client/prost-codec",
-  "raft/prost-codec",
-  "raftstore/prost-codec",
-  "raft_log_engine/prost-codec",
-  "security/prost-codec",
-  "tikv/prost-codec",
-  "tikv_util/prost-codec",
-  "txn_types/prost-codec",
-  "file_system/prost-codec",
+    "backup/prost-codec",
+    "cdc/prost-codec",
+    "concurrency_manager/prost-codec",
+    "encryption_export/prost-codec",
+    "engine_rocks/prost-codec",
+    "engine_traits/prost-codec",
+    "error_code/prost-codec",
+    "grpcio/prost-codec",
+    "keys/prost-codec",
+    "kvproto/prost-codec",
+    "pd_client/prost-codec",
+    "raft/prost-codec",
+    "raftstore/prost-codec",
+    "raft_log_engine/prost-codec",
+    "security/prost-codec",
+    "tikv/prost-codec",
+    "tikv_util/prost-codec",
+    "txn_types/prost-codec",
+    "file_system/prost-codec",
 ]
 test-engines-rocksdb = [
-  "tikv/test-engines-rocksdb",
+    "tikv/test-engines-rocksdb",
 ]
 test-engines-panic = [
-  "tikv/test-engines-panic",
+    "tikv/test-engines-panic",
 ]
 
 [lib]
@@ -92,7 +92,7 @@ file_system = { path = "../components/file_system", default-features = false }
 fs2 = "0.4"
 futures = "0.3"
 tokio = { version = "0.2", features = ["rt-threaded", "time"] }
-grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
+grpcio = { version = "0.8", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../components/keys", default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -95,7 +95,7 @@ tokio = { version = "0.2", features = ["rt-threaded", "time"] }
 grpcio = { version = "0.8", default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../components/keys", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../components/log_wrappers" }

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -73,7 +73,7 @@ futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
 keys = { path = "../keys", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 pd_client = { path = "../pd_client", default-features = false }

--- a/components/cdc/Cargo.toml
+++ b/components/cdc/Cargo.toml
@@ -58,7 +58,7 @@ engine_traits = { path = "../engine_traits", default-features = false }
 failure = "0.1"
 futures = "0.3"
 grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 raftstore = { path = "../raftstore", default-features = false }

--- a/components/cloud/Cargo.toml
+++ b/components/cloud/Cargo.toml
@@ -19,7 +19,7 @@ derive_more = "0.99.3"
 error_code = { path = "../error_code", default-features = false }
 failure = "0.1"
 futures-io = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 rusoto_core = "0.45.0"

--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -28,7 +28,7 @@ grpcio = { version = "0.8",  default-features = false, features = ["openssl-vend
 http = "0.2.0"
 hyper = "0.13.3"
 hyper-tls = "0.4.1"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 rusoto_core = "0.45.0"
 rusoto_credential = "0.45.0"
 rusoto_kms = { version = "0.45.0", features = ["serialize_structs"] }

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = "1.3"
 prometheus = { version = "0.10", features = ["nightly"] }
 futures-util = { version = "0.3", default-features = false, features = ["std", "io"] }
 hex = "0.4.2"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 rand = "0.7"

--- a/components/encryption/export/Cargo.toml
+++ b/components/encryption/export/Cargo.toml
@@ -33,7 +33,7 @@ derive_more = "0.99.3"
 encryption = { path = "../", default-features = false }
 error_code = { path = "../../error_code", default-features = false }
 file_system = { path = "../../file_system", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 openssl = "0.10"
 protobuf = "2.8"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/components/engine_panic/Cargo.toml
+++ b/components/engine_panic/Cargo.toml
@@ -28,5 +28,5 @@ tikv_alloc = { path = "../tikv_alloc" }
 # FIXME: Remove this dep from the engine_traits interface
 tikv_util = { path = "../tikv_util", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 txn_types = { path = "../txn_types", default-features = false }

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -64,7 +64,7 @@ configuration = { path = "../configuration" }
 tempfile = "3.0"
 serde = "1.0"
 serde_derive = "1.0"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 protobuf = "2"
 fail = "0.4"
@@ -76,6 +76,6 @@ branch = "tikv-5.0"
 features = ["encryption", "static_libcpp"]
 
 [dev-dependencies]
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 rand = "0.7"
 toml = "0.5"

--- a/components/engine_traits/Cargo.toml
+++ b/components/engine_traits/Cargo.toml
@@ -35,7 +35,7 @@ txn_types = { path = "../txn_types", default-features = false }
 serde = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 
 [dev-dependencies]

--- a/components/engine_traits/src/misc.rs
+++ b/components/engine_traits/src/misc.rs
@@ -11,10 +11,17 @@ use crate::range::Range;
 
 #[derive(Clone, Debug)]
 pub enum DeleteStrategy {
+    /// Delete the SST files that are fullly fit in range. However, the SST files that are partially
+    /// overlapped with the range will not be touched.
     DeleteFiles,
+    /// Delete the data stored in Titan.
     DeleteBlobs,
+    /// Scan for keys and then delete. Useful when we know the keys in range are not too many.
     DeleteByKey,
+    /// Delete by range. Note that this is experimental and you should check whether it is enbaled
+    /// in config before using it.
     DeleteByRange,
+    /// Delete by ingesting a SST file with deletions. Useful when the number of ranges is too many.
     DeleteByWriter { sst_path: String },
 }
 

--- a/components/error_code/Cargo.toml
+++ b/components/error_code/Cargo.toml
@@ -26,7 +26,7 @@ path = "bin.rs"
 [dependencies]
 lazy_static = "1.3"
 raft = { version = "0.6.0-alpha", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 tikv_alloc = { path = "../tikv_alloc" }
 grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
 toml = "0.5"

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -28,7 +28,7 @@ grpcio = { version = "0.8",  default-features = false, features = ["openssl-vend
 http = "0.2.0"
 hyper = "0.13.3"
 hyper-tls = "0.4.1"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 lazy_static = "1.3"
 prometheus = { version = "0.10", default-features = false, features = ["nightly", "push"] }
 rand = "0.7"

--- a/components/into_other/Cargo.toml
+++ b/components/into_other/Cargo.toml
@@ -19,5 +19,5 @@ prost-codec = [
 
 [dependencies]
 engine_traits = { path = "../engine_traits", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }

--- a/components/keys/Cargo.toml
+++ b/components/keys/Cargo.toml
@@ -19,7 +19,7 @@ prost-codec = [
 byteorder = "1.2"
 derive_more = "0.99.3"
 failure = "0.1"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 tikv_alloc = { path = "../tikv_alloc" }
 tikv_util = { path = "../tikv_util", default-features = false }

--- a/components/pd_client/Cargo.toml
+++ b/components/pd_client/Cargo.toml
@@ -28,7 +28,7 @@ failpoints = ["fail/failpoints"]
 error_code = { path = "../error_code", default-features = false }
 futures = "0.3"
 grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/raft_log_engine/Cargo.toml
+++ b/components/raft_log_engine/Cargo.toml
@@ -31,7 +31,7 @@ time = "0.1"
 configuration = { path = "../configuration" }
 serde = "1.0"
 serde_derive = "1.0"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 raft-engine = { git = "https://github.com/tikv/raft-engine", branch = "master" }
 protobuf = "2"

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -71,7 +71,7 @@ futures = "0.3"
 futures-util = { version = "0.3.1", default-features = false, features = ["io"] }
 into_other = { path = "../into_other",  default-features = false }
 keys = { path = "../keys", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 log_wrappers = { path = "../log_wrappers" }

--- a/components/raftstore/src/store/worker/region.rs
+++ b/components/raftstore/src/store/worker/region.rs
@@ -550,6 +550,7 @@ where
 
     fn delete_all_in_range(&self, ranges: &[Range]) -> Result<()> {
         for cf in self.engine.cf_names() {
+            // CF_LOCK usually contains fewer keys than other CFs, so we delete them by key.
             let strategy = if cf == CF_LOCK {
                 DeleteStrategy::DeleteByKey
             } else if self.use_delete_range {

--- a/components/resolved_ts/Cargo.toml
+++ b/components/resolved_ts/Cargo.toml
@@ -47,7 +47,7 @@ fail = "0.4"
 futures = "0.3"
 grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
 hex = "0.4"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 log_wrappers = { path = "../log_wrappers" }
 pd_client = { path = "../pd_client", default-features = false }
 prost = "0.7"

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -45,7 +45,7 @@ futures = { version = "0.3", features = ["thread-pool"] }
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
 keys = { path = "../keys", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.10", default-features = false }

--- a/components/test_backup/Cargo.toml
+++ b/components/test_backup/Cargo.toml
@@ -26,7 +26,7 @@ futures = "0.3"
 futures-executor = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 rand = "0.7"
 tempfile = "3.0"
 test_raftstore = { path = "../test_raftstore" }

--- a/components/test_coprocessor/Cargo.toml
+++ b/components/test_coprocessor/Cargo.toml
@@ -40,7 +40,7 @@ test-engines-panic = [
 [dependencies]
 engine_rocks = { path = "../engine_rocks", default-features = false }
 futures = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 protobuf = "2"
 test_storage = { path = "../test_storage", default-features = false }
 tidb_query_datatype = { path = "../tidb_query_datatype", default-features = false }

--- a/components/test_pd/Cargo.toml
+++ b/components/test_pd/Cargo.toml
@@ -25,7 +25,7 @@ prost-codec = [
 fail = "0.4"
 futures = "0.3"
 grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }
 pd_client = { path = "../pd_client", default-features = false }

--- a/components/test_raftstore/Cargo.toml
+++ b/components/test_raftstore/Cargo.toml
@@ -58,7 +58,7 @@ grpcio = { version = "0.8",  default-features = false, features = ["openssl-vend
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 keys = { path = "../keys", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 raft = { version = "0.6.0-alpha", default-features = false }
 raftstore = { path = "../raftstore", default-features = false }

--- a/components/test_sst_importer/Cargo.toml
+++ b/components/test_sst_importer/Cargo.toml
@@ -28,5 +28,5 @@ crc32fast = "1.2"
 engine_rocks = { path = "../engine_rocks", default-features = false }
 engine_traits = { path = "../engine_traits", default-features = false }
 keys = { path = "../keys", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }

--- a/components/test_storage/Cargo.toml
+++ b/components/test_storage/Cargo.toml
@@ -33,7 +33,7 @@ test-engines-panic = [
 
 [dependencies]
 futures = "0.3"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 raftstore = { path = "../raftstore", default-features = false }
 pd_client = { path = "../pd_client", default-features = false }
 test_raftstore = { path = "../test_raftstore", default-features = false }

--- a/components/test_util/Cargo.toml
+++ b/components/test_util/Cargo.toml
@@ -27,7 +27,7 @@ cloud-gcp = [ "encryption_export/cloud-gcp" ]
 encryption_export = { path = "../encryption/export", default-features = false }
 fail = "0.4"
 grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 rand = "0.7"
 rand_isaac = "0.2"
 security = { path = "../security", default-features = false }

--- a/components/tidb_query_common/Cargo.toml
+++ b/components/tidb_query_common/Cargo.toml
@@ -22,7 +22,7 @@ failure = "0.1"
 derive_more = "0.99.3"
 error_code = { path = "../error_code", default-features = false }
 tikv_util = { path = "../tikv_util", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 prometheus = { version = "0.10", features = ["nightly"] }
 prometheus-static-metric = "0.4"
 lazy_static = "1.3"

--- a/components/tidb_query_datatype/Cargo.toml
+++ b/components/tidb_query_datatype/Cargo.toml
@@ -34,7 +34,7 @@ codec = { path = "../codec", default-features = false }
 error_code = { path = "../error_code", default-features = false }
 failure = "0.1"
 hex = "0.4"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 lazy_static = "1.3"
 match_template = { path = "../match_template" }
 nom = { version = "5.1.0", default-features = false, features = ["std"] }

--- a/components/tidb_query_executors/Cargo.toml
+++ b/components/tidb_query_executors/Cargo.toml
@@ -32,7 +32,7 @@ prost-codec = [
 protobuf = "2.8"
 codec = { path = "../codec", default-features = false }
 fail = "0.4"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 match_template = { path = "../match_template" }
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }
 slog-global = { version = "0.1", git = "https://github.com/breeswish/slog-global.git", rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9" }

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -61,7 +61,7 @@ tokio = { version = "0.2", features = ["rt-util", "rt-threaded"] }
 tokio-executor = "0.1"
 tokio-timer = "0.2"
 url = "2"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 minitrace = { git = "https://github.com/pingcap-incubator/minitrace-rust.git", branch = "master" }
 protobuf = "2"
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }

--- a/components/txn_types/Cargo.toml
+++ b/components/txn_types/Cargo.toml
@@ -24,7 +24,7 @@ byteorder = "1.2"
 farmhash = "1.1.5"
 error_code = { path = "../error_code", default-features = false }
 codec = { path = "../codec", default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 slog = "2.3"
 quick-error = "1.2.3"
 tikv_alloc = { path = "../tikv_alloc" }

--- a/scripts/check-redact-log
+++ b/scripts/check-redact-log
@@ -7,12 +7,12 @@ function error_msg() {
 }
 
 if [[ "$(uname)" == "Darwin" ]] ; then
-   if grep -r -n --color=always --include '*.rs' --exclude hex.rs --exclude-dir target 'encode_upper' . | grep -v log_wrappers ; then
+   if grep -r -n --color=always --include '*.rs' --exclude hex.rs --exclude tikv-ctl.rs --exclude-dir target 'encode_upper' . | grep -v log_wrappers ; then
 	error_msg
 	exit 1
    fi
 else
-    if grep -r -n -P '(?<!hex_)encode_upper' -C 1 --color=always --include \*.rs --exclude hex.rs --exclude-dir target . ; then
+    if grep -r -n -P '(?<!hex_)encode_upper' -C 1 --color=always --include \*.rs --exclude hex.rs --exclude tikv-ctl.rs --exclude-dir target . ; then
 	error_msg
         exit 1
      fi

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -11,12 +11,12 @@ use engine_rocks::util::get_cf_handle;
 use engine_rocks::{Compat, RocksEngine, RocksEngineIterator, RocksWriteBatch};
 use engine_traits::{
     Engines, IterOptions, Iterable, Iterator as EngineIterator, Mutable, Peekable, RaftEngine,
-    RangePropertiesExt, SeekKey, TableProperties, TablePropertiesCollection, TablePropertiesExt,
-    WriteBatch, WriteOptions,
+    RangePropertiesExt, SeekKey, SyncMutable, TableProperties, TablePropertiesCollection,
+    TablePropertiesExt, WriteBatch, WriteOptions,
 };
 use engine_traits::{MvccProperties, Range, WriteBatchExt, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 use kvproto::debugpb::{self, Db as DBType};
-use kvproto::metapb::Region;
+use kvproto::metapb::{PeerRole, Region};
 use kvproto::raft_serverpb::*;
 use protobuf::Message;
 use raft::eraftpb::Entry;
@@ -30,7 +30,6 @@ use raftstore::coprocessor::get_region_approximate_middle;
 use raftstore::store::util as raftstore_util;
 use raftstore::store::PeerStorage;
 use raftstore::store::{write_initial_apply_state, write_initial_raft_state, write_peer_state};
-use tikv_util::codec::bytes;
 use tikv_util::config::ReadableSize;
 use tikv_util::keybuilder::KeyBuilder;
 use tikv_util::worker::Worker;
@@ -141,7 +140,7 @@ impl<ER: RaftEngine> Debugger<ER> {
     }
 
     /// Get all regions holding region meta data from raft CF in KV storage.
-    pub fn get_all_meta_regions(&self) -> Result<Vec<u64>> {
+    pub fn get_all_regions_in_store(&self) -> Result<Vec<u64>> {
         let db = &self.engines.kv;
         let cf = CF_RAFT;
         let start_key = keys::REGION_META_MIN_KEY;
@@ -155,6 +154,7 @@ impl<ER: RaftEngine> Debugger<ER> {
             regions.push(id);
             Ok(true)
         }));
+        regions.sort_unstable();
         Ok(regions)
     }
 
@@ -555,6 +555,7 @@ impl<ER: RaftEngine> Debugger<ER> {
         &self,
         store_ids: Vec<u64>,
         region_ids: Option<Vec<u64>>,
+        promote_learner: bool,
     ) -> Result<()> {
         let store_id = self.get_store_id()?;
         if store_ids.iter().any(|&s| s == store_id) {
@@ -582,6 +583,43 @@ impl<ER: RaftEngine> Debugger<ER> {
 
                 let region_id = region_state.get_region().get_id();
                 let old_peers = region_state.mut_region().take_peers();
+
+                if promote_learner {
+                    if new_peers
+                        .iter()
+                        .filter(|peer| peer.get_role() != PeerRole::Learner)
+                        .count()
+                        != 0
+                    {
+                        // no need to promote learner, do nothing
+                    } else if new_peers
+                        .iter()
+                        .filter(|peer| peer.get_role() == PeerRole::Learner)
+                        .count()
+                        > 1
+                    {
+                        error!(
+                            "failed to promote learner due to multiple learners, skip promote learner";
+                            "region_id" => region_id,
+                        )
+                    } else {
+                        for peer in &mut new_peers {
+                            match peer.get_role() {
+                                PeerRole::Voter
+                                | PeerRole::IncomingVoter
+                                | PeerRole::DemotingVoter => {}
+                                PeerRole::Learner => {
+                                    info!(
+                                        "promote learner";
+                                        "region_id" => region_id,
+                                        "peer_id" => peer.get_id(),
+                                    );
+                                    peer.set_role(PeerRole::Voter);
+                                }
+                            }
+                        }
+                    }
+                }
                 info!(
                     "peers changed";
                     "region_id" => region_id,
@@ -619,6 +657,73 @@ impl<ER: RaftEngine> Debugger<ER> {
         let mut write_opts = WriteOptions::new();
         write_opts.set_sync(true);
         box_try!(wb.write_opt(&write_opts));
+        Ok(())
+    }
+
+    pub fn drop_unapplied_raftlog(&self, region_ids: Option<Vec<u64>>) -> Result<()> {
+        let kv = &self.engines.kv;
+        let raft = &self.engines.raft;
+
+        let region_ids = region_ids.unwrap_or(self.get_all_regions_in_store()?);
+        for region_id in region_ids {
+            let region_state = self.region_info(region_id)?;
+
+            // It's safe to unwrap region_local_state here, because get_all_regions_in_store()
+            // guarantees that the region state exists in kvdb.
+            if region_state.region_local_state.unwrap().state == PeerState::Tombstone {
+                continue;
+            }
+
+            let old_raft_local_state = region_state.raft_local_state.ok_or_else(|| {
+                Error::Other(format!("No RaftLocalState found for region {}", region_id).into())
+            })?;
+            let old_raft_apply_state = region_state.raft_apply_state.ok_or_else(|| {
+                Error::Other(format!("No RaftApplyState found for region {}", region_id).into())
+            })?;
+
+            let applied_index = old_raft_apply_state.applied_index;
+            let last_index = old_raft_local_state.last_index;
+
+            let new_raft_local_state = RaftLocalState {
+                last_index: applied_index,
+                ..old_raft_local_state.clone()
+            };
+            let new_raft_apply_state = RaftApplyState {
+                commit_index: applied_index,
+                ..old_raft_apply_state.clone()
+            };
+
+            info!(
+                "dropping unapplied raft log";
+                "region_id" => region_id,
+                "old_raft_local_state" => ?old_raft_local_state,
+                "new_raft_local_state" => ?new_raft_local_state,
+                "old_raft_apply_state" => ?old_raft_apply_state,
+                "new_raft_apply_state" => ?new_raft_apply_state,
+            );
+
+            // flush the changes
+            box_try!(kv.put_msg_cf(
+                CF_RAFT,
+                &keys::apply_state_key(region_id),
+                &new_raft_apply_state
+            ));
+            box_try!(raft.put_raft_state(region_id, &new_raft_local_state));
+            let deleted_logs = box_try!(raft.gc(region_id, applied_index + 1, last_index + 1));
+            raft.sync().unwrap();
+            kv.sync().unwrap();
+
+            info!(
+                "dropped unapplied raft log";
+                "region_id" => region_id,
+                "old_raft_local_state" => ?old_raft_local_state,
+                "new_raft_local_state" => ?new_raft_local_state,
+                "old_raft_apply_state" => ?old_raft_apply_state,
+                "new_raft_apply_state" => ?new_raft_apply_state,
+                "deleted logs" => deleted_logs,
+            );
+        }
+
         Ok(())
     }
 
@@ -748,16 +853,17 @@ impl<ER: RaftEngine> Debugger<ER> {
         let mut res = dump_mvcc_properties(self.engines.kv.as_inner(), &start, &end)?;
 
         let middle_key = match box_try!(get_region_approximate_middle(&self.engines.kv, region)) {
-            Some(data_key) => {
-                let mut key = keys::origin_key(&data_key);
-                box_try!(bytes::decode_bytes(&mut key, false))
-            }
+            Some(data_key) => keys::origin_key(&data_key).to_vec(),
             None => Vec::new(),
         };
 
-        // Middle key of the range.
         res.push((
-            "middle_key_by_approximate_size".to_owned(),
+            "region.start_key".to_owned(),
+            hex::encode(&region.start_key),
+        ));
+        res.push(("region.end_key".to_owned(), hex::encode(&region.end_key)));
+        res.push((
+            "region.middle_key_by_approximate_size".to_owned(),
             hex::encode(&middle_key),
         ));
 
@@ -1220,7 +1326,7 @@ mod tests {
     use std::sync::Arc;
 
     use engine_rocks::raw::{ColumnFamilyOptions, DBOptions};
-    use kvproto::metapb::{Peer, Region};
+    use kvproto::metapb::{Peer, PeerRole, Region};
     use raft::eraftpb::EntryType;
     use tempfile::Builder;
 
@@ -1231,13 +1337,22 @@ mod tests {
     use engine_traits::{Mutable, SyncMutable};
     use engine_traits::{ALL_CFS, CF_DEFAULT, CF_LOCK, CF_RAFT, CF_WRITE};
 
-    fn init_region_state(engine: &Arc<DB>, region_id: u64, stores: &[u64]) -> Region {
+    fn init_region_state(
+        engine: &Arc<DB>,
+        region_id: u64,
+        stores: &[u64],
+        mut learner: usize,
+    ) -> Region {
         let mut region = Region::default();
         region.set_id(region_id);
         for (i, &store_id) in stores.iter().enumerate() {
             let mut peer = Peer::default();
             peer.set_id(i as u64);
             peer.set_store_id(store_id);
+            if learner > 0 {
+                peer.set_role(PeerRole::Learner);
+                learner -= 1;
+            }
             region.mut_peers().push(peer);
         }
         let mut region_state = RegionLocalState::default();
@@ -1246,6 +1361,28 @@ mod tests {
         let key = keys::region_state_key(region_id);
         engine.c().put_msg_cf(CF_RAFT, &key, &region_state).unwrap();
         region
+    }
+
+    fn init_raft_state(
+        kv_engine: &RocksEngine,
+        raft_engine: &RocksEngine,
+        region_id: u64,
+        last_index: u64,
+        commit_index: u64,
+        applied_index: u64,
+    ) {
+        let apply_state_key = keys::apply_state_key(region_id);
+        let mut apply_state = RaftApplyState::default();
+        apply_state.set_applied_index(applied_index);
+        apply_state.set_commit_index(commit_index);
+        kv_engine
+            .put_msg_cf(CF_RAFT, &apply_state_key, &apply_state)
+            .unwrap();
+
+        let raft_state_key = keys::raft_state_key(region_id);
+        let mut raft_state = RaftLocalState::default();
+        raft_state.set_last_index(last_index);
+        raft_engine.put_msg(&raft_state_key, &raft_state).unwrap();
     }
 
     fn get_region_state(engine: &Arc<DB>, region_id: u64) -> RegionLocalState {
@@ -1269,33 +1406,33 @@ mod tests {
         // For normal case.
         assert!(region_overlap(
             &new_region(b"a", b"z"),
-            &new_region(b"b", b"y")
+            &new_region(b"b", b"y"),
         ));
         assert!(region_overlap(
             &new_region(b"a", b"n"),
-            &new_region(b"m", b"z")
+            &new_region(b"m", b"z"),
         ));
         assert!(!region_overlap(
             &new_region(b"a", b"m"),
-            &new_region(b"n", b"z")
+            &new_region(b"n", b"z"),
         ));
 
         // For the first or last region.
         assert!(region_overlap(
             &new_region(b"m", b""),
-            &new_region(b"a", b"n")
+            &new_region(b"a", b"n"),
         ));
         assert!(region_overlap(
             &new_region(b"a", b"n"),
-            &new_region(b"m", b"")
+            &new_region(b"m", b""),
         ));
         assert!(region_overlap(
             &new_region(b"", b""),
-            &new_region(b"m", b"")
+            &new_region(b"m", b""),
         ));
         assert!(!region_overlap(
             &new_region(b"a", b"m"),
-            &new_region(b"n", b"")
+            &new_region(b"n", b""),
         ));
     }
 
@@ -1517,21 +1654,21 @@ mod tests {
         let engine = &debugger.engines.kv;
 
         // region 1 with peers at stores 11, 12, 13.
-        let region_1 = init_region_state(engine.as_inner(), 1, &[11, 12, 13]);
+        let region_1 = init_region_state(engine.as_inner(), 1, &[11, 12, 13], 0);
         // Got the target region from pd, which doesn't contains the store.
         let mut target_region_1 = region_1.clone();
         target_region_1.mut_peers().remove(0);
         target_region_1.mut_region_epoch().set_conf_ver(100);
 
         // region 2 with peers at stores 11, 12, 13.
-        let region_2 = init_region_state(engine.as_inner(), 2, &[11, 12, 13]);
+        let region_2 = init_region_state(engine.as_inner(), 2, &[11, 12, 13], 0);
         // Got the target region from pd, which has different peer_id.
         let mut target_region_2 = region_2.clone();
         target_region_2.mut_peers()[0].set_id(100);
         target_region_2.mut_region_epoch().set_conf_ver(100);
 
         // region 3 with peers at stores 21, 22, 23.
-        let region_3 = init_region_state(engine.as_inner(), 3, &[21, 22, 23]);
+        let region_3 = init_region_state(engine.as_inner(), 3, &[21, 22, 23], 0);
         // Got the target region from pd but the peers are not changed.
         let mut target_region_3 = region_3;
         target_region_3.mut_region_epoch().set_conf_ver(100);
@@ -1575,7 +1712,7 @@ mod tests {
         assert!(!errors.is_empty());
 
         // region 1 with peers at stores 11, 12, 13.
-        init_region_state(engine.as_inner(), 1, &[11, 12, 13]);
+        init_region_state(engine.as_inner(), 1, &[11, 12, 13], 0);
         let mut expected_state = get_region_state(engine.as_inner(), 1);
         expected_state.set_state(PeerState::Tombstone);
 
@@ -1605,14 +1742,23 @@ mod tests {
                 .collect::<Vec<_>>()
         };
 
+        let get_region_learner = |engine: &Arc<DB>, region_id: u64| {
+            get_region_state(engine, region_id)
+                .get_region()
+                .get_peers()
+                .iter()
+                .filter(|p| p.get_role() == PeerRole::Learner)
+                .count()
+        };
+
         // region 1 with peers at stores 11, 12, 13 and 14.
-        init_region_state(engine.as_inner(), 1, &[11, 12, 13, 14]);
+        init_region_state(engine.as_inner(), 1, &[11, 12, 13, 14], 0);
         // region 2 with peers at stores 21, 22 and 23.
-        init_region_state(engine.as_inner(), 2, &[21, 22, 23]);
+        init_region_state(engine.as_inner(), 2, &[21, 22, 23], 0);
 
         // Only remove specified stores from region 1.
         debugger
-            .remove_failed_stores(vec![13, 14, 21, 23], Some(vec![1]))
+            .remove_failed_stores(vec![13, 14, 21, 23], Some(vec![1]), false)
             .unwrap();
 
         // 13 and 14 should be removed from region 1.
@@ -1621,14 +1767,81 @@ mod tests {
         assert_eq!(get_region_stores(engine.as_inner(), 2), &[21, 22, 23]);
 
         // Remove specified stores from all regions.
-        debugger.remove_failed_stores(vec![11, 23], None).unwrap();
+        debugger
+            .remove_failed_stores(vec![11, 23], None, false)
+            .unwrap();
 
         assert_eq!(get_region_stores(engine.as_inner(), 1), &[12]);
         assert_eq!(get_region_stores(engine.as_inner(), 2), &[21, 22]);
 
         // Should fail when the store itself is in the failed list.
-        init_region_state(engine.as_inner(), 3, &[100, 31, 32, 33]);
-        debugger.remove_failed_stores(vec![100], None).unwrap_err();
+        init_region_state(engine.as_inner(), 3, &[100, 31, 32, 33], 0);
+        debugger
+            .remove_failed_stores(vec![100], None, false)
+            .unwrap_err();
+
+        // no learner, promote learner does nothing
+        init_region_state(engine.as_inner(), 4, &[41, 42, 43, 44], 0);
+        debugger.remove_failed_stores(vec![44], None, true).unwrap();
+        assert_eq!(get_region_stores(engine.as_inner(), 4), &[41, 42, 43]);
+        assert_eq!(get_region_learner(engine.as_inner(), 4), 0);
+
+        // promote learner
+        init_region_state(engine.as_inner(), 5, &[51, 52, 53, 54], 1);
+        debugger
+            .remove_failed_stores(vec![52, 53, 54], None, true)
+            .unwrap();
+        assert_eq!(get_region_stores(engine.as_inner(), 5), &[51]);
+        assert_eq!(get_region_learner(engine.as_inner(), 5), 0);
+
+        // no need to promote learner
+        init_region_state(engine.as_inner(), 6, &[61, 62, 63, 64], 1);
+        debugger.remove_failed_stores(vec![64], None, true).unwrap();
+        assert_eq!(get_region_stores(engine.as_inner(), 6), &[61, 62, 63]);
+        assert_eq!(get_region_learner(engine.as_inner(), 6), 1);
+    }
+
+    #[test]
+    fn test_drop_unapplied_raftlog() {
+        let debugger = new_debugger();
+        debugger.set_store_id(100);
+        let kv_engine = &debugger.engines.kv;
+        let raft_engine = &debugger.engines.raft;
+
+        init_region_state(kv_engine.as_inner(), 1, &[100, 101], 1);
+        init_region_state(kv_engine.as_inner(), 2, &[100, 103], 1);
+        init_raft_state(kv_engine, raft_engine, 1, 100, 90, 80);
+        init_raft_state(kv_engine, raft_engine, 2, 80, 80, 80);
+
+        let region_info_2_before = debugger.region_info(2).unwrap();
+
+        // Drop raftlog on all regions
+        debugger.drop_unapplied_raftlog(None).unwrap();
+
+        let region_info_1 = debugger.region_info(1).unwrap();
+        let region_info_2 = debugger.region_info(2).unwrap();
+
+        assert_eq!(
+            region_info_1.raft_local_state.as_ref().unwrap().last_index,
+            80
+        );
+        assert_eq!(
+            region_info_1
+                .raft_apply_state
+                .as_ref()
+                .unwrap()
+                .applied_index,
+            80
+        );
+        assert_eq!(
+            region_info_1
+                .raft_apply_state
+                .as_ref()
+                .unwrap()
+                .commit_index,
+            80
+        );
+        assert_eq!(region_info_2, region_info_2_before);
     }
 
     #[test]

--- a/src/server/service/debug.rs
+++ b/src/server/service/debug.rs
@@ -484,6 +484,30 @@ impl<ER: RaftEngine, T: RaftStoreRouter<RocksEngine> + 'static> debugpb::Debug f
 
         self.handle_response(ctx, sink, f, TAG);
     }
+
+    fn get_all_regions_in_store(
+        &mut self,
+        ctx: RpcContext<'_>,
+        _: GetAllRegionsInStoreRequest,
+        sink: UnarySink<GetAllRegionsInStoreResponse>,
+    ) {
+        const TAG: &str = "debug_get_all_regions_in_store";
+        let debugger = self.debugger.clone();
+
+        let f = self
+            .pool
+            .spawn(async move {
+                let mut resp = GetAllRegionsInStoreResponse::default();
+                match debugger.get_all_regions_in_store() {
+                    Ok(regions) => resp.set_regions(regions),
+                    Err(_) => resp.set_regions(vec![]),
+                }
+                Ok(resp)
+            })
+            .map(|res| res.unwrap());
+
+        self.handle_response(ctx, sink, f, TAG);
+    }
 }
 
 fn region_detail<T: RaftStoreRouter<RocksEngine>>(

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -122,7 +122,7 @@ futures = "0.3"
 grpcio = { version = "0.8",  default-features = false, features = ["openssl-vendored"] }
 grpcio-health = { version = "0.8", default-features = false }
 log_wrappers = { path = "../components/log_wrappers" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0", default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-5.0-20210906", default-features = false }
 paste = "1.0"
 pd_client = { path = "../components/pd_client", default-features = false }
 protobuf = "2.8"


### PR DESCRIPTION
Signed-off-by: Andy Lok <andylokandy@hotmail.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What is changed and how it works?

1. Allow getting region info for all regions from the remote store:

`tikv-ctl --host 127.0.0.1:20160 raft region --all-regions`

2. Print region start key and end key with:

`tikv-ctl --host 127.0.0.1:20160 region-properties -r 1`

3. Added subcommand:

- `tikv-ctl unsafe-recover remove-failed-stores -s 1,2,3 -r 1,2,3 --promote-learner`: Promote the learner to leader if only one learner exists
- `tikv-ctl unsafe-recover drop-unapplied-raftlog -r 1,2,3`: regress the commit index to the apply index for the region

### Related changes

- https://github.com/pingcap/kvproto/pull/797
- PR to update `pingcap/docs`/`pingcap/docs-cn`: yes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
1. Allow getting region info for all regions on the remote store:

`tikv-ctl --host 127.0.0.1:20160 raft region --all-regions`

2. Print region start key and end key with:

`tikv-ctl --host 127.0.0.1:20160 region-properties -r 1`

3. Added subcommand:

- `tikv-ctl unsafe-recover remove-failed-stores -s 1,2,3 -r 1,2,3 --promote-learner`: Promote the learner to leader if only one learner exists
- `tikv-ctl unsafe-recover drop-unapplied-raftlog -r 1,2,3`: regress the commit index to the apply index for the region
```