### PR TITLE
tests: cache symbols ahead of time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2720,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2766204889d09937d00bfbb7fec56bb2a199e2ade963cab19185d8a6104c7c"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "memchr",
 ]
@@ -4873,6 +4873,7 @@ dependencies = [
 name = "test_util"
 version = "0.0.1"
 dependencies = [
+ "backtrace",
  "collections",
  "encryption_export",
  "fail",

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -373,7 +373,7 @@ impl Drop for CallbackLeakDetector {
         if self.called {
             return;
         }
-        
+
         debug!("before capture");
         let bt = backtrace::Backtrace::new();
         warn!("callback is dropped"; "backtrace" => ?bt);

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -373,6 +373,8 @@ impl Drop for CallbackLeakDetector {
         if self.called {
             return;
         }
+        
+        debug!("before capture");
         let bt = backtrace::Backtrace::new();
         warn!("callback is dropped"; "backtrace" => ?bt);
     }

--- a/components/test_util/Cargo.toml
+++ b/components/test_util/Cargo.toml
@@ -24,6 +24,7 @@ cloud-aws = [ "encryption_export/cloud-aws" ]
 cloud-gcp = [ "encryption_export/cloud-gcp" ]
 
 [dependencies]
+backtrace = "0.3"
 encryption_export = { path = "../encryption/export", default-features = false }
 fail = "0.4"
 grpcio = { version = "0.9",  default-features = false, features = ["openssl-vendored"] }

--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -14,7 +14,7 @@ mod runner;
 mod security;
 
 use rand::Rng;
-use std::env;
+use std::{env, thread};
 use std::sync::atomic::{AtomicU16, Ordering};
 
 pub use crate::encryption::*;
@@ -27,6 +27,14 @@ pub use crate::runner::{
 pub use crate::security::*;
 
 pub fn setup_for_ci() {
+    // We use backtrace in tests to record suspicious problems. And loading backtrace
+    // the first time can take several seconds. Spawning a thread and load it ahead
+    // of time to avoid causing timeout.
+    thread::Builder::new()
+        .name(tikv_util::thd_name!("backtrace-loader"))
+        .spawn(::backtrace::Backtrace::new)
+        .unwrap();
+
     if env::var("CI").is_ok() {
         // HACK! Use `epollex` as the polling engine for gRPC when running CI tests on
         // Linux and it hasn't been set before.

--- a/components/test_util/src/lib.rs
+++ b/components/test_util/src/lib.rs
@@ -14,8 +14,8 @@ mod runner;
 mod security;
 
 use rand::Rng;
-use std::{env, thread};
 use std::sync::atomic::{AtomicU16, Ordering};
+use std::{env, thread};
 
 pub use crate::encryption::*;
 pub use crate::kv_generator::*;


### PR DESCRIPTION
### What is changed and how it works?

What's Changed:

TiKV uses backtrace to record suspicious problems in tests. But creating
a backtrace can take several seconds and lead to unexpected timeout for
cases.

This PR loads all symbols ahead of time to reduce the probability of
timeout. tikv-server binary also uses similar way to get around the
issue.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```