### PR TITLE
external-storage: add HdfsStorage upload

### DIFF
--- a/components/external_storage/export/examples/scli.rs
+++ b/components/external_storage/export/examples/scli.rs
@@ -6,10 +6,7 @@ use std::{
     path::Path,
 };
 
-use external_storage_export::{
-    create_storage, make_cloud_backend, make_gcs_backend, make_local_backend, make_noop_backend,
-    make_s3_backend, ExternalStorage,
-};
+use external_storage_export::{ExternalStorage, create_storage, make_cloud_backend, make_gcs_backend, make_hdfs_backend, make_local_backend, make_noop_backend, make_s3_backend};
 use futures_util::io::{copy, AllowStdIo};
 use ini::ini::Ini;
 use kvproto::brpb::{Bucket, CloudDynamic, Gcs, StorageBackend, S3};
@@ -22,6 +19,7 @@ arg_enum! {
     enum StorageType {
         Noop,
         Local,
+        Hdfs,
         S3,
         GCS,
         Cloud,
@@ -43,7 +41,7 @@ pub struct Opt {
     name: String,
     /// Path to use for local storage.
     #[structopt(short, long)]
-    path: String,
+    path: Option<String>,
     /// Credential file path. For S3, use ~/.aws/credentials.
     #[structopt(short, long)]
     credential_file: Option<String>,
@@ -170,7 +168,8 @@ fn process() -> Result<()> {
     let storage: Box<dyn ExternalStorage> = create_storage(
         &(match opt.storage {
             StorageType::Noop => make_noop_backend(),
-            StorageType::Local => make_local_backend(Path::new(&opt.path)),
+            StorageType::Local => make_local_backend(Path::new(&opt.path.unwrap())),
+            StorageType::Hdfs => make_hdfs_backend(opt.path.unwrap()),
             StorageType::S3 => create_s3_storage(&opt)?,
             StorageType::GCS => create_gcs_storage(&opt)?,
             StorageType::Cloud => create_cloud_storage(&opt)?,

--- a/components/external_storage/src/hdfs.rs
+++ b/components/external_storage/src/hdfs.rs
@@ -1,0 +1,111 @@
+use std::{
+    io, path,
+    process::{Command, Stdio},
+    str::FromStr,
+};
+
+use futures::io::AllowStdIo;
+use futures_executor::block_on;
+use futures_util::io::copy;
+use url::Url;
+
+use crate::ExternalStorage;
+
+fn get_hadoop_home() -> Option<String> {
+    std::env::var("HADOOP_HOME").ok()
+}
+
+/// Returns `$HDFS_CMD` if exists, otherwise return `$HADOOP_HOME/bin/hdfs`
+fn get_hdfs_bin() -> Option<String> {
+    std::env::var("HDFS_CMD")
+        .ok()
+        .or_else(|| get_hadoop_home().map(|hadoop| format!("{}/bin/hdfs", hadoop)))
+}
+
+/// A storage to upload file to HDFS
+pub struct HdfsStorage {
+    remote: Url,
+}
+
+impl HdfsStorage {
+    pub fn new(remote: &str) -> io::Result<HdfsStorage> {
+        let remote = Url::from_str(remote).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        Ok(HdfsStorage { remote })
+    }
+}
+
+const STORAGE_NAME: &str = "hdfs";
+
+impl ExternalStorage for HdfsStorage {
+    fn name(&self) -> &'static str {
+        STORAGE_NAME
+    }
+
+    fn url(&self) -> io::Result<Url> {
+        Ok(self.remote.clone())
+    }
+
+    fn write(
+        &self,
+        name: &str,
+        reader: Box<dyn futures::AsyncRead + Send + Unpin>,
+        _content_length: u64,
+    ) -> io::Result<()> {
+        if name.contains(path::MAIN_SEPARATOR) {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("[{}] parent is not allowed in storage", name),
+            ));
+        }
+
+        let cmd_path = get_hdfs_bin().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "Cannot fount hdfs command, please specify HADOOP_HOME or HDFS_CMD",
+            )
+        })?;
+
+        let path = self.remote.clone().join(name).unwrap();
+        let mut hdfs_cmd = Command::new(cmd_path)
+            .stdin(Stdio::piped())
+            .args(["dfs", "-put", "-", &path.to_string()])
+            .spawn()?;
+        let stdin = hdfs_cmd.stdin.as_mut().unwrap();
+
+        block_on(copy(reader, &mut AllowStdIo::new(stdin)))?;
+
+        let status = hdfs_cmd.wait()?;
+        if status.success() {
+            debug!("save file to hdfs"; "path" => ?path);
+            Ok(())
+        } else {
+            error!("hdfs returned non-zero status"; "code" => status.code());
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("hdfs returned non-zero status: {:?}", status.code()),
+            ))
+        }
+    }
+
+    fn read(&self, _name: &str) -> Box<dyn futures::AsyncRead + Unpin + '_> {
+        unimplemented!("currently only HDFS export is implemented")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_hdfs_bin() {
+        std::env::remove_var("HADOOP_HOME");
+        std::env::remove_var("HDFS_CMD");
+        assert!(get_hdfs_bin().is_none());
+
+        std::env::set_var("HADOOP_HOME", "/opt/hadoop");
+        assert_eq!(get_hdfs_bin().as_deref(), Some("/opt/hadoop/bin/hdfs"));
+
+        std::env::set_var("HDFS_CMD", "/opt/hdfs.sh");
+        assert_eq!(get_hdfs_bin().as_deref(), Some("/opt/hdfs.sh"));
+    }
+}

--- a/components/external_storage/src/lib.rs
+++ b/components/external_storage/src/lib.rs
@@ -20,6 +20,8 @@ use tikv_util::stream::{block_on_external_io, READ_BUF_SIZE};
 use tikv_util::time::{Instant, Limiter};
 use tokio::time::timeout;
 
+mod hdfs;
+pub use hdfs::HdfsStorage;
 mod local;
 pub use local::LocalStorage;
 mod noop;


### PR DESCRIPTION
Signed-off-by: Peng Guanwen <pg999w@outlook.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: TBD

Problem Summary: add a storage backend to support hdfs upload.

### What is changed and how it works?

Proposal: TBD

What's Changed: a `HdfsStorage` type in `external_storage` is added.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test
`components/external_storage/export/examples/scli.rs` can be used to test locally
```console
$ cargo run --example scli -- --file Cargo.toml --name test1.txt --storage hdfs --path hdfs://172.16.5.82:49000/ save
error: Custom { kind: Other, error: "Cannot fount hdfs command, please specify HADOOP_HOME or HDFS_CMD" }
$ JAVA_HOME=/usr/lib/jvm/java-1.8.0/ HADOOP_HOME=/root/peng1999/hadoop-3.3.1 cargo run --example scli -- --file test1.txt --name test1.txt --storage hdfs --path hdfs://172.16.5.82:49000/ save
done
```

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Support RawKV backup to HDFS.
```