### PR TITLE
coprocessor: disable coproccesor when dir config is not presented.

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -445,8 +445,7 @@
 [coprocessor-v2]
 ## Path to the directory where compiled coprocessor plugins are located.
 ## Plugins in this directory will be automatically loaded by TiKV.
-## If a coprocessor plugin file is deleted, it will be automatically unloaded.
-## If the config value is not set, hot-reloading will be disabled.
+## If the config value is not set, the coprocessor plugin will be disabled.
 # coprocessor-plugin-directory = "./coprocessors"
 
 [rocksdb]

--- a/src/coprocessor_v2/endpoint.rs
+++ b/src/coprocessor_v2/endpoint.rs
@@ -34,9 +34,11 @@ impl Endpoint {
                     let mut plugin_registry = PluginRegistry::new();
 
                     if let Err(err) = plugin_registry.start_hot_reloading(plugin_directory) {
-                        warn!("unable to start hot-reloading for coprocessor plugins.";
-                    "coprocessor_directory" => plugin_directory.display(),
-                    "error" => ?err);
+                        warn!(
+                            "unable to start hot-reloading for coprocessor plugins.";
+                            "coprocessor_directory" => plugin_directory.display(),
+                            "error" => ?err
+                        );
                     }
 
                     Arc::new(plugin_registry)


### PR DESCRIPTION
Signed-off-by: Peng Guanwen <pg999w@outlook.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed

If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/tikv/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #10855 

### What is changed and how it works?

Disable plugin when `coprocessor-plugin-directory` is not presented.
coprocessor request will result an error when it  is disabled.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Adjust the behaviour of  `coprocessor-v2.coprocessor-plugin-directory` config item.
```