### PR TITLE
[WIP]*: fix the high cost in destroying peers

### DIFF
--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -512,6 +512,8 @@ pub enum PeerMsg<EK: KvEngine> {
     UpdateReplicationMode,
     Destroy(u64),
     UpdateRegionForUnsafeRecover(metapb::Region),
+    /// All data has been cleaned.
+    Cleaned(bool),
 }
 
 impl<EK: KvEngine> fmt::Debug for PeerMsg<EK> {
@@ -543,6 +545,7 @@ impl<EK: KvEngine> fmt::Debug for PeerMsg<EK> {
             PeerMsg::UpdateRegionForUnsafeRecover(region) => {
                 write!(fmt, "Update Region {} to {:?}", region.get_id(), region)
             }
+            PeerMsg::Cleaned(_) => write!(fmt, "Cleaned"),
         }
     }
 }

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -850,6 +850,11 @@ where
     }
 
     #[inline]
+    pub fn raft_local_state(&self) -> &RaftLocalState {
+        &self.raft_state
+    }
+
+    #[inline]
     pub fn apply_state(&self) -> &RaftApplyState {
         &self.apply_state
     }
@@ -2104,7 +2109,7 @@ mod tests {
         let mut s = new_storage_from_ents(sched.clone(), &td, &ents);
         let (router, _) = mpsc::sync_channel(100);
         let runner = RegionRunner::new(
-            s.engines.kv.clone(),
+            s.engines.clone(),
             mgr,
             0,
             true,
@@ -2481,7 +2486,7 @@ mod tests {
         let s1 = new_storage_from_ents(sched.clone(), &td1, &ents);
         let (router, _) = mpsc::sync_channel(100);
         let runner = RegionRunner::new(
-            s1.engines.kv.clone(),
+            s1.engines.clone(),
             mgr,
             0,
             true,

--- a/components/raftstore/src/store/worker/mod.rs
+++ b/components/raftstore/src/store/worker/mod.rs
@@ -26,7 +26,7 @@ pub use self::pd::{
 pub use self::query_stats::QueryStats;
 pub use self::raftlog_gc::{Runner as RaftlogGcRunner, Task as RaftlogGcTask};
 pub use self::read::{LocalReader, Progress as ReadProgress, ReadDelegate, ReadExecutor, TrackVer};
-pub use self::region::{Runner as RegionRunner, Task as RegionTask};
+pub use self::region::{CleanedNotifier, Runner as RegionRunner, Task as RegionTask};
 pub use self::split_check::{KeyEntry, Runner as SplitCheckRunner, Task as SplitCheckTask};
 pub use self::split_config::{SplitConfig, SplitConfigManager};
 pub use self::split_controller::{AutoSplitController, ReadStats, WriteStats};

--- a/components/tikv_util/src/worker/pool.rs
+++ b/components/tikv_util/src/worker/pool.rs
@@ -115,6 +115,13 @@ impl<T: Display + Send> Scheduler<T> {
         if self.counter.load(Ordering::Acquire) >= self.pending_capacity {
             return Err(ScheduleError::Full(task));
         }
+        self.must_schedule(task)
+    }
+
+    /// Schedules as task to run but ignore the pending capacity limits.
+    ///
+    /// If the worker is stopped, an error will return.
+    pub fn must_schedule(&self, task: T) -> Result<(), ScheduleError<T>> {
         self.counter.fetch_add(1, Ordering::SeqCst);
         self.metrics_pending_task_count.inc();
         if let Err(e) = self.sender.unbounded_send(Msg::Task(task)) {


### PR DESCRIPTION
Reading the first index from TruncatedState instead of performing
a seeking operations.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #10210  <!-- REMOVE this line if no issue to close -->

Problem Summary: Cleaning raft log costs too much time during destroying a peer and cause much high jitter of latency and leaders to drop.

### What is changed and how it works?

What's Changed: read the first index from ApplyState::TruncatedState (if it's exists).

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```