### PR TITLE
docs: Fix build status CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## [Website](https://tikv.org) | [Documentation](https://tikv.org/docs/latest/concepts/overview/) | [Community Chat](https://tikv.org/chat)
 
-[![Build Status](https://ci.pingcap.net/buildStatus/icon?job=tikv_ghpr_integration_common_test)](https://ci.pingcap.net/blue/organizations/jenkins/tikv_ghpr_integration_common_test/activity)
+[![Build Status](https://ci.pingcap.net/buildStatus/icon?job=tikv_ghpr_build_master)](https://ci.pingcap.net/blue/organizations/jenkins/tikv_ghpr_build_master/activity)
 [![Coverage Status](https://codecov.io/gh/tikv/tikv/branch/master/graph/badge.svg)](https://codecov.io/gh/tikv/tikv)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2574/badge)](https://bestpractices.coreinfrastructure.org/projects/2574)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## [Website](https://tikv.org) | [Documentation](https://tikv.org/docs/latest/concepts/overview/) | [Community Chat](https://tikv.org/chat)
 
-[![Build Status](https://internal.pingcap.net/idc-jenkins/buildStatus/icon?job=build_tikv_multi_branch%2Fmaster)](https://internal.pingcap.net/idc-jenkins/job/build_tikv_multi_branch/)
+[![Build Status](https://ci.pingcap.net/buildStatus/icon?job=tikv_ghpr_integration_common_test)](https://ci.pingcap.net/blue/organizations/jenkins/tikv_ghpr_integration_common_test/activity)
 [![Coverage Status](https://codecov.io/gh/tikv/tikv/branch/master/graph/badge.svg)](https://codecov.io/gh/tikv/tikv)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2574/badge)](https://bestpractices.coreinfrastructure.org/projects/2574)
 


### PR DESCRIPTION
### What problem does this PR solve?

![image](https://user-images.githubusercontent.com/5351546/132451159-66c97ca3-ce78-4688-97ba-723b39f89620.png)


### What is changed and how it works?

Replaced by new CI service's badge.



### Release note

```release-note
None.
```