### PR TITLE
github/workflow: adopt new DCO validator

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,9 @@
+name: DCO Check
+
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ziggurat-project/actions-dco@v1.0


### PR DESCRIPTION
Signed-off-by: tison <wander4096@gmail.com>

This closes #11078 

```release-note
None
```

A drawback is that we may pick this workflow to almost every active branch so that the check can be apply on them.